### PR TITLE
fix: correct Claude model IDs to match Anthropic API format (#649)

### DIFF
--- a/assemblyzero/core/config.py
+++ b/assemblyzero/core/config.py
@@ -32,7 +32,7 @@ FORBIDDEN_MODELS = [
 # Claude Model (REQ-2: Claude 4.6)
 # =============================================================================
 
-CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-4.6-sonnet")
+CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
 
 # =============================================================================
 # Credential Paths

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -264,17 +264,17 @@ class ClaudeCLIProvider(LLMProvider):
     Issue #605: Updated to Claude 4.6 model IDs (REQ-2).
 
     Supported models:
-    - opus (claude-4.6-opus)
-    - sonnet (claude-4.6-sonnet)
-    - haiku (claude-4.5-haiku)
+    - opus (claude-opus-4-6)
+    - sonnet (claude-sonnet-4-6)
+    - haiku (claude-haiku-4-5)
     """
 
     # Model mapping from friendly names to actual model specs
     # Issue #605: Claude 4.6 (REQ-2)
     MODEL_MAP = {
-        "opus": "claude-4.6-opus",
-        "sonnet": "claude-4.6-sonnet",
-        "haiku": "claude-4.5-haiku",
+        "opus": "claude-opus-4-6",
+        "sonnet": "claude-sonnet-4-6",
+        "haiku": "claude-haiku-4-5",
     }
 
     def __init__(self, model: str = "opus"):
@@ -292,7 +292,7 @@ class ClaudeCLIProvider(LLMProvider):
             self._model = model_lower
             self._model_id = self.MODEL_MAP[model_lower]
         elif model_lower.startswith("claude-"):
-            # Passthrough: accept full model IDs like claude-4.6-opus-20260415
+            # Passthrough: accept full model IDs like claude-opus-4-6-20260415
             self._model = model_lower
             self._model_id = model_lower
         else:
@@ -387,7 +387,7 @@ class ClaudeCLIProvider(LLMProvider):
             "--setting-sources", "user",  # Skip project CLAUDE.md context
             "--tools", "",  # Disable built-in tools
             "--strict-mcp-config",  # Disable MCP tools (issue #157)
-            "--model", self._model_id,  # Use full model ID (e.g., claude-4.6-opus)
+            "--model", self._model_id,  # Use full model ID (e.g., claude-opus-4-6)
         ]
 
         if system_prompt:
@@ -528,26 +528,26 @@ class AnthropicProvider(LLMProvider):
     Issue #605: Updated to Claude 4.6 model IDs (REQ-2).
 
     Supported models:
-    - opus (claude-4.6-opus)
-    - sonnet (claude-4.6-sonnet)
-    - haiku (claude-4.5-haiku)
-    - Any full model ID as passthrough (e.g. claude-4.6-opus-20260415)
+    - opus (claude-opus-4-6)
+    - sonnet (claude-sonnet-4-6)
+    - haiku (claude-haiku-4-5)
+    - Any full model ID as passthrough (e.g. claude-opus-4-6-20260415)
     """
 
     # Issue #605: Claude 4.6 (REQ-2)
     MODEL_MAP = {
-        "opus": "claude-4.6-opus",
-        "sonnet": "claude-4.6-sonnet",
-        "haiku": "claude-4.5-haiku",
+        "opus": "claude-opus-4-6",
+        "sonnet": "claude-sonnet-4-6",
+        "haiku": "claude-haiku-4-5",
     }
 
     MAX_TOKENS = 65536
 
     # Pricing per million tokens (input, output)
     _PRICING: dict[str, tuple[float, float]] = {
-        "claude-4.6-opus": (5.0, 25.0),
-        "claude-4.6-sonnet": (3.0, 15.0),
-        "claude-4.5-haiku": (1.0, 5.0),
+        "claude-opus-4-6": (5.0, 25.0),
+        "claude-sonnet-4-6": (3.0, 15.0),
+        "claude-haiku-4-5": (1.0, 5.0),
     }
 
     def __init__(self, model: str = "opus"):

--- a/tests/test_assemblyzero_config.py
+++ b/tests/test_assemblyzero_config.py
@@ -431,7 +431,7 @@ class TestModelIdVerification:
         )
 
     def test_t020_claude_model_id_is_4_6(self):
-        """T020: CLAUDE_MODEL defaults to claude-4.6-sonnet (REQ-2).
+        """T020: CLAUDE_MODEL defaults to claude-sonnet-4-6 (REQ-2).
 
         Verifies the default Claude model in config.py has been updated
         to Claude 4.6 as part of the systemic model refresh.
@@ -443,8 +443,8 @@ class TestModelIdVerification:
         import assemblyzero.core.config as config_module
         importlib.reload(config_module)
         source = inspect.getsource(config_module)
-        assert 'claude-4.6-sonnet' in source, (
-            "config.py source must reference claude-4.6-sonnet as default"
+        assert 'claude-sonnet-4-6' in source, (
+            "config.py source must reference claude-sonnet-4-6 as default"
         )
 
         # Force-reload llm_provider to get fresh source
@@ -452,15 +452,8 @@ class TestModelIdVerification:
         importlib.reload(llm_module)
         provider_source = inspect.getsource(llm_module)
 
-        # llm_provider may use either naming convention:
-        # - Friendly: claude-4.6-sonnet, claude-4.6-opus
-        # - Official: claude-sonnet-4-6, claude-opus-4-6
-        # Both indicate Claude 4.6 models are configured
-        has_friendly_claude = 'claude-4.6' in provider_source
-        has_official_claude = 'claude-sonnet-4-6' in provider_source or 'claude-opus-4-6' in provider_source
-        assert has_friendly_claude or has_official_claude, (
-            "llm_provider.py must reference claude 4.6 model "
-            "(as claude-4.6-* or claude-*-4-6)"
+        assert 'claude-sonnet-4-6' in provider_source and 'claude-opus-4-6' in provider_source, (
+            "llm_provider.py must reference claude-sonnet-4-6 and claude-opus-4-6"
         )
 
         assert 'gemini-3.1' in provider_source, (

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -263,9 +263,9 @@ class TestClaudeCLIProvider:
 
     def test_model_maps_to_current_ids(self):
         """Verify MODEL_MAP uses current model IDs."""
-        assert ClaudeCLIProvider.MODEL_MAP["opus"] == "claude-4.6-opus"
-        assert ClaudeCLIProvider.MODEL_MAP["sonnet"] == "claude-4.6-sonnet"
-        assert ClaudeCLIProvider.MODEL_MAP["haiku"] == "claude-4.5-haiku"
+        assert ClaudeCLIProvider.MODEL_MAP["opus"] == "claude-opus-4-6"
+        assert ClaudeCLIProvider.MODEL_MAP["sonnet"] == "claude-sonnet-4-6"
+        assert ClaudeCLIProvider.MODEL_MAP["haiku"] == "claude-haiku-4-5"
 
     @patch("shutil.which")
     def test_find_cli_in_path(self, mock_which):
@@ -360,19 +360,19 @@ class TestAnthropicProvider:
         provider = AnthropicProvider(model="opus")
         assert provider.provider_name == "anthropic"
         assert provider.model == "opus"
-        assert provider._model_id == "claude-4.6-opus"
+        assert provider._model_id == "claude-opus-4-6"
 
     def test_init_sonnet(self):
         """Test creating provider with sonnet model."""
         provider = AnthropicProvider(model="sonnet")
         assert provider.model == "sonnet"
-        assert provider._model_id == "claude-4.6-sonnet"
+        assert provider._model_id == "claude-sonnet-4-6"
 
     def test_init_haiku(self):
         """Test creating provider with haiku model."""
         provider = AnthropicProvider(model="haiku")
         assert provider.model == "haiku"
-        assert provider._model_id == "claude-4.5-haiku"
+        assert provider._model_id == "claude-haiku-4-5"
 
     def test_passthrough_full_model_id(self):
         """Accept full model IDs as passthrough."""
@@ -384,7 +384,7 @@ class TestAnthropicProvider:
         """Model names are case-insensitive."""
         provider = AnthropicProvider(model="HAIKU")
         assert provider.model == "haiku"
-        assert provider._model_id == "claude-4.5-haiku"
+        assert provider._model_id == "claude-haiku-4-5"
 
     def test_no_api_key_returns_error(self):
         """Return error result when API key not found."""


### PR DESCRIPTION
## Summary

- Fix all Claude model IDs from incorrect `claude-{version}-{family}` format to correct `claude-{family}-{version}` format
- `claude-4.6-sonnet` → `claude-sonnet-4-6`, `claude-4.6-opus` → `claude-opus-4-6`, `claude-4.5-haiku` → `claude-haiku-4-5`
- All workflows were broken with 404 errors from the Anthropic API

## Test plan

- [x] `tests/unit/test_llm_provider.py` — 91 passed
- [x] `tests/test_assemblyzero_config.py -k t020` — 1 passed

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)