### PR TITLE
feat: wire the typed error hierarchy across all API call sites

### DIFF
--- a/assemblyzero/core/claude_client.py
+++ b/assemblyzero/core/claude_client.py
@@ -2,6 +2,13 @@
 
 Issue #138: Add retry/backoff handling for Claude CLI invocations.
 
+.. deprecated::
+    This module has zero production callers as of issue #546.
+    Use ``assemblyzero.core.llm_provider.ClaudeCLIProvider`` (for CLI access)
+    or ``assemblyzero.core.llm_provider.AnthropicProvider`` (for API access)
+    instead.  ``ClaudeRateLimitError`` maps to ``assemblyzero.core.errors.RateLimitError``.
+    ``ClaudeClientError`` has no direct equivalent — use ``errors.APIError``.
+
 This module provides a robust interface to the Claude CLI with:
 - Exponential backoff on rate limit errors (429)
 - Configurable retry attempts

--- a/assemblyzero/core/errors.py
+++ b/assemblyzero/core/errors.py
@@ -204,6 +204,78 @@ def classify_anthropic_error(exc: Exception) -> APIError:
 
 
 # ---------------------------------------------------------------------------
+# Classifier: Gemini (google.genai / google.api_core)
+# ---------------------------------------------------------------------------
+
+
+def classify_gemini_error(exc: Exception) -> APIError:
+    """Translate a Gemini/google-api exception into the unified hierarchy.
+
+    Import ``google.api_core.exceptions`` lazily so this module has no hard
+    dependency on the Google SDK.
+
+    Args:
+        exc: An exception raised by the ``google.genai`` or ``google.api_core``
+             packages, or any generic exception from a Gemini API call.
+
+    Returns:
+        The appropriate ``APIError`` subclass wrapping the original exception.
+    """
+    msg = str(exc)
+
+    # Try isinstance checks against google.api_core.exceptions (lazy import)
+    try:
+        from google.api_core import exceptions as gexc
+
+        if isinstance(exc, gexc.ResourceExhausted):
+            # Distinguish quota (429) from capacity (503-like)
+            msg_lower = msg.lower()
+            if any(p in msg_lower for p in ("quota", "rate", "per minute", "per day")):
+                return RateLimitError(msg, provider="gemini")
+            return CapacityError(msg, provider="gemini", status_code=429)
+
+        if isinstance(exc, gexc.ServiceUnavailable):
+            return CapacityError(msg, provider="gemini", status_code=503)
+
+        if isinstance(exc, gexc.Unauthenticated):
+            return AuthenticationError(msg, provider="gemini", status_code=401)
+
+        if isinstance(exc, gexc.PermissionDenied):
+            return AuthenticationError(msg, provider="gemini", status_code=403)
+
+        if isinstance(exc, gexc.DeadlineExceeded):
+            return TimeoutError_(msg, provider="gemini")
+
+        if isinstance(exc, gexc.NotFound):
+            return NotFoundError(msg, provider="gemini")
+
+        if isinstance(exc, gexc.InternalServerError):
+            return ServerError(msg, provider="gemini", status_code=500)
+
+        # Generic google.api_core error with a grpc_status_code or code
+        status = getattr(exc, "code", None)
+        if status is not None and isinstance(status, int):
+            return classify_http_status(status, msg)
+
+    except ImportError:
+        pass
+
+    # Fallback: pattern-match on the stringified exception (covers cases
+    # where the SDK wraps errors in generic Exception or RuntimeError)
+    msg_lower = msg.lower()
+    if any(p in msg_lower for p in ("429", "quota", "resource_exhausted", "resource has been exhausted")):
+        return RateLimitError(msg, provider="gemini")
+    if any(p in msg_lower for p in ("503", "529", "capacity", "overloaded")):
+        return CapacityError(msg, provider="gemini", status_code=503)
+    if any(p in msg_lower for p in ("401", "403", "api_key_invalid", "unauthenticated", "permission_denied")):
+        return AuthenticationError(msg, provider="gemini")
+    if "timeout" in msg_lower or "deadline" in msg_lower:
+        return TimeoutError_(msg, provider="gemini")
+
+    return APIError(msg, retryable=False, provider="gemini")
+
+
+# ---------------------------------------------------------------------------
 # Classifier: HTTP status codes (generic)
 # ---------------------------------------------------------------------------
 

--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -35,6 +35,13 @@ from assemblyzero.core.config import (
     MAX_RETRIES_PER_CREDENTIAL,
     ROTATION_STATE_FILE,
 )
+from assemblyzero.core.errors import (
+    AuthenticationError as TypedAuthError,
+    CapacityError as TypedCapacityError,
+    RateLimitError as TypedRateLimitError,
+    TimeoutError_ as TypedTimeoutError,
+    classify_gemini_error,
+)
 
 
 # =============================================================================
@@ -572,7 +579,10 @@ class GeminiClient:
 
                 except Exception as e:
                     error_str = str(e)
-                    error_type = self._classify_error(error_str)
+                    # Issue #546: Classify through the typed error hierarchy
+                    classified = classify_gemini_error(e)
+                    status_code = classified.status_code
+                    error_type = self._error_type_from_classified(classified)
 
                     if error_type == GeminiErrorType.CAPACITY_EXHAUSTED:
                         # 529/503: Backoff and retry same credential
@@ -581,14 +591,14 @@ class GeminiClient:
                             event_type="capacity_exhausted",
                             credential_name=cred.name,
                             model=self.model,
-                            error_message=f"529 capacity exhausted, backing off {delay:.1f}s (attempt {attempt})",
-                            details={"backoff_seconds": delay, "attempt": attempt},
+                            error_message=f"{status_code or 503} capacity exhausted, backing off {delay:.1f}s (attempt {attempt})",
+                            details={"backoff_seconds": delay, "attempt": attempt, "status_code": status_code},
                         )
                         # Issue #537: Log retries to stdout so babysitters see progress
                         print(
                             f"    [LLM] provider=gemini model={self.model} "
                             f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
-                            f"503/529 capacity exhausted (retrying in {delay:.0f}s)"
+                            f"{status_code or 503} capacity exhausted (retrying in {delay:.0f}s)"
                         )
                         time.sleep(delay)
                         continue
@@ -604,7 +614,7 @@ class GeminiClient:
                             model=self.model,
                             reset_time=reset_time,
                             error_message=f"429 quota exhausted, will reset in {reset_hours}h",
-                            details={"reset_hours": reset_hours, "cred_type": cred.cred_type},
+                            details={"reset_hours": reset_hours, "cred_type": cred.cred_type, "status_code": status_code},
                         )
                         # Issue #537: Log rotation to stdout
                         print(
@@ -621,22 +631,42 @@ class GeminiClient:
                             credential_name=cred.name,
                             model=self.model,
                             error_message=error_str[:200],
+                            details={"status_code": status_code},
                         )
                         # Issue #537: Log auth errors to stdout
                         print(
                             f"    [LLM] provider=gemini credential={cred.name}: "
-                            f"auth error — skipping credential"
+                            f"auth error (status={status_code}) — skipping credential"
                         )
                         errors.append(f"{cred.name}: Authentication failed")
                         break  # Move to next credential
 
                     else:
-                        # Unknown error: Log and try next credential
+                        # Unknown/retryable transient error: retry if classified as retryable
+                        if classified.retryable and attempt < MAX_RETRIES_PER_CREDENTIAL - 1:
+                            delay = self._backoff_delay(attempt)
+                            log_gemini_event(
+                                event_type="api_error",
+                                credential_name=cred.name,
+                                model=self.model,
+                                error_message=error_str[:200],
+                                details={"status_code": status_code, "retryable": True, "backoff_seconds": delay},
+                            )
+                            print(
+                                f"    [LLM] provider=gemini model={self.model} "
+                                f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
+                                f"transient error (status={status_code}), retrying in {delay:.0f}s"
+                            )
+                            time.sleep(delay)
+                            continue
+
+                        # Non-retryable or last attempt: Log and try next credential
                         log_gemini_event(
                             event_type="api_error",
                             credential_name=cred.name,
                             model=self.model,
                             error_message=error_str[:200],
+                            details={"status_code": status_code, "retryable": classified.retryable},
                         )
                         errors.append(f"{cred.name}: {error_str[:100]}")
                         break  # Move to next credential
@@ -818,7 +848,11 @@ class GeminiClient:
         self._save_state(state)
 
     def _classify_error(self, error_output: str) -> GeminiErrorType:
-        """Classify error type from API response."""
+        """Classify error type from API response string.
+
+        Deprecated: Use classify_gemini_error() + _error_type_from_classified()
+        for new code paths. Kept for backward compatibility.
+        """
         error_lower = error_output.lower()
 
         # Check quota patterns first
@@ -836,6 +870,23 @@ class GeminiClient:
             if pattern.lower() in error_lower:
                 return GeminiErrorType.AUTH_ERROR
 
+        return GeminiErrorType.UNKNOWN
+
+    @staticmethod
+    def _error_type_from_classified(classified) -> GeminiErrorType:
+        """Derive GeminiErrorType from a typed errors.py exception.
+
+        Issue #546: Bridge between the unified error hierarchy and the
+        GeminiErrorType enum used by the rotation/retry logic.
+        """
+        if isinstance(classified, TypedRateLimitError):
+            return GeminiErrorType.QUOTA_EXHAUSTED
+        if isinstance(classified, TypedCapacityError):
+            return GeminiErrorType.CAPACITY_EXHAUSTED
+        if isinstance(classified, TypedAuthError):
+            return GeminiErrorType.AUTH_ERROR
+        if isinstance(classified, TypedTimeoutError):
+            return GeminiErrorType.CAPACITY_EXHAUSTED  # Treat timeout as capacity for retry
         return GeminiErrorType.UNKNOWN
 
     def _backoff_delay(self, attempt: int) -> float:

--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -12,12 +12,22 @@ Creates a LangGraph-compatible node that:
 
 from pathlib import Path
 
+from assemblyzero.core.errors import (
+    AuthenticationError,
+    CapacityError,
+    RateLimitError,
+    classify_http_status,
+)
 from assemblyzero.core.recovery_plan import generate_recovery_plan
 from assemblyzero.core.state_persistence import STATE_DIR, save_state_snapshot
 
 
 def classify_error(error_message: str) -> str:
     """Classify error type from the error_message string.
+
+    Issue #546: Delegates to errors.py for HTTP-related classifications,
+    preserving domain-specific patterns (stagnation, budget, preflight)
+    that have no HTTP equivalent.
 
     Args:
         error_message: The error message from the workflow state.
@@ -27,23 +37,38 @@ def classify_error(error_message: str) -> str:
     """
     msg_lower = error_message.lower()
 
-    if any(p in msg_lower for p in ("capacity exhausted", "503", "529", "overloaded")):
-        return "capacity_exhausted"
-    elif any(p in msg_lower for p in ("quota exhausted", "429", "all credentials exhausted")):
-        return "quota_exhausted"
-    elif any(p in msg_lower for p in ("stagnation", "same issues", "same blocking", "two consecutive")):
+    # Domain-specific classifications first (no HTTP equivalent)
+    if any(p in msg_lower for p in ("stagnation", "same issues", "same blocking", "two consecutive")):
         return "stagnation"
-    elif any(p in msg_lower for p in ("budget", "cost budget exceeded")):
+    if any(p in msg_lower for p in ("budget", "cost budget exceeded")):
         return "budget"
-    elif any(p in msg_lower for p in ("auth", "api_key_invalid", "permission_denied", "unauthenticated")):
-        return "auth"
-    elif "preflight" in msg_lower:
-        # Pre-flight failures inherit the underlying type
+    if "preflight" in msg_lower:
         if "unavailable" in msg_lower or "exhausted" in msg_lower:
             return "quota_exhausted"
         return "preflight"
-    else:
-        return "unknown"
+
+    # Try to extract an HTTP status code and delegate to errors.py
+    import re
+    status_match = re.search(r'\bstatus[=: ]*(\d{3})\b', msg_lower)
+    if status_match:
+        status_code = int(status_match.group(1))
+        classified = classify_http_status(status_code, error_message)
+        if isinstance(classified, CapacityError):
+            return "capacity_exhausted"
+        if isinstance(classified, RateLimitError):
+            return "quota_exhausted"
+        if isinstance(classified, AuthenticationError):
+            return "auth"
+
+    # Fallback: pattern matching for messages without status codes
+    if any(p in msg_lower for p in ("capacity exhausted", "503", "529", "overloaded")):
+        return "capacity_exhausted"
+    if any(p in msg_lower for p in ("quota exhausted", "429", "all credentials exhausted")):
+        return "quota_exhausted"
+    if any(p in msg_lower for p in ("auth", "api_key_invalid", "permission_denied", "unauthenticated")):
+        return "auth"
+
+    return "unknown"
 
 
 def create_halt_node(workflow_name: str):

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -78,6 +78,9 @@ class LLMCallResult:
     cache_creation_tokens: int = 0
     cost_usd: float = 0.0
     rate_limited: bool = False
+    status_code: Optional[int] = None
+    retry_after: Optional[float] = None
+    retryable: bool = True
 
 
 # =============================================================================
@@ -143,8 +146,14 @@ def log_llm_call(result: LLMCallResult) -> None:
     parts.append(f"duration={duration_s:.1f}s")
     if not result.success:
         parts.append(f"ERROR={result.error_message or 'unknown'}")
+    if result.status_code is not None:
+        parts.append(f"status={result.status_code}")
     if result.rate_limited:
         parts.append("RATE_LIMITED=true")
+    if result.retry_after is not None:
+        parts.append(f"retry_after={result.retry_after:.1f}")
+    if not result.retryable:
+        parts.append("retryable=false")
 
     print("    " + " ".join(parts))
 
@@ -715,14 +724,21 @@ class AnthropicProvider(LLMProvider):
 
             duration_ms = int((time.time() - start_time) * 1000)
 
-            # Issue #542: Classify through the typed error hierarchy
+            # Issue #542/#546: Classify through the typed error hierarchy
+            # and propagate status_code, retry_after, retryable to LLMCallResult
             if isinstance(e, (anthropic.APIError, anthropic.APITimeoutError)):
                 classified = classify_anthropic_error(e)
                 rate_limited = isinstance(classified, RateLimitError)
                 error_msg = str(classified)
+                status_code = classified.status_code
+                retry_after = classified.retry_after
+                retryable = classified.retryable
             else:
                 rate_limited = False
                 error_msg = f"Anthropic API error: {e}"
+                status_code = None
+                retry_after = None
+                retryable = False
 
             call_result = LLMCallResult(
                 success=False,
@@ -734,6 +750,9 @@ class AnthropicProvider(LLMProvider):
                 duration_ms=duration_ms,
                 attempts=1,
                 rate_limited=rate_limited,
+                status_code=status_code,
+                retry_after=retry_after,
+                retryable=retryable,
             )
             log_llm_call(call_result)
             return call_result
@@ -1008,8 +1027,11 @@ class GeminiProvider(LLMProvider):
             return call_result
 
         except Exception as e:
-            # Issue #399: detect 429 in credential pool exhaustion
-            is_rate_limit = "quota" in str(e).lower() or "429" in str(e)
+            # Issue #546: Classify through the typed error hierarchy
+            from assemblyzero.core.errors import classify_gemini_error
+
+            classified = classify_gemini_error(e)
+            is_rate_limit = isinstance(classified, RateLimitError)
             if is_rate_limit:
                 print(f"    [LLM] RATE LIMITED: provider=gemini model={self._model} error={str(e)[:100]}")
 
@@ -1017,12 +1039,15 @@ class GeminiProvider(LLMProvider):
                 success=False,
                 response=None,
                 raw_response=None,
-                error_message=str(e),
+                error_message=str(classified),
                 provider=self.provider_name,
                 model_used=self._model,
                 duration_ms=0,
                 attempts=0,
                 rate_limited=is_rate_limit,
+                status_code=classified.status_code,
+                retry_after=classified.retry_after,
+                retryable=classified.retryable,
             )
             log_llm_call(call_result)
             return call_result

--- a/assemblyzero/workflows/scout/nodes.py
+++ b/assemblyzero/workflows/scout/nodes.py
@@ -269,7 +269,7 @@ Please also identify GAPS between our implementation and the external best pract
         if result.success:
             analysis = result.response or "No response received."
         else:
-            raise RuntimeError(result.error or "Unknown error")
+            raise RuntimeError(result.error_message or "Unknown error")
     except ImportError:
         # Fallback to direct API if client not available
         try:

--- a/assemblyzero/workflows/testing/adversarial_gemini.py
+++ b/assemblyzero/workflows/testing/adversarial_gemini.py
@@ -10,6 +10,11 @@ provider infrastructure.
 import logging
 from typing import Any
 
+from assemblyzero.core.errors import (
+    RateLimitError,
+    TimeoutError_ as TypedTimeoutError,
+    classify_gemini_error,
+)
 from assemblyzero.core.text_sanitizer import strip_emoji
 
 from assemblyzero.workflows.testing.adversarial_prompts import (
@@ -23,20 +28,15 @@ from assemblyzero.workflows.testing.knowledge.adversarial_patterns import (
 logger = logging.getLogger(__name__)
 
 
-class GeminiQuotaExhaustedError(Exception):
-    """Raised when Gemini API quota is exhausted (HTTP 429)."""
-
-    pass
+# Issue #546: GeminiQuotaExhaustedError and GeminiTimeoutError are now
+# aliases for the unified error hierarchy.  Kept as names for backward
+# compatibility with existing except-clauses in callers.
+GeminiQuotaExhaustedError = RateLimitError
+GeminiTimeoutError = TypedTimeoutError
 
 
 class GeminiModelDowngradeError(Exception):
     """Raised when Gemini silently downgrades from Pro to Flash."""
-
-    pass
-
-
-class GeminiTimeoutError(Exception):
-    """Raised when Gemini API response exceeds timeout."""
 
     pass
 
@@ -198,16 +198,22 @@ class AdversarialGeminiClient:
             )
         except TimeoutError as e:
             raise GeminiTimeoutError(
-                f"Gemini API response exceeded {timeout}s timeout"
+                f"Gemini API response exceeded {timeout}s timeout",
+                provider="gemini",
             ) from e
         except TypeError:
             raise  # Unsupported provider type — propagate as-is
         except Exception as e:
-            # Classify common Gemini errors rather than swallowing them
-            err_msg = str(e).lower()
-            if "429" in str(e) or "quota" in err_msg or "resource_exhausted" in err_msg:
-                raise GeminiQuotaExhaustedError(f"Gemini quota exhausted: {e}") from e
-            raise GeminiTimeoutError(f"Gemini API error: {e}") from e
+            # Issue #546: Classify through the typed error hierarchy
+            classified = classify_gemini_error(e)
+            if isinstance(classified, RateLimitError):
+                raise GeminiQuotaExhaustedError(
+                    f"Gemini quota exhausted: {e}", provider="gemini",
+                ) from e
+            raise GeminiTimeoutError(
+                f"Gemini API error (status={classified.status_code}): {e}",
+                provider="gemini",
+            ) from e
 
         # Check for quota exhaustion in response or exception
         if self._is_quota_error(raw_response, metadata):

--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -978,14 +978,16 @@ def call_claude_for_file(prompt: str, file_path: str = "") -> tuple[str, str]:
         return "", f"SDK timeout after {timeout}s waiting for response"
     except TimeoutError:
         return "", f"SDK timeout after {timeout}s waiting for response"
-    except anthropic.AuthenticationError as e:
-        return "", f"SDK auth error (check API key): {e}"
-    except anthropic.RateLimitError as e:
-        return "", f"SDK rate limited: {e}"
-    except anthropic.APIStatusError as e:
-        return "", f"SDK API error (status {e.status_code}): {e}"
-    except anthropic.APIError as e:
-        return "", f"SDK error: {e}"
+    except Exception as e:
+        # Issue #546: Classify through the typed error hierarchy
+        try:
+            from assemblyzero.core.errors import classify_anthropic_error
+            classified = classify_anthropic_error(e)
+            status_code = classified.status_code
+            prefix = "[NON-RETRYABLE] " if not classified.retryable else ""
+            return "", f"{prefix}SDK error (status={status_code}): {e}"
+        except Exception:
+            return "", f"SDK error: {e}"
 
 
 # =============================================================================
@@ -1079,6 +1081,13 @@ def generate_file_with_retry(
         # Check for API error
         if api_error:
             last_error = f"API error: {api_error}"
+            # Issue #546: Non-retryable errors (auth, billing) skip retry loop
+            if "[NON-RETRYABLE]" in api_error:
+                raise ImplementationError(
+                    filepath=filepath,
+                    reason=f"Non-retryable API error: {api_error}",
+                    response_preview=None
+                )
             if attempt < max_retries - 1:
                 print(f"        [RETRY {attempt_num}/{max_retries}] {last_error}")
                 continue


### PR DESCRIPTION
## Summary

Closes #546.

The error hierarchy (`errors.py`) and retry contract (`retry.py`) were built in #542 but had **zero production callers** — every call site caught exceptions, classified them, then immediately discarded all typed information into `str(e)`. During babysitting, transient HTTP errors (429, 503) were indistinguishable from permanent failures (401, 403).

This PR wires the hierarchy across all 8 affected files:

- **LLMCallResult**: new `status_code`, `retry_after`, `retryable` fields — the data bottleneck
- **AnthropicProvider**: propagates classified error fields instead of flattening to string
- **errors.py**: new `classify_gemini_error()` for `google.api_core.exceptions`
- **gemini_client.py**: replaces string-pattern `_classify_error` with typed classifier + real status codes in logs
- **implement_code.py**: classifies SDK errors, `[NON-RETRYABLE]` prefix skips useless retry loops
- **adversarial_gemini.py**: aliases custom exceptions to `errors.py` hierarchy
- **halt_node.py**: delegates HTTP classification to `errors.py`, preserves domain patterns (stagnation, budget)
- **scout/nodes.py**: fixes `result.error` → `result.error_message` (actual bug)
- **claude_client.py**: deprecation docstring (zero production callers confirmed)

## Test plan

- [x] `poetry run pytest tests/unit/ --tb=short -q` — 3619 passed, 0 failures
- [x] `poetry run pytest tests/unit/test_errors.py tests/unit/test_llm_provider.py -xvs` — hierarchy + provider tests green
- [x] Grep `str(e)` in `assemblyzero/core/` — remaining uses are non-HTTP paths (CLI not found, OSError)
- [x] All `log_gemini_event` calls include `status_code` in details dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)