### PR TITLE
test: add unit tests for circuit breaker module (#443)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -319,7 +319,53 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 coverage_module = coverage_module[4:]
             break
 
-    # Default to assemblyzero if no implementation files
+    # Issue #462: When all impl files are test files (test-only issues),
+    # fall back to files_to_modify from LLD to find the source module
+    if not coverage_module:
+        files_to_modify = state.get("files_to_modify", [])
+        for file_info in files_to_modify:
+            fpath = file_info.get("path", "")
+            if "test" in fpath.lower():
+                continue
+            if fpath.endswith("__init__.py"):
+                continue
+            if not fpath.endswith(".py"):
+                continue
+            rel_str = fpath
+            if rel_str.endswith(".py"):
+                rel_str = rel_str[:-3]
+            coverage_module = rel_str.replace("/", ".").replace("\\", ".")
+            if coverage_module.startswith("src."):
+                coverage_module = coverage_module[4:]
+            print(f"    [N5] Derived coverage module from LLD files_to_modify: {coverage_module}")
+            break
+
+    # Issue #462 fallback 2: reverse-map test file name to source module
+    # e.g., tests/unit/test_circuit_breaker.py → find circuit_breaker.py in repo
+    if not coverage_module and test_files:
+        for tf in test_files:
+            tf_name = Path(tf).name  # e.g., test_circuit_breaker.py
+            if tf_name.startswith("test_"):
+                src_name = tf_name[5:]  # e.g., circuit_breaker.py
+                # Search for matching source file in repo
+                matches = list(repo_root.rglob(src_name)) if repo_root else []
+                # Filter to .py files not in tests/ directories
+                for match in matches:
+                    match_parts = match.relative_to(repo_root).parts
+                    if any(p.lower() in ("tests", "test") for p in match_parts):
+                        continue
+                    rel_str = str(match.relative_to(repo_root))
+                    if rel_str.endswith(".py"):
+                        rel_str = rel_str[:-3]
+                    coverage_module = rel_str.replace("/", ".").replace("\\", ".")
+                    if coverage_module.startswith("src."):
+                        coverage_module = coverage_module[4:]
+                    print(f"    [N5] Derived coverage module from test filename: {coverage_module}")
+                    break
+                if coverage_module:
+                    break
+
+    # Last resort: default to top-level package
     if not coverage_module:
         coverage_module = "assemblyzero"
 


### PR DESCRIPTION
## Summary

- Unit tests for all 4 public functions in `circuit_breaker.py` (25 tests, 100% pass)
- Edge cases: zero budget, huge budget, empty state, accumulation, negative tokens
- Generated via full LLD → Impl Spec → TDD pipeline
- Also fixes circular import in hooks/telemetry and coverage module derivation for test-only issues

Closes #443
Closes #462

## Changes

1. **`tests/unit/test_circuit_breaker.py`** (Add) — 25 unit tests covering `estimate_iteration_cost()`, `check_circuit_breaker()`, `record_iteration_cost()`, `budget_summary()`
2. **`assemblyzero/hooks/cascade_action.py`** (Fix) — Break circular import by making telemetry imports lazy
3. **`tests/unit/test_cascade_action.py`** + **`tests/unit/test_cascade_detector.py`** (Fix) — Update mock patch targets to match lazy import
4. **`assemblyzero/workflows/testing/nodes/verify_phases.py`** (Fix) — Derive coverage module from test filename when all impl files are test files (#462)

## Test plan

- [x] `poetry run python -m pytest tests/unit/test_circuit_breaker.py -x` — 25 passed
- [x] No regressions in existing test suite (2937 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)