### PR TITLE
Add runbook 0926: branch protection setup for new repos (#719)

### DIFF
--- a/docs/runbooks/0900-runbook-index.md
+++ b/docs/runbooks/0900-runbook-index.md
@@ -43,6 +43,7 @@ Quick reference for the user (Marty) on how to run tools, commands, agents, audi
 | 0922 | [N9 Cleanup Node](0922-implementation-spec-n9-cleanup-node---worktree-removal-lineage-archival-and-learning-summary.md) | Manual | Post-merge | - |
 | 0923 | [Workflow Recovery and --resume](0923-workflow-recovery.md) | Manual | On interruption | - |
 | 0925 | [Agent Token Setup](0925-agent-token-setup.md) | Manual | Quarterly (rotation) | - |
+| 0926 | [Branch Protection Setup](0926-branch-protection-setup.md) | Manual | On new repo | - |
 
 ## Model Selection Guide
 

--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -136,7 +136,11 @@ options:
 
 ## Post-Setup Steps
 
-### 1. Add Advanced Hooks (Optional)
+### 1. Set Up Branch Protection (Required)
+
+The agent PAT cannot configure branch protection (by design — see [0925](0925-agent-token-setup.md)). Follow [0926 - Branch Protection Setup](0926-branch-protection-setup.md) to configure it manually via browser. Takes ~30 seconds.
+
+### 3. Add Advanced Hooks (Optional)
 
 The script creates a minimal `settings.json` without hooks. For worktree protection and security linting:
 
@@ -144,13 +148,13 @@ The script creates a minimal `settings.json` without hooks. For worktree protect
 poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-generate.py --project MyNewProject
 ```
 
-### 2. Set Up Encrypted Ideas Folder (Optional)
+### 4. Set Up Encrypted Ideas Folder (Optional)
 
 ```bash
 poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-generate.py --project MyNewProject --ideas
 ```
 
-### 3. Customize CLAUDE.md
+### 5. Customize CLAUDE.md
 
 Edit `MyNewProject/CLAUDE.md` to add project-specific:
 - Workflow rules
@@ -158,7 +162,7 @@ Edit `MyNewProject/CLAUDE.md` to add project-specific:
 - Forbidden commands
 - Integration details
 
-### 4. Create First Issue
+### 6. Create First Issue
 
 ```bash
 gh issue create --repo your-username/MyNewProject --title "Initial setup" --body "Project scaffolded with AssemblyZero"

--- a/docs/runbooks/0926-branch-protection-setup.md
+++ b/docs/runbooks/0926-branch-protection-setup.md
@@ -1,0 +1,123 @@
+# 0926 - Branch Protection Setup (Manual)
+
+**Category:** Runbook / Operational Procedure
+**Version:** 1.0
+**Last Updated:** 2026-03-09
+
+---
+
+## Purpose
+
+Configure branch protection for new repos when the agent PAT cannot do it. The fine-grained PAT deliberately excludes Administration scope (see [0925](0925-agent-token-setup.md)), so branch protection must be set manually via browser.
+
+**When to use:** After creating a new repo with `new_repo_setup.py --no-github` and pushing, or after any repo creation where the agent reports a 403 on branch protection.
+
+---
+
+## Prerequisites
+
+| Requirement | Check |
+|-------------|-------|
+| Repo exists on GitHub | `gh repo view martymcenroe/REPO` |
+| At least one commit pushed to `main` | Branch must exist before it can be protected |
+
+---
+
+## Steps
+
+### 1. Navigate to Branch Rules
+
+Go to: `https://github.com/martymcenroe/REPO/settings/rules`
+
+Click **"New ruleset"** → **"New branch ruleset"**
+
+### 2. Configure Ruleset Header
+
+| Field | Value |
+|-------|-------|
+| **Ruleset Name** | `main` |
+| **Enforcement status** | **Active** (NOT Disabled) |
+
+### 3. Add Target Branch
+
+Under **"Target branches"**:
+1. Click **"Add target"**
+2. Select **"Include default branch"**
+
+This targets `main`. The warning "This ruleset does not target any resources" should disappear.
+
+### 4. Set Branch Rules
+
+Check the following:
+
+| Rule | Check? | Why |
+|------|--------|-----|
+| **Restrict deletions** | Yes | Prevent deleting `main` |
+| **Block force pushes** | Yes | Prevent `git push --force` to `main` |
+| **Require a pull request before merging** | Yes | Force PR workflow, no direct pushes |
+
+Under **"Require a pull request before merging"** additional settings:
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| **Required approvals** | **0** | Solo developer — enforces PR workflow without needing a reviewer |
+| Everything else | Unchecked | Not needed for solo workflow |
+
+Leave all other rules unchecked (Restrict creations, Restrict updates, Require status checks, etc.) unless the repo has CI.
+
+### 5. Leave Bypass List Empty
+
+The bypass list should stay empty. No roles, teams, or apps should bypass protection.
+
+### 6. Save
+
+Click **"Create"** (green button at bottom).
+
+---
+
+## Verification
+
+After saving, verify the ruleset is active:
+
+1. The ruleset page should show **"Active"** (not "Disabled")
+2. The target should show **"Default branch"** or **"main"**
+3. Test from the agent:
+
+```bash
+# This should FAIL with "protected branch" error
+cd /c/Users/mcwiz/Projects/REPO
+echo "test" >> README.md
+git add README.md && git commit -m "test direct push"
+git push origin main
+# Expected: remote rejected (protected branch hook declined)
+git reset HEAD~1  # clean up
+git checkout -- README.md
+```
+
+---
+
+## Quick Reference (30-Second Version)
+
+For when you've done this before and just need the checklist:
+
+1. `https://github.com/martymcenroe/REPO/settings/rules` → New branch ruleset
+2. Name: `main`, Enforcement: **Active**
+3. Add target → Include default branch
+4. Check: Restrict deletions, Block force pushes, Require PR (0 approvals)
+5. Create
+
+---
+
+## Related Documents
+
+- [0901 - New Project Setup](0901-new-project-setup.md) — Repo scaffolding (triggers this runbook)
+- [0925 - Agent Token Setup](0925-agent-token-setup.md) — Why the PAT can't do this
+- `docs/standards/0003-agent-prohibited-actions.md` — Agent safety rules
+
+---
+
+## History
+
+| Date | Change |
+|------|--------|
+| 2026-03-09 | Initial runbook created (from patent-general setup experience) |


### PR DESCRIPTION
## Summary
- New runbook `0926-branch-protection-setup.md` documenting manual browser steps for branch protection
- Includes quick-reference 30-second checklist for repeat use
- Updates `0901-new-project-setup.md` to reference branch protection as a required post-setup step
- Updates runbook index

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)