### PR TITLE
feat: API cost optimization — 6 changes to reduce spend (#638, #639, #640, #644, #645, #646)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -648,6 +648,12 @@ class AnthropicProvider(LLMProvider):
             # generated: the connection stays active, and any real stall
             # surfaces as a read-timeout on a per-chunk basis.
             # Issue #488: cache_control directives still work with streaming.
+            # Issue #645: Pre-call cost estimate
+            est_input_tokens = (len(system_prompt) + len(content)) // 4
+            pricing = self._PRICING.get(self._model_id)
+            if pricing:
+                est_cost = est_input_tokens * pricing[0] / 1_000_000
+                print(f"    [COST EST] ~${est_cost:.2f} input ({est_input_tokens:,} tokens, {self._model_id})")
             response_text = ""
             last_progress = time.time()
             with client.messages.stream(
@@ -819,14 +825,14 @@ class FallbackProvider(LLMProvider):
         self,
         primary: LLMProvider,
         fallback: LLMProvider,
-        primary_timeout: int = 180,
+        primary_timeout: int = 300,
     ):
         """Initialize fallback provider.
 
         Args:
             primary: First provider to try.
             fallback: Provider to use if primary fails.
-            primary_timeout: Max timeout for primary (default 180s).
+            primary_timeout: Max timeout for primary (default 300s).
         """
         self._primary = primary
         self._fallback = fallback
@@ -884,7 +890,7 @@ class FallbackProvider(LLMProvider):
 
         # Issue #539: Skip CLI for large prompts — they always time out.
         # LLD/spec prompts are 100K+ chars; the CLI subprocess overhead
-        # guarantees a 180s timeout.  Go straight to the API.
+        # guarantees a timeout.  Go straight to the API.
         prompt_size = len(system_prompt) + len(content)
         if prompt_size > 50_000:
             print(
@@ -1211,7 +1217,7 @@ def get_provider(spec: str) -> LLMProvider:
         # If API key available, wrap with automatic fallback
         if _load_anthropic_api_key():
             api = AnthropicProvider(model=model)
-            return FallbackProvider(primary=cli, fallback=api, primary_timeout=180)
+            return FallbackProvider(primary=cli, fallback=api, primary_timeout=300)
         return cli
     elif provider == "anthropic":
         return AnthropicProvider(model=model)

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -88,6 +88,7 @@ from assemblyzero.workflows.testing.nodes.adversarial_node import (
     run_adversarial_node,
 )
 from assemblyzero.core.halt_node import create_halt_node
+from assemblyzero.core.llm_provider import get_cumulative_cost
 
 
 def route_after_load(
@@ -277,6 +278,13 @@ def route_after_green(
         max_iterations = state.get("max_iterations", 3)
         if iteration >= max_iterations:
             return "end"
+        # Issue #640: Budget check before looping back
+        budget = state.get("cost_budget_usd", 0.0)
+        if budget > 0:
+            cumulative = get_cumulative_cost()
+            if cumulative > budget:
+                print(f"    [BUDGET] ${cumulative:.2f} exceeds ${budget:.2f} budget. Halting.")
+                return "end"
         return "N4_implement_code"
 
     if next_node == "N6_e2e_validation":

--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -20,6 +20,7 @@ import re
 import random
 import shutil
 
+from assemblyzero.core.config import CLAUDE_MODEL
 from assemblyzero.core.text_sanitizer import strip_emoji
 import subprocess
 import sys
@@ -63,6 +64,9 @@ LARGE_FILE_BYTE_THRESHOLD = 15000  # Bytes (~15KB)
 # Issue #373: Increased from 300s — large test file prompts need more time
 CLI_TIMEOUT = 600  # 10 minutes base for CLI subprocess
 SDK_TIMEOUT = 600  # 10 minutes base for SDK API call
+
+# Issue #644: Prompt size cap for code generation (chars)
+CODE_GEN_PROMPT_CAP = 60_000
 
 
 class ProgressReporter:
@@ -974,7 +978,7 @@ def call_claude_for_file(prompt: str, file_path: str = "") -> tuple[str, str]:
         # and httpx timeouts never fired on Windows/MSYS2.
         response_text = ""
         with client.messages.stream(
-            model="claude-opus-4-6",
+            model=CLAUDE_MODEL,
             max_tokens=32768,
             messages=[{"role": "user", "content": prompt}],
         ) as stream:
@@ -1452,6 +1456,11 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             context_content=state.get("context_content", ""),
             repo_structure=repo_structure,
         )
+
+        # Issue #644: Enforce prompt size cap — use pruned prompt if full exceeds cap
+        if len(prompt) > CODE_GEN_PROMPT_CAP:
+            print(f"        [PRUNE] Prompt {len(prompt):,} → {len(pruned_prompt):,} chars (cap: {CODE_GEN_PROMPT_CAP:,})")
+            prompt = pruned_prompt
 
         # Call Claude with retry logic (Issue #309)
         # Issue #267: Progress feedback during long API calls

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -56,7 +56,8 @@ from assemblyzero.tracing import configure_langsmith
 configure_langsmith()
 
 # Issue #424: Telemetry instrumentation
-from assemblyzero.telemetry import flush, track_tool
+from assemblyzero.telemetry import emit, flush, track_tool
+from assemblyzero.core.llm_provider import get_cumulative_cost
 atexit.register(flush)
 
 
@@ -423,8 +424,8 @@ def create_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--budget",
         type=float,
-        default=5.0,
-        help="Max API cost in USD before halting (default $5.00, 0=unlimited)",
+        default=3.0,
+        help="Max API cost in USD before halting (default $3.00, 0=unlimited)",
     )
     parser.add_argument(
         "--token-budget",
@@ -801,10 +802,37 @@ def main():
 
                 if values.get("error_message"):
                     print(f"Status: {values['error_message']}")
+                    # Issue #646: Emit per-issue cost even on failure
+                    total_cost = get_cumulative_cost()
+                    if total_cost > 0:
+                        print(f"Cost:   ${total_cost:.4f}")
+                        emit(
+                            "workflow.cost",
+                            repo="AssemblyZero",
+                            metadata={
+                                "workflow_type": "implementation",
+                                "issue_number": args.issue,
+                                "total_cost_usd": round(total_cost, 6),
+                                "status": "failed",
+                            },
+                        )
                     _write_status_file(repo_root, args.issue, "FAILED", values.get("error_message", ""), state=values)
                     return 1
                 else:
                     print("Status: SUCCESS")
+                    # Issue #646: Emit per-issue cost summary
+                    total_cost = get_cumulative_cost()
+                    if total_cost > 0:
+                        print(f"Cost:   ${total_cost:.4f}")
+                        emit(
+                            "workflow.cost",
+                            repo="AssemblyZero",
+                            metadata={
+                                "workflow_type": "implementation",
+                                "issue_number": args.issue,
+                                "total_cost_usd": round(total_cost, 6),
+                            },
+                        )
                     _write_status_file(repo_root, args.issue, "SUCCESS", state=values)
 
                     # Show next steps for worktree workflow

--- a/tools/run_implementation_spec_workflow.py
+++ b/tools/run_implementation_spec_workflow.py
@@ -206,8 +206,8 @@ Examples:
     parser.add_argument(
         "--budget",
         type=float,
-        default=5.0,
-        help="Max API cost in USD before halting (default $5.00, 0=unlimited)",
+        default=3.0,
+        help="Max API cost in USD before halting (default $3.00, 0=unlimited)",
     )
 
     # Issue #517: Global workflow timeout

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -440,8 +440,8 @@ Examples:
     parser.add_argument(
         "--budget",
         type=float,
-        default=5.0,
-        help="Max API cost in USD before halting (default $5.00, 0=unlimited)",
+        default=3.0,
+        help="Max API cost in USD before halting (default $3.00, 0=unlimited)",
     )
 
     # Issue #517: Global workflow timeout


### PR DESCRIPTION
## Summary

Six cost optimization changes targeting the ~$25/every-other-day API spend:

1. **Opus → Sonnet** (#638): `implement_code.py` now reads `config.CLAUDE_MODEL` (Sonnet) instead of hardcoding Opus. ~40% cost reduction on code gen.
2. **CLI timeout 180→300s** (#639): `FallbackProvider` gives CLI more time before falling back to paid API. Fewer unnecessary fallbacks.
3. **Budget cap $5→$3** (#640): Default budget reduced across all 3 workflow CLIs. Added budget enforcement to the implementation workflow graph (was missing — only requirements had it).
4. **60K prompt cap** (#644): If prompt exceeds 60K chars, auto-switches to pruned prompt (no `completed_files`). Logs: `[PRUNE] Prompt 85K → 58K chars`.
5. **Cost estimator** (#645): Logs `[COST EST] ~$0.15 input (25K tokens, claude-4.6-sonnet)` before each Anthropic API call.
6. **Per-issue cost tracking** (#646): Implementation workflow now emits `workflow.cost` telemetry with `issue_number` and `total_cost_usd` on both success and failure.

Closes #638, closes #639, closes #640, closes #644, closes #645, closes #646

## Test plan

- [x] `test_implement_code_size_gate.py` — 5 tests pass
- [x] `test_telemetry_events.py` — 4 tests pass
- [x] `test_requirements_graph.py` — 40 tests pass
- [x] `test_requirements_state.py` — 13 tests pass
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)