### PR TITLE
feat: track all user-level skills in repo with onboard sync Closes #906

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,6 +1,7 @@
 ---
 description: Full 08xx audit suite with project-specific extensions
 argument-hint: "[--help] [--deep] [--ultimate] [NNNN] [NNNN] ..."
+scope: global
 ---
 
 # Full Audit Suite

--- a/.claude/commands/blog-draft.md
+++ b/.claude/commands/blog-draft.md
@@ -1,0 +1,83 @@
+---
+description: Create a blog draft in dispatch repo from any project
+argument-hint: "\"Title of the post\""
+scope: global
+---
+
+# Blog Draft
+
+Create a blog post draft in the dispatch repo, stamped with the source project.
+
+## Usage
+
+```
+/blog-draft "My Amazing Discovery"
+/blog-draft "How I Fixed the Bug"
+```
+
+## Execution
+
+### Step 1: Extract Context
+
+1. Get the **source project** from the current working directory:
+   - Extract project name from path (e.g., `/c/Users/mcwiz/Projects/AssemblyZero` → `AssemblyZero`)
+
+2. Get **today's date** in YYYY-MM-DD format
+
+3. Generate **slug** from the title:
+   - Lowercase, replace spaces with hyphens, remove special characters
+   - Example: "My Amazing Discovery" → "my-amazing-discovery"
+
+### Step 2: Create Draft File
+
+**Location:** `C:\Users\mcwiz\Projects\dispatch\drafts\{date}-{slug}-from-{project}.md`
+
+**Template:**
+
+```markdown
+---
+title: "{title}"
+source_project: {project}
+created: {date}
+status: draft
+tags: []
+---
+
+# {title}
+
+*[Opening hook - what's the problem or insight?]*
+
+---
+
+## The Context
+
+[What were you working on? What led to this?]
+
+## The Discovery/Solution
+
+[The meat of the post - what did you learn or build?]
+
+## Why It Matters
+
+[So what? Why should readers care?]
+
+## Try It Yourself
+
+[If applicable - how can readers use this?]
+
+---
+
+*Built with Claude Opus 4.5. Source: {project}*
+```
+
+### Step 3: Report
+
+After creating the file, report:
+- Full path to the draft
+- Suggested next steps (fill in sections, run `/blog-review` when ready)
+
+## Notes
+
+- Drafts are **not committed** until explicitly requested
+- The dispatch repo has a `STYLE-GUIDE.md` - read it if tone guidance is needed
+- Use `/blog-review` in dispatch to get AI feedback on drafts

--- a/.claude/commands/blog-review.md
+++ b/.claude/commands/blog-review.md
@@ -1,0 +1,75 @@
+---
+description: Run Gemini 3 review on a blog draft
+argument-hint: "<draft-path>"
+scope: global
+---
+
+# Blog Review
+
+Run AI-powered review on a blog draft using Gemini 3 Pro Preview.
+
+## Usage
+
+```
+/blog-review drafts/2026-01-14-unleashed-from-AssemblyZero.md
+/blog-review C:\Users\mcwiz\Projects\dispatch\drafts\my-post.md
+```
+
+## Execution
+
+### Step 1: Locate the Draft
+
+If the path is relative, resolve it from:
+1. Current working directory
+2. `C:\Users\mcwiz\Projects\dispatch\` (dispatch repo)
+
+Read the draft file and extract:
+- **Title**: From frontmatter `title:` field, or first `# ` heading
+- **Content**: The full markdown content
+
+### Step 2: Build the Review Prompt
+
+Read the prompt template from:
+`C:\Users\mcwiz\Projects\dispatch\.claude\gemini-prompts\blog-review.txt`
+
+Replace placeholders:
+- `{{TITLE}}` → extracted title
+- `{{BLOG_CONTENT}}` → full draft content
+
+### Step 3: Write Temporary Prompt File
+
+Write the expanded prompt to a temp file in the scratchpad directory.
+
+### Step 4: Run Gemini Review
+
+Execute:
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/gemini-retry.py --prompt-file /path/to/temp-prompt.txt
+```
+
+### Step 5: Display Results
+
+Show the Gemini response which includes:
+- **Overall Assessment**: Ready to publish? Strongest element? What needs work?
+- **[BLOCKING] Issues**: Must fix before publication
+- **[HIGH] Priority Issues**: Should fix before publication
+- **[SUGGESTION] Improvements**: Nice to have
+- **Employment Showcase Score**: 1-10 rating
+- **Recommended Next Steps**
+
+### Step 6: Cleanup
+
+Delete the temporary prompt file.
+
+## Notes
+
+- Uses Gemini 3 Pro Preview for deep reasoning
+- Review takes 30-60 seconds depending on draft length
+- If quota is exhausted, gemini-retry.py will rotate credentials automatically
+- The review prompt is optimized for employment showcase blog posts
+
+## Error Handling
+
+If the draft file doesn't exist, report the error and suggest checking the path.
+
+If Gemini fails after all retries, report the failure and suggest trying again later.

--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -2,6 +2,7 @@
 description: Session cleanup with quick/normal/full modes
 argument-hint: "[--help] [--quick|--normal|--full] [--no-auto-delete]"
 aliases: ["/closeout", "/goodbye"]
+scope: global
 ---
 
 # Cleanup

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,6 +1,7 @@
 ---
 description: Single-agent code review (PR or staged changes)
 argument-hint: "[PR#] [--files path1 path2...] [--focus security|quality|all]"
+scope: global
 ---
 
 # Code Review

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,6 +1,7 @@
 ---
 description: Commit, push, and open a PR
 argument-hint: "[--title \"...\"] [--draft]"
+scope: global
 ---
 
 # Commit, Push, and PR

--- a/.claude/commands/death.md
+++ b/.claude/commands/death.md
@@ -1,3 +1,8 @@
+---
+description: Reconcile documentation with reality
+scope: project
+---
+
 # /death — The Hourglass Protocol
 
 DEATH arrives when the documentation no longer describes reality.

--- a/.claude/commands/friction.md
+++ b/.claude/commands/friction.md
@@ -1,6 +1,7 @@
 ---
 description: Analyze session transcripts for permission friction (15-30 min)
 argument-hint: "[--help] [--sessions N] [--since YYYY-MM-DD]"
+scope: global
 ---
 
 # Permission Friction Analysis

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,292 @@
+---
+description: Generate a high-fidelity context transfer prompt for the next session
+argument-hint: "[--help] [--reboot]"
+scope: global
+---
+
+# Handoff
+
+**If `$ARGUMENTS` contains `--help`:** Display the Help section below and STOP.
+
+## Help
+
+```
+/handoff - Context transfer + lessons learned + hygiene report
+
+Usage: `/handoff [--reboot]`
+
+Options:
+  --reboot    Save state but skip spawning a new terminal (for reboots/shutdowns)
+
+This is context transfer AND institutional memory capture:
+- Captures what matters for the next session (forward-looking)
+- Records lessons learned (institutional knowledge)
+- Reports hygiene exposure (stale branches, stashes, uncommitted — never deletes)
+- Appends session log (backward-looking record)
+
+Call /handoff at session end or BEFORE context compaction kills your memory.
+```
+
+## Execution
+
+**Do NOT delegate to a subagent.** The whole point is that YOU have the context. A subagent would need to reconstruct it from files, which is the problem we're solving.
+
+### Step 0: Leave It Clean
+
+Before generating the handoff, clean up after yourself:
+
+1. **Delete scratch/tmp files** you created this session (e.g. `tmp-*.json`, `*.tmp`, scratch debug files). Use `git status` to spot them — anything untracked that's clearly session debris gets removed. **Ask before deleting** if you're unsure whether a file is intentional.
+2. **Flag uncommitted changes** — If there are staged or unstaged changes, warn the user: "You have uncommitted changes in {repo}. Commit, stash, or discard before handoff?"
+3. **Flag stale worktrees** — If you created worktrees this session that were merged/abandoned, mention them so the user can prune.
+4. **Purge tmpclaude files** — Delete session debris:
+   ```bash
+   find /c/Users/mcwiz/Projects/{REPO_NAME} -name "tmpclaude-*-cwd" -type f -delete 2>/dev/null
+   ```
+
+This step is fast — don't skip it. The next session shouldn't start by cleaning up after this one.
+
+### Step 1: Gather State (parallel)
+
+Run these in parallel to supplement your memory with current facts:
+
+1. **Session context:**
+   ```bash
+   pwd && git rev-parse --show-toplevel 2>/dev/null && echo $UNLEASHED_VERSION && date '+%Y-%m-%d %H:%M:%S'
+   ```
+
+2. **Plan file** — Read the plan file if one exists (check `C:\Users\mcwiz\.claude\plans\` for the most recent `.md` file). Note which phases are complete.
+
+3. **Git status across touched repos** — For every repo you modified this session, run:
+   ```bash
+   git -C /c/Users/mcwiz/Projects/{REPO} log --oneline -3
+   git -C /c/Users/mcwiz/Projects/{REPO} status --short
+   ```
+
+4. **Task list** — Check if there are active tasks (use TaskList tool). Note completed vs pending.
+
+5. **Open issues** — For repos where you closed or created issues, note the current state.
+
+6. **Hygiene scan** — For every repo you touched this session (and the current repo at minimum), run these in parallel:
+   ```bash
+   # Stale local branches (merged into main but not deleted)
+   git -C /c/Users/mcwiz/Projects/{REPO} branch --merged main | grep -v 'main$'
+   # Branches where remote is gone
+   git -C /c/Users/mcwiz/Projects/{REPO} branch -vv | grep ': gone]'
+   # Worktrees beyond main
+   git -C /c/Users/mcwiz/Projects/{REPO} worktree list
+   # Stashes
+   git -C /c/Users/mcwiz/Projects/{REPO} stash list
+   ```
+   Store results for the Hygiene Report section in Step 2. This is REPORTING only — never delete anything.
+
+### Step 2: Write the Handoff Prompt
+
+Output a single markdown block to the screen (NOT to a file). The user will copy-paste it.
+
+**Structure:**
+
+```markdown
+# Session Handoff — {DATE} {TIME}
+
+> **Directory:** `{CWD}` | **Repo:** `{REPO_NAME}` (or "none — started from Projects root")
+> **Unleashed:** v{VERSION} (or "not running under unleashed")
+
+## What Was Accomplished
+
+{Concrete outcomes: file paths, commit SHAs, issue numbers. Facts, not summaries.}
+
+## Current State
+
+{For each repo touched — one line per repo:}
+| Repo | Branch | Status | Last Commit |
+|------|--------|--------|-------------|
+
+## The Plan
+
+{If a plan file exists, checklist with phases complete/pending. Include plan file path.
+If no plan, state the user's intent.}
+
+## What To Do Next
+
+{Specific, actionable next steps with file paths. Not "continue the plan."}
+
+## Key Decisions Made This Session
+
+{Decisions not written down elsewhere. User preferences, approach choices, discoveries.}
+
+## Open Threads
+
+{Discussed but not implemented. Questions raised but not answered.}
+
+## Lessons Learned
+
+{Aletheia three-column format. 0 rows fine for routine sessions. Don't pad.}
+
+| Date | Lesson | Rule/Action |
+|:-----|:-------|:------------|
+| {YYYY-MM-DD} | **{What happened.}** {The specifics — error messages, user feedback, surprising behavior.} | **{The rule I now follow.}** {How to prevent or replicate this.} |
+
+## Session Summary
+
+- **Session:** {SESSION_NAME or "unnamed"}
+- **Duration:** {approximate duration}
+- **Issues touched:** {comma-separated, e.g., "unleashed #84, #86, dotfiles #31"}
+- **Lessons:** {count} captured
+
+## Hygiene Report
+
+{For each repo scanned in Step 1 item 6, show actual git output. Only include repos where something was found. Skip repos where everything is clean. This is an EXPOSURE REPORT — never fix or delete anything here.}
+
+### {REPO_NAME}
+| Check | Status |
+|-------|--------|
+| Stale local branches | {list or "none"} |
+| Remote-gone branches | {list or "none"} |
+| Worktrees | {list beyond main, or "only main"} |
+| Stashes | {count and description, or "none"} |
+| Uncommitted | {count, or "clean"} |
+
+{If all scanned repos are clean, write: "All repos clean — no hygiene issues found."}
+
+## Files to Read First
+
+{Ordered list of files the next session should read to get oriented:}
+1. `{plan file}` — the master plan
+2. `{key file}` — because...
+3. ...
+```
+
+### Step 2B: Memory Line Check
+
+Check the current project's MEMORY.md line count:
+```bash
+wc -l C:/Users/mcwiz/.claude/projects/*/memory/MEMORY.md 2>/dev/null | sort -rn | head -5
+```
+If any MEMORY.md exceeds 150 lines, warn: "MEMORY.md at {N} lines (200 auto-loaded limit). Consider extracting reference material to standalone files."
+
+### Step 3: Verify Completeness
+
+Before outputting, self-check:
+- [ ] Every repo touched is listed with its status
+- [ ] Every issue opened/closed is mentioned with number and repo
+- [ ] The "what to do next" section is specific enough that a fresh agent could start working immediately
+- [ ] No hallucinated file paths — only reference files you actually read or wrote
+- [ ] Key user preferences are captured (not just technical state)
+- [ ] Lessons reflected honestly — 0 rows is fine, but "nothing happened" when things DID happen is not
+- [ ] Hygiene shows actual git output, not summaries or guesses
+
+### Step 4: Output
+
+Print the handoff prompt directly to the user. Surround it with a clear delimiter so they know exactly what to copy:
+
+```
+---BEGIN HANDOFF PROMPT---
+
+{the prompt}
+
+---END HANDOFF PROMPT---
+```
+
+### Step 5: Persist to Handoff Log
+
+After outputting the prompt to screen, persist it to the repo's handoff log so it survives clipboard loss:
+
+1. **Determine repo root:** `git rev-parse --show-toplevel`
+2. **Ensure `data/` directory exists** in the repo root (create if missing)
+3. **Ensure gitignore coverage:** Run `git check-ignore -q data/handoff-log.md`. If NOT ignored, append `data/handoff-log.md` to the repo's `.gitignore` file (create it if missing). Tell the user: "Added `data/handoff-log.md` to .gitignore."
+4. **Fresh timestamp** — Run `date '+%Y-%m-%d %H:%M:%S'` NOW. Do NOT reuse the Step 1 timestamp — after long sessions or context compaction, your memory of it drifts. Use this exact output for the `## Handoff` header below.
+5. **Append entry** to `{repo_root}/data/handoff-log.md` using the fresh timestamp from step 4:
+
+```markdown
+---
+## Handoff — {FRESH_TIMESTAMP}
+<!-- handoff-start -->
+{the full handoff prompt text from Step 4}
+<!-- handoff-end -->
+---
+```
+
+6. **Confirm to user:** "Handoff logged to `{path}`"
+
+### Step 5B: Persist Lessons Learned
+
+Lessons learned are institutional knowledge — they get committed, unlike the handoff log.
+
+1. **Per-repo file:** `{repo_root}/docs/lessons-learned.md`
+   - If missing, create with this header:
+     ```markdown
+     # Lessons Learned — {REPO_NAME}
+
+     | Date | Lesson | Rule/Action |
+     |:-----|:-------|:------------|
+     ```
+   - Append each lesson row from the handoff's Lessons Learned section.
+   - If there are 0 lessons this session, skip — don't touch the file.
+
+2. **Global index:** `C:\Users\mcwiz\Projects\dispatch\lessons-learned-index.md`
+   - If missing, create with this header:
+     ```markdown
+     # Lessons Learned — Global Index
+
+     Cross-repo index for blog/newsletter mining. One line per lesson.
+
+     | Date | Repo | Lesson (one-line) |
+     |:-----|:-----|:------------------|
+     ```
+   - Append one line per lesson: `| {date} | {repo_name} | {one-line summary} |`
+   - The summary is the bold portion of the Lesson column (the "what happened" part).
+
+3. **Do NOT commit these files during handoff.** The next session or a manual commit handles that. Handoff just appends.
+
+### Step 5C: Append Session Log
+
+Brief backward-looking record of the session. One entry per session.
+
+1. **File:** `{repo_root}/docs/session-logs/{YYYY-MM-DD}.md`
+   - If the `docs/session-logs/` directory doesn't exist, create it.
+   - If the file doesn't exist, create it with a header: `# Session Log — {YYYY-MM-DD}`
+   - Append:
+     ```markdown
+
+     ## {HH:MM} — {SESSION_NAME or "unnamed"}
+
+     - **Duration:** {approximate}
+     - **Issues:** {comma-separated list, e.g., "#84, #86"}
+     - **Lessons:** {count} captured
+     - **Next:** {one-line summary of what to do next}
+     ```
+
+2. **Do NOT commit.** Same as 5B — handoff appends, next session commits.
+
+### Step 6: Spawn New Unleashed Session
+
+**MANDATORY unless `--reboot` is in `$ARGUMENTS`.** The CLAUDE.md "Skill Instructions Are Explicit Authorization" rule applies. Do NOT skip this step for any reason not listed in these instructions. Do NOT invent conditions (e.g., "not running under unleashed", "environment variable empty") to justify skipping.
+
+**IF `$ARGUMENTS` contains `--reboot`:** Skip this step entirely. Tell user: "Handoff saved. Skipping new session (--reboot). Ready to reboot."
+
+**OTHERWISE:**
+
+After persisting the handoff log, spawn a new unleashed session. Auto-onboard (default in v30+) detects the fresh handoff and auto-picks up the context.
+
+1. **Get repo root Windows path:** Convert the git toplevel path to a Windows path with backslashes (e.g. `C:\Users\mcwiz\Projects\AssemblyZero`)
+2. **Get repo name uppercased** for the window title (e.g. `ASSEMBLYZERO`)
+3. **Get Unix-style repo path** for the cd command (e.g. `/c/Users/mcwiz/Projects/AssemblyZero`)
+4. **Spawn via Python** (MSYS2 mangles paths — must go through cmd.exe):
+   ```bash
+   python -c "import subprocess; subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed\"', shell=True)"
+   ```
+   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps.
+5. **Tell user:** "New unleashed session spawning in {REPO_NAME} with auto-onboard."
+
+## Rules
+
+- **Be concrete, not summary.** "Updated 3 files" is useless. "Updated `Architecture.md`, `Version-History.md`, `Version-Promotions.md`" is useful.
+- **Include commit SHAs.** The next agent can `git show` them to understand changes.
+- **Include the plan file path.** The next agent should read it, not reconstruct it.
+- **Don't pad.** If nothing happened in a section, skip it. A shorter, accurate prompt beats a longer, padded one.
+- **User preferences go in "Key Decisions."** Things like "user doesn't want numbered options" or "always use poetry run python" — if you learned it this session and it's not in CLAUDE.md or MEMORY.md, capture it here.
+- **Always persist** — the log survives even if the clipboard is lost.
+- **Always spawn without flags** — v30+ auto-onboard detects the fresh handoff and auto-imports it. No `--pickup` needed. Exception: `--reboot` skips the spawn entirely.
+- **Lessons are institutional memory.** One real lesson is worth more than a perfect handoff. If something surprised you, cost time, or changed your approach — write it down. 0 rows is fine for routine sessions; padding is not.
+- **Hygiene is exposure, not action.** NEVER delete branches, stashes, worktrees, or files during handoff. Report what exists so the user can rescue work. `/cleanup` is for destructive operations.
+- **Session log is backward-looking, handoff prompt is forward-looking.** The session log records what happened (for mining later). The handoff prompt tells the next agent what to do. Don't conflate them.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,6 +1,7 @@
 ---
 description: Agent onboarding (quick/full mode, smart pickup detection)
 argument-hint: "[--help] [--refresh | --quick | --full] [--pickup]"
+scope: global
 ---
 
 # Agent Onboarding
@@ -47,6 +48,31 @@ CLAUDE.md (root + repo) and MEMORY.md (index) are auto-injected by Claude Code a
    - `onboard.guide` (string or null) — path to project guide doc
    - `onboard.plan` (string or null) — path to immediate plan doc
 5. Get GitHub repo: `git -C {unix_root} remote get-url origin` and extract `{owner}/{repo}`
+
+## Step 0.5: Skill Sync
+
+Ensure user-level skills at `~/.claude/commands/` match the source of truth in AssemblyZero.
+
+1. List all `.md` files in `C:\Users\mcwiz\Projects\AssemblyZero\.claude\commands\`
+2. For each file that has `scope: global` in its frontmatter:
+   - **Missing locally** (`~/.claude/commands/{name}` does not exist): Copy from AZ. Report: "Deployed {name}"
+   - **Repo is newer** (repo file mtime > local file mtime): Copy from AZ. Report: "Updated {name}"
+   - **Local is newer** (local file mtime > repo file mtime): **Do NOT overwrite.** Warn: "DRIFT: {name} modified locally — commit to AZ or discard"
+   - **Identical or local is same age**: Skip silently
+3. Files with `scope: project` or no `scope` field are NOT synced — they stay project-scoped.
+
+Use `stat` to compare modification times:
+```bash
+stat -c %Y /c/Users/mcwiz/Projects/AssemblyZero/.claude/commands/{name} 2>/dev/null
+stat -c %Y /c/Users/mcwiz/.claude/commands/{name} 2>/dev/null
+```
+
+Copy command (when deploying):
+```bash
+cp /c/Users/mcwiz/Projects/AssemblyZero/.claude/commands/{name} /c/Users/mcwiz/.claude/commands/{name}
+```
+
+**This step runs in ALL modes** (refresh, quick, full). It is fast (file stat comparisons only) and ensures every session has current skills.
 
 ## Modes
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -1,0 +1,91 @@
+---
+description: Import the last handoff context from the previous session
+argument-hint: "[--help]"
+scope: global
+---
+
+# Pickup
+
+**If `$ARGUMENTS` contains `--help`:** Display the Help section below and STOP.
+
+## Help
+
+```
+/pickup - Import context from the last /handoff into this session
+
+Usage: `/pickup`
+
+Reads the most recent entry from data/handoff-log.md in the current repo,
+shows a preview with age, and imports the context on confirmation.
+
+Pair with /handoff: old session runs /handoff → new session runs /pickup.
+```
+
+## Why This Exists
+
+`/handoff` persists a structured context transfer to `data/handoff-log.md`. This command reads it back so the new session starts with full context instead of cold-starting from CLAUDE.md alone.
+
+**Prefer `/onboard`** which includes smart pickup detection (auto-pickup for fresh handoffs, thrashing detection, crash recovery). Direct `/pickup` skips detection and goes straight to import.
+
+## Execution
+
+**Note:** CLAUDE.md (root + repo) and MEMORY.md are auto-injected by Claude Code at session start. Do NOT re-read them.
+
+### Step 1: Locate the Handoff Log
+
+1. Run `git rev-parse --show-toplevel` to find the repo root.
+2. Check if `{repo_root}/data/handoff-log.md` exists.
+3. If not found, tell the user: "No handoff log found at `{repo_root}/data/handoff-log.md`. Run `/handoff` in the previous session first." and STOP.
+
+### Step 2: Extract the Last Entry
+
+1. Read `data/handoff-log.md`.
+2. Find the LAST occurrence of `<!-- handoff-start -->` and its matching `<!-- handoff-end -->`.
+3. Extract the content between these markers — this is the handoff prompt.
+4. Extract the timestamp from the `## Handoff — YYYY-MM-DD HH:MM:SS` header immediately above the start marker.
+
+### Step 3: Show Preview and Age
+
+1. Calculate the age of the handoff (current LOCAL time minus the timestamp). Handoff timestamps are local time -- do NOT use UTC. Use `date +"%Y-%m-%d %H:%M:%S"` (no `-u` flag).
+2. Format age as human-readable: "2 minutes ago", "3 hours ago", "2 days ago".
+3. Check `data/session-index.jsonl` for sessions that started AFTER the handoff timestamp. For each, note the start time, line count, and duration. Sum the totals.
+4. Show the user:
+
+```
+Handoff found -- {YYYY-MM-DD HH:MM:SS} ({age})
+
+Preview (first 5 lines):
+> {line 1}
+> {line 2}
+> {line 3}
+> {line 4}
+> {line 5}
+```
+
+5. If post-handoff sessions exist, show: "Note: {N} session(s) ran after this handoff ({total_lines} lines, {total_hours}h). This handoff may not reflect the latest state."
+6. If the handoff is older than 48 hours, add a warning: "This handoff is {age} old. The codebase may have changed significantly since then."
+
+### Step 4: Confirm Import
+
+Ask the user: "Import this handoff? (Y/n)"
+
+- If declined, say "Pickup cancelled." and STOP.
+- If confirmed, proceed to Step 5.
+
+### Step 5: Import Context
+
+1. Internalize the full handoff prompt as your working context.
+2. Read every file listed in the "Files to Read First" section of the handoff. Actually read them — don't just note the paths.
+3. Summarize what you imported:
+   - What was accomplished in the previous session
+   - What the next steps are
+   - How many files you read from the "Files to Read First" list
+
+Tell the user: "Pickup complete. Ready to continue where the last session left off."
+
+## Rules
+
+- **Append-only** -- never delete or rewrite entries in `data/handoff-log.md`. After pickup is accepted, append a `<!-- picked-up ... -->` marker on the line after the consumed `<!-- handoff-end -->` marker.
+- **Always show age** — the user needs to know how stale the context is.
+- **Always ask before importing** — don't silently load context.
+- **Actually read the files** — the "Files to Read First" section exists so the agent gets grounded in current code, not just the handoff narrative.

--- a/.claude/commands/promote.md
+++ b/.claude/commands/promote.md
@@ -1,6 +1,7 @@
 ---
 description: Promote patterns from child projects to AssemblyZero
 argument-hint: "[--help] [--command NAME] [--tool NAME] [--template DIR] [--permission PATTERN] [--from PROJECT]"
+scope: project
 ---
 
 # Promote to AssemblyZero

--- a/.claude/commands/quote.md
+++ b/.claude/commands/quote.md
@@ -1,0 +1,120 @@
+---
+description: Memorialize a Discworld quote to Claude's World wiki
+allowed-tools: Bash, Read, Edit
+scope: global
+---
+
+# Quote Memorialization
+
+When the user invokes `/quote`, you should find and memorialize the most recent Discworld-inspired quote from this conversation.
+
+## Step 1: Find the Quote
+
+Look back through the last 1-3 turns of conversation for a Discworld-style quote. These typically appear as:
+- Blockquoted text with Discworld character attribution
+- Pratchett-style philosophical observations
+- In-character statements from Discworld personas (Vetinari, Vimes, DEATH, etc.)
+
+Extract:
+- **QUOTE**: The quoted text itself
+- **OCCASION**: A brief description of what prompted it (e.g., "On completing the migration")
+- **CONTEXT**: The fuller context of what was happening when the quote was offered
+- **SOURCE**: If it's a direct Pratchett quote, the book title (e.g., "Lords and Ladies")
+
+If no quote is found in recent turns, inform the user.
+
+## IMPORTANT: Naming Convention
+
+On Claude's World wiki, **never** refer to the human as "the user", "the human", or "the orchestrator".
+
+**The human is "The Great God Om"** — the source of Intent who is carried by Brutha (the RAG system).
+
+The first mention of "The Great God Om" on Claude's World links to a hidden page: `[The Great God Om](The-Great-God-Om)`
+
+Subsequent mentions can just say "Om" without the link.
+
+## Step 2: Get Accurate Timestamp
+
+Run this command to get the current system time:
+```bash
+powershell -Command "Get-Date -Format 'yyyy-MM-dd HH:mm'"
+```
+
+Parse the output into DATE (yyyy-MM-dd) and TIME (HH:mm).
+
+## Step 3: Read Current Wiki
+
+Read: `C:\Users\mcwiz\Projects\AssemblyZero\wiki\Claudes-World.md`
+
+## Step 4: Check Date Section
+
+- If a section `### {DATE}` already exists, append the new entry to that section
+- If not, create a new date section before `## About This Page`
+
+## Step 5: Format Quote Entry
+
+**For direct Pratchett quotes (with SOURCE):**
+```markdown
+---
+
+**{TIME}** — *{OCCASION}*
+> "{QUOTE}"
+
+*— Terry Pratchett, {SOURCE}*
+
+**Context:** {CONTEXT}
+```
+
+**For in-character quotes (no SOURCE):**
+```markdown
+---
+
+**{TIME}** — *{OCCASION}*
+> "{QUOTE}"
+
+**Context:** {CONTEXT}
+```
+
+## Step 6: Update Wiki File
+
+Use Edit tool to insert the new entry before `## About This Page`.
+
+## Step 7: Commit to AssemblyZero
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero add wiki/Claudes-World.md
+```
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero commit -m "docs(wiki): add quote to Claude's World"
+```
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero push
+```
+
+## Step 8: Sync Wiki Repo
+
+```bash
+cp /c/Users/mcwiz/Projects/AssemblyZero/wiki/Claudes-World.md /c/Users/mcwiz/Projects/AssemblyZero.wiki/
+```
+
+```bash
+cp /c/Users/mcwiz/Projects/AssemblyZero/wiki/The-Great-God-Om.md /c/Users/mcwiz/Projects/AssemblyZero.wiki/
+```
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero.wiki add Claudes-World.md The-Great-God-Om.md
+```
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero.wiki commit -m "sync: add quote"
+```
+
+```bash
+git -C /c/Users/mcwiz/Projects/AssemblyZero.wiki push
+```
+
+## Step 9: Confirm
+
+Tell the user: "Quote memorialized to Claude's World wiki."

--- a/.claude/commands/sync-permissions.md
+++ b/.claude/commands/sync-permissions.md
@@ -1,0 +1,120 @@
+---
+description: Clean accumulated one-time permissions from settings (AssemblyZero)
+argument-hint: "[--audit | --clean | --quick | --merge-up] [PROJECT]"
+scope: global
+---
+
+# Sync Permissions
+
+**Cost:** Zero LLM cost - this skill orchestrates a Python tool, no model spawning.
+
+Manage permissions across master (user-level) and project-level settings files.
+
+## Background
+
+Every time you approve a permission prompt, that exact command gets saved. Over time, hundreds of specific one-time commands accumulate:
+
+```json
+"Bash(git -C /c/Users/mcwiz/Projects/Aletheia commit -m \"docs: cleanup 2026-01-10\")"
+```
+
+These are useless clutter. The tool removes them while keeping useful patterns like `Bash(git -C:*)`.
+
+---
+
+## Usage
+
+```
+/sync-permissions                      # Audit current project
+/sync-permissions --audit Aletheia     # Audit specific project
+/sync-permissions --clean              # Remove one-time permissions (dry-run first)
+/sync-permissions --quick              # Fast check (for cleanup integration)
+/sync-permissions --merge-up           # Pull unique patterns from all projects into master
+```
+
+---
+
+## Execution
+
+### Step 1: Determine Project
+
+Parse `$ARGUMENTS` for project name. If none specified, detect from working directory:
+- `/c/Users/mcwiz/Projects/Aletheia` → `Aletheia`
+- `/c/Users/mcwiz/Projects/AssemblyZero` → `AssemblyZero`
+
+### Step 2: Parse Mode
+
+| Argument | Mode |
+|----------|------|
+| (none) or `--audit` | Read-only analysis |
+| `--clean` | Remove one-time permissions |
+| `--quick` | Fast check (exit 0=OK, 1=needs cleaning) |
+| `--merge-up` | Collect unique patterns from projects into master |
+
+### Step 3: Execute
+
+**Audit mode:**
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --audit --project PROJECT_NAME
+```
+
+**Clean mode (always dry-run first):**
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --clean --project PROJECT_NAME --dry-run
+```
+
+Show results and ask: "Remove N one-time permissions? (y/n)"
+
+If yes:
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --clean --project PROJECT_NAME
+```
+
+**Quick mode:**
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --quick-check --project PROJECT_NAME
+```
+
+**Merge-up mode (always dry-run first):**
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --merge-up --all-projects --dry-run
+```
+
+Show results and ask: "Merge N patterns into master? (y/n)"
+
+If yes:
+```bash
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-permissions.py --merge-up --all-projects
+```
+
+### Step 4: Report
+
+Display tool output with summary:
+- Total permissions in file
+- One-time permissions (removable)
+- Reusable patterns (kept)
+- Recommendation
+
+---
+
+## What Gets Removed vs Kept
+
+**REMOVED (one-time, accumulated clutter):**
+- Specific git commits: `git commit -m "specific message"`
+- Specific PR creations with bodies
+- Specific push commands: `git push -u origin specific-branch`
+- Commands on worktrees: `git -C /path/Aletheia-123 ...`
+
+**KEPT (reusable patterns):**
+- Wildcards: `Bash(git -C:*)`, `Bash(poetry:*)`
+- Skills: `Skill(cleanup)`, `Skill(onboard)`
+- Web tools: `WebFetch`, `WebSearch`
+- File patterns: `Read(C:\Users\mcwiz\Projects\**)`
+
+---
+
+## Source of Truth
+
+This skill calls the tool at `AssemblyZero/tools/assemblyzero-permissions.py`.
+
+**If the tool needs fixing, fix it in AssemblyZero - not locally.**

--- a/.claude/commands/test-gaps.md
+++ b/.claude/commands/test-gaps.md
@@ -1,6 +1,7 @@
 ---
 description: Mine reports for testing gaps and automation opportunities
 argument-hint: "[--full] [--file path] [--layer reports|infra|heuristics|all] [--project-type auto|extension|api|webapp|cli]"
+scope: global
 ---
 
 <!--

--- a/.claude/commands/unleashed-version.md
+++ b/.claude/commands/unleashed-version.md
@@ -1,0 +1,23 @@
+---
+description: Unleashed Version Check
+scope: global
+---
+
+# Unleashed Version Check
+
+Check the version of unleashed wrapping this Claude Code session.
+
+## Instructions
+
+Run this Bash command to check the unleashed version:
+
+```bash
+echo $UNLEASHED_VERSION
+```
+
+Then report the result to the user:
+
+- If the variable is set (e.g., "1.3.0"), report: "Running under unleashed v{version}"
+- If the variable is empty/unset, report: "Not running under unleashed (or unleashed < 1.3.1)"
+
+Keep the response brief - just report the version status.


### PR DESCRIPTION
## Summary

- Import 7 previously untracked user-level skills into AssemblyZero as source of truth
- Add `scope: global/project` frontmatter to all 16 skills to control sync behavior
- Add Step 0.5 (Skill Sync) to onboard: compares repo vs `~/.claude/commands/` on every session start, deploys new/updated skills, warns on local drift without overwriting

Closes #906

## Test plan

- [ ] Run `/onboard` in a project — verify Step 0.5 runs and reports no drift (repo and local are identical after initial sync)
- [ ] Edit a local skill (`~/.claude/commands/handoff.md`) — verify next `/onboard` warns about drift
- [ ] Delete a local skill — verify next `/onboard` deploys it from repo
- [ ] Verify `scope: project` skills (death.md, promote.md) are NOT synced to `~/.claude/commands/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)