### PR TITLE
fix: new_repo_setup.py — sane .unleashed.json defaults (Closes #1059, Closes #1060)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -518,6 +518,26 @@ class TestMainLocalWorkflow:
 
     @patch("new_repo_setup.config")
     @patch("new_repo_setup.run_command")
+    def test_T265_unleashed_json_defaults(self, mock_run, mock_config, tmp_path):
+        """`.unleashed.json` defaults to assemblyZero=true (#1059) and
+        does NOT include the deprecated pickupThresholdMinutes (#1060)."""
+        _setup_config_mock(mock_config, tmp_path)
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch("sys.argv", ["new_repo_setup.py", "DefaultsProject", "--no-github"]):
+            main()
+        unleashed_json = (tmp_path / "DefaultsProject" / ".unleashed.json").read_text()
+        config = json.loads(unleashed_json)
+        # #1059: AZ-managed repos load AZ rules on /onboard.
+        assert config["assemblyZero"] is True
+        # #1060: deprecated and ignored by /onboard; should not be emitted.
+        assert "pickupThresholdMinutes" not in config["onboard"]
+        # Sanity: still has the rest of the structure.
+        assert config["claude"]["model"] == "opus"
+        assert config["claude"]["effort"] == "max"
+        assert config["onboard"]["auto"] is True
+
+    @patch("new_repo_setup.config")
+    @patch("new_repo_setup.run_command")
     def test_T270_force_flag_passed(self, mock_run, mock_config, tmp_path):
         """--force flag is accepted without error."""
         _setup_config_mock(mock_config, tmp_path)

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1008,6 +1008,14 @@ def create_unleashed_json(project_path: Path) -> None:
     Sets model=opus, effort=max so unleashed wrappers pass the correct
     CLI flags. Without this file, wrappers fall back to tool defaults.
 
+    `assemblyZero` defaults to True (#1059): repos created by this tool
+    are by definition AssemblyZero-managed, so /onboard should load
+    AssemblyZero's CLAUDE.md when a session starts here.
+
+    `pickupThresholdMinutes` is intentionally NOT emitted (#1060): the
+    /onboard skill is event-ordered now and explicitly ignores this
+    field, so writing it just confuses future readers tuning the value.
+
     Args:
         project_path: Path to the project root.
     """
@@ -1017,10 +1025,9 @@ def create_unleashed_json(project_path: Path) -> None:
             "model": "opus",
             "effort": "max"
         },
-        "assemblyZero": False,
+        "assemblyZero": True,
         "onboard": {
             "auto": True,
-            "pickupThresholdMinutes": 10,
             "guide": None,
             "plan": None
         }


### PR DESCRIPTION
## Summary

Two related defects in the .unleashed.json template generated by \`new_repo_setup.py\`. Both surfaced by the boostgauge readiness audit (\`docs/audit-results/0001-...\` in that repo).

Closes #1059 (assemblyZero default).
Closes #1060 (deprecated pickupThresholdMinutes).

## Defects

| # | Field | Before | After | Why |
|---|---|---|---|---|
| 1059 | \`assemblyZero\` | \`false\` | \`true\` | Repos created by AZ's own setup tool ARE AZ-managed; \`/onboard\` should load AZ's CLAUDE.md when a session starts in them. The wrong default leaves agents cold. |
| 1060 | \`onboard.pickupThresholdMinutes\` | \`10\` | (removed) | \`/onboard\` skill explicitly notes this field is DEPRECATED and ignored — pickup is event-ordered now. Writing it just confuses future readers tuning the value. |

## Implementation

Single edit in \`create_unleashed_json()\` at \`tools/new_repo_setup.py:1014-1027\`. Docstring updated to record both decisions.

## Test

New \`test_T265_unleashed_json_defaults\` locks both behaviors:
- Asserts \`config[\"assemblyZero\"] is True\`.
- Asserts \`\"pickupThresholdMinutes\" not in config[\"onboard\"]\`.
- Sanity-checks the rest of the structure (\`claude.model\`, \`claude.effort\`, \`onboard.auto\`).

29 \`test_new_repo_setup.py\` tests pass.

## Out of scope

Existing repos created with the old defaults keep them. A fleet-rollout script to backfill \`assemblyZero=true\` and strip \`pickupThresholdMinutes\` could be filed separately if the user wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)