### PR TITLE
fix: use poetry run pytest for correct virtualenv (#268)

### DIFF
--- a/agentos/workflows/testing/nodes/verify_phases.py
+++ b/agentos/workflows/testing/nodes/verify_phases.py
@@ -39,7 +39,8 @@ def run_pytest(
     Returns:
         Dict with returncode, stdout, stderr, and parsed results.
     """
-    cmd = ["pytest", "-v", "--tb=short"]
+    # Issue #268: Use poetry run to ensure correct virtualenv with dependencies
+    cmd = ["poetry", "run", "pytest", "-v", "--tb=short"]
     cmd.extend(test_files)
 
     if coverage_module:


### PR DESCRIPTION
## Summary

- Fix TDD workflow running bare `pytest` instead of `poetry run pytest`
- Add test to verify poetry run is used in commands

## Problem

The `run_pytest` function in `verify_phases.py` was using bare `pytest` command:
```python
cmd = ["pytest", "-v", "--tb=short"]
```

This uses the system Python which doesn't have project dependencies installed. In worktrees, this caused:
```
ModuleNotFoundError: No module named 'langgraph'
```

## Fix

Use `poetry run pytest` to ensure the correct virtualenv is used:
```python
cmd = ["poetry", "run", "pytest", "-v", "--tb=short"]
```

## Test plan

- [x] New test `test_run_pytest_uses_poetry_run` verifies command structure
- [x] All existing `run_pytest` tests pass (6/6)

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)