### PR TITLE
docs: fix obsolete content in new-repo runbook chain (Closes #924)

### DIFF
--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -4654,8 +4654,8 @@ Skill documentation uses the c/p convention (CLI + Prompt pairs).
 | docs/runbooks/0924-implementation-spec-feature-inventory-as-code-node.md | 0924-implementation-spec-feature-inventory-as-code-node.md | Runbooks | Active |
 | docs/runbooks/0925-agent-token-setup.md | 0925-agent-token-setup.md | Runbooks | Active |
 | docs/runbooks/0926-branch-protection-setup.md | 0926-branch-protection-setup.md | Runbooks | Active |
-| docs/runbooks/0927-ai-cli-tools-reference.md | 0927-ai-cli-tools-reference.md | Runbooks | Active |
 | docs/runbooks/0927-new-repo-human-checklist.md | 0927-new-repo-human-checklist.md | Runbooks | Active |
+| docs/runbooks/0929-ai-cli-tools-reference.md | 0929-ai-cli-tools-reference.md | Runbooks | Active |
 | docs/security/secret-guard-briefing.md | secret-guard-briefing.md | Security | Active |
 | docs/session-logs/2026-01-13.md | 2026-01-13.md | Session-logs | Active |
 | docs/session-logs/2026-01-14.md | 2026-01-14.md | Session-logs | Active |

--- a/docs/runbooks/0900-runbook-index.md
+++ b/docs/runbooks/0900-runbook-index.md
@@ -44,9 +44,9 @@ Quick reference for the user (Marty) on how to run tools, commands, agents, audi
 | 0923 | [Workflow Recovery and --resume](0923-workflow-recovery.md) | Manual | On interruption | - |
 | 0925 | [Agent Token Setup](0925-agent-token-setup.md) | Manual | Quarterly (rotation) | - |
 | 0926 | [Branch Protection Setup](0926-branch-protection-setup.md) | Manual | On new repo | - |
-| 0927 | [AI CLI Tools Reference](0927-ai-cli-tools-reference.md) | Reference | - | All |
-| 0928 | [New Repo: Human Checklist](0927-new-repo-human-checklist.md) | Manual | On new repo | - |
-| 0929 | [Cloudflare Zone Setup](0928-cloudflare-zone-setup.md) | Manual | On new domain | - |
+| 0927 | [New Repo: Human Checklist](0927-new-repo-human-checklist.md) | Manual | On new repo | - |
+| 0928 | [Cloudflare Zone Setup](0928-cloudflare-zone-setup.md) | Manual | On new domain | - |
+| 0929 | [AI CLI Tools Reference](0929-ai-cli-tools-reference.md) | Reference | - | All |
 
 ## Model Selection Guide
 
@@ -61,7 +61,7 @@ When running audits or tasks, use the appropriate model to balance cost and capa
 | **GPT-5.4 (Codex)** | With ChatGPT sub | Security-sensitive execution (native sandbox) |
 
 See `docs/0800-common-audits.md` for per-audit model recommendations.
-See [0927](0927-ai-cli-tools-reference.md) for full tool comparison.
+See [0929](0929-ai-cli-tools-reference.md) for full tool comparison.
 
 ## Extended Thinking / Reasoning Effort
 

--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -25,6 +25,8 @@ Initialize a new project with the canonical AssemblyZero structure, enabling:
 | AssemblyZero cloned | `ls /c/Users/mcwiz/Projects/AssemblyZero` |
 | GitHub CLI | `gh auth status` |
 
+> **PAT dance required.** The setup script pushes `.github/workflows/` files, which needs a classic PAT (the fine-grained agent PAT deliberately lacks `workflow` scope). Switch to classic PAT before running, then switch back immediately after. Full procedure: [0927 - New Repo: Human Checklist](0927-new-repo-human-checklist.md) steps 1 and 3.
+
 ---
 
 ## Quick Start (Automated)
@@ -141,7 +143,7 @@ options:
 
 ### 1. Deploy Cerberus Secrets (If Needed)
 
-The script deploys PR governance workflows (`pr-sentinel.yml`, `auto-reviewer.yml`) and configures branch protection automatically. The only remaining step is ensuring Cerberus secrets exist on the new repo. See [0927 - Human Checklist](0927-new-repo-human-checklist.md) step 2 for the fleet-wide deploy process.
+The script deploys PR governance workflows (`pr-sentinel.yml`, `auto-reviewer.yml`) and configures branch protection automatically. The only remaining step is ensuring Cerberus secrets exist on the new repo. See the [Cerberus secrets section of the Human Checklist](0927-new-repo-human-checklist.md#4-deploy-cerberus-secrets-if-needed) for the fleet-wide deploy process.
 
 ### 2. Add Advanced Hooks (Optional)
 
@@ -151,13 +153,13 @@ The script creates a minimal `settings.json` without hooks. For worktree protect
 poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-generate.py --project MyNewProject
 ```
 
-### 4. Set Up Encrypted Ideas Folder (Optional)
+### 3. Set Up Encrypted Ideas Folder (Optional)
 
 ```bash
 poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/assemblyzero-generate.py --project MyNewProject --ideas
 ```
 
-### 5. Customize CLAUDE.md
+### 4. Customize CLAUDE.md
 
 Edit `MyNewProject/CLAUDE.md` to add project-specific:
 - Workflow rules
@@ -165,7 +167,7 @@ Edit `MyNewProject/CLAUDE.md` to add project-specific:
 - Forbidden commands
 - Integration details
 
-### 6. Create First Issue
+### 5. Create First Issue
 
 ```bash
 gh issue create --repo your-username/MyNewProject --title "Initial setup" --body "Project scaffolded with AssemblyZero"

--- a/docs/runbooks/0925-agent-token-setup.md
+++ b/docs/runbooks/0925-agent-token-setup.md
@@ -61,7 +61,6 @@ Select **All repositories** (public and private).
 | Pages | Read and Write | Wiki pages, GitHub Pages deployments |
 | Pull requests | Read and Write | Create/merge PRs |
 | Webhooks | Read and Write | Webhook management (sentinel, etc.) |
-| Workflows | Read and Write | Create/modify `.github/workflows/` files |
 
 **Read-only (auto-enabled):**
 
@@ -69,12 +68,13 @@ Select **All repositories** (public and private).
 |------------|--------|-----|
 | Metadata | Read-only | Required by GitHub (cannot change) |
 
-**DO NOT GRANT (the only two that matter):**
+**DO NOT GRANT (the three that matter):**
 
 | Permission | Why NOT |
 |------------|---------|
 | **Administration** | Would allow bypassing branch protection (`--admin`) |
 | **Secrets** | Agents must never access repo secrets |
+| **Workflows** | Would allow the agent to modify its own governance workflows (`.github/workflows/pr-sentinel.yml`, `auto-reviewer.yml`). Agents must not modify their own guardrails. Pushing workflow files is a human task — switch to a classic PAT temporarily, see [0927 - New Repo: Human Checklist](0927-new-repo-human-checklist.md) steps 1 and 3. |
 
 Everything else not listed above: leave at **No access**.
 
@@ -214,3 +214,4 @@ This token is one layer in a three-layer defense:
 |------|--------|
 | 2026-03-07 | Initial runbook created |
 | 2026-03-07 | Updated permissions: grant Actions, Commit statuses, Dependabot alerts, Pages, Webhooks, Workflows. Block only Administration + Secrets. All repos scope. |
+| 2026-04-18 | **Correction:** removed `Workflows` from granted permissions and added to DO NOT GRANT list. The agent PAT must not be able to modify its own governance workflows. Workflow pushes are a human task via classic PAT. Aligns with 0927, 0926, and Standard 0016. (Closes #924) |

--- a/docs/runbooks/0926-branch-protection-setup.md
+++ b/docs/runbooks/0926-branch-protection-setup.md
@@ -1,8 +1,8 @@
 # 0926 - Branch Protection Setup (Manual)
 
 **Category:** Runbook / Operational Procedure
-**Version:** 2.0
-**Last Updated:** 2026-03-18
+**Version:** 2.1
+**Last Updated:** 2026-04-18
 
 ---
 
@@ -11,6 +11,16 @@
 Configure branch protection for new repos when the agent PAT cannot do it. The fine-grained PAT deliberately excludes Administration scope (see [0925](0925-agent-token-setup.md)), so branch protection must be set manually via browser.
 
 **When to use:** After creating a new repo and pushing at least one commit, or after any repo creation where the agent reports a 403 on branch protection.
+
+> ### ⚠️ Mechanism mismatch — read before following these steps
+>
+> This runbook uses GitHub's newer **Rulesets** UI. However, `tools/new_repo_setup.py` uses the **classic Branch Protection API** (`PUT /repos/{owner}/{repo}/branches/main/protection`), as does every script in the fleet (`fix_branch_protections.py`, `deploy_auto_reviewer_fleet.py`, `github_protection_audit.py`). All 48+ protected repos in the fleet use classic branch protection, not rulesets.
+>
+> **If the script ran successfully:** you do NOT need this runbook. The script already set classic branch protection correctly.
+>
+> **If you follow the manual steps below:** the resulting ruleset works functionally (same rules enforced), but the repo will appear as a ruleset-protected outlier in `data/branch-protection-audit.csv` instead of matching the fleet majority. Known outlier of this type: `patent-general` (#748 history).
+>
+> **Preferred recovery path when the script fails on branch protection:** re-run only the `configure_branch_protection()` step with a classic PAT. This keeps the repo consistent with the fleet. Full alignment to classic-protection manual steps is tracked under #924.
 
 ---
 
@@ -119,3 +129,4 @@ git checkout -- README.md
 |------|--------|
 | 2026-03-09 | Initial runbook created (from patent-general setup experience) |
 | 2026-03-18 | v2.0: Reordered rules to match GitHub UI top-to-bottom. Added Cerberus-AZ step. Changed required approvals from 0 to 1 (Cerberus auto-approves). Removed smart quotes and ambiguous backtick formatting from values. |
+| 2026-04-18 | v2.1: Added mechanism-mismatch warning. Manual steps use Rulesets; the script and fleet use classic Branch Protection API. (Closes #924) |

--- a/docs/runbooks/0929-ai-cli-tools-reference.md
+++ b/docs/runbooks/0929-ai-cli-tools-reference.md
@@ -1,8 +1,10 @@
-# 0927 - AI CLI Tools Reference
+# 0929 - AI CLI Tools Reference
 
 **Category:** Runbook / Reference
-**Version:** 1.0
-**Last Updated:** 2026-03-09
+**Version:** 1.1
+**Last Updated:** 2026-04-18
+
+> **Renumbered from 0927 → 0929** to resolve a filename collision with `0927-new-repo-human-checklist.md`. (Closes #924)
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only cleanup of the new-repo runbook chain. Addresses items 1-6 and 8 from #924. Item 7 (pr-sentinel.yml as automatic artifact) is deferred to #886 Phase 4.

- **0925** (security-relevant): removed `Workflows: Read+Write` from the agent fine-grained PAT granted-permissions table; added to the "DO NOT GRANT" list. Aligns with 0927, 0926, and Standard 0016. The agent PAT must not be able to modify its own governance workflows.
- **0901**:
  - Replaced "0927 step 2" with a section link (step numbers drift; anchors don't).
  - Fixed post-setup numbering gap (`1, 2, 4, 5, 6` -> `1, 2, 3, 4, 5`).
  - Added a PAT-dance pointer to 0927 steps 1 and 3 in the Prerequisites area.
- **0926**: added a prominent mechanism-mismatch warning at the top. Manual steps use GitHub **Rulesets**; `tools/new_repo_setup.py` and every script in the fleet use the **classic Branch Protection API**. Explains which path preserves fleet consistency.
- **Filename collision resolved**: `0927-ai-cli-tools-reference.md` -> `0929-ai-cli-tools-reference.md` (was colliding with `0927-new-repo-human-checklist.md`).
- **0900 runbook index** updated to align IDs and filenames.
- **0003 file inventory** updated to reflect the rename.

## Test plan

- [ ] Confirm no stale links to `0927-ai-cli-tools-reference` remain in the repo (verified locally: zero matches).
- [ ] Confirm 0900 index rows map 1:1 with filenames on disk.
- [ ] Confirm 0925's granted-permission table no longer includes `Workflows`.
- [ ] Confirm 0925's "DO NOT GRANT" list now includes `Workflows`.
- [ ] Confirm 0901's post-setup steps are sequential.
- [ ] Confirm 0926's warning box is rendered at the top before the "Steps" section.

Closes #924