### PR TITLE
fix: resolve 10 new-repo workflow friction points Closes #883

### DIFF
--- a/docs/runbooks/0900-runbook-index.md
+++ b/docs/runbooks/0900-runbook-index.md
@@ -46,6 +46,7 @@ Quick reference for the user (Marty) on how to run tools, commands, agents, audi
 | 0926 | [Branch Protection Setup](0926-branch-protection-setup.md) | Manual | On new repo | - |
 | 0927 | [AI CLI Tools Reference](0927-ai-cli-tools-reference.md) | Reference | - | All |
 | 0928 | [New Repo: Human Checklist](0927-new-repo-human-checklist.md) | Manual | On new repo | - |
+| 0929 | [Cloudflare Zone Setup](0928-cloudflare-zone-setup.md) | Manual | On new domain | - |
 
 ## Model Selection Guide
 

--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,8 +1,8 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 2.0
-**Last Updated:** 2026-04-05
+**Version:** 3.0
+**Last Updated:** 2026-04-08
 
 ---
 
@@ -10,13 +10,23 @@
 
 The human steps when creating a new repo. Most of the work is automated by `new_repo_setup.py` — it creates the local scaffold, GitHub repo, branch protection, workflow files, and initial push in one command.
 
-The human handles only what the script can't: Cerberus secret deployment (requires a .pem from the GitHub UI) and wiki setup (a human decision).
+The human handles only what the script can't: PAT switching for workflow files, Cerberus secret deployment, and optional wiki/domain setup.
 
 ---
 
 ## Checklist
 
-### 1. Run the setup script
+### 1. Switch to classic PAT (required for workflow files)
+
+The setup script creates `.github/workflows/` files. Pushing these requires a PAT with `workflow` scope. The fine-grained PAT deliberately lacks this scope (agents must not modify their own guardrails).
+
+```bash
+gh auth login -h github.com -p https
+# Paste classic PAT with: repo + workflow scopes
+# Get one from: https://github.com/settings/tokens
+```
+
+### 2. Run the setup script
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
@@ -24,62 +34,75 @@ poetry run python tools/new_repo_setup.py {name} [--public] [--license mit]
 ```
 
 The script handles all of the following automatically:
-- Local directory structure (31 dirs) + all config files
-- GitHub repo creation via `gh repo create --source . --push`
-- Branch protection (require PR, block force push, block deletion, pr-sentinel check)
+- Local directory structure + all config files
+- GitHub repo creation (forced lowercase) via `gh repo create --source . --push`
+- Repo settings: wiki disabled, projects disabled, squash-only merge, delete branch on merge
+- Branch protection: require PR (1 review), block force push, block deletion, enforce_admins, pr-sentinel check
 - PR governance workflows (`pr-sentinel.yml`, `auto-reviewer.yml`)
-- Wiki disable (default — override below if needed)
 - `.unleashed.json`, `.claude/settings.json`, security hooks
 - Initial commit and push
 
-If `gh repo create` fails (PAT lacks create permission), the script prints manual fallback steps.
+The script prints a summary showing what succeeded and what failed. If push fails, it prints manual steps.
 
-### 2. Deploy Cerberus secrets (if needed)
+### 3. Switch back to fine-grained PAT (immediately)
 
-The auto-reviewer workflow (deployed by the script in step 1) needs two GitHub Actions secrets to approve PRs: `REVIEWER_APP_ID` and `REVIEWER_APP_PRIVATE_KEY`. These are deployed **fleet-wide** — the script covers ALL repos at once, not just the new one.
-
-**Check if secrets are already deployed:** If you've run `deploy_cerberus_secrets.py` since the last time you created a repo, the new repo might not have secrets yet. If your last fleet deploy was recent and you haven't created repos since, you're fine — skip to step 3.
-
-**If the new repo needs secrets:**
-
-Run all of this in your own git-bash (never an agent session):
-
-**Step 2a: Generate a private key**
-
-1. Go to https://github.com/settings/apps/cerberus-az
-2. Scroll down to Private keys
-3. Click Generate a private key
-4. Browser downloads a .pem file to your Downloads folder
-   (filename like cerberus-az.2026-03-18.private-key.pem)
-
-**Important:** generating a new .pem does NOT invalidate existing keys. GitHub Apps support multiple active private keys simultaneously.
-
-**Step 2b: Deploy to all repos**
-
-```
-cd /c/Users/mcwiz/Projects/AssemblyZero
-poetry run python tools/deploy_cerberus_secrets.py /c/Users/mcwiz/Downloads/THE-FILE.pem
+```bash
+gh auth login -h github.com -p https
+# Paste fine-grained PAT
 ```
 
-The script deploys to ALL repos. Check the output — look for OK next to your new repo name(s).
+**Do this immediately.** The classic PAT has broader permissions than agents should ever have access to. Every minute it stays active is a risk window.
 
-**Step 2c: Delete the .pem and revoke**
+### 4. Deploy Cerberus secrets (if needed)
 
-1. Delete the .pem file from Downloads immediately
-2. Go back to https://github.com/settings/apps/cerberus-az > Private keys
-3. Click Revoke on the key you just generated (the most recent one)
-   — The secrets are already stored in GitHub Actions. The .pem is never needed again.
-   — Revoking prevents the key from being used if the file wasn't fully deleted.
+The auto-reviewer needs two secrets per repo: `REVIEWER_APP_ID` and `REVIEWER_APP_PRIVATE_KEY`. These are deployed **fleet-wide** — the script covers ALL repos at once, not just the new one.
 
-**What happens without secrets:** PRs on the new repo will pass pr-sentinel (the check) but won't get auto-approved (the auto-reviewer workflow will fail). You can still merge manually via the GitHub UI until secrets are deployed.
+**Skip this step if** you've deployed Cerberus secrets since the last time you created a repo (the new repo is already covered by the fleet-wide install).
 
-### 3. Create wiki (if needed)
+**If the new repo needs secrets**, follow this checklist as one uninterrupted sequence. Run all commands in your own git-bash (never an agent session):
+
+1. Go to https://github.com/settings/apps/cerberus-az > Private keys
+2. Click **Generate a private key** — browser downloads a `.pem` file
+   (generating a new key does NOT invalidate existing keys)
+3. Deploy to all repos:
+   ```bash
+   cd /c/Users/mcwiz/Projects/AssemblyZero
+   poetry run python tools/deploy_cerberus_secrets.py /c/Users/mcwiz/Downloads/THE-FILE.pem
+   ```
+4. **Verify:** Look for `OK` next to your new repo name in the output
+5. **Delete the .pem file immediately:**
+   ```bash
+   rm /c/Users/mcwiz/Downloads/THE-FILE.pem
+   ```
+6. Go back to https://github.com/settings/apps/cerberus-az > Private keys
+7. Click **Revoke** on the key you just generated (most recent one)
+   - The secrets are already stored in GitHub Actions — the .pem is never needed again
+   - Revoking prevents the key from being used if the file wasn't fully deleted
+   - **Note:** GitHub Apps require at least one active key. If only one key exists, you cannot revoke it. File deletion (step 5) is your only protection.
+8. **Done.** Secrets deployed, .pem deleted, key revoked.
+
+**What happens without secrets:** PRs pass pr-sentinel but don't get auto-approved. You can merge manually via the GitHub UI until secrets are deployed.
+
+### 5. Create wiki (if needed)
 
 Skip this step if the repo doesn't need a wiki.
 
 **Public repos:** Enable the wiki in Settings > Features > Wikis. The wiki inherits the repo's visibility. Create the first wiki page.
 
-**Private repos:** GitHub wikis inherit the repo's visibility — a private repo's wiki is also private. If you need a public-facing wiki for a private repo, create a separate public repo (e.g., `my-project-wiki`) and manage wiki content there instead.
+**Private repos (shadow wiki):** GitHub wikis inherit the repo's visibility — a private repo's wiki is also private. Create a separate public repo using the naming convention `{repo}-wiki`:
+
+```bash
+gh repo create martymcenroe/{name}-wiki --public --description "{Name} public wiki" --repo martymcenroe/{name}-wiki
+```
+
+Then initialize it with a Home page:
+```bash
+gh repo clone martymcenroe/{name}-wiki /c/Users/mcwiz/Projects/{name}-wiki
+cd /c/Users/mcwiz/Projects/{name}-wiki
+echo "# {Name} Wiki" > Home.md
+git add . && git commit -m "docs: initialize wiki"
+git push
+```
 
 ---
 
@@ -93,10 +116,11 @@ These all happen without any per-repo human intervention:
 | pr-sentinel check (Cloudflare Worker) | Receives webhooks for all repos, authenticates with its own stored credentials |
 | pr-sentinel check (GitHub Actions) | Workflow file created by setup script in initial commit |
 | Auto-reviewer workflow file | Created by setup script in initial commit |
-| Branch protection | Configured by setup script via GitHub API |
+| Repo settings | Configured by setup script: wiki off, projects off, squash-only, delete-branch-on-merge |
+| Branch protection | Configured by setup script: 1 review, enforce_admins, pr-sentinel check, strict=false |
 | Directory structure + configs | Created by setup script |
 
-The **only** per-repo human steps are Cerberus secrets (fleet deploy covers it) and wiki setup.
+The **per-repo human steps** are: PAT switch (before/after), Cerberus secrets (fleet deploy), and optional wiki/domain setup.
 
 ---
 
@@ -117,3 +141,4 @@ The **only** per-repo human steps are Cerberus secrets (fleet deploy covers it) 
 | 2026-03-18 | v1.2: Expanded .pem walkthrough. Clarified multi-key support. Added revoke step. |
 | 2026-04-05 | v1.3: Made wiki step conditional with public/private guidance. |
 | 2026-04-05 | v2.0: Complete rewrite. Script now handles repo creation, branch protection, and workflow deployment. Human steps reduced to Cerberus secrets (fleet-wide) and wiki setup. |
+| 2026-04-08 | v3.0: Added PAT switch protocol (steps 1/3). Expanded repo settings (projects, merge, delete-branch). Rewrote Cerberus section as numbered checklist with .pem lifecycle notes. Added shadow wiki creation steps. (#883) |

--- a/docs/runbooks/0928-cloudflare-zone-setup.md
+++ b/docs/runbooks/0928-cloudflare-zone-setup.md
@@ -1,0 +1,98 @@
+# 0928 - New Domain: Cloudflare Zone Setup
+
+**Category:** Runbook / Operational Procedure
+**Version:** 1.0
+**Last Updated:** 2026-04-08
+
+---
+
+## Purpose
+
+Steps for adding a new domain to Cloudflare for use with Workers. All projects deploy to the same Cloudflare account (`4fe1c5e241425c85d0f2c35c69fb45b8`, mcwizard1@gmail.com).
+
+---
+
+## Prerequisites
+
+- Cloudflare account access (mcwizard1@gmail.com)
+- Domain purchased from a registrar (Namecheap, etc.)
+- The domain's TLD must be supported by Cloudflare (most are; `.study` is not)
+
+---
+
+## Steps
+
+### 1. Add zone in Cloudflare
+
+1. Go to https://dash.cloudflare.com/
+2. Click **Add a site**
+3. Enter the domain (e.g., `sextant.ceo`)
+4. Select the **Free** plan
+5. Cloudflare will scan existing DNS records — review and confirm
+6. Cloudflare assigns two nameservers (e.g., `ada.ns.cloudflare.com`, `bob.ns.cloudflare.com`)
+
+### 2. Change nameservers at registrar
+
+**Namecheap:**
+1. Go to https://www.namecheap.com/ > Domain List > Manage
+2. Under **Nameservers**, switch from "Namecheap BasicDNS" to **Custom DNS**
+3. Enter the two Cloudflare nameservers from step 1
+4. Save
+
+**Other registrars:** Find the DNS/Nameserver settings and replace with Cloudflare's nameservers.
+
+### 3. Verify propagation
+
+Nameserver changes can take 1-24 hours. Check status:
+
+```bash
+# Check nameservers
+dig NS sextant.ceo +short
+
+# Or use Cloudflare's dashboard — it shows "Active" when propagated
+```
+
+Cloudflare also sends an email when the zone becomes active.
+
+### 4. Configure Worker route (in wrangler.toml)
+
+```toml
+[[routes]]
+pattern = "subdomain.yourdomain.com"
+custom_domain = true
+```
+
+Then `wrangler deploy` will automatically create the DNS record and route.
+
+### 5. Verify HTTPS
+
+Cloudflare provides free SSL. After deploying the Worker:
+
+```bash
+curl -I https://subdomain.yourdomain.com
+# Should return HTTP/2 200 with Cloudflare headers
+```
+
+---
+
+## Notes
+
+- `.ceo`, `.dev`, `.com`, `.io` — all supported by Cloudflare
+- `.study` — NOT supported by Cloudflare (discovered during Aletheia setup)
+- Free plan is sufficient for Workers + D1 + custom domains
+- Each domain is a separate "zone" in Cloudflare, but all under the same account
+
+---
+
+## Related Documents
+
+- [0901 - New Project Setup](0901-new-project-setup.md) — Script reference
+- [0927 - New Repo: Human Steps Checklist](0927-new-repo-human-checklist.md) — Full new-repo workflow
+
+---
+
+## History
+
+| Date | Change |
+|------|--------|
+| 2026-04-08 | v1.0: Initial runbook. Documented from Sextant domain setup experience (#883). |

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1041,6 +1041,8 @@ on:
 permissions:
   checks: write
   statuses: write
+  pull-requests: read
+  contents: read
 
 jobs:
   issue-reference:
@@ -1192,19 +1194,31 @@ def configure_branch_protection(github_user: str, repo_name: str) -> bool:
     Returns:
         True if protection was configured, False if it failed.
     """
-    # Branch protection requires at least one commit on main
-    # We configure it after the initial push
+    # Branch protection requires at least one commit on main.
+    # Verify remote branch exists before attempting.
+    try:
+        check = subprocess.run(
+            ["gh", "api", f"/repos/{github_user}/{repo_name}/branches/main"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if check.returncode != 0:
+            print("    Remote branch 'main' not found — skipping branch protection.")
+            print("    Push to main first, then re-run or configure manually.")
+            return False
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+
     try:
         result = subprocess.run(
             ["gh", "api", "-X", "PUT",
              f"/repos/{github_user}/{repo_name}/branches/main/protection",
-             "-f", "required_pull_request_reviews[dismiss_stale_reviews]=false",
-             "-f", "required_pull_request_reviews[require_code_owner_reviews]=false",
-             "-F", "required_pull_request_reviews[required_approving_review_count]=0",
+             "-F", "required_pull_request_reviews[dismiss_stale_reviews]=false",
+             "-F", "required_pull_request_reviews[require_code_owner_reviews]=false",
+             "-F", "required_pull_request_reviews[required_approving_review_count]=1",
              "-F", "enforce_admins=true",
              "-F", "restrictions=null",
-             "-f", "required_status_checks[strict]=true",
-             "-f", "required_status_checks[contexts][]=pr-sentinel",
+             "-F", "required_status_checks[strict]=false",
+             "-f", "required_status_checks[contexts][]=pr-sentinel / issue-reference",
              "-F", "allow_force_pushes=false",
              "-F", "allow_deletions=false",
              ],
@@ -1217,25 +1231,28 @@ def configure_branch_protection(github_user: str, repo_name: str) -> bool:
         return False
 
 
-def disable_wiki(github_user: str, repo_name: str) -> bool:
+def configure_repo_settings(github_user: str, repo_name: str) -> bool:
     """
-    Disable wiki on a GitHub repo.
+    Configure GitHub repo settings to match fleet standards.
 
-    Wikis have no protection mechanisms (no branch protection, no review gate).
-    They should be disabled by default and only enabled when explicitly needed.
+    Sets: wiki disabled, projects disabled, squash-only merge, delete branch on merge.
 
     Args:
         github_user: GitHub username
         repo_name: Repository name
 
     Returns:
-        True if wiki was disabled, False if it failed.
+        True if settings were applied, False if it failed.
     """
     try:
         result = subprocess.run(
             ["gh", "api", "-X", "PATCH",
              f"/repos/{github_user}/{repo_name}",
-             "-F", "has_wiki=false"],
+             "-F", "has_wiki=false",
+             "-F", "has_projects=false",
+             "-F", "delete_branch_on_merge=true",
+             "-F", "allow_merge_commit=false",
+             "-F", "allow_rebase_merge=false"],
             capture_output=True,
             text=True,
             timeout=30,
@@ -1509,54 +1526,95 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     print("  Created initial commit")
 
     github_created = False
+    push_succeeded = False
+    repo_settings_ok = False
+    protection_ok = False
+
     if not args.no_github:
+        print("\n" + "=" * 60)
+        print("GITHUB REMOTE")
+        print("=" * 60)
+
+        # Detect PAT type and warn about workflow scope
+        try:
+            auth_result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True, text=True, timeout=15,
+            )
+            auth_output = auth_result.stdout + auth_result.stderr
+            if "github_pat_" in auth_output:
+                print("\n  NOTE: Fine-grained PAT detected.")
+                print("  Workflow files (.github/workflows/) require 'workflow' scope.")
+                print("  If push fails, switch to classic PAT:")
+                print("    gh auth login -h github.com -p https")
+                print("  Then push manually: git push -u origin main")
+                print("  Then switch back to fine-grained PAT.\n")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
         # Step 13: Create GitHub repo
-        print("\n13. Creating GitHub repository...")
+        repo_name_lower = args.name.lower()
+        print(f"\n13. Creating GitHub repository ({repo_name_lower})...")
         visibility = "--public" if args.public else "--private"
         try:
             run_command(
-                ["gh", "repo", "create", f"{github_user}/{args.name}", visibility, "--source", ".", "--push"],
+                ["gh", "repo", "create", f"{github_user}/{repo_name_lower}", visibility, "--source", ".", "--push"],
                 cwd=project_path
             )
-            print(f"  Created: https://github.com/{github_user}/{args.name}")
+            print(f"  Created: https://github.com/{github_user}/{repo_name_lower}")
             github_created = True
+            push_succeeded = True
         except Exception as e:
             print(f"  WARNING: gh repo create failed: {e}")
-            print(f"  Your PAT may lack the 'create repository' permission.")
-            print(f"  The local repo is fully valid. To finish manually:")
-            print(f"    1. Create repo at https://github.com/new")
-            print(f"    2. git remote add origin https://github.com/{github_user}/{args.name}.git")
-            print(f"    3. git push -u origin main")
+            print("  Your PAT may lack 'create repository' or 'workflow' scope.")
+            print("  The local repo is fully valid. To finish manually:")
+            print("    1. Create repo at https://github.com/new")
+            print(f"    2. git remote add origin https://github.com/{github_user}/{repo_name_lower}.git")
+            print("    3. gh auth login -h github.com -p https  # classic PAT with workflow scope")
+            print("    4. git push -u origin main")
+            print("    5. gh auth login -h github.com -p https  # back to fine-grained PAT")
 
         if github_created:
             # Step 14: Star the repo
             print("\n14. Starring repository...")
             run_command(
-                ["gh", "api", "-X", "PUT", f"/user/starred/{github_user}/{args.name}"],
+                ["gh", "api", "-X", "PUT", f"/user/starred/{github_user}/{repo_name_lower}"],
                 cwd=project_path,
                 check=False  # Don't fail if starring fails
             )
             print("  Starred repository")
 
-            # Step 15: Disable wiki (no protection mechanisms available)
-            print("\n15. Disabling wiki (no protection mechanisms available)...")
-            if disable_wiki(github_user, args.name):
-                print("  Wiki disabled")
+            # Step 15: Configure repo settings (wiki, projects, merge strategy)
+            print("\n15. Configuring repo settings...")
+            if configure_repo_settings(github_user, repo_name_lower):
+                print("  Repo settings configured:")
+                print("    - Wiki: disabled")
+                print("    - Projects: disabled")
+                print("    - Merge strategy: squash only")
+                print("    - Delete branch on merge: enabled")
+                repo_settings_ok = True
             else:
-                print("  WARNING: Could not disable wiki — do this manually!")
+                print("  WARNING: Could not configure repo settings.")
 
             # Step 16: Configure branch protection
             print("\n16. Configuring branch protection...")
-            if configure_branch_protection(github_user, args.name):
-                print("  Branch protection configured:")
-                print("    - Force push: blocked")
-                print("    - Deletion: blocked")
-                print("    - enforce_admins: enabled")
-                print("    - Required check: pr-sentinel")
+            if push_succeeded:
+                if configure_branch_protection(github_user, repo_name_lower):
+                    print("  Branch protection configured:")
+                    print("    - Force push: blocked")
+                    print("    - Deletion: blocked")
+                    print("    - enforce_admins: enabled")
+                    print("    - Required reviews: 1 (Cerberus auto-approves)")
+                    print("    - Required check: pr-sentinel / issue-reference")
+                    print("    - strict: false")
+                    protection_ok = True
+                else:
+                    print("  WARNING: Could not configure branch protection.")
+                    print("  This may fail if the token lacks admin scope.")
+                    print("  Configure manually or re-run with a classic token.")
             else:
-                print("  WARNING: Could not configure branch protection.")
-                print("  This may fail if the token lacks admin scope.")
-                print("  Configure manually or re-run with a classic token.")
+                print("  SKIPPED: Push failed — no remote branch to protect.")
+                print("  After pushing, configure branch protection manually.")
 
     # Post-setup verification
     print("\n" + "=" * 60)
@@ -1606,13 +1664,31 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     if checks_passed < checks_total:
         print("\nWARNING: Some checks failed. Review and fix before starting work!")
 
+    # Final summary
+    if not args.no_github:
+        print("\n" + "=" * 60)
+        print("SUMMARY")
+        print("=" * 60)
+        repo_name_lower = args.name.lower()
+        print("  Local scaffold:     OK")
+        print(f"  GitHub repo:        {'OK' if github_created else 'FAILED'}")
+        print(f"  Push:               {'OK' if push_succeeded else 'FAILED'}")
+        print(f"  Repo settings:      {'OK' if repo_settings_ok else 'FAILED — configure manually'}")
+        print(f"  Branch protection:  {'OK' if protection_ok else 'FAILED — configure manually or re-run with classic PAT'}")
+
     print("\n" + "=" * 60)
-    print(f"[SUCCESS] Repository '{args.name}' created successfully!")
-    print(f"\nNext steps:")
+    print(f"[SUCCESS] Repository '{args.name}' created!")
+    print("\nNext steps:")
     print(f"  cd {project_path}")
     if not args.no_github:
-        print(f"  # Repository is live at: https://github.com/{github_user}/{args.name}")
-    print(f"  # Start coding!")
+        repo_name_lower = args.name.lower()
+        print(f"  # Repository: https://github.com/{github_user}/{repo_name_lower}")
+        if not push_succeeded:
+            print("  # IMPORTANT: Push failed. Switch to classic PAT and push:")
+            print("  #   gh auth login -h github.com -p https  # classic PAT")
+            print("  #   git push -u origin main")
+            print("  #   gh auth login -h github.com -p https  # fine-grained PAT")
+    print("  # Deploy Cerberus secrets: see runbook 0927")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix all 10 friction points from Sextant repo creation (#883)
- Script: PAT detection, section headers, repo settings, branch protection fixes, lowercase names, workflow permissions
- Docs: PAT switch protocol, shadow wiki steps, Cerberus rewrite, new Cloudflare zone runbook

## Changes

### new_repo_setup.py
- Detect fine-grained PAT and warn about `workflow` scope before push
- Force lowercase repo name (`gh repo create`)
- Add `pull-requests: read` + `contents: read` to pr-sentinel template
- Expand `disable_wiki` -> `configure_repo_settings` (wiki, projects, merge strategy, delete-branch)
- Fix `configure_branch_protection`: review count 0->1, strict true->false, context `pr-sentinel` -> `pr-sentinel / issue-reference`, boolean field types
- Check remote branch exists before branch protection
- Add section headers and pass/fail summary to output

### Runbooks
- 0927 v3.0: PAT switch protocol, shadow wiki steps, Cerberus numbered checklist
- 0928 (new): Cloudflare zone setup
- 0900: Index updated

## Test plan
- [ ] `poetry run python tools/new_repo_setup.py --help` runs
- [ ] Script imports cleanly
- [ ] Review branch protection API call matches fleet standard (0016)
- [ ] Review pr-sentinel workflow template has all 4 permissions
- [ ] Review runbook 0927 flow makes sense end-to-end

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)