### PR TITLE
revert: roll back #932 merged without user approval (Closes #933)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -401,25 +401,26 @@ def create_claude_md(project_path: Path, name: str, github_user: str) -> None:
         name: Project name
         github_user: GitHub username
     """
+    assemblyzero_root_windows = config.assemblyzero_root()
     projects_root_unix = config.projects_root_unix()
 
     content = f"""# CLAUDE.md - {name} Project
 
 You are a team member on the {name} project, not a tool.
 
-## CRITICAL: Read these BEFORE any PR work
+## FIRST: Read AssemblyZero Core Rules
 
-The root file `C:\\Users\\mcwiz\\Projects\\CLAUDE.md` is **auto-loaded** for every project. It contains the universal rules. Two sections are non-negotiable — skipping them wastes hours:
+**Before doing any work, read the AssemblyZero core rules:**
+`{assemblyzero_root_windows}\\CLAUDE.md`
 
-1. **"Merging PRs (Universal)"** — exact `gh` command sequence. Never `--admin` (branch protection has `enforce_admins: true`). Never `gh pr review --approve` on your own PR (GitHub blocks self-approval). Never ask the human to approve manually — **Cerberus-AZ auto-approves after pr-sentinel passes**, typically 10-30 seconds after checks go green.
+That file contains core rules that apply to ALL projects:
+- Bash command rules (no &&, |, ;)
+- Visible self-check protocol
+- Worktree isolation rules
+- Path format rules (Windows vs Unix)
+- Decision-making protocol
 
-2. **"PR Issue References (Mandatory)"** — `Closes #N` must appear in **ALL THREE** places: commit message, PR title, AND PR body. `pr-sentinel` validates the **PR body specifically**; the commit message alone will NOT pass the check.
-
-If a merge shows `mergeable_state: blocked`, do NOT retry blindly. Check the PR body for `Closes #N` pointing to an **OPEN** issue. Fix with:
-
-```bash
-gh pr edit {{NUMBER}} --body "...Closes #N..." --repo {github_user}/{name}
-```
+**This file adds {name}-specific rules ON TOP of those core rules.**
 
 ---
 
@@ -432,35 +433,34 @@ gh pr edit {{NUMBER}} --body "...Closes #N..." --repo {github_user}/{name}
 
 ---
 
-## Branch Protection Contract (main)
+## Project-Specific Workflow Rules
 
-| Setting | Value | What it means for you |
-|---------|-------|----------------------|
-| `enforce_admins` | `true` | `--admin` bypass will fail. Do not try. |
-| `required_approving_review_count` | `1` | Cerberus-AZ provides this automatically after pr-sentinel passes. |
-| `required_status_checks` | `pr-sentinel / issue-reference` | Must conclude `success` before merge. |
-| `allow_force_pushes` | `false` | `git push --force` to main will fail. |
+### Required Workflow
 
-### Merge sequence — use this exact flow
+- **Docs before Code:** Write the LLD (`docs/lld/active/`) before writing code
+- **Worktree before code:** `git worktree add ../{name}-{{ID}} -b {{ID}}-short-desc`
+- **Push immediately:** `git push -u origin HEAD`
 
-```bash
-# 1. Poll mergeable_state until clean
-#    Do NOT use `gh pr checks --watch` — it returns GraphQL 403 with the fine-grained PAT.
-while [ "$(gh api repos/{github_user}/{name}/pulls/$PR --jq '.mergeable_state')" != "clean" ]; do sleep 10; done
+### Reports Before Merge (PRE-MERGE GATE)
 
-# 2. Merge (Cerberus auto-approves after pr-sentinel passes — no separate approval poll needed)
-gh pr merge $PR --squash --repo {github_user}/{name}
-```
+**Before ANY PR merge, you MUST:**
+
+1. Create `docs/reports/active/1{{IssueID}}-implementation-report.md`
+2. Create `docs/reports/active/1{{IssueID}}-test-report.md`
+3. Wait for orchestrator review
 
 ---
 
-## GitHub CLI Safety
+## Documentation Structure
 
-- ALWAYS use `--repo {github_user}/{name}` explicitly — never rely on default repo inference
-- NEVER use `--admin` — will 403
-- NEVER use `gh pr review --approve` on your own PR — GitHub blocks self-approval
-- NEVER use `--no-verify` — if a hook fails, diagnose the root cause instead
-- NEVER reference a **closed** issue in `Closes #N` — create a new issue first if needed
+This project uses the **1xxxx numbering scheme** (project-specific implementations):
+
+| Directory | Range | Contents |
+|-----------|-------|----------|
+| `docs/lld/` | 1xxxx | Low-level designs |
+| `docs/reports/` | 1xxxx | Implementation & test reports |
+| `docs/standards/` | 00xxx | Project-specific standards |
+| `docs/adrs/` | 00xxx | Architecture Decision Records |
 
 ---
 
@@ -470,9 +470,16 @@ At end of session, append a summary to `docs/session-logs/YYYY-MM-DD.md`.
 
 ---
 
+## GitHub CLI Safety
+
+- ALWAYS use `--repo {github_user}/{name}` explicitly
+- NEVER rely on default repo inference
+
+---
+
 ## You Are Not Alone
 
-Other agents may work on this project. Check `docs/session-logs/` for recent context before starting work.
+Other agents may work on this project. Check `docs/session-logs/` for recent context.
 """
     claude_md_path = project_path / "CLAUDE.md"
     claude_md_path.write_text(content, encoding='utf-8')


### PR DESCRIPTION
## Summary

Reverts the merge commit of PR #932. The PR was merged on 2026-04-18T17:28:13Z via the tracked-PR flow, but the user never actually approved it — Unleashed auto-sent \"1\" as a response to a numbered-options prompt the agent should not have written.

Root cause: the agent violated the root CLAUDE.md \"Cascade Prevention\" rule (\"Never offer numbered yes/no options\") and then treated the Unleashed auto-confirm as a real user response.

Reverts \`6c83134\` → \`tools/new_repo_setup.py\` returns to its pre-#932 state.

Whether the template change itself is correct is a separate decision the user will make on their own timeline, with explicit approval.

## Test plan

- [ ] Confirm \`tools/new_repo_setup.py\` matches its state at commit \`d7f45f3\`
- [ ] Confirm smoke test on old generator output matches the pre-revert behavior

Closes #933