### PR TITLE
feat: dependabot — review-comment on deferral + --fleet mode (Closes #1091)

### DIFF
--- a/.claude/commands/dependabot.md
+++ b/.claude/commands/dependabot.md
@@ -1,6 +1,6 @@
 ---
 description: Run the dependabot PR review + merge tool (test-then-approve, author-gated)
-argument-hint: "[--help] [--dry-run]"
+argument-hint: "[--help] [--dry-run] [--fleet]"
 scope: global
 ---
 
@@ -14,16 +14,17 @@ Runs `tools/dependabot_review.py` — a deterministic, author-gated, exit-code-g
 
 ## Help
 
-Usage: `/dependabot [--help] [--dry-run]`
+Usage: `/dependabot [--help] [--dry-run] [--fleet]`
 
 | Argument | Effect |
 |---|---|
 | `--help` | Show this help and exit |
 | `--dry-run` | List dependabot PRs that would be processed; take no action |
+| `--fleet` | Process across ALL user-owned Poetry repos, not just AssemblyZero (#1091) |
 
-The tool operates ONLY on PRs authored by `dependabot[bot]`. Any other author is refused at the author gate. Tests must exit 0; non-zero exit means the PR is commented on and left for human review (not approved, not merged). No LLM in the decision loop — decisions are pure exit-code / string-match.
+The tool operates ONLY on PRs authored by `dependabot[bot]`. Any other author is refused at the author gate. Tests must exit 0; non-zero exit means the PR gets a `gh pr review --comment` posted (deferred PRs accrue Code Review credit too — #1091) and is left for human review. No LLM in the decision loop — decisions are pure exit-code / string-match.
 
-Reference: runbook `docs/runbooks/0911-dependabot-pr-audit.md` v2.0.
+Reference: runbook `docs/runbooks/0911-dependabot-pr-audit.md` v2.1.
 
 ---
 
@@ -48,11 +49,19 @@ cd /c/Users/mcwiz/Projects/AssemblyZero
 poetry run python tools/dependabot_review.py
 ```
 
-Pass `--dry-run` through if the user supplied it:
+Pass `--dry-run` and/or `--fleet` through if the user supplied them:
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
+
+# Single-repo dry-run (default behavior)
 poetry run python tools/dependabot_review.py --dry-run
+
+# Fleet mode — every user-owned Poetry repo
+poetry run python tools/dependabot_review.py --fleet
+
+# Fleet dry-run — preview the queue across the fleet
+poetry run python tools/dependabot_review.py --fleet --dry-run
 ```
 
 Stream the tool's output to the user as-is.

--- a/docs/runbooks/0911-dependabot-pr-audit.md
+++ b/docs/runbooks/0911-dependabot-pr-audit.md
@@ -1,8 +1,8 @@
 # 0911 - Dependabot PR Audit
 
 **Category:** Runbook / Security Maintenance
-**Version:** 2.0
-**Last Updated:** 2026-04-19
+**Version:** 2.1
+**Last Updated:** 2026-05-10
 
 ---
 
@@ -21,6 +21,10 @@ Safely review, approve, and merge Dependabot PRs with regression verification. D
 - Poetry venv eviction integrated (#944 / Fix 5 pattern) so worktrees remove cleanly on Windows
 - Mechanical implementation: `tools/dependabot_review.py`
 
+**New in v2.1 (#1091):**
+- Failure-path comments now use `gh pr review --comment` (creates a `PullRequestReview` event) instead of `gh pr comment` (creates an unattributed issue comment). Result: deferred PRs also accrue Code Review credit for the operator who audited them.
+- `--fleet` flag enumerates user-owned Poetry repos via `gh repo list` and processes dependabot PRs across all of them. Multiplies review-event volume. Single-repo mode unchanged when the flag is omitted.
+
 ---
 
 ## Implementation
@@ -29,10 +33,18 @@ The manual procedure in v1.0 has been replaced by a deterministic Python tool at
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
+
+# Single-repo (default — AssemblyZero only)
 poetry run python tools/dependabot_review.py [--dry-run]
+
+# Specific repo
+poetry run python tools/dependabot_review.py --repo martymcenroe/Aletheia
+
+# Fleet — every user-owned Poetry repo (#1091)
+poetry run python tools/dependabot_review.py --fleet
 ```
 
-Or via the skill: `/dependabot`.
+Or via the skill: `/dependabot` (single-repo) or `/dependabot --fleet` (fleet mode).
 
 ---
 
@@ -210,3 +222,4 @@ Run this audit:
 |------|--------|
 | 2026-02-15 | v1.0: Initial runbook — manual procedure, merge-first / test-after, no pr-sentinel integration |
 | 2026-04-19 | v2.0 (#949): Rewritten for current branch protection + pr-sentinel. Test-then-merge order. Author gate, exit-code gate, `No-Issue:` body injection, approval attributed to invoking user (Code Review stat), multi-package split via `@dependabot recreate`, poetry venv eviction. Mechanical implementation at `tools/dependabot_review.py` and `/dependabot` skill. |
+| 2026-05-10 | v2.1 (#1091): Failure-path comments switched to `gh pr review --comment` so deferred PRs also accrue Code Review credit. `--fleet` flag added — enumerates user-owned Poetry repos and processes dependabot PRs across the fleet for cross-repo coverage. |

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -48,6 +48,9 @@ from pathlib import Path
 
 GITHUB_USER = "martymcenroe"
 DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
+# Issue #1091: --fleet mode uses gh repo list to enumerate user-owned repos.
+# Cap at 200 — well above current ~60-repo count without paginating.
+FLEET_REPO_LIMIT = 200
 # GitHub returns different strings for the same bot depending on API surface:
 #   - REST API / web UI:              "dependabot[bot]"
 #   - gh CLI GraphQL .author.login:   "app/dependabot"
@@ -264,10 +267,44 @@ def squash_merge(pr_number: int, repo: str) -> bool:
 
 
 def comment_on_pr(pr_number: int, repo: str, body: str) -> None:
+    """Post a regular issue comment. Use for @dependabot bot commands.
+
+    Issue comments do NOT count toward the user's Code Review profile
+    stat. For comments where the user wants attribution credit (e.g.,
+    test-failure deferral notes), use `review_comment_on_pr` instead.
+    Bot-directed commands like `@dependabot recreate` / `@dependabot
+    rebase` should stay as issue comments — that's the form dependabot
+    documents and there's no need to risk parsing differences.
+    """
     run_gh_with_body(
         ["gh", "pr", "comment", str(pr_number), "--repo", repo],
         body,
     )
+
+
+def review_comment_on_pr(pr_number: int, repo: str, body: str) -> bool:
+    """Post a comment AS A FORMAL REVIEW (#1091).
+
+    Creates a `PullRequestReview` event with state=COMMENTED. This
+    counts toward the invoking user's Code Review profile stat (the
+    GitHub activity overview wedge), unlike `gh pr comment` which
+    creates an unattributed issue comment.
+
+    Use for comments on the deferral path (test failure, install
+    failure) where the user — having gone through the trouble of
+    auditing the PR — should get review credit even though the PR
+    isn't being merged.
+
+    Returns True on success.
+    """
+    result = run_gh_with_body(
+        [
+            "gh", "pr", "review", str(pr_number),
+            "--repo", repo, "--comment",
+        ],
+        body,
+    )
+    return result.returncode == 0
 
 
 def request_dependabot_recreate(pr_number: int, repo: str) -> None:
@@ -356,9 +393,13 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
 
     if not install_deps(worktree):
         print("  ERROR: poetry install failed")
-        comment_on_pr(pr.number, repo,
-                      "Automated review via tools/dependabot_review.py — "
-                      "`poetry install` failed. Check Actions / worktree for details.")
+        # Issue #1091: post as a formal review-comment so the failure
+        # path also accrues to the user's Code Review profile stat.
+        review_comment_on_pr(
+            pr.number, repo,
+            "Automated review via tools/dependabot_review.py — "
+            "`poetry install` failed. Check Actions / worktree for details.",
+        )
         # Leave worktree for forensics
         return "deferred"
 
@@ -366,7 +407,11 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
 
     if exit_code != 0:
         package_count = count_packages(pr.body)
-        comment_on_pr(
+        # Issue #1091: post as a formal review-comment (creates a
+        # PullRequestReview event attributed to the invoking user)
+        # rather than an issue comment. Even on the deferral path the
+        # user has audited the PR; the credit should reflect that.
+        review_comment_on_pr(
             pr.number, repo,
             f"Automated review via tools/dependabot_review.py — test suite "
             f"FAILED (exit {exit_code}). Worktree retained at `{worktree}` "
@@ -416,6 +461,50 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Fleet enumeration (Issue #1091)
+# ---------------------------------------------------------------------------
+
+def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
+    """List user-owned repos that we should attempt to process.
+
+    Returns repos as 'owner/name' strings. Filters to repos where this
+    tool can actually run the test gate — i.e., repos with a
+    `pyproject.toml` on `main`. Non-Poetry repos (npm, Cargo, etc.)
+    are omitted because the existing test gate can't validate them.
+    Future per-language test runners can lift this filter.
+    """
+    result = run([
+        "gh", "repo", "list", user,
+        "--limit", str(FLEET_REPO_LIMIT),
+        "--json", "name,nameWithOwner,isArchived,isFork",
+    ])
+    if result.returncode != 0:
+        sys.exit(f"Failed to list fleet repos: {result.stderr}")
+    repos = json.loads(result.stdout or "[]")
+
+    candidates: list[str] = []
+    for r in repos:
+        if r.get("isArchived") or r.get("isFork"):
+            continue
+        candidates.append(r["nameWithOwner"])
+
+    # Filter to repos that have a pyproject.toml on main. Non-Python
+    # repos would defer every PR (poetry run pytest fails) which is a
+    # waste — and would file failure-path review-comments on PRs the
+    # user can't actually approve. Skip silently instead.
+    processable: list[str] = []
+    for repo in candidates:
+        check = run([
+            "gh", "api", f"repos/{repo}/contents/pyproject.toml",
+            "--jq", ".name",
+        ])
+        if check.returncode == 0 and check.stdout.strip():
+            processable.append(repo)
+
+    return processable
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -426,6 +515,15 @@ def main() -> None:
     )
     parser.add_argument("--repo", default=DEFAULT_REPO,
                         help=f"GitHub repo (default: {DEFAULT_REPO})")
+    parser.add_argument(
+        "--fleet", action="store_true",
+        help=(
+            "Process dependabot PRs across ALL user-owned repos with a "
+            "pyproject.toml on main, not just --repo. Multiplies review-"
+            "event volume across the fleet. Mutually exclusive with "
+            "--repo (--fleet wins). (#1091)"
+        ),
+    )
     parser.add_argument("--main-repo", default=str(Path.cwd()),
                         help="Path to main repo (default: cwd)")
     parser.add_argument("--dry-run", action="store_true",
@@ -436,23 +534,40 @@ def main() -> None:
     if not (main_repo / ".git").exists():
         sys.exit(f"Not a git repo: {main_repo}")
 
-    prs = list_dependabot_prs(args.repo)
-    if not prs:
-        print("No open dependabot PRs. Nothing to do.")
-        return
+    # Issue #1091: fleet mode enumerates user-owned Poetry repos.
+    if args.fleet:
+        print(f"Fleet mode — enumerating {GITHUB_USER}'s Python repos...")
+        repos = list_fleet_repos()
+        print(f"  Found {len(repos)} Poetry-based repo(s) to scan.")
+    else:
+        repos = [args.repo]
 
-    print(f"Found {len(prs)} open dependabot PR(s):")
-    for pr in prs:
-        print(f"  #{pr.number}: {pr.title} ({count_packages(pr.body)} packages)")
+    # Aggregate results across repos.
+    results: dict[str, list[str]] = {
+        "merged": [], "deferred": [], "errored": [],
+    }
+
+    for repo in repos:
+        print(f"\n{'=' * 60}")
+        print(f"REPO: {repo}")
+        print(f"{'=' * 60}")
+        prs = list_dependabot_prs(repo)
+        if not prs:
+            print(f"  No open dependabot PRs in {repo}.")
+            continue
+        print(f"  Found {len(prs)} open dependabot PR(s):")
+        for pr in prs:
+            print(f"    #{pr.number}: {pr.title} "
+                  f"({count_packages(pr.body)} packages)")
+        if args.dry_run:
+            continue
+        for pr in prs:
+            status = process_pr(pr, repo, main_repo)
+            results[status].append(f"{repo}#{pr.number}")
 
     if args.dry_run:
         print("\n(dry-run; exiting)")
         return
-
-    results: dict[str, list[int]] = {"merged": [], "deferred": [], "errored": []}
-    for pr in prs:
-        status = process_pr(pr, args.repo, main_repo)
-        results[status].append(pr.number)
 
     print("\n=== Summary ===")
     print(f"  Merged:   {results['merged']}")


### PR DESCRIPTION
## Summary

Two surgical changes to \`tools/dependabot_review.py\` to lift the user's Code Review profile-stat volume without changing the procedure's safety properties:

- **A.** Failure-path comments use \`gh pr review --comment\` (creates a \`PullRequestReview\` event) instead of \`gh pr comment\` (creates an unattributed issue comment).
- **B.** \`--fleet\` flag enumerates user-owned Poetry repos and processes dependabot PRs across all of them.

Closes #1091

## Surfaced by

2026-05-10 audit of the GitHub activity-overview chart (Code Review wedge rounding-to-zero). Verified the v2.0 approval mechanism does correctly attribute reviews to the user — PRs #973/#953/#741/#479 all show \`martymcenroe\` as reviewer of record. The issue was volume, not attribution.

| Before | After |
|---|---|
| ~5 review events / 6 weeks (AssemblyZero only) | Roughly 10× volume from fleet enumeration alone |
| Deferred PRs got an issue comment (no review credit) | Deferred PRs get a formal review-comment (review credit) |

## What changed

### tools/dependabot_review.py

- \`review_comment_on_pr()\` — new helper using \`gh pr review --comment\` for deferral notes.
- \`comment_on_pr()\` retained for \`@dependabot recreate\` / \`@dependabot rebase\` (bot-directed commands stay as issue comments to match dependabot's documented form).
- \`process_pr()\` deferral path uses \`review_comment_on_pr\` for both test-failure and install-failure messages.
- \`list_fleet_repos()\` — new function that enumerates user-owned repos via \`gh repo list\`, filters out archived/forks, and keeps only repos with a \`pyproject.toml\` on \`main\` (the test gate can't validate non-Poetry repos).
- \`main()\` — accepts \`--fleet\` flag; iterates repo list and aggregates merged/deferred/errored summary across all repos.

### docs/runbooks/0911-dependabot-pr-audit.md

- Bumped to v2.1 with \"New in v2.1\" section + history entry.
- Updated implementation examples to show single-repo / specific-repo / fleet invocations.

### .claude/commands/dependabot.md

- \`--fleet\` documented in the help table + execution examples.
- Reference bumped to runbook v2.1.

## Why @dependabot commands stay as issue comments

\`@dependabot recreate\` and \`@dependabot rebase\` are commands dependabot's bot scans for. Dependabot's docs describe these as \"PR comments\" (the issue-comment form), and there's no upside to risking parsing differences by switching them to review-comments. The user-credit changes target the OPERATOR's notes about test outcomes, not the bot-directed commands.

## How acceptance is met

- [x] \`comment_on_pr\` retained for bot commands; new \`review_comment_on_pr\` for deferral notes
- [x] Failure path verified by reading the patched code — both test-failure and install-failure use \`review_comment_on_pr\`
- [x] \`--fleet\` flag accepted and documented in skill + runbook
- [x] Existing single-repo behavior preserved (no \`--fleet\` = today's flow)
- [x] Runbook 0911 updated to v2.1 with new behaviors + history entry
- [ ] Live verification — will land when this PR merges and \`/dependabot --fleet\` runs against the actual queue (next task in the plan)

## Test plan

- [x] Syntax check — \`ast.parse\` succeeds
- [x] CLI \`--help\` output shows new flag
- [x] Existing tests untouched (this is additive)
- [ ] First live \`--fleet\` run — will produce review events the chart picks up

## Out of scope (separate issues)

- /schedule integration for daily passive processing — #1092
- Multi-PR cross-repo parallelization + review-event counter in summary — #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)