### PR TITLE
fix: include lineage files in workflow commit (#241)

### DIFF
--- a/agentos/workflows/requirements/nodes/finalize.py
+++ b/agentos/workflows/requirements/nodes/finalize.py
@@ -265,6 +265,13 @@ def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
     # Add to created_files for commit
     created_files = list(state.get("created_files", []))
     created_files.append(str(lld_path))
+
+    # Add ALL lineage files to created_files (Issue #241)
+    if audit_dir.exists():
+        for lineage_file in audit_dir.glob("*"):
+            if lineage_file.is_file():
+                created_files.append(str(lineage_file))
+
     state["created_files"] = created_files
     state["final_lld_path"] = str(lld_path)
 


### PR DESCRIPTION
## Summary
- Workflow was only committing LLD, not lineage files
- Added glob to include all files in audit_dir
- Audit trail now persisted to git

## Changes
- `agentos/workflows/requirements/nodes/finalize.py`: Added 7-line fix to glob lineage files
- `tests/unit/test_requirements_nodes.py`: Added 4 tests (TDD approach)

## Test plan
- [x] `test_finalize_includes_lineage_files_in_created_files`
- [x] `test_finalize_commits_entire_audit_directory`
- [x] `test_finalize_handles_empty_audit_dir`
- [x] `test_finalize_handles_nonexistent_audit_dir`
- [x] Full regression passes (78 tests)

fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)