### PR TITLE
feat: /handoff persistence + /pickup command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ docs/blog/
 
 # Session transcripts (auto-generated, untracked)
 data/unleashed/
+data/handoff-log.md
 transcripts/


### PR DESCRIPTION
## Summary
- Adds `data/handoff-log.md` to `.gitignore` for persistent handoff logging
- `/handoff` skill enhanced with Step 5 (persist to log) and Step 6 (spawn new session)
- `/pickup` skill created to import last handoff context in new sessions

Closes #420

## Test plan
- [x] `git check-ignore data/handoff-log.md` confirms coverage
- [ ] `/handoff` creates log with structured markers + spawns new terminal
- [ ] `/pickup` reads last entry, shows age, imports on confirmation
- [ ] Second `/handoff` appends (not overwrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)