### PR TITLE
fix: add Cascade Prevention section to CLAUDE.md (#575)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ Worktree isolation: required
 - `tools/` — Shared tooling (merge, batch-workflow, gemini-model-check)
 - `docs/standards/` — Engineering standards (0001–0999)
 
+## Cascade Prevention
+
+After completing a task, ask "What would you like to work on next?" as an open-ended question. Never offer numbered yes/no options or suggest continuing to the next issue unprompted.
+
 ## Merging PRs
 
 NEVER use `gh pr merge` directly. Always follow post-merge cleanup:


### PR DESCRIPTION
## Summary
- Adds `## Cascade Prevention` section to AssemblyZero's CLAUDE.md
- Fixes 8 test failures across `test_cascade_detector.py` and `test_cascade_hook_integration.py`

## Test plan
- [x] All 8 `TestClaudeMdCascadeRule` tests pass

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)