### PR TITLE
feat: post-plan-write hook + plan-state handoff support (Closes #916)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -60,7 +60,11 @@ Run these in parallel to supplement your memory with current facts:
    pwd && git rev-parse --show-toplevel 2>/dev/null && echo $UNLEASHED_VERSION && date '+%Y-%m-%d %H:%M:%S'
    ```
 
-2. **Plan file** — Read the plan file if one exists (check `C:\Users\mcwiz\.claude\plans\` for the most recent `.md` file). Note which phases are complete.
+2. **Plan snapshot (deterministic):** Run
+   ```bash
+   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py status
+   ```
+   Read the emitted JSON. Use its fields (`plan_path`, `plan_slug`, `plan_state`, `total_steps`, `completed_steps`, `remaining_steps`) in the `## The Plan` section below. Do NOT reconstruct plan state from memory — the JSON is the source of truth. If `status: "no_plan"`, skip the `## The Plan` section entirely. If `status: "error"`, note the error in `## The Plan` and continue.
 
 3. **Git status across touched repos** — For every repo you modified this session, run:
    ```bash
@@ -109,8 +113,21 @@ Output a single markdown block to the screen (NOT to a file). The user will copy
 
 ## The Plan
 
-{If a plan file exists, checklist with phases complete/pending. Include plan file path.
-If no plan, state the user's intent.}
+{If Step 1.2 emitted `status: "ok"`, include the parseable block below filled in from the JSON. /onboard and /pickup parse this block to decide whether to resume the plan. If `status: "no_plan"`, omit this section entirely.}
+
+<!-- plan-state-start -->
+```yaml
+plan_path: {from JSON plan_path}
+plan_slug: {from JSON plan_slug}
+plan_state: {active | completed}
+total_steps: {from JSON}
+completed_steps: {from JSON}
+remaining_steps: {from JSON}
+archive_path: {from the Step 5.4B archive call result, or omit if archive failed}
+```
+<!-- plan-state-end -->
+
+{Optional human-readable checklist or narrative below the block — agents can read it, but machines read the block above.}
 
 ## What To Do Next
 
@@ -214,6 +231,14 @@ After outputting the prompt to screen, persist it to the repo's handoff log so i
 
 6. **Confirm to user:** "Handoff logged to `{path}`"
 
+7. **Archive the active plan (deterministic):** If the Step 1.2 JSON had `status: "ok"`, run:
+   ```bash
+   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py archive --slug {plan_slug}
+   ```
+   If `plan_state == "completed"` in that JSON, add `--mark-completed` to the command. The archiver is idempotent — if the live plan matches the newest archive, it emits `status: "already_archived"` and no-ops. Skip this step if Step 1.2 returned `status: "no_plan"` or `status: "error"`.
+
+   After archiving succeeds, update the `archive_path` field in the `<!-- plan-state-start -->` block in `data/handoff-log.md` with the path from the archiver's JSON output. This is what /onboard and /pickup read to resume or ignore the plan.
+
 ### Step 5B: Persist Lessons Learned
 
 Lessons learned are institutional knowledge — they get committed, unlike the handoff log.
@@ -288,7 +313,7 @@ After persisting the handoff log, spawn a new unleashed session. Auto-onboard (d
 
 - **Be concrete, not summary.** "Updated 3 files" is useless. "Updated `Architecture.md`, `Version-History.md`, `Version-Promotions.md`" is useful.
 - **Include commit SHAs.** The next agent can `git show` them to understand changes.
-- **Include the plan file path.** The next agent should read it, not reconstruct it.
+- **Plan state is machine-read.** The `<!-- plan-state-start -->` YAML block in `## The Plan` is the source of truth for /onboard and /pickup. Fill it from `plan_archiver.py status` output — do NOT reconstruct it from memory. Archive the plan in Step 5.7 so the next session knows whether to resume it.
 - **Don't pad.** If nothing happened in a section, skip it. A shorter, accurate prompt beats a longer, padded one.
 - **User preferences go in "Key Decisions."** Things like "user doesn't want numbered options" or "always use poetry run python" — if you learned it this session and it's not in CLAUDE.md or MEMORY.md, capture it here.
 - **Always persist** — the log survives even if the clipboard is lost.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -139,8 +139,15 @@ If post-handoff sessions exist, show: "Note: {N} session(s) ran after this hando
 **Pickup import (when triggered):**
 1. Extract full content between `<!-- handoff-start -->` and `<!-- handoff-end -->`
 2. Internalize as working context
-3. Read every file listed in the "Files to Read First" section
-4. Report: "Picked up handoff from {age}. {N} files read."
+3. **Parse the plan-state block (deterministic).** If the handoff contains a `<!-- plan-state-start -->` / `<!-- plan-state-end -->` block, read the YAML inside. Apply this decision logic:
+   - `plan_state: completed` → Tell user: "Previous plan `{plan_slug}` was completed (archived at `{archive_path}`). Starting fresh." Do NOT read the plan file.
+   - `plan_state: active` with `remaining_steps > 0` → Tell user: "Resuming plan `{plan_slug}`: {completed_steps}/{total_steps} steps done." Read `{plan_path}` and treat it as the active plan for this session.
+   - `plan_path` is set but the file is missing → Fall back to `{archive_path}`. Warn user: "Live plan missing, reading archived copy instead."
+   - No plan-state block, or `plan_state: none` → Continue without a plan.
+4. Read every file listed in the "Files to Read First" section
+5. **Write the pickup marker** by running: `python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
+   If it fails, report the error to the user. Do NOT proceed silently.
+6. Report: "Picked up handoff from {age}. {N} files read."
 
 ### Step 2: Project Context
 
@@ -183,6 +190,6 @@ Then ask: "What do you want to work on next?"
 - Use absolute paths and `git -C` patterns (no cd && chaining)
 - Use `--repo {owner}/{repo}` for all gh commands
 - CLAUDE.md and MEMORY.md are already in context — never re-read them
-- `data/handoff-log.md` is append-only -- never delete or rewrite entries. Pickup markers (`<!-- picked-up ... -->`) may be appended after `<!-- handoff-end -->`
+- `data/handoff-log.md` is append-only -- never delete or rewrite entries. Pickup markers are written by `pickup_marker.py` (Step 1C.5), not by the agent directly.
 - `data/session-index.jsonl` is read-only — never modify it
 - If no `.unleashed.json` exists, use defaults: `assemblyZero=false`, `pickupThreshold=10`, no guide, no plan

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -75,17 +75,25 @@ Ask the user: "Import this handoff? (Y/n)"
 ### Step 5: Import Context
 
 1. Internalize the full handoff prompt as your working context.
-2. Read every file listed in the "Files to Read First" section of the handoff. Actually read them — don't just note the paths.
-3. Summarize what you imported:
+2. **Parse the plan-state block (deterministic).** If the handoff contains a `<!-- plan-state-start -->` / `<!-- plan-state-end -->` block, read the YAML inside. Apply this decision logic:
+   - `plan_state: completed` → Tell user: "Previous plan `{plan_slug}` was completed (archived at `{archive_path}`). Starting fresh." Do NOT read the plan file.
+   - `plan_state: active` with `remaining_steps > 0` → Tell user: "Resuming plan `{plan_slug}`: {completed_steps}/{total_steps} steps done." Read `{plan_path}` and treat it as the active plan for this session.
+   - `plan_path` is set but the file is missing → Fall back to `{archive_path}`. Warn user: "Live plan missing, reading archived copy instead."
+   - No plan-state block, or `plan_state: none` → Continue without a plan.
+3. Read every file listed in the "Files to Read First" section of the handoff. Actually read them — don't just note the paths.
+4. Summarize what you imported:
    - What was accomplished in the previous session
    - What the next steps are
    - How many files you read from the "Files to Read First" list
+   - Whether a plan was resumed, started fresh, or absent
+5. **Write the pickup marker** by running: `python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
+   If it fails, report the error to the user. Do NOT proceed silently.
 
 Tell the user: "Pickup complete. Ready to continue where the last session left off."
 
 ## Rules
 
-- **Append-only** -- never delete or rewrite entries in `data/handoff-log.md`. After pickup is accepted, append a `<!-- picked-up ... -->` marker on the line after the consumed `<!-- handoff-end -->` marker.
+- **Append-only** -- never delete or rewrite entries in `data/handoff-log.md`. The pickup marker is written by `pickup_marker.py` (Step 5.5), not by the agent directly.
 - **Always show age** — the user needs to know how stale the context is.
 - **Always ask before importing** — don't silently load context.
 - **Actually read the files** — the "Files to Read First" section exists so the agent gets grounded in current code, not just the handoff narrative.

--- a/.claude/hooks/post-plan-write.sh
+++ b/.claude/hooks/post-plan-write.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# post-plan-write.sh — PostToolUse hook for Edit|Write.
+#
+# Fires on every Write/Edit to any file. Filters by path: if the
+# edited file is under ~/.claude/plans/*.md (but NOT under plans-archive/),
+# invokes unleashed/src/plan_archiver.py to archive with versioning.
+#
+# Contract:
+# - Reads hook JSON from stdin (tool_input.file_path is the edited file).
+# - Always exits 0 — hook failures must NEVER block the tool call.
+# - The archiver runs in --from-hook mode: quiet, always exits 0, writes
+#   status JSON to ~/.claude/plans-archive/.last-archive.json.
+#
+# Fixes: unleashed #275, #276
+# Canonical source: AssemblyZero/.claude/hooks/post-plan-write.sh
+# ADR: docs/adrs/0215-claude-hook-locations.md
+
+set -u
+
+PLAN_ARCHIVER="/c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py"
+
+# Read hook input from stdin. jq is available on the user's machine per
+# CLAUDE.md install.sh. If jq is missing or the JSON is malformed, exit 0.
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Nothing to do if jq failed or there's no file_path
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+# Normalize backslashes to forward slashes for bash path matching
+NORMALIZED=${FILE_PATH//\\//}
+
+# Match ~/.claude/plans/*.md but exclude plans-archive/*
+case "$NORMALIZED" in
+    */.claude/plans/*.md)
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+
+# Explicitly exclude archive dir (shouldn't match above but be safe)
+case "$NORMALIZED" in
+    */.claude/plans-archive/*)
+        exit 0
+        ;;
+esac
+
+# Skip hidden files (e.g. .plan-status.json — though the glob above
+# should not match it anyway)
+BASENAME=$(basename "$NORMALIZED")
+case "$BASENAME" in
+    .*) exit 0 ;;
+esac
+
+# Extract slug: strip directory and .md extension
+SLUG="${BASENAME%.md}"
+
+# Skip if plan_archiver.py is missing (e.g. unleashed moved or not yet deployed)
+if [ ! -f "$PLAN_ARCHIVER" ]; then
+    exit 0
+fi
+
+# Invoke archiver in hook mode. Always exit 0.
+python "$PLAN_ARCHIVER" archive --slug "$SLUG" --from-hook >/dev/null 2>&1 || true
+
+exit 0

--- a/docs/adrs/0215-claude-hook-locations.md
+++ b/docs/adrs/0215-claude-hook-locations.md
@@ -1,0 +1,78 @@
+# ADR-0215: Claude Hook Canonical Locations
+
+**Status:** Accepted
+**Date:** 2026-04-12
+**Categories:** Process, Tooling
+
+## 1. Context
+
+Claude Code hooks configured in `~/.claude/settings.json` currently reference scripts living in three different locations with no single canonical source:
+
+- **User-local** — `~/.claude/hooks/*.sh` — 6 scripts, not under version control, edited in place
+- **AssemblyZero** — `AssemblyZero/.claude/hooks/*.sh` — 5 scripts, versioned in this repo, some overlap with user-local
+- **dotfiles** — `dotfiles/.claude/hooks/*.sh` — 2 scripts, versioned in the dotfiles repo, references a `dotfiles/.claude/settings.json` that has diverged from the live `~/.claude/settings.json`
+
+Adding a new hook (the `post-plan-write.sh` shipped in this PR for the plan-archiver work on unleashed #275/#276) forced the question: where does this one live, and where should all hooks live long term?
+
+## 2. Inventory of current hooks
+
+Hooks referenced by the live `~/.claude/settings.json` as of 2026-04-12:
+
+| Hook | Path | Matcher | Canonical source today |
+|------|------|---------|-----------------------|
+| `secret-guard.sh` | `~/.claude/hooks/` | PreToolUse / Bash | user-local (also copy in dotfiles) |
+| `bash-gate.sh` | `~/.claude/hooks/` | PreToolUse / Bash | user-local (also copy in dotfiles) |
+| `pre-commit-report-check.sh` | `~/.claude/hooks/` | PreToolUse / Bash | user-local only |
+| `pre-edit-check.sh` | `~/.claude/hooks/` | PreToolUse / Edit\|Write | user-local only |
+| `pre-edit-security-warn.sh` | `~/.claude/hooks/` | PreToolUse / Edit\|Write | user-local only |
+| `secret-file-guard.sh` | `AssemblyZero/.claude/hooks/` | PreToolUse / Edit\|Write | AZ (this repo) |
+| `post-edit-lint.sh` | `~/.claude/hooks/` | PostToolUse / Edit\|Write | user-local only |
+| `post-plan-write.sh` (NEW) | `AssemblyZero/.claude/hooks/` | PostToolUse / Edit\|Write | AZ (this repo) |
+
+Additional scripts present in each directory but NOT referenced by any hook in `~/.claude/settings.json`:
+
+- `AssemblyZero/.claude/hooks/post_output_cascade_check.py`
+- `AssemblyZero/.claude/hooks/post-commit`
+- `AssemblyZero/.claude/hooks/bash-gate.sh` (duplicate of user-local — history unclear)
+- `AssemblyZero/.claude/hooks/secret-guard.sh` (duplicate of user-local — history unclear)
+- `dotfiles/.claude/hooks/bash-gate.sh`
+- `dotfiles/.claude/hooks/secret-guard.sh`
+
+## 3. Decision
+
+**New rule for all future hooks:** canonical source is `AssemblyZero/.claude/hooks/`. `~/.claude/settings.json` references them via absolute path (`/c/Users/mcwiz/Projects/AssemblyZero/.claude/hooks/{name}.sh`).
+
+**Why AssemblyZero and not dotfiles or unleashed:**
+
+- **dotfiles** — the live `~/.claude/settings.json` has diverged significantly (~105 lines vs 24 in dotfiles). Sync is broken. Using dotfiles as canonical would require fixing the sync first, and the user memory "Never push to dotfiles repo directly — edit `~/.bash_profile`, auto-sync handles the rest" only covers bash_profile, not `.claude`. Out of scope.
+- **unleashed** — unleashed is a Python wrapper product, not a dotfiles/config home. Adding a top-level `hooks/` dir there mixes concerns.
+- **AssemblyZero** — already hosts `.claude/commands/` as canonical source for user skills (synced by `unleashed/src/skill_sync.py` to `~/.claude/commands/`), already has a `.claude/hooks/` dir with one production hook (`secret-file-guard.sh`) referenced by the live settings. AZ is the existing pattern.
+
+**Rule:** the new `post-plan-write.sh` lives in AZ. The existing user-local hooks are NOT migrated in this ADR — that's a follow-up chore — but new hooks MUST go to AZ unless there's a written exception.
+
+**No sync script for hooks (yet).** Unlike `.claude/commands/` (synced by `skill_sync.py` because `~/.claude/commands/` is the path Claude Code reads skills from), `.claude/hooks/` files are referenced by absolute path from `~/.claude/settings.json`. They do NOT need to be copied anywhere — Claude Code invokes them directly via the path in the settings file. This means no sync fragility: if AZ is on disk, the hook works; if AZ is moved, the hook path breaks the same way `secret-file-guard.sh` would.
+
+## 4. Settings.json source of truth
+
+Separately: the live `~/.claude/settings.json` is the working copy. The `dotfiles/.claude/settings.json` has drifted. The decision here is **NOT** to back-port the live settings into dotfiles in this PR (see unleashed #275 open question "edit both and reconcile later"). A future ADR / chore will reconcile them. For now: edit `~/.claude/settings.json` directly when adding hooks, and accept that dotfiles is a stale copy.
+
+## 5. Follow-up (not in this PR)
+
+1. Move the 6 user-local `~/.claude/hooks/*.sh` scripts into `AssemblyZero/.claude/hooks/` and update `~/.claude/settings.json` paths. One PR, pure move, verify each hook still fires.
+2. Delete the unused duplicates in `AssemblyZero/.claude/hooks/` (`bash-gate.sh`, `secret-guard.sh`) or promote them to canonical and point settings at them.
+3. Reconcile `dotfiles/.claude/settings.json` with the live file, or remove the stale copy from dotfiles.
+4. Decide whether `.claude/hooks/post_output_cascade_check.py` and `.claude/hooks/post-commit` should be wired up or deleted.
+
+## 6. Consequences
+
+**Good:**
+
+- One canonical home for new hooks — no per-case relocation debate.
+- AZ is already trusted as a canonical source for `.claude/commands/`; reusing it for hooks is consistent.
+- No new sync tooling. The absolute-path model keeps hooks simple.
+
+**Bad:**
+
+- Absolute paths tie the hook config to the specific filesystem layout. Moving `~/Projects/AssemblyZero` breaks every hook that references it. This risk is pre-existing (the `secret-file-guard.sh` reference has the same exposure).
+- Existing user-local hooks are left in place, so the state is "new hooks in AZ, old hooks in `~/`" until the follow-up migration runs. Mixed state is confusing.
+- The sync problem with `dotfiles/.claude/settings.json` is acknowledged but not fixed here.


### PR DESCRIPTION
## Summary

- Part 2 of a 2-PR plan lifecycle feature. Part 1 is unleashed #278 which added `src/plan_archiver.py`.
- Adds `.claude/hooks/post-plan-write.sh` — a PostToolUse hook that fires on every Edit/Write and archives any write to `~/.claude/plans/*.md`.
- Edits `/handoff`, `/onboard`, `/pickup` skills to use deterministic `plan_archiver.py` calls instead of agent-prose plan reading.
- Adds ADR 0215 documenting canonical hook locations (AZ `.claude/hooks/`).

## Why

Plans were being overwritten in place and finished plans were re-executing after context compact. Two root causes (unleashed #275 + #276):

- `/handoff` told agents to 'read the plan file and note which phases are complete' as prose — agents skipped, misread, or hallucinated the state.
- `/plan` overwrites `~/.claude/plans/{slug}.md` every call, destroying history. Same slug got clobbered 10+ times in one session.

Both are fixed by deterministic Python + a PostToolUse hook.

## The changes

### New hook: .claude/hooks/post-plan-write.sh

- Triggered by existing PostToolUse Edit|Write matcher (second entry under the same hook block in ~/.claude/settings.json).
- Reads hook JSON from stdin, extracts tool_input.file_path via jq.
- Filters: only fires for *.claude/plans/*.md (excludes archive dir and hidden files).
- Extracts slug from basename, invokes plan_archiver.py archive --slug {slug} --from-hook.
- Always exits 0 — hook failures must never block the tool call.
- The archiver is idempotent on content hash, so the hook is safe to fire on every keystroke-sized edit.

### Skill edits

handoff.md:
- Step 1.2: replaces prose Read the plan file with a literal python plan_archiver.py status subprocess call.
- Step 5.7 (NEW): after appending the handoff block, archives the plan via plan_archiver.py archive --slug {plan_slug}. Uses --mark-completed when plan_state=completed.
- ## The Plan section template: replaces prose checklist with a parseable <!-- plan-state-start --> / <!-- plan-state-end --> YAML block.

onboard.md and pickup.md:
- Added plan-state parsing to the pickup-import path with a decision table.
- Drift reconcile: both files were missing the pickup_marker.py subprocess step that had been edited into ~/.claude/commands/ without being committed here. Back-ported so AZ is the source of truth again.

### New ADR: 0215-claude-hook-locations.md

Inventories every hook currently referenced in ~/.claude/settings.json (6 user-local, 1 AZ, 1 new). Establishes AZ .claude/hooks/ as canonical for new hooks.

## Dependencies

Requires unleashed #278 (src/plan_archiver.py) to be merged on main. Already merged as of this PR.

## Test plan

- [x] Hook end-to-end smoke test: sent simulated hook JSON through post-plan-write.sh, confirmed plan_archiver.py ran, archive file created, status JSON written
- [x] Idempotence: second invocation emitted status=already_archived with no new file
- [x] Path filter: non-plan path (README.md) exits 0 without invoking archiver
- [x] Error path: non-existent slug writes error JSON and exits 0
- [ ] Post-merge: verify /plan triggers the hook (depends on whether it uses the public Write tool). If not, Step 5.7 is the backstop.
- [ ] Post-merge: /handoff test session with active plan, inspect handoff block for YAML plan-state section.
- [ ] Post-merge: /onboard --pickup with plan_state=completed and verify plan file is NOT re-read.

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)