### PR TITLE
refactor: deploy_cerberus_secrets — in-process PAT + sealed-box (Closes #1007)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,7 +1,7 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 5.0
+**Version:** 5.1
 **Last Updated:** 2026-04-22
 
 ---
@@ -10,7 +10,7 @@
 
 The human steps when creating a new repo. Most of the work is automated by `new_repo_setup.py` — it creates the local scaffold, GitHub repo, branch protection, workflow files, initial push, and (with `--cerberus-pem`) the Cerberus secrets deploy.
 
-Post-#1000 (PR landed 2026-04-22), the script needs **no environment-variable prefix**. The classic PAT stays encrypted at rest (`~/.secrets/classic-pat.gpg`), the script decrypts it inline only when a specific API call needs admin/workflow scope, and the PAT lives only in the Python process heap — never in the env block.
+Post-#1000 + #1007 (both landed 2026-04-22), the script needs **no environment-variable prefix**, even when `--cerberus-pem` is used. The classic PAT stays encrypted at rest (`~/.secrets/classic-pat.gpg`), the script decrypts it inline only when a specific API call needs admin/workflow/secrets scope, and the PAT lives only in the Python process heap — never in the env block.
 
 The human handles only what the script genuinely can't: the one-time gpg encryption of the classic PAT, the gpg passphrase prompt (per gpg-agent cache window), downloading the Cerberus `.pem` from the browser, and revoking the Cerberus key when done.
 
@@ -57,7 +57,7 @@ poetry run python tools/new_repo_setup.py {name} [--public] [--license mit] [--c
 
 gpg-agent will prompt for your passphrase once per cache window (controlled by `~/.gnupg/gpg-agent.conf`) and the script handles the rest.
 
-**What the script does under the hood (post-#1000):**
+**What the script does under the hood (post-#1000 + #1007):**
 
 | Step | Operation | Auth path |
 |------|-----------|-----------|
@@ -68,10 +68,9 @@ gpg-agent will prompt for your passphrase once per cache window (controlled by `
 | 16 | `git pull --rebase` to sync local with the Contents-API commits | `gh auth` (read-only) |
 | 17 | **Configure repo settings (wiki/projects/merge strategy)** via PATCH | In-process classic PAT |
 | 18 | **Configure branch protection** via PUT | In-process classic PAT |
+| — | **Cerberus secrets** (if `--cerberus-pem` passed): sealed-box encrypt + PUT | In-process classic PAT (#1007) |
 
-Steps in **bold** require the classic-PAT admin scopes (`repo`, `workflow`, `admin:repo_hook`). The PAT never enters the env block or subprocess argv — the three calls share a single `classic_pat_session()`, so gpg is prompted at most once per run.
-
-**If you pass `--cerberus-pem PATH`:** the Cerberus secret-set step (`gh secret set` → `PUT /repos/.../actions/secrets/*`) currently uses `gh auth` credentials. If your fine-grained PAT has `Actions: write` (or equivalent secrets write permission), bare invocation still works. If not, prepend `env GH_TOKEN=$(gpg -d ~/.secrets/classic-pat.gpg)` just for that specific invocation. A follow-up migration of the Cerberus path to in-process PAT will be filed if needed.
+Steps in **bold** require classic-PAT scopes. The PAT never enters the env block or subprocess argv — privileged calls share a `classic_pat_session()`, and gpg-agent caches the passphrase across sessions, so you'll typically see the prompt at most once per shell.
 
 The script handles all of the following automatically:
 - Local directory structure + all config files
@@ -85,9 +84,9 @@ The script handles all of the following automatically:
 
 The script prints a summary showing what succeeded and what failed.
 
-### 2. Emergency fallback — `gh auth login` swap (almost never needed now)
+### 2. Emergency fallback — `gh auth login` swap (legacy; should never be needed)
 
-Only use this if **both** Step 1 failed AND `--cerberus-pem` is needed AND your fine-grained PAT lacks `Actions: write`. For a plain `poetry run python tools/new_repo_setup.py ...` invocation, this path is dead.
+All privileged paths now route through in-process classic PAT (#964 + #1000 + #1007). The `gh auth login` swap is retained only as a break-glass fallback if `classic_pat_session()` itself fails (e.g., missing `~/.secrets/classic-pat.gpg` or broken gpg-agent):
 
 ```bash
 gh auth login -h github.com -p https   # paste classic PAT
@@ -218,3 +217,4 @@ The **per-repo human steps** are: entering the gpg passphrase (once per gpg-agen
 | 2026-04-18 | v4.0: Replaced interactive `gh auth login` swap with env-scoped `GH_TOKEN=$(gpg -d ...) poetry run ...` as preferred. Documented one-time gpg setup for at-rest PAT encryption. Legacy swap retained as fallback. Removed `pr-sentinel.yml` from automatic-component table (Worker-only after #938/#939). Documented `--cerberus-pem` flag as preferred Cerberus path (#940/#941). Added security note on env-var snooping via OS APIs. (#942) |
 | 2026-04-22 | v4.1: Fixed unsafe one-time-setup command (`echo '...' \| gpg -c` → `cat /dev/clipboard \| gpg -c`, matching the canonical form in `tools/_pat_session.py`). Updated "What GH_TOKEN does" paragraph to reflect Phase A of #964 (PR #1001): branch protection + repo settings now use in-process classic PAT via `classic_pat_session()` and do not read `GH_TOKEN`; only the initial git push and Cerberus secret-set still do. Toned down the env-snooping mitigation note — window shrank from ~90s to ~5s. Added forward-reference to #1000 (Phase B will eliminate the remaining window). (#1004) |
 | 2026-04-22 | v5.0: Phase B of #964 / #1000 landed. Invocation is now bare `poetry run python tools/new_repo_setup.py NAME [...]`; no `env GH_TOKEN` prefix required. Script splits step 13 into non-workflow initial commit (pushed via `git` with fine-grained PAT) + workflow upload via Contents API (PUT with in-process classic PAT) + `git pull` to sync. Env-block exposure of the classic PAT is eliminated for the common path. Cerberus secret-set (`--cerberus-pem`) still uses `gh auth` — bare works if your fine-grained PAT has `Actions: write`, else prepend `env GH_TOKEN=...` for that invocation. Demoted the "`gh auth login` swap" section to emergency-fallback. Replaced Section 3 (env-snooping mitigation) with a historical note. |
+| 2026-04-22 | v5.1: #1007 — `tools/deploy_cerberus_secrets.py` migrated to in-process classic PAT (pynacl sealed-box encryption + REST API). `--cerberus-pem` invocation no longer needs `env GH_TOKEN` regardless of fine-grained PAT scope. `gh auth login` swap section updated to reflect it's now fully legacy (only relevant if `classic_pat_session` itself fails). Updated the under-the-hood table to include Cerberus secret-set on the in-process path. |

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -13,19 +13,46 @@ The script sets two GitHub Actions secrets on every repo:
     - REVIEWER_APP_ID (3079970)
     - REVIEWER_APP_PRIVATE_KEY (contents of the .pem)
 
-Issue: #736 | Related: #732
+All secret writes use an in-process classic PAT via
+`tools/_pat_session.classic_pat_session()` (ADR-0216). The PAT is
+never placed in the shell env block or subprocess argv. Secret values
+are encrypted with libsodium sealed-box against the repo's public key
+per GitHub's API contract.
+
+Issue: #736 | Related: #732, #1007 (in-process PAT migration)
 """
 
+import base64
 import subprocess
 import sys
 from pathlib import Path
 
+import requests
+from nacl import encoding, public
+
+# Shared with new_repo_setup.py and other v3 callers.
+try:
+    from _pat_session import classic_pat_session
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _pat_session import classic_pat_session
+
 APP_ID = "3079970"
 GITHUB_USER = "martymcenroe"
+_GH_API = "https://api.github.com"
+_HTTP_TIMEOUT_S = 30
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
 
 
 def get_all_repos() -> list[str]:
-    """Get all repos for the user via gh CLI."""
+    """Get all repos for the user via gh CLI. Read-only — fine-grained PAT OK."""
     result = subprocess.run(
         ["gh", "repo", "list", GITHUB_USER, "--limit", "200",
          "--json", "name", "--jq", ".[].name"],
@@ -35,52 +62,112 @@ def get_all_repos() -> list[str]:
     return sorted(repos)
 
 
-def set_secret(repo: str, name: str, value: str) -> bool:
-    """Set a GitHub Actions secret on a repo."""
-    result = subprocess.run(
-        ["gh", "secret", "set", name, "--repo", f"{GITHUB_USER}/{repo}",
-         "--body", value],
-        capture_output=True, text=True
-    )
-    return result.returncode == 0
+def _get_repo_public_key(repo: str, pat: str) -> tuple[str, str] | None:
+    """Fetch the repo's Actions-secrets public key.
+
+    Returns (key_id, base64_public_key) on success, or None on failure.
+    GitHub requires the sealed-box encrypted secret value + key_id when
+    creating/updating a repo secret via the REST API.
+    """
+    try:
+        resp = requests.get(
+            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets/public-key",
+            headers=_gh_headers(pat),
+            timeout=_HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None
+    if resp.status_code >= 300:
+        return None
+    data = resp.json()
+    return data["key_id"], data["key"]
 
 
-def deploy_to_repo(repo: str, pem_content: str) -> tuple[bool, list[str]]:
+def _encrypt_secret(public_key_b64: str, secret_value: str) -> str:
+    """Sealed-box encrypt `secret_value` against the repo's public key.
+
+    Matches the scheme documented at
+    https://docs.github.com/en/rest/actions/secrets#create-or-update-a-repository-secret
+    """
+    pk = public.PublicKey(public_key_b64.encode("utf-8"), encoding.Base64Encoder())
+    sealed_box = public.SealedBox(pk)
+    encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+    return base64.b64encode(encrypted).decode("utf-8")
+
+
+def set_secret(repo: str, name: str, value: str, pat: str) -> bool:
+    """Set a GitHub Actions secret on a repo via REST API with in-process PAT.
+
+    Args:
+        repo: Repo name (no owner prefix); paired with GITHUB_USER.
+        name: Secret name (e.g. "REVIEWER_APP_ID").
+        value: Plaintext secret value (will be sealed-box encrypted before PUT).
+        pat: Classic PAT from classic_pat_session().
+
+    Returns:
+        True on HTTP 2xx; False otherwise (including failure to fetch public key).
+    """
+    pk = _get_repo_public_key(repo, pat)
+    if pk is None:
+        return False
+    key_id, public_key_b64 = pk
+    encrypted_value = _encrypt_secret(public_key_b64, value)
+    try:
+        resp = requests.put(
+            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets/{name}",
+            headers=_gh_headers(pat),
+            json={"encrypted_value": encrypted_value, "key_id": key_id},
+            timeout=_HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return False
+    return resp.status_code < 300
+
+
+def deploy_to_repo(repo: str, pem_content: str, pat: str) -> tuple[bool, list[str]]:
     """Deploy REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY to a single repo.
 
     Args:
         repo: Repo name (not owner/name) under GITHUB_USER.
         pem_content: The raw .pem file contents.
+        pat: Classic PAT from classic_pat_session().
 
     Returns:
         (success, failed_secret_names). `success` is True iff both secrets set.
     """
     failed: list[str] = []
-    if not set_secret(repo, "REVIEWER_APP_ID", APP_ID):
+    if not set_secret(repo, "REVIEWER_APP_ID", APP_ID, pat):
         failed.append("REVIEWER_APP_ID")
-    if not set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content):
+    if not set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content, pat):
         failed.append("REVIEWER_APP_PRIVATE_KEY")
     return (len(failed) == 0, failed)
 
 
-def verify_secrets(repo: str) -> tuple[bool, list[str]]:
+def verify_secrets(repo: str, pat: str) -> tuple[bool, list[str]]:
     """Check that both required Cerberus secrets are present on the repo.
+
+    Uses the same in-process PAT as deploy_to_repo for consistency (avoids
+    depending on whatever gh auth happens to be pointed at).
 
     Args:
         repo: Repo name (not owner/name) under GITHUB_USER.
+        pat: Classic PAT from classic_pat_session().
 
     Returns:
         (all_present, missing_secret_names).
     """
     required = {"REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"}
-    result = subprocess.run(
-        ["gh", "api", f"repos/{GITHUB_USER}/{repo}/actions/secrets",
-         "--jq", ".secrets[].name"],
-        capture_output=True, text=True
-    )
-    if result.returncode != 0:
+    try:
+        resp = requests.get(
+            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets",
+            headers=_gh_headers(pat),
+            timeout=_HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
         return (False, sorted(required))
-    present = {n.strip() for n in result.stdout.split("\n") if n.strip()}
+    if resp.status_code >= 300:
+        return (False, sorted(required))
+    present = {s["name"] for s in resp.json().get("secrets", [])}
     missing = sorted(required - present)
     return (len(missing) == 0, missing)
 
@@ -117,15 +204,16 @@ def main():
     succeeded = 0
     failed = []
 
-    for i, repo in enumerate(repos, 1):
-        prefix = f"[{i}/{len(repos)}] {repo}"
-        ok, failed_names = deploy_to_repo(repo, pem_content)
-        if ok:
-            print(f"  {prefix}: OK")
-            succeeded += 1
-        else:
-            print(f"  {prefix}: FAILED ({', '.join(failed_names)})")
-            failed.append(repo)
+    with classic_pat_session() as pat:
+        for i, repo in enumerate(repos, 1):
+            prefix = f"[{i}/{len(repos)}] {repo}"
+            ok, failed_names = deploy_to_repo(repo, pem_content, pat)
+            if ok:
+                print(f"  {prefix}: OK")
+                succeeded += 1
+            else:
+                print(f"  {prefix}: FAILED ({', '.join(failed_names)})")
+                failed.append(repo)
 
     print(f"\n{'=' * 50}")
     print(f"Done: {succeeded}/{len(repos)} repos configured")

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1379,16 +1379,19 @@ def audit_structure(project_path: Path, name: str) -> int:
         return 1
 
 
-def _deploy_cerberus(repo_name: str, pem_path: Path) -> str:
+def _deploy_cerberus(repo_name: str, pem_path: Path, pat: str) -> str:
     """Deploy Cerberus secrets to a single repo and handle pem file lifecycle.
 
     Reads the .pem file, deploys REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
-    to the specified repo, verifies they landed, deletes the .pem, and
-    prints a reminder to revoke the key in the app UI.
+    to the specified repo via in-process classic PAT (sealed-box encrypted
+    per GitHub's secrets API), verifies they landed, deletes the .pem, and
+    prints a reminder to revoke the key in the app UI. (#1007)
 
     Args:
         repo_name: The new repo name (lowercased, owner-less).
         pem_path: Path to the Cerberus App .pem file.
+        pat: Classic PAT from classic_pat_session() — consumed by
+            deploy_to_repo / verify_secrets, never placed in env.
 
     Returns a short status string for the summary table.
     """
@@ -1408,7 +1411,7 @@ def _deploy_cerberus(repo_name: str, pem_path: Path) -> str:
     print(f"  Target repo: {repo_name}")
     print(f"  .pem file:   {pem_path.name} ({len(pem_content)} chars)")
 
-    ok, failed = deploy_to_repo(repo_name, pem_content)
+    ok, failed = deploy_to_repo(repo_name, pem_content, pat)
     if not ok:
         print(f"  FAILED to deploy: {', '.join(failed)}")
         print(f"  .pem file NOT deleted — retry manually:")
@@ -1416,7 +1419,7 @@ def _deploy_cerberus(repo_name: str, pem_path: Path) -> str:
         return f"FAILED: {', '.join(failed)}"
     print("  Secrets set.")
 
-    ok, missing = verify_secrets(repo_name)
+    ok, missing = verify_secrets(repo_name, pat)
     if not ok:
         print(f"  WARNING: verification failed; missing {missing}")
         print(f"  .pem file NOT deleted — investigate before deleting.")
@@ -1846,10 +1849,24 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     if checks_passed < checks_total:
         print("\nWARNING: Some checks failed. Review and fix before starting work!")
 
-    # Cerberus secrets deploy (if --cerberus-pem provided, and repo was created)
+    # Cerberus secrets deploy (if --cerberus-pem provided, and repo was created).
+    # Acquire the classic PAT in-process — no env GH_TOKEN needed. gpg-agent
+    # will typically reuse the cached passphrase from the earlier session.
     cerberus_status: str | None = None
     if not args.no_github and push_succeeded and args.cerberus_pem:
-        cerberus_status = _deploy_cerberus(args.name.lower(), Path(args.cerberus_pem))
+        try:
+            with classic_pat_session() as pat:
+                cerberus_status = _deploy_cerberus(
+                    args.name.lower(), Path(args.cerberus_pem), pat,
+                )
+        except FileNotFoundError as e:
+            print(f"\n  WARNING: classic PAT not configured: {e}")
+            print("  Skipping Cerberus deploy. Retry later with:")
+            print(f"    poetry run python tools/deploy_cerberus_secrets.py {args.cerberus_pem}")
+            cerberus_status = "PAT_NOT_CONFIGURED"
+        except RuntimeError as e:
+            print(f"\n  WARNING: gpg decrypt failed: {e}")
+            cerberus_status = "GPG_FAILED"
 
     # Final summary
     if not args.no_github:


### PR DESCRIPTION
## Summary

Kills the last env-scoped GH_TOKEN hold-out. After this lands, \`--cerberus-pem\` works with bare invocation regardless of the fine-grained PAT's scopes. Three files: the Cerberus tool, the new-repo script's Cerberus caller, and the runbook.

Closes #1007.

## Mechanism

GitHub's secret API requires libsodium sealed-box encryption of the secret value against the repo's per-repo public key. The migration:

1. \`GET /repos/{owner}/{repo}/actions/secrets/public-key\` → \`(key_id, base64_pubkey)\`
2. \`nacl.public.SealedBox(pubkey).encrypt(value)\` → base64-encoded ciphertext
3. \`PUT /repos/{owner}/{repo}/actions/secrets/{name}\` with \`{encrypted_value, key_id}\`

All three steps use the classic PAT from \`classic_pat_session()\`. No \`gh\` subprocess, no env block, no argv.

## Files

| File | Change |
|------|--------|
| \`tools/deploy_cerberus_secrets.py\` | Full rewrite of secret-write path. \`set_secret\`, \`deploy_to_repo\`, \`verify_secrets\` now take a \`pat\`. \`main()\` wraps its deploy loop in \`classic_pat_session\`. Adds \`pynacl\`-based \`_encrypt_secret\`. |
| \`tools/new_repo_setup.py\` | \`_deploy_cerberus\` gains a \`pat\` parameter. The call at the end of \`_create_repo\` opens its own \`classic_pat_session\` (gpg-agent cache means usually no second prompt). |
| \`docs/runbooks/0927-new-repo-human-checklist.md\` | v5.1. Under-the-hood table adds the Cerberus row on the in-process path. Removes the \`--cerberus-pem\` caveat. Emergency-fallback section clarified as fully legacy. |

## Verification

- \`poetry run python -m py_compile tools/deploy_cerberus_secrets.py tools/new_repo_setup.py\` — OK
- \`import deploy_cerberus_secrets\` — OK; all four function signatures confirmed (\`set_secret\` takes \`(repo, name, value, pat)\`, \`deploy_to_repo\` takes \`(repo, pem_content, pat)\`, \`verify_secrets\` takes \`(repo, pat)\`)
- \`poetry run pytest tests/test_new_repo_setup.py -q\` — 28 passed
- **Sealed-box roundtrip**: generated a fresh nacl keypair, ran the value through \`_encrypt_secret(pk, 'hello-secret')\`, decrypted with the matching private key. Output: \`roundtrip result: hello-secret\`. Encryption scheme is correct per GitHub's API contract.

## Not verified

No live smoke test — requires downloading a real Cerberus .pem from the browser and having target repos. That's the user's next step. Expected behavior: bare \`poetry run python tools/new_repo_setup.py NAME --cerberus-pem PATH\` succeeds with at most one gpg passphrase prompt for the entire run.

## Dependency

\`pynacl\` was already installed (1.6.2). No \`poetry add\` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)