### PR TITLE
docs: add runbook 0931 (fleet-branch-cleanup) + refresh 0003-file-inventory after 2.5mo drift (Closes #1039)

### DIFF
--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -1,8 +1,8 @@
 # AssemblyZero - File Inventory & Status Map
 
 **Document:** 0003
-**Version:** 2.0
-**Last Updated:** 2026-03-01
+**Version:** 3.0
+**Last Updated:** 2026-05-07
 
 ## 1. Status Taxonomy
 
@@ -52,7 +52,7 @@
 | `0108-test-report-template.md` | Stable | Test results format |
 | `0109-runbook-template.md` | Stable | Operational procedures |
 
-### ADRs (02xx) - 14 files (12 active, 2 superseded)
+### ADRs (02xx) - 20 files (18 active, 2 superseded)
 
 | File | Status | Description |
 |------|--------|-------------|
@@ -70,6 +70,12 @@
 | `0210-discworld-persona-convention.md` | Stable | Persona naming rules |
 | `0211-rag-architecture.md` | Stable | RAG architecture (Brutha foundation) |
 | `0212-local-only-embeddings.md` | Stable | Local-only embeddings policy |
+| `0213-aws-multi-app-cost-separation.md` | Stable | AWS account/cost separation across apps |
+| `0214-fleet-wide-workflow-permissions-enforcement.md` | Stable | Workflow permissions enforcement fleet-wide |
+| `0215-claude-hook-locations.md` | Stable | Claude Code hook placement (global vs per-repo) |
+| `0216-in-process-classic-pat-decryption.md` | Stable | In-process classic PAT decryption (no env block) |
+| `0216-playwright-system-chrome-channel.md` | Stable | Playwright system Chrome channel; **NOTE:** numbering collision with 0216-in-process-classic-pat-decryption.md — renumber when convenient |
+| `0217-squash-merge-orphan-graft-cleanup.md` | Stable | Force-free squash-merge orphan cleanup via `git replace --graft` |
 
 ### Research (02xx-R) - 1 file
 
@@ -145,7 +151,7 @@ Skill documentation uses the c/p convention (CLI + Prompt pairs).
 | `0838-audit-broken-references.md` | Stable | Cross-reference validation |
 | `0899-meta-audit.md` | Stable | Audit the audits |
 
-### Runbooks (09xx) - 5 files
+### Runbooks (09xx) - 31 files
 
 | File | Status | Description |
 |------|--------|-------------|
@@ -153,11 +159,37 @@ Skill documentation uses the c/p convention (CLI + Prompt pairs).
 | `0901-new-project-setup.md` | Stable | Project init |
 | `0902-nightly-assemblyzero-audit.md` | Stable | Scheduled audit |
 | `0903-windows-scheduled-tasks.md` | Stable | Windows Task Scheduler |
+| `0904-issue-governance-workflow.md` | Stable | Per-issue governance flow |
 | `0905-gemini-credentials.md` | Stable | Gemini credential management |
+| `0906-lld-governance-workflow.md` | Stable | Per-LLD governance flow |
+| `0907-unified-requirements-workflow.md` | Stable | Pluggable requirements pipeline |
+| `0908-the-scout-external-intelligence-gathering-workflow.md` | Stable | Scout (Angua) external research |
+| `0909-tdd-implementation-workflow.md` | Stable | TDD implementation pipeline |
+| `0910-verdict-analyzer---template-improvement-from-gemini-verdicts.md` | Stable | Template improvement from verdicts |
+| `0911-dependabot-pr-audit.md` | Stable | Dependabot PR audit + auto-merge |
+| `0912-github-projects.md` | Stable | GitHub Projects reference |
+| `0913-skill-command-reference.md` | Stable | Skill command reference |
+| `0914-fix-implementation-workflow-should-archive-lld-and-reports-to-done--on-completion.md` | Stable | Post-merge LLD/reports archival |
+| `0915-backfill-audit-directories.md` | Stable | One-time audit dir backfill |
+| `0916-batch-workflow-runner.md` | Stable | Unattended batch workflow runner |
+| `0917-audit-skill-runbook.md` | Stable | `/audit` skill operation |
+| `0918-heartbeat-lite-install-guide.md` | Stable | Heartbeat-lite install |
+| `0919-no-lld-workflow.md` | Stable | Hotfix flow without LLD |
+| `0920-implementation-spec-hard-gate-wrapper-for-skipped-test-enforcement-test-gatepy.md` | Stable | Skipped-test enforcement gate |
+| `0921-implementation-spec-cross-project-metrics-aggregation-for-assemblyzero-usage-tracking.md` | Stable | Cross-project metrics aggregation |
+| `0922-implementation-spec-n9-cleanup-node---worktree-removal-lineage-archival-and-learning-summary.md` | Stable | N9 cleanup node (worktree + lineage) |
+| `0923-workflow-recovery.md` | Stable | Workflow recovery and `--resume` |
+| `0925-agent-token-setup.md` | Stable | Agent PAT permissions and rotation |
+| `0926-branch-protection-setup.md` | Stable | Manual branch protection (fallback) |
+| `0927-new-repo-human-checklist.md` | Stable | New-repo human checklist |
+| `0928-cloudflare-zone-setup.md` | Stable | Cloudflare zone setup on new domain |
+| `0929-ai-cli-tools-reference.md` | Stable | AI CLI tools reference |
+| `0930-gpg-and-classic-pat-rotation.md` | Stable | GPG + classic-PAT rotation procedure |
+| `0931-fleet-branch-cleanup.md` | Stable | Fleet-wide local-branch cleanup (#437; tool in unleashed) |
 
 ---
 
-## 3. Tools Inventory (36 files)
+## 3. Tools Inventory (43 files)
 
 ### Workflow Runners
 
@@ -182,7 +214,21 @@ Skill documentation uses the c/p convention (CLI + Prompt pairs).
 | `tools/assemblyzero_credentials.py` | Stable | Credential management utilities |
 | `tools/assemblyzero-harvest.py` | Beta | Pattern harvester for permission discovery |
 | `tools/archive_worktree_lineage.py` | Stable | Post-merge lineage archival |
-| `tools/new_repo_setup.py` | Stable | New repository initialization |
+| `tools/new_repo_setup.py` | Stable | New repository initialization (with `--cerberus-pem`, in-process classic PAT) |
+
+### Privileged-Path / Fleet Tools (in-process classic PAT — ADR-0216)
+
+These tools use `tools/_pat_session.classic_pat_session()` so the classic PAT never enters the env block. See ADR-0216.
+
+| File | Status | Description |
+|------|--------|-------------|
+| `tools/_pat_session.py` | Stable | Context manager for in-process classic PAT decryption |
+| `tools/deploy_cerberus_secrets.py` | Stable | Per-repo Cerberus secret deployment (sealed-box + Contents API; #1007) |
+| `tools/sentinel_migrate.py` | Stable | Migrate outlier repos to fleet-standard pr-sentinel context (#960) |
+| `tools/fleet_delete_pr_sentinel.py` | Stable | Fleet-wide deletion of legacy pr-sentinel.yml (#975 / #886 Phase 3) |
+| `tools/fleet_set_delete_branch_on_merge.py` | Stable | Fleet flip of `delete_branch_on_merge: true` (#1019); reference `_request_with_retry` |
+| `tools/fleet_set_permission_mode.py` | In-Progress | Fleet rollout of `claude.permissionMode=auto` (#979) |
+| `tools/dependabot_review.py` | Stable | Deterministic dependabot PR audit + merge (#949; runbook 0911) |
 
 ### RAG & Knowledge Base
 
@@ -224,6 +270,17 @@ Skill documentation uses the c/p convention (CLI + Prompt pairs).
 | `tools/transcript_filters.py` | Stable | Transcript filter utilities |
 | `tools/backfill_issue_audit.py` | Stable | Bulk audit backfill |
 | `tools/backfill_telemetry.py` | Stable | Historical telemetry backfill |
+
+### Cross-Repo / Fleet Tools (live in `unleashed/`)
+
+These tools live outside AZ but operate fleet-wide. The user invokes them from the `unleashed/` directory; AZ provides their runbooks.
+
+| File | Status | Description | Runbook |
+|------|--------|-------------|---------|
+| `unleashed/src/fleet_branch_cleanup.py` | Stable | Force-free squash-merge orphan cleanup across all repos under `~/Projects/` (ADR-0217) | [0931](runbooks/0931-fleet-branch-cleanup.md) |
+| `unleashed/src/repo_inventory_scan.py` | Stable | Discover all git repos under configured roots; upload metadata to Panopticon | (in unleashed) |
+| `unleashed/src/active_session_scan.py` | Stable | 1-min Panopticon active-session state sync | (in unleashed) |
+| `unleashed/src/session_artifact_scan.py` | Stable | Hourly Panopticon session-artifact upload | (in unleashed) |
 
 ---
 

--- a/docs/runbooks/0900-runbook-index.md
+++ b/docs/runbooks/0900-runbook-index.md
@@ -47,6 +47,8 @@ Quick reference for the user (Marty) on how to run tools, commands, agents, audi
 | 0927 | [New Repo: Human Checklist](0927-new-repo-human-checklist.md) | Manual | On new repo | - |
 | 0928 | [Cloudflare Zone Setup](0928-cloudflare-zone-setup.md) | Manual | On new domain | - |
 | 0929 | [AI CLI Tools Reference](0929-ai-cli-tools-reference.md) | Reference | - | All |
+| 0930 | [GPG and Classic-PAT Rotation](0930-gpg-and-classic-pat-rotation.md) | Manual | Quarterly | - |
+| 0931 | [Fleet Branch Cleanup](0931-fleet-branch-cleanup.md) | Manual | Periodic / post-merge | - |
 
 ## Model Selection Guide
 

--- a/docs/runbooks/0931-fleet-branch-cleanup.md
+++ b/docs/runbooks/0931-fleet-branch-cleanup.md
@@ -1,0 +1,173 @@
+# 0931 - Fleet Branch Cleanup
+
+**Category:** Runbook / Fleet Hygiene
+**Version:** 1.0
+**Last Updated:** 2026-05-07
+**Tool location:** `unleashed/src/fleet_branch_cleanup.py`
+**Related:** ADR-0217 (squash-merge orphan graft cleanup), unleashed#437
+
+---
+
+## Purpose
+
+Periodically sweep local squash-merge orphan branches across every git repo under `~/Projects/`. After GitHub squash-merges a PR and auto-deletes the remote branch, the local branch ref persists indefinitely because git's `branch -d` reachability check refuses to delete branches whose tip SHA isn't an ancestor of main. Without this tool, every squash-merged feature branch becomes immortal local clutter.
+
+The tool applies the ADR-0217 four-step `git replace --graft` recipe to delete safely **without ever using `-D` or `--force`**.
+
+## When to Run
+
+- **After a session that merged multiple PRs** — clean up the orphans before they pile up.
+- **Periodically** (weekly/biweekly) as fleet hygiene.
+- **Before audit/review tasks** that depend on `git branch --list` accuracy.
+- **When you notice clutter** in `git branch --list` after switching to a repo.
+
+## Prerequisites
+
+- `gh auth status` — fine-grained PAT works (only read-only PR queries).
+- `core.useReplaceRefs = true` (the git default; the recipe needs it).
+- Network access to GitHub (for `gh pr list` lookups).
+
+## Invocation
+
+```bash
+cd /c/Users/mcwiz/Projects/unleashed
+
+# Default: dry-run across the whole fleet
+poetry run python src/fleet_branch_cleanup.py
+
+# Actually clean up
+poetry run python src/fleet_branch_cleanup.py --apply
+
+# Limit to one repo
+poetry run python src/fleet_branch_cleanup.py --repo Aletheia
+poetry run python src/fleet_branch_cleanup.py --repo Aletheia --apply
+```
+
+**Always do `--dry-run` first** (the default) and read the classifications before passing `--apply`.
+
+## What the Tool Does
+
+For every git repo directly under `~/Projects/` (skipping worktrees and the test-rig sextant-2/-4/-6 dirs), the tool walks each non-default-branch local ref and:
+
+1. **Skips** if the branch is checked out in any worktree.
+2. **Looks up the merged PR** via `gh pr list --state merged --search head:<branch>` to find the squash commit on main.
+3. **Verifies content equivalence via `git cherry origin/main <branch>`** — every commit on the branch must have content already in main (cherry's `-` prefix). This is more permissive than tree-equivalence: it tolerates main absorbing intervening commits during the squash.
+4. **Applies the four-step recipe** (ADR-0217):
+   ```
+   BASE=$(git rev-parse <SQUASH_SHA>^)
+   git replace --graft <SQUASH_SHA> $BASE <BRANCH_TIP_SHA>
+   git branch -d <BRANCH>      # NEVER -D
+   git replace -d <SQUASH_SHA> # cleanup
+   ```
+
+## Classifications
+
+Every branch ends up in exactly one of these buckets:
+
+| Status | Meaning | Tool action |
+|--------|---------|-------------|
+| `cleaned` | All gates passed; graft+delete completed (or `dry_run_would_clean` in dry-run) | branch removed |
+| `has_worktree` | Branch is checked out in a worktree | left alone |
+| `has_unmerged_commits` | `git cherry` showed commits NOT in `origin/main` (`+` prefix) | left alone — needs human review |
+| `no_merged_pr` | `gh pr list` found no merged PR with this branch as head | left alone — likely active feature or abandoned |
+| `error` | Unexpected failure (e.g. squash commit missing locally even after fetch) | left alone — surface in summary |
+
+Only `cleaned` branches are actually mutated.
+
+## Safety
+
+- **Defaults to dry-run.** `--apply` required to act.
+- **Never uses `git branch -D` or any `--force` flag.** Every step uses safe-mode git commands.
+- **Step 4 (`replace -d`) cleanup runs regardless of step 3 outcome** — no stray graft refs linger.
+- **Per-branch try/except.** A failure on one repo doesn't stop the rest.
+- **Local-only.** No remote refs are touched. No data leaves the machine beyond the read-only `gh pr list` queries.
+- **`--apply` is idempotent.** Re-running on a clean fleet is a no-op (every branch is left in `no_merged_pr`, `has_worktree`, or `has_unmerged_commits`).
+
+## Output Interpretation
+
+The tool prints a per-branch line during the scan and a categorized summary at the end. Read the summary first.
+
+### `cleaned` / `dry_run_would_clean`
+
+These are the squash-merge orphans the tool identified and (will / did) remove. No further action needed. Re-run `git branch --list` in any cleaned repo to confirm.
+
+### `has_unmerged_commits`
+
+The branch has commits whose content is NOT in `origin/main`. Possibilities:
+- Active feature work that was never merged.
+- Local commits made AFTER the merge (your work after PR closed).
+- Cherry-picked work that diverged.
+
+**Don't use this tool on these.** Inspect manually:
+```bash
+cd ~/Projects/<repo>
+git log --oneline origin/main..<branch>
+```
+
+If the commits matter, finish the work and merge. If they don't, manually delete with `git branch -D` (one-time, with eyes open).
+
+### `no_merged_pr`
+
+No merged PR was found with this branch as head on GitHub. Possibilities:
+- Branch was created locally but never pushed.
+- PR is still open (check `gh pr list --state open`).
+- PR was closed without merging.
+- Branch name on GitHub differs from local (rename history).
+
+Inspect manually before deleting.
+
+### `has_worktree`
+
+Branch is in active use somewhere. Don't delete. Resolve by removing the worktree first (`git worktree remove ...`) when you're done with that work.
+
+### `error`
+
+Tool hit something unexpected. Read the detail line. Common cause: the merged PR's squash commit isn't fetched locally even after the tool's auto-fetch. Recovery: `git -C <repo> fetch --all`, then re-run.
+
+## Recovery if Things Go Sideways
+
+The tool's only mutations are local. Worst case is a stranded replace ref:
+
+```bash
+# Find lingering replace refs (should be zero after a normal run)
+for d in ~/Projects/*/; do
+    if [ -d "$d/.git" ]; then
+        n=$(git -C "$d" replace --list 2>/dev/null | wc -l)
+        [ "$n" -gt 0 ] && echo "$(basename $d): $n"
+    fi
+done
+
+# Remove any lingering ones
+git -C <repo> replace -d <sha>
+```
+
+A stranded replace ref is harmless (only changes how `git log` resolves that one commit locally). It's just untidy.
+
+## What This Doesn't Solve
+
+- **Worktree leftovers** — see runbook 0922 (N9 cleanup node).
+- **Stale remote branches** — auto-deleted on merge fleet-wide since 2026-04-30 via `delete_branch_on_merge: true` set on every repo.
+- **Pre-existing replace refs from manual ADR-0217 runs** — sweep with the recovery loop above.
+
+## Validation
+
+First production run: 2026-05-07 (unleashed#437 / unleashed#470).
+
+- 78 non-default local branches → 34 (45 cleaned, all squash-merge orphans).
+- Zero errors.
+- Zero lingering replace refs after the run.
+- Confirmed `git branch --list` accuracy across the fleet post-run.
+
+## Related
+
+- ADR-0217 — `git replace --graft` decomposition for force-free squash-merge orphan cleanup
+- Issue #998 — onboard skill must scrutinize handoff `--force` directives
+- Root `CLAUDE.md` — "Git destructive (... `branch -D` ...) require explicit user approval" rule
+- Runbook 0922 — N9 cleanup node (worktrees, lineage, learning summary)
+- Runbook 0911 — Dependabot PR audit (also creates audit-worktree branches that this tool will sweep when their PRs merge)
+
+## History
+
+| Date | Change |
+|------|--------|
+| 2026-05-07 | v1.0: Initial runbook. Tool shipped in unleashed#470 closing unleashed#437. |


### PR DESCRIPTION
## Summary

Three coordinated documentation updates to make the new fleet branch cleanup tool discoverable and bring the file inventory up to date.

Closes #1039.

### 1. New: \`docs/runbooks/0931-fleet-branch-cleanup.md\`

Documents \`unleashed/src/fleet_branch_cleanup.py\` (shipped in unleashed#470, closing unleashed#437). Covers when to run, mechanism, the 5 classification buckets, safety guarantees, output interpretation, recovery commands, and the 2026-05-07 validation run results (78 → 34 branches, zero errors).

Runbook lives in AZ per \"AssemblyZero is the canonical source for runbooks\"; the tool lives in unleashed.

### 2. Update: \`docs/runbooks/0900-runbook-index.md\`

Adds 0930 (GPG/classic-PAT rotation) and 0931 (fleet branch cleanup).

### 3. Update: \`docs/0003-file-inventory.md\` (was 2.5 months stale)

- Version 2.0 → 3.0; last-updated 2026-03-01 → 2026-05-07.
- **ADRs**: 14 → 20 entries. Adds 0213 (AWS multi-app), 0214 (workflow permissions), 0215 (hook locations), 0216 (in-process classic PAT), 0216 (Playwright Chrome — numbering collision flagged), 0217 (squash-merge orphan graft).
- **Runbooks**: 5 → 31 entries. Backfills the 26 runbooks (0904, 0906–0931) that runbook-index already lists but inventory hadn't caught up to.
- **Tools Inventory**: adds two new subsections:
  - **Privileged-Path / Fleet Tools** — \`_pat_session\`, \`deploy_cerberus_secrets\`, \`sentinel_migrate\`, \`fleet_delete_pr_sentinel\`, \`fleet_set_delete_branch_on_merge\`, \`fleet_set_permission_mode\`, \`dependabot_review\` (all in-process classic PAT per ADR-0216).
  - **Cross-Repo / Fleet Tools** — \`unleashed/src/fleet_branch_cleanup.py\` and three Panopticon scanners. Tools live in unleashed; AZ provides their runbooks.

## Note: ADR-0216 numbering collision

Two ADRs are numbered 0216:
- \`0216-in-process-classic-pat-decryption.md\` (canonical, referenced everywhere)
- \`0216-playwright-system-chrome-channel.md\` (added later via PR #1012, mirrored from Clio)

Flagged in the inventory's ADR table. Renumber as a separate concern when convenient.

## Verification

Docs-only. Diff is 238+/6- across three files. No code changes.