### PR TITLE
fix: move ideas to done/ after issue creation

### DIFF
--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -424,6 +424,14 @@ def build_initial_state(
 
     # Build state based on workflow type
     if args.type == "issue":
+        # Detect if brief is in ideas/active/ for cleanup after success
+        source_idea = ""
+        if args.brief:
+            brief_path = Path(args.brief).resolve()
+            ideas_active = (target_repo / "ideas" / "active").resolve()
+            if brief_path.parent == ideas_active:
+                source_idea = str(brief_path)
+
         return create_initial_state(
             workflow_type="issue",
             agentos_root=str(agentos_root),
@@ -436,6 +444,7 @@ def build_initial_state(
             mock_mode=args.mock,
             max_iterations=args.max_iterations,
             brief_file=args.brief or "",
+            source_idea=source_idea,
         )
     else:  # lld
         return create_initial_state(


### PR DESCRIPTION
## Summary
- Detect when `--brief` points to `ideas/active/` and set `source_idea` in initial state
- Add `_cleanup_source_idea()` function to move idea file to `ideas/done/{issue#}-filename.md` after successful issue creation
- Fix state merge bug in `finalize()` that was losing state fields when calling `_finalize_issue()`

fixes #219

## Test plan
- [x] Run `pytest tests/unit/test_requirements_nodes.py -k TestIdeasCleanup -v` - 4 tests pass
- [x] Run `pytest tests/unit/test_requirements_nodes.py -v` - all 68 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)