### PR TITLE
feat: /dependabot skill + dependabot_review.py test-then-approve tool (Closes #949)

### DIFF
--- a/.claude/commands/dependabot.md
+++ b/.claude/commands/dependabot.md
@@ -1,0 +1,85 @@
+---
+description: Run the dependabot PR review + merge tool (test-then-approve, author-gated)
+argument-hint: "[--help] [--dry-run]"
+scope: global
+---
+
+# Dependabot
+
+Runs `tools/dependabot_review.py` — a deterministic, author-gated, exit-code-gated tool that processes open dependabot PRs. Tests each PR in an audit worktree, and on green: injects `No-Issue:` into the body so pr-sentinel passes, approves with the invoking user's credentials (creating a `PullRequestReview` event that accrues to the user's profile Code Review stat), and squash-merges.
+
+**If `$ARGUMENTS` contains `--help`:** Display the Help section below and STOP.
+
+---
+
+## Help
+
+Usage: `/dependabot [--help] [--dry-run]`
+
+| Argument | Effect |
+|---|---|
+| `--help` | Show this help and exit |
+| `--dry-run` | List dependabot PRs that would be processed; take no action |
+
+The tool operates ONLY on PRs authored by `dependabot[bot]`. Any other author is refused at the author gate. Tests must exit 0; non-zero exit means the PR is commented on and left for human review (not approved, not merged). No LLM in the decision loop — decisions are pure exit-code / string-match.
+
+Reference: runbook `docs/runbooks/0911-dependabot-pr-audit.md` v2.0.
+
+---
+
+## Execution
+
+Runs inline in the main agent context. No subagent — the Python tool does all the orchestration; the skill is a thin wrapper.
+
+### Step 1 — Verify there are dependabot PRs to process
+
+```bash
+gh pr list --repo martymcenroe/AssemblyZero --author "app/dependabot" --state open --json number,title --jq 'length'
+```
+
+If the result is `0`: print "No open dependabot PRs. Nothing to do." and STOP.
+
+### Step 2 — Invoke the tool
+
+Run from the AssemblyZero root (NOT a worktree):
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/dependabot_review.py
+```
+
+Pass `--dry-run` through if the user supplied it:
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/dependabot_review.py --dry-run
+```
+
+Stream the tool's output to the user as-is.
+
+### Step 3 — Report the summary
+
+When the tool finishes, it prints a summary line like:
+
+```
+=== Summary ===
+  Merged:   [756, 741]
+  Deferred: [479]
+  Errored:  []
+```
+
+Relay that summary to the user. If any PRs are in `Deferred`, note:
+
+- The worktree for each deferred PR has been retained at `C:/Users/mcwiz/Projects/AssemblyZero-dependabot-<N>` for forensics
+- Multi-package PRs that failed tests will have an `@dependabot recreate` comment posted; dependabot will generate per-package PRs shortly, which can be processed with another `/dependabot` run
+
+If any PRs are in `Errored`, flag them plainly — those are infrastructure failures, not test failures, and likely need manual attention.
+
+---
+
+## Rules
+
+- NEVER modify the Python tool from this skill — the skill is a wrapper, not a logic layer.
+- NEVER approve or merge dependabot PRs outside this tool. The tool enforces the author gate and exit-code gate; ad-hoc approvals bypass those guarantees.
+- The tool uses the invoking user's `gh` credentials to create the approval event. That's intentional — the `PullRequestReview` event attributes to the user, which is how the Code Review profile stat accrues. This only applies to dependabot PRs (author-gated) and only after tests pass (exit-code-gated).
+- Do NOT invoke from inside a worktree. The tool needs access to the main repo to create audit worktrees.

--- a/docs/runbooks/0911-dependabot-pr-audit.md
+++ b/docs/runbooks/0911-dependabot-pr-audit.md
@@ -1,207 +1,192 @@
 # 0911 - Dependabot PR Audit
 
 **Category:** Runbook / Security Maintenance
-**Version:** 1.0
-**Last Updated:** 2026-02-15
+**Version:** 2.0
+**Last Updated:** 2026-04-19
 
 ---
 
 ## Purpose
 
-Safely merge Dependabot PRs with regression verification. Dependency updates are merged automatically when tests pass, with automatic rollback when problems occur.
+Safely review, approve, and merge Dependabot PRs with regression verification. Dependency updates land on main only after the full test suite passes against the bumped versions in an isolated worktree. On test failure, PRs are commented and left for human review; multi-package PRs are split via `@dependabot recreate`.
 
-**Key Principle:** Trust exit codes, not LLM interpretation of test output.
+**Key principle (unchanged from v1.0):** Trust exit codes, not LLM interpretation of test output.
+
+**New in v2.0:**
+- Test-then-merge order (v1.0 merged-then-tested — wrong order on branch-protected repos)
+- Author gate: tool refuses any PR not authored by `dependabot[bot]`
+- `No-Issue:` body injection so pr-sentinel's exemption path passes (v1.0 predated this)
+- Explicit approval step attributing to the invoking user (Code Review profile stat accrues to the user, not to Cerberus-AZ)
+- Multi-package split via `@dependabot recreate` on failure
+- Poetry venv eviction integrated (#944 / Fix 5 pattern) so worktrees remove cleanly on Windows
+- Mechanical implementation: `tools/dependabot_review.py`
+
+---
+
+## Implementation
+
+The manual procedure in v1.0 has been replaced by a deterministic Python tool at `tools/dependabot_review.py` invokable via the `/dependabot` skill.
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/dependabot_review.py [--dry-run]
+```
+
+Or via the skill: `/dependabot`.
 
 ---
 
 ## Prerequisites
 
 | Requirement | Check |
-|-------------|-------|
-| Clean working directory | `git status` shows no changes |
-| On main branch | `git branch --show-current` |
-| Poetry environment | `poetry run python --version` |
+|---|---|
+| Clean working directory on main | `git status` |
+| Poetry installed | `poetry --version` |
 | GitHub CLI authenticated | `gh auth status` |
+| Must NOT run from inside a worktree | `git rev-parse --show-toplevel` matches main repo path |
 
 ---
 
-## Quick Reference
+## Hard gates (enforced by the tool)
 
-```bash
-# List Dependabot PRs
-gh pr list --author "app/dependabot" --json number,title
+### Author gate
 
-# List security alerts
-gh api repos/OWNER/REPO/dependabot/alerts --jq '.[] | select(.state=="open")'
+For each PR returned by `gh pr list --author app/dependabot`, the tool re-verifies `pr.author.login == "dependabot[bot]"` before any action. Any mismatch is a hard refusal — no approval, no merge, status recorded as `errored`.
 
-# Run tests with exit code capture
-poetry run pytest; echo "EXIT_CODE=$?"
-```
+This prevents the tool from ever operating on a PR it wasn't designed to handle. Even if someone crafts an unrelated PR and passes it through this tool, it won't be approved or merged.
+
+### Exit-code gate
+
+`poetry run pytest -q --tb=short` must exit 0. Any non-zero exit means:
+- No approval, no merge
+- A comment is posted on the PR noting the exit code and the forensics worktree path
+- The PR is recorded as `deferred`
+- The worktree is NOT cleaned up — it's left in place so the user can investigate
+- If the PR updates multiple packages, `@dependabot recreate` is posted to split it into per-package PRs
+
+No human judgment is applied to the exit code. No LLM is consulted about whether "the failures look related." Trust the exit code.
 
 ---
 
-## Procedure
+## End-to-end flow (per PR)
 
-### Phase 1: Setup & Baseline
-
-```bash
-# 1.1 Create Audit Worktree
-# Use a timestamped branch for uniqueness
-AUDIT_ID=$(date +%Y%m%d-%H%M)
-git worktree add ../AssemblyZero-dependabot-audit-$AUDIT_ID -b dependabot-audit-$AUDIT_ID
-git -C ../AssemblyZero-dependabot-audit-$AUDIT_ID push -u origin HEAD
-
-# 1.2 Run baseline tests in worktree - CAPTURE EXIT CODE
-poetry --directory ../AssemblyZero-dependabot-audit-$AUDIT_ID run pytest --tb=short -q
-BASELINE_EXIT=$?
-echo "BASELINE_EXIT=$BASELINE_EXIT"
-
-# 1.3 Capture baseline test count
-poetry --directory ../AssemblyZero-dependabot-audit-$AUDIT_ID run pytest --collect-only -q 2>/dev/null | tail -1
 ```
+1. Create audit worktree from current main at ../AssemblyZero-dependabot-<N>
+2. `gh pr checkout <N>` into the worktree — brings the dependabot bump in
+3. Evict cached poetry venv (Fix 5 / #944) so locks release
+4. `poetry install` — fresh install of updated dependencies
+5. `poetry run pytest -q --tb=short` — capture exit code
 
-**STOP if baseline fails (exit code != 0).** Fix existing issues first.
+   --- exit != 0 ---
+6a. Comment on PR with exit code + worktree path (forensics)
+6b. If multi-package, comment `@dependabot recreate`
+6c. Leave worktree in place; move to next PR
 
-### Phase 2: Identify PRs
-
-```bash
-# 2.1 List Dependabot PRs
-gh pr list --author "app/dependabot" --json number,title,headRefName
-
-# 2.2 List security alerts (for context)
-gh api repos/OWNER/REPO/dependabot/alerts \
-  --jq '.[] | select(.state=="open") | "\(.number) | \(.security_advisory.severity) | \(.dependency.package.name)"'
-
-# 2.3 Store PR numbers
-DEPENDABOT_PRS=$(gh pr list --author "app/dependabot" --json number --jq '.[].number' | tr '\n' ' ')
-echo "PRs to process: $DEPENDABOT_PRS"
-```
-
-**If no PRs exist, proceed to Phase 5 (Cleanup).**
-
-### Phase 3: Merge and Test (In Worktree)
-
-```bash
-# 3.1 For each PR, merge and test within the worktree
-for PR in $DEPENDABOT_PRS; do
-    echo "=== Processing PR #$PR ==="
-
-    # Merge PR into worktree branch
-    # Note: Using 'gh pr merge' with --merge flag handles the remote update
-    gh pr merge $PR --merge --repo martymcenroe/AssemblyZero
-    git -C ../AssemblyZero-dependabot-audit-$AUDIT_ID pull origin main
-
-    # Test - CAPTURE EXIT CODE
-    poetry --directory ../AssemblyZero-dependabot-audit-$AUDIT_ID run pytest --tb=short -q
-    POST_MERGE_EXIT=$?
-    echo "POST_MERGE_EXIT=$POST_MERGE_EXIT"
-
-    # If failed, revert in main immediately (to keep main clean)
-    if [ $POST_MERGE_EXIT -ne 0 ]; then
-        echo "REGRESSION DETECTED - Reverting PR #$PR"
-        # We must revert on a fresh branch or main since main was modified by the merge
-        git checkout main
-        git pull origin main
-        git revert HEAD --no-edit
-        git push origin main
-        
-        # Sync worktree back to main
-        git -C ../AssemblyZero-dependabot-audit-$AUDIT_ID pull origin main
-
-        # Comment on PR
-        gh pr comment $PR --body "❌ Automated regression detected. Merge reverted. Manual investigation required."
-
-        # Create issue
-        gh issue create \
-            --title "Dependabot PR #$PR causes regression" \
-            --body "PR #$PR was merged but caused test failures. Reverted automatically." \
-            --label "dependencies,regression,bug"
-    else
-        echo "PR #$PR merged successfully - tests pass"
-
-        # Approve the PR for contribution graph credit
-        gh pr review $PR --approve --repo martymcenroe/AssemblyZero \
-            --body "Automated review: regression tests pass. Merged via 0911 dependabot audit."
-    fi
-done
-```
-
-### Phase 4: Verify Final State
-
-```bash
-# 4.1 Final test run in worktree
-poetry --directory ../AssemblyZero-dependabot-audit-$AUDIT_ID run pytest --tb=short -q
-FINAL_EXIT=$?
-
-# 4.2 Compare with baseline
-echo "Baseline exit: $BASELINE_EXIT"
-echo "Final exit: $FINAL_EXIT"
-```
-
-### Phase 5: Cleanup
-
-```bash
-# 5.1 Remove Worktree
-git worktree remove ../AssemblyZero-dependabot-audit-$AUDIT_ID
-
-# 5.2 Delete local audit branch
-git branch -D dependabot-audit-$AUDIT_ID
-
-# 5.3 Sync main repo
-git pull origin main
+   --- exit == 0 ---
+6a. `gh pr edit <N> --body "<body>\n\nNo-Issue: automated dependency update (...)"`
+     — satisfies pr-sentinel Worker's No-Issue exemption
+6b. Wait 5s for pr-sentinel to re-evaluate
+6c. `gh pr review <N> --approve --body "..."` — PullRequestReview event
+     attributed to the invoking user (Code Review profile stat accrues to that user)
+6d. Poll `mergeable_state` until `clean` (up to 5 min)
+6e. `gh pr merge <N> --squash`
+6f. Evict worktree's poetry venv; `git worktree remove`; `git branch -D` the
+     audit branch
 ```
 
 ---
 
-## Decision Tree
+## Why the invoking user approves (not Cerberus-AZ)
 
-```
-Baseline passes?
-├── No → ABORT: Fix existing issues first
-└── Yes → Any Dependabot PRs?
-    ├── No → PASS: No action needed
-    └── Yes → For each PR:
-        ├── Merge and test
-        ├── Tests pass? → Keep merged
-        └── Tests fail? → Revert, comment, create issue
-```
+Cerberus-AZ auto-approves Marty-authored PRs after pr-sentinel passes. Its approval events are attributed to the Cerberus-AZ GitHub App, not to the user. GitHub's Code Review profile stat counts reviews authored by the user.
+
+For dependabot PRs specifically — where the user did NOT author the code — the correct attribution is the user. The tool uses the invoking user's `gh` credentials to create the approval event. This is a bounded, author-gated, exit-code-gated scope; the same credentials do NOT approve anything else.
+
+Constraints embedded in the tool:
+- Author must be `dependabot[bot]` (hard gate)
+- Tests must exit 0 (hard gate)
+- Approval body explicitly names the tool and its gates
+
+Outside this specific tool, agent-initiated approvals remain disallowed.
 
 ---
 
-## Automation Status
+## On multi-package PRs
 
-**Current:** Manual procedure (this runbook)
+Dependabot PR bodies include one `` Updates `<package>` `` block per bumped package. The tool counts these via regex. If a multi-package PR fails tests:
 
-**Planned:** LangGraph workflow (see brief: Issue #TBD)
-- Programmatic exit code verification
-- No LLM interpretation of "passed" / "failed"
-- Structured state machine for rollback
+1. The failure comment is posted
+2. `@dependabot recreate` is posted as a second comment — dependabot listens for this and splits the grouped update into per-package PRs
+3. The next `/dependabot` run processes the smaller PRs, and typically only one of the per-package splits actually fails
+
+This is bisect-by-dependabot, not bisect-by-us. Dependabot does the splitting; our tool processes whatever dependabot produces.
+
+---
+
+## Forensics on failure
+
+When the tool leaves a worktree in place, it's at `C:/Users/mcwiz/Projects/AssemblyZero-dependabot-<N>`. You can:
+
+```bash
+cd C:/Users/mcwiz/Projects/AssemblyZero-dependabot-<N>
+poetry run pytest --tb=long <path_to_failing_test> -x
+```
+
+When done investigating:
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry env remove --all
+git worktree remove ../AssemblyZero-dependabot-<N>
+git branch -D dependabot-audit-<N>
+```
+
+The cleanup skill will also catch this as an orphan directory per Fix 5's logic.
+
+---
+
+## Summary output
+
+At end of run, the tool prints:
+
+```
+=== Summary ===
+  Merged:   [756, 741]
+  Deferred: [479]
+  Errored:  []
+```
+
+- **Merged:** PR passed both gates and is on main.
+- **Deferred:** PR failed a gate (test failure or poetry install failure). Worktree retained, comment posted, possibly `@dependabot recreate` posted.
+- **Errored:** Infrastructure failure (couldn't create worktree, couldn't checkout PR, couldn't approve, etc.). Worktree is cleaned up; the PR needs manual attention.
 
 ---
 
 ## Integration
 
 Run this audit:
-- Before Security Audit (0809)
-- Weekly as maintenance
-- When Dependabot alerts accumulate
+
+- On demand via `/dependabot`
+- Before shipping a batch of features (so dependencies stay current)
+- Weekly as maintenance if the queue has been neglected
+- Can be wired to the `schedule` skill for passive processing — not in scope for v2.0
 
 ---
 
-## Audit Record
+## Related Documents
 
-| Date | Auditor | PRs Processed | Outcome | Issues Created |
-|------|---------|---------------|---------|----------------|
-| | | | | |
-
----
-
-## References
-
-- `.claude/templates/docs/dependabot-audit.md` - Original template
-- `docs/audits/0812-ai-supply-chain.md` - Supply chain context
-- GitHub Dependabot documentation
+- `tools/dependabot_review.py` — the implementation
+- `.claude/commands/dependabot.md` — the skill wrapper
+- `docs/standards/0016-pr-sentinel-system-architecture.md` — pr-sentinel `No-Issue:` semantics
+- #949 — tracking issue for v2.0
+- #692 — auto-merge variant (related; different goal — this runbook keeps a human-in-the-loop via the review attribution)
+- #944 / PR #945 — poetry venv eviction (Fix 5), reused here
 
 ---
 
-*Template source: AssemblyZero/.claude/templates/docs/dependabot-audit.md*
+## History
+
+| Date | Change |
+|------|--------|
+| 2026-02-15 | v1.0: Initial runbook — manual procedure, merge-first / test-after, no pr-sentinel integration |
+| 2026-04-19 | v2.0 (#949): Rewritten for current branch protection + pr-sentinel. Test-then-merge order. Author gate, exit-code gate, `No-Issue:` body injection, approval attributed to invoking user (Code Review stat), multi-package split via `@dependabot recreate`, poetry venv eviction. Mechanical implementation at `tools/dependabot_review.py` and `/dependabot` skill. |

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Deterministic dependabot PR review + merge.
+
+Hard gates (no LLM in the loop):
+
+1. Author gate: every PR must be authored by `dependabot[bot]`. Any other
+   author is a hard refusal — the script will not approve or merge it.
+2. Test gate: `poetry run pytest` must exit 0. Non-zero exit means the PR
+   is commented on and left for human review; no approval, no merge.
+
+For each open dependabot-authored PR:
+
+- Create an audit worktree from current main
+- `gh pr checkout <N>` into the worktree (brings the dep bump in)
+- Evict any poetry-cached venv (Fix 5 / #944) so Windows file locks release
+- `poetry install` (fresh)
+- `poetry run pytest` — capture exit code
+- On green (exit 0):
+    - Edit PR body to append `No-Issue: automated dependency update (...)`
+      so pr-sentinel's No-Issue exemption passes
+    - `gh pr review --approve` via the invoking user's credentials (creates a
+      PullRequestReview event attributed to that user)
+    - Poll `mergeable_state` until clean
+    - `gh pr merge --squash`
+    - Clean up worktree + audit branch
+- On red (non-zero):
+    - Comment on PR with exit code + forensics worktree path
+    - If multi-package PR: request `@dependabot recreate` to split into
+      per-package PRs
+    - Leave worktree in place for forensics
+    - Move to next PR (one failure does not block the queue)
+
+Usage:
+    poetry run python tools/dependabot_review.py [--repo OWNER/REPO] [--dry-run]
+
+Issue: #949 | Related: #692 | Runbook: 0911 v2.0
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+GITHUB_USER = "martymcenroe"
+DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
+EXPECTED_AUTHOR = "dependabot[bot]"
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 300
+PYTEST_TIMEOUT_S = 1800
+POETRY_INSTALL_TIMEOUT_S = 600
+
+
+@dataclass
+class PRInfo:
+    number: int
+    title: str
+    author_login: str
+    body: str
+    head_ref: str
+
+
+# ---------------------------------------------------------------------------
+# Subprocess wrapper — every command is visible
+# ---------------------------------------------------------------------------
+
+def run(cmd: list[str], cwd: str | None = None,
+        timeout: int | None = None) -> subprocess.CompletedProcess:
+    """Run a subprocess and echo the command to stdout."""
+    print(f"  $ {' '.join(cmd)}")
+    try:
+        return subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True,
+            timeout=timeout, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  TIMEOUT after {timeout}s")
+        return subprocess.CompletedProcess(cmd, returncode=124, stdout="", stderr="TIMEOUT")
+
+
+# ---------------------------------------------------------------------------
+# PR enumeration
+# ---------------------------------------------------------------------------
+
+def list_dependabot_prs(repo: str) -> list[PRInfo]:
+    result = run([
+        "gh", "pr", "list", "--repo", repo,
+        "--author", "app/dependabot",
+        "--state", "open",
+        "--json", "number,title,author,body,headRefName",
+    ])
+    if result.returncode != 0:
+        sys.exit(f"Failed to list PRs: {result.stderr}")
+    raw = json.loads(result.stdout or "[]")
+    return [
+        PRInfo(
+            number=r["number"],
+            title=r["title"],
+            author_login=r["author"]["login"],
+            body=r["body"] or "",
+            head_ref=r["headRefName"],
+        )
+        for r in raw
+    ]
+
+
+def count_packages(body: str) -> int:
+    """Count 'Updates `pkg`' blocks in the PR body — one per package bumped."""
+    return len(re.findall(r"Updates `[^`]+`", body))
+
+
+# ---------------------------------------------------------------------------
+# Hard gates
+# ---------------------------------------------------------------------------
+
+def verify_author(pr: PRInfo) -> bool:
+    if pr.author_login != EXPECTED_AUTHOR:
+        print(f"  REFUSE: PR #{pr.number} author is '{pr.author_login}', "
+              f"expected '{EXPECTED_AUTHOR}' — this script operates only on "
+              f"dependabot PRs")
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Worktree + env setup
+# ---------------------------------------------------------------------------
+
+def create_audit_worktree(main_repo: Path, pr_number: int) -> tuple[Path, str]:
+    worktree = main_repo.parent / f"{main_repo.name}-dependabot-{pr_number}"
+    branch = f"dependabot-audit-{pr_number}"
+    result = run(["git", "-C", str(main_repo), "worktree", "add",
+                  str(worktree), "-b", branch, "main"])
+    if result.returncode != 0:
+        sys.exit(f"Could not create worktree: {result.stderr}")
+    return worktree, branch
+
+
+def checkout_pr_into_worktree(worktree: Path, pr_number: int, repo: str) -> bool:
+    result = run(["gh", "pr", "checkout", str(pr_number), "--repo", repo],
+                 cwd=str(worktree))
+    return result.returncode == 0
+
+
+def evict_poetry_venv(worktree: Path) -> None:
+    """Fix 5 / #944 — evict poetry-cached venv to release Windows file locks."""
+    if not (worktree / "pyproject.toml").exists():
+        return
+    run(["poetry", "env", "remove", "--all"], cwd=str(worktree))
+
+
+def install_deps(worktree: Path) -> bool:
+    if not (worktree / "pyproject.toml").exists():
+        return True  # Not a poetry project
+    result = run(["poetry", "install"], cwd=str(worktree),
+                 timeout=POETRY_INSTALL_TIMEOUT_S)
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Test gate
+# ---------------------------------------------------------------------------
+
+def run_tests(worktree: Path) -> int:
+    result = run(["poetry", "run", "pytest", "-q", "--tb=short"],
+                 cwd=str(worktree), timeout=PYTEST_TIMEOUT_S)
+    print(f"  pytest exit code: {result.returncode}")
+    return result.returncode
+
+
+# ---------------------------------------------------------------------------
+# PR mutation (only after both gates pass)
+# ---------------------------------------------------------------------------
+
+def inject_no_issue(pr: PRInfo, repo: str) -> bool:
+    package_count = count_packages(pr.body)
+    tag = (
+        f"No-Issue: automated dependency update "
+        f"({package_count} package{'s' if package_count != 1 else ''}, "
+        f"approved after green test run via tools/dependabot_review.py)"
+    )
+    new_body = pr.body.rstrip() + "\n\n" + tag
+    result = run(["gh", "pr", "edit", str(pr.number), "--repo", repo,
+                  "--body", new_body])
+    return result.returncode == 0
+
+
+def approve_pr(pr_number: int, repo: str) -> bool:
+    result = run([
+        "gh", "pr", "review", str(pr_number), "--repo", repo, "--approve",
+        "--body",
+        "Automated review via tools/dependabot_review.py — test suite passed "
+        "(exit 0). Deterministic gate; no LLM in loop. "
+        "Author and exit-code gates enforced.",
+    ])
+    return result.returncode == 0
+
+
+def wait_for_mergeable(pr_number: int, repo: str) -> bool:
+    deadline = time.time() + MERGEABLE_TIMEOUT_S
+    while time.time() < deadline:
+        result = run(["gh", "api", f"repos/{repo}/pulls/{pr_number}",
+                      "--jq", ".mergeable_state"])
+        state = (result.stdout or "").strip().strip('"')
+        print(f"  mergeable_state: {state}")
+        if state == "clean":
+            return True
+        time.sleep(POLL_INTERVAL_S)
+    return False
+
+
+def squash_merge(pr_number: int, repo: str) -> bool:
+    result = run(["gh", "pr", "merge", str(pr_number), "--repo", repo, "--squash"])
+    return result.returncode == 0
+
+
+def comment_on_pr(pr_number: int, repo: str, body: str) -> None:
+    run(["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", body])
+
+
+def request_dependabot_recreate(pr_number: int, repo: str) -> None:
+    comment_on_pr(
+        pr_number, repo,
+        "Test suite failed on this multi-package PR. Splitting via @dependabot "
+        "recreate to isolate the failing package.",
+    )
+    comment_on_pr(pr_number, repo, "@dependabot recreate")
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> None:
+    evict_poetry_venv(worktree)
+    run(["git", "-C", str(main_repo), "worktree", "remove", str(worktree)])
+    run(["git", "-C", str(main_repo), "branch", "-D", branch])
+
+
+# ---------------------------------------------------------------------------
+# Per-PR processing
+# ---------------------------------------------------------------------------
+
+def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
+    """Process a single PR. Returns 'merged', 'deferred', or 'errored'."""
+    print(f"\n=== PR #{pr.number}: {pr.title} ===")
+
+    if not verify_author(pr):
+        return "errored"
+
+    worktree, branch = create_audit_worktree(main_repo, pr.number)
+
+    if not checkout_pr_into_worktree(worktree, pr.number, repo):
+        print("  ERROR: gh pr checkout failed")
+        cleanup_worktree(main_repo, worktree, branch)
+        return "errored"
+
+    evict_poetry_venv(worktree)
+
+    if not install_deps(worktree):
+        print("  ERROR: poetry install failed")
+        comment_on_pr(pr.number, repo,
+                      "Automated review via tools/dependabot_review.py — "
+                      "`poetry install` failed. Check Actions / worktree for details.")
+        # Leave worktree for forensics
+        return "deferred"
+
+    exit_code = run_tests(worktree)
+
+    if exit_code != 0:
+        package_count = count_packages(pr.body)
+        comment_on_pr(
+            pr.number, repo,
+            f"Automated review via tools/dependabot_review.py — test suite "
+            f"FAILED (exit {exit_code}). Worktree retained at `{worktree}` "
+            f"for forensics. Not approving, not merging.",
+        )
+        if package_count > 1:
+            print(f"  Multi-package PR ({package_count} packages) — "
+                  f"requesting dependabot recreate")
+            request_dependabot_recreate(pr.number, repo)
+        # Leave worktree in place for forensics
+        return "deferred"
+
+    # ---- Green path ----
+    if not inject_no_issue(pr, repo):
+        print("  ERROR: inject No-Issue failed")
+        cleanup_worktree(main_repo, worktree, branch)
+        return "errored"
+
+    # Small wait for pr-sentinel to re-evaluate the edited body
+    time.sleep(5)
+
+    if not approve_pr(pr.number, repo):
+        print("  ERROR: approve failed")
+        cleanup_worktree(main_repo, worktree, branch)
+        return "errored"
+
+    if not wait_for_mergeable(pr.number, repo):
+        print(f"  ERROR: mergeable_state never reached 'clean' within {MERGEABLE_TIMEOUT_S}s")
+        cleanup_worktree(main_repo, worktree, branch)
+        return "errored"
+
+    if not squash_merge(pr.number, repo):
+        print("  ERROR: merge failed")
+        cleanup_worktree(main_repo, worktree, branch)
+        return "errored"
+
+    cleanup_worktree(main_repo, worktree, branch)
+    return "merged"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Deterministic dependabot PR review + merge "
+                    "(author gate + exit-code gate, no LLM in loop).",
+    )
+    parser.add_argument("--repo", default=DEFAULT_REPO,
+                        help=f"GitHub repo (default: {DEFAULT_REPO})")
+    parser.add_argument("--main-repo", default=str(Path.cwd()),
+                        help="Path to main repo (default: cwd)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List PRs that would be processed; take no action")
+    args = parser.parse_args()
+
+    main_repo = Path(args.main_repo).resolve()
+    if not (main_repo / ".git").exists():
+        sys.exit(f"Not a git repo: {main_repo}")
+
+    prs = list_dependabot_prs(args.repo)
+    if not prs:
+        print("No open dependabot PRs. Nothing to do.")
+        return
+
+    print(f"Found {len(prs)} open dependabot PR(s):")
+    for pr in prs:
+        print(f"  #{pr.number}: {pr.title} ({count_packages(pr.body)} packages)")
+
+    if args.dry_run:
+        print("\n(dry-run; exiting)")
+        return
+
+    results: dict[str, list[int]] = {"merged": [], "deferred": [], "errored": []}
+    for pr in prs:
+        status = process_pr(pr, args.repo, main_repo)
+        results[status].append(pr.number)
+
+    print("\n=== Summary ===")
+    print(f"  Merged:   {results['merged']}")
+    print(f"  Deferred (test failures / install errors, worktree retained): "
+          f"{results['deferred']}")
+    print(f"  Errored:  {results['errored']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Deterministic, author-gated, exit-code-gated tool for processing open dependabot PRs. Tests each PR in an audit worktree; on green, injects \`No-Issue:\` into the body (pr-sentinel exemption), approves using the invoking user's credentials (creates a \`PullRequestReview\` event attributed to the user, which accrues on the user's Code Review profile stat), then squash-merges. On red: comments with forensics path and leaves for human review; splits multi-package PRs via \`@dependabot recreate\`.

## Hard gates — no LLM in the loop

- **Author gate:** PR author must be \`dependabot[bot]\`. Any other author is refused at the first check. Belt-and-suspenders with the \`gh pr list --author app/dependabot\` enumeration filter.
- **Exit-code gate:** \`poetry run pytest -q --tb=short\` must exit 0. Non-zero means no approval, no merge, PR comment with forensics worktree path. The LLM is not consulted about "whether failures look related."

## Three artifacts

### \`tools/dependabot_review.py\`

~300 lines, stdlib + subprocess. Every command echoed to stdout before execution. \`--dry-run\` lists candidates without action. Reuses Fix 5 / #944 poetry venv eviction pattern for Windows file-lock release. Per-PR flow:

1. Verify author
2. Create audit worktree from main
3. \`gh pr checkout\` into worktree
4. Evict cached poetry venv + \`poetry install\`
5. \`poetry run pytest\` → capture exit code
6. **Green path:** inject \`No-Issue:\` → \`gh pr review --approve\` (attributed to user) → poll \`mergeable_state\` → \`gh pr merge --squash\` → cleanup
7. **Red path:** comment with exit code + worktree path; if multi-package, post \`@dependabot recreate\`; leave worktree retained; move on

### \`.claude/commands/dependabot.md\`

Thin skill wrapper. Checks for non-zero dependabot PR count before invoking; relays the tool's summary at end.

### \`docs/runbooks/0911-dependabot-pr-audit.md\` v2.0

Rewritten from v1.0's merge-first / test-after (backwards order) to test-then-approve. Documents:
- Hard gates
- \`No-Issue:\` injection
- Why the invoking user approves (not Cerberus-AZ — attribution matters for profile stats)
- Multi-package split via \`@dependabot recreate\`
- Forensics on failure
- Integration with \`/dependabot\` skill

## Attribution rationale

Cerberus-AZ auto-approves Marty-authored PRs; that attribution goes to the Cerberus-AZ App, not to the user. For dependabot PRs (where the user did not author the code), the correct attribution is the user. The tool uses the invoking user's \`gh\` credentials to create the approval event in a bounded scope — author-gated + exit-code-gated. Outside this tool, agent-initiated approvals remain disallowed.

## Smoke tests (on this PR's branch)

- \`--help\` renders the argparse output cleanly
- \`--dry-run\` enumerates the three current open dependabot PRs:
  - #756 (3 packages: hono, undici x2)
  - #741 (2 packages: hono, fast-xml-parser)
  - #479 (1 package: torch)

Package counts derived via regex on \`Updates \\`<pkg>\\`\` blocks in each PR body — matches manual inspection.

## Test plan

- [ ] After merge, run \`/dependabot\` (or invoke the tool directly) against the three open dependabot PRs
- [ ] Verify Code Review quadrant moves off 0% on the user's profile after the run
- [ ] Verify worktree retention on any PR that fails tests
- [ ] Verify \`@dependabot recreate\` comment posted on any multi-package PR that fails

## Non-goals

- Scheduling (can be layered via the \`schedule\` skill later, not in scope for v2.0)
- Cerberus reconfiguration (attribution intentionally diverges from Cerberus's role)
- Folding into \`/cleanup\` / \`/handoff\` / \`/pickup\` (rejected — test runs are long, don't belong in session-boundary rituals)

## References

- Runbook 0911 v1.0 (baseline replaced)
- #692 (auto-merge variant; this PR is the human-gated-review variant)
- #944 / PR #945 (Fix 5 poetry venv eviction, reused)
- Standard 0016 (pr-sentinel \`No-Issue:\` semantics)

Closes #949