### PR TITLE
fix: RED phase accepts import errors as valid TDD (#263)

### DIFF
--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -1639,8 +1639,12 @@ class TestVerifyPhasesModule:
 
         assert "passed unexpectedly" in result.get("error_message", "")
 
-    def test_verify_red_phase_errors(self, tmp_path):
-        """verify_red_phase blocks when tests have errors."""
+    def test_verify_red_phase_errors_are_valid_red(self, tmp_path):
+        """verify_red_phase accepts import errors as valid RED behavior.
+
+        Issue #263: Import errors mean "module doesn't exist yet" which is
+        exactly what TDD RED phase should catch.
+        """
         from agentos.workflows.testing.nodes.verify_phases import verify_red_phase
 
         audit_dir = tmp_path / "audit"
@@ -1667,7 +1671,9 @@ class TestVerifyPhasesModule:
 
             result = verify_red_phase(state)
 
-        assert "error" in result.get("error_message", "").lower()
+        # Import errors now count as valid RED phase (Issue #263)
+        assert result.get("error_message") == ""
+        assert result.get("next_node") == "N4_implement_code"
 
     def test_verify_red_phase_no_tests_ran(self, tmp_path):
         """verify_red_phase blocks when no tests collected."""


### PR DESCRIPTION
## Summary

- Import errors during RED phase are now valid (module doesn't exist yet)
- Combines errors + failures as total "red" count
- Updates test to reflect new behavior

## Problem

With import-based TDD scaffolding (#261), the scaffold generates:
```python
from agentos.workflows.requirements.parsers.verdict_parser import *
```

This ImportError is the correct RED phase behavior - the module doesn't exist. But verify_phases was rejecting it as invalid.

## Solution

```python
# Before:
if error_count > 0:
    return error  # Blocked

# After:
total_red = failed_count + error_count
if total_red > 0 and passed_count == 0:
    return success  # Valid RED phase
```

## Test plan

- [x] 7 red_phase tests pass
- [x] Updated test to expect success on import errors

Fixes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)