### PR TITLE
feat: enforce extract-and-discard pattern (#507)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -583,7 +583,7 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
             gemini_feedback = _extract_feedback(verdict_content)
         return {
             "test_plan_status": "BLOCKED",
-            "test_plan_verdict": verdict_content,
+            "test_plan_verdict": f"BLOCKED: {gemini_feedback[:200]}",
             "gemini_feedback": gemini_feedback,
             "file_counter": file_num,
             "error_message": "Test plan review BLOCKED - requires LLD revision",
@@ -593,7 +593,11 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
 
     return {
         "test_plan_status": "APPROVED",
-        "test_plan_verdict": verdict_content,
+        "test_plan_verdict": (
+            f"APPROVED: {structured.get('summary', 'Test plan approved')[:200]}"
+            if structured
+            else "APPROVED"
+        ),
         "test_plan_review_prompt": full_prompt,
         "file_counter": file_num,
         "error_message": "",
@@ -740,7 +744,7 @@ def _mock_review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
 
     return {
         "test_plan_status": test_plan_status,
-        "test_plan_verdict": verdict_content,
+        "test_plan_verdict": f"{test_plan_status}: {gemini_feedback[:200]}" if gemini_feedback else test_plan_status,
         "gemini_feedback": gemini_feedback,
         "file_counter": file_num,
         "error_message": "" if test_plan_status == "APPROVED" else "Test plan review BLOCKED",

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -76,7 +76,7 @@ class TestingWorkflowState(TypedDict, total=False):
 
         # Review artifacts
         test_plan_review_prompt: Prompt sent to Gemini for test plan review.
-        test_plan_verdict: Gemini's verdict on test plan.
+        test_plan_verdict: Extracted verdict summary (not raw prose). Full response in audit trail.
         test_plan_status: APPROVED or BLOCKED.
         gemini_feedback: Feedback from Gemini if BLOCKED.
 

--- a/docs/standards/0014-extract-and-discard-pattern.md
+++ b/docs/standards/0014-extract-and-discard-pattern.md
@@ -1,0 +1,44 @@
+# Standard 0014: Extract-and-Discard Pattern for LLM Responses
+
+**Status:** Approved
+**Issue:** #507
+**Date:** 2026-03-01
+
+## Pattern Definition
+
+Every LLM-calling node MUST follow this sequence:
+
+1. **Save** the full raw LLM response to an audit file (before any processing)
+2. **Extract** structured/actionable data from the response
+3. **Store** only the extracted data in workflow state — never raw prose
+
+This ensures audit traceability (full response preserved) while keeping workflow
+state small and deterministic (no multi-KB prose blobs flowing between nodes).
+
+## Field Categories
+
+| Category | Rule | Example |
+|----------|------|---------|
+| **Artifacts** | Full content OK — the LLM output IS the deliverable | `generate_draft.py` → draft content, `generate_spec.py` → spec content |
+| **Verdicts/Feedback** | Extracted summary only — status + key feedback, ≤200 chars | `review.py` → `_extract_actionable_feedback()`, `review_test_plan.py` → `"BLOCKED: {summary}"` |
+| **Code** | Extracted blocks only — strip surrounding prose | `implement_code.py` → code fence extraction |
+
+## Compliance Checklist (New LLM-Calling Nodes)
+
+When adding a new node that calls an LLM:
+
+- [ ] Raw response saved to audit file via `save_audit_file()` BEFORE extraction
+- [ ] State fields contain only extracted/structured data
+- [ ] No raw prose longer than 200 characters stored in state
+- [ ] Artifact fields (where content IS the deliverable) are documented as such
+
+## Current Node Compliance
+
+| Node | Workflow | Compliant | Method |
+|------|----------|-----------|--------|
+| `generate_draft.py` | Requirements | Yes (artifact) | Draft content is the deliverable |
+| `review.py` | Requirements | Yes | `_extract_actionable_feedback()` extracts structured feedback |
+| `generate_spec.py` | Impl Spec | Yes (artifact) | Spec content is the deliverable |
+| `review_spec.py` | Impl Spec | Yes | Stores `review_verdict` enum + `review_feedback` summary |
+| `review_test_plan.py` | Testing | Yes (#507) | Stores `"STATUS: summary[:200]"`, raw response in audit trail |
+| `implement_code.py` | Testing | Yes | Extracts code blocks, discards surrounding prose |

--- a/tests/unit/test_extract_and_discard.py
+++ b/tests/unit/test_extract_and_discard.py
@@ -1,0 +1,229 @@
+"""Tests for Issue #507: Extract-and-discard pattern in review_test_plan.
+
+Validates that test_plan_verdict stores concise extracted summaries,
+not raw LLM prose. Full responses are saved to audit files only.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.review_test_plan import (
+    review_test_plan,
+    _mock_review_test_plan,
+)
+
+
+def _make_state(**overrides) -> dict:
+    """Minimal state for review_test_plan."""
+    base = {
+        "test_scenarios": [
+            {"name": "test_create", "type": "unit", "requirement_ref": "REQ-1"},
+            {"name": "test_delete", "type": "unit", "requirement_ref": "REQ-2"},
+        ],
+        "requirements": ["REQ-1: Create", "REQ-2: Delete"],
+        "lld_content": "Detailed LLD content with enough words to pass the gate. " * 5,
+        "issue_number": 42,
+        "repo_root": str(Path("/tmp/test-repo")),
+        "audit_dir": str(Path("/tmp/nonexistent-audit")),
+        "mock_mode": False,
+        "node_costs": {},
+        "node_tokens": {},
+        "file_counter": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestBlockedVerdictExtraction:
+    """BLOCKED path should store extracted feedback, not raw prose."""
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_blocked_verdict_stores_summary_not_prose(self, mock_root, mock_prompt, mock_log):
+        """Gemini BLOCKED → test_plan_verdict is short summary, not full response."""
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        raw_prose = "A" * 500  # Long raw prose that should NOT appear in state
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.response = json.dumps({
+            "verdict": "BLOCKED",
+            "summary": "Missing edge case coverage for REQ-2.",
+            "blocking_issues": [
+                {"section": "Coverage", "issue": "REQ-2 missing edge cases", "severity": "BLOCKING"},
+            ],
+        })
+        mock_result.input_tokens = 100
+        mock_result.output_tokens = 50
+
+        with patch("assemblyzero.core.gemini_client.GeminiClient") as mock_cls, \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost", return_value=0.0), \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.check_requirement_coverage") as mock_cov:
+            mock_cls.return_value.invoke.return_value = mock_result
+            # Force past fast-path
+            mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
+
+            state = _make_state()
+            result = review_test_plan(state)
+
+        assert result["test_plan_status"] == "BLOCKED"
+        assert result["test_plan_verdict"].startswith("BLOCKED:")
+        assert len(result["test_plan_verdict"]) <= 210  # "BLOCKED: " + 200 chars max
+
+
+class TestApprovedVerdictExtraction:
+    """APPROVED path should store concise summary, not raw prose."""
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_approved_verdict_stores_summary_not_prose(self, mock_root, mock_prompt, mock_log):
+        """Gemini APPROVED → test_plan_verdict is concise, not full response."""
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.response = json.dumps({
+            "verdict": "APPROVED",
+            "summary": "All requirements covered with good edge cases.",
+        })
+        mock_result.input_tokens = 100
+        mock_result.output_tokens = 50
+
+        with patch("assemblyzero.core.gemini_client.GeminiClient") as mock_cls, \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost", return_value=0.0), \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.check_requirement_coverage") as mock_cov:
+            mock_cls.return_value.invoke.return_value = mock_result
+            mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
+
+            state = _make_state()
+            result = review_test_plan(state)
+
+        assert result["test_plan_status"] == "APPROVED"
+        assert result["test_plan_verdict"].startswith("APPROVED:")
+        assert "All requirements covered" in result["test_plan_verdict"]
+        assert len(result["test_plan_verdict"]) <= 210
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_approved_regex_fallback_stores_bare_approved(self, mock_root, mock_prompt, mock_log):
+        """Regex fallback (no structured JSON) → bare 'APPROVED' string."""
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.response = "## Verdict\n[x] **APPROVED** - Test plan is ready.\n\nLong explanation here..." + ("x" * 500)
+        mock_result.input_tokens = 100
+        mock_result.output_tokens = 50
+
+        with patch("assemblyzero.core.gemini_client.GeminiClient") as mock_cls, \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost", return_value=0.0), \
+             patch("assemblyzero.workflows.testing.nodes.review_test_plan.check_requirement_coverage") as mock_cov:
+            mock_cls.return_value.invoke.return_value = mock_result
+            mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
+
+            state = _make_state()
+            result = review_test_plan(state)
+
+        assert result["test_plan_status"] == "APPROVED"
+        assert result["test_plan_verdict"] == "APPROVED"
+
+
+class TestFastPathCompliance:
+    """Fast-path (mechanical approval) already stores concise summary."""
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_fast_path_stores_concise_verdict(self, mock_root, mock_prompt, mock_log):
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        state = _make_state()
+        result = review_test_plan(state)
+
+        assert result["test_plan_status"] == "APPROVED"
+        assert "mechanical" in result["test_plan_verdict"].lower()
+        # Fast-path verdict is a short formatted summary, not raw LLM prose
+        assert len(result["test_plan_verdict"]) < 500
+
+
+class TestMockModeCompliance:
+    """Mock mode should store concise verdict, not raw prose."""
+
+    def test_mock_approved_stores_concise_verdict(self):
+        state = _make_state(mock_mode=True)
+        result = _mock_review_test_plan(state)
+
+        assert result["test_plan_status"] == "APPROVED"
+        # Should be "APPROVED" (no feedback) — not the multi-line prose
+        assert result["test_plan_verdict"] == "APPROVED"
+        assert len(result["test_plan_verdict"]) < 200
+
+    def test_mock_blocked_stores_concise_verdict(self):
+        state = _make_state(
+            mock_mode=True,
+            test_scenarios=[
+                {"name": "test_create", "type": "unit", "requirement_ref": "REQ-1"},
+            ],
+            requirements=["REQ-1: Create", "REQ-2: Delete"],
+        )
+        result = _mock_review_test_plan(state)
+
+        assert result["test_plan_status"] == "BLOCKED"
+        assert result["test_plan_verdict"].startswith("BLOCKED:")
+        assert len(result["test_plan_verdict"]) <= 210
+
+
+class TestAuditFilePreservation:
+    """Raw response MUST be saved to audit file before extraction."""
+
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.save_audit_file")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.next_file_number", return_value=5)
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+    @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+    def test_raw_prose_saved_to_audit_file(self, mock_root, mock_prompt, mock_log, mock_num, mock_save):
+        """Full Gemini response written to audit file before extraction."""
+        mock_root.return_value = Path("/tmp/test-repo")
+        mock_prompt.return_value = "review prompt"
+
+        raw_json = json.dumps({
+            "verdict": "APPROVED",
+            "summary": "All good.",
+        })
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.response = raw_json
+        mock_result.input_tokens = 100
+        mock_result.output_tokens = 50
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("assemblyzero.core.gemini_client.GeminiClient") as mock_cls, \
+                 patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost", return_value=0.0), \
+                 patch("assemblyzero.workflows.testing.nodes.review_test_plan.check_requirement_coverage") as mock_cov:
+                mock_cls.return_value.invoke.return_value = mock_result
+                mock_cov.return_value = {"passed": False, "total": 2, "covered": 1, "coverage_pct": 50.0, "missing": ["REQ-2"]}
+
+                state = _make_state(audit_dir=tmpdir)
+                result = review_test_plan(state)
+
+            # Verify save_audit_file was called with the FULL raw response
+            verdict_calls = [
+                c for c in mock_save.call_args_list
+                if "verdict.md" in str(c)
+            ]
+            assert len(verdict_calls) >= 1, "Raw verdict must be saved to audit file"
+            # The saved content should be the full raw response
+            saved_content = verdict_calls[0][0][3]  # 4th positional arg
+            assert saved_content == raw_json


### PR DESCRIPTION
## Summary
- Replace raw LLM prose in `test_plan_verdict` with concise extracted summaries at 3 return sites (BLOCKED, APPROVED, mock mode)
- Full Gemini responses preserved in audit trail files — only extracted data flows through workflow state
- Add Engineering Standard 0014 documenting the extract-and-discard pattern for all LLM-calling nodes
- 7 new tests covering all verdict paths and audit file preservation

## Test plan
- [x] `poetry run pytest tests/unit/test_extract_and_discard.py -v` — 7/7 pass
- [x] `poetry run pytest tests/unit/test_preflight_skip.py tests/unit/test_json_verdict_review_test_plan.py tests/unit/test_mechanical_gates.py -v` — 41/41 pass (no regressions)
- [x] `poetry run pytest tests/unit/ -x -q` — 956 passed (1 pre-existing failure in test_gate/test_parser.py unrelated to this change)

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)