### PR TITLE
feat: TDD workflow commit checkpoints after N2/N4/N5 (Closes #689)

### DIFF
--- a/assemblyzero/workflows/testing/checkpoints.py
+++ b/assemblyzero/workflows/testing/checkpoints.py
@@ -1,0 +1,121 @@
+"""TDD workflow git checkpoints (Issue #689).
+
+Each TDD node generates code (scaffolded tests in N2, implementation in N4,
+verified-green state in N5) but does not commit. A crash, timeout, or
+premature cleanup at any point loses everything since the last human commit.
+
+The 2026-01-31 incident lost 6,114 lines of working code via worktree
+deletion before commit. This module provides `commit_checkpoint()`, called
+at the end of N2, N4, and N5 to stage + commit + push the current state.
+
+Design rules:
+1. **Best-effort.** Checkpoint failures must NOT fail the node they were
+   protecting. The original work survives in the working tree either way;
+   committing is a recovery convenience, not a correctness guarantee.
+2. **Worktree-scoped.** Stages only files inside the worktree. Excludes
+   workflow-internal dirs (.assemblyzero/, data/lineage/) so the checkpoint
+   commits represent ONLY the work the human cares about.
+3. **Squashable.** Commit message prefix `[CP:NAME]` is recognizable so
+   the post-merge squash collapses them cleanly.
+4. **Network-tolerant.** `git push` failures are warned but ignored --
+   the local commit is the primary recovery artifact; remote backup is
+   nice-to-have.
+5. **Idempotent on empty.** If `git diff --cached` is empty after staging,
+   skips the commit (no empty-commit pollution).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Paths excluded from checkpoint commits (workflow-internal, not user work).
+_EXCLUDE_PATHSPECS = (
+    ":!.assemblyzero",
+    ":!data/lineage",
+    ":!data/hourglass",
+)
+
+_GIT_TIMEOUT_S = 30
+_PUSH_TIMEOUT_S = 60
+
+
+def commit_checkpoint(worktree_path: str | Path | None,
+                       issue_number: int | str | None,
+                       name: str) -> bool:
+    """Stage + commit + push the current state of `worktree_path`.
+
+    Args:
+        worktree_path: Path to the git worktree to checkpoint. If None or
+            not a directory, no-op (returns False).
+        issue_number: Issue number for the commit message reference. Can
+            be int, str, or None (omitted from message).
+        name: Checkpoint name -- inserted as `[CP:<name>]` in the commit
+            message. Conventional values: "post-scaffold", "post-impl",
+            "post-green".
+
+    Returns:
+        True if a checkpoint commit was created. False if no-op (no
+        worktree, nothing to commit, or any failure -- failures are
+        warned to stdout but never raised).
+    """
+    if not worktree_path:
+        return False
+    wt = Path(worktree_path)
+    if not wt.is_dir():
+        return False
+
+    try:
+        # Stage everything except workflow-internal dirs
+        add_args = ["git", "-C", str(wt), "add", "-A", "--", "."]
+        add_args.extend(_EXCLUDE_PATHSPECS)
+        _run(add_args, timeout=_GIT_TIMEOUT_S)
+
+        # Skip if nothing staged
+        diff = _run(
+            ["git", "-C", str(wt), "diff", "--cached", "--quiet"],
+            timeout=_GIT_TIMEOUT_S,
+        )
+        if diff.returncode == 0:
+            return False  # nothing to commit; benign
+
+        if issue_number is not None:
+            msg = f"[CP:{name}] issue #{issue_number}: workflow checkpoint"
+        else:
+            msg = f"[CP:{name}] workflow checkpoint"
+
+        commit = _run(
+            ["git", "-C", str(wt), "commit", "-m", msg],
+            timeout=_GIT_TIMEOUT_S,
+        )
+        if commit.returncode != 0:
+            print(f"  [CP:{name}] commit failed (non-fatal): "
+                  f"{(commit.stderr or commit.stdout).strip()[:200]}")
+            return False
+
+        # Push -- non-fatal if offline / no upstream / rejected
+        push = _run(
+            ["git", "-C", str(wt), "push"],
+            timeout=_PUSH_TIMEOUT_S,
+        )
+        if push.returncode != 0:
+            print(f"  [CP:{name}] commit OK, push failed (non-fatal): "
+                  f"{(push.stderr or '').strip()[:200]}")
+
+        return True
+
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f"  [CP:{name}] checkpoint failed (non-fatal): {e}")
+        return False
+
+
+def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
+    """subprocess.run with the encoding defaults from #837."""
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -57,10 +57,11 @@ Graph structure:
                                                          END
 """
 
-from typing import Literal
+from typing import Any, Callable, Literal
 
 from langgraph.graph import END, StateGraph
 
+from assemblyzero.workflows.testing.checkpoints import commit_checkpoint
 from assemblyzero.workflows.testing.nodes import (
     cleanup,
     document,
@@ -74,6 +75,8 @@ from assemblyzero.workflows.testing.nodes import (
     verify_green_phase,
     verify_red_phase,
 )
+
+
 from assemblyzero.workflows.testing.nodes.completeness_gate import (
     completeness_gate,
     route_after_completeness_gate,
@@ -91,6 +94,34 @@ from assemblyzero.workflows.testing.nodes.adversarial_node import (
 )
 from assemblyzero.core.halt_node import create_halt_node
 from assemblyzero.core.llm_provider import get_cumulative_cost
+
+
+def _wrap_with_checkpoint(node_fn: Callable[..., dict[str, Any]],
+                            ckpt_name: str) -> Callable[..., dict[str, Any]]:
+    """Wrap a TDD node so it triggers a git checkpoint after it returns.
+
+    Pulls worktree_path and issue_number out of the workflow state. The
+    checkpoint itself is best-effort (see commit_checkpoint) -- any
+    failure is logged but never propagated to the node's caller, so a
+    flaky network or missing remote can't break the workflow.
+
+    Issue #689 -- 2026-01-31 lost 6,114 lines because TDD nodes didn't
+    commit between phases.
+    """
+    def wrapped(state: dict[str, Any]) -> dict[str, Any]:
+        result = node_fn(state)
+        worktree = state.get("worktree_path") or state.get("repo_path")
+        issue_obj = state.get("issue") or {}
+        issue_n = (
+            state.get("issue_number")
+            or (issue_obj.get("number") if isinstance(issue_obj, dict) else None)
+        )
+        try:
+            commit_checkpoint(worktree, issue_n, ckpt_name)
+        except Exception as e:
+            print(f"  [CP:{ckpt_name}] wrapper caught unexpected error: {e}")
+        return result
+    return wrapped
 
 
 def route_after_load(
@@ -419,12 +450,14 @@ def build_testing_workflow() -> StateGraph:
     workflow.add_node("N0_load_lld", load_lld)
     workflow.add_node("N1_review_test_plan", review_test_plan)
     workflow.add_node("N1_5_revise_test_plan", revise_test_plan)  # Issue #1072
-    workflow.add_node("N2_scaffold_tests", scaffold_tests)
+    # Issue #689: checkpoint after N2/N4/N5 so a crash between phases
+    # doesn't lose generated tests / implementation code.
+    workflow.add_node("N2_scaffold_tests", _wrap_with_checkpoint(scaffold_tests, "post-scaffold"))
     workflow.add_node("N2_5_validate_tests", validate_tests_mechanical_node)  # Issue #335
     workflow.add_node("N3_verify_red", verify_red_phase)
-    workflow.add_node("N4_implement_code", implement_code)
+    workflow.add_node("N4_implement_code", _wrap_with_checkpoint(implement_code, "post-impl"))
     workflow.add_node("N4b_completeness_gate", completeness_gate)  # Issue #147
-    workflow.add_node("N5_verify_green", verify_green_phase)
+    workflow.add_node("N5_verify_green", _wrap_with_checkpoint(verify_green_phase, "post-green"))
     workflow.add_node("N6_e2e_validation", e2e_validation)
     workflow.add_node("N7_finalize", finalize)
     workflow.add_node("N7_5_adversarial", run_adversarial_node)  # Issue #352

--- a/tests/unit/test_tdd_checkpoints.py
+++ b/tests/unit/test_tdd_checkpoints.py
@@ -1,0 +1,183 @@
+"""Tests for the TDD workflow checkpoint helper (Issue #689)."""
+import subprocess
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing import checkpoints
+
+
+def _mk_completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---- commit_checkpoint -- best-effort guards ----
+
+def test_returns_false_when_worktree_is_none():
+    assert checkpoints.commit_checkpoint(None, 123, "post-scaffold") is False
+
+
+def test_returns_false_when_worktree_path_is_not_directory(tmp_path):
+    nonexistent = tmp_path / "nope"
+    assert checkpoints.commit_checkpoint(nonexistent, 123, "post-scaffold") is False
+
+
+def test_returns_false_when_nothing_to_commit(tmp_path):
+    """If `git diff --cached --quiet` returns 0, no commit is created (idempotent)."""
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    def fake_run(cmd, **kw):
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=0)  # nothing staged
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is False
+
+
+def test_creates_commit_when_diff_has_staged_changes(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)  # diff non-empty -> 1
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is True
+
+    # Verify commit message contains [CP:post-scaffold] and issue #123
+    commit_calls = [c for c in cmds if "commit" in c]
+    assert any("[CP:post-scaffold]" in arg for c in commit_calls for arg in c), commit_calls
+    assert any("#123" in arg for c in commit_calls for arg in c), commit_calls
+
+
+def test_pushes_after_successful_commit(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        checkpoints.commit_checkpoint(wt, 123, "post-scaffold")
+
+    pushes = [c for c in cmds if "push" in c]
+    assert len(pushes) == 1, f"expected exactly one push, got {pushes}"
+
+
+def test_returns_true_even_when_push_fails(tmp_path):
+    """commit succeeded -> True. Push failure is logged but not propagated."""
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    def fake_run(cmd, **kw):
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)
+        if "push" in cmd:
+            return _mk_completed(returncode=128, stderr="fatal: could not resolve host")
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is True
+
+
+def test_returns_false_when_commit_itself_fails(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    def fake_run(cmd, **kw):
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)
+        if "commit" in cmd:
+            return _mk_completed(returncode=128, stderr="fatal: not a git repo")
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is False
+
+
+def test_omits_issue_reference_when_issue_number_is_none(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        checkpoints.commit_checkpoint(wt, None, "post-scaffold")
+
+    commit_calls = [c for c in cmds if "commit" in c]
+    # When issue is None, the message should NOT contain "issue #"
+    for c in commit_calls:
+        for arg in c:
+            assert "issue #" not in arg, f"message should not reference issue when None: {arg}"
+
+
+def test_excludes_workflow_internal_dirs_from_staging(tmp_path):
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    cmds: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        cmds.append(cmd)
+        if "diff" in cmd and "--quiet" in cmd:
+            return _mk_completed(returncode=1)
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        checkpoints.commit_checkpoint(wt, 123, "post-scaffold")
+
+    add_calls = [c for c in cmds if "add" in c]
+    assert add_calls, f"expected at least one git add call, got {cmds}"
+    # Each add call should include the exclude pathspecs for workflow-internal dirs
+    add_args = " ".join(add_calls[0])
+    assert ":!.assemblyzero" in add_args, f"exclude missing in {add_args}"
+    assert ":!data/lineage" in add_args, f"exclude missing in {add_args}"
+
+
+def test_timeout_handled_as_non_fatal(tmp_path):
+    """A subprocess timeout must not propagate -- the workflow node would
+    otherwise fail on a transient git issue."""
+    wt = tmp_path / "wt"
+    wt.mkdir()
+
+    def fake_run(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        # Should not raise
+        result = checkpoints.commit_checkpoint(wt, 123, "post-scaffold")
+    assert result is False
+
+
+# ---- _run wrapper has encoding defaults from #837 ----
+
+def test_underscore_run_uses_utf8_encoding_with_replace(tmp_path):
+    """The _run helper inherits the #837 defaults so any UTF-8 in git output
+    doesn't crash the checkpoint helper itself."""
+    captured_kw: list[dict] = []
+
+    def fake_run(cmd, **kw):
+        captured_kw.append(kw)
+        return _mk_completed(returncode=0)
+
+    with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
+        checkpoints._run(["git", "--version"], timeout=10)
+
+    assert captured_kw[0].get("encoding") == "utf-8"
+    assert captured_kw[0].get("errors") == "replace"


### PR DESCRIPTION
Closes #689

## Summary

Adds git commit checkpoints to the TDD workflow at the end of N2 (scaffold_tests), N4 (implement_code), and N5 (verify_green_phase). 2026-01-31 lost 6,114 lines because a worktree was deleted before the nodes had committed anything.

## Design

- New \`assemblyzero/workflows/testing/checkpoints.py\` with \`commit_checkpoint(worktree, issue, name)\`: best-effort stage + commit + push. Idempotent on empty diff, network-tolerant on push, never raises.
- New \`_wrap_with_checkpoint(node_fn, name)\` in \`graph.py\`: wrapper that runs the node then commits. Three lines changed in \`build_testing_workflow()\` to apply it to N2/N4/N5.
- 11 unit tests covering nil-worktree, empty-diff idempotency, push-failure-non-fatal, timeout-handling, exclude pathspecs, etc.

## Why best-effort?

A checkpoint failure must NOT fail the node it was protecting. The node's WORK lives in the working tree either way; committing is a recovery convenience. If git push fails (offline, no upstream, rejected), the local commit is still the primary recovery artifact.

## Speedrun impact

Direct: when boostgauge's implementation workflow runs tomorrow, a crash between N2 and N5 will leave the partial work committed in the feature branch instead of vaporizing it.

## Test plan
- [x] \`poetry run pytest tests/unit/test_tdd_checkpoints.py -v\` — 11 passing
- [x] \`poetry run ruff check --isolated\` — clean
- [x] Workflow graph wiring verified by reading graph.py: only the three target nodes wrapped, no other node touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)