### PR TITLE
docs: update runbook 0926 — UI order, Cerberus fleet-wide, approvals fix (#758)

### DIFF
--- a/docs/runbooks/0926-branch-protection-setup.md
+++ b/docs/runbooks/0926-branch-protection-setup.md
@@ -1,8 +1,8 @@
 # 0926 - Branch Protection Setup (Manual)
 
 **Category:** Runbook / Operational Procedure
-**Version:** 1.0
-**Last Updated:** 2026-03-09
+**Version:** 2.0
+**Last Updated:** 2026-03-18
 
 ---
 
@@ -10,7 +10,7 @@
 
 Configure branch protection for new repos when the agent PAT cannot do it. The fine-grained PAT deliberately excludes Administration scope (see [0925](0925-agent-token-setup.md)), so branch protection must be set manually via browser.
 
-**When to use:** After creating a new repo with `new_repo_setup.py --no-github` and pushing, or after any repo creation where the agent reports a 403 on branch protection.
+**When to use:** After creating a new repo and pushing at least one commit, or after any repo creation where the agent reports a 403 on branch protection.
 
 ---
 
@@ -19,7 +19,8 @@ Configure branch protection for new repos when the agent PAT cannot do it. The f
 | Requirement | Check |
 |-------------|-------|
 | Repo exists on GitHub | `gh repo view martymcenroe/REPO` |
-| At least one commit pushed to `main` | Branch must exist before it can be protected |
+| At least one commit pushed to main | Branch must exist before it can be protected |
+| Cerberus-AZ installed | Already fleet-wide (All repositories) — no action needed |
 
 ---
 
@@ -27,51 +28,49 @@ Configure branch protection for new repos when the agent PAT cannot do it. The f
 
 ### 1. Navigate to Branch Rules
 
-Go to: `https://github.com/martymcenroe/REPO/settings/rules`
+Go to: https://github.com/martymcenroe/REPO/settings/rules
 
-Click **"New ruleset"** → **"New branch ruleset"**
+Click New ruleset > New branch ruleset
 
 ### 2. Configure Ruleset Header
 
-| Field | Value |
-|-------|-------|
-| **Ruleset Name** | `main` |
-| **Enforcement status** | **Active** (NOT Disabled) |
+| Field | Value (type exactly, no quotes) |
+|-------|--------------------------------|
+| Ruleset Name | main |
+| Enforcement status | Active (NOT Disabled) |
 
 ### 3. Add Target Branch
 
-Under **"Target branches"**:
-1. Click **"Add target"**
-2. Select **"Include default branch"**
+Under Target branches:
+1. Click Add target
+2. Select Include default branch
 
-This targets `main`. The warning "This ruleset does not target any resources" should disappear.
+The warning about no targeted resources should disappear.
 
 ### 4. Set Branch Rules
 
-Check the following:
+Rules are listed in the order they appear in the GitHub UI. Check only these three, leave everything else unchecked:
 
-| Rule | Check? | Why |
-|------|--------|-----|
-| **Restrict deletions** | Yes | Prevent deleting `main` |
-| **Block force pushes** | Yes | Prevent `git push --force` to `main` |
-| **Require a pull request before merging** | Yes | Force PR workflow, no direct pushes |
+| UI Position | Rule | Check? | Why |
+|-------------|------|--------|-----|
+| 3rd | Restrict deletions | Yes | Prevent deleting main |
+| 7th | Require a pull request before merging | Yes | Force PR workflow, no direct pushes |
+| 9th | Block force pushes | Yes | Prevent git push --force to main |
 
-Under **"Require a pull request before merging"** additional settings:
+Under Require a pull request before merging, expand the additional settings:
 
 | Setting | Value | Why |
 |---------|-------|-----|
-| **Required approvals** | **0** | Solo developer — enforces PR workflow without needing a reviewer |
-| Everything else | Unchecked | Not needed for solo workflow |
-
-Leave all other rules unchecked (Restrict creations, Restrict updates, Require status checks, etc.) unless the repo has CI.
+| Required approvals | 1 | Cerberus-AZ auto-approves after pr-sentinel passes |
+| Everything else | Unchecked | Not needed |
 
 ### 5. Leave Bypass List Empty
 
-The bypass list should stay empty. No roles, teams, or apps should bypass protection.
+No roles, teams, or apps should bypass protection.
 
 ### 6. Save
 
-Click **"Create"** (green button at bottom).
+Click Create (green button at bottom).
 
 ---
 
@@ -79,12 +78,12 @@ Click **"Create"** (green button at bottom).
 
 After saving, verify the ruleset is active:
 
-1. The ruleset page should show **"Active"** (not "Disabled")
-2. The target should show **"Default branch"** or **"main"**
-3. Test from the agent:
+1. The ruleset page should show Active (not Disabled)
+2. The target should show Default branch or main
+3. Agent verification:
 
 ```bash
-# This should FAIL with "protected branch" error
+# This should FAIL with protected branch error
 cd /c/Users/mcwiz/Projects/REPO
 echo "test" >> README.md
 git add README.md && git commit -m "test direct push"
@@ -98,12 +97,10 @@ git checkout -- README.md
 
 ## Quick Reference (30-Second Version)
 
-For when you've done this before and just need the checklist:
-
-1. `https://github.com/martymcenroe/REPO/settings/rules` → New branch ruleset
-2. Name: `main`, Enforcement: **Active**
-3. Add target → Include default branch
-4. Check: Restrict deletions, Block force pushes, Require PR (0 approvals)
+1. https://github.com/martymcenroe/REPO/settings/rules > New branch ruleset
+2. Name: main, Enforcement: Active
+3. Add target > Include default branch
+4. Check (in UI order): Restrict deletions, Require PR (1 approval), Block force pushes
 5. Create
 
 ---
@@ -121,3 +118,4 @@ For when you've done this before and just need the checklist:
 | Date | Change |
 |------|--------|
 | 2026-03-09 | Initial runbook created (from patent-general setup experience) |
+| 2026-03-18 | v2.0: Reordered rules to match GitHub UI top-to-bottom. Added Cerberus-AZ step. Changed required approvals from 0 to 1 (Cerberus auto-approves). Removed smart quotes and ambiguous backtick formatting from values. |


### PR DESCRIPTION
## Summary

- Reordered branch rules table to match GitHub UI top-to-bottom order (Restrict deletions, Require PR, Block force pushes)
- Changed required approvals from 0 to 1 (Cerberus-AZ auto-approves after pr-sentinel)
- Cerberus noted as fleet-wide in prerequisites, removed per-repo install step
- Removed smart quotes and ambiguous backtick formatting from all typed values
- Added UI Position column for explicit mapping
- Version bumped to 2.0

## Test plan

- [ ] Follow the 30-second quick reference on a new repo and confirm steps match the GitHub UI

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)