### PR TITLE
fix: refactor mock-heavy tests to verify actual behavior

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure tools directory is importable
 tools_dir = Path(__file__).parent.parent / "tools"
 if str(tools_dir.parent) not in sys.path:
@@ -10,8 +12,12 @@ if str(tools_dir.parent) not in sys.path:
 
 
 def pytest_configure(config):
-    """Configure pytest."""
+    """Configure pytest markers."""
     config.addinivalue_line(
         "markers",
         "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+    )
+    config.addinivalue_line(
+        "markers",
+        "e2e: marks tests as end-to-end tests (require full environment)",
     )


### PR DESCRIPTION
## Summary

- Added pytest markers (`integration`, `e2e`) for test categorization
- Added integration tests that verify real dependencies (gh CLI, file system)
- Refactored unit tests to verify **actual outcomes**, not just mock calls
- Tests now verify state changes, file contents, and error message quality

## What Changed

**Before:** Tests verified mocks were called correctly. Real integrations could be broken and tests would pass.

**After:** Tests verify actual behavior:
- State transitions are correct
- Files are actually written with correct content
- Error messages help users
- Audit entries contain required fields

## Running Tests

```bash
pytest -m integration           # Real dependencies
pytest -m "not integration"     # Fast unit tests (19 tests)
pytest tests/test_designer.py   # All tests (24 tests)
```

## Test plan
- [x] All 24 designer tests pass (19 unit + 5 integration)
- [x] Integration tests verify real gh CLI and file system operations
- [x] Unit tests verify outcomes, not mock calls
- [x] Tests follow TDD approach (tests written first)

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)