### PR TITLE
fix: auto-detect audit numbering prefix for cross-project support (#407)

### DIFF
--- a/tests/unit/test_audit_schedule_check.py
+++ b/tests/unit/test_audit_schedule_check.py
@@ -1,0 +1,343 @@
+"""Tests for tools/audit_schedule_check.py — audit schedule compliance checker."""
+
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from tools.audit_schedule_check import (
+    check_audit_schedule,
+    detect_audit_index,
+    get_latest_audit_date,
+    parse_frequency_matrix,
+    to_project_number,
+)
+
+
+# --- detect_audit_index ---
+
+
+def test_detect_index_assemblyzero(tmp_path):
+    """AssemblyZero uses 0800 numbering."""
+    audits = tmp_path / "audits"
+    audits.mkdir()
+    (audits / "0800-audit-index.md").write_text("# Index")
+
+    path, base, pad = detect_audit_index(tmp_path)
+    assert path is not None
+    assert base == 800
+    assert pad == 4
+
+
+def test_detect_index_aletheia(tmp_path):
+    """Aletheia uses 10800 numbering."""
+    audits = tmp_path / "audits"
+    audits.mkdir()
+    (audits / "10800-audit-index.md").write_text("# Index")
+
+    path, base, pad = detect_audit_index(tmp_path)
+    assert path is not None
+    assert base == 10800
+    assert pad == 5
+
+
+def test_detect_index_no_audits_dir(tmp_path):
+    """Returns None when docs/audits/ doesn't exist."""
+    path, base, pad = detect_audit_index(tmp_path)
+    assert path is None
+    assert base is None
+    assert pad is None
+
+
+def test_detect_index_no_index_file(tmp_path):
+    """Returns None when no audit-index.md is found."""
+    audits = tmp_path / "audits"
+    audits.mkdir()
+    (audits / "0809-some-audit.md").write_text("not an index")
+
+    path, base, pad = detect_audit_index(tmp_path)
+    assert path is None
+
+
+# --- parse_frequency_matrix ---
+
+
+SAMPLE_INDEX = textwrap.dedent("""\
+    # Audit Index
+
+    ## 5. Frequency Matrix
+
+    ### 5.1 By Frequency
+
+    | Frequency | Audits |
+    |-----------|--------|
+    | **Per PR** | 0813 |
+    | **Weekly** | 0816, 0828 |
+    | **Monthly + on change** | 0811, 0817 |
+    | **Monthly** | 0815, 0821 |
+    | **Quarterly** | 0809, 0810, 0899 |
+    | **On Event** | 0823, 0824 |
+    | **Ultimate** | 0801, 0802 |
+
+    ### 5.2 Calendar View
+""")
+
+
+def test_parse_frequency_matrix():
+    """Parses weekly, monthly, quarterly; skips per-pr, on-event, ultimate."""
+    result = parse_frequency_matrix(SAMPLE_INDEX)
+
+    assert result["0816"] == "weekly"
+    assert result["0828"] == "weekly"
+    assert result["0811"] == "monthly"
+    assert result["0817"] == "monthly"
+    assert result["0815"] == "monthly"
+    assert result["0821"] == "monthly"
+    assert result["0809"] == "quarterly"
+    assert result["0810"] == "quarterly"
+    assert result["0899"] == "quarterly"
+
+    # Skipped categories
+    assert "0813" not in result  # per pr
+    assert "0823" not in result  # on event
+    assert "0801" not in result  # ultimate
+
+
+def test_parse_frequency_matrix_empty():
+    """Returns empty dict when no frequency section found."""
+    result = parse_frequency_matrix("# No frequency section here")
+    assert result == {}
+
+
+def test_parse_frequency_matrix_starred_audits():
+    """Handles asterisk-suffixed audit numbers (under development)."""
+    content = textwrap.dedent("""\
+        ### 5.1 By Frequency
+
+        | Frequency | Audits |
+        |-----------|--------|
+        | **Weekly** | 0816, 0841*, 0842* |
+    """)
+    result = parse_frequency_matrix(content)
+    assert result["0816"] == "weekly"
+    assert result["0841"] == "weekly"
+    assert result["0842"] == "weekly"
+
+
+# --- to_project_number ---
+
+
+def test_to_project_number_assemblyzero():
+    """AssemblyZero: 0809 stays 0809."""
+    assert to_project_number("0809", 800, 4) == "0809"
+    assert to_project_number("0816", 800, 4) == "0816"
+    assert to_project_number("0899", 800, 4) == "0899"
+
+
+def test_to_project_number_aletheia():
+    """Aletheia: 0809 becomes 10809."""
+    assert to_project_number("0809", 10800, 5) == "10809"
+    assert to_project_number("0816", 10800, 5) == "10816"
+    assert to_project_number("0899", 10800, 5) == "10899"
+
+
+# --- get_latest_audit_date ---
+
+
+def test_get_latest_audit_date():
+    """Extracts most recent date from audit record table."""
+    content = textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings Summary | Issues Created |
+        |------|---------|------------------|----------------|
+        | 2026-01-10 | Claude | PASS | None |
+        | 2026-02-15 | Claude | PASS | None |
+        | 2026-01-25 | Claude | PASS | None |
+    """)
+    result = get_latest_audit_date(content)
+    assert result == datetime(2026, 2, 15)
+
+
+def test_get_latest_audit_date_no_section():
+    """Returns None when no Audit Record section exists."""
+    assert get_latest_audit_date("# Some other content") is None
+
+
+def test_get_latest_audit_date_empty_table():
+    """Returns None when Audit Record has no data rows."""
+    content = textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings Summary |
+        |------|---------|------------------|
+    """)
+    assert get_latest_audit_date(content) is None
+
+
+# --- check_audit_schedule ---
+
+
+def test_check_ok(tmp_path):
+    """Audit run recently is OK."""
+    audit_file = tmp_path / "0809-audit.md"
+    audit_file.write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-18 | Claude | PASS |
+    """))
+    result = check_audit_schedule("0809", "quarterly", audit_file, datetime(2026, 2, 20))
+    assert result["status"] == "ok"
+    assert result["days_since"] == 2
+
+
+def test_check_warn(tmp_path):
+    """Audit approaching deadline gets a warning."""
+    audit_file = tmp_path / "0816-audit.md"
+    audit_file.write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-14 | Claude | PASS |
+    """))
+    # 6 days ago for a weekly audit (warn threshold = 5)
+    result = check_audit_schedule("0816", "weekly", audit_file, datetime(2026, 2, 20))
+    assert result["status"] == "warn"
+
+
+def test_check_block(tmp_path):
+    """Overdue audit blocks."""
+    audit_file = tmp_path / "0816-audit.md"
+    audit_file.write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-01 | Claude | PASS |
+    """))
+    # 19 days ago for weekly (block threshold = 7)
+    result = check_audit_schedule("0816", "weekly", audit_file, datetime(2026, 2, 20))
+    assert result["status"] == "block"
+
+
+def test_check_no_audit_record(tmp_path):
+    """New audit with no record gets a warning, not a block."""
+    audit_file = tmp_path / "0809-audit.md"
+    audit_file.write_text("# New Audit\n\nNo record yet.\n")
+    result = check_audit_schedule("0809", "quarterly", audit_file, datetime(2026, 2, 20))
+    assert result["status"] == "warn"
+    assert "new audit" in result["reason"]
+
+
+def test_check_unreadable_file(tmp_path):
+    """Missing file returns block status."""
+    missing = tmp_path / "does-not-exist.md"
+    result = check_audit_schedule("0809", "quarterly", missing, datetime(2026, 2, 20))
+    assert result["status"] == "block"
+    assert "cannot read" in result["reason"]
+
+
+# --- Integration: end-to-end with project detection ---
+
+
+def test_end_to_end_assemblyzero_numbering(tmp_path):
+    """Full flow with AssemblyZero 0xxx numbering."""
+    audits = tmp_path / "audits"
+    audits.mkdir()
+
+    # Create index with frequency matrix
+    (audits / "0800-audit-index.md").write_text(textwrap.dedent("""\
+        # Audit Index
+
+        ### 5.1 By Frequency
+
+        | Frequency | Audits |
+        |-----------|--------|
+        | **Weekly** | 0816 |
+    """))
+
+    # Create the audit file with a recent date
+    (audits / "0816-audit-permissiveness.md").write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-19 | Claude | PASS |
+    """))
+
+    path, base, pad = detect_audit_index(tmp_path)
+    assert base == 800
+
+    content = path.read_text()
+    freq_map = parse_frequency_matrix(content)
+    assert freq_map == {"0816": "weekly"}
+
+    project_num = to_project_number("0816", base, pad)
+    assert project_num == "0816"
+
+    matches = list(audits.glob(f"{project_num}-*.md"))
+    assert len(matches) == 1
+
+
+def test_end_to_end_aletheia_numbering(tmp_path):
+    """Full flow with Aletheia 10xxx numbering."""
+    audits = tmp_path / "audits"
+    audits.mkdir()
+
+    # Create index with frequency matrix
+    (audits / "10800-audit-index.md").write_text(textwrap.dedent("""\
+        # Audit Index
+
+        ### 5.1 By Frequency
+
+        | Frequency | Audits |
+        |-----------|--------|
+        | **Weekly** | 0816 |
+        | **Quarterly** | 0809, 0899 |
+    """))
+
+    # Create audit files with Aletheia numbering
+    (audits / "10816-audit-dependabot-prs.md").write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-19 | Claude | PASS |
+    """))
+    (audits / "10809-audit-security.md").write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-01-10 | Claude | PASS |
+    """))
+    (audits / "10899-meta-audit.md").write_text(textwrap.dedent("""\
+        ## 7. Audit Record
+
+        | Date | Auditor | Findings |
+        |------|---------|----------|
+        | 2026-02-01 | Claude | PASS |
+    """))
+
+    path, base, pad = detect_audit_index(tmp_path)
+    assert base == 10800
+    assert pad == 5
+
+    content = path.read_text()
+    freq_map = parse_frequency_matrix(content)
+    assert freq_map == {"0816": "weekly", "0809": "quarterly", "0899": "quarterly"}
+
+    # Verify number conversion
+    assert to_project_number("0816", base, pad) == "10816"
+    assert to_project_number("0809", base, pad) == "10809"
+    assert to_project_number("0899", base, pad) == "10899"
+
+    # All files found with project-specific numbering
+    for base_num in freq_map:
+        project_num = to_project_number(base_num, base, pad)
+        matches = list(audits.glob(f"{project_num}-*.md"))
+        assert len(matches) == 1, f"No file found for {project_num} (base: {base_num})"

--- a/tools/audit_schedule_check.py
+++ b/tools/audit_schedule_check.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+tools/audit_schedule_check.py - Audit Schedule Compliance Check
+
+Enforces audit schedule from the project's audit index (Section 5.1):
+- Quarterly audits: Block if > 90 days overdue, warn at 67 days (75%)
+- Monthly audits: Block if > 30 days overdue, warn at 22 days (75%)
+- Weekly audits: Block if > 7 days overdue, warn at 5 days (75%)
+- Per PR / On Event / Ultimate: Skip (handled separately)
+
+Auto-detects project numbering prefix from the audit-index file,
+so it works for both AssemblyZero (0xxx) and Aletheia (10xxx).
+
+Reference: Issue #250, #407
+"""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Thresholds in days
+THRESHOLDS = {
+    "quarterly": {"block": 90, "warn": 67},  # 75% of 90
+    "monthly": {"block": 30, "warn": 22},    # ~75% of 30
+    "weekly": {"block": 7, "warn": 5},        # ~75% of 7
+}
+
+# Frequencies we enforce (everything else is skipped)
+ENFORCED_FREQUENCIES = {"weekly", "monthly", "quarterly"}
+
+
+def detect_audit_index(docs_dir: Path) -> tuple[Path | None, int | None, int | None]:
+    """
+    Find the audit index file and extract the base number.
+
+    Returns (index_path, index_base, pad_length) or (None, None, None).
+    Example: 0800-audit-index.md → (path, 800, 4)
+             10800-audit-index.md → (path, 10800, 5)
+    """
+    audits_dir = docs_dir / "audits"
+    if not audits_dir.exists():
+        return None, None, None
+
+    index_files = list(audits_dir.glob("*audit-index.md"))
+    if not index_files:
+        return None, None, None
+
+    index_path = index_files[0]
+    match = re.match(r"(\d+)-audit-index", index_path.stem)
+    if not match:
+        return None, None, None
+
+    num_str = match.group(1)
+    return index_path, int(num_str), len(num_str)
+
+
+def parse_frequency_matrix(content: str) -> dict[str, str]:
+    """
+    Parse Section 5.1 "By Frequency" table from the audit index.
+
+    Expected format:
+    | Frequency | Audits |
+    |-----------|--------|
+    | **Weekly** | 0816, 0828, 0834 |
+    | **Monthly** | 0804, 0809, ... |
+
+    Returns dict mapping base audit number (str) to normalized frequency.
+    Example: {"0816": "weekly", "0809": "monthly", ...}
+    """
+    result = {}
+
+    # Find Section 5.1 content
+    section_match = re.search(r"### 5\.1\s+By Frequency", content)
+    if not section_match:
+        # Try without subsection numbering
+        section_match = re.search(r"## 5\.\s*Frequency", content)
+    if not section_match:
+        return result
+
+    section_content = content[section_match.end():]
+
+    # Stop at next section
+    next_section = re.search(r"\n##[# ]", section_content)
+    if next_section:
+        section_content = section_content[:next_section.start()]
+
+    # Parse table rows: | **Frequency** | audit_list |
+    for line in section_content.split("\n"):
+        if not line.strip().startswith("|"):
+            continue
+        if re.match(r"\|\s*-+", line):
+            continue
+
+        # Extract frequency name and audit list
+        row_match = re.match(
+            r"\|\s*\*?\*?([^*|]+?)\*?\*?\s*\|\s*([^|]+)\|",
+            line,
+        )
+        if not row_match:
+            continue
+
+        freq_raw = row_match.group(1).strip().lower()
+        audits_raw = row_match.group(2).strip()
+
+        # Normalize frequency to our enforced categories
+        if "weekly" in freq_raw:
+            freq = "weekly"
+        elif "monthly" in freq_raw:
+            freq = "monthly"
+        elif "quarterly" in freq_raw:
+            freq = "quarterly"
+        else:
+            # Skip: per pr, continuous, on event, on demand, ultimate
+            continue
+
+        # Extract audit numbers (e.g., "0816, 0828*, 0834")
+        for num_match in re.finditer(r"(\d{3,5})\*?", audits_raw):
+            audit_num = num_match.group(1)
+            result[audit_num] = freq
+
+    return result
+
+
+def to_project_number(base_num: str, index_base: int, pad_len: int) -> str:
+    """
+    Convert a base audit number to a project-specific file number.
+
+    For AssemblyZero (index_base=800, pad=4):
+      0809 → offset 9 → 800+9=809 → "0809"
+    For Aletheia (index_base=10800, pad=5):
+      0809 → offset 9 → 10800+9=10809 → "10809"
+    """
+    # The base in the frequency table is always 08xx format
+    offset = int(base_num) - 800
+    return str(index_base + offset).zfill(pad_len)
+
+
+def get_latest_audit_date(content: str) -> datetime | None:
+    """
+    Extract the most recent audit date from the audit record table.
+
+    Expected format:
+    | Date | Auditor | Findings Summary | Issues Created |
+    |------|---------|------------------|----------------|
+    | 2026-01-10 | Claude Opus 4.5 | PASS: ... | None |
+    """
+    audit_record_match = re.search(r"## \d+\.\s*Audit Record", content)
+    if not audit_record_match:
+        return None
+
+    section_content = content[audit_record_match.end():]
+
+    next_section = re.search(r"\n## ", section_content)
+    if next_section:
+        section_content = section_content[:next_section.start()]
+
+    dates = []
+    in_table = False
+
+    for line in section_content.strip().split("\n"):
+        if not line.strip().startswith("|"):
+            continue
+
+        if re.match(r"\|\s*-+", line):
+            in_table = True
+            continue
+
+        if not in_table:
+            continue
+
+        cells = [c.strip() for c in line.split("|")]
+        cells = [c for c in cells if c]
+
+        if len(cells) >= 1:
+            try:
+                date = datetime.strptime(cells[0], "%Y-%m-%d")
+                dates.append(date)
+            except ValueError:
+                continue
+
+    return max(dates) if dates else None
+
+
+def check_audit_schedule(
+    project_num: str,
+    frequency: str,
+    file_path: Path,
+    today: datetime,
+) -> dict:
+    """
+    Check if an audit is overdue.
+
+    Returns dict with:
+    - status: "ok", "warn", "block"
+    - days_since: days since last audit
+    - threshold: applicable threshold
+    - frequency: weekly/monthly/quarterly
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception:
+        return {"status": "block", "reason": "cannot read file"}
+
+    last_audit = get_latest_audit_date(content)
+    if not last_audit:
+        return {
+            "status": "warn",
+            "reason": "new audit - needs initial execution",
+            "frequency": frequency,
+            "days_since": None,
+        }
+
+    days_since = (today - last_audit).days
+    thresholds = THRESHOLDS[frequency]
+
+    if days_since > thresholds["block"]:
+        return {
+            "status": "block",
+            "days_since": days_since,
+            "threshold": thresholds["block"],
+            "frequency": frequency,
+            "last_audit": last_audit.strftime("%Y-%m-%d"),
+        }
+    elif days_since > thresholds["warn"]:
+        return {
+            "status": "warn",
+            "days_since": days_since,
+            "threshold": thresholds["block"],
+            "frequency": frequency,
+            "last_audit": last_audit.strftime("%Y-%m-%d"),
+        }
+    else:
+        return {
+            "status": "ok",
+            "days_since": days_since,
+            "frequency": frequency,
+            "last_audit": last_audit.strftime("%Y-%m-%d"),
+        }
+
+
+def main() -> int:
+    """Run audit schedule compliance check."""
+    print("=== Audit Schedule Compliance Check ===")
+
+    docs_dir = Path("docs")
+    if not docs_dir.exists():
+        print("  No docs/ directory found, skipping...")
+        return 0
+
+    # Auto-detect project numbering
+    index_path, index_base, pad_len = detect_audit_index(docs_dir)
+    if not index_path or index_base is None or pad_len is None:
+        print("  No audit index file found, skipping...")
+        return 0
+
+    print(f"  Index: {index_path.name} (base: {index_base})")
+
+    # Parse frequency mapping from the index
+    content = index_path.read_text(encoding="utf-8")
+    freq_map = parse_frequency_matrix(content)
+
+    if not freq_map:
+        print("  No frequency matrix found in index (Section 5.1), skipping...")
+        return 0
+
+    print(f"  Scheduled audits: {len(freq_map)}")
+
+    today = datetime.now()
+    blocks = []
+    warns = []
+    oks = []
+
+    audits_dir = docs_dir / "audits"
+
+    for base_num, frequency in sorted(freq_map.items()):
+        project_num = to_project_number(base_num, index_base, pad_len)
+
+        # Find the audit file
+        pattern = f"{project_num}-audit-*.md"
+        matches = list(audits_dir.glob(pattern))
+
+        if not matches:
+            # Try alternate patterns (e.g., horizon scanning, meta-audit)
+            alt_pattern = f"{project_num}-*.md"
+            matches = list(audits_dir.glob(alt_pattern))
+
+        if not matches:
+            blocks.append({
+                "audit": project_num,
+                "base": base_num,
+                "status": "block",
+                "reason": f"audit file not found (pattern: {pattern})",
+            })
+            continue
+
+        file_path = matches[0]
+        result = check_audit_schedule(project_num, frequency, file_path, today)
+        result["audit"] = project_num
+        result["base"] = base_num
+        result["file"] = file_path.name
+
+        if result["status"] == "block":
+            blocks.append(result)
+        elif result["status"] == "warn":
+            warns.append(result)
+        elif result["status"] == "ok":
+            oks.append(result)
+
+    # Print results
+    print(f"\n  Today: {today.strftime('%Y-%m-%d')}")
+    print(f"  Checked: {len(freq_map)} scheduled audits\n")
+
+    if oks:
+        print("  OK:")
+        for item in oks:
+            print(f"    {item['audit']} ({item['frequency']}): "
+                  f"last run {item['last_audit']} ({item['days_since']}d ago)")
+
+    if warns:
+        print("\n  WARNING (approaching deadline or needs attention):")
+        for item in warns:
+            if item.get("days_since") is not None:
+                days_left = item["threshold"] - item["days_since"]
+                print(f"    {item['audit']} ({item['frequency']}): "
+                      f"last run {item['last_audit']} ({item['days_since']}d ago) - "
+                      f"{days_left}d until overdue")
+            else:
+                print(f"    {item['audit']} ({item['frequency']}): "
+                      f"{item.get('reason', 'needs attention')}")
+
+    if blocks:
+        print("\n  BLOCKED (overdue):")
+        for item in blocks:
+            days_since_val = item.get("days_since")
+            threshold_val = item.get("threshold")
+            if isinstance(days_since_val, int) and isinstance(threshold_val, int):
+                overdue = days_since_val - threshold_val
+                print(f"    {item['audit']} ({item['frequency']}): "
+                      f"last run {item['last_audit']} ({days_since_val}d ago) - "
+                      f"{overdue}d OVERDUE")
+            else:
+                print(f"    {item['audit']}: {item.get('reason', 'unknown error')}")
+
+    print()
+
+    if blocks:
+        print(f"FAILED: {len(blocks)} audit(s) overdue. Run these audits before merging.")
+        print("See audit index Section 5 for audit schedule requirements.")
+        return 1
+
+    if warns:
+        print(f"PASSED with {len(warns)} warning(s). Consider running these audits soon.")
+    else:
+        print("=== AUDIT SCHEDULE CHECK PASSED ===")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds `tools/audit_schedule_check.py` as canonical shared tool (previously only in Aletheia)
- Auto-detects project numbering prefix from `*-audit-index.md` filename (e.g., `0800` → prefix `08`, `10800` → prefix `108`)
- Parses frequency matrix from Section 5.1 instead of hardcoding — works for any project without modification
- Maps base audit numbers (0809) to project-specific file numbers (0809 or 10809) dynamically

## Test plan
- [x] 19 unit tests covering prefix detection, frequency parsing, number conversion, schedule checking, and end-to-end flows for both AssemblyZero (0xxx) and Aletheia (10xxx) numbering
- [x] Verified against real AssemblyZero docs (29 scheduled audits detected correctly)
- [x] Full test suite: 2546 passed, 0 failures

Closes #407

---
Generated with Claude Code