### PR TITLE
docs: backfill standards inventory 0015×2/0016/0017 (Closes #1079)

### DIFF
--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -1,8 +1,8 @@
 # AssemblyZero - File Inventory & Status Map
 
 **Document:** 0003
-**Version:** 3.0
-**Last Updated:** 2026-05-07
+**Version:** 3.1
+**Last Updated:** 2026-05-10
 
 ## 1. Status Taxonomy
 
@@ -18,7 +18,9 @@
 
 ## 2. Documentation Inventory
 
-### Standards (00xx) - 18 files in inventory (3 known-missing entries — see follow-up #1079)
+### Standards (00xx) - 22 files
+
+> **Note: 0015 collision (intentional, documented).** Two files share `0015-` prefix: `0015-age-transition-protocol.md` is a generated artifact written by the `death` workflow at a path hard-coded in `assemblyzero/workflows/death/constants.py:52` (and tested by `tests/unit/test_death/test_reconciler.py`). It uses ADR format inside but is filed under `docs/standards/` by historical contract — renaming would require a code+test change. `0015-spelunking-audit-standard.md` is the hand-written spelunking standard (Issue #534). Decision (#1079): keep both at 0015, document the collision rather than renumber. Reformatting / renumbering / migrating to `docs/adrs/` is deferred to a future content-scope issue.
 
 | File | Status | Description |
 |------|--------|-------------|
@@ -36,6 +38,10 @@
 | `0012-lineage-versioning.md` | Stable | Lineage file versioning |
 | `0013-operational-dashboard-reference-architecture.md` | Stable | Dashboard reference architecture |
 | `0014-extract-and-discard-pattern.md` | Stable | Extract-and-discard pattern |
+| `0015-age-transition-protocol.md` | Stable | Death-workflow output (ADR-format content; filed at fixed path per `death/constants.py`) |
+| `0015-spelunking-audit-standard.md` | Stable | Spelunking audit protocol — verify docs match codebase reality (#534) |
+| `0016-pr-sentinel-system-architecture.md` | Stable | pr-sentinel reference architecture: webhook → worker → check-run lifecycle |
+| `0017-classic-pat-fleet-tooling-reference-architecture.md` | Stable | Reference architecture for classic-PAT fleet tooling (ADR 0216 in-process pattern) |
 | `0018-issue-spec-quality.md` | Stable | Pre-LLD-workflow issue quality rubric (six dimensions) |
 | `0019-lld-mechanical-validation.md` | Stable | Eleven structural checks the LLD validator runs (deterministic, pre-Gemini) |
 | `0020-test-plan-quality.md` | Stable | Three-layer test plan review (mechanical gates + fast-path + Gemini semantic) + standalone validator |


### PR DESCRIPTION
Closes #1079

## Summary
- Backfills the four missing standards inventory entries flagged in #1079 (0015-spelunking-audit, 0015-age-transition, 0016-pr-sentinel, 0017-classic-pat-fleet).
- Documents the intentional 0015 collision in an inline note (rename is deferred — see below) rather than renumbering either file.
- Bumps header count 18 → 22, version 3.0 → 3.1, Last Updated → 2026-05-10.

## Why not renumber the 0015 collision

`0015-age-transition-protocol.md` is a workflow-generated artifact, not a hand-written standard:

- `assemblyzero/workflows/death/constants.py:52` — `ADR_OUTPUT_PATH = "docs/standards/0015-age-transition-protocol.md"` (load-bearing constant)
- `assemblyzero/workflows/death/reconciler.py:199` — writes the file at that exact path
- `tests/unit/test_death/test_reconciler.py` — three assertions on that exact filename
- `.claude/commands/death.md:22` — refers to the produced filename

Renaming/moving it requires changing all four sites and is a code+test change, not an inventory hygiene change. The decision is to keep both 0015 files and document the contract; reformatting / renumbering / migrating to `docs/adrs/` is a future content-scope issue.

## Out of scope (surfaced for future hygiene)

While verifying disk vs inventory I noticed two additional drift signals not covered by #1079:

1. **0010 collision** — `docs/standards/0010-prompt-schema.md` (in inventory) AND `docs/standards/0010-model-qualification.md` (NOT in inventory). Both are hand-written standards with substantive content. This is a real collision, not a generated-artifact case. Worth a follow-up.
2. **07xx files in `docs/standards/`** — `0701-implementation-spec-template.md` and `0702-implementation-readiness-review.md` exist but the 07xx range isn't documented in standard 0009. Could be misfiled templates, or a new section that needs an inventory subsection.

These are intentionally **not** addressed in this PR (single-issue scope) but should get tracking issues.

## Test plan
- [x] disk count for `docs/standards/*.md` matches inventory count (22 entries cover the four ranges 0001-0014, 0015×2, 0016, 0017, 0018-0021; the 0010-model-qualification and 0701/0702 outliers are surfaced above for follow-up)
- [x] all four backfilled rows render with correct status + description in the inventory table
- [x] the 0015 collision note explains the death-workflow contract so a future agent doesn't accidentally rename the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)