### PR TITLE
feat: Sprint 1 reliability — failure feedback, timeout, e2e guards

### DIFF
--- a/assemblyzero/utils/workflow_timeout.py
+++ b/assemblyzero/utils/workflow_timeout.py
@@ -1,0 +1,106 @@
+"""Global workflow timeout utility.
+
+Issue #517: Prevents stuck workflows from running forever by enforcing
+a wall-clock timeout across the entire workflow execution.
+
+Usage:
+    from assemblyzero.utils.workflow_timeout import WorkflowTimeout
+
+    with WorkflowTimeout(minutes=90):
+        # ... run workflow ...
+        # Raises SystemExit if timeout exceeded
+
+    # Or with 0 to disable:
+    with WorkflowTimeout(minutes=0):
+        # No timeout enforced
+        pass
+"""
+
+import sys
+import threading
+
+
+class WorkflowTimeoutError(SystemExit):
+    """Raised when workflow exceeds its wall-clock timeout.
+
+    Inherits from SystemExit so it propagates through LangGraph's
+    exception handling without being caught by generic Exception handlers.
+    """
+
+    def __init__(self, minutes: int):
+        self.minutes = minutes
+        super().__init__(
+            f"\n[TIMEOUT] Workflow exceeded {minutes}-minute wall-clock limit. "
+            f"Shutting down cleanly.\n"
+            f"This is a safety guard to prevent stuck workflows from running forever.\n"
+            f"Use --timeout to adjust (e.g., --timeout 120 for 2 hours, --timeout 0 to disable)."
+        )
+
+
+class WorkflowTimeout:
+    """Context manager that enforces a global wall-clock timeout.
+
+    Uses a daemon thread timer that interrupts the main thread via
+    SystemExit after the specified duration. The daemon thread ensures
+    cleanup even if the main thread is stuck.
+
+    Args:
+        minutes: Timeout in minutes. 0 disables the timeout.
+    """
+
+    def __init__(self, minutes: int = 30):
+        self.minutes = minutes
+        self._timer: threading.Timer | None = None
+
+    def __enter__(self) -> "WorkflowTimeout":
+        if self.minutes <= 0:
+            return self
+
+        seconds = self.minutes * 60
+
+        def _timeout_handler():
+            print(
+                f"\n{'=' * 70}\n"
+                f"[TIMEOUT] Workflow exceeded {self.minutes}-minute wall-clock limit.\n"
+                f"Forcing shutdown to prevent resource waste.\n"
+                f"{'=' * 70}\n",
+                file=sys.stderr,
+                flush=True,
+            )
+            # os._exit is the nuclear option — it bypasses all cleanup.
+            # We use it because the main thread may be stuck in a blocking call
+            # (subprocess, network I/O) that won't respond to exceptions.
+            import os
+            os._exit(42)
+
+        self._timer = threading.Timer(seconds, _timeout_handler)
+        self._timer.daemon = True
+        self._timer.start()
+
+        remaining = self.minutes
+        print(f"    [TIMEOUT] Global workflow timeout: {remaining} minutes")
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+        return False  # Don't suppress exceptions
+
+
+def add_timeout_argument(parser) -> None:
+    """Add --timeout argument to an argparse parser.
+
+    Issue #517: Shared helper so all workflow runners use the same flag.
+
+    Args:
+        parser: argparse.ArgumentParser instance.
+    """
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        metavar="MINUTES",
+        help="Global wall-clock timeout in minutes (default: 30, 0=disable)",
+    )

--- a/assemblyzero/workflows/testing/nodes/e2e_validation.py
+++ b/assemblyzero/workflows/testing/nodes/e2e_validation.py
@@ -60,6 +60,54 @@ def _extract_failed_test_names(output: str) -> list[str]:
     return sorted(set(failures))
 
 
+# Issue #498: Max chars for E2E failure summary
+MAX_E2E_FAILURE_SUMMARY_CHARS = 2000
+
+
+def _build_e2e_failure_summary(output: str) -> str:
+    """Extract a concise failure summary from E2E pytest output.
+
+    Issue #498: Mirrors _build_failure_summary from verify_phases.py
+    but for E2E test output. Feeds N4 targeted error context.
+
+    Args:
+        output: Combined stdout + stderr from E2E pytest run.
+
+    Returns:
+        Concise failure summary, truncated to MAX_E2E_FAILURE_SUMMARY_CHARS.
+        Empty string if no failures found.
+    """
+    lines = output.split("\n")
+    summary_lines: list[str] = []
+
+    # Extract "short test summary info" section
+    in_summary = False
+    for line in lines:
+        if "short test summary info" in line:
+            in_summary = True
+            continue
+        if in_summary:
+            if line.startswith("=" * 10):
+                summary_lines.append(line.strip("= \n"))
+                break
+            if line.strip():
+                summary_lines.append(line.strip())
+
+    if not summary_lines:
+        # Fallback: extract FAILED lines from anywhere
+        for line in lines:
+            if re.match(r"FAILED\s+", line):
+                summary_lines.append(line.strip())
+
+    if not summary_lines:
+        return ""
+
+    result = "\n".join(summary_lines)
+    if len(result) > MAX_E2E_FAILURE_SUMMARY_CHARS:
+        result = result[:MAX_E2E_FAILURE_SUMMARY_CHARS] + "\n... (truncated)"
+    return result
+
+
 def run_e2e_tests(
     test_files: list[str],
     sandbox_repo: str | None,
@@ -282,6 +330,9 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
         current_failures = _extract_failed_test_names(output)
         previous_failures = state.get("previous_e2e_failures", [])
 
+        # Issue #498: Build concise failure summary for N4 feedback
+        e2e_failure_summary = _build_e2e_failure_summary(output)
+
         print(f"    E2E tests failed - iteration {iteration_count} | passed: {e2e_passed}")
 
         log_workflow_execution(
@@ -314,6 +365,7 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
                 "file_counter": file_num,
                 "previous_e2e_passed": e2e_passed,
                 "previous_e2e_failures": current_failures,
+                "e2e_failure_summary": e2e_failure_summary,
                 "error_message": stagnant_msg,
             }
 
@@ -326,6 +378,7 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
                 "file_counter": file_num,
                 "previous_e2e_passed": e2e_passed,
                 "previous_e2e_failures": current_failures,
+                "e2e_failure_summary": e2e_failure_summary,
                 "error_message": trip_reason,
             }
 
@@ -337,6 +390,7 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
                 "file_counter": file_num,
                 "previous_e2e_passed": e2e_passed,
                 "previous_e2e_failures": current_failures,
+                "e2e_failure_summary": e2e_failure_summary,
                 "iteration_count": iteration_count + 1,
                 "next_node": "N4_implement_code",
                 "error_message": "",
@@ -347,6 +401,7 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
                 "file_counter": file_num,
                 "previous_e2e_passed": e2e_passed,
                 "previous_e2e_failures": current_failures,
+                "e2e_failure_summary": e2e_failure_summary,
                 "error_message": f"E2E failed after {max_iterations} iterations",
             }
 

--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -811,15 +811,15 @@ Modify this file according to the LLD specification.
     # Include previous error if this is a retry... wait, no retries!
     # Actually we might loop back from green phase failure, so include error context
     if previous_error:
-        prompt += f"""## Previous Attempt Failed
+        prompt += f"""## Previous Attempt Failed — Fix These Specific Errors
 
-The previous implementation had this error:
+The previous implementation failed these tests:
 
 ```
 {previous_error}
 ```
 
-Fix the issue in your implementation.
+Read the error messages carefully and fix the root cause in your implementation.
 
 """
 
@@ -1213,6 +1213,9 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
     files_to_modify = state.get("files_to_modify", [])
     test_files = state.get("test_files", [])
     green_phase_output = state.get("green_phase_output", "")
+    # Issue #498: Prefer structured failure summaries over raw pytest output
+    test_failure_summary = state.get("test_failure_summary", "")
+    e2e_failure_summary = state.get("e2e_failure_summary", "")
     audit_dir = Path(state.get("audit_dir", ""))
 
     if not files_to_modify:
@@ -1344,7 +1347,9 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             completed_files=completed_files,
             repo_root=repo_root,
             test_content=test_content,
-            previous_error=green_phase_output if iteration_count > 0 else "",
+            # Issue #498: Use structured failure summary (targeted) over raw output (noisy)
+            previous_error=(test_failure_summary or e2e_failure_summary or green_phase_output)
+            if iteration_count > 0 else "",
             path_enforcement_section=path_enforcement_section,
             context_content=state.get("context_content", ""),
             repo_structure=repo_structure,
@@ -1535,11 +1540,16 @@ def build_implementation_prompt(state: TestingWorkflowState) -> str:
                     except Exception:
                         pass
 
-    if iteration_count > 0 and green_phase_output:
+    # Issue #498: Use structured failure summary when available
+    test_failure_summary = state.get("test_failure_summary", "")
+    e2e_failure_summary = state.get("e2e_failure_summary", "")
+    error_feedback = test_failure_summary or e2e_failure_summary or green_phase_output
+
+    if iteration_count > 0 and error_feedback:
         prompt += f"""## Previous Test Run (FAILED)
 
 ```
-{green_phase_output}
+{error_feedback}
 ```
 
 Fix the issues and regenerate the implementation.

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -21,6 +21,7 @@ from assemblyzero.workflows.testing.audit import (
     save_audit_file,
 )
 from assemblyzero.workflows.testing.circuit_breaker import check_circuit_breaker
+from assemblyzero.workflows.testing.nodes.e2e_validation import _extract_failed_test_names
 from assemblyzero.workflows.testing.exit_code_router import (
     EXIT_INTERRUPTED,
     EXIT_INTERNALERROR,
@@ -36,6 +37,58 @@ from assemblyzero.workflows.testing.state import TestingWorkflowState
 
 # Timeout for pytest execution
 PYTEST_TIMEOUT_SECONDS = 300
+
+# Issue #498: Max chars for failure summary fed back to N4
+MAX_FAILURE_SUMMARY_CHARS = 2000
+
+
+def _build_failure_summary(output: str) -> str:
+    """Extract a concise failure summary from pytest output.
+
+    Issue #498: Instead of feeding N4 the entire pytest output, extract
+    only the "short test summary info" section which contains test names
+    and one-line error messages. This tells N4 exactly what to fix.
+
+    Args:
+        output: Combined stdout + stderr from pytest.
+
+    Returns:
+        Concise failure summary, truncated to MAX_FAILURE_SUMMARY_CHARS.
+        Empty string if no failures found.
+    """
+    import re
+
+    lines = output.split("\n")
+    summary_lines: list[str] = []
+
+    # Extract "short test summary info" section
+    in_summary = False
+    for line in lines:
+        if "short test summary info" in line:
+            in_summary = True
+            continue
+        if in_summary:
+            # Section ends at the next separator line (====)
+            if line.startswith("=" * 10):
+                # Capture the final summary (e.g., "2 failed, 1 passed in 0.15s")
+                summary_lines.append(line.strip("= \n"))
+                break
+            if line.strip():
+                summary_lines.append(line.strip())
+
+    if not summary_lines:
+        # Fallback: extract FAILED lines from anywhere in output
+        for line in lines:
+            if re.match(r"FAILED\s+", line):
+                summary_lines.append(line.strip())
+
+    if not summary_lines:
+        return ""
+
+    result = "\n".join(summary_lines)
+    if len(result) > MAX_FAILURE_SUMMARY_CHARS:
+        result = result[:MAX_FAILURE_SUMMARY_CHARS] + "\n... (truncated)"
+    return result
 
 
 def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
@@ -499,6 +552,12 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     previous_coverage = state.get("previous_coverage", -1.0)
     max_iterations = state.get("max_iterations", 5)
 
+    # Issue #498: Build concise failure summary for N4 feedback
+    failure_summary = _build_failure_summary(output)
+
+    # Issue #501: Extract failed test names for identity-based stagnation
+    current_green_failures = _extract_failed_test_names(output)
+
     # Check for failures
     if failed_count > 0 or error_count > 0:
         # Check if we've exhausted iterations
@@ -510,6 +569,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -531,6 +592,36 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "iteration_count": iteration_count + 1,
+                "next_node": "end",
+                "error_message": stagnant_msg,
+            }
+
+        # Issue #501: Identity-based stagnation — same tests failing across iterations.
+        # Catches cases where pass count fluctuates but the SAME tests keep failing.
+        previous_green_failures = state.get("previous_green_failures", [])
+        identity_stagnant = (
+            bool(current_green_failures)
+            and bool(previous_green_failures)
+            and current_green_failures == sorted(previous_green_failures)
+        )
+        if identity_stagnant:
+            stagnant_msg = (
+                f"Test identity stagnant: same {len(current_green_failures)} test(s) failing "
+                f"across iterations. Halting to prevent token waste."
+            )
+            print(f"    [STAGNANT] {stagnant_msg}")
+            return {
+                "green_phase_output": output,
+                "coverage_achieved": coverage_achieved,
+                "previous_coverage": coverage_achieved,
+                "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -552,6 +643,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -568,6 +661,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -593,12 +688,14 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             },
         )
 
-        # Loop back to implementation
+        # Loop back to implementation with failure feedback
         return {
             "green_phase_output": output,
             "coverage_achieved": coverage_achieved,
             "previous_coverage": coverage_achieved,
             "previous_passed": passed_count,
+            "previous_green_failures": current_green_failures,
+            "test_failure_summary": failure_summary,
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
             "iteration_count": iteration_count + 1,
@@ -616,6 +713,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -635,6 +734,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -651,6 +752,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "coverage_achieved": coverage_achieved,
                 "previous_coverage": coverage_achieved,
                 "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
@@ -681,6 +784,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "coverage_achieved": coverage_achieved,
             "previous_coverage": coverage_achieved,
             "previous_passed": passed_count,
+            "previous_green_failures": current_green_failures,
+            "test_failure_summary": failure_summary,
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
             "iteration_count": iteration_count + 1,
@@ -710,6 +815,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "coverage_achieved": coverage_achieved,
             "previous_coverage": coverage_achieved,
             "previous_passed": passed_count,
+            "previous_green_failures": [],
+            "test_failure_summary": "",
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
             "next_node": "N7_finalize",  # Skip E2E
@@ -721,6 +828,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         "coverage_achieved": coverage_achieved,
         "previous_coverage": coverage_achieved,
         "previous_passed": passed_count,
+        "previous_green_failures": [],
+        "test_failure_summary": "",
         "file_counter": file_num,
         "pytest_exit_code": exit_code,
         "next_node": "N6_e2e_validation",

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -166,6 +166,9 @@ class TestingWorkflowState(TypedDict, total=False):
     e2e_output: str
     previous_e2e_passed: int  # Previous E2E pass count for stagnation detection
     previous_e2e_failures: list[str]  # Issue #504: Previous E2E failed test names for identity comparison
+    previous_green_failures: list[str]  # Issue #501: Previous green phase failed test names for identity comparison
+    test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
+    e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
 
     # Review artifacts
     test_plan_review_prompt: str

--- a/tests/unit/test_failure_feedback.py
+++ b/tests/unit/test_failure_feedback.py
@@ -1,0 +1,324 @@
+"""Tests for Issue #498 (test failure feedback to N4) and #501 (green phase identity stagnation).
+
+Issue #498: N4 receives structured failure summaries instead of raw pytest output.
+Issue #501: Green phase detects when the same tests fail across iterations (identity stagnation).
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _build_failure_summary,
+    verify_green_phase,
+)
+
+
+# ===========================================================================
+# Issue #498: _build_failure_summary
+# ===========================================================================
+
+
+class TestBuildFailureSummary:
+    """Tests for extracting concise failure summaries from pytest output."""
+
+    def test_extracts_short_summary_section(self):
+        """Extracts FAILED lines from 'short test summary info' section."""
+        output = """============================= test session starts ==============================
+collected 5 items
+
+tests/test_foo.py::test_a PASSED
+tests/test_foo.py::test_b FAILED
+tests/test_foo.py::test_c FAILED
+
+=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_b - AssertionError: 446 != 143
+FAILED tests/test_foo.py::test_c - TypeError: unsupported operand
+============================== 2 failed, 1 passed in 0.15s ====================
+"""
+        result = _build_failure_summary(output)
+        assert "AssertionError: 446 != 143" in result
+        assert "TypeError: unsupported operand" in result
+        assert "test_b" in result
+        assert "test_c" in result
+
+    def test_includes_final_count_line(self):
+        """Includes the '2 failed, 1 passed' line from separator."""
+        output = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_b - AssertionError
+============================== 1 failed, 2 passed in 0.15s ====================
+"""
+        result = _build_failure_summary(output)
+        assert "1 failed" in result
+
+    def test_fallback_to_failed_lines(self):
+        """Falls back to FAILED lines when no summary section exists."""
+        output = """FAILED tests/test_foo.py::test_a - Error: something broke
+FAILED tests/test_foo.py::test_b - ValueError: bad input
+3 failed in 1.00s
+"""
+        result = _build_failure_summary(output)
+        assert "test_a" in result
+        assert "test_b" in result
+
+    def test_returns_empty_for_no_failures(self):
+        """Returns empty string when no failures detected."""
+        output = """============================= test session starts ==============================
+collected 3 items
+
+tests/test_foo.py::test_a PASSED
+tests/test_foo.py::test_b PASSED
+
+============================== 2 passed in 0.12s ===============================
+"""
+        result = _build_failure_summary(output)
+        assert result == ""
+
+    def test_truncates_long_output(self):
+        """Truncates output exceeding MAX_FAILURE_SUMMARY_CHARS."""
+        # Build output with many FAILED lines
+        lines = ["=========================== short test summary info ============================"]
+        for i in range(200):
+            lines.append(f"FAILED tests/test_x.py::test_{i:04d} - AssertionError: value mismatch")
+        lines.append("=" * 50 + " 200 failed " + "=" * 50)
+        output = "\n".join(lines)
+
+        result = _build_failure_summary(output)
+        assert len(result) <= 2100  # 2000 + truncation message
+        assert "truncated" in result
+
+    def test_empty_input(self):
+        """Empty input returns empty string."""
+        assert _build_failure_summary("") == ""
+
+
+# ===========================================================================
+# Issue #498: verify_green_phase returns test_failure_summary
+# ===========================================================================
+
+
+def _make_state(**overrides):
+    """Create a minimal TestingWorkflowState for testing."""
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 42,
+        "iteration_count": 1,
+        "max_iterations": 10,
+        "coverage_target": 90,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+        "previous_green_failures": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_pytest_result(returncode, passed=0, failed=0, errors=0, coverage=0, summary_section=""):
+    """Create a mock pytest result dict with optional summary section."""
+    stdout = f"{passed} passed, {failed} failed"
+    if summary_section:
+        stdout = summary_section
+    return {
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": "",
+        "parsed": {
+            "passed": passed,
+            "failed": failed,
+            "errors": errors,
+            "coverage": coverage,
+        },
+    }
+
+
+class TestFailureSummaryInGreenPhase:
+    """Tests that verify_green_phase includes test_failure_summary in results."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.check_circuit_breaker")
+    def test_failure_summary_populated_on_loop(self, mock_cb, mock_log, mock_pytest):
+        """When tests fail and we loop back, test_failure_summary is set."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_bar - AssertionError: 446 != 143
+============================== 1 failed, 2 passed in 0.15s ===================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=2, failed=1, errors=0, coverage=50, summary_section=summary,
+        )
+        mock_cb.return_value = (False, "")
+        state = _make_state(previous_passed=-1, previous_coverage=-1.0)
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "N4_implement_code"
+        assert "test_failure_summary" in result
+        assert "AssertionError: 446 != 143" in result["test_failure_summary"]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    def test_failure_summary_empty_on_success(self, mock_log, mock_pytest):
+        """When tests pass, test_failure_summary is empty."""
+        mock_pytest.return_value = _make_pytest_result(
+            0, passed=5, failed=0, errors=0, coverage=95,
+        )
+        state = _make_state()
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "N7_finalize"
+        assert result["test_failure_summary"] == ""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_failure_summary_on_stagnation_halt(self, mock_pytest):
+        """Even on stagnation halt, failure summary is populated."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_x.py::test_a - AssertionError
+============================== 1 failed in 0.10s ==============================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=0, failed=1, errors=0, coverage=0, summary_section=summary,
+        )
+        state = _make_state(previous_passed=0, previous_coverage=0.0)
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "end"
+        assert "stagnant" in result["error_message"].lower()
+        assert "test_failure_summary" in result
+        assert result["test_failure_summary"] != ""
+
+
+# ===========================================================================
+# Issue #501: Green phase identity-based stagnation
+# ===========================================================================
+
+
+class TestGreenPhaseIdentityStagnation:
+    """Tests for identity-based stagnation detection in verify_green_phase."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_same_failures_triggers_identity_stagnation(self, mock_pytest):
+        """Same test names failing across iterations → identity stagnant → halt."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_bar - AssertionError
+FAILED tests/test_foo.py::test_baz - TypeError
+============================== 2 failed, 3 passed in 0.20s ===================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=3, failed=2, errors=0, coverage=60, summary_section=summary,
+        )
+        # previous_passed=1 and current passed=3 → count check passes (improvement)
+        # But same tests failing → identity stagnation triggers
+        state = _make_state(
+            previous_passed=1,
+            previous_coverage=-1.0,
+            previous_green_failures=[
+                "tests/test_foo.py::test_bar",
+                "tests/test_foo.py::test_baz",
+            ],
+        )
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "end"
+        assert "identity stagnant" in result["error_message"].lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.check_circuit_breaker")
+    def test_different_failures_not_stagnant(self, mock_cb, mock_log, mock_pytest):
+        """Different test names failing → not identity stagnant → continue."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_new_failure - AssertionError
+============================== 1 failed, 4 passed in 0.20s ===================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=4, failed=1, errors=0, coverage=70, summary_section=summary,
+        )
+        mock_cb.return_value = (False, "")
+        state = _make_state(
+            previous_passed=3,
+            previous_coverage=50.0,
+            previous_green_failures=["tests/test_foo.py::test_old_failure"],
+        )
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "N4_implement_code"
+        assert result["error_message"] == ""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.check_circuit_breaker")
+    def test_first_iteration_no_identity_stagnation(self, mock_cb, mock_log, mock_pytest):
+        """First iteration (no previous failures) → no identity stagnation."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_bar - AssertionError
+============================== 1 failed, 2 passed in 0.15s ===================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=2, failed=1, errors=0, coverage=50, summary_section=summary,
+        )
+        mock_cb.return_value = (False, "")
+        state = _make_state(
+            previous_passed=-1,
+            previous_coverage=-1.0,
+            previous_green_failures=[],
+        )
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "N4_implement_code"
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_previous_green_failures_propagated(self, mock_pytest):
+        """Result always includes previous_green_failures for next iteration."""
+        summary = """=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_x - Error
+============================== 1 failed, 2 passed in 0.15s ===================="""
+        mock_pytest.return_value = _make_pytest_result(
+            1, passed=2, failed=1, errors=0, coverage=50, summary_section=summary,
+        )
+        # Will hit count stagnation (previous_passed=2, current=2)
+        state = _make_state(previous_passed=2, previous_coverage=50.0)
+        result = verify_green_phase(state)
+
+        assert "previous_green_failures" in result
+        assert "tests/test_foo.py::test_x" in result["previous_green_failures"]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")
+    def test_success_clears_green_failures(self, mock_log, mock_pytest):
+        """On success, previous_green_failures is cleared."""
+        mock_pytest.return_value = _make_pytest_result(
+            0, passed=5, failed=0, errors=0, coverage=95,
+        )
+        state = _make_state(previous_green_failures=["tests/test_foo.py::test_x"])
+        result = verify_green_phase(state)
+
+        assert result["next_node"] == "N7_finalize"
+        assert result["previous_green_failures"] == []
+
+
+# ===========================================================================
+# Issue #498: E2E failure summary
+# ===========================================================================
+
+
+class TestE2EFailureSummary:
+    """Tests for _build_e2e_failure_summary."""
+
+    def test_extracts_e2e_failure_summary(self):
+        """Extracts failure summary from E2E pytest output."""
+        from assemblyzero.workflows.testing.nodes.e2e_validation import (
+            _build_e2e_failure_summary,
+        )
+
+        output = """=========================== short test summary info ============================
+FAILED tests/test_e2e.py::test_workflow - AssertionError: expected 200, got 500
+============================== 1 failed in 5.23s ===============================
+"""
+        result = _build_e2e_failure_summary(output)
+        assert "expected 200, got 500" in result
+
+    def test_returns_empty_for_no_failures(self):
+        """Returns empty string when no failures."""
+        from assemblyzero.workflows.testing.nodes.e2e_validation import (
+            _build_e2e_failure_summary,
+        )
+
+        output = "3 passed in 2.00s"
+        assert _build_e2e_failure_summary(output) == ""

--- a/tests/unit/test_workflow_timeout.py
+++ b/tests/unit/test_workflow_timeout.py
@@ -1,0 +1,112 @@
+"""Tests for Issue #517: Global workflow timeout utility.
+
+Tests the WorkflowTimeout context manager and add_timeout_argument helper.
+"""
+
+import argparse
+import time
+
+from assemblyzero.utils.workflow_timeout import (
+    WorkflowTimeout,
+    WorkflowTimeoutError,
+    add_timeout_argument,
+)
+
+
+class TestWorkflowTimeout:
+    """Tests for WorkflowTimeout context manager."""
+
+    def test_no_timeout_when_zero(self):
+        """minutes=0 disables timeout — no timer created."""
+        wt = WorkflowTimeout(minutes=0)
+        with wt:
+            assert wt._timer is None
+
+    def test_timer_created_for_positive_minutes(self):
+        """Positive minutes creates a daemon timer."""
+        wt = WorkflowTimeout(minutes=90)
+        with wt:
+            assert wt._timer is not None
+            assert wt._timer.daemon is True
+            assert wt._timer.is_alive()
+        # Timer cancelled and cleared on exit
+        assert wt._timer is None
+
+    def test_timer_cleared_on_normal_exit(self):
+        """Timer ref is cleared when context exits normally."""
+        wt = WorkflowTimeout(minutes=90)
+        with wt:
+            assert wt._timer is not None
+        # Timer ref cleared on exit
+        assert wt._timer is None
+
+    def test_timer_cleared_on_exception(self):
+        """Timer ref is cleared even when context exits via exception."""
+        wt = WorkflowTimeout(minutes=90)
+        try:
+            with wt:
+                assert wt._timer is not None
+                raise ValueError("test error")
+        except ValueError:
+            pass
+        assert wt._timer is None
+
+    def test_does_not_suppress_exceptions(self):
+        """Context manager does not suppress exceptions."""
+        with_error = False
+        try:
+            with WorkflowTimeout(minutes=90):
+                raise RuntimeError("should propagate")
+        except RuntimeError:
+            with_error = True
+        assert with_error
+
+    def test_default_minutes_is_30(self):
+        """Default timeout is 30 minutes."""
+        wt = WorkflowTimeout()
+        assert wt.minutes == 30
+
+
+class TestWorkflowTimeoutError:
+    """Tests for the WorkflowTimeoutError exception."""
+
+    def test_is_system_exit(self):
+        """WorkflowTimeoutError inherits from SystemExit."""
+        err = WorkflowTimeoutError(minutes=90)
+        assert isinstance(err, SystemExit)
+
+    def test_stores_minutes(self):
+        """Stores the timeout value."""
+        err = WorkflowTimeoutError(minutes=45)
+        assert err.minutes == 45
+
+    def test_message_includes_timeout_value(self):
+        """Error message mentions the timeout duration."""
+        err = WorkflowTimeoutError(minutes=90)
+        assert "90" in str(err)
+        assert "TIMEOUT" in str(err)
+
+
+class TestAddTimeoutArgument:
+    """Tests for the add_timeout_argument helper."""
+
+    def test_adds_timeout_flag(self):
+        """Adds --timeout with default 90."""
+        parser = argparse.ArgumentParser()
+        add_timeout_argument(parser)
+        args = parser.parse_args([])
+        assert args.timeout == 30
+
+    def test_custom_timeout(self):
+        """--timeout accepts custom value."""
+        parser = argparse.ArgumentParser()
+        add_timeout_argument(parser)
+        args = parser.parse_args(["--timeout", "120"])
+        assert args.timeout == 120
+
+    def test_disable_timeout(self):
+        """--timeout 0 disables."""
+        parser = argparse.ArgumentParser()
+        add_timeout_argument(parser)
+        args = parser.parse_args(["--timeout", "0"])
+        assert args.timeout == 0

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -432,6 +432,10 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="Max estimated tokens before circuit breaker trips (0 = unlimited)",
     )
 
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import add_timeout_argument
+    add_timeout_argument(parser)
+
     return parser
 
 
@@ -660,6 +664,8 @@ def main():
         print(f"[implement] Mode: DRY RUN")
     if args.token_budget > 0:
         print(f"[implement] Token budget: {args.token_budget:,}")
+    if args.timeout > 0:
+        print(f"[implement] Timeout: {args.timeout} minutes")
     print()
 
     # Issue #290: Dry-run — preview execution plan and exit
@@ -737,7 +743,11 @@ def main():
             db_path.unlink()
             print(f"[implement] Cleared stale checkpoint DB: {db_path}")
 
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import WorkflowTimeout
+
     try:
+      with WorkflowTimeout(minutes=args.timeout):
         with SqliteSaver.from_conn_string(str(db_path)) as memory:
             app = workflow.compile(checkpointer=memory)
 

--- a/tools/run_implementation_spec_workflow.py
+++ b/tools/run_implementation_spec_workflow.py
@@ -217,6 +217,10 @@ Examples:
         help="Max API cost in USD before halting (default $5.00, 0=unlimited)",
     )
 
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import add_timeout_argument
+    add_timeout_argument(parser)
+
     return parser
 
 
@@ -548,7 +552,11 @@ def run_workflow(
         print(f"DEBUG: repo_root = {state.get('repo_root', '')}")
 
     # Create and run graph
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import WorkflowTimeout
+
     try:
+      with WorkflowTimeout(minutes=args.timeout):
         graph = create_implementation_spec_graph()
 
         # Calculate recursion limit: each iteration can touch N2->N3->N5 (3 nodes)

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -436,6 +436,10 @@ Examples:
         help="Max API cost in USD before halting (default $5.00, 0=unlimited)",
     )
 
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import add_timeout_argument
+    add_timeout_argument(parser)
+
     return parser.parse_args(args)
 
 
@@ -631,7 +635,11 @@ def run_single_workflow(
         return 0
 
     # Create and run graph
+    # Issue #517: Global workflow timeout
+    from assemblyzero.utils.workflow_timeout import WorkflowTimeout
+
     try:
+      with WorkflowTimeout(minutes=args.timeout):
         graph = create_requirements_graph()
         compiled = graph.compile()
 


### PR DESCRIPTION
## Summary
- **#498**: Failure identity stagnation detection in `verify_phases` — tracks green-phase failures across iterations, halts when identical failures repeat
- **#501**: E2E validation failure summaries extracted and propagated to `implement_code` for targeted fixes instead of blind retries  
- **#517**: Workflow timeout context manager with CLI `--timeout` flag across all three workflow entry points

## Test plan
- [x] 28 new unit tests (test_failure_feedback.py, test_workflow_timeout.py)
- [x] Full suite: 3902 pass, 0 regressions (4 pre-existing failures unrelated)

Closes #498, closes #501, closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)