### PR TITLE
fix: always return lineage_path from check_existing_lld (#341)

### DIFF
--- a/agentos/workflows/requirements/audit.py
+++ b/agentos/workflows/requirements/audit.py
@@ -670,12 +670,17 @@ def generate_slug(brief_file: str) -> str:
 
 
 class ExistingLLDInfo(TypedDict):
-    """Information about existing LLD and lineage for an issue."""
+    """Information about existing LLD and lineage for an issue.
+
+    Note: lineage_path is always returned (even if directory doesn't exist yet)
+    so that validation can create it to save error files. Use lineage_exists
+    to check if the directory already exists.
+    """
 
     lld_exists: bool
     lineage_exists: bool
     lld_path: Path | None
-    lineage_path: Path | None
+    lineage_path: Path  # Always returned - Issue #341
 
 
 def check_existing_lld(issue_number: int, target_repo: Path) -> ExistingLLDInfo:
@@ -699,7 +704,9 @@ def check_existing_lld(issue_number: int, target_repo: Path) -> ExistingLLDInfo:
         "lld_exists": lld_path.exists(),
         "lineage_exists": lineage_path.exists(),
         "lld_path": lld_path if lld_path.exists() else None,
-        "lineage_path": lineage_path if lineage_path.exists() else None,
+        # Issue #341: Always return lineage_path so validation can create
+        # the directory and save error files for new LLDs
+        "lineage_path": lineage_path,
     }
 
 

--- a/tests/unit/test_requirements_audit.py
+++ b/tests/unit/test_requirements_audit.py
@@ -795,15 +795,21 @@ class TestCheckExistingLLD:
     """Tests for check_existing_lld function."""
 
     def test_returns_false_when_nothing_exists(self, tmp_path):
-        """Test returns all false when no LLD or lineage exists."""
-        from agentos.workflows.requirements.audit import check_existing_lld
+        """Test returns all false when no LLD or lineage exists.
+
+        Issue #341: lineage_path is always returned (even when dir doesn't exist)
+        so validation can create it to save error files.
+        """
+        from agentos.workflows.requirements.audit import check_existing_lld, AUDIT_ACTIVE_DIR
 
         result = check_existing_lld(42, tmp_path)
 
         assert result["lld_exists"] is False
         assert result["lineage_exists"] is False
         assert result["lld_path"] is None
-        assert result["lineage_path"] is None
+        # Issue #341: lineage_path always returned, even if doesn't exist yet
+        expected_lineage = tmp_path / AUDIT_ACTIVE_DIR / "42-lld"
+        assert result["lineage_path"] == expected_lineage
 
     def test_detects_existing_lld_file(self, tmp_path):
         """Test detects existing LLD file."""


### PR DESCRIPTION
## Summary

- Always return `lineage_path` from `check_existing_lld()` even when the directory doesn't exist yet
- This allows validation to create the directory and save error files for new LLDs
- The `lineage_exists` boolean still indicates whether the directory already exists

## Problem

For new LLDs, validation errors weren't being saved to the lineage folder because:
1. `check_existing_lld()` returned `None` for `lineage_path` when folder didn't exist
2. Validation checked `if lineage_path:` before saving errors
3. Since `lineage_path` was `None`, no error files were created

## Solution

Always return the expected `lineage_path` from `check_existing_lld()`. The `save_validation_errors_to_lineage()` function already handles directory creation with `mkdir(parents=True, exist_ok=True)`.

## Test plan

- [x] Updated test `test_returns_false_when_nothing_exists` to expect `lineage_path` always returned
- [x] All 136 audit and validation tests pass
- [x] No breaking changes - consumers already check `lineage_exists` bool before accessing path

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)