### PR TITLE
feat: TDD context injection + path security (#288, #289)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -664,10 +664,12 @@ def build_single_file_prompt(
     test_content: str = "",
     previous_error: str = "",
     path_enforcement_section: str = "",
+    context_content: str = "",
 ) -> str:
     """Build prompt for a single file with accumulated context.
 
     Issue #188: Added path_enforcement_section parameter to inject allowed paths.
+    Issue #288: Added context_content parameter for injected architectural context.
     """
 
     change_type = file_spec.get("change_type", "Add")
@@ -691,6 +693,14 @@ Description: {description}
     # Issue #188: Add path enforcement section
     if path_enforcement_section:
         prompt += path_enforcement_section + "\n"
+
+    # Issue #288: Add injected context
+    if context_content:
+        prompt += f"""## Additional Context
+
+{context_content}
+
+"""
 
     # Include existing file content if modifying
     if change_type.lower() == "modify":
@@ -1180,6 +1190,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             test_content=test_content,
             previous_error=green_phase_output if iteration_count > 0 else "",
             path_enforcement_section=path_enforcement_section,
+            context_content=state.get("context_content", ""),
         )
 
         # Call Claude with retry logic (Issue #309)

--- a/assemblyzero/workflows/testing/path_validator.py
+++ b/assemblyzero/workflows/testing/path_validator.py
@@ -1,0 +1,181 @@
+"""Path security validation for TDD workflow context files.
+
+Issue #289: Prevents directory traversal, secret file exposure,
+and oversized file injection into LLM prompts.
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Secret file patterns (case-insensitive)
+SECRET_PATTERNS = [
+    r"\.env$",
+    r"\.env\.",
+    r"credentials",
+    r"secret",
+    r"\.pem$",
+    r"\.key$",
+    r"\.p12$",
+    r"\.pfx$",
+    r"\.jks$",
+    r"\.keystore$",
+    r"id_rsa",
+    r"id_ed25519",
+    r"\.aws/",
+]
+
+# Default size limit: 100KB
+DEFAULT_SIZE_LIMIT = 100 * 1024
+
+
+def is_secret_file(path: str | Path) -> bool:
+    """Check if a file path matches known secret file patterns.
+
+    Args:
+        path: File path to check.
+
+    Returns:
+        True if the file matches a secret pattern.
+    """
+    path_str = str(path).replace("\\", "/").lower()
+    name = Path(path_str).name.lower()
+
+    for pattern in SECRET_PATTERNS:
+        if re.search(pattern, name, re.IGNORECASE):
+            return True
+        if re.search(pattern, path_str, re.IGNORECASE):
+            return True
+
+    return False
+
+
+def check_file_size(path: Path, limit: int = DEFAULT_SIZE_LIMIT) -> tuple[bool, str]:
+    """Check if a file exceeds the size limit.
+
+    Args:
+        path: Path to the file.
+        limit: Maximum allowed size in bytes.
+
+    Returns:
+        Tuple of (ok, error_message). ok=True if within limit.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        return False, f"Cannot stat file: {e}"
+
+    if size > limit:
+        return False, (
+            f"File too large: {size:,} bytes "
+            f"(limit: {limit:,} bytes / {limit // 1024}KB)"
+        )
+
+    return True, ""
+
+
+def validate_context_path(
+    path: str | Path,
+    project_root: str | Path,
+) -> tuple[bool, str]:
+    """Validate a context file path for security.
+
+    Checks:
+    1. No directory traversal (../)
+    2. Resolves within project root
+    3. Not a secret file
+    4. File exists and is readable
+    5. File size within limit
+
+    Args:
+        path: File path to validate (absolute or relative to project_root).
+        project_root: Project root directory.
+
+    Returns:
+        Tuple of (valid, error_message). valid=True if all checks pass.
+    """
+    path = Path(path)
+    project_root = Path(project_root).resolve()
+
+    # Check for traversal sequences in the raw path string
+    raw = str(path).replace("\\", "/")
+    if ".." in raw.split("/"):
+        return False, f"Directory traversal rejected: {path}"
+
+    # Resolve the path (relative to project_root if not absolute)
+    if not path.is_absolute():
+        resolved = (project_root / path).resolve()
+    else:
+        resolved = path.resolve()
+
+    # Check resolved path is within project root
+    try:
+        resolved.relative_to(project_root)
+    except ValueError:
+        return False, f"Path outside project root: {resolved} (root: {project_root})"
+
+    # Check for symlink escape
+    if resolved.is_symlink():
+        real = resolved.resolve()
+        try:
+            real.relative_to(project_root)
+        except ValueError:
+            return False, f"Symlink escapes project root: {resolved} -> {real}"
+
+    # Check for secret files
+    if is_secret_file(resolved):
+        return False, f"Secret file rejected: {resolved.name}"
+
+    # Check file exists
+    if not resolved.exists():
+        return False, f"File not found: {resolved}"
+
+    if not resolved.is_file():
+        return False, f"Not a file: {resolved}"
+
+    # Check file size
+    ok, size_error = check_file_size(resolved)
+    if not ok:
+        return False, f"{resolved.name}: {size_error}"
+
+    return True, ""
+
+
+def load_context_files(
+    paths: list[str],
+    project_root: str | Path,
+) -> tuple[str, list[str]]:
+    """Load and concatenate validated context files.
+
+    Args:
+        paths: List of file paths to load.
+        project_root: Project root for path validation.
+
+    Returns:
+        Tuple of (concatenated_content, error_list).
+        Content is empty string if all files fail validation.
+    """
+    project_root = Path(project_root).resolve()
+    contents: list[str] = []
+    errors: list[str] = []
+
+    for raw_path in paths:
+        valid, error = validate_context_path(raw_path, project_root)
+        if not valid:
+            errors.append(f"[CONTEXT] REJECTED: {raw_path} — {error}")
+            continue
+
+        # Resolve path for reading
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = project_root / path
+
+        path = path.resolve()
+
+        try:
+            text = path.read_text(encoding="utf-8")
+            contents.append(f"# Context: {path.name}\n\n{text}")
+        except Exception as e:
+            errors.append(f"[CONTEXT] Read error: {raw_path} — {e}")
+
+    return "\n\n---\n\n".join(contents), errors

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -88,6 +88,10 @@ class TestingWorkflowState(TypedDict, total=False):
         # Error handling
         error_message: Last error message if any.
 
+        # Context injection (Issue #288)
+        context_files: List of context file paths from --context flag.
+        context_content: Concatenated content from validated context files.
+
         # Mode flags (from CLI)
         auto_mode: If True, skip human gates and auto-approve.
         mock_mode: If True, use fixtures instead of real APIs.
@@ -167,6 +171,10 @@ class TestingWorkflowState(TypedDict, total=False):
 
     # Error handling
     error_message: str
+
+    # Context injection (Issue #288)
+    context_files: list[str]
+    context_content: str
 
     # Mode flags
     auto_mode: bool

--- a/tests/unit/test_path_validator.py
+++ b/tests/unit/test_path_validator.py
@@ -1,0 +1,188 @@
+"""Tests for path security validation (Issue #289).
+
+Tests validate_context_path, is_secret_file, check_file_size,
+and load_context_files.
+"""
+
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.path_validator import (
+    check_file_size,
+    is_secret_file,
+    load_context_files,
+    validate_context_path,
+)
+
+
+class TestIsSecretFile:
+    """Test secret file pattern matching."""
+
+    @pytest.mark.parametrize("path", [
+        ".env",
+        ".env.local",
+        ".env.production",
+        "credentials.json",
+        "aws-credentials",
+        "secret.yaml",
+        "my-secret-config.json",
+        "server.pem",
+        "private.key",
+        "id_rsa",
+        "id_ed25519",
+        "keystore.p12",
+        "cert.pfx",
+        "app.jks",
+    ])
+    def test_rejects_secret_files(self, path):
+        assert is_secret_file(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "main.py",
+        "README.md",
+        "config.yaml",
+        "test_env.py",
+        "utils/helpers.py",
+        "docs/architecture.md",
+    ])
+    def test_allows_safe_files(self, path):
+        assert is_secret_file(path) is False
+
+
+class TestCheckFileSize:
+    """Test file size limit checks."""
+
+    def test_within_limit(self, tmp_path):
+        f = tmp_path / "small.txt"
+        f.write_text("hello" * 10)
+        ok, error = check_file_size(f)
+        assert ok is True
+        assert error == ""
+
+    def test_exceeds_limit(self, tmp_path):
+        f = tmp_path / "large.txt"
+        f.write_bytes(b"x" * 200_000)
+        ok, error = check_file_size(f, limit=100_000)
+        assert ok is False
+        assert "too large" in error.lower()
+        assert "200,000" in error
+
+    def test_custom_limit(self, tmp_path):
+        f = tmp_path / "medium.txt"
+        f.write_bytes(b"x" * 500)
+        ok, _ = check_file_size(f, limit=100)
+        assert ok is False
+
+    def test_nonexistent_file(self, tmp_path):
+        ok, error = check_file_size(tmp_path / "missing.txt")
+        assert ok is False
+        assert "cannot stat" in error.lower()
+
+
+class TestValidateContextPath:
+    """Test full path validation pipeline."""
+
+    def test_valid_file(self, tmp_path):
+        f = tmp_path / "context.py"
+        f.write_text("# valid context")
+        valid, error = validate_context_path(str(f), tmp_path)
+        assert valid is True
+        assert error == ""
+
+    def test_relative_path(self, tmp_path):
+        f = tmp_path / "src" / "module.py"
+        f.parent.mkdir()
+        f.write_text("# module")
+        valid, error = validate_context_path("src/module.py", tmp_path)
+        assert valid is True
+
+    def test_rejects_traversal(self, tmp_path):
+        valid, error = validate_context_path("../../../etc/passwd", tmp_path)
+        assert valid is False
+        assert "traversal" in error.lower()
+
+    def test_rejects_path_outside_root(self, tmp_path):
+        # Create a file outside project root
+        outside = tmp_path.parent / "outside.txt"
+        outside.write_text("secret")
+        try:
+            valid, error = validate_context_path(str(outside), tmp_path)
+            assert valid is False
+            assert "outside project root" in error.lower()
+        finally:
+            outside.unlink(missing_ok=True)
+
+    def test_rejects_secret_file(self, tmp_path):
+        f = tmp_path / ".env"
+        f.write_text("SECRET=value")
+        valid, error = validate_context_path(str(f), tmp_path)
+        assert valid is False
+        assert "secret" in error.lower()
+
+    def test_rejects_credentials(self, tmp_path):
+        f = tmp_path / "credentials.json"
+        f.write_text("{}")
+        valid, error = validate_context_path(str(f), tmp_path)
+        assert valid is False
+        assert "secret" in error.lower()
+
+    def test_rejects_nonexistent(self, tmp_path):
+        valid, error = validate_context_path("missing.py", tmp_path)
+        assert valid is False
+        assert "not found" in error.lower()
+
+    def test_rejects_directory(self, tmp_path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        valid, error = validate_context_path(str(d), tmp_path)
+        assert valid is False
+        assert "not a file" in error.lower()
+
+    def test_rejects_oversized(self, tmp_path):
+        f = tmp_path / "huge.py"
+        f.write_bytes(b"x" * 200_000)
+        valid, error = validate_context_path(str(f), tmp_path)
+        assert valid is False
+        assert "too large" in error.lower()
+
+
+class TestLoadContextFiles:
+    """Test context file loading and concatenation."""
+
+    def test_loads_single_file(self, tmp_path):
+        f = tmp_path / "context.py"
+        f.write_text("# context code")
+        content, errors = load_context_files([str(f)], tmp_path)
+        assert "# context code" in content
+        assert errors == []
+
+    def test_loads_multiple_files(self, tmp_path):
+        f1 = tmp_path / "a.py"
+        f2 = tmp_path / "b.md"
+        f1.write_text("# file a")
+        f2.write_text("# file b")
+        content, errors = load_context_files([str(f1), str(f2)], tmp_path)
+        assert "# file a" in content
+        assert "# file b" in content
+        assert errors == []
+
+    def test_skips_invalid_files(self, tmp_path):
+        good = tmp_path / "good.py"
+        good.write_text("# good")
+        bad_path = str(tmp_path / "missing.py")
+        content, errors = load_context_files([str(good), bad_path], tmp_path)
+        assert "# good" in content
+        assert len(errors) == 1
+        assert "REJECTED" in errors[0]
+
+    def test_rejects_all_invalid(self, tmp_path):
+        content, errors = load_context_files(["missing.py"], tmp_path)
+        assert content == ""
+        assert len(errors) == 1
+
+    def test_empty_list(self, tmp_path):
+        content, errors = load_context_files([], tmp_path)
+        assert content == ""
+        assert errors == []

--- a/tests/unit/test_tdd_context_injection.py
+++ b/tests/unit/test_tdd_context_injection.py
@@ -1,0 +1,72 @@
+"""Tests for TDD context injection (Issue #288).
+
+Tests the --context CLI flag, state propagation, and prompt injection.
+"""
+
+import pytest
+from pathlib import Path
+
+from assemblyzero.workflows.testing.nodes.implement_code import (
+    build_single_file_prompt,
+)
+
+
+class TestContextCLIFlag:
+    """Test --context flag parsing in the CLI argument parser."""
+
+    def test_context_flag_accepted(self):
+        from tools.run_implement_from_lld import create_argument_parser
+
+        parser = create_argument_parser()
+        args = parser.parse_args([
+            "--issue", "42",
+            "--context", "src/core.py",
+            "--context", "docs/spec.md",
+        ])
+        assert args.context == ["src/core.py", "docs/spec.md"]
+
+    def test_context_defaults_to_empty(self):
+        from tools.run_implement_from_lld import create_argument_parser
+
+        parser = create_argument_parser()
+        args = parser.parse_args(["--issue", "42"])
+        assert args.context == []
+
+
+class TestContextInPrompt:
+    """Test that context_content appears in generated prompts."""
+
+    def test_context_injected_into_prompt(self, tmp_path):
+        prompt = build_single_file_prompt(
+            filepath="src/module.py",
+            file_spec={"change_type": "Add", "description": "New module"},
+            lld_content="# LLD\nImplement feature X",
+            completed_files=[],
+            repo_root=tmp_path,
+            context_content="# Context: audit.py\n\ndef existing_function(): pass",
+        )
+        assert "Additional Context" in prompt
+        assert "existing_function" in prompt
+
+    def test_no_context_section_when_empty(self, tmp_path):
+        prompt = build_single_file_prompt(
+            filepath="src/module.py",
+            file_spec={"change_type": "Add", "description": "New module"},
+            lld_content="# LLD\nImplement feature X",
+            completed_files=[],
+            repo_root=tmp_path,
+            context_content="",
+        )
+        assert "Additional Context" not in prompt
+
+
+class TestStateContextField:
+    """Test context fields in TestingWorkflowState."""
+
+    def test_state_accepts_context_fields(self):
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        # Verify the fields exist in the TypedDict annotations
+        annotations = TestingWorkflowState.__annotations__
+        assert "context_files" in annotations
+        assert "context_content" in annotations


### PR DESCRIPTION
## Summary
- Added `--context FILE [FILE ...]` flag to `run_implement_from_lld.py` for injecting architectural context into LLM prompts
- Created `assemblyzero/workflows/testing/path_validator.py` with security guards: directory traversal rejection, secret file detection (.env, credentials, .pem, .key), symlink resolution, and 100KB size limits
- Context content flows through `TestingWorkflowState` and is injected into implementation prompts via `build_single_file_prompt()`

## Test plan
- [x] 43 new tests covering all validation paths (secret patterns, traversal, size limits, loading)
- [x] Full suite: 2589 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)