### PR TITLE
fix: scaffold real tests, add validation node (#335)

### DIFF
--- a/agentos/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/agentos/workflows/testing/nodes/validate_tests_mechanical.py
@@ -1,0 +1,320 @@
+"""Mechanical validation of generated tests.
+
+Issue #335: Validates that generated tests are real executable tests,
+not stubs with `assert False` placeholders.
+
+This node runs after scaffold_tests and before verify_red to catch
+stub tests early and route back for regeneration.
+"""
+
+import ast
+import logging
+import re
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Stub Pattern Detection
+# =============================================================================
+
+# Patterns that indicate a stub test
+STUB_PATTERNS = [
+    re.compile(r'assert\s+False', re.IGNORECASE),
+    re.compile(r'raise\s+NotImplementedError', re.IGNORECASE),
+    re.compile(r'TDD\s*(?:RED|:)', re.IGNORECASE),
+    re.compile(r'Implementation\s+pending', re.IGNORECASE),
+    re.compile(r'not\s+implemented', re.IGNORECASE),
+    re.compile(r'#\s*TODO:\s*implement', re.IGNORECASE),
+    re.compile(r'#\s*stub', re.IGNORECASE),
+]
+
+
+def detect_stub_patterns(test_content: str) -> list[str]:
+    """Find stub test patterns that indicate placeholder tests.
+
+    Issue #335: Detects common stub patterns like `assert False`,
+    `raise NotImplementedError`, "TDD RED", etc.
+
+    Args:
+        test_content: The generated test file content.
+
+    Returns:
+        List of error messages describing detected stub patterns.
+    """
+    errors = []
+
+    lines = test_content.split('\n')
+    for i, line in enumerate(lines, 1):
+        for pattern in STUB_PATTERNS:
+            if pattern.search(line):
+                # Get a clean snippet of the line
+                snippet = line.strip()[:60]
+                errors.append(
+                    f"Line {i}: Stub pattern detected: '{snippet}'"
+                )
+                break  # Only report first pattern match per line
+
+    return errors
+
+
+# =============================================================================
+# AST Validation
+# =============================================================================
+
+
+def validate_test_structure(
+    test_content: str,
+    scenarios: list[dict],
+) -> list[str]:
+    """AST validation: verify imports, calls, and assertions exist.
+
+    Issue #335: Uses Python AST to verify that tests have proper structure:
+    - At least one import statement
+    - Each test function has at least one real assertion
+    - Assertions aren't just `assert False`
+
+    Args:
+        test_content: The generated test file content.
+        scenarios: List of test scenario dicts with test_id and test_name.
+
+    Returns:
+        List of error messages for structural issues.
+    """
+    errors = []
+
+    try:
+        tree = ast.parse(test_content)
+    except SyntaxError as e:
+        errors.append(f"Syntax error in generated tests: {e}")
+        return errors
+
+    # Check for imports
+    has_import = any(
+        isinstance(node, (ast.Import, ast.ImportFrom))
+        for node in ast.walk(tree)
+    )
+
+    if not has_import:
+        errors.append("No import statements found - tests need imports")
+
+    # Check each test function
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith('test_'):
+            # Check for assertions in this function
+            has_real_assertion = False
+
+            for child in ast.walk(node):
+                if isinstance(child, ast.Assert):
+                    # Check if it's a real assertion (not assert False)
+                    if isinstance(child.test, ast.Constant):
+                        if child.test.value is False:
+                            continue  # Skip assert False
+                    has_real_assertion = True
+                    break
+
+                # Also accept pytest.raises as valid
+                if isinstance(child, ast.With):
+                    for item in child.items:
+                        if isinstance(item.context_expr, ast.Call):
+                            call = item.context_expr
+                            if isinstance(call.func, ast.Attribute):
+                                if call.func.attr == 'raises':
+                                    has_real_assertion = True
+                                    break
+
+            if not has_real_assertion:
+                # Check if function only has pass
+                func_has_only_pass = (
+                    len(node.body) == 1 and
+                    isinstance(node.body[0], (ast.Pass, ast.Expr)) and
+                    (isinstance(node.body[0], ast.Pass) or
+                     (isinstance(node.body[0], ast.Expr) and
+                      isinstance(node.body[0].value, ast.Constant)))
+                )
+
+                if func_has_only_pass:
+                    errors.append(
+                        f"Function '{node.name}' has no assertions - only pass/docstring"
+                    )
+                else:
+                    # Check if any assert exists (even assert False)
+                    any_assert = any(
+                        isinstance(child, ast.Assert)
+                        for child in ast.walk(node)
+                    )
+                    if not any_assert:
+                        errors.append(
+                            f"Function '{node.name}' has no assertion statements"
+                        )
+
+    return errors
+
+
+def validate_scenario_coverage(
+    test_content: str,
+    scenarios: list[dict],
+) -> list[str]:
+    """Ensure all LLD scenarios have corresponding test functions.
+
+    Issue #335: Verifies that every test scenario from the LLD
+    has a corresponding test function in the generated code.
+
+    Args:
+        test_content: The generated test file content.
+        scenarios: List of test scenario dicts with test_id and test_name.
+
+    Returns:
+        List of error messages for missing test functions.
+    """
+    errors = []
+
+    # Extract function names from test content
+    try:
+        tree = ast.parse(test_content)
+    except SyntaxError:
+        return []  # Don't add coverage errors if file doesn't parse
+
+    test_functions = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith('test_'):
+            test_functions.add(node.name.lower())
+
+    # Check each scenario
+    for scenario in scenarios:
+        test_name = scenario.get("test_name", "").lower()
+        test_id = scenario.get("test_id", "")
+
+        if not test_name:
+            continue
+
+        # Normalize test name
+        if not test_name.startswith("test_"):
+            test_name = f"test_{test_name}"
+
+        if test_name not in test_functions:
+            errors.append(
+                f"Missing test function for scenario {test_id}: {scenario.get('test_name')}"
+            )
+
+    return errors
+
+
+# =============================================================================
+# LangGraph Node
+# =============================================================================
+
+
+def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
+    """LangGraph node: Mechanical validation of generated tests.
+
+    Issue #335: Validates generated tests to catch stubs before
+    the green phase. Routes back to scaffold for regeneration if
+    stubs are detected.
+
+    Args:
+        state: Workflow state with generated_tests and parsed_scenarios.
+
+    Returns:
+        State updates with validation_result and scaffold_attempts.
+    """
+    print("\n[N2.5] Validating generated tests (mechanical)...")
+
+    generated_tests = state.get("generated_tests", "")
+    parsed_scenarios = state.get("parsed_scenarios", {})
+    scenarios = parsed_scenarios.get("scenarios", [])
+    scaffold_attempts = state.get("scaffold_attempts", 0)
+
+    all_errors = []
+    stub_count = 0
+
+    # Step 1: Detect stub patterns
+    stub_errors = detect_stub_patterns(generated_tests)
+    if stub_errors:
+        stub_count = len(stub_errors)
+        all_errors.extend(stub_errors)
+        print(f"    Found {stub_count} stub patterns")
+
+    # Step 2: Validate structure with AST
+    structure_errors = validate_test_structure(generated_tests, scenarios)
+    all_errors.extend(structure_errors)
+
+    # Step 3: Validate scenario coverage
+    coverage_errors = validate_scenario_coverage(generated_tests, scenarios)
+    all_errors.extend(coverage_errors)
+
+    # Build validation result
+    is_valid = len(all_errors) == 0
+
+    # Count real tests (functions without stub patterns)
+    try:
+        tree = ast.parse(generated_tests)
+        total_tests = sum(
+            1 for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name.startswith('test_')
+        )
+        real_test_count = total_tests - stub_count
+    except SyntaxError:
+        total_tests = 0
+        real_test_count = 0
+
+    validation_result = {
+        "is_valid": is_valid,
+        "errors": all_errors,
+        "warnings": [],
+        "stub_count": stub_count,
+        "real_test_count": max(0, real_test_count),
+    }
+
+    if is_valid:
+        print(f"    Validation PASSED: {real_test_count} real tests")
+    else:
+        print(f"    Validation FAILED: {len(all_errors)} errors")
+        for error in all_errors[:5]:
+            print(f"      - {error}")
+        if len(all_errors) > 5:
+            print(f"      ... and {len(all_errors) - 5} more")
+
+    # Increment attempts if validation failed
+    new_attempts = scaffold_attempts + 1 if not is_valid else scaffold_attempts
+
+    return {
+        "validation_result": validation_result,
+        "scaffold_attempts": new_attempts,
+    }
+
+
+# =============================================================================
+# Routing Function
+# =============================================================================
+
+
+def should_regenerate(state: dict[str, Any]) -> Literal["regenerate", "continue", "escalate"]:
+    """Conditional edge: return routing decision based on validation.
+
+    Issue #335: Routes the workflow based on validation results:
+    - "regenerate": Validation failed, attempts < 3, retry scaffold
+    - "continue": Validation passed, proceed to verify_red
+    - "escalate": Validation failed, attempts >= 3, use Claude
+
+    Args:
+        state: Workflow state with validation_result and scaffold_attempts.
+
+    Returns:
+        Routing decision string.
+    """
+    validation_result = state.get("validation_result", {})
+    is_valid = validation_result.get("is_valid", False)
+    scaffold_attempts = state.get("scaffold_attempts", 0)
+
+    if is_valid:
+        return "continue"
+
+    # Max 3 attempts before escalation
+    if scaffold_attempts >= 3:
+        print(f"    [ESCALATE] Max attempts ({scaffold_attempts}) reached, escalating to Claude")
+        return "escalate"
+
+    print(f"    [REGENERATE] Attempt {scaffold_attempts}/3, returning to scaffold")
+    return "regenerate"

--- a/agentos/workflows/testing/state.py
+++ b/agentos/workflows/testing/state.py
@@ -3,6 +3,7 @@
 Issue #101: Test Plan Reviewer
 Issue #102: TDD Initialization
 Issue #93: N8 Documentation Node
+Issue #335: Scaffold validation fields
 
 This TypedDict travels through nodes N0-N8, tracking the testing workflow
 from LLD loading through test generation, implementation, E2E validation,
@@ -180,3 +181,9 @@ class TestingWorkflowState(TypedDict, total=False):
     # Documentation control
     skip_docs: bool
     doc_scope: Literal["full", "minimal", "auto", "none"]
+
+    # Issue #335: Scaffold validation
+    generated_tests: str  # Generated test file content
+    parsed_scenarios: dict  # ParsedLLDTests from Section 10.0
+    validation_result: dict  # TestValidationResult from mechanical validation
+    scaffold_attempts: int  # Number of scaffold regeneration attempts

--- a/tests/unit/test_scaffold_tests.py
+++ b/tests/unit/test_scaffold_tests.py
@@ -1,0 +1,437 @@
+"""Tests for Issue #335: Scaffold real tests from LLD Section 10.0.
+
+Real TDD tests - NOT stubs. Tests the scaffold improvements to generate
+actual executable tests instead of `assert False` placeholders.
+"""
+
+import pytest
+from pathlib import Path
+
+
+# =============================================================================
+# Test: parse_lld_test_section()
+# =============================================================================
+
+
+class TestParseLLDTestSection:
+    """Tests for extracting test scenarios from LLD Section 10.0."""
+
+    def test_parse_basic_test_table(self):
+        """Extract scenarios from valid Section 10.0 table."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            parse_lld_test_section,
+        )
+
+        lld_content = """
+## 10. Verification & Testing
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+| Test ID | Test Description | Expected Behavior | Req ID | Status |
+|---------|------------------|-------------------|--------|--------|
+| T010 | test_add_numbers | Returns sum of two numbers | R010 | RED |
+| T020 | test_subtract_numbers | Returns difference of two numbers | R020 | RED |
+"""
+
+        result = parse_lld_test_section(lld_content)
+
+        assert len(result["scenarios"]) == 2
+        assert result["scenarios"][0]["test_id"] == "T010"
+        assert result["scenarios"][0]["test_name"] == "test_add_numbers"
+        assert "sum" in result["scenarios"][0]["expected_behavior"].lower()
+
+    def test_parse_missing_section_10(self):
+        """Returns empty list for LLD without Section 10.0."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            parse_lld_test_section,
+        )
+
+        lld_content = """
+## 1. Context & Goal
+
+Some content without a test section.
+
+## 2. Proposed Changes
+
+More content.
+"""
+
+        result = parse_lld_test_section(lld_content)
+
+        assert result["scenarios"] == []
+
+    def test_parse_extracts_input_output(self):
+        """Extracts input/output patterns from description."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            parse_lld_test_section,
+        )
+
+        lld_content = """
+### 10.0 Test Plan
+
+| Test ID | Test Description | Expected Behavior | Req ID | Status |
+|---------|------------------|-------------------|--------|--------|
+| T010 | test_normalize_type | "Add (Directory)" -> ("add", True) | R010 | RED |
+"""
+
+        result = parse_lld_test_section(lld_content)
+
+        scenario = result["scenarios"][0]
+        # Should extract the input/output pattern
+        assert "Add (Directory)" in scenario.get("expected_behavior", "")
+
+
+# =============================================================================
+# Test: infer_module_path()
+# =============================================================================
+
+
+class TestInferModulePath:
+    """Tests for determining target module from LLD Section 2.1."""
+
+    def test_infer_from_section_2_1(self):
+        """Extracts module from Section 2.1 Files Changed."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            infer_module_path,
+        )
+
+        lld_content = """
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `agentos/workflows/testing/nodes/scaffold_tests.py` | Modify | Fix scaffold |
+| `tests/unit/test_scaffold.py` | Add | Unit tests |
+"""
+
+        result = infer_module_path(lld_content)
+
+        # Should return the non-test Python module
+        assert result == "agentos.workflows.testing.nodes.scaffold_tests"
+
+    def test_infer_skips_test_files(self):
+        """Skips test files when inferring module."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            infer_module_path,
+        )
+
+        lld_content = """
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/test_foo.py` | Add | Tests |
+| `agentos/foo.py` | Add | Implementation |
+"""
+
+        result = infer_module_path(lld_content)
+
+        # Should return foo.py, not test_foo.py
+        assert "test" not in result.lower()
+        assert "agentos.foo" == result
+
+
+# =============================================================================
+# Test: generate_test_code()
+# =============================================================================
+
+
+class TestGenerateTestCode:
+    """Tests for generating real pytest code."""
+
+    def test_generates_real_assertion(self):
+        """Generated test has real assertion, not assert False."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            generate_test_code,
+        )
+
+        scenarios = {
+            "module_path": "agentos.mymodule",
+            "scenarios": [
+                {
+                    "test_id": "T010",
+                    "test_name": "test_add_numbers",
+                    "expected_behavior": "add(2, 3) returns 5",
+                    "requirement_id": "R010",
+                }
+            ],
+            "imports_needed": ["add"],
+        }
+
+        code = generate_test_code(scenarios)
+
+        # Should NOT contain stub patterns
+        assert "assert False" not in code
+        # Should have a real assertion
+        assert "assert" in code
+        # Should reference the function
+        assert "add" in code
+
+    def test_includes_proper_imports(self):
+        """Generated test imports target module."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            generate_test_code,
+        )
+
+        scenarios = {
+            "module_path": "agentos.workflows.testing.nodes.scaffold_tests",
+            "scenarios": [
+                {
+                    "test_id": "T010",
+                    "test_name": "test_scaffold",
+                    "expected_behavior": "scaffold_tests returns dict",
+                    "requirement_id": "R010",
+                }
+            ],
+            "imports_needed": ["scaffold_tests"],
+        }
+
+        code = generate_test_code(scenarios)
+
+        assert "from agentos.workflows.testing.nodes.scaffold_tests import" in code
+
+    def test_includes_requirement_docstring(self):
+        """Generated test has requirement ID in docstring."""
+        from agentos.workflows.testing.nodes.scaffold_tests import (
+            generate_test_code,
+        )
+
+        scenarios = {
+            "module_path": "mymodule",
+            "scenarios": [
+                {
+                    "test_id": "T010",
+                    "test_name": "test_foo",
+                    "expected_behavior": "foo() returns bar",
+                    "requirement_id": "R010",
+                }
+            ],
+            "imports_needed": [],
+        }
+
+        code = generate_test_code(scenarios)
+
+        assert "R010" in code
+
+
+# =============================================================================
+# Test: detect_stub_patterns() - Validation
+# =============================================================================
+
+
+class TestDetectStubPatterns:
+    """Tests for detecting stub test patterns."""
+
+    def test_detects_assert_false(self):
+        """Detects `assert False` pattern."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            detect_stub_patterns,
+        )
+
+        test_content = '''
+def test_example():
+    assert False, "stub"
+'''
+
+        errors = detect_stub_patterns(test_content)
+
+        assert len(errors) > 0
+        assert any("assert False" in e.lower() or "stub" in e.lower() for e in errors)
+
+    def test_detects_tdd_red_message(self):
+        """Detects 'TDD RED' in assertion message."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            detect_stub_patterns,
+        )
+
+        test_content = '''
+def test_example():
+    assert False, "TDD RED: not implemented"
+'''
+
+        errors = detect_stub_patterns(test_content)
+
+        assert len(errors) > 0
+
+    def test_no_error_for_real_assertion(self):
+        """No error for tests with real assertions."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            detect_stub_patterns,
+        )
+
+        test_content = '''
+def test_example():
+    result = add(2, 3)
+    assert result == 5
+'''
+
+        errors = detect_stub_patterns(test_content)
+
+        assert len(errors) == 0
+
+
+# =============================================================================
+# Test: validate_test_structure() - AST Validation
+# =============================================================================
+
+
+class TestValidateTestStructure:
+    """Tests for AST-based test validation."""
+
+    def test_rejects_missing_imports(self):
+        """Rejects tests without proper imports."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_test_structure,
+        )
+
+        # Test with no imports at all
+        test_content = '''
+def test_example():
+    result = mysterious_function()
+    assert result == 42
+'''
+
+        scenarios = [{"test_id": "T010", "test_name": "test_example"}]
+        errors = validate_test_structure(test_content, scenarios)
+
+        # Should warn about missing imports for the function being tested
+        assert len(errors) > 0
+
+    def test_rejects_no_real_assertion(self):
+        """Rejects tests with only pass statement."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_test_structure,
+        )
+
+        test_content = '''
+import pytest
+
+def test_example():
+    pass
+'''
+
+        scenarios = [{"test_id": "T010", "test_name": "test_example"}]
+        errors = validate_test_structure(test_content, scenarios)
+
+        assert len(errors) > 0
+        assert any("assertion" in e.lower() for e in errors)
+
+    def test_accepts_valid_test(self):
+        """Accepts test with import and real assertion."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_test_structure,
+        )
+
+        test_content = '''
+import pytest
+from mymodule import add
+
+def test_add():
+    result = add(2, 3)
+    assert result == 5
+'''
+
+        scenarios = [{"test_id": "T010", "test_name": "test_add"}]
+        errors = validate_test_structure(test_content, scenarios)
+
+        assert len(errors) == 0
+
+
+# =============================================================================
+# Test: validate_scenario_coverage()
+# =============================================================================
+
+
+class TestValidateScenarioCoverage:
+    """Tests for verifying all scenarios have test functions."""
+
+    def test_all_scenarios_covered(self):
+        """Passes when all scenarios have tests."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_scenario_coverage,
+        )
+
+        test_content = '''
+def test_add():
+    pass
+
+def test_subtract():
+    pass
+'''
+
+        scenarios = [
+            {"test_id": "T010", "test_name": "test_add"},
+            {"test_id": "T020", "test_name": "test_subtract"},
+        ]
+        errors = validate_scenario_coverage(test_content, scenarios)
+
+        assert len(errors) == 0
+
+    def test_missing_scenario(self):
+        """Fails when scenario is missing test function."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_scenario_coverage,
+        )
+
+        test_content = '''
+def test_add():
+    pass
+'''
+
+        scenarios = [
+            {"test_id": "T010", "test_name": "test_add"},
+            {"test_id": "T020", "test_name": "test_subtract"},  # Missing!
+        ]
+        errors = validate_scenario_coverage(test_content, scenarios)
+
+        assert len(errors) > 0
+        assert any("T020" in e or "test_subtract" in e for e in errors)
+
+
+# =============================================================================
+# Test: Integration - scaffold_tests_node
+# =============================================================================
+
+
+class TestScaffoldIntegration:
+    """Integration tests for the full scaffold node."""
+
+    def test_scaffold_produces_runnable_tests(self, tmp_path):
+        """Full scaffold produces syntactically valid Python."""
+        from agentos.workflows.testing.nodes.scaffold_tests import scaffold_tests
+        import ast
+
+        # Create minimal state with test scenarios
+        state = {
+            "issue_number": 999,
+            "test_scenarios": [
+                {
+                    "name": "test_example",
+                    "description": "Example test",
+                    "requirement_ref": "R001",
+                    "test_type": "unit",
+                    "mock_needed": False,
+                    "assertions": ["result equals expected"],
+                }
+            ],
+            "files_to_modify": [
+                {"path": "mymodule.py", "change_type": "Add"}
+            ],
+            "repo_root": str(tmp_path),
+            "audit_dir": str(tmp_path / "audit"),
+        }
+        (tmp_path / "audit").mkdir()
+
+        result = scaffold_tests(state)
+
+        # Should produce test file
+        assert result.get("test_files")
+        test_file = Path(result["test_files"][0])
+        assert test_file.exists()
+
+        # Content should be valid Python
+        content = test_file.read_text()
+        try:
+            ast.parse(content)
+        except SyntaxError as e:
+            pytest.fail(f"Generated test is not valid Python: {e}")

--- a/tests/unit/test_validate_tests_mechanical.py
+++ b/tests/unit/test_validate_tests_mechanical.py
@@ -1,0 +1,217 @@
+"""Tests for Issue #335: Mechanical validation of generated tests.
+
+Real TDD tests - NOT stubs. Tests the validation node that catches
+stub tests and other structural issues before the green phase.
+"""
+
+import pytest
+
+
+# =============================================================================
+# Test: validate_tests_mechanical_node()
+# =============================================================================
+
+
+class TestValidateMechanicalNode:
+    """Tests for the validation LangGraph node."""
+
+    def test_node_returns_valid_for_good_tests(self):
+        """Validation node passes for well-structured tests."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_tests_mechanical_node,
+        )
+
+        state = {
+            "generated_tests": '''
+import pytest
+from mymodule import add
+
+def test_add():
+    """Test addition. Requirement: R010"""
+    result = add(2, 3)
+    assert result == 5
+''',
+            "parsed_scenarios": {
+                "scenarios": [
+                    {"test_id": "T010", "test_name": "test_add"}
+                ]
+            },
+            "scaffold_attempts": 0,
+        }
+
+        result = validate_tests_mechanical_node(state)
+
+        assert result.get("validation_result", {}).get("is_valid", False) is True
+
+    def test_node_returns_invalid_for_stubs(self):
+        """Validation node fails for stub tests."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_tests_mechanical_node,
+        )
+
+        state = {
+            "generated_tests": '''
+import pytest
+
+def test_example():
+    assert False, "TDD RED: not implemented"
+''',
+            "parsed_scenarios": {
+                "scenarios": [
+                    {"test_id": "T010", "test_name": "test_example"}
+                ]
+            },
+            "scaffold_attempts": 0,
+        }
+
+        result = validate_tests_mechanical_node(state)
+
+        validation = result.get("validation_result", {})
+        assert validation.get("is_valid") is False
+        assert validation.get("stub_count", 0) > 0
+
+    def test_node_increments_attempts(self):
+        """Validation node increments scaffold_attempts on failure."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            validate_tests_mechanical_node,
+        )
+
+        state = {
+            "generated_tests": '''
+def test_example():
+    assert False, "stub"
+''',
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 1,
+        }
+
+        result = validate_tests_mechanical_node(state)
+
+        assert result.get("scaffold_attempts", 0) == 2
+
+
+# =============================================================================
+# Test: Graph routing - should_regenerate()
+# =============================================================================
+
+
+class TestShouldRegenerate:
+    """Tests for conditional edge routing."""
+
+    def test_regenerate_on_validation_failure(self):
+        """Routes to regenerate when validation fails and attempts < 3."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            should_regenerate,
+        )
+
+        state = {
+            "validation_result": {
+                "is_valid": False,
+                "errors": ["Stub detected"],
+            },
+            "scaffold_attempts": 1,
+        }
+
+        result = should_regenerate(state)
+
+        assert result == "regenerate"
+
+    def test_continue_on_validation_success(self):
+        """Routes to continue when validation passes."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            should_regenerate,
+        )
+
+        state = {
+            "validation_result": {
+                "is_valid": True,
+                "errors": [],
+            },
+            "scaffold_attempts": 1,
+        }
+
+        result = should_regenerate(state)
+
+        assert result == "continue"
+
+    def test_escalate_after_max_attempts(self):
+        """Routes to escalate after 3 failed attempts."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            should_regenerate,
+        )
+
+        state = {
+            "validation_result": {
+                "is_valid": False,
+                "errors": ["Still failing"],
+            },
+            "scaffold_attempts": 3,
+        }
+
+        result = should_regenerate(state)
+
+        assert result == "escalate"
+
+
+# =============================================================================
+# Test: Full validation flow
+# =============================================================================
+
+
+class TestValidationFlow:
+    """Integration tests for the validation flow."""
+
+    def test_validation_catches_common_stub_patterns(self):
+        """Validates all common stub patterns are detected."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            detect_stub_patterns,
+        )
+
+        stub_examples = [
+            'assert False, "TDD: Implementation pending"',
+            'assert False, "TDD RED: not implemented"',
+            "assert False  # TODO: Implement",
+            'raise NotImplementedError("Test not implemented")',
+            "pass  # stub",
+        ]
+
+        for stub in stub_examples:
+            test_content = f'''
+def test_example():
+    {stub}
+'''
+            errors = detect_stub_patterns(test_content)
+            assert len(errors) > 0, f"Should detect stub pattern: {stub}"
+
+    def test_validation_accepts_various_assertion_styles(self):
+        """Accepts different valid assertion styles."""
+        from agentos.workflows.testing.nodes.validate_tests_mechanical import (
+            detect_stub_patterns,
+            validate_test_structure,
+        )
+
+        valid_tests = [
+            '''
+def test_equality():
+    assert result == 5
+''',
+            '''
+def test_truth():
+    assert is_valid
+''',
+            '''
+def test_in():
+    assert "foo" in result
+''',
+            '''
+def test_raises():
+    with pytest.raises(ValueError):
+        bad_function()
+''',
+        ]
+
+        for test_content in valid_tests:
+            # Add import for completeness
+            full_content = "import pytest\n" + test_content
+            errors = detect_stub_patterns(full_content)
+            assert len(errors) == 0, f"Should accept: {test_content[:50]}..."


### PR DESCRIPTION
## Summary

- Fix scaffold node to generate real executable tests from LLD Section 10.0 instead of stubs
- Add mechanical validation node (N2.5) between scaffold and verify_red
- Validation detects stub patterns and routes back for regeneration (max 3 attempts)

## Root Cause

Scaffold generated tests with `assert False, "TDD RED: ..."` which:
1. Always fail regardless of implementation
2. Cause infinite TDD workflow loops
3. Were never fixable by the implement_code node

## Implementation

### scaffold_tests.py
- `parse_lld_test_section()` - Extract scenarios from Section 10.0 table
- `infer_module_path()` - Get module from Section 2.1 (fixed "testing" vs "test" detection)
- `generate_test_code()` - Generate real assertions from expected behavior
- `_generate_assertion_from_expected()` - Parse "input -> output" patterns

### validate_tests_mechanical.py (NEW)
- `detect_stub_patterns()` - Catch `assert False`, "TDD RED", NotImplementedError
- `validate_test_structure()` - AST validation for imports and assertions
- `validate_scenario_coverage()` - Ensure all scenarios have test functions
- `validate_tests_mechanical_node()` - LangGraph node
- `should_regenerate()` - Routing: pass -> N3, fail -> N2 (retry), 3 fails -> N4 (escalate)

### graph.py
- Added N2_5_validate_tests node between N2 (scaffold) and N3 (verify_red)
- Routing allows regeneration loop with max 3 attempts before escalation

## Test plan

- [x] 25 unit tests covering parsing, generation, and validation
- [x] `poetry run pytest tests/unit/test_scaffold_tests.py tests/unit/test_validate_tests_mechanical.py -v` - all pass
- [x] Graph compiles successfully with new node
- [x] Full test suite: 1502 passed (excluding 1 pre-existing failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)