### PR TITLE
feat: move lineage active→done on workflow completion (#100)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/finalize_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/finalize_spec.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from assemblyzero.workflows.requirements.audit import (
+    move_lineage_to_done,
     next_file_number,
     save_audit_file,
 )
@@ -214,6 +215,10 @@ def finalize_spec(state: ImplementationSpecState) -> dict[str, Any]:
             audit_dir, file_num, "final-spec.md", finalized_content
         )
         print(f"    Audit trail: {audit_path.name}")
+
+    # Issue #100: Move lineage from active/ to done/
+    if audit_dir and audit_dir.exists():
+        move_lineage_to_done(audit_dir, repo_root)
 
     # -------------------------------------------------------------------------
     # Return state updates

--- a/assemblyzero/workflows/requirements/audit.py
+++ b/assemblyzero/workflows/requirements/audit.py
@@ -18,12 +18,16 @@ CRITICAL PATH RULES:
 """
 
 import json
+import logging
 import re
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, TypedDict
 
 from assemblyzero.core.config import REVIEWER_MODEL
+
+logger = logging.getLogger(__name__)
 
 
 # Base directories relative to repo root
@@ -254,6 +258,46 @@ def create_audit_dir(
 
     audit_dir.mkdir(parents=True, exist_ok=True)
     return audit_dir
+
+
+# =============================================================================
+# Lineage Active → Done
+# =============================================================================
+
+
+def move_lineage_to_done(audit_dir: Path, target_repo: Path) -> Path | None:
+    """Move a lineage directory from active/ to done/ on workflow completion.
+
+    Issue #100: All 4 workflows create docs/lineage/active/{id}/ and save
+    artifacts there, but none moved to done/ on completion.
+
+    Args:
+        audit_dir: The active lineage directory (e.g., target_repo/docs/lineage/active/42-lld).
+        target_repo: Target repository root (used for log messages).
+
+    Returns:
+        Path to the done/ directory if moved successfully, None on failure or skip.
+    """
+    if not audit_dir.exists():
+        logger.info("Lineage dir not found, skipping move: %s", audit_dir)
+        return None
+
+    # Build destination: swap active/ for done/ in the path
+    done_dir = target_repo / AUDIT_DONE_DIR / audit_dir.name
+    done_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    # Idempotent: if done/ target already exists, skip
+    if done_dir.exists():
+        logger.info("Lineage already in done/, skipping: %s", done_dir)
+        return done_dir
+
+    try:
+        shutil.move(str(audit_dir), str(done_dir))
+        logger.info("Moved lineage to done: %s -> %s", audit_dir.name, done_dir)
+        return done_dir
+    except OSError as e:
+        logger.error("Failed to move lineage to done: %s", e)
+        return None
 
 
 # =============================================================================

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -15,6 +15,7 @@ from typing import Any, Dict
 
 from assemblyzero.workflows.requirements.audit import (
     embed_review_evidence,
+    move_lineage_to_done,
     next_file_number,
     save_audit_file,
     update_lld_status,
@@ -440,6 +441,13 @@ def finalize(state: Dict[str, Any]) -> Dict[str, Any]:
 
     # Then, commit and push artifacts to git
     state = _commit_and_push_files(state)
+
+    # Issue #100: Move lineage from active/ to done/ on successful completion
+    if not state.get("error_message"):
+        audit_dir = Path(state.get("audit_dir", ""))
+        target_repo = Path(state.get("target_repo", "."))
+        if audit_dir.exists():
+            move_lineage_to_done(audit_dir, target_repo)
 
     # Cleanup source idea after successful issue creation
     if workflow_type == "issue" and not state.get("error_message"):

--- a/assemblyzero/workflows/testing/nodes/finalize.py
+++ b/assemblyzero/workflows/testing/nodes/finalize.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.workflows.requirements.audit import move_lineage_to_done
 from assemblyzero.workflows.testing.audit import (
     TestReportMetadata,
     gate_log,
@@ -213,11 +214,15 @@ def finalize(state: TestingWorkflowState) -> dict[str, Any]:
     # Archive workflow artifacts (LLD and reports)
     archival_result = _archive_workflow_artifacts(state)
     archived_files = archival_result["archived"]
-    
+
     if archived_files:
         print(f"\n    Archived artifacts:")
         for file_path in archived_files:
             print(f"      - {file_path}")
+
+    # Issue #100: Move lineage from active/ to done/
+    if audit_dir.exists():
+        move_lineage_to_done(audit_dir, repo_root)
 
     # Issue #511: Include cost data in completion event
     # Issue #513: First-pass = all tests pass on iteration 1

--- a/tests/unit/test_move_lineage.py
+++ b/tests/unit/test_move_lineage.py
@@ -1,0 +1,95 @@
+"""Tests for move_lineage_to_done() utility.
+
+Issue #100: Lineage active→done moves on workflow completion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assemblyzero.workflows.requirements.audit import move_lineage_to_done
+
+
+def _setup_lineage(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create a mock repo with lineage/active/ and lineage/done/ dirs.
+
+    Returns:
+        (target_repo, active_dir, done_dir_parent)
+    """
+    target_repo = tmp_path / "repo"
+    active_dir = target_repo / "docs" / "lineage" / "active" / "42-lld"
+    active_dir.mkdir(parents=True)
+    # Add a file so we can verify it moved
+    (active_dir / "001-brief.md").write_text("# Brief\n")
+    return target_repo, active_dir, target_repo / "docs" / "lineage" / "done"
+
+
+def test_happy_path(tmp_path: Path) -> None:
+    """Move lineage dir from active/ to done/ successfully."""
+    target_repo, active_dir, done_parent = _setup_lineage(tmp_path)
+
+    result = move_lineage_to_done(active_dir, target_repo)
+
+    assert result is not None
+    assert result == done_parent / "42-lld"
+    assert result.exists()
+    assert (result / "001-brief.md").read_text() == "# Brief\n"
+    # Source should be gone
+    assert not active_dir.exists()
+
+
+def test_dir_not_found(tmp_path: Path) -> None:
+    """Returns None when the active lineage dir doesn't exist."""
+    target_repo = tmp_path / "repo"
+    nonexistent = target_repo / "docs" / "lineage" / "active" / "99-lld"
+
+    result = move_lineage_to_done(nonexistent, target_repo)
+
+    assert result is None
+
+
+def test_dest_exists_skip(tmp_path: Path) -> None:
+    """Returns existing done/ path when destination already exists (idempotent)."""
+    target_repo, active_dir, done_parent = _setup_lineage(tmp_path)
+
+    # Pre-create done target
+    done_dir = done_parent / "42-lld"
+    done_dir.mkdir(parents=True)
+    (done_dir / "old-file.md").write_text("old content")
+
+    result = move_lineage_to_done(active_dir, target_repo)
+
+    assert result == done_dir
+    # Active dir should still exist (wasn't moved)
+    assert active_dir.exists()
+    # Done dir should still have old content (wasn't overwritten)
+    assert (done_dir / "old-file.md").read_text() == "old content"
+
+
+def test_os_error_returns_none(tmp_path: Path, monkeypatch) -> None:
+    """Returns None on OSError during move."""
+    target_repo, active_dir, _ = _setup_lineage(tmp_path)
+
+    def failing_move(src, dst):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr("assemblyzero.workflows.requirements.audit.shutil.move", failing_move)
+
+    result = move_lineage_to_done(active_dir, target_repo)
+
+    assert result is None
+    # Active dir should still exist (move failed)
+    assert active_dir.exists()
+
+
+def test_creates_done_parent(tmp_path: Path) -> None:
+    """Creates the done/ parent directory if it doesn't exist."""
+    target_repo, active_dir, done_parent = _setup_lineage(tmp_path)
+
+    # Verify done/ doesn't exist yet
+    assert not done_parent.exists()
+
+    result = move_lineage_to_done(active_dir, target_repo)
+
+    assert result is not None
+    assert done_parent.exists()


### PR DESCRIPTION
## Summary
- Added shared `move_lineage_to_done()` utility in `audit.py` (idempotent, fail-safe)
- Wired into LLD finalize (`requirements/nodes/finalize.py`) — after commit+push
- Wired into impl spec finalize (`implementation_spec/nodes/finalize_spec.py`) — after audit trail save
- Wired into testing finalize (`testing/nodes/finalize.py`) — after artifact archival
- 5 unit tests covering happy path, dir-not-found, dest-exists (skip), OSError, and parent creation

## Test plan
- [x] `poetry run pytest tests/unit/test_move_lineage.py -v` — 5/5 passed
- [x] Verified `docs/lineage/done/` directory exists and is populated

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)