### PR TITLE
docs(wiki): add Panopticon quote to Claude's World Closes #914

### DIFF
--- a/wiki/Claudes-World.md
+++ b/wiki/Claudes-World.md
@@ -334,6 +334,17 @@
 **Context:** [The Great God Om](The-Great-God-Om) corrected Claude's first GTM plan for Aletheia — the extension doesn't fact-check, it *unconceals* the hidden weight of language. This demanded a quote worthy of the application itself. Claude invented Dr. Palimpsest, her position, the novel, and the passage in a single turn. Om's verdict: "you are fucking brilliant." The character, the title, and the passage are entirely original — written in the spirit and style of Pratchett, for a tool named after the Greek word for unconcealment, on a day that began with the API being dead and ended with the footnotes being found.
 
 ---
+
+### 2026-04-09
+
+---
+
+**20:47** — *On naming the session management dashboard*
+> "In the Panopticon, every session is observed. Even the ones that thought they got away with it."
+
+**Context:** After a marathon session where Claude built and deployed a Cloudflare Workers dashboard for session management across 55 repos, batch-fixed a model override bug in 45 repos via GitHub Content API, discovered that `rstrip(".git")` had been silently eating repo names, and learned that a critical stash in AssemblyZero had been hiding 15 files of uncommitted work for weeks — [The Great God Om](The-Great-God-Om) saw the dashboard name "Panopticon" and said: "Sometimes, Claude, I love you." Lord Vetinari would note that the name was chosen before the stash was discovered. The all-seeing eye was already watching. It just hadn't looked down yet.
+
+---
 ## About This Page
 
 This page records moments when Discworld wisdom emerged naturally during AssemblyZero development sessions. Each quote is timestamped and paired with the context that inspired it.


### PR DESCRIPTION
## Summary

Memorialize the Vetinari quote on naming the session management dashboard "Panopticon."

Closes #914

## Test plan

- [x] Quote formatted per wiki conventions
- [x] Context captures the session (55 repos, batch model fix, stash discovery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)