### PR TITLE
fix: set lld_status=PENDING when validation passes

### DIFF
--- a/agentos/workflows/requirements/nodes/validate_mechanical.py
+++ b/agentos/workflows/requirements/nodes/validate_mechanical.py
@@ -658,8 +658,12 @@ def validate_lld_mechanical(state: Dict[str, Any]) -> Dict[str, Any]:
             print(f"  - {msg}")
 
     # Validation passed - return updates without error
+    # Issue #302: Explicitly set lld_status to clear any previous BLOCKED status
+    # (e.g., from a Gemini verdict). This prevents the router from thinking
+    # validation failed when it actually passed.
     return {
         "validation_errors": [],
         "validation_warnings": warning_messages,
+        "lld_status": "PENDING",  # Clear BLOCKED status from previous Gemini verdicts
         "error_message": "",
     }


### PR DESCRIPTION
## Summary

- Set `lld_status="PENDING"` when mechanical validation passes
- This clears stale "BLOCKED" status from previous Gemini verdicts

## Problem

After Gemini returns a BLOCK verdict, the drafter generates a revision. If that revision passes validation, the workflow should proceed to Gemini review. But it was looping back to the drafter because:

1. Gemini verdict set `lld_status="BLOCKED"`
2. Validation passed but didn't update `lld_status`
3. Router saw stale "BLOCKED" → routed back to drafter
4. Infinite loop

## Fix

Return `lld_status: "PENDING"` when validation passes, clearing any stale BLOCKED status.

## Test plan

- [x] Relevant tests pass
- [x] Manual test: validation now returns `lld_status: "PENDING"` on pass

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)