### PR TITLE
fix: pr-sentinel auto-pass dependabot PRs instead of skipping (#749)

### DIFF
--- a/sentinel/src/webhook.js
+++ b/sentinel/src/webhook.js
@@ -82,16 +82,29 @@ export async function handleWebhook(request, env) {
 
     const pr = payload.pull_request;
 
-    // Skip dependabot PRs
-    if (pr.user?.login === "dependabot[bot]") {
-      return new Response("Skipped dependabot", { status: 200 });
-    }
-
     const owner = payload.repository.owner.login;
     const repo = payload.repository.name;
     const headSha = pr.head.sha;
     const installationId = payload.installation.id;
     const checkName = env.CHECK_NAME || "pr-sentinel / issue-reference";
+
+    // Auto-pass dependabot PRs — they don't have issue references
+    // but the check run must be created to complete the check suite
+    if (pr.user?.login === "dependabot[bot]") {
+      const token = await getInstallationToken(
+        env.APP_ID,
+        env.PRIVATE_KEY_B64,
+        installationId
+      );
+      await createCheckRun(token, owner, repo, headSha, checkName, {
+        valid: true,
+        reason: "Dependabot PR — issue reference not required.",
+      });
+      return new Response(
+        JSON.stringify({ conclusion: "success", skipped: "dependabot" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
 
     // Validate PR body (regex check)
     let result = validatePRBody(pr.body);


### PR DESCRIPTION
## Summary
- pr-sentinel-mm was skipping dependabot PRs entirely (no check run created), leaving check suites permanently queued
- Now creates a passing check run for dependabot PRs with reason "Dependabot PR — issue reference not required"

## Test plan
- [ ] Deploy sentinel worker: `cd sentinel && npx wrangler deploy`
- [ ] Close/reopen Aletheia PR #567 to retrigger
- [ ] Verify pr-sentinel-mm check suite completes and check run shows success
- [ ] Merge all 3 blocked Aletheia dependabot PRs (#567, #484, #566)

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)