### PR TITLE
fix: remove model override that downgrades Opus from 1M to 256K context Closes #903

### DIFF
--- a/.unleashed.json
+++ b/.unleashed.json
@@ -1,7 +1,6 @@
 {
   "profile": "default",
   "claude": {
-    "model": "opus",
     "effort": "max"
   }
 }


### PR DESCRIPTION
## Summary

- Remove `"model": "opus"` from `.unleashed.json` -- downgrades Opus from 1M to 256K context
- `"effort": "max"` is retained and works independently
- See martymcenroe/unleashed#186 for full details

Closes #903