### PR TITLE
feat: wire skip audit gate into TDD green phase

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -8,6 +8,7 @@ errors) route back to N2_scaffold_tests instead of endlessly looping through
 N4_implement_code. Exit codes 2/3 (interrupt/internal error) stop the workflow.
 """
 
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,47 @@ PYTEST_TIMEOUT_SECONDS = 300
 
 # Issue #498: Max chars for failure summary fed back to N4
 MAX_FAILURE_SUMMARY_CHARS = 2000
+
+# Issue #562: Critical skip keywords (aligned with tools/test-gate.py)
+_CRITICAL_SKIP_KEYWORDS = ["security", "auth", "payment", "critical"]
+
+# Regex for verbose pytest skip lines: "test_name SKIPPED"
+_SKIP_PATTERN = re.compile(r"([\w/\\.\-]+::[\w\[\]\-]+)\s+SKIPPED")
+
+
+def _validate_skip_audit(output: str) -> dict[str, Any]:
+    """Post-run validation of skipped tests (Issue #562).
+
+    Parses pytest verbose output for SKIPPED tests, checks for critical
+    keywords. Returns audit info for state tracking and logging.
+
+    Args:
+        output: Combined stdout+stderr from pytest.
+
+    Returns:
+        Dict with skip_count, critical_count, critical_tests, gate_passed.
+    """
+    skipped_names = _SKIP_PATTERN.findall(output)
+    if not skipped_names:
+        return {
+            "skip_count": 0,
+            "critical_count": 0,
+            "critical_tests": [],
+            "gate_passed": True,
+        }
+
+    critical = []
+    for name in skipped_names:
+        name_lower = name.lower()
+        if any(kw in name_lower for kw in _CRITICAL_SKIP_KEYWORDS):
+            critical.append(name)
+
+    return {
+        "skip_count": len(skipped_names),
+        "critical_count": len(critical),
+        "critical_tests": critical,
+        "gate_passed": len(critical) == 0,
+    }
 
 
 def _build_failure_summary(output: str) -> str:
@@ -796,6 +838,32 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     # Success: all tests pass and coverage meets target
     print(f"    [N5] Green phase PASSED: {passed_count} tests, {coverage_achieved:.1f}% coverage")
 
+    # --------------------------------------------------------------------------
+    # Issue #562: Skip audit gate — validate skipped tests post-run
+    # --------------------------------------------------------------------------
+    skipped_count = parsed.get("skipped", 0)
+    skip_audit = _validate_skip_audit(output)
+    if skip_audit["skip_count"] > 0:
+        if skip_audit["critical_count"] > 0:
+            print(f"    [SKIP-GATE] WARNING: {skip_audit['critical_count']} critical skipped test(s): "
+                  f"{', '.join(skip_audit['critical_tests'])}")
+        else:
+            print(f"    [SKIP-GATE] {skip_audit['skip_count']} skipped test(s) (none critical)")
+
+        log_workflow_execution(
+            target_repo=repo_root,
+            issue_number=state.get("issue_number", 0),
+            workflow_type="testing",
+            event="skip_audit",
+            details={
+                "skip_count": skip_audit["skip_count"],
+                "critical_count": skip_audit["critical_count"],
+                "critical_tests": skip_audit["critical_tests"],
+                "gate_passed": skip_audit["gate_passed"],
+            },
+        )
+    # --------------------------------------------------------------------------
+
     log_workflow_execution(
         target_repo=repo_root,
         issue_number=state.get("issue_number", 0),
@@ -805,6 +873,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "passed": passed_count,
             "coverage": coverage_achieved,
             "iterations": iteration_count,
+            "skipped": skipped_count,
         },
     )
 
@@ -819,6 +888,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "test_failure_summary": "",
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
+            "skip_audit": skip_audit,
             "next_node": "N7_finalize",  # Skip E2E
             "error_message": "",
         }
@@ -832,6 +902,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         "test_failure_summary": "",
         "file_counter": file_num,
         "pytest_exit_code": exit_code,
+        "skip_audit": skip_audit,
         "next_node": "N6_e2e_validation",
         "error_message": "",
     }

--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -5870,5 +5870,59 @@ Verify logout clears session.
         assert "Appendix" not in result
 
 
+class TestSkipAuditGate:
+    """Tests for _validate_skip_audit (Issue #562)."""
+
+    def test_no_skips(self):
+        """No skipped tests returns clean audit."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import _validate_skip_audit
+
+        result = _validate_skip_audit("5 passed in 1.23s")
+        assert result["skip_count"] == 0
+        assert result["gate_passed"] is True
+
+    def test_non_critical_skips(self):
+        """Non-critical skips pass the gate."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import _validate_skip_audit
+
+        output = (
+            "tests/test_foo.py::test_bar SKIPPED (no reason)\n"
+            "tests/test_baz.py::test_qux SKIPPED (platform)\n"
+            "2 skipped, 5 passed"
+        )
+        result = _validate_skip_audit(output)
+        assert result["skip_count"] == 2
+        assert result["critical_count"] == 0
+        assert result["gate_passed"] is True
+
+    def test_critical_skip_detected(self):
+        """Critical skip keyword triggers gate failure."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import _validate_skip_audit
+
+        output = (
+            "tests/test_auth.py::test_auth_login SKIPPED (needs credentials)\n"
+            "1 skipped, 5 passed"
+        )
+        result = _validate_skip_audit(output)
+        assert result["skip_count"] == 1
+        assert result["critical_count"] == 1
+        assert result["gate_passed"] is False
+        assert "test_auth_login" in result["critical_tests"][0]
+
+    def test_mixed_critical_and_non_critical(self):
+        """Mix of critical and non-critical skips."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import _validate_skip_audit
+
+        output = (
+            "tests/test_utils.py::test_helper SKIPPED (optional)\n"
+            "tests/test_security.py::test_security_check SKIPPED (needs env)\n"
+            "2 skipped, 10 passed"
+        )
+        result = _validate_skip_audit(output)
+        assert result["skip_count"] == 2
+        assert result["critical_count"] == 1
+        assert result["gate_passed"] is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add `_validate_skip_audit()` to `verify_phases.py` — parses pytest output for SKIPPED tests
- Flags critical skips (security, auth, payment, critical keywords) aligned with `tools/test-gate.py`
- Wired into green phase success path: logs skip audit results, adds `skip_audit` dict to state
- Critical skips emit `[SKIP-GATE] WARNING`; non-critical skips logged for visibility
- 4 unit tests for the new function

Closes #562

## Test plan
- [x] 4533 passed, 0 failed (full suite)
- [x] 4 new tests for `_validate_skip_audit`
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)