### PR TITLE
chore: purge remaining ThriveTech-AI references (#682)

### DIFF
--- a/docs/audits/0812-ai-supply-chain.md
+++ b/docs/audits/0812-ai-supply-chain.md
@@ -187,7 +187,7 @@ Following SPDX 3.0 AI Profile concepts:
 # Aletheia AI Bill of Materials
 aibom_version: "1.0"
 generated: "2026-01-06"
-organization: "ThriveTech.ai"
+organization: "martymcenroe"
 project: "Aletheia"
 
 models:

--- a/docs/audits/reports/0849-mermaid-visual-audit-2026-02-15.md
+++ b/docs/audits/reports/0849-mermaid-visual-audit-2026-02-15.md
@@ -217,7 +217,7 @@ All `flowchart LR` / `graph LR` diagrams checked for backward edges:
 
 | Repo | Reason |
 |------|--------|
-| ThriveTech-AI/Hermes wiki | 404 — wiki not published on GitHub |
+| martymcenroe/Hermes wiki | 404 — wiki not published on GitHub |
 | Talos, career, dispatch, maintenance | Private repos — not authenticated in Playwright |
 | GentlePersuader, CS512_link_predictor | Private repos — not authenticated |
 | Aletheia docs/ (65 files) | Source-audited only (too many for individual Playwright screenshots) |
@@ -254,7 +254,7 @@ All unleashed wiki custom fills use saturated mid-tones per §8.6 guidance. No �
 | 4 | Fix AZ wiki Implementation-Workflow.md diagram 2 — backward LR edge | AssemblyZero wiki | P2 |
 | 5 | Investigate unleashed README oversized canvas | unleashed | P3 |
 | 6 | Closer inspection of unleashed wiki Architecture three-thread diagram | unleashed wiki | P3 |
-| 7 | Publish Hermes wiki or document as intentionally unpublished | ThriveTech-AI/Hermes | P3 |
+| 7 | Publish Hermes wiki or document as intentionally unpublished | martymcenroe/Hermes | P3 |
 
 ---
 

--- a/docs/lineage/archived/283-lld-n1/001-issue.md
+++ b/docs/lineage/archived/283-lld-n1/001-issue.md
@@ -1,7 +1,7 @@
 ---
-repo: ThriveTech-AI/Hermes
+repo: martymcenroe/Hermes
 issue: 283
-url: https://github.com/ThriveTech-AI/Hermes/issues/283
+url: https://github.com/martymcenroe/Hermes/issues/283
 fetched: 2026-03-04T01:07:14.969942Z
 ---
 


### PR DESCRIPTION
## Summary

- Replace 5 stale `ThriveTech-AI`/`ThriveTech.ai` references with `martymcenroe` across 3 docs files
- All URLs now resolve correctly instead of 404ing

Closes #682