### PR TITLE
fix: move Ponder before validation, add directory ordering rule, reset counter (#565, #566, #567)

### DIFF
--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -19,10 +19,10 @@ Creates a LangGraph StateGraph that connects:
 - N5: finalize (issue filing or LLD saving)
 
 Graph structure (LLD workflow):
-    START -> N0 -> N0b -> N1 -> N1.5 -> N1b -> N2 -> N3 -> N4 -> N5 -> END
-                          ^                          |         |
-                          |                          v         |
-                          +----------<---------------+---------+
+    START -> N0 -> N0b -> N1 -> Ponder -> N1.5 -> N1b -> N2 -> N3 -> N4 -> N5 -> END
+                          ^                                    |         |
+                          |                                    v         |
+                          +----------------<-------------------+---------+
 
 Issue #248 addition: After N3 (review), if open questions are UNANSWERED,
 loop back to N3 with a followup prompt. If HUMAN_REQUIRED, force N4.
@@ -118,19 +118,17 @@ def route_after_load_input(
 
 def route_after_generate_draft(
     state: RequirementsWorkflowState,
-) -> Literal["N1_5_validate_mechanical", "N2_human_gate_draft", "N3_review", "HALT"]:
+) -> Literal["N_ponder_stibbons", "N2_human_gate_draft", "N3_review", "HALT"]:
     """Route after generate_draft node.
 
     Routes to:
-    - N1_5_validate_mechanical: LLD workflow (Issue #277)
+    - N_ponder_stibbons: LLD workflow — auto-fix before validation (#565)
     - N2_human_gate_draft: Issue workflow with gate enabled
     - N3_review: Issue workflow with gate disabled
     - HALT: Error generating draft (Issue #486)
 
-    Issue #248: Pre-review validation gate removed. Drafts with open
-    questions now proceed to review where Gemini can answer them.
-
-    Issue #277: LLD workflows now go through mechanical validation first.
+    Issue #565: LLD workflows now route through Ponder (auto-fix) BEFORE
+    mechanical validation, so fixes apply before validation loops back.
 
     Args:
         state: Current workflow state.
@@ -141,9 +139,9 @@ def route_after_generate_draft(
     if state.get("error_message"):
         return "HALT"
 
-    # Issue #277: LLD workflows go through mechanical validation
+    # Issue #565: LLD workflows go through Ponder auto-fix first
     if state.get("workflow_type") == "lld":
-        return "N1_5_validate_mechanical"
+        return "N_ponder_stibbons"
 
     # Issue workflows skip mechanical validation
     if state.get("config_gates_draft", True):
@@ -195,15 +193,16 @@ def route_after_validate_mechanical(
 
 def route_after_validate_test_plan(
     state: RequirementsWorkflowState,
-) -> Literal["N_ponder_stibbons", "N1_generate_draft", "HALT"]:
+) -> Literal["N2_human_gate_draft", "N3_review", "N1_generate_draft", "HALT"]:
     """Route after validate_test_plan node.
 
     Issue #166: Routes based on test plan validation result.
-    Issue #307: Pass now routes to Ponder (auto-fix) before N2/N3.
+    Issue #565: Pass now routes to N2/N3 (Ponder already ran before validation).
     Issue #486: Error/max-iteration routes to HALT.
 
     Routes to:
-    - N_ponder_stibbons: Validation passed, apply auto-fixes
+    - N2_human_gate_draft: Validation passed, gate enabled
+    - N3_review: Validation passed, gate disabled
     - N1_generate_draft: Validation failed, return to drafter
     - HALT: Error or max iterations reached
 
@@ -228,17 +227,20 @@ def route_after_validate_test_plan(
         print("    [ROUTING] Test plan validation failed - returning to drafter")
         return "N1_generate_draft"
 
-    # Validation passed - route through Ponder for auto-fixes (Issue #307)
-    return "N_ponder_stibbons"
+    # Issue #565: Validation passed — proceed to human gate or review
+    if state.get("config_gates_draft", True):
+        return "N2_human_gate_draft"
+    else:
+        return "N3_review"
 
 
 def route_after_ponder(
     state: RequirementsWorkflowState,
-) -> Literal["N2_human_gate_draft", "N3_review"]:
+) -> Literal["N1_5_validate_mechanical"]:
     """Route after Ponder Stibbons auto-fix node.
 
-    Issue #307: After auto-fixes, proceed to human gate or review.
-    Ponder never routes back to drafter — it only fixes mechanical issues.
+    Issue #565: Ponder now runs BEFORE validation. Always proceeds to
+    mechanical validation (N1.5) so fixes are validated immediately.
 
     Args:
         state: Current workflow state.
@@ -246,10 +248,7 @@ def route_after_ponder(
     Returns:
         Next node name.
     """
-    if state.get("config_gates_draft", True):
-        return "N2_human_gate_draft"
-    else:
-        return "N3_review"
+    return "N1_5_validate_mechanical"
 
 
 def route_from_human_gate_draft(
@@ -482,13 +481,13 @@ def create_requirements_graph() -> StateGraph:
     # N0b -> N1 (always proceeds to draft generation)
     graph.add_edge(N0B_ANALYZE_CODEBASE, N1_GENERATE_DRAFT)
 
-    # N1 -> N1.5 (LLD) or N2 or N3 or HALT (based on workflow type, gates, error)
-    # Issue #277: LLD workflows go through mechanical validation
+    # N1 -> Ponder (LLD) or N2 or N3 or HALT (based on workflow type, gates, error)
+    # Issue #565: LLD workflows go through Ponder auto-fix first
     graph.add_conditional_edges(
         N1_GENERATE_DRAFT,
         route_after_generate_draft,
         {
-            "N1_5_validate_mechanical": N1_5_VALIDATE_MECHANICAL,
+            "N_ponder_stibbons": N_PONDER,
             "N2_human_gate_draft": N2_HUMAN_GATE_DRAFT,
             "N3_review": N3_REVIEW,
             "HALT": HALT,
@@ -508,26 +507,25 @@ def create_requirements_graph() -> StateGraph:
         },
     )
 
-    # N1b -> Ponder or N1 or HALT (based on test plan validation)
-    # Issue #166: Test plan validation routes
-    # Issue #307: Pass goes through Ponder before N2/N3
+    # N1b -> N2 or N3 or N1 or HALT (based on test plan validation)
+    # Issue #565: Pass goes to N2/N3 (Ponder already ran before validation)
     graph.add_conditional_edges(
         N1B_VALIDATE_TEST_PLAN,
         route_after_validate_test_plan,
         {
-            "N_ponder_stibbons": N_PONDER,
+            "N2_human_gate_draft": N2_HUMAN_GATE_DRAFT,
+            "N3_review": N3_REVIEW,
             "N1_generate_draft": N1_GENERATE_DRAFT,
             "HALT": HALT,
         },
     )
 
-    # Ponder -> N2 or N3 (Issue #307: always proceeds after auto-fix)
+    # Ponder -> N1.5 (Issue #565: auto-fix before validation)
     graph.add_conditional_edges(
         N_PONDER,
         route_after_ponder,
         {
-            "N2_human_gate_draft": N2_HUMAN_GATE_DRAFT,
-            "N3_review": N3_REVIEW,
+            "N1_5_validate_mechanical": N1_5_VALIDATE_MECHANICAL,
         },
     )
 

--- a/assemblyzero/workflows/requirements/nodes/ponder_rules.py
+++ b/assemblyzero/workflows/requirements/nodes/ponder_rules.py
@@ -169,12 +169,113 @@ def fix_missing_blank_before_heading(
     return "\n".join(result), fixes
 
 
+def fix_directory_ordering(
+    draft: str, ctx: dict[str, Any]
+) -> tuple[str, list[AutoFix]]:
+    """Sort directory entries before file entries in Section 2.1 table.
+
+    Issue #566: LLD Section 2.1 (Proposed Changes) tables should list
+    directory entries before file entries so the structure reads top-down.
+    Only applies to LLD workflows.
+    """
+    if ctx.get("workflow_type") != "lld":
+        return draft, []
+
+    # Find Section 2.1
+    section_match = re.search(
+        r"(###\s*2\.1[^\n]*\n)(.*?)(?=###|\Z)", draft, re.DOTALL
+    )
+    if not section_match:
+        return draft, []
+
+    header = section_match.group(1)
+    body = section_match.group(2)
+
+    # Parse table rows (skip header row and separator)
+    lines = body.split("\n")
+    table_header_lines: list[str] = []
+    data_rows: list[str] = []
+    post_table: list[str] = []
+    in_table = False
+    past_table = False
+
+    for line in lines:
+        if past_table:
+            post_table.append(line)
+        elif line.strip().startswith("|") and not in_table:
+            in_table = True
+            table_header_lines.append(line)
+        elif in_table and line.strip().startswith("|"):
+            # Check if separator row
+            if re.match(r"^\s*\|[-| :]+\|\s*$", line):
+                table_header_lines.append(line)
+            else:
+                data_rows.append(line)
+        elif in_table and not line.strip().startswith("|"):
+            past_table = True
+            post_table.append(line)
+        else:
+            table_header_lines.append(line)
+
+    if not data_rows:
+        return draft, []
+
+    # Detect directory rows by checking the change type column
+    def _is_directory_row(row: str) -> bool:
+        cells = [c.strip() for c in row.split("|")]
+        # cells[0] is empty (before first |), cells[-1] is empty (after last |)
+        for cell in cells:
+            if "directory" in cell.lower():
+                return True
+        return False
+
+    has_directory = any(_is_directory_row(r) for r in data_rows)
+    if not has_directory:
+        return draft, []
+
+    # Check if any directory appears after a file
+    seen_file = False
+    needs_sort = False
+    for row in data_rows:
+        if _is_directory_row(row):
+            if seen_file:
+                needs_sort = True
+                break
+        else:
+            seen_file = True
+
+    if not needs_sort:
+        return draft, []
+
+    # Stable sort: directories first
+    dir_rows = [r for r in data_rows if _is_directory_row(r)]
+    file_rows = [r for r in data_rows if not _is_directory_row(r)]
+    sorted_rows = dir_rows + file_rows
+
+    # Reconstruct section body
+    new_body = "\n".join(table_header_lines + sorted_rows + post_table)
+
+    # Replace in draft
+    start = section_match.start(2)
+    end = section_match.end(2)
+    fixed = draft[:start] + new_body + draft[end:]
+
+    return fixed, [
+        AutoFix(
+            rule="directory_ordering",
+            description=f"Moved {len(dir_rows)} directory entries before {len(file_rows)} file entries in Section 2.1",
+            section="2.1",
+        )
+    ]
+
+
 # Registry of all auto-fix rules, applied in order
 PONDER_RULES = [
     fix_title_issue_number,
     fix_section_heading_format,
     fix_trailing_whitespace,
     fix_missing_blank_before_heading,
+    fix_directory_ordering,
 ]
 
 

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -198,6 +198,7 @@ Follow the Review Instructions exactly. Be specific about what needs to change f
         "error_message": "",
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
+        "test_plan_validation_attempts": 0,  # Issue #567: reset after review
     }
 
 

--- a/tests/test_issue_248.py
+++ b/tests/test_issue_248.py
@@ -30,6 +30,7 @@ from assemblyzero.workflows.requirements.graph import (
     route_after_generate_draft,
     route_after_validate_mechanical,
     route_after_validate_test_plan,
+    route_after_ponder,
     route_after_review,
 )
 
@@ -219,17 +220,17 @@ def test_t010(draft_with_open_questions, mock_state_base):
     result_after_test_plan = route_after_validate_test_plan(state)
 
     # TDD: Assert
-    # Step 1: After draft, LLD workflows go to mechanical validation
-    assert result_after_draft == "N1_5_validate_mechanical", \
-        "LLD workflows should go to mechanical validation after draft (Issue #277)"
+    # Step 1: After draft, LLD workflows go to Ponder auto-fix (#565)
+    assert result_after_draft == "N_ponder_stibbons", \
+        "LLD workflows should go to Ponder after draft (#565)"
 
     # Step 2: After mechanical validation passes, go to test plan validation (Issue #166)
     assert result_after_validation == "N1b_validate_test_plan", \
         "After mechanical validation passes, should proceed to test plan validation"
 
-    # Step 3: After test plan validation passes, proceed through Ponder (Issue #307)
-    assert result_after_test_plan == "N_ponder_stibbons", \
-        "After test plan validation passes, should proceed to Ponder auto-fix"
+    # Step 3: After test plan validation passes, proceed to review (#565, gates disabled)
+    assert result_after_test_plan == "N3_review", \
+        "After test plan validation passes, should proceed to review (#565)"
 
 
 def test_t020(draft_with_open_questions, verdict_with_resolved_questions):
@@ -390,15 +391,15 @@ def test_010(draft_with_open_questions, mock_state_base):
 
     # TDD: Assert
     assert has_questions, "Draft should have unchecked open questions"
-    # Issue #277: LLD workflows go to N1.5 first
-    assert route_after_draft == "N1_5_validate_mechanical", \
-        "LLD workflows go to mechanical validation after draft"
+    # Issue #565: LLD workflows go to Ponder first
+    assert route_after_draft == "N_ponder_stibbons", \
+        "LLD workflows go to Ponder after draft (#565)"
     # Issue #166: Then N1b test plan validation
     assert route_after_validation == "N1b_validate_test_plan", \
         "After mechanical validation passes, go to test plan validation"
-    # Issue #307: Then through Ponder auto-fix before review
-    assert route_after_test_plan == "N_ponder_stibbons", \
-        "Should proceed to Ponder auto-fix after test plan validation passes"
+    # Issue #565: Then to review (gates disabled)
+    assert route_after_test_plan == "N3_review", \
+        "Should proceed to review after test plan validation passes (#565)"
 
 
 def test_020(draft_with_open_questions, verdict_with_resolved_questions):
@@ -522,3 +523,19 @@ def test_070():
     else:
         # File not found at test location - skip
         pytest.skip("Prompt file not found in expected location")
+
+
+def test_lld_routes_through_ponder_before_validation(mock_state_base):
+    """Issue #565: LLD draft routes to Ponder first, then to N1.5."""
+    state = mock_state_base.copy()
+    state["workflow_type"] = "lld"
+
+    # After draft, LLD goes to Ponder
+    result = route_after_generate_draft(state)
+    assert result == "N_ponder_stibbons", \
+        "LLD should route to Ponder after draft (#565)"
+
+    # After Ponder, always goes to mechanical validation
+    result = route_after_ponder(state)
+    assert result == "N1_5_validate_mechanical", \
+        "Ponder should always route to mechanical validation (#565)"

--- a/tests/unit/test_ponder.py
+++ b/tests/unit/test_ponder.py
@@ -13,6 +13,7 @@ from assemblyzero.workflows.requirements.nodes.ponder_rules import (
     fix_section_heading_format,
     fix_trailing_whitespace,
     fix_missing_blank_before_heading,
+    fix_directory_ordering,
 )
 from assemblyzero.workflows.requirements.nodes.ponder import (
     ponder_stibbons_node,
@@ -224,3 +225,72 @@ class TestPonderStibbonsNode:
         saved = draft_file.read_text(encoding="utf-8")
         assert "# 99 -" in saved
         assert saved == result["current_draft"]
+
+
+class TestFixDirectoryOrdering:
+    """Tests for directory ordering auto-fix rule (Issue #566)."""
+
+    def test_moves_directories_before_files(self):
+        draft = (
+            "### 2.1 Proposed Changes\n"
+            "| Path | Change Type |\n"
+            "|------|-------------|\n"
+            "| src/foo.py | Modify file |\n"
+            "| src/bar/ | Create directory |\n"
+            "| src/baz.py | Create file |\n"
+        )
+        fixed, fixes = fix_directory_ordering(draft, {"workflow_type": "lld"})
+        assert len(fixes) == 1
+        assert fixes[0].rule == "directory_ordering"
+        # Directory row should come before file rows
+        dir_pos = fixed.index("directory")
+        file_pos = fixed.index("foo.py")
+        assert dir_pos < file_pos
+
+    def test_no_change_when_already_ordered(self):
+        draft = (
+            "### 2.1 Proposed Changes\n"
+            "| Path | Change Type |\n"
+            "|------|-------------|\n"
+            "| src/bar/ | Create directory |\n"
+            "| src/foo.py | Modify file |\n"
+            "| src/baz.py | Create file |\n"
+        )
+        fixed, fixes = fix_directory_ordering(draft, {"workflow_type": "lld"})
+        assert fixed == draft
+        assert len(fixes) == 0
+
+    def test_no_change_for_issue_workflow(self):
+        draft = (
+            "### 2.1 Proposed Changes\n"
+            "| Path | Change Type |\n"
+            "|------|-------------|\n"
+            "| src/foo.py | Modify file |\n"
+            "| src/bar/ | Create directory |\n"
+        )
+        fixed, fixes = fix_directory_ordering(draft, {"workflow_type": "issue"})
+        assert fixed == draft
+        assert len(fixes) == 0
+
+    def test_no_change_without_section_21(self):
+        draft = (
+            "### 2.2 Other Section\n"
+            "| Path | Change Type |\n"
+            "|------|-------------|\n"
+            "| src/foo.py | Modify file |\n"
+        )
+        fixed, fixes = fix_directory_ordering(draft, {"workflow_type": "lld"})
+        assert fixed == draft
+        assert len(fixes) == 0
+
+    def test_no_change_when_no_directories(self):
+        draft = (
+            "### 2.1 Proposed Changes\n"
+            "| Path | Change Type |\n"
+            "|------|-------------|\n"
+            "| src/foo.py | Modify file |\n"
+            "| src/bar.py | Create file |\n"
+        )
+        fixed, fixes = fix_directory_ordering(draft, {"workflow_type": "lld"})
+        assert fixed == draft
+        assert len(fixes) == 0

--- a/tests/unit/test_validate_test_plan_node.py
+++ b/tests/unit/test_validate_test_plan_node.py
@@ -3,6 +3,8 @@
 Issue #166: Test IDs match LLD Section 10.0 (T110-T130).
 """
 
+from pathlib import Path
+
 import pytest
 
 from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
@@ -94,8 +96,8 @@ class TestNodeRoutesToGeminiOnPass:
         assert result["error_message"] == ""
         assert result["test_plan_validation_attempts"] == 1
 
-    def test_routing_passes_to_ponder(self):
-        """T110: Route function sends to Ponder on pass (Issue #307)."""
+    def test_routing_passes_to_human_gate(self):
+        """T110: Route function sends to N2 on pass with gates enabled (#565)."""
         state = _make_state(
             current_draft=LLD_PASSING,
             test_plan_validation_result={"passed": True},
@@ -103,17 +105,17 @@ class TestNodeRoutesToGeminiOnPass:
             error_message="",
         )
         route = route_after_validate_test_plan(state)
-        assert route == "N_ponder_stibbons"
+        assert route == "N2_human_gate_draft"
 
-    def test_routing_passes_to_ponder_gates_disabled(self):
-        """Routing sends to Ponder on pass regardless of gate config (Issue #307)."""
+    def test_routing_passes_to_review_gates_disabled(self):
+        """Routing sends to N3 on pass with gates disabled (#565)."""
         state = _make_state(
             test_plan_validation_result={"passed": True},
             config_gates_draft=False,
             error_message="",
         )
         route = route_after_validate_test_plan(state)
-        assert route == "N_ponder_stibbons"
+        assert route == "N3_review"
 
 
 # =============================================================================
@@ -202,6 +204,36 @@ class TestNodeEdgeCases:
         state = _make_state(iteration_count=5, current_draft=LLD_PASSING)
         result = validate_test_plan_node(state)
         assert result["iteration_count"] == 6
+
+
+class TestCounterResetAfterReview:
+    """Issue #567: test_plan_validation_attempts resets after Gemini review."""
+
+    def test_review_resets_counter(self):
+        """Review node return dict includes test_plan_validation_attempts: 0."""
+        from assemblyzero.workflows.requirements.nodes.review import review
+
+        state = {
+            "workflow_type": "lld",
+            "assemblyzero_root": str(Path(__file__).parent.parent.parent),
+            "target_repo": "/fake/repo",
+            "config_mock_mode": True,
+            "config_reviewer": "mock:review",
+            "config_gates_draft": True,
+            "config_gates_verdict": True,
+            "audit_dir": "/tmp/fake_audit",
+            "current_draft": "# 99 - Feature\n\n## 1. Context\n\nContent.\n",
+            "verdict_history": [],
+            "verdict_count": 0,
+            "iteration_count": 1,
+            "max_iterations": 20,
+            "test_plan_validation_attempts": 2,
+            "cost_budget_usd": 0.0,
+            "node_costs": {},
+            "node_tokens": {},
+        }
+        result = review(state)
+        assert result["test_plan_validation_attempts"] == 0
 
 
 class TestBuildValidationFeedback:


### PR DESCRIPTION
## Summary
- **#565**: Restructure LLD graph so Ponder auto-fix runs BEFORE mechanical validation (N1→Ponder→N1.5→N1b→N2/N3), ensuring fixes apply before validation loops back to drafter
- **#566**: New Ponder rule `fix_directory_ordering` — sorts directory entries before file entries in Section 2.1 tables (LLD only)
- **#567**: Reset `test_plan_validation_attempts` to 0 in review node return dict, giving drafter fresh validation attempts after BLOCKED verdict

## Test plan
- [x] `poetry run pytest tests/unit/test_ponder.py -v` — 29 passed (5 new directory ordering tests)
- [x] `poetry run pytest tests/unit/test_validate_test_plan_node.py -v` — 14 passed (1 new counter reset test)
- [x] `poetry run pytest tests/test_issue_248.py -v` — 16 passed (1 new routing chain test)
- [x] Full regression (excluding integration) — all failures pre-existing, none in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)