### PR TITLE
fix: correct section header format in mechanical validation

### DIFF
--- a/agentos/workflows/requirements/nodes/validate_mechanical.py
+++ b/agentos/workflows/requirements/nodes/validate_mechanical.py
@@ -46,8 +46,9 @@ class ValidationError:
 # Constants
 # =============================================================================
 
-# Section headers that must be present (using ### format)
-MANDATORY_SECTIONS = ["### 2.1", "### 11", "### 12"]
+# Section headers that must be present
+# Note: 2.1 is h3 (###), but 11 and 12 are h2 (##) in the LLD template
+MANDATORY_SECTIONS = ["### 2.1", "## 11", "## 12"]
 
 # Common placeholder prefixes that often indicate hallucinated paths
 PLACEHOLDER_PREFIXES = ["src", "lib", "app"]
@@ -277,15 +278,15 @@ def extract_files_from_section(lld_content: str, section_header: str) -> set[str
 
     Args:
         lld_content: The LLD markdown content.
-        section_header: The section header to search (e.g., "### 12").
+        section_header: The section header to search (e.g., "## 12").
 
     Returns:
         Set of file paths mentioned in the section.
     """
     files = set()
 
-    # Find the section
-    pattern = rf"{re.escape(section_header)}[^\n]*\n(.*?)(?=###|\Z)"
+    # Find the section (stop at next ## or ### heading, or end of string)
+    pattern = rf"{re.escape(section_header)}[^\n]*\n(.*?)(?=##|\Z)"
     section_match = re.search(pattern, lld_content, re.DOTALL)
 
     if not section_match:
@@ -320,8 +321,8 @@ def cross_reference_sections(
     """
     errors = []
 
-    # Get files mentioned in Section 12 (Definition of Done)
-    dod_files = extract_files_from_section(lld_content, "### 12")
+    # Get files mentioned in Section 12 (Definition of Done, uses ## heading)
+    dod_files = extract_files_from_section(lld_content, "## 12")
 
     # Get files from Section 2.1
     fc_files = {f["path"] for f in files_changed}
@@ -355,9 +356,9 @@ def extract_mitigations_from_risks(lld_content: str) -> list[str]:
     """
     mitigations = []
 
-    # Find Section 11
+    # Find Section 11 (uses ## heading in LLD template)
     section_match = re.search(
-        r"###\s*11[^\n]*\n(.*?)(?=###|\Z)",
+        r"##\s*11[^\n]*\n(.*?)(?=##|\Z)",
         lld_content,
         re.DOTALL,
     )

--- a/tests/unit/test_validate_mechanical.py
+++ b/tests/unit/test_validate_mechanical.py
@@ -81,14 +81,14 @@ def validate_file_paths(files, repo_root):
     ...
 ```
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
 | Regex fails | Med | Low | Add comprehensive tests |
 | False positives | High | Med | Validate file paths conservatively |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] `agentos/workflows/requirements/nodes/validate_mechanical.py` implemented
 - [ ] `agentos/workflows/requirements/graph.py` updated
@@ -104,13 +104,13 @@ def lld_missing_section_21():
 ## 1. Context & Goal
 Test objective.
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
 | Test | Low |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Something done
 """
@@ -130,7 +130,7 @@ Test objective.
 |------|-------------|-------------|
 | `test.py` | Add | Test file |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Something done
 """
@@ -150,7 +150,7 @@ Test objective.
 |------|-------------|-------------|
 | `test.py` | Add | Test file |
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
@@ -170,13 +170,13 @@ def lld_with_invalid_modify_path():
 | `agentos/workflows/requirements/nonexistent.py` | Modify | Does not exist |
 | `agentos/workflows/requirements/graph.py` | Modify | Exists |
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
 | Test | Low |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Done
 """
@@ -193,13 +193,13 @@ def lld_with_placeholder_prefix():
 |------|-------------|-------------|
 | `src/components/Button.tsx` | Add | New component |
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
 | Test | Low |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Done
 """
@@ -216,13 +216,13 @@ def lld_with_dod_mismatch():
 |------|-------------|-------------|
 | `agentos/workflows/requirements/graph.py` | Modify | Update graph |
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
 | Test | Low |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] `agentos/workflows/requirements/graph.py` updated
 - [ ] `agentos/workflows/requirements/extra_file.py` created
@@ -249,13 +249,13 @@ def do_something():
     ...
 ```
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
 | Token exhaustion | High | Med | Track token count and implement rate limiting |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Done
 """
@@ -272,13 +272,13 @@ This section has text but no proper table format.
 
 Just some random content without table structure.
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 | Risk | Impact |
 |------|--------|
 | Test | Low |
 
-### 12. Definition of Done
+## 12. Definition of Done
 
 - [ ] Done
 """
@@ -688,7 +688,7 @@ class TestExtractMitigationsFromRisks:
         """LLD without proper Section 11 returns empty list."""
         content = """# Test LLD
 
-### 11. Risks & Mitigations
+## 11. Risks & Mitigations
 
 No table here.
 """


### PR DESCRIPTION
## Summary

- Fix section header mismatch causing infinite validation loop
- Validator expected `### 11` (h3) but LLD template uses `## 11.` (h2)

## Root Cause

`MANDATORY_SECTIONS` constant was checking for wrong heading format:
- Expected: `### 11`, `### 12` 
- Actual LLD format: `## 11.`, `## 12.`

This caused validation to always fail with "Critical: Section 11 missing from LLD" even when the section existed, creating an infinite loop between draft generation and validation.

## Changes

**validate_mechanical.py:**
- `MANDATORY_SECTIONS`: Changed `### 11` → `## 11`, `### 12` → `## 12`
- `extract_files_from_section()`: Fixed regex to stop at `##` headings
- `extract_mitigations_from_risks()`: Fixed Section 11 regex

**test_validate_mechanical.py:**
- Updated all test fixtures to use correct `## 11.` and `## 12.` format

## Test plan

- [x] All 33 validation tests pass
- [x] Manual test: validation now passes for issue #99 draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)