### PR TITLE
fix: CRLF normalize Contents API workflow upload (Closes #1031)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1072,7 +1072,12 @@ jobs:
       REVIEWER_APP_ID: ${{ secrets.REVIEWER_APP_ID }}
       REVIEWER_APP_PRIVATE_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
 '''
-    (workflows_dir / "auto-reviewer.yml").write_text(auto_reviewer, encoding="utf-8")
+    # newline="" disables Python's Windows LF→CRLF translation. The
+    # workflow file lands on disk with LF — same as every other repo
+    # in the fleet, and matches what the Contents API upload sends.
+    (workflows_dir / "auto-reviewer.yml").write_text(
+        auto_reviewer, encoding="utf-8", newline="",
+    )
 
 
 def create_settings_json(project_path: Path) -> None:
@@ -1289,9 +1294,14 @@ def _deploy_workflows_via_contents_api(
     uploaded = 0
     for wf in files:
         rel_path = f".github/workflows/{wf.name}"
+        # CRLF normalize before base64 — Path.write_text on Windows
+        # writes CRLF, and the Contents API stores bytes verbatim, so
+        # without this the workflow lands on origin with CRLF where the
+        # rest of the fleet uses LF. Per root CLAUDE.md gotcha (2026-04-30 #3).
+        content_bytes = wf.read_bytes().replace(b"\r\n", b"\n")
         payload = {
             "message": f"chore: add {rel_path}",
-            "content": base64.b64encode(wf.read_bytes()).decode("ascii"),
+            "content": base64.b64encode(content_bytes).decode("ascii"),
             "branch": branch,
         }
         try:


### PR DESCRIPTION
## Summary

Two-part fix for a gotcha already documented in root \`CLAUDE.md\` (2026-04-30 #3) but not applied when #1006 shipped.

Closes #1031.

## Changes

\`tools/new_repo_setup.py\`:

1. **Line 1075** (\`create_github_workflows\`): \`write_text(..., newline=\"\")\` so the on-disk file is LF-only on Windows (default \`write_text\` translates \`\n\` → \`\r\n\` on Windows).
2. **\`_deploy_workflows_via_contents_api\`**: \`read_bytes().replace(b\"\r\n\", b\"\n\")\` before base64 — defensive normalization so even a stray CRLF file lands on origin as LF.

## Why both

The first change makes the local file correct for any consumer (git, downstream tools). The second is the defensive net the canonical CLAUDE.md gotcha calls for — it survives any future refactor that reintroduces CRLF on disk.

## Without this fix

Every new repo created post-#1006 would have \`auto-reviewer.yml\` on origin in CRLF where the rest of the fleet uses LF. Step 16's \`git pull --rebase\` could leave the working tree dirty depending on how \`core.autocrlf=true\` interpreted the inbound CRLF.

Found by an audit pass before the user smoke-tests #1006/#1008/#1001 on a real new repo.

## Verification

\`\`\`
$ poetry run python -c \"...create_github_workflows(tempdir)...\"
CRLF count: 0 | total bytes: 671
\`\`\`

\`poetry run pytest tests/test_new_repo_setup.py -q\` — 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)