### PR TITLE
fix: use correct history filename in test_merges_history_and_shards

### DIFF
--- a/tests/test_audit_sharding.py
+++ b/tests/test_audit_sharding.py
@@ -248,7 +248,7 @@ class TestTailMerges:
 
     def test_merges_history_and_shards(self, temp_repo: Path) -> None:
         """Tail should merge entries from history file and active shards."""
-        history_file = temp_repo / "logs" / "governance_history.jsonl"
+        history_file = temp_repo / "logs" / "review_history.jsonl"
 
         # Create history entries
         history_entries = []


### PR DESCRIPTION
## Summary
- Fixed test using wrong history filename (`governance_history.jsonl` instead of `review_history.jsonl`)
- The test was creating history entries in a file that `audit.py` wasn't reading, causing `tail()` to miss them

## Test plan
- [x] `pytest tests/test_audit_sharding.py -v` passes (all 22 tests)
- [x] Specifically `test_merges_history_and_shards` now returns 5 entries (3 history + 2 shard) instead of just 2

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)