### PR TITLE
feat: /handoff Step 6 spawns unleashed-alpha, not unleashed (Closes #921)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -297,17 +297,17 @@ Brief backward-looking record of the session. One entry per session.
 
 **OTHERWISE:**
 
-After persisting the handoff log, spawn a new unleashed session. Auto-onboard (default in v30+) detects the fresh handoff and auto-picks up the context.
+After persisting the handoff log, spawn a new `unleashed-alpha` session. Auto-onboard (default in v30+) detects the fresh handoff and auto-picks up the context. **Always spawn the alpha tier**, not production — this ensures every post-handoff session lands on the current-iteration build so new fixes get exercised. Users who need production can still invoke `unleashed` manually.
 
 1. **Get repo root Windows path:** Convert the git toplevel path to a Windows path with backslashes (e.g. `C:\Users\mcwiz\Projects\AssemblyZero`)
 2. **Get repo name uppercased** for the window title (e.g. `ASSEMBLYZERO`)
 3. **Get Unix-style repo path** for the cd command (e.g. `/c/Users/mcwiz/Projects/AssemblyZero`)
 4. **Spawn via Python** (MSYS2 mangles paths — must go through cmd.exe):
    ```bash
-   python -c "import subprocess; subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed\"', shell=True)"
+   python -c "import subprocess; subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed-alpha\"', shell=True)"
    ```
-   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps.
-5. **Tell user:** "New unleashed session spawning in {REPO_NAME} with auto-onboard."
+   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed-alpha`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps.
+5. **Tell user:** "New unleashed-alpha session spawning in {REPO_NAME} with auto-onboard."
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- **Change:** `/handoff` Step 6 spawn command now ends in `&& unleashed-alpha` instead of `&& unleashed`. Every post-handoff Windows Terminal session lands on the current alpha build.
- **File:** `.claude/commands/handoff.md` — 4 lines changed (lines 300, 307, 309, 310: command + description + user-facing message).
- **Deployed:** `~/.claude/commands/handoff.md` already synced via `python /c/Users/mcwiz/Projects/unleashed/src/skill_sync.py`. Verified `unleashed-alpha` appears on all four lines.

## Motivation

Today (2026-04-15) I shipped unleashed c-33 with the Tab-to-amend false-positive fix (unleashed #311, PR #312). `/handoff` was still spawning production c-31, so new sessions never landed on c-33 — the whole point of the alpha tier is undermined when the handoff flow routes around it.

More generally: the alpha → beta → prod tier system exists so the current-iteration build gets exercised. If /handoff bypasses alpha, bugs fixed in alpha don't surface until someone manually runs `unleashed-alpha`, which is rare after a handoff-triggered window reboot.

Users who specifically need production can still invoke `unleashed` manually — this change only affects the auto-spawn path.

## Risk

- **Low.** `unleashed-alpha` is a bash function defined in `~/.bash_profile`, available in any `bash -l` shell the spawn creates.
- If an alpha ever breaks badly enough that the spawn fails outright, the user can fall back to `unleashed` in any terminal.
- Rollback: revert commit, re-run `skill_sync.py`.

## Not in this PR

- No change to the gemini or codex alpha routing (handoff only spawns the claude wrapper).
- No change to the manual `unleashed` / `unleashed-beta` aliases.

Closes #921

## Test plan

- [x] Edit applied to `AssemblyZero/.claude/commands/handoff.md`
- [x] `skill_sync.py` deployed edit to `~/.claude/commands/handoff.md`
- [x] Verified all four references (spawn command + description + user message) now say `unleashed-alpha`
- [ ] Run `/handoff` in a test session — confirm spawned window runs `unleashed-alpha` and lands on c-33

🤖 Generated with [Claude Code](https://claude.com/claude-code)