### PR TITLE
fix: add auth preflight for concurrent session spawn (#635)

### DIFF
--- a/tools/auth-preflight.sh
+++ b/tools/auth-preflight.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Auth Preflight — retry claude auth status before spawning a new session.
+#
+# Why: ~/.claude/.credentials.json has no file lock. When one session refreshes
+# the OAuth token, a newly spawned session can read partial/stale JSON and show
+# a transient "claude.ai connector needs auth" error.
+#
+# This script retries auth status with exponential backoff (2s, 4s, 6s),
+# then drops into an interactive login shell with CLAUDECODE unset.
+#
+# Called from /handoff Step 6 spawn command.
+
+for i in 1 2 3; do
+    claude auth status > /dev/null 2>&1 && break
+    echo "Auth check attempt $i failed, retrying in $((i * 2))s..."
+    sleep $((i * 2))
+done
+
+unset CLAUDECODE
+exec bash -l


### PR DESCRIPTION
## Summary
- Adds `tools/auth-preflight.sh` — retries `claude auth status` with exponential backoff (2s/4s/6s) before dropping into a login shell
- Prevents transient "claude.ai connector needs auth" errors from credential file race conditions during concurrent sessions
- Updates `~/.claude/commands/handoff.md` Step 6 to call the preflight script instead of bare `exec bash -l`

Closes #635

## Root Cause
`~/.claude/.credentials.json` has no file lock. When one session refreshes the OAuth token (read -> API call -> write), a newly spawned session can read partial/stale JSON during the write window.

## Test plan
- [ ] Run 5+ concurrent Claude Code sessions
- [ ] Execute `/handoff` — new terminal should show auth retry messages if race occurs
- [ ] Verify new terminal drops into clean bash login shell after auth stabilizes
- [ ] Verify auth check adds at most 6s delay (worst case: 3 retries)

## Blast radius
None — adds a lightweight pre-flight check. If all 3 retries fail, terminal still opens normally (the `exec bash -l` runs unconditionally).

Generated with [Claude Code](https://claude.com/claude-code)