### PR TITLE
fix: /park skips spawn + distinct close-state marker (Closes #1047)

### DIFF
--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,6 +1,6 @@
 ---
 description: Generate a high-fidelity context transfer prompt for the next session
-argument-hint: "[--help] [--reboot]"
+argument-hint: "[--help] [--reboot] [--park]"
 scope: global
 ---
 
@@ -13,10 +13,11 @@ scope: global
 ```
 /handoff - Context transfer + lessons learned + hygiene report
 
-Usage: `/handoff [--reboot]`
+Usage: `/handoff [--reboot] [--park]`
 
 Options:
-  --reboot    Save state but skip spawning a new terminal (for reboots/shutdowns)
+  --reboot    Save state, write reboot-parked marker, skip spawn (for forced reboots/shutdowns)
+  --park      Save state, write park marker, skip spawn (for "I'm done for now, will resume later")
 
 This is context transfer AND institutional memory capture:
 - Captures what matters for the next session (forward-looking)
@@ -242,6 +243,19 @@ After outputting the prompt to screen, persist it to the repo's handoff log so i
 
    After archiving succeeds, update the `archive_path` field in the `<!-- plan-state-start -->` block in `data/handoff-log.md` with the path from the archiver's JSON output. This is what /onboard and /pickup read to resume or ignore the plan.
 
+8. **Write close-state marker (deterministic):** Append the appropriate close-state marker to `data/handoff-log.md` so panopticon and `pickup_decide.py` can distinguish the user's intent post-hoc. Run:
+
+   ```bash
+   poetry run python /c/Users/mcwiz/Projects/unleashed/src/handoff_marker.py --repo-root {REPO_ROOT} --marker {MARKER}
+   ```
+
+   Where `{MARKER}` is:
+   - `park` if `$ARGUMENTS` contains `--park`
+   - `reboot-parked` if `$ARGUMENTS` contains `--reboot`
+   - `handoff` otherwise (plain `/handoff`, including the auto-spawn case for "context window filling up")
+
+   The script is idempotent — rerunning with the same marker is a no-op. Runs BEFORE Step 6 (spawn) so the new auto-onboarding session sees the marker.
+
 ### Step 5B: Persist Lessons Learned
 
 Lessons learned are institutional knowledge — they get committed, unlike the handoff log.
@@ -294,9 +308,11 @@ Brief backward-looking record of the session. One entry per session.
 
 ### Step 6: Spawn New Unleashed Session
 
-**MANDATORY unless `--reboot` is in `$ARGUMENTS`.** The CLAUDE.md "Skill Instructions Are Explicit Authorization" rule applies. Do NOT skip this step for any reason not listed in these instructions. Do NOT invent conditions (e.g., "not running under unleashed", "environment variable empty") to justify skipping.
+**MANDATORY unless `--reboot` or `--park` is in `$ARGUMENTS`.** The CLAUDE.md "Skill Instructions Are Explicit Authorization" rule applies. Do NOT skip this step for any reason not listed in these instructions. Do NOT invent conditions (e.g., "not running under unleashed", "environment variable empty") to justify skipping.
 
-**IF `$ARGUMENTS` contains `--reboot`:** Skip this step entirely. Tell user: "Handoff saved. Skipping new session (--reboot). Ready to reboot."
+**IF `$ARGUMENTS` contains `--reboot`:** Skip this step entirely. Tell user: "Handoff saved (reboot-parked). Skipping new session. Ready to reboot."
+
+**IF `$ARGUMENTS` contains `--park`:** Skip this step entirely. Tell user: "Handoff saved and parked. Ready to /exit when you are. Next /onboard against this repo will pick it up."
 
 **OTHERWISE:**
 
@@ -318,7 +334,7 @@ After persisting the handoff log, spawn a new `unleashed-alpha` session. Auto-on
 - **Don't pad.** If nothing happened in a section, skip it. A shorter, accurate prompt beats a longer, padded one.
 - **User preferences go in "Key Decisions."** Things like "user doesn't want numbered options" or "always use poetry run python" — if you learned it this session and it's not in CLAUDE.md or MEMORY.md, capture it here.
 - **Always persist** — the log survives even if the clipboard is lost.
-- **Always spawn without flags** — v30+ auto-onboard detects the fresh handoff and auto-imports it. No `--pickup` needed. Exception: `--reboot` skips the spawn entirely.
+- **Always spawn without flags** — v30+ auto-onboard detects the fresh handoff and auto-imports it. No `--pickup` needed. Exceptions: `--reboot` and `--park` both skip the spawn entirely. The difference is the marker written in Step 5.8 — `reboot-parked` (indefinite shelf intent) vs. `park` (deliberate stop-for-now) — which panopticon and `pickup_decide.py` use to distinguish the user's intent.
 - **Lessons are institutional memory.** One real lesson is worth more than a perfect handoff. If something surprised you, cost time, or changed your approach — write it down. 0 rows is fine for routine sessions; padding is not.
 - **Hygiene is exposure, not action.** NEVER delete branches, stashes, worktrees, or files during handoff. Report what exists so the user can rescue work. `/cleanup` is for destructive operations.
 - **Session log is backward-looking, handoff prompt is forward-looking.** The session log records what happened (for mining later). The handoff prompt tells the next agent what to do. Don't conflate them.

--- a/.claude/commands/park.md
+++ b/.claude/commands/park.md
@@ -1,0 +1,47 @@
+---
+description: Park the session for deliberate pickup later (alias for /handoff --park)
+argument-hint: "[--help]"
+scope: global
+---
+
+# Park
+
+**If `$ARGUMENTS` contains `--help`:** Display the Help section below and STOP.
+
+## Help
+
+```
+/park - Generate a handoff AND mark this session as deliberately parked
+
+Usage: `/park`
+
+What it does:
+- Runs the full /handoff machinery (state capture, lessons, hygiene, log append).
+- Writes a `<!-- park YYYY-MM-DD HH:MM:SS -->` close-state marker after the
+  handoff entry in data/handoff-log.md.
+- DOES NOT spawn a new wt window. /park is for "I'm done for now, will resume
+  later" — distinct from plain /handoff which spawns a fresh session for
+  "context window filling up" mid-work.
+- Surfaces in panopticon's Exit column as `park` (distinct from `exit`,
+  `handoff`, `reboot-parked`, `away`, `null`) so future-you can see at a
+  glance "I deliberately parked this one — pick it up next time."
+
+Equivalent to: `/handoff --park`. /park exists as a shorter, more
+intention-revealing alias.
+
+After /park, run `/exit` to close the session. `/onboard` against this
+repo next time will detect the unconsumed handoff and pick it up.
+```
+
+## Execution
+
+Invoke the `/handoff` skill with the `--park` argument. All of /handoff's
+behavior applies — state gathering, lessons-learned capture, hygiene
+report, log persistence, plan archive — plus the park marker written in
+Step 5.8 by `handoff_marker.py`. Step 6 (spawn) is skipped per the
+`--park` clause; the user closes via `/exit` when ready.
+
+The user's intent here is unambiguous: they typed /park because they're
+done for now and want this session to surface as the resume target next
+time. Don't second-guess that intent. Don't suggest /handoff (without
+--park) as an alternative — they already chose the parking variant.


### PR DESCRIPTION
## Summary
- `/park` (and `/handoff --park`) no longer spawn a new wt window. The skip-spawn condition in `handoff.md` Step 6 now covers both `--reboot` and `--park`.
- New Step 5 sub-step 8 invokes `unleashed/src/handoff_marker.py` to write `<!-- park / reboot-parked / handoff TIMESTAMP -->` to `data/handoff-log.md` per flag, idempotent.
- `park.md` canonicalized into AssemblyZero (was previously local-only in `~/.claude/commands/`, flagged as skill_sync drift). Wording updated to match the new marker convention and Step 5.8 reference.

## Context
Plan: `~/.claude/plans/unleashed/yes-examine-the-code-snazzy-liskov.md`. This is the skill side of Issue A; the data side (`handoff_marker.py` + `pickup_decide.py`) shipped via martymcenroe/unleashed#490. Together they fix the `/park`-spawns-new-window bug surfaced in this morning's design conversation.

The marker is written BEFORE the spawn step so the new auto-onboarding session sees the marker — avoids a race where pickup_decide.py would classify the just-written handoff before the marker landed.

## Test plan
- [ ] Run `/park` in any repo: confirm NO new wt window opens; confirm `data/handoff-log.md` ends with both `<!-- handoff-end -->` and `<!-- park YYYY-MM-DD HH:MM:SS -->`.
- [ ] Run `/handoff --reboot`: NO spawn; marker `<!-- reboot-parked ... -->`.
- [ ] Run plain `/handoff`: spawn happens (existing behavior); marker `<!-- handoff ... -->`.
- [ ] Skill sync runs cleanly: `python /c/Users/mcwiz/Projects/unleashed/src/skill_sync.py` deploys both updated handoff.md and new park.md to `~/.claude/commands/` without drift warnings.

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)