### PR TITLE
feat: propagate transcript cleanup infrastructure (#361)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ docs/blog/
 *.db
 *.sqlite
 
-# Unleashed session transcripts (auto-generated, untracked)
+# Session transcripts (auto-generated, untracked)
 data/unleashed/
+transcripts/

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -245,6 +245,30 @@ The documentation system exists so you don't need persistent memory. USE IT.
 
 ---
 
+## Post-Session Transcript Cleanup
+
+**After any PTY-recorded session, clean the raw transcript:**
+
+```bash
+# Clean a raw transcript (removes TUI garbage, preserves conversation)
+poetry run python tools/clean_transcript.py transcripts/session.raw
+
+# Optional: fix word-merged text (requires: poetry add wordninja)
+poetry run python tools/clean_transcript.py --fix-spaces transcripts/session.raw
+```
+
+**Outputs:**
+- `session.clean` — Garbage removed, content preserved
+- `session.user` — Extracted user input only
+
+**Tools:**
+- `tools/transcript_filters.py` — 95-pattern regex filter for PTY artifacts (spinners, status bars, permission UI)
+- `tools/clean_transcript.py` — Multi-pass cleaner (garbage removal → dedup → block dedup → optional space fix)
+
+**The original `.raw` file is NEVER modified.**
+
+---
+
 ## You Are Not Alone
 
 Other agents may work on this project. Check session logs for recent context. Coordinate via the project's issue tracker.

--- a/tools/clean_transcript.py
+++ b/tools/clean_transcript.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+clean_transcript.py — Clean PTY session transcripts.
+
+Removes TUI garbage (spinners, status bars, permission UI, thinking fragments,
+logo chrome, etc.) while preserving actual conversation content.
+
+Origin: unleashed/src/clean_transcript.py (propagated via Issue #361)
+
+Usage:
+    poetry run python tools/clean_transcript.py transcripts/session.raw
+    poetry run python tools/clean_transcript.py --fix-spaces transcripts/session.raw
+
+Options:
+    --fix-spaces    Reinsert spaces into word-merged text using dictionary lookup
+                    (requires: poetry add wordninja)
+
+Writes cleaned output to <filename>.clean — NEVER modifies the original.
+Also writes <filename>.user — extracted user input only.
+"""
+import argparse
+import re
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+
+# Add tools directory to path for sibling imports
+sys.path.insert(0, str(Path(__file__).parent))
+
+from transcript_filters import is_garbage, normalize_for_dedup
+
+
+def dedup_consecutive(lines: list[str]) -> tuple[list[str], int]:
+    """Remove consecutive duplicate lines (TUI repaint artifacts)."""
+    if not lines:
+        return lines, 0
+
+    result = [lines[0]]
+    removed = 0
+    prev_norm = normalize_for_dedup(lines[0])
+
+    for line in lines[1:]:
+        norm = normalize_for_dedup(line)
+        if not norm:
+            result.append(line)
+            prev_norm = norm
+            continue
+        if norm == prev_norm:
+            removed += 1
+            continue
+        result.append(line)
+        prev_norm = norm
+
+    return result, removed
+
+
+def dedup_blocks(lines: list[str], window: int = 5, min_block: int = 8) -> tuple[list[str], int]:
+    """Remove duplicate blocks that appear far apart in the transcript."""
+    norms = []
+    for i, line in enumerate(lines):
+        n = normalize_for_dedup(line)
+        if n:
+            norms.append((i, n))
+
+    if len(norms) < window * 2:
+        return lines, 0
+
+    seen_windows = {}
+    duplicate_line_indices = set()
+
+    for wi in range(len(norms) - window + 1):
+        window_hash = hash(tuple(norms[wi + j][1] for j in range(window)))
+
+        if window_hash in seen_windows:
+            first_wi = seen_windows[window_hash]
+            match = all(norms[first_wi + j][1] == norms[wi + j][1] for j in range(window))
+            if not match:
+                continue
+
+            block_end = window
+            while (wi + block_end < len(norms)
+                   and first_wi + block_end < len(norms)
+                   and first_wi + block_end < wi
+                   and norms[first_wi + block_end][1] == norms[wi + block_end][1]):
+                block_end += 1
+
+            if block_end >= min_block:
+                for j in range(block_end):
+                    duplicate_line_indices.add(norms[wi + j][0])
+        else:
+            seen_windows[window_hash] = wi
+
+    if not duplicate_line_indices:
+        return lines, 0
+
+    result = []
+    removed = 0
+    for i, line in enumerate(lines):
+        if i in duplicate_line_indices:
+            removed += 1
+        elif not line.strip() and removed > 0:
+            next_content = None
+            for j in range(i + 1, min(i + 3, len(lines))):
+                if lines[j].strip():
+                    next_content = j
+                    break
+            if next_content and next_content in duplicate_line_indices:
+                removed += 1
+            else:
+                result.append(line)
+        else:
+            result.append(line)
+
+    return result, removed
+
+
+def extract_user_input(lines: list[str]) -> list[str]:
+    """Extract only user input lines from cleaned transcript."""
+    user_lines = []
+    in_user_block = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith('❯'):
+            if user_lines and user_lines[-1] != '':
+                user_lines.append('')
+            content = stripped[1:].strip()
+            if content:
+                user_lines.append(content)
+            in_user_block = True
+        elif in_user_block and stripped and not stripped.startswith('●'):
+            if any(stripped.startswith(p) for p in ('●', 'Bash(', 'Read(', 'Write(',
+                    'Edit(', 'Search(', 'Grep(', 'Glob(', 'Explore(', '⎿', '┌', '├',
+                    '│', '└', 'plugin:', 'Error:')):
+                in_user_block = False
+            else:
+                user_lines.append(stripped)
+        else:
+            in_user_block = False
+
+    while user_lines and user_lines[-1] == '':
+        user_lines.pop()
+
+    user_lines, _ = dedup_typing_repaints(user_lines)
+    return user_lines
+
+
+def dedup_typing_repaints(lines: list[str]) -> tuple[list[str], int]:
+    """Remove progressive typing repaints and duplicate blocks from user input."""
+    blocks = []
+    current_block = []
+    current_start = 0
+
+    for i, line in enumerate(lines):
+        if line.strip() == '':
+            if current_block:
+                blocks.append((current_start, current_block[:]))
+                current_block = []
+            current_start = i + 1
+        else:
+            if not current_block:
+                current_start = i
+            current_block.append(line)
+    if current_block:
+        blocks.append((current_start, current_block[:]))
+
+    if len(blocks) < 2:
+        return lines, 0
+
+    def normalize_block(block_lines):
+        text = ''.join(block_lines).lower()
+        text = re.sub(r'[\s,.:;]+', '', text)
+        return text
+
+    block_norms = [normalize_block(b[1]) for b in blocks]
+
+    MIN_LEN = 15
+    MATCH_RATIO = 0.75
+    remove_indices = set()
+
+    def is_fuzzy_prefix(shorter, longer):
+        if len(shorter) < MIN_LEN:
+            return False
+        target = longer[:len(shorter) + max(5, len(shorter) // 5)]
+        return SequenceMatcher(None, shorter, target).ratio() >= MATCH_RATIO
+
+    for i in range(len(blocks)):
+        if i in remove_indices:
+            continue
+        norm_i = block_norms[i]
+        if len(norm_i) < MIN_LEN:
+            continue
+
+        for j in range(i + 1, len(blocks)):
+            if j in remove_indices:
+                continue
+            norm_j = block_norms[j]
+            if len(norm_j) < MIN_LEN:
+                continue
+
+            if len(norm_i) <= len(norm_j) and is_fuzzy_prefix(norm_i, norm_j):
+                remove_indices.add(i)
+                break
+
+            if len(norm_j) < len(norm_i) and is_fuzzy_prefix(norm_j, norm_i):
+                remove_indices.add(j)
+
+    if not remove_indices:
+        return lines, 0
+
+    result = []
+    removed = 0
+    for bi, (start, block_lines) in enumerate(blocks):
+        if bi in remove_indices:
+            removed += len(block_lines)
+            continue
+        if result and result[-1] != '':
+            result.append('')
+        result.extend(block_lines)
+
+    while result and result[-1] == '':
+        result.pop()
+
+    return result, removed
+
+
+def fix_merged_spaces(line: str) -> str:
+    """Reinsert spaces into word-merged text segments.
+
+    Requires wordninja package: poetry add wordninja
+    """
+    try:
+        import wordninja
+    except ImportError:
+        return line
+
+    stripped = line.strip()
+    if not stripped:
+        return line
+
+    skip_indicators = [
+        stripped.startswith(('/', 'C:\\', 'http', '#', '//', '/*', '```', '|', '+')),
+        stripped.startswith(('-', '>')) and len(stripped) < 5,
+        re.match(r'^\s*(?:def |class |import |from |if |for |while |return )', stripped),
+        re.match(r'^\s*[\{\}\[\]<>]', stripped),
+        '.py:' in stripped or '.js:' in stripped or '.sql' in stripped,
+    ]
+    if any(skip_indicators):
+        return line
+
+    def split_merged(match):
+        segment = match.group(0)
+        if any(c in segment for c in ['/', '\\', '::', '://', '_', '.']):
+            return segment
+        if segment.islower() or segment.isupper():
+            return segment
+        if len(segment) < 15:
+            return segment
+        words = wordninja.split(segment)
+        if len(words) <= 1:
+            return segment
+        return ' '.join(words)
+
+    return re.sub(r'\S{15,}', split_merged, line)
+
+
+def replace_nbsp(text: str) -> str:
+    """Replace non-breaking spaces (U+00A0) with regular ASCII spaces."""
+    return text.replace('\xa0', ' ')
+
+
+def clean_transcript(input_path: Path, fix_spaces: bool = False) -> tuple[Path, dict]:
+    """Clean a transcript file. Returns (output_path, stats)."""
+    raw = input_path.read_text(encoding='utf-8', errors='replace')
+    raw = replace_nbsp(raw)
+
+    lines = raw.splitlines()
+    total = len(lines)
+
+    # Pass 1: Remove garbage lines
+    kept = []
+    removed_garbage = 0
+    prev_blank = False
+
+    for line in lines:
+        if is_garbage(line):
+            removed_garbage += 1
+            if kept and not prev_blank:
+                prev_blank = True
+        else:
+            if prev_blank and kept:
+                kept.append('')
+            kept.append(line)
+            prev_blank = False
+
+    # Pass 2: Deduplicate consecutive lines
+    kept, removed_dedup = dedup_consecutive(kept)
+
+    # Pass 3: Remove duplicate blocks
+    kept, removed_blocks = dedup_blocks(kept)
+
+    # Pass 4: Fix word-merged text (optional)
+    spaces_fixed = 0
+    if fix_spaces:
+        fixed = []
+        for line in kept:
+            new_line = fix_merged_spaces(line)
+            if new_line != line:
+                spaces_fixed += 1
+            fixed.append(new_line)
+        kept = fixed
+
+    total_removed = removed_garbage + removed_dedup + removed_blocks
+
+    output_path = input_path.with_suffix('.clean')
+    output_path.write_text('\n'.join(kept) + '\n', encoding='utf-8')
+
+    user_lines = extract_user_input(kept)
+    user_path = input_path.with_suffix('.user')
+    user_path.write_text('\n'.join(user_lines) + '\n', encoding='utf-8')
+
+    stats = {
+        'total_lines': total,
+        'removed_garbage': removed_garbage,
+        'removed_dedup': removed_dedup,
+        'removed_blocks': removed_blocks,
+        'total_removed': total_removed,
+        'kept': len(kept),
+        'user_lines': len(user_lines),
+        'pct_removed': round(total_removed / total * 100, 1) if total else 0,
+        'spaces_fixed': spaces_fixed,
+    }
+    return output_path, stats
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Clean PTY session transcripts — remove TUI garbage, preserve content.'
+    )
+    parser.add_argument('file', type=Path, help='Transcript file to clean')
+    parser.add_argument('--fix-spaces', action='store_true',
+                        help='Reinsert spaces into word-merged text (requires wordninja)')
+    args = parser.parse_args()
+
+    if not args.file.exists():
+        print(f"File not found: {args.file}")
+        sys.exit(1)
+
+    output_path, stats = clean_transcript(args.file, fix_spaces=args.fix_spaces)
+
+    print(f"Input:    {args.file} ({stats['total_lines']} lines)")
+    print(f"Output:   {output_path} ({stats['kept']} lines)")
+    print(f"Garbage:  {stats['removed_garbage']} lines")
+    print(f"Dedup:    {stats['removed_dedup']} lines")
+    print(f"Blocks:   {stats['removed_blocks']} lines (duplicate sections)")
+    print(f"Total:    {stats['total_removed']} lines removed ({stats['pct_removed']}%)")
+    print(f"User:     {stats['user_lines']} user input lines -> {args.file.with_suffix('.user')}")
+    if stats['spaces_fixed']:
+        print(f"Spaces:   {stats['spaces_fixed']} lines had word-merged text fixed")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/transcript_filters.py
+++ b/tools/transcript_filters.py
@@ -1,0 +1,365 @@
+"""
+transcript_filters.py — Shared garbage pattern matching for PTY transcripts.
+
+Single source of truth for TUI garbage detection. Used by:
+- clean_transcript.py (post-session cleaning)
+
+95 compiled regex patterns covering spinners, timing fragments, permission UI,
+status bars, agent trees, checklist repaints, CLI help, and garbled TUI artifacts.
+
+Origin: unleashed/src/transcript_filters.py (propagated via Issue #361)
+"""
+import re
+
+
+# --- Compiled patterns (order matters — most frequent first) ---
+GARBAGE_PATTERNS = [
+    # 1. GENERIC spinner pattern: spinner char(s) + Capitalized verb + optional words + …
+    re.compile(
+        r'^[\s*·✶✻✽✢●◼❯⏵▐▝▘☵⎿]*\s*'
+        r"[A-Z][a-zéèêë'-]+(?:ing|ed|ion|ting|in')\b.*…"
+    ),
+    re.compile(
+        r'^[\s*·✶✻✽✢●◼❯⏵▐▝▘☵⎿]*\s*'
+        r"[A-Z][a-zéèêë'-]+(?:ing|ed|ion|ting|in')…?\s*\d*\s*$"
+    ),
+    re.compile(
+        r'^[\s*·✶✻✽✢●◼❯⏵▐▝▘☵⎿]*\s*'
+        r'(?:Auto-updating|Pasting\s*text)'
+    ),
+
+    # 2. Character-by-character thinking fragments
+    re.compile(r'^[\s*·✶✻✽✢]*\s*.{0,10}\s+\(?thinking\)?\s*\)?$'),
+    re.compile(r'.{0,6}\(thinking\)\s*$'),
+
+    # 3. Status bar timestamps
+    re.compile(r'^\[?\d{2}-\d{2}\s*\d{2}:\d{2}:\d{2}\]?\s+'),
+
+    # 4. Auto-update failed line
+    re.compile(r'✗\s*Auto-?update\s*failed'),
+    re.compile(r'Auto-?update\s*failed\s*·\s*Try'),
+
+    # 5. Accept edits chrome
+    re.compile(r'^⏵+\s*accept\s*edits?\s*on', re.IGNORECASE),
+    re.compile(r'⏵+\s*accepteditson', re.IGNORECASE),
+
+    # 6. Permission prompt UI lines
+    re.compile(r'^>>>\s*\[PERMISSION\]'),
+    re.compile(r'Esc\s*to\s*cancel\s*·'),
+    re.compile(r'Esctocancel'),
+    re.compile(r'^\s*❯\s*\d+\.\s*(?:Yes|No)'),
+    re.compile(r'^\s*\d+\.\s*(?:Yes|No)\s*$'),
+    re.compile(r'Do\s*you\s*want\s*to\s*proceed\s*\?'),
+    re.compile(r'Doyouwanttoproceed'),
+
+    # 7. Claude Code ASCII logo
+    re.compile(r'^[\s▐▝▜▛█▘]*[▐▝▜▛█▘]{3,}'),
+
+    # 8. Ctrl hints
+    re.compile(r'^\s*ctrl\+[a-z]\s+to\s+\w+', re.IGNORECASE),
+
+    # 9. Token/timing-only fragments
+    re.compile(r'^\s*[\s·✶✻✽✢*]*\s*\d*\.?\d*k?\s*(?:tokens|↑|↓)'),
+    re.compile(r'^\s*[\d\s·↑↓]+(?:tokens|thinking)\s*\)?$'),
+    re.compile(r'^\s*[\s·✶✻✽✢*]*\d+\s+0?s\s*·\s*[↑↓]'),
+    re.compile(r'^\s*\d+\s+·\s+\d+\.?\d*k?\s+tokens'),
+
+    # 10. Bare timing fragments
+    re.compile(r'^\s*[\(·]\s*\d+s\s*·\s*(?:timeout|↑|↓)'),
+    re.compile(r'^[\s*·✶✻✽✢]*\s*\(?\s*thought for \d+s\)?\s*$'),
+
+    # 11. Press up / image tags / Wait
+    re.compile(r'Press\s*up\s*to\s*edit\s*queued'),
+    re.compile(r'Pressuptoeditqueued'),
+    re.compile(r'^\s*\[Image #\d+\]\s*(?:\(↑ to select\))?\s*$'),
+    re.compile(r'^\s*⎿\s*\[Image #\d+\]'),
+    re.compile(r'^Wait$'),
+
+    # 12. Path-only status lines
+    re.compile(r'^(?:s/|/c/Users/mcwiz/Projects/)\S+\s*(?:\(main\)\s*)?.{0,5}$'),
+    re.compile(r'^\s*~\\Projects\\\S+\s*.{0,5}$'),
+    re.compile(r'^C:\\Users\\mcwiz\\Projects\\\S+\s*.{0,5}$'),
+
+    # 13. Running N agents lines
+    re.compile(r'^Running\s+\d+\s+Bash\s+ag[ne]+ts'),
+
+    # 14. Wrangler boilerplate
+    re.compile(r'^⛅️\s*wrangler\s*\d'),
+    re.compile(r'^🌀\s*(?:Executing on|To execute on)'),
+    re.compile(r'^Resource\s*location:\s*remote$'),
+
+    # 15. Orphan spinner/timing lines
+    re.compile(r'^[\s*·✶✻✽✢]*\s*\d{1,3}\s*$'),
+
+    # 16. Bare "Bash command" label
+    re.compile(r'^Bash\s+command\s*$'),
+
+    # 17. Partial spinner word (truncated repaints)
+    re.compile(r'^[a-z]perspacing'),
+
+    # 18. Token count fragments with thought
+    re.compile(r'^\s*[\s·✶✻✽✢*]*\s*\d+\.?\d*k?\s*tokens\s*·\s*thought'),
+
+    # 19. "↑ to select" standalone
+    re.compile(r'^\s*\(?↑\s*to\s*select\)?\s*$'),
+
+    # 20. Lines that are ONLY timing
+    re.compile(r'^\s*⎿?\s*\((?:timeout\s*\d+\w?s?|\d+s\s*·\s*time\s*o[tu]+\s*\d+\w?s?)\)\s*$'),
+
+    # 21. Plan mode chrome
+    re.compile(r'^⏸\s*plan\s*mode\s*on'),
+    re.compile(r'^⏸planmodeon'),
+    re.compile(r'^●?\s*Entered plan mode'),
+    re.compile(r'^Claude is now exploring and designing'),
+
+    # 22. "Worked for Nm Ns" summary
+    re.compile(r'^[\s*·✶✻✽✢]*\s*Worked for \d+'),
+
+    # 23. Agent tree lines
+    re.compile(r'^[├│└─]+\s(?!.*\w+.*│)'),
+
+    # 24. Done summary
+    re.compile(r'^⎿\s*Done\s*\('),
+
+    # 25. Garbled repaints
+    re.compile(r'^[A-Z]\s+[a-z]{1,3}\('),
+    re.compile(r'^\d+[a-z].*\.sql\)?\s*$'),
+    re.compile(r'^\d+\s+more\s+to[lo]*\s+uses'),
+
+    # 27. Partial/bare path fragments
+    re.compile(r'^s/\w+\s*\(main\)\s*$'),
+
+    # 28. Generic spinner+timing
+    re.compile(r'^[\s*·✶✻✽✢]+.*\(\d+[ms]?\s*\d*s?\s*·\s*[↑↓]'),
+
+    # 29. Bare timing with "tokens"
+    re.compile(r'^\s*\d+m?\s*\d*s?\s*·?\s*[↑↓]\s*\d'),
+
+    # 30-31. Checklist repaints
+    re.compile(r'^◻\s*(?:Remove|Add|Update|Create)'),
+    re.compile(r'^◼\s*(?:Remove|Add|Update|Create)'),
+
+    # 32. Standalone "(ctrl+o to expand)"
+    re.compile(r'^\s*\(ctrl\+o\s*to\s*(?:expand|see)'),
+
+    # 33. Bare arrow lines
+    re.compile(r'^\s*[↑↓]\s*$'),
+
+    # 35. Bare status line fragments
+    re.compile(r'^\s*\+\d+\s+more\s+tool\s+uses'),
+
+    # 36. Permission auto-approve artifacts
+    re.compile(r'^\s*\d+\.\s*Yes\s*,?\s*and\s*don'),
+    re.compile(r"don'taskagain"),
+
+    # 37. Bare spinner characters
+    re.compile(r'^[\s*·✶✻✽✢●]+\s*$'),
+
+    # 38. "Waiting…"
+    re.compile(r'^Waiting…'),
+
+    # 39. Activity summary
+    re.compile(r'^[\s*·✶✻✽✢]*\s*[A-Z][a-zéèêë]+(?:ed|éed)\s*for\s*\d'),
+    re.compile(r'^[\s*·✶✻✽✢]*\s*[A-Z][a-zéèêë]+(?:edfor|éedfor)\d'),
+
+    # 40. ANSI color code fragments
+    re.compile(r'^\s*;?\d+m\s'),
+    re.compile(r'^255;255;255m\s'),
+
+    # 41. "Reading N file(s)…"
+    re.compile(r'^Reading\s*\d+\s*file'),
+
+    # 42. Short garbled fragments
+    re.compile(r'^\s*[\s●⎿]*\s*\d+\s+(?:s…|files?\s*\(ctrl)'),
+
+    # 43. Garbled truncated checklist repaints
+    re.compile(r'^Create\s+[a-z]*cruiters?\s+m[a-z]*gration'),
+    re.compile(r'^Create\s+firs-'),
+    re.compile(r'^name-extractor\.js\s*\+'),
+
+    # 44. Garbled tool result
+    re.compile(r'^⎿\s+\w+\s+follow-up\s+cr\b'),
+
+    # 45. Timing with garbled text
+    re.compile(r'^[\s*·✶✻✽✢]*\s*\w{0,5}\s+\d+\s*0?s\s*·\s*[↑↓]'),
+
+    # 46. Truncated spinner words
+    re.compile(r'^Hatch\s+…'),
+
+    # 47. Ultra-short fragment lines
+    re.compile(r'^\d+\s+s?…'),
+
+    # 48. Mid-word fragments
+    re.compile(r'^[a-z]\s+\w{1,3}\s+the\s+\w+\.\s*$'),
+
+    # 49. Checklist items with › blocked by
+    re.compile(r'^◻?\s*Wire\s.*›\s*blocked\s*by'),
+
+    # 50. ⎿ lines with partial checklist content
+    re.compile(r'^⎿\s+(?:◼|◻)?\s*(?:Create|Wire|Add|Remove|Update)\s+\w'),
+
+    # 51. Repeated checklist lines
+    re.compile(r'^[◼◻✔]\s+(?:Deploy|Wire|Create|Add|Remove|Update|Run|Verify)'),
+    re.compile(r'^⎿\s+[◼◻✔]\s+'),
+
+    # 52. "ctrl+o to expand/see all" markers
+    re.compile(r'ctrl\+o\s*to\s*(?:expand|see)'),
+
+    # 53. Very short garbled fragments
+    re.compile(r'^[\s*·✶✻✽✢]*\s*[a-z]{1,2}\s+[a-z]{1,3}\s*\d*\s*$'),
+
+    # 54. "Running in the background"
+    re.compile(r'Running in the background'),
+
+    # 55. Truncated UI hints
+    re.compile(r'shift\+tab\s+to\s+cyc'),
+
+    # 56. "Tab to amend"
+    re.compile(r'^[\s*·✶✻✽✢]*\s*Tab\s+to\s+amend'),
+
+    # 57. Word-merged task descriptions
+    re.compile(r'^[A-Z][a-z]+[A-Z][a-z]+[A-Z][a-z]+\w{10,}$'),
+
+    # 58. Thought fragments
+    re.compile(r'^\s*[\s*·✶✻✽✢]*\s*\w{0,6}ought\s+for\s+\d+s?\)'),
+
+    # 59. Garbled spinner fragments with timing
+    re.compile(r'^[\s*·✶✻✽✢]+[A-Z]?\s*[a-z]?\s+\d+s\s*·\s*[↑↓]'),
+
+    # 60. Standalone "running N file…"
+    re.compile(r'^running\s+\d+\s+file'),
+
+    # 61. Bare timing
+    re.compile(r'^\s*\d+\s+s\s*·\s*\d+\.?\d*k?\s*tokens'),
+
+    # 62. Bare "N thought for Ns)"
+    re.compile(r'^\s*\d+\s+thought\s+for\s+\d+'),
+
+    # 63. Garbled spinner with …
+    re.compile(r'^[\s*·✶✻✽✢]+\s*\w{0,5}\s*…\s*\d+'),
+
+    # 64. Truncated "shift+tab" hint
+    re.compile(r'ift\+tab\s+to\s+cyc'),
+
+    # 65. Bare timing without opening paren
+    re.compile(r'^\s*\d+s?\s*·\s*timeout\s+\d+'),
+
+    # 66. Truncated "Running in the background"
+    re.compile(r'^Runn\w*\s+in\s+the\s+background'),
+
+    # 67. Timeout with Nm Ns format
+    re.compile(r'^\s*⎿?\s*\(timeout\s+\d+m?\s*\d*s?\)'),
+
+    # 68. "Task Output <hex>"
+    re.compile(r'^Task\s+Output\s+[a-f0-9]+'),
+
+    # 69. "Waiting for task"
+    re.compile(r'Waiting\s*for\s*task'),
+    re.compile(r'Waitingfortask'),
+
+    # 70. Ultra-garbled spinner fragments
+    re.compile(r'^\w{1,5}\s+\w{0,3}…\s*[↑↓]'),
+
+    # 71. CLI help listings
+    re.compile(r'\((?:user|usr|sr)\)\s*$'),
+
+    # 72. CLI help — slash command format
+    re.compile(r'^/\w[\w-]+\s{2,}\S'),
+
+    # 73. CLI help — garbled command descriptions
+    re.compile(r'^(?:unleashed-version|upgrde|usage|sage|ext\s+-usage)\s'),
+
+    # 74. Plan mode chrome
+    re.compile(r'^⎿\s*/plan\s+to\s+preview'),
+    re.compile(r'^Ready\s+to\s+code\s*\?'),
+
+    # 75. Garbled spinner without leading char but with … + (timing)
+    re.compile(r'^[A-Z]\w*\s+\w*\s+\w*\s*…\s*\(\d+[ms]?\s*\d*s?\s*·\s*[↑↓]'),
+
+    # 76. Lone bullet point
+    re.compile(r'^\s*●\s*$'),
+
+    # 77. "+N more lines"
+    re.compile(r'^\s*\+\d+\s+more\s+lines?\s'),
+
+    # 78. Task list summary
+    re.compile(r'^\d+\s+tasks?\s*\(\d+\s+done'),
+
+    # 79-80. Ultra-garbled thought fragments
+    re.compile(r'^[\s*·✶✻✽✢]*\s*\w{0,5}\s*…\s*ought\s+for\s+\d+'),
+    re.compile(r'^[a-z\s]{1,10}\d+\s+\d*\s*thought\s+for\s+\d+'),
+
+    # 81. Playwright "No open tabs"
+    re.compile(r'No\s*open\s*tabs\s*\.?\s*Navigate\s*to', re.IGNORECASE),
+    re.compile(r'Noopentabs'),
+
+    # 82-83. Garbled timing/tool fragments
+    re.compile(r'^[A-Z]\s+\d+m?\s*\d*s?\s*·\s*[↑↓]'),
+    re.compile(r'^[a-z]{1,6}(?:ing|ching)\s+\d+\s+(?:files?|patterns?)'),
+
+    # 84-86. Garbled search/timing fragments
+    re.compile(r'^S\s*\w*rching\s+\w+\s+\d+\s+pattern'),
+    re.compile(r'^\d+\s+to[lo]*\s+uses?\s*·'),
+    re.compile(r'^\d+\s+s[,·]\s*(?:reading|searching)'),
+
+    # 87. CLI help — garbled command listings
+    re.compile(r'^(?:status|statusline|fronend|passes|conext|sage|ext\s+-usage)\s{2,}'),
+    re.compile(r'^(?:status|statusline|fronend|passes|conext)\s+\w'),
+
+    # 88-89. "+N more" variants
+    re.compile(r'^\s*\+\d+\s+more\s+tool\s+use\w*'),
+    re.compile(r'^\s*\+\d+\s+more\s+lines?\s*\('),
+
+    # 90. Wrangler deploy stats
+    re.compile(r'^Total\s*Upload:\s*\d'),
+
+    # 91. Broad … + (Ns · ↓) pattern
+    re.compile(r'…\s*\(\d+m?\s*\d*s?\s*·\s*[↑↓]'),
+
+    # 92. Truncated spinner word fragments
+    re.compile(r'^[*·✶✻✽✢]*[A-Z][a-z]{1,6}$'),
+
+    # 93. Spinner verb + … + bare timing
+    re.compile(r"^[A-Z][a-zéèêë'-]+(?:ing|ed|ion|ting|in')…?\s+\d+\s"),
+
+    # 94. Lines that are only Unicode whitespace
+    re.compile(r'^[\s\xa0\u200b\u2000-\u200a\u2028\u2029\u3000]+$'),
+
+    # 95. Garbled "Hatch g…" truncated spinner
+    re.compile(r'^[A-Z][a-z]+\s+[a-z]?…'),
+]
+
+
+# Lines containing these strings are ALWAYS kept (compaction markers)
+COMPACTION_KEEP = [
+    'compacting conversation',
+    'conversation compacted',
+    'compactingconversation',
+    'conversationcompacted',
+]
+
+
+def is_garbage(line: str) -> bool:
+    """Return True if line is TUI garbage that should be removed."""
+    stripped = line.strip()
+    if not stripped:
+        return True  # blank lines (we'll re-add spacing intelligently later)
+
+    # Preserve compaction markers — these track context lobotomy events
+    lower = stripped.lower()
+    for marker in COMPACTION_KEEP:
+        if marker in lower:
+            return False
+
+    for pattern in GARBAGE_PATTERNS:
+        if pattern.search(stripped):
+            return True
+    return False
+
+
+def normalize_for_dedup(line: str) -> str:
+    """Normalize a line for deduplication comparison."""
+    s = line.strip()
+    s = re.sub(r'^[\s*·✶✻✽✢●◼◻❯⏵⎿]+', '', s)
+    s = re.sub(r'\s+', '', s)
+    return s.lower()


### PR DESCRIPTION
## Summary
- Port transcript capture and cleanup tools from unleashed to shared `tools/` directory
- Add `tools/transcript_filters.py` — 95-pattern regex filter for PTY artifacts (spinners, status bars, permission UI, TUI chrome)
- Add `tools/clean_transcript.py` — multi-pass cleaner (garbage removal → dedup → block dedup → optional word-merge fix)
- Update `.gitignore` with `transcripts/` directory pattern
- Update `WORKFLOW.md` with post-session transcript cleanup instructions

## Test plan
- [x] Full test suite passes (2589 passed, 0 failed)
- [x] Transcript tools are standalone scripts with no new dependencies (wordninja is optional)
- [x] Original `.raw` files are never modified — outputs go to `.clean` and `.user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)