### PR TITLE
feat: new_repo_setup pre-flight collision detection (Closes #1033)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1571,8 +1571,85 @@ Examples:
         sys.exit(1)
 
 
+def _diagnose_existing_path(project_path: Path) -> tuple[str, list[str]]:
+    """Classify what's at project_path when it already exists.
+
+    Pre-flight helper for _create_repo. Returns (kind, recovery_lines)
+    where `kind` is one of:
+        'file'           — path exists as a regular file, not a directory
+        'stale_worktree' — directory has a `.git` FILE pointing at a
+                            worktree registration (the #935 case — usually
+                            a leftover from a prior worktree-based session)
+        'live_repo'      — directory has a `.git` DIRECTORY (real local repo)
+        'unknown_dir'    — directory exists, no `.git` of any kind
+
+    `recovery_lines` is a list of human-readable strings the caller prints
+    to help the user clean up and retry. No side effects performed —
+    callers must not auto-delete; the user decides.
+    """
+    if project_path.is_file():
+        return ("file", [
+            f"Path is a regular file, not a directory.",
+            f"Remove it: rm '{project_path}'",
+            f"Then re-run.",
+        ])
+
+    git_path = project_path / ".git"
+
+    if git_path.is_file():
+        registration = ""
+        try:
+            registration = git_path.read_text(encoding="utf-8", errors="ignore").strip()
+        except OSError:
+            pass
+        return ("stale_worktree", [
+            f"Directory contains a `.git` FILE — looks like a stale git-worktree leftover (#935).",
+            f"  .git contents: {registration or '(unreadable)'}",
+            "Recovery options (try in this order):",
+            f"  1. cd '{project_path}' && poetry env remove --all  # release venv file locks",
+            f"  2. rm -rf '{project_path}'                          # may still fail if other locks remain",
+            f"  3. powershell -c \"Get-Process | Where-Object {{ \\$_.Path -like '*{project_path.name}*' }}\"  # find lock-holder",
+            f"  4. If a stale Python process holds the lock: powershell -c \"Get-Process python | Stop-Process\" (carefully)",
+            f"  5. Reboot is the nuclear option.",
+        ])
+
+    if git_path.is_dir():
+        return ("live_repo", [
+            f"Directory is an existing git repo (has a `.git` directory).",
+            f"This is NOT a leftover. Refusing to overwrite.",
+            f"Pick a different name for your new repo, or move/rename the existing repo first.",
+        ])
+
+    try:
+        entry_count = sum(1 for _ in project_path.iterdir())
+    except OSError:
+        entry_count = -1
+    return ("unknown_dir", [
+        f"Directory exists with {entry_count} entries but no `.git` of any kind.",
+        f"Either remove it (if not yours) or pick a different name:",
+        f"  rm -rf '{project_path}'  # if you confirm you don't need it",
+    ])
+
+
 def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str) -> None:
     """Internal repo creation logic, separated for error handling."""
+    # Pre-flight: refuse to proceed if anything already exists at project_path.
+    # No GitHub state should be created when there's a local collision; the
+    # user resolves it and re-runs. Covers the #935 stale-worktree case
+    # plus typos and accidental name reuse.
+    if project_path.exists():
+        kind, recovery_lines = _diagnose_existing_path(project_path)
+        print("\n" + "=" * 60)
+        print(f"[PRE-FLIGHT] Refusing to proceed: target path already exists")
+        print("=" * 60)
+        print(f"Path: {project_path}")
+        print(f"Kind: {kind}")
+        for line in recovery_lines:
+            print(f"  {line}")
+        print()
+        print("No local files written, no GitHub repo created. Resolve the collision and re-run.")
+        sys.exit(1)
+
     # Step 1: Create directory
     print("\n1. Creating directory...")
     project_path.mkdir(parents=True)


### PR DESCRIPTION
## Summary

Adds pre-flight detection at the top of \`_create_repo\` so the script refuses to do anything (no mkdir, no git init, no GitHub API calls) when something already exists at \`project_path\`.

Closes #1033 (subset of #935's create-path concern).

## Mechanism

\`_diagnose_existing_path(project_path)\` returns one of four \`kind\`s plus a list of human-readable recovery lines:

| kind | trigger | recovery hint |
|------|---------|---------------|
| \`file\` | path is a regular file | \`rm '<path>'\` |
| \`stale_worktree\` | dir contains \`.git\` FILE (worktree registration) — the #935 case | poetry env remove, rm -rf, PowerShell process inspection, reboot |
| \`live_repo\` | dir contains \`.git\` DIRECTORY (real repo) | pick a different name |
| \`unknown_dir\` | dir exists, no \`.git\` | rm or rename |

When triggered, prints a clearly-bordered \"PRE-FLIGHT\" block and exits 1 — no local files written, no GitHub repo created.

## Why this isn't all of #935

#935 has broader acceptance criteria: identifying which Windows process holds the file lock, validating mitigations against a stuck directory, cleaning up the historical \`AssemblyZero-884\` exhibit. Right now there are no stale \`AssemblyZero-*\` dirs on disk, so the experimental validation will have to wait for one to surface.

This PR is focused on the user-facing concern: \"won't make a mess if I run it tonight.\" It guarantees that any local collision is caught BEFORE GitHub state is created.

## Verification

\`\`\`
$ python -c \"...four kinds against tempdir fixtures...\"
file,stale_worktree,live_repo,unknown_dir
\`\`\`

All four \`kind\`s classify correctly. \`pytest tests/test_new_repo_setup.py -q\` — 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)