### PR TITLE
chore: pass --project to plan_archiver from /handoff + post-plan-write hook (Closes #1045)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -62,9 +62,12 @@ Run these in parallel to supplement your memory with current facts:
 
 2. **Plan snapshot (deterministic):** Run
    ```bash
-   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py status
+   PROJECT=$(basename "$(git rev-parse --show-toplevel)")
+   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py status --project "$PROJECT"
    ```
    Read the emitted JSON. Use its fields (`plan_path`, `plan_slug`, `plan_state`, `total_steps`, `completed_steps`, `remaining_steps`) in the `## The Plan` section below. Do NOT reconstruct plan state from memory — the JSON is the source of truth. If `status: "no_plan"`, skip the `## The Plan` section entirely. If `status: "error"`, note the error in `## The Plan` and continue.
+
+   #310: `--project` scopes the lookup to `~/.claude/plans/{project}/*.md`. Without it, `find_newest_plan` would still return whatever's globally newest by mtime, which is exactly the cross-project pollution we're fixing.
 
 3. **Git status across touched repos** — For every repo you modified this session, run:
    ```bash
@@ -233,9 +236,9 @@ After outputting the prompt to screen, persist it to the repo's handoff log so i
 
 7. **Archive the active plan (deterministic):** If the Step 1.2 JSON had `status: "ok"`, run:
    ```bash
-   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py archive --slug {plan_slug}
+   python /c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py archive --slug {plan_slug} --project "$PROJECT"
    ```
-   If `plan_state == "completed"` in that JSON, add `--mark-completed` to the command. The archiver is idempotent — if the live plan matches the newest archive, it emits `status: "already_archived"` and no-ops. Skip this step if Step 1.2 returned `status: "no_plan"` or `status: "error"`.
+   `$PROJECT` was set in Step 1.2 (`basename "$(git rev-parse --show-toplevel)"`). If `plan_state == "completed"` in that JSON, add `--mark-completed` to the command. The archiver is idempotent — if the live plan matches the newest archive, it emits `status: "already_archived"` and no-ops. Skip this step if Step 1.2 returned `status: "no_plan"` or `status: "error"`.
 
    After archiving succeeds, update the `archive_path` field in the `<!-- plan-state-start -->` block in `data/handoff-log.md` with the path from the archiver's JSON output. This is what /onboard and /pickup read to resume or ignore the plan.
 

--- a/.claude/hooks/post-plan-write.sh
+++ b/.claude/hooks/post-plan-write.sh
@@ -2,16 +2,21 @@
 # post-plan-write.sh — PostToolUse hook for Edit|Write.
 #
 # Fires on every Write/Edit to any file. Filters by path: if the
-# edited file is under ~/.claude/plans/*.md (but NOT under plans-archive/),
-# invokes unleashed/src/plan_archiver.py to archive with versioning.
+# edited file is under ~/.claude/plans/*.md (but NOT already under a
+# project subdir), relocates the file to ~/.claude/plans/<project>/*.md
+# and invokes unleashed/src/plan_archiver.py to archive with versioning.
+#
+# #310: per-project plan storage. The relocation step is what physically
+# scopes plans by project. After this hook runs, /handoff and /onboard
+# only ever see plans inside the current project's subdir.
 #
 # Contract:
-# - Reads hook JSON from stdin (tool_input.file_path is the edited file).
+# - Reads hook JSON from stdin (cwd, tool_input.file_path).
+# - Project derived from cwd (`git rev-parse --show-toplevel | basename`).
 # - Always exits 0 — hook failures must NEVER block the tool call.
-# - The archiver runs in --from-hook mode: quiet, always exits 0, writes
-#   status JSON to ~/.claude/plans-archive/.last-archive.json.
+# - Skips already-migrated files (path already under plans/<project>/).
 #
-# Fixes: unleashed #275, #276
+# Fixes: unleashed #275, #276, #310
 # Canonical source: AssemblyZero/.claude/hooks/post-plan-write.sh
 # ADR: docs/adrs/0215-claude-hook-locations.md
 
@@ -19,21 +24,21 @@ set -u
 
 PLAN_ARCHIVER="/c/Users/mcwiz/Projects/unleashed/src/plan_archiver.py"
 
-# Read hook input from stdin. jq is available on the user's machine per
-# CLAUDE.md install.sh. If jq is missing or the JSON is malformed, exit 0.
+# Read hook input from stdin.
 INPUT=$(cat)
 
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
 
-# Nothing to do if jq failed or there's no file_path
+# Nothing to do if jq failed or there's no file_path.
 if [ -z "$FILE_PATH" ]; then
     exit 0
 fi
 
-# Normalize backslashes to forward slashes for bash path matching
+# Normalize backslashes for bash path matching.
 NORMALIZED=${FILE_PATH//\\//}
 
-# Match ~/.claude/plans/*.md but exclude plans-archive/*
+# Must be under ~/.claude/plans/.
 case "$NORMALIZED" in
     */.claude/plans/*.md)
         ;;
@@ -42,29 +47,72 @@ case "$NORMALIZED" in
         ;;
 esac
 
-# Explicitly exclude archive dir (shouldn't match above but be safe)
+# Explicitly exclude archive dir.
 case "$NORMALIZED" in
     */.claude/plans-archive/*)
         exit 0
         ;;
 esac
 
-# Skip hidden files (e.g. .plan-status.json — though the glob above
-# should not match it anyway)
+# Skip hidden files.
 BASENAME=$(basename "$NORMALIZED")
 case "$BASENAME" in
     .*) exit 0 ;;
 esac
 
-# Extract slug: strip directory and .md extension
+# Already under a project subdir? Pattern: .../plans/<project>/<slug>.md
+# where <project> is one path component before the final .md file. We
+# detect this by checking whether there's another component between
+# ".claude/plans/" and the basename.
+case "$NORMALIZED" in
+    */.claude/plans/*/*.md)
+        ALREADY_MIGRATED=1
+        ;;
+    *)
+        ALREADY_MIGRATED=0
+        ;;
+esac
+
+# Strip .md to get the slug.
 SLUG="${BASENAME%.md}"
 
-# Skip if plan_archiver.py is missing (e.g. unleashed moved or not yet deployed)
+# Determine project: prefer git toplevel of HOOK_CWD; fall back to basename.
+PROJECT=""
+if [ -n "$HOOK_CWD" ]; then
+    if PROJECT_PATH=$(git -C "$HOOK_CWD" rev-parse --show-toplevel 2>/dev/null); then
+        PROJECT=$(basename "$PROJECT_PATH")
+    else
+        PROJECT=$(basename "$HOOK_CWD")
+    fi
+fi
+# Fallback to current $PWD if hook input had no cwd.
+if [ -z "$PROJECT" ]; then
+    if PROJECT_PATH=$(git rev-parse --show-toplevel 2>/dev/null); then
+        PROJECT=$(basename "$PROJECT_PATH")
+    fi
+fi
+
+# If we still couldn't figure out a project, do nothing — better to leave
+# the file at root for the migration script to sort than to invent a name.
+if [ -z "$PROJECT" ]; then
+    exit 0
+fi
+
+# Relocate the new plan into its project subdir (if not already there).
+if [ "$ALREADY_MIGRATED" = "0" ]; then
+    PROJECT_DIR=$(dirname "$NORMALIZED")/$PROJECT
+    mkdir -p "$PROJECT_DIR" 2>/dev/null || true
+    NEW_PATH="$PROJECT_DIR/$BASENAME"
+    # Atomic rename — best-effort. Failure is non-fatal.
+    mv -f "$NORMALIZED" "$NEW_PATH" 2>/dev/null || true
+fi
+
+# Skip if plan_archiver.py is missing.
 if [ ! -f "$PLAN_ARCHIVER" ]; then
     exit 0
 fi
 
-# Invoke archiver in hook mode. Always exit 0.
-python "$PLAN_ARCHIVER" archive --slug "$SLUG" --from-hook >/dev/null 2>&1 || true
+# Invoke archiver in hook mode with --project. Always exit 0.
+python "$PLAN_ARCHIVER" archive --slug "$SLUG" --project "$PROJECT" --from-hook >/dev/null 2>&1 || true
 
 exit 0


### PR DESCRIPTION
## Summary

Closes #1045. Companion to martymcenroe/unleashed#310 (already merged).

`unleashed/src/plan_archiver.py` now scopes plan storage to per-project subdirectories `~/.claude/plans/<project>/`. This PR updates AssemblyZero's canonical `/handoff` skill and `post-plan-write.sh` hook to pass `--project` explicitly.

## Changes

**`.claude/commands/handoff.md`**

- Step 1.2 (status call): set `PROJECT=$(basename "$(git rev-parse --show-toplevel)")` and pass `--project "$PROJECT"`.
- Step 5.7 (archive call): same `--project`.

**`.claude/hooks/post-plan-write.sh`**

- Read `cwd` from hook input via `jq '.cwd'`, fall back to `$PWD`.
- Resolve to project name via `git rev-parse --show-toplevel | basename`.
- After plan mode writes a new plan to `~/.claude/plans/<slug>.md`, atomically `mv` it to `~/.claude/plans/<project>/<slug>.md`.
- Pass `--project` to `plan_archiver archive`.
- Idempotent: skip relocate if the path is already under a project subdir.

## Non-blocking ordering

`unleashed/src/plan_archiver.py` keeps `--project` optional with a transitional cwd-fallback, so this PR is non-blocking. `/handoff` keeps working in the window between unleashed#310 merging and skill_sync rolling these commands to `~/.claude/`. After this lands, the deprecation-warning fallback is no longer exercised.

## Test plan

- [x] Hook updated to handle `cwd` input + relocate logic
- [x] `/handoff` skill updated to derive \`\$PROJECT\` and pass it through
- [ ] After merge + skill_sync: write a plan from any project's session, verify the file lands in `~/.claude/plans/<project>/`
- [ ] After merge + skill_sync: invoke `/handoff` and confirm the plan-state block carries `plan_path: ~/.claude/plans/<project>/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)