### PR TITLE
refactor: new_repo_setup — in-process classic PAT for branch protection + repo settings (Closes #964)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -47,6 +47,19 @@ except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
     from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
 
+# In-process classic PAT for privileged REST calls (ADR-0216).
+# Branch protection PUT and repo settings PATCH used to shell out to
+# `gh api` which reads GH_TOKEN from the env block (snoopable by sibling
+# same-user processes); the PAT now lives only in the Python heap via
+# classic_pat_session(). gh repo create --source . --push still reads
+# GH_TOKEN for the workflow-scoped initial push — tracked in #1000.
+import requests  # noqa: E402
+try:
+    from _pat_session import classic_pat_session
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _pat_session import classic_pat_session
+
 
 # ---------------------------------------------------------------------------
 # Schema types and exceptions
@@ -1132,22 +1145,40 @@ def deploy_canonical_hooks(project_path: Path) -> None:
         shutil.copy2(str(source), str(target))
 
 
-def configure_branch_protection(github_user: str, repo_name: str) -> bool:
-    """
-    Configure branch protection on the main branch via GitHub API.
+_GH_API = "https://api.github.com"
+_HTTP_TIMEOUT_S = 30
 
-    Sets: require PR, block force push, block deletion.
-    Does NOT set required status checks (repo needs at least one push first).
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def configure_branch_protection(github_user: str, repo_name: str, pat: str) -> bool:
+    """
+    Configure branch protection on the main branch via GitHub REST API.
+
+    The privileged PUT is issued via `requests` using an in-process classic
+    PAT (ADR-0216) so the token never enters the subprocess argv or env block.
+    The branch-existence pre-check stays on `gh api` (read-only, fine-grained
+    PAT suffices and keeps a single source of truth for gh-CLI auth state).
+
+    Sets: require PR, block force push, block deletion, enforce_admins,
+    pr-sentinel / issue-reference required check.
 
     Args:
         github_user: GitHub username
         repo_name: Repository name
+        pat: Classic PAT obtained via classic_pat_session().
 
     Returns:
         True if protection was configured, False if it failed.
     """
     # Branch protection requires at least one commit on main.
-    # Verify remote branch exists before attempting.
+    # Verify remote branch exists before attempting. Read-only — no classic PAT needed.
     try:
         check = subprocess.run(
             ["gh", "api", f"/repos/{github_user}/{repo_name}/branches/main"],
@@ -1160,57 +1191,64 @@ def configure_branch_protection(github_user: str, repo_name: str) -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
 
+    body = {
+        "required_status_checks": {
+            "strict": False,
+            "contexts": ["pr-sentinel / issue-reference"],
+        },
+        "enforce_admins": True,
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 1,
+        },
+        "restrictions": None,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+    }
     try:
-        result = subprocess.run(
-            ["gh", "api", "-X", "PUT",
-             f"/repos/{github_user}/{repo_name}/branches/main/protection",
-             "-F", "required_pull_request_reviews[dismiss_stale_reviews]=false",
-             "-F", "required_pull_request_reviews[require_code_owner_reviews]=false",
-             "-F", "required_pull_request_reviews[required_approving_review_count]=1",
-             "-F", "enforce_admins=true",
-             "-F", "restrictions=null",
-             "-F", "required_status_checks[strict]=false",
-             "-f", "required_status_checks[contexts][]=pr-sentinel / issue-reference",
-             "-F", "allow_force_pushes=false",
-             "-F", "allow_deletions=false",
-             ],
-            capture_output=True,
-            text=True,
-            timeout=30,
+        resp = requests.put(
+            f"{_GH_API}/repos/{github_user}/{repo_name}/branches/main/protection",
+            headers=_gh_headers(pat),
+            json=body,
+            timeout=_HTTP_TIMEOUT_S,
         )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return resp.status_code < 300
+    except requests.RequestException:
         return False
 
 
-def configure_repo_settings(github_user: str, repo_name: str) -> bool:
+def configure_repo_settings(github_user: str, repo_name: str, pat: str) -> bool:
     """
-    Configure GitHub repo settings to match fleet standards.
+    Configure GitHub repo settings to match fleet standards via REST API
+    using an in-process classic PAT (ADR-0216).
 
     Sets: wiki disabled, projects disabled, squash-only merge, delete branch on merge.
 
     Args:
         github_user: GitHub username
         repo_name: Repository name
+        pat: Classic PAT obtained via classic_pat_session().
 
     Returns:
         True if settings were applied, False if it failed.
     """
+    body = {
+        "has_wiki": False,
+        "has_projects": False,
+        "delete_branch_on_merge": True,
+        "allow_merge_commit": False,
+        "allow_rebase_merge": False,
+    }
     try:
-        result = subprocess.run(
-            ["gh", "api", "-X", "PATCH",
-             f"/repos/{github_user}/{repo_name}",
-             "-F", "has_wiki=false",
-             "-F", "has_projects=false",
-             "-F", "delete_branch_on_merge=true",
-             "-F", "allow_merge_commit=false",
-             "-F", "allow_rebase_merge=false"],
-            capture_output=True,
-            text=True,
-            timeout=30,
+        resp = requests.patch(
+            f"{_GH_API}/repos/{github_user}/{repo_name}",
+            headers=_gh_headers(pat),
+            json=body,
+            timeout=_HTTP_TIMEOUT_S,
         )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return resp.status_code < 300
+    except requests.RequestException:
         return False
 
 
@@ -1631,37 +1669,45 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             )
             print("  Starred repository")
 
-            # Step 15: Configure repo settings (wiki, projects, merge strategy)
-            print("\n15. Configuring repo settings...")
-            if configure_repo_settings(github_user, repo_name_lower):
-                print("  Repo settings configured:")
-                print("    - Wiki: disabled")
-                print("    - Projects: disabled")
-                print("    - Merge strategy: squash only")
-                print("    - Delete branch on merge: enabled")
-                repo_settings_ok = True
-            else:
-                print("  WARNING: Could not configure repo settings.")
-
-            # Step 16: Configure branch protection
-            print("\n16. Configuring branch protection...")
-            if push_succeeded:
-                if configure_branch_protection(github_user, repo_name_lower):
-                    print("  Branch protection configured:")
-                    print("    - Force push: blocked")
-                    print("    - Deletion: blocked")
-                    print("    - enforce_admins: enabled")
-                    print("    - Required reviews: 1 (Cerberus auto-approves)")
-                    print("    - Required check: pr-sentinel / issue-reference")
-                    print("    - strict: false")
-                    protection_ok = True
+            # Steps 15 + 16 are privileged (admin scope). Acquire the
+            # classic PAT once, in-process, and pass it to both functions
+            # in a single `with` so gpg-agent is prompted at most once per
+            # run (ADR-0216). Exceptions propagate to _create_repo's outer
+            # try/except — FileNotFoundError means the user hasn't run the
+            # one-time gpg setup (docs/runbooks/0927); RuntimeError means
+            # gpg decryption failed.
+            with classic_pat_session() as pat:
+                # Step 15: Configure repo settings (wiki, projects, merge strategy)
+                print("\n15. Configuring repo settings...")
+                if configure_repo_settings(github_user, repo_name_lower, pat):
+                    print("  Repo settings configured:")
+                    print("    - Wiki: disabled")
+                    print("    - Projects: disabled")
+                    print("    - Merge strategy: squash only")
+                    print("    - Delete branch on merge: enabled")
+                    repo_settings_ok = True
                 else:
-                    print("  WARNING: Could not configure branch protection.")
-                    print("  This may fail if the token lacks admin scope.")
-                    print("  Configure manually or re-run with a classic token.")
-            else:
-                print("  SKIPPED: Push failed — no remote branch to protect.")
-                print("  After pushing, configure branch protection manually.")
+                    print("  WARNING: Could not configure repo settings.")
+
+                # Step 16: Configure branch protection
+                print("\n16. Configuring branch protection...")
+                if push_succeeded:
+                    if configure_branch_protection(github_user, repo_name_lower, pat):
+                        print("  Branch protection configured:")
+                        print("    - Force push: blocked")
+                        print("    - Deletion: blocked")
+                        print("    - enforce_admins: enabled")
+                        print("    - Required reviews: 1 (Cerberus auto-approves)")
+                        print("    - Required check: pr-sentinel / issue-reference")
+                        print("    - strict: false")
+                        protection_ok = True
+                    else:
+                        print("  WARNING: Could not configure branch protection.")
+                        print("  This may fail if the PAT lacks admin scope.")
+                        print("  Configure manually or re-run after fixing the PAT.")
+                else:
+                    print("  SKIPPED: Push failed — no remote branch to protect.")
+                    print("  After pushing, configure branch protection manually.")
 
     # Post-setup verification
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary

Narrow scope of #964: migrates the two privileged REST calls in `tools/new_repo_setup.py` from `subprocess(gh api)` to `requests` + `classic_pat_session()`. Per ADR-0216, the PAT now lives only in the Python heap for these calls; it never enters the env block where sibling same-user processes can snoop.

Closes #964.

## Changes

- `configure_branch_protection`: `gh api -X PUT` → `requests.put`. Keeps the branch-exists pre-check on `gh api` (read-only — fine-grained PAT suffices, single source of truth for CLI auth state).
- `configure_repo_settings`: `gh api -X PATCH` → `requests.patch`.
- `_create_repo`: wraps both calls in a single `with classic_pat_session() as pat:` so gpg-agent is prompted at most once per run. Matches the fleet_delete_pr_sentinel.py pattern.
- Adds `_gh_headers(pat)` helper, `_GH_API` and `_HTTP_TIMEOUT_S` constants (leading-underscore to keep them private to the module).
- Imports `requests` and `classic_pat_session` at module scope, using the same import-fallback pattern the file already uses for sibling `tools/` modules.

## Scope decision — hybrid v2/v3 path

Intentionally narrow. The initial `gh repo create --source . --push` still requires `env GH_TOKEN=\$(gpg -d ...)` because pushing workflow files needs the `workflow` scope that fine-grained PATs lack. Eliminating that last env-scoped invocation (via Contents API for workflows + git-push for non-workflow files) is tracked separately in #1000.

Rationale: new-repo creation is critical infra. Splitting the work captures ~90% of the exposure-window reduction (30–90s of sequential privileged API calls eliminated) with minimal blast-radius risk.

This creates a novel hybrid pattern in the codebase (env-scoped GH_TOKEN for the push + in-process PAT for the 2 API calls). All previous #959-pattern migrations went all-in v3. The hybrid is documented in the module-level comment and the PR body here.

## Verification

- `poetry run python -m py_compile tools/new_repo_setup.py` — OK
- `python -c 'import new_repo_setup'` — OK; both functions now show `('github_user', 'repo_name', 'pat')` signatures
- `poetry run pytest tests/test_new_repo_setup.py -q` — 28 passed (existing tests don't cover these two functions; adding tests is deferred to #1000 since signatures will change again)
- `poetry run ruff check tools/new_repo_setup.py` — fails, but with a pyproject.toml parse error (`^3.10`) that is pre-existing on main and unrelated to this change

### Not verified in this session

Manual smoke test (create a test repo end-to-end) has not been run from here — it has side effects (creates a real GitHub repo). User can run it when convenient; the invocation is unchanged:

```bash
cd /c/Users/mcwiz/Projects/AssemblyZero
env GH_TOKEN=\$(gpg -d ~/.secrets/classic-pat.gpg) poetry run python tools/new_repo_setup.py TestRepo --private
```

Steps 15 and 16 will log `Configuring repo settings...` and `Configuring branch protection...` exactly as before; the difference is internal (no subprocess, no argv exposure, no env-block read for these two steps).

## Closing discipline

#1000 filed before this PR lands to track the Phase B follow-up (eliminate the remaining env-scoped push invocation). No deferred scope left as a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)