### PR TITLE
fix: replace inline pytest.skip() with explicit decorators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,7 @@ if str(tools_dir.parent) not in sys.path:
 
 def pytest_configure(config):
     """Configure pytest."""
-    pass
+    config.addinivalue_line(
+        "markers",
+        "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+    )

--- a/tests/test_integration_workflow.py
+++ b/tests/test_integration_workflow.py
@@ -4,11 +4,18 @@ These tests actually run subprocess commands - they will fail
 if the environment isn't set up correctly. That's the point.
 """
 
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
+
+# Mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
+# Check for claude CLI availability at module load time
+CLAUDE_AVAILABLE = shutil.which("claude") is not None
 
 
 class TestVSCodeIntegration:
@@ -16,7 +23,6 @@ class TestVSCodeIntegration:
 
     def test_code_command_exists(self):
         """Verify 'code' command is in PATH."""
-        import shutil
         code_path = shutil.which("code")
         assert code_path is not None, "'code' command not found in PATH. Install VS Code and add to PATH."
 
@@ -58,7 +64,6 @@ class TestClaudeHeadlessIntegration:
 
     def test_claude_command_exists(self):
         """Verify 'claude' command is in PATH."""
-        import shutil
         claude_path = shutil.which("claude")
         if claude_path is None:
             # Check common npm locations
@@ -68,6 +73,10 @@ class TestClaudeHeadlessIntegration:
             except RuntimeError:
                 pytest.fail("'claude' command not found. Install with: npm install -g @anthropic-ai/claude-code")
 
+    @pytest.mark.skipif(
+        not CLAUDE_AVAILABLE,
+        reason="claude CLI not found in PATH - install with: npm install -g @anthropic-ai/claude-code"
+    )
     def test_claude_headless_generates_output(self):
         """Test that claude -p actually works with real prompt."""
         from agentos.workflows.issue.nodes.draft import call_claude_headless
@@ -75,15 +84,14 @@ class TestClaudeHeadlessIntegration:
         # Simple test prompt
         prompt = "Respond with exactly: TEST_PASSED"
 
-        try:
-            result = call_claude_headless(prompt)
-            assert result, "claude -p returned empty response"
-            assert "TEST_PASSED" in result or len(result) > 0, f"Unexpected response: {result}"
-        except RuntimeError as e:
-            if "'code' command not found" in str(e):
-                pytest.skip("claude command not found in PATH")
-            raise
+        result = call_claude_headless(prompt)
+        assert result, "claude -p returned empty response"
+        assert "TEST_PASSED" in result or len(result) > 0, f"Unexpected response: {result}"
 
+    @pytest.mark.skipif(
+        not CLAUDE_AVAILABLE,
+        reason="claude CLI not found in PATH - install with: npm install -g @anthropic-ai/claude-code"
+    )
     def test_claude_headless_with_unicode(self):
         """Test that UTF-8 encoding works (Windows cp1252 issue)."""
         from agentos.workflows.issue.nodes.draft import call_claude_headless
@@ -91,14 +99,9 @@ class TestClaudeHeadlessIntegration:
         # Prompt with unicode characters that cp1252 can't encode
         prompt = "Echo back these characters: → ← ↑ ↓ • ★"
 
-        try:
-            result = call_claude_headless(prompt)
-            # Should not raise UnicodeEncodeError
-            assert result, "claude -p returned empty response for unicode prompt"
-        except RuntimeError as e:
-            if "'code' command not found" in str(e):
-                pytest.skip("claude command not found in PATH")
-            raise
+        result = call_claude_headless(prompt)
+        # Should not raise UnicodeEncodeError
+        assert result, "claude -p returned empty response for unicode prompt"
 
 
 class TestCleanOption:
@@ -106,7 +109,6 @@ class TestCleanOption:
 
     def test_clean_deletes_checkpoint_and_audit(self):
         """Verify Clean option actually deletes checkpoint and audit dir."""
-        import shutil
         from agentos.workflows.issue.audit import create_audit_dir, get_repo_root
         from langgraph.checkpoint.sqlite import SqliteSaver
         from pathlib import Path
@@ -150,7 +152,6 @@ class TestWorkflowFailureModes:
         from agentos.workflows.issue.nodes.sandbox import check_vscode_available
 
         # Mock shutil.which to return None
-        import shutil
         original_which = shutil.which
         def mock_which(cmd):
             if cmd == "code":
@@ -168,7 +169,6 @@ class TestWorkflowFailureModes:
         from agentos.workflows.issue.nodes.sandbox import check_gh_authenticated
 
         # Mock shutil.which to return None for gh
-        import shutil
         original_which = shutil.which
         def mock_which(cmd):
             if cmd == "gh":

--- a/tests/test_issue_78.py
+++ b/tests/test_issue_78.py
@@ -312,6 +312,10 @@ def test_100(temp_git_repo: Path):
         os.chdir(original_cwd)
 
 
+@pytest.mark.skipif(
+    not (Path(__file__).parent.parent / ".gitignore").exists(),
+    reason="Source .gitignore not accessible from test location"
+)
 def test_110(temp_git_repo: Path):
     """
     .gitignore contains .agentos/ pattern | Auto | Check `.gitignore`
@@ -319,12 +323,8 @@ def test_110(temp_git_repo: Path):
     assert pattern present
     """
     source_gitignore = Path(__file__).parent.parent / ".gitignore"
-    
-    if source_gitignore.exists():
-        content = source_gitignore.read_text()
-        assert ".agentos/" in content or ".agentos/issue_workflow.db" in content
-    else:
-        pytest.skip("Source .gitignore not accessible from test location")
+    content = source_gitignore.read_text()
+    assert ".agentos/" in content or ".agentos/issue_workflow.db" in content
 
 
 def test_120(tmp_path: Path, clean_env: None):

--- a/tests/unit/test_explicit_skips.py
+++ b/tests/unit/test_explicit_skips.py
@@ -1,0 +1,148 @@
+"""Unit tests verifying test skip patterns are explicit.
+
+Issue #154: Environmental test skips hide failures instead of failing clearly
+
+Problem: Tests use inline pytest.skip() which hides environmental issues.
+Fix: Use explicit @pytest.mark.skipif decorators that are visible and configured.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+class TestNoInlineSkips:
+    """Verify tests don't use inline pytest.skip() for environmental conditions."""
+
+    def test_issue_78_no_inline_skip(self):
+        """test_issue_78.py should not have inline pytest.skip() calls."""
+        test_file = Path(__file__).parent.parent / "test_issue_78.py"
+
+        if not test_file.exists():
+            pytest.skip("test_issue_78.py not found")
+
+        content = test_file.read_text(encoding="utf-8")
+
+        # Parse AST and look for Call nodes to pytest.skip inside functions
+        tree = ast.parse(content)
+
+        skip_calls_in_functions = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Call):
+                        if isinstance(child.func, ast.Attribute):
+                            if (child.func.attr == "skip" and
+                                isinstance(child.func.value, ast.Name) and
+                                child.func.value.id == "pytest"):
+                                skip_calls_in_functions.append(node.name)
+
+        assert not skip_calls_in_functions, (
+            f"Found inline pytest.skip() in functions: {skip_calls_in_functions}. "
+            f"Use @pytest.mark.skipif decorator instead for explicit, visible skips."
+        )
+
+    def test_integration_workflow_no_inline_skip(self):
+        """test_integration_workflow.py should not have inline pytest.skip() calls."""
+        test_file = Path(__file__).parent.parent / "test_integration_workflow.py"
+
+        if not test_file.exists():
+            pytest.skip("test_integration_workflow.py not found")
+
+        content = test_file.read_text(encoding="utf-8")
+
+        tree = ast.parse(content)
+
+        skip_calls_in_functions = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Call):
+                        if isinstance(child.func, ast.Attribute):
+                            if (child.func.attr == "skip" and
+                                isinstance(child.func.value, ast.Name) and
+                                child.func.value.id == "pytest"):
+                                skip_calls_in_functions.append(node.name)
+
+        assert not skip_calls_in_functions, (
+            f"Found inline pytest.skip() in functions: {skip_calls_in_functions}. "
+            f"Use @pytest.mark.skipif decorator instead for explicit, visible skips."
+        )
+
+
+class TestIntegrationMarkers:
+    """Verify integration tests have proper markers."""
+
+    def test_integration_workflow_has_markers(self):
+        """Integration tests should have @pytest.mark.integration marker."""
+        test_file = Path(__file__).parent.parent / "test_integration_workflow.py"
+
+        if not test_file.exists():
+            pytest.skip("test_integration_workflow.py not found")
+
+        content = test_file.read_text(encoding="utf-8")
+
+        # Check for integration marker on the class or functions
+        has_integration_marker = (
+            "@pytest.mark.integration" in content or
+            'pytestmark = pytest.mark.integration' in content
+        )
+
+        assert has_integration_marker, (
+            "test_integration_workflow.py should have @pytest.mark.integration "
+            "marker to clearly identify integration tests"
+        )
+
+
+class TestSkipifDecoratorUsage:
+    """Verify skipif decorators are used properly."""
+
+    def test_claude_dependency_uses_skipif(self):
+        """Tests depending on claude CLI should use @pytest.mark.skipif."""
+        test_file = Path(__file__).parent.parent / "test_integration_workflow.py"
+
+        if not test_file.exists():
+            pytest.skip("test_integration_workflow.py not found")
+
+        content = test_file.read_text(encoding="utf-8")
+
+        # Should have skipif for claude dependency
+        has_skipif_for_claude = (
+            "skipif" in content and
+            ("claude" in content.lower() or "shutil.which" in content)
+        )
+
+        # The skipif should be a decorator, not inline
+        has_decorator_skipif = "@pytest.mark.skipif" in content
+
+        assert has_decorator_skipif, (
+            "Tests depending on claude CLI should use @pytest.mark.skipif "
+            "decorator with shutil.which('claude') check"
+        )
+
+    def test_gitignore_test_uses_skipif(self):
+        """test_110 should use @pytest.mark.skipif for file existence check."""
+        test_file = Path(__file__).parent.parent / "test_issue_78.py"
+
+        if not test_file.exists():
+            pytest.skip("test_issue_78.py not found")
+
+        content = test_file.read_text(encoding="utf-8")
+
+        # Find the test_110 function and check it has skipif
+        tree = ast.parse(content)
+
+        test_110_has_skipif = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "test_110":
+                for decorator in node.decorator_list:
+                    if isinstance(decorator, ast.Call):
+                        if isinstance(decorator.func, ast.Attribute):
+                            if decorator.func.attr == "skipif":
+                                test_110_has_skipif = True
+
+        assert test_110_has_skipif, (
+            "test_110 should use @pytest.mark.skipif decorator for "
+            ".gitignore file existence check, not inline pytest.skip()"
+        )


### PR DESCRIPTION
## Summary
- Replace inline `pytest.skip()` calls with `@pytest.mark.skipif` decorators in `test_issue_78.py` and `test_integration_workflow.py`
- Add `pytestmark = pytest.mark.integration` to mark integration tests explicitly
- Register `integration` marker in `conftest.py`
- Add TDD tests in `tests/unit/test_explicit_skips.py` to enforce explicit skip patterns

Fixes #154

## Test plan
- [x] Run `pytest tests/unit/test_explicit_skips.py -v` - 5 tests pass
- [x] Run `pytest tests/test_issue_78.py -v` - 16 tests pass
- [x] Run `pytest tests/test_integration_workflow.py -v` - 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)