### PR TITLE
fix: review parser correctly parses verdict formats (#182)

### DIFF
--- a/agentos/core/llm_provider.py
+++ b/agentos/core/llm_provider.py
@@ -410,7 +410,7 @@ class MockProvider(LLMProvider):
             "# Mock Issue Title\n\n## Summary\n\nThis is a mock draft for testing.\n\n## Requirements\n\n- Mock requirement 1\n- Mock requirement 2\n\n## Acceptance Criteria\n\n- [ ] Mock criteria met",
         ],
         "review": [
-            "## Verdict: APPROVED\n\nThe document meets all requirements.\n\n### Strengths\n- Well-structured\n- Clear requirements\n\n### Recommendations\n- None required for approval",
+            "## Final Verdict\n\n[X] **APPROVED** - Ready for implementation\n[ ] **REVISE** - Requires changes\n[ ] **DISCUSS** - Needs clarification\n\n### Strengths\n- Well-structured\n- Clear requirements\n\n### Recommendations\n- None required for approval",
         ],
     }
 

--- a/agentos/workflows/requirements/nodes/review.py
+++ b/agentos/workflows/requirements/nodes/review.py
@@ -127,7 +127,7 @@ Be specific about what needs to change for BLOCKED verdicts."""
     elif re.search(r"\[X\]\s*\**DISCUSS\**", verdict_upper):
         lld_status = "BLOCKED"
     # Fallback: Look for explicit keywords (legacy/simple responses)
-    elif "VERDICT: APPROVED" in verdict_upper or "**APPROVED**" in verdict_upper.split("[X]")[0] if "[X]" in verdict_upper else False:
+    elif "VERDICT: APPROVED" in verdict_upper:
         lld_status = "APPROVED"
     elif "VERDICT: BLOCKED" in verdict_upper or "VERDICT: REVISE" in verdict_upper:
         lld_status = "BLOCKED"


### PR DESCRIPTION
## Summary

- Fix review parser bug where `VERDICT: APPROVED` format was never recognized
- Update mock provider to return checkbox format for better test fidelity

## Root Cause

Line 130 in `review.py` had a Python operator precedence bug:

```python
# BUG: The entire elif evaluates to False if no [X] in text
elif "VERDICT: APPROVED" in verdict_upper or ... if "[X]" in verdict_upper else False:
```

Due to how Python parses `A or B if C else D` as `(A or B) if C else D`, the `VERDICT: APPROVED` check was gated behind the `[X]` check. If Gemini returned `VERDICT: APPROVED` without any `[X]` checkbox, the parser defaulted to BLOCKED.

## The Fix

Simplified line 130 to just check for the keyword directly:

```python
elif "VERDICT: APPROVED" in verdict_upper:
```

Also updated mock provider to return checkbox format for better test fidelity.

## Test plan

- [x] All 7 review-related tests pass
- [x] Verified diff is correct
- [ ] End-to-end test with real Gemini (deferred to #176 verification)

Fixes #182
Related: #176

:robot: Generated with [Claude Code](https://claude.ai/code)
