### PR TITLE
fix: implement file-by-file prompting with mechanical validation (#272)

### DIFF
--- a/agentos/workflows/testing/state.py
+++ b/agentos/workflows/testing/state.py
@@ -61,6 +61,7 @@ class TestingWorkflowState(TypedDict, total=False):
         # Test artifacts
         test_files: List of generated test file paths.
         implementation_files: List of generated implementation file paths.
+        completed_files: List of (filepath, content) tuples for context accumulation (#272).
         red_phase_output: Pytest output from red phase verification.
         green_phase_output: Pytest output from green phase verification.
         coverage_achieved: Actual coverage percentage achieved.
@@ -133,6 +134,7 @@ class TestingWorkflowState(TypedDict, total=False):
     # Test artifacts
     test_files: list[str]
     implementation_files: list[str]
+    completed_files: list[tuple[str, str]]  # Issue #272: (filepath, content) for context accumulation
     coverage_module: str  # Module path for coverage measurement (e.g., "agentos.workflows.scout")
     red_phase_output: str
     green_phase_output: str

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -471,6 +471,20 @@ def main():
         return 130
 
     except Exception as e:
+        # Check if this is an ImplementationError (issue #272)
+        if type(e).__name__ == "ImplementationError":
+            print(f"\n{'='*60}")
+            print("IMPLEMENTATION FAILED")
+            print(f"{'='*60}")
+            print(f"File: {getattr(e, 'filepath', 'unknown')}")
+            print(f"Reason: {getattr(e, 'reason', str(e))}")
+            preview = getattr(e, 'response_preview', None)
+            if preview:
+                print(f"\nResponse preview:\n{preview[:500]}")
+            print(f"\nThis is a hard failure. The implementation node could not produce valid code.")
+            print("Check the LLD specification and try again.")
+            return 1
+
         print(f"\n[FATAL] Unexpected error: {e}")
         import traceback
         traceback.print_exc()


### PR DESCRIPTION
## Summary

- Rewrites `implement_code.py` to use file-by-file prompting instead of batch prompting
- Claude no longer invents file paths - WE specify the path, extract just the code, and write to OUR path
- Mechanical validation via `ast.parse()` and code block extraction
- Hard failure on first validation error (`ImplementationError` exception)
- Accumulating context: file N sees LLD + files 1..(N-1)

## Key Changes

**implement_code.py:**
- `ImplementationError` typed exception for clean failure handling
- `extract_code_block()` - extracts code from response, ignores Claude's paths
- `validate_code_response()` - mechanical validation via ast.parse()
- `detect_summary_response()` - fast rejection of non-code responses
- `build_single_file_prompt()` - builds prompt for single file with context
- `call_claude_for_file()` - single file API call, NO RETRIES
- Main loop iterates through `files_to_modify` one by one

**Backward compatibility wrappers (deprecated):**
- `build_implementation_prompt()` - old batch-style prompt
- `parse_implementation_response()` - old multi-file parser
- `write_implementation_files()` - old batch writer
- `call_claude_headless()` - alias for call_claude_for_file

## Test Plan

- [x] All 287 tests pass
- [x] Updated 3 tests to match new architecture (use `call_claude_for_file` mock, expect `ImplementationError`)
- [ ] Manual test of implementation workflow on real LLD

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)