### PR TITLE
chore: default LLD drafter → claude:sonnet (#578)

### DIFF
--- a/assemblyzero/workflows/requirements/config.py
+++ b/assemblyzero/workflows/requirements/config.py
@@ -90,7 +90,7 @@ class WorkflowConfig:
     """
 
     workflow_type: Literal["issue", "lld"]
-    drafter: str = "claude:opus"
+    drafter: str = "claude:sonnet"
     reviewer: str = "gemini:3.1-pro-preview"
     draft_template_path: Path = field(default_factory=lambda: Path(""))
     review_prompt_path: Path = field(default_factory=lambda: Path(""))
@@ -158,7 +158,7 @@ class WorkflowConfig:
 
 
 def create_issue_config(
-    drafter: str = "claude:opus",
+    drafter: str = "claude:sonnet",
     reviewer: str = "gemini:3.1-pro-preview",
     gates: str = "none",
     max_iterations: int = 20,
@@ -198,7 +198,7 @@ def create_issue_config(
 
 
 def create_lld_config(
-    drafter: str = "claude:opus",
+    drafter: str = "claude:sonnet",
     reviewer: str = "gemini:3.1-pro-preview",
     gates: str = "none",
     max_iterations: int = 20,

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -81,7 +81,7 @@ def generate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
     if mock_mode:
         drafter_spec = "mock:draft"
     else:
-        drafter_spec = state.get("config_drafter", "claude:opus")
+        drafter_spec = state.get("config_drafter", "claude:sonnet")
 
     # Determine template path based on workflow type
     if workflow_type == "issue":

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -255,7 +255,7 @@ def create_initial_state(
     workflow_type: Literal["issue", "lld"],
     assemblyzero_root: str,
     target_repo: str,
-    drafter: str = "claude:opus",
+    drafter: str = "claude:sonnet",
     reviewer: str = "gemini:3.1-pro-preview",
     gates_draft: bool = True,
     gates_verdict: bool = True,

--- a/tests/unit/test_requirements_cli.py
+++ b/tests/unit/test_requirements_cli.py
@@ -147,7 +147,7 @@ class TestArgumentParsing:
             "--issue", "42",
         ])
 
-        assert args.drafter == "claude:opus"
+        assert args.drafter == "claude:sonnet"
         assert args.reviewer == "gemini:3.1-pro-preview"
         assert args.review == "none"
         assert args.mock is False

--- a/tests/unit/test_requirements_config.py
+++ b/tests/unit/test_requirements_config.py
@@ -106,7 +106,7 @@ class TestWorkflowConfig:
         """Test issue workflow has correct default paths."""
         config = WorkflowConfig(workflow_type="issue")
         assert config.workflow_type == "issue"
-        assert config.drafter == "claude:opus"
+        assert config.drafter == "claude:sonnet"
         assert config.reviewer == "gemini:3.1-pro-preview"
         assert "0101" in str(config.draft_template_path)
         assert "0701c" in str(config.review_prompt_path)
@@ -205,7 +205,7 @@ class TestCreateIssueConfig:
         """Test default issue config (auto, no review)."""
         config = create_issue_config()
         assert config.workflow_type == "issue"
-        assert config.drafter == "claude:opus"
+        assert config.drafter == "claude:sonnet"
         assert config.reviewer == "gemini:3.1-pro-preview"
         assert config.gates.draft_gate is False
         assert config.gates.verdict_gate is False
@@ -234,7 +234,7 @@ class TestCreateLLDConfig:
         """Test default LLD config."""
         config = create_lld_config()
         assert config.workflow_type == "lld"
-        assert config.drafter == "claude:opus"
+        assert config.drafter == "claude:sonnet"
         assert config.reviewer == "gemini:3.1-pro-preview"
 
     def test_custom_drafter_reviewer(self):

--- a/tests/unit/test_requirements_state.py
+++ b/tests/unit/test_requirements_state.py
@@ -126,7 +126,7 @@ class TestCreateInitialState:
             issue_number=1,
         )
 
-        assert state["config_drafter"] == "claude:opus"
+        assert state["config_drafter"] == "claude:sonnet"
         assert state["config_reviewer"] == "gemini:3.1-pro-preview"
         assert state["config_gates_draft"] is True
         assert state["config_gates_verdict"] is True

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -373,8 +373,8 @@ Examples:
     # LLM configuration
     parser.add_argument(
         "--drafter",
-        default="claude:opus",
-        help="Drafter LLM spec (default: claude:opus)",
+        default="claude:sonnet",
+        help="Drafter LLM spec (default: claude:sonnet)",
     )
     parser.add_argument(
         "--reviewer",


### PR DESCRIPTION
## Summary
- Changes default drafter from `claude:opus` to `claude:sonnet` in CLI, config, state, and generate_draft fallback
- Updates 3 test files to match new defaults
- `--drafter claude:opus` still works for complex/ambiguous work

## Rationale
Sonnet qualification trial (#400) showed $0.47/approval vs Opus $1.12 — 2.4x cheaper with identical approval rate. The Gemini review gate catches quality issues regardless of drafter.

## Test plan
- [x] 135 unit tests pass (requirements config, CLI, state)

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)