### PR TITLE
docs: runbook 0927 v1.2 — full .pem walkthrough for Cerberus secret deployment (#765)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,14 +1,14 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 1.0
+**Version:** 1.2
 **Last Updated:** 2026-03-18
 
 ---
 
 ## Purpose
 
-Every step the human must do when creating a new GitHub repo. The agent PAT cannot create repos or configure rulesets. Cerberus-AZ is fleet-wide (All repositories) so it covers new repos automatically.
+Every step the human must do when creating a new GitHub repo. The agent PAT (fine-grained) cannot create repos or configure rulesets. Cerberus-AZ app installation is fleet-wide (All repositories), but its GitHub Actions secrets must be deployed per-repo.
 
 After completing this checklist, hand off to the agent for scaffolding (CLAUDE.md, directory structure, poetry init, etc.).
 
@@ -45,7 +45,44 @@ Follow [0926 - Branch Protection Setup](0926-branch-protection-setup.md), quick 
 4. Check (in UI order): Restrict deletions, Require PR (1 approval), Block force pushes
 5. Create
 
-### 4. Hand off to agent
+### 4. Deploy Cerberus secrets
+
+Cerberus-AZ needs two GitHub Actions secrets (REVIEWER_APP_ID, REVIEWER_APP_PRIVATE_KEY) to approve PRs. The Cerberus app installation is fleet-wide, but GitHub Actions secrets are per-repo on personal accounts. New repos don't inherit secrets from existing repos.
+
+**Important: generating a new .pem does NOT invalidate existing keys.** GitHub Apps support multiple active private keys simultaneously. Your existing repos keep working. You can generate and delete .pem files freely.
+
+Run all of this in your own git-bash (never an agent session):
+
+**Step 4a: Generate a private key**
+
+1. Go to https://github.com/settings/apps/cerberus-az
+2. Scroll down to Private keys
+3. Click Generate a private key
+4. Browser downloads a .pem file to your Downloads folder
+   (filename like cerberus-az.2026-03-18.private-key.pem)
+
+**Step 4b: Deploy to new repo(s)**
+
+```
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/deploy_cerberus_secrets.py /c/Users/mcwiz/Downloads/THE-FILE.pem
+```
+
+The script deploys to all repos. Check the output — look for OK next to your new repo name(s).
+
+(Future: #763 will add auto-detection of repos missing secrets, so you only deploy where needed.)
+
+**Step 4c: Delete the .pem and revoke**
+
+1. Delete the .pem file from Downloads immediately
+2. Go back to https://github.com/settings/apps/cerberus-az > Private keys
+3. Click Revoke on the key you just generated (the most recent one)
+   — The secrets are already stored in GitHub Actions. The .pem is never needed again.
+   — Revoking prevents the key from being used if the file wasn't fully deleted.
+
+**If you skip this step:** PRs on the new repo will hang on the 1-approval requirement with no way to merge. Cerberus cannot approve without the secrets.
+
+### 5. Hand off to agent
 
 Tell the agent the repo is ready. The agent will:
 - Clone locally via gh repo clone (HTTPS, never SSH)
@@ -68,3 +105,5 @@ Tell the agent the repo is ready. The agent will:
 | Date | Change |
 |------|--------|
 | 2026-03-18 | Initial runbook created |
+| 2026-03-18 | v1.1: Added Step 4 — Cerberus secrets deployment. App is fleet-wide but secrets are per-repo. |
+| 2026-03-18 | v1.2: Expanded Step 4 with full .pem walkthrough. Clarified that new keys don't invalidate existing ones. Added revoke step. Referenced #763 for future auto-detection. |


### PR DESCRIPTION
## Summary

- Expanded Step 4 into three sub-steps: generate .pem, deploy, delete+revoke
- Documented that new .pem keys do NOT invalidate existing ones (multiple active keys supported)
- Added revoke step so the key cannot be used after deployment
- Added consequence statement if step is skipped
- Referenced #763 for future auto-detection

## Test plan

- [ ] Follow step 4 on next new repo to verify accuracy

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)