### PR TITLE
feat: dependabot — cross-repo parallelism + review-event counter (Closes #1093)

### DIFF
--- a/docs/runbooks/0911-dependabot-pr-audit.md
+++ b/docs/runbooks/0911-dependabot-pr-audit.md
@@ -1,7 +1,7 @@
 # 0911 - Dependabot PR Audit
 
 **Category:** Runbook / Security Maintenance
-**Version:** 2.2
+**Version:** 2.3
 **Last Updated:** 2026-05-10
 
 ---
@@ -27,6 +27,10 @@ Safely review, approve, and merge Dependabot PRs with regression verification. D
 
 **New in v2.2 (#1092):**
 - Windows Task Scheduler integration. `tools/run_dependabot_fleet.ps1` wraps the `--fleet` invocation; `Claude-DependabotFleet` runs daily at 06:00 with the operator's gh credentials so review-event attribution stays correct. See §Integration → Daily Schedule.
+
+**New in v2.3 (#1093):**
+- `--workers N` flag (default 3) enables cross-repo parallelism in `--fleet` mode. PRs within a single repo remain sequential (subsequent PRs need to test against the post-merge HEAD); only repos run in parallel. Substantially shortens fleet-sweep wall-clock time when many repos have queued PRs.
+- Summary now prints a review-event counter line (`N APPROVED + M COMMENTED = N+M total`) so the Code Review profile-stat math is visible per-run. Lets the operator verify each fleet sweep is delivering the expected credit.
 
 ---
 
@@ -268,3 +272,4 @@ The PowerShell wrapper at `tools/run_dependabot_fleet.ps1` is the durable defini
 | 2026-04-19 | v2.0 (#949): Rewritten for current branch protection + pr-sentinel. Test-then-merge order. Author gate, exit-code gate, `No-Issue:` body injection, approval attributed to invoking user (Code Review stat), multi-package split via `@dependabot recreate`, poetry venv eviction. Mechanical implementation at `tools/dependabot_review.py` and `/dependabot` skill. |
 | 2026-05-10 | v2.1 (#1091): Failure-path comments switched to `gh pr review --comment` so deferred PRs also accrue Code Review credit. `--fleet` flag added — enumerates user-owned Poetry repos and processes dependabot PRs across the fleet for cross-repo coverage. |
 | 2026-05-10 | v2.2 (#1092): Windows Task Scheduler integration — `tools/run_dependabot_fleet.ps1` + daily `Claude-DependabotFleet` task at 06:00. Passive cross-repo processing with operator-credentialed review attribution. |
+| 2026-05-10 | v2.3 (#1093): Cross-repo parallelism via `--workers N` (default 3) for shorter fleet sweeps. Summary now reports review-event count (APPROVED + COMMENTED) so Code Review profile-stat math is visible per run. |

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -505,6 +506,45 @@ def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Per-repo processing (Issue #1093 — extracted for cross-repo parallelism)
+# ---------------------------------------------------------------------------
+
+def process_repo(
+    repo: str,
+    main_repo: Path,
+    dry_run: bool = False,
+) -> dict[str, list[str]]:
+    """Process all dependabot PRs in one repo, sequentially.
+
+    Within a repo, PR processing is sequential — each merge moves
+    `main` and subsequent PRs need to test against the new HEAD.
+    Cross-repo parallelism is the caller's responsibility.
+
+    Returns a per-repo result dict with the same shape as the
+    aggregate (merged / deferred / errored lists of `repo#N` strings).
+    Empty lists when no PRs are open.
+    """
+    sub: dict[str, list[str]] = {"merged": [], "deferred": [], "errored": []}
+    print(f"\n{'=' * 60}")
+    print(f"REPO: {repo}")
+    print(f"{'=' * 60}")
+    prs = list_dependabot_prs(repo)
+    if not prs:
+        print(f"  No open dependabot PRs in {repo}.")
+        return sub
+    print(f"  Found {len(prs)} open dependabot PR(s):")
+    for pr in prs:
+        print(f"    #{pr.number}: {pr.title} "
+              f"({count_packages(pr.body)} packages)")
+    if dry_run:
+        return sub
+    for pr in prs:
+        status = process_pr(pr, repo, main_repo)
+        sub[status].append(f"{repo}#{pr.number}")
+    return sub
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -522,6 +562,16 @@ def main() -> None:
             "pyproject.toml on main, not just --repo. Multiplies review-"
             "event volume across the fleet. Mutually exclusive with "
             "--repo (--fleet wins). (#1091)"
+        ),
+    )
+    parser.add_argument(
+        "--workers", type=int, default=3,
+        help=(
+            "Cross-repo parallelism (#1093). Number of repos to process "
+            "concurrently in --fleet mode. PRs within a single repo "
+            "remain sequential (each merge moves main; the next PR "
+            "should test against the new HEAD). Ignored when --fleet "
+            "is not set. Default: 3."
         ),
     )
     parser.add_argument("--main-repo", default=str(Path.cwd()),
@@ -547,33 +597,55 @@ def main() -> None:
         "merged": [], "deferred": [], "errored": [],
     }
 
-    for repo in repos:
-        print(f"\n{'=' * 60}")
-        print(f"REPO: {repo}")
-        print(f"{'=' * 60}")
-        prs = list_dependabot_prs(repo)
-        if not prs:
-            print(f"  No open dependabot PRs in {repo}.")
-            continue
-        print(f"  Found {len(prs)} open dependabot PR(s):")
-        for pr in prs:
-            print(f"    #{pr.number}: {pr.title} "
-                  f"({count_packages(pr.body)} packages)")
-        if args.dry_run:
-            continue
-        for pr in prs:
-            status = process_pr(pr, repo, main_repo)
-            results[status].append(f"{repo}#{pr.number}")
+    # Issue #1093: parallelize across repos in --fleet mode. Single-
+    # repo mode (or --workers=1) keeps the sequential path. Within a
+    # repo, processing is always sequential.
+    if args.fleet and args.workers > 1 and not args.dry_run:
+        print(f"\nProcessing {len(repos)} repo(s) with {args.workers} "
+              f"worker(s)...")
+        with ThreadPoolExecutor(max_workers=args.workers) as executor:
+            futures = {
+                executor.submit(process_repo, repo, main_repo, args.dry_run): repo
+                for repo in repos
+            }
+            for future in as_completed(futures):
+                repo = futures[future]
+                try:
+                    sub = future.result()
+                except Exception as e:
+                    print(f"\n  [ERROR] worker for {repo} raised: {e}")
+                    sub = {"merged": [], "deferred": [], "errored": [repo]}
+                for k in ("merged", "deferred", "errored"):
+                    results[k].extend(sub[k])
+    else:
+        for repo in repos:
+            sub = process_repo(repo, main_repo, args.dry_run)
+            for k in ("merged", "deferred", "errored"):
+                results[k].extend(sub[k])
 
     if args.dry_run:
         print("\n(dry-run; exiting)")
         return
+
+    # Issue #1093: review-event counter — every merged PR generated
+    # one APPROVED review event; every deferred PR generated one
+    # COMMENTED review event (per change A in #1091). Errored PRs
+    # generated nothing (the script bailed before any gh pr review
+    # call). The counter makes Code Review profile-stat math visible
+    # so the operator can verify credit was earned each run.
+    approved_events = len(results["merged"])
+    commented_events = len(results["deferred"])
+    total_events = approved_events + commented_events
 
     print("\n=== Summary ===")
     print(f"  Merged:   {results['merged']}")
     print(f"  Deferred (test failures / install errors, worktree retained): "
           f"{results['deferred']}")
     print(f"  Errored:  {results['errored']}")
+    print(
+        f"  Review events created: {approved_events} APPROVED "
+        f"+ {commented_events} COMMENTED = {total_events} total"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two final improvements completing the dependabot tool's Code Review profile-stat optimization arc:

- **D.** \`--workers N\` flag (default 3) — cross-repo parallelism in \`--fleet\` mode via \`ThreadPoolExecutor\`. Substantially shortens fleet-sweep wall-clock.
- **E.** Summary now prints \`Review events created: N APPROVED + M COMMENTED = N+M total\` — makes the Code Review profile-stat math visible per run.

Closes #1093

## What changed

### tools/dependabot_review.py

- \`process_repo(repo, main_repo, dry_run)\` extracted from the inline loop in \`main()\`. Returns a per-repo subtotal dict.
- \`main()\` uses \`ThreadPoolExecutor\` when \`--fleet\` AND \`--workers > 1\` AND \`not --dry-run\`. Otherwise falls back to sequential processing.
- Worker exceptions are captured + the offending repo recorded as errored so one bad repo doesn't sink the run.
- Summary block adds the review-event counter line.

### docs/runbooks/0911-dependabot-pr-audit.md

- Bumped to v2.3 with \"New in v2.3\" + history entry.

## Why parallelism is across-repo, not across-PR-within-a-repo

Each merge moves the repo's main branch. Subsequent PRs in the same repo should test against the post-merge HEAD (the next PR may be trivially fixable by the previous merge, or its tests may need to see new code). Parallel processing of two PRs in the same repo would race, possibly merging an out-of-date snapshot.

Cross-repo parallelism has none of this concern: each repo's worktree, branch, and main are independent.

## Why ThreadPoolExecutor (not asyncio)

The work is subprocess-bound: \`gh\` calls, \`poetry install\`, \`pytest\`. Subprocess.run is thread-safe and the GIL doesn't matter for I/O-bound work. \`ThreadPoolExecutor\` keeps the code synchronous + readable. \`asyncio.gather\` would force a much bigger refactor for no win.

## How acceptance is met

- [x] \`--workers N\` flag accepted; default 3
- [x] Single-repo PR processing remains sequential (verified — \`process_repo\` iterates PRs in order)
- [x] Cross-repo work runs in parallel when \`--fleet\` + \`--workers > 1\`
- [x] Summary output includes the review-event count line
- [x] Existing single-repo mode preserved (no \`--fleet\` = today's sequential flow)
- [x] Runbook 0911 v2.3 with history entry
- [ ] Live test of the 3-worker parallel sweep — will hit on next \`/dependabot --fleet\` (manual or 06:00 scheduled run); 2 new dependabot PRs already queued (AZ #1095, #1097)

## Test plan

- [x] Syntax check via \`ast.parse\`
- [x] CLI \`--help\` shows new flag
- [x] Single-repo \`--dry-run\` still works (verified — found AZ #1097 + #1095)
- [ ] Live parallel run — next scheduled or manual fleet sweep

## Out of scope

- Worker auto-scaling based on system load
- Cross-PR dependency detection (delaying transitive bumps until parents merge)
- Per-language test runners (would broaden \`list_fleet_repos\` beyond Poetry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)