### PR TITLE
fix: implement actual input prompts in human gates

### DIFF
--- a/agentos/workflows/requirements/nodes/human_gate.py
+++ b/agentos/workflows/requirements/nodes/human_gate.py
@@ -1,12 +1,14 @@
 """N2/N4: Human gate nodes for Requirements Workflow.
 
 Issue #101: Unified Requirements Workflow
+Issue #160: Fix human gates to actually gate
 
 Provides human checkpoints:
 - human_gate_draft: After draft generation (S/R/M choices)
 - human_gate_verdict: After Gemini review (A/R/W/M choices)
 
 When gates are disabled or auto_mode is enabled, gates are skipped.
+When gates are enabled and not in auto_mode, prompts user for input.
 """
 
 from pathlib import Path
@@ -15,13 +17,63 @@ from typing import Any
 from agentos.workflows.requirements.state import RequirementsWorkflowState, HumanDecision
 
 
+def _prompt_draft_gate() -> str:
+    """Prompt user for draft gate decision.
+
+    Returns:
+        User's choice (S/R/M), uppercase.
+    """
+    valid_choices = {"S", "R", "M"}
+
+    while True:
+        print()
+        print("    Draft Gate Options:")
+        print("      [S] Send to Gemini review")
+        print("      [R] Revise draft (return to drafter)")
+        print("      [M] Manual handling (exit workflow)")
+        print()
+        choice = input("    Enter choice (S/R/M): ").strip().upper()
+
+        if choice in valid_choices:
+            return choice
+
+        print(f"    Invalid choice '{choice}'. Please enter S, R, or M.")
+
+
+def _prompt_verdict_gate(lld_status: str) -> str:
+    """Prompt user for verdict gate decision.
+
+    Args:
+        lld_status: Current LLD status (APPROVED/BLOCKED).
+
+    Returns:
+        User's choice (A/R/W/M), uppercase.
+    """
+    valid_choices = {"A", "R", "W", "M"}
+
+    while True:
+        print()
+        print(f"    Verdict Gate Options (current status: {lld_status}):")
+        print("      [A] Approve and finalize")
+        print("      [R] Revise draft (return to drafter)")
+        print("      [W] Write feedback (add comments, then revise)")
+        print("      [M] Manual handling (exit workflow)")
+        print()
+        choice = input("    Enter choice (A/R/W/M): ").strip().upper()
+
+        if choice in valid_choices:
+            return choice
+
+        print(f"    Invalid choice '{choice}'. Please enter A, R, W, or M.")
+
+
 def human_gate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
     """N2: Human checkpoint after draft generation.
 
     Routes to:
-    - N3_review: Send draft to reviewer (auto_mode or gate disabled)
-    - N1_generate_draft: Revise with feedback (if verdict shows BLOCKED)
-    - END: Manual handling
+    - N3_review: Send draft to reviewer (user chooses S, or auto_mode/disabled)
+    - N1_generate_draft: Revise with feedback (user chooses R)
+    - END: Manual handling (user chooses M)
 
     Args:
         state: Current workflow state.
@@ -64,29 +116,45 @@ def human_gate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
             "error_message": "",
         }
 
-    # Interactive mode would go here
-    # For now, default to sending to review
-    print("    Proceeding to review")
-    return {
-        "next_node": "N3_review",
-        "iteration_count": iteration_count,
-        "error_message": "",
-    }
+    # Interactive mode: prompt user for decision
+    choice = _prompt_draft_gate()
+
+    if choice == HumanDecision.SEND.value:  # "S"
+        print("    User chose: Send to review")
+        return {
+            "next_node": "N3_review",
+            "iteration_count": iteration_count,
+            "error_message": "",
+        }
+    elif choice == HumanDecision.REVISE.value:  # "R"
+        print("    User chose: Revise draft")
+        return {
+            "next_node": "N1_generate_draft",
+            "iteration_count": iteration_count,
+            "error_message": "",
+        }
+    else:  # "M" - Manual
+        print("    User chose: Manual handling")
+        return {
+            "next_node": "END",
+            "iteration_count": iteration_count,
+            "error_message": "",
+        }
 
 
 def human_gate_verdict(state: RequirementsWorkflowState) -> dict[str, Any]:
     """N4: Human checkpoint after Gemini review.
 
     Routes to:
-    - N5_finalize: Approve verdict and finalize
-    - N1_generate_draft: Revise with feedback
-    - END: Manual handling
+    - N5_finalize: Approve verdict and finalize (user chooses A, or auto_mode/disabled with APPROVED)
+    - N1_generate_draft: Revise with feedback (user chooses R/W, or auto_mode/disabled with BLOCKED)
+    - END: Manual handling (user chooses M)
 
     Args:
         state: Current workflow state.
 
     Returns:
-        State updates with next_node, iteration_count.
+        State updates with next_node, iteration_count, user_feedback (if W chosen).
     """
     gates_verdict = state.get("config_gates_verdict", True)
     auto_mode = state.get("config_auto_mode", False)
@@ -132,19 +200,38 @@ def human_gate_verdict(state: RequirementsWorkflowState) -> dict[str, Any]:
                 "error_message": "",
             }
 
-    # Interactive mode: default to finalize if approved
-    if lld_status == "APPROVED":
-        print("    APPROVED -> finalizing")
+    # Interactive mode: prompt user for decision
+    choice = _prompt_verdict_gate(lld_status)
+
+    if choice == HumanDecision.APPROVE.value:  # "A"
+        print("    User chose: Approve and finalize")
         return {
             "next_node": "N5_finalize",
             "iteration_count": iteration_count,
             "error_message": "",
         }
-
-    # Default to revise for blocked verdicts
-    print("    BLOCKED -> revising draft")
-    return {
-        "next_node": "N1_generate_draft",
-        "iteration_count": iteration_count,
-        "error_message": "",
-    }
+    elif choice == HumanDecision.REVISE.value:  # "R"
+        print("    User chose: Revise draft")
+        return {
+            "next_node": "N1_generate_draft",
+            "iteration_count": iteration_count,
+            "error_message": "",
+        }
+    elif choice == HumanDecision.WRITE_FEEDBACK.value:  # "W"
+        print("    User chose: Write feedback")
+        print()
+        feedback = input("    Enter feedback for drafter: ").strip()
+        print(f"    Feedback recorded: {feedback[:50]}..." if len(feedback) > 50 else f"    Feedback recorded: {feedback}")
+        return {
+            "next_node": "N1_generate_draft",
+            "iteration_count": iteration_count,
+            "user_feedback": feedback,
+            "error_message": "",
+        }
+    else:  # "M" - Manual
+        print("    User chose: Manual handling")
+        return {
+            "next_node": "END",
+            "iteration_count": iteration_count,
+            "error_message": "",
+        }

--- a/tests/unit/test_human_gate_interactive.py
+++ b/tests/unit/test_human_gate_interactive.py
@@ -1,0 +1,294 @@
+"""Unit tests for human gate interactive mode.
+
+Issue #160: Human gates in requirements workflow don't actually gate
+
+Problem: When gates are enabled (--gates draft,verdict), the workflow runs
+straight through without pausing for human input.
+
+Fix: Implement actual input() prompts in interactive mode.
+"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+from agentos.workflows.requirements.state import create_initial_state, HumanDecision
+
+
+class TestDraftGateInteractive:
+    """Test that draft gate actually pauses for human input when enabled."""
+
+    @patch("builtins.input", return_value="S")
+    def test_draft_gate_prompts_for_input(self, mock_input, tmp_path):
+        """Draft gate should prompt user for input when gate is enabled."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,  # Gate enabled
+            auto_mode=False,   # Not auto mode
+        )
+        state["current_draft"] = "# Test Draft"
+
+        result = human_gate_draft(state)
+
+        # input() should have been called
+        assert mock_input.called, "Draft gate should prompt for user input"
+
+    @patch("builtins.input", return_value="S")
+    def test_draft_gate_send_routes_to_review(self, mock_input, tmp_path):
+        """User choosing 'S' (Send) should route to review."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,
+            auto_mode=False,
+        )
+        state["current_draft"] = "# Test Draft"
+
+        result = human_gate_draft(state)
+
+        assert result["next_node"] == "N3_review"
+
+    @patch("builtins.input", return_value="R")
+    def test_draft_gate_revise_routes_to_generate(self, mock_input, tmp_path):
+        """User choosing 'R' (Revise) should route back to draft generation."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,
+            auto_mode=False,
+        )
+        state["current_draft"] = "# Test Draft"
+
+        result = human_gate_draft(state)
+
+        assert result["next_node"] == "N1_generate_draft"
+
+    @patch("builtins.input", return_value="M")
+    def test_draft_gate_manual_routes_to_end(self, mock_input, tmp_path):
+        """User choosing 'M' (Manual) should end workflow."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,
+            auto_mode=False,
+        )
+        state["current_draft"] = "# Test Draft"
+
+        result = human_gate_draft(state)
+
+        assert result["next_node"] == "END"
+
+    def test_draft_gate_no_prompt_when_disabled(self, tmp_path):
+        """Draft gate should NOT prompt when gate is disabled."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=False,  # Gate disabled
+            auto_mode=False,
+        )
+
+        # Should not call input() when gate is disabled
+        with patch("builtins.input") as mock_input:
+            result = human_gate_draft(state)
+            assert not mock_input.called, "Should not prompt when gate is disabled"
+
+    def test_draft_gate_no_prompt_in_auto_mode(self, tmp_path):
+        """Draft gate should NOT prompt when in auto mode."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,
+            auto_mode=True,  # Auto mode
+        )
+
+        with patch("builtins.input") as mock_input:
+            result = human_gate_draft(state)
+            assert not mock_input.called, "Should not prompt in auto mode"
+
+
+class TestVerdictGateInteractive:
+    """Test that verdict gate actually pauses for human input when enabled."""
+
+    @patch("builtins.input", return_value="A")
+    def test_verdict_gate_prompts_for_input(self, mock_input, tmp_path):
+        """Verdict gate should prompt user for input when gate is enabled."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,  # Gate enabled
+            auto_mode=False,     # Not auto mode
+        )
+        state["lld_status"] = "APPROVED"
+        state["current_verdict"] = "APPROVED - looks good"
+
+        result = human_gate_verdict(state)
+
+        assert mock_input.called, "Verdict gate should prompt for user input"
+
+    @patch("builtins.input", return_value="A")
+    def test_verdict_gate_approve_routes_to_finalize(self, mock_input, tmp_path):
+        """User choosing 'A' (Approve) should route to finalize."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,
+            auto_mode=False,
+        )
+        state["lld_status"] = "APPROVED"
+        state["current_verdict"] = "APPROVED"
+
+        result = human_gate_verdict(state)
+
+        assert result["next_node"] == "N5_finalize"
+
+    @patch("builtins.input", return_value="R")
+    def test_verdict_gate_revise_routes_to_generate(self, mock_input, tmp_path):
+        """User choosing 'R' (Revise) should route back to draft generation."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,
+            auto_mode=False,
+        )
+        state["lld_status"] = "BLOCKED"
+        state["current_verdict"] = "BLOCKED - issues found"
+
+        result = human_gate_verdict(state)
+
+        assert result["next_node"] == "N1_generate_draft"
+
+    @patch("builtins.input", return_value="M")
+    def test_verdict_gate_manual_routes_to_end(self, mock_input, tmp_path):
+        """User choosing 'M' (Manual) should end workflow."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,
+            auto_mode=False,
+        )
+        state["lld_status"] = "APPROVED"
+
+        result = human_gate_verdict(state)
+
+        assert result["next_node"] == "END"
+
+    def test_verdict_gate_no_prompt_when_disabled(self, tmp_path):
+        """Verdict gate should NOT prompt when gate is disabled."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=False,  # Gate disabled
+            auto_mode=False,
+        )
+        state["lld_status"] = "APPROVED"
+
+        with patch("builtins.input") as mock_input:
+            result = human_gate_verdict(state)
+            assert not mock_input.called, "Should not prompt when gate is disabled"
+
+    def test_verdict_gate_no_prompt_in_auto_mode(self, tmp_path):
+        """Verdict gate should NOT prompt when in auto mode."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,
+            auto_mode=True,  # Auto mode
+        )
+        state["lld_status"] = "APPROVED"
+
+        with patch("builtins.input") as mock_input:
+            result = human_gate_verdict(state)
+            assert not mock_input.called, "Should not prompt in auto mode"
+
+
+class TestInvalidInputHandling:
+    """Test that invalid input is handled gracefully."""
+
+    @patch("builtins.input", side_effect=["X", "invalid", "S"])
+    def test_draft_gate_reprompts_on_invalid_input(self, mock_input, tmp_path):
+        """Draft gate should reprompt when user enters invalid choice."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_draft=True,
+            auto_mode=False,
+        )
+        state["current_draft"] = "# Test"
+
+        result = human_gate_draft(state)
+
+        # Should have been called 3 times (2 invalid + 1 valid)
+        assert mock_input.call_count == 3
+        assert result["next_node"] == "N3_review"
+
+    @patch("builtins.input", side_effect=["invalid", "A"])
+    def test_verdict_gate_reprompts_on_invalid_input(self, mock_input, tmp_path):
+        """Verdict gate should reprompt when user enters invalid choice."""
+        from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
+
+        state = create_initial_state(
+            workflow_type="lld",
+            agentos_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+            gates_verdict=True,
+            auto_mode=False,
+        )
+        state["lld_status"] = "APPROVED"
+
+        result = human_gate_verdict(state)
+
+        assert mock_input.call_count == 2
+        assert result["next_node"] == "N5_finalize"

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1591,8 +1591,9 @@ class TestLoadInputEmptyResponseExhaustsRetries:
 class TestHumanGateInteractiveMode:
     """Tests for human_gate interactive mode paths."""
 
-    def test_draft_gate_interactive_defaults_to_review(self, tmp_path):
-        """Test draft gate in interactive mode defaults to review."""
+    @patch("builtins.input", return_value="S")
+    def test_draft_gate_interactive_defaults_to_review(self, mock_input, tmp_path):
+        """Test draft gate in interactive mode routes to review when user chooses S."""
         from agentos.workflows.requirements.nodes.human_gate import human_gate_draft
         from agentos.workflows.requirements.state import create_initial_state
 
@@ -1609,6 +1610,7 @@ class TestHumanGateInteractiveMode:
 
         result = human_gate_draft(state)
 
+        assert mock_input.called, "Interactive mode should prompt for input"
         assert result.get("next_node") == "N3_review"
 
     def test_verdict_gate_disabled_approved_routes_to_finalize(self, tmp_path):
@@ -1630,8 +1632,9 @@ class TestHumanGateInteractiveMode:
 
         assert result.get("next_node") == "N5_finalize"
 
-    def test_verdict_gate_interactive_approved_routes_to_finalize(self, tmp_path):
-        """Test verdict gate in interactive mode routes to finalize on APPROVED."""
+    @patch("builtins.input", return_value="A")
+    def test_verdict_gate_interactive_approved_routes_to_finalize(self, mock_input, tmp_path):
+        """Test verdict gate in interactive mode routes to finalize when user chooses A."""
         from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
         from agentos.workflows.requirements.state import create_initial_state
 
@@ -1648,10 +1651,12 @@ class TestHumanGateInteractiveMode:
 
         result = human_gate_verdict(state)
 
+        assert mock_input.called, "Interactive mode should prompt for input"
         assert result.get("next_node") == "N5_finalize"
 
-    def test_verdict_gate_interactive_blocked_routes_to_revise(self, tmp_path):
-        """Test verdict gate in interactive mode routes to revise on BLOCKED."""
+    @patch("builtins.input", return_value="R")
+    def test_verdict_gate_interactive_blocked_routes_to_revise(self, mock_input, tmp_path):
+        """Test verdict gate in interactive mode routes to revise when user chooses R."""
         from agentos.workflows.requirements.nodes.human_gate import human_gate_verdict
         from agentos.workflows.requirements.state import create_initial_state
 
@@ -1668,4 +1673,5 @@ class TestHumanGateInteractiveMode:
 
         result = human_gate_verdict(state)
 
+        assert mock_input.called, "Interactive mode should prompt for input"
         assert result.get("next_node") == "N1_generate_draft"


### PR DESCRIPTION
## Summary

The human gates (draft and verdict) were configured but never actually paused for user input. The "interactive mode" was stubbed out and just auto-routed, making `--gates draft,verdict` ineffective.

## Changes

- **human_gate.py**: Added `_prompt_draft_gate()` and `_prompt_verdict_gate()` helpers
- **human_gate.py**: Implemented input loop with validation for invalid choices
- **human_gate.py**: Route based on actual user choice (S/R/M for draft, A/R/W/M for verdict)
- **human_gate.py**: Added `user_feedback` support for W (Write feedback) choice
- **test_human_gate_interactive.py**: 14 new TDD tests for interactive mode
- **test_requirements_nodes.py**: Updated existing tests to mock `input()` 

## User Experience

When `--gates draft,verdict` (the default), workflow now pauses:

```
[N2] Human gate (draft)...

    Draft Gate Options:
      [S] Send to Gemini review
      [R] Revise draft (return to drafter)
      [M] Manual handling (exit workflow)

    Enter choice (S/R/M): _
```

## Test Results

```
tests/unit/test_human_gate_interactive.py - 14 passed
tests/unit/test_requirements_nodes.py - 64 passed
```

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)