### PR TITLE
fix: guard None node_output + fix scaffold regeneration dead loop (#571)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/scaffold_tests.py
+++ b/assemblyzero/workflows/testing/nodes/scaffold_tests.py
@@ -868,10 +868,17 @@ def scaffold_tests(state: TestingWorkflowState) -> dict[str, Any]:
         return _mock_scaffold_tests(state)
 
     # Issue #547: Skip-on-resume — don't re-call Claude if tests already scaffolded
+    # Issue #571: BUT if validation errors exist, this is a regeneration loop,
+    # not a resume. Delete stale files so scaffold can regenerate.
     existing_test_files = state.get("test_files", [])
     if existing_test_files and all(Path(f).exists() for f in existing_test_files):
-        gate_log(f"[N2] {len(existing_test_files)} test files already exist — skipping scaffold")
-        return {}
+        if state.get("scaffold_validation_errors"):
+            gate_log(f"[N2] Regeneration: deleting {len(existing_test_files)} stale test files")
+            for f in existing_test_files:
+                Path(f).unlink(missing_ok=True)
+        else:
+            gate_log(f"[N2] {len(existing_test_files)} test files already exist — skipping scaffold")
+            return {}
 
     # Issue #381: Framework-aware scaffolding
     framework_config = state.get("framework_config")

--- a/tests/unit/test_scaffold_tests.py
+++ b/tests/unit/test_scaffold_tests.py
@@ -435,3 +435,86 @@ class TestScaffoldIntegration:
             ast.parse(content)
         except SyntaxError as e:
             pytest.fail(f"Generated test is not valid Python: {e}")
+
+
+# =============================================================================
+# Test: Issue #571 — Regeneration vs resume
+# =============================================================================
+
+
+class TestRegenerationDeletesStaleFiles:
+    """Issue #571: Scaffold must delete stale files on regeneration."""
+
+    def test_regeneration_deletes_stale_files(self, tmp_path):
+        """When scaffold_validation_errors exist, stale files are deleted and re-scaffolded."""
+        from assemblyzero.workflows.testing.nodes.scaffold_tests import scaffold_tests
+
+        # First scaffold to create a file
+        state = {
+            "issue_number": 571,
+            "test_scenarios": [
+                {
+                    "name": "test_example",
+                    "description": "Example test",
+                    "requirement_ref": "R001",
+                    "test_type": "unit",
+                    "mock_needed": False,
+                    "assertions": ["result equals expected"],
+                }
+            ],
+            "files_to_modify": [{"path": "mymodule.py", "change_type": "Add"}],
+            "repo_root": str(tmp_path),
+            "audit_dir": str(tmp_path / "audit"),
+        }
+        (tmp_path / "audit").mkdir()
+
+        result1 = scaffold_tests(state)
+        assert result1.get("test_files")
+        test_file = Path(result1["test_files"][0])
+        assert test_file.exists()
+
+        # Write known content to detect if file gets regenerated
+        test_file.write_text("# STALE CONTENT", encoding="utf-8")
+
+        # Simulate regeneration: validation errors present, files exist
+        state["test_files"] = result1["test_files"]
+        state["scaffold_validation_errors"] = ["Empty test file"]
+
+        result2 = scaffold_tests(state)
+
+        # Should have regenerated (not skipped)
+        assert result2.get("test_files")
+        content = test_file.read_text(encoding="utf-8")
+        assert "STALE CONTENT" not in content
+
+    def test_resume_skips_when_no_errors(self, tmp_path):
+        """Without validation errors, existing files cause skip (resume behavior)."""
+        from assemblyzero.workflows.testing.nodes.scaffold_tests import scaffold_tests
+
+        # Create a test file
+        test_file = tmp_path / "tests" / "test_issue_571.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("# EXISTING", encoding="utf-8")
+
+        state = {
+            "issue_number": 571,
+            "test_files": [str(test_file)],
+            "test_scenarios": [
+                {
+                    "name": "test_example",
+                    "description": "Example",
+                    "requirement_ref": "R001",
+                    "test_type": "unit",
+                    "mock_needed": False,
+                    "assertions": ["passes"],
+                }
+            ],
+            "repo_root": str(tmp_path),
+        }
+
+        result = scaffold_tests(state)
+
+        # Should skip (return empty dict)
+        assert result == {}
+        # File should be untouched
+        assert test_file.read_text(encoding="utf-8") == "# EXISTING"

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -772,8 +772,8 @@ def main():
                     if node_name == "__end__":
                         continue
 
-                    # Check for errors
-                    error = node_output.get("error_message", "")
+                    # Check for errors (node_output may be None/empty)
+                    error = (node_output or {}).get("error_message", "")
                     if error:
                         print(f"\n[ERROR] {error}")
                         if "GUARD" in error or "BLOCKED" in error:

--- a/tools/run_implementation_spec_workflow.py
+++ b/tools/run_implementation_spec_workflow.py
@@ -583,11 +583,12 @@ def run_workflow(
                 if node_name == "__end__":
                     continue
 
-                # Accumulate state updates from each node
-                final_state.update(node_output)
+                # Accumulate state updates from each node (Issue #571)
+                if node_output:
+                    final_state.update(node_output)
 
-                # Check for errors from nodes
-                error = node_output.get("error_message", "")
+                # Check for errors from nodes (node_output may be None)
+                error = (node_output or {}).get("error_message", "")
                 if error:
                     print(f"\n[ERROR] {error}")
 

--- a/tools/run_issue_workflow.py
+++ b/tools/run_issue_workflow.py
@@ -362,7 +362,7 @@ def run_new_workflow(
                         # Process each node's output
                         for node_name, node_output in event.items():
                             print(f"\n>>> Executing: {node_name}")
-                            if node_output.get("error_message"):
+                            if (node_output or {}).get("error_message"):
                                 error = node_output["error_message"]
                                 if error.startswith("SLUG_COLLISION:"):
                                     # Handle collision mid-stream (shouldn't happen, but safety)
@@ -530,7 +530,7 @@ def run_resume_workflow(brief_file: str, repo_root: Path | None = None) -> int:
                     for event in app.stream(None, config):
                         for node_name, node_output in event.items():
                             print(f"\n>>> Executing: {node_name}")
-                            if node_output.get("error_message"):
+                            if (node_output or {}).get("error_message"):
                                 error = node_output["error_message"]
                                 if "ABORTED" in error or "MANUAL" in error:
                                     print(f"\n>>> Workflow stopped: {error}")


### PR DESCRIPTION
## Summary
- Guard `node_output.get()` with `(node_output or {})` in all 3 workflow runners to prevent `AttributeError` crash when nodes return None
- Fix scaffold regeneration dead loop: when `scaffold_validation_errors` exist, delete stale files and re-scaffold instead of skipping
- Same None guard applied to `run_issue_workflow.py` and `run_implementation_spec_workflow.py` (same pattern, same risk)

## Test plan
- [x] `poetry run pytest tests/unit/test_scaffold_tests.py -v` — 19 passed (2 new regeneration tests)
- [x] `test_regeneration_deletes_stale_files` — verifies stale file is deleted and re-scaffolded
- [x] `test_resume_skips_when_no_errors` — verifies resume behavior preserved

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)