### PR TITLE
fix: new_repo_setup.py generates correct CLAUDE.md — point to root, surface PR discipline (Closes #931)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -401,26 +401,25 @@ def create_claude_md(project_path: Path, name: str, github_user: str) -> None:
         name: Project name
         github_user: GitHub username
     """
-    assemblyzero_root_windows = config.assemblyzero_root()
     projects_root_unix = config.projects_root_unix()
 
     content = f"""# CLAUDE.md - {name} Project
 
 You are a team member on the {name} project, not a tool.
 
-## FIRST: Read AssemblyZero Core Rules
+## CRITICAL: Read these BEFORE any PR work
 
-**Before doing any work, read the AssemblyZero core rules:**
-`{assemblyzero_root_windows}\\CLAUDE.md`
+The root file `C:\\Users\\mcwiz\\Projects\\CLAUDE.md` is **auto-loaded** for every project. It contains the universal rules. Two sections are non-negotiable — skipping them wastes hours:
 
-That file contains core rules that apply to ALL projects:
-- Bash command rules (no &&, |, ;)
-- Visible self-check protocol
-- Worktree isolation rules
-- Path format rules (Windows vs Unix)
-- Decision-making protocol
+1. **"Merging PRs (Universal)"** — exact `gh` command sequence. Never `--admin` (branch protection has `enforce_admins: true`). Never `gh pr review --approve` on your own PR (GitHub blocks self-approval). Never ask the human to approve manually — **Cerberus-AZ auto-approves after pr-sentinel passes**, typically 10-30 seconds after checks go green.
 
-**This file adds {name}-specific rules ON TOP of those core rules.**
+2. **"PR Issue References (Mandatory)"** — `Closes #N` must appear in **ALL THREE** places: commit message, PR title, AND PR body. `pr-sentinel` validates the **PR body specifically**; the commit message alone will NOT pass the check.
+
+If a merge shows `mergeable_state: blocked`, do NOT retry blindly. Check the PR body for `Closes #N` pointing to an **OPEN** issue. Fix with:
+
+```bash
+gh pr edit {{NUMBER}} --body "...Closes #N..." --repo {github_user}/{name}
+```
 
 ---
 
@@ -433,34 +432,35 @@ That file contains core rules that apply to ALL projects:
 
 ---
 
-## Project-Specific Workflow Rules
+## Branch Protection Contract (main)
 
-### Required Workflow
+| Setting | Value | What it means for you |
+|---------|-------|----------------------|
+| `enforce_admins` | `true` | `--admin` bypass will fail. Do not try. |
+| `required_approving_review_count` | `1` | Cerberus-AZ provides this automatically after pr-sentinel passes. |
+| `required_status_checks` | `pr-sentinel / issue-reference` | Must conclude `success` before merge. |
+| `allow_force_pushes` | `false` | `git push --force` to main will fail. |
 
-- **Docs before Code:** Write the LLD (`docs/lld/active/`) before writing code
-- **Worktree before code:** `git worktree add ../{name}-{{ID}} -b {{ID}}-short-desc`
-- **Push immediately:** `git push -u origin HEAD`
+### Merge sequence — use this exact flow
 
-### Reports Before Merge (PRE-MERGE GATE)
+```bash
+# 1. Poll mergeable_state until clean
+#    Do NOT use `gh pr checks --watch` — it returns GraphQL 403 with the fine-grained PAT.
+while [ "$(gh api repos/{github_user}/{name}/pulls/$PR --jq '.mergeable_state')" != "clean" ]; do sleep 10; done
 
-**Before ANY PR merge, you MUST:**
-
-1. Create `docs/reports/active/1{{IssueID}}-implementation-report.md`
-2. Create `docs/reports/active/1{{IssueID}}-test-report.md`
-3. Wait for orchestrator review
+# 2. Merge (Cerberus auto-approves after pr-sentinel passes — no separate approval poll needed)
+gh pr merge $PR --squash --repo {github_user}/{name}
+```
 
 ---
 
-## Documentation Structure
+## GitHub CLI Safety
 
-This project uses the **1xxxx numbering scheme** (project-specific implementations):
-
-| Directory | Range | Contents |
-|-----------|-------|----------|
-| `docs/lld/` | 1xxxx | Low-level designs |
-| `docs/reports/` | 1xxxx | Implementation & test reports |
-| `docs/standards/` | 00xxx | Project-specific standards |
-| `docs/adrs/` | 00xxx | Architecture Decision Records |
+- ALWAYS use `--repo {github_user}/{name}` explicitly — never rely on default repo inference
+- NEVER use `--admin` — will 403
+- NEVER use `gh pr review --approve` on your own PR — GitHub blocks self-approval
+- NEVER use `--no-verify` — if a hook fails, diagnose the root cause instead
+- NEVER reference a **closed** issue in `Closes #N` — create a new issue first if needed
 
 ---
 
@@ -470,16 +470,9 @@ At end of session, append a summary to `docs/session-logs/YYYY-MM-DD.md`.
 
 ---
 
-## GitHub CLI Safety
-
-- ALWAYS use `--repo {github_user}/{name}` explicitly
-- NEVER rely on default repo inference
-
----
-
 ## You Are Not Alone
 
-Other agents may work on this project. Check `docs/session-logs/` for recent context.
+Other agents may work on this project. Check `docs/session-logs/` for recent context before starting work.
 """
     claude_md_path = project_path / "CLAUDE.md"
     claude_md_path.write_text(content, encoding='utf-8')


### PR DESCRIPTION
## Summary

Fixes the per-repo CLAUDE.md generated by `tools/new_repo_setup.py`. Previously every new repo baked in a CLAUDE.md that (a) misdirected agents to AZ's project-specific CLAUDE.md as "core rules", (b) listed stale bash rules that don't exist in current root CLAUDE.md, and (c) buried the PR discipline behind AZ-specific LLD/reports workflow.

The new template opens with a **CRITICAL** block naming the two non-negotiable root-CLAUDE.md sections, includes a repo-name-substituted merge sequence, documents the branch protection contract, and explicitly lists anti-patterns (`--admin`, self-approve, `--no-verify`, referencing closed issues).

## Smoke test

```
$ poetry run python -c "from tools.new_repo_setup import create_claude_md; ..."
# CLAUDE.md - DemoProject Project
...
## CRITICAL: Read these BEFORE any PR work
...
1. **"Merging PRs (Universal)"** — ...
2. **"PR Issue References (Mandatory)"** — ...
...
gh pr edit {NUMBER} --body "...Closes #N..." --repo martymcenroe/DemoProject
```

All f-string substitutions resolve correctly. Literal `{IssueID}` and `{NUMBER}` placeholders preserved.

## Test plan

- [ ] Create a test repo with the fixed script, inspect generated CLAUDE.md
- [ ] Confirm root CLAUDE.md is referenced (not AZ's)
- [ ] Confirm merge sequence has the actual repo name substituted
- [ ] Confirm anti-pattern list is present

## Follow-up (not in this PR)

`create_gemini_md()` in the same file has the identical misdirection pattern. Can file a follow-up if needed.

Closes #931