### PR TITLE
chore: instruction hierarchy audit — reduce context bloat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,36 @@ Universal rules are in `C:\Users\mcwiz\Projects\CLAUDE.md` (auto-loaded for all 
 
 AssemblyZero is the canonical source for core rules, tools, and workflow.
 
-## AssemblyZero Workflows
+## Running Workflows (CRITICAL)
 
-This repo uses AssemblyZero workflows (LLD, impl spec, TDD).
-Babysit protocol: read `C:\Users\mcwiz\Projects\AssemblyZero\docs\babysit-protocol.md` before running.
-Worktree isolation: required
+All workflow scripts live in `tools/` and MUST be run from the AssemblyZero directory with `poetry run python`.
+Babysit protocol: read `docs/babysit-protocol.md` before running.
+
+### LLD Workflow (write an LLD for an issue)
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+PYTHONUNBUFFERED=1 poetry run python tools/run_requirements_workflow.py \
+    --type lld --issue NUMBER --repo /c/Users/mcwiz/Projects/TARGET_REPO --yes
+```
+
+### Implementation Workflow (implement code from an LLD)
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+PYTHONUNBUFFERED=1 poetry run python tools/run_implement_from_lld.py \
+    --issue NUMBER --repo /c/Users/mcwiz/Projects/TARGET_REPO --no-worktree
+```
+
+### Common Gotchas
+
+| Gotcha | Fix |
+|--------|-----|
+| No output in background runs | `PYTHONUNBUFFERED=1` — Python buffers stdout when not on a TTY |
+| Nested Claude sessions fail | `CLAUDECODE= PYTHONUNBUFFERED=1 poetry run ...` (empty string, NOT unset) |
+| `--yes` flag on implementation | Does NOT exist — only the LLD workflow has `--yes` |
+| Worktree already exists | Use `--no-worktree` flag on implementation workflow |
+| Workflow runs from wrong dir | ALWAYS `cd` to AssemblyZero first. The `--repo` flag points to the target |
 
 ## Key Files
 


### PR DESCRIPTION
## Summary
- Move "Running AssemblyZero Workflows" from root CLAUDE.md to AZ-specific CLAUDE.md
- Compress verbose sections: "When Blocked" (25→8 lines), "Two-Strike Rule" (12→3), "Implicit Commit/Push/Deploy" (21→7)
- Root CLAUDE.md: 9,323 → 5,820 bytes (**37.6% reduction**)
- Same rules, fewer tokens loaded per session

**Note:** Root `C:\Users\mcwiz\Projects\CLAUDE.md` is outside this repo — changes applied directly to filesystem, not tracked in git.

Closes #554

## Test plan
- [x] 4529 passed, 0 failed
- [x] All 63 cascade detection tests pass with new CLAUDE.md content
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)