### PR TITLE
fix: #773 wiring gaps — config_effort state initialization (#779)

### DIFF
--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -263,6 +263,7 @@ def create_initial_state(
     auto_mode: bool = False,
     mock_mode: bool = False,
     max_iterations: int = 3,
+    effort: str = "max",
     # Issue-specific
     brief_file: str = "",
     source_idea: str = "",
@@ -310,6 +311,7 @@ def create_initial_state(
         "target_repo": target_repo,
         "config_drafter": drafter,
         "config_reviewer": reviewer,
+        "config_effort": effort,
         "config_gates_draft": gates_draft,
         "config_gates_verdict": gates_verdict,
         "config_auto_mode": auto_mode,

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -193,6 +193,7 @@ class TestingWorkflowState(TypedDict, total=False):
 
     # Mode flags
     config_reviewer: str  # Issue #773: Reviewer LLM spec (e.g., "claude:opus")
+    config_effort: str  # Issue #779: Effort level for Claude reviewer
     auto_mode: bool
     mock_mode: bool
     skip_e2e: bool

--- a/docs/babysit-protocol.md
+++ b/docs/babysit-protocol.md
@@ -57,7 +57,7 @@ Two-strike rule applies per issue per phase.
 ## Done Criteria
 
 - LLD: `docs/lld/active/LLD-{NUMBER}.md` exists with APPROVED verdict
-- Impl Spec: spec exists under `docs/lld/drafts/` with Gemini APPROVED
+- Impl Spec: spec exists under `docs/lld/drafts/` with APPROVED verdict
 - TDD: tests pass, no regressions
 
 ## Closing Issues

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1394,7 +1394,7 @@ class TestReviewNodeCoverage:
 
         review(state)
 
-        mock_get_provider.assert_called_with("mock:review", effort=None)
+        mock_get_provider.assert_called_with("mock:review", effort="max")
 
     @patch("assemblyzero.workflows.requirements.nodes.review.get_provider")
     def test_handles_invalid_reviewer(self, mock_get_provider, tmp_path):

--- a/tests/unit/test_requirements_state.py
+++ b/tests/unit/test_requirements_state.py
@@ -128,6 +128,7 @@ class TestCreateInitialState:
 
         assert state["config_drafter"] == "claude:sonnet"
         assert state["config_reviewer"] == "claude:opus"
+        assert state["config_effort"] == "max"
         assert state["config_gates_draft"] is True
         assert state["config_gates_verdict"] is True
         assert state["config_auto_mode"] is False
@@ -142,6 +143,7 @@ class TestCreateInitialState:
             issue_number=1,
             drafter="gemini:flash",
             reviewer="claude:sonnet",
+            effort="high",
             gates_draft=False,
             gates_verdict=True,
             auto_mode=True,
@@ -150,6 +152,7 @@ class TestCreateInitialState:
 
         assert state["config_drafter"] == "gemini:flash"
         assert state["config_reviewer"] == "claude:sonnet"
+        assert state["config_effort"] == "high"
         assert state["config_gates_draft"] is False
         assert state["config_gates_verdict"] is True
         assert state["config_auto_mode"] is True

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -599,6 +599,7 @@ def build_initial_state(
             auto_mode=args.review == "none",
             mock_mode=args.mock,
             max_iterations=args.max_iterations,
+            effort=getattr(args, "effort", "max"),
             brief_file=args.brief or "",
             source_idea=source_idea,
         )
@@ -614,15 +615,13 @@ def build_initial_state(
             auto_mode=args.review == "none",
             mock_mode=args.mock,
             max_iterations=args.max_iterations,
+            effort=getattr(args, "effort", "max"),
             issue_number=args.issue or 0,
             context_files=args.context or [],
         )
 
     # Issue #476: API cost budget
     state["cost_budget_usd"] = getattr(args, "budget", 5.0)
-
-    # Issue #773: Effort level for Claude reviewer
-    state["config_effort"] = getattr(args, "effort", "max")
 
     return state
 


### PR DESCRIPTION
## Summary
- Add `effort` parameter to `create_initial_state()` in requirements/state.py (was patched post-hoc by CLI)
- Add `config_effort` to `TestingWorkflowState` TypedDict (code reads it but TypedDict didn't declare it)
- Fix stale "Gemini APPROVED" reference in babysit-protocol.md
- Add test coverage for effort default ("max") and custom effort values

## Test plan
- [x] `test_default_config_values` asserts `config_effort == "max"`
- [x] `test_custom_config_values` asserts `config_effort == "high"` when passed
- [x] `test_mock_mode_uses_mock_provider` updated for `effort="max"` (was `None`)
- [x] Full suite: 3884 passed, 0 failed

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)