### PR TITLE
chore: dependency audit and pytest fixes

### DIFF
--- a/assemblyzero/workflows/testing/audit.py
+++ b/assemblyzero/workflows/testing/audit.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestReportMetadata(TypedDict):
+    __test__ = False
     """Schema for test-report.json metadata file."""
 
     issue_number: int

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -24,6 +24,7 @@ class HumanDecision(str, Enum):
 
 
 class TestScenario(TypedDict):
+    __test__ = False
     """A single test scenario extracted from the LLD."""
 
     name: str  # Test name (e.g., "test_login_success")
@@ -35,6 +36,7 @@ class TestScenario(TypedDict):
 
 
 class TestingWorkflowState(TypedDict, total=False):
+    __test__ = False
     """State for the TDD testing workflow.
 
     Attributes:

--- a/poetry.lock
+++ b/poetry.lock
@@ -655,14 +655,14 @@ httplib2 = ">=0.19.0,<1.0.0"
 
 [[package]]
 name = "google-genai"
-version = "1.60.0"
+version = "1.62.0"
 description = "GenAI Python SDK"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "google_genai-1.60.0-py3-none-any.whl", hash = "sha256:967338378ffecebec19a8ed90cf8797b26818bacbefd7846a9280beb1099f7f3"},
-    {file = "google_genai-1.60.0.tar.gz", hash = "sha256:9768061775fddfaecfefb0d6d7a6cabefb3952ebd246cd5f65247151c07d33d1"},
+    {file = "google_genai-1.62.0-py3-none-any.whl", hash = "sha256:4c3daeff3d05fafee4b9a1a31f9c07f01bc22051081aa58b4d61f58d16d1bcc0"},
+    {file = "google_genai-1.62.0.tar.gz", hash = "sha256:709468a14c739a080bc240a4f3191df597bf64485b1ca3728e0fb67517774c18"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Updates google-genai to 1.62.0 and silences pytest collection warnings for TypedDicts.