### PR TITLE
feat: speed-run instrumentation (Closes #1076)

### DIFF
--- a/assemblyzero/utils/speedrun.py
+++ b/assemblyzero/utils/speedrun.py
@@ -1,0 +1,328 @@
+"""Speed-run instrumentation for the boostgauge YouTube demo (#1076).
+
+Three concerns in one module:
+
+1. **Lap splits.** A `LapSplitWriter` emits timestamped beats during a
+   workflow run to `data/speedrun/{issue}-{attempt}.json`. Beats are
+   recorded as wall-clock elapsed seconds since `started_at`. Hooked
+   from the entry-point scripts (`tools/run_requirements_workflow.py`,
+   `tools/run_implement_from_lld.py`); finer-grained per-node beats
+   are deferred to follow-ups so this PR doesn't touch every node.
+
+2. **Failure-mode classifier.** `classify_halt(state, error_message)`
+   inspects the workflow state at HALT and returns one of eight labels
+   (gemini-503, gemini-quota, stagnation, mech-validation-loop,
+   test-plan-blocked, completeness-gate-failed, coverage-target-missed,
+   unknown). Used by the run logger to track which improvements help.
+
+3. **Run log.** `RunLogger.complete_run(...)` appends one JSONL entry
+   per attempt to `data/speedrun/run-log.jsonl`. The companion CLI
+   `tools/speedrun_summarize.py` aggregates this into a human-readable
+   table for cross-attempt review.
+
+The module is OPT-IN: workflows that don't pass `--speedrun` (or the
+equivalent state field) skip all of this. Existing operators who never
+run the speed-run see no change.
+
+Design notes:
+
+- Files are written immediately on each beat — robust to crashes, no
+  buffer to flush. `data/speedrun/{issue}-{attempt}.json` is rewritten
+  in full each time (idempotent; small files).
+- `RunLogger` appends only — never rewrites. The log is the durable
+  cross-attempt record. Crash safety: `tail -1` always shows the
+  current run state.
+- `classify_halt` is pure (no side effects) so tests can trivially
+  inject state dicts.
+- Wall-clock uses `time.time()` (UTC seconds since epoch). All beats
+  are deltas from `started_at`, so timezone is irrelevant.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Lap splits
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LapSplitWriter:
+    """Appends timestamped beats to data/speedrun/{issue}-{attempt}.json.
+
+    Lifetime spans one workflow attempt. Construct at workflow start with
+    `LapSplitWriter.start(...)`, call `.beat(name)` at known points, then
+    `.finalize(outcome=...)` at end.
+
+    Attributes:
+        issue: GitHub issue number being worked.
+        attempt: Sequential attempt number for this issue (1, 2, ...).
+        started_at: Wall-clock time of run start (UTC seconds since epoch).
+        output_path: Where the JSON file is written.
+        splits: List of {beat, t} dicts; t is seconds since started_at.
+    """
+    issue: int
+    attempt: int
+    started_at: float
+    output_path: Path
+    splits: list[dict[str, Any]] = field(default_factory=list)
+    started_at_iso: str = ""
+
+    @classmethod
+    def start(
+        cls,
+        repo_root: Path,
+        issue: int,
+        attempt: Optional[int] = None,
+    ) -> "LapSplitWriter":
+        """Create a writer for issue+attempt; write initial state.
+
+        If attempt is None, auto-increments from existing files for the
+        same issue.
+        """
+        speedrun_dir = repo_root / "data" / "speedrun"
+        speedrun_dir.mkdir(parents=True, exist_ok=True)
+        if attempt is None:
+            attempt = _next_attempt_number(speedrun_dir, issue)
+        started_at = time.time()
+        # ISO-format started_at separately so consumers don't have to
+        # do epoch math just to display the run timestamp.
+        started_at_iso = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(started_at),
+        )
+        writer = cls(
+            issue=issue,
+            attempt=attempt,
+            started_at=started_at,
+            output_path=speedrun_dir / f"{issue}-{attempt}.json",
+            started_at_iso=started_at_iso,
+        )
+        writer._write()
+        return writer
+
+    def beat(self, name: str) -> None:
+        """Record a beat at the current wall-clock time."""
+        elapsed = round(time.time() - self.started_at, 2)
+        self.splits.append({"beat": name, "t": elapsed})
+        self._write()
+
+    def finalize(self, outcome: str, failure_mode: Optional[str] = None) -> None:
+        """Write the terminal beat with outcome metadata.
+
+        Outcome is one of "success", "fail", "halt". `failure_mode` is
+        the classifier label from `classify_halt()` when outcome is
+        "fail" or "halt".
+        """
+        elapsed = round(time.time() - self.started_at, 2)
+        self.splits.append({
+            "beat": f"completed_{outcome}",
+            "t": elapsed,
+            **({"failure_mode": failure_mode} if failure_mode else {}),
+        })
+        self._write()
+
+    def _write(self) -> None:
+        """Rewrite the JSON file with current state."""
+        payload = {
+            "issue": self.issue,
+            "attempt": self.attempt,
+            "started_at": self.started_at_iso,
+            "splits": self.splits,
+        }
+        try:
+            self.output_path.write_text(
+                json.dumps(payload, indent=2) + "\n", encoding="utf-8",
+            )
+        except OSError as e:
+            logger.warning("Failed to write lap splits: %s", e)
+
+
+def _next_attempt_number(speedrun_dir: Path, issue: int) -> int:
+    """Find the next sequential attempt for this issue.
+
+    Scans `{issue}-*.json` files in speedrun_dir and returns max+1.
+    Returns 1 if no prior attempts exist.
+    """
+    if not speedrun_dir.exists():
+        return 1
+    max_attempt = 0
+    for f in speedrun_dir.glob(f"{issue}-*.json"):
+        # Extract the attempt number from the filename stem.
+        # Format: {issue}-{attempt}.json
+        stem = f.stem
+        parts = stem.rsplit("-", 1)
+        if len(parts) != 2:
+            continue
+        try:
+            n = int(parts[1])
+            if n > max_attempt:
+                max_attempt = n
+        except ValueError:
+            continue
+    return max_attempt + 1
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode classifier
+# ---------------------------------------------------------------------------
+
+
+# Eight known halt classifications. `unknown` is the fallback.
+HALT_CLASSIFICATIONS = (
+    "gemini-503",
+    "gemini-quota",
+    "stagnation",
+    "mech-validation-loop",
+    "test-plan-blocked",
+    "completeness-gate-failed",
+    "coverage-target-missed",
+    "unknown",
+)
+
+
+def classify_halt(
+    state: dict[str, Any],
+    error_message: str = "",
+) -> str:
+    """Return a label naming the cause of a workflow halt.
+
+    Pure function — no side effects. Inspects state fields and the
+    error message string to match against known patterns. The classifier
+    is intentionally generous on string matching: speed-run telemetry
+    is more useful when a halt is at least categorized than when an
+    unknown bucket dominates.
+
+    Args:
+        state: Workflow state dict at the moment of halt.
+        error_message: Optional explicit error string to scan.
+
+    Returns:
+        One of HALT_CLASSIFICATIONS.
+    """
+    msg = (error_message or state.get("error_message", "") or "").lower()
+
+    # Explicit state signals first — most reliable.
+    if state.get("test_plan_status") == "BLOCKED":
+        return "test-plan-blocked"
+
+    if state.get("validation_iteration_count", 0) >= state.get("max_iterations", 20):
+        # If mechanical validation looped to its limit, that's the cause.
+        # Use validation_errors as a secondary signal.
+        if state.get("validation_errors"):
+            return "mech-validation-loop"
+
+    if state.get("completeness_iteration_count", 0) >= state.get(
+        "max_completeness_iterations", 3
+    ):
+        if state.get("completeness_errors") or "completeness" in msg:
+            return "completeness-gate-failed"
+
+    coverage_pct = state.get("coverage_percentage")
+    coverage_target = state.get("coverage_target")
+    if (
+        coverage_pct is not None
+        and coverage_target is not None
+        and coverage_pct < coverage_target
+    ):
+        return "coverage-target-missed"
+
+    # Stagnation: two consecutive REVISE verdicts, similar bodies. The
+    # workflow code already detects this and sets a flag; we mirror it.
+    if state.get("stagnation_detected") or "two-strike stagnation" in msg:
+        return "stagnation"
+
+    # Provider-specific transient signals from the error message.
+    if "503" in msg or "service unavailable" in msg or "overloaded" in msg:
+        return "gemini-503"
+    if (
+        "quota" in msg
+        or "resource_exhausted" in msg
+        or "rate limit" in msg
+        or "429" in msg
+    ):
+        return "gemini-quota"
+
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Run log
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunLogger:
+    """Appends one JSONL entry per attempt to data/speedrun/run-log.jsonl.
+
+    Use as a context-friendly accessor:
+
+        logger = RunLogger(repo_root)
+        ...
+        logger.complete_run(
+            issue=35, attempt=7, started_at_iso="...", outcome="success",
+            failure_mode=None, total_seconds=542.0,
+        )
+    """
+    repo_root: Path
+
+    @property
+    def log_path(self) -> Path:
+        return self.repo_root / "data" / "speedrun" / "run-log.jsonl"
+
+    def complete_run(
+        self,
+        issue: int,
+        attempt: int,
+        started_at_iso: str,
+        outcome: str,
+        total_seconds: float,
+        failure_mode: Optional[str] = None,
+        notes: str = "",
+    ) -> None:
+        """Append one run entry to the log.
+
+        Idempotency: this function does NOT deduplicate. Calling it
+        twice for the same (issue, attempt) results in two entries.
+        Callers should ensure single-call discipline.
+        """
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        ended_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        entry = {
+            "attempt": attempt,
+            "issue": issue,
+            "started_at": started_at_iso,
+            "ended_at": ended_at,
+            "outcome": outcome,
+            "failure_mode": failure_mode,
+            "total_seconds": round(total_seconds, 2),
+            "notes": notes,
+        }
+        try:
+            with self.log_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+        except OSError as e:
+            logger.warning("Failed to append run-log entry: %s", e)
+
+    def read_all(self) -> list[dict[str, Any]]:
+        """Read all entries from the log. Returns [] if log doesn't exist."""
+        if not self.log_path.exists():
+            return []
+        entries = []
+        with self.log_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    logger.warning("Skipping malformed run-log line: %s", e)
+        return entries

--- a/tests/test_speedrun.py
+++ b/tests/test_speedrun.py
@@ -1,0 +1,226 @@
+"""Tests for assemblyzero.utils.speedrun (#1076)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.utils.speedrun import (
+    HALT_CLASSIFICATIONS,
+    LapSplitWriter,
+    RunLogger,
+    _next_attempt_number,
+    classify_halt,
+)
+
+
+# ---------------------------------------------------------------------------
+# LapSplitWriter
+# ---------------------------------------------------------------------------
+
+
+def test_lap_split_writer_creates_initial_file(tmp_path: Path):
+    """start() writes the JSON file immediately with empty splits."""
+    writer = LapSplitWriter.start(tmp_path, issue=42)
+    assert writer.issue == 42
+    assert writer.attempt == 1  # First attempt for this issue
+    assert writer.output_path.exists()
+    data = json.loads(writer.output_path.read_text(encoding="utf-8"))
+    assert data["issue"] == 42
+    assert data["attempt"] == 1
+    assert data["splits"] == []
+    assert "started_at" in data
+
+
+def test_lap_split_writer_increments_attempt(tmp_path: Path):
+    """Second start() for same issue gets attempt=2."""
+    LapSplitWriter.start(tmp_path, issue=42)
+    second = LapSplitWriter.start(tmp_path, issue=42)
+    assert second.attempt == 2
+
+
+def test_lap_split_writer_explicit_attempt(tmp_path: Path):
+    """Caller can override attempt number."""
+    writer = LapSplitWriter.start(tmp_path, issue=42, attempt=7)
+    assert writer.attempt == 7
+
+
+def test_lap_split_writer_records_beats_with_elapsed_time(tmp_path: Path):
+    """beat() appends a {beat, t} entry; t is seconds since start."""
+    writer = LapSplitWriter.start(tmp_path, issue=42)
+    # Mock the started_at to a known value so we can assert deltas.
+    writer.started_at = time.time() - 10.0  # Pretend run started 10s ago
+    writer.beat("lld_drafted")
+    data = json.loads(writer.output_path.read_text(encoding="utf-8"))
+    assert len(data["splits"]) == 1
+    assert data["splits"][0]["beat"] == "lld_drafted"
+    assert 9.5 < data["splits"][0]["t"] < 11.0  # ~10s elapsed
+
+
+def test_lap_split_writer_finalize_writes_outcome(tmp_path: Path):
+    """finalize() writes a completed_<outcome> beat with optional failure_mode."""
+    writer = LapSplitWriter.start(tmp_path, issue=42)
+    writer.finalize("success")
+    data = json.loads(writer.output_path.read_text(encoding="utf-8"))
+    assert data["splits"][-1]["beat"] == "completed_success"
+    assert "failure_mode" not in data["splits"][-1]
+
+
+def test_lap_split_writer_finalize_with_failure_mode(tmp_path: Path):
+    """finalize('fail', 'gemini-503') writes the classification."""
+    writer = LapSplitWriter.start(tmp_path, issue=42)
+    writer.finalize("fail", failure_mode="gemini-503")
+    data = json.loads(writer.output_path.read_text(encoding="utf-8"))
+    assert data["splits"][-1]["beat"] == "completed_fail"
+    assert data["splits"][-1]["failure_mode"] == "gemini-503"
+
+
+def test_next_attempt_number_finds_max(tmp_path: Path):
+    """_next_attempt_number scans existing files and returns max+1."""
+    speedrun_dir = tmp_path / "data" / "speedrun"
+    speedrun_dir.mkdir(parents=True)
+    # Create some existing attempt files
+    (speedrun_dir / "42-1.json").write_text("{}")
+    (speedrun_dir / "42-3.json").write_text("{}")
+    (speedrun_dir / "42-5.json").write_text("{}")
+    # Different issue, should not interfere
+    (speedrun_dir / "99-10.json").write_text("{}")
+    assert _next_attempt_number(speedrun_dir, 42) == 6
+    assert _next_attempt_number(speedrun_dir, 99) == 11
+    assert _next_attempt_number(speedrun_dir, 100) == 1  # No prior attempts
+
+
+def test_next_attempt_number_handles_empty_dir(tmp_path: Path):
+    """Returns 1 when dir doesn't exist or has no matching files."""
+    assert _next_attempt_number(tmp_path / "nope", 42) == 1
+
+
+# ---------------------------------------------------------------------------
+# classify_halt
+# ---------------------------------------------------------------------------
+
+
+def test_classify_halt_returns_known_label():
+    """Every classification returned by classify_halt is in HALT_CLASSIFICATIONS."""
+    # Cover all named classifications
+    cases = [
+        ({}, "503 Service Unavailable", "gemini-503"),
+        ({}, "RESOURCE_EXHAUSTED quota exceeded", "gemini-quota"),
+        ({"test_plan_status": "BLOCKED"}, "", "test-plan-blocked"),
+        (
+            {"validation_iteration_count": 20, "max_iterations": 20,
+             "validation_errors": ["x"]},
+            "",
+            "mech-validation-loop",
+        ),
+        (
+            {"completeness_iteration_count": 3, "max_completeness_iterations": 3,
+             "completeness_errors": ["x"]},
+            "",
+            "completeness-gate-failed",
+        ),
+        (
+            {"coverage_percentage": 70.0, "coverage_target": 80.0},
+            "",
+            "coverage-target-missed",
+        ),
+        ({"stagnation_detected": True}, "", "stagnation"),
+        ({}, "", "unknown"),
+        ({}, "completely random error", "unknown"),
+    ]
+    for state, msg, expected in cases:
+        result = classify_halt(state, msg)
+        assert result in HALT_CLASSIFICATIONS, f"Unknown result: {result}"
+        assert result == expected, f"Expected {expected}, got {result} for {state}/{msg!r}"
+
+
+def test_classify_halt_test_plan_blocked_takes_priority():
+    """test_plan_status=BLOCKED beats other signals."""
+    result = classify_halt(
+        {"test_plan_status": "BLOCKED"},
+        "503 Service Unavailable",
+    )
+    assert result == "test-plan-blocked"
+
+
+def test_classify_halt_recognizes_429_in_message():
+    result = classify_halt({}, "HTTP 429 rate limit hit")
+    assert result == "gemini-quota"
+
+
+def test_classify_halt_recognizes_overloaded():
+    result = classify_halt({}, "Anthropic Overloaded")
+    assert result == "gemini-503"
+
+
+# ---------------------------------------------------------------------------
+# RunLogger
+# ---------------------------------------------------------------------------
+
+
+def test_run_logger_complete_run_appends_jsonl(tmp_path: Path):
+    """complete_run appends one JSONL entry."""
+    logger = RunLogger(tmp_path)
+    logger.complete_run(
+        issue=42,
+        attempt=1,
+        started_at_iso="2026-05-09T20:00:00Z",
+        outcome="success",
+        total_seconds=523.4,
+    )
+    log = tmp_path / "data" / "speedrun" / "run-log.jsonl"
+    assert log.exists()
+    content = log.read_text(encoding="utf-8")
+    line = content.strip()
+    entry = json.loads(line)
+    assert entry["issue"] == 42
+    assert entry["attempt"] == 1
+    assert entry["outcome"] == "success"
+    assert entry["total_seconds"] == 523.4
+    assert entry["failure_mode"] is None
+
+
+def test_run_logger_appends_multiple_runs(tmp_path: Path):
+    """Multiple complete_run calls append; don't overwrite."""
+    logger = RunLogger(tmp_path)
+    logger.complete_run(
+        issue=42, attempt=1, started_at_iso="2026-05-09T20:00:00Z",
+        outcome="fail", total_seconds=120.0, failure_mode="gemini-503",
+    )
+    logger.complete_run(
+        issue=42, attempt=2, started_at_iso="2026-05-09T20:10:00Z",
+        outcome="success", total_seconds=480.0,
+    )
+    entries = logger.read_all()
+    assert len(entries) == 2
+    assert entries[0]["attempt"] == 1
+    assert entries[0]["failure_mode"] == "gemini-503"
+    assert entries[1]["attempt"] == 2
+    assert entries[1]["failure_mode"] is None
+
+
+def test_run_logger_read_all_handles_missing_log(tmp_path: Path):
+    """read_all() returns [] when log file doesn't exist."""
+    logger = RunLogger(tmp_path)
+    assert logger.read_all() == []
+
+
+def test_run_logger_skips_malformed_lines(tmp_path: Path, caplog):
+    """read_all skips invalid JSONL lines and logs a warning."""
+    log_path = tmp_path / "data" / "speedrun" / "run-log.jsonl"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(
+        '{"valid": 1}\n'
+        'not json at all\n'
+        '{"valid": 2}\n',
+        encoding="utf-8",
+    )
+    logger = RunLogger(tmp_path)
+    entries = logger.read_all()
+    # Two valid lines kept; one malformed silently skipped (with WARNING).
+    assert len(entries) == 2
+    assert entries[0]["valid"] == 1
+    assert entries[1]["valid"] == 2

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -469,6 +469,18 @@ def create_argument_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # Issue #1076: Speed-run instrumentation (lap splits + run log)
+    parser.add_argument(
+        "--speedrun",
+        action="store_true",
+        default=False,
+        help=(
+            "Emit speed-run lap-splits to data/speedrun/{issue}-{attempt}.json "
+            "and append one run-log entry to data/speedrun/run-log.jsonl on "
+            "completion. For the boostgauge YouTube demo. (#1076)"
+        ),
+    )
+
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import add_timeout_argument
     add_timeout_argument(parser)
@@ -790,6 +802,47 @@ def main():
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import WorkflowTimeout
 
+    # Issue #1076: Speed-run instrumentation. Set up lap-split writer +
+    # run-logger if --speedrun was passed; both are no-ops otherwise.
+    speedrun_splits = None
+    speedrun_logger = None
+    if getattr(args, "speedrun", False):
+        from assemblyzero.utils.speedrun import (
+            LapSplitWriter, RunLogger, classify_halt,
+        )
+        speedrun_splits = LapSplitWriter.start(repo_root, args.issue)
+        speedrun_logger = RunLogger(repo_root)
+        speedrun_splits.beat("workflow_started")
+        print(
+            f"[speedrun] Lap splits: {speedrun_splits.output_path} "
+            f"(attempt {speedrun_splits.attempt})"
+        )
+
+    def _finalize_speedrun(outcome: str, state: dict | None = None,
+                          error_msg: str = "", notes: str = "") -> None:
+        """Write terminal beat + run-log entry. Safe to call multiple times."""
+        nonlocal speedrun_splits, speedrun_logger
+        if speedrun_splits is None or speedrun_logger is None:
+            return
+        from assemblyzero.utils.speedrun import classify_halt as _classify
+        import time as _time
+        failure_mode = None
+        if outcome != "success":
+            failure_mode = _classify(state or {}, error_msg)
+        speedrun_splits.finalize(outcome, failure_mode)
+        speedrun_logger.complete_run(
+            issue=speedrun_splits.issue,
+            attempt=speedrun_splits.attempt,
+            started_at_iso=speedrun_splits.started_at_iso,
+            outcome=outcome,
+            total_seconds=_time.time() - speedrun_splits.started_at,
+            failure_mode=failure_mode,
+            notes=notes,
+        )
+        # Set to None so subsequent calls in the same run are no-ops.
+        speedrun_splits = None
+        speedrun_logger = None
+
     try:
       with WorkflowTimeout(minutes=args.timeout):
         with SqliteSaver.from_conn_string(str(db_path)) as memory:
@@ -859,6 +912,7 @@ def main():
                             },
                         )
                     _write_status_file(repo_root, args.issue, "FAILED", values.get("error_message", ""), state=values)
+                    _finalize_speedrun("fail", state=values, error_msg=values.get("error_message", ""))
                     return 1
                 else:
                     print("Status: SUCCESS")
@@ -876,6 +930,7 @@ def main():
                             },
                         )
                     _write_status_file(repo_root, args.issue, "SUCCESS", state=values)
+                    _finalize_speedrun("success", state=values)
 
                     # Show next steps for worktree workflow
                     if worktree_path:
@@ -890,6 +945,7 @@ def main():
 
     except KeyboardInterrupt:
         print("\n\nWorkflow interrupted. Use --resume to continue.")
+        _finalize_speedrun("halt", error_msg="user interrupt", notes="KeyboardInterrupt")
         return 130
 
     except Exception as e:
@@ -910,6 +966,7 @@ def main():
         print(f"\n[FATAL] Unexpected error: {e}")
         import traceback
         traceback.print_exc()
+        _finalize_speedrun("halt", error_msg=str(e), notes=f"exception:{type(e).__name__}")
         return 1
 
     return 0

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -403,6 +403,17 @@ Examples:
         ),
     )
 
+    # Issue #1076: Speed-run instrumentation.
+    parser.add_argument(
+        "--speedrun",
+        action="store_true",
+        default=False,
+        help=(
+            "Emit speed-run lap-splits and append a run-log entry to "
+            "data/speedrun/. (#1076)"
+        ),
+    )
+
     # Review configuration (human gates)
     parser.add_argument(
         "--review",
@@ -696,6 +707,39 @@ def run_single_workflow(
             print(f"  LLD would be saved to: {target_repo}/docs/lld/active/LLD-{args.issue:03d}.md")
         return 0
 
+    # Issue #1076: Speed-run instrumentation
+    speedrun_splits = None
+    speedrun_logger = None
+    if getattr(args, "speedrun", False) and getattr(args, "issue", None):
+        from assemblyzero.utils.speedrun import LapSplitWriter, RunLogger
+        speedrun_splits = LapSplitWriter.start(target_repo, args.issue)
+        speedrun_logger = RunLogger(target_repo)
+        speedrun_splits.beat("workflow_started")
+        print(f"[speedrun] Lap splits: {speedrun_splits.output_path}")
+
+    def _finalize_speedrun(outcome: str, fstate: dict | None = None,
+                          error_msg: str = "", notes: str = "") -> None:
+        nonlocal speedrun_splits, speedrun_logger
+        if speedrun_splits is None or speedrun_logger is None:
+            return
+        from assemblyzero.utils.speedrun import classify_halt as _classify
+        import time as _time
+        failure_mode = None
+        if outcome != "success":
+            failure_mode = _classify(fstate or {}, error_msg)
+        speedrun_splits.finalize(outcome, failure_mode)
+        speedrun_logger.complete_run(
+            issue=speedrun_splits.issue,
+            attempt=speedrun_splits.attempt,
+            started_at_iso=speedrun_splits.started_at_iso,
+            outcome=outcome,
+            total_seconds=_time.time() - speedrun_splits.started_at,
+            failure_mode=failure_mode,
+            notes=notes,
+        )
+        speedrun_splits = None
+        speedrun_logger = None
+
     # Create and run graph
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import WorkflowTimeout
@@ -720,12 +764,15 @@ def run_single_workflow(
         print_result(final_state)
 
         if final_state.get("error_message"):
+            _finalize_speedrun("fail", fstate=final_state, error_msg=final_state.get("error_message", ""))
             return 1
 
+        _finalize_speedrun("success", fstate=final_state)
         return 0
 
     except KeyboardInterrupt:
         print("\n\nWorkflow interrupted by user.")
+        _finalize_speedrun("halt", error_msg="user interrupt", notes="KeyboardInterrupt")
         return 130
 
     except Exception as e:
@@ -733,6 +780,7 @@ def run_single_workflow(
         if args.debug:
             import traceback
             traceback.print_exc()
+        _finalize_speedrun("halt", error_msg=str(e), notes=f"exception:{type(e).__name__}")
         return 1
 
 

--- a/tools/speedrun_overlay.py
+++ b/tools/speedrun_overlay.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Read a speed-run lap-splits JSON and print a clean overlay (#1076).
+
+Designed to be piped into a `pet` overlay window during recording, OR
+just printed to a side terminal so the operator can see lap times
+develop in real-time.
+
+Usage:
+
+    # Latest attempt for an issue:
+    poetry run python tools/speedrun_overlay.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 35
+
+    # Specific attempt:
+    poetry run python tools/speedrun_overlay.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 35 --attempt 7
+
+    # Watch mode — re-render every second:
+    poetry run python tools/speedrun_overlay.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 35 --watch
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+
+def _latest_attempt(speedrun_dir: Path, issue: int) -> int | None:
+    """Find the highest attempt number for this issue."""
+    if not speedrun_dir.exists():
+        return None
+    max_attempt = 0
+    for f in speedrun_dir.glob(f"{issue}-*.json"):
+        parts = f.stem.rsplit("-", 1)
+        if len(parts) != 2:
+            continue
+        try:
+            n = int(parts[1])
+            if n > max_attempt:
+                max_attempt = n
+        except ValueError:
+            continue
+    return max_attempt if max_attempt > 0 else None
+
+
+def _format_t(t: float) -> str:
+    """Format seconds as MM:SS."""
+    minutes, seconds = divmod(int(t), 60)
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def render(splits_file: Path) -> str:
+    """Read splits file and produce the overlay text."""
+    if not splits_file.exists():
+        return f"(no lap splits file at {splits_file})"
+    try:
+        data = json.loads(splits_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        return f"(error reading splits: {e})"
+
+    issue = data.get("issue", "?")
+    attempt = data.get("attempt", "?")
+    started_at = data.get("started_at", "?")
+    splits = data.get("splits", [])
+
+    lines = [
+        f"=== speed-run #{issue} attempt {attempt} ===",
+        f"started: {started_at}",
+        "",
+    ]
+    if not splits:
+        lines.append("(no beats yet)")
+    else:
+        for split in splits:
+            beat = split.get("beat", "?")
+            t = split.get("t", 0.0)
+            failure_mode = split.get("failure_mode")
+            line = f"  [{_format_t(t)}] {beat}"
+            if failure_mode:
+                line += f"  -- {failure_mode}"
+            lines.append(line)
+        # Live elapsed (if not yet finalized)
+        last_beat = splits[-1].get("beat", "")
+        if not last_beat.startswith("completed_"):
+            lines.append("")
+            lines.append("  (in progress)")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Speed-run lap split overlay")
+    parser.add_argument("--repo", required=True, type=Path)
+    parser.add_argument("--issue", required=True, type=int)
+    parser.add_argument(
+        "--attempt", type=int, default=None,
+        help="Specific attempt number (default: latest)",
+    )
+    parser.add_argument(
+        "--watch", action="store_true",
+        help="Re-render every second until interrupted",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo.resolve()
+    speedrun_dir = repo_root / "data" / "speedrun"
+
+    attempt = args.attempt
+    if attempt is None:
+        attempt = _latest_attempt(speedrun_dir, args.issue)
+        if attempt is None:
+            print(f"No attempts found for issue #{args.issue}")
+            return 1
+
+    splits_file = speedrun_dir / f"{args.issue}-{attempt}.json"
+
+    if not args.watch:
+        print(render(splits_file))
+        return 0
+
+    try:
+        while True:
+            print("\033[2J\033[H", end="")  # clear screen + home
+            print(render(splits_file))
+            time.sleep(1)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Reset spawn state for a speed-run attempt (#1076).
+
+Performs the cleanup needed between attempts:
+
+  1. Closes any open PR for the issue (without merging).
+  2. Removes the worktree at `{repo}-{issue}` if it exists.
+  3. Deletes the local feature branch (safe-delete).
+  4. Deletes `docs/lineage/active/{issue}-*/` directories.
+  5. Reopens the issue if it was closed.
+  6. Prints "spawn state restored" on success.
+
+Idempotent: safe to run multiple times. Each step is independently
+guarded — a missing PR / worktree / branch is not an error.
+
+Usage:
+
+    poetry run python tools/speedrun_reset.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge \\
+        --issue 35
+
+    # Reset all known speed-run issues at once:
+    poetry run python tools/speedrun_reset.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge \\
+        --all-issues
+
+The `--all-issues` mode reads `data/speedrun/run-log.jsonl` and resets
+every issue that's appeared in any attempt (covers the full speed-run
+arc across multiple takes).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path | None = None, check: bool = False):
+    """Subprocess wrapper that returns the result and captures both streams."""
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=check,
+    )
+
+
+def _gh_repo(repo_root: Path) -> str:
+    """Read GitHub remote and extract owner/repo."""
+    result = _run(["git", "remote", "get-url", "origin"], cwd=repo_root)
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not read git remote: {result.stderr}")
+    url = result.stdout.strip()
+    # https://github.com/owner/repo.git → owner/repo
+    if url.startswith("https://github.com/"):
+        path = url[len("https://github.com/"):]
+    elif url.startswith("git@github.com:"):
+        path = url[len("git@github.com:"):]
+    else:
+        raise RuntimeError(f"Unrecognized remote URL: {url}")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return path
+
+
+def close_open_prs(repo: str, issue: int) -> int:
+    """Close any open PR that closes this issue. Returns count closed."""
+    # Find PRs that reference the issue in body.
+    result = _run([
+        "gh", "pr", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--search", f"Closes #{issue}",
+        "--json", "number,title",
+    ])
+    if result.returncode != 0:
+        print(f"  WARNING: gh pr list failed: {result.stderr.strip()}")
+        return 0
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return 0
+    closed = 0
+    for pr in prs:
+        n = pr["number"]
+        r = _run(["gh", "pr", "close", str(n), "--repo", repo])
+        if r.returncode == 0:
+            print(f"  Closed PR #{n}: {pr['title']}")
+            closed += 1
+        else:
+            print(f"  WARNING: could not close PR #{n}: {r.stderr.strip()}")
+    return closed
+
+
+def remove_worktree(repo_root: Path, issue: int) -> bool:
+    """Remove worktree at `{repo}-{issue}` if it exists."""
+    parent = repo_root.parent
+    worktree_path = parent / f"{repo_root.name}-{issue}"
+    if not worktree_path.exists():
+        return False
+    result = _run(
+        ["git", "worktree", "remove", str(worktree_path)],
+        cwd=repo_root,
+    )
+    if result.returncode == 0:
+        print(f"  Removed worktree: {worktree_path}")
+        return True
+    # Worktree might exist but be unregistered in git's view. Try direct rmdir.
+    try:
+        shutil.rmtree(worktree_path)
+        print(f"  Removed worktree directory: {worktree_path}")
+        return True
+    except OSError as e:
+        print(f"  WARNING: could not remove worktree {worktree_path}: {e}")
+        return False
+
+
+def delete_local_branches(repo_root: Path, issue: int) -> int:
+    """Delete local branches matching `{issue}-*` pattern. Returns count deleted."""
+    result = _run(
+        ["git", "branch", "--list", f"{issue}-*"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return 0
+    branches = [
+        line.strip().lstrip("* ").strip()
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+    deleted = 0
+    for branch in branches:
+        if not branch:
+            continue
+        # Try safe-delete first; never use -D
+        r = _run(["git", "branch", "-d", branch], cwd=repo_root)
+        if r.returncode == 0:
+            print(f"  Deleted local branch: {branch}")
+            deleted += 1
+        else:
+            # Branch wasn't merged. For speed-run reset, that's expected
+            # (we're discarding work). Use -d still — the user can decide
+            # if they want -D themselves. We don't auto-escalate.
+            print(
+                f"  Skipped branch {branch} (not merged; "
+                f"reset with `git branch -D {branch}` if intentional)"
+            )
+    return deleted
+
+
+def delete_lineage_dirs(repo_root: Path, issue: int) -> int:
+    """Delete docs/lineage/active/{issue}-* directories. Returns count deleted."""
+    lineage_active = repo_root / "docs" / "lineage" / "active"
+    if not lineage_active.exists():
+        return 0
+    deleted = 0
+    for d in lineage_active.glob(f"{issue}-*"):
+        if not d.is_dir():
+            continue
+        try:
+            shutil.rmtree(d)
+            print(f"  Deleted lineage dir: {d.relative_to(repo_root)}")
+            deleted += 1
+        except OSError as e:
+            print(f"  WARNING: could not delete {d}: {e}")
+    return deleted
+
+
+def reopen_issue(repo: str, issue: int) -> bool:
+    """Reopen the GitHub issue if it's currently closed."""
+    result = _run([
+        "gh", "issue", "view", str(issue),
+        "--repo", repo,
+        "--json", "state",
+    ])
+    if result.returncode != 0:
+        return False
+    try:
+        info = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return False
+    if info.get("state") == "OPEN":
+        return False
+    r = _run([
+        "gh", "issue", "reopen", str(issue),
+        "--repo", repo,
+    ])
+    if r.returncode == 0:
+        print(f"  Reopened issue #{issue}")
+        return True
+    print(f"  WARNING: could not reopen issue #{issue}: {r.stderr.strip()}")
+    return False
+
+
+def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
+    """Run all six reset steps for one issue."""
+    print(f"\nResetting issue #{issue}:")
+    close_open_prs(repo, issue)
+    remove_worktree(repo_root, issue)
+    delete_local_branches(repo_root, issue)
+    delete_lineage_dirs(repo_root, issue)
+    reopen_issue(repo, issue)
+
+
+def all_logged_issues(repo_root: Path) -> list[int]:
+    """Read run-log.jsonl and return unique issue numbers."""
+    log_path = repo_root / "data" / "speedrun" / "run-log.jsonl"
+    if not log_path.exists():
+        return []
+    issues: set[int] = set()
+    with log_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if "issue" in entry:
+                    issues.add(int(entry["issue"]))
+            except (json.JSONDecodeError, ValueError, TypeError):
+                continue
+    return sorted(issues)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reset speed-run state for one or more issues",
+    )
+    parser.add_argument(
+        "--repo", required=True, type=Path,
+        help="Path to the target repo (e.g., /c/Users/mcwiz/Projects/boostgauge)",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--issue", type=int, help="Reset a single issue")
+    group.add_argument(
+        "--all-issues", action="store_true",
+        help="Reset every issue that has appeared in run-log.jsonl",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo.resolve()
+    if not repo_root.exists():
+        print(f"ERROR: repo path does not exist: {repo_root}")
+        return 1
+
+    try:
+        repo = _gh_repo(repo_root)
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        return 1
+
+    if args.issue:
+        reset_one_issue(repo_root, repo, args.issue)
+    else:
+        issues = all_logged_issues(repo_root)
+        if not issues:
+            print("No issues in run-log.jsonl — nothing to reset.")
+            return 0
+        print(f"Resetting {len(issues)} issue(s) from run-log: {issues}")
+        for issue in issues:
+            reset_one_issue(repo_root, repo, issue)
+
+    print("\nspawn state restored")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/speedrun_summarize.py
+++ b/tools/speedrun_summarize.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Aggregate data/speedrun/run-log.jsonl into a readable table (#1076).
+
+Reads the run log and prints two sections:
+
+  1. Per-attempt timeline (one row per attempt, chronological).
+  2. Summary by failure mode (counts and percentages).
+
+Usage:
+
+    poetry run python tools/speedrun_summarize.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge
+
+    # Filter to a single issue:
+    poetry run python tools/speedrun_summarize.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 35
+
+The output is plain text suitable for between-attempt review or for
+pasting into a session log. Designed to be useful with `tail -1` style
+single-take inspection too — even a fresh, mostly-empty log produces
+useful output.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+# Make assemblyzero/ importable when run from the repo root.
+_TOOLS = Path(__file__).resolve().parent
+sys.path.insert(0, str(_TOOLS.parent))
+
+from assemblyzero.utils.speedrun import RunLogger  # noqa: E402
+
+
+def _format_seconds(s: float) -> str:
+    """Format seconds as MM:SS for human readability."""
+    if s is None:
+        return "?"
+    minutes, seconds = divmod(int(s), 60)
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def print_timeline(entries: list[dict]) -> None:
+    """Print a per-attempt table."""
+    if not entries:
+        print("\nNo attempts logged yet.")
+        return
+    print("\n## Timeline\n")
+    headers = ("attempt", "issue", "outcome", "failure", "duration", "started_at")
+    rows = [
+        (
+            str(e.get("attempt", "?")),
+            str(e.get("issue", "?")),
+            e.get("outcome", "?"),
+            e.get("failure_mode") or "-",
+            _format_seconds(e.get("total_seconds")),
+            e.get("started_at", "?"),
+        )
+        for e in entries
+    ]
+    widths = [
+        max(len(h), max((len(r[i]) for r in rows), default=0))
+        for i, h in enumerate(headers)
+    ]
+    fmt = " | ".join(f"{{:<{w}}}" for w in widths)
+    print(fmt.format(*headers))
+    print(" | ".join("-" * w for w in widths))
+    for row in rows:
+        print(fmt.format(*row))
+
+
+def print_failure_summary(entries: list[dict]) -> None:
+    """Print a counts-by-failure-mode table."""
+    if not entries:
+        return
+    print("\n## Summary by outcome\n")
+    outcome_counts = Counter(e.get("outcome", "unknown") for e in entries)
+    total = sum(outcome_counts.values())
+    for outcome, count in outcome_counts.most_common():
+        pct = 100.0 * count / total
+        print(f"  {outcome:<8} {count:>3}  ({pct:5.1f}%)")
+
+    failures = [e for e in entries if e.get("outcome") != "success"]
+    if not failures:
+        return
+    print("\n## Summary by failure mode (non-success only)\n")
+    fail_counts = Counter(e.get("failure_mode") or "unknown" for e in failures)
+    total_fail = sum(fail_counts.values())
+    for mode, count in fail_counts.most_common():
+        pct = 100.0 * count / total_fail
+        print(f"  {mode:<28} {count:>3}  ({pct:5.1f}%)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize data/speedrun/run-log.jsonl",
+    )
+    parser.add_argument("--repo", required=True, type=Path)
+    parser.add_argument(
+        "--issue", type=int, default=None,
+        help="Filter to a single issue number",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo.resolve()
+    if not repo_root.exists():
+        print(f"ERROR: repo path does not exist: {repo_root}")
+        return 1
+
+    runlogger = RunLogger(repo_root)
+    entries = runlogger.read_all()
+
+    if args.issue is not None:
+        entries = [e for e in entries if e.get("issue") == args.issue]
+
+    print(f"# Speed-run summary — {repo_root.name}")
+    if args.issue:
+        print(f"Issue filter: #{args.issue}")
+    print(f"Log: {runlogger.log_path}")
+    print(f"Total attempts: {len(entries)}")
+
+    print_timeline(entries)
+    print_failure_summary(entries)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Four deliverables in one PR: lap splits + classifier + reset script + run log + summarizer + overlay.
- All gated on \`--speedrun\` (off by default — operators not running speedruns see no change).
- 16 unit tests, all pass.
- Phase B SECOND (after #1071, before #1072).

Closes #1076

## What ships

| Component | Purpose |
|---|---|
| \`assemblyzero/utils/speedrun.py\` | \`LapSplitWriter\` (per-attempt JSON), \`classify_halt\` (8 labels), \`RunLogger\` (append-only JSONL) |
| \`tools/speedrun_reset.py\` | --issue N / --all-issues; closes PR, removes worktree, deletes branches + lineage, reopens issue. Idempotent. |
| \`tools/speedrun_overlay.py\` | Reads {issue}-{attempt}.json → prints \`[MM:SS] beat\` table. \`--watch\` re-renders 1Hz. |
| \`tools/speedrun_summarize.py\` | Aggregates run-log.jsonl into timeline + outcome counts + failure-mode counts. \`--issue N\` filter. |
| Runner hooks in \`run_implement_from_lld.py\` + \`run_requirements_workflow.py\` | --speedrun flag; start beat + finalize hooks at success/fail/halt/exception |

## Eight halt classifications

\`gemini-503\`, \`gemini-quota\`, \`stagnation\`, \`mech-validation-loop\`, \`test-plan-blocked\`, \`completeness-gate-failed\`, \`coverage-target-missed\`, \`unknown\`. State signals take priority over message-pattern matching; \`unknown\` is the explicit fallback.

## Design choices worth noting

- **Crash-safe lap splits.** File is rewritten in full on each beat, no buffer. \`tail data/speedrun/{issue}-{attempt}.json\` always shows current state.
- **Append-only run log.** \`RunLogger.complete_run\` opens-appends-closes; never rewrites. \`tail -1 run-log.jsonl\` shows the most recent attempt regardless of crashes.
- **Pure classifier.** \`classify_halt\` is side-effect-free, takes a state dict + error string, returns a label. Tests trivially inject state; integration is a one-liner at every halt site.
- **Reset never escalates \`-d\` to \`-D\`.** Per root CLAUDE.md hard rule. If the speed-run reset can't safe-delete a branch, it surfaces the warning rather than discarding work.
- **Per-node beats deferred.** Acceptance lists lap_loaded / lld_drafted / red_phase_passed / etc. as example beats. Hooking each one requires touching ~10 node files in two workflows. This PR provides the runner-level start/end beats (which the run-log only cares about) and leaves the finer-grained per-node beats to incremental follow-ups so the diff stays surgical.

## How acceptance is met

- [x] Lap splits file written automatically by both LLD + implementation workflows when \`--speedrun\` passed.
- [x] Classifier covers 7 named modes + \`unknown\` fallback (8 total per HALT_CLASSIFICATIONS).
- [x] Reset script restores spawn state on a fresh repo (close PRs, remove worktree, delete branches/lineage, reopen issue). Idempotent. \`--all-issues\` mode reads run-log to find every issue that's appeared.
- [x] Run log writes one entry per attempt; summarizer produces a readable timeline + counts table.
- [x] Per-node beats (lld_drafted, etc.) — deferred to follow-up PRs.

## Test plan

- [x] 16 tests in \`tests/test_speedrun.py\` — all pass
- [x] Syntax check on all 6 modified/created Python files
- [x] LapSplitWriter, classify_halt, RunLogger covered by unit tests
- [x] Auto-attempt incrementing tested
- [ ] End-to-end smoke test against a real speedrun run — out of scope; deferred to first actual boostgauge run

## Out of scope

- Per-node beats (\`lld_drafted\`, \`red_phase_passed\`, etc.) — incremental follow-up PRs.
- Visual overlay rendering (e.g., OBS browser source) — \`speedrun_overlay.py --watch\` is the operator-side stub for now.
- Cross-attempt dashboards beyond the table summarizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)