### PR TITLE
fix: /handoff Step 4 delegates spawn to deterministic script (Closes #983)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -299,15 +299,13 @@ Brief backward-looking record of the session. One entry per session.
 
 After persisting the handoff log, spawn a new `unleashed-alpha` session. Auto-onboard (default in v30+) detects the fresh handoff and auto-picks up the context. **Always spawn the alpha tier**, not production — this ensures every post-handoff session lands on the current-iteration build so new fixes get exercised. Users who need production can still invoke `unleashed` manually.
 
-1. **Get repo root Windows path:** Convert the git toplevel path to a Windows path with backslashes (e.g. `C:\Users\mcwiz\Projects\AssemblyZero`)
-2. **Get repo name uppercased** for the window title (e.g. `ASSEMBLYZERO`)
-3. **Get Unix-style repo path** for the cd command (e.g. `/c/Users/mcwiz/Projects/AssemblyZero`)
-4. **Spawn via Python** (MSYS2 mangles paths — must go through cmd.exe). Capture the user's foreground HWND before the spawn and restore it after an 800ms delay so the new WT window can't steal focus from whatever app they switched to mid-handoff (see #969):
+1. **Get repo root:** `git rev-parse --show-toplevel` (MSYS form is fine; the script accepts either MSYS `/c/...` or Windows `C:\...`).
+2. **Delegate to the spawn script** (deterministic Python, tested — replaces the prior inline `python -c "..."` that agents skipped per `feedback_deterministic_python_not_agent_instructions.md`). The script normalizes paths, saves the user's foreground HWND, spawns `wt.exe -w new nt ...` running `unleashed-alpha` in the target repo, then restores foreground after 800ms so the new WT window can't steal focus:
    ```bash
-   python -c "import ctypes,subprocess,time; u32=ctypes.windll.user32; h=u32.GetForegroundWindow(); subprocess.Popen(r'wt.exe -w new nt --title \"{REPO_NAME}\" --suppressApplicationTitle -d \"{WINDOWS_PATH}\" \"C:\Program Files\Git\usr\bin\bash.exe\" -l -c \"cd {UNIX_PATH} && unleashed-alpha\"', shell=True); time.sleep(0.8); u32.SetForegroundWindow(h)"
+   poetry run python C:/Users/mcwiz/Projects/unleashed/src/handoff_spawn.py --repo-root {REPO_ROOT}
    ```
-   This opens a new Windows Terminal window, cd's to the target repo, and runs `unleashed-alpha`. The wrapper auto-injects `/onboard` after Claude's first prompt. Onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps. The HWND save/restore keeps the user's original foreground window (Chrome/IDE/etc.) in focus after the new WT window appears.
-5. **Tell user:** "New unleashed-alpha session spawning in {REPO_NAME} with auto-onboard."
+   On success it prints `Spawned unleashed-alpha in new window: {REPO_NAME} ({WINDOWS_PATH})`. On failure it prints `ERROR:` to stderr and exits non-zero — report that to the user. The wrapper auto-injects `/onboard` after Claude's first prompt; onboard detects the fresh handoff (< 10 min old) and auto-imports it. Zero manual steps.
+3. **Tell user:** "New unleashed-alpha session spawning with auto-onboard."
 
 ## Rules
 


### PR DESCRIPTION
## Summary

`/handoff` Step 4 is now a one-liner that calls `src/handoff_spawn.py` in the unleashed repo (added in martymcenroe/unleashed#347). The inline `python -c "..."` that agents skipped per `feedback_deterministic_python_not_agent_instructions.md` is gone.

Before:
```bash
python -c "import ctypes,subprocess,time; u32=ctypes.windll.user32; h=u32.GetForegroundWindow(); subprocess.Popen(r'wt.exe -w new nt --title \"...\" ...', shell=True); time.sleep(0.8); u32.SetForegroundWindow(h)"
```

After:
```bash
poetry run python C:/Users/mcwiz/Projects/unleashed/src/handoff_spawn.py --repo-root {REPO_ROOT}
```

Steps 1-3 collapsed to steps 1-2 (script handles path normalization internally).

## Test plan

- [x] `grep -n "python -c" .claude/commands/handoff.md` returns no matches
- [x] Script exists at referenced path (merged via martymcenroe/unleashed#347)
- [ ] After merge, run `poetry run python src/skill_sync.py` from unleashed to propagate into `~/.claude/commands/`
- [ ] Next /handoff actually spawns a window (verifiable next session)

Closes #983