### PR TITLE
feat: workflow auto-retry with backoff (Closes #1071)

### DIFF
--- a/assemblyzero/utils/retry.py
+++ b/assemblyzero/utils/retry.py
@@ -1,0 +1,247 @@
+"""Retry utility for LLM-calling workflow nodes (#1071).
+
+Wraps any callable that returns an `LLMCallResult` and retries on
+retryable failures (5xx, 429, capacity, timeout) with exponential
+backoff. The retryability decision is delegated to the call site via
+the `retryable` flag on `LLMCallResult` — populated by the providers
+in `assemblyzero/core/llm_provider.py` based on the typed exception
+hierarchy in `assemblyzero/core/errors.py`. This module does NOT do
+its own error classification; it trusts what the provider reports.
+
+Why a wrapper rather than a decorator: most LLM-calling nodes already
+build the call inline with closure over local context (system prompt,
+schema kwargs, audit-trail callbacks). A `with_retry(lambda: ...)`
+form keeps that ergonomics; a decorator would force the call to be
+factored into a separate function.
+
+Three policies ship: `default` (5 retries, 2s→32s backoff), `aggressive`
+(8 retries, 60s cap), and `none` (no retry — preserves the current
+fail-fast behavior). The policy name flows through workflow state via
+`config_retry_policy`, set by the entry-point script's `--retry-policy`
+flag.
+
+Usage:
+
+    from assemblyzero.utils.retry import with_retry, get_policy
+
+    policy = get_policy(state.get("config_retry_policy", "default"))
+    result = with_retry(
+        lambda: reviewer.invoke(
+            system_prompt=sys_prompt,
+            content=user_prompt,
+            response_schema=VERDICT_SCHEMA,
+        ),
+        policy=policy,
+        description="N1 testing reviewer",
+    )
+
+    if result.success:
+        ...
+
+`with_retry` ALWAYS returns an `LLMCallResult` — the caller's existing
+`if result.success: ...` branch handles both first-try success and
+retry-exhaustion failure paths uniformly.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from assemblyzero.core.llm_provider import LLMCallResult
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RetryPolicy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """How retries are scheduled for transient LLM failures.
+
+    Attributes:
+        max_retries: Number of retry attempts AFTER the first call. So
+            max_retries=5 means up to 6 total invocations of fn (one
+            initial + five retries). max_retries=0 disables retry.
+        initial_backoff_s: Sleep before the FIRST retry. Subsequent
+            retries multiply by `backoff_multiplier`, capped at
+            `max_backoff_s`.
+        max_backoff_s: Ceiling on backoff duration. Prevents the
+            sequence from growing unboundedly with high max_retries.
+        backoff_multiplier: Per-retry multiplier on the backoff. 2.0
+            yields 2s → 4s → 8s → 16s → 32s for default policy.
+    """
+    max_retries: int
+    initial_backoff_s: float
+    max_backoff_s: float
+    backoff_multiplier: float
+
+    @classmethod
+    def default(cls) -> "RetryPolicy":
+        """Default — 5 retries, 2s → 4s → 8s → 16s → 32s.
+
+        Tuned for the boostgauge speed-run: covers most Gemini 503
+        bursts (typically 10-30s) without crossing into recording
+        dead-air territory (>2 minutes total).
+        """
+        return cls(
+            max_retries=5,
+            initial_backoff_s=2.0,
+            max_backoff_s=32.0,
+            backoff_multiplier=2.0,
+        )
+
+    @classmethod
+    def aggressive(cls) -> "RetryPolicy":
+        """Aggressive — 8 retries, 60s cap. For longer outages."""
+        return cls(
+            max_retries=8,
+            initial_backoff_s=2.0,
+            max_backoff_s=60.0,
+            backoff_multiplier=2.0,
+        )
+
+    @classmethod
+    def none(cls) -> "RetryPolicy":
+        """None — no retry. Preserves pre-#1071 fail-fast behavior."""
+        return cls(
+            max_retries=0,
+            initial_backoff_s=0.0,
+            max_backoff_s=0.0,
+            backoff_multiplier=1.0,
+        )
+
+
+def get_policy(name: str) -> RetryPolicy:
+    """Look up a named policy.
+
+    Args:
+        name: One of "default", "aggressive", "none".
+
+    Returns:
+        The matching RetryPolicy.
+
+    Raises:
+        ValueError: If name is unknown.
+    """
+    factories = {
+        "default": RetryPolicy.default,
+        "aggressive": RetryPolicy.aggressive,
+        "none": RetryPolicy.none,
+    }
+    factory = factories.get(name)
+    if factory is None:
+        raise ValueError(
+            f"Unknown retry policy: {name!r}. "
+            f"Valid: {sorted(factories.keys())}"
+        )
+    return factory()
+
+
+# ---------------------------------------------------------------------------
+# with_retry
+# ---------------------------------------------------------------------------
+
+
+def with_retry(
+    fn: Callable[[], LLMCallResult],
+    policy: Optional[RetryPolicy] = None,
+    *,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    description: str = "LLM call",
+) -> LLMCallResult:
+    """Call fn() and retry on retryable failures.
+
+    Args:
+        fn: A zero-argument callable that returns an LLMCallResult.
+            Typically a lambda wrapping a provider's `.invoke()` call.
+        policy: Retry schedule. Defaults to RetryPolicy.default().
+        sleep_fn: Override for `time.sleep`. Tests inject a no-op.
+        description: Used in log messages to identify the call site
+            (e.g., "N3 LLD reviewer", "N4 implementer").
+
+    Returns:
+        The first successful LLMCallResult, OR the final failed
+        LLMCallResult after retries are exhausted (whether the
+        exhaustion is from max_retries or a non-retryable failure).
+        Never raises; the caller's existing `if result.success` branch
+        handles both cases uniformly.
+
+    Behavior:
+        - Success on first try → no retry, returns immediately.
+        - Failure with `retryable=False` → no retry, returns immediately.
+        - Failure with `retryable=True`, attempts left → sleep + retry.
+        - All retries exhausted → returns the last failed result.
+
+    Backoff calculation:
+        - If the result has `retry_after` set (e.g., from a 429
+          response with a Retry-After header), sleep for exactly that
+          many seconds. The provider populates this from the typed
+          RateLimitError's retry_after field.
+        - Otherwise, use exponential backoff: initial_backoff_s,
+          ×backoff_multiplier per retry, capped at max_backoff_s.
+    """
+    policy = policy or RetryPolicy.default()
+    backoff = policy.initial_backoff_s
+    last_result: Optional[LLMCallResult] = None
+
+    for attempt in range(policy.max_retries + 1):
+        result = fn()
+        last_result = result
+
+        # Success — return immediately.
+        if result.success:
+            if attempt > 0:
+                logger.info(
+                    "%s succeeded on retry %d/%d",
+                    description, attempt, policy.max_retries,
+                )
+            return result
+
+        # Permanent failure — don't retry.
+        if not result.retryable:
+            logger.info(
+                "%s failed permanently (non-retryable, status=%s): %s",
+                description, result.status_code, result.error_message,
+            )
+            return result
+
+        # Transient failure — decide whether to retry.
+        is_final_attempt = attempt >= policy.max_retries
+        if is_final_attempt:
+            logger.warning(
+                "%s retries exhausted after %d attempt(s); last error: %s",
+                description, attempt + 1, result.error_message,
+            )
+            return result
+
+        # Compute sleep duration. Server-provided retry_after wins; else
+        # fall back to exponential backoff capped at max_backoff_s.
+        if result.retry_after is not None:
+            sleep_for = float(result.retry_after)
+        else:
+            sleep_for = min(backoff, policy.max_backoff_s)
+            backoff = min(
+                backoff * policy.backoff_multiplier,
+                policy.max_backoff_s,
+            )
+
+        logger.info(
+            "%s transient failure (attempt %d/%d, status=%s); "
+            "sleeping %.1fs then retrying: %s",
+            description,
+            attempt + 1,
+            policy.max_retries + 1,
+            result.status_code,
+            sleep_for,
+            result.error_message,
+        )
+        sleep_fn(sleep_for)
+
+    # Unreachable — the loop body always returns or breaks. Defensive.
+    assert last_result is not None
+    return last_result

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -162,6 +162,7 @@ class RequirementsWorkflowState(TypedDict, total=False):
     config_drafter: str
     config_reviewer: str
     config_effort: str  # Issue #773: Effort level for Claude reviewer
+    config_retry_policy: str  # Issue #1071: "default" | "aggressive" | "none"
     config_gates_draft: bool
     config_gates_verdict: bool
     config_auto_mode: bool
@@ -264,6 +265,8 @@ def create_initial_state(
     mock_mode: bool = False,
     max_iterations: int = 3,
     effort: str = "max",
+    # Issue #1071: retry policy for transient LLM failures.
+    retry_policy: str = "default",
     # Issue-specific
     brief_file: str = "",
     source_idea: str = "",
@@ -312,6 +315,7 @@ def create_initial_state(
         "config_drafter": drafter,
         "config_reviewer": reviewer,
         "config_effort": effort,
+        "config_retry_policy": retry_policy,
         "config_gates_draft": gates_draft,
         "config_gates_verdict": gates_verdict,
         "config_auto_mode": auto_mode,

--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -505,42 +505,44 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
 
     cost_before = get_cumulative_cost()
     try:
-        import time
+        # Issue #775: Pass VERDICT_SCHEMA to provider for structured output (REQ-2)
+        from assemblyzero.core.llm_provider import GeminiProvider
 
-        # N1 Retry: 2 attempts with exponential backoff
-        max_attempts = 2
-        last_error = ""
-        result = None
+        schema_kwargs: dict[str, Any] = {}
+        if isinstance(reviewer, GeminiProvider):
+            schema_kwargs["response_schema"] = VERDICT_SCHEMA
+        else:
+            schema_kwargs["json_schema"] = VERDICT_SCHEMA
 
-        for attempt in range(1, max_attempts + 1):
-            # Issue #775: Pass VERDICT_SCHEMA to provider for structured output (REQ-2)
-            from assemblyzero.core.llm_provider import GeminiProvider
+        # Issue #1071: Centralized retry. Replaces the previous inline
+        # 2-attempt loop. Policy comes from workflow state (set by the
+        # entry-point script's --retry-policy flag); default = 5
+        # retries, 2s→32s exponential backoff.
+        from assemblyzero.utils.retry import get_policy, with_retry
 
-            schema_kwargs = {}
-            if isinstance(reviewer, GeminiProvider):
-                schema_kwargs["response_schema"] = VERDICT_SCHEMA
-            else:
-                schema_kwargs["json_schema"] = VERDICT_SCHEMA
+        retry_policy_name = state.get("config_retry_policy", "default")
+        retry_policy = get_policy(retry_policy_name)
 
-            result = reviewer.invoke(
-                system_prompt="You are a senior QA engineer reviewing a test plan for coverage and quality.",
+        result = with_retry(
+            lambda: reviewer.invoke(
+                system_prompt=(
+                    "You are a senior QA engineer reviewing a test plan "
+                    "for coverage and quality."
+                ),
                 content=full_prompt,
                 **schema_kwargs,
-            )
+            ),
+            policy=retry_policy,
+            description="N1 testing reviewer",
+        )
 
-            if result.success:
-                break
-
+        if not result.success:
             last_error = result.error_message or "Unknown error"
-            print(f"    [N1] Reviewer attempt {attempt}/{max_attempts} failed: {last_error}")
-
-            if attempt < max_attempts:
-                backoff = 2 ** attempt  # 2s, 4s
-                print(f"    [N1] Retrying in {backoff}s...")
-                time.sleep(backoff)
-
-        if not result or not result.success:
-            error_msg = f"Reviewer failed after {max_attempts} attempts: {last_error}"
+            attempts_made = retry_policy.max_retries + 1
+            error_msg = (
+                f"Reviewer failed after up to {attempts_made} attempt(s) "
+                f"({retry_policy_name} retry policy): {last_error}"
+            )
             print(f"    [ERROR] {error_msg}")
 
             # Save error to audit trail
@@ -550,7 +552,12 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
                     audit_dir,
                     file_num,
                     "reviewer-error.md",
-                    f"# Review Error\n\nAttempts: {max_attempts}\nLast error: {last_error}\n",
+                    (
+                        f"# Review Error\n\n"
+                        f"Retry policy: {retry_policy_name}\n"
+                        f"Max attempts: {attempts_made}\n"
+                        f"Last error: {last_error}\n"
+                    ),
                 )
 
             return {

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -196,6 +196,7 @@ class TestingWorkflowState(TypedDict, total=False):
     # Mode flags
     config_reviewer: str  # Issue #773: Reviewer LLM spec (e.g., "claude:opus")
     config_effort: str  # Issue #779: Effort level for Claude reviewer
+    config_retry_policy: str  # Issue #1071: "default" | "aggressive" | "none"
     auto_mode: bool
     mock_mode: bool
     skip_e2e: bool

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,294 @@
+"""Tests for assemblyzero.utils.retry (#1071)."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from assemblyzero.core.llm_provider import LLMCallResult
+from assemblyzero.utils.retry import RetryPolicy, get_policy, with_retry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok_result(provider: str = "claude") -> LLMCallResult:
+    """LLMCallResult representing a successful call."""
+    return LLMCallResult(
+        success=True,
+        response="ok",
+        raw_response="ok",
+        error_message=None,
+        provider=provider,
+        model_used="opus-4-7",
+        duration_ms=100,
+        attempts=1,
+        retryable=True,
+    )
+
+
+def _transient_result(
+    status_code: int = 503,
+    retry_after: float | None = None,
+    provider: str = "anthropic",
+) -> LLMCallResult:
+    """LLMCallResult representing a retryable transient failure."""
+    return LLMCallResult(
+        success=False,
+        response=None,
+        raw_response=None,
+        error_message=f"HTTP {status_code} transient",
+        provider=provider,
+        model_used="opus-4-7",
+        duration_ms=100,
+        attempts=1,
+        status_code=status_code,
+        retryable=True,
+        retry_after=retry_after,
+    )
+
+
+def _permanent_result(
+    status_code: int = 401,
+    provider: str = "anthropic",
+) -> LLMCallResult:
+    """LLMCallResult representing a non-retryable permanent failure."""
+    return LLMCallResult(
+        success=False,
+        response=None,
+        raw_response=None,
+        error_message=f"HTTP {status_code} auth",
+        provider=provider,
+        model_used="opus-4-7",
+        duration_ms=100,
+        attempts=1,
+        status_code=status_code,
+        retryable=False,
+    )
+
+
+class _FakeFn:
+    """Replays a scripted sequence of LLMCallResults."""
+
+    def __init__(self, results: list[LLMCallResult]):
+        self.results = list(results)
+        self.calls = 0
+
+    def __call__(self) -> LLMCallResult:
+        self.calls += 1
+        if self.results:
+            return self.results.pop(0)
+        # Default to last result if scripted list is exhausted
+        raise AssertionError("FakeFn called more times than scripted")
+
+
+# ---------------------------------------------------------------------------
+# RetryPolicy / get_policy
+# ---------------------------------------------------------------------------
+
+
+def test_default_policy_values():
+    p = RetryPolicy.default()
+    assert p.max_retries == 5
+    assert p.initial_backoff_s == 2.0
+    assert p.max_backoff_s == 32.0
+    assert p.backoff_multiplier == 2.0
+
+
+def test_aggressive_policy_values():
+    p = RetryPolicy.aggressive()
+    assert p.max_retries == 8
+    assert p.max_backoff_s == 60.0
+
+
+def test_none_policy_disables_retry():
+    p = RetryPolicy.none()
+    assert p.max_retries == 0
+
+
+def test_get_policy_default():
+    p = get_policy("default")
+    assert p.max_retries == 5
+
+
+def test_get_policy_aggressive():
+    p = get_policy("aggressive")
+    assert p.max_retries == 8
+
+
+def test_get_policy_none():
+    p = get_policy("none")
+    assert p.max_retries == 0
+
+
+def test_get_policy_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown retry policy"):
+        get_policy("turbo")
+
+
+# ---------------------------------------------------------------------------
+# with_retry — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_succeeds_immediately():
+    """Success on first try → no retry, no sleep."""
+    fn = _FakeFn([_ok_result()])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is True
+    assert fn.calls == 1
+    assert sleeps == []
+
+
+def test_with_retry_recovers_after_one_transient():
+    """One 503 then success → 2 calls, 1 sleep."""
+    fn = _FakeFn([_transient_result(503), _ok_result()])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is True
+    assert fn.calls == 2
+    assert sleeps == [2.0]  # default initial_backoff
+
+
+def test_with_retry_recovers_after_three_transients():
+    """503, 503, 503, success → 4 calls, exponential backoff."""
+    fn = _FakeFn([
+        _transient_result(503),
+        _transient_result(503),
+        _transient_result(503),
+        _ok_result(),
+    ])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is True
+    assert fn.calls == 4
+    assert sleeps == [2.0, 4.0, 8.0]
+
+
+# ---------------------------------------------------------------------------
+# with_retry — retry-after handling
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_honors_server_retry_after():
+    """retry_after on the result overrides exponential backoff."""
+    fn = _FakeFn([
+        _transient_result(429, retry_after=15.0),
+        _ok_result(),
+    ])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is True
+    assert sleeps == [15.0]
+
+
+def test_with_retry_mixes_retry_after_and_backoff():
+    """When some attempts have retry_after and others don't, both honored."""
+    fn = _FakeFn([
+        _transient_result(429, retry_after=10.0),  # explicit retry_after
+        _transient_result(503),  # no retry_after — use backoff
+        _ok_result(),
+    ])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is True
+    # First sleep: 10s from retry_after. Second: starts from initial_backoff
+    # (the backoff variable hasn't been advanced because retry_after won).
+    assert sleeps == [10.0, 2.0]
+
+
+# ---------------------------------------------------------------------------
+# with_retry — exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_exhausts_after_max_retries():
+    """All transient → returns last failed result, no exception."""
+    # max_retries=5 → 6 total invocations (1 initial + 5 retries).
+    fn = _FakeFn([_transient_result(503)] * 6)
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is False
+    assert result.retryable is True
+    assert result.status_code == 503
+    assert fn.calls == 6
+    # 5 sleeps (one per retry); last attempt is the 6th call but no
+    # sleep follows it (loop returns).
+    assert len(sleeps) == 5
+    assert sleeps == [2.0, 4.0, 8.0, 16.0, 32.0]
+
+
+def test_with_retry_caps_backoff_at_max_backoff_s():
+    """Backoff is capped at max_backoff_s even with many retries."""
+    # Aggressive policy: max_retries=8, max_backoff_s=60.0
+    # Sequence: 2, 4, 8, 16, 32, 60, 60, 60 (capped at 60)
+    fn = _FakeFn([_transient_result(503)] * 9)
+    sleeps: List[float] = []
+    with_retry(fn, policy=RetryPolicy.aggressive(), sleep_fn=sleeps.append)
+    assert sleeps == [2.0, 4.0, 8.0, 16.0, 32.0, 60.0, 60.0, 60.0]
+
+
+# ---------------------------------------------------------------------------
+# with_retry — non-retryable
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_does_not_retry_non_retryable():
+    """retryable=False (e.g., 401 auth) → returns after one call."""
+    fn = _FakeFn([_permanent_result(401)])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.success is False
+    assert result.retryable is False
+    assert fn.calls == 1
+    assert sleeps == []
+
+
+def test_with_retry_with_none_policy_does_not_retry():
+    """get_policy('none') → max_retries=0 → no retry even on transient."""
+    fn = _FakeFn([_transient_result(503)])
+    sleeps: List[float] = []
+    result = with_retry(fn, policy=get_policy("none"), sleep_fn=sleeps.append)
+    assert result.success is False
+    assert fn.calls == 1
+    assert sleeps == []
+
+
+# ---------------------------------------------------------------------------
+# with_retry — integration semantics
+# ---------------------------------------------------------------------------
+
+
+def test_with_retry_default_policy_is_used_when_none_passed():
+    """Passing policy=None falls back to RetryPolicy.default()."""
+    # Five 503s then success — default policy allows up to 5 retries.
+    fn = _FakeFn([_transient_result(503)] * 5 + [_ok_result()])
+    sleeps: List[float] = []
+    result = with_retry(fn, policy=None, sleep_fn=sleeps.append)
+    assert result.success is True
+    assert fn.calls == 6
+
+
+def test_with_retry_preserves_last_failure_attributes():
+    """When retries exhaust, the returned result is the LAST failed call."""
+    last_failure = _transient_result(503)
+    last_failure.error_message = "final error"
+    fn = _FakeFn([_transient_result(503)] * 5 + [last_failure])
+    sleeps: List[float] = []
+    result = with_retry(fn, sleep_fn=sleeps.append)
+    assert result.error_message == "final error"
+
+
+def test_with_retry_log_description_in_messages(caplog: pytest.LogCaptureFixture):
+    """The `description` arg appears in log records."""
+    import logging
+    caplog.set_level(logging.INFO, logger="assemblyzero.utils.retry")
+    fn = _FakeFn([_transient_result(503), _ok_result()])
+    with_retry(fn, description="N3 LLD reviewer", sleep_fn=lambda s: None)
+    # Both the failure log and success log mention the description.
+    descriptions_seen = [r.getMessage() for r in caplog.records]
+    assert any("N3 LLD reviewer" in m for m in descriptions_seen)

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -454,6 +454,21 @@ def create_argument_parser() -> argparse.ArgumentParser:
         help="Claude reviewer effort level (default: max)",
     )
 
+    # Issue #1071: Retry policy for transient LLM failures.
+    parser.add_argument(
+        "--retry-policy",
+        choices=["default", "aggressive", "none"],
+        default="default",
+        help=(
+            "Retry policy for transient LLM API failures (5xx, 429, "
+            "timeouts). 'default': 5 retries, 2s→32s exponential "
+            "backoff. 'aggressive': 8 retries, 60s cap. 'none': no "
+            "retry (pre-#1071 fail-fast behavior). Server-provided "
+            "Retry-After headers are honored regardless of policy. "
+            "(#1071)"
+        ),
+    )
+
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import add_timeout_argument
     add_timeout_argument(parser)
@@ -732,6 +747,7 @@ def main():
         "repo_root": str(repo_root),
         "config_reviewer": args.reviewer,  # Issue #773
         "config_effort": args.effort,  # Issue #773
+        "config_retry_policy": args.retry_policy,  # Issue #1071
         "auto_mode": args.auto_mode,
         "mock_mode": args.mock,
         "skip_e2e": args.skip_e2e,

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -388,6 +388,21 @@ Examples:
         help="Claude reviewer effort level (default: max)",
     )
 
+    # Issue #1071: Retry policy for transient LLM failures.
+    parser.add_argument(
+        "--retry-policy",
+        choices=["default", "aggressive", "none"],
+        default="default",
+        help=(
+            "Retry policy for transient LLM API failures (5xx, 429, "
+            "timeouts). 'default': 5 retries, 2s→32s exponential "
+            "backoff. 'aggressive': 8 retries, 60s cap. 'none': no "
+            "retry (pre-#1071 fail-fast behavior). Server-provided "
+            "Retry-After headers are honored regardless of policy. "
+            "(#1071)"
+        ),
+    )
+
     # Review configuration (human gates)
     parser.add_argument(
         "--review",
@@ -620,6 +635,7 @@ def build_initial_state(
             mock_mode=args.mock,
             max_iterations=args.max_iterations,
             effort=getattr(args, "effort", "max"),
+            retry_policy=getattr(args, "retry_policy", "default"),
             brief_file=args.brief or "",
             source_idea=source_idea,
         )
@@ -636,6 +652,7 @@ def build_initial_state(
             mock_mode=args.mock,
             max_iterations=args.max_iterations,
             effort=getattr(args, "effort", "max"),
+            retry_policy=getattr(args, "retry_policy", "default"),
             issue_number=args.issue or 0,
             context_files=args.context or [],
         )


### PR DESCRIPTION
## Summary

- Centralizes retry-on-transient-failure for LLM-calling workflow nodes via new \`assemblyzero/utils/retry.py\`
- 19 unit tests covering policy values, success paths, exhaustion, retry-after handling, non-retryable failures
- Migrated \`review_test_plan.py\` (testing N1) from its inline 2-attempt loop to \`with_retry()\`
- Added \`--retry-policy {default|aggressive|none}\` flag to both entry-point scripts
- Phase B FIRST (strict sequence: this → #1076 → #1072)

Closes #1071

## Why this is on the speed-run critical path

The boostgauge YouTube take cannot survive a transient Gemini 503 mid-recording. Pre-#1071, a single 503 forced \`--resume-review\` and broke the take. This PR converts that fail-fast into 5 retries with 2s→32s exponential backoff, covering the typical Gemini outage burst (~10-30s) within the recording dead-air budget.

## Design

| Decision | Why |
|---|---|
| Wrapper (\`with_retry(lambda: ...)\`), not decorator | Call sites carry inline closures over system prompt, schema kwargs, audit callbacks. A decorator would force factoring into a separate function. |
| Retryability delegated to \`LLMCallResult.retryable\` | The provider already classifies errors via \`classify_anthropic_error\` / \`classify_gemini_error\` / \`classify_http_status\`. \`retry.py\` trusts that classification rather than duplicating it. |
| Returns last failed result on exhaustion (never raises) | Caller's existing \`if result.success\` branch handles both first-try and exhausted-retry paths uniformly — no \`try/except\` rewrite needed. |
| Server \`retry_after\` honored regardless of policy | A 429 with \`Retry-After: 60\` should sleep 60s even on \`--retry-policy default\`. Pure backoff would either be too short (fall back to retrying into the same throttle) or wastefully long. |
| Three policies | \`default\` for the speed-run; \`aggressive\` for unattended overnight runs; \`none\` for \"I want fail-fast, sentinel-style\" runs and tests. |

## Test coverage (19 cases)

| Case | Validates |
|---|---|
| Policy values | Default, aggressive, none have correct max_retries / backoff |
| \`get_policy\` dispatch | Maps name → factory, raises on unknown |
| First-try success | No retry, no sleep |
| Recover after 1 transient | 2 calls, 1 sleep at initial_backoff |
| Recover after 3 transients | 4 calls, exponential backoff 2/4/8 |
| Server retry_after | Overrides exponential backoff exactly |
| Mixed retry_after + backoff | Each respects its rule |
| Exhaustion | Returns last failed result; backoff sequence correct |
| Backoff cap | aggressive policy caps at 60s |
| Non-retryable | retryable=False → no retry, no sleep |
| 'none' policy | max_retries=0 → no retry even on transient |
| Default policy fallback | policy=None → uses RetryPolicy.default() |
| Last-failure preservation | Returned result is the LAST failed call |
| Description in logs | Custom \`description=\` appears in log records |

All 19 pass locally.

## Migration scope

This PR migrates ONE node (\`review_test_plan.py\`) as the proof-of-concept. The drafter (N1 LLD), LLD reviewer (N3), and implementer (N4) will migrate incrementally in follow-up PRs — per acceptance criteria's \"Each LLM-calling node opts in via a decorator or wrapper.\"

The state TypedDicts in both workflows (testing + requirements) and the entry-point scripts are wired now so future migrations only need to change the call site.

## Test plan

- [x] 19 unit tests for retry module — all pass
- [x] Syntax check on all 7 modified files
- [x] Imports verified in a fresh interpreter
- [x] \`config_retry_policy\` field added to both state TypedDicts
- [x] \`--retry-policy\` flag accepts choices and threads through to state
- [ ] Live test against a real transient Gemini 503 — this PR does not artificially induce one; the next \`run_requirements_workflow.py\` invocation that hits a 503 will be the smoke test

## Out of scope

- Migrating the other LLM-calling nodes (drafter, LLD reviewer, implementer) — incremental follow-ups.
- Cross-model fallback (Gemini → Claude on exhaustion) — separate concern, mentioned in the issue body.
- Test-mode integration tests of the migrated node — \`review_test_plan.py\` has no existing test suite to extend; would be a separate scoped effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)