### PR TITLE
feat: /onboard skill -- detect handoff-repo drift (Closes #1077)

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -147,7 +147,12 @@ If post-handoff sessions exist, show: "Note: {N} session(s) ran after this hando
 4. Read every file listed in the "Files to Read First" section
 5. **Write the pickup marker** by running: `poetry run python C:/Users/mcwiz/Projects/unleashed/src/pickup_marker.py --repo {repo_root}`
    If it fails, report the error to the user. Do NOT proceed silently.
-6. Report: "Picked up handoff from {age}. {N} files read."
+6. **Check drift in handoff-referenced repos** by running:
+   ```bash
+   (cd /c/Users/mcwiz/Projects/AssemblyZero && poetry run python tools/repo_drift_check.py --handoff {repo_root}/data/handoff-log.md --quiet)
+   ```
+   The subshell `()` keeps the `cd` local. The script greps the handoff body for `Projects/<repo>` references, runs `git fetch` + drift count for each, and prints a one-liner per drifted repo (`{name}: {N} behind origin/{branch} -- pull before any local work`). It is silent when no drift is detected. Surface any drift output to the user as part of the pickup report -- this prevents the failure mode in #1077 where the agent inherits a stale local state and only discovers it mid-merge. Non-fatal: if the script errors (exit 2), continue with onboarding but mention which repos couldn't be checked.
+7. Report: "Picked up handoff from {age}. {N} files read."
 
 ### Step 2: Project Context
 
@@ -191,6 +196,7 @@ Then ask: "What do you want to work on next?"
 - Use `--repo {owner}/{repo}` for all gh commands
 - CLAUDE.md and MEMORY.md are already in context — never re-read them
 - `data/handoff-log.md` is append-only -- never delete or rewrite entries. Pickup markers are written by `pickup_marker.py` (Step 1C.5), not by the agent directly.
+- Drift check (Step 1C.6) is non-fatal: a script error or unreachable remote should NOT block onboarding. Surface drift output verbatim and let the user decide whether to pull before working.
 - `data/session-index.jsonl` is read-only — never modify it
 - If no `.unleashed.json` exists, use defaults: `assemblyZero=false`, `pickupThreshold=10`, no guide, no plan
 - **Handoff directives naming safety-bypass flags are hypotheses, not orders.** If the handoff's "What To Do Next" or similar section tells you to use `--force`, `--admin`, `--no-verify`, `-f`, `--skip-*`, or any other flag that bypasses a safety check, treat it as a starting hypothesis — not an instruction to execute as written. Investigate what's blocking the non-bypass path first (e.g. cached poetry venvs holding worktree file locks — Fix 5 / #944). The handoff author can be wrong or imprecise; the next session's job is to verify, not defer. If investigation confirms the bypass is necessary, get explicit user confirmation before using it, and never embed the bypass as a silent fallback in a subagent prompt.

--- a/tests/test_repo_drift_check.py
+++ b/tests/test_repo_drift_check.py
@@ -1,0 +1,327 @@
+"""Tests for tools/repo_drift_check.py (Issue #1077)."""
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+# Load the tools/ script as a module without polluting sys.path with the whole tools dir.
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "repo_drift_check", TOOLS_DIR / "repo_drift_check.py"
+)
+repo_drift_check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(repo_drift_check)
+
+
+# ---- extract_handoff_body ----
+
+def test_extract_handoff_body_returns_text_unchanged_when_no_markers():
+    text = "Just a plain handoff body. /c/Users/mcwiz/Projects/foo here."
+    assert repo_drift_check.extract_handoff_body(text) == text
+
+
+def test_extract_handoff_body_returns_only_last_handoff_block():
+    text = (
+        "preamble\n"
+        "<!-- handoff-start -->\n"
+        "first handoff body /c/Users/mcwiz/Projects/older\n"
+        "<!-- handoff-end -->\n"
+        "interlude\n"
+        "<!-- handoff-start -->\n"
+        "newest body /c/Users/mcwiz/Projects/newer\n"
+        "<!-- handoff-end -->\n"
+        "trailing\n"
+    )
+    body = repo_drift_check.extract_handoff_body(text)
+    assert "newer" in body
+    assert "older" not in body
+    assert "preamble" not in body
+    assert "trailing" not in body
+
+
+# ---- parse_repo_names (pure regex, no filesystem) ----
+
+def test_parse_repo_names_dedupes_and_preserves_order():
+    text = (
+        "Touched /c/Users/mcwiz/Projects/alpha and "
+        "C:\\Users\\mcwiz\\Projects\\beta and "
+        "Projects/gamma. Then back to /c/Users/mcwiz/Projects/alpha."
+    )
+    names = repo_drift_check.parse_repo_names(text)
+    assert names == ["alpha", "beta", "gamma"]
+
+
+def test_parse_repo_names_filters_denylist():
+    text = (
+        "/c/Users/mcwiz/Projects/legit "
+        "/c/Users/mcwiz/Projects/node_modules "
+        "/c/Users/mcwiz/Projects/.git"
+    )
+    names = repo_drift_check.parse_repo_names(text)
+    assert names == ["legit"]
+
+
+def test_parse_repo_names_skips_filenames_with_extensions():
+    # "Projects/CLAUDE.md" should not produce "CLAUDE.md" because "." is excluded
+    # from the capture char class. The regex stops at the dot, so the capture is
+    # "CLAUDE" -- which extract_repo_names then filters via the directory check.
+    text = "/c/Users/mcwiz/Projects/CLAUDE.md was edited"
+    names = repo_drift_check.parse_repo_names(text)
+    assert "CLAUDE.md" not in names
+    assert names == ["CLAUDE"]  # the dot truncates the match
+
+
+def test_parse_repo_names_empty_when_no_paths():
+    assert repo_drift_check.parse_repo_names("nothing relevant here") == []
+
+
+# ---- extract_repo_names (regex + filesystem validation) ----
+
+def test_extract_repo_names_drops_names_without_real_directories(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    (fake_root / "real").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+    text = "/c/Users/mcwiz/Projects/real and /c/Users/mcwiz/Projects/CLAUDE.md"
+    names = repo_drift_check.extract_repo_names(text)
+    assert names == ["real"]
+
+
+def test_extract_repo_names_strips_worktree_suffix_when_parent_exists(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    (fake_root / "alpha").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    text = "Worked in /c/Users/mcwiz/Projects/alpha-1099 today."
+    names = repo_drift_check.extract_repo_names(text)
+    assert names == ["alpha"]
+
+
+def test_extract_repo_names_skips_suffix_name_when_neither_parent_nor_full_exists(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    fake_root.mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    text = "/c/Users/mcwiz/Projects/standalone-1077"
+    names = repo_drift_check.extract_repo_names(text)
+    assert names == []  # neither "standalone-1077" nor "standalone" exists -> dropped
+
+
+def test_extract_repo_names_keeps_suffix_name_when_full_path_exists(tmp_path, monkeypatch):
+    # If the full "name-NNNN" path actually exists (e.g., a real repo that
+    # happens to end in digits), keep it instead of incorrectly stripping.
+    fake_root = tmp_path / "Projects"
+    (fake_root / "standalone-1077").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    text = "/c/Users/mcwiz/Projects/standalone-1077"
+    names = repo_drift_check.extract_repo_names(text)
+    assert names == ["standalone-1077"]
+
+
+# ---- _run_git ----
+
+def test_run_git_returns_timeout_code_on_subprocess_timeout(tmp_path):
+    with patch.object(
+        repo_drift_check.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="git", timeout=30),
+    ):
+        rc, stdout, stderr = repo_drift_check._run_git(["status"], tmp_path)
+    assert rc == 124
+    assert "timeout" in stderr
+
+
+def test_run_git_returns_127_when_git_missing(tmp_path):
+    with patch.object(
+        repo_drift_check.subprocess, "run", side_effect=FileNotFoundError
+    ):
+        rc, _, stderr = repo_drift_check._run_git(["status"], tmp_path)
+    assert rc == 127
+    assert "not found" in stderr
+
+
+# ---- check_repo_drift -- non-existent and non-git paths ----
+
+def test_check_repo_drift_marks_missing_for_nonexistent_path(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    fake_root.mkdir()
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+    result = repo_drift_check.check_repo_drift("nope")
+    assert result["status"] == "missing"
+    assert result["name"] == "nope"
+
+
+def test_check_repo_drift_marks_not_git_when_dir_lacks_dot_git(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    (fake_root / "plain-dir").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+    result = repo_drift_check.check_repo_drift("plain-dir")
+    assert result["status"] == "not_git"
+
+
+# ---- check_repo_drift -- happy paths via _run_git mocking ----
+
+def _make_git_responder(responses: dict[tuple, tuple]) -> callable:
+    """
+    Build a fake _run_git that returns canned responses keyed by the args tuple.
+    Any unmatched call returns (1, '', 'unmatched'); helps surface test gaps.
+    """
+    def _fake(args, cwd):
+        return responses.get(tuple(args), (1, "", f"unmatched: {args}"))
+    return _fake
+
+
+def test_check_repo_drift_reports_in_sync_when_both_counts_zero(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    repo = fake_root / "alpha"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    responses = {
+        ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (0, "origin/main", ""),
+        ("fetch", "origin", "--quiet"): (0, "", ""),
+        ("rev-list", "--count", "main..origin/main"): (0, "0", ""),
+        ("rev-list", "--count", "origin/main..main"): (0, "0", ""),
+    }
+    monkeypatch.setattr(repo_drift_check, "_run_git", _make_git_responder(responses))
+
+    result = repo_drift_check.check_repo_drift("alpha")
+    assert result["status"] == "in_sync"
+    assert result["behind"] == 0
+    assert result["ahead"] == 0
+    assert result["branch"] == "main"
+
+
+def test_check_repo_drift_reports_drift_with_counts(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    repo = fake_root / "beta"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    responses = {
+        ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (0, "origin/main", ""),
+        ("fetch", "origin", "--quiet"): (0, "", ""),
+        ("rev-list", "--count", "main..origin/main"): (0, "3", ""),
+        ("rev-list", "--count", "origin/main..main"): (0, "1", ""),
+    }
+    monkeypatch.setattr(repo_drift_check, "_run_git", _make_git_responder(responses))
+
+    result = repo_drift_check.check_repo_drift("beta")
+    assert result["status"] == "drift"
+    assert result["behind"] == 3
+    assert result["ahead"] == 1
+
+
+def test_check_repo_drift_reports_fetch_error_when_fetch_fails(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    repo = fake_root / "gamma"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    responses = {
+        ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (0, "origin/main", ""),
+        ("fetch", "origin", "--quiet"): (128, "", "could not resolve host"),
+    }
+    monkeypatch.setattr(repo_drift_check, "_run_git", _make_git_responder(responses))
+
+    result = repo_drift_check.check_repo_drift("gamma")
+    assert result["status"] == "fetch_error"
+    assert "could not resolve" in result["error"]
+
+
+def test_check_repo_drift_falls_back_to_main_when_origin_head_unset(tmp_path, monkeypatch):
+    fake_root = tmp_path / "Projects"
+    repo = fake_root / "delta"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    responses = {
+        # symbolic-ref fails (no origin/HEAD) -- script should fall through to checking 'main' / 'master'
+        ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"): (1, "", "no symbolic ref"),
+        ("rev-parse", "--verify", "refs/heads/main"): (0, "", ""),
+        ("fetch", "origin", "--quiet"): (0, "", ""),
+        ("rev-list", "--count", "main..origin/main"): (0, "0", ""),
+        ("rev-list", "--count", "origin/main..main"): (0, "0", ""),
+    }
+    monkeypatch.setattr(repo_drift_check, "_run_git", _make_git_responder(responses))
+
+    result = repo_drift_check.check_repo_drift("delta")
+    assert result["branch"] == "main"
+    assert result["status"] == "in_sync"
+
+
+# ---- format_text_report ----
+
+def test_format_text_report_quiet_returns_empty_when_no_drift_or_errors():
+    report = {"repos": [{"name": "x", "status": "in_sync", "behind": 0, "ahead": 0, "branch": "main"}]}
+    assert repo_drift_check.format_text_report(report, quiet=True) == ""
+
+
+def test_format_text_report_lists_drift_with_pull_hint():
+    report = {
+        "repos": [
+            {"name": "alpha", "status": "drift", "behind": 2, "ahead": 0, "branch": "main"},
+        ]
+    }
+    out = repo_drift_check.format_text_report(report, quiet=False)
+    assert "alpha" in out
+    assert "2 behind origin/main" in out
+    assert "pull before any local work" in out
+
+
+def test_format_text_report_handles_no_repos_gracefully():
+    report = {"repos": []}
+    assert "No repo references" in repo_drift_check.format_text_report(report, quiet=False)
+
+
+# ---- main (CLI integration) ----
+
+def test_main_emits_json_when_flag_passed(tmp_path, monkeypatch, capsys):
+    # Set up a fake Projects root with one real "real-repo" dir lacking .git --
+    # this drives extract_repo_names through the dir-validation path AND lets
+    # check_repo_drift report "not_git" so we exercise the error-exit-code branch.
+    fake_root = tmp_path / "Projects"
+    (fake_root / "real-repo").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    handoff = tmp_path / "h.md"
+    handoff.write_text("Worked in /c/Users/mcwiz/Projects/real-repo today.", encoding="utf-8")
+
+    rc = repo_drift_check.main(["--handoff", str(handoff), "--json"])
+    captured = capsys.readouterr().out
+    parsed = json.loads(captured)
+    assert parsed["names_extracted"] == ["real-repo"]
+    assert parsed["repos"][0]["status"] == "not_git"
+    # not_git is treated as an error status in main()'s exit-code logic
+    assert rc == 2
+
+
+def test_main_filters_filename_false_positives_via_dir_check(tmp_path, monkeypatch, capsys):
+    # Regression test for the actual bug surfaced in smoke testing:
+    # "/c/Users/mcwiz/Projects/CLAUDE.md" used to extract as "CLAUDE.md".
+    # After the fix, the regex captures "CLAUDE" (period excluded from char class)
+    # and the dir-check filter drops it because no "CLAUDE" directory exists.
+    fake_root = tmp_path / "Projects"
+    fake_root.mkdir()
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+
+    handoff = tmp_path / "h.md"
+    handoff.write_text(
+        "Edited C:\\Users\\mcwiz\\Projects\\CLAUDE.md and "
+        "/c/Users/mcwiz/Projects/dependabot-fleet.log today.",
+        encoding="utf-8",
+    )
+
+    rc = repo_drift_check.main(["--handoff", str(handoff), "--json"])
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed["names_extracted"] == []
+    assert parsed["repos"] == []
+    assert rc == 0  # no extracted repos = no errors
+
+
+def test_main_returns_1_when_handoff_path_missing(tmp_path, capsys):
+    rc = repo_drift_check.main(["--handoff", str(tmp_path / "nope.md")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err

--- a/tools/repo_drift_check.py
+++ b/tools/repo_drift_check.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+tools/repo_drift_check.py - Detect local-vs-origin drift in repos referenced by a handoff
+
+Surfaced by #1077: when /onboard imports a handoff that touched multiple repos,
+the agent inherits a stale assumption about each of those repos' local-vs-origin
+state. Drift is silent until the agent tries to merge or push, by which point
+recovery is more expensive.
+
+This tool:
+  1. Reads a handoff file (a single handoff body OR a handoff-log.md)
+  2. Extracts repo references from path patterns
+  3. For each unique repo: git fetch (timeout-bounded), then count drift commits
+  4. Reports per-repo drift behind/ahead of origin
+
+Output formats:
+  - Default: human-readable text (one line per repo with drift)
+  - --json:  machine-readable JSON for skill consumption
+  - --quiet: only emit if drift is non-zero (text mode only)
+
+Exit codes:
+  0 -- ran successfully (regardless of whether drift was found)
+  1 -- argument or file error
+  2 -- one or more repos errored during fetch/check (drift state partial)
+
+Usage:
+  poetry run python tools/repo_drift_check.py --handoff /path/to/handoff-log.md
+  poetry run python tools/repo_drift_check.py --handoff /path/to/handoff-body.md --json
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Match repo references in handoff bodies. Two path families to cover:
+#   /c/Users/mcwiz/Projects/<repo>      (Bash / Git Bash)
+#   C:\Users\mcwiz\Projects\<repo>      (Windows native, with or without trailing slash)
+# We also match bare "Projects/<repo>" since handoffs sometimes use shorthand.
+# The capture group is the repo name only. We deliberately exclude "." from the
+# character class because real repo directory names don't contain dots, and
+# admitting "." causes "Projects/CLAUDE.md" -> "CLAUDE.md" false positives.
+_PATH_PATTERNS = [
+    re.compile(r"/c/Users/mcwiz/Projects/([A-Za-z0-9_-]+)", re.IGNORECASE),
+    re.compile(r"C:\\Users\\mcwiz\\Projects\\([A-Za-z0-9_-]+)", re.IGNORECASE),
+    re.compile(r"(?<![A-Za-z0-9_-])Projects/([A-Za-z0-9_-]+)"),
+]
+
+# Marker delimiters for the most-recent handoff inside a handoff-log.md.
+_HANDOFF_START_RE = re.compile(r"<!--\s*handoff-start\s*-->")
+_HANDOFF_END_RE = re.compile(r"<!--\s*handoff-end\s*-->")
+
+# Repo names we never want to count as a real repo (worktree paths, build artifacts).
+_REPO_DENYLIST = {
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "AppData",
+    "OneDrive",
+}
+
+# Hard timeout for any git subprocess call (seconds). Network ops should never block /onboard.
+_GIT_TIMEOUT = 30
+
+PROJECTS_ROOT = Path("C:/Users/mcwiz/Projects")
+
+
+def extract_handoff_body(text: str) -> str:
+    """
+    If the input contains <!-- handoff-start --> ... <!-- handoff-end --> markers,
+    return only the LAST such block. Otherwise return the input unchanged.
+
+    This lets the same code path consume a full handoff-log.md or a single
+    handoff body the caller already extracted.
+    """
+    end_matches = list(_HANDOFF_END_RE.finditer(text))
+    if not end_matches:
+        return text
+    last_end = end_matches[-1]
+
+    # Find the start marker preceding this end marker.
+    start_match = None
+    for m in _HANDOFF_START_RE.finditer(text):
+        if m.end() <= last_end.start():
+            start_match = m
+        else:
+            break
+
+    if start_match is None:
+        return text
+    return text[start_match.end():last_end.start()]
+
+
+def parse_repo_names(text: str) -> list[str]:
+    """
+    Pure regex extraction of repo-like names from text. Does NOT validate
+    that the names correspond to real directories -- callers that want a
+    filesystem-validated list should use `extract_repo_names`.
+
+    Returns unique names, preserving first-seen order.
+    """
+    seen: dict[str, None] = {}
+    for pattern in _PATH_PATTERNS:
+        for match in pattern.finditer(text):
+            name = match.group(1)
+            if not name or name in _REPO_DENYLIST:
+                continue
+            seen.setdefault(name, None)
+    return list(seen.keys())
+
+
+def extract_repo_names(text: str) -> list[str]:
+    """
+    Return unique repo names from text that correspond to real directories
+    under PROJECTS_ROOT. Preserves first-seen order.
+
+    Worktree-style names (e.g., "AssemblyZero-1077") are normalised to their
+    parent repo when the parent exists; otherwise kept as-is so we don't
+    silently drop genuinely-named repos that happen to end in -NNNN.
+    """
+    candidates = parse_repo_names(text)
+    seen: dict[str, None] = {}
+    for name in candidates:
+        # Worktree normalisation: try stripping a "-NNNN" suffix.
+        stripped = re.sub(r"-\d+$", "", name)
+        if stripped != name and (PROJECTS_ROOT / stripped).is_dir():
+            candidate = stripped
+        elif (PROJECTS_ROOT / name).is_dir():
+            candidate = name
+        else:
+            # Not a real repo directory -- skip silently. (Common case: file
+            # names like "CLAUDE" extracted from "Projects/CLAUDE.md" after
+            # the dot was already stripped by the regex char class.)
+            continue
+        seen.setdefault(candidate, None)
+    return list(seen.keys())
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+    """Run a git command, return (returncode, stdout, stderr). Never raises on timeout/error."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {_GIT_TIMEOUT}s"
+    except FileNotFoundError:
+        return 127, "", "git executable not found"
+
+
+def detect_default_branch(repo: Path) -> str:
+    """
+    Resolve the repo's default branch via origin/HEAD. Falls back to 'main', then
+    'master' if origin/HEAD isn't set (rare, but happens on shallow clones).
+    """
+    rc, stdout, _ = _run_git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repo)
+    if rc == 0 and stdout.startswith("origin/"):
+        return stdout[len("origin/"):]
+
+    for candidate in ("main", "master"):
+        rc, _, _ = _run_git(["rev-parse", "--verify", f"refs/heads/{candidate}"], repo)
+        if rc == 0:
+            return candidate
+
+    return "main"
+
+
+def check_repo_drift(name: str) -> dict:
+    """Return a dict describing drift state for one repo. Always returns a dict; never raises."""
+    path = PROJECTS_ROOT / name
+    result: dict = {"name": name, "path": str(path)}
+
+    if not path.is_dir():
+        result["status"] = "missing"
+        result["error"] = "path does not exist"
+        return result
+    if not (path / ".git").exists():
+        result["status"] = "not_git"
+        result["error"] = ".git not present"
+        return result
+
+    branch = detect_default_branch(path)
+    result["branch"] = branch
+
+    rc, _, stderr = _run_git(["fetch", "origin", "--quiet"], path)
+    if rc != 0:
+        result["status"] = "fetch_error"
+        result["error"] = stderr or f"git fetch returned {rc}"
+        return result
+
+    rc_b, behind, _ = _run_git(["rev-list", "--count", f"{branch}..origin/{branch}"], path)
+    rc_a, ahead, _ = _run_git(["rev-list", "--count", f"origin/{branch}..{branch}"], path)
+    if rc_b != 0 or rc_a != 0:
+        result["status"] = "rev_list_error"
+        result["error"] = f"rev-list failed (behind rc={rc_b}, ahead rc={rc_a})"
+        return result
+
+    behind_n = int(behind or "0")
+    ahead_n = int(ahead or "0")
+    result["behind"] = behind_n
+    result["ahead"] = ahead_n
+    if behind_n == 0 and ahead_n == 0:
+        result["status"] = "in_sync"
+    else:
+        result["status"] = "drift"
+    return result
+
+
+def format_text_report(report: dict, quiet: bool) -> str:
+    lines = []
+    drift_repos = [r for r in report["repos"] if r["status"] == "drift"]
+    error_repos = [r for r in report["repos"] if r["status"] not in ("in_sync", "drift")]
+
+    if quiet and not drift_repos and not error_repos:
+        return ""
+
+    if not report["repos"]:
+        return "No repo references found in handoff body."
+
+    if drift_repos:
+        lines.append("Drift detected in handoff-referenced repos:")
+        for r in drift_repos:
+            parts = []
+            if r["behind"]:
+                parts.append(f"{r['behind']} behind origin/{r['branch']}")
+            if r["ahead"]:
+                parts.append(f"{r['ahead']} ahead of origin/{r['branch']}")
+            lines.append(f"  {r['name']}: {' / '.join(parts)} -- pull before any local work")
+
+    if error_repos:
+        if lines:
+            lines.append("")
+        lines.append("Repos that could not be checked:")
+        for r in error_repos:
+            lines.append(f"  {r['name']}: {r['status']} ({r.get('error', 'no detail')})")
+
+    if not quiet:
+        in_sync = [r for r in report["repos"] if r["status"] == "in_sync"]
+        if in_sync:
+            if lines:
+                lines.append("")
+            lines.append(f"In sync ({len(in_sync)}): {', '.join(r['name'] for r in in_sync)}")
+
+    return "\n".join(lines)
+
+
+def build_report(handoff_text: str) -> dict:
+    body = extract_handoff_body(handoff_text)
+    names = extract_repo_names(body)
+    repos = [check_repo_drift(name) for name in names]
+    return {"repos": repos, "names_extracted": names}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument("--handoff", required=True, help="Path to handoff-log.md or a handoff body file")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    parser.add_argument("--quiet", action="store_true", help="Text mode: only print if drift or errors")
+    args = parser.parse_args(argv)
+
+    handoff_path = Path(args.handoff)
+    if not handoff_path.is_file():
+        print(f"ERROR: handoff file not found: {handoff_path}", file=sys.stderr)
+        return 1
+
+    handoff_text = handoff_path.read_text(encoding="utf-8", errors="replace")
+    report = build_report(handoff_text)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        text = format_text_report(report, quiet=args.quiet)
+        if text:
+            print(text)
+
+    has_errors = any(r["status"] not in ("in_sync", "drift") for r in report["repos"])
+    return 2 if has_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1077

## Summary
- Adds `tools/repo_drift_check.py` -- pure-stdlib script that greps a handoff body for `Projects/<repo>` references, runs `git fetch` + drift count for each, and reports which repos are behind/ahead of origin.
- Wires it into `.claude/commands/onboard.md` as Step 1C.6 (after the pickup marker is written), so /onboard surfaces drift before the agent does any local work.
- 24 unit tests covering parse + filesystem + git-mocked + CLI integration paths.

## Failure mode this prevents

From #1077: a handoff that touches multiple repos leaves the agent inheriting a stale local-vs-origin assumption. Trip-up surfaces only mid-merge -- by which point the agent has a feature branch rooted at stale state and a manual unblock to do.

After this change, /onboard's pickup report includes a one-liner per drifted repo, e.g.:

```
boostgauge: 2 behind origin/main -- pull before any local work
```

The script is silent under `--quiet` when no drift exists, so onboarding stays clean when there's nothing to surface.

## Implementation notes

- **Two-layer extraction.** `parse_repo_names` is pure regex; `extract_repo_names` adds a `PROJECTS_ROOT/<name>` directory check that drops filename false positives. The smoke-test regression that motivated the split: `/c/Users/mcwiz/Projects/CLAUDE.md` was extracting as `CLAUDE.md` because `.` was in the regex char class. Removing `.` plus the dir-validation filter eliminates the noise without dropping any real repo.
- **30s git timeout per call.** A hung remote can never block /onboard.
- **Default branch resolved via origin/HEAD,** with main → master fallbacks for older / shallow-cloned repos.
- **Worktree normalisation:** names like `AssemblyZero-1077` are mapped to `AssemblyZero` when the parent exists, so worktree references in the handoff don't show as separate "missing" repos.

## Out of scope (deliberately)

The issue mentions an optional check for "untracked files that collide with tracked origin files" -- the specific failure mode that bit boostgauge PR #38. That check needs a different mechanism (`git status --porcelain` plus `git ls-tree HEAD` cross-reference) and a separate decision about how aggressively to interrupt onboarding. Filing as a follow-up rather than expanding scope here.

## Test plan
- [x] `poetry run pytest tests/test_repo_drift_check.py -v` -- 24 passing, including regression test for the `CLAUDE.md` false positive
- [x] `poetry run ruff check --isolated tools/repo_drift_check.py tests/test_repo_drift_check.py` -- clean
- [x] Smoke-tested against the live `data/handoff-log.md`: extracts only `AssemblyZero` (correctly filters `CLAUDE.md` and `dependabot-fleet.log` filename mentions), reports "In sync"
- [x] Skill instruction edit reviewed: Step 1C.6 inserted in the pickup-import flow, Rules section updated to note non-fatal behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)