### PR TITLE
fix: fleet_delete_pr_sentinel.py PR_BODY template correct for cross-repo refs (Closes #988)

### DIFF
--- a/tests/tools/test_fleet_delete_pr_sentinel.py
+++ b/tests/tools/test_fleet_delete_pr_sentinel.py
@@ -516,3 +516,76 @@ class TestWaitForMergeable_BlockedToleration:
         # With timeout_s=0 the loop exits immediately with last_state
         result = fdps.wait_for_mergeable("X", 1, FAKE_PAT, timeout_s=0, sleep_fn=lambda s: None)
         assert result == "unknown"
+
+
+# --- #988: PR_BODY template correctness for same-repo and cross-repo refs
+
+
+class TestProcessRepoBodyFormatting:
+    """Issue #988: PR_BODY template must produce a well-formed `Closes <ref>`
+    line regardless of whether the ref is same-repo (`#42`) or cross-repo
+    (`owner/repo#42`). The previous template hardcoded a `#` before
+    `{issue_number}` which silently survived same-repo (the worker's regex
+    skipped the spurious `#`) but broke cross-repo (no digit pattern
+    immediately after `#`)."""
+
+    def _setup_mocks(self, monkeypatch, body_capture: dict):
+        monkeypatch.setattr(fdps, "get_file_info", mock.Mock(return_value={"sha": "abc"}))
+        monkeypatch.setattr(fdps, "find_existing_deletion_pr", mock.Mock(return_value=None))
+        monkeypatch.setattr(fdps, "get_branch_head", mock.Mock(return_value="mainsha"))
+        monkeypatch.setattr(fdps, "create_branch", mock.Mock())
+        monkeypatch.setattr(fdps, "delete_file_on_branch", mock.Mock())
+
+        def _capture_pr(repo, head, base, title, body, pat):
+            body_capture["title"] = title
+            body_capture["body"] = body
+            return 42
+
+        monkeypatch.setattr(fdps, "create_pr", mock.Mock(side_effect=_capture_pr))
+        monkeypatch.setattr(fdps, "wait_for_mergeable", mock.Mock(return_value="clean"))
+        monkeypatch.setattr(fdps, "merge_pr", mock.Mock(return_value="mergesha"))
+
+    def test_same_repo_body_has_single_hash(self, monkeypatch):
+        captured: dict = {}
+        monkeypatch.setattr(fdps, "create_issue", mock.Mock(return_value=99))
+        self._setup_mocks(monkeypatch, captured)
+
+        fdps.process_repo("X", FAKE_PAT, dry_run=False)
+
+        # Body must contain `Closes #99` — single `#`, worker regex matches cleanly
+        assert "Closes #99" in captured["body"]
+        assert "Closes ##99" not in captured["body"], (
+            "double `#` is the old bug — template hardcoded `#` before the "
+            "substituted value which itself started with `#`"
+        )
+
+    def test_cross_repo_body_has_no_leading_hash(self, monkeypatch):
+        captured: dict = {}
+        create_issue_mock = mock.Mock(side_effect=AssertionError("must not be called"))
+        monkeypatch.setattr(fdps, "create_issue", create_issue_mock)
+        self._setup_mocks(monkeypatch, captured)
+
+        fdps.process_repo(
+            "X", FAKE_PAT, dry_run=False,
+            external_issue_ref="martymcenroe/AssemblyZero#982",
+        )
+
+        # Body must contain `Closes martymcenroe/AssemblyZero#982` — NO leading `#`.
+        # The old template produced `Closes #martymcenroe/AssemblyZero#982` which the
+        # worker's regex couldn't parse (not `owner/repo#N` shape, not `#N` shape).
+        assert "Closes martymcenroe/AssemblyZero#982" in captured["body"]
+        assert "Closes #martymcenroe/AssemblyZero#982" not in captured["body"], (
+            "the old template bug — hardcoded `#` in front of a cross-repo ref "
+            "broke the worker's extractIssueRefs regex"
+        )
+
+    def test_title_unaffected_by_bug(self, monkeypatch):
+        """Title construction was always correct; this is a regression guard."""
+        captured: dict = {}
+        monkeypatch.setattr(fdps, "create_issue", mock.Mock(return_value=99))
+        self._setup_mocks(monkeypatch, captured)
+
+        fdps.process_repo("X", FAKE_PAT, dry_run=False)
+
+        assert "Closes #99" in captured["title"]
+        assert "Closes ##99" not in captured["title"]

--- a/tools/fleet_delete_pr_sentinel.py
+++ b/tools/fleet_delete_pr_sentinel.py
@@ -103,7 +103,7 @@ processed automatically by `tools/fleet_delete_pr_sentinel.py`.
 
 PR_BODY = """## Summary
 
-Deletes `.github/workflows/pr-sentinel.yml`. Closes #{issue_number}.
+Deletes `.github/workflows/pr-sentinel.yml`. Closes {issue_number}.
 
 Branch protection on this repo gates on the Cloudflare Worker check
 `pr-sentinel / issue-reference` (app_id 2975092). The legacy per-repo


### PR DESCRIPTION
## Summary

Fixes a latent bug in `tools/fleet_delete_pr_sentinel.py` — the `PR_BODY` template had a hardcoded `#` before `{issue_number}` which broke cross-repo refs. Closes #988.

Discovered today running the tool against hermes-docs (the 44th and final repo in the fleet retirement) with `--external-issue-ref`. The PR sat blocked for the full 900s window because the worker check kept returning "No issue reference found." The body had a malformed double-hash ref that the worker's regex couldn't parse. Manual body edit unblocked it; that's how the 44/44 cleanup actually landed.

## Root cause

```python
# Old template (bug)
PR_BODY = "... (close-directive) #{issue_number}. ..."

# ref_for_pr construction:
if external_issue_ref:
    ref_for_pr = external_issue_ref  # e.g., "owner/repo#N"
else:
    ref_for_pr = f"#{issue_number}"  # e.g., "#N" with leading hash
```

After substitution, the template's hardcoded `#` collides with the one already inside `ref_for_pr`:

- **Same-repo**: produces `<directive> ##N`. Worker regex `/\b(?:close[sd]?)\s+...#(\d+)/gi` skips the spurious `#` and still extracts N from the second `#`. Silently survived — bug was invisible.
- **Cross-repo**: produces `<directive> #owner/repo#N`. Regex can't parse — not the `owner/repo#N` shape (leading `#` breaks it), not the `#N` shape (no digits right after the `#`). Extracted no refs. Worker rejected.

(Using `<directive>` above instead of the actual word so the PR body itself doesn't get flagged by the worker's own regex — which is exactly the class of false positive that killed PR #989 on its first attempt.)

## Fix

One-character change: drop the `#` from the template. `ref_for_pr` supplies it in the same-repo case; cross-repo refs don't need one.

## Tests

+3 cases in `test_fleet_delete_pr_sentinel.py`:
- same-repo body has single `#` in front of the number
- cross-repo body has NO leading `#` in front of the owner/repo
- title unaffected by bug (regression guard — title path was always correct)

38/38 tests in this file pass. 85/85 across related test files (`fleet_delete_pr_sentinel`, `dependabot_review`, `pat_session`, `sentinel_migrate`).

## Blast radius

Low — the fleet retirement is complete (all 44 repos done), so this bug would only bite a future reuse of the tool with `--external-issue-ref`. But the bug is latent and the fix is trivial; worth closing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
