### PR TITLE
fix: restore 287 missing lines in audit.py from dangling commit

### DIFF
--- a/agentos/workflows/requirements/audit.py
+++ b/agentos/workflows/requirements/audit.py
@@ -1,136 +1,511 @@
-"""Audit utilities for requirements workflow.
+"""Unified audit trail utilities for Requirements Workflow.
 
-Provides functions for creating audit directories and saving audit files.
+Issue #101: Unified Requirements Workflow
+
+Provides functions for:
+- Unified audit directory creation (issue and LLD workflows)
+- Sequential file numbering (001, 002, 003...)
+- Saving audit files (brief/issue, draft, feedback, verdict)
+- Path resolution (agentos_root vs target_repo)
+- Finalization (issue filing or LLD saving)
+- LLD status tracking
+
+CRITICAL PATH RULES:
+- Templates and prompts are loaded from agentos_root
+- Outputs (LLDs, audit trails, status files) are written to target_repo
+- Never use "" (empty string) for paths - it causes auto-detection bugs
+- All functions receive explicit paths - no fallback auto-detection
 """
 
+import json
 import re
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Literal, TypedDict
 
 from agentos.core.config import REVIEWER_MODEL
 
 
+# Base directories relative to repo root
+AUDIT_ACTIVE_DIR = Path("docs/lineage/active")
+AUDIT_DONE_DIR = Path("docs/lineage/done")
+LLD_ACTIVE_DIR = Path("docs/lld/active")
+LLD_DONE_DIR = Path("docs/lld/done")
+LLD_STATUS_FILE = Path("docs/lld/lld-status.json")
+IDEAS_ACTIVE_DIR = Path("ideas/active")
+IDEAS_DONE_DIR = Path("ideas/done")
+
+
+# =============================================================================
+# Path Resolution
+# =============================================================================
+
+
+def resolve_roots(
+    agentos_root: str,
+    target_repo: str,
+) -> tuple[Path, Path]:
+    """Resolve and validate agentos_root and target_repo paths.
+
+    Args:
+        agentos_root: Path to AgentOS installation.
+        target_repo: Path to target repository.
+
+    Returns:
+        Tuple of (agentos_root, target_repo) as resolved Path objects.
+
+    Raises:
+        ValueError: If either path is empty.
+    """
+    if not agentos_root or not agentos_root.strip():
+        raise ValueError("agentos_root must be set and non-empty")
+    if not target_repo or not target_repo.strip():
+        raise ValueError("target_repo must be set and non-empty")
+
+    return Path(agentos_root).resolve(), Path(target_repo).resolve()
+
+
+def get_audit_dir_path(
+    workflow_type: Literal["issue", "lld"],
+    target_repo: Path,
+    slug: str = "",
+    issue_number: int = 0,
+) -> Path:
+    """Get the audit directory path for a workflow.
+
+    Args:
+        workflow_type: Either "issue" or "lld".
+        target_repo: Path to target repository.
+        slug: Workflow slug (for issue workflow).
+        issue_number: GitHub issue number (for LLD workflow).
+
+    Returns:
+        Path to audit directory.
+    """
+    if workflow_type == "issue":
+        return target_repo / AUDIT_ACTIVE_DIR / slug
+    else:
+        return target_repo / AUDIT_ACTIVE_DIR / f"{issue_number}-lld"
+
+
+# =============================================================================
+# Audit Directory Creation
+# =============================================================================
+
+
 def create_audit_dir(
     target_repo: Path,
-    workflow_type: str,
+    workflow_type: Literal["issue", "lld"],
     slug: str = "",
     issue_number: int | None = None,
 ) -> Path:
-    """Create audit directory for workflow execution.
-
-    Creates lineage directory at docs/lineage/active/{dir_name}/
-    - Issue workflow: dir_name = slug (e.g., "my-feature")
-    - LLD workflow: dir_name = "{issue_number}-lld" (e.g., "42-lld")
+    """Create audit directory for a workflow.
 
     Args:
-        target_repo: Repository root path
-        workflow_type: Type of workflow ("issue" or "lld")
-        slug: Slug name for issue workflow
-        issue_number: Issue number for LLD workflow
+        target_repo: Path to target repository.
+        workflow_type: Either "issue" or "lld".
+        slug: Workflow slug (for issue workflow).
+        issue_number: GitHub issue number (for LLD workflow).
 
     Returns:
-        Path to audit directory
+        Path to created directory.
     """
-    # Build directory name based on workflow type
-    if workflow_type == "issue":
-        dir_name = slug if slug else "issue"
-    else:  # lld
-        dir_name = f"{issue_number}-lld" if issue_number else "lld"
+    audit_dir = get_audit_dir_path(
+        workflow_type=workflow_type,
+        target_repo=target_repo,
+        slug=slug,
+        issue_number=issue_number or 0,
+    )
 
-    audit_dir = target_repo / "docs" / "lineage" / "active" / dir_name
     audit_dir.mkdir(parents=True, exist_ok=True)
     return audit_dir
 
 
+# =============================================================================
+# File Numbering and Saving
+# =============================================================================
+
+
 def next_file_number(audit_dir: Path) -> int:
-    """Get next sequential file number for audit files.
-    
+    """Get next sequential file number.
+
+    Scans audit_dir for NNN-*.* files and returns max + 1.
+
     Args:
-        audit_dir: Audit directory path
-        
+        audit_dir: Path to the audit directory.
+
     Returns:
-        Next available file number
+        Next file number (starts at 1 if directory is empty).
     """
     if not audit_dir.exists():
         return 1
-    
-    existing_files = list(audit_dir.glob("*.md"))
-    if not existing_files:
-        return 1
-    
-    # Extract numbers from filenames (format: NNN-type.md)
-    numbers = []
-    for f in existing_files:
-        try:
-            num = int(f.stem.split("-")[0])
-            numbers.append(num)
-        except (ValueError, IndexError):
-            continue
-    
-    return max(numbers, default=0) + 1
+
+    max_num = 0
+    for f in audit_dir.iterdir():
+        if f.is_file():
+            match = re.match(r"^(\d{3})-", f.name)
+            if match:
+                num = int(match.group(1))
+                max_num = max(max_num, num)
+
+    return max_num + 1
 
 
 def save_audit_file(
     audit_dir: Path,
-    file_num: int,
-    file_type: str,
+    number: int,
+    suffix: str,
     content: str,
 ) -> Path:
-    """Save audit file with sequential numbering.
+    """Save an audit file with sequential numbering.
 
     Args:
-        audit_dir: Audit directory path
-        file_num: File number
-        file_type: Type of file (e.g., 'issue', 'error', 'finalize')
-        content: File content
+        audit_dir: Path to the audit directory.
+        number: File number (1-999).
+        suffix: File suffix (e.g., "draft.md", "verdict.md", "issue.md").
+        content: File content.
 
     Returns:
-        Path to saved file
+        Path to the saved file.
     """
-    filename = f"{file_num:03d}-{file_type}.md"
+    filename = f"{number:03d}-{suffix}"
     file_path = audit_dir / filename
     file_path.write_text(content, encoding="utf-8")
     return file_path
 
 
-def load_template(template_path: Path, agentos_root: Path) -> str:
-    """Load template file from agentos_root.
+# =============================================================================
+# Template Loading (from AgentOS root)
+# =============================================================================
+
+
+def load_template(
+    template_path: Path,
+    agentos_root: Path,
+) -> str:
+    """Load a template file from AgentOS root.
+
+    Templates are part of AgentOS, not the target repo. This function
+    enforces loading from agentos_root to prevent path confusion.
 
     Args:
-        template_path: Relative path to template file
-        agentos_root: Root directory of AgentOS
+        template_path: Relative path to template (e.g., "docs/templates/0102...").
+        agentos_root: Path to AgentOS installation.
 
     Returns:
-        Template content as string
+        Template content.
 
     Raises:
-        FileNotFoundError: If template file doesn't exist
+        FileNotFoundError: If template doesn't exist.
     """
     full_path = agentos_root / template_path
+
     if not full_path.exists():
-        raise FileNotFoundError(f"Template not found: {full_path}")
+        raise FileNotFoundError(
+            f"Template not found: {full_path}\n"
+            f"Expected template at: {template_path}"
+        )
 
     return full_path.read_text(encoding="utf-8")
 
 
-def load_review_prompt(prompt_path: Path, agentos_root: Path) -> str:
-    """Load review prompt file from agentos_root.
+def load_review_prompt(
+    prompt_path: Path,
+    agentos_root: Path,
+) -> str:
+    """Load a review prompt from AgentOS root.
+
+    Review prompts are part of AgentOS, not the target repo.
 
     Args:
-        prompt_path: Relative path to review prompt file
-        agentos_root: Root directory of AgentOS
+        prompt_path: Relative path to prompt (e.g., "docs/skills/0702c...").
+        agentos_root: Path to AgentOS installation.
 
     Returns:
-        Review prompt content as string
+        Prompt content.
 
     Raises:
-        FileNotFoundError: If review prompt file doesn't exist
+        FileNotFoundError: If prompt doesn't exist.
     """
     full_path = agentos_root / prompt_path
+
     if not full_path.exists():
-        raise FileNotFoundError(f"Review prompt not found: {full_path}")
+        raise FileNotFoundError(
+            f"Review prompt not found: {full_path}\n"
+            f"Expected prompt at: {prompt_path}"
+        )
 
     return full_path.read_text(encoding="utf-8")
+
+
+# =============================================================================
+# Context Assembly
+# =============================================================================
+
+
+def validate_context_path(context_path: str, target_repo: Path) -> Path | None:
+    """Validate and resolve a context file path.
+
+    Security check: Reject paths outside target_repo.
+
+    Args:
+        context_path: User-provided path (may be relative or absolute).
+        target_repo: Target repository root.
+
+    Returns:
+        Resolved absolute Path if valid, None if invalid.
+    """
+    path = Path(context_path)
+
+    # Resolve to absolute path
+    if not path.is_absolute():
+        path = (target_repo / path).resolve()
+    else:
+        path = path.resolve()
+
+    # Security check: must be under target_repo
+    try:
+        path.relative_to(target_repo)
+    except ValueError:
+        return None  # Path is outside target_repo
+
+    # Existence check
+    if not path.exists():
+        return None
+
+    return path
+
+
+def assemble_context(
+    context_files: list[str],
+    target_repo: Path,
+) -> str:
+    """Assemble context content from multiple files.
+
+    Args:
+        context_files: List of paths to context files.
+        target_repo: Target repository root.
+
+    Returns:
+        Assembled context as a single string with file headers.
+    """
+    if not context_files:
+        return ""
+
+    context_parts = []
+
+    for ctx_path in context_files:
+        path = validate_context_path(ctx_path, target_repo)
+        if path is None:
+            continue
+
+        try:
+            if path.is_file():
+                content = path.read_text(encoding="utf-8", errors="replace")
+                rel_path = path.relative_to(target_repo)
+                context_parts.append(
+                    f"## Reference: {rel_path}\n\n```\n{content}\n```"
+                )
+            elif path.is_dir():
+                # Read all text files in directory
+                for f in sorted(path.iterdir()):
+                    if f.is_file() and f.suffix in (".md", ".py", ".json", ".yaml", ".txt"):
+                        content = f.read_text(encoding="utf-8", errors="replace")
+                        rel_path = f.relative_to(target_repo)
+                        context_parts.append(
+                            f"## Reference: {rel_path}\n\n```\n{content}\n```"
+                        )
+        except (OSError, UnicodeDecodeError):
+            continue
+
+    return "\n\n".join(context_parts)
+
+
+# =============================================================================
+# LLD Status Tracking
+# =============================================================================
+
+
+class LLDStatusEntry(TypedDict):
+    """Schema for a single LLD status entry."""
+
+    lld_path: str
+    status: str  # "draft", "approved", "blocked"
+    has_gemini_review: bool
+    final_verdict: str | None
+    last_review_date: str | None
+    review_count: int
+
+
+class LLDStatusCache(TypedDict):
+    """Schema for lld-status.json cache file."""
+
+    version: str
+    last_updated: str
+    issues: dict[str, LLDStatusEntry]
+
+
+def load_lld_tracking(target_repo: Path) -> LLDStatusCache:
+    """Load lld-status.json cache file.
+
+    Args:
+        target_repo: Target repository root.
+
+    Returns:
+        LLDStatusCache dict. Returns empty cache if file doesn't exist.
+    """
+    status_file = target_repo / LLD_STATUS_FILE
+
+    if not status_file.exists():
+        return {
+            "version": "1.0",
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "issues": {},
+        }
+
+    try:
+        content = status_file.read_text(encoding="utf-8")
+        data = json.loads(content)
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {
+            "version": "1.0",
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+            "issues": {},
+        }
+
+
+def save_lld_tracking(tracking: LLDStatusCache, target_repo: Path) -> None:
+    """Save lld-status.json cache file.
+
+    Args:
+        tracking: LLDStatusCache dict to save.
+        target_repo: Target repository root.
+    """
+    status_file = target_repo / LLD_STATUS_FILE
+
+    # Ensure directory exists
+    status_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Update timestamp
+    tracking["last_updated"] = datetime.now(timezone.utc).isoformat()
+
+    # Write file
+    status_file.write_text(
+        json.dumps(tracking, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def update_lld_status(
+    issue_number: int,
+    lld_path: str,
+    review_info: dict,
+    target_repo: Path,
+) -> None:
+    """Update tracking for a single issue.
+
+    Args:
+        issue_number: GitHub issue number.
+        lld_path: Path to LLD file (relative or absolute).
+        review_info: Dict with has_gemini_review, final_verdict, etc.
+        target_repo: Target repository root.
+    """
+    # Make path relative to repo root for storage
+    lld_path_obj = Path(lld_path)
+    if lld_path_obj.is_absolute():
+        try:
+            lld_path = str(lld_path_obj.relative_to(target_repo))
+        except ValueError:
+            pass  # Keep as-is if not under target_repo
+
+    # Load existing cache
+    tracking = load_lld_tracking(target_repo)
+
+    # Determine status
+    if review_info.get("has_gemini_review"):
+        if review_info.get("final_verdict") == "APPROVED":
+            status = "approved"
+        else:
+            status = "blocked"
+    else:
+        status = "draft"
+
+    # Update entry
+    tracking["issues"][str(issue_number)] = {
+        "lld_path": lld_path,
+        "status": status,
+        "has_gemini_review": review_info.get("has_gemini_review", False),
+        "final_verdict": review_info.get("final_verdict"),
+        "last_review_date": review_info.get("last_review_date"),
+        "review_count": review_info.get("review_count", 0),
+    }
+
+    # Save
+    save_lld_tracking(tracking, target_repo)
+
+
+# =============================================================================
+# LLD Finalization
+# =============================================================================
+
+
+def save_final_lld(
+    issue_number: int,
+    lld_content: str,
+    target_repo: Path,
+) -> Path:
+    """Save approved LLD to target_repo/docs/lld/active/.
+
+    CRITICAL: This writes to target_repo, NOT agentos_root.
+
+    Args:
+        issue_number: GitHub issue number.
+        lld_content: Final LLD content.
+        target_repo: Target repository root.
+
+    Returns:
+        Path to saved LLD file.
+    """
+    lld_dir = target_repo / LLD_ACTIVE_DIR
+    lld_dir.mkdir(parents=True, exist_ok=True)
+
+    lld_path = lld_dir / f"LLD-{issue_number:03d}.md"
+    lld_path.write_text(lld_content, encoding="utf-8")
+    return lld_path
+
+
+# =============================================================================
+# Slug Generation (Issue workflow)
+# =============================================================================
+
+
+def generate_slug(brief_file: str) -> str:
+    """Generate slug from brief filename.
+
+    Args:
+        brief_file: Path to the brief file.
+
+    Returns:
+        Slug string (filename without extension, lowercase, hyphens for spaces).
+
+    Examples:
+        "governance-notes.md" -> "governance-notes"
+        "My Feature Ideas.md" -> "my-feature-ideas"
+    """
+    filename = Path(brief_file).stem
+    # Lowercase, replace spaces and underscores with hyphens
+    slug = filename.lower().replace(" ", "-").replace("_", "-")
+    # Remove any non-alphanumeric except hyphens
+    slug = re.sub(r"[^a-z0-9-]", "", slug)
+    # Collapse multiple hyphens
+    slug = re.sub(r"-+", "-", slug)
+    return slug.strip("-")
+
+
+# =============================================================================
+# Review Evidence Embedding
+# =============================================================================
 
 
 def embed_review_evidence(

--- a/agentos/workflows/requirements/nodes/finalize.py
+++ b/agentos/workflows/requirements/nodes/finalize.py
@@ -178,7 +178,7 @@ def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
     # Save to audit trail
     if audit_dir.exists():
         file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "final", lld_content)
+        save_audit_file(audit_dir, file_num, "final.md", lld_content)
 
     return state
 

--- a/agentos/workflows/requirements/nodes/generate_draft.py
+++ b/agentos/workflows/requirements/nodes/generate_draft.py
@@ -119,7 +119,7 @@ Use the template structure provided. Include all sections. Be specific about:
     iteration_count = state.get("iteration_count", 0) + 1
     file_num = next_file_number(audit_dir)
     if audit_dir.exists():
-        draft_path = save_audit_file(audit_dir, file_num, "draft", draft_content)
+        draft_path = save_audit_file(audit_dir, file_num, "draft.md", draft_content)
     else:
         draft_path = None
 

--- a/agentos/workflows/requirements/nodes/load_input.py
+++ b/agentos/workflows/requirements/nodes/load_input.py
@@ -55,7 +55,7 @@ def _load_issue(state: Dict[str, Any]) -> Dict[str, Any]:
             state["error_message"] = error_msg
             # Save error to audit
             file_num = next_file_number(audit_dir)
-            save_audit_file(audit_dir, file_num, "error", error_msg)
+            save_audit_file(audit_dir, file_num, "error.md", error_msg)
             return state
         
         # Parse JSON response
@@ -69,23 +69,23 @@ def _load_issue(state: Dict[str, Any]) -> Dict[str, Any]:
         audit_content = f"# Issue #{issue_number}\n\n"
         audit_content += f"**Title:** {state['issue_title']}\n\n"
         audit_content += f"**Body:**\n{state['issue_body']}\n"
-        save_audit_file(audit_dir, file_num, "issue", audit_content)
+        save_audit_file(audit_dir, file_num, "issue.md", audit_content)
         
     except subprocess.TimeoutExpired:
         error_msg = f"Timeout fetching issue #{issue_number}"
         state["error_message"] = error_msg
         file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error", error_msg)
+        save_audit_file(audit_dir, file_num, "error.md", error_msg)
     except json.JSONDecodeError as e:
         error_msg = f"Failed to parse issue JSON: {e}"
         state["error_message"] = error_msg
         file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error", error_msg)
+        save_audit_file(audit_dir, file_num, "error.md", error_msg)
     except Exception as e:
         error_msg = f"Unexpected error loading issue: {e}"
         state["error_message"] = error_msg
         file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error", error_msg)
+        save_audit_file(audit_dir, file_num, "error.md", error_msg)
     
     return state
 

--- a/agentos/workflows/requirements/nodes/review.py
+++ b/agentos/workflows/requirements/nodes/review.py
@@ -101,7 +101,7 @@ Be specific about what needs to change for BLOCKED verdicts."""
     file_num = next_file_number(audit_dir)
     if audit_dir.exists():
         verdict_path = save_audit_file(
-            audit_dir, file_num, "verdict", verdict_content
+            audit_dir, file_num, "verdict.md", verdict_content
         )
     else:
         verdict_path = None


### PR DESCRIPTION
## Summary

- Restores 287 lines of code that were lost when audit.py was partially recovered from dangling commit e234b22
- Fixes test failures by restoring missing functions that tests were expecting
- Updates node files to use correct ".md" suffix pattern

## Details

Missing functions restored:
- `resolve_roots()` - Path resolution and validation
- `get_audit_dir_path()` - Audit directory path calculation
- `validate_context_path()` - Security validation for context paths
- `assemble_context()` - Context assembly from multiple files
- `LLDStatusEntry` and `LLDStatusCache` TypedDicts
- `load_lld_tracking()` and `save_lld_tracking()` - LLD status persistence
- `update_lld_status()` - Status tracking updates
- `save_final_lld()` - Final LLD file saving
- `generate_slug()` - Slug generation for issue workflow

Node file updates:
- generate_draft.py: "draft" → "draft.md"
- review.py: "verdict" → "verdict.md"
- finalize.py: "final" → "final.md"
- load_input.py: "error" → "error.md", "issue" → "issue.md"

## Test plan

- [x] Run pytest tests/unit/test_requirements_audit.py - 22 passed
- [x] Run pytest tests/unit/test_requirements_*.py - 144 passed, 7 failed
- [ ] Remaining 7 failures are in node implementation (separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)