### PR TITLE
fix: remove deprecated google.generativeai from scout/nodes.py

### DIFF
--- a/tests/unit/test_scout_nodes.py
+++ b/tests/unit/test_scout_nodes.py
@@ -682,13 +682,13 @@ class TestGapAnalystNode:
 
         # Simulate ImportError for GeminiClient
         with patch.dict("sys.modules", {"agentos.core.gemini_client": None}):
-            with patch("google.generativeai.configure"):
-                with patch("google.generativeai.GenerativeModel") as MockModel:
+            with patch.dict(os.environ, {"GEMINI_API_KEY": "test-key"}):
+                with patch("google.genai.Client") as MockClient:
                     mock_response = MagicMock()
                     mock_response.text = "Fallback analysis"
-                    mock_model = MagicMock()
-                    mock_model.generate_content.return_value = mock_response
-                    MockModel.return_value = mock_model
+                    mock_client = MagicMock()
+                    mock_client.models.generate_content.return_value = mock_response
+                    MockClient.return_value = mock_client
 
                     # This will raise ImportError internally and use fallback
                     result = gap_analyst_node(state)


### PR DESCRIPTION
## Summary

- Remove deprecated `google.generativeai` import from `gap_analyst_node` function
- Update fallback code to use new `google.genai` SDK pattern
- Update test mocks to patch new SDK

## Context

The migration in #53 updated `GeminiClient` but missed the fallback code in `gap_analyst_node`. The deprecated import at function entry was triggering `FutureWarning` during tests even when the fallback wasn't used.

## Test plan

- [x] All 48 tests in `test_scout_nodes.py` pass
- [x] No more `google.generativeai` deprecation warning

Fixes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)