### PR TITLE
feat: testing workflow — recover from BLOCKED test plan (Closes #1072)

### DIFF
--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -84,6 +84,8 @@ from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
 )
 from assemblyzero.workflows.testing.state import TestingWorkflowState
 
+from assemblyzero.workflows.testing.nodes.revise_test_plan import revise_test_plan  # Issue #1072
+
 from assemblyzero.workflows.testing.nodes.adversarial_node import (
     run_adversarial_node,
 )
@@ -110,8 +112,20 @@ def route_after_load(
 
 def route_after_review(
     state: TestingWorkflowState,
-) -> Literal["N2_scaffold_tests", "end"]:
+) -> Literal["N2_scaffold_tests", "N1_5_revise_test_plan", "end"]:
     """Route after N1 (review_test_plan).
+
+    Issue #1072: BLOCKED no longer terminates by default. The
+    test_plan_policy controls behavior:
+
+    - "revise" (default): route to N1_5_revise_test_plan up to
+      MAX_REVISION_CYCLES; END after exhaustion.
+    - "auto": continue to N2_scaffold_tests despite BLOCKED (matches
+      the legacy auto_mode bypass).
+    - "strict": END on BLOCKED (legacy default behavior).
+
+    The legacy `auto_mode` flag is honored for backward compatibility:
+    when set, it forces the auto path regardless of test_plan_policy.
 
     Args:
         state: Current workflow state.
@@ -119,20 +133,42 @@ def route_after_review(
     Returns:
         Next node name or END.
     """
+    from assemblyzero.workflows.testing.nodes.revise_test_plan import (
+        MAX_REVISION_CYCLES,
+    )
+
     error = state.get("error_message", "")
     test_plan_status = state.get("test_plan_status", "")
     auto_mode = state.get("auto_mode", False)
+    policy = state.get("test_plan_policy", "revise")
+    revision_count = state.get("test_plan_revision_count", 0)
 
     if error and not auto_mode:
         return "end"
 
-    # BLOCKED means test plan needs revision - this requires returning
-    # to the LLD workflow (outside scope of this workflow)
-    # In auto_mode, continue anyway (skip human gate)
     if test_plan_status == "BLOCKED":
-        if auto_mode:
-            print("    [AUTO] Continuing despite BLOCKED verdict - auto mode enabled")
+        # Legacy auto_mode flag OR policy=auto bypasses the gate.
+        if auto_mode or policy == "auto":
+            print(
+                "    [AUTO] Continuing despite BLOCKED verdict "
+                "(test_plan_policy=auto)"
+            )
             return "N2_scaffold_tests"
+        # Strict policy preserves the original END-on-BLOCKED behavior.
+        if policy == "strict":
+            print("    [STRICT] BLOCKED → END (test_plan_policy=strict)")
+            return "end"
+        # Default revise policy: try to fix the test plan up to N cycles.
+        if revision_count < MAX_REVISION_CYCLES:
+            print(
+                f"    [REVISE] BLOCKED → N1.5 revise cycle "
+                f"{revision_count + 1}/{MAX_REVISION_CYCLES}"
+            )
+            return "N1_5_revise_test_plan"
+        print(
+            f"    [REVISE] BLOCKED after {MAX_REVISION_CYCLES} revision "
+            "cycles — END"
+        )
         return "end"
 
     return "N2_scaffold_tests"
@@ -382,6 +418,7 @@ def build_testing_workflow() -> StateGraph:
     # Add nodes
     workflow.add_node("N0_load_lld", load_lld)
     workflow.add_node("N1_review_test_plan", review_test_plan)
+    workflow.add_node("N1_5_revise_test_plan", revise_test_plan)  # Issue #1072
     workflow.add_node("N2_scaffold_tests", scaffold_tests)
     workflow.add_node("N2_5_validate_tests", validate_tests_mechanical_node)  # Issue #335
     workflow.add_node("N3_verify_red", verify_red_phase)
@@ -408,15 +445,19 @@ def build_testing_workflow() -> StateGraph:
         },
     )
 
-    # N1 -> N2 (with error/blocked check)
+    # N1 -> N2 / N1.5 / END (Issue #1072: revise on BLOCKED)
     workflow.add_conditional_edges(
         "N1_review_test_plan",
         route_after_review,
         {
             "N2_scaffold_tests": "N2_scaffold_tests",
+            "N1_5_revise_test_plan": "N1_5_revise_test_plan",
             "end": END,
         },
     )
+
+    # N1.5 -> N1 (revisions always loop back for re-review; Issue #1072)
+    workflow.add_edge("N1_5_revise_test_plan", "N1_review_test_plan")
 
     # N2 -> N2.5 (with scaffold_only check) - Issue #335
     workflow.add_conditional_edges(

--- a/assemblyzero/workflows/testing/nodes/revise_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/revise_test_plan.py
@@ -1,0 +1,274 @@
+"""N1.5: Revise Test Plan node — recover from BLOCKED at N1 (#1072).
+
+When N1 (review_test_plan) returns BLOCKED, the workflow used to END.
+With this node in the graph, the BLOCKED feedback is fed back to an
+LLM revisor that produces a fresh Test Scenarios table; the loop then
+returns to N1 for re-review. Hard cap: 2 revision cycles before END.
+
+The revisor is invoked via the same provider abstraction as N1 with
+the #1071 retry policy, so transient failures during revision retry
+in line with the operator's --retry-policy flag.
+
+Mock mode produces deterministic scenarios from the requirements list,
+identical to _mock_review_test_plan's coverage shape — used by tests.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+logger = logging.getLogger(__name__)
+
+
+# Maximum revision cycles before END. Hard cap prevents infinite loops
+# when the LLM cannot fix the underlying issue. Per #1072 acceptance.
+MAX_REVISION_CYCLES = 2
+
+
+# Pattern: T001 / T1 / 001 — captured by the same regex used in
+# extract_test_scenarios (test_plan_validator.py). Mirroring that here
+# so revisions produce IDs the validator will recognize.
+_SCENARIO_ID_PATTERN = re.compile(r"^(?:T?\d+)$", re.IGNORECASE)
+
+
+def _build_revision_prompt(
+    lld_content: str,
+    feedback: str,
+    requirements: list[str],
+) -> tuple[str, str]:
+    """Build (system_prompt, user_prompt) for the test-plan revisor."""
+    requirement_block = "\n".join(f"- {r}" for r in requirements) or "(none)"
+    system_prompt = (
+        "You are revising the Test Scenarios table in a Low-Level Design "
+        "(LLD) document. The previous test plan was rejected with the "
+        "feedback below. Output ONLY a markdown table with columns: "
+        "ID | Scenario | Type | Requirements. Use IDs T001, T002, ... "
+        "Use types: unit | integration | e2e | benchmark | smoke. "
+        "Reference requirements as 'Req N' or 'REQ-N' in the Requirements "
+        "column. Cover EVERY requirement listed; the table must have at "
+        "least one row per requirement. Address every BLOCKING issue "
+        "called out in the feedback. Do NOT add prose, explanations, or "
+        "commentary — only the table."
+    )
+    user_prompt = (
+        f"## Reviewer feedback (BLOCKED — must be addressed)\n\n"
+        f"{feedback or '(no feedback provided)'}\n\n"
+        f"## Requirements to cover\n\n"
+        f"{requirement_block}\n\n"
+        f"## Current LLD content (for context)\n\n"
+        f"{lld_content[:8000]}"  # cap to avoid bloating the prompt
+    )
+    return system_prompt, user_prompt
+
+
+def _parse_scenarios_from_table(table_md: str) -> list[dict[str, Any]]:
+    """Parse a revised scenarios table into [scenario] dicts.
+
+    Mirrors the parsing logic in
+    test_plan_validator.extract_test_scenarios so the gate logic at
+    N1 sees the same shape regardless of whether the scenarios came
+    from the LLD or from a revision.
+
+    Each row produces:
+
+        {
+            "name": "T001_short_name",
+            "test_type": "unit",
+            "requirement_ref": "REQ-1",  # primary req for fast-path
+            "description": "...",
+            "assertions": [],
+            "mock_needed": False,
+        }
+    """
+    scenarios: list[dict[str, Any]] = []
+    for raw_line in table_md.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.split("|")]
+        cells = [c for c in cells if c]
+        if len(cells) < 3:
+            continue
+        # Skip separator rows
+        if all(set(c) <= set("-: ") for c in cells):
+            continue
+        # Skip header rows
+        if cells[0].lower() in ("id", "test id", "#"):
+            continue
+        if not _SCENARIO_ID_PATTERN.match(cells[0]):
+            continue
+
+        scenario_id = cells[0].upper()
+        if not scenario_id.startswith("T"):
+            scenario_id = f"T{scenario_id.zfill(3)}"
+
+        description = cells[1] if len(cells) > 1 else ""
+        test_type = (cells[2] if len(cells) > 2 else "unit").lower()
+
+        # Find first requirement reference in the row text
+        full_row = " ".join(cells)
+        req_match = re.search(
+            r"\b(?:req(?:uirement)?)\s*[-.]?\s*(\d+)\b",
+            full_row,
+            re.IGNORECASE,
+        )
+        requirement_ref = f"REQ-{req_match.group(1)}" if req_match else ""
+
+        # Build a name out of the ID + a slug of the description
+        slug = re.sub(r"[^a-zA-Z0-9]+", "_", description).strip("_").lower()
+        slug = (slug[:40]) if slug else "scenario"
+        name = f"{scenario_id.lower()}_{slug}"
+
+        scenarios.append({
+            "name": name,
+            "test_type": test_type,
+            "requirement_ref": requirement_ref,
+            "description": description,
+            "assertions": [],
+            "mock_needed": False,
+        })
+    return scenarios
+
+
+def _mock_revise(state: TestingWorkflowState) -> dict[str, Any]:
+    """Deterministic revision used in test mode.
+
+    Produces one scenario per requirement, satisfying both the gate-3
+    (scenario count >= requirement count) and the fast-path (100%
+    coverage by requirement_ref) checks.
+    """
+    requirements = state.get("requirements", [])
+    revision_count = state.get("test_plan_revision_count", 0) + 1
+
+    scenarios: list[dict[str, Any]] = []
+    table_lines = ["| ID | Scenario | Type | Requirements |", "|---|---|---|---|"]
+    for i, req_text in enumerate(requirements, start=1):
+        sid = f"T{i:03d}"
+        # Extract REQ-N from the requirement string if present
+        req_match = re.match(r"(req-[\w.]+)", req_text.strip(), re.IGNORECASE)
+        req_ref = req_match.group(1).upper() if req_match else f"REQ-{i}"
+        scenarios.append({
+            "name": f"{sid.lower()}_revised",
+            "test_type": "unit",
+            "requirement_ref": req_ref,
+            "description": f"Revised scenario for {req_ref}",
+            "assertions": [],
+            "mock_needed": False,
+        })
+        table_lines.append(
+            f"| {sid} | Revised scenario for {req_ref} | unit | {req_ref} |"
+        )
+
+    return {
+        "test_plan_status": "PENDING",
+        "test_plan_section": "\n".join(table_lines),
+        "test_scenarios": scenarios,
+        "test_plan_revision_count": revision_count,
+        "error_message": "",
+        "gemini_feedback": "",
+    }
+
+
+def revise_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
+    """N1.5: Revise the test plan based on BLOCKED feedback.
+
+    Args:
+        state: Current workflow state. Reads `gemini_feedback`,
+            `lld_content`, `requirements`, `test_plan_revision_count`,
+            `config_drafter`, `config_effort`, `config_retry_policy`,
+            `mock_mode`.
+
+    Returns:
+        Dict of state updates:
+        - On success (parseable revision): clears test_plan_status to
+          PENDING, replaces test_scenarios + test_plan_section,
+          increments revision count, clears error / feedback.
+        - On failure (LLM error or no scenarios parsed): increments
+          revision count + sets error_message so the router routes
+          the workflow to END after the next pass.
+    """
+    revision_count = state.get("test_plan_revision_count", 0) + 1
+    print(f"\n[N1.5] Revising test plan (cycle {revision_count}/{MAX_REVISION_CYCLES})")
+
+    if state.get("mock_mode", False):
+        return _mock_revise(state)
+
+    feedback = state.get("gemini_feedback", "") or ""
+    lld_content = state.get("lld_content", "") or ""
+    requirements = state.get("requirements", []) or []
+
+    if not requirements:
+        # Without requirements, can't produce scenario rows. Emit a
+        # blocking error so the router ends gracefully.
+        return {
+            "test_plan_revision_count": revision_count,
+            "error_message": (
+                "Test plan revision blocked: no requirements available "
+                "to map scenarios against."
+            ),
+        }
+
+    # Lazy imports — keeps the test surface trivial when mock_mode is on.
+    from assemblyzero.core.llm_provider import get_provider
+    from assemblyzero.utils.retry import get_policy, with_retry
+
+    revisor_spec = state.get("config_drafter", "claude:opus")
+    effort = state.get("config_effort")
+    try:
+        revisor = get_provider(revisor_spec, effort=effort)
+    except ValueError as e:
+        return {
+            "test_plan_revision_count": revision_count,
+            "error_message": f"Test plan revision: invalid revisor spec: {e}",
+        }
+
+    system_prompt, user_prompt = _build_revision_prompt(
+        lld_content, feedback, requirements,
+    )
+
+    retry_policy = get_policy(state.get("config_retry_policy", "default"))
+    result = with_retry(
+        lambda: revisor.invoke(
+            system_prompt=system_prompt,
+            content=user_prompt,
+        ),
+        policy=retry_policy,
+        description=f"N1.5 test plan revision #{revision_count}",
+    )
+
+    if not result.success:
+        return {
+            "test_plan_revision_count": revision_count,
+            "error_message": (
+                f"Test plan revision LLM call failed: {result.error_message}"
+            ),
+        }
+
+    revised_table = (result.response or "").strip()
+    scenarios = _parse_scenarios_from_table(revised_table)
+
+    if len(scenarios) < len(requirements):
+        # Couldn't produce enough scenarios — increment count and let
+        # the router decide whether to retry or END.
+        return {
+            "test_plan_revision_count": revision_count,
+            "test_plan_section": revised_table,
+            "error_message": (
+                f"Revised plan covers only {len(scenarios)}/{len(requirements)} "
+                "requirements — needs another revision cycle"
+            ),
+        }
+
+    # Success: hand back the revised plan and clear the BLOCKED state.
+    print(f"    Parsed {len(scenarios)} revised scenarios from revision.")
+    return {
+        "test_plan_status": "PENDING",
+        "test_plan_section": revised_table,
+        "test_scenarios": scenarios,
+        "test_plan_revision_count": revision_count,
+        "error_message": "",
+        "gemini_feedback": "",
+    }

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -197,6 +197,9 @@ class TestingWorkflowState(TypedDict, total=False):
     config_reviewer: str  # Issue #773: Reviewer LLM spec (e.g., "claude:opus")
     config_effort: str  # Issue #779: Effort level for Claude reviewer
     config_retry_policy: str  # Issue #1071: "default" | "aggressive" | "none"
+    config_drafter: str  # Issue #1072: drafter spec for test-plan revision
+    test_plan_policy: str  # Issue #1072: "revise" (default) | "auto" | "strict"
+    test_plan_revision_count: int  # Issue #1072: incremented per revision cycle
     auto_mode: bool
     mock_mode: bool
     skip_e2e: bool

--- a/tests/test_revise_test_plan.py
+++ b/tests/test_revise_test_plan.py
@@ -1,0 +1,205 @@
+"""Tests for revise_test_plan node + route_after_review (#1072)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from assemblyzero.workflows.testing.graph import route_after_review
+from assemblyzero.workflows.testing.nodes.revise_test_plan import (
+    MAX_REVISION_CYCLES,
+    _parse_scenarios_from_table,
+    revise_test_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# route_after_review — policy dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_route_default_revise_policy_routes_to_revise_node():
+    """BLOCKED + revise policy + count<MAX → N1_5_revise_test_plan."""
+    state: dict[str, Any] = {
+        "test_plan_status": "BLOCKED",
+        "test_plan_policy": "revise",
+        "test_plan_revision_count": 0,
+        "auto_mode": False,
+    }
+    assert route_after_review(state) == "N1_5_revise_test_plan"
+
+
+def test_route_revise_policy_exhausts_after_max_cycles():
+    """BLOCKED + revise policy + count==MAX → end."""
+    state: dict[str, Any] = {
+        "test_plan_status": "BLOCKED",
+        "test_plan_policy": "revise",
+        "test_plan_revision_count": MAX_REVISION_CYCLES,
+        "auto_mode": False,
+    }
+    assert route_after_review(state) == "end"
+
+
+def test_route_strict_policy_ends_immediately():
+    """BLOCKED + strict policy → end (legacy behavior)."""
+    state: dict[str, Any] = {
+        "test_plan_status": "BLOCKED",
+        "test_plan_policy": "strict",
+        "test_plan_revision_count": 0,
+        "auto_mode": False,
+    }
+    assert route_after_review(state) == "end"
+
+
+def test_route_auto_policy_continues_to_scaffold():
+    """BLOCKED + auto policy → N2_scaffold_tests (legacy auto bypass)."""
+    state: dict[str, Any] = {
+        "test_plan_status": "BLOCKED",
+        "test_plan_policy": "auto",
+        "test_plan_revision_count": 0,
+        "auto_mode": False,
+    }
+    assert route_after_review(state) == "N2_scaffold_tests"
+
+
+def test_route_legacy_auto_mode_overrides_revise_policy():
+    """auto_mode=True forces auto path even when policy=revise."""
+    state: dict[str, Any] = {
+        "test_plan_status": "BLOCKED",
+        "test_plan_policy": "revise",
+        "test_plan_revision_count": 0,
+        "auto_mode": True,
+    }
+    assert route_after_review(state) == "N2_scaffold_tests"
+
+
+def test_route_approved_goes_straight_to_scaffold_regardless_of_policy():
+    """APPROVED is unchanged across policies."""
+    for policy in ("revise", "auto", "strict"):
+        state: dict[str, Any] = {
+            "test_plan_status": "APPROVED",
+            "test_plan_policy": policy,
+            "test_plan_revision_count": 0,
+            "auto_mode": False,
+        }
+        assert route_after_review(state) == "N2_scaffold_tests"
+
+
+def test_route_error_with_no_auto_mode_ends():
+    """error_message + auto_mode=False → end (preserves prior behavior)."""
+    state: dict[str, Any] = {
+        "error_message": "something blew up",
+        "test_plan_status": "PENDING",
+        "auto_mode": False,
+    }
+    assert route_after_review(state) == "end"
+
+
+# ---------------------------------------------------------------------------
+# revise_test_plan — mock mode (deterministic)
+# ---------------------------------------------------------------------------
+
+
+def test_revise_test_plan_mock_mode_increments_count():
+    """Mock revise increments revision_count from 0 → 1."""
+    state: dict[str, Any] = {
+        "mock_mode": True,
+        "requirements": ["1. First requirement", "2. Second requirement"],
+        "test_plan_revision_count": 0,
+    }
+    update = revise_test_plan(state)
+    assert update["test_plan_revision_count"] == 1
+
+
+def test_revise_test_plan_mock_mode_clears_blocked_status():
+    """Mock revise sets test_plan_status to PENDING for re-review."""
+    state: dict[str, Any] = {
+        "mock_mode": True,
+        "requirements": ["1. Req one"],
+        "test_plan_revision_count": 0,
+    }
+    update = revise_test_plan(state)
+    assert update["test_plan_status"] == "PENDING"
+    assert update["error_message"] == ""
+    assert update["gemini_feedback"] == ""
+
+
+def test_revise_test_plan_mock_mode_produces_one_scenario_per_req():
+    """Mock revise satisfies the count gate (>= len(requirements))."""
+    state: dict[str, Any] = {
+        "mock_mode": True,
+        "requirements": [
+            "1. Cover X",
+            "2. Cover Y",
+            "3. Cover Z",
+        ],
+        "test_plan_revision_count": 0,
+    }
+    update = revise_test_plan(state)
+    assert len(update["test_scenarios"]) == 3
+    refs = {s["requirement_ref"] for s in update["test_scenarios"]}
+    assert refs == {"REQ-1", "REQ-2", "REQ-3"}
+
+
+def test_revise_test_plan_mock_mode_emits_markdown_table():
+    """Mock revise's test_plan_section parses back into the same scenarios."""
+    state: dict[str, Any] = {
+        "mock_mode": True,
+        "requirements": ["1. Req one", "2. Req two"],
+        "test_plan_revision_count": 0,
+    }
+    update = revise_test_plan(state)
+    parsed = _parse_scenarios_from_table(update["test_plan_section"])
+    assert len(parsed) == 2
+
+
+# ---------------------------------------------------------------------------
+# _parse_scenarios_from_table — markdown parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_scenarios_skips_header_and_separator():
+    """Header rows and ---|--- separators don't become scenarios."""
+    md = """
+    | ID | Scenario | Type | Requirements |
+    |---|---|---|---|
+    | T001 | Test the thing | unit | REQ-1 |
+    | T002 | Test the other | integration | Req 2 |
+    """
+    parsed = _parse_scenarios_from_table(md)
+    assert len(parsed) == 2
+    assert parsed[0]["requirement_ref"] == "REQ-1"
+    assert parsed[1]["requirement_ref"] == "REQ-2"
+    assert parsed[0]["test_type"] == "unit"
+    assert parsed[1]["test_type"] == "integration"
+
+
+def test_parse_scenarios_normalizes_id_format():
+    """Bare numeric IDs become T-prefixed; T1 becomes T1 (not zero-padded)."""
+    md = """
+    | ID | Scenario | Type | Reqs |
+    | 1 | A | unit | REQ-1 |
+    | T7 | B | unit | REQ-2 |
+    """
+    parsed = _parse_scenarios_from_table(md)
+    assert len(parsed) == 2
+    assert parsed[0]["name"].startswith("t001_")
+    assert parsed[1]["name"].startswith("t7_")
+
+
+def test_parse_scenarios_handles_no_requirement_ref():
+    """A row without a Req mention still parses (with empty req_ref)."""
+    md = """
+    | ID | Scenario | Type |
+    | T001 | Standalone test | unit |
+    """
+    parsed = _parse_scenarios_from_table(md)
+    assert len(parsed) == 1
+    assert parsed[0]["requirement_ref"] == ""
+
+
+def test_parse_scenarios_returns_empty_for_no_table():
+    """Garbage input produces empty list, not exception."""
+    assert _parse_scenarios_from_table("no table here at all") == []
+    assert _parse_scenarios_from_table("") == []

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -481,6 +481,21 @@ def create_argument_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # Issue #1072: Test-plan policy on BLOCKED at N1.
+    parser.add_argument(
+        "--test-plan-policy",
+        choices=["revise", "auto", "strict"],
+        default="revise",
+        help=(
+            "Behavior when N1 returns BLOCKED on the test plan. "
+            "'revise' (default): up to 2 revision cycles, then END. "
+            "'auto': continue to scaffold despite BLOCKED (legacy "
+            "auto_mode bypass). 'strict': END immediately on BLOCKED "
+            "(pre-#1072 behavior). The legacy auto_mode setting still "
+            "forces the auto path regardless of this flag. (#1072)"
+        ),
+    )
+
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import add_timeout_argument
     add_timeout_argument(parser)
@@ -760,6 +775,9 @@ def main():
         "config_reviewer": args.reviewer,  # Issue #773
         "config_effort": args.effort,  # Issue #773
         "config_retry_policy": args.retry_policy,  # Issue #1071
+        "config_drafter": args.reviewer,  # Issue #1072: revisor reuses reviewer spec
+        "test_plan_policy": args.test_plan_policy,  # Issue #1072
+        "test_plan_revision_count": 0,  # Issue #1072
         "auto_mode": args.auto_mode,
         "mock_mode": args.mock,
         "skip_e2e": args.skip_e2e,


### PR DESCRIPTION
## Summary

- Adds new node N1.5 \`revise_test_plan\` to the testing workflow that recovers from BLOCKED at N1 by calling an LLM to revise the Test Scenarios table and looping back to N1 for re-review (max 2 cycles).
- New \`--test-plan-policy {revise|auto|strict}\` CLI flag — default \"revise\" (this PR's new behavior); \"strict\" preserves the pre-#1072 END-on-BLOCKED.
- 15 unit tests covering route logic + mock-mode revision + scenario parsing.
- Phase B FINAL — completes the strict #1071 → #1076 → #1072 sequence.

Closes #1072

## What changes

| Before | After |
|---|---|
| N1 BLOCKED → END (only \`--auto-mode\` bypassed) | N1 BLOCKED → N1.5 revise → N1 re-review (up to 2 cycles), then END |
| Single \`--auto-mode\` toggle | \`--test-plan-policy revise|auto|strict\` (auto_mode still works for backward compat) |
| Lost feedback on BLOCKED | Feedback fed into revision prompt; revisor must address every BLOCKING issue |

## Design

### Three policies

| Policy | Behavior on BLOCKED |
|---|---|
| \`revise\` (new default) | Loop to N1.5; up to 2 revision cycles; then END |
| \`auto\` | Continue to N2 scaffold — equivalent to legacy \`auto_mode\` bypass |
| \`strict\` | END immediately — pre-#1072 default |

Legacy \`auto_mode\` setting still forces the auto path regardless of policy (preserves backward compatibility for existing scripts).

### Hard cap

\`MAX_REVISION_CYCLES = 2\`. The router enforces this — N1.5 can be entered at most twice before the workflow ends. Prevents infinite loops when the LLM cannot fix the underlying issue.

### Revision integrates with #1071 retry

\`revise_test_plan\` invokes its LLM call via \`with_retry\` (from #1071), so transient Gemini 503s during revision honor the operator's \`--retry-policy\`. The two features stack cleanly.

### Scenario parsing

\`_parse_scenarios_from_table\` mirrors the parsing logic in \`test_plan_validator.extract_test_scenarios\` so the gates at N1 see the same shape regardless of whether scenarios came from the original LLD or a revision.

## How acceptance is met

- [x] New node \`N1_5_revise_test_plan\` in \`assemblyzero/workflows/testing/nodes/\` (named \`revise_test_plan\`).
- [x] Graph routes BLOCKED → N1.5 → N1 with hard cap of 2 cycles.
- [x] Test 1: revise succeeds — 4 mock-mode tests show count increment, status flip to PENDING, scenarios produced per requirement, parseable table emitted.
- [x] Test 2: revise exhausts — \`test_route_revise_policy_exhausts_after_max_cycles\` verifies count==MAX → end.
- [x] Test 3: strict mode unchanged — \`test_route_strict_policy_ends_immediately\` verifies BLOCKED → end with strict policy.
- [x] Plus auto-bypass test, legacy auto_mode override test, APPROVED unchanged across policies, error path test.

## Test plan

- [x] 15 unit tests in \`tests/test_revise_test_plan.py\` — all pass
- [x] Graph compiles with new node + edges (verified via build_testing_workflow().compile())
- [x] All three policies produce expected routing for all BLOCKED/APPROVED/error states
- [x] Mock-mode revision produces parseable scenarios that re-extract back to same requirement_refs
- [ ] Live test against a real Gemini-driven revision — manual smoke test against an actual workflow run (out of scope for this PR; \`--mock\` mode covers the structural path)

## Out of scope

- Editing the LLD file on disk to reflect the revised plan — the revision lives in workflow state only; the operator can decide whether to commit the revised plan back to the LLD as a separate concern.
- Deeper revision strategies (multi-round prompt iteration on revision content quality) — \`MAX_REVISION_CYCLES\` is intentionally low; future PRs can experiment with higher caps if useful.
- Auto-revision UI / human gate — operators using \`--review verdict\` should still get the verdict gate; this just changes what happens when the gate is BLOCKED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)