### PR TITLE
feat: remediate_fleet_branch_protection.py -- fix boostgauge / gh-galaxy-quest / comp-environ (Closes #1126)

### DIFF
--- a/tests/test_remediate_fleet_branch_protection.py
+++ b/tests/test_remediate_fleet_branch_protection.py
@@ -1,0 +1,182 @@
+"""Tests for tools/remediate_fleet_branch_protection.py (#1126)."""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "remediate_fleet_branch_protection",
+    TOOLS_DIR / "remediate_fleet_branch_protection.py",
+)
+remediate = importlib.util.module_from_spec(_spec)
+sys.modules["remediate_fleet_branch_protection"] = remediate
+_spec.loader.exec_module(remediate)
+
+
+# ---- Target list is hard-coded (scope guard) ----
+
+def test_target_repos_is_exactly_three_named_repos():
+    """Regression guard: the target list must not widen accidentally."""
+    assert remediate.TARGET_REPOS == ("boostgauge", "gh-galaxy-quest", "comp-environ")
+
+
+def test_target_config_matches_fleet_canonical_strict():
+    cfg = remediate.TARGET_CONFIG
+    assert cfg["required_pull_request_reviews"]["required_approving_review_count"] == 1
+    assert cfg["enforce_admins"] is True
+    assert cfg["allow_force_pushes"] is False
+    assert cfg["allow_deletions"] is False
+    # Status check requires the canonical pr-sentinel context
+    contexts = [c["context"] for c in cfg["required_status_checks"]["checks"]]
+    assert "pr-sentinel / issue-reference" in contexts
+
+
+# ---- summarize_protection ----
+
+def test_summarize_none_reports_unprotected():
+    s = remediate.summarize_protection(None)
+    assert s["protected"] is False
+    assert s["required_reviews"] is None
+    assert s["enforce_admins"] is False
+
+
+def test_summarize_strict_protection_blob():
+    blob = {
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "required_status_checks": {"contexts": ["pr-sentinel / issue-reference"]},
+        "enforce_admins": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+        "allow_deletions": {"enabled": False},
+    }
+    s = remediate.summarize_protection(blob)
+    assert s["protected"] is True
+    assert s["required_reviews"] == 1
+    assert s["has_status_checks"] is True
+    assert s["enforce_admins"] is True
+
+
+def test_summarize_weak_blob_matches_boostgauge():
+    """Audit reported `required_reviews=None` for boostgauge -- the API
+    returns the section but with no count field."""
+    blob = {
+        "required_pull_request_reviews": {},  # no count -> reports None
+        "required_status_checks": None,
+        "enforce_admins": {"enabled": False},
+    }
+    s = remediate.summarize_protection(blob)
+    assert s["protected"] is True
+    assert s["required_reviews"] is None
+    assert s["has_status_checks"] is False
+    assert s["enforce_admins"] is False
+
+
+# ---- diff_lines ----
+
+def test_diff_strict_repo_returns_empty():
+    summary = {
+        "protected": True,
+        "required_reviews": 1,
+        "has_status_checks": True,
+        "enforce_admins": True,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+    }
+    assert remediate.diff_lines(summary) == []
+
+
+def test_diff_weak_repo_reports_all_failed_bars():
+    """boostgauge / gh-galaxy-quest -- weak protected repo."""
+    summary = {
+        "protected": True,
+        "required_reviews": None,
+        "has_status_checks": False,
+        "enforce_admins": False,
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+    }
+    deltas = remediate.diff_lines(summary)
+    assert any("required_reviews" in d for d in deltas)
+    assert any("required_status_checks" in d for d in deltas)
+    assert any("enforce_admins" in d for d in deltas)
+
+
+def test_diff_unprotected_repo_includes_protection_creation_line():
+    """comp-environ -- has no protection at all."""
+    summary = remediate.summarize_protection(None)
+    deltas = remediate.diff_lines(summary)
+    # The first line should communicate "creating protection from scratch"
+    assert deltas[0].startswith("protected: false -> true")
+
+
+# ---- main() guard: --apply requires --confirm-yes ----
+
+def test_main_rejects_apply_without_confirm_yes(capsys):
+    rc = remediate.main(["--apply"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "--confirm-yes" in err
+
+
+# ---- main() dry-run does NOT call apply_protection ----
+
+def test_main_dry_run_never_calls_apply(capsys):
+    """Even if every target repo needs changes, dry-run must not PUT."""
+    with patch.object(remediate, "classic_pat_session") as mock_ctx, \
+         patch.object(remediate, "get_default_branch", return_value="main"), \
+         patch.object(remediate, "get_current_protection", return_value=None) as mock_get, \
+         patch.object(remediate, "apply_protection") as mock_apply:
+        mock_ctx.return_value.__enter__.return_value = "fake-pat"
+        rc = remediate.main([])  # no flags = dry-run
+
+    # All three targets were inspected (None protection -> needs changes)
+    assert mock_get.call_count == 3
+    # But no PUTs
+    mock_apply.assert_not_called()
+    assert rc == 0
+
+
+# ---- main() apply path does call apply_protection ----
+
+def test_main_apply_path_calls_apply_for_each_target():
+    with patch.object(remediate, "classic_pat_session") as mock_ctx, \
+         patch.object(remediate, "get_default_branch", return_value="main"), \
+         patch.object(remediate, "get_current_protection", return_value=None), \
+         patch.object(remediate, "apply_protection", return_value=True) as mock_apply:
+        mock_ctx.return_value.__enter__.return_value = "fake-pat"
+        rc = remediate.main(["--apply", "--confirm-yes"])
+
+    assert mock_apply.call_count == 3
+    repos_called = [c.args[0] for c in mock_apply.call_args_list]
+    assert set(repos_called) == {"boostgauge", "gh-galaxy-quest", "comp-environ"}
+    assert rc == 0
+
+
+def test_main_returns_2_when_any_apply_fails():
+    def fake_apply(repo, branch, pat):
+        return repo != "boostgauge"  # boostgauge fails
+
+    with patch.object(remediate, "classic_pat_session") as mock_ctx, \
+         patch.object(remediate, "get_default_branch", return_value="main"), \
+         patch.object(remediate, "get_current_protection", return_value=None), \
+         patch.object(remediate, "apply_protection", side_effect=fake_apply):
+        mock_ctx.return_value.__enter__.return_value = "fake-pat"
+        rc = remediate.main(["--apply", "--confirm-yes"])
+
+    assert rc == 2
+
+
+def test_main_skips_target_with_unresolvable_default_branch():
+    """If a repo's default branch can't be fetched (archived? deleted?),
+    the script must report it as a failure but continue with the others."""
+    def fake_default(repo, pat):
+        return None if repo == "comp-environ" else "main"
+
+    with patch.object(remediate, "classic_pat_session") as mock_ctx, \
+         patch.object(remediate, "get_default_branch", side_effect=fake_default), \
+         patch.object(remediate, "get_current_protection", return_value=None), \
+         patch.object(remediate, "apply_protection", return_value=True):
+        mock_ctx.return_value.__enter__.return_value = "fake-pat"
+        rc = remediate.main(["--apply", "--confirm-yes"])
+
+    assert rc == 2  # one failure

--- a/tools/remediate_fleet_branch_protection.py
+++ b/tools/remediate_fleet_branch_protection.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Remediate weak / unprotected branch protection on the 3 named repos
+identified by the #1124 audit (Closes #1126).
+
+THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
+It uses an in-process classic PAT (ADR-0216). The PAT is decrypted into
+the Python process heap; an agent-spawned subprocess would have
+theoretical heap-read access.
+
+What this script does:
+
+  1. Iterates TARGET_REPOS -- a hard-coded list of three repos
+     (boostgauge, gh-galaxy-quest, comp-environ) that the #1124 audit
+     flagged. NOT parameter-driven so a re-run can't accidentally
+     widen scope.
+  2. For each target, GETs the current protection state.
+  3. Computes the diff against the TARGET_CONFIG (fleet-canonical
+     strict config: 1 review, pr-sentinel status check, enforce_admins,
+     no force pushes, no deletions).
+  4. In --dry-run (default): prints the diff per repo, exits 0.
+  5. In --apply --confirm-yes: PUTs the target config per repo,
+     prints the resulting state, exits 0 on success.
+
+Idempotent: a repo already at TARGET_CONFIG gets the same PUT and
+GitHub no-ops it. Safe to re-run.
+
+Usage:
+
+    # Preview what would change (default; safe)
+    poetry run python tools/remediate_fleet_branch_protection.py
+
+    # Actually apply the changes
+    poetry run python tools/remediate_fleet_branch_protection.py --apply --confirm-yes
+
+Issue: #1126 | Related: #1124 (audit), ADR-0216 (classic PAT)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+
+# Hard-coded scope (#1126). Not parameter-driven on purpose: a re-run
+# must not be able to widen the blast radius via accidental --repos flag.
+TARGET_REPOS: tuple[str, ...] = (
+    "boostgauge",
+    "gh-galaxy-quest",
+    "comp-environ",
+)
+
+# Canonical strict config. Matches what the 49 STRICT fleet repos use.
+TARGET_CONFIG: dict[str, Any] = {
+    "required_pull_request_reviews": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews": False,
+        "require_code_owner_reviews": False,
+    },
+    "required_status_checks": {
+        "strict": True,
+        "checks": [{"context": "pr-sentinel / issue-reference"}],
+    },
+    "enforce_admins": True,
+    "restrictions": None,
+    "allow_force_pushes": False,
+    "allow_deletions": False,
+}
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_default_branch(repo: str, pat: str) -> str | None:
+    """Fetch the repo's default branch name. Returns None on any failure."""
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None
+    if r.status_code >= 300:
+        return None
+    return r.json().get("default_branch")
+
+
+def get_current_protection(repo: str, default_branch: str, pat: str) -> dict | None:
+    """GET current branch protection. Returns dict on 200, None on 404 / error."""
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/branches/{default_branch}/protection",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None
+    if r.status_code == 404:
+        return None  # unprotected
+    if r.status_code >= 300:
+        return None
+    return r.json()
+
+
+def summarize_protection(prot: dict | None) -> dict[str, Any]:
+    """Reduce a protection blob to the fields the policy bar cares about."""
+    if prot is None:
+        return {
+            "protected": False,
+            "required_reviews": None,
+            "has_status_checks": False,
+            "enforce_admins": False,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+        }
+    rpr = prot.get("required_pull_request_reviews") or {}
+    rsc = prot.get("required_status_checks") or {}
+    enforce = prot.get("enforce_admins") or {}
+    afp = prot.get("allow_force_pushes") or {}
+    adel = prot.get("allow_deletions") or {}
+    return {
+        "protected": True,
+        "required_reviews": rpr.get("required_approving_review_count"),
+        "has_status_checks": bool(
+            (rsc.get("contexts") or []) or (rsc.get("checks") or [])
+        ),
+        "enforce_admins": bool(enforce.get("enabled")) if isinstance(enforce, dict) else False,
+        "allow_force_pushes": bool(afp.get("enabled")) if isinstance(afp, dict) else False,
+        "allow_deletions": bool(adel.get("enabled")) if isinstance(adel, dict) else False,
+    }
+
+
+def diff_lines(summary: dict[str, Any]) -> list[str]:
+    """Return per-field deltas vs TARGET_CONFIG. Empty list = no change."""
+    deltas: list[str] = []
+    target_reviews = TARGET_CONFIG["required_pull_request_reviews"]["required_approving_review_count"]
+    if summary["required_reviews"] != target_reviews:
+        deltas.append(
+            f"required_reviews: {summary['required_reviews']} -> {target_reviews}"
+        )
+    if not summary["has_status_checks"]:
+        deltas.append(
+            "required_status_checks: NONE -> [pr-sentinel / issue-reference]"
+        )
+    if not summary["enforce_admins"]:
+        deltas.append(f"enforce_admins: {summary['enforce_admins']} -> True")
+    if summary["allow_force_pushes"]:
+        deltas.append("allow_force_pushes: True -> False")
+    if summary["allow_deletions"]:
+        deltas.append("allow_deletions: True -> False")
+    if not summary["protected"]:
+        deltas.insert(0, "protected: false -> true (creating protection)")
+    return deltas
+
+
+def apply_protection(repo: str, default_branch: str, pat: str) -> bool:
+    """PUT the target protection config. Returns True on 2xx."""
+    try:
+        r = requests.put(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/branches/{default_branch}/protection",
+            headers=_headers(pat),
+            json=TARGET_CONFIG,
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        print(f"    PUT failed: {e}")
+        return False
+    if r.status_code >= 300:
+        print(f"    PUT returned {r.status_code}: {r.text[:300]}")
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually PUT the target config. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--confirm-yes", action="store_true",
+        help="Belt-and-braces second flag required alongside --apply.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.apply and not args.confirm_yes:
+        print("ERROR: --apply requires --confirm-yes (a deliberate second flag "
+              "to defeat muscle-memory mistakes).", file=sys.stderr)
+        return 1
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"Mode: {mode}")
+    print(f"Targets: {', '.join(TARGET_REPOS)}")
+    print()
+
+    failures: list[str] = []
+    no_changes: list[str] = []
+
+    with classic_pat_session() as pat:
+        for repo in TARGET_REPOS:
+            print(f"--- {repo} ---")
+            default = get_default_branch(repo, pat)
+            if not default:
+                print("  ERROR: could not resolve default branch (repo missing? archived?)")
+                failures.append(repo)
+                continue
+            prot = get_current_protection(repo, default, pat)
+            summary = summarize_protection(prot)
+            deltas = diff_lines(summary)
+
+            if not deltas:
+                print("  no changes needed (already at target config)")
+                no_changes.append(repo)
+                continue
+
+            print(f"  branch: {default}")
+            print("  changes:")
+            for d in deltas:
+                print(f"    - {d}")
+
+            if not args.apply:
+                continue
+
+            ok = apply_protection(repo, default, pat)
+            if ok:
+                print("  APPLIED")
+            else:
+                print("  FAILED to apply (see error above)")
+                failures.append(repo)
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    if no_changes:
+        print(f"  no-op (already strict): {', '.join(no_changes)}")
+    if not args.apply:
+        print("  dry-run mode -- no changes were written.")
+        print("  Re-run with --apply --confirm-yes to apply.")
+    if failures:
+        print(f"  FAILURES: {', '.join(failures)}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1126
Refs #1124

## What this PR adds

\`tools/remediate_fleet_branch_protection.py\` -- the remediation half of the #1124 follow-up. PUTs the canonical strict branch-protection config (1 review, pr-sentinel status check, enforce_admins, no force pushes, no deletions) on the three repos flagged by the audit:

- \`boostgauge\` (WEAK -- the original trigger)
- \`gh-galaxy-quest\` (WEAK)
- \`comp-environ\` (UNPROTECTED -- creating protection from scratch)

## Safety design

| Risk | Mitigation |
|---|---|
| Scope creep via accidental \`--repos\` flag | TARGET_REPOS is a hard-coded tuple; no flag accepts a different list |
| Muscle-memory \`--apply\` | Default mode is \`--dry-run\`; actual apply requires BOTH \`--apply\` AND \`--confirm-yes\` |
| Replay on already-strict repo | Idempotent -- GitHub no-ops on identical PUT |
| One bad PUT aborting others | Per-repo failure isolated; exit code 2 if any fail |
| PAT exposure | Classic PAT in-process via ADR-0216 \`_pat_session.classic_pat_session()\`; user runs the script |

## How to use after merge

\`\`\`bash
cd /c/Users/mcwiz/Projects/AssemblyZero

# 1) Preview the diff for each repo (safe -- read only)
poetry run python tools/remediate_fleet_branch_protection.py

# 2) Apply
poetry run python tools/remediate_fleet_branch_protection.py --apply --confirm-yes

# 3) Re-run the audit to verify
poetry run python tools/audit_fleet_branch_protection.py
\`\`\`

## Test plan
- [x] 13 unit tests passing, including:
  - Scope guard: TARGET_REPOS frozen to exactly the three named
  - Apply-without-confirm-yes rejected (rc=1)
  - Dry-run never calls apply_protection
  - Apply path PUTs all three targets
  - Per-repo failure preserves rc=2
- [x] \`poetry run ruff check --isolated\` -- clean

## Followup (out of scope for this PR)

- \`comp-environ\` and \`gh-galaxy-quest\` may not have auto-reviewer.yml deployed. Once branch protection is strict, PRs in those repos will sit waiting on a review that never comes from Cerberus. The user can deploy via \`poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem --repo comp-environ\` etc. when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)