### PR TITLE
fix: move skill sync from onboard to handoff, AZ-only Closes #909

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -43,6 +43,12 @@ Before generating the handoff, clean up after yourself:
    find /c/Users/mcwiz/Projects/{REPO_NAME} -name "tmpclaude-*-cwd" -type f -delete 2>/dev/null
    ```
 
+5. **Skill sync (AssemblyZero only):** If the current repo is AssemblyZero, run:
+   ```bash
+   python /c/Users/mcwiz/Projects/unleashed/src/skill_sync.py
+   ```
+   This deploys updated `scope: global` skills to `~/.claude/commands/` and warns on local drift. Zero LLM cost — Python handles the comparison.
+
 This step is fast — don't skip it. The next session shouldn't start by cleaning up after this one.
 
 ### Step 1: Gather State (parallel)

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -49,31 +49,6 @@ CLAUDE.md (root + repo) and MEMORY.md (index) are auto-injected by Claude Code a
    - `onboard.plan` (string or null) — path to immediate plan doc
 5. Get GitHub repo: `git -C {unix_root} remote get-url origin` and extract `{owner}/{repo}`
 
-## Step 0.5: Skill Sync
-
-Ensure user-level skills at `~/.claude/commands/` match the source of truth in AssemblyZero.
-
-1. List all `.md` files in `C:\Users\mcwiz\Projects\AssemblyZero\.claude\commands\`
-2. For each file that has `scope: global` in its frontmatter:
-   - **Missing locally** (`~/.claude/commands/{name}` does not exist): Copy from AZ. Report: "Deployed {name}"
-   - **Repo is newer** (repo file mtime > local file mtime): Copy from AZ. Report: "Updated {name}"
-   - **Local is newer** (local file mtime > repo file mtime): **Do NOT overwrite.** Warn: "DRIFT: {name} modified locally — commit to AZ or discard"
-   - **Identical or local is same age**: Skip silently
-3. Files with `scope: project` or no `scope` field are NOT synced — they stay project-scoped.
-
-Use `stat` to compare modification times:
-```bash
-stat -c %Y /c/Users/mcwiz/Projects/AssemblyZero/.claude/commands/{name} 2>/dev/null
-stat -c %Y /c/Users/mcwiz/.claude/commands/{name} 2>/dev/null
-```
-
-Copy command (when deploying):
-```bash
-cp /c/Users/mcwiz/Projects/AssemblyZero/.claude/commands/{name} /c/Users/mcwiz/.claude/commands/{name}
-```
-
-**This step runs in ALL modes** (refresh, quick, full). It is fast (file stat comparisons only) and ensures every session has current skills.
-
 ## Modes
 
 | Mode | Use Case |


### PR DESCRIPTION
## Summary

- Remove Step 0.5 (Skill Sync) from onboard.md — it cost LLM tokens on every session start across all projects
- Add skill sync to handoff.md Step 0, gated on repo == AssemblyZero
- Sync runs via `python unleashed/src/skill_sync.py` — zero LLM cost
- Only triggers when handing off from AZ (where skills are edited)

Closes #909

## Test plan

- [ ] Run `/onboard` — verify no skill sync step executes
- [ ] Run `/handoff` in AZ — verify skill sync runs and reports status
- [ ] Run `/handoff` in unleashed — verify skill sync does NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)