### PR TITLE
fix: resolve --cov module fallback for non-package targets

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -36,6 +36,37 @@ from assemblyzero.workflows.testing.state import TestingWorkflowState
 PYTEST_TIMEOUT_SECONDS = 300
 
 
+def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
+    """Convert a relative file path to the correct --cov target.
+
+    For Python packages (top-level dir has __init__.py), returns dotted
+    module format (e.g., ``assemblyzero.utils.file_type``).
+    For standalone scripts (no __init__.py, e.g., ``tools/``), returns
+    the file path so pytest-cov measures the right file.
+    """
+    rel = Path(rel_path)
+    top_level = rel.parts[0] if rel.parts else None
+    is_package = (
+        top_level
+        and repo_root
+        and (repo_root / top_level / "__init__.py").exists()
+    )
+
+    rel_str = str(rel)
+    if rel_str.endswith(".py"):
+        rel_str = rel_str[:-3]
+
+    if is_package:
+        module = rel_str.replace("/", ".").replace("\\", ".")
+        # Issue #387: Strip src. prefix for src-layout projects
+        if module.startswith("src."):
+            module = module[4:]
+        return module
+    else:
+        # Return as a file path — pytest-cov accepts paths for non-package code
+        return str(rel).replace("\\", "/")
+
+
 def run_pytest(
     test_files: list[str],
     coverage_module: str | None = None,
@@ -307,16 +338,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 print(f"    [N5] Skipping non-Python file for coverage: {impl_path}")
                 continue
             rel_path = Path(impl_path).relative_to(repo_root) if repo_root else Path(impl_path)
-            # Convert file path to module format for pytest-cov
-            # e.g., assemblyzero/workflows/testing/nodes/finalize.py -> assemblyzero.workflows.testing.nodes.finalize
-            rel_path_str = str(rel_path)
-            if rel_path_str.endswith(".py"):
-                rel_path_str = rel_path_str[:-3]  # Remove .py extension
-            coverage_module = rel_path_str.replace("/", ".").replace("\\", ".")
-            # Issue #387: Strip src. prefix for src-layout projects
-            # src/ is a namespace directory, not a Python package
-            if coverage_module.startswith("src."):
-                coverage_module = coverage_module[4:]
+            # Issue #474: Use helper that handles both packages and standalone scripts
+            coverage_module = _path_to_cov_target(rel_path, repo_root)
             break
 
     # Issue #462: When all impl files are test files (test-only issues),
@@ -331,12 +354,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 continue
             if not fpath.endswith(".py"):
                 continue
-            rel_str = fpath
-            if rel_str.endswith(".py"):
-                rel_str = rel_str[:-3]
-            coverage_module = rel_str.replace("/", ".").replace("\\", ".")
-            if coverage_module.startswith("src."):
-                coverage_module = coverage_module[4:]
+            # Issue #474: Use helper that handles both packages and standalone scripts
+            coverage_module = _path_to_cov_target(fpath, repo_root)
             print(f"    [N5] Derived coverage module from LLD files_to_modify: {coverage_module}")
             break
 
@@ -354,20 +373,42 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                     match_parts = match.relative_to(repo_root).parts
                     if any(p.lower() in ("tests", "test") for p in match_parts):
                         continue
-                    rel_str = str(match.relative_to(repo_root))
-                    if rel_str.endswith(".py"):
-                        rel_str = rel_str[:-3]
-                    coverage_module = rel_str.replace("/", ".").replace("\\", ".")
-                    if coverage_module.startswith("src."):
-                        coverage_module = coverage_module[4:]
+                    # Issue #474: Use helper that handles both packages and standalone scripts
+                    rel_path = match.relative_to(repo_root)
+                    coverage_module = _path_to_cov_target(rel_path, repo_root)
                     print(f"    [N5] Derived coverage module from test filename: {coverage_module}")
                     break
                 if coverage_module:
                     break
 
-    # Last resort: default to top-level package
+    # Issue #474: Last resort — infer from any available file paths before
+    # falling back to a hardcoded default.  Previous versions always fell
+    # back to "assemblyzero", which measured 0% for tools/ targets.
     if not coverage_module:
-        coverage_module = "assemblyzero"
+        # Try ALL files (including non-.py) to at least get the right directory
+        all_candidate_paths = [
+            p for p in impl_files
+            if not any(part.lower() in ("tests", "test") for part in Path(p).parts)
+        ]
+        if not all_candidate_paths:
+            all_candidate_paths = [
+                fi.get("path", "")
+                for fi in state.get("files_to_modify", [])
+                if fi.get("path") and "test" not in fi["path"].lower()
+            ]
+        if all_candidate_paths:
+            rel = Path(all_candidate_paths[0])
+            if repo_root:
+                try:
+                    rel = rel.relative_to(repo_root)
+                except ValueError:
+                    pass
+            # Use the top-level directory as coverage scope
+            coverage_module = str(rel.parts[0]).replace("\\", "/") if rel.parts else "assemblyzero"
+            print(f"    [N5] Fallback: inferred coverage scope from file paths: {coverage_module}")
+        else:
+            coverage_module = "assemblyzero"
+            print(f"    [N5] Fallback: no file paths available, defaulting to: {coverage_module}")
 
     print(f"    Coverage module: {coverage_module}")
 

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -1,0 +1,224 @@
+"""Tests for --cov target resolution in the TDD pipeline.
+
+Issue #474: TDD pipeline --cov module fallback fails for tools/ targets.
+
+Verifies that _path_to_cov_target correctly distinguishes Python packages
+(dotted module format) from standalone scripts (file path format), and
+that the fallback in verify_green_phase infers the right scope.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import _path_to_cov_target
+
+
+# ---------------------------------------------------------------------------
+# _path_to_cov_target — package paths (has __init__.py)
+# ---------------------------------------------------------------------------
+
+
+def test_package_path_returns_dotted_module(tmp_path: Path) -> None:
+    """Package file → dotted module format."""
+    (tmp_path / "assemblyzero" / "__init__.py").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "assemblyzero" / "__init__.py").touch()
+
+    result = _path_to_cov_target("assemblyzero/utils/file_type.py", tmp_path)
+    assert result == "assemblyzero.utils.file_type"
+
+
+def test_package_nested_path(tmp_path: Path) -> None:
+    """Deeply nested package path → correct dotted module."""
+    (tmp_path / "assemblyzero" / "__init__.py").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "assemblyzero" / "__init__.py").touch()
+
+    result = _path_to_cov_target("assemblyzero/workflows/testing/nodes/verify_phases.py", tmp_path)
+    assert result == "assemblyzero.workflows.testing.nodes.verify_phases"
+
+
+def test_src_layout_strips_prefix(tmp_path: Path) -> None:
+    """src-layout project → strips src. prefix."""
+    (tmp_path / "src" / "__init__.py").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "__init__.py").touch()
+
+    result = _path_to_cov_target("src/mypackage/core.py", tmp_path)
+    assert result == "mypackage.core"
+
+
+# ---------------------------------------------------------------------------
+# _path_to_cov_target — standalone scripts (no __init__.py)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_path_returns_file_path(tmp_path: Path) -> None:
+    """tools/ script (no __init__.py) → file path format."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+    # No __init__.py in tools/
+
+    result = _path_to_cov_target("tools/consolidate_logs.py", tmp_path)
+    assert result == "tools/consolidate_logs.py"
+
+
+def test_tools_nested_path(tmp_path: Path) -> None:
+    """Nested tools/ script → file path with forward slashes."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+
+    result = _path_to_cov_target("tools/sub/my_script.py", tmp_path)
+    assert result == "tools/sub/my_script.py"
+
+
+def test_scripts_dir_returns_file_path(tmp_path: Path) -> None:
+    """scripts/ directory (no __init__.py) → file path format."""
+    (tmp_path / "scripts").mkdir(exist_ok=True)
+
+    result = _path_to_cov_target("scripts/deploy.py", tmp_path)
+    assert result == "scripts/deploy.py"
+
+
+def test_no_repo_root_returns_file_path() -> None:
+    """No repo_root → can't check __init__.py, returns file path."""
+    result = _path_to_cov_target("tools/foo.py", None)
+    assert result == "tools/foo.py"
+
+
+# ---------------------------------------------------------------------------
+# _path_to_cov_target — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_backslash_normalized(tmp_path: Path) -> None:
+    """Windows backslashes → normalized to forward slashes in path mode."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+
+    result = _path_to_cov_target("tools\\my_script.py", tmp_path)
+    assert "/" in result or "\\" not in result  # No backslashes in output
+
+
+def test_non_py_file_keeps_extension(tmp_path: Path) -> None:
+    """Non-.py file → keeps its extension in path mode."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+
+    result = _path_to_cov_target("tools/config.yml", tmp_path)
+    assert result == "tools/config.yml"
+
+
+# ---------------------------------------------------------------------------
+# verify_green_phase fallback — integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_state(**overrides):
+    """Minimal state dict for verify_green_phase."""
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 42,
+        "iteration_count": 0,
+        "max_iterations": 10,
+        "coverage_target": 90,
+        "implementation_files": [],
+        "skip_e2e": True,
+    }
+    base.update(overrides)
+    return base
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.get_repo_root")
+def test_fallback_infers_tools_from_impl_files(mock_root, mock_pytest, tmp_path: Path) -> None:
+    """Fallback uses top-level dir from impl_files when .py filter skips them."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+    # No __init__.py — tools/ is not a package
+    mock_root.return_value = tmp_path
+
+    mock_pytest.return_value = {
+        "returncode": 0,
+        "stdout": "1 passed",
+        "stderr": "",
+        "parsed": {"passed": 1, "failed": 0, "coverage": 95.0},
+    }
+
+    # impl_files has a .json file (skipped by .py filter) — fallback should still find "tools"
+    state = _make_state(
+        repo_root=str(tmp_path),
+        implementation_files=["tools/config.json"],
+    )
+
+    from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+    verify_green_phase(state)
+
+    # Check that run_pytest was called with coverage_module starting with "tools"
+    call_args = mock_pytest.call_args
+    assert call_args is not None
+    cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
+    if cov_module is None:
+        # Positional arg
+        cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
+    assert cov_module is not None
+    assert cov_module.startswith("tools"), f"Expected 'tools' scope, got: {cov_module}"
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.get_repo_root")
+def test_tools_impl_file_uses_file_path_not_dotted(mock_root, mock_pytest, tmp_path: Path) -> None:
+    """tools/*.py impl file → --cov gets file path, not dotted module."""
+    (tmp_path / "tools").mkdir(exist_ok=True)
+    mock_root.return_value = tmp_path
+
+    mock_pytest.return_value = {
+        "returncode": 0,
+        "stdout": "1 passed",
+        "stderr": "",
+        "parsed": {"passed": 1, "failed": 0, "coverage": 95.0},
+    }
+
+    state = _make_state(
+        repo_root=str(tmp_path),
+        implementation_files=[str(tmp_path / "tools" / "consolidate_logs.py")],
+    )
+
+    from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+    verify_green_phase(state)
+
+    call_args = mock_pytest.call_args
+    cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
+    if cov_module is None:
+        cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
+    assert cov_module is not None
+    assert "." not in cov_module or "/" in cov_module, (
+        f"Expected file path format for tools/ target, got dotted module: {cov_module}"
+    )
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.get_repo_root")
+def test_package_impl_file_uses_dotted_module(mock_root, mock_pytest, tmp_path: Path) -> None:
+    """assemblyzero/*.py impl file → --cov gets dotted module (existing behavior)."""
+    (tmp_path / "assemblyzero" / "__init__.py").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "assemblyzero" / "__init__.py").touch()
+    mock_root.return_value = tmp_path
+
+    mock_pytest.return_value = {
+        "returncode": 0,
+        "stdout": "1 passed",
+        "stderr": "",
+        "parsed": {"passed": 1, "failed": 0, "coverage": 95.0},
+    }
+
+    state = _make_state(
+        repo_root=str(tmp_path),
+        implementation_files=[str(tmp_path / "assemblyzero" / "utils" / "file_type.py")],
+    )
+
+    from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+    verify_green_phase(state)
+
+    call_args = mock_pytest.call_args
+    cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
+    if cov_module is None:
+        cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
+    assert cov_module == "assemblyzero.utils.file_type"


### PR DESCRIPTION
## Summary

- Extract `_path_to_cov_target()` helper that checks `__init__.py` to distinguish Python packages (dotted module → `assemblyzero.utils.file_type`) from standalone scripts (file path → `tools/consolidate_logs.py`)
- Replace inline dotted-module conversion in all 3 inference steps with the new helper
- Improve last-resort fallback to infer top-level directory from available file paths before defaulting to `assemblyzero`

## Test plan

- [x] 12 new unit tests in `test_cov_target_resolution.py` — helper + integration
- [x] 27 existing verify_phases tests pass (0 regressions)

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)