### PR TITLE
docs: add runbook for archive-worktree-lineage tool

### DIFF
--- a/docs/skills/0631c-archive-worktree-lineage-cli.md
+++ b/docs/skills/0631c-archive-worktree-lineage-cli.md
@@ -1,0 +1,158 @@
+# archive-worktree-lineage - CLI Usage
+
+**File:** `docs/skills/0631c-archive-worktree-lineage-cli.md`
+**Prompt Guide:** [0631p-archive-worktree-lineage-prompt.md](0631p-archive-worktree-lineage-prompt.md)
+**Version:** 2026-02-03
+**Issue:** #189
+
+---
+
+## Overview
+
+Archives valuable artifacts from a worktree before deletion. Prevents loss of iteration history, coverage data, and execution traces.
+
+---
+
+## Quick Start
+
+```bash
+# From main repo directory
+python tools/archive_worktree_lineage.py --worktree ../AgentOS-42 --issue 42
+```
+
+---
+
+## Command Reference
+
+```bash
+python tools/archive_worktree_lineage.py [OPTIONS]
+
+Required:
+  --worktree PATH    Path to the worktree being removed
+  --issue NUMBER     Issue number for this worktree
+
+Optional:
+  --main-repo PATH   Path to main repo (default: current directory)
+  --no-commit        Skip automatic git commit
+```
+
+---
+
+## What It Does
+
+### 1. Archives Lineage
+
+Copies `docs/lineage/active/{issue}-*/` from worktree to main repo's `docs/lineage/archived/`:
+
+```
+Worktree:  docs/lineage/active/42-testing/001-issue.md
+    ↓
+Main:      docs/lineage/archived/42-testing/001-issue.md
+```
+
+### 2. Cleans Ephemeral Files
+
+Removes from worktree (NOT archived):
+- `.coverage` - pytest coverage data
+- `__pycache__/` - Python bytecode
+- `.pytest_cache/` - pytest cache
+- `.agentos/audit/` - execution traces
+
+### 3. Commits to Main (unless --no-commit)
+
+```bash
+git add docs/lineage/archived/
+git commit -m "chore: archive workflow lineage for #42"
+```
+
+---
+
+## Usage in Post-Merge Cleanup
+
+This tool is step 1 of the post-merge cleanup protocol:
+
+```
+Post-Merge Cleanup:
+├── Archive lineage: python tools/archive_worktree_lineage.py --worktree ../ProjectName-{ID} --issue {ID}
+├── Remove worktree: git worktree remove ../ProjectName-{ID}
+├── Delete local branch: git branch -d {ID}-desc
+├── Delete remote branch: git push origin --delete {ID}-desc
+├── Pull merged changes: git pull
+└── Verify: git branch -a (should show only main)
+```
+
+---
+
+## Examples
+
+### Standard Usage (after PR merge)
+
+```bash
+# Archive lineage, clean ephemeral, commit
+python tools/archive_worktree_lineage.py --worktree ../AgentOS-155 --issue 155
+
+# Then remove worktree
+git worktree remove ../AgentOS-155
+```
+
+### Review Before Commit
+
+```bash
+# Archive without commit
+python tools/archive_worktree_lineage.py --worktree ../AgentOS-155 --issue 155 --no-commit
+
+# Review what was archived
+ls docs/lineage/archived/
+
+# Manually commit if satisfied
+git add docs/lineage/archived/
+git commit -m "chore: archive workflow lineage for #155"
+```
+
+### Non-Standard Main Repo Location
+
+```bash
+python tools/archive_worktree_lineage.py \
+  --worktree /c/Users/mcwiz/Projects/AgentOS-42 \
+  --issue 42 \
+  --main-repo /c/Users/mcwiz/Projects/AgentOS
+```
+
+---
+
+## What Gets Archived vs Cleaned
+
+| Item | Action | Why |
+|------|--------|-----|
+| `docs/lineage/active/{issue}-*/` | Archived | Iteration history valuable for analysis |
+| `.coverage` | Cleaned | Binary, regeneratable |
+| `__pycache__/` | Cleaned | Bytecode, regeneratable |
+| `.pytest_cache/` | Cleaned | Cache, regeneratable |
+| `.agentos/audit/` | Cleaned | Execution traces, large |
+
+---
+
+## Troubleshooting
+
+### "No lineage directory found"
+
+The worktree doesn't have `docs/lineage/active/`. This is normal for worktrees that didn't use the lineage workflow.
+
+### Permission denied on Windows
+
+Close any editors or terminals that have files open in the worktree.
+
+### Commit fails
+
+If git commit fails, check:
+1. You're in a git repo
+2. You have write permissions
+3. The main repo isn't locked by another process
+
+---
+
+## Related Files
+
+- Tool: `tools/archive_worktree_lineage.py`
+- Tests: `tests/unit/test_worktree_cleanup.py`
+- CLAUDE.md: POST-MERGE CLEANUP section

--- a/docs/skills/0631p-archive-worktree-lineage-prompt.md
+++ b/docs/skills/0631p-archive-worktree-lineage-prompt.md
@@ -1,0 +1,107 @@
+# archive-worktree-lineage - Prompt Usage
+
+**File:** `docs/skills/0631p-archive-worktree-lineage-prompt.md`
+**CLI Guide:** [0631c-archive-worktree-lineage-cli.md](0631c-archive-worktree-lineage-cli.md)
+**Version:** 2026-02-03
+**Issue:** #189
+
+---
+
+## Quick Reference
+
+This is a CLI tool, not a slash command. Use it as part of post-merge cleanup.
+
+```
+# After merging a PR, run:
+python tools/archive_worktree_lineage.py --worktree ../AgentOS-{ID} --issue {ID}
+```
+
+---
+
+## When Claude Should Use This
+
+Claude should run this tool automatically as part of post-merge cleanup when:
+
+1. A PR has just been merged
+2. There's a worktree to clean up
+3. The worktree may contain lineage data
+
+---
+
+## Integration with Post-Merge Cleanup
+
+When the user says "merge the PR" and Claude merges it, the post-merge cleanup should include:
+
+```python
+# Step 1: Archive lineage (NEW - Issue #189)
+python tools/archive_worktree_lineage.py --worktree ../AgentOS-{ID} --issue {ID}
+
+# Step 2: Remove worktree
+git worktree remove ../AgentOS-{ID}
+
+# Step 3: Delete local branch
+git branch -d {ID}-desc
+
+# Step 4: Pull merged changes
+git pull
+```
+
+---
+
+## Example Conversation
+
+**User:** merge the PR
+
+**Claude:**
+```
+PR merged. Executing post-merge cleanup:
+
+**Bash Check:** `python tools/archive_worktree_lineage.py --worktree ../AgentOS-155 --issue 155`
+**Scan:** No &&, no |, no ;, no cd at start → CLEAN
+**Friction Risk:** LOW
+**Action:** Execute
+
+[runs archive tool]
+
+**Bash Check:** `git worktree remove ../AgentOS-155`
+**Scan:** No &&, no |, no ;, no cd at start → CLEAN
+**Friction Risk:** LOW
+**Action:** Execute
+
+[removes worktree]
+
+Done. PR merged and cleanup complete.
+- ✅ Lineage archived to docs/lineage/archived/155-*/
+- ✅ Worktree removed
+- ✅ Branch deleted
+- ✅ Main updated
+```
+
+---
+
+## What Gets Preserved
+
+The tool preserves iteration history that helps with:
+
+- **Workflow analysis:** How many drafts/reviews before approval?
+- **Pattern mining:** Common failure modes in reviews
+- **Improvement measurement:** Are iterations decreasing over time?
+
+---
+
+## Manual vs Automatic
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Standard PR merge | Claude runs automatically |
+| Need to inspect first | Use `--no-commit` flag |
+| No lineage exists | Tool handles gracefully |
+| Want to skip entirely | Just don't run the tool |
+
+---
+
+## Related Documentation
+
+- CLI details: [0631c-archive-worktree-lineage-cli.md](0631c-archive-worktree-lineage-cli.md)
+- CLAUDE.md: POST-MERGE CLEANUP section
+- Tool source: `tools/archive_worktree_lineage.py`


### PR DESCRIPTION
## Summary

Adds the missing c/p documentation for the archive-worktree-lineage tool from #189.

## Files Added

- `docs/skills/0631c-archive-worktree-lineage-cli.md` - CLI usage guide
- `docs/skills/0631p-archive-worktree-lineage-prompt.md` - Prompt integration guide

## Content

**CLI Guide covers:**
- Command reference with all flags
- What gets archived vs cleaned
- Usage in post-merge cleanup
- Examples and troubleshooting

**Prompt Guide covers:**
- When Claude should use the tool
- Integration with post-merge cleanup
- Example conversation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)