### PR TITLE
feat: migrate from google.generativeai to google.genai SDK

### DIFF
--- a/agentos/core/gemini_client.py
+++ b/agentos/core/gemini_client.py
@@ -20,7 +20,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
-import google.generativeai as genai
+from google import genai
+from google.genai import types
 
 from agentos.core.config import (
     BACKOFF_BASE_SECONDS,
@@ -516,17 +517,17 @@ class GeminiClient:
                             # Raise exception to trigger error handling
                             raise RuntimeError(error_msg)
                     else:
-                        # API key: use SDK
-                        genai.configure(api_key=cred.key)
+                        # API key: use new google.genai SDK
+                        client = genai.Client(api_key=cred.key)
 
-                        # Create model instance
-                        model = genai.GenerativeModel(
-                            model_name=self.model,
-                            system_instruction=system_instruction,
+                        # Make the API call with system instruction in config
+                        response = client.models.generate_content(
+                            model=self.model,
+                            contents=content,
+                            config=types.GenerateContentConfig(
+                                system_instruction=system_instruction,
+                            ),
                         )
-
-                        # Make the API call
-                        response = model.generate_content(content)
 
                         # Check for successful response
                         if response.text:


### PR DESCRIPTION
## Summary

Migrates the Gemini client from the deprecated `google.generativeai` SDK to the new `google.genai` SDK.

- Updated imports: `import google.generativeai as genai` → `from google import genai`
- Changed API call pattern: `genai.configure()` + `GenerativeModel.generate_content()` → `genai.Client(api_key=...)` + `client.models.generate_content()`
- Use `types.GenerateContentConfig` for system instruction
- Updated test mocks to use new SDK patterns
- Fixed test fixture to include `type: api_key` in credentials

## Test plan

- [x] All 17 gemini_client tests pass
- [x] 545/546 total tests pass (1 pre-existing failure on main)
- [x] FutureWarning about deprecated SDK eliminated

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)