### PR TITLE
fix: /onboard and /pickup use poetry run python (Closes #977)

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -145,7 +145,7 @@ If post-handoff sessions exist, show: "Note: {N} session(s) ran after this hando
    - `plan_path` is set but the file is missing → Fall back to `{archive_path}`. Warn user: "Live plan missing, reading archived copy instead."
    - No plan-state block, or `plan_state: none` → Continue without a plan.
 4. Read every file listed in the "Files to Read First" section
-5. **Write the pickup marker** by running: `python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
+5. **Write the pickup marker** by running: `poetry run python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
    If it fails, report the error to the user. Do NOT proceed silently.
 6. Report: "Picked up handoff from {age}. {N} files read."
 

--- a/.claude/commands/pickup.md
+++ b/.claude/commands/pickup.md
@@ -86,7 +86,7 @@ Ask the user: "Import this handoff? (Y/n)"
    - What the next steps are
    - How many files you read from the "Files to Read First" list
    - Whether a plan was resumed, started fresh, or absent
-5. **Write the pickup marker** by running: `python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
+5. **Write the pickup marker** by running: `poetry run python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
    If it fails, report the error to the user. Do NOT proceed silently.
 
 Tell the user: "Pickup complete. Ready to continue where the last session left off."


### PR DESCRIPTION
## Summary

- Replace bare `python` with `poetry run python` in both `/onboard` (Step 1C.5) and `/pickup` (Step 5) skill instructions for the `pickup_marker.py` invocation.
- Brings the skills into line with the root `Projects/CLAUDE.md` rule: "\`poetry run python\` for all execution — never bare \`python\`".

Two lines, two files:
- `.claude/commands/onboard.md:148`
- `.claude/commands/pickup.md:89`

## Test plan

- [ ] After merge, run `python src/skill_sync.py` from the unleashed repo to propagate into `~/.claude/commands/`
- [ ] Next `/onboard` or `/pickup` invocation writes the pickup marker via `poetry run python` (visible in Bash tool call log)
- [ ] `grep -n "\`python C:" .claude/commands/*.md` returns no matches

Closes #977