### PR TITLE
fix: implement --auto flag to skip Gemini review in TDD workflow

### DIFF
--- a/agentos/workflows/testing/nodes/review_test_plan.py
+++ b/agentos/workflows/testing/nodes/review_test_plan.py
@@ -271,6 +271,15 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
     if state.get("mock_mode"):
         return _mock_review_test_plan(state)
 
+    # Check for auto mode - skip Gemini review and auto-approve
+    if state.get("auto_mode"):
+        print("    [AUTO] Skipping Gemini review - auto mode enabled")
+        return {
+            "test_plan_status": "APPROVED",
+            "test_plan_verdict": "[AUTO] Review skipped - auto mode enabled",
+            "file_counter": state.get("file_counter", 0),
+        }
+
     # Get repo root
     repo_root_str = state.get("repo_root", "")
     repo_root = Path(repo_root_str) if repo_root_str else get_repo_root()


### PR DESCRIPTION
## Summary

The `--auto` flag was defined but never implemented. Now it works:

- Added `auto_mode` check in `review_test_plan()` after `mock_mode` check
- When `--auto` is passed, workflow skips Gemini review and auto-approves
- Added test: `test_review_test_plan_auto_mode_skips_review`

## Test plan

- [x] New test passes
- [x] All 62 testing workflow tests pass
- [x] `--auto` flag now skips review

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)