### PR TITLE
feat: add cache_control headers for prompt caching (#625)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
@@ -213,12 +213,16 @@ def call_claude_for_file(
             timeout=httpx.Timeout(timeout, connect=30.0)
         )
 
-        # Issue #643: Pass system prompt as structured block for caching.
-        # When system_prompt is provided, use it directly as the system= kwarg.
-        # The per-file build_system_prompt() output format instructions are
-        # redundant with ## Output Format in the user message (prompts.py),
-        # so we skip it for the SDK path when a stable prompt is provided.
-        sdk_system = effective_system_prompt
+        # Issue #625: Pass system prompt as structured block with cache_control.
+        # Mirrors the pattern in AnthropicProvider (llm_provider.py:662-670).
+        # First file pays 125% (cache write), files 2+ pay 10% (cache read).
+        sdk_system = [
+            {
+                "type": "text",
+                "text": effective_system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
 
         # Issue #541: Streaming eliminates timeout blindness — chunks
         # arrive incrementally so the connection stays active.  The old
@@ -233,6 +237,14 @@ def call_claude_for_file(
         ) as stream:
             for text in stream.text_stream:
                 response_text += text
+
+        # Issue #625: Log cache metrics for cost visibility
+        final_msg = stream.get_final_message()
+        usage = final_msg.usage
+        cache_read = getattr(usage, "cache_read_input_tokens", 0) or 0
+        cache_create = getattr(usage, "cache_creation_input_tokens", 0) or 0
+        if cache_read or cache_create:
+            print(f"        [CACHE] read={cache_read} create={cache_create}")
 
         # Issue #527: Strip emojis from code gen response
         return strip_emoji(response_text), ""

--- a/tests/unit/test_stable_system_prompt.py
+++ b/tests/unit/test_stable_system_prompt.py
@@ -172,14 +172,19 @@ class TestCallClaudeSystemPrompt:
     """Verify system_prompt parameter is passed to SDK."""
 
     @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client._find_claude_cli")
-    def test_sdk_receives_system_kwarg(self, mock_cli):
-        """When system_prompt is provided, SDK stream() gets system= kwarg."""
+    def test_sdk_receives_system_kwarg_with_cache_control(self, mock_cli):
+        """When system_prompt is provided, SDK stream() gets structured system block with cache_control."""
         mock_cli.return_value = None  # Force SDK path
+
+        mock_final_msg = MagicMock()
+        mock_final_msg.usage.cache_read_input_tokens = 0
+        mock_final_msg.usage.cache_creation_input_tokens = 100
 
         mock_stream = MagicMock()
         mock_stream.__enter__ = MagicMock(return_value=mock_stream)
         mock_stream.__exit__ = MagicMock(return_value=False)
         mock_stream.text_stream = ["```python\nprint('hi')\n```"]
+        mock_stream.get_final_message.return_value = mock_final_msg
 
         mock_anthropic = MagicMock()
         mock_client = MagicMock()
@@ -200,17 +205,28 @@ class TestCallClaudeSystemPrompt:
             )
 
             call_kwargs = mock_client.messages.stream.call_args
-            assert call_kwargs.kwargs["system"] == stable_prompt
+            system_val = call_kwargs.kwargs["system"]
+            # Issue #625: Must be structured block list with cache_control
+            assert isinstance(system_val, list)
+            assert len(system_val) == 1
+            assert system_val[0]["type"] == "text"
+            assert system_val[0]["text"] == stable_prompt
+            assert system_val[0]["cache_control"] == {"type": "ephemeral"}
 
     @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client._find_claude_cli")
     def test_sdk_no_system_prompt_still_works(self, mock_cli):
-        """When system_prompt is empty, SDK uses build_system_prompt fallback."""
+        """When system_prompt is empty, SDK uses build_system_prompt fallback with cache_control."""
         mock_cli.return_value = None
+
+        mock_final_msg = MagicMock()
+        mock_final_msg.usage.cache_read_input_tokens = 0
+        mock_final_msg.usage.cache_creation_input_tokens = 0
 
         mock_stream = MagicMock()
         mock_stream.__enter__ = MagicMock(return_value=mock_stream)
         mock_stream.__exit__ = MagicMock(return_value=False)
         mock_stream.text_stream = ["```python\nprint('hi')\n```"]
+        mock_stream.get_final_message.return_value = mock_final_msg
 
         mock_anthropic = MagicMock()
         mock_client = MagicMock()
@@ -227,8 +243,10 @@ class TestCallClaudeSystemPrompt:
 
             call_kwargs = mock_client.messages.stream.call_args
             system_val = call_kwargs.kwargs["system"]
-            # Should be the build_system_prompt() fallback, not empty
-            assert "file generator" in system_val.lower()
+            # Should be structured block list even for fallback
+            assert isinstance(system_val, list)
+            assert system_val[0]["cache_control"] == {"type": "ephemeral"}
+            assert "file generator" in system_val[0]["text"].lower()
 
     @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client._find_claude_cli")
     @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client.run_command")
@@ -256,3 +274,72 @@ class TestCallClaudeSystemPrompt:
         # Find --system-prompt flag and its value
         idx = cmd_args.index("--system-prompt")
         assert cmd_args[idx + 1] == stable
+
+
+# ---------------------------------------------------------------------------
+# Issue #625: Cache metric logging
+# ---------------------------------------------------------------------------
+
+
+class TestCacheMetricLogging:
+    """Verify cache metrics are logged when present."""
+
+    @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client._find_claude_cli")
+    def test_cache_log_printed_when_nonzero(self, mock_cli, capsys):
+        """[CACHE] log line should appear when cache_read or cache_create > 0."""
+        mock_cli.return_value = None
+
+        mock_final_msg = MagicMock()
+        mock_final_msg.usage.cache_read_input_tokens = 5000
+        mock_final_msg.usage.cache_creation_input_tokens = 0
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.text_stream = ["```python\nprint('hi')\n```"]
+        mock_stream.get_final_message.return_value = mock_final_msg
+
+        mock_anthropic = MagicMock()
+        mock_client = MagicMock()
+        mock_client.messages.stream.return_value = mock_stream
+        mock_anthropic.Anthropic.return_value = mock_client
+
+        import sys
+        with patch.dict(sys.modules, {"anthropic": mock_anthropic, "httpx": MagicMock()}):
+            from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+                call_claude_for_file,
+            )
+            call_claude_for_file(prompt="# foo", file_path="foo.py", system_prompt="stable")
+
+        captured = capsys.readouterr()
+        assert "[CACHE] read=5000 create=0" in captured.out
+
+    @patch("assemblyzero.workflows.testing.nodes.implementation.claude_client._find_claude_cli")
+    def test_cache_log_not_printed_when_zero(self, mock_cli, capsys):
+        """No [CACHE] log when both cache metrics are 0."""
+        mock_cli.return_value = None
+
+        mock_final_msg = MagicMock()
+        mock_final_msg.usage.cache_read_input_tokens = 0
+        mock_final_msg.usage.cache_creation_input_tokens = 0
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.text_stream = ["```python\nprint('hi')\n```"]
+        mock_stream.get_final_message.return_value = mock_final_msg
+
+        mock_anthropic = MagicMock()
+        mock_client = MagicMock()
+        mock_client.messages.stream.return_value = mock_stream
+        mock_anthropic.Anthropic.return_value = mock_client
+
+        import sys
+        with patch.dict(sys.modules, {"anthropic": mock_anthropic, "httpx": MagicMock()}):
+            from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+                call_claude_for_file,
+            )
+            call_claude_for_file(prompt="# foo", file_path="foo.py", system_prompt="stable")
+
+        captured = capsys.readouterr()
+        assert "[CACHE]" not in captured.out


### PR DESCRIPTION
## Summary
- Send system prompt as structured block with `cache_control: {"type": "ephemeral"}` in SDK `messages.stream()` calls
- First file in a run pays 125% (cache creation), files 2+ pay 10% (cache read) — up to 90% savings
- Log `[CACHE] read=N create=N` after each SDK call for cost visibility
- Mirrors existing pattern in `AnthropicProvider` (llm_provider.py:662-670)

## Test plan
- [x] Verify `system` kwarg is structured block list with `cache_control` (not plain string)
- [x] Verify cache log appears when `cache_read_input_tokens > 0`
- [x] Verify no cache log when both metrics are 0
- [x] All 18 tests pass (16 from #643 + 2 new cache tests)

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)