### PR TITLE
feat: GitHub App auto-reviewer for agent PR governance (#736)

### DIFF
--- a/.github/workflows/auto-reviewer-caller.yml
+++ b/.github/workflows/auto-reviewer-caller.yml
@@ -1,0 +1,23 @@
+name: Auto Review
+
+# Caller workflow: invokes the reusable auto-reviewer from AssemblyZero.
+# Copy this file to .github/workflows/auto-reviewer.yml in each repo.
+#
+# For repos with additional required checks beyond pr-sentinel, override:
+#   required_checks: "pr-sentinel, CI, CodeQL"
+#
+# Issue: #736
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-review:
+    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
+    with:
+      required_checks: "pr-sentinel"
+    secrets:
+      REVIEWER_APP_ID: ${{ secrets.REVIEWER_APP_ID }}
+      REVIEWER_APP_PRIVATE_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}

--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -1,0 +1,116 @@
+name: auto-reviewer
+
+# Reusable workflow: auto-approves PRs when all required checks pass.
+#
+# This uses a GitHub App identity (not the repo owner) to submit an
+# approving review, breaking the self-authorization loop where agents
+# create issues, create PRs, and merge their own PRs.
+#
+# Prerequisites:
+#   1. GitHub App "AssemblyZero Reviewer" created and installed on all repos
+#   2. App ID stored as org/repo variable: REVIEWER_APP_ID
+#   3. App private key stored as org/repo secret: REVIEWER_APP_PRIVATE_KEY
+#   4. Branch protection: require 1 approving review, enforce admins
+#
+# Called from each repo via:
+#   uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
+#
+# Issue: #736 | Related: #732
+
+on:
+  workflow_call:
+    inputs:
+      required_checks:
+        description: >
+          Comma-separated list of check names that must pass before approval.
+          Default: pr-sentinel. Override per-repo if additional checks exist.
+        required: false
+        type: string
+        default: "pr-sentinel"
+    secrets:
+      REVIEWER_APP_ID:
+        required: true
+      REVIEWER_APP_PRIVATE_KEY:
+        required: true
+
+permissions:
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-review:
+    runs-on: ubuntu-latest
+    # Only run on PRs, not on the PR created by the App itself (prevent loops)
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
+      - name: Wait for required checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REQUIRED_CHECKS: ${{ inputs.required_checks }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "PR #${PR_NUMBER} — waiting for required checks: ${REQUIRED_CHECKS}"
+
+          IFS=',' read -ra CHECKS <<< "$REQUIRED_CHECKS"
+          MAX_ATTEMPTS=30   # 30 × 20s = 10 minutes max wait
+          ATTEMPT=0
+
+          while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
+            ALL_PASSED=true
+
+            for check_name in "${CHECKS[@]}"; do
+              check_name=$(echo "$check_name" | xargs)  # trim whitespace
+
+              # Query check runs for this SHA and check name
+              STATUS=$(gh api \
+                "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+                --jq ".check_runs[] | select(.name == \"${check_name}\") | .conclusion" \
+                2>/dev/null | head -1)
+
+              if [ "$STATUS" = "success" ]; then
+                echo "  ✅ ${check_name}: passed"
+              elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
+                echo "  ❌ ${check_name}: ${STATUS} — will NOT approve"
+                exit 1
+              else
+                echo "  ⏳ ${check_name}: pending (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS})"
+                ALL_PASSED=false
+              fi
+            done
+
+            if [ "$ALL_PASSED" = true ]; then
+              echo ""
+              echo "All required checks passed."
+              exit 0
+            fi
+
+            ATTEMPT=$((ATTEMPT+1))
+            sleep 20
+          done
+
+          echo "❌ Timed out waiting for checks after $((MAX_ATTEMPTS * 20))s"
+          exit 1
+
+      - name: Approve PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Submitting approving review as GitHub App..."
+
+          gh api \
+            "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            -f event="APPROVE" \
+            -f body="Auto-approved: all required checks passed. 🤖"
+
+          echo "✅ PR #${PR_NUMBER} approved by AssemblyZero Reviewer"

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Deploy Cerberus (GitHub App) secrets to all repos.
+
+THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
+It handles a private key file — agents must never touch this.
+
+Usage:
+    1. Download the .pem from GitHub App settings
+    2. Run:  poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem
+    3. DELETE the .pem file immediately after
+
+The script sets two GitHub Actions secrets on every repo:
+    - REVIEWER_APP_ID (3079970)
+    - REVIEWER_APP_PRIVATE_KEY (contents of the .pem)
+
+Issue: #736 | Related: #732
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+APP_ID = "3079970"
+GITHUB_USER = "martymcenroe"
+
+
+def get_all_repos() -> list[str]:
+    """Get all repos for the user via gh CLI."""
+    result = subprocess.run(
+        ["gh", "repo", "list", GITHUB_USER, "--limit", "200",
+         "--json", "name", "--jq", ".[].name"],
+        capture_output=True, text=True, check=True
+    )
+    repos = [r.strip() for r in result.stdout.strip().split("\n") if r.strip()]
+    return sorted(repos)
+
+
+def set_secret(repo: str, name: str, value: str) -> bool:
+    """Set a GitHub Actions secret on a repo."""
+    result = subprocess.run(
+        ["gh", "secret", "set", name, "--repo", f"{GITHUB_USER}/{repo}",
+         "--body", value],
+        capture_output=True, text=True
+    )
+    return result.returncode == 0
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem")
+        sys.exit(1)
+
+    pem_path = Path(sys.argv[1])
+    if not pem_path.exists():
+        print(f"ERROR: File not found: {pem_path}")
+        sys.exit(1)
+
+    if not pem_path.suffix == ".pem":
+        print(f"WARNING: Expected .pem file, got: {pem_path.name}")
+        response = input("Continue anyway? [y/N] ")
+        if response.lower() != "y":
+            sys.exit(1)
+
+    pem_content = pem_path.read_text(encoding="utf-8").strip()
+    if "PRIVATE KEY" not in pem_content:
+        print("ERROR: File doesn't look like a private key")
+        sys.exit(1)
+
+    print(f"Cerberus App ID: {APP_ID}")
+    print(f"Private key: {pem_path.name} ({len(pem_content)} chars)")
+    print()
+
+    print("Fetching repo list...")
+    repos = get_all_repos()
+    print(f"Found {len(repos)} repos\n")
+
+    succeeded = 0
+    failed = []
+
+    for i, repo in enumerate(repos, 1):
+        prefix = f"[{i}/{len(repos)}] {repo}"
+
+        ok_id = set_secret(repo, "REVIEWER_APP_ID", APP_ID)
+        ok_key = set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content)
+
+        if ok_id and ok_key:
+            print(f"  {prefix}: OK")
+            succeeded += 1
+        else:
+            parts = []
+            if not ok_id:
+                parts.append("APP_ID")
+            if not ok_key:
+                parts.append("PRIVATE_KEY")
+            print(f"  {prefix}: FAILED ({', '.join(parts)})")
+            failed.append(repo)
+
+    print(f"\n{'=' * 50}")
+    print(f"Done: {succeeded}/{len(repos)} repos configured")
+    if failed:
+        print(f"Failed: {', '.join(failed)}")
+    print(f"\n*** NOW DELETE THE .pem FILE: {pem_path} ***")
+    print("The secret is stored in GitHub — you never need the file again.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add reusable `auto-reviewer.yml` workflow — waits for required checks to pass, then submits an approving review via the AssemblyZero Reviewer GitHub App identity
- Add `auto-reviewer-caller.yml` template for per-repo deployment
- Add `deploy_cerberus_secrets.py` — air-gapped script for deploying App secrets fleet-wide (human-run only)

Breaks the agent self-authorization loop: agents can no longer create issues, open PRs, and merge their own PRs without an independent identity (the App) validating that checks passed.

Closes #736

## Test plan

- [ ] Verify reusable workflow syntax is valid
- [ ] Verify caller template references correct workflow path
- [ ] Verify deploy script requires .pem argument and validates input
- [ ] After merge: deploy caller workflow to fleet, enable required reviews in branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)