### PR TITLE
fix: scaffold_tests missing generated_tests state + pytest-cov guard (#789)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/scaffold_tests.py
+++ b/assemblyzero/workflows/testing/nodes/scaffold_tests.py
@@ -957,6 +957,7 @@ def scaffold_tests(state: TestingWorkflowState) -> dict[str, Any]:
 
     return {
         "test_files": [str(test_file_path)],
+        "generated_tests": content,  # Issue #789: validate_tests_mechanical reads this
         "file_counter": file_num,
         "error_message": "",
     }
@@ -999,6 +1000,7 @@ def test_mock_example():
 
     return {
         "test_files": [str(test_file_path)],
+        "generated_tests": content,  # Issue #789: validate_tests_mechanical reads this
         "file_counter": file_num,
         "error_message": "",
     }

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -186,10 +186,17 @@ def run_pytest(
     cmd = ["poetry", "run", "pytest", "-v", "--tb=short"]
     cmd.extend(test_files)
 
+    # Issue #789: Only add --cov flags if pytest-cov is installed.
+    # Without it, pytest returns exit code 4 ("unrecognized arguments")
+    # which the workflow misclassifies as "collection/syntax error" and loops.
     if coverage_module:
-        cmd.extend([f"--cov={coverage_module}", "--cov-report=term-missing"])
-        if coverage_target:
-            cmd.append(f"--cov-fail-under={coverage_target}")
+        try:
+            import pytest_cov  # noqa: F401
+            cmd.extend([f"--cov={coverage_module}", "--cov-report=term-missing"])
+            if coverage_target:
+                cmd.append(f"--cov-fail-under={coverage_target}")
+        except ImportError:
+            print("    [WARN] pytest-cov not installed — skipping coverage measurement")
 
     try:
         result = run_command(


### PR DESCRIPTION
## Summary

- **Bug 1:** `scaffold_tests()` returned `test_files` (paths) but not `generated_tests` (content). `validate_tests_mechanical` read empty string, failed "No import statements found" on every scaffold, looped 3x then escalated — skipping red-phase entirely.
- **Bug 2:** `run_pytest` passed `--cov` flags without checking if pytest-cov is installed. Pytest returned exit 4, misclassified as "collection/syntax error", looped 4 iterations burning $4+.

## Test plan

- [x] 3936 unit tests pass
- [x] No regressions in scaffold or verify_phases tests
- [ ] Re-run #774 TDD workflow to verify end-to-end fix

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)