### PR TITLE
fix: unify history filename to review_history.jsonl

### DIFF
--- a/tests/test_audit_sharding.py
+++ b/tests/test_audit_sharding.py
@@ -398,7 +398,7 @@ class TestConsolidation:
         assert count == 1  # One shard created by this session
 
         # Verify history file exists and contains entries
-        history_file = temp_repo / "logs" / "governance_history.jsonl"
+        history_file = temp_repo / "logs" / "review_history.jsonl"
         assert history_file.exists()
 
         with open(history_file, encoding="utf-8") as f:
@@ -470,7 +470,7 @@ class TestConsolidation:
         assert first_count == 1
 
         # Get history file content after first consolidation
-        history_file = temp_repo / "logs" / "governance_history.jsonl"
+        history_file = temp_repo / "logs" / "review_history.jsonl"
         with open(history_file, encoding="utf-8") as f:
             first_content = f.read()
 

--- a/tools/consolidate_logs.py
+++ b/tools/consolidate_logs.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Consolidate session shards into governance history.
+"""Consolidate session shards into review history.
 
 This script is invoked by the post-commit git hook to merge all active
-session shards into the permanent governance_history.jsonl file.
+session shards into the permanent review_history.jsonl file.
 
 Uses atomic write pattern: temp file + os.replace() for crash safety.
 
@@ -15,6 +15,8 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+from agentos.core.config import DEFAULT_AUDIT_LOG_PATH
 
 
 def read_jsonl(path: Path) -> list[dict]:
@@ -86,7 +88,7 @@ def consolidate(repo_root: Path) -> int:
         OSError: If atomic write fails.
     """
     active_dir = repo_root / "logs" / "active"
-    history_file = repo_root / "logs" / "governance_history.jsonl"
+    history_file = repo_root / DEFAULT_AUDIT_LOG_PATH
 
     # Find all shards (exclude .gitkeep)
     if not active_dir.exists():


### PR DESCRIPTION
## Summary
- `consolidate_logs.py` now imports and uses `DEFAULT_AUDIT_LOG_PATH` from config
- Eliminates hardcoded `governance_history.jsonl` filename
- Both read and write operations now use the same `review_history.jsonl` path

## Root Cause
`consolidate_logs.py` was writing to `governance_history.jsonl` while `audit.py` was reading from `review_history.jsonl`. Consolidated history was invisible to `tail()`.

## Test plan
- [x] All 22 tests in `test_audit_sharding.py` pass
- [x] Consolidation tests now correctly verify `review_history.jsonl`

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)