### PR TITLE
fix: Resume workflow uses proper LangGraph interrupt mechanism

### DIFF
--- a/agentos/workflows/issue/nodes/human_edit_draft.py
+++ b/agentos/workflows/issue/nodes/human_edit_draft.py
@@ -226,11 +226,17 @@ def human_edit_draft(state: IssueWorkflowState) -> dict[str, Any]:
     decision, feedback = prompt_user_decision_draft()
 
     if decision == HumanDecision.MANUAL:
-        # Raise KeyboardInterrupt to pause workflow WITHOUT completing this node.
-        # This ensures the checkpoint is saved BEFORE this node, so resume
-        # will re-run this node and show the prompt again.
-        print("\n>>> Pausing workflow for manual handling...")
-        raise KeyboardInterrupt("User chose manual handling")
+        # Return with next_node pointing back to N3 (this node).
+        # The workflow will route back to N3, where interrupt_before will pause.
+        # This ensures the checkpoint is saved with state.next = ("N3_human_edit_draft",)
+        # so resume will properly continue from this node.
+        print("\n>>> Saving workflow state for later...")
+        return {
+            "current_draft": draft_content,
+            "iteration_count": iteration_count,
+            "next_node": "N3_human_edit_draft",
+            "error_message": "",
+        }
 
     if decision == HumanDecision.REVISE:
         # Save feedback to audit trail


### PR DESCRIPTION
## Summary

- Fixes resume workflow bug where program exits immediately without executing pending nodes
- Replaces KeyboardInterrupt hack with proper LangGraph `interrupt_before` mechanism
- Adds N3 self-loop route for "save and exit" option

## Problem

When resuming an interrupted workflow via `[R]esume`, the program printed checkpoint state but exited immediately:

```
>>> Resuming from iteration 2
>>> Drafts: 2
>>> Verdicts: 1
[user@host]$   ← Immediate exit, no node execution
```

Root cause: `state.next` was empty because `KeyboardInterrupt` doesn't properly save LangGraph checkpoints.

## Solution

1. **graph.py**: Add route for N3 to loop back to itself (for "save and exit")
2. **human_edit_draft.py**: Replace `KeyboardInterrupt` with proper return that routes to N3
3. **run_issue_workflow.py**: Add `interrupt_before=["N3_human_edit_draft"]` and handle interrupt points

## How It Works

With `interrupt_before`, the workflow pauses before N3 runs, saving `state.next = ("N3_human_edit_draft",)`. On resume, `app.stream(None, config)` continues from this point correctly.

When user chooses [S]ave:
1. N3 returns with `next_node = "N3_human_edit_draft"`
2. Conditional edge routes back to N3
3. `interrupt_before` triggers, pausing workflow
4. CLI detects N3 ran this iteration → exits cleanly
5. Resume works because `state.next` is populated

## Test Plan

```bash
# Manual test
poetry run python tools/run_issue_workflow.py --select
# Select an idea, at N3 prompt choose [S]ave
# Run again, select same idea, choose [R]esume
# Verify N3 prompt appears and workflow continues
```

Fixes #89

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)