### PR TITLE
chore: land prior-session uncommitted work (Closes #1121)

### DIFF
--- a/data/handoff-marker-status.json
+++ b/data/handoff-marker-status.json
@@ -1,0 +1,8 @@
+{
+  "status": "ok",
+  "marker": "handoff",
+  "timestamp": "2026-05-10 17:31:28",
+  "handoff_timestamp": "2026-05-10 17:27:58",
+  "repo": "AssemblyZero",
+  "message": "Marked handoff from 2026-05-10 17:27:58 as handoff at 2026-05-10 17:31:28"
+}

--- a/docs/runbooks/0935-pr-stuck-recovery.md
+++ b/docs/runbooks/0935-pr-stuck-recovery.md
@@ -1,0 +1,230 @@
+# 0935 - PR Stuck on `mergeable_state=blocked`: Recovery Procedures
+
+**Category:** Runbook / Operational Procedure
+**Version:** 1.0
+**Last Updated:** 2026-05-10
+
+---
+
+## Purpose
+
+Diagnose and recover when a PR stays at `mergeable_state=blocked` long after creation. Standard 0016 documents the PR governance architecture; this runbook documents recovery when that architecture rejects a PR for a non-obvious reason.
+
+**Use when:** `gh api repos/{owner}/{repo}/pulls/{N} --jq '.mergeable_state'` returns `blocked` and the typical 30-second auto-approval window has passed (Cerberus-AZ should approve within 10–30s after pr-sentinel passes).
+
+**Do NOT use this for:** legitimate failures where pr-sentinel reported `failure` (those are diagnosed by reading the check output and fixing the actual problem). This runbook is for the harder case where a check stays `pending` forever or `action_required` is silently misclassified.
+
+---
+
+## Prerequisites
+
+| Requirement | Check |
+|-------------|-------|
+| `gh` CLI authenticated with fine-grained PAT | `gh auth status` |
+| Issue referenced by PR exists and is open | `gh issue view {N} --jq '.state'` returns `open` |
+| Worker `/health` reachable | See Step 1 |
+
+---
+
+## Step 0: Grep Lessons-Learned First
+
+This runbook exists because the same traps recur. Before any diagnostic action:
+
+```bash
+grep -nE "sentinel|blocked|action_required|stuck.*PR" /c/Users/mcwiz/Projects/AssemblyZero/docs/lessons-learned.md
+```
+
+If a known trap matches your symptoms, follow that lesson's prescription instead of running this runbook from the top.
+
+**Known recurring traps:**
+- 2026-04-21: PR body example text parsed by sentinel — extracted `#42` as a Closes ref (PR #989, #974).
+- 2026-05-10: PR body negation phrasing parsed by sentinel — `Does not close #523` extracted as Closes #523 (PR #527).
+
+---
+
+## Step 1: Confirm pr-sentinel-mm Worker Is Up
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://pr-sentinel.mcwizard1.workers.dev/health
+```
+
+Expected: `200`. If non-200, the Worker is genuinely down — escalate to operator (this runbook does not cover Worker outages). Skip remaining steps.
+
+---
+
+## Step 2: Read the PR Body Sentinel Sees
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{N} --jq '.body'
+```
+
+Verify body contains `Closes #ISSUE_N` where `ISSUE_N` is an **open issue** (not a PR). The fine-grained PAT cannot read check-runs (`gh api .../check-runs` returns 403), so symptom-based diagnosis is required.
+
+---
+
+## Step 3: Audit Body for Parasitic Issue Extraction
+
+Sentinel's regex (`AssemblyZero/sentinel/src/validate.js`):
+
+```regex
+/\b(?:close[sd]?)\s+(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gi
+```
+
+This matches ANY occurrence of `close`/`closes`/`closed` followed by whitespace and `#N`, regardless of:
+
+| Form | Extracted? |
+|------|-----------|
+| `Closes #N` (intended) | YES |
+| `Does not close #N` | YES (negation does not block) |
+| `auto-close #N` | YES (hyphen is a word boundary) |
+| `` `Closes #N` `` (backticked example) | YES (worker doesn't parse markdown) |
+| `"Closes #N"` (quoted) | YES |
+| `Won't close #N` | YES |
+| `(close #N)` | YES |
+| `from #N`, `diagnoses #N`, `Leaves #N open` | NO (no `close` keyword) |
+
+Run the same regex against the PR body locally:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{N} --jq '.body' \
+  | grep -niE '\b(close[sd]?)\s+#[0-9]+'
+```
+
+For EACH match, verify the referenced `#N` is an open issue (not closed, not a PR):
+
+```bash
+gh api repos/{owner}/{repo}/issues/{N} --jq '{state: .state, is_pr: (.pull_request != null)}'
+```
+
+If `state=closed` OR `is_pr=true` → worker rejects → posts `action_required` → Auto Review treats as pending → 10-minute timeout → repeat. **This is the failure.**
+
+---
+
+## Step 4: Why Auto Review Says "pending" When Worker Already Failed
+
+Auto Review (`AssemblyZero/.github/workflows/auto-reviewer.yml`) poll-loop branch logic:
+
+```bash
+if [ "$STATUS" = "success" ]; then
+  echo "  ✅ ${check_name}: passed"
+elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
+  echo "  ❌ ${check_name}: ${STATUS} — will NOT approve"
+  exit 1
+else
+  echo "  ⏳ ${check_name}: pending (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS})"
+  ALL_PASSED=false
+fi
+```
+
+The check-run conclusion `action_required` is neither `success`, `failure`, nor `cancelled` — it falls through to the `else` branch and prints `⏳ pending`. The poll runs 30 attempts × 20s = 10 min, then times out. The check ran and FAILED at second 0 — Auto Review just doesn't classify the failure correctly.
+
+**Symptomatic signature:** Auto Review log shows 30 consecutive `⏳ ... pending` lines, never `❌`, then `Timed out waiting for checks after 600s`.
+
+(Bug worth filing against `AssemblyZero/.github/workflows/auto-reviewer.yml` to handle `action_required` and `timed_out` as failures.)
+
+---
+
+## Step 5: Recovery — Re-phrase the Body
+
+Edit the PR body to remove the parasitic match. Replacement phrasings:
+
+| Avoid | Use instead |
+|-------|-------------|
+| `Does not close #N` | `Leaves #N open` / `#N stays open` |
+| `Won't auto-close #N` | `#N remains pending` |
+| `Closes none of the related issues (#A, #B)` | `Related (kept open): #A, #B` |
+| Example: `` `Closes #N` `` (in instructional text) | `<directive> #N` (use placeholder) |
+
+Apply via:
+
+```bash
+gh pr edit {N} --repo {owner}/{repo} --body "...rephrased body..."
+```
+
+The `edited` webhook re-fires sentinel. Worker re-evaluates against the new body and posts a fresh check-run. If body now passes regex + all extracted refs are open issues, conclusion is `success`.
+
+---
+
+## Step 6: Re-trigger Auto Review (Without a New Commit)
+
+Auto Review only triggers on `pull_request` event types `[opened, synchronize, reopened]` — NOT `edited`. After Step 5, sentinel's check is fresh but Auto Review is still showing the stale failed run.
+
+The fine-grained PAT cannot `gh run rerun` (needs `actions:write`). The non-destructive trigger:
+
+```bash
+gh pr close {N}  --repo {owner}/{repo}
+gh pr reopen {N} --repo {owner}/{repo}
+```
+
+`reopened` is in Auto Review's trigger list. New run starts, polls for issue-reference (now `success`), Cerberus-AZ submits the approving review.
+
+**DO NOT** push an empty commit to re-trigger — git history pollution. Force-push to "clean up" the noise commit afterward is BANNED.
+
+---
+
+## Step 7: Wait for `clean`, Merge, Cleanup
+
+```bash
+until [ "$(gh api repos/{owner}/{repo}/pulls/{N} --jq '.mergeable_state')" = "clean" ]; do sleep 20; done
+gh pr merge {N} --squash --repo {owner}/{repo}
+git checkout main && git fetch origin && git merge origin/main --ff-only && git branch -d {branch}
+```
+
+Squash merge collapses any noise commits on the branch into ONE commit on main with the PR title — so even if you accidentally pushed extra commits during diagnosis, main history stays clean.
+
+---
+
+## Banned Recovery Actions
+
+These have all been attempted; all violate user-set rules. Memory: `feedback_never_force_overwrite_user_data`. Root CLAUDE.md "Hard Rules" section.
+
+| Action | Why banned |
+|--------|-----------|
+| `git push --force` / `--force-with-lease` | Overwrites user data (lost session names 2026-04-11) |
+| `git reset --hard` then push | Same effect as force-push |
+| `git branch -D` | For squash-merge orphans use ADR-0217's `git replace --graft`, not `-D` |
+| `gh pr merge --admin` | Bypasses branch protection; governance requires non-author approval |
+| `gh pr review --approve` (self-approve) | GitHub blocks; would bypass governance even if it worked |
+| Asking user to manually approve | Cerberus-AZ exists for this — its job to approve, not user's |
+| Pushing empty / noise commits to re-trigger workflows | Git history pollution; `gh pr close && gh pr reopen` works without a commit |
+| `gh pr merge --auto` | `allow_auto_merge=false` on all repos (Standard 0016) |
+
+---
+
+## Diagnostic Decision Tree
+
+```
+mergeable_state == "blocked"
+│
+├─ Step 1: Worker /health returns non-200
+│   └─→ Worker DOWN, escalate, do not proceed
+│
+├─ Step 2: PR body lacks `Closes #N`
+│   └─→ Step 5 (add it), then Step 6 (close/reopen), then Step 7
+│
+├─ Step 2: PR body has `Closes #ISSUE_N` but ISSUE_N is closed
+│   └─→ Create new issue, Step 5 with new ref, Step 6, Step 7
+│
+├─ Step 3: PR body has parasitic match (close/closed/closes near non-target #N)
+│   └─→ Step 5 (rephrase), Step 6 (close/reopen), Step 7
+│
+└─ All above pass + Auto Review last run >10 min ago
+    └─→ Step 6 (close/reopen) to re-trigger, Step 7
+```
+
+---
+
+## Related Documents
+
+- [0016 - PR Governance System Architecture](../standards/0016-pr-sentinel-system-architecture.md) — How the system works (sentinel Worker, Cerberus-AZ App, branch protection, auto-reviewer)
+- [0021 - Workflow Error Recovery](../standards/0021-workflow-error-recovery.md) — Recovery for LLM/LangGraph workflows (different system)
+- [0217 - Squash-merge Orphan Graft Cleanup](../adrs/0217-squash-merge-orphan-graft-cleanup.md) — When `git branch -d` refuses on squash-merged branches
+- Project-root `CLAUDE.md` "If `mergeable_state` stays `blocked`" section — Quick-reference summary
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-05-10 | Initial. Captures the PR #527 incident (negation-parsed-as-Closes) and codifies the broader recovery procedures. |

--- a/tools/fleet_set_delete_branch_on_merge.py
+++ b/tools/fleet_set_delete_branch_on_merge.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Fleet-wide: flip delete_branch_on_merge to True on every owned, non-archived repo.
+
+Follow-up to today's bulk merge of 38 cleanup-security-hooks PRs (2026-04-30):
+17 of the merged repos still had "Automatically delete head branches" disabled,
+leaving stale remote branches that needed manual cleanup. This script flips the
+setting on every owned, non-archived repo so future merges auto-clean.
+
+Idempotent. Safe to re-run. Skips repos already set to True.
+
+Required scopes on the classic PAT:
+  - repo (full) -- the classic 'repo' scope grants Administration:write on
+                   owned repos, which is what PATCH /repos/{owner}/{repo}
+                   needs to mutate delete_branch_on_merge.
+
+OPERATIONAL RULE (per ADR-0216 + 2026-04-30 hardenings):
+  This script MUST be run by the user in their own Git Bash. It MUST NOT be
+  invoked by an agent (Claude Code, Codex, Gemini) via the agent's Bash tool.
+  Reason: the agent's subprocess inherits theoretical heap-read access to the
+  PAT during the seconds the script runs.
+
+Assumes ~/.gnupg/gpg-agent.conf has all cache TTLs at 0 (applied 2026-04-30
+per ADR-0216 hardening). The script does not depend on this for correctness,
+but security depends on it: with caching disabled, every gpg invocation
+prompts pinentry fresh, so a sibling process's silent decrypt attempt would
+surface a dialog the user can refuse. See _pat_session.py docstring for the
+rationale.
+
+Usage:
+    poetry run python tools/fleet_set_delete_branch_on_merge.py [--dry-run]
+                                                                 [--repos R1,R2,...]
+                                                                 [--include-archived]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+REPO_OWNER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+MAX_RETRIES = 4
+INITIAL_BACKOFF_S = 1.0
+PER_PAGE = 100
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _request_with_retry(
+    method: str, url: str, pat: str, **kwargs
+) -> requests.Response:
+    """HTTP request with exponential backoff on transient errors.
+
+    Retries: connection errors, timeouts, 5xx, 429 (rate-limited), and
+    403 with X-RateLimit-Remaining=0 (secondary rate limit).
+
+    Does NOT retry: 4xx other than 403/429 (permanent for this caller).
+    """
+    backoff = INITIAL_BACKOFF_S
+    last_exc: Exception | None = None
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            r = requests.request(
+                method, url, headers=_gh_headers(pat), timeout=HTTP_TIMEOUT_S, **kwargs
+            )
+        except (requests.ConnectionError, requests.Timeout) as e:
+            last_exc = e
+            if attempt < MAX_RETRIES:
+                print(f"    network error ({type(e).__name__}); retry in {backoff}s")
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+            raise
+
+        # Rate limit detection
+        if r.status_code == 429:
+            retry_after = int(r.headers.get("Retry-After", "30"))
+            if attempt < MAX_RETRIES:
+                print(f"    HTTP 429; sleeping {retry_after}s per Retry-After")
+                time.sleep(retry_after)
+                continue
+        if r.status_code == 403 and r.headers.get("X-RateLimit-Remaining") == "0":
+            reset = int(r.headers.get("X-RateLimit-Reset", "0"))
+            wait = max(reset - int(time.time()), 30)
+            if attempt < MAX_RETRIES:
+                print(f"    primary rate limit hit; sleeping {wait}s until reset")
+                time.sleep(wait)
+                continue
+        if 500 <= r.status_code < 600:
+            if attempt < MAX_RETRIES:
+                print(f"    HTTP {r.status_code}; retry in {backoff}s")
+                time.sleep(backoff)
+                backoff *= 2
+                continue
+
+        # All other responses: return as-is (caller decides 4xx handling)
+        return r
+
+    if last_exc:
+        raise last_exc
+    raise RuntimeError(f"exhausted retries on {method} {url}")
+
+
+def list_owned_repos(pat: str, include_archived: bool) -> list[dict[str, Any]]:
+    """Return list of repos owned by the authenticated user.
+
+    Each entry: {"name": str, "full_name": str, "archived": bool,
+                 "delete_branch_on_merge": bool, ...}
+    """
+    repos: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        r = _request_with_retry(
+            "GET",
+            f"{GH_API}/user/repos",
+            pat,
+            params={
+                "affiliation": "owner",
+                "per_page": PER_PAGE,
+                "page": page,
+            },
+        )
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        repos.extend(batch)
+        if len(batch) < PER_PAGE:
+            break
+        page += 1
+    if not include_archived:
+        repos = [r for r in repos if not r.get("archived", False)]
+    return repos
+
+
+def get_setting(repo_full_name: str, pat: str) -> bool | None:
+    """Return current delete_branch_on_merge for the repo, or None on error."""
+    r = _request_with_retry("GET", f"{GH_API}/repos/{repo_full_name}", pat)
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    return bool(r.json().get("delete_branch_on_merge", False))
+
+
+def set_setting(repo_full_name: str, value: bool, pat: str) -> None:
+    """Flip delete_branch_on_merge to value. Raises on non-2xx."""
+    r = _request_with_retry(
+        "PATCH",
+        f"{GH_API}/repos/{repo_full_name}",
+        pat,
+        json={"delete_branch_on_merge": value},
+    )
+    r.raise_for_status()
+
+
+def process_repo(
+    repo: dict[str, Any], pat: str, dry_run: bool
+) -> tuple[str, str]:
+    """Return (status, detail) for one repo.
+
+    status in: 'already_on', 'flipped', 'would_flip', 'archived',
+               'permission_denied', 'not_found', 'error'
+    """
+    full_name = repo["full_name"]
+    if repo.get("archived", False):
+        return ("archived", f"{full_name}: archived, skipped")
+    current = repo.get("delete_branch_on_merge")
+    if current is True:
+        return ("already_on", f"{full_name}: already true, skipped")
+    if current is None:
+        # Wasn't in the list response; explicit GET to confirm.
+        try:
+            current = get_setting(full_name, pat)
+        except requests.HTTPError as e:
+            return ("error", f"{full_name}: GET failed: {e}")
+        if current is None:
+            return ("not_found", f"{full_name}: GET returned 404")
+        if current is True:
+            return ("already_on", f"{full_name}: already true (post-GET), skipped")
+    if dry_run:
+        return ("would_flip", f"{full_name}: WOULD flip false -> true")
+    try:
+        set_setting(full_name, True, pat)
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            return ("permission_denied", f"{full_name}: 403 -- PAT lacks scope")
+        return ("error", f"{full_name}: PATCH failed: {e}")
+    return ("flipped", f"{full_name}: flipped false -> true")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List what would change; take no action.")
+    parser.add_argument("--repos", default="",
+                        help="Comma-separated owner-less repo names. "
+                             "Defaults to all owned, non-archived repos.")
+    parser.add_argument("--include-archived", action="store_true",
+                        help="Include archived repos (default: skip).")
+    args = parser.parse_args()
+
+    with classic_pat_session() as pat:
+        # Pre-flight: one cheap call to confirm PAT auth works before we
+        # start iterating. Fail fast if scope is wrong.
+        r = _request_with_retry("GET", f"{GH_API}/user", pat)
+        if r.status_code != 200:
+            print(f"ERROR: pre-flight /user check failed: {r.status_code} {r.text[:200]}")
+            return 1
+        whoami = r.json().get("login", "?")
+        print(f"Authenticated as: {whoami}")
+
+        if args.repos:
+            names = [n.strip() for n in args.repos.split(",") if n.strip()]
+            # Build minimal repo dicts; explicit GET fills in missing fields.
+            repos = [{"name": n, "full_name": f"{REPO_OWNER}/{n}",
+                      "archived": False, "delete_branch_on_merge": None}
+                     for n in names]
+        else:
+            try:
+                repos = list_owned_repos(pat, include_archived=args.include_archived)
+            except Exception as e:  # noqa: BLE001
+                print(f"ERROR: discovery failed: {e}")
+                return 2
+
+        print(f"Processing {len(repos)} repo(s){' (DRY-RUN)' if args.dry_run else ''}")
+        print()
+
+        counts: dict[str, int] = {}
+        for repo in repos:
+            try:
+                status, detail = process_repo(repo, pat, args.dry_run)
+            except Exception as e:  # noqa: BLE001
+                status, detail = "error", f"{repo.get('full_name','?')}: UNEXPECTED {type(e).__name__}: {e}"
+            counts[status] = counts.get(status, 0) + 1
+            print(f"  [{status:18s}] {detail}")
+
+        print()
+        print("=== Summary ===")
+        for status in ("flipped", "would_flip", "already_on", "archived",
+                       "not_found", "permission_denied", "error"):
+            n = counts.get(status, 0)
+            if n:
+                print(f"  {status}: {n}")
+
+        # Non-zero exit if any repo errored or hit permission denied.
+        if counts.get("error", 0) or counts.get("permission_denied", 0):
+            return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/merge_aletheia_603_audit_gate.py
+++ b/tools/merge_aletheia_603_audit_gate.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Land Aletheia #603 (remove abandoned audit-schedule gate) via API only.
+
+Issue #603. The active fine-grained PAT lacks `workflow` scope so `git push`
+is rejected. This script reproduces the local single-file commit on origin
+via the GitHub Contents API, opens the PR, polls until mergeable_state is
+'clean', squash-merges, and cleans up the remote branch. As a final step
+it nudges PR #584 (close+reopen) which became unstable behind the same
+dead audit-schedule check.
+
+All authentication via _pat_session.classic_pat_session() per ADR-0216:
+gpg-decrypted in-process, never written to env, never logged, never passed
+via subprocess argv.
+
+Required scopes on the classic PAT:
+  - repo (full)  -- for PR/merge/branch operations
+  - workflow     -- for the commit modifying .github/workflows/ci.yml
+
+Usage:
+    poetry run python tools/merge_aletheia_603_audit_gate.py [--dry-run]
+                                                              [--skip-584-nudge]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+REPO_OWNER = "martymcenroe"
+REPO_NAME = "Aletheia"
+GH_API = "https://api.github.com"
+ISSUE_NUMBER = 603
+BRANCH_NAME = "603-remove-audit-schedule-gate"
+WORKFLOW_PATH = ".github/workflows/ci.yml"
+LOCAL_FILE = Path("C:/Users/mcwiz/Projects/Aletheia/.github/workflows/ci.yml")
+COMPANION_PR = 584
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 600
+
+PR_TITLE = "ci: remove abandoned audit-schedule gate (Closes #603)"
+
+COMMIT_MESSAGE = """ci: remove abandoned audit-schedule gate (Closes #603)
+
+The audit-schedule CI job runs tools/audit_schedule_check.py against
+docs/0800-audit-*.md schedule data that no longer exists in the repo.
+The audit policy was retired but the enforcing job was not.
+
+Effect: every PR shows UNSTABLE, main's nightly CI reports failure.
+Not a required check, so no merge gate is being lifted -- just CI noise.
+
+The audit_*.py scripts in tools/ remain in place; their cleanup is a
+separate decision.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"""
+
+PR_BODY = """## Summary
+
+Removes the `audit-schedule` job from `.github/workflows/ci.yml`. The job
+referenced `tools/audit_schedule_check.py` against `docs/0800-audit-*.md`
+schedule data that no longer exists in the repo, so it failed on every PR
+(UNSTABLE mergeable_state) and on every nightly main run.
+
+Not a required check; no merge gate is being lifted -- just CI noise.
+
+The local `git push` was rejected because the fine-grained PAT lacks
+`workflow` scope. Landed via `tools/merge_aletheia_603_audit_gate.py`
+following ADR-0216 (in-process classic PAT decryption).
+
+Closes #603.
+"""
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_file_info(path: str, ref: str, pat: str) -> dict[str, Any]:
+    r = requests.get(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/contents/{path}",
+        params={"ref": ref},
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def get_branch_head(branch: str, pat: str) -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/git/refs/heads/{branch}",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def create_branch(branch: str, source_sha: str, pat: str) -> None:
+    r = requests.post(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/git/refs",
+        headers=_gh_headers(pat),
+        json={"ref": f"refs/heads/{branch}", "sha": source_sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 422:
+        existing_sha = get_branch_head(branch, pat)
+        if existing_sha != source_sha:
+            raise RuntimeError(
+                f"Branch refs/heads/{branch} already exists pointing at "
+                f"{existing_sha[:8]} (expected {source_sha[:8]}). "
+                f"Either delete the stale ref or rerun with a different branch name."
+            )
+        print("  (branch ref already exists at expected sha; idempotent)")
+        return
+    r.raise_for_status()
+
+
+def update_file_on_branch(
+    path: str, file_sha: str, content_bytes: bytes, message: str, branch: str, pat: str
+) -> None:
+    r = requests.put(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/contents/{path}",
+        headers=_gh_headers(pat),
+        json={
+            "message": message,
+            "content": base64.b64encode(content_bytes).decode("ascii"),
+            "sha": file_sha,
+            "branch": branch,
+        },
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 409:
+        raise RuntimeError(
+            f"PUT /contents returned 409 Conflict. Likely the branch already "
+            f"has a newer version of {path} from a previous run. Delete the "
+            f"branch ref and rerun, or inspect the branch state manually."
+        )
+    r.raise_for_status()
+
+
+def find_existing_pr(head: str, pat: str) -> int | None:
+    r = requests.get(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/pulls",
+        params={"state": "open", "head": f"{REPO_OWNER}:{head}", "per_page": 5},
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    prs = r.json()
+    return prs[0]["number"] if prs else None
+
+
+def create_pr(head: str, base: str, title: str, body: str, pat: str) -> int:
+    r = requests.post(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/pulls",
+        headers=_gh_headers(pat),
+        json={"title": title, "head": head, "base": base, "body": body},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["number"]
+
+
+def get_mergeable_state(pr_number: int, pat: str) -> str | None:
+    r = requests.get(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json().get("mergeable_state")
+
+
+def wait_for_mergeable(pr_number: int, pat: str, timeout_s: int) -> str:
+    """Poll until mergeable_state is mergeable. Returns the final state.
+
+    Accepts 'clean' OR 'unstable'. The bootstrap reality of this PR: it
+    deletes the audit-schedule job, but until merged, audit-schedule still
+    runs on the PR itself and fails -- making mergeable_state stuck at
+    'unstable' forever. The only path to 'clean' is to merge through
+    unstable. fleet_delete_pr_sentinel.py uses the same logic for the same
+    reason (the legacy check fails on the PR that deletes the legacy check).
+
+    'dirty' / 'blocked' return as-is for the caller to abort.
+    """
+    deadline = time.time() + timeout_s
+    last = "unknown"
+    polled_once = False
+    while time.time() < deadline:
+        state = get_mergeable_state(pr_number, pat) or "unknown"
+        last = state
+        print(f"  mergeable_state: {state}")
+        if state in ("clean", "unstable"):
+            return state
+        if state == "dirty":
+            return state
+        if state == "blocked" and polled_once:
+            return state
+        polled_once = True
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+def merge_pr_squash(pr_number: int, pat: str) -> str:
+    r = requests.put(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}/merge",
+        headers=_gh_headers(pat),
+        json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json().get("sha", "")
+
+
+def delete_branch_ref(branch: str, pat: str) -> None:
+    r = requests.delete(
+        f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/git/refs/heads/{branch}",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code in (404, 422):
+        print("  (branch already deleted -- likely repo auto-delete-head setting)")
+        return
+    r.raise_for_status()
+
+
+def nudge_pr(pr_number: int, pat: str) -> None:
+    """Close then reopen a PR to re-trigger CI checks."""
+    for state in ("closed", "open"):
+        r = requests.patch(
+            f"{GH_API}/repos/{REPO_OWNER}/{REPO_NAME}/pulls/{pr_number}",
+            headers=_gh_headers(pat),
+            json={"state": state},
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+
+
+def land_change(pat: str) -> tuple[int, str]:
+    """Run the full ladder. Returns (pr_number, merge_sha)."""
+    content = LOCAL_FILE.read_bytes()
+    # Normalize CRLF -> LF. The Contents API stores the bytes verbatim; on
+    # Windows with core.autocrlf=true the working tree is CRLF but blobs
+    # are LF. Submitting raw bytes flips the whole file's line endings on
+    # origin and creates a noisy whole-file diff. Normalize to match what
+    # `git commit` would have produced.
+    content = content.replace(b"\r\n", b"\n")
+    if b"\n  audit-schedule:" in content:
+        raise RuntimeError(
+            f"Local file {LOCAL_FILE} still contains the audit-schedule job. "
+            f"Refusing to commit a non-fix as a fix."
+        )
+
+    file_info = get_file_info(WORKFLOW_PATH, "main", pat)
+    main_file_sha = file_info["sha"]
+    print(f"main file sha: {main_file_sha[:8]}")
+
+    main_head = get_branch_head("main", pat)
+    print(f"main HEAD:     {main_head[:8]}")
+
+    existing = find_existing_pr(BRANCH_NAME, pat)
+    if existing is not None:
+        print(f"Existing PR #{existing} found; resuming at poll step.")
+        pr_number = existing
+    else:
+        create_branch(BRANCH_NAME, main_head, pat)
+        print(f"branch ref created: refs/heads/{BRANCH_NAME}")
+
+        update_file_on_branch(
+            path=WORKFLOW_PATH,
+            file_sha=main_file_sha,
+            content_bytes=content,
+            message=COMMIT_MESSAGE,
+            branch=BRANCH_NAME,
+            pat=pat,
+        )
+        print("file updated on branch")
+
+        try:
+            pr_number = create_pr(
+                head=BRANCH_NAME,
+                base="main",
+                title=PR_TITLE,
+                body=PR_BODY,
+                pat=pat,
+            )
+            print(f"PR opened: #{pr_number}")
+        except Exception:
+            print(
+                f"\nERROR after branch ref + commit creation:\n"
+                f"  Branch on origin: refs/heads/{BRANCH_NAME}\n"
+                f"  Manual cleanup: DELETE /repos/{REPO_OWNER}/{REPO_NAME}/"
+                f"git/refs/heads/{BRANCH_NAME}\n"
+            )
+            raise
+
+    print(f"Polling mergeable_state (timeout {MERGEABLE_TIMEOUT_S}s)...")
+    state = wait_for_mergeable(pr_number, pat, MERGEABLE_TIMEOUT_S)
+    if state not in ("clean", "unstable"):
+        raise RuntimeError(
+            f"PR #{pr_number} did not reach a mergeable state "
+            f"(final state: {state!r}). REFUSING to merge.\n"
+            f"  PR: https://github.com/{REPO_OWNER}/{REPO_NAME}/pull/{pr_number}\n"
+            f"  Branch ref left in place: refs/heads/{BRANCH_NAME}"
+        )
+
+    merge_sha = merge_pr_squash(pr_number, pat)
+    print(f"merged at: {merge_sha[:8]}")
+
+    delete_branch_ref(BRANCH_NAME, pat)
+
+    return pr_number, merge_sha
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="List what would happen; take no action.")
+    parser.add_argument("--skip-584-nudge", action="store_true",
+                        help="Skip the close+reopen of PR #584.")
+    args = parser.parse_args()
+
+    if not LOCAL_FILE.exists():
+        print(f"ERROR: local file missing: {LOCAL_FILE}")
+        return 1
+
+    if args.dry_run:
+        print(f"[DRY-RUN] target: {REPO_OWNER}/{REPO_NAME}")
+        print(f"[DRY-RUN] would create branch: {BRANCH_NAME}")
+        print(f"[DRY-RUN] would update {WORKFLOW_PATH}")
+        print(f"[DRY-RUN] would open PR: {PR_TITLE}")
+        if not args.skip_584_nudge:
+            print(f"[DRY-RUN] would nudge PR #{COMPANION_PR}")
+        return 0
+
+    with classic_pat_session() as pat:
+        try:
+            pr_number, merge_sha = land_change(pat)
+        except Exception as e:  # noqa: BLE001
+            print(f"FATAL: {e}")
+            return 2
+
+        print(f"\nMain change landed: PR #{pr_number} merged at {merge_sha[:8]}")
+
+        if not args.skip_584_nudge:
+            try:
+                nudge_pr(COMPANION_PR, pat)
+                print(f"PR #{COMPANION_PR} closed+reopened (re-triggered checks)")
+            except requests.HTTPError as e:
+                print(f"WARNING: PR #{COMPANION_PR} nudge failed -- "
+                      f"manual close+reopen needed. {e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1121

## Summary
Lands four files that were sitting in the working tree from prior sessions:

- \`docs/runbooks/0935-pr-stuck-recovery.md\` — already referenced by root CLAUDE.md; load-bearing
- \`tools/fleet_set_delete_branch_on_merge.py\` — one-shot script from 2026-04-30, retained as reference
- \`tools/merge_aletheia_603_audit_gate.py\` — one-shot script for Aletheia #603, retained alongside sibling \`fleet_delete_pr_sentinel.py\`
- \`data/handoff-marker-status.json\` — runtime handoff state, alongside existing \`data/pickup-status.json\`

## Test plan
- [x] \`poetry run ruff check --isolated\` — clean (4 pre-existing F401/F541 errors auto-fixed; no logic changes)
- [x] No new tests broken (no logic changes to existing code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)