### PR TITLE
chore: renumber 0216-playwright → 0218 + add untracked ADR-0217 (Closes #1041)

### DIFF
--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -74,8 +74,8 @@
 | `0214-fleet-wide-workflow-permissions-enforcement.md` | Stable | Workflow permissions enforcement fleet-wide |
 | `0215-claude-hook-locations.md` | Stable | Claude Code hook placement (global vs per-repo) |
 | `0216-in-process-classic-pat-decryption.md` | Stable | In-process classic PAT decryption (no env block) |
-| `0216-playwright-system-chrome-channel.md` | Stable | Playwright system Chrome channel; **NOTE:** numbering collision with 0216-in-process-classic-pat-decryption.md — renumber when convenient |
 | `0217-squash-merge-orphan-graft-cleanup.md` | Stable | Force-free squash-merge orphan cleanup via `git replace --graft` |
+| `0218-playwright-system-chrome-channel.md` | Stable | Playwright system Chrome channel for anti-automation-gated sites (mirrored from Clio) |
 
 ### Research (02xx-R) - 1 file
 

--- a/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
+++ b/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
@@ -1,0 +1,188 @@
+# ADR 0217: Squash-Merge Orphan Branch Cleanup via `git replace --graft`
+
+**Status:** Implemented
+**Date:** 2026-04-28
+**Categories:** Process, Git Hygiene, No-Force Policy
+
+## 1. Context
+
+When a feature branch is squash-merged into main, GitHub (and most tools) deletes the remote branch and creates a single squash commit on main. The squash commit's *content* is identical to the feature branch's tip, but its *SHA differs* — squash-merge always rewrites parentage and metadata.
+
+Local clones are then left holding the original feature branch ref, with these properties:
+
+- Local branch tip SHA (e.g., `d1983a3`) is **not** an ancestor of `main`
+- The squash commit on main (e.g., `bb717abe`) **is** content-identical (`git diff` returns zero) but is a different SHA
+- `origin/<branch>` is gone (deleted by the platform on merge)
+
+`git branch -d <branch>` then refuses to delete the local ref. Git's safety check is **SHA-reachability-based, not content-based** — it cannot recognize squash-merge equivalence. The only standard-git operation that succeeds is `git branch -D` (force).
+
+For workflows operating under a strict no-force policy (AI agents, security-conscious teams, audit-graded environments), this leaves a permanent gap: every squash-merged feature branch becomes an immortal local orphan unless you bypass the safety check.
+
+A deep-research investigation (full prompt at `Aletheia/data/deep-research-squash-merge-cleanup.md`) identified `git replace --graft` as a clean decomposition: it provides git's DAG traversal with the equivalence proof it needs, satisfying the safety check legitimately, then is removed cleanly.
+
+## 2. Decision
+
+**For deleting a local branch ref orphaned by a squash-merge, when no-force policy applies, use the four-step `git replace --graft` decomposition:**
+
+```bash
+# 1. Identify the parent of the squash commit on main
+BASE_SHA=$(git rev-parse <SQUASH_SHA>^)
+
+# 2. Graft the squash commit to have the orphan tip as a second parent
+#    (creates a new replace ref; no force needed because no existing replace ref to overwrite)
+git replace --graft <SQUASH_SHA> $BASE_SHA <ORPHAN_TIP_SHA>
+
+# 3. Standard non-force delete; succeeds because the orphan tip is now reachable from main
+#    via the grafted parent edge
+git branch -d <ORPHAN_BRANCH_NAME>
+
+# 4. Remove the temporary graft; original commit and main are restored to pristine state
+git replace -d <SQUASH_SHA>
+```
+
+After step 4: local main is unchanged, the squash commit's parents are restored to their original single-parent form, no replace refs remain, and the orphan local branch ref is gone. The orphan commit itself becomes unreachable from any ref and is collected by `git gc` on its normal schedule.
+
+## 3. Alternatives Considered
+
+### Option A: `git replace --graft` decomposition — SELECTED
+
+Described above. Force-free, non-polluting, validated by sandbox and real-repo tests.
+
+**Pros:**
+- No force flag at any step
+- No history pollution (no merge commits, no cherry-picks, no main divergence from origin/main)
+- Fully reversible up until step 3
+- Standard porcelain commands only (no plumbing, no filesystem ref manipulation)
+- Decomposes the "force" into providing legitimate evidence to git's safety check
+
+**Cons:**
+- Higher overhead than `-D` (4 commands vs 1)
+- Transient (~1 second) window where the local repo's view of the squash commit shows two parents — any concurrent process reading the repo would see the grafted view
+- Requires `core.useReplaceRefs = true` (the default)
+- If the squash commit is GPG-signed, step 2 prints a warning that the *replacement* commit (the temporary grafted object) cannot inherit the signature. The original commit on main is not modified; its signature is intact.
+
+### Option B: `git branch -D` (force) — Rejected for no-force workflows
+
+The standard answer everywhere else, including in tools like `git-extras` and `git-trim` which call `git branch -D` under the hood after content-equivalence checks.
+
+**Pros:**
+- One command
+- Universally understood
+
+**Cons:**
+- Bypasses git's safety check entirely
+- For no-force-policy workflows, this is precisely the operation that is forbidden
+- Provides no decomposition — if the safety check is wrong, force is the only recourse
+
+### Option C: Local merge into main, then `-d` — Rejected
+
+Run `git merge <orphan-branch>` into local main to manufacture reachability, then `-d`.
+
+**Pros:**
+- No force flag on the deletion itself
+
+**Cons:**
+- Creates a merge commit on local main that diverges from `origin/main`
+- Subsequent `git push` from local main fails without `--force-push` (forbidden)
+- Reverting the merge adds yet another commit, leaving permanent residue
+- Pollutes history irrecoverably without a force-push escape
+
+### Option D: Cherry-pick orphan tip onto main, then `-d` — Rejected
+
+Same divergence problem as Option C, plus the cherry-pick conflicts because the squash already added the same content.
+
+### Option E: Plain `git replace <orig> <new>` (no graft), then `-d` — Rejected (verified ineffective)
+
+`git replace <orig> <new>` swaps the lookup target so `<orig>` resolves to `<new>`. The hypothesis was that this would make `<orig>` "reachable" because lookups would return the squash commit (which is on main).
+
+**Verified by sandbox test:** does NOT work. Git's `branch -d` reachability check walks parent pointers from main outward — it does not honor lookup-replacement for the deletion target. Only `--graft` (which rewrites parent pointers) satisfies the check.
+
+### Option F: Archive ref + upstream reconfiguration — Rejected as incomplete
+
+Push the orphan to a non-standard namespace (e.g., `refs/archive/<branch>`), configure that ref as the branch's upstream, then `-d` succeeds because the branch tip equals the configured upstream.
+
+**Pros:**
+- No force flag
+
+**Cons:**
+- The archive ref persists in `refs/archive/` indefinitely, holding the orphan commit alive
+- Effectively renames the orphan rather than removing it
+- Accumulates dead refs over time
+
+### Option G: Leave the orphan branch alone — Acceptable fallback
+
+Local branch refs cost essentially nothing. If `-D` is forbidden and `--graft` is unavailable for some reason, leaving orphans alone is principled and harmless (apart from cluttering `git branch --list`).
+
+**Pros:**
+- Zero risk
+- Zero effort
+
+**Cons:**
+- `git branch --list` accumulates dead refs over time
+- Tooling that operates on the branch list (e.g., automated cleanup, branch counters) sees noise
+
+## 4. Rationale
+
+Option A was selected because it is the only path that:
+
+1. **Decomposes the force** rather than bypassing or relocating it (analog to using `rm file1 file2 && rmdir dir/` instead of `rm -rf dir/`)
+2. **Satisfies git's safety check legitimately** by providing the topological equivalence proof the check is asking for
+3. **Leaves no residue** — sandbox and real-repo tests verified that final state is identical to a clone where the orphan never existed (modulo reflog, which is acceptable)
+
+The selected option is a "Level 3" tool: higher overhead than `-D`, used only when the no-force policy is in force. For environments without that constraint, `-D` remains correct and simpler.
+
+## 5. Security Risk Analysis
+
+| Risk | Impact | Likelihood | Severity | Mitigation |
+|------|--------|------------|----------|------------|
+| Concurrent process sees grafted view of squash commit during ~1 second graft window | Low (transient stale read; no data corruption) | Very Low (only if another git process is actively reading the repo at that exact moment) | 1 | Run the four steps as a tight sequence; no manual delays |
+| GPG signature warning misread as repo damage | None (warning is about the temporary replacement object only) | Medium | 1 | Documented in this ADR; original commit signature is intact post-cleanup |
+| `core.useReplaceRefs` set to false locally | Method silently ineffective | Very Low (default is true) | 2 | Verify with `git config --get core.useReplaceRefs` before applying; falls back to leaving orphan alone |
+| Step 3 succeeds but step 4 fails | Replace ref lingers, distorting subsequent reads of the squash commit | Very Low | 2 | Step 4 is one command; if it fails, run it manually; check `git replace -l` after |
+| Operator types wrong SHAs (e.g., not actually content-equivalent) | Could leave a graft mapping unrelated commits | Low | 2 | Verify content equivalence with `git diff <ORPHAN_SHA> <SQUASH_SHA>` before step 2 (must return zero output) |
+
+**Residual Risk:** Minimal for properly verified inputs.
+
+## 6. Consequences
+
+### Positive
+
+- Restores the ability to clean up squash-merged orphans under a no-force policy
+- Preserves git's safety check as a real check, not a check-with-bypass-flag
+- Provides a teachable decomposition pattern: legitimate-evidence-to-the-check, not bypass-the-check
+- Validated end-to-end in both sandbox and real repo (Aletheia `582-session-docs`, 2026-04-28)
+
+### Negative
+
+- Higher cognitive overhead than `-D` (4 commands, requires understanding of `replace` semantics)
+- Operators unfamiliar with `git replace --graft` may misread the GPG-signature warning as damage
+- Each application of the technique creates and removes one replace ref — slightly more activity in `.git/refs/replace/` than the simple force path
+
+### Neutral
+
+- The technique is local-only; no impact on remotes, CI, or other clones
+- Reflog records the graft-and-delete sequence (acceptable; no leak of sensitive data)
+
+## 7. Implementation
+
+- **Sandbox test:** `Aletheia/data/sandbox-method-b-test.sh` — reproducible verification
+- **First real-repo application:** Aletheia `582-session-docs`, 2026-04-28 (orphan from PR #585 squash-merge on 2026-03-28)
+- **Deep-research source:** `Aletheia/data/deep-research-squash-merge-cleanup.md` — original prompt that generated the technique
+- **Status:** Validated, ready for repeat application
+
+## 8. References
+
+- [`git-replace(1)`](https://git-scm.com/docs/git-replace) — official docs, particularly the `--graft` option
+- [`core.useReplaceRefs` config](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreuseReplaceRefs) — must be true (default) for replace refs to be honored
+- [`commit-reach.c` in git source](https://github.com/git/git/blob/master/commit-reach.c) — implements `repo_is_descendant_of` used by `branch -d`
+- [`builtin/branch.c` in git source](https://github.com/git/git/blob/master/builtin/branch.c) — implements `delete_branches`
+- AssemblyZero ADR 0203 (git worktree isolation) — adjacent topic
+- Aletheia `CLAUDE.md` — "use `-d`, never `-D`" rule that motivated this decomposition
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-04-28 | Claude Opus 4.7 | Initial draft after sandbox + real-repo validation |

--- a/docs/adrs/0218-playwright-system-chrome-channel.md
+++ b/docs/adrs/0218-playwright-system-chrome-channel.md
@@ -1,4 +1,6 @@
-# 0216 - ADR: System Chrome Channel for Playwright Automation Against Anti-Automation-Gated Sites
+# 0218 - ADR: System Chrome Channel for Playwright Automation Against Anti-Automation-Gated Sites
+
+> **Renumbered 2026-05-07** from 0216 to 0218 to resolve a numbering collision with `0216-in-process-classic-pat-decryption.md`. Original Clio source ADR (`Clio/docs/adrs/0201-playwright-system-chrome-channel.md`) is unchanged.
 
 **Status:** Implemented
 **Date:** 2026-04-22


### PR DESCRIPTION
## Summary

Resolves the ADR-0216 numbering collision. While doing it, discovered ADR-0217 was untracked in git despite being referenced fleet-wide and driving unleashed#437.

Closes #1041.

## Changes

### 1. Renumber 0216-playwright-system-chrome-channel.md → 0218

The 0216 number had two ADRs:
- \`0216-in-process-classic-pat-decryption.md\` (canonical, referenced ~20 places fleet-wide)
- \`0216-playwright-system-chrome-channel.md\` (added later via PR #1012, mirror from Clio)

Renaming the canonical one would touch ~20 files. Renaming the Playwright one only touched the inventory. Picked the low-blast-radius option.

Updated the H1 heading to match the new number and added a provenance line about the renumber.

### 2. Add untracked ADR-0217

Discovered \`docs/adrs/0217-squash-merge-orphan-graft-cleanup.md\` was UNTRACKED in git. It existed on disk locally, was referenced from root \`CLAUDE.md\`, drove the recent unleashed#437/#470 work, and was listed in the inventory as Stable — but was never actually committed. Anyone cloning fresh would not have it. This commit adds it.

### 3. Inventory update

Removed the collision note. Added 0218. Kept ADR count at 20 (one rename, neither add nor delete from the count's perspective; the 0217 add brings tracked-in-git up to actual on-disk count).

## Verification

- \`grep -r 0216-playwright\` — only the inventory referenced it; updated.
- \`grep -r 0217\` — references work (file now present in git).
- File listing post-merge: \`docs/adrs/021*.md\` shows 0210, 0211, 0212, 0213, 0214, 0215, 0216, 0217, 0218 — clean monotonic series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)