### PR TITLE
refactor: new_repo_setup — eliminate env-scoped GH_TOKEN via Contents API (Closes #1000)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,7 +1,7 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 4.1
+**Version:** 5.0
 **Last Updated:** 2026-04-22
 
 ---
@@ -10,7 +10,9 @@
 
 The human steps when creating a new repo. Most of the work is automated by `new_repo_setup.py` — it creates the local scaffold, GitHub repo, branch protection, workflow files, initial push, and (with `--cerberus-pem`) the Cerberus secrets deploy.
 
-The human handles only what the script genuinely can't: supplying a classic PAT for privileged operations (workflow push + branch protection), downloading the Cerberus `.pem` from the browser, and revoking the Cerberus key when done.
+Post-#1000 (PR landed 2026-04-22), the script needs **no environment-variable prefix**. The classic PAT stays encrypted at rest (`~/.secrets/classic-pat.gpg`), the script decrypts it inline only when a specific API call needs admin/workflow scope, and the PAT lives only in the Python process heap — never in the env block.
+
+The human handles only what the script genuinely can't: the one-time gpg encryption of the classic PAT, the gpg passphrase prompt (per gpg-agent cache window), downloading the Cerberus `.pem` from the browser, and revoking the Cerberus key when done.
 
 ---
 
@@ -46,63 +48,65 @@ With `default-cache-ttl 0`, gpg prompts for the passphrase every decryption (ins
 
 ## Checklist
 
-### 1. Run the setup script with env-scoped classic PAT (preferred)
+### 1. Run the setup script (bare — no env prefix needed)
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
-env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg) \
-  poetry run python tools/new_repo_setup.py {name} [--public] [--license mit] [--cerberus-pem PATH]
+poetry run python tools/new_repo_setup.py {name} [--public] [--license mit] [--cerberus-pem PATH]
 ```
 
-**Why `env VAR=VALUE command` instead of `export`:**
-- The variable is scoped to the single command's process tree
-- When the script exits, `GH_TOKEN` ceases to exist — no `unset` to forget
-- Never touches `gh auth` storage, so the classic PAT isn't left sitting there for other agents
+gpg-agent will prompt for your passphrase once per cache window (controlled by `~/.gnupg/gpg-agent.conf`) and the script handles the rest.
 
-**What `GH_TOKEN` does:** the `gh` CLI documented behavior is to honor `GH_TOKEN` over whatever's in `gh auth` storage for the duration of the process. This is needed for the two remaining `gh`-backed privileged operations:
+**What the script does under the hood (post-#1000):**
 
-- the initial `git push` of the scaffold (via `gh repo create --source . --push`) — requires `workflow` scope because the push includes `.github/workflows/*.yml` files, which fine-grained PATs can't push.
-- Cerberus secret-set (via `gh api`) — requires the `secrets` scope.
+| Step | Operation | Auth path |
+|------|-----------|-----------|
+| 12 | Local initial commit — non-workflow files only | (local git) |
+| 13 | Create GitHub repo + push initial commit | `gh auth` (fine-grained PAT is sufficient because the push contains no workflow-file changes) |
+| 14 | Star the repo | `gh auth` (fine-grained PAT) |
+| 15 | **Upload `.github/workflows/*` via Contents API** | In-process classic PAT via `classic_pat_session()` — PAT stays in Python heap |
+| 16 | `git pull --rebase` to sync local with the Contents-API commits | `gh auth` (read-only) |
+| 17 | **Configure repo settings (wiki/projects/merge strategy)** via PATCH | In-process classic PAT |
+| 18 | **Configure branch protection** via PUT | In-process classic PAT |
 
-**Branch protection and repo settings no longer need `GH_TOKEN`.** After PR #1001 (Phase A of #964), those two REST calls decrypt the same gpg file inline via `tools/_pat_session.py` (per ADR-0216) and consume the PAT as a Python heap variable. The PAT never enters the env block for those calls. Net effect: the snoopable env-block exposure window shrank from ~90s (full privileged sequence) to ~5s (the git push only). Phase B — tracked in #1000 — will eliminate even the push window by deploying workflow files via the Contents API.
+Steps in **bold** require the classic-PAT admin scopes (`repo`, `workflow`, `admin:repo_hook`). The PAT never enters the env block or subprocess argv — the three calls share a single `classic_pat_session()`, so gpg is prompted at most once per run.
+
+**If you pass `--cerberus-pem PATH`:** the Cerberus secret-set step (`gh secret set` → `PUT /repos/.../actions/secrets/*`) currently uses `gh auth` credentials. If your fine-grained PAT has `Actions: write` (or equivalent secrets write permission), bare invocation still works. If not, prepend `env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg)` just for that specific invocation. A follow-up migration of the Cerberus path to in-process PAT will be filed if needed.
 
 The script handles all of the following automatically:
 - Local directory structure + all config files
-- GitHub repo creation (forced lowercase) via `gh repo create --source . --push`
+- GitHub repo creation (forced lowercase) + initial push of non-workflow files
+- Workflow file upload via Contents API (one PUT per file)
 - Repo settings: wiki disabled, projects disabled, squash-only merge, delete branch on merge
 - Branch protection: require PR (1 review), block force push, block deletion, enforce_admins, pr-sentinel check
 - PR governance workflow (`auto-reviewer.yml` — pr-sentinel check comes from the Cloudflare Worker fleet-wide)
 - `.unleashed.json`, `.claude/settings.json`, security hooks
-- Initial commit and push
 - Cerberus secrets deploy (if `--cerberus-pem` supplied)
 
 The script prints a summary showing what succeeded and what failed.
 
-### 2. Legacy fallback — `gh auth login` swap (if you haven't set up gpg)
+### 2. Emergency fallback — `gh auth login` swap (almost never needed now)
 
-If you haven't done the one-time gpg setup, you can still use the legacy two-paste swap:
+Only use this if **both** Step 1 failed AND `--cerberus-pem` is needed AND your fine-grained PAT lacks `Actions: write`. For a plain `poetry run python tools/new_repo_setup.py ...` invocation, this path is dead.
 
 ```bash
 gh auth login -h github.com -p https   # paste classic PAT
 
 cd /c/Users/mcwiz/Projects/AssemblyZero
-poetry run python tools/new_repo_setup.py {name} [--public] [--license mit]
+poetry run python tools/new_repo_setup.py {name} [--public] [--license mit] [--cerberus-pem PATH]
 
 gh auth login -h github.com -p https   # paste fine-grained PAT back — do this immediately
 ```
 
-**Risk:** if you forget the swap-back, classic-PAT access stays live in `gh auth` storage and any agent using the same storage inherits it. The env-scoped path in Step 1 avoids this entirely.
+**Risk:** if you forget the swap-back, classic-PAT access stays live in `gh auth` storage and any agent using the same storage inherits it.
 
-### 3. Security considerations for `GH_TOKEN` env var
+### 3. Env-block exposure — historical note
 
-While `GH_TOKEN` is in the env block, it is readable by same-user processes via OS APIs (`/proc/<pid>/environ` on Linux, `NtQueryInformationProcess` on Windows). Secret-guard hooks catch `echo $GH_TOKEN` / `printenv` patterns, but a subprocess making direct syscalls can snoop around the hook.
+Pre-#1000, the runbook required `env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg) poetry run ...` to give the initial git push `workflow` scope. While `GH_TOKEN` was in the env block, it was readable by same-user processes via OS APIs (`/proc/<pid>/environ` on Linux, `NtQueryInformationProcess` on Windows).
 
-Post-Phase-A (#964 / PR #1001), that window is approximately **the 5 seconds of the initial git push** — not the full privileged sequence. Cerberus secret-set also uses `GH_TOKEN` briefly. The branch-protection and repo-settings calls no longer widen the window because they don't read `GH_TOKEN` at all.
+After #1000, the script no longer needs `GH_TOKEN` for the git push — workflow files are deployed via Contents API with an in-process classic PAT instead, and the initial push contains no workflow changes (so fine-grained PAT suffices).
 
-Practical guidance:
-- For the typical case, the ~5s window is small enough to not require special precautions.
-- If you're especially cautious, run new-repo creation in a terminal where no other agent session is running.
-- Phase B (#1000) will eliminate the window entirely by deploying workflow files via Contents API instead of git push.
+Net effect: **no `GH_TOKEN` env-block exposure for a plain invocation**. The only time `GH_TOKEN` might still appear in env is if the user passes `--cerberus-pem` AND their fine-grained PAT lacks `Actions: write` — a narrow edge case not applicable to most runs.
 
 ### 4. Deploy Cerberus secrets (if needed)
 
@@ -183,13 +187,13 @@ These all happen without any per-repo human intervention:
 |-----------|-------------------|
 | Cerberus-AZ app access | Fleet-wide installation ("All repositories") — new repos are covered instantly |
 | pr-sentinel check (Cloudflare Worker) | Receives webhooks for all repos, authenticates with its own stored credentials |
-| Auto-reviewer workflow file | Created by setup script in initial commit |
-| Repo settings | Configured by setup script: wiki off, projects off, squash-only, delete-branch-on-merge |
-| Branch protection | Configured by setup script: 1 review, enforce_admins, pr-sentinel check, strict=false |
+| Auto-reviewer workflow file | Uploaded by setup script via Contents API (#1000) — in-process classic PAT |
+| Repo settings | PATCHed by setup script — in-process classic PAT (#964 Phase A) |
+| Branch protection | PUT by setup script — in-process classic PAT (#964 Phase A) |
 | Directory structure + configs | Created by setup script |
 | Cerberus secrets deploy | Handled by the script when `--cerberus-pem PATH` is passed |
 
-The **per-repo human steps** are: supplying the classic PAT (via env-scoped GH_TOKEN or legacy swap), downloading the Cerberus `.pem`, revoking the Cerberus key when done, and optional wiki/domain setup.
+The **per-repo human steps** are: entering the gpg passphrase (once per gpg-agent cache window), downloading the Cerberus `.pem` if `--cerberus-pem` is used, revoking the Cerberus key when done, and optional wiki/domain setup.
 
 ---
 
@@ -213,3 +217,4 @@ The **per-repo human steps** are: supplying the classic PAT (via env-scoped GH_T
 | 2026-04-08 | v3.0: Added PAT switch protocol (steps 1/3). Expanded repo settings (projects, merge, delete-branch). Rewrote Cerberus section as numbered checklist with .pem lifecycle notes. Added shadow wiki creation steps. (#883) |
 | 2026-04-18 | v4.0: Replaced interactive `gh auth login` swap with env-scoped `GH_TOKEN=$(gpg -d ...) poetry run ...` as preferred. Documented one-time gpg setup for at-rest PAT encryption. Legacy swap retained as fallback. Removed `pr-sentinel.yml` from automatic-component table (Worker-only after #938/#939). Documented `--cerberus-pem` flag as preferred Cerberus path (#940/#941). Added security note on env-var snooping via OS APIs. (#942) |
 | 2026-04-22 | v4.1: Fixed unsafe one-time-setup command (`echo '...' \| gpg -c` → `cat /dev/clipboard \| gpg -c`, matching the canonical form in `tools/_pat_session.py`). Updated "What GH_TOKEN does" paragraph to reflect Phase A of #964 (PR #1001): branch protection + repo settings now use in-process classic PAT via `classic_pat_session()` and do not read `GH_TOKEN`; only the initial git push and Cerberus secret-set still do. Toned down the env-snooping mitigation note — window shrank from ~90s to ~5s. Added forward-reference to #1000 (Phase B will eliminate the remaining window). (#1004) |
+| 2026-04-22 | v5.0: Phase B of #964 / #1000 landed. Invocation is now bare `poetry run python tools/new_repo_setup.py NAME [...]`; no `env GH_TOKEN` prefix required. Script splits step 13 into non-workflow initial commit (pushed via `git` with fine-grained PAT) + workflow upload via Contents API (PUT with in-process classic PAT) + `git pull` to sync. Env-block exposure of the classic PAT is eliminated for the common path. Cerberus secret-set (`--cerberus-pem`) still uses `gh auth` — bare works if your fine-grained PAT has `Actions: write`, else prepend `env GH_TOKEN=...` for that invocation. Demoted the "`gh auth login` swap" section to emergency-fallback. Replaced Section 3 (env-snooping mitigation) with a historical note. |

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1252,6 +1252,65 @@ def configure_repo_settings(github_user: str, repo_name: str, pat: str) -> bool:
         return False
 
 
+def _deploy_workflows_via_contents_api(
+    project_path: Path,
+    github_user: str,
+    repo_name: str,
+    pat: str,
+    branch: str = "main",
+) -> tuple[bool, int]:
+    """Upload all files under .github/workflows/ via the GitHub Contents API.
+
+    Each PUT creates one commit on the remote. Fine-grained PATs cannot
+    push workflow-file changes via git (they lack the `workflow` scope),
+    so this path uses classic-PAT REST calls instead. Invoked after the
+    non-workflow initial commit is already on the remote. (#1000 / ADR-0216.)
+
+    Args:
+        project_path: Local repo root.
+        github_user: GitHub username (owner).
+        repo_name: Lowercased repository name.
+        pat: Classic PAT from classic_pat_session().
+        branch: Target branch (default "main").
+
+    Returns:
+        (success, count) — success is True iff every workflow file was
+        uploaded (HTTP < 300). count is the number of files uploaded.
+        If the workflows directory is missing or empty, returns (True, 0).
+    """
+    import base64
+    workflows_dir = project_path / ".github" / "workflows"
+    if not workflows_dir.exists():
+        return True, 0
+    files = sorted(p for p in workflows_dir.iterdir() if p.is_file())
+    if not files:
+        return True, 0
+
+    uploaded = 0
+    for wf in files:
+        rel_path = f".github/workflows/{wf.name}"
+        payload = {
+            "message": f"chore: add {rel_path}",
+            "content": base64.b64encode(wf.read_bytes()).decode("ascii"),
+            "branch": branch,
+        }
+        try:
+            resp = requests.put(
+                f"{_GH_API}/repos/{github_user}/{repo_name}/contents/{rel_path}",
+                headers=_gh_headers(pat),
+                json=payload,
+                timeout=_HTTP_TIMEOUT_S,
+            )
+        except requests.RequestException as e:
+            print(f"  Contents API PUT errored for {rel_path}: {e}")
+            return False, uploaded
+        if resp.status_code >= 300:
+            print(f"  Contents API PUT failed for {rel_path}: HTTP {resp.status_code} — {resp.text[:200]}")
+            return False, uploaded
+        uploaded += 1
+    return True, uploaded
+
+
 def audit_structure(project_path: Path, name: str) -> int:
     """
     Audit an existing project structure against the canonical schema.
@@ -1578,20 +1637,40 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     # Step 11c: Create GitHub Actions workflows (PR governance)
     print("\n11c. Creating GitHub Actions workflows...")
     create_github_workflows(project_path)
-    print("  Created pr-sentinel.yml (issue reference check)")
     print("  Created auto-reviewer.yml (Cerberus auto-approval caller)")
 
-    # Step 12: Initial commit
-    print("\n12. Creating initial commit...")
-    run_command(["git", "add", "."], cwd=project_path)
+    # Step 12: Initial commit — non-workflow files only.
+    # Workflow files (.github/workflows/*) require the `workflow` scope on
+    # push, which fine-grained PATs lack. Instead of requiring env-scoped
+    # classic PAT for the initial push, we commit non-workflow files here,
+    # push via normal git, then upload workflows via Contents API using an
+    # in-process classic PAT (ADR-0216, #1000).
+    print("\n12. Creating initial commit (non-workflow files)...")
     run_command(
-        ["git", "commit", "-m", "chore: initialize project with AssemblyZero\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"],
+        ["git", "add", "--", ".", ":!.github/workflows"],
+        cwd=project_path,
+    )
+    run_command(
+        ["git", "commit", "-m", "chore: initialize project with AssemblyZero\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"],
         cwd=project_path
     )
-    print("  Created initial commit")
+    print("  Created initial commit (workflows deferred — go via Contents API)")
+
+    # Step 12b: If skipping GitHub, commit workflows locally as a second
+    # commit so the local repo is complete. With GitHub in play, workflow
+    # files stay untracked locally until `git pull` brings them back after
+    # the Contents API upload (step 16 below).
+    if args.no_github:
+        run_command(["git", "add", ".github/workflows"], cwd=project_path)
+        run_command(
+            ["git", "commit", "-m", "chore: add GitHub Actions workflows"],
+            cwd=project_path,
+        )
+        print("  Created workflow commit (local-only mode)")
 
     github_created = False
     push_succeeded = False
+    workflows_deployed = False
     repo_settings_ok = False
     protection_ok = False
 
@@ -1599,36 +1678,16 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("\n" + "=" * 60)
         print("GITHUB REMOTE")
         print("=" * 60)
+        print("\n  Post-#1000: GH_TOKEN is not required.")
+        print("  - Step 13 pushes non-workflow files with your fine-grained gh auth.")
+        print("  - Step 15 uploads workflows via Contents API + in-process classic PAT.")
+        print("  - Steps 17-18 configure settings + protection via in-process classic PAT.\n")
 
-        # Detect PAT type and warn about workflow scope
-        if os.environ.get("GH_TOKEN"):
-            # User has set GH_TOKEN (the preferred env-scoped path). Assume they
-            # pointed it at a classic PAT and skip the "swap your auth" warning —
-            # it will only confuse them.
-            print("\n  NOTE: GH_TOKEN env var detected. gh CLI will use it for all")
-            print("  calls this run. If it maps to a classic PAT with workflow +")
-            print("  admin scopes, privileged operations will succeed.\n")
-        else:
-            try:
-                auth_result = subprocess.run(
-                    ["gh", "auth", "status"],
-                    capture_output=True, text=True, timeout=15,
-                )
-                auth_output = auth_result.stdout + auth_result.stderr
-                if "github_pat_" in auth_output:
-                    print("\n  NOTE: Fine-grained PAT detected and GH_TOKEN not set.")
-                    print("  Workflow files (.github/workflows/) require 'workflow' scope.")
-                    print("  Preferred: re-run with env-scoped classic PAT:")
-                    print("    env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg) \\")
-                    print("      poetry run python tools/new_repo_setup.py ... --cerberus-pem ...")
-                    print("  Fallback: switch gh auth storage manually:")
-                    print("    gh auth login -h github.com -p https  # paste classic PAT")
-                    print("    [re-run script]")
-                    print("    gh auth login -h github.com -p https  # paste fine-grained PAT back\n")
-            except (subprocess.TimeoutExpired, FileNotFoundError):
-                pass
-
-        # Step 13: Create GitHub repo
+        # Step 13: Create GitHub repo + push non-workflow files.
+        # The initial commit excludes .github/workflows (step 12), so this
+        # push succeeds with fine-grained PAT — it does not cross the
+        # `workflow` scope boundary. If GH_TOKEN happens to be set (legacy
+        # invocation), `gh` still honors it, which is harmless.
         repo_name_lower = args.name.lower()
         print(f"\n13. Creating GitHub repository ({repo_name_lower})...")
         visibility = "--public" if args.public else "--private"
@@ -1642,25 +1701,14 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             push_succeeded = True
         except Exception as e:
             print(f"  WARNING: gh repo create failed: {e}")
-            print("  Your PAT may lack 'create repository' or 'workflow' scope.")
             print("  The local repo is fully valid. To finish manually:")
             print("    1. Create repo at https://github.com/new")
             print(f"    2. git remote add origin https://github.com/{github_user}/{repo_name_lower}.git")
-            if os.environ.get("GH_TOKEN"):
-                print("    3. GH_TOKEN is set but the scope was insufficient — check that your")
-                print("       gpg-decrypted classic PAT has 'repo' + 'workflow' + 'admin:repo_hook'")
-                print("    4. git push -u origin main")
-            else:
-                print("    3. Re-run the script with env-scoped classic PAT (preferred):")
-                print("       env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg) \\")
-                print(f"         poetry run python tools/new_repo_setup.py {args.name} ...")
-                print("       — OR legacy fallback —")
-                print("       gh auth login -h github.com -p https  # paste classic PAT")
-                print("       git push -u origin main")
-                print("       gh auth login -h github.com -p https  # paste fine-grained PAT back")
+            print("    3. git push -u origin main  # workflows are NOT in this push — fine-grained PAT OK")
+            print("    4. Re-run this script (it will skip create+push and proceed to workflow upload + settings).")
 
         if github_created:
-            # Step 14: Star the repo
+            # Step 14: Star the repo (non-privileged — uses gh auth).
             print("\n14. Starring repository...")
             run_command(
                 ["gh", "api", "-X", "PUT", f"/user/starred/{github_user}/{repo_name_lower}"],
@@ -1669,16 +1717,57 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             )
             print("  Starred repository")
 
-            # Steps 15 + 16 are privileged (admin scope). Acquire the
-            # classic PAT once, in-process, and pass it to both functions
-            # in a single `with` so gpg-agent is prompted at most once per
-            # run (ADR-0216). Exceptions propagate to _create_repo's outer
-            # try/except — FileNotFoundError means the user hasn't run the
-            # one-time gpg setup (docs/runbooks/0927); RuntimeError means
-            # gpg decryption failed.
+            # Steps 15, 17, 18 are privileged (need workflow / admin scope).
+            # Step 16 is a local `git pull` that uses gh auth. All four run
+            # inside a single classic_pat_session so gpg-agent is prompted
+            # at most once per run (ADR-0216).
+            # Exceptions propagate to _create_repo's outer try/except:
+            # FileNotFoundError means the user hasn't run the one-time gpg
+            # setup (docs/runbooks/0927); RuntimeError means gpg decryption
+            # failed.
             with classic_pat_session() as pat:
-                # Step 15: Configure repo settings (wiki, projects, merge strategy)
-                print("\n15. Configuring repo settings...")
+                # Step 15: Upload workflow files via Contents API.
+                # Fine-grained PATs can't push workflow changes via git,
+                # so we create them on the remote directly. Each PUT is a
+                # separate commit (one per workflow file).
+                print("\n15. Uploading workflow files via Contents API...")
+                success, count = _deploy_workflows_via_contents_api(
+                    project_path, github_user, repo_name_lower, pat,
+                )
+                if success:
+                    workflows_deployed = True
+                    if count > 0:
+                        print(f"  Uploaded {count} workflow file(s) to main")
+                    else:
+                        print("  No workflow files to upload (skipped)")
+                else:
+                    print("  WARNING: Workflow upload failed. You can retry manually with:")
+                    print(f"    cd {project_path}")
+                    print("    git add .github/workflows && git commit -m 'chore: add workflows'")
+                    print("    git push  # requires classic PAT in gh auth or GH_TOKEN")
+
+                # Step 16: Sync local repo with the Contents API commits.
+                # The remote now has workflow file(s) that the local repo
+                # doesn't track yet; the local filesystem already has the
+                # same files (untracked). We remove them, then pull, which
+                # fast-forwards and checks them out tracked.
+                if workflows_deployed and count > 0:
+                    print("\n16. Syncing local repo with remote workflow commits...")
+                    import shutil as _shutil
+                    workflows_dir = project_path / ".github" / "workflows"
+                    if workflows_dir.exists():
+                        _shutil.rmtree(workflows_dir)
+                    pull = subprocess.run(
+                        ["git", "pull", "--rebase", "origin", "main"],
+                        cwd=str(project_path), capture_output=True, text=True, timeout=60,
+                    )
+                    if pull.returncode == 0:
+                        print("  Synced — local is now at remote HEAD with workflows tracked.")
+                    else:
+                        print(f"  WARNING: git pull failed: {pull.stderr.strip()}")
+
+                # Step 17: Configure repo settings (was step 15).
+                print("\n17. Configuring repo settings...")
                 if configure_repo_settings(github_user, repo_name_lower, pat):
                     print("  Repo settings configured:")
                     print("    - Wiki: disabled")
@@ -1689,8 +1778,8 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 else:
                     print("  WARNING: Could not configure repo settings.")
 
-                # Step 16: Configure branch protection
-                print("\n16. Configuring branch protection...")
+                # Step 18: Configure branch protection (was step 16).
+                print("\n18. Configuring branch protection...")
                 if push_succeeded:
                     if configure_branch_protection(github_user, repo_name_lower, pat):
                         print("  Branch protection configured:")


### PR DESCRIPTION
## Summary

Phase B of #964. After this lands, the new-repo script needs **no env-var prefix**:

\`\`\`bash
poetry run python tools/new_repo_setup.py NAME [--public] [--license mit] [--cerberus-pem PATH]
\`\`\`

The classic PAT stays in the Python heap via \`classic_pat_session()\` (ADR-0216) and never enters the env block. Sibling same-user processes cannot snoop it via \`/proc/<pid>/environ\` or \`NtQueryInformationProcess\`.

Closes #1000.

## Mechanism

| Step | Before | After |
|------|--------|-------|
| Step 12 (initial commit) | \`git add .\` — includes workflows | \`git add -- . ':!.github/workflows'\` — excludes workflows |
| Step 13 (push) | Needed \`GH_TOKEN=<classic>\` for workflow scope | Works with fine-grained PAT (no workflow changes in push) |
| Step 15 (new) | N/A | Upload \`.github/workflows/*\` via Contents API PUT with in-process classic PAT |
| Step 16 (new) | N/A | \`git pull --rebase\` to sync local with Contents-API commits |
| Steps 17-18 (settings + protection) | In-process classic PAT (unchanged since Phase A / #1001) | Same |

Steps 15, 17, 18 share a single \`classic_pat_session\` so gpg-agent is prompted at most once per run.

**--no-github mode:** workflow files are committed locally as a second commit so the offline repo is complete.

## Also in this PR

- Fixed a stale print at line 1581 (\"Created pr-sentinel.yml\") — the pr-sentinel.yml workflow was removed after #938/#939 but the print lingered.
- Bumped the initial-commit Co-Authored-By from 4.5 to 4.7.
- **Runbook 0927 bumped to v5.0** — documents the bare invocation as the primary path, demotes the \`gh auth login\` swap to emergency fallback, replaces the env-snooping mitigation section with a historical note.

## Verification

- \`poetry run python -m py_compile tools/new_repo_setup.py\` — OK
- \`python -c 'import new_repo_setup'\` — OK; \`_deploy_workflows_via_contents_api\` exposed with correct signature
- \`poetry run pytest tests/test_new_repo_setup.py -q\` — 28 passed (existing tests don't cover the new workflow-upload path; adding integration tests is deferred — smoke test is the real validation)

## Caveat on Cerberus

Cerberus secret-set (\`--cerberus-pem\`) still goes through \`gh secret set\` using \`gh auth\` credentials. If your fine-grained PAT has \`Actions: write\`, bare invocation still works for that path. If not, you'd need to prepend \`env GH_TOKEN=...\` for that specific run. Migrating Cerberus to in-process PAT is out of scope for #1000 and can be filed as a follow-up if needed.

## Smoke test (user-driven, post-merge)

The real validation is creating a disposable repo end-to-end with the new invocation. I have NOT done this from the session — it has side effects (creates a real GitHub repo). Suggested test:

\`\`\`bash
cd /c/Users/mcwiz/Projects/AssemblyZero
poetry run python tools/new_repo_setup.py TestPhaseBScratch --private
\`\`\`

Expected: gpg passphrase prompt once (if cache is cold), then the full 18-step output. No \`env GH_TOKEN=...\` needed. The new repo should have 2 commits (initial non-workflow + auto-reviewer.yml via Contents API), branch protection, and correct settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)