### PR TITLE
feat: full suite regression gate in green phase (#842)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -950,6 +950,82 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     print(f"    [N5] Green phase PASSED: {passed_count} tests, {coverage_achieved:.1f}% coverage")
 
     # --------------------------------------------------------------------------
+    # Issue #842: Full suite regression gate — run ONCE after new tests pass.
+    # Catches regressions in existing 4000+ tests that the targeted test run misses.
+    # --------------------------------------------------------------------------
+    if not state.get("full_suite_validated", False):
+        print("    [N5] Running full test suite regression check...")
+        full_result = run_pytest([], repo_root=repo_root)
+        full_parsed = full_result["parsed"]
+        full_failed = full_parsed.get("failed", 0)
+        full_errors = full_parsed.get("errors", 0)
+        full_passed = full_parsed.get("passed", 0)
+
+        if full_failed > 0 or full_errors > 0:
+            full_output = full_result["stdout"] + "\n" + full_result["stderr"]
+            regression_summary = _build_failure_summary(full_output)
+            regression_names = _extract_failed_test_names(full_output)
+
+            # Check for stagnation: same regressions across 2 iterations → halt
+            previous_regressions = state.get("full_suite_regressions", [])
+            if previous_regressions and sorted(regression_names) == sorted(previous_regressions):
+                stagnant_msg = (
+                    f"Full suite regression stagnant: same {len(regression_names)} test(s) "
+                    f"failing across iterations. Halting."
+                )
+                print(f"    [STAGNANT] {stagnant_msg}")
+                return {
+                    "green_phase_output": output,
+                    "coverage_achieved": coverage_achieved,
+                    "previous_coverage": coverage_achieved,
+                    "previous_passed": passed_count,
+                    "previous_green_failures": [],
+                    "test_failure_summary": regression_summary,
+                    "full_suite_validated": False,
+                    "full_suite_regressions": regression_names,
+                    "file_counter": file_num,
+                    "pytest_exit_code": exit_code,
+                    "iteration_count": iteration_count + 1,
+                    "next_node": "end",
+                    "error_message": stagnant_msg,
+                }
+
+            print(f"    [N5] Full suite: {full_failed + full_errors} regression(s) detected "
+                  f"({full_passed} passed) — routing back to N4")
+
+            log_workflow_execution(
+                target_repo=repo_root,
+                issue_number=state.get("issue_number", 0),
+                workflow_type="testing",
+                event="full_suite_regression",
+                details={
+                    "full_passed": full_passed,
+                    "full_failed": full_failed,
+                    "full_errors": full_errors,
+                    "regression_names": regression_names[:10],
+                },
+            )
+
+            return {
+                "green_phase_output": output,
+                "coverage_achieved": coverage_achieved,
+                "previous_coverage": coverage_achieved,
+                "previous_passed": passed_count,
+                "previous_green_failures": [],
+                "test_failure_summary": regression_summary,
+                "full_suite_validated": False,
+                "full_suite_regressions": regression_names,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "iteration_count": iteration_count + 1,
+                "next_node": "N4_implement_code",
+                "error_message": "",
+            }
+
+        print(f"    [N5] Full suite: {full_passed} tests passed — no regressions")
+    # --------------------------------------------------------------------------
+
+    # --------------------------------------------------------------------------
     # Issue #562: Skip audit gate — validate skipped tests post-run
     # --------------------------------------------------------------------------
     skipped_count = parsed.get("skipped", 0)
@@ -997,6 +1073,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "previous_passed": passed_count,
             "previous_green_failures": [],
             "test_failure_summary": "",
+            "full_suite_validated": True,
+            "full_suite_regressions": [],
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
             "skip_audit": skip_audit,
@@ -1011,6 +1089,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         "previous_passed": passed_count,
         "previous_green_failures": [],
         "test_failure_summary": "",
+        "full_suite_validated": True,
+        "full_suite_regressions": [],
         "file_counter": file_num,
         "pytest_exit_code": exit_code,
         "skip_audit": skip_audit,

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -169,6 +169,8 @@ class TestingWorkflowState(TypedDict, total=False):
     previous_green_failures: list[str]  # Issue #501: Previous green phase failed test names for identity comparison
     test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
     e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
+    full_suite_validated: bool  # Issue #842: True after full test suite passes regression check
+    full_suite_regressions: list[str]  # Issue #842: Failed test names from last full suite run (for stagnation)
 
     # Review artifacts
     test_plan_review_prompt: str

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -151,8 +151,9 @@ def test_fallback_infers_tools_from_impl_files(mock_root, mock_pytest, tmp_path:
     from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
     verify_green_phase(state)
 
-    # Check that run_pytest was called with coverage_module starting with "tools"
-    call_args = mock_pytest.call_args
+    # Check that the FIRST run_pytest call used coverage_module starting with "tools"
+    # (Issue #842: second call is the full suite regression check with no coverage_module)
+    call_args = mock_pytest.call_args_list[0]
     assert call_args is not None
     cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
     if cov_module is None:
@@ -184,7 +185,8 @@ def test_tools_impl_file_uses_file_path_not_dotted(mock_root, mock_pytest, tmp_p
     from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
     verify_green_phase(state)
 
-    call_args = mock_pytest.call_args
+    # Issue #842: use first call (targeted tests), not last call (full suite check)
+    call_args = mock_pytest.call_args_list[0]
     cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
     if cov_module is None:
         cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
@@ -217,7 +219,8 @@ def test_package_impl_file_uses_dotted_module(mock_root, mock_pytest, tmp_path: 
     from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
     verify_green_phase(state)
 
-    call_args = mock_pytest.call_args
+    # Issue #842: use first call (targeted tests), not last call (full suite check)
+    call_args = mock_pytest.call_args_list[0]
     cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
     if cov_module is None:
         cov_module = call_args[0][1] if len(call_args[0]) > 1 else None


### PR DESCRIPTION
## Summary
- After new tests pass in green phase, runs the FULL test suite (~4000 tests) as a one-time regression check before declaring success
- Gated by `full_suite_validated` state key — only runs once, not on every N4/N5 iteration
- If regressions detected, routes back to N4 with a failure summary naming the broken tests
- Stagnation detection: if the same regressions persist across 2 iterations, halts to prevent token waste
- Fixes 3 existing tests in `test_cov_target_resolution.py` that assumed `run_pytest` was called once (now called twice: targeted + full suite)

## Test plan
- [x] `poetry run pytest tests/unit/ -x -q` — 4193 passed, 0 regressions
- [x] `poetry run pytest tests/unit/test_cov_target_resolution.py -v` — 12 passed
- [x] `poetry run pytest tests/unit/test_exit_code_verify_phases.py -v` — 22 passed
- [ ] Verify full suite gate is skipped when `full_suite_validated: True` in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)