### PR TITLE
fix: evict poetry venv before worktree removal on Windows (Closes #944)

### DIFF
--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -197,19 +197,30 @@ Session: {SESSION_NAME}
      - Check if corresponding branch has an OPEN PR
      - If PR is MERGED or CLOSED: worktree is orphaned → REPORT AS ERROR
    - Worktrees for merged work MUST be removed manually (safety)
+   - **Pre-removal poetry venv eviction (Windows file-lock mitigation):** Before calling `git worktree remove` on any worktree, run the following inside that worktree so its cached poetry virtualenv doesn't hold file locks:
+     ```bash
+     poetry env remove --all  # run from inside the worktree
+     ```
+     Without this, `git worktree remove` will succeed in deregistration but leave the on-disk directory locked by the venv's Python process handles. (#944)
 
 5. **Delete Empty Orphaned Worktree Directories:**
-   - After `git -C ... worktree prune`, scan for leftover empty directories:
+   - After `git -C ... worktree prune`, scan for leftover orphan directories:
      ```bash
      ls -d /c/Users/mcwiz/Projects/{PROJECT_NAME}-*/ 2>/dev/null
      ```
    - For each matching directory:
      - Skip if it appears in `git worktree list` (still active)
+     - **Evict cached poetry venv first** (releases Windows file locks):
+       ```bash
+       cd /c/Users/mcwiz/Projects/{DIR_NAME}
+       poetry env remove --all 2>/dev/null || true
+       cd -
+       ```
      - Check if empty: `ls -A /c/Users/mcwiz/Projects/{DIR_NAME}/`
      - If empty: `rmdir /c/Users/mcwiz/Projects/{DIR_NAME}` (safe — fails if not empty)
      - If contains only `.git` file: remove it first, then rmdir
-     - If not empty: report as warning (do NOT rm -rf)
-   - Report count of deleted directories
+     - If still not empty after venv eviction: report as warning with contents listing (do NOT `rm -rf` from the skill — user decides)
+   - Report count of deleted directories and any residue
 
 6. **Open PRs** - Flag if any exist
 

--- a/tools/archive_worktree_lineage.py
+++ b/tools/archive_worktree_lineage.py
@@ -97,6 +97,48 @@ def stage_archived(main_repo: Path, issue_number: int) -> None:
         print("  No lineage changes to stage")
 
 
+def evict_poetry_venv(worktree_path: Path) -> None:
+    """Evict poetry-cached virtualenvs tied to the worktree path.
+
+    On Windows, poetry creates a cached venv in ~/.cache/pypoetry/virtualenvs/
+    whose interpreter references the worktree root. The venv's open file
+    handles prevent `git worktree remove` from deleting the on-disk
+    directory (Windows "Device or resource busy" / "Permission denied").
+
+    Running `poetry env remove --all` inside the worktree before removal
+    evicts the cached venv and releases the locks.
+
+    Args:
+        worktree_path: Path to the worktree being cleaned.
+    """
+    pyproject = worktree_path / "pyproject.toml"
+    if not pyproject.exists():
+        # Not a poetry project — skip silently.
+        return
+
+    print("  Evicting poetry-cached virtualenvs (so the worktree can be removed cleanly)...")
+    result = subprocess.run(
+        ["poetry", "env", "remove", "--all"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        # poetry prints one line per env removed; keep it minimal
+        output = (result.stdout or "").strip()
+        if output:
+            # Indent each line under the parent bullet
+            for line in output.splitlines():
+                print(f"    {line}")
+        else:
+            print("    No poetry venvs were cached for this worktree.")
+    else:
+        # Non-fatal — worktree removal may still work, just log and continue.
+        err = (result.stderr or result.stdout or "").strip()
+        print(f"    WARNING: `poetry env remove --all` returned {result.returncode}: {err[:200]}")
+        print("    The worktree may still have locked files when you run `git worktree remove`.")
+
+
 def main():
     """Main entry point for CLI usage."""
     parser = argparse.ArgumentParser(description="Archive worktree lineage before deletion")
@@ -120,6 +162,9 @@ def main():
     # Stage in repo
     if archived and not args.no_stage:
         stage_archived(main_repo, args.issue)
+
+    # Evict poetry venvs that lock the worktree directory on Windows
+    evict_poetry_venv(worktree)
 
     print(f"\nDone. You can now remove the worktree:")
     print(f"  git worktree remove {worktree}")


### PR DESCRIPTION
## Summary

Fixes the #935 symptom: every PR cycle on Windows leaves an orphan worktree directory because `git worktree remove` deregisters the worktree but can't delete the on-disk files (poetry-cached venv holds Windows file locks). This single session accumulated 7 orphan directories.

Two-tier fix:

1. **Archive script** (`tools/archive_worktree_lineage.py`) — attempts venv eviction as its final step. Gracefully degrades when called inside poetry (the invoking process is itself using the venv, so it can't evict its own interpreter — expected). Non-fatal warning, script completes normally.

2. **Cleanup skill** (`.claude/commands/cleanup.md`) — the line of defense that will actually work:
   - Phase 2 Step 4: before any `git worktree remove`, run `poetry env remove --all` inside the worktree.
   - Phase 2 Step 5: orphan-directory scan evicts cached venvs BEFORE attempting `rmdir`. Since cleanup runs in its own process context (not inside poetry's venv), the eviction succeeds against prior sessions' orphans.
   - Non-destructive guarantee preserved — no `rm -rf` from the skill.

## Why the two-tier design

The archive script runs *inside* `poetry run python`, so its own Python interpreter is the one holding the venv's `python.exe` open. Windows won't let you delete a running executable. The eviction attempt in the archive script therefore can't succeed — but that's fine: it logs the failure and continues. The cleanup skill runs in its own process context, after the archive script has exited and Windows has released the lock, so its `poetry env remove --all` actually works.

## Smoke test results (9/9)

- `evict_poetry_venv` function exists
- `poetry env remove --all` command present in archive script
- `--all` flag used
- `cleanup.md` references `poetry env remove --all`
- `cleanup.md` explains pre-removal eviction
- `cleanup.md` Step 5 includes venv eviction
- `cleanup.md` preserves non-destructive guarantee (no `rm -rf`)
- `cleanup.md` references #944
- `evict_poetry_venv` skips silently on non-poetry dirs

## Test plan

- [ ] After merge, run `/cleanup --full` on AssemblyZero; verify the 7 orphan `AssemblyZero-*` directories from this session get cleaned up.
- [ ] Create a new worktree, run full work cycle, verify `git worktree remove` succeeds without `--force`.

## Non-goals

- Full #935 investigation (this addresses the poetry-venv case specifically, which is the dominant lock cause)
- Sysinternals `handle.exe` integration for other lock sources
- Cross-platform implementation (Linux/macOS don't have this bug)

Fix 5 of 5 — completes the new-repo friction-removal sequence in plan `~/.claude/plans/nifty-prancing-willow.md`.

Closes #944