### PR TITLE
feat: deploy_cerberus_secrets.py auto-detect missing-secret repos (Closes #763)

### DIFF
--- a/tests/test_deploy_cerberus_secrets.py
+++ b/tests/test_deploy_cerberus_secrets.py
@@ -1,0 +1,123 @@
+"""Tests for tools/deploy_cerberus_secrets.py argparse + filter behavior (Issue #763)."""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+# _pat_session uses gpg-decrypted PAT and triggers pinentry on import-time
+# touch in some cases; ensure the module loads in test env by faking sys.path
+# behavior the script uses.
+sys.path.insert(0, str(TOOLS_DIR))
+
+_spec = importlib.util.spec_from_file_location(
+    "deploy_cerberus_secrets", TOOLS_DIR / "deploy_cerberus_secrets.py"
+)
+deploy_cerberus_secrets = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_cerberus_secrets)
+
+
+# ---- _parse_args ----
+
+def test_parse_args_default_no_pem_no_flags():
+    args = deploy_cerberus_secrets._parse_args([])
+    assert args.pem_path is None
+    assert args.all is False
+    assert args.repo is None
+    assert args.dry_run is False
+
+
+def test_parse_args_with_pem_only():
+    args = deploy_cerberus_secrets._parse_args(["/path/to/key.pem"])
+    assert args.pem_path == "/path/to/key.pem"
+    assert args.all is False
+
+
+def test_parse_args_with_all_flag():
+    args = deploy_cerberus_secrets._parse_args(["/x.pem", "--all"])
+    assert args.all is True
+
+
+def test_parse_args_with_repo_flag():
+    args = deploy_cerberus_secrets._parse_args(["/x.pem", "--repo", "boostgauge"])
+    assert args.repo == "boostgauge"
+
+
+def test_parse_args_with_dry_run_no_pem():
+    args = deploy_cerberus_secrets._parse_args(["--dry-run"])
+    assert args.dry_run is True
+    assert args.pem_path is None
+
+
+# ---- _select_target_repos ----
+
+def _verify_factory(present_repos: set[str]):
+    """Build a fake verify_secrets that says `present_repos` are configured."""
+    def fake_verify(repo, pat):
+        if repo in present_repos:
+            return (True, [])
+        return (False, ["REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"])
+    return fake_verify
+
+
+def test_select_target_repos_default_filters_already_configured():
+    args = deploy_cerberus_secrets._parse_args([])  # no flags
+    with patch.object(deploy_cerberus_secrets, "get_all_repos",
+                      return_value=["alpha", "beta", "gamma"]):
+        with patch.object(deploy_cerberus_secrets, "verify_secrets",
+                          side_effect=_verify_factory({"alpha", "beta"})):
+            targets, skipped = deploy_cerberus_secrets._select_target_repos(args, "fake-pat")
+    assert targets == ["gamma"]  # only the one missing secrets
+    assert set(skipped) == {"alpha", "beta"}
+
+
+def test_select_target_repos_all_flag_returns_everything():
+    args = deploy_cerberus_secrets._parse_args(["x.pem", "--all"])
+    with patch.object(deploy_cerberus_secrets, "get_all_repos",
+                      return_value=["alpha", "beta", "gamma"]):
+        # verify_secrets should not be called when --all is set
+        with patch.object(deploy_cerberus_secrets, "verify_secrets") as mock_verify:
+            targets, skipped = deploy_cerberus_secrets._select_target_repos(args, "fake-pat")
+    assert targets == ["alpha", "beta", "gamma"]
+    assert skipped == []
+    mock_verify.assert_not_called()
+
+
+def test_select_target_repos_repo_flag_targets_one_only():
+    args = deploy_cerberus_secrets._parse_args(["x.pem", "--repo", "boostgauge"])
+    with patch.object(deploy_cerberus_secrets, "get_all_repos") as mock_list_all:
+        with patch.object(deploy_cerberus_secrets, "verify_secrets",
+                          side_effect=_verify_factory(set())):  # boostgauge missing
+            targets, skipped = deploy_cerberus_secrets._select_target_repos(args, "fake-pat")
+    assert targets == ["boostgauge"]
+    assert skipped == []
+    # get_all_repos must NOT be called when --repo is set (we don't need the fleet)
+    mock_list_all.assert_not_called()
+
+
+def test_select_target_repos_repo_flag_with_already_configured_returns_empty_targets():
+    """If --repo is given but that repo already has secrets, target list is empty (unless --all)."""
+    args = deploy_cerberus_secrets._parse_args(["x.pem", "--repo", "already-set"])
+    with patch.object(deploy_cerberus_secrets, "verify_secrets",
+                      side_effect=_verify_factory({"already-set"})):
+        targets, skipped = deploy_cerberus_secrets._select_target_repos(args, "fake-pat")
+    assert targets == []
+    assert skipped == ["already-set"]
+
+
+def test_select_target_repos_repo_flag_plus_all_skips_filtering():
+    args = deploy_cerberus_secrets._parse_args(["x.pem", "--repo", "already-set", "--all"])
+    with patch.object(deploy_cerberus_secrets, "verify_secrets") as mock_verify:
+        targets, skipped = deploy_cerberus_secrets._select_target_repos(args, "fake-pat")
+    assert targets == ["already-set"]
+    assert skipped == []
+    mock_verify.assert_not_called()
+
+
+# ---- main() rejects bad invocations ----
+
+def test_main_returns_1_when_no_pem_and_no_dry_run(capsys):
+    rc = deploy_cerberus_secrets.main([])  # neither pem nor --dry-run
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "pem_path is required" in err

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -1,15 +1,29 @@
 #!/usr/bin/env python3
-"""Deploy Cerberus (GitHub App) secrets to all repos.
+"""Deploy Cerberus (GitHub App) secrets to repos missing them.
 
 THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
-It handles a private key file — agents must never touch this.
+It handles a private key file -- agents must never touch this.
 
 Usage:
-    1. Download the .pem from GitHub App settings
-    2. Run:  poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem
-    3. DELETE the .pem file immediately after
+    1. Download the .pem from GitHub App settings (only if you'll deploy)
+    2. Run one of:
+         # Default: scan, deploy ONLY to repos missing both secrets (#763)
+         poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem
 
-The script sets two GitHub Actions secrets on every repo:
+         # All repos (use for key rotation -- old default behavior):
+         poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem --all
+
+         # Single repo:
+         poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem --repo NAME
+
+         # Dry-run: report which repos are missing secrets, no PUTs.
+         # .pem is optional in dry-run.
+         poetry run python tools/deploy_cerberus_secrets.py --dry-run
+         poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem --dry-run
+
+    3. DELETE the .pem file immediately after (skip if dry-run with no .pem)
+
+The script sets two GitHub Actions secrets on each target repo:
     - REVIEWER_APP_ID (3079970)
     - REVIEWER_APP_PRIVATE_KEY (contents of the .pem)
 
@@ -19,9 +33,10 @@ never placed in the shell env block or subprocess argv. Secret values
 are encrypted with libsodium sealed-box against the repo's public key
 per GitHub's API contract.
 
-Issue: #736 | Related: #732, #1007 (in-process PAT migration)
+Issue: #736 | Related: #732, #763 (auto-detect flags), #1007 (in-process PAT migration)
 """
 
+import argparse
 import base64
 import subprocess
 import sys
@@ -173,41 +188,122 @@ def verify_secrets(repo: str, pat: str) -> tuple[bool, list[str]]:
     return (len(missing) == 0, missing)
 
 
-def main():
-    if len(sys.argv) != 2:
-        print("Usage: poetry run python tools/deploy_cerberus_secrets.py /path/to/cerberus.pem")
-        sys.exit(1)
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Deploy Cerberus GitHub App secrets to repos missing them.",
+        epilog="Default behavior: scan all repos, deploy only to ones missing both secrets.",
+    )
+    parser.add_argument(
+        "pem_path", nargs="?", default=None,
+        help="Path to the Cerberus .pem private key. "
+             "Required unless --dry-run is set.",
+    )
+    parser.add_argument(
+        "--all", action="store_true",
+        help="Deploy to all repos (skip the missing-secrets filter). "
+             "Use for key rotation.",
+    )
+    parser.add_argument(
+        "--repo", metavar="NAME", default=None,
+        help="Target a single repo by name (no owner prefix). "
+             "If the repo already has both secrets it is still skipped unless --all is set.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Scan and print which repos would be deployed to. "
+             "Performs no PUTs. .pem is optional in this mode.",
+    )
+    return parser.parse_args(argv)
 
-    pem_path = Path(sys.argv[1])
+
+def _load_pem(pem_path: Path) -> str:
+    """Read and validate a .pem file. Exits the process on error."""
     if not pem_path.exists():
-        print(f"ERROR: File not found: {pem_path}")
+        print(f"ERROR: File not found: {pem_path}", file=sys.stderr)
         sys.exit(1)
-
-    if not pem_path.suffix == ".pem":
+    if pem_path.suffix != ".pem":
         print(f"WARNING: Expected .pem file, got: {pem_path.name}")
         response = input("Continue anyway? [y/N] ")
         if response.lower() != "y":
             sys.exit(1)
-
     pem_content = pem_path.read_text(encoding="utf-8").strip()
     if "PRIVATE KEY" not in pem_content:
-        print("ERROR: File doesn't look like a private key")
+        print("ERROR: File doesn't look like a private key", file=sys.stderr)
         sys.exit(1)
+    return pem_content
 
-    print(f"Cerberus App ID: {APP_ID}")
-    print(f"Private key: {pem_path.name} ({len(pem_content)} chars)")
-    print()
 
-    print("Fetching repo list...")
-    repos = get_all_repos()
-    print(f"Found {len(repos)} repos\n")
+def _select_target_repos(args: argparse.Namespace, pat: str) -> tuple[list[str], list[str]]:
+    """Return (target_repos, skipped_already_configured).
 
-    succeeded = 0
-    failed = []
+    Selection rules:
+        --repo NAME            -> only that repo (still respects missing-secrets filter unless --all)
+        --all                  -> every repo, no filtering
+        (default)              -> every repo MINUS those that already have both secrets
+    """
+    if args.repo:
+        candidates = [args.repo]
+    else:
+        candidates = get_all_repos()
+
+    if args.all:
+        return candidates, []
+
+    targets: list[str] = []
+    already_configured: list[str] = []
+    for repo in candidates:
+        all_present, _missing = verify_secrets(repo, pat)
+        if all_present:
+            already_configured.append(repo)
+        else:
+            targets.append(repo)
+    return targets, already_configured
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    if not args.dry_run and args.pem_path is None:
+        print("ERROR: pem_path is required unless --dry-run is set.", file=sys.stderr)
+        return 1
+
+    pem_content: str | None = None
+    pem_path: Path | None = None
+    if args.pem_path is not None:
+        pem_path = Path(args.pem_path)
+        pem_content = _load_pem(pem_path)
+        print(f"Cerberus App ID: {APP_ID}")
+        print(f"Private key: {pem_path.name} ({len(pem_content)} chars)")
+        print()
+    elif args.dry_run:
+        print("Dry-run mode (no .pem provided). Scanning only.\n")
 
     with classic_pat_session() as pat:
-        for i, repo in enumerate(repos, 1):
-            prefix = f"[{i}/{len(repos)}] {repo}"
+        print("Fetching target repos...")
+        targets, skipped = _select_target_repos(args, pat)
+        print(f"Targets: {len(targets)} | Already configured: {len(skipped)}\n")
+
+        if args.dry_run:
+            if targets:
+                print("Would deploy to:")
+                for r in targets:
+                    print(f"  - {r}")
+            else:
+                print("All scanned repos already have both Cerberus secrets. Nothing to do.")
+            if skipped and not args.all:
+                print(f"\nAlready configured ({len(skipped)}): {', '.join(skipped)}")
+            return 0
+
+        if not targets:
+            print("All scanned repos already have both Cerberus secrets. Nothing to do.")
+            return 0
+
+        assert pem_content is not None  # _load_pem populated this above
+
+        succeeded = 0
+        failed: list[str] = []
+        for i, repo in enumerate(targets, 1):
+            prefix = f"[{i}/{len(targets)}] {repo}"
             ok, failed_names = deploy_to_repo(repo, pem_content, pat)
             if ok:
                 print(f"  {prefix}: OK")
@@ -217,12 +313,14 @@ def main():
                 failed.append(repo)
 
     print(f"\n{'=' * 50}")
-    print(f"Done: {succeeded}/{len(repos)} repos configured")
+    print(f"Done: {succeeded}/{len(targets)} repos configured")
     if failed:
         print(f"Failed: {', '.join(failed)}")
-    print(f"\n*** NOW DELETE THE .pem FILE: {pem_path} ***")
-    print("The secret is stored in GitHub — you never need the file again.")
+    if pem_path is not None:
+        print(f"\n*** NOW DELETE THE .pem FILE: {pem_path} ***")
+        print("The secret is stored in GitHub -- you never need the file again.")
+    return 0 if not failed else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Closes #763

## Summary
- Refactor \`main()\` with argparse; add four flags: \`--all\`, \`--repo NAME\`, \`--dry-run\`, plus positional pem_path (now optional in dry-run).
- Default behavior changes: scan + deploy only to repos missing both secrets (was: deploy to all). \`--all\` retains the old behavior for key rotation.
- Detection uses the existing \`verify_secrets()\` primitive — no new API surface.
- 11 unit tests covering parse + selection logic with mocked filesystem and HTTP layers.

## Failure mode this prevents

Re-running the tool after a single new repo would re-deploy to all 60+ repos, requiring re-downloading the .pem each time. With this change, the user can just re-run after \`new_repo_setup.py\` lands a new repo and only that repo gets the secrets (or the user can confirm via \`--dry-run\` first).

## Flag matrix

| Invocation | Behavior |
|---|---|
| \`tool.py cerberus.pem\` | Scan, deploy to repos missing both secrets |
| \`tool.py cerberus.pem --all\` | Deploy to every repo (key rotation flow) |
| \`tool.py cerberus.pem --repo NAME\` | Target one repo; still skipped if already configured |
| \`tool.py cerberus.pem --repo NAME --all\` | Target one repo, force deploy |
| \`tool.py --dry-run\` | List repos missing secrets, no PUTs, no .pem required |
| \`tool.py cerberus.pem --dry-run\` | Same as above, with .pem-size header for context |

## Test plan
- [x] \`poetry run pytest tests/test_deploy_cerberus_secrets.py -v\` — 11 passing
- [x] \`poetry run ruff check --isolated tools/deploy_cerberus_secrets.py tests/test_deploy_cerberus_secrets.py\` — clean

## Out of scope
- Network-integration test against a real repo. Existing tests mock at the verify_secrets / get_all_repos layer; end-to-end test would require a sacrificial repo and a real classic PAT, neither of which CI has.
- Updating runbook 0927 to mention the new flags. The runbook references usage; the new flags are additive and don't break the old invocation. A docs follow-up can land if the user uses the new mode often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)