### PR TITLE
refactor: extract _request_with_retry into shared tools/_gh_retry.py (Closes #1052)

### DIFF
--- a/tests/test_gh_retry.py
+++ b/tests/test_gh_retry.py
@@ -1,0 +1,179 @@
+"""Unit tests for tools/_gh_retry.py.
+
+Exercises the retry/backoff helper without making real HTTP calls.
+Mocks `requests.request` and `time.sleep` so tests are deterministic
+and fast.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+import _gh_retry as gh  # noqa: E402
+
+
+def _resp(status: int, headers: dict | None = None) -> requests.Response:
+    r = requests.Response()
+    r.status_code = status
+    if headers:
+        r.headers.update(headers)
+    return r
+
+
+class TestSuccessPaths:
+    def test_success_on_first_try(self):
+        with mock.patch("requests.request", return_value=_resp(200)) as m:
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+        assert m.call_count == 1
+
+    def test_passes_kwargs_through(self):
+        with mock.patch("requests.request", return_value=_resp(200)) as m:
+            gh.request_with_retry("PUT", "https://example/x", "pat", json={"k": "v"})
+        kwargs = m.call_args.kwargs
+        assert kwargs.get("json") == {"k": "v"}
+
+    def test_sets_auth_header(self):
+        with mock.patch("requests.request", return_value=_resp(200)) as m:
+            gh.request_with_retry("GET", "https://example/x", "secret_pat")
+        headers = m.call_args.kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer secret_pat"
+        assert headers.get("Accept") == "application/vnd.github+json"
+
+
+class TestPermanent4xx:
+    def test_404_returned_without_retry(self):
+        with mock.patch("requests.request", return_value=_resp(404)) as m:
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 404
+        assert m.call_count == 1
+
+    def test_422_returned_without_retry(self):
+        with mock.patch("requests.request", return_value=_resp(422)) as m:
+            r = gh.request_with_retry("PUT", "https://example/x", "pat")
+        assert r.status_code == 422
+        assert m.call_count == 1
+
+
+class TestServer5xx:
+    def test_recovers_after_transient_5xx(self):
+        responses = [_resp(502), _resp(503), _resp(200)]
+        with mock.patch("requests.request", side_effect=responses) as m, \
+             mock.patch.object(time, "sleep"):
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+        assert m.call_count == 3
+
+    def test_5xx_exhaustion_raises_http_error(self):
+        with mock.patch("requests.request", return_value=_resp(502)), \
+             mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.HTTPError):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+
+class TestSecondaryRateLimit429:
+    def test_recovers_after_429(self):
+        responses = [_resp(429, {"Retry-After": "5"}), _resp(200)]
+        sleep = mock.MagicMock()
+        with mock.patch("requests.request", side_effect=responses), \
+             mock.patch.object(time, "sleep", sleep):
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+        # Honors Retry-After value.
+        assert any(call.args == (5,) for call in sleep.call_args_list)
+
+    def test_429_exhaustion_raises_http_error(self):
+        with mock.patch(
+            "requests.request",
+            return_value=_resp(429, {"Retry-After": "1"}),
+        ), mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.HTTPError):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+
+class TestPrimaryRateLimit403:
+    def test_recovers_after_primary_rate_limit(self):
+        future = int(time.time()) + 5
+        responses = [
+            _resp(403, {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(future)}),
+            _resp(200),
+        ]
+        with mock.patch("requests.request", side_effect=responses), \
+             mock.patch.object(time, "sleep"):
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+
+    def test_403_without_rate_limit_header_returned_as_is(self):
+        # 403 not flagged as rate-limit (no X-RateLimit-Remaining=0) is permanent
+        with mock.patch("requests.request", return_value=_resp(403)) as m:
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 403
+        assert m.call_count == 1
+
+    def test_primary_rate_limit_exhaustion_raises_http_error(self):
+        future = int(time.time()) + 1
+        resp = _resp(403, {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": str(future)})
+        with mock.patch("requests.request", return_value=resp), \
+             mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.HTTPError):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+
+class TestNetworkErrors:
+    def test_recovers_after_connection_error(self):
+        side_effects = [requests.ConnectionError("nope"), _resp(200)]
+        with mock.patch("requests.request", side_effect=side_effects), \
+             mock.patch.object(time, "sleep"):
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+
+    def test_recovers_after_timeout(self):
+        side_effects = [requests.Timeout("slow"), _resp(200)]
+        with mock.patch("requests.request", side_effect=side_effects), \
+             mock.patch.object(time, "sleep"):
+            r = gh.request_with_retry("GET", "https://example/x", "pat")
+        assert r.status_code == 200
+
+    def test_connection_error_exhaustion_raises(self):
+        with mock.patch(
+            "requests.request",
+            side_effect=requests.ConnectionError("nope"),
+        ), mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.ConnectionError):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+    def test_timeout_exhaustion_raises(self):
+        with mock.patch(
+            "requests.request",
+            side_effect=requests.Timeout("slow"),
+        ), mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.Timeout):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+
+class TestExceptionHierarchy:
+    """All raised exceptions must be requests.RequestException so existing
+    `except requests.RequestException` handlers in caller tools keep
+    catching retry-exhausted failures."""
+
+    def test_http_error_is_request_exception(self):
+        with mock.patch("requests.request", return_value=_resp(502)), \
+             mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.RequestException):
+                gh.request_with_retry("GET", "https://example/x", "pat")
+
+    def test_connection_error_is_request_exception(self):
+        with mock.patch(
+            "requests.request",
+            side_effect=requests.ConnectionError("nope"),
+        ), mock.patch.object(time, "sleep"):
+            with pytest.raises(requests.RequestException):
+                gh.request_with_retry("GET", "https://example/x", "pat")

--- a/tools/_gh_retry.py
+++ b/tools/_gh_retry.py
@@ -1,0 +1,132 @@
+"""Shared retry helper for in-process classic-PAT GitHub API calls.
+
+Companion to `tools/_pat_session.py`. Where `_pat_session` decides
+*how* the PAT is sourced (ADR-0216), this module decides *how* the
+HTTP call wrapping the PAT-bearing request handles transient failures.
+
+Single function: `_request_with_retry`. Exponential backoff on
+ConnectionError/Timeout/5xx, primary rate limit (403 +
+X-RateLimit-Remaining=0, X-RateLimit-Reset honored), secondary rate
+limit (429, Retry-After honored). Permanent 4xx responses (404, 422,
+etc.) are returned as-is for the caller to inspect.
+
+On retry exhaustion, raises rather than silently returning a failed
+response. This is the loud-failure variant; the silent-return form
+(used previously in `new_repo_setup.py` and `deploy_cerberus_secrets.py`)
+let permanent transient failures masquerade as flow control. (#1052)
+
+Existing callers wrap calls in `try / except requests.RequestException`
+and check `resp.status_code < 300` on the way out. The exceptions
+raised by this module — `requests.ConnectionError`, `requests.Timeout`,
+`requests.HTTPError` — are all subclasses of `RequestException`, so
+the existing handlers continue to catch them.
+
+Usage:
+
+    from _gh_retry import request_with_retry
+
+    with classic_pat_session() as pat:
+        try:
+            r = request_with_retry(
+                "PUT", f"{_GH_API}/repos/{owner}/{repo}/...", pat,
+                json=body,
+            )
+        except requests.RequestException:
+            # network or retry-exhausted failure
+            return False
+        return r.status_code < 300
+"""
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import requests
+
+_HTTP_TIMEOUT_S = 30
+_MAX_RETRIES = 4
+_INITIAL_BACKOFF_S = 1.0
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    pat: str,
+    **kwargs: Any,
+) -> requests.Response:
+    """HTTP request with exponential backoff on transient errors.
+
+    Retries: ConnectionError, Timeout, HTTP 5xx, HTTP 429 (Retry-After
+    honored), HTTP 403 with X-RateLimit-Remaining=0 (X-RateLimit-Reset
+    honored).
+
+    Returns: the response object on success or on permanent 4xx (caller
+    decides what to do with non-retried 4xx like 404, 422).
+
+    Raises (on retry exhaustion):
+    - `requests.ConnectionError` or `requests.Timeout` — last
+      network-level exception when retries are exhausted on transport
+      errors.
+    - `requests.HTTPError` — when retries are exhausted on a retried
+      HTTP status (5xx, 429, or 403 rate-limit). Subclass of
+      RequestException so callers' existing `except RequestException`
+      handlers catch it.
+    """
+    backoff = _INITIAL_BACKOFF_S
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            r = requests.request(
+                method, url, headers=_gh_headers(pat),
+                timeout=_HTTP_TIMEOUT_S, **kwargs,
+            )
+        except (requests.ConnectionError, requests.Timeout) as e:
+            if attempt < _MAX_RETRIES:
+                print(f"    network error ({type(e).__name__}); retry in {backoff}s")
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            raise
+
+        # Secondary rate limit (429 + Retry-After)
+        if r.status_code == 429:
+            if attempt < _MAX_RETRIES:
+                retry_after = int(r.headers.get("Retry-After", "30"))
+                print(f"    HTTP 429; sleeping {retry_after}s per Retry-After")
+                time.sleep(retry_after)
+                continue
+            r.raise_for_status()  # exhausted -> HTTPError
+
+        # Primary rate limit (403 + X-RateLimit-Remaining=0)
+        if r.status_code == 403 and r.headers.get("X-RateLimit-Remaining") == "0":
+            if attempt < _MAX_RETRIES:
+                reset = int(r.headers.get("X-RateLimit-Reset", "0"))
+                wait = max(reset - int(time.time()), 30)
+                print(f"    primary rate limit hit; sleeping {wait}s until reset")
+                time.sleep(wait)
+                continue
+            r.raise_for_status()  # exhausted -> HTTPError
+
+        # Server-side transient (5xx)
+        if 500 <= r.status_code < 600:
+            if attempt < _MAX_RETRIES:
+                print(f"    HTTP {r.status_code}; retry in {backoff}s")
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            r.raise_for_status()  # exhausted -> HTTPError
+
+        # Success or permanent 4xx (non-retried) — return as-is
+        return r
+
+    # Defensive: the loop body always either continues, returns, or raises.
+    # If somehow we fall through, raise on the last response.
+    r.raise_for_status()
+    return r

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -25,7 +25,6 @@ Issue: #736 | Related: #732, #1007 (in-process PAT migration)
 import base64
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import requests
@@ -41,70 +40,16 @@ except ImportError:
 APP_ID = "3079970"
 GITHUB_USER = "martymcenroe"
 _GH_API = "https://api.github.com"
-_HTTP_TIMEOUT_S = 30
-_MAX_RETRIES = 4
-_INITIAL_BACKOFF_S = 1.0
 
-
-def _gh_headers(pat: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {pat}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-
-
-def _request_with_retry(
-    method: str, url: str, pat: str, **kwargs
-) -> requests.Response:
-    """HTTP request with exponential backoff on transient errors.
-
-    Retries: connection errors, timeouts, 5xx, 429 (Retry-After honored),
-    403 with X-RateLimit-Remaining=0 (X-RateLimit-Reset honored).
-
-    Does NOT retry: 4xx other than 403/429 (permanent for this caller).
-
-    Ported per #1036 from new_repo_setup.py / fleet_set_delete_branch_on_merge.py
-    so a transient 502 mid-secret-set doesn't leave a half-deployed Cerberus state.
-    """
-    backoff = _INITIAL_BACKOFF_S
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            r = requests.request(
-                method, url, headers=_gh_headers(pat),
-                timeout=_HTTP_TIMEOUT_S, **kwargs,
-            )
-        except (requests.ConnectionError, requests.Timeout) as e:
-            if attempt < _MAX_RETRIES:
-                print(f"    network error ({type(e).__name__}); retry in {backoff}s")
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            raise
-
-        if r.status_code == 429:
-            retry_after = int(r.headers.get("Retry-After", "30"))
-            if attempt < _MAX_RETRIES:
-                print(f"    HTTP 429; sleeping {retry_after}s per Retry-After")
-                time.sleep(retry_after)
-                continue
-        if r.status_code == 403 and r.headers.get("X-RateLimit-Remaining") == "0":
-            reset = int(r.headers.get("X-RateLimit-Reset", "0"))
-            wait = max(reset - int(time.time()), 30)
-            if attempt < _MAX_RETRIES:
-                print(f"    primary rate limit hit; sleeping {wait}s until reset")
-                time.sleep(wait)
-                continue
-        if 500 <= r.status_code < 600:
-            if attempt < _MAX_RETRIES:
-                print(f"    HTTP {r.status_code}; retry in {backoff}s")
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-
-        return r
-
-    return r
+# Shared retry helper (#1052). Imported as _request_with_retry to keep
+# existing call-sites unchanged. Loud-failure variant: retry exhaustion
+# raises requests.HTTPError / ConnectionError / Timeout (all
+# RequestException subclasses, so existing except handlers still catch).
+try:
+    from _gh_retry import request_with_retry as _request_with_retry
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _gh_retry import request_with_retry as _request_with_retry  # noqa: F401
 
 
 def get_all_repos() -> list[str]:

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -28,7 +28,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -1152,74 +1151,16 @@ def deploy_canonical_hooks(project_path: Path) -> None:
 
 
 _GH_API = "https://api.github.com"
-_HTTP_TIMEOUT_S = 30
-_MAX_RETRIES = 4
-_INITIAL_BACKOFF_S = 1.0
 
-
-def _gh_headers(pat: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {pat}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-
-
-def _request_with_retry(
-    method: str, url: str, pat: str, **kwargs
-) -> requests.Response:
-    """HTTP request with exponential backoff on transient errors.
-
-    Retries: connection errors, timeouts, 5xx, 429 (rate-limited), and
-    403 with X-RateLimit-Remaining=0 (secondary rate limit).
-
-    Does NOT retry: 4xx other than 403/429 (permanent for this caller).
-
-    Ported from tools/fleet_set_delete_branch_on_merge.py per #1022 so
-    a transient 502 mid-setup doesn't leave a half-deployed new repo.
-    """
-    backoff = _INITIAL_BACKOFF_S
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            r = requests.request(
-                method, url, headers=_gh_headers(pat),
-                timeout=_HTTP_TIMEOUT_S, **kwargs,
-            )
-        except (requests.ConnectionError, requests.Timeout) as e:
-            if attempt < _MAX_RETRIES:
-                print(f"    network error ({type(e).__name__}); retry in {backoff}s")
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-            raise
-
-        # Rate limit: secondary (429 with Retry-After)
-        if r.status_code == 429:
-            retry_after = int(r.headers.get("Retry-After", "30"))
-            if attempt < _MAX_RETRIES:
-                print(f"    HTTP 429; sleeping {retry_after}s per Retry-After")
-                time.sleep(retry_after)
-                continue
-        # Rate limit: primary (403 + X-RateLimit-Remaining=0)
-        if r.status_code == 403 and r.headers.get("X-RateLimit-Remaining") == "0":
-            reset = int(r.headers.get("X-RateLimit-Reset", "0"))
-            wait = max(reset - int(time.time()), 30)
-            if attempt < _MAX_RETRIES:
-                print(f"    primary rate limit hit; sleeping {wait}s until reset")
-                time.sleep(wait)
-                continue
-        # Server-side transient
-        if 500 <= r.status_code < 600:
-            if attempt < _MAX_RETRIES:
-                print(f"    HTTP {r.status_code}; retry in {backoff}s")
-                time.sleep(backoff)
-                backoff *= 2
-                continue
-
-        # All other responses: return as-is (caller decides 4xx handling)
-        return r
-
-    return r  # final attempt's response, even if it was a retryable error
+# Shared retry helper (#1052). Imported as _request_with_retry to keep
+# existing call-sites unchanged. Loud-failure variant: retry exhaustion
+# raises requests.HTTPError / ConnectionError / Timeout (all
+# RequestException subclasses, so existing except handlers still catch).
+try:
+    from _gh_retry import request_with_retry as _request_with_retry
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _gh_retry import request_with_retry as _request_with_retry  # noqa: F401
 
 
 def configure_branch_protection(github_user: str, repo_name: str, pat: str) -> bool:


### PR DESCRIPTION
## Summary

Two callers had near-identical retry/backoff helpers diverging only in post-exhaustion behavior. Extracts to one shared module with the loud-failure variant (raise on retry exhaustion) per user decision 2026-05-09.

Closes #1052.

## Decision (recap)

The 3 implementations diverged on retry-exhaustion behavior:
- \`new_repo_setup.py\` and \`deploy_cerberus_secrets.py\`: returned the failed response silently.
- \`fleet_set_delete_branch_on_merge.py\` (currently untracked locally — out of PR scope): raised.

User picked **raise**. Silent permanent failure in deployment-critical paths is a footgun — the script can report 'OK' while a privileged GitHub API call permanently failed. Existing \`try / except requests.RequestException\` callers continue to work because all raised exceptions (\`requests.HTTPError\`, \`requests.ConnectionError\`, \`requests.Timeout\`) are RequestException subclasses.

## Changes

| File | Change |
|---|---|
| **NEW** \`tools/_gh_retry.py\` | Single \`request_with_retry\` function. Full docstring on retry semantics + raise-on-exhaustion contract. |
| **NEW** \`tests/test_gh_retry.py\` | 18 unit tests; mocks \`requests.request\` and \`time.sleep\`. Closes the test gap surfaced by 0852 audit (zero retry-helper tests existed before this PR). |
| \`tools/new_repo_setup.py\` | Deletes ~70 lines of local copy + retry constants. Imports as \`_request_with_retry\` to keep every call-site unchanged. Removes now-unused \`import time\`. |
| \`tools/deploy_cerberus_secrets.py\` | Same swap pattern. Removes now-unused \`import time\`. |

## Tests

93 passed across the relevant suites:
- \`test_gh_retry.py\` (18 new): success-on-first, retry-then-succeed, exhaustion-raises (5xx / 429 / 403-rate-limit / ConnectionError / Timeout), permanent 4xx (404, 422, plain 403), header propagation, kwargs passthrough, exception-hierarchy.
- \`test_new_repo_setup.py\` (28 existing): unchanged behavior.
- \`test_audit_deferred_scope.py\` (47 existing): unchanged behavior.

## Smoke

- \`poetry run python tools/new_repo_setup.py --help\` — clean load, parser intact.
- \`poetry run python tools/deploy_cerberus_secrets.py\` — clean load (positional .pem arg parser).
- \`grep -r 'def _request_with_retry\|def request_with_retry' tools/\` → exactly one match (\`tools/_gh_retry.py:59\`).

## Out-of-scope note

A third local copy lives in untracked \`tools/fleet_set_delete_branch_on_merge.py\` (per 2026-05-08 handoff). Not part of this PR. When that file gets committed, swap should be even cleaner — it was already the loud-raise variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)