### PR TITLE
fix: dependabot_review.py accepts both author string forms (Closes #951)

### DIFF
--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -47,7 +47,11 @@ from pathlib import Path
 
 GITHUB_USER = "martymcenroe"
 DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
-EXPECTED_AUTHOR = "dependabot[bot]"
+# GitHub returns different strings for the same bot depending on API surface:
+#   - REST API / web UI:              "dependabot[bot]"
+#   - gh CLI GraphQL .author.login:   "app/dependabot"
+# Accept both forms at the hard gate — still refuses anything else.
+ACCEPTED_AUTHORS: tuple[str, ...] = ("dependabot[bot]", "app/dependabot")
 POLL_INTERVAL_S = 10
 MERGEABLE_TIMEOUT_S = 300
 PYTEST_TIMEOUT_S = 1800
@@ -117,10 +121,10 @@ def count_packages(body: str) -> int:
 # ---------------------------------------------------------------------------
 
 def verify_author(pr: PRInfo) -> bool:
-    if pr.author_login != EXPECTED_AUTHOR:
+    if pr.author_login not in ACCEPTED_AUTHORS:
         print(f"  REFUSE: PR #{pr.number} author is '{pr.author_login}', "
-              f"expected '{EXPECTED_AUTHOR}' — this script operates only on "
-              f"dependabot PRs")
+              f"expected one of {ACCEPTED_AUTHORS} — this script operates only "
+              f"on dependabot PRs")
         return False
     return True
 


### PR DESCRIPTION
## Summary

Single-character-class fix to the author gate in `tools/dependabot_review.py`. GitHub returns `app/dependabot` as `.author.login` via the gh CLI but `dependabot[bot]` via REST/web UI. The tool hardcoded the REST form, so the gh-CLI-returned string didn't match and every dependabot PR was refused.

Observed on first real run of #950's tool — all three pending PRs (#756, #741, #479) fell through to the REFUSE branch. Tool logic correct; input expectation wrong.

## Change

`EXPECTED_AUTHOR = "dependabot[bot]"` → `ACCEPTED_AUTHORS = ("dependabot[bot]", "app/dependabot")`. Same hard-gate behavior — only those two specific strings pass, everything else refused — just covering both representations GitHub returns.

## Smoke test

- `app/dependabot` → accepted ✓
- `dependabot[bot]` → accepted ✓
- `malicious-actor` → refused with clear message ✓

## Non-goals

- No change to the skill or runbook
- No change to exit-code gate or any other logic
- No relaxation of the gate — still only two specific bot identities accepted

Closes #951