### PR TITLE
feat: implement Unleashed PTY wrapper for auto-approval (#10)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,8 @@ Projects use **5-digit numbers** (prefix `1` + AgentOS number) for implementatio
 | [0600](skills/0600-command-reference.md) | Command Reference | All 8 AgentOS commands |
 | [0601](skills/0601-gemini-dual-review.md) | Gemini Dual Review | AI-to-AI review |
 | [0602](skills/0602-gemini-lld-review.md) | Gemini LLD Review | Design review |
+| [0603](skills/0603-unleashed.md) | Unleashed | Auto-approval PTY wrapper |
+| [0604](skills/0604-gemini-retry.md) | Gemini Retry | Exponential backoff for Gemini |
 | [0699](skills/0699-skill-instructions-index.md) | Skill Index | All skills listed |
 
 ### Audits (08xx)
@@ -199,6 +201,9 @@ See [0600-command-reference.md](skills/0600-command-reference.md) for full detai
 | .claude/project.json.example | Template for project configuration |
 | tools/agentos-generate.py | Generate configs from templates |
 | tools/agentos-permissions.py | Manage permission settings |
+| tools/unleashed.py | Auto-approval PTY wrapper for Claude |
+| tools/gemini-retry.py | Gemini CLI wrapper with exponential backoff |
+| tools/claude-usage-scraper.py | Usage quota extraction via TUI automation |
 
 ---
 
@@ -264,3 +269,4 @@ See `.claude/project-registry.json` for current list.
 | 2.1 | 2026-01-13 | Added parent-child numbering scheme (4-digit AgentOS, 5-digit projects) |
 | 2.2 | 2026-01-13 | ADR 0206: Bidirectional sync architecture, project registry created |
 | 2.3 | 2026-01-14 | Added 0008 Documentation Convention (c/p pattern) |
+| 2.4 | 2026-01-14 | Added 0603 Unleashed, 0604 Gemini Retry, updated Key Files |

--- a/docs/reports/10/implementation-report.md
+++ b/docs/reports/10/implementation-report.md
@@ -1,0 +1,172 @@
+# Implementation Report: Issue #10 - Unleashed PTY Wrapper
+
+**Issue:** [#10](https://github.com/martymcenroe/AgentOS/issues/10)
+**Branch:** `10-unleashed-pty-wrapper`
+**Date:** 2026-01-14
+**Status:** Implementation Complete
+
+---
+
+## Summary
+
+Implemented a PTY wrapper (`unleashed.py`) that auto-approves Claude Code permission prompts after a configurable countdown, providing a dead man's switch for unattended operation.
+
+---
+
+## Files Created
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `tools/unleashed.py` | ~400 | Main PTY wrapper implementation |
+| `tools/unleashed` | ~20 | Bash wrapper for PATH integration |
+| `docs/skills/0603-unleashed.md` | ~200 | Full documentation |
+
+---
+
+## Design Decisions
+
+### 1. PTY Library: winpty
+
+Followed existing pattern from `claude-usage-scraper.py`. The `winpty` library provides:
+- Full TUI fidelity with ANSI support
+- Non-blocking reads via background thread
+- Process lifecycle management
+
+### 2. Threading Model
+
+Three background threads:
+- `PtyReader` - Non-blocking PTY output reading
+- `InputReader` - Non-blocking keyboard input (msvcrt on Windows)
+- Main loop - Coordinates state, overlay, and injection
+
+### 3. Footer Detection
+
+Regex pattern with flexible Unicode handling:
+```python
+FOOTER_PATTERN = re.compile(
+    r'Esc to cancel[-·–—\s]+Tab to add additional instructions',
+    re.IGNORECASE
+)
+```
+
+Handles middle dot (·), en-dash (–), em-dash (—), and ASCII hyphen.
+
+### 4. ANSI Overlay
+
+Non-corrupting overlay using cursor save/restore:
+```python
+CURSOR_SAVE = '\x1b[s'
+CURSOR_RESTORE = '\x1b[u'
+CURSOR_HOME = '\x1b[H'
+```
+
+Overlay draws at top-left, restores cursor to prevent TUI corruption.
+
+### 5. Cancel Detection
+
+Only printable keys cancel the countdown:
+```python
+def is_printable_key(char: str) -> bool:
+    return len(char) == 1 and (char.isprintable() or char in '\r\n\t')
+```
+
+This prevents accidental cancellation from modifier keys (Shift, Ctrl, Alt alone).
+
+### 6. Logging Strategy
+
+Dual logging approach:
+- **Raw log** (`*.log`) - Full byte stream for debugging
+- **Event log** (`*.jsonl`) - Structured events for auditing
+
+Screen context captured on footer detection for audit trail.
+
+---
+
+## Deviations from Issue Spec
+
+### 1. Horizontal Rule Detection (Deferred)
+
+The issue mentioned optional secondary validation using `─` (U+2500) horizontal rule. This was **not implemented** for MVP since footer detection alone is sufficient and more reliable.
+
+### 2. Modifier Key Detection (Simplified)
+
+Rather than explicitly detecting Shift/Ctrl/Alt alone, the implementation uses `is_printable_key()` which naturally excludes non-printable characters. Same effect, simpler code.
+
+### 3. Window Resize Events (Not Implemented)
+
+The issue mentioned handling window resize events. The current implementation uses initial terminal size but does not dynamically resize. This is acceptable for typical usage where terminal size is stable.
+
+---
+
+## Architecture
+
+```
+User Input ──▶ InputReader ──┬──▶ Unleashed ──▶ PTY Process
+                             │       │              │
+                             │       ▼              ▼
+                             │  Footer Check   PtyReader
+                             │       │              │
+                             │       ▼              ▼
+                             └─▶ Countdown ◀── stdout display
+                                    │
+                                    ▼
+                               EventLogger
+```
+
+---
+
+## Key Code Sections
+
+### Footer Detection (`unleashed.py:190-193`)
+```python
+def _detect_footer(self, text: str) -> bool:
+    clean_text = strip_ansi(text)
+    return bool(FOOTER_PATTERN.search(clean_text))
+```
+
+### Countdown Loop (`unleashed.py:207-246`)
+```python
+for remaining in range(self.delay, 0, -1):
+    self.overlay.show(remaining)
+    # Check for user input during this second
+    start = time.time()
+    while time.time() - start < 1.0:
+        user_input = self.input_reader.read_nowait()
+        if user_input:
+            for char in user_input:
+                if is_printable_key(char):
+                    # User cancelled
+                    ...
+```
+
+### Auto-Inject (`unleashed.py:257-260`)
+```python
+if not self.dry_run:
+    if self.pty_process and self.pty_process.isalive():
+        self.pty_process.write('\r')
+    self.logger.log_event("AUTO_APPROVED", context=screen_context[:500])
+```
+
+---
+
+## Dependencies
+
+No new dependencies added. Uses existing `pywinpty` from `pyproject.toml`.
+
+---
+
+## Testing Notes
+
+Test with `--dry-run` to verify detection without injection:
+```bash
+unleashed --dry-run
+```
+
+See `test-report.md` for full test scenarios and results.
+
+---
+
+## Related Documentation
+
+- Skill documentation: `docs/skills/0603-unleashed.md`
+- Test report: `docs/reports/10/test-report.md`

--- a/docs/reports/10/test-report.md
+++ b/docs/reports/10/test-report.md
@@ -1,0 +1,242 @@
+# Test Report: Issue #10 - Unleashed PTY Wrapper
+
+**Issue:** [#10](https://github.com/martymcenroe/AgentOS/issues/10)
+**Date:** 2026-01-14
+**Status:** Pre-Merge Testing
+
+---
+
+## Testing Methodology
+
+Testing was performed in stages:
+1. **Static validation** - Syntax check, import validation
+2. **CLI validation** - `--help` flag, argument parsing
+3. **Unit testing** - Individual components (regex, ANSI stripping)
+4. **Integration testing** - Full PTY wrapper with Claude (manual)
+
+---
+
+## Test Results
+
+### 1. Static Validation
+
+**Test:** Python syntax check
+```bash
+python -m py_compile tools/unleashed.py
+```
+**Result:** PASS (no syntax errors)
+
+### 2. CLI Validation
+
+**Test:** Help output
+```bash
+poetry run python tools/unleashed.py --help
+```
+**Result:** PASS
+
+```
+usage: unleashed.py [-h] [--dry-run] [--delay DELAY]
+
+Unleashed - Auto-approval wrapper for Claude Code
+...
+```
+
+### 3. Footer Detection Regex
+
+**Test:** Pattern matching for various footer formats
+
+| Input | Expected | Result |
+|-------|----------|--------|
+| `Esc to cancel · Tab to add additional instructions` | Match | PASS |
+| `Esc to cancel- Tab to add additional instructions` | Match | PASS |
+| `Esc to cancel – Tab to add additional instructions` | Match | PASS |
+| `Esc to cancel — Tab to add additional instructions` | Match | PASS |
+| `Esc to cancel   Tab to add additional instructions` | Match | PASS |
+| `Some other text` | No match | PASS |
+
+**Regex tested:**
+```python
+FOOTER_PATTERN = re.compile(
+    r'Esc to cancel[-·–—\s]+Tab to add additional instructions',
+    re.IGNORECASE
+)
+```
+
+### 4. ANSI Stripping
+
+**Test:** Remove ANSI sequences for detection
+
+| Input | Expected Output |
+|-------|-----------------|
+| `\x1b[1mBold\x1b[0m text` | `Bold text` |
+| `\x1b[31mRed\x1b[0m` | `Red` |
+| `Normal text` | `Normal text` |
+
+**Result:** PASS (using same pattern as claude-usage-scraper.py)
+
+### 5. Printable Key Detection
+
+**Test:** `is_printable_key()` function
+
+| Input | Expected | Result |
+|-------|----------|--------|
+| `'a'` | True | PASS |
+| `'\r'` | True | PASS |
+| `'\t'` | True | PASS |
+| `'\x1b'` | False | PASS |
+| `''` | False | PASS |
+
+---
+
+## Integration Testing (Manual)
+
+### Test Scenario 1: Startup Banner
+
+**Steps:**
+1. Run `unleashed`
+2. Observe startup banner
+
+**Expected:**
+```
+╔══════════════════════════════════════════════════════════════╗
+║  UNLEASHED - Auto-approval wrapper for Claude Code            ║
+║  Countdown: 10s | Press any key during countdown to cancel   ║
+║  Dry-run: OFF                                                   ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+**Result:** Pending live testing
+
+### Test Scenario 2: Transparent Passthrough
+
+**Steps:**
+1. Run `unleashed`
+2. Use Claude normally (type commands, read output)
+3. Verify TUI appearance matches direct `claude` run
+
+**Expected:** Identical appearance and behavior
+
+**Result:** Pending live testing
+
+### Test Scenario 3: Footer Detection
+
+**Steps:**
+1. Run `unleashed --dry-run`
+2. Trigger a permission prompt (e.g., run `ls /`)
+3. Observe countdown overlay
+
+**Expected:** Overlay appears at top of screen
+
+**Result:** Pending live testing
+
+### Test Scenario 4: Auto-Approval
+
+**Steps:**
+1. Run `unleashed` (not dry-run)
+2. Trigger permission prompt
+3. Wait 10 seconds without input
+
+**Expected:** Prompt auto-approved, Enter injected
+
+**Result:** Pending live testing
+
+### Test Scenario 5: User Cancellation
+
+**Steps:**
+1. Run `unleashed`
+2. Trigger permission prompt
+3. Press any printable key during countdown
+
+**Expected:** Countdown aborted, key passed to Claude
+
+**Result:** Pending live testing
+
+### Test Scenario 6: Modifier Keys (No Cancel)
+
+**Steps:**
+1. Run `unleashed`
+2. Trigger permission prompt
+3. Press Shift/Ctrl/Alt alone during countdown
+
+**Expected:** Countdown continues (not cancelled)
+
+**Result:** Pending live testing
+
+### Test Scenario 7: Child Process Exit
+
+**Steps:**
+1. Run `unleashed`
+2. Exit Claude with `/exit`
+3. Observe wrapper termination
+
+**Expected:** Wrapper exits cleanly, logs `CHILD_EXITED` event
+
+**Result:** Pending live testing
+
+### Test Scenario 8: Event Logging
+
+**Steps:**
+1. Run any of the above scenarios
+2. Check `logs/unleashed_events_*.jsonl`
+
+**Expected:** Structured JSONL events logged
+
+**Result:** Pending live testing
+
+---
+
+## Known Issues
+
+### 1. Python 3.14 Warning
+
+```
+SyntaxWarning: 'break' in a 'finally' block
+```
+
+**Cause:** pywinpty library code (not our code)
+**Impact:** Cosmetic warning only, no functional impact
+**Resolution:** Wait for pywinpty update or suppress warning
+
+### 2. Window Resize
+
+Window resize events are not dynamically handled. Terminal dimensions are captured at startup only.
+
+**Impact:** Low - most sessions use stable terminal size
+**Resolution:** Deferred to future enhancement
+
+---
+
+## Acceptance Criteria Checklist
+
+| Criterion | Status |
+|-----------|--------|
+| Running `unleashed` spawns Claude with identical TUI appearance | Pending |
+| Startup banner displays on launch | Code complete, pending test |
+| Footer detection uses flexible separator pattern | PASS (regex validated) |
+| Screen state is captured and visible during countdown | Code complete, pending test |
+| Countdown overlay uses ANSI cursor save/restore | Code complete |
+| Countdown displays visibly with second-by-second update | Code complete, pending test |
+| `UNLEASHED_DELAY=N` environment variable overrides default | Code complete |
+| Pressing printable key during countdown aborts and passes key | Code complete, pending test |
+| Modifier keys alone do NOT cancel countdown | Code complete, pending test |
+| Uninterrupted countdown injects Enter and approves prompt | Code complete, pending test |
+| Child process termination detected, wrapper exits cleanly | Code complete, pending test |
+| Session log captures full raw output | Code complete |
+| Event log captures structured events with prompt context | Code complete |
+
+---
+
+## Conclusion
+
+All static tests pass. Integration tests require live Claude session and are marked pending.
+
+The implementation follows the established patterns from `claude-usage-scraper.py` and addresses all requirements from Issue #10.
+
+**Recommendation:** Merge after manual integration testing confirms expected behavior.
+
+---
+
+## Related Documentation
+
+- Implementation report: `docs/reports/10/implementation-report.md`
+- Skill documentation: `docs/skills/0603-unleashed.md`

--- a/docs/skills/0603-unleashed.md
+++ b/docs/skills/0603-unleashed.md
@@ -1,0 +1,247 @@
+# 0603 Unleashed - Auto-Approval PTY Wrapper
+
+**Tool:** `tools/unleashed.py`
+**Bash Wrapper:** `tools/unleashed`
+**Issue:** [#10](https://github.com/martymcenroe/AgentOS/issues/10)
+
+---
+
+## Overview
+
+Unleashed is a PTY wrapper that eliminates permission friction by auto-approving Claude Code permission prompts after a 10-second countdown, giving users a window to cancel.
+
+**Use case:** Unattended or low-friction Claude sessions where you trust the operations but want a safety window.
+
+---
+
+## Quick Start
+
+### CLI Usage
+
+```bash
+# Add to PATH (add to ~/.bashrc for persistence)
+export PATH="/c/Users/mcwiz/Projects/AgentOS/tools:$PATH"
+
+# Run unleashed instead of claude
+unleashed
+
+# Test detection without injection
+unleashed --dry-run
+
+# Custom countdown delay
+unleashed --delay 5
+UNLEASHED_DELAY=5 unleashed
+```
+
+### From Poetry
+
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AgentOS python tools/unleashed.py
+poetry run --directory /c/Users/mcwiz/Projects/AgentOS python tools/unleashed.py --dry-run
+```
+
+---
+
+## How It Works
+
+### Detection
+
+Unleashed detects permission prompts by looking for Claude Code's footer pattern:
+
+```
+Esc to cancel · Tab to add additional instructions
+```
+
+The regex handles Unicode variations in the separator:
+- `·` (U+00B7 middle dot)
+- `–` (U+2013 en-dash)
+- `—` (U+2014 em-dash)
+- `-` (ASCII hyphen)
+
+### Countdown Sequence
+
+1. Footer detected in PTY output
+2. Screen state captured (for audit logging)
+3. Countdown overlay displayed (top of screen)
+4. 10-second countdown (configurable)
+5. If user presses printable key → cancelled, key passed to Claude
+6. If countdown completes → Enter injected, prompt approved
+
+### Overlay
+
+The countdown overlay uses ANSI cursor save/restore sequences to avoid corrupting Claude's TUI:
+
+```
+[UNLEASHED] Auto-approving in 8s... (Press any key to cancel)
+```
+
+---
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Test detection without injecting Enter |
+| `--delay N` | Countdown delay in seconds (default: 10) |
+| `--help` | Show help message |
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `UNLEASHED_DELAY` | Countdown delay in seconds | 10 |
+
+---
+
+## Logging
+
+All sessions are logged to `logs/`:
+
+### Raw Log (`unleashed_TIMESTAMP.log`)
+
+Full raw byte stream from Claude's PTY output. Useful for debugging.
+
+**Warning:** Raw logs can be large for long sessions. Consider periodic cleanup.
+
+### Event Log (`unleashed_events_TIMESTAMP.jsonl`)
+
+Structured JSONL events:
+
+```jsonl
+{"ts": "2026-01-14T12:00:00Z", "event": "START", "delay": 10, "dry_run": false}
+{"ts": "2026-01-14T12:00:05Z", "event": "FOOTER_DETECTED"}
+{"ts": "2026-01-14T12:00:05Z", "event": "SCREEN_CAPTURED", "context_length": 1500}
+{"ts": "2026-01-14T12:00:05Z", "event": "COUNTDOWN_START", "delay": 10}
+{"ts": "2026-01-14T12:00:15Z", "event": "AUTO_APPROVED", "context": "...first 500 chars..."}
+{"ts": "2026-01-14T12:00:30Z", "event": "CHILD_EXITED", "exit_code": 0}
+{"ts": "2026-01-14T12:00:30Z", "event": "END"}
+```
+
+**Event Types:**
+- `START` - Session started
+- `FOOTER_DETECTED` - Permission prompt detected
+- `SCREEN_CAPTURED` - Screen context saved
+- `COUNTDOWN_START` - Countdown began
+- `AUTO_APPROVED` - Prompt auto-approved (includes context)
+- `AUTO_APPROVED_DRY_RUN` - Would have approved (dry-run mode)
+- `CANCELLED_BY_USER` - User pressed key to cancel
+- `INTERRUPTED` - Session interrupted (Ctrl+C)
+- `CHILD_EXITED` - Claude process exited
+- `ERROR` - Error occurred
+- `END` - Session ended
+
+---
+
+## Security Considerations
+
+### This is NOT a Security Tool
+
+Unleashed auto-approves ALL permission prompts. It does not:
+- Inspect or filter commands
+- Distinguish "safe" from "dangerous" operations
+- Provide any sandboxing
+
+### Mitigations
+
+1. **10-second delay** - Visual review window before auto-action
+2. **Screen capture** - User sees WHAT is being approved
+3. **Cancel capability** - Any printable key aborts countdown
+4. **Full logging** - Audit trail of all auto-approvals
+
+### When to Use
+
+- Unattended batch operations
+- Trusted development workflows
+- When you trust the agent's judgment
+- When permission prompts are friction, not protection
+
+### When NOT to Use
+
+- Working with untrusted code
+- Operations affecting production systems
+- When you need to review each action
+- When running commands from untrusted sources
+
+---
+
+## Troubleshooting
+
+### "pywinpty not installed"
+
+```bash
+poetry add pywinpty
+```
+
+### Countdown doesn't trigger
+
+1. Check if the footer pattern is visible in Claude's output
+2. Run with `--dry-run` to test detection
+3. Check raw log for the footer text
+
+### TUI corruption
+
+If the display looks corrupted:
+1. Press Ctrl+L to redraw Claude's screen
+2. Try a larger terminal window
+3. Check terminal emulator compatibility with ANSI sequences
+
+### Input not working
+
+Unleashed uses `msvcrt` on Windows for keyboard input. If keys aren't registering:
+1. Ensure running in a proper terminal (Git Bash, Windows Terminal)
+2. Not running in a non-interactive shell
+
+---
+
+## Architecture
+
+```
+┌─────────────────┐
+│   User Input    │
+│   (keyboard)    │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     ┌─────────────────┐
+│  InputReader    │────▶│   Unleashed     │
+│  (background)   │     │   (main loop)   │
+└─────────────────┘     └────────┬────────┘
+                                 │
+         ┌───────────────────────┼───────────────────────┐
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   PTY Process   │     │  Footer Check   │     │   Event Logger  │
+│   (winpty)      │     │  (regex match)  │     │   (JSONL)       │
+└────────┬────────┘     └────────┬────────┘     └─────────────────┘
+         │                       │
+         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│   PtyReader     │     │ CountdownOverlay│
+│   (background)  │     │ (ANSI escape)   │
+└────────┬────────┘     └─────────────────┘
+         │
+         ▼
+┌─────────────────┐
+│   stdout        │
+│   (display)     │
+└─────────────────┘
+```
+
+---
+
+## Dependencies
+
+- `pywinpty` - PTY handling for Windows (already in pyproject.toml)
+- Python 3.8+
+- Git Bash or compatible terminal
+
+---
+
+## Future Enhancements (Out of Scope)
+
+- Command blacklist/whitelist filtering
+- Cross-platform Unix pty support
+- Log rotation/size capping
+- Integration with `.claude/settings.json`
+- Configuration file for settings

--- a/tools/unleashed
+++ b/tools/unleashed
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Unleashed - Bash wrapper for the Python PTY wrapper
+#
+# Usage:
+#   unleashed [--dry-run] [--delay N]
+#
+# Environment Variables:
+#   UNLEASHED_DELAY=N  Override countdown delay (default: 10 seconds)
+#
+# Add to PATH:
+#   export PATH="/c/Users/mcwiz/Projects/AgentOS/tools:$PATH"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_SCRIPT="$SCRIPT_DIR/unleashed.py"
+
+# Check if Python script exists
+if [[ ! -f "$PYTHON_SCRIPT" ]]; then
+    echo "[UNLEASHED] Error: unleashed.py not found at $PYTHON_SCRIPT" >&2
+    exit 1
+fi
+
+# Run with poetry from AgentOS directory
+AGENTOS_DIR="$(dirname "$SCRIPT_DIR")"
+poetry run --directory "$AGENTOS_DIR" python "$PYTHON_SCRIPT" "$@"

--- a/tools/unleashed.py
+++ b/tools/unleashed.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""
+Unleashed - PTY Wrapper for Claude Code Auto-Approval
+
+A convenience wrapper that auto-approves Claude Code permission prompts
+after a 10-second countdown, giving users a window to cancel.
+
+Usage:
+  python tools/unleashed.py [--dry-run] [--help]
+
+Environment Variables:
+  UNLEASHED_DELAY=N  Override default 10-second countdown (default: 10)
+
+Security Note:
+  This is a convenience tool, not a security tool. It auto-approves ALL
+  permission prompts after the countdown. Use at your own risk.
+
+References:
+  - Issue #10: https://github.com/martymcenroe/AgentOS/issues/10
+"""
+
+import argparse
+import json
+import os
+import queue
+import re
+import select
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import winpty
+except ImportError:
+    print("[UNLEASHED] Error: pywinpty not installed. Run: poetry add pywinpty", file=sys.stderr)
+    sys.exit(1)
+
+# Try to import msvcrt for Windows keyboard input
+try:
+    import msvcrt
+    HAS_MSVCRT = True
+except ImportError:
+    HAS_MSVCRT = False
+
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+DEFAULT_DELAY = 10  # seconds
+FOOTER_PATTERN = re.compile(
+    r'Esc to cancel[-·–—\s]+Tab to add additional instructions',
+    re.IGNORECASE
+)
+ANSI_ESCAPE = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+
+# ANSI escape sequences for overlay
+CURSOR_SAVE = '\x1b[s'
+CURSOR_RESTORE = '\x1b[u'
+CURSOR_HOME = '\x1b[H'
+CLEAR_LINE = '\x1b[2K'
+BOLD = '\x1b[1m'
+YELLOW = '\x1b[33m'
+RESET = '\x1b[0m'
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from terminal output."""
+    return ANSI_ESCAPE.sub('', text)
+
+
+def is_printable_key(char: str) -> bool:
+    """Check if a character is a printable key (not a modifier alone)."""
+    if not char:
+        return False
+    # Printable ASCII range or common keys
+    return len(char) == 1 and (char.isprintable() or char in '\r\n\t')
+
+
+def get_timestamp() -> str:
+    """Get ISO 8601 timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+# =============================================================================
+# PTY Reader (from claude-usage-scraper.py pattern)
+# =============================================================================
+
+class PtyReader:
+    """Non-blocking PTY reader using a background thread."""
+
+    def __init__(self, pty):
+        self.pty = pty
+        self.queue = queue.Queue()
+        self.running = True
+        self.thread = threading.Thread(target=self._reader_thread, daemon=True)
+        self.thread.start()
+
+    def _reader_thread(self):
+        """Background thread that continuously reads from PTY."""
+        while self.running and self.pty.isalive():
+            try:
+                chunk = self.pty.read(4096)
+                if chunk:
+                    self.queue.put(chunk)
+            except EOFError:
+                break
+            except Exception:
+                break
+
+    def read_nowait(self) -> str:
+        """Read all available data without blocking."""
+        result = ''
+        while True:
+            try:
+                chunk = self.queue.get_nowait()
+                result += chunk
+            except queue.Empty:
+                break
+        return result
+
+    def read(self, timeout: float = 0.1) -> str:
+        """Read all available data with timeout."""
+        result = ''
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            try:
+                chunk = self.queue.get(timeout=0.05)
+                result += chunk
+            except queue.Empty:
+                if result:
+                    break
+        return result
+
+    def stop(self):
+        self.running = False
+
+
+# =============================================================================
+# Input Reader (for user keyboard input)
+# =============================================================================
+
+class InputReader:
+    """Non-blocking stdin reader."""
+
+    def __init__(self):
+        self.queue = queue.Queue()
+        self.running = True
+        self.thread = threading.Thread(target=self._reader_thread, daemon=True)
+        self.thread.start()
+
+    def _reader_thread(self):
+        """Background thread for reading stdin."""
+        while self.running:
+            try:
+                if HAS_MSVCRT:
+                    # Windows: use msvcrt for non-blocking input
+                    if msvcrt.kbhit():
+                        char = msvcrt.getwch()
+                        self.queue.put(char)
+                    else:
+                        time.sleep(0.01)
+                else:
+                    # Unix: use select for non-blocking input
+                    if select.select([sys.stdin], [], [], 0.01)[0]:
+                        char = sys.stdin.read(1)
+                        if char:
+                            self.queue.put(char)
+            except Exception:
+                time.sleep(0.01)
+
+    def read_nowait(self) -> str:
+        """Read all available input without blocking."""
+        result = ''
+        while True:
+            try:
+                char = self.queue.get_nowait()
+                result += char
+            except queue.Empty:
+                break
+        return result
+
+    def stop(self):
+        self.running = False
+
+
+# =============================================================================
+# Event Logger
+# =============================================================================
+
+class EventLogger:
+    """Structured event logger for unleashed sessions."""
+
+    def __init__(self, log_dir: Path, session_id: str):
+        self.log_dir = log_dir
+        self.session_id = session_id
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Raw output log
+        self.raw_log_path = log_dir / f"unleashed_{session_id}.log"
+        self.raw_log = open(self.raw_log_path, 'wb')
+
+        # Structured event log
+        self.event_log_path = log_dir / f"unleashed_events_{session_id}.jsonl"
+        self.event_log = open(self.event_log_path, 'a', encoding='utf-8')
+
+    def log_raw(self, data: bytes):
+        """Log raw bytes to session log."""
+        self.raw_log.write(data)
+        self.raw_log.flush()
+
+    def log_event(self, event_type: str, **kwargs):
+        """Log structured event."""
+        event = {
+            "ts": get_timestamp(),
+            "event": event_type,
+            **kwargs
+        }
+        self.event_log.write(json.dumps(event) + '\n')
+        self.event_log.flush()
+
+    def close(self):
+        """Close all log files."""
+        self.raw_log.close()
+        self.event_log.close()
+
+
+# =============================================================================
+# Countdown Overlay
+# =============================================================================
+
+class CountdownOverlay:
+    """Manages the ANSI overlay for countdown display."""
+
+    def __init__(self, writer):
+        self.writer = writer  # Function to write to stdout
+        self.active = False
+
+    def show(self, seconds_remaining: int):
+        """Show countdown overlay."""
+        self.active = True
+        message = f"{CURSOR_SAVE}{CURSOR_HOME}{BOLD}{YELLOW}[UNLEASHED] Auto-approving in {seconds_remaining}s... (Press any key to cancel){RESET}{CLEAR_LINE}{CURSOR_RESTORE}"
+        self.writer(message)
+
+    def hide(self):
+        """Hide countdown overlay."""
+        if self.active:
+            # Clear the overlay line
+            message = f"{CURSOR_SAVE}{CURSOR_HOME}{CLEAR_LINE}{CURSOR_RESTORE}"
+            self.writer(message)
+            self.active = False
+
+    def show_approved(self):
+        """Show approval message briefly."""
+        message = f"{CURSOR_SAVE}{CURSOR_HOME}{BOLD}{YELLOW}[UNLEASHED] Auto-approved!{RESET}{CLEAR_LINE}{CURSOR_RESTORE}"
+        self.writer(message)
+
+    def show_cancelled(self):
+        """Show cancellation message briefly."""
+        message = f"{CURSOR_SAVE}{CURSOR_HOME}{BOLD}{YELLOW}[UNLEASHED] Cancelled by user{RESET}{CLEAR_LINE}{CURSOR_RESTORE}"
+        self.writer(message)
+
+
+# =============================================================================
+# Main Unleashed Wrapper
+# =============================================================================
+
+class Unleashed:
+    """Main PTY wrapper for auto-approval."""
+
+    def __init__(self, delay: int = DEFAULT_DELAY, dry_run: bool = False):
+        self.delay = delay
+        self.dry_run = dry_run
+        self.pty_process = None
+        self.pty_reader = None
+        self.input_reader = None
+        self.logger = None
+        self.overlay = None
+        self.running = False
+        self.in_countdown = False
+        self.screen_buffer = ""  # Recent screen content for context
+        self.buffer_max_size = 8192  # Keep last 8KB for context
+
+    def _write_stdout(self, data: str):
+        """Write to stdout and flush."""
+        sys.stdout.write(data)
+        sys.stdout.flush()
+
+    def _detect_footer(self, text: str) -> bool:
+        """Check if the permission footer is present in text."""
+        clean_text = strip_ansi(text)
+        return bool(FOOTER_PATTERN.search(clean_text))
+
+    def _capture_screen_context(self) -> str:
+        """Capture current screen context for logging."""
+        return strip_ansi(self.screen_buffer)[-2000:]  # Last 2KB stripped
+
+    def _handle_countdown(self) -> bool:
+        """
+        Handle the countdown sequence.
+        Returns True if auto-approved, False if cancelled.
+        """
+        self.in_countdown = True
+        screen_context = self._capture_screen_context()
+
+        self.logger.log_event("FOOTER_DETECTED")
+        self.logger.log_event("SCREEN_CAPTURED", context_length=len(screen_context))
+        self.logger.log_event("COUNTDOWN_START", delay=self.delay)
+
+        for remaining in range(self.delay, 0, -1):
+            self.overlay.show(remaining)
+
+            # Check for user input during this second
+            start = time.time()
+            while time.time() - start < 1.0:
+                user_input = self.input_reader.read_nowait()
+                if user_input:
+                    for char in user_input:
+                        if is_printable_key(char):
+                            # User cancelled
+                            self.overlay.show_cancelled()
+                            time.sleep(0.5)
+                            self.overlay.hide()
+                            self.in_countdown = False
+                            self.logger.log_event("CANCELLED_BY_USER", key=repr(char))
+
+                            # Pass the keypress through to Claude
+                            if self.pty_process and self.pty_process.isalive():
+                                self.pty_process.write(char)
+
+                            return False
+
+                time.sleep(0.05)
+
+        # Countdown completed - auto-approve
+        self.overlay.show_approved()
+        time.sleep(0.3)
+        self.overlay.hide()
+        self.in_countdown = False
+
+        if not self.dry_run:
+            # Inject Enter to approve
+            if self.pty_process and self.pty_process.isalive():
+                self.pty_process.write('\r')
+            self.logger.log_event("AUTO_APPROVED", context=screen_context[:500])
+        else:
+            self.logger.log_event("AUTO_APPROVED_DRY_RUN", context=screen_context[:500])
+
+        return True
+
+    def _show_banner(self):
+        """Display startup banner."""
+        banner = f"""
+{BOLD}{YELLOW}╔══════════════════════════════════════════════════════════════╗
+║  UNLEASHED - Auto-approval wrapper for Claude Code            ║
+║  Countdown: {self.delay}s | Press any key during countdown to cancel   ║
+║  Dry-run: {'ON' if self.dry_run else 'OFF'}                                                   ║
+╚══════════════════════════════════════════════════════════════╝{RESET}
+"""
+        self._write_stdout(banner)
+
+    def run(self):
+        """Main run loop."""
+        session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_dir = Path(__file__).parent.parent / "logs"
+
+        self.logger = EventLogger(log_dir, session_id)
+        self.logger.log_event("START", delay=self.delay, dry_run=self.dry_run)
+
+        self.overlay = CountdownOverlay(self._write_stdout)
+        self._show_banner()
+
+        try:
+            # Get terminal dimensions
+            try:
+                import shutil
+                cols, rows = shutil.get_terminal_size()
+            except Exception:
+                cols, rows = 120, 40
+
+            # Spawn Claude Code
+            self.pty_process = winpty.PtyProcess.spawn(
+                ['claude'],
+                dimensions=(rows, cols)
+            )
+
+            self.pty_reader = PtyReader(self.pty_process)
+            self.input_reader = InputReader()
+            self.running = True
+
+            # Main loop
+            while self.running and self.pty_process.isalive():
+                # Read PTY output
+                pty_output = self.pty_reader.read_nowait()
+                if pty_output:
+                    # Log raw output
+                    self.logger.log_raw(pty_output.encode('utf-8', errors='replace'))
+
+                    # Update screen buffer
+                    self.screen_buffer += pty_output
+                    if len(self.screen_buffer) > self.buffer_max_size:
+                        self.screen_buffer = self.screen_buffer[-self.buffer_max_size:]
+
+                    # Display output
+                    self._write_stdout(pty_output)
+
+                    # Check for footer (permission prompt)
+                    if not self.in_countdown and self._detect_footer(pty_output):
+                        self._handle_countdown()
+
+                # Read user input (when not in countdown)
+                if not self.in_countdown:
+                    user_input = self.input_reader.read_nowait()
+                    if user_input:
+                        # Pass through to PTY
+                        if self.pty_process.isalive():
+                            self.pty_process.write(user_input)
+
+                # Small sleep to prevent CPU spin
+                time.sleep(0.01)
+
+        except KeyboardInterrupt:
+            self.logger.log_event("INTERRUPTED")
+        except Exception as e:
+            self.logger.log_event("ERROR", error=str(e))
+            raise
+        finally:
+            self._cleanup()
+
+    def _cleanup(self):
+        """Clean up resources."""
+        self.running = False
+
+        if self.pty_reader:
+            self.pty_reader.stop()
+
+        if self.input_reader:
+            self.input_reader.stop()
+
+        if self.pty_process:
+            exit_code = None
+            if self.pty_process.isalive():
+                try:
+                    self.pty_process.terminate()
+                    time.sleep(0.3)
+                except Exception:
+                    pass
+
+            try:
+                exit_code = self.pty_process.exitstatus
+            except Exception:
+                pass
+
+            if self.logger:
+                self.logger.log_event("CHILD_EXITED", exit_code=exit_code)
+
+        if self.logger:
+            self.logger.log_event("END")
+            self.logger.close()
+            print(f"\n[UNLEASHED] Logs saved to: {self.logger.log_dir}", file=sys.stderr)
+
+
+# =============================================================================
+# Signal Handlers
+# =============================================================================
+
+def setup_signal_handlers(unleashed_instance):
+    """Set up signal handlers for graceful shutdown."""
+    def handler(signum, frame):
+        unleashed_instance.running = False
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+# =============================================================================
+# Main Entry Point
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Unleashed - Auto-approval wrapper for Claude Code",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Environment Variables:
+  UNLEASHED_DELAY=N  Override countdown delay (default: 10 seconds)
+
+Examples:
+  python tools/unleashed.py              # Normal mode
+  python tools/unleashed.py --dry-run    # Test detection without injection
+  UNLEASHED_DELAY=5 python tools/unleashed.py  # 5-second countdown
+
+Security Note:
+  This tool auto-approves ALL permission prompts. Use at your own risk.
+        """
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Test detection without actually injecting Enter"
+    )
+    parser.add_argument(
+        "--delay",
+        type=int,
+        default=None,
+        help="Countdown delay in seconds (overrides UNLEASHED_DELAY env var)"
+    )
+
+    args = parser.parse_args()
+
+    # Determine delay
+    delay = args.delay
+    if delay is None:
+        delay = int(os.environ.get("UNLEASHED_DELAY", DEFAULT_DELAY))
+
+    # Create and run unleashed
+    unleashed = Unleashed(delay=delay, dry_run=args.dry_run)
+    setup_signal_handlers(unleashed)
+
+    try:
+        unleashed.run()
+    except Exception as e:
+        print(f"[UNLEASHED] Fatal error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Implement `unleashed.py` PTY wrapper that auto-approves Claude Code permission prompts after 10-second countdown
- Add bash wrapper script for PATH integration
- Full documentation and reports

## Features

- **Footer detection** with flexible Unicode handling (`[-·–—]` separator)
- **Non-corrupting ANSI overlay** using cursor save/restore
- **Dead man's switch** - any printable key cancels (modifiers don't)
- **Dual logging** - raw byte stream + structured JSONL events
- **Screen context capture** for audit trail
- **Child process monitoring** - clean exit on Claude termination

## Files Changed

| File | Description |
|------|-------------|
| `tools/unleashed.py` | Main PTY wrapper (~400 lines) |
| `tools/unleashed` | Bash wrapper for PATH integration |
| `docs/skills/0603-unleashed.md` | Full documentation |
| `docs/reports/10/implementation-report.md` | Implementation details |
| `docs/reports/10/test-report.md` | Test scenarios and results |
| `docs/index.md` | Updated with new skill |

## Test Plan

- [x] Syntax validation (`python -m py_compile`)
- [x] CLI help output (`--help`)
- [x] Footer regex validation
- [ ] Live integration test with Claude (pending manual)
- [ ] Countdown display verification
- [ ] User cancellation test
- [ ] Child process exit handling

## Notes

- Uses same PTY patterns as `claude-usage-scraper.py`
- No new dependencies (uses existing `pywinpty`)
- Gemini review attempted but capacity exhausted; issue was already Gemini-reviewed

Closes #10

---
Generated with [Claude Code](https://claude.com/claude-code)