### PR TITLE
fix(dependabot): delete worktrees immediately on every path (Closes #1116)

### DIFF
--- a/.claude/commands/dependabot.md
+++ b/.claude/commands/dependabot.md
@@ -79,20 +79,19 @@ When the tool finishes, it prints a summary line like:
 
 Relay that summary to the user. If any PRs are in `Deferred`, note:
 
-- The worktree for each deferred PR has been retained at `C:/Users/mcwiz/Projects/AssemblyZero-dependabot-<N>` for forensics
-- **Forensic worktrees expire after 14 days.** At the start of every `/dependabot` run, the tool's `gc_stale_forensic_worktrees` pass removes deferred-PR worktrees whose `.git` mtime is older than `FORENSIC_WORKTREE_AGE_DAYS` (default 14). This prevents indefinite accumulation while preserving the standard human-inspection window. (#1107)
+- The PR's Actions output and `gh pr view` are the forensic record. The worktree is removed immediately on every path (#1116) -- if you need to reproduce locally, run `gh pr checkout <N>` to recreate a fresh worktree.
 - Multi-package PRs that failed tests will have an `@dependabot recreate` comment posted; dependabot will generate per-package PRs shortly, which can be processed with another `/dependabot` run
 
 If any PRs are in `Errored`, flag them plainly — those are infrastructure failures, not test failures, and likely need manual attention.
 
 ## Cleanup contract
 
-The tool produces no persistent artifacts on the green path:
+**Zero persistent disk artifacts on ANY exit path** (#1116). Every return from `process_pr` -- merged, deferred (install fail), deferred (test fail), errored -- invokes `cleanup_worktree` before returning.
 
 - **PR's local branch:** never created. `gh pr checkout --detach` is used so no `dependabot/<group>/<branch-name>` ref is left behind. (#1107)
-- **Audit branch (`dependabot-audit-<N>`):** safe-deleted via `git branch -d` after merge. (Banned: `git branch -D` -- this was a #1107 regression that left orphan refs.)
-- **Worktree:** removed via `git worktree remove` after merge. Poetry venv is evicted first to release Windows file locks (#944).
-- **Forensic worktrees from deferred PRs:** retained for 14 days then GC'd at the next run start.
+- **Audit branch (`dependabot-audit-<N>`):** safe-deleted via `git branch -d` after worktree removal. (Banned: `git branch -D`.)
+- **Worktree:** removed via `git worktree remove` after every PR. Poetry venv is evicted first to release Windows file locks (#944).
+- **No forensic retention.** The PR + GitHub Actions output captures the test output, exit codes, and error messages. If you need to reproduce locally days later, `gh pr checkout <N>` recreates a fresh worktree.
 
 ---
 

--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -1,7 +1,6 @@
-"""Tests for tools/dependabot_review.py cleanup behavior (Issue #1107)."""
+"""Tests for tools/dependabot_review.py cleanup behavior (Issues #1107, #1116)."""
 import importlib.util
 import subprocess
-import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -86,134 +85,77 @@ def test_checkout_pr_into_worktree_uses_detach_flag(tmp_path):
     assert "owner/repo" in cmd
 
 
-# ---- Bug 3: gc_stale_forensic_worktrees age + registration filtering ----
+# ---- #1116: ALL deferred/errored exit paths must call cleanup_worktree.
+# No forensic retention. The PR + Actions output is the forensic record.
 
-def test_gc_returns_empty_when_no_dependabot_directories_exist(tmp_path):
+def test_gc_function_removed_no_forensic_retention():
+    """Regression guard: the #1107 GC function and constant must NOT exist.
+    #1116 removed them after user feedback that the 14-day retention window
+    was unacceptable."""
+    assert not hasattr(dependabot_review, "gc_stale_forensic_worktrees"), \
+        "gc_stale_forensic_worktrees was removed in #1116 -- no forensic retention"
+    assert not hasattr(dependabot_review, "FORENSIC_WORKTREE_AGE_DAYS"), \
+        "FORENSIC_WORKTREE_AGE_DAYS was removed in #1116 -- no forensic retention"
+
+
+def test_deferred_install_fail_path_calls_cleanup_worktree(tmp_path):
+    """When poetry install fails, the worktree must be removed before
+    returning 'deferred'. #1116."""
     main_repo = tmp_path / "repo"
     main_repo.mkdir()
-    with patch.object(dependabot_review, "run", return_value=_mk_completed()):
-        cleaned = dependabot_review.gc_stale_forensic_worktrees(main_repo)
-    assert cleaned == []
+    pr = dependabot_review.PRInfo(
+        number=42, title="bump foo", author_login="dependabot[bot]",
+        body="", head_ref="dependabot/pip/foo",
+    )
+
+    cleanup_called: list[tuple[Path, Path, str]] = []
+
+    def fake_cleanup(main_repo_arg, worktree_arg, branch_arg):
+        cleanup_called.append((main_repo_arg, worktree_arg, branch_arg))
+
+    with patch.object(dependabot_review, "verify_author", return_value=True), \
+         patch.object(dependabot_review, "create_audit_worktree",
+                      return_value=(tmp_path / "repo-dependabot-42", "dependabot-audit-42")), \
+         patch.object(dependabot_review, "checkout_pr_into_worktree", return_value=True), \
+         patch.object(dependabot_review, "evict_poetry_venv"), \
+         patch.object(dependabot_review, "install_deps", return_value=False), \
+         patch.object(dependabot_review, "review_comment_on_pr"), \
+         patch.object(dependabot_review, "cleanup_worktree", side_effect=fake_cleanup):
+        status = dependabot_review.process_pr(pr, "owner/repo", main_repo)
+
+    assert status == "deferred"
+    assert len(cleanup_called) == 1, \
+        f"cleanup_worktree must be called exactly once on install-fail path, got {len(cleanup_called)}"
 
 
-def test_gc_returns_empty_when_parent_directory_missing(tmp_path):
-    # main_repo points at something whose parent doesn't exist
-    nowhere = tmp_path / "deeply" / "missing" / "repo"
-    cleaned = dependabot_review.gc_stale_forensic_worktrees(nowhere)
-    assert cleaned == []
-
-
-def test_gc_skips_unregistered_directory_even_if_old(tmp_path):
-    """A dependabot-shaped directory that ISN'T a registered worktree must
-    be left alone -- could be user data."""
+def test_deferred_test_fail_path_calls_cleanup_worktree(tmp_path):
+    """When pytest exits non-zero, the worktree must be removed before
+    returning 'deferred'. #1116."""
     main_repo = tmp_path / "repo"
     main_repo.mkdir()
-    stray = tmp_path / "repo-dependabot-999"
-    stray.mkdir()
-    (stray / ".git").write_text("gitdir: irrelevant")
-    # Backdate the .git file mtime so the age filter would otherwise match.
-    old_ts = time.time() - (30 * 86400)
-    (stray / ".git").touch()
-    import os
-    os.utime(stray / ".git", (old_ts, old_ts))
+    pr = dependabot_review.PRInfo(
+        number=43, title="bump foo", author_login="dependabot[bot]",
+        body="", head_ref="dependabot/pip/foo",
+    )
 
-    # Mock run() so worktree list returns NOTHING (not registered).
-    def fake_run(cmd, cwd=None, timeout=None):
-        if "worktree" in cmd and "list" in cmd:
-            return _mk_completed(stdout="worktree /c/Users/mcwiz/Projects/repo\nHEAD abc\nbranch refs/heads/main\n")
-        return _mk_completed()
+    cleanup_called: list[tuple[Path, Path, str]] = []
 
-    with patch.object(dependabot_review, "run", side_effect=fake_run):
-        cleaned = dependabot_review.gc_stale_forensic_worktrees(main_repo, max_age_days=14)
+    def fake_cleanup(main_repo_arg, worktree_arg, branch_arg):
+        cleanup_called.append((main_repo_arg, worktree_arg, branch_arg))
 
-    assert cleaned == []  # stray dir not in worktree list -> skipped
-    assert stray.exists()
+    with patch.object(dependabot_review, "verify_author", return_value=True), \
+         patch.object(dependabot_review, "create_audit_worktree",
+                      return_value=(tmp_path / "repo-dependabot-43", "dependabot-audit-43")), \
+         patch.object(dependabot_review, "checkout_pr_into_worktree", return_value=True), \
+         patch.object(dependabot_review, "evict_poetry_venv"), \
+         patch.object(dependabot_review, "install_deps", return_value=True), \
+         patch.object(dependabot_review, "run_tests", return_value=1), \
+         patch.object(dependabot_review, "count_packages", return_value=1), \
+         patch.object(dependabot_review, "review_comment_on_pr"), \
+         patch.object(dependabot_review, "is_pr_branch_stale", return_value=False), \
+         patch.object(dependabot_review, "cleanup_worktree", side_effect=fake_cleanup):
+        status = dependabot_review.process_pr(pr, "owner/repo", main_repo)
 
-
-def test_gc_skips_young_registered_worktree(tmp_path):
-    main_repo = tmp_path / "repo"
-    main_repo.mkdir()
-    young = tmp_path / "repo-dependabot-100"
-    young.mkdir()
-    (young / ".git").write_text("gitdir: x")
-    # Default mtime = now -> too young
-
-    young_str = str(young).replace("\\", "/")
-
-    def fake_run(cmd, cwd=None, timeout=None):
-        if "worktree" in cmd and "list" in cmd:
-            return _mk_completed(stdout=f"worktree {young_str}\nHEAD x\nbranch refs/heads/y\n")
-        return _mk_completed()
-
-    with patch.object(dependabot_review, "run", side_effect=fake_run):
-        cleaned = dependabot_review.gc_stale_forensic_worktrees(main_repo, max_age_days=14)
-
-    assert cleaned == []
-    assert young.exists()
-
-
-def test_gc_removes_old_registered_worktree(tmp_path):
-    main_repo = tmp_path / "repo"
-    main_repo.mkdir()
-    old = tmp_path / "repo-dependabot-200"
-    old.mkdir()
-    (old / ".git").write_text("gitdir: x")
-    # Backdate the .git file mtime to look stale.
-    old_ts = time.time() - (30 * 86400)
-    import os
-    os.utime(old / ".git", (old_ts, old_ts))
-
-    old_str = str(old).replace("\\", "/")
-
-    captured: list[list[str]] = []
-
-    def fake_run(cmd, cwd=None, timeout=None):
-        captured.append(cmd)
-        if "worktree" in cmd and "list" in cmd:
-            return _mk_completed(stdout=f"worktree {old_str}\nHEAD x\nbranch refs/heads/y\n")
-        return _mk_completed()
-
-    with patch.object(dependabot_review, "run", side_effect=fake_run):
-        cleaned = dependabot_review.gc_stale_forensic_worktrees(main_repo, max_age_days=14)
-
-    assert cleaned == [str(old)]
-    # Verify cleanup_worktree was invoked (saw worktree remove + branch -d for audit-200)
-    cmd_strs = [" ".join(c) for c in captured]
-    assert any("worktree remove" in s for s in cmd_strs), cmd_strs
-    assert any("branch -d dependabot-audit-200" in s for s in cmd_strs), cmd_strs
-    # And critically: NEVER -D
-    assert not any("branch -D" in s for s in cmd_strs), \
-        f"BANNED: -D found in GC path -- {cmd_strs}"
-
-
-def test_gc_skips_directory_with_unparseable_pr_number(tmp_path):
-    main_repo = tmp_path / "repo"
-    main_repo.mkdir()
-    # Looks like a worktree dir but PR-number suffix is garbage
-    bad = tmp_path / "repo-dependabot-foobar"
-    bad.mkdir()
-    (bad / ".git").write_text("gitdir: x")
-    old_ts = time.time() - (30 * 86400)
-    import os
-    os.utime(bad / ".git", (old_ts, old_ts))
-
-    bad_str = str(bad).replace("\\", "/")
-
-    def fake_run(cmd, cwd=None, timeout=None):
-        if "worktree" in cmd and "list" in cmd:
-            return _mk_completed(stdout=f"worktree {bad_str}\nHEAD x\nbranch refs/heads/y\n")
-        return _mk_completed()
-
-    with patch.object(dependabot_review, "run", side_effect=fake_run):
-        cleaned = dependabot_review.gc_stale_forensic_worktrees(main_repo, max_age_days=14)
-
-    assert cleaned == []
-    assert bad.exists()
-
-
-# ---- Constants sanity ----
-
-def test_forensic_age_constant_is_reasonable_days():
-    # If anyone changes this to seconds-typed or zero, fail loudly.
-    assert isinstance(dependabot_review.FORENSIC_WORKTREE_AGE_DAYS, int)
-    assert 1 <= dependabot_review.FORENSIC_WORKTREE_AGE_DAYS <= 90
+    assert status == "deferred"
+    assert len(cleanup_called) == 1, \
+        f"cleanup_worktree must be called exactly once on test-fail path, got {len(cleanup_called)}"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -24,16 +24,23 @@ For each open dependabot-authored PR:
     - `gh pr merge --squash`
     - Clean up worktree + audit branch
 - On red (non-zero):
-    - Comment on PR with exit code + forensics worktree path
+    - Comment on PR with exit code (PR + Actions output is the forensic
+      record -- no local artifact retained, #1116)
     - If multi-package PR: request `@dependabot recreate` to split into
       per-package PRs
-    - Leave worktree in place for forensics
+    - Clean up worktree + audit branch
     - Move to next PR (one failure does not block the queue)
+
+Cleanup contract: zero persistent disk artifacts on ANY exit path. Every
+return from process_pr (merged / deferred / errored) must call
+cleanup_worktree before returning. If a future maintainer wants to
+inspect a failure, they re-create the worktree via `gh pr checkout` --
+the PR + Actions output captures everything else (#1116).
 
 Usage:
     poetry run python tools/dependabot_review.py [--repo OWNER/REPO] [--dry-run]
 
-Issue: #949 | Related: #692 | Runbook: 0911 v2.0
+Issue: #949 | Related: #692, #1116 | Runbook: 0911 v2.0
 """
 
 import argparse
@@ -64,12 +71,6 @@ POLL_INTERVAL_S = 10
 MERGEABLE_TIMEOUT_S = 900
 PYTEST_TIMEOUT_S = 1800
 POETRY_INSTALL_TIMEOUT_S = 600
-# Issue #1107: forensic worktrees from deferred PRs are retained for human
-# inspection but accumulate forever without a cleanup contract. Worktrees
-# older than this threshold are GC'd at the start of each /dependabot run.
-# 14 days covers the typical "I'll look at it next week" window without
-# letting the directory grow unboundedly.
-FORENSIC_WORKTREE_AGE_DAYS = 14
 
 
 @dataclass
@@ -377,73 +378,6 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
 # Cleanup
 # ---------------------------------------------------------------------------
 
-def gc_stale_forensic_worktrees(main_repo: Path,
-                                 max_age_days: int = FORENSIC_WORKTREE_AGE_DAYS) -> list[str]:
-    """Remove forensic worktrees from deferred PRs older than max_age_days.
-
-    Walks <projects-root>/<repo>-dependabot-* directories. For each that:
-    1. Is registered as a worktree of main_repo
-    2. Has a worktree-add timestamp older than max_age_days
-    -- run cleanup_worktree on it. Returns the list of cleaned-up worktree
-    paths (for reporting / logging).
-
-    The age signal is the worktree's HEAD .git file mtime, which git sets
-    when the worktree is created and updates only on git operations against
-    that worktree. Forensic worktrees see no git activity after deferral,
-    so the mtime accurately reflects "time since deferral".
-
-    Issue #1107.
-    """
-    import time as _time
-
-    cleaned: list[str] = []
-    pattern = f"{main_repo.name}-dependabot-*"
-    parent = main_repo.parent
-    if not parent.is_dir():
-        return cleaned
-
-    # Get the set of registered worktree paths (so we don't try to remove
-    # a directory that isn't actually a worktree -- could be user data).
-    wt_list = run(["git", "-C", str(main_repo), "worktree", "list", "--porcelain"])
-    if wt_list.returncode != 0:
-        return cleaned
-    registered = set()
-    for line in wt_list.stdout.splitlines():
-        if line.startswith("worktree "):
-            registered.add(line[len("worktree "):].strip())
-
-    cutoff = _time.time() - (max_age_days * 86400)
-    for candidate in sorted(parent.glob(pattern)):
-        candidate_str = str(candidate).replace("\\", "/")
-        # Only operate on registered worktrees; skip stray directories.
-        # (git uses forward slashes in worktree list output even on Windows.)
-        if candidate_str not in registered and str(candidate) not in registered:
-            continue
-        # Use the worktree's .git file mtime as the age signal.
-        # In a worktree, .git is a file (not a directory) pointing to the
-        # main repo's worktrees/<name>/ subdir; the file's mtime is set at
-        # creation and survives all PR-deferral operations untouched.
-        git_link = candidate / ".git"
-        if not git_link.exists():
-            continue
-        if git_link.stat().st_mtime >= cutoff:
-            continue  # too young -- keep for forensic value
-
-        # Derive the audit branch name (matches create_audit_worktree).
-        # candidate.name is "{repo}-dependabot-{N}"; extract N.
-        try:
-            pr_num = int(candidate.name.rsplit("-", 1)[-1])
-        except ValueError:
-            continue
-        audit_branch = f"dependabot-audit-{pr_num}"
-
-        print(f"  GC: removing stale forensic worktree {candidate} "
-              f"(age > {max_age_days}d)")
-        cleanup_worktree(main_repo, candidate, audit_branch)
-        cleaned.append(str(candidate))
-    return cleaned
-
-
 def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> None:
     # `git branch -d` (lowercase, safe) is sufficient here because the audit
     # branch is created from `main` by create_audit_worktree and never moves --
@@ -483,10 +417,12 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
         # path also accrues to the user's Code Review profile stat.
         review_comment_on_pr(
             pr.number, repo,
-            "Automated review via tools/dependabot_review.py — "
-            "`poetry install` failed. Check Actions / worktree for details.",
+            "Automated review via tools/dependabot_review.py -- "
+            "`poetry install` failed. See the PR's Actions output for the "
+            "captured stderr; re-run locally via `gh pr checkout` if needed.",
         )
-        # Leave worktree for forensics
+        # #1116: no retention. The PR + Actions output is the forensic record.
+        cleanup_worktree(main_repo, worktree, branch)
         return "deferred"
 
     exit_code = run_tests(worktree)
@@ -499,23 +435,25 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
         # user has audited the PR; the credit should reflect that.
         review_comment_on_pr(
             pr.number, repo,
-            f"Automated review via tools/dependabot_review.py — test suite "
-            f"FAILED (exit {exit_code}). Worktree retained at `{worktree}` "
-            f"for forensics. Not approving, not merging.",
+            f"Automated review via tools/dependabot_review.py -- test suite "
+            f"FAILED (exit {exit_code}). Not approving, not merging. "
+            f"Re-run locally via `gh pr checkout` if needed; the PR's Actions "
+            f"output is the forensic record.",
         )
         # Issue #994: prefer staleness diagnosis over recreate.
         # If the branch is behind main, the failure may be an artifact of a
         # missing fix on main; rebase first before considering the upgrade
         # incompatible.
         if is_pr_branch_stale(pr.number, repo):
-            print("  PR branch is stale (base behind main) — "
+            print("  PR branch is stale (base behind main) -- "
                   "requesting @dependabot rebase")
             request_dependabot_rebase(pr.number, repo)
         elif package_count > 1:
-            print(f"  Multi-package PR ({package_count} packages) — "
+            print(f"  Multi-package PR ({package_count} packages) -- "
                   f"requesting dependabot recreate")
             request_dependabot_recreate(pr.number, repo)
-        # Leave worktree in place for forensics
+        # #1116: no retention. The PR + Actions output is the forensic record.
+        cleanup_worktree(main_repo, worktree, branch)
         return "deferred"
 
     # ---- Green path ----
@@ -613,13 +551,6 @@ def process_repo(
     print(f"\n{'=' * 60}")
     print(f"REPO: {repo}")
     print(f"{'=' * 60}")
-    # GC stale forensic worktrees before processing this repo's PRs (#1107).
-    # Forensic worktrees retained from prior deferred PRs are bounded by
-    # FORENSIC_WORKTREE_AGE_DAYS so the directory doesn't accumulate cruft.
-    cleaned = gc_stale_forensic_worktrees(main_repo)
-    if cleaned:
-        print(f"  GC removed {len(cleaned)} stale forensic worktree(s) "
-              f"(age > {FORENSIC_WORKTREE_AGE_DAYS}d)")
     prs = list_dependabot_prs(repo)
     if not prs:
         print(f"  No open dependabot PRs in {repo}.")


### PR DESCRIPTION
Closes #1116
Refs #1107 #1108

## Summary

Reverses the 14-day forensic retention policy introduced by #1108. Every exit path from \`process_pr\` (merged / deferred install-fail / deferred test-fail / errored) now calls \`cleanup_worktree\` before returning. Zero persistent disk artifacts after any /dependabot run.

## Why the previous policy was wrong

The forensic-retention claim doesn't hold up:

- **PR + Actions output is the forensic record.** Test exit codes, stderr, dep diff, recreate/rebase comments — all on GitHub.
- **\`gh pr checkout\` recreates the worktree on demand** if anyone genuinely wants to reproduce locally days later.
- **Worktrees on disk are not free:** visible clutter, Windows file locks (death/hourglass workflow writes into them), mental load.

User feedback was direct (paraphrased): the 14-day retention treats agent-created artifacts as the user's problem to live with rather than the agent's problem to clean up. (Verbatim quote redacted per CLAUDE.md profanity rule.)

## Changes

- Removed \`gc_stale_forensic_worktrees()\` and \`FORENSIC_WORKTREE_AGE_DAYS\`
- Removed the GC call from \`process_repo\`
- Added \`cleanup_worktree(main_repo, worktree, branch)\` to both deferred return paths
- Updated review-comment text to reference \"the PR's Actions output\" instead of \"Worktree retained at <path>\"
- Header docstring now states \"Cleanup contract: zero persistent disk artifacts on ANY exit path\"
- Skill doc \`.claude/commands/dependabot.md\` updated to match

## Tests

6 passing, including a regression guard that fails loudly if anyone reintroduces \`gc_stale_forensic_worktrees\` or \`FORENSIC_WORKTREE_AGE_DAYS\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
