### PR TITLE
feat: add smoke test node for TDD workflow (#172)

### DIFF
--- a/agentos/nodes/__init__.py
+++ b/agentos/nodes/__init__.py
@@ -3,5 +3,15 @@
 from agentos.nodes.check_type_renames import check_type_renames
 from agentos.nodes.designer import design_lld_node
 from agentos.nodes.lld_reviewer import review_lld_node
+from agentos.nodes.smoke_test_node import (
+    integration_smoke_test,
+    should_run_smoke_test,
+)
 
-__all__ = ["check_type_renames", "design_lld_node", "review_lld_node"]
+__all__ = [
+    "check_type_renames",
+    "design_lld_node",
+    "review_lld_node",
+    "integration_smoke_test",
+    "should_run_smoke_test",
+]

--- a/agentos/nodes/smoke_test_node.py
+++ b/agentos/nodes/smoke_test_node.py
@@ -1,0 +1,204 @@
+"""Smoke test node for LangGraph TDD workflow.
+
+This module provides smoke testing functionality that runs after the GREEN phase
+to catch integration breaks that unit tests with mocks might miss.
+
+Ref: Issue #172, LLD: docs/LLDs/active/172-smoke-test-node.md
+"""
+
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional, TypedDict
+
+from langgraph.graph import StateGraph
+
+
+class SmokeTestResult(TypedDict):
+    """Result from running a single smoke test."""
+    success: bool
+    entry_point: str
+    error_type: Optional[str]
+    error_message: Optional[str]
+    execution_time_ms: int
+
+
+class SmokeTestState(TypedDict):
+    """State for smoke test node in LangGraph."""
+    smoke_test_enabled: bool
+    smoke_test_results: list[SmokeTestResult]
+    smoke_test_passed: bool
+    project_root: Path
+
+
+def discover_entry_points(project_root: Path) -> list[Path]:
+    """Find all tools/run_*.py entry points in the project.
+    
+    Excludes __pycache__ and hidden directories (.*) from discovery.
+    
+    Args:
+        project_root: Root directory of the project
+        
+    Returns:
+        List of absolute paths to entry point scripts
+    """
+    tools_dir = project_root / "tools"
+    if not tools_dir.exists():
+        return []
+    
+    entry_points = []
+    for path in tools_dir.rglob("run_*.py"):
+        # Exclude __pycache__ and hidden directories
+        if "__pycache__" in path.parts:
+            continue
+        if any(part.startswith(".") for part in path.parts):
+            continue
+        entry_points.append(path)
+    
+    return sorted(entry_points)
+
+
+def parse_import_error(stderr: str) -> tuple[Optional[str], Optional[str]]:
+    """Extract error type and module from import error output.
+    
+    Args:
+        stderr: Standard error output from the subprocess
+        
+    Returns:
+        Tuple of (error_type, module_name) or (None, None) if not an import error
+    """
+    # Match ModuleNotFoundError: No module named 'foo'
+    module_not_found = re.search(r"ModuleNotFoundError: No module named ['\"]([^'\"]+)['\"]", stderr)
+    if module_not_found:
+        return ("ModuleNotFoundError", module_not_found.group(1))
+    
+    # Match ImportError: cannot import name 'foo' from 'bar'
+    import_error = re.search(r"ImportError: (.+)", stderr)
+    if import_error:
+        return ("ImportError", import_error.group(1))
+    
+    return (None, None)
+
+
+def run_smoke_test(entry_point: Path, timeout_seconds: int = 30) -> SmokeTestResult:
+    """Execute a single entry point with --help and capture results.
+    
+    Uses subprocess.run with shell=False to prevent shell injection.
+    
+    Args:
+        entry_point: Path to the entry point script
+        timeout_seconds: Maximum time to wait for the process
+        
+    Returns:
+        SmokeTestResult with success/failure and error details
+    """
+    start_time = time.perf_counter()
+    
+    try:
+        # Run with shell=False for security
+        result = subprocess.run(
+            ["python", str(entry_point), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            shell=False,
+        )
+        
+        execution_time_ms = int((time.perf_counter() - start_time) * 1000)
+        
+        if result.returncode == 0:
+            return SmokeTestResult(
+                success=True,
+                entry_point=str(entry_point),
+                error_type=None,
+                error_message=None,
+                execution_time_ms=execution_time_ms,
+            )
+        else:
+            error_type, error_detail = parse_import_error(result.stderr)
+            return SmokeTestResult(
+                success=False,
+                entry_point=str(entry_point),
+                error_type=error_type or "UnknownError",
+                error_message=result.stderr.strip() or result.stdout.strip(),
+                execution_time_ms=execution_time_ms,
+            )
+    
+    except subprocess.TimeoutExpired:
+        execution_time_ms = int((time.perf_counter() - start_time) * 1000)
+        return SmokeTestResult(
+            success=False,
+            entry_point=str(entry_point),
+            error_type="TimeoutError",
+            error_message=f"Process timed out after {timeout_seconds} seconds",
+            execution_time_ms=execution_time_ms,
+        )
+    
+    except Exception as e:
+        execution_time_ms = int((time.perf_counter() - start_time) * 1000)
+        return SmokeTestResult(
+            success=False,
+            entry_point=str(entry_point),
+            error_type=type(e).__name__,
+            error_message=str(e),
+            execution_time_ms=execution_time_ms,
+        )
+
+
+def integration_smoke_test(state: SmokeTestState) -> dict:
+    """LangGraph node: Run smoke tests on all entry points after green phase.
+    
+    Args:
+        state: Current workflow state
+        
+    Returns:
+        Updated state with smoke test results
+    """
+    project_root = state.get("project_root")
+    if not project_root:
+        return {
+            "smoke_test_passed": False,
+            "smoke_test_results": [
+                SmokeTestResult(
+                    success=False,
+                    entry_point="N/A",
+                    error_type="ConfigurationError",
+                    error_message="project_root not set in state",
+                    execution_time_ms=0,
+                )
+            ],
+        }
+    
+    entry_points = discover_entry_points(project_root)
+    
+    if not entry_points:
+        # No entry points found - consider this a pass
+        return {
+            "smoke_test_passed": True,
+            "smoke_test_results": [],
+        }
+    
+    results = []
+    for entry_point in entry_points:
+        result = run_smoke_test(entry_point)
+        results.append(result)
+    
+    all_passed = all(result["success"] for result in results)
+    
+    return {
+        "smoke_test_passed": all_passed,
+        "smoke_test_results": results,
+    }
+
+
+def should_run_smoke_test(state: SmokeTestState) -> bool:
+    """Conditional edge: Determine if smoke test should run based on smoke_test_enabled flag.
+    
+    Args:
+        state: Current workflow state
+        
+    Returns:
+        True if smoke test should run, False to bypass
+    """
+    return state.get("smoke_test_enabled", True)

--- a/tests/integration/test_smoke_test_integration.py
+++ b/tests/integration/test_smoke_test_integration.py
@@ -1,0 +1,124 @@
+"""Integration tests for smoke test node.
+
+Reference: Issue #172, LLD docs/LLDs/active/172-smoke-test-node.md
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentos.nodes.smoke_test_node import (
+    SmokeTestResult,
+    SmokeTestState,
+    discover_entry_points,
+    integration_smoke_test,
+    parse_import_error,
+    run_smoke_test,
+    should_run_smoke_test,
+)
+
+
+@pytest.mark.integration
+def test_integration_smoke_test_all_pass(tmp_path):
+    """test_integration_smoke_test_all_pass | Updates state with passed=True | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    script1 = tools_dir / "run_foo.py"
+    script1.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    script2 = tools_dir / "run_bar.py"
+    script2.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": False,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is True
+    assert len(result["smoke_test_results"]) == 2
+    assert all(r["success"] for r in result["smoke_test_results"])
+
+
+@pytest.mark.integration
+def test_integration_smoke_test_one_fails(tmp_path):
+    """test_integration_smoke_test_one_fails | Updates state with passed=False | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    script1 = tools_dir / "run_foo.py"
+    script1.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    script2 = tools_dir / "run_bar.py"
+    script2.write_text("import nonexistent_module\nprint('--help')")
+    
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": True,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is False
+    assert len(result["smoke_test_results"]) == 2
+    assert any(not r["success"] for r in result["smoke_test_results"])
+
+
+@pytest.mark.integration
+def test_workflow_integration_smoke_after_green(tmp_path):
+    """test_workflow_integration_smoke_after_green | Smoke test runs after green phase | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    script = tools_dir / "run_test.py"
+    script.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": False,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    # Verify conditional edge allows smoke test to run
+    should_run = should_run_smoke_test(state)
+    assert should_run is True
+    
+    # Run smoke test node
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    # Verify smoke test executed and passed
+    assert result["smoke_test_passed"] is True
+    assert len(result["smoke_test_results"]) == 1
+    assert result["smoke_test_results"][0]["success"] is True
+
+
+@pytest.mark.integration
+def test_integration_smoke_test_no_entry_points(tmp_path):
+    """test_integration_smoke_test_no_entry_points | Passes when no entry points found | RED"""
+    # TDD: Arrange
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": False,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is True
+    assert len(result["smoke_test_results"]) == 0

--- a/tests/unit/test_explicit_skips.py
+++ b/tests/unit/test_explicit_skips.py
@@ -86,7 +86,8 @@ class TestIntegrationMarkers:
         # Check for integration marker on the class or functions
         has_integration_marker = (
             "@pytest.mark.integration" in content or
-            'pytestmark = pytest.mark.integration' in content
+            'pytestmark = pytest.mark.integration' in content or
+            'pytest.mark.integration,' in content  # List form: pytestmark = [pytest.mark.integration, ...]
         )
 
         assert has_integration_marker, (
@@ -113,12 +114,15 @@ class TestSkipifDecoratorUsage:
             ("claude" in content.lower() or "shutil.which" in content)
         )
 
-        # The skipif should be a decorator, not inline
-        has_decorator_skipif = "@pytest.mark.skipif" in content
+        # The skipif should be a decorator or module-level marker, not inline
+        has_decorator_skipif = (
+            "@pytest.mark.skipif" in content or
+            "pytest.mark.skipif(" in content  # pytestmark list form
+        )
 
         assert has_decorator_skipif, (
             "Tests depending on claude CLI should use @pytest.mark.skipif "
-            "decorator with shutil.which('claude') check"
+            "decorator or pytestmark with skipif"
         )
 
     def test_gitignore_test_uses_skipif(self):

--- a/tests/unit/test_smoke_test_node.py
+++ b/tests/unit/test_smoke_test_node.py
@@ -1,0 +1,318 @@
+"""Unit tests for smoke test functionality.
+
+Reference: Issue #172, LLD docs/LLDs/active/172-smoke-test-node.md
+"""
+
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentos.nodes.smoke_test_node import (
+    SmokeTestResult,
+    SmokeTestState,
+    discover_entry_points,
+    integration_smoke_test,
+    parse_import_error,
+    run_smoke_test,
+    should_run_smoke_test,
+)
+
+
+# Unit Tests
+# -----------
+
+def test_discover_entry_points_finds_run_scripts(tmp_path):
+    """test_discover_entry_points_finds_run_scripts | Returns list of tools/run_*.py paths | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "run_foo.py").touch()
+    (tools_dir / "run_bar.py").touch()
+    (tools_dir / "not_run.py").touch()
+    
+    # TDD: Act
+    result = discover_entry_points(tmp_path)
+    
+    # TDD: Assert
+    assert len(result) == 2
+    assert all(p.name.startswith("run_") for p in result)
+    assert all(p.suffix == ".py" for p in result)
+
+
+def test_discover_entry_points_excludes_pycache(tmp_path):
+    """test_discover_entry_points_excludes_pycache | Excludes __pycache__ directories | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "run_foo.py").touch()
+    pycache_dir = tools_dir / "__pycache__"
+    pycache_dir.mkdir()
+    (pycache_dir / "run_cached.py").touch()
+    
+    # TDD: Act
+    result = discover_entry_points(tmp_path)
+    
+    # TDD: Assert
+    assert len(result) == 1
+    assert "__pycache__" not in str(result[0])
+
+
+def test_discover_entry_points_excludes_hidden_dirs(tmp_path):
+    """test_discover_entry_points_excludes_hidden_dirs | Excludes hidden directories | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    (tools_dir / "run_foo.py").touch()
+    hidden_dir = tools_dir / ".hidden"
+    hidden_dir.mkdir()
+    (hidden_dir / "run_secret.py").touch()
+    
+    # TDD: Act
+    result = discover_entry_points(tmp_path)
+    
+    # TDD: Assert
+    assert len(result) == 1
+    assert ".hidden" not in str(result[0])
+
+
+def test_run_smoke_test_success(tmp_path):
+    """test_run_smoke_test_success | Returns success=True for valid script | RED"""
+    # TDD: Arrange
+    script = tmp_path / "valid.py"
+    script.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    
+    # TDD: Act
+    result = run_smoke_test(script, timeout_seconds=5)
+    
+    # TDD: Assert
+    assert result["success"] is True
+    assert result["error_type"] is None
+    assert result["error_message"] is None
+    assert result["execution_time_ms"] > 0
+
+
+def test_run_smoke_test_import_error(tmp_path):
+    """test_run_smoke_test_import_error | Returns success=False with error details for ImportError | RED"""
+    # TDD: Arrange
+    script = tmp_path / "broken.py"
+    script.write_text("import nonexistent_module\nprint('--help')")
+    
+    # TDD: Act
+    result = run_smoke_test(script, timeout_seconds=5)
+    
+    # TDD: Assert
+    assert result["success"] is False
+    assert result["error_type"] in ["ImportError", "ModuleNotFoundError"]
+    assert result["error_message"] is not None
+    assert "nonexistent_module" in result["error_message"]
+
+
+def test_run_smoke_test_module_not_found(tmp_path):
+    """test_run_smoke_test_module_not_found | Returns success=False with error details for ModuleNotFoundError | RED"""
+    # TDD: Arrange
+    script = tmp_path / "missing.py"
+    script.write_text("from missing_package import foo\nprint('--help')")
+    
+    # TDD: Act
+    result = run_smoke_test(script, timeout_seconds=5)
+    
+    # TDD: Assert
+    assert result["success"] is False
+    assert result["error_type"] in ["ImportError", "ModuleNotFoundError"]
+    assert result["error_message"] is not None
+
+
+def test_run_smoke_test_timeout(tmp_path):
+    """test_run_smoke_test_timeout | Returns failure after timeout | RED"""
+    # TDD: Arrange
+    script = tmp_path / "slow.py"
+    script.write_text("import time\ntime.sleep(60)\nprint('--help')")
+
+    # TDD: Act
+    result = run_smoke_test(script, timeout_seconds=1)
+
+    # TDD: Assert
+    assert result["success"] is False
+    assert result["error_type"] == "TimeoutError"
+    assert "timed out" in result["error_message"].lower()
+
+
+def test_parse_import_error_extracts_module():
+    """test_parse_import_error_extracts_module | Parses ModuleNotFoundError correctly | RED"""
+    # TDD: Arrange
+    stderr = "ModuleNotFoundError: No module named 'foo'"
+    
+    # TDD: Act
+    error_type, module_name = parse_import_error(stderr)
+    
+    # TDD: Assert
+    assert error_type == "ModuleNotFoundError"
+    assert module_name == "foo"
+
+
+def test_parse_import_error_extracts_import_error():
+    """test_parse_import_error_extracts_import_error | Parses ImportError correctly | RED"""
+    # TDD: Arrange
+    stderr = "ImportError: cannot import name 'bar' from 'foo'"
+
+    # TDD: Act
+    error_type, error_detail = parse_import_error(stderr)
+
+    # TDD: Assert
+    assert error_type == "ImportError"
+    assert "bar" in error_detail  # Error detail contains the full message
+
+
+def test_parse_import_error_generic_import_error():
+    """test_parse_import_error_generic_import_error | Handles generic ImportError | RED"""
+    # TDD: Arrange
+    stderr = "ImportError: something went wrong"
+
+    # TDD: Act
+    error_type, error_detail = parse_import_error(stderr)
+
+    # TDD: Assert
+    assert error_type == "ImportError"
+    assert error_detail == "something went wrong"  # Captures error details
+
+
+def test_parse_import_error_no_error():
+    """test_parse_import_error_no_error | Returns None for non-import errors | RED"""
+    # TDD: Arrange
+    stderr = "SyntaxError: invalid syntax"
+    
+    # TDD: Act
+    error_type, module_name = parse_import_error(stderr)
+    
+    # TDD: Assert
+    assert error_type is None
+    assert module_name is None
+
+
+def test_smoke_test_skipped_when_disabled():
+    """test_smoke_test_skipped_when_disabled | Smoke test skipped when smoke_test_enabled=False | RED"""
+    # TDD: Arrange
+    state: SmokeTestState = {
+        "smoke_test_enabled": False,
+        "smoke_test_results": [],
+        "smoke_test_passed": True,
+        "project_root": Path.cwd(),
+    }
+    
+    # TDD: Act
+    result = should_run_smoke_test(state)
+    
+    # TDD: Assert
+    assert result is False
+
+
+def test_should_run_smoke_test_enabled():
+    """test_should_run_smoke_test_enabled | Returns True when smoke_test_enabled=True | RED"""
+    # TDD: Arrange
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": True,
+        "project_root": Path.cwd(),
+    }
+    
+    # TDD: Act
+    result = should_run_smoke_test(state)
+    
+    # TDD: Assert
+    assert result is True
+
+
+def test_should_run_smoke_test_default():
+    """test_should_run_smoke_test_default | Defaults to True when flag not present | RED"""
+    # TDD: Arrange
+    state: SmokeTestState = {
+        "smoke_test_results": [],
+        "smoke_test_passed": True,
+        "project_root": Path.cwd(),
+    }
+    
+    # TDD: Act
+    result = should_run_smoke_test(state)
+    
+    # TDD: Assert
+    assert result is True
+
+
+# Integration Tests
+# -----------------
+
+@pytest.mark.integration
+def test_integration_smoke_test_all_pass(tmp_path):
+    """test_integration_smoke_test_all_pass | Updates state with passed=True | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    script1 = tools_dir / "run_foo.py"
+    script1.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    script2 = tools_dir / "run_bar.py"
+    script2.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": False,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is True
+    assert len(result["smoke_test_results"]) == 2
+    assert all(r["success"] for r in result["smoke_test_results"])
+
+
+@pytest.mark.integration
+def test_integration_smoke_test_one_fails(tmp_path):
+    """test_integration_smoke_test_one_fails | Updates state with passed=False | RED"""
+    # TDD: Arrange
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    script1 = tools_dir / "run_foo.py"
+    script1.write_text("import sys\nprint('--help')\nsys.exit(0)")
+    script2 = tools_dir / "run_bar.py"
+    script2.write_text("import nonexistent_module\nprint('--help')")
+    
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": True,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is False
+    assert len(result["smoke_test_results"]) == 2
+    assert any(not r["success"] for r in result["smoke_test_results"])
+
+
+@pytest.mark.integration
+def test_integration_smoke_test_no_entry_points(tmp_path):
+    """test_integration_smoke_test_no_entry_points | Passes when no entry points found | RED"""
+    # TDD: Arrange
+    state: SmokeTestState = {
+        "smoke_test_enabled": True,
+        "smoke_test_results": [],
+        "smoke_test_passed": False,
+        "project_root": tmp_path,
+    }
+    
+    # TDD: Act
+    result = integration_smoke_test(state)
+    
+    # TDD: Assert
+    assert result["smoke_test_passed"] is True
+    assert len(result["smoke_test_results"]) == 0


### PR DESCRIPTION
## Summary
- Add `smoke_test_node.py` with entry point discovery and smoke testing
- 17 unit tests + 4 integration tests covering all functionality
- Fix meta-tests to recognize pytestmark list form

## Implementation Details
- `discover_entry_points()`: Finds tools/run_*.py entry points, excludes __pycache__ and hidden dirs
- `run_smoke_test()`: Executes with --help, captures import errors, handles timeout
- `parse_import_error()`: Extracts error type and module from stderr
- `integration_smoke_test()`: LangGraph node that runs all smoke tests
- `should_run_smoke_test()`: Conditional edge for enabling/disabling

## Test plan
- [x] Unit tests: 17 tests covering all functions
- [x] Integration tests: 4 tests for workflow behavior
- [x] Full regression: 1653 passed, 8 skipped

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)