### PR TITLE
feat: add worktree creation to TDD workflow (#130)

### DIFF
--- a/agentos/workflows/testing/state.py
+++ b/agentos/workflows/testing/state.py
@@ -41,6 +41,8 @@ class TestingWorkflowState(TypedDict, total=False):
         issue_number: GitHub issue number (links to LLD).
         lld_path: Path to the approved LLD file.
         repo_root: Target repository root path (for cross-repo workflows).
+        worktree_path: Path to git worktree (if created for this workflow).
+        original_repo_root: Original repository root before worktree switch.
 
         # LLD content (populated by N0)
         lld_content: Full LLD content.
@@ -108,6 +110,10 @@ class TestingWorkflowState(TypedDict, total=False):
     issue_number: int
     lld_path: str
     repo_root: str
+
+    # Worktree isolation (for multi-branch safety)
+    worktree_path: str  # Path to worktree if created
+    original_repo_root: str  # Original repo root (for reference)
 
     # LLD content
     lld_content: str


### PR DESCRIPTION
## Summary

The TDD workflow now creates a git worktree before writing any code, ensuring all implementation happens in an isolated branch.

## Problem

Previously, running `python tools/run_implement_from_lld.py --issue 78` would write implementation files directly to main, violating the worktree isolation rule.

## Solution

The workflow now:

1. **Detects current branch**
   - If on `main`/`master` → creates new worktree
   - If existing worktree found for issue → reuses it
   - If already on issue branch → continues in place
   - If on other branch → exits with error (safety)

2. **Creates worktree**: `../AgentOS-{issue}` with branch `{issue}-implementation`

3. **Pushes branch** to remote for tracking

4. **Shows next steps** on completion:
   ```
   Next steps:
     1. cd ../AgentOS-78
     2. Review changes: git diff
     3. Commit: git add . && git commit
     4. Create PR: gh pr create
   ```

## Changes

- `tools/run_implement_from_lld.py`:
  - Added `get_current_branch()`, `find_existing_worktree()`, `create_worktree()`
  - Added `--no-worktree` flag for manual control
  - Added worktree detection and creation logic
  - Added next steps output on success

- `agentos/workflows/testing/state.py`:
  - Added `worktree_path` field
  - Added `original_repo_root` field

## Test plan

- [x] All 63 testing workflow tests pass
- [ ] Manual test: run workflow on main, verify worktree created
- [ ] Manual test: run workflow with existing worktree, verify reused

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)