### PR TITLE
docs: 0901 — drop stale pr-sentinel.yml ref; clarify Worker-only check (Closes #1053)

### DIFF
--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -142,7 +142,7 @@ options:
 
 ### 1. Deploy Cerberus Secrets (If Needed)
 
-The script deploys PR governance workflows (`pr-sentinel.yml`, `auto-reviewer.yml`) and configures branch protection automatically. The only remaining step is ensuring Cerberus secrets exist on the new repo. See the [Cerberus secrets section of the Human Checklist](0927-new-repo-human-checklist.md#4-deploy-cerberus-secrets-if-needed) for the fleet-wide deploy process.
+The script deploys the `auto-reviewer.yml` workflow and configures branch protection automatically. The `pr-sentinel/issue-reference` check is provided fleet-wide by the Cloudflare Worker (per #938 / #939), not by a per-repo workflow file. The only remaining step is ensuring Cerberus secrets exist on the new repo. See the [Cerberus secrets section of the Human Checklist](0927-new-repo-human-checklist.md#4-deploy-cerberus-secrets-if-needed) for the fleet-wide deploy process.
 
 ### 2. Add Advanced Hooks (Optional)
 


### PR DESCRIPTION
## Summary

Single-line fix to runbook 0901-new-project-setup.md. Line 145 claimed the script deploys \`pr-sentinel.yml\`; it has not since #938/#939. Runbook 0927 was updated; 0901 was missed.

Closes #1053.

## Change

Before:
> The script deploys PR governance workflows (\`pr-sentinel.yml\`, \`auto-reviewer.yml\`) and configures branch protection automatically.

After:
> The script deploys the \`auto-reviewer.yml\` workflow and configures branch protection automatically. The \`pr-sentinel/issue-reference\` check is provided fleet-wide by the Cloudflare Worker (per #938 / #939), not by a per-repo workflow file.

## Verification

- \`grep -in pr-sentinel docs/runbooks/0901-new-project-setup.md\` — no matches outside expected reference (the new wording mentions \`pr-sentinel/issue-reference\` as the Worker-provided check, which is accurate).
- Cross-checked against runbook 0927 v4.0 changelog and \`tools/new_repo_setup.py\` (zero \`pr-sentinel.yml\` matches in script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)