### PR TITLE
fix: restore missing workflow functions from inhume operation

### DIFF
--- a/agentos/workflows/requirements/git_operations.py
+++ b/agentos/workflows/requirements/git_operations.py
@@ -25,7 +25,7 @@ def format_commit_message(workflow_type: str, issue_number: Optional[int] = None
         Formatted commit message
     """
     if workflow_type == "lld":
-        return f"docs: add LLD-{issue_number} via requirements workflow"
+        return f"docs: add LLD-{issue_number} via requirements workflow\n\nCloses #{issue_number}"
     else:  # issue
         return f"docs: add lineage for {slug} via requirements workflow"
 

--- a/agentos/workflows/requirements/nodes/load_input.py
+++ b/agentos/workflows/requirements/nodes/load_input.py
@@ -1,102 +1,267 @@
-"""Load input node for requirements workflow.
+"""N0: Load input node for Requirements Workflow.
 
-Fetches GitHub issue details and prepares them for processing.
+Issue #101: Unified Requirements Workflow
+
+Handles loading input for both workflow types:
+- Issue workflow: Load brief file content
+- LLD workflow: Fetch GitHub issue via gh CLI
+
+Creates audit directory and saves initial input to audit trail.
 """
 
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Dict
 
 from agentos.workflows.requirements.audit import (
+    assemble_context,
     create_audit_dir,
+    generate_slug,
     next_file_number,
     save_audit_file,
 )
+from agentos.workflows.requirements.state import RequirementsWorkflowState
 
-# Constants
+
+# Timeout for gh CLI commands
 GH_TIMEOUT_SECONDS = 30
 
+# Retry configuration for gh CLI
+GH_MAX_RETRIES = 3
+GH_BACKOFF_BASE_SECONDS = 1.0
+GH_BACKOFF_MAX_SECONDS = 10.0
 
-def _load_issue(state: Dict[str, Any]) -> Dict[str, Any]:
-    """Load issue details from GitHub.
-    
+
+def load_input(state: RequirementsWorkflowState) -> Dict[str, Any]:
+    """N0: Load input based on workflow type.
+
+    For issue workflow:
+    - Loads brief file content
+    - Generates slug from filename
+    - Creates audit directory
+    - Saves brief to audit trail
+
+    For LLD workflow:
+    - Fetches issue from GitHub via gh CLI
+    - Assembles context from context_files
+    - Creates audit directory
+    - Saves issue content to audit trail
+
     Args:
-        state: Workflow state containing issue_number and target_repo
-        
+        state: Current workflow state.
+
     Returns:
-        Updated state with issue details or error message
+        State updates with input content and audit_dir.
     """
-    issue_number = state.get("issue_number")
-    target_repo = state.get("target_repo", ".")
-    
-    # Create audit directory with issue number for unique path
-    audit_dir = create_audit_dir(
-        target_repo=Path(target_repo),
-        workflow_type=state.get("workflow_type", "lld"),
-        issue_number=issue_number,
-    )
-    state["audit_dir"] = str(audit_dir)
-    
+    workflow_type = state.get("workflow_type", "lld")
+
+    if workflow_type == "issue":
+        return _load_brief(state)
+    else:
+        return _load_issue(state)
+
+
+def _load_brief(state: RequirementsWorkflowState) -> Dict[str, Any]:
+    """Load brief file for issue workflow.
+
+    Args:
+        state: Current workflow state.
+
+    Returns:
+        State updates with brief_content, slug, and audit_dir.
+    """
+    brief_file = state.get("brief_file", "")
+    target_repo = Path(state.get("target_repo", ""))
+
+    if not brief_file:
+        return {"error_message": "No brief file specified"}
+
+    brief_path = Path(brief_file)
+    if not brief_path.is_absolute():
+        brief_path = target_repo / brief_path
+
+    if not brief_path.exists():
+        return {"error_message": f"Brief file not found: {brief_path}"}
+
+    # Load content
     try:
-        # Fetch issue details from GitHub with UTF-8 encoding
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",  # Fix for Unicode handling on Windows
-            cwd=target_repo,
-            timeout=GH_TIMEOUT_SECONDS,
-            check=False,
-        )
-        
-        if result.returncode != 0:
-            error_msg = f"Failed to fetch issue #{issue_number}: {result.stderr}"
-            state["error_message"] = error_msg
-            # Save error to audit
-            file_num = next_file_number(audit_dir)
-            save_audit_file(audit_dir, file_num, "error.md", error_msg)
-            return state
-        
-        # Parse JSON response
-        issue_data = json.loads(result.stdout)
-        state["issue_title"] = issue_data.get("title", "")
-        state["issue_body"] = issue_data.get("body", "")
-        state["error_message"] = ""
-        
-        # Save issue data to audit
-        file_num = next_file_number(audit_dir)
-        audit_content = f"# Issue #{issue_number}\n\n"
-        audit_content += f"**Title:** {state['issue_title']}\n\n"
-        audit_content += f"**Body:**\n{state['issue_body']}\n"
-        save_audit_file(audit_dir, file_num, "issue.md", audit_content)
-        
-    except subprocess.TimeoutExpired:
-        error_msg = f"Timeout fetching issue #{issue_number}"
-        state["error_message"] = error_msg
-        file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error.md", error_msg)
-    except json.JSONDecodeError as e:
-        error_msg = f"Failed to parse issue JSON: {e}"
-        state["error_message"] = error_msg
-        file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error.md", error_msg)
-    except Exception as e:
-        error_msg = f"Unexpected error loading issue: {e}"
-        state["error_message"] = error_msg
-        file_num = next_file_number(audit_dir)
-        save_audit_file(audit_dir, file_num, "error.md", error_msg)
-    
-    return state
+        brief_content = brief_path.read_text(encoding="utf-8")
+    except OSError as e:
+        return {"error_message": f"Failed to read brief: {e}"}
+
+    # Generate slug
+    slug = generate_slug(str(brief_file))
+
+    # Create audit directory
+    audit_dir = create_audit_dir(
+        workflow_type="issue",
+        slug=slug,
+        target_repo=target_repo,
+    )
+
+    # Save brief to audit trail
+    file_num = next_file_number(audit_dir)
+    save_audit_file(audit_dir, file_num, "brief.md", brief_content)
+
+    return {
+        "brief_content": brief_content,
+        "slug": slug,
+        "audit_dir": str(audit_dir),
+        "file_counter": file_num,
+        "error_message": "",
+    }
 
 
-def load_input(state: Dict[str, Any]) -> Dict[str, Any]:
-    """Public interface for load_input node.
-    
+def _load_issue(state: RequirementsWorkflowState) -> Dict[str, Any]:
+    """Load GitHub issue for LLD workflow.
+
     Args:
-        state: Workflow state
-        
+        state: Current workflow state.
+
     Returns:
-        Updated state with issue details
+        State updates with issue content and audit_dir.
     """
-    return _load_issue(state)
+    issue_number = state.get("issue_number", 0)
+    target_repo = Path(state.get("target_repo", ""))
+    context_files = state.get("context_files", [])
+
+    if not issue_number:
+        return {"error_message": "No issue number specified"}
+
+    # Check for mock mode
+    if state.get("config_mock_mode"):
+        return _mock_load_issue(state)
+
+    # Fetch issue via gh CLI with exponential backoff retry
+    issue_data = None
+    last_error = ""
+
+    for attempt in range(1, GH_MAX_RETRIES + 1):
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",  # Fix for Unicode handling on Windows
+                timeout=GH_TIMEOUT_SECONDS,
+                cwd=str(target_repo),
+            )
+
+            if result.returncode != 0:
+                last_error = f"Issue #{issue_number} not found: {result.stderr.strip()}"
+                # Non-zero return code is likely a permanent error (issue doesn't exist)
+                break
+
+            if not result.stdout:
+                last_error = f"Empty response from gh issue view #{issue_number} (attempt {attempt}/{GH_MAX_RETRIES})"
+                # Empty response is transient - retry with backoff
+                if attempt < GH_MAX_RETRIES:
+                    delay = min(
+                        GH_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)),
+                        GH_BACKOFF_MAX_SECONDS,
+                    )
+                    time.sleep(delay)
+                    continue
+                break
+
+            issue_data = json.loads(result.stdout)
+            break  # Success - exit retry loop
+
+        except subprocess.TimeoutExpired:
+            last_error = f"Timeout fetching issue #{issue_number} (attempt {attempt}/{GH_MAX_RETRIES})"
+            if attempt < GH_MAX_RETRIES:
+                delay = min(
+                    GH_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)),
+                    GH_BACKOFF_MAX_SECONDS,
+                )
+                time.sleep(delay)
+                continue
+            break
+        except json.JSONDecodeError as e:
+            last_error = f"Failed to parse issue data: {e}"
+            # JSON parse error on non-empty response is likely permanent
+            break
+
+    if issue_data is None:
+        return {"error_message": last_error}
+
+    issue_title = issue_data.get("title", "")
+    issue_body = issue_data.get("body", "")
+
+    # Assemble context
+    context_content = ""
+    if context_files:
+        context_content = assemble_context(context_files, target_repo)
+
+    # Create audit directory
+    audit_dir = create_audit_dir(
+        workflow_type="lld",
+        issue_number=issue_number,
+        target_repo=target_repo,
+    )
+
+    # Save issue to audit trail
+    issue_content = f"# Issue #{issue_number}: {issue_title}\n\n{issue_body}"
+    if context_content:
+        issue_content += f"\n\n---\n\n# Context Files\n\n{context_content}"
+
+    file_num = next_file_number(audit_dir)
+    save_audit_file(audit_dir, file_num, "issue.md", issue_content)
+
+    return {
+        "issue_title": issue_title,
+        "issue_body": issue_body,
+        "context_content": context_content,
+        "audit_dir": str(audit_dir),
+        "file_counter": file_num,
+        "error_message": "",
+    }
+
+
+def _mock_load_issue(state: RequirementsWorkflowState) -> Dict[str, Any]:
+    """Mock implementation for testing.
+
+    Args:
+        state: Current workflow state.
+
+    Returns:
+        State updates with mock issue content.
+    """
+    issue_number = state.get("issue_number", 42)
+    target_repo = Path(state.get("target_repo", ""))
+
+    mock_title = f"Mock Issue #{issue_number}"
+    mock_body = """## Requirements
+
+This is a mock issue for testing.
+
+## Acceptance Criteria
+
+- [ ] Feature implemented
+- [ ] Tests passing
+"""
+
+    # Create audit directory
+    audit_dir = create_audit_dir(
+        workflow_type="lld",
+        issue_number=issue_number,
+        target_repo=target_repo,
+    )
+
+    # Save to audit
+    file_num = next_file_number(audit_dir)
+    save_audit_file(
+        audit_dir, file_num, "issue.md",
+        f"# Issue #{issue_number}: {mock_title}\n\n{mock_body}"
+    )
+
+    return {
+        "issue_title": mock_title,
+        "issue_body": mock_body,
+        "context_content": "",
+        "audit_dir": str(audit_dir),
+        "file_counter": file_num,
+        "error_message": "",
+    }

--- a/tests/test_issue_162.py
+++ b/tests/test_issue_162.py
@@ -58,8 +58,8 @@ def test_010(tmp_path):
         assert mock_run.call_args_list[0][0][0] == ["git", "add", "docs/lld/active/LLD-162.md"]
         assert mock_run.call_args_list[1][0][0] == ["git", "add", "docs/lld/lld-status.json"]
         
-        # Verify git commit
-        assert mock_run.call_args_list[2][0][0] == ["git", "commit", "-m", "docs: add LLD-162 via requirements workflow"]
+        # Verify git commit (includes "Closes #N" footer to auto-close GitHub issue)
+        assert mock_run.call_args_list[2][0][0] == ["git", "commit", "-m", "docs: add LLD-162 via requirements workflow\n\nCloses #162"]
         
         # Verify git push
         assert mock_run.call_args_list[3][0][0] == ["git", "push"]
@@ -121,8 +121,7 @@ def test_030(tmp_path):
 def test_040():
     """
     Commit message format - LLD | Auto | workflow_type="lld", issue=162 |
-    Formatted message | Message matches `docs: add LLD-162 via
-    requirements workflow`
+    Formatted message | Message includes title and "Closes #N" footer
     """
     # TDD: Arrange
     # (no setup needed)
@@ -130,8 +129,8 @@ def test_040():
     # TDD: Act
     message = format_commit_message("lld", issue_number=162)
 
-    # TDD: Assert
-    assert message == "docs: add LLD-162 via requirements workflow"
+    # TDD: Assert - message includes "Closes #N" to auto-close GitHub issue
+    assert message == "docs: add LLD-162 via requirements workflow\n\nCloses #162"
 
 
 def test_050():


### PR DESCRIPTION
## Summary

- Restores functionality lost when PR #140 deleted shared code between deprecated `workflows/lld/` and unified `workflows/requirements/`
- Fixes 7 failing tests (down from 8 to 1 pre-existing failure)
- Brings requirements workflow coverage to 89%

## Changes

**load_input.py:**
- Add `_load_brief()` for issue workflow
- Add `_mock_load_issue()` for testing
- Add context file loading via `assemble_context()`
- Add exponential backoff retry logic

**finalize.py:**
- Restore `_finalize_issue()` to create GitHub issues (not post comments)
- Add `_parse_issue_content()` helper
- Add `update_lld_status()` call to track LLDs
- Add output verification guards

**git_operations.py:**
- Fix commit message to include "Closes #N" for auto-closing issues

**tests/test_issue_162.py:**
- Update tests to expect new commit message format

## Test plan

- [x] All 32 requirements node tests pass
- [x] All test_issue_162 tests pass
- [x] 587 tests pass overall (1 pre-existing failure in audit_sharding)

## Follow-up Issues

- #193 - Fix failing test_merges_history_and_shards
- #194 - Increase requirements workflow coverage to >95%
- #195 - Increase implementation workflow coverage to >95%

🤖 Generated with [Claude Code](https://claude.ai/code)