### PR TITLE
chore: rewrite /onboard skill — config-driven, pickup detection

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,183 +1,182 @@
 ---
-description: Agent onboarding (quick/full mode)
-argument-hint: "[--help] [--refresh | --quick | --full]"
+description: Agent onboarding (quick/full mode, smart pickup detection)
+argument-hint: "[--help] [--refresh | --quick | --full] [--pickup]"
 ---
 
 # Agent Onboarding
 
 **If `$ARGUMENTS` contains `--help`:** Display the Help section below and STOP. Do not execute onboarding.
 
-Onboard yourself to the current project by reading and understanding the documentation.
+Onboard yourself to the current project. Detects whether a recent handoff exists and offers pickup automatically.
 
 ## Help
 
 ```
 /onboard - Agent onboarding for current project
 
-Usage: `/onboard [--help] [--refresh | --quick | --full]`
+Usage: `/onboard [--help] [--refresh | --quick | --full] [--pickup]`
 
 Options:
 | Flag | Effect |
 |------|--------|
 | `--help` | Show this help message and exit |
-| `--refresh` | Reload rules only (~$0.01, 15s) - for post-compact/resumed sessions |
-| `--quick` | Read digest only, report age (~$0.02, 30s) - for simple tasks |
-| `--full` | Full onboarding (~$0.35, 2min) - for complex work (default) |
+| `--refresh` | Reload rules only — for post-compact/resumed sessions |
+| `--quick` | Config + session log + issues — for simple tasks |
+| `--full` | Full onboarding with pickup detection (default) |
+| `--pickup` | Skip detection, go straight to pickup import |
 
 Examples:
-- `/onboard --help` - show this help
+- `/onboard` - full onboard with smart pickup detection
+- `/onboard --pickup` - skip detection, import last handoff immediately
 - `/onboard --refresh` - reload rules after context compaction
 - `/onboard --quick` - quick onboard for status check
-- `/onboard --full` - full onboard for feature work
-- `/onboard` - same as --full
 ```
 
-## Step 0: Project Detection (ALWAYS FIRST)
+## Important: What Is Already In Context
 
-Detect the current project from working directory:
-1. Get working directory (e.g., `/c/Users/mcwiz/Projects/AssemblyZero`)
-2. Extract project name from path → `AssemblyZero`
-3. Project root (Windows): `C:\Users\mcwiz\Projects\{PROJECT}`
-4. Project root (Unix): `/c/Users/mcwiz/Projects/{PROJECT}`
+CLAUDE.md (root + repo) and MEMORY.md (index) are auto-injected by Claude Code at session start. **Do NOT re-read them.** Individual memory files are loaded on demand when relevant — do not bulk-read them during onboard.
 
-**Known Projects and Their Structure:**
+## Step 0: Project Detection and Config
 
-| Project | GitHub Repo | Main Guide | Immediate Plan |
-|---------|-------------|------------|----------------|
-| AssemblyZero | martymcenroe/AssemblyZero | `docs/index.md` | `docs/10000a-IMMEDIATE-PLAN.md` |
-| Aletheia | martymcenroe/Aletheia | `docs/10000-GUIDE.md` | `docs/10000a-IMMEDIATE-PLAN.md` |
-| Talos | martymcenroe/Talos | `docs/10000-GUIDE.md` | `docs/10000a-IMMEDIATE-PLAN.md` |
-| maintenance | martymcenroe/maintenance | `docs/10000-GUIDE.md` | `docs/10000a-IMMEDIATE-PLAN.md` |
-| claude-code | anthropics/claude-code | `README.md` | None |
-
-**CRITICAL:** Use the correct file paths for the detected project. Do NOT use Aletheia paths when in AssemblyZero.
+1. Get working directory and extract project name from path
+2. Project root (Windows): `C:\Users\mcwiz\Projects\{PROJECT}`
+3. Project root (Unix): `/c/Users/mcwiz/Projects/{PROJECT}`
+4. Read `{repo_root}/.unleashed.json` (if exists). Extract:
+   - `assemblyZero` (bool, default false) — whether to read AssemblyZero rules
+   - `onboard.pickupThresholdMinutes` (int, default 10) — age below which auto-pickup fires
+   - `onboard.guide` (string or null) — path to project guide doc
+   - `onboard.plan` (string or null) — path to immediate plan doc
+5. Get GitHub repo: `git -C {unix_root} remote get-url origin` and extract `{owner}/{repo}`
 
 ## Modes
 
-| Mode | Cost | Time | Use Case |
-|------|------|------|----------|
-| `--refresh` | ~$0.01 | ~15s | Post-compact, resumed sessions, rule reload |
-| `--quick` | ~$0.02 | ~30s | Simple tasks, status checks |
-| `--full` (default) | ~$0.35 | ~2min | Complex features, audits |
+| Mode | Use Case |
+|------|----------|
+| `--refresh` | Post-compact, resumed sessions, rule reload |
+| `--quick` | Simple tasks, status checks |
+| `--full` (default) | Complex work, session start, pickup detection |
+
+---
 
 ## Refresh Mode (`--refresh`)
 
-**Purpose:** Reload core rules after context compaction or when resuming a session. Does NOT re-read project state or session logs.
-
-**Model hint:** Refresh mode can use **Haiku** since it only reads rule files.
-
-**Use when:**
-- Session was compacted and you need to reload rules
-- Resuming a session with `/resume` and need rules refreshed
-- You've been working for a while and want to re-anchor on constraints
-- Quick sanity check that bash rules, worktree rules, etc. are loaded
+**Purpose:** Reload rules after context compaction. Does NOT re-read project state or session logs.
 
 **Steps (parallel reads):**
 
-1. Read AssemblyZero core rules:
-   `C:\Users\mcwiz\Projects\AssemblyZero\CLAUDE.md`
+1. Read project config (Step 0 above)
+2. IF `assemblyZero == true`:
+   - Read `C:\Users\mcwiz\Projects\AssemblyZero\CLAUDE.md`
+   - Read `C:\Users\mcwiz\Projects\AssemblyZero\docs\prompts\gemini-rotation-instructions.md`
 
-2. Read Projects root rules (if exists):
-   `C:\Users\mcwiz\Projects\CLAUDE.md`
-
-3. Read current project CLAUDE.md (detected from working directory)
-
-4. Read Gemini rotation instructions (CRITICAL for reviews):
-   `C:\Users\mcwiz\Projects\AssemblyZero\docs\prompts\gemini-rotation-instructions.md`
-
-5. Optionally scan current permissions:
-   `C:\Users\mcwiz\Projects\.claude\settings.local.json` (just the `allow` array)
-
-**Report format:**
+**Report:**
 ```
-✓ Rules refreshed for {PROJECT}
-• AssemblyZero core: Bash constraints, worktree isolation, visible self-check
-• Gemini: Rotation tool, encoding rules, model verification
-• Project rules: {one-line summary}
-• Session permissions: {count} active allows
+Rules refreshed for {PROJECT}
+Model: {model} | Effort: {effort} | Window: {window}
 Ready to continue.
 ```
 
+---
+
 ## Quick Mode (`--quick`)
 
-**Model hint:** Quick mode can use **Haiku** (~66% cost savings) since it only reads existing docs.
+Read config + most recent session log + open issues. No pickup detection.
 
-Read only the essential files for the detected project:
-1. Read `CLAUDE.md` in the project root
-2. Read the project's main guide (see table above)
-3. Glob `docs/session-logs/*.md` and read the most recent entry
-4. Report readiness
+1. Read project config (Step 0)
+2. IF `onboard.guide` is set: read `{repo_root}/{guide}`
+3. Glob `docs/session-logs/*.md`, read the most recent file
+4. `gh issue list --state open --limit 10 --repo {owner}/{repo}`
+5. Report (same format as full mode, abbreviated)
 
-**Use when:** Task is simple, context is clear, or you're resuming recent work.
+---
 
 ## Full Mode (`--full` or no argument)
 
-Complete onboarding for the **detected project**:
+### Step 1: Pickup Detection
 
-### Step 1: Core Documentation (parallel reads)
+**IF `--pickup` flag is set:** Skip detection. Go directly to Step 1C (import).
 
-Read these files simultaneously based on project:
+**OTHERWISE:**
 
-**For AssemblyZero:**
-- `CLAUDE.md` - Core rules
-- `docs/index.md` - Documentation index
-- `docs/10000a-IMMEDIATE-PLAN.md` - Current focus (AssemblyZero-specific work only)
+**A) Check handoff log:**
+1. Check if `{repo_root}/data/handoff-log.md` exists
+2. If exists, find the LAST `<!-- handoff-start -->` / `<!-- handoff-end -->` pair
+3. Extract timestamp from `## Handoff — YYYY-MM-DD HH:MM:SS` header above start marker
+4. Calculate age: current LOCAL time minus handoff timestamp (no UTC — use `date +"%Y-%m-%d %H:%M:%S"`)
 
-**For Aletheia:**
-- `CLAUDE.md` - Project rules
-- `docs/10000-GUIDE.md` - Filing system and prime directives
-- `docs/10000a-IMMEDIATE-PLAN.md` - Current sprint focus
+**B) Check session index (if exists):**
+1. Read `{repo_root}/data/session-index.jsonl`
+2. Parse last 5 entries (each is one JSON object per line)
+3. Check for thrashing and crash patterns (see below)
 
-**For Talos:**
-- `CLAUDE.md` - Project rules
-- `docs/10000-GUIDE.md` - Project guide
-- `docs/10000a-IMMEDIATE-PLAN.md` - Current focus (if exists)
+**C) Apply decision logic:**
 
-**For maintenance:**
-- `CLAUDE.md` - Project rules
-- `docs/10000-GUIDE.md` - Project guide
-- `docs/10000a-IMMEDIATE-PLAN.md` - Current focus (may be empty for ad-hoc project)
+| Condition | Action |
+|-----------|--------|
+| `--pickup` flag set | Auto-pickup, no confirmation |
+| Handoff age < threshold (default 10 min) | Auto-pickup, no confirmation |
+| Handoff age 10 min - 48h | Show 5-line preview + age, ask user to confirm |
+| Handoff age > 48h or no handoff | Skip pickup, proceed to Step 2 |
+| THRASHING detected | Skip pickup, report thrashing, find last substantive session |
+| CRASH detected | Report crash, offer session log as partial context |
 
-**For claude-code:**
-- `README.md` - Project overview
-- `CONTRIBUTING.md` - Contribution guidelines (if exists)
+**Thrashing detection:**
+- From session-index.jsonl, check if 3+ entries have start timestamps within a 30-minute window AND each has `line_count < 50`
+- If detected: "Detected {N} brief sessions in last 30 min — resume thrashing or recovery. Last substantive session: {timestamp} ({duration}). Skipping pickup."
+- Find the most recent entry with `line_count >= 50` for context reference
 
-### Step 2: Current State
+**Crash detection:**
+- Last session-index entry has `line_count >= 50` (substantive work happened)
+- No handoff-log entry exists with a timestamp after that session's start time
+- If detected: "Last session ({start}, {duration}) ended without handoff — possible crash or manual close. Session log may have partial context."
 
-1. Read recent session log: Glob `docs/session-logs/*.md`, read most recent (last 3 entries)
-2. Check open issues: `gh issue list --state open --limit 10 --repo {GITHUB_REPO}`
-   - Use the correct repo from the table above
-   - If repo unknown, get it from: `git remote -v`
+**Pickup import (when triggered):**
+1. Extract full content between `<!-- handoff-start -->` and `<!-- handoff-end -->`
+2. Internalize as working context
+3. Read every file listed in the "Files to Read First" section
+4. Report: "Picked up handoff from {age}. {N} files read."
 
-### Step 3: Project-Specific Setup
+### Step 2: Project Context
 
-**Aletheia only:**
-- Check for `docs/10000b-ONBOARD-DIGEST.md` and read it
-- Check for `tools/generate_onboard_digest.py` and run it if exists
+**IF pickup was imported:** Skip session log reads (handoff has the context). Still read open issues.
 
-### Step 4: Acknowledge
+**IF `assemblyZero == true` (from config):**
+- Read `C:\Users\mcwiz\Projects\AssemblyZero\CLAUDE.md`
+- Read `C:\Users\mcwiz\Projects\AssemblyZero\docs\prompts\gemini-rotation-instructions.md`
 
-Report:
-1. **Project name** - Which project you onboarded to
-2. **Project type** - What kind of project it is
-3. **Current focus** - From sprint doc or recent session
-4. **Top 3 priority issues** - If any open issues exist
-5. **Ready for command**
+**IF `onboard.guide` is set:** Read `{repo_root}/{onboard.guide}`
+
+**IF `onboard.plan` is set:** Read `{repo_root}/{onboard.plan}`
+
+**IF pickup was NOT imported:**
+- Glob `docs/session-logs/*.md`, read the most recent file
+
+**Always:** `gh issue list --state open --limit 10 --repo {owner}/{repo}`
+
+### Step 3: Report
+
+```
+Project: {name}
+Type: {from CLAUDE.md description — already in context}
+Focus: {from plan doc, handoff, or session log}
+Top 3 issues: {from gh issue list}
+Model: {from system prompt} | Effort: {from config or "default"} | Window: {model window}
+```
+
+IF pickup was imported:
+  "Picked up handoff from {age}. Ready to continue."
+ELSE:
+  "Onboarded fresh. Ready."
+
+Then ask: "What do you want to work on next?"
+
+---
 
 ## Rules
 
 - Use absolute paths and `git -C` patterns (no cd && chaining)
-- Use `--repo {owner}/{repo}` for all gh commands (see table above)
-- Never use forbidden commands (git reset, git push --force, pip install, etc.)
-- **Code changes** require worktrees - never commit code directly to main
-- **Documentation changes** can be committed directly to main (no worktree needed)
-
-## Fallback for Unknown Projects
-
-If the project is not in the known projects table:
-1. Read `CLAUDE.md` (if exists)
-2. Read `README.md`
-3. Try `docs/10000-GUIDE.md` or `docs/index.md`
-4. List top-level directories to understand structure
-5. Get GitHub repo from: `git remote -v`
-6. Report: "Project {NAME} - onboarding complete. Structure: {description}"
+- Use `--repo {owner}/{repo}` for all gh commands
+- CLAUDE.md and MEMORY.md are already in context — never re-read them
+- `data/handoff-log.md` is read-only — never modify it
+- `data/session-index.jsonl` is read-only — never modify it
+- If no `.unleashed.json` exists, use defaults: `assemblyZero=false`, `pickupThreshold=10`, no guide, no plan


### PR DESCRIPTION
## Summary

- Rewrite onboard.md: config-driven via `.unleashed.json` instead of hardcoded known-projects table
- Smart pickup detection with auto-import, thrashing recognition, and crash recovery
- Delete cost/time estimates, fallback section, redundant CLAUDE.md re-reads
- `assemblyZero` flag in config controls whether AZ rules are loaded during onboard
- Companion to martymcenroe/unleashed#129 (wrapper changes)

## Test plan

- [ ] `/onboard` in an AZ repo with `assemblyZero: true` reads AZ CLAUDE.md
- [ ] `/onboard` in unleashed with `assemblyZero: false` skips AZ reads
- [ ] `/onboard --pickup` skips detection, goes straight to import
- [ ] `/onboard --refresh` reloads rules without session state

Closes #870

Generated with [Claude Code](https://claude.com/claude-code)