### PR TITLE
fix: replace Unicode arrow with ASCII in print statement (#653)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implement_code.py
+++ b/assemblyzero/workflows/testing/nodes/implement_code.py
@@ -1459,7 +1459,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
 
         # Issue #644: Enforce prompt size cap — use pruned prompt if full exceeds cap
         if len(prompt) > CODE_GEN_PROMPT_CAP:
-            print(f"        [PRUNE] Prompt {len(prompt):,} → {len(pruned_prompt):,} chars (cap: {CODE_GEN_PROMPT_CAP:,})")
+            print(f"        [PRUNE] Prompt {len(prompt):,} -> {len(pruned_prompt):,} chars (cap: {CODE_GEN_PROMPT_CAP:,})")
             prompt = pruned_prompt
 
         # Call Claude with retry logic (Issue #309)


### PR DESCRIPTION
## Summary

- Replace `→` (U+2192) with `->` in implement_code.py print statement
- Fixes UnicodeEncodeError crash on Windows cp1252 encoding during TDD workflow

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)