### PR TITLE
fix: /handoff Step 6 preserves foreground window (#969)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -302,11 +302,11 @@ After persisting the handoff log, spawn a new `unleashed-alpha` session. Auto-on
 1. **Get repo root Windows path:** Convert the git toplevel path to a Windows path with backslashes (e.g. `C:\Users\mcwiz\Projects\AssemblyZero`)
 2. **Get repo name uppercased** for the window title (e.g. `ASSEMBLYZERO`)
 3. **Get Unix-style repo path** for the cd command (e.g. `/c/Users/mcwiz/Projects/AssemblyZero`)
-4. **Spawn via Python** (MSYS2 mangles paths — must go through cmd.exe):
+4. **Spawn via Python** (MSYS2 mangles paths — must go through cmd.exe). Capture the user's foreground HWND before the spawn and restore it after an 800ms delay so the new WT window can't steal focus from whatever app they switched to mid-handoff (see #969):
    ```bash
-   python -c "import subprocess; subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed-alpha\"', shell=True)"
+   python -c "import ctypes,subprocess,time; u32=ctypes.windll.user32; h=u32.GetForegroundWindow(); subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed-alpha\"', shell=True); time.sleep(0.8); u32.SetForegroundWindow(h)"
    ```
-   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed-alpha`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps.
+   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed-alpha`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps. The HWND save/restore keeps the user's original foreground window (Chrome/IDE/etc.) in focus after the new WT window appears.
 5. **Tell user:** "New unleashed-alpha session spawning in {REPO_NAME} with auto-onboard."
 
 ## Rules


### PR DESCRIPTION
## Summary

\`/handoff\` Step 6 spawns a new \`unleashed-alpha\` window via \`wt.exe -w new nt\`. With no focus-preservation around that call, the new WT window yanks OS-level focus away from whatever app the user switched to while the handoff was persisting artifacts. Observed today: typing in a browser was redirected into the freshly spawned onboard session.

## Fix

Inline HWND save/restore bracket around the existing Python one-liner in \`.claude/commands/handoff.md\` line 307:

\`\`\`python
u32 = ctypes.windll.user32
h = u32.GetForegroundWindow()      # capture BEFORE spawn
subprocess.Popen(r'wt.exe ...')    # spawn new WT window
time.sleep(0.8)                    # let wt.exe finish activation
u32.SetForegroundWindow(h)         # restore user's app
\`\`\`

## Related

- Sibling fix unleashed#337 / #338 (companion tabs INSIDE the wrapper, already merged). 
- This PR covers the separate spawn-time steal that happens BEFORE the wrapper process exists.

## Test plan (manual, post-merge)

1. In a Claude session, run \`/handoff\`.
2. Immediately switch to Chrome and start typing in the address bar.
3. Wait for handoff to complete (~30s). New WT window pops open.
4. Expected: Chrome keeps focus; mid-sentence keystrokes stay in the address bar.

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)