### PR TITLE
feat: strip emoji from all LLM output (#527)

### DIFF
--- a/assemblyzero/core/claude_client.py
+++ b/assemblyzero/core/claude_client.py
@@ -13,6 +13,8 @@ import subprocess
 import time
 from pathlib import Path
 
+from assemblyzero.core.text_sanitizer import strip_emoji
+
 # Configuration
 MAX_RETRIES = 5
 BASE_DELAY = 1.0  # seconds
@@ -67,7 +69,8 @@ def invoke_claude(
             )
 
             if result.returncode == 0:
-                return result.stdout
+                # Issue #527: Strip emojis from CLI output
+                return strip_emoji(result.stdout)
 
             # Check for rate limit (429)
             if _is_rate_limit_error(result):

--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
+
+from assemblyzero.core.text_sanitizer import strip_emoji
 from typing import Optional
 
 from google import genai
@@ -502,9 +504,10 @@ class GeminiClient:
 
                             duration_ms = int((time.time() - start_time) * 1000)
 
+                            # Issue #527: Strip emojis (preserve raw)
                             return GeminiCallResult(
                                 success=True,
-                                response=response_text,
+                                response=strip_emoji(response_text),
                                 raw_response=response_text,
                                 error_type=None,
                                 error_message=None,
@@ -550,9 +553,10 @@ class GeminiClient:
 
                             duration_ms = int((time.time() - start_time) * 1000)
 
+                            # Issue #527: Strip emojis (preserve raw)
                             return GeminiCallResult(
                                 success=True,
-                                response=response.text,
+                                response=strip_emoji(response.text),
                                 raw_response=str(response),
                                 error_type=None,
                                 error_message=None,

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from assemblyzero.core.text_sanitizer import strip_emoji
+
 
 @dataclass
 class LLMCallResult:
@@ -438,6 +440,9 @@ class ClaudeCLIProvider(LLMProvider):
                 # Fall back to raw stdout if not valid JSON
                 response_text = stdout.strip()
 
+            # Issue #527: Strip emojis from response (preserve raw_response)
+            response_text = strip_emoji(response_text)
+
             call_result = LLMCallResult(
                 success=True,
                 response=response_text,
@@ -617,6 +622,9 @@ class AnthropicProvider(LLMProvider):
             for block in response.content:
                 if hasattr(block, "text"):
                     response_text += block.text
+
+            # Issue #527: Strip emojis from response (preserve raw_response)
+            response_text = strip_emoji(response_text)
 
             # Extract usage
             input_tokens = response.usage.input_tokens
@@ -919,9 +927,12 @@ class GeminiProvider(LLMProvider):
                 and str(result.error_type) == "GeminiErrorType.QUOTA_EXHAUSTED"
             ) if hasattr(result, "error_type") else False
 
+            # Issue #527: Strip emojis from response (preserve raw_response)
+            sanitized_response = strip_emoji(result.response) if result.response else result.response
+
             call_result = LLMCallResult(
                 success=result.success,
-                response=result.response,
+                response=sanitized_response,
                 raw_response=result.raw_response,
                 error_message=result.error_message,
                 provider=self.provider_name,

--- a/assemblyzero/core/text_sanitizer.py
+++ b/assemblyzero/core/text_sanitizer.py
@@ -1,0 +1,81 @@
+"""Text sanitizer for LLM output — strip emojis that crash Windows cp1252.
+
+Issue #527: Strip emoji from all LLM output.
+
+Windows cp1252 encoding can't handle Unicode emojis (U+1F000+), causing
+crashes in CLI output and read_text(). This module provides a single
+function to sanitize LLM responses before they reach downstream code.
+"""
+
+import re
+
+# Semantic replacements: preserve meaning before stripping
+_SEMANTIC_MAP: list[tuple[str, str]] = [
+    # Checkmarks / success
+    ("\u2705", "[PASS]"),   # white heavy check mark
+    ("\u2714", "[PASS]"),   # heavy check mark
+    ("\u2611", "[PASS]"),   # ballot box with check
+    # Crosses / failure
+    ("\u274C", "[FAIL]"),   # cross mark
+    ("\u274E", "[FAIL]"),   # cross mark with negative squared
+    ("\u2716", "[FAIL]"),   # heavy multiplication x
+    ("\u2718", "[FAIL]"),   # heavy ballot x
+    # Warnings
+    ("\u26A0", "[WARN]"),   # warning sign
+    ("\u26A0\uFE0F", "[WARN]"),  # warning sign + variation selector
+    # Info / tips
+    ("\U0001F4A1", "[TIP]"),   # light bulb
+    ("\u2139", "[NOTE]"),      # information source
+    ("\u2139\uFE0F", "[NOTE]"),  # information source + variation selector
+    # Arrows
+    ("\u27A1", "->"),        # black rightwards arrow
+    ("\u27A1\uFE0F", "->"),  # + variation selector
+    ("\u2B05", "<-"),        # leftwards black arrow
+    ("\u2B05\uFE0F", "<-"),  # + variation selector
+    ("\u2192", "->"),        # rightwards arrow
+    ("\u2190", "<-"),        # leftwards arrow
+]
+
+# Regex pattern for emoji Unicode ranges
+_EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001F600-\U0001F64F"  # emoticons
+    "\U0001F300-\U0001F5FF"  # misc symbols and pictographs
+    "\U0001F680-\U0001F6FF"  # transport and map
+    "\U0001F700-\U0001F77F"  # alchemical symbols
+    "\U0001F900-\U0001F9FF"  # supplemental symbols
+    "\U0001FA00-\U0001FA6F"  # chess symbols
+    "\U0001FA70-\U0001FAFF"  # symbols and pictographs extended-A
+    "\U00002600-\U000027BF"  # misc symbols (sun, stars, etc.)
+    "\U00002B00-\U00002BFF"  # misc symbols and arrows (includes stars)
+    "\U0000FE00-\U0000FE0F"  # variation selectors
+    "\U0000200D"             # zero-width joiner
+    "\U000020E3"             # combining enclosing keycap
+    "\U00002702-\U000027B0"  # dingbats
+    "\U0001F1E0-\U0001F1FF"  # flags (regional indicator symbols)
+    "]+",
+    flags=re.UNICODE,
+)
+
+def strip_emoji(text: str | None) -> str:
+    """Strip emojis from text, replacing common ones with ASCII equivalents.
+
+    Args:
+        text: The text to sanitize. None returns empty string.
+
+    Returns:
+        Sanitized text with emojis removed and common symbols replaced.
+    """
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        return str(text)
+
+    # Step 1: Semantic replacements (longest match first — variation selectors)
+    for emoji, replacement in _SEMANTIC_MAP:
+        text = text.replace(emoji, replacement)
+
+    # Step 2: Strip remaining emojis
+    text = _EMOJI_PATTERN.sub("", text)
+
+    return text

--- a/assemblyzero/workflows/issue/nodes/draft.py
+++ b/assemblyzero/workflows/issue/nodes/draft.py
@@ -12,6 +12,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.core.text_sanitizer import strip_emoji
+
 from assemblyzero.workflows.issue.audit import (
     get_repo_root,
     next_file_number,
@@ -130,10 +132,11 @@ def call_claude_headless(prompt: str, system_prompt: str | None = None) -> str:
         # Parse JSON response
         try:
             response = json.loads(result.stdout)
-            return response.get("result", "")
+            # Issue #527: Strip emojis from LLM response
+            return strip_emoji(response.get("result", ""))
         except json.JSONDecodeError:
             # Fall back to raw stdout if not valid JSON
-            return result.stdout.strip()
+            return strip_emoji(result.stdout.strip())
 
     except subprocess.TimeoutExpired:
         raise RuntimeError("claude -p timed out after 5 minutes")

--- a/assemblyzero/workflows/testing/adversarial_gemini.py
+++ b/assemblyzero/workflows/testing/adversarial_gemini.py
@@ -10,6 +10,8 @@ provider infrastructure.
 import logging
 from typing import Any
 
+from assemblyzero.core.text_sanitizer import strip_emoji
+
 from assemblyzero.workflows.testing.adversarial_prompts import (
     build_adversarial_analysis_prompt,
     build_adversarial_system_prompt,
@@ -243,6 +245,8 @@ class AdversarialGeminiClient:
                 },
             )
             text = response.text if hasattr(response, "text") else str(response)
+            # Issue #527: Strip emojis from Gemini response
+            text = strip_emoji(text)
             metadata: dict[str, Any] = {}
             if hasattr(response, "model"):
                 metadata["model"] = response.model
@@ -264,6 +268,8 @@ class AdversarialGeminiClient:
             ]
             response = provider.invoke(messages)
             text = response.content if hasattr(response, "content") else str(response)
+            # Issue #527: Strip emojis from Gemini response
+            text = strip_emoji(text)
             metadata = getattr(response, "response_metadata", {})
             return text, metadata
 

--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -18,6 +18,8 @@ import os
 import re
 import random
 import shutil
+
+from assemblyzero.core.text_sanitizer import strip_emoji
 import subprocess
 import sys
 import threading
@@ -930,7 +932,8 @@ def call_claude_for_file(prompt: str, file_path: str = "") -> tuple[str, str]:
             )
 
             if result.returncode == 0 and result.stdout.strip():
-                return result.stdout, ""
+                # Issue #527: Strip emojis from code gen response
+                return strip_emoji(result.stdout), ""
             else:
                 stderr = result.stderr[:200] if result.stderr else "no stderr"
                 # Fall through to SDK
@@ -962,7 +965,8 @@ def call_claude_for_file(prompt: str, file_path: str = "") -> tuple[str, str]:
             if hasattr(block, "text"):
                 response_text += block.text
 
-        return response_text, ""
+        # Issue #527: Strip emojis from code gen response
+        return strip_emoji(response_text), ""
 
     except ImportError:
         return "", "Neither Claude CLI nor Anthropic SDK available"

--- a/tests/unit/test_text_sanitizer.py
+++ b/tests/unit/test_text_sanitizer.py
@@ -1,0 +1,151 @@
+"""Tests for text_sanitizer.strip_emoji().
+
+Issue #527: Strip emoji from all LLM output.
+"""
+
+from assemblyzero.core.text_sanitizer import strip_emoji
+
+
+class TestSemanticReplacements:
+    """Emojis with meaning get replaced with ASCII equivalents."""
+
+    def test_checkmark_to_pass(self):
+        assert strip_emoji("Tests passed \u2705") == "Tests passed [PASS]"
+
+    def test_heavy_checkmark_to_pass(self):
+        assert strip_emoji("\u2714 All good") == "[PASS] All good"
+
+    def test_ballot_check_to_pass(self):
+        assert strip_emoji("\u2611 Done") == "[PASS] Done"
+
+    def test_cross_to_fail(self):
+        assert strip_emoji("Build \u274C") == "Build [FAIL]"
+
+    def test_heavy_x_to_fail(self):
+        assert strip_emoji("\u2716 Error") == "[FAIL] Error"
+
+    def test_warning_to_warn(self):
+        assert strip_emoji("\u26A0 Caution") == "[WARN] Caution"
+
+    def test_warning_with_variation_selector(self):
+        assert strip_emoji("\u26A0\uFE0F Caution") == "[WARN] Caution"
+
+    def test_lightbulb_to_tip(self):
+        assert strip_emoji("\U0001F4A1 Idea") == "[TIP] Idea"
+
+    def test_info_to_note(self):
+        assert strip_emoji("\u2139 See docs") == "[NOTE] See docs"
+
+    def test_right_arrow(self):
+        assert strip_emoji("A \u27A1 B") == "A -> B"
+
+    def test_left_arrow(self):
+        assert strip_emoji("B \u2B05 A") == "B <- A"
+
+    def test_unicode_arrows(self):
+        assert strip_emoji("input \u2192 output") == "input -> output"
+        assert strip_emoji("output \u2190 input") == "output <- input"
+
+
+class TestEmojiStripping:
+    """Remaining emojis get stripped completely."""
+
+    def test_emoticons_stripped(self):
+        assert strip_emoji("Hello \U0001F600 world") == "Hello  world"
+
+    def test_transport_stripped(self):
+        assert strip_emoji("Ship it \U0001F680") == "Ship it "
+
+    def test_misc_symbols_stripped(self):
+        assert strip_emoji("Weather \u2600 report") == "Weather  report"
+
+    def test_multiple_emojis_stripped(self):
+        result = strip_emoji("\U0001F600\U0001F601\U0001F602 text \U0001F680")
+        assert result == " text "
+
+    def test_flag_emojis_stripped(self):
+        assert strip_emoji("Flag \U0001F1FA\U0001F1F8 here") == "Flag  here"
+
+    def test_zwj_sequences_stripped(self):
+        # Family emoji: man + ZWJ + woman + ZWJ + girl
+        assert strip_emoji("Family \U0001F468\u200D\U0001F469\u200D\U0001F467 here") == "Family  here"
+
+    def test_variation_selectors_stripped(self):
+        assert strip_emoji("Star \u2B50\uFE0F here") == "Star  here"
+
+    def test_star_emoji_stripped(self):
+        assert strip_emoji("\u2B50") == ""
+
+
+class TestCleanPassthrough:
+    """Non-emoji text passes through unchanged."""
+
+    def test_plain_text(self):
+        text = "This is plain text with no emojis."
+        assert strip_emoji(text) == text
+
+    def test_code_block_indentation_preserved(self):
+        text = "```python\ndef foo():\n    return 42\n```"
+        assert strip_emoji(text) == text
+
+    def test_markdown_table_alignment_preserved(self):
+        text = "| Col1 | Col2 |\n|------|------|\n| a    | b    |"
+        assert strip_emoji(text) == text
+
+    def test_markdown_headers(self):
+        text = "# Header\n## Subheader\n### Third"
+        assert strip_emoji(text) == text
+
+    def test_urls_preserved(self):
+        text = "Visit https://example.com/path?q=1&r=2"
+        assert strip_emoji(text) == text
+
+    def test_ascii_symbols_preserved(self):
+        text = "Result: pass/fail [OK] (done) {key: value} @user #tag"
+        assert strip_emoji(text) == text
+
+    def test_numbers_and_math(self):
+        text = "Score: 95.5% (19/20) = 0.975"
+        assert strip_emoji(text) == text
+
+    def test_multiple_spaces_preserved(self):
+        """Intentional multiple spaces are not collapsed."""
+        text = "A   B"
+        assert strip_emoji(text) == text
+
+    def test_newlines_preserved(self):
+        text = "Line 1\n\nLine 3"
+        assert strip_emoji(text) == text
+
+    def test_tabs_preserved(self):
+        text = "Col1\tCol2\tCol3"
+        assert strip_emoji(text) == text
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_none_returns_empty(self):
+        assert strip_emoji(None) == ""
+
+    def test_empty_string(self):
+        assert strip_emoji("") == ""
+
+    def test_only_emojis(self):
+        result = strip_emoji("\U0001F600\U0001F601\U0001F602")
+        assert result == ""
+
+    def test_non_string_input(self):
+        assert strip_emoji(42) == "42"
+
+    def test_mixed_semantic_and_strip(self):
+        result = strip_emoji("\u2705 Test passed \U0001F680 deploying")
+        assert result == "[PASS] Test passed  deploying"
+
+    def test_repeated_semantic_emojis(self):
+        result = strip_emoji("\u2705 first \u2705 second \u2705 third")
+        assert result == "[PASS] first [PASS] second [PASS] third"
+
+    def test_emoji_only_line_in_multiline(self):
+        text = "Line 1\n\U0001F680\nLine 3"
+        assert strip_emoji(text) == "Line 1\n\nLine 3"


### PR DESCRIPTION
## Summary
- New `assemblyzero/core/text_sanitizer.py` with `strip_emoji()` — semantic replacements (checkmarks→[PASS], crosses→[FAIL], warnings→[WARN], arrows→ASCII) then regex stripping of all emoji Unicode ranges
- Applied at 11 insertion points across 6 files: `llm_provider.py` (3), `gemini_client.py` (2), `claude_client.py` (1), `draft.py` (1), `implement_code.py` (2), `adversarial_gemini.py` (2)
- `raw_response` fields are never sanitized (preserved for debugging)
- 37 unit tests covering semantic replacements, emoji stripping, clean passthrough, formatting preservation, and edge cases

## Test plan
- [x] `poetry run pytest tests/unit/test_text_sanitizer.py -v` — 37/37 pass
- [x] `poetry run pytest --tb=short` — 0 regressions (14 pre-existing failures unchanged)
- [x] Verified `raw_response` fields untouched (grep confirms no `strip_emoji` on `raw_response`)
- [x] Code indentation and markdown table alignment preserved (no multi-space collapse)

Closes #527

---
Generated with Claude Code