### PR TITLE
feat: dependency modernization tool (#351)

### DIFF
--- a/tests/tools/test_modernize_dependencies.py
+++ b/tests/tools/test_modernize_dependencies.py
@@ -1,0 +1,239 @@
+"""Tests for the Dependency Modernization Tool.
+
+Issue #351: Automated dependency update cycles with rollback.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Import under test — we need to add tools/ to sys.path
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "tools"))
+
+from modernize_dependencies import (
+    commit_update,
+    discover_outdated,
+    modernize,
+    restore_lockfiles,
+    save_lockfiles,
+    update_package,
+)
+
+
+SAMPLE_POETRY_OUTPUT = """\
+langchain-core  0.3.50  0.3.52  Core APIs for LangChain
+chromadb        0.6.3   0.6.5   Chroma AI native vector database
+ruff            0.9.9   0.11.0  An extremely fast linter
+"""
+
+SAMPLE_POETRY_OUTPUT_WITH_MARKER = """\
+pydantic  2.10.6  (!)  2.11.0  Data validation
+ruff      0.9.9        0.11.0  An extremely fast linter
+"""
+
+
+class TestDiscoverOutdated:
+    """Tests for discover_outdated()."""
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_parses_standard_output(self, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=SAMPLE_POETRY_OUTPUT, stderr=""
+        )
+        result = discover_outdated(tmp_path)
+        assert len(result) == 3
+        assert result[0]["name"] == "langchain-core"
+        assert result[0]["current"] == "0.3.50"
+        assert result[0]["latest"] == "0.3.52"
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_handles_bang_marker(self, mock_run, tmp_path):
+        """Packages with (!) semver-incompatible marker are parsed correctly."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=SAMPLE_POETRY_OUTPUT_WITH_MARKER, stderr=""
+        )
+        result = discover_outdated(tmp_path)
+        assert len(result) == 2
+        assert result[0]["name"] == "pydantic"
+        assert result[0]["latest"] == "2.11.0"
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_empty_output(self, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        result = discover_outdated(tmp_path)
+        assert result == []
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_command_failure(self, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="error"
+        )
+        result = discover_outdated(tmp_path)
+        assert result == []
+
+
+class TestSaveRestoreLockfiles:
+    """Tests for save/restore lockfile functions."""
+
+    def test_roundtrip(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        lock = tmp_path / "poetry.lock"
+        pyproject.write_text("[tool.poetry]\nname = 'test'\n")
+        lock.write_text("[[package]]\nname = 'foo'\n")
+
+        saved_pyproject, saved_lock = save_lockfiles(tmp_path)
+
+        # Modify files
+        pyproject.write_text("modified")
+        lock.write_text("modified")
+
+        with mock.patch("modernize_dependencies.subprocess.run"):
+            restore_lockfiles(tmp_path, saved_pyproject, saved_lock)
+
+        assert pyproject.read_text() == "[tool.poetry]\nname = 'test'\n"
+        assert lock.read_text() == "[[package]]\nname = 'foo'\n"
+
+    def test_missing_lock(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[tool.poetry]")
+
+        saved_pyproject, saved_lock = save_lockfiles(tmp_path)
+        assert saved_lock == ""
+
+
+class TestUpdatePackage:
+    """Tests for update_package()."""
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_success(self, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Updated ruff to 0.11.0", stderr=""
+        )
+        success, output = update_package(tmp_path, "ruff")
+        assert success is True
+        assert "Updated" in output
+
+    @mock.patch("modernize_dependencies.subprocess.run")
+    def test_failure(self, mock_run, tmp_path):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Conflict"
+        )
+        success, output = update_package(tmp_path, "bad-pkg")
+        assert success is False
+
+
+class TestModernize:
+    """Tests for the main modernize() function."""
+
+    @mock.patch("modernize_dependencies.commit_update")
+    @mock.patch("modernize_dependencies.run_tests")
+    @mock.patch("modernize_dependencies.update_package")
+    @mock.patch("modernize_dependencies.restore_lockfiles")
+    @mock.patch("modernize_dependencies.save_lockfiles")
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_update_pass_commit(self, mock_discover, mock_save, mock_restore,
+                                 mock_update, mock_tests, mock_commit, tmp_path):
+        """Happy path: discover → update → tests pass → commit."""
+        mock_discover.return_value = [{"name": "ruff", "current": "0.9.9", "latest": "0.11.0"}]
+        mock_save.return_value = ("pyproject", "lock")
+        mock_update.return_value = (True, "ok")
+        mock_tests.return_value = (True, "all passed")
+        mock_commit.return_value = True
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, report_file=report_file)
+
+        assert report["summary"]["updated"] == 1
+        assert report["summary"]["failed"] == 0
+        assert report["packages"][0]["status"] == "updated"
+        assert report_file.exists()
+
+    @mock.patch("modernize_dependencies.commit_update")
+    @mock.patch("modernize_dependencies.run_tests")
+    @mock.patch("modernize_dependencies.update_package")
+    @mock.patch("modernize_dependencies.restore_lockfiles")
+    @mock.patch("modernize_dependencies.save_lockfiles")
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_update_fail_rollback(self, mock_discover, mock_save, mock_restore,
+                                   mock_update, mock_tests, mock_commit, tmp_path):
+        """Tests fail after update → rollback."""
+        mock_discover.return_value = [{"name": "ruff", "current": "0.9.9", "latest": "0.11.0"}]
+        mock_save.return_value = ("pyproject", "lock")
+        mock_update.return_value = (True, "ok")
+        mock_tests.return_value = (False, "FAILED test_foo.py")
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, report_file=report_file)
+
+        assert report["summary"]["failed"] == 1
+        assert report["packages"][0]["status"] == "tests_failed"
+        mock_restore.assert_called_once()
+
+    @mock.patch("modernize_dependencies.restore_lockfiles")
+    @mock.patch("modernize_dependencies.save_lockfiles")
+    @mock.patch("modernize_dependencies.update_package")
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_poetry_add_fail_skip(self, mock_discover, mock_update,
+                                   mock_save, mock_restore, tmp_path):
+        """poetry add fails → skip and restore."""
+        mock_discover.return_value = [{"name": "bad", "current": "1.0", "latest": "2.0"}]
+        mock_save.return_value = ("pyproject", "lock")
+        mock_update.return_value = (False, "Conflict resolution failed")
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, report_file=report_file)
+
+        assert report["summary"]["failed"] == 1
+        assert report["packages"][0]["status"] == "add_failed"
+        mock_restore.assert_called_once()
+
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_dry_run(self, mock_discover, tmp_path):
+        """Dry run lists packages without updating."""
+        mock_discover.return_value = [
+            {"name": "ruff", "current": "0.9.9", "latest": "0.11.0"},
+        ]
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, dry_run=True, report_file=report_file)
+
+        assert report["summary"]["skipped"] == 1
+        assert report["summary"]["updated"] == 0
+        assert report["packages"][0]["status"] == "dry_run"
+
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_report_only(self, mock_discover, tmp_path):
+        """Report-only mode generates report without updates."""
+        mock_discover.return_value = [
+            {"name": "ruff", "current": "0.9.9", "latest": "0.11.0"},
+        ]
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, report_only=True, report_file=report_file)
+
+        assert report["packages"][0]["status"] == "report_only"
+        # Verify report file is valid JSON
+        data = json.loads(report_file.read_text())
+        assert data["summary"]["total"] == 1
+
+    @mock.patch("modernize_dependencies.discover_outdated")
+    def test_package_filter(self, mock_discover, tmp_path):
+        """Package filter only processes the specified package."""
+        mock_discover.return_value = [
+            {"name": "ruff", "current": "0.9.9", "latest": "0.11.0"},
+            {"name": "pytest", "current": "8.0", "latest": "9.0"},
+        ]
+
+        report_file = tmp_path / "report.json"
+        report = modernize(tmp_path, dry_run=True, package_filter="ruff", report_file=report_file)
+
+        assert report["summary"]["total"] == 1
+        assert report["packages"][0]["name"] == "ruff"

--- a/tools/modernize_dependencies.py
+++ b/tools/modernize_dependencies.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Dependency Modernization Tool.
+
+Issue #351: Automates the tedious cycle of checking outdated dependencies,
+updating them one-by-one, running tests, and committing or rolling back.
+
+Usage:
+    poetry run python tools/modernize_dependencies.py [OPTIONS]
+
+Options:
+    --dry-run       Show what would be updated without making changes
+    --package NAME  Update only a specific package
+    --report-only   Only generate the outdated report, don't update
+    --report-file   Path for JSON report (default: docs/reports/dep-modernization-{timestamp}.json)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def discover_outdated(repo_root: Path) -> list[dict]:
+    """Parse `poetry show --outdated --top-level` for outdated packages.
+
+    Args:
+        repo_root: Repository root (where pyproject.toml lives).
+
+    Returns:
+        List of dicts with keys: name, current, latest, description.
+    """
+    result = subprocess.run(
+        ["poetry", "show", "--outdated", "--top-level"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=120,
+    )
+
+    if result.returncode != 0:
+        print(f"Warning: poetry show --outdated failed: {result.stderr.strip()}")
+        return []
+
+    packages = []
+    for line in result.stdout.strip().splitlines():
+        # Format: "package-name    current    latest    description..."
+        # Some lines may have (!) markers for semver-incompatible updates
+        parts = line.split()
+        if len(parts) >= 3:
+            name = parts[0]
+            # Skip header-like lines
+            if name.startswith("-") or name == "name":
+                continue
+            current = parts[1]
+            # Handle (!) marker: latest might be at index 2 or 3
+            latest_idx = 2
+            if parts[latest_idx] == "(!)":
+                latest_idx = 3
+            if latest_idx < len(parts):
+                latest = parts[latest_idx]
+            else:
+                continue
+            description = " ".join(parts[latest_idx + 1:]) if len(parts) > latest_idx + 1 else ""
+            packages.append({
+                "name": name,
+                "current": current,
+                "latest": latest,
+                "description": description,
+            })
+
+    return packages
+
+
+def save_lockfiles(repo_root: Path) -> tuple[str, str]:
+    """Save current pyproject.toml and poetry.lock content for rollback.
+
+    Returns:
+        Tuple of (pyproject_content, lock_content).
+    """
+    pyproject = repo_root / "pyproject.toml"
+    lock = repo_root / "poetry.lock"
+    return (
+        pyproject.read_text(encoding="utf-8"),
+        lock.read_text(encoding="utf-8") if lock.exists() else "",
+    )
+
+
+def restore_lockfiles(repo_root: Path, pyproject_content: str, lock_content: str) -> None:
+    """Restore pyproject.toml and poetry.lock from saved content."""
+    (repo_root / "pyproject.toml").write_text(pyproject_content, encoding="utf-8")
+    lock_path = repo_root / "poetry.lock"
+    if lock_content:
+        lock_path.write_text(lock_content, encoding="utf-8")
+
+    # Reinstall to sync the venv with restored lockfile
+    subprocess.run(
+        ["poetry", "install", "--no-interaction"],
+        capture_output=True,
+        cwd=str(repo_root),
+        timeout=300,
+    )
+
+
+def update_package(repo_root: Path, package_name: str) -> tuple[bool, str]:
+    """Run `poetry add package@latest` for a single package.
+
+    Returns:
+        Tuple of (success, output_or_error).
+    """
+    result = subprocess.run(
+        ["poetry", "add", f"{package_name}@latest", "--no-interaction"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=300,
+    )
+    output = result.stdout + result.stderr
+    return result.returncode == 0, output.strip()
+
+
+def run_tests(repo_root: Path) -> tuple[bool, str]:
+    """Run the test suite to verify the update didn't break anything.
+
+    Returns:
+        Tuple of (passed, output).
+    """
+    result = subprocess.run(
+        ["poetry", "run", "pytest", "--tb=short", "-q"],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        timeout=600,
+    )
+    output = result.stdout + result.stderr
+    return result.returncode == 0, output.strip()
+
+
+def commit_update(repo_root: Path, package_name: str, old_version: str, new_version: str) -> bool:
+    """Commit the updated pyproject.toml and poetry.lock.
+
+    Returns:
+        True if commit succeeded.
+    """
+    # Stage files
+    subprocess.run(
+        ["git", "add", "pyproject.toml", "poetry.lock"],
+        capture_output=True,
+        cwd=str(repo_root),
+    )
+
+    # Commit
+    msg = f"deps: update {package_name} {old_version} -> {new_version}"
+    result = subprocess.run(
+        ["git", "commit", "-m", msg],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+    )
+    return result.returncode == 0
+
+
+def modernize(
+    repo_root: Path,
+    *,
+    dry_run: bool = False,
+    package_filter: str | None = None,
+    report_only: bool = False,
+    report_file: Path | None = None,
+) -> dict:
+    """Main modernization loop.
+
+    Args:
+        repo_root: Repository root path.
+        dry_run: If True, only show what would be done.
+        package_filter: If set, only update this package.
+        report_only: If True, only generate the report.
+        report_file: Path for the JSON report.
+
+    Returns:
+        Report dict with results.
+    """
+    print("Discovering outdated dependencies...")
+    outdated = discover_outdated(repo_root)
+
+    if package_filter:
+        outdated = [p for p in outdated if p["name"] == package_filter]
+
+    if not outdated:
+        print("All dependencies are up to date!")
+        return {"packages": [], "summary": {"total": 0, "updated": 0, "failed": 0, "skipped": 0}}
+
+    print(f"Found {len(outdated)} outdated package(s):")
+    for pkg in outdated:
+        print(f"  {pkg['name']}: {pkg['current']} -> {pkg['latest']}")
+
+    report = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "repo": str(repo_root),
+        "packages": [],
+        "summary": {"total": len(outdated), "updated": 0, "failed": 0, "skipped": 0},
+    }
+
+    if dry_run or report_only:
+        for pkg in outdated:
+            report["packages"].append({
+                "name": pkg["name"],
+                "current": pkg["current"],
+                "latest": pkg["latest"],
+                "status": "dry_run" if dry_run else "report_only",
+            })
+        report["summary"]["skipped"] = len(outdated)
+        _save_report(report, repo_root, report_file)
+        return report
+
+    # Sequential update loop
+    for pkg in outdated:
+        name = pkg["name"]
+        print(f"\nUpdating {name} ({pkg['current']} -> {pkg['latest']})...")
+
+        # Save state for rollback
+        pyproject_saved, lock_saved = save_lockfiles(repo_root)
+
+        # Try to update
+        success, add_output = update_package(repo_root, name)
+        if not success:
+            print(f"  SKIP: poetry add failed: {add_output[:200]}")
+            restore_lockfiles(repo_root, pyproject_saved, lock_saved)
+            report["packages"].append({
+                "name": name,
+                "current": pkg["current"],
+                "latest": pkg["latest"],
+                "status": "add_failed",
+                "error": add_output[:500],
+            })
+            report["summary"]["failed"] += 1
+            continue
+
+        # Run tests
+        tests_passed, test_output = run_tests(repo_root)
+        if not tests_passed:
+            print(f"  ROLLBACK: tests failed after updating {name}")
+            restore_lockfiles(repo_root, pyproject_saved, lock_saved)
+            report["packages"].append({
+                "name": name,
+                "current": pkg["current"],
+                "latest": pkg["latest"],
+                "status": "tests_failed",
+                "error": test_output[-500:],
+            })
+            report["summary"]["failed"] += 1
+            continue
+
+        # Commit
+        committed = commit_update(repo_root, name, pkg["current"], pkg["latest"])
+        status = "updated" if committed else "update_no_commit"
+        print(f"  OK: {name} updated to {pkg['latest']}")
+
+        report["packages"].append({
+            "name": name,
+            "current": pkg["current"],
+            "latest": pkg["latest"],
+            "status": status,
+        })
+        report["summary"]["updated"] += 1
+
+    _save_report(report, repo_root, report_file)
+
+    # Print summary
+    s = report["summary"]
+    print(f"\nSummary: {s['updated']} updated, {s['failed']} failed, {s['skipped']} skipped out of {s['total']}")
+
+    return report
+
+
+def _save_report(report: dict, repo_root: Path, report_file: Path | None) -> None:
+    """Save the JSON report to disk."""
+    if report_file is None:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        reports_dir = repo_root / "docs" / "reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        report_file = reports_dir / f"dep-modernization-{timestamp}.json"
+
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    report_file.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"Report saved to: {report_file}")
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Dependency Modernization Tool")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be updated")
+    parser.add_argument("--package", type=str, help="Update only this package")
+    parser.add_argument("--report-only", action="store_true", help="Only generate outdated report")
+    parser.add_argument("--report-file", type=Path, help="Path for JSON report")
+    args = parser.parse_args()
+
+    # Find repo root (assume we're running from it or a subdirectory)
+    repo_root = Path.cwd()
+    if not (repo_root / "pyproject.toml").exists():
+        print("Error: pyproject.toml not found in current directory", file=sys.stderr)
+        sys.exit(1)
+
+    report = modernize(
+        repo_root,
+        dry_run=args.dry_run,
+        package_filter=args.package,
+        report_only=args.report_only,
+        report_file=args.report_file,
+    )
+
+    # Exit with non-zero if any updates failed
+    if report["summary"]["failed"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New `tools/modernize_dependencies.py` — discovers outdated deps, updates one-by-one with test validation
- Sequential update cycle: save lockfiles → `poetry add pkg@latest` → run tests → commit or rollback
- File-content rollback (not worktrees) — simpler and sufficient for serial updates
- Flags: `--dry-run`, `--package <name>`, `--report-only`, `--report-file <path>`
- JSON report saved to `docs/reports/dep-modernization-{timestamp}.json`
- 14 unit tests covering discover parsing, update+pass→commit, update+fail→rollback, add-fail→skip, dry-run, report-only, package filter

## Test plan
- [x] `poetry run pytest tests/tools/test_modernize_dependencies.py -v` — 14/14 passed
- [x] `poetry run python tools/modernize_dependencies.py --dry-run` — found 12 outdated packages, report generated

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)