### PR TITLE
fix(cerberus): deploy secrets to BOTH Actions and Dependabot scopes (Closes #1118)

### DIFF
--- a/tests/test_deploy_cerberus_secrets.py
+++ b/tests/test_deploy_cerberus_secrets.py
@@ -52,11 +52,21 @@ def test_parse_args_with_dry_run_no_pem():
 # ---- _select_target_repos ----
 
 def _verify_factory(present_repos: set[str]):
-    """Build a fake verify_secrets that says `present_repos` are configured."""
+    """Build a fake verify_secrets that says `present_repos` are configured.
+
+    Returns the post-#1118 missing-descriptor shape: when a repo is missing,
+    the list contains '<scope>/<name>' entries covering both scopes.
+    """
     def fake_verify(repo, pat):
         if repo in present_repos:
             return (True, [])
-        return (False, ["REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"])
+        missing = [
+            "actions/REVIEWER_APP_ID",
+            "actions/REVIEWER_APP_PRIVATE_KEY",
+            "dependabot/REVIEWER_APP_ID",
+            "dependabot/REVIEWER_APP_PRIVATE_KEY",
+        ]
+        return (False, missing)
     return fake_verify
 
 
@@ -121,3 +131,159 @@ def test_main_returns_1_when_no_pem_and_no_dry_run(capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "pem_path is required" in err
+
+
+# ---- #1118: dual-scope (Actions + Dependabot) deployment ----
+
+def test_scopes_constant_includes_both_actions_and_dependabot():
+    """Regression guard against single-scope regression."""
+    assert deploy_cerberus_secrets._SCOPES == ("actions", "dependabot"), \
+        "Cerberus must deploy to both scopes; dependabot PRs fail without it (#1118)"
+
+
+def test_get_public_key_uses_scope_in_url():
+    """Default scope is actions (back-compat); dependabot scope hits a
+    different URL path. #1118."""
+    captured_urls: list[str] = []
+
+    def fake_request(method, url, pat, **kw):
+        captured_urls.append(url)
+        # Minimal valid public-key response shape
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"key_id": "k", "key": "AAAA"}
+        return r
+
+    with patch.object(deploy_cerberus_secrets, "_request_with_retry", side_effect=fake_request):
+        deploy_cerberus_secrets._get_public_key("alpha", "pat")
+        deploy_cerberus_secrets._get_public_key("alpha", "pat", scope="dependabot")
+
+    assert "/actions/secrets/public-key" in captured_urls[0]
+    assert "/dependabot/secrets/public-key" in captured_urls[1]
+
+
+def test_set_secret_uses_scope_in_url():
+    """PUT must go to the correct scope-specific path. #1118."""
+    captured: list[tuple[str, str]] = []  # (method, url)
+
+    def fake_request(method, url, pat, **kw):
+        captured.append((method, url))
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"key_id": "k", "key": "AAAA" * 8}  # valid b64 32-byte key
+        return r
+
+    # Use a real-ish 32-byte public key b64 so the sealed-box encryption works.
+    import base64
+    import nacl.public
+    real_key = nacl.public.PrivateKey.generate().public_key
+    real_key_b64 = base64.b64encode(bytes(real_key)).decode("ascii")
+
+    def fake_request_with_real_key(method, url, pat, **kw):
+        captured.append((method, url))
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"key_id": "k", "key": real_key_b64}
+        return r
+
+    with patch.object(deploy_cerberus_secrets, "_request_with_retry",
+                      side_effect=fake_request_with_real_key):
+        deploy_cerberus_secrets.set_secret("alpha", "TEST", "value", "pat", scope="actions")
+        deploy_cerberus_secrets.set_secret("alpha", "TEST", "value", "pat", scope="dependabot")
+
+    # 4 calls total: 2x (public-key GET + secret PUT)
+    methods_urls = [(m, u.split("/repos/")[-1]) for m, u in captured]
+    # Actions scope
+    assert any("actions/secrets/public-key" in u for m, u in methods_urls if m == "GET")
+    assert any("actions/secrets/TEST" in u for m, u in methods_urls if m == "PUT")
+    # Dependabot scope
+    assert any("dependabot/secrets/public-key" in u for m, u in methods_urls if m == "GET")
+    assert any("dependabot/secrets/TEST" in u for m, u in methods_urls if m == "PUT")
+
+
+def test_deploy_to_repo_writes_to_both_scopes():
+    """deploy_to_repo must write each secret to BOTH Actions and Dependabot.
+    Four total set_secret calls per repo: 2 secrets × 2 scopes. #1118."""
+    set_secret_calls: list[tuple[str, str, str]] = []
+
+    def fake_set_secret(repo, name, value, pat, scope="actions"):
+        set_secret_calls.append((repo, name, scope))
+        return True
+
+    with patch.object(deploy_cerberus_secrets, "set_secret", side_effect=fake_set_secret):
+        ok, failed = deploy_cerberus_secrets.deploy_to_repo("alpha", "pem-content", "pat")
+
+    assert ok is True
+    assert failed == []
+    # Should be 4 calls: REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY × actions + dependabot
+    scope_name_pairs = {(name, scope) for _, name, scope in set_secret_calls}
+    assert ("REVIEWER_APP_ID", "actions") in scope_name_pairs
+    assert ("REVIEWER_APP_PRIVATE_KEY", "actions") in scope_name_pairs
+    assert ("REVIEWER_APP_ID", "dependabot") in scope_name_pairs
+    assert ("REVIEWER_APP_PRIVATE_KEY", "dependabot") in scope_name_pairs
+    assert len(scope_name_pairs) == 4
+
+
+def test_deploy_to_repo_reports_failures_by_scope_and_name():
+    """Failed entries must include the scope so the operator can see exactly
+    which scope failed. #1118."""
+    def fake_set_secret(repo, name, value, pat, scope="actions"):
+        # Simulate only the dependabot/REVIEWER_APP_PRIVATE_KEY failing
+        if scope == "dependabot" and name == "REVIEWER_APP_PRIVATE_KEY":
+            return False
+        return True
+
+    with patch.object(deploy_cerberus_secrets, "set_secret", side_effect=fake_set_secret):
+        ok, failed = deploy_cerberus_secrets.deploy_to_repo("alpha", "pem-content", "pat")
+
+    assert ok is False
+    assert failed == ["dependabot/REVIEWER_APP_PRIVATE_KEY"]
+
+
+def test_verify_secrets_reports_missing_per_scope():
+    """verify_secrets must check BOTH scopes and report which scope-name
+    combos are missing. #1118."""
+    def fake_request(method, url, pat, **kw):
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = 200
+        # Actions scope has REVIEWER_APP_ID only; Dependabot scope has both.
+        if "/actions/secrets" in url and "public-key" not in url:
+            r.json.return_value = {"secrets": [{"name": "REVIEWER_APP_ID"}]}
+        elif "/dependabot/secrets" in url and "public-key" not in url:
+            r.json.return_value = {"secrets": [
+                {"name": "REVIEWER_APP_ID"},
+                {"name": "REVIEWER_APP_PRIVATE_KEY"},
+            ]}
+        else:
+            r.json.return_value = {}
+        return r
+
+    with patch.object(deploy_cerberus_secrets, "_request_with_retry", side_effect=fake_request):
+        ok, missing = deploy_cerberus_secrets.verify_secrets("alpha", "pat")
+
+    assert ok is False
+    assert "actions/REVIEWER_APP_PRIVATE_KEY" in missing
+    # Dependabot was complete; nothing missing from that scope
+    assert not any(m.startswith("dependabot/") for m in missing)
+
+
+def test_verify_secrets_passes_when_both_scopes_have_both_secrets():
+    def fake_request(method, url, pat, **kw):
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = 200
+        if "secrets" in url and "public-key" not in url:
+            r.json.return_value = {"secrets": [
+                {"name": "REVIEWER_APP_ID"},
+                {"name": "REVIEWER_APP_PRIVATE_KEY"},
+            ]}
+        return r
+
+    with patch.object(deploy_cerberus_secrets, "_request_with_retry", side_effect=fake_request):
+        ok, missing = deploy_cerberus_secrets.verify_secrets("alpha", "pat")
+    assert ok is True
+    assert missing == []

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -78,17 +78,25 @@ def get_all_repos() -> list[str]:
     return sorted(repos)
 
 
-def _get_repo_public_key(repo: str, pat: str) -> tuple[str, str] | None:
-    """Fetch the repo's Actions-secrets public key.
+_SCOPES = ("actions", "dependabot")
+
+
+def _get_public_key(repo: str, pat: str, scope: str = "actions") -> tuple[str, str] | None:
+    """Fetch the repo's secrets public key for a given scope.
+
+    Args:
+        scope: Either "actions" (default) or "dependabot". GitHub maintains
+            SEPARATE secret stores for these two contexts -- a secret set in
+            one is not visible to workflow runs in the other. Dependabot PRs
+            run with the Dependabot scope, regular workflow runs with the
+            Actions scope. (#1118)
 
     Returns (key_id, base64_public_key) on success, or None on failure.
-    GitHub requires the sealed-box encrypted secret value + key_id when
-    creating/updating a repo secret via the REST API.
     """
     try:
         resp = _request_with_retry(
             "GET",
-            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets/public-key",
+            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/{scope}/secrets/public-key",
             pat,
         )
     except requests.RequestException:
@@ -97,6 +105,10 @@ def _get_repo_public_key(repo: str, pat: str) -> tuple[str, str] | None:
         return None
     data = resp.json()
     return data["key_id"], data["key"]
+
+
+# Backwards-compat alias (still imported by external callers / tests).
+_get_repo_public_key = _get_public_key
 
 
 def _encrypt_secret(public_key_b64: str, secret_value: str) -> str:
@@ -111,19 +123,22 @@ def _encrypt_secret(public_key_b64: str, secret_value: str) -> str:
     return base64.b64encode(encrypted).decode("utf-8")
 
 
-def set_secret(repo: str, name: str, value: str, pat: str) -> bool:
-    """Set a GitHub Actions secret on a repo via REST API with in-process PAT.
+def set_secret(repo: str, name: str, value: str, pat: str, scope: str = "actions") -> bool:
+    """Set a GitHub secret on a repo via REST API in the given scope.
 
     Args:
         repo: Repo name (no owner prefix); paired with GITHUB_USER.
         name: Secret name (e.g. "REVIEWER_APP_ID").
         value: Plaintext secret value (will be sealed-box encrypted before PUT).
         pat: Classic PAT from classic_pat_session().
+        scope: "actions" (default) or "dependabot". The dependabot scope's
+            secrets are the ones visible to workflows triggered by Dependabot
+            PR events. Cerberus needs both scopes populated to function. (#1118)
 
     Returns:
         True on HTTP 2xx; False otherwise (including failure to fetch public key).
     """
-    pk = _get_repo_public_key(repo, pat)
+    pk = _get_public_key(repo, pat, scope=scope)
     if pk is None:
         return False
     key_id, public_key_b64 = pk
@@ -131,7 +146,7 @@ def set_secret(repo: str, name: str, value: str, pat: str) -> bool:
     try:
         resp = _request_with_retry(
             "PUT",
-            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets/{name}",
+            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/{scope}/secrets/{name}",
             pat,
             json={"encrypted_value": encrypted_value, "key_id": key_id},
         )
@@ -141,7 +156,8 @@ def set_secret(repo: str, name: str, value: str, pat: str) -> bool:
 
 
 def deploy_to_repo(repo: str, pem_content: str, pat: str) -> tuple[bool, list[str]]:
-    """Deploy REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY to a single repo.
+    """Deploy REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY to BOTH scopes
+    (Actions and Dependabot) on a single repo.
 
     Args:
         repo: Repo name (not owner/name) under GITHUB_USER.
@@ -149,18 +165,22 @@ def deploy_to_repo(repo: str, pem_content: str, pat: str) -> tuple[bool, list[st
         pat: Classic PAT from classic_pat_session().
 
     Returns:
-        (success, failed_secret_names). `success` is True iff both secrets set.
+        (success, failed_descriptors). Each failed entry is
+        "<scope>/<secret-name>" so the operator can see exactly which
+        scope-secret combo did not land. (#1118)
     """
     failed: list[str] = []
-    if not set_secret(repo, "REVIEWER_APP_ID", APP_ID, pat):
-        failed.append("REVIEWER_APP_ID")
-    if not set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content, pat):
-        failed.append("REVIEWER_APP_PRIVATE_KEY")
+    for scope in _SCOPES:
+        if not set_secret(repo, "REVIEWER_APP_ID", APP_ID, pat, scope=scope):
+            failed.append(f"{scope}/REVIEWER_APP_ID")
+        if not set_secret(repo, "REVIEWER_APP_PRIVATE_KEY", pem_content, pat, scope=scope):
+            failed.append(f"{scope}/REVIEWER_APP_PRIVATE_KEY")
     return (len(failed) == 0, failed)
 
 
 def verify_secrets(repo: str, pat: str) -> tuple[bool, list[str]]:
-    """Check that both required Cerberus secrets are present on the repo.
+    """Check that both required Cerberus secrets are present on the repo
+    in BOTH the Actions and Dependabot scopes.
 
     Uses the same in-process PAT as deploy_to_repo for consistency (avoids
     depending on whatever gh auth happens to be pointed at).
@@ -170,21 +190,31 @@ def verify_secrets(repo: str, pat: str) -> tuple[bool, list[str]]:
         pat: Classic PAT from classic_pat_session().
 
     Returns:
-        (all_present, missing_secret_names).
+        (all_present, missing_descriptors). Each missing entry is
+        "<scope>/<secret-name>" so the caller can see which scope and
+        which secret is missing -- a repo with secrets only in Actions
+        scope (the pre-#1118 default) will report all 2 dependabot/*
+        entries as missing. (#1118)
     """
-    required = {"REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"}
-    try:
-        resp = _request_with_retry(
-            "GET",
-            f"{_GH_API}/repos/{GITHUB_USER}/{repo}/actions/secrets",
-            pat,
-        )
-    except requests.RequestException:
-        return (False, sorted(required))
-    if resp.status_code >= 300:
-        return (False, sorted(required))
-    present = {s["name"] for s in resp.json().get("secrets", [])}
-    missing = sorted(required - present)
+    required_names = {"REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"}
+    missing: list[str] = []
+    for scope in _SCOPES:
+        try:
+            resp = _request_with_retry(
+                "GET",
+                f"{_GH_API}/repos/{GITHUB_USER}/{repo}/{scope}/secrets",
+                pat,
+            )
+        except requests.RequestException:
+            missing.extend(f"{scope}/{n}" for n in sorted(required_names))
+            continue
+        if resp.status_code >= 300:
+            missing.extend(f"{scope}/{n}" for n in sorted(required_names))
+            continue
+        present = {s["name"] for s in resp.json().get("secrets", [])}
+        for n in sorted(required_names):
+            if n not in present:
+                missing.append(f"{scope}/{n}")
     return (len(missing) == 0, missing)
 
 


### PR DESCRIPTION
Closes #1118

## Summary

Root cause of why **every dependabot PR fleet-wide has been failing auto-review** for months.

GitHub maintains **separate** secret stores for Actions and Dependabot contexts. When dependabot opens a PR, the workflow runs in the Dependabot scope. Secrets set via \`/actions/secrets/\` are **not visible** in the Dependabot scope. \`deploy_cerberus_secrets.py\` was only writing to Actions.

Effect: auto-reviewer.yml dies 3-5s into every dependabot run with \`Error: Input required and not supplied: app-id\` because \`REVIEWER_APP_ID\` is empty in the Dependabot context.

## Evidence (stuck dependabot PRs found)

| Repo | PR | Stuck since | Auto-review error |
|---|---|---|---|
| automation-scripts | #29 (pillow) | 2026-02-11 (3 months) | \`Input required and not supplied: app-id\` |
| AssemblyZero | #1095 (npm bump) | 2026-05 | Same |
| AssemblyZero | #1097 (langchain) | 2026-05 | Same |

## Changes

- New \`_SCOPES = ("actions", "dependabot")\` constant
- \`_get_public_key(repo, pat, scope="actions")\` -- scoped public-key fetch
- \`set_secret(..., scope="actions")\` -- scoped PUT
- \`deploy_to_repo()\` loops over both scopes -- 4 PUTs per repo
- \`verify_secrets()\` reports missing in \`<scope>/<name>\` shape

Back-compat: old single-scope callers (none in the codebase but possibly externally) get the default \`scope="actions"\` behavior unchanged. \`_get_repo_public_key\` alias retained.

## Operational followup (USER action after merge)

Re-deploy across the fleet to backfill the dependabot scope:

\`\`\`
# Test on one repo first
poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem --repo automation-scripts --dry-run

# If it shows automation-scripts as missing -> deploy
poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem --repo automation-scripts

# Verify the stuck PR re-runs and passes
gh pr checks 29 --repo martymcenroe/automation-scripts

# Then fleet-wide (every repo with missing dependabot scope will be touched)
poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem
\`\`\`

The default \`--new-only\` mode (no --all) will identify every repo as needing deployment because the dependabot scope is empty everywhere right now. The --new-only filter compares against BOTH scopes after this PR.

## Test plan

- [x] \`poetry run pytest tests/test_deploy_cerberus_secrets.py -v\` -- 18 passing
- [x] \`poetry run ruff check --isolated\` -- clean
- [x] New regression guard: \`test_scopes_constant_includes_both_actions_and_dependabot\` fails if anyone single-scopes again

🤖 Generated with [Claude Code](https://claude.com/claude-code)