### PR TITLE
feat: new_repo_setup.py — create canonical labels (implementation, lld) (Closes #1061)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -417,6 +417,71 @@ class TestValidateName:
             assert not valid, f"'{name}' ({reason}) should be invalid"
 
 
+class TestCanonicalLabels:
+    """T215-T219: create_canonical_labels (#1061)."""
+
+    @patch("new_repo_setup.run_command")
+    def test_T215_creates_all_canonical_labels(self, mock_run):
+        """Both implementation and lld labels get created."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from new_repo_setup import create_canonical_labels
+        created, total = create_canonical_labels("martymcenroe", "boostgauge")
+        assert created == 2
+        assert total == 2
+        # Both labels were attempted via gh CLI.
+        commands = [call[0][0] for call in mock_run.call_args_list]
+        label_names = [c[3] for c in commands if c[:3] == ["gh", "label", "create"]]
+        assert "implementation" in label_names
+        assert "lld" in label_names
+
+    @patch("new_repo_setup.run_command")
+    def test_T216_uses_force_for_idempotency(self, mock_run):
+        """gh label create is invoked with --force so reruns succeed."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from new_repo_setup import create_canonical_labels
+        create_canonical_labels("martymcenroe", "TestRepo")
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            assert "--force" in cmd, f"--force missing from: {cmd}"
+
+    @patch("new_repo_setup.run_command")
+    def test_T217_targets_correct_repo(self, mock_run):
+        """--repo flag is set to {github_user}/{repo_name}."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from new_repo_setup import create_canonical_labels
+        create_canonical_labels("martymcenroe", "MyRepo")
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            repo_idx = cmd.index("--repo")
+            assert cmd[repo_idx + 1] == "martymcenroe/MyRepo"
+
+    @patch("new_repo_setup.run_command")
+    def test_T218_partial_failure_returns_partial_count(self, mock_run, capsys):
+        """If one label fails, count reflects only successes; warning printed."""
+        # First call succeeds, second call fails.
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stderr=""),
+            MagicMock(returncode=1, stderr="GraphQL error: insufficient scope"),
+        ]
+        from new_repo_setup import create_canonical_labels
+        created, total = create_canonical_labels("martymcenroe", "TestRepo")
+        assert created == 1
+        assert total == 2
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+
+    @patch("new_repo_setup.run_command")
+    def test_T219_check_false_passed(self, mock_run):
+        """run_command is called with check=False so non-zero exit doesn't raise."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from new_repo_setup import create_canonical_labels
+        create_canonical_labels("martymcenroe", "TestRepo")
+        for call in mock_run.call_args_list:
+            kwargs = call[1] if len(call) > 1 else call.kwargs
+            assert kwargs.get("check") is False, \
+                f"check=False missing from call: {call}"
+
+
 class TestMainAuditMode:
     """T220: --audit flag triggers audit path."""
 

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1329,6 +1329,55 @@ def _deploy_workflows_via_contents_api(
     return True, uploaded
 
 
+# Canonical AZ labels (#1061). The metrics_aggregator counts the
+# `implementation` label as the in-implementation classifier; `lld`
+# is convention for issues with an approved LLD ready for the
+# implementation workflow. Kept deliberately small — workflow
+# CONFIG names like `lld-standard` belong in code, not GitHub labels.
+_CANONICAL_LABELS: list[tuple[str, str, str]] = [
+    ("implementation", "0E8A16",
+     "Issue is in implementation or has a paired implementation PR"),
+    ("lld", "5319E7",
+     "Issue has an approved LLD in docs/lld/active/LLD-NNN.md"),
+]
+
+
+def create_canonical_labels(github_user: str, repo_name: str) -> tuple[int, int]:
+    """Create canonical AssemblyZero labels on the new repo.
+
+    Idempotent via `gh label create --force` — pre-existing labels
+    get updated to the canonical color/description rather than failing.
+
+    Args:
+        github_user: GitHub username (owner).
+        repo_name: Lowercased repository name.
+
+    Returns:
+        (created, total) — count of labels successfully created/updated
+        and total attempted.
+    """
+    repo = f"{github_user}/{repo_name}"
+    created = 0
+    for name, color, description in _CANONICAL_LABELS:
+        cmd = [
+            "gh", "label", "create", name,
+            "--color", color,
+            "--description", description,
+            "--force",
+            "--repo", repo,
+        ]
+        try:
+            r = run_command(cmd, check=False)
+            if r.returncode == 0:
+                created += 1
+            else:
+                print(f"  WARNING: failed to create label '{name}': "
+                      f"{(r.stderr or '').strip()}")
+        except (subprocess.TimeoutExpired, OSError) as e:
+            print(f"  WARNING: error creating label '{name}': {e}")
+    return created, len(_CANONICAL_LABELS)
+
+
 def audit_structure(project_path: Path, name: str) -> int:
     """
     Audit an existing project structure against the canonical schema.
@@ -1895,6 +1944,17 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 else:
                     print("  SKIPPED: Push failed — no remote branch to protect.")
                     print("  After pushing, configure branch protection manually.")
+
+                # Step 19: Create canonical AZ workflow labels (#1061).
+                print("\n19. Creating canonical labels...")
+                if push_succeeded:
+                    created, total = create_canonical_labels(
+                        github_user, repo_name_lower
+                    )
+                    print(f"  {created}/{total} labels created or updated "
+                          f"({', '.join(n for n, _, _ in _CANONICAL_LABELS)})")
+                else:
+                    print("  SKIPPED: Push failed — no remote repo to label.")
 
     # Post-setup verification
     print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary

New repos arrive with only GitHub default labels (\`bug\`, \`enhancement\`, etc.). Adds two AZ ecosystem labels at creation time:

| Label | Color | Why |
|---|---|---|
| \`implementation\` | \`#0E8A16\` | Counted by \`metrics_aggregator.py\` to classify in-implementation issues. Without it, metrics under-count. |
| \`lld\` | \`#5319E7\` | Convention for issues with an approved LLD ready for the implementation workflow. |

Closes #1061. Surfaced by boostgauge readiness audit §3.1.

## Implementation

- New \`create_canonical_labels(github_user, repo_name)\` function in \`tools/new_repo_setup.py\`.
- Uses \`gh label create --force\` so re-running on an existing repo updates rather than fails.
- Wired in as step 19 after branch protection.
- Skipped if the initial push failed (no remote repo to label).

## Tests

5 new tests in \`TestCanonicalLabels\`:
- T215: both canonical labels created.
- T216: \`--force\` is in every \`gh label create\` invocation (idempotency).
- T217: \`--repo\` targets \`{github_user}/{repo_name}\`.
- T218: partial failure returns partial count and prints a warning.
- T219: \`run_command(check=False)\` so non-zero exits surface as warnings rather than raise.

34 \`test_new_repo_setup.py\` tests pass.

## Out of scope

- Workflow CONFIG names (\`lld-standard\`, \`lld-reviewed\`, etc. in \`assemblyzero/workflows/requirements/config.py\`) staying in code; not promoted to GitHub labels.
- Backfilling labels into the ~60 existing fleet repos (separate fleet-rollout issue if user wants).
- Auto-applying labels to PRs/issues based on content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)