### PR TITLE
Fix stale LLD approval status on regeneration (#279)

### DIFF
--- a/agentos/workflows/requirements/nodes/finalize.py
+++ b/agentos/workflows/requirements/nodes/finalize.py
@@ -316,6 +316,11 @@ def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
             if lineage_file.is_file():
                 created_files.append(str(lineage_file))
 
+    # Add lld-status.json to commit (Issue #279: was missing, causing stale status)
+    lld_status_path = target_repo / "docs" / "lld" / "lld-status.json"
+    if lld_status_path.exists():
+        created_files.append(str(lld_status_path))
+
     state["created_files"] = created_files
     state["final_lld_path"] = str(lld_path)
 

--- a/tests/unit/test_requirements_audit.py
+++ b/tests/unit/test_requirements_audit.py
@@ -947,7 +947,9 @@ class TestShiftLineageVersions:
 
         operations = shift_lineage_versions(42, tmp_path)
 
-        assert operations == []
+        # Issue #279: Now always resets lld-status.json even if nothing else exists
+        assert len(operations) == 1
+        assert "Reset status" in operations[0]
 
     def test_handles_only_lld_file(self, tmp_path):
         """Test handles case where only LLD file exists."""
@@ -962,5 +964,7 @@ class TestShiftLineageVersions:
         operations = shift_lineage_versions(42, tmp_path)
 
         assert not lld_file.exists()
-        assert len(operations) == 1
+        # Issue #279: Now 2 operations - delete + reset status
+        assert len(operations) == 2
         assert "Deleted" in operations[0]
+        assert "Reset status" in operations[1]


### PR DESCRIPTION
## Summary
- Fix lld-status.json not being committed with LLD finalization
- Reset status entry when regenerating an LLD via shift_lineage_versions
- Prevents stale "APPROVED" status from carrying over to new drafts

## Test plan
- [x] Run `test_requirements_audit.py` - 59 tests pass
- [x] Run `TestFinalizeNode` tests - 12 tests pass
- [x] Run `TestShiftLineageVersions` tests - 6 tests pass

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)