### PR TITLE
fix: skip code-fence headings in TDD test plan parser (#455)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -150,10 +150,17 @@ def extract_test_plan_section(lld_content: str) -> str:
         r"##\s*(?:Verification|Testing)\s*\n(.*?)(?=\n##|\Z)",
     ]
 
+    # Pre-compute code fence regions to skip false-positive matches
+    # inside ```...``` blocks (e.g., headings embedded in string literals).
+    fence_regions = [
+        (m.start(), m.end())
+        for m in re.finditer(r"```.*?```", lld_content, re.DOTALL)
+    ]
+
     for pattern in patterns:
-        match = re.search(pattern, lld_content, re.DOTALL | re.IGNORECASE)
-        if match:
-            return match.group(1).strip()
+        for match in re.finditer(pattern, lld_content, re.DOTALL | re.IGNORECASE):
+            if not any(s <= match.start() < e for s, e in fence_regions):
+                return match.group(1).strip()
 
     # Fallback: extract test scenarios from Python test code blocks in
     # Implementation Spec sections (e.g., ### 6.9 `tests/unit/test_*.py`)

--- a/tests/unit/test_extract_test_plan_section.py
+++ b/tests/unit/test_extract_test_plan_section.py
@@ -1,0 +1,68 @@
+"""Tests for extract_test_plan_section — code-fence false-positive fix (#455)."""
+
+from assemblyzero.workflows.testing.nodes.load_lld import extract_test_plan_section
+
+
+def test_skips_heading_inside_code_fence():
+    """A ## 10. heading inside a code block must not match."""
+    content = '''\
+Some intro text.
+
+```python
+example = """
+## 10. Verification & Testing
+
+This is inside a code fence and should be ignored.
+"""
+```
+
+## 10. Verification & Testing
+
+Real test plan content here.
+
+| ID | Test |
+|----|------|
+| T1 | Check something |
+
+## 11. Next Section
+'''
+    result = extract_test_plan_section(content)
+    assert "Real test plan content here." in result
+    assert "inside a code fence" not in result
+
+
+def test_matches_normal_heading():
+    """Standard heading outside code fences works as before."""
+    content = """\
+## 10. Test Plan
+
+| ID | Scenario |
+|----|----------|
+| T1 | Basic check |
+
+## 11. Appendix
+"""
+    result = extract_test_plan_section(content)
+    assert "Basic check" in result
+
+
+def test_section_9_test_mapping():
+    """Implementation spec Section 9 format still works."""
+    content = """\
+## 9. Test Mapping
+
+| Test ID | Tests Function |
+|---------|---------------|
+| T010 | detect_cascade_risk() |
+
+## 10. Dependencies
+"""
+    result = extract_test_plan_section(content)
+    assert "detect_cascade_risk" in result
+
+
+def test_no_match_returns_empty():
+    """Returns empty string when no test section found."""
+    content = "# Just a README\n\nNo test section here.\n"
+    result = extract_test_plan_section(content)
+    assert result == ""


### PR DESCRIPTION
## Summary
- `extract_test_plan_section()` matched `## 10. Verification & Testing` inside a fenced code block (a Python string literal example in the impl spec), yielding 0 test scenarios and blocking the TDD workflow
- Pre-compute code-fence regions and skip any heading match whose start position falls inside one
- Added 4 unit tests covering: false-positive skip, normal heading, Section 9 format, empty fallback

Closes #455

## Test plan
- [x] `test_skips_heading_inside_code_fence` — heading inside ``` block is ignored
- [x] `test_matches_normal_heading` — standard Section 10 still works
- [x] `test_section_9_test_mapping` — impl spec Section 9 still works
- [x] `test_no_match_returns_empty` — graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)