### PR TITLE
fix: adversarial node type mismatches + workflow state hygiene (#550)

### DIFF
--- a/assemblyzero/workflows/testing/adversarial_state.py
+++ b/assemblyzero/workflows/testing/adversarial_state.py
@@ -32,9 +32,9 @@ class AdversarialNodeState(TypedDict, total=False):
     """State extension for the adversarial testing node."""
 
     # Inputs (populated by prior nodes)
-    implementation_files: dict[str, str]
+    implementation_files: list[str]
     lld_content: str
-    existing_tests: dict[str, str]
+    test_files: list[str]
     issue_id: int
 
     # Outputs (populated by adversarial node)

--- a/assemblyzero/workflows/testing/nodes/adversarial_node.py
+++ b/assemblyzero/workflows/testing/nodes/adversarial_node.py
@@ -68,7 +68,7 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
     logger.info("[ADV] Starting adversarial test generation node")
 
     # Check for implementation files
-    impl_files = state.get("implementation_files", {})
+    impl_files = state.get("implementation_files", [])
     if not impl_files:
         logger.info("[ADV] No implementation files in state — skipping")
         return {
@@ -223,19 +223,23 @@ def _collect_context(state: AdversarialNodeState) -> tuple[str, str, str]:
     Returns:
         Tuple of (implementation_context, lld_context, existing_test_context).
     """
-    impl_files = state.get("implementation_files", {})
+    impl_files = state.get("implementation_files", [])
     lld_content = state.get("lld_content", "")
-    existing_tests = state.get("existing_tests", {})
+    test_files = state.get("test_files", [])
 
-    # Build raw context strings
+    # Build raw context strings by reading files from disk
     impl_parts: list[str] = []
-    for filepath, content in impl_files.items():
-        impl_parts.append(f"# {filepath}\n{content}")
+    for filepath in impl_files:
+        content = _read_file_safe(filepath)
+        if content:
+            impl_parts.append(f"# {filepath}\n{content}")
     impl_raw = "\n\n".join(impl_parts)
 
     test_parts: list[str] = []
-    for filepath, content in existing_tests.items():
-        test_parts.append(f"# {filepath}\n{content}")
+    for filepath in test_files:
+        content = _read_file_safe(filepath)
+        if content:
+            test_parts.append(f"# {filepath}\n{content}")
     test_raw = "\n\n".join(test_parts)
 
     # Apply budget
@@ -295,6 +299,23 @@ def _trim_to_budget(text: str, max_bytes: int) -> str:
             truncated = truncated[:last_newline]
 
     return truncated + "\n\n... [TRUNCATED - token budget exceeded] ..."
+
+
+def _read_file_safe(filepath: str) -> str:
+    """Read a file from disk, returning empty string on failure.
+
+    Args:
+        filepath: Path to the file to read.
+
+    Returns:
+        File contents, or empty string if the file cannot be read.
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            return f.read()
+    except (OSError, UnicodeDecodeError) as e:
+        logger.warning("[ADV] Could not read file %s: %s", filepath, e)
+        return ""
 
 
 def _parse_gemini_response(raw_response: str) -> AdversarialAnalysis:

--- a/tests/unit/test_adversarial_node.py
+++ b/tests/unit/test_adversarial_node.py
@@ -81,11 +81,9 @@ class TestRunAdversarialNode:
         }
 
         state = {
-            "implementation_files": {
-                "module.py": "def function(x):\n    return x"
-            },
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# Feature\n## Requirements\n1. Handles all inputs",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -108,9 +106,9 @@ class TestRunAdversarialNode:
         )
 
         state = {
-            "implementation_files": {"module.py": "def f(): pass"},
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -132,9 +130,9 @@ class TestRunAdversarialNode:
         )
 
         state = {
-            "implementation_files": {"module.py": "def f(): pass"},
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -146,9 +144,9 @@ class TestRunAdversarialNode:
     def test_empty_implementation_skip(self):
         """T040: With no implementation files, skips gracefully."""
         state = {
-            "implementation_files": {},
+            "implementation_files": [],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -168,9 +166,9 @@ class TestRunAdversarialNode:
         mock_client.generate_adversarial_tests.return_value = "{broken json"
 
         state = {
-            "implementation_files": {"module.py": "def f(): pass"},
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -191,9 +189,9 @@ class TestRunAdversarialNode:
         )
 
         state = {
-            "implementation_files": {"module.py": "def f(): pass"},
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -243,9 +241,9 @@ class TestRunAdversarialNode:
         }
 
         state = {
-            "implementation_files": {"module.py": "def f(): pass"},
+            "implementation_files": ["/fake/module.py"],
             "lld_content": "# LLD",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -437,16 +435,17 @@ class TestParseGeminiResponse:
 class TestCollectContext:
     """Tests for _collect_context (T190)."""
 
-    def test_token_budget_trimming(self):
+    def test_token_budget_trimming(self, tmp_path):
         """T190: With oversized input, output fits within 60KB."""
+        big_file = tmp_path / "big_file.py"
+        big_file.write_text("x" * 200_000, encoding="utf-8")
+        test_file = tmp_path / "test.py"
+        test_file.write_text("z" * 50_000, encoding="utf-8")
+
         state = {
-            "implementation_files": {
-                "big_file.py": "x" * 200_000,
-            },
+            "implementation_files": [str(big_file)],
             "lld_content": "y" * 100_000,
-            "existing_tests": {
-                "test.py": "z" * 50_000,
-            },
+            "test_files": [str(test_file)],
             "issue_id": 352,
         }
 
@@ -463,9 +462,9 @@ class TestCollectContext:
     def test_empty_state(self):
         """Handles empty state gracefully."""
         state = {
-            "implementation_files": {},
+            "implementation_files": [],
             "lld_content": "",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -474,16 +473,17 @@ class TestCollectContext:
         assert lld == ""
         assert tests == ""
 
-    def test_small_input_not_truncated(self):
+    def test_small_input_not_truncated(self, tmp_path):
         """Small inputs are returned without truncation."""
+        small_file = tmp_path / "small.py"
+        small_file.write_text("def foo():\n    return 42\n", encoding="utf-8")
+        test_file = tmp_path / "test_small.py"
+        test_file.write_text("def test_foo():\n    assert foo() == 42\n", encoding="utf-8")
+
         state = {
-            "implementation_files": {
-                "small.py": "def foo():\n    return 42\n",
-            },
+            "implementation_files": [str(small_file)],
             "lld_content": "# Small LLD\n## Requirements\n1. foo returns 42",
-            "existing_tests": {
-                "test_small.py": "def test_foo():\n    assert foo() == 42\n",
-            },
+            "test_files": [str(test_file)],
             "issue_id": 352,
         }
 
@@ -497,15 +497,17 @@ class TestCollectContext:
         assert "TRUNCATED" not in lld
         assert "TRUNCATED" not in tests
 
-    def test_multiple_impl_files_concatenated(self):
+    def test_multiple_impl_files_concatenated(self, tmp_path):
         """Multiple implementation files are concatenated with headers."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("def foo(): pass", encoding="utf-8")
+        file2 = tmp_path / "file2.py"
+        file2.write_text("def bar(): pass", encoding="utf-8")
+
         state = {
-            "implementation_files": {
-                "file1.py": "def foo(): pass",
-                "file2.py": "def bar(): pass",
-            },
+            "implementation_files": [str(file1), str(file2)],
             "lld_content": "",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 
@@ -516,14 +518,15 @@ class TestCollectContext:
         assert "def foo():" in impl
         assert "def bar():" in impl
 
-    def test_oversized_impl_truncated_with_marker(self):
+    def test_oversized_impl_truncated_with_marker(self, tmp_path):
         """Implementation exceeding budget gets truncation marker."""
+        big_file = tmp_path / "big.py"
+        big_file.write_text("x" * 200_000, encoding="utf-8")
+
         state = {
-            "implementation_files": {
-                "big.py": "x" * 200_000,
-            },
+            "implementation_files": [str(big_file)],
             "lld_content": "",
-            "existing_tests": {},
+            "test_files": [],
             "issue_id": 352,
         }
 

--- a/tools/run_implementation_spec_workflow.py
+++ b/tools/run_implementation_spec_workflow.py
@@ -366,7 +366,6 @@ def build_initial_state(
         "spec_draft": "",
         "spec_path": "",
         # Validation
-        "completeness_checks": [],
         "completeness_issues": [],
         "validation_passed": False,
         # Review
@@ -386,6 +385,9 @@ def build_initial_state(
         "config_reviewer": args.reviewer,
         "config_drafter": args.drafter,
         "config_mock_mode": args.mock,
+        # Issue #511: Per-node LLM cost tracking
+        "node_costs": {},
+        "node_tokens": {},
     }
 
     return state


### PR DESCRIPTION
## Summary

- Fix N7.5 adversarial node crash: `implementation_files` was `dict[str, str]` in adversarial state but `list[str]` in reality — node called `.items()` on a list
- Fix dead `existing_tests` field (never populated) — renamed to `test_files` to match upstream
- Remove undeclared `completeness_checks` init from impl spec workflow
- Add missing `node_costs`/`node_tokens` init (#511)

Closes #550

## Test plan

- [x] `poetry run pytest tests/unit/test_adversarial_node.py -v` — 29/29 pass
- [x] Full unit suite — 1029 passed, 1 pre-existing failure (unrelated, filed as #551)


🤖 Generated with [Claude Code](https://claude.com/claude-code)