### PR TITLE
chore: context window optimization — CLAUDE.md dedup + cleanup hygiene (#768)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -218,6 +218,15 @@ Session: {SESSION_NAME}
    - `find /c/Users/mcwiz/Projects/{PROJECT_NAME} -name "tmpclaude-*-cwd" -type f -delete`
    - Report count in results
 
+9. **Filesystem Hygiene Report** (counts only — no auto-delete):
+   ```bash
+   find /c/Users/mcwiz/.claude/todos/ -name "*.json" -size -20c 2>/dev/null | wc -l
+   ls /c/Users/mcwiz/.claude/plans/*.md 2>/dev/null | wc -l
+   ls /c/Users/mcwiz/.claude/security_warnings_state_*.json 2>/dev/null | wc -l
+   ```
+   - Report: "Filesystem: {N} empty todos, {N} plan files, {N} stale state files"
+   - If empty todos > 100 or plan files > 20: suggest purge
+
 ## Phase 3: Session Log
 
 Create/append session log:
@@ -279,6 +288,9 @@ git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} branch -r
 | Empty Worktree Dirs Deleted | {count} / 0 |
 | Stashes | None / {count} |
 | tmpclaude Purged | {count} files / 0 |
+| Empty Todos | {count} (purge if >100) |
+| Plan Files | {count} (archive if >20) |
+| Stale State Files | {count} (purge if >0) |
 | Commit | Pushed |
 
 **BLOCKING CONDITIONS (must be resolved):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 Universal rules are in `C:\Users\mcwiz\Projects\CLAUDE.md` (auto-loaded for all projects).
 
 AssemblyZero is the canonical source for core rules, tools, and workflow.
+Fix things in AssemblyZero, not in local project copies. Tools execute from `AssemblyZero/tools/`, not copied locally.
 
 ## Running Workflows (CRITICAL)
 
@@ -47,23 +48,12 @@ After completing a task, ask "What would you like to work on next?" as an open-e
 
 ## Merging PRs
 
-NEVER use `gh pr merge` directly. Always follow post-merge cleanup:
+Follow root CLAUDE.md "Merging PRs (Universal)" with `--repo martymcenroe/AssemblyZero`, then:
 
 ```bash
-# 1. Merge (squash)
-gh pr merge {NUMBER} --squash --repo martymcenroe/AssemblyZero
-
-# 2. Archive lineage (if worktree was used)
+# If worktree was used — archive lineage before removing
 poetry run python tools/archive_worktree_lineage.py --worktree ../AssemblyZero-{ID} --issue {ID}
-
-# 3. Remove worktree (if used — clean ephemeral files first, never --force)
 git worktree remove ../AssemblyZero-{ID}
-
-# 4. Delete local branch
-git branch -d {BRANCH}
-
-# 5. Pull merged changes
-git checkout main && git pull
 ```
 
-Steps 2-3 only apply when a worktree was used. Steps 1, 4-5 always apply.
+Then: `git branch -d {BRANCH} && git checkout main && git pull`


### PR DESCRIPTION
## Summary
- Add Source of Truth rule to AssemblyZero CLAUDE.md (moved from root)
- Dedup merge section to reference root instead of duplicating
- Add filesystem hygiene report (empty todos, plans, state files) to /cleanup

Closes #768

## Test plan
- [ ] Verify CLAUDE.md loads correctly in new session
- [ ] Run `/cleanup --normal` and verify hygiene report appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)