### PR TITLE
feat: integrate Cerberus secrets deploy into new_repo_setup.py (Closes #940)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -55,30 +55,48 @@ gh auth login -h github.com -p https
 
 ### 4. Deploy Cerberus secrets (if needed)
 
-The auto-reviewer needs two secrets per repo: `REVIEWER_APP_ID` and `REVIEWER_APP_PRIVATE_KEY`. These are deployed **fleet-wide** — the script covers ALL repos at once, not just the new one.
+The auto-reviewer needs two secrets per repo: `REVIEWER_APP_ID` and `REVIEWER_APP_PRIVATE_KEY`. Without them, PRs pass pr-sentinel but don't get auto-approved.
 
-**Skip this step if** you've deployed Cerberus secrets since the last time you created a repo (the new repo is already covered by the fleet-wide install).
+**Skip this step if** you've deployed Cerberus secrets since the last time you created a repo (the new repo may already be covered).
 
-**If the new repo needs secrets**, follow this checklist as one uninterrupted sequence. Run all commands in your own git-bash (never an agent session):
+Two ways to do this: **preferred** (integrated into `new_repo_setup.py`) or **fallback** (standalone fleet-wide script).
+
+#### Preferred: pass `--cerberus-pem PATH` to `new_repo_setup.py`
+
+When you invoke `new_repo_setup.py` with the flag, the script handles steps 3-5 below automatically after the repo is created:
 
 1. Go to https://github.com/settings/apps/cerberus-az > Private keys
 2. Click **Generate a private key** — browser downloads a `.pem` file
-   (generating a new key does NOT invalidate existing keys)
+3. Run the setup script with the flag (re-using the same invocation if this is the first time):
+   ```bash
+   cd /c/Users/mcwiz/Projects/AssemblyZero
+   poetry run python tools/new_repo_setup.py MyNewRepo --cerberus-pem /c/Users/mcwiz/Downloads/THE-FILE.pem
+   ```
+   The script deploys both secrets to ONLY the new repo, verifies they landed via `gh api`, then deletes the `.pem`.
+4. Go to https://github.com/settings/apps/cerberus-az > Private keys
+5. Click **Revoke** on the key you just generated (browser-only — the GitHub App management API does not expose programmatic revocation).
+
+#### Fallback: standalone fleet-wide script
+
+Use this path if the new repo was already created (without the flag) or if you want to deploy to multiple repos at once.
+
+1. Go to https://github.com/settings/apps/cerberus-az > Private keys
+2. Click **Generate a private key** — browser downloads a `.pem` file
 3. Deploy to all repos:
    ```bash
    cd /c/Users/mcwiz/Projects/AssemblyZero
    poetry run python tools/deploy_cerberus_secrets.py /c/Users/mcwiz/Downloads/THE-FILE.pem
    ```
-4. **Verify:** Look for `OK` next to your new repo name in the output
+4. **Verify:** Look for `OK` next to your new repo name in the output.
 5. **Delete the .pem file immediately:**
    ```bash
    rm /c/Users/mcwiz/Downloads/THE-FILE.pem
    ```
 6. Go back to https://github.com/settings/apps/cerberus-az > Private keys
-7. Click **Revoke** on the key you just generated (most recent one)
-   - The secrets are already stored in GitHub Actions — the .pem is never needed again
-   - Revoking prevents the key from being used if the file wasn't fully deleted
-   - **Note:** GitHub Apps require at least one active key. If only one key exists, you cannot revoke it. File deletion (step 5) is your only protection.
+7. Click **Revoke** on the key you just generated.
+   - The secrets are already stored in GitHub Actions — the .pem is never needed again.
+   - Revoking prevents the key from being used if the file wasn't fully deleted.
+   - **Note:** GitHub Apps require at least one active key. If only one exists, you cannot revoke it. File deletion (step 5) is your only protection.
 8. **Done.** Secrets deployed, .pem deleted, key revoked.
 
 **What happens without secrets:** PRs pass pr-sentinel but don't get auto-approved. You can merge manually via the GitHub UI until secrets are deployed.

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -45,6 +45,46 @@ def set_secret(repo: str, name: str, value: str) -> bool:
     return result.returncode == 0
 
 
+def deploy_to_repo(repo: str, pem_content: str) -> tuple[bool, list[str]]:
+    """Deploy REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY to a single repo.
+
+    Args:
+        repo: Repo name (not owner/name) under GITHUB_USER.
+        pem_content: The raw .pem file contents.
+
+    Returns:
+        (success, failed_secret_names). `success` is True iff both secrets set.
+    """
+    failed: list[str] = []
+    if not set_secret(repo, "REVIEWER_APP_ID", APP_ID):
+        failed.append("REVIEWER_APP_ID")
+    if not set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content):
+        failed.append("REVIEWER_APP_PRIVATE_KEY")
+    return (len(failed) == 0, failed)
+
+
+def verify_secrets(repo: str) -> tuple[bool, list[str]]:
+    """Check that both required Cerberus secrets are present on the repo.
+
+    Args:
+        repo: Repo name (not owner/name) under GITHUB_USER.
+
+    Returns:
+        (all_present, missing_secret_names).
+    """
+    required = {"REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"}
+    result = subprocess.run(
+        ["gh", "api", f"repos/{GITHUB_USER}/{repo}/actions/secrets",
+         "--jq", ".secrets[].name"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return (False, sorted(required))
+    present = {n.strip() for n in result.stdout.split("\n") if n.strip()}
+    missing = sorted(required - present)
+    return (len(missing) == 0, missing)
+
+
 def main():
     if len(sys.argv) != 2:
         print("Usage: poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem")
@@ -79,20 +119,12 @@ def main():
 
     for i, repo in enumerate(repos, 1):
         prefix = f"[{i}/{len(repos)}] {repo}"
-
-        ok_id = set_secret(repo, "REVIEWER_APP_ID", APP_ID)
-        ok_key = set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content)
-
-        if ok_id and ok_key:
+        ok, failed_names = deploy_to_repo(repo, pem_content)
+        if ok:
             print(f"  {prefix}: OK")
             succeeded += 1
         else:
-            parts = []
-            if not ok_id:
-                parts.append("APP_ID")
-            if not ok_key:
-                parts.append("PRIVATE_KEY")
-            print(f"  {prefix}: FAILED ({', '.join(parts)})")
+            print(f"  {prefix}: FAILED ({', '.join(failed_names)})")
             failed.append(repo)
 
     print(f"\n{'=' * 50}")

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -39,6 +39,13 @@ except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
     from assemblyzero_config import config
 
+# Cerberus secret deploy helpers (used by --cerberus-pem flag)
+try:
+    from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
+
 
 # ---------------------------------------------------------------------------
 # Schema types and exceptions
@@ -1274,6 +1281,65 @@ def audit_structure(project_path: Path, name: str) -> int:
         return 1
 
 
+def _deploy_cerberus(repo_name: str, pem_path: Path) -> str:
+    """Deploy Cerberus secrets to a single repo and handle pem file lifecycle.
+
+    Reads the .pem file, deploys REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
+    to the specified repo, verifies they landed, deletes the .pem, and
+    prints a reminder to revoke the key in the app UI.
+
+    Args:
+        repo_name: The new repo name (lowercased, owner-less).
+        pem_path: Path to the Cerberus App .pem file.
+
+    Returns a short status string for the summary table.
+    """
+    print("\n" + "=" * 60)
+    print("CERBERUS SECRETS DEPLOY")
+    print("=" * 60)
+
+    if not pem_path.exists():
+        print(f"  ERROR: .pem file not found: {pem_path}")
+        return "PEM_MISSING"
+
+    pem_content = pem_path.read_text(encoding="utf-8").strip()
+    if "PRIVATE KEY" not in pem_content:
+        print(f"  ERROR: File does not look like a private key: {pem_path}")
+        return "INVALID_PEM"
+
+    print(f"  Target repo: {repo_name}")
+    print(f"  .pem file:   {pem_path.name} ({len(pem_content)} chars)")
+
+    ok, failed = deploy_to_repo(repo_name, pem_content)
+    if not ok:
+        print(f"  FAILED to deploy: {', '.join(failed)}")
+        print(f"  .pem file NOT deleted — retry manually:")
+        print(f"    poetry run python tools/deploy_cerberus_secrets.py {pem_path}")
+        return f"FAILED: {', '.join(failed)}"
+    print("  Secrets set.")
+
+    ok, missing = verify_secrets(repo_name)
+    if not ok:
+        print(f"  WARNING: verification failed; missing {missing}")
+        print(f"  .pem file NOT deleted — investigate before deleting.")
+        return f"UNVERIFIED: {', '.join(missing)}"
+    print("  Secrets verified on GitHub (both REVIEWER_APP_ID and REVIEWER_APP_PRIVATE_KEY present).")
+
+    try:
+        pem_path.unlink()
+        print(f"  .pem file deleted: {pem_path}")
+    except OSError as e:
+        print(f"  WARNING: could not delete .pem file: {e}")
+        print(f"  DELETE MANUALLY: {pem_path}")
+
+    print()
+    print("  NEXT STEP (browser-only, cannot be automated):")
+    print("    Revoke the key you just used in the GitHub App UI:")
+    print("    https://github.com/settings/apps/cerberus-az > Private keys > Revoke")
+
+    return "OK"
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Scaffold a new repository with AssemblyZero structure",
@@ -1323,8 +1389,24 @@ Examples:
         default="polyform",
         help="License type (default: polyform)"
     )
+    parser.add_argument(
+        "--cerberus-pem",
+        metavar="PATH",
+        default=None,
+        help="Path to Cerberus App .pem file. When provided, after repo "
+             "creation the script deploys REVIEWER_APP_ID and "
+             "REVIEWER_APP_PRIVATE_KEY secrets to the new repo, verifies "
+             "they landed, deletes the .pem file, and prints a reminder "
+             "to revoke the key in the app UI. When omitted, runbook "
+             "0927 step 4 is printed as manual fallback."
+    )
 
     args = parser.parse_args()
+
+    # --cerberus-pem requires --no-github not set (need the repo to deploy to)
+    if args.cerberus_pem and args.no_github:
+        print("ERROR: --cerberus-pem requires GitHub repo creation (cannot be combined with --no-github)")
+        sys.exit(1)
 
     # Validate name
     valid, error = validate_name(args.name)
@@ -1608,6 +1690,11 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     if checks_passed < checks_total:
         print("\nWARNING: Some checks failed. Review and fix before starting work!")
 
+    # Cerberus secrets deploy (if --cerberus-pem provided, and repo was created)
+    cerberus_status: str | None = None
+    if not args.no_github and push_succeeded and args.cerberus_pem:
+        cerberus_status = _deploy_cerberus(args.name.lower(), Path(args.cerberus_pem))
+
     # Final summary
     if not args.no_github:
         print("\n" + "=" * 60)
@@ -1619,6 +1706,8 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print(f"  Push:               {'OK' if push_succeeded else 'FAILED'}")
         print(f"  Repo settings:      {'OK' if repo_settings_ok else 'FAILED — configure manually'}")
         print(f"  Branch protection:  {'OK' if protection_ok else 'FAILED — configure manually or re-run with classic PAT'}")
+        if cerberus_status is not None:
+            print(f"  Cerberus secrets:   {cerberus_status}")
 
     print("\n" + "=" * 60)
     print(f"[SUCCESS] Repository '{args.name}' created!")
@@ -1632,7 +1721,19 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             print("  #   gh auth login -h github.com -p https  # classic PAT")
             print("  #   git push -u origin main")
             print("  #   gh auth login -h github.com -p https  # fine-grained PAT")
-    print("  # Deploy Cerberus secrets: see runbook 0927")
+    if args.cerberus_pem is None and not args.no_github:
+        print()
+        print("  # Cerberus secrets (manual):")
+        print("  #   Without secrets, PRs pass pr-sentinel but are never auto-approved.")
+        print("  #   1. https://github.com/settings/apps/cerberus-az > Private keys > Generate")
+        print("  #   2. poetry run python tools/deploy_cerberus_secrets.py /path/to/downloaded.pem")
+        print("  #   3. Delete the .pem, revoke the key in the app UI")
+        print("  #   See runbook 0927 step 4 for full procedure.")
+        print("  #   OR re-run this script with --cerberus-pem PATH to automate.")
+    elif cerberus_status == "OK":
+        print()
+        print("  # Cerberus secrets deployed and verified.")
+        print("  # REMEMBER to revoke the key in the app UI (browser-only step).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`new_repo_setup.py` now accepts `--cerberus-pem PATH`. When provided, the script handles Cerberus secret deployment end-to-end after repo creation: reads the .pem, deploys both secrets to the new repo, verifies they landed via `gh api`, deletes the .pem, and prints a reminder to revoke the key. The only manual step left is the browser-only key revocation (GitHub App management API doesn't expose programmatic revoke).

Without the flag, the "Next steps" output surfaces runbook 0927 step 4 inline as fallback.

## Changes

- `tools/deploy_cerberus_secrets.py`: extracted reusable helpers `deploy_to_repo()` and `verify_secrets()`. The existing fleet-wide `main()` now uses `deploy_to_repo()` for consistency.
- `tools/new_repo_setup.py`:
  - Imports the new helpers
  - `--cerberus-pem PATH` argparse flag
  - Rejects `--cerberus-pem` + `--no-github` (no repo to deploy to)
  - New `_deploy_cerberus()` helper: read pem → deploy → verify → delete pem → print revoke reminder
  - Summary table shows Cerberus status when the flag is used
  - Next-steps output adapts based on whether Cerberus was handled
- `docs/runbooks/0927-new-repo-human-checklist.md`:
  - Documents the `--cerberus-pem` flag as **preferred** path
  - Keeps standalone fleet-wide script as fallback for multi-repo deployment

## Smoke test results

- `tools.new_repo_setup` imports cleanly
- `deploy_to_repo` and `verify_secrets` importable
- `_deploy_cerberus` helper present in module
- `--cerberus-pem` appears in `--help` output
- `--cerberus-pem` + `--no-github` combination is rejected with clear error

Net diff: 3 files changed, 172 insertions(+), 21 deletions(-).

## Test plan

- [ ] Generate a disposable test repo with `--cerberus-pem` and verify both secrets land on it
- [ ] Verify the .pem is deleted after successful deploy
- [ ] Verify without the flag, the next-steps output surfaces the manual runbook path

## Non-goals

- Fleet-wide auto-deployment (existing `deploy_cerberus_secrets.py main()` still handles that)
- Server-side Cerberus elimination (#764)
- Automating the key revocation (browser-only; GitHub App management API doesn't expose it)

Fix 3 of 5 in plan `~/.claude/plans/nifty-prancing-willow.md`.

Closes #940