### PR TITLE
fix: add pytest markers in scaffold_tests for e2e/integration tests

### DIFF
--- a/agentos/workflows/testing/nodes/scaffold_tests.py
+++ b/agentos/workflows/testing/nodes/scaffold_tests.py
@@ -155,8 +155,16 @@ def _generate_test_function(
     requirement_ref = scenario.get("requirement_ref", "")
     assertions = scenario.get("assertions", [])
     mock_needed = scenario.get("mock_needed", False)
+    test_type = scenario.get("test_type", "unit").lower()
 
     lines = []
+
+    # Add pytest markers for non-unit test types
+    # This enables e2e_validation.py to filter with '-m e2e or integration'
+    if test_type == "e2e":
+        lines.append("@pytest.mark.e2e")
+    elif test_type == "integration":
+        lines.append("@pytest.mark.integration")
 
     # Function signature
     if fixture:

--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -3447,15 +3447,10 @@ class TestScaffoldEdgeCases:
         assert "def test_api" in content
         assert "Integration" in content or "integration" in content.lower()
 
-    @pytest.mark.xfail(reason="Issue #178: scaffold_tests doesn't add pytest markers")
     def test_generate_test_file_content_adds_e2e_marker(self):
-        """generate_test_file_content should add @pytest.mark.e2e for e2e tests.
+        """generate_test_file_content adds @pytest.mark.e2e for e2e tests.
 
-        Issue #178: Currently _generate_test_function() doesn't add markers,
-        but e2e_validation.py filters for '-m e2e or integration', causing
-        'no tests collected' failures.
-
-        This test documents the CORRECT behavior and will pass once #178 is fixed.
+        This enables e2e_validation.py to filter tests with '-m e2e or integration'.
         """
         from agentos.workflows.testing.nodes.scaffold_tests import generate_test_file_content
 
@@ -3480,15 +3475,10 @@ class TestScaffoldEdgeCases:
             "can filter for them with '-m e2e or integration'"
         )
 
-    @pytest.mark.xfail(reason="Issue #178: scaffold_tests doesn't add pytest markers")
     def test_generate_test_file_content_adds_integration_marker(self):
-        """generate_test_file_content should add @pytest.mark.integration for integration tests.
+        """generate_test_file_content adds @pytest.mark.integration for integration tests.
 
-        Issue #178: Currently _generate_test_function() doesn't add markers,
-        but e2e_validation.py filters for '-m e2e or integration', causing
-        'no tests collected' failures.
-
-        This test documents the CORRECT behavior and will pass once #178 is fixed.
+        This enables e2e_validation.py to filter tests with '-m e2e or integration'.
         """
         from agentos.workflows.testing.nodes.scaffold_tests import generate_test_file_content
 


### PR DESCRIPTION
## Summary

- `_generate_test_function()` now adds `@pytest.mark.e2e` or `@pytest.mark.integration` decorators based on the scenario's `test_type`
- This fixes the "no tests collected" (return code 5) error in `e2e_validation.py`
- Removes xfail markers from tests that documented this bug (they now pass)

## Test plan

- [x] Run marker-related tests: `pytest -k "marker"` - all pass
- [x] Run full test suite: 270 passed
- [x] Verify xfail tests now pass as regular tests

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)