### PR TITLE
feat: fleet auto-merge readiness audit + auto-reviewer.yml deploy (Closes #1128)

### DIFF
--- a/tests/test_fleet_readiness.py
+++ b/tests/test_fleet_readiness.py
@@ -1,0 +1,232 @@
+"""Tests for the fleet auto-merge readiness audit + workflow deploy (#1128)."""
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, TOOLS_DIR / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+audit = _load("audit_fleet_auto_merge_readiness")
+deploy = _load("deploy_auto_reviewer_workflow")
+
+
+# =========================================================================
+# audit_fleet_auto_merge_readiness
+# =========================================================================
+
+def _strict_protection_body():
+    return {
+        "required_pull_request_reviews": {"required_approving_review_count": 1},
+        "required_status_checks": {"contexts": ["pr-sentinel / issue-reference"]},
+        "enforce_admins": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+    }
+
+
+def _ready_secrets_body():
+    return {"secrets": [
+        {"name": "REVIEWER_APP_ID"},
+        {"name": "REVIEWER_APP_PRIVATE_KEY"},
+    ]}
+
+
+def test_audit_one_ready_repo_passes_all_four_dimensions():
+    repo = {"name": "good", "defaultBranchRef": {"name": "main"}}
+
+    def fake_get(url, pat):
+        if "/protection" in url:
+            return 200, _strict_protection_body()
+        if "/contents/.github/workflows/auto-reviewer.yml" in url:
+            return 200, {"name": "auto-reviewer.yml"}
+        if "/actions/secrets" in url or "/dependabot/secrets" in url:
+            return 200, _ready_secrets_body()
+        return 200, {}
+
+    with patch.object(audit, "_api_get", side_effect=fake_get):
+        r = audit.audit_one(repo, "pat")
+
+    assert r.verdict == "READY"
+    assert r.failures == []
+    assert r.protection_strict is True
+    assert r.workflow_present is True
+    assert r.actions_secrets_complete is True
+    assert r.dependabot_secrets_complete is True
+
+
+def test_audit_one_repo_missing_workflow_classified_not_ready():
+    """The exact scenario that motivated #1128 -- comp-environ has strict
+    protection but no auto-reviewer.yml."""
+    repo = {"name": "comp-environ", "defaultBranchRef": {"name": "main"}}
+
+    def fake_get(url, pat):
+        if "/protection" in url:
+            return 200, _strict_protection_body()
+        if "/contents/.github/workflows/auto-reviewer.yml" in url:
+            return 404, None
+        if "/actions/secrets" in url or "/dependabot/secrets" in url:
+            return 200, _ready_secrets_body()
+        return 200, {}
+
+    with patch.object(audit, "_api_get", side_effect=fake_get):
+        r = audit.audit_one(repo, "pat")
+
+    assert r.verdict == "NOT_READY"
+    assert "auto_reviewer_yml_missing" in r.failures
+    # The other 3 dimensions should be OK; workflow is the only failure
+    assert "branch_protection_not_strict" not in r.failures
+
+
+def test_audit_one_repo_missing_dependabot_secrets_classified_not_ready():
+    """The #1118 / PR #1119 failure mode."""
+    repo = {"name": "old-repo", "defaultBranchRef": {"name": "main"}}
+
+    def fake_get(url, pat):
+        if "/protection" in url:
+            return 200, _strict_protection_body()
+        if "/contents/.github/workflows/auto-reviewer.yml" in url:
+            return 200, {}
+        if "/actions/secrets" in url:
+            return 200, _ready_secrets_body()
+        if "/dependabot/secrets" in url:
+            return 200, {"secrets": []}  # empty -- the #1118 fail mode
+        return 200, {}
+
+    with patch.object(audit, "_api_get", side_effect=fake_get):
+        r = audit.audit_one(repo, "pat")
+
+    assert r.verdict == "NOT_READY"
+    assert "dependabot_secrets_incomplete" in r.failures
+
+
+def test_audit_one_repo_with_no_default_branch_unknown():
+    repo = {"name": "empty", "defaultBranchRef": None}
+    with patch.object(audit, "_api_get") as mock_get:
+        r = audit.audit_one(repo, "pat")
+    assert r.verdict == "UNKNOWN"
+    assert r.error == "no_default_branch"
+    mock_get.assert_not_called()
+
+
+def test_audit_one_accumulates_multiple_failures():
+    """A repo can fail multiple dimensions; we report all of them."""
+    repo = {"name": "x", "defaultBranchRef": {"name": "main"}}
+
+    def fake_get(url, pat):
+        if "/protection" in url:
+            return 404, None  # unprotected
+        if "/contents/.github/workflows/auto-reviewer.yml" in url:
+            return 404, None  # missing
+        if "/actions/secrets" in url:
+            return 200, {"secrets": []}  # missing both
+        if "/dependabot/secrets" in url:
+            return 200, {"secrets": []}
+        return 200, {}
+
+    with patch.object(audit, "_api_get", side_effect=fake_get):
+        r = audit.audit_one(repo, "pat")
+
+    assert r.verdict == "NOT_READY"
+    assert len(r.failures) == 4
+
+
+def test_audit_tsv_row_includes_all_four_dims():
+    r = audit.RepoReadiness(
+        name="x", default_branch="main",
+        protection_strict=True, workflow_present=True,
+        actions_secrets_complete=True, dependabot_secrets_complete=False,
+        failures=["dependabot_secrets_incomplete"],
+    )
+    cols = r.tsv_row().split("\t")
+    assert cols[0] == "x"
+    assert cols[1] == "NOT_READY"
+    assert cols[2] == "main"
+    assert cols[3] == "True"
+    assert cols[4] == "True"
+    assert cols[5] == "True"
+    assert cols[6] == "False"
+
+
+# =========================================================================
+# deploy_auto_reviewer_workflow
+# =========================================================================
+
+def test_caller_workflow_calls_az_reusable():
+    """The caller content must reference the AZ reusable workflow path."""
+    assert "uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main" \
+        in deploy.CALLER_WORKFLOW
+    assert "secrets: inherit" in deploy.CALLER_WORKFLOW
+    assert "pull_request" in deploy.CALLER_WORKFLOW
+
+
+def test_caller_workflow_triggers_on_only_needed_pr_events():
+    """opened/synchronize/reopened -- nothing else. 'edited' must NOT be
+    here per the existing auto-reviewer / pr-sentinel architecture."""
+    assert "opened" in deploy.CALLER_WORKFLOW
+    assert "synchronize" in deploy.CALLER_WORKFLOW
+    assert "reopened" in deploy.CALLER_WORKFLOW
+    assert "edited" not in deploy.CALLER_WORKFLOW
+
+
+def test_deploy_main_rejects_apply_without_confirm_yes(capsys):
+    rc = deploy.main(["--repos", "x", "--apply"])
+    assert rc == 1
+    assert "--confirm-yes" in capsys.readouterr().err
+
+
+def test_deploy_main_rejects_empty_repos(capsys):
+    rc = deploy.main(["--repos", ""])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "empty" in err.lower()
+
+
+def test_deploy_skips_repo_that_already_has_workflow():
+    with patch.object(deploy, "classic_pat_session") as mock_ctx, \
+         patch.object(deploy, "get_default_branch", return_value="main"), \
+         patch.object(deploy, "workflow_status", return_value=(True, "existing-sha")), \
+         patch.object(deploy, "put_workflow") as mock_put:
+        mock_ctx.return_value.__enter__.return_value = "pat"
+        rc = deploy.main(["--repos", "alpha", "--apply", "--confirm-yes"])
+    mock_put.assert_not_called()
+    assert rc == 0
+
+
+def test_deploy_puts_when_missing():
+    with patch.object(deploy, "classic_pat_session") as mock_ctx, \
+         patch.object(deploy, "get_default_branch", return_value="main"), \
+         patch.object(deploy, "workflow_status", return_value=(False, None)), \
+         patch.object(deploy, "put_workflow", return_value=(True, None)) as mock_put:
+        mock_ctx.return_value.__enter__.return_value = "pat"
+        rc = deploy.main(["--repos", "alpha,beta", "--apply", "--confirm-yes"])
+    assert mock_put.call_count == 2
+    assert rc == 0
+
+
+def test_deploy_dry_run_never_calls_put():
+    with patch.object(deploy, "classic_pat_session") as mock_ctx, \
+         patch.object(deploy, "get_default_branch", return_value="main"), \
+         patch.object(deploy, "workflow_status", return_value=(False, None)), \
+         patch.object(deploy, "put_workflow") as mock_put:
+        mock_ctx.return_value.__enter__.return_value = "pat"
+        rc = deploy.main(["--repos", "alpha"])  # no --apply
+    mock_put.assert_not_called()
+    assert rc == 0
+
+
+def test_deploy_returns_2_when_put_fails():
+    with patch.object(deploy, "classic_pat_session") as mock_ctx, \
+         patch.object(deploy, "get_default_branch", return_value="main"), \
+         patch.object(deploy, "workflow_status", return_value=(False, None)), \
+         patch.object(deploy, "put_workflow", return_value=(False, "PUT 403")):
+        mock_ctx.return_value.__enter__.return_value = "pat"
+        rc = deploy.main(["--repos", "alpha", "--apply", "--confirm-yes"])
+    assert rc == 2

--- a/tools/audit_fleet_auto_merge_readiness.py
+++ b/tools/audit_fleet_auto_merge_readiness.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Comprehensive fleet audit: is each repo ready for PRs to auto-merge?
+
+THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
+Uses an in-process classic PAT (ADR-0216).
+
+A repo is auto-merge-ready iff ALL FOUR are true:
+
+  1. Branch protection is strict
+       (>=1 review, status checks required, enforce_admins, no force pushes)
+  2. .github/workflows/auto-reviewer.yml exists on the default branch
+  3. Actions secrets contain REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
+  4. Dependabot secrets contain REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
+
+#1124 audited dimension 1. #1118 added dimension 4. This script checks
+all four and reports per-repo readiness.
+
+Output:
+  - audit_fleet_auto_merge_readiness_results.tsv (one row per repo)
+  - Summary printed listing every NOT_READY repo with the failing dims
+
+Issue: #1128 | Related: #1124 (protection audit), #1118 (dependabot scope)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+WORKFLOW_PATH = ".github/workflows/auto-reviewer.yml"
+REQUIRED_SECRETS = {"REVIEWER_APP_ID", "REVIEWER_APP_PRIVATE_KEY"}
+DEFAULT_OUTPUT = Path("audit_fleet_auto_merge_readiness_results.tsv")
+
+
+@dataclass
+class RepoReadiness:
+    name: str
+    default_branch: str | None = None
+    protection_strict: bool | None = None
+    workflow_present: bool | None = None
+    actions_secrets_complete: bool | None = None
+    dependabot_secrets_complete: bool | None = None
+    failures: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def verdict(self) -> str:
+        if self.error:
+            return "UNKNOWN"
+        if self.failures:
+            return "NOT_READY"
+        return "READY"
+
+    def tsv_row(self) -> str:
+        return "\t".join([
+            self.name,
+            self.verdict,
+            self.default_branch or "",
+            _b(self.protection_strict),
+            _b(self.workflow_present),
+            _b(self.actions_secrets_complete),
+            _b(self.dependabot_secrets_complete),
+            ",".join(self.failures),
+            self.error or "",
+        ])
+
+
+def _b(v: bool | None) -> str:
+    return "" if v is None else str(v)
+
+
+TSV_HEADER = "\t".join([
+    "repo", "verdict", "default_branch",
+    "protection_strict", "workflow_present",
+    "actions_secrets_complete", "dependabot_secrets_complete",
+    "failures", "error",
+])
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _api_get(url: str, pat: str) -> tuple[int, dict | list | None]:
+    try:
+        r = requests.get(url, headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+    except requests.RequestException as e:
+        return 0, {"_error": str(e)}
+    try:
+        body = r.json() if r.text else None
+    except ValueError:
+        body = None
+    return r.status_code, body
+
+
+def list_repos() -> list[dict]:
+    """List martymcenroe repos via gh CLI (read-only; fine-grained PAT OK)."""
+    result = subprocess.run(
+        ["gh", "repo", "list", GITHUB_USER, "--limit", "200",
+         "--json", "name,defaultBranchRef,isArchived,isFork"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        check=False, timeout=60,
+    )
+    if result.returncode != 0:
+        sys.exit(f"gh repo list failed: {result.stderr.strip()[:300]}")
+    return json.loads(result.stdout or "[]")
+
+
+def check_protection(repo: str, default: str, pat: str) -> tuple[bool | None, str | None]:
+    """Return (is_strict, error). is_strict=None on error."""
+    code, body = _api_get(
+        f"{GH_API}/repos/{GITHUB_USER}/{repo}/branches/{default}/protection", pat,
+    )
+    if code == 404:
+        return False, None  # unprotected
+    if code == 0 or not isinstance(body, dict):
+        return None, f"protection GET {code}"
+    if code >= 300:
+        return None, f"protection GET {code}"
+
+    rpr = body.get("required_pull_request_reviews") or {}
+    rsc = body.get("required_status_checks") or {}
+    enforce = body.get("enforce_admins") or {}
+    afp = body.get("allow_force_pushes") or {}
+
+    reviews_ok = rpr.get("required_approving_review_count", 0) >= 1
+    checks_ok = bool((rsc.get("contexts") or []) or (rsc.get("checks") or []))
+    enforce_ok = bool(enforce.get("enabled")) if isinstance(enforce, dict) else False
+    no_force = not (bool(afp.get("enabled")) if isinstance(afp, dict) else False)
+
+    return (reviews_ok and checks_ok and enforce_ok and no_force), None
+
+
+def check_workflow(repo: str, default: str, pat: str) -> tuple[bool | None, str | None]:
+    """Return (workflow_present, error). Checks default-branch HEAD."""
+    code, body = _api_get(
+        f"{GH_API}/repos/{GITHUB_USER}/{repo}/contents/{WORKFLOW_PATH}?ref={default}", pat,
+    )
+    if code == 404:
+        return False, None
+    if code == 200:
+        return True, None
+    return None, f"workflow GET {code}"
+
+
+def check_secrets(repo: str, scope: str, pat: str) -> tuple[bool | None, str | None]:
+    """scope: 'actions' or 'dependabot'. Returns (all_present, error)."""
+    code, body = _api_get(
+        f"{GH_API}/repos/{GITHUB_USER}/{repo}/{scope}/secrets", pat,
+    )
+    if code != 200 or not isinstance(body, dict):
+        return None, f"{scope}/secrets GET {code}"
+    present = {s["name"] for s in body.get("secrets", [])}
+    return REQUIRED_SECRETS.issubset(present), None
+
+
+def audit_one(repo_obj: dict, pat: str) -> RepoReadiness:
+    name = repo_obj["name"]
+    default = (repo_obj.get("defaultBranchRef") or {}).get("name")
+    r = RepoReadiness(name=name, default_branch=default)
+
+    if not default:
+        r.error = "no_default_branch"
+        return r
+
+    # 1. Branch protection
+    is_strict, err = check_protection(name, default, pat)
+    r.protection_strict = is_strict
+    if err:
+        r.error = err
+        return r
+    if not is_strict:
+        r.failures.append("branch_protection_not_strict")
+
+    # 2. Workflow file
+    has_wf, err = check_workflow(name, default, pat)
+    r.workflow_present = has_wf
+    if err:
+        r.error = err
+        return r
+    if not has_wf:
+        r.failures.append("auto_reviewer_yml_missing")
+
+    # 3. Actions secrets
+    has_act, err = check_secrets(name, "actions", pat)
+    r.actions_secrets_complete = has_act
+    if err:
+        r.error = err
+        return r
+    if not has_act:
+        r.failures.append("actions_secrets_incomplete")
+
+    # 4. Dependabot secrets
+    has_dep, err = check_secrets(name, "dependabot", pat)
+    r.dependabot_secrets_complete = has_dep
+    if err:
+        r.error = err
+        return r
+    if not has_dep:
+        r.failures.append("dependabot_secrets_incomplete")
+
+    return r
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Audit only the first N repos (smoke test)")
+    parser.add_argument("--repos", default=None,
+                        help="Comma-separated repo names; overrides full discovery")
+    args = parser.parse_args(argv)
+
+    print("Listing repos via gh CLI (read-only)...")
+    all_repos = list_repos()
+
+    if args.repos:
+        names = {r.strip() for r in args.repos.split(",") if r.strip()}
+        repos = [r for r in all_repos if r["name"] in names]
+    else:
+        repos = [r for r in all_repos if not r.get("isArchived") and not r.get("isFork")]
+        if args.limit:
+            repos = repos[: args.limit]
+
+    print(f"Auditing {len(repos)} repos across 4 dimensions...\n")
+
+    results: list[RepoReadiness] = []
+    with classic_pat_session() as pat:
+        for i, repo_obj in enumerate(repos, 1):
+            r = audit_one(repo_obj, pat)
+            results.append(r)
+            tag = r.verdict
+            extra = (f" -- {', '.join(r.failures)}" if r.failures else "")
+            err = (f" ERROR: {r.error}" if r.error else "")
+            print(f"  [{i}/{len(repos)}] {r.name}: {tag}{extra}{err}")
+
+    args.output.write_text(
+        TSV_HEADER + "\n" + "\n".join(r.tsv_row() for r in results) + "\n",
+        encoding="utf-8",
+    )
+    print(f"\nTSV written: {args.output.resolve()}")
+
+    by_verdict: dict[str, list[RepoReadiness]] = {}
+    for r in results:
+        by_verdict.setdefault(r.verdict, []).append(r)
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for v in ("READY", "NOT_READY", "UNKNOWN"):
+        count = len(by_verdict.get(v, []))
+        print(f"  {v}: {count}")
+
+    not_ready = by_verdict.get("NOT_READY", [])
+    if not_ready:
+        print("\nREPOS NOT READY FOR AUTO-MERGE:")
+        for r in not_ready:
+            print(f"  - {r.name}: {', '.join(r.failures)}")
+        return 2
+
+    print("\nAll audited repos ready for auto-merge.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/deploy_auto_reviewer_workflow.py
+++ b/tools/deploy_auto_reviewer_workflow.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Deploy the canonical auto-reviewer.yml workflow to repos missing it (#1128).
+
+THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
+Uses an in-process classic PAT (ADR-0216). The PAT carries `workflow`
+scope so it can push `.github/workflows/*` via the Contents API --
+fine-grained PATs intentionally lack that scope.
+
+What this script does:
+
+  1. Determines the canonical auto-reviewer.yml content. By default,
+     reads it from the local AssemblyZero checkout (the one this
+     script lives in -- AssemblyZero's own auto-reviewer.yml IS the
+     canonical source since other repos call it as a reusable workflow
+     via `uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main`).
+     But wait -- each repo ALSO needs its own auto-reviewer.yml that
+     calls the reusable one. That caller file is the CALLER pattern
+     used by every other repo. We deploy THAT caller pattern.
+  2. For each target repo, PUTs the caller file via Contents API to
+     `.github/workflows/auto-reviewer.yml` on the default branch.
+  3. Idempotent: skips repos that already have the file.
+
+The canonical CALLER file is a 6-line YAML that invokes the AZ
+reusable workflow on PR events:
+
+    name: auto-reviewer
+    on:
+      pull_request:
+        types: [opened, synchronize, reopened]
+    jobs:
+      review:
+        uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
+        secrets: inherit
+
+Usage:
+
+    # Dry-run (default; safe)
+    poetry run python tools/deploy_auto_reviewer_workflow.py --repos comp-environ,gh-galaxy-quest
+
+    # Apply
+    poetry run python tools/deploy_auto_reviewer_workflow.py \
+        --repos comp-environ,gh-galaxy-quest --apply --confirm-yes
+
+Issue: #1128 | Related: PR #1119 (#1118 dual-scope secrets), ADR-0216
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+WORKFLOW_PATH = ".github/workflows/auto-reviewer.yml"
+
+# Canonical caller workflow. Mirrors what every other repo in the fleet
+# uses to invoke the AssemblyZero reusable auto-reviewer.yml.
+CALLER_WORKFLOW = """\
+name: auto-reviewer
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
+    secrets: inherit
+"""
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_default_branch(repo: str, pat: str) -> str | None:
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None
+    if r.status_code >= 300:
+        return None
+    return r.json().get("default_branch")
+
+
+def workflow_status(repo: str, branch: str, pat: str) -> tuple[bool | None, str | None]:
+    """Return (exists, blob_sha). exists=None means GET errored.
+    blob_sha is the SHA of the existing file (needed for PUT-update),
+    or None when the file doesn't exist."""
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/contents/{WORKFLOW_PATH}?ref={branch}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        return None, None
+    if r.status_code == 404:
+        return False, None
+    if r.status_code != 200:
+        return None, None
+    return True, r.json().get("sha")
+
+
+def put_workflow(repo: str, branch: str, existing_sha: str | None,
+                 pat: str) -> tuple[bool, str | None]:
+    """PUT the canonical workflow content to the repo's default branch.
+    CRLF-normalised per memory: Contents API stores bytes verbatim;
+    Windows working trees ship CRLF which would flip line endings.
+
+    Returns (success, error)."""
+    content_bytes = CALLER_WORKFLOW.replace("\r\n", "\n").encode("utf-8")
+    payload: dict = {
+        "message": (
+            "ci: add auto-reviewer.yml -- Cerberus auto-approve on PRs "
+            "(fleet readiness, #1128)"
+        ),
+        "content": base64.b64encode(content_bytes).decode("ascii"),
+        "branch": branch,
+    }
+    if existing_sha:
+        payload["sha"] = existing_sha
+
+    try:
+        r = requests.put(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/contents/{WORKFLOW_PATH}",
+            headers=_headers(pat), json=payload, timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return False, f"network: {e}"
+    if r.status_code >= 300:
+        return False, f"PUT {r.status_code}: {r.text[:300]}"
+    return True, None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument(
+        "--repos", required=True,
+        help="Comma-separated repo names to target. Required -- no default-list "
+             "discovery; the operator must name each target explicitly.",
+    )
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually PUT the file. Default is dry-run.")
+    parser.add_argument("--confirm-yes", action="store_true",
+                        help="Belt-and-braces second flag required with --apply.")
+    args = parser.parse_args(argv)
+
+    if args.apply and not args.confirm_yes:
+        print("ERROR: --apply requires --confirm-yes (deliberate second flag).",
+              file=sys.stderr)
+        return 1
+
+    targets = [r.strip() for r in args.repos.split(",") if r.strip()]
+    if not targets:
+        print("ERROR: --repos was empty after parsing.", file=sys.stderr)
+        return 1
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"Mode: {mode}")
+    print(f"Targets: {', '.join(targets)}")
+    print()
+
+    failures: list[str] = []
+    skipped: list[str] = []
+
+    with classic_pat_session() as pat:
+        for repo in targets:
+            print(f"--- {repo} ---")
+            branch = get_default_branch(repo, pat)
+            if not branch:
+                print("  ERROR: could not resolve default branch")
+                failures.append(repo)
+                continue
+
+            exists, sha = workflow_status(repo, branch, pat)
+            if exists is None:
+                print("  ERROR: could not query workflow file state")
+                failures.append(repo)
+                continue
+            if exists:
+                print("  already present -- skipping (idempotent)")
+                skipped.append(repo)
+                continue
+
+            print(f"  branch: {branch}")
+            print(f"  would PUT {WORKFLOW_PATH} ({len(CALLER_WORKFLOW)} bytes)")
+            if not args.apply:
+                continue
+
+            ok, err = put_workflow(repo, branch, None, pat)
+            if ok:
+                print("  APPLIED")
+            else:
+                print(f"  FAILED: {err}")
+                failures.append(repo)
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    if skipped:
+        print(f"  already present (no-op): {', '.join(skipped)}")
+    if not args.apply:
+        print("  dry-run -- no PUTs. Re-run with --apply --confirm-yes to apply.")
+    if failures:
+        print(f"  FAILURES: {', '.join(failures)}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1128

## What this PR adds

Two tools that close the gap exposed when comp-environ + gh-galaxy-quest got strict branch protection but turned out to be missing the workflow file that makes that protection workable:

1. **\`tools/audit_fleet_auto_merge_readiness.py\`** -- audits all FOUR dimensions a repo needs to auto-merge PRs (branch protection / workflow file / Actions secrets / Dependabot secrets). The previous audit (#1124) only checked dimension 1.

2. **\`tools/deploy_auto_reviewer_workflow.py\`** -- deploys the canonical caller workflow to named repos via classic-PAT Contents API. The caller is the 8-line YAML that every STRICT fleet repo uses to invoke AssemblyZero's reusable auto-reviewer.yml.

## How to use after merge

\`\`\`bash
cd /c/Users/mcwiz/Projects/AssemblyZero
git pull

# 1) Comprehensive audit -- shows every repo's full readiness state
poetry run python tools/audit_fleet_auto_merge_readiness.py

# 2) Deploy auto-reviewer.yml to comp-environ + gh-galaxy-quest (the
#    two known offenders -- the audit will tell you if there are more)
poetry run python tools/deploy_auto_reviewer_workflow.py \
    --repos comp-environ,gh-galaxy-quest

poetry run python tools/deploy_auto_reviewer_workflow.py \
    --repos comp-environ,gh-galaxy-quest --apply --confirm-yes

# 3) Deploy Cerberus secrets (covers both Actions and Dependabot scopes
#    per #1118) -- uses the EXISTING tool from PR #1119
poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem \
    --repo comp-environ
poetry run python tools/deploy_cerberus_secrets.py CERBERUS.pem \
    --repo gh-galaxy-quest

# 4) Re-audit to confirm READY across the fleet
poetry run python tools/audit_fleet_auto_merge_readiness.py
\`\`\`

## Why this miss happened in #1126

#1126's PR description called out auto-reviewer.yml + Cerberus deployment as \"out of scope\" -- framing them as optional followups. That framing was wrong: without dimensions 2-4, dimension 1 (strict protection) is unworkable. The four dimensions are a single binary, not independent.

The audit tool guarantees this miss can't recur -- any combination of missing dimensions surfaces as NOT_READY with the specific failed dims listed.

## Test plan
- [x] \`poetry run pytest tests/test_fleet_readiness.py -v\` -- 14 passing
- [x] Audit happy path + every known failure mode covered (workflow missing, dependabot scope missing, no default branch, multi-failure aggregation)
- [x] Deploy guards covered: --apply rejected without --confirm-yes, empty --repos rejected, already-present skipped, missing-repo PUT, dry-run no-PUT, PUT-failure rc=2
- [x] \`poetry run ruff check --isolated\` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)