### PR TITLE
feat: telemetry module with DynamoDB + JSONL fallback

### DIFF
--- a/assemblyzero/telemetry/__init__.py
+++ b/assemblyzero/telemetry/__init__.py
@@ -1,0 +1,21 @@
+"""AssemblyZero telemetry — structured event emission.
+
+Fire-and-forget telemetry that never raises, never blocks tool execution.
+Events go to DynamoDB with local JSONL fallback when offline.
+
+Usage:
+    from assemblyzero.telemetry import emit, track_tool
+
+    # Direct event emission
+    emit("workflow.start", repo="AssemblyZero", metadata={"issue": 42})
+
+    # Context manager for tool tracking
+    with track_tool("run_audit", repo="AssemblyZero"):
+        do_work()  # emits tool.start, tool.complete (or tool.error)
+
+Kill switch: set ASSEMBLYZERO_TELEMETRY=0 to disable all emission.
+"""
+
+from assemblyzero.telemetry.emitter import emit, flush, track_tool
+
+__all__ = ["emit", "flush", "track_tool"]

--- a/assemblyzero/telemetry/__main__.py
+++ b/assemblyzero/telemetry/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as: python -m assemblyzero.telemetry.sync"""
+
+from assemblyzero.telemetry.sync import main
+
+main()

--- a/assemblyzero/telemetry/actor.py
+++ b/assemblyzero/telemetry/actor.py
@@ -1,0 +1,62 @@
+"""Actor detection for telemetry events.
+
+Determines whether the current execution is driven by a human or Claude,
+and identifies the GitHub user and machine.
+"""
+
+import hashlib
+import os
+import platform
+import subprocess
+
+
+def detect_actor() -> str:
+    """Detect whether current execution is human or Claude.
+
+    Returns "claude" if CLAUDECODE or UNLEASHED_VERSION env vars are set,
+    otherwise returns "human".
+    """
+    if os.environ.get("CLAUDECODE") is not None:
+        return "claude"
+    if os.environ.get("UNLEASHED_VERSION"):
+        return "claude"
+    return "human"
+
+
+def detect_github_user() -> str:
+    """Detect the current GitHub user via gh CLI.
+
+    Returns the GitHub username, or "unknown" if detection fails.
+    Caches the result for the process lifetime.
+    """
+    if not hasattr(detect_github_user, "_cached"):
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status", "--show-token"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            for line in result.stdout.splitlines() + result.stderr.splitlines():
+                if "Logged in to github.com account" in line:
+                    # Format: "  ✓ Logged in to github.com account USERNAME ..."
+                    parts = line.split("account")
+                    if len(parts) > 1:
+                        username = parts[1].strip().split()[0].strip("()")
+                        detect_github_user._cached = username
+                        return username
+        except Exception:
+            pass
+        detect_github_user._cached = "unknown"
+    return detect_github_user._cached
+
+
+def get_machine_id() -> str:
+    """Generate a stable machine identifier (hashed for privacy).
+
+    Returns a short hash based on hostname + platform, stable across sessions.
+    """
+    if not hasattr(get_machine_id, "_cached"):
+        raw = f"{platform.node()}:{platform.system()}:{platform.machine()}"
+        get_machine_id._cached = hashlib.sha256(raw.encode()).hexdigest()[:12]
+    return get_machine_id._cached

--- a/assemblyzero/telemetry/emitter.py
+++ b/assemblyzero/telemetry/emitter.py
@@ -1,0 +1,243 @@
+"""Core telemetry emitter — fire-and-forget event recording.
+
+Design principles:
+- Never raise exceptions (telemetry must not break tools)
+- Never block tool execution (DynamoDB writes are best-effort)
+- Local JSONL fallback when DynamoDB is unreachable
+- Kill switch via ASSEMBLYZERO_TELEMETRY=0
+"""
+
+import json
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Generator, Optional
+
+from assemblyzero.telemetry.actor import detect_actor, detect_github_user, get_machine_id
+
+# Kill switch
+_ENABLED_ENV = "ASSEMBLYZERO_TELEMETRY"
+
+# Buffer directory for offline fallback
+_BUFFER_DIR = Path.home() / ".assemblyzero" / "telemetry-buffer"
+
+# Lazy-initialized DynamoDB client
+_dynamo_client: Optional[Any] = None
+_dynamo_init_attempted = False
+
+
+def _is_enabled() -> bool:
+    """Check if telemetry is enabled (default: yes)."""
+    return os.environ.get(_ENABLED_ENV, "1") != "0"
+
+
+def _get_dynamo_client() -> Optional[Any]:
+    """Lazy-initialize DynamoDB client from stored credentials.
+
+    Returns None if boto3 unavailable or credentials missing.
+    Never raises.
+    """
+    global _dynamo_client, _dynamo_init_attempted
+
+    if _dynamo_init_attempted:
+        return _dynamo_client
+
+    _dynamo_init_attempted = True
+
+    try:
+        import boto3
+
+        creds_path = Path.home() / ".assemblyzero" / "aws-telemetry-credentials.json"
+        if not creds_path.exists():
+            return None
+
+        with open(creds_path) as f:
+            creds = json.load(f)
+
+        _dynamo_client = boto3.resource(
+            "dynamodb",
+            region_name=creds.get("region", "us-east-1"),
+            aws_access_key_id=creds["access_key_id"],
+            aws_secret_access_key=creds["secret_access_key"],
+        ).Table(creds.get("table_name", "assemblyzero-telemetry"))
+
+        return _dynamo_client
+    except Exception:
+        return None
+
+
+def _write_to_buffer(event: dict[str, Any]) -> None:
+    """Write event to local JSONL buffer for later sync.
+
+    Never raises — silently drops if buffer dir is not writable.
+    """
+    try:
+        _BUFFER_DIR.mkdir(parents=True, exist_ok=True)
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        buffer_file = _BUFFER_DIR / f"{date_str}.jsonl"
+        with open(buffer_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+            f.flush()
+    except Exception:
+        pass  # Telemetry must never break tools
+
+
+def _build_event(
+    event_type: str,
+    repo: str = "",
+    metadata: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build a structured telemetry event dict."""
+    now = datetime.now(timezone.utc)
+    event_id = uuid.uuid4().hex[:12]
+    timestamp = now.isoformat()
+    date_str = now.strftime("%Y-%m-%d")
+    actor = detect_actor()
+    github_user = detect_github_user()
+    ttl_epoch = int(now.timestamp()) + (90 * 86400)  # 90-day expiry
+
+    event = {
+        # DynamoDB keys
+        "pk": f"REPO#{repo}" if repo else "REPO#unknown",
+        "sk": f"EVENT#{timestamp}#{event_id}",
+        "gsi1pk": f"ACTOR#{actor}",
+        "gsi1sk": timestamp,
+        "gsi2pk": f"USER#{github_user}",
+        "gsi2sk": timestamp,
+        "gsi3pk": f"DATE#{date_str}",
+        "gsi3sk": f"REPO#{repo}#EVENT#{timestamp}" if repo else f"REPO#unknown#EVENT#{timestamp}",
+        # Event data
+        "event_type": event_type,
+        "actor": actor,
+        "repo": repo or "unknown",
+        "github_user": github_user,
+        "machine_id": get_machine_id(),
+        "timestamp": timestamp,
+        "ttl": ttl_epoch,
+    }
+
+    if metadata:
+        event["metadata"] = metadata
+
+    return event
+
+
+def emit(
+    event_type: str,
+    repo: str = "",
+    metadata: Optional[dict[str, Any]] = None,
+) -> None:
+    """Emit a telemetry event. Fire-and-forget — never raises.
+
+    Args:
+        event_type: Event type (e.g., "workflow.start", "tool.error").
+        repo: Repository name (e.g., "AssemblyZero").
+        metadata: Optional additional data for the event.
+    """
+    if not _is_enabled():
+        return
+
+    try:
+        event = _build_event(event_type, repo, metadata)
+
+        client = _get_dynamo_client()
+        if client is not None:
+            try:
+                client.put_item(Item=event)
+                return  # Success — no need for buffer
+            except Exception:
+                pass  # Fall through to buffer
+
+        # DynamoDB unavailable — write to local buffer
+        _write_to_buffer(event)
+    except Exception:
+        pass  # Telemetry must never break tools
+
+
+def flush() -> int:
+    """Flush any buffered events to DynamoDB.
+
+    Returns:
+        Number of events successfully flushed.
+    """
+    if not _is_enabled():
+        return 0
+
+    client = _get_dynamo_client()
+    if client is None:
+        return 0
+
+    flushed = 0
+    try:
+        if not _BUFFER_DIR.exists():
+            return 0
+
+        for buffer_file in sorted(_BUFFER_DIR.glob("*.jsonl")):
+            remaining_lines: list[str] = []
+            try:
+                with open(buffer_file, encoding="utf-8") as f:
+                    lines = f.readlines()
+
+                for line in lines:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event = json.loads(line)
+                        client.put_item(Item=event)
+                        flushed += 1
+                    except Exception:
+                        remaining_lines.append(line)
+
+                if remaining_lines:
+                    with open(buffer_file, "w", encoding="utf-8") as f:
+                        f.write("\n".join(remaining_lines) + "\n")
+                else:
+                    buffer_file.unlink()
+            except Exception:
+                continue
+
+    except Exception:
+        pass
+
+    return flushed
+
+
+@contextmanager
+def track_tool(
+    tool_name: str,
+    repo: str = "",
+    metadata: Optional[dict[str, Any]] = None,
+) -> Generator[None, None, None]:
+    """Context manager that emits start/complete/error events with duration.
+
+    Usage:
+        with track_tool("run_audit", repo="AssemblyZero"):
+            do_work()
+
+    Emits:
+        - tool.start on entry
+        - tool.complete on success (with duration_ms)
+        - tool.error on exception (with duration_ms and error info)
+    """
+    start_time = time.monotonic()
+    tool_meta = dict(metadata or {})
+    tool_meta["tool_name"] = tool_name
+
+    emit("tool.start", repo=repo, metadata=tool_meta)
+
+    try:
+        yield
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        tool_meta["duration_ms"] = duration_ms
+        emit("tool.complete", repo=repo, metadata=tool_meta)
+    except Exception as exc:
+        duration_ms = int((time.monotonic() - start_time) * 1000)
+        tool_meta["duration_ms"] = duration_ms
+        tool_meta["error_type"] = type(exc).__name__
+        tool_meta["error_message"] = str(exc)[:500]
+        emit("tool.error", repo=repo, metadata=tool_meta)
+        raise  # Re-raise — telemetry must not swallow exceptions

--- a/assemblyzero/telemetry/sync.py
+++ b/assemblyzero/telemetry/sync.py
@@ -1,0 +1,22 @@
+"""Buffer sync CLI — flush local telemetry buffer to DynamoDB.
+
+Usage:
+    poetry run python -m assemblyzero.telemetry.sync
+"""
+
+import sys
+
+from assemblyzero.telemetry.emitter import flush
+
+
+def main() -> None:
+    """Flush local buffer and report count."""
+    count = flush()
+    if count > 0:
+        print(f"Synced {count} buffered event(s) to DynamoDB.")
+    else:
+        print("No buffered events to sync.")
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,6 +93,46 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "rst.linker (>=1.9)", "sphinx (>=3.5
 testing = ["jaraco.test", "pytest (!=8.0.*)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.42.55"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "boto3-1.42.55-py3-none-any.whl", hash = "sha256:cb4bc94c0ba522242e291d16b4f631e139f525fbc9772229f3e84f5d834fd88e"},
+    {file = "boto3-1.42.55.tar.gz", hash = "sha256:e7b8fcc123da442449da8a2be65b3e60a3d8cfb2b26a52f7b3c6f9f8e84cbdf0"},
+]
+
+[package.dependencies]
+botocore = ">=1.42.55,<1.43.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.16.0,<0.17.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.42.55"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "botocore-1.42.55-py3-none-any.whl", hash = "sha256:c092eb99d17b653af3ec9242061a7cde1c7b1940ed4abddfada68a9e1a3492d6"},
+    {file = "botocore-1.42.55.tar.gz", hash = "sha256:af22a7d7881883bcb475a627d0750ec6f8ee3d7b2f673e9ff342ebaa498447ee"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.31.2)"]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -953,6 +993,18 @@ files = [
     {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59"},
     {file = "jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19"},
     {file = "jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4"},
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
 ]
 
 [[package]]
@@ -1919,6 +1971,21 @@ pytest = ">=7"
 testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
@@ -2208,6 +2275,24 @@ files = [
 pyasn1 = ">=0.1.3"
 
 [[package]]
+name = "s3transfer"
+version = "0.16.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe"},
+    {file = "s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a0)"]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 description = "Python bindings to FreeDesktop.org Secret Service API"
@@ -2223,6 +2308,18 @@ files = [
 [package.dependencies]
 cryptography = ">=2.0"
 jeepney = ">=0.6"
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
 
 [[package]]
 name = "sniffio"
@@ -2884,4 +2981,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "69668c72a9ce4c0199a92310b1677d93e7f55f20b313525d891ac5c2c02cf60c"
+content-hash = "5becf19e00dd331676bae7dd6d040a79669a1f232aa16fe99ed1412970377760"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "orjson (>=3.11.7,<4.0.0)",
     "langsmith (>=0.6.9,<0.7.0)",
     "google-auth (>=2.48.0,<3.0.0)",
-    "pycparser (>=3.0,<4.0)"
+    "pycparser (>=3.0,<4.0)",
+    "boto3 (>=1.35.0,<2.0.0)"
 ]
 
 [tool.pytest.ini_options]

--- a/tests/unit/test_telemetry_actor.py
+++ b/tests/unit/test_telemetry_actor.py
@@ -1,0 +1,88 @@
+"""Tests for assemblyzero.telemetry.actor — actor detection."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.telemetry.actor import detect_actor, detect_github_user, get_machine_id
+
+
+class TestDetectActor:
+    """Test actor detection logic."""
+
+    def test_human_by_default(self):
+        """No Claude env vars → human."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove CLAUDECODE and UNLEASHED_VERSION if present
+            os.environ.pop("CLAUDECODE", None)
+            os.environ.pop("UNLEASHED_VERSION", None)
+            assert detect_actor() == "human"
+
+    def test_claude_via_claudecode(self):
+        """CLAUDECODE set (even empty) → claude."""
+        with patch.dict(os.environ, {"CLAUDECODE": ""}, clear=False):
+            assert detect_actor() == "claude"
+
+    def test_claude_via_claudecode_nonempty(self):
+        """CLAUDECODE with value → claude."""
+        with patch.dict(os.environ, {"CLAUDECODE": "1"}, clear=False):
+            assert detect_actor() == "claude"
+
+    def test_claude_via_unleashed_version(self):
+        """UNLEASHED_VERSION set → claude."""
+        env = {"UNLEASHED_VERSION": "c-24"}
+        with patch.dict(os.environ, env, clear=True):
+            assert detect_actor() == "claude"
+
+
+class TestDetectGithubUser:
+    """Test GitHub user detection."""
+
+    def test_returns_string(self):
+        """Should always return a string, never None."""
+        # Clear cache
+        if hasattr(detect_github_user, "_cached"):
+            delattr(detect_github_user, "_cached")
+        result = detect_github_user()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_caches_result(self):
+        """Second call returns cached value without subprocess."""
+        if hasattr(detect_github_user, "_cached"):
+            delattr(detect_github_user, "_cached")
+        first = detect_github_user()
+        second = detect_github_user()
+        assert first == second
+
+    def test_fallback_on_error(self):
+        """Returns 'unknown' when gh CLI fails."""
+        if hasattr(detect_github_user, "_cached"):
+            delattr(detect_github_user, "_cached")
+        with patch("assemblyzero.telemetry.actor.subprocess.run", side_effect=FileNotFoundError):
+            result = detect_github_user()
+            assert result == "unknown"
+
+
+class TestGetMachineId:
+    """Test machine ID generation."""
+
+    def test_returns_stable_hash(self):
+        """Same machine → same ID across calls."""
+        if hasattr(get_machine_id, "_cached"):
+            delattr(get_machine_id, "_cached")
+        first = get_machine_id()
+        # Clear cache and call again
+        if hasattr(get_machine_id, "_cached"):
+            delattr(get_machine_id, "_cached")
+        second = get_machine_id()
+        assert first == second
+
+    def test_returns_12_char_hex(self):
+        """Machine ID is a 12-char hex string."""
+        if hasattr(get_machine_id, "_cached"):
+            delattr(get_machine_id, "_cached")
+        result = get_machine_id()
+        assert len(result) == 12
+        assert all(c in "0123456789abcdef" for c in result)

--- a/tests/unit/test_telemetry_emitter.py
+++ b/tests/unit/test_telemetry_emitter.py
@@ -1,0 +1,237 @@
+"""Tests for assemblyzero.telemetry.emitter — core emit/track functionality."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from assemblyzero.telemetry import emitter
+from assemblyzero.telemetry.emitter import (
+    _build_event,
+    _is_enabled,
+    _write_to_buffer,
+    emit,
+    flush,
+    track_tool,
+)
+
+
+class TestIsEnabled:
+    """Test kill switch behavior."""
+
+    def test_enabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert _is_enabled() is True
+
+    def test_enabled_when_set_to_1(self):
+        with patch.dict(os.environ, {"ASSEMBLYZERO_TELEMETRY": "1"}):
+            assert _is_enabled() is True
+
+    def test_disabled_when_set_to_0(self):
+        with patch.dict(os.environ, {"ASSEMBLYZERO_TELEMETRY": "0"}):
+            assert _is_enabled() is False
+
+
+class TestBuildEvent:
+    """Test event construction."""
+
+    def test_contains_required_fields(self):
+        event = _build_event("workflow.start", repo="AssemblyZero")
+        assert event["event_type"] == "workflow.start"
+        assert event["repo"] == "AssemblyZero"
+        assert event["pk"] == "REPO#AssemblyZero"
+        assert event["sk"].startswith("EVENT#")
+        assert event["gsi1pk"].startswith("ACTOR#")
+        assert event["gsi2pk"].startswith("USER#")
+        assert event["gsi3pk"].startswith("DATE#")
+        assert "timestamp" in event
+        assert "machine_id" in event
+        assert "ttl" in event
+        assert isinstance(event["ttl"], int)
+
+    def test_metadata_included(self):
+        event = _build_event("tool.start", repo="Talos", metadata={"issue": 42})
+        assert event["metadata"]["issue"] == 42
+
+    def test_no_metadata_when_none(self):
+        event = _build_event("tool.start", repo="Talos")
+        assert "metadata" not in event
+
+    def test_unknown_repo_fallback(self):
+        event = _build_event("error.unhandled")
+        assert event["pk"] == "REPO#unknown"
+        assert event["repo"] == "unknown"
+
+
+class TestWriteToBuffer:
+    """Test local JSONL buffer fallback."""
+
+    def test_writes_jsonl(self, tmp_path):
+        """Events are written as JSONL to the buffer directory."""
+        with patch.object(emitter, "_BUFFER_DIR", tmp_path / "buffer"):
+            event = {"event_type": "test", "timestamp": "2026-01-01T00:00:00"}
+            _write_to_buffer(event)
+
+            files = list((tmp_path / "buffer").glob("*.jsonl"))
+            assert len(files) == 1
+
+            with open(files[0]) as f:
+                data = json.loads(f.readline())
+            assert data["event_type"] == "test"
+
+    def test_appends_multiple_events(self, tmp_path):
+        """Multiple events append to the same daily file."""
+        with patch.object(emitter, "_BUFFER_DIR", tmp_path / "buffer"):
+            _write_to_buffer({"n": 1})
+            _write_to_buffer({"n": 2})
+
+            files = list((tmp_path / "buffer").glob("*.jsonl"))
+            assert len(files) == 1
+
+            with open(files[0]) as f:
+                lines = f.readlines()
+            assert len(lines) == 2
+
+    def test_never_raises(self, tmp_path):
+        """Buffer write failures are silently swallowed."""
+        with patch.object(emitter, "_BUFFER_DIR", Path("/nonexistent/path/buffer")):
+            # Should not raise
+            _write_to_buffer({"event_type": "test"})
+
+
+class TestEmit:
+    """Test the main emit() function."""
+
+    def test_disabled_does_nothing(self):
+        """When kill switch is off, emit does nothing."""
+        with patch.dict(os.environ, {"ASSEMBLYZERO_TELEMETRY": "0"}):
+            # Should not raise, should not write
+            emit("test.event", repo="Test")
+
+    def test_falls_back_to_buffer_when_no_dynamo(self, tmp_path):
+        """Without DynamoDB, events go to buffer."""
+        with (
+            patch.object(emitter, "_dynamo_client", None),
+            patch.object(emitter, "_dynamo_init_attempted", True),
+            patch.object(emitter, "_BUFFER_DIR", tmp_path / "buffer"),
+        ):
+            emit("test.event", repo="TestRepo")
+
+            files = list((tmp_path / "buffer").glob("*.jsonl"))
+            assert len(files) == 1
+
+    def test_never_raises_on_any_error(self):
+        """emit() must never raise, even with catastrophic failures."""
+        with patch.object(emitter, "_build_event", side_effect=RuntimeError("boom")):
+            # Should not raise
+            emit("test.event")
+
+
+class TestTrackTool:
+    """Test the track_tool context manager."""
+
+    def test_emits_start_and_complete(self):
+        """Successful execution emits start + complete."""
+        events = []
+        with patch.object(emitter, "emit", side_effect=lambda *a, **kw: events.append(a[0])):
+            with track_tool("my_tool", repo="TestRepo"):
+                pass
+
+        assert events == ["tool.start", "tool.complete"]
+
+    def test_emits_start_and_error_on_exception(self):
+        """Failed execution emits start + error, re-raises."""
+        events = []
+        with patch.object(emitter, "emit", side_effect=lambda *a, **kw: events.append(a[0])):
+            with pytest.raises(ValueError, match="boom"):
+                with track_tool("my_tool", repo="TestRepo"):
+                    raise ValueError("boom")
+
+        assert events == ["tool.start", "tool.error"]
+
+    def test_preserves_original_exception(self):
+        """track_tool re-raises the original exception unmodified."""
+        with patch.object(emitter, "emit"):
+            with pytest.raises(TypeError, match="bad type"):
+                with track_tool("my_tool"):
+                    raise TypeError("bad type")
+
+    def test_includes_duration_ms(self):
+        """Complete/error events include duration_ms in metadata."""
+        captured_metadata = {}
+
+        def capture_emit(event_type, repo="", metadata=None):
+            if metadata and "duration_ms" in metadata:
+                captured_metadata[event_type] = metadata["duration_ms"]
+
+        with patch.object(emitter, "emit", side_effect=capture_emit):
+            with track_tool("my_tool"):
+                pass
+
+        assert "tool.complete" in captured_metadata
+        assert isinstance(captured_metadata["tool.complete"], int)
+        assert captured_metadata["tool.complete"] >= 0
+
+
+class TestFlush:
+    """Test buffer flush to DynamoDB."""
+
+    def test_returns_zero_when_disabled(self):
+        with patch.dict(os.environ, {"ASSEMBLYZERO_TELEMETRY": "0"}):
+            assert flush() == 0
+
+    def test_returns_zero_when_no_client(self):
+        with (
+            patch.object(emitter, "_dynamo_client", None),
+            patch.object(emitter, "_dynamo_init_attempted", True),
+        ):
+            assert flush() == 0
+
+    def test_flushes_buffer_files(self, tmp_path):
+        """Flush reads buffer files and sends to DynamoDB."""
+        buffer_dir = tmp_path / "buffer"
+        buffer_dir.mkdir()
+        buffer_file = buffer_dir / "2026-02-24.jsonl"
+        buffer_file.write_text('{"event_type":"test","pk":"REPO#X","sk":"EVENT#1"}\n')
+
+        mock_table = MagicMock()
+        with (
+            patch.object(emitter, "_BUFFER_DIR", buffer_dir),
+            patch.object(emitter, "_dynamo_client", mock_table),
+            patch.object(emitter, "_dynamo_init_attempted", True),
+        ):
+            count = flush()
+
+        assert count == 1
+        mock_table.put_item.assert_called_once()
+        # Buffer file should be deleted after successful flush
+        assert not buffer_file.exists()
+
+    def test_keeps_failed_lines_in_buffer(self, tmp_path):
+        """Lines that fail to sync remain in the buffer file."""
+        buffer_dir = tmp_path / "buffer"
+        buffer_dir.mkdir()
+        buffer_file = buffer_dir / "2026-02-24.jsonl"
+        buffer_file.write_text(
+            '{"n":1}\n'
+            '{"n":2}\n'
+        )
+
+        mock_table = MagicMock()
+        # First put succeeds, second fails
+        mock_table.put_item.side_effect = [None, Exception("throttled")]
+
+        with (
+            patch.object(emitter, "_BUFFER_DIR", buffer_dir),
+            patch.object(emitter, "_dynamo_client", mock_table),
+            patch.object(emitter, "_dynamo_init_attempted", True),
+        ):
+            count = flush()
+
+        assert count == 1
+        # Buffer file should still exist with the failed line
+        assert buffer_file.exists()
+        remaining = buffer_file.read_text().strip()
+        assert '"n": 2' in remaining or '"n":2' in remaining


### PR DESCRIPTION
## Summary

- New `assemblyzero/telemetry/` package with `emit()` (fire-and-forget) and `track_tool()` (context manager)
- Actor detection: `CLAUDECODE`/`UNLEASHED_VERSION` → claude, else → human
- DynamoDB client with local JSONL buffer fallback at `~/.assemblyzero/telemetry-buffer/`
- Kill switch via `ASSEMBLYZERO_TELEMETRY=0`
- `boto3` added to `pyproject.toml` (lazy-imported only when telemetry fires)
- 30 unit tests, all passing
- Smoke-tested: real event confirmed in `assemblyzero-telemetry` DynamoDB table

Closes #423

## Test plan

- [x] 30 unit tests pass (`test_telemetry_actor.py`, `test_telemetry_emitter.py`)
- [x] Smoke test: `emit()` writes to DynamoDB
- [x] Kill switch: `ASSEMBLYZERO_TELEMETRY=0` disables emission
- [x] Buffer fallback: events written to JSONL when DynamoDB unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)