### PR TITLE
fix(arch): auto-reviewer skips dependabot + audit drops it as dimension (Closes #1131)

### DIFF
--- a/tests/test_fleet_readiness.py
+++ b/tests/test_fleet_readiness.py
@@ -85,9 +85,12 @@ def test_audit_one_repo_missing_workflow_classified_not_ready():
     assert "branch_protection_not_strict" not in r.failures
 
 
-def test_audit_one_repo_missing_dependabot_secrets_classified_not_ready():
-    """The #1118 / PR #1119 failure mode."""
-    repo = {"name": "old-repo", "defaultBranchRef": {"name": "main"}}
+def test_audit_one_repo_missing_dependabot_secrets_still_classified_ready():
+    """Per #1131: Dependabot-scope is INFORMATIONAL ONLY -- not a readiness
+    blocker. Cerberus skips dependabot PRs at the workflow level so the
+    scope's emptiness is irrelevant to whether the repo can auto-merge
+    agent PRs."""
+    repo = {"name": "any-repo", "defaultBranchRef": {"name": "main"}}
 
     def fake_get(url, pat):
         if "/protection" in url:
@@ -97,14 +100,17 @@ def test_audit_one_repo_missing_dependabot_secrets_classified_not_ready():
         if "/actions/secrets" in url:
             return 200, _ready_secrets_body()
         if "/dependabot/secrets" in url:
-            return 200, {"secrets": []}  # empty -- the #1118 fail mode
+            return 200, {"secrets": []}  # empty -- previously failed; now OK
         return 200, {}
 
     with patch.object(audit, "_api_get", side_effect=fake_get):
         r = audit.audit_one(repo, "pat")
 
-    assert r.verdict == "NOT_READY"
-    assert "dependabot_secrets_incomplete" in r.failures
+    assert r.verdict == "READY", \
+        "Dependabot-scope emptiness must not flag a repo as NOT_READY (#1131)"
+    assert "dependabot_secrets_incomplete" not in r.failures
+    # The dimension is still reported for visibility
+    assert r.dependabot_secrets_complete is False
 
 
 def test_audit_one_repo_with_no_default_branch_unknown():
@@ -117,7 +123,10 @@ def test_audit_one_repo_with_no_default_branch_unknown():
 
 
 def test_audit_one_accumulates_multiple_failures():
-    """A repo can fail multiple dimensions; we report all of them."""
+    """A repo can fail multiple dimensions; we report all of them.
+
+    Post-#1131: only 3 dimensions count as readiness failures. Dependabot
+    scope is reported but not in failures."""
     repo = {"name": "x", "defaultBranchRef": {"name": "main"}}
 
     def fake_get(url, pat):
@@ -135,7 +144,10 @@ def test_audit_one_accumulates_multiple_failures():
         r = audit.audit_one(repo, "pat")
 
     assert r.verdict == "NOT_READY"
-    assert len(r.failures) == 4
+    # 3 readiness failures (protection, workflow, actions-secrets)
+    # Dependabot-scope is reported in the field but NOT in failures (#1131)
+    assert len(r.failures) == 3
+    assert "dependabot_secrets_incomplete" not in r.failures
 
 
 def test_audit_tsv_row_includes_all_four_dims():

--- a/tests/test_land_1131_auto_reviewer_skip_dependabot.py
+++ b/tests/test_land_1131_auto_reviewer_skip_dependabot.py
@@ -1,0 +1,57 @@
+"""Tests for tools/land_1131_auto_reviewer_skip_dependabot.py (#1131)."""
+import importlib.util
+import sys
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "land_1131_auto_reviewer_skip_dependabot",
+    TOOLS_DIR / "land_1131_auto_reviewer_skip_dependabot.py",
+)
+land = importlib.util.module_from_spec(_spec)
+sys.modules["land_1131_auto_reviewer_skip_dependabot"] = land
+_spec.loader.exec_module(land)
+
+
+def test_apply_patch_against_current_workflow_file_produces_diff():
+    """End-to-end smoke: read the live auto-reviewer.yml and patch it."""
+    local = TOOLS_DIR.parent / ".github" / "workflows" / "auto-reviewer.yml"
+    assert local.is_file(), \
+        f"workflow file missing at {local} -- can't smoke-test the patch"
+    content = local.read_text(encoding="utf-8", errors="replace")
+    patched = land.apply_patch(content)
+    assert patched is not None, \
+        "patch should apply -- file may already contain the #1131 change"
+    assert "dependabot[bot]" in patched
+    assert "#1131" in patched
+
+
+def test_apply_patch_idempotent_on_already_patched():
+    already = "anything with #1131 and dependabot[bot] sentinel"
+    assert land.apply_patch(already) is None
+
+
+def test_apply_patch_aborts_on_drift_when_old_if_missing():
+    """If the source file has drifted (the old `if:` line no longer matches),
+    refuse to apply rather than write nonsense."""
+    drifted = "completely different workflow structure with no matching if:"
+    import pytest
+    with pytest.raises(SystemExit):
+        land.apply_patch(drifted)
+
+
+def test_old_if_string_matches_actual_workflow_file():
+    """The OLD_IF byte-string in the script must literally appear in the
+    current auto-reviewer.yml. If it doesn't, the script is broken before
+    a single API call is made."""
+    local = TOOLS_DIR.parent / ".github" / "workflows" / "auto-reviewer.yml"
+    content = local.read_text(encoding="utf-8", errors="replace")
+    assert land.OLD_IF in content, \
+        "OLD_IF doesn't match -- workflow file has drifted, patch will fail"
+
+
+def test_new_if_contains_required_dependabot_skip_clause():
+    assert "dependabot[bot]" in land.NEW_IF
+    assert "pull_request.user.login" in land.NEW_IF
+    # Comment reference makes the intent traceable
+    assert "#1131" in land.NEW_IF

--- a/tools/audit_fleet_auto_merge_readiness.py
+++ b/tools/audit_fleet_auto_merge_readiness.py
@@ -4,22 +4,29 @@
 THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
 Uses an in-process classic PAT (ADR-0216).
 
-A repo is auto-merge-ready iff ALL FOUR are true:
+A repo is auto-merge-ready iff ALL THREE are true:
 
   1. Branch protection is strict
        (>=1 review, status checks required, enforce_admins, no force pushes)
   2. .github/workflows/auto-reviewer.yml exists on the default branch
   3. Actions secrets contain REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
-  4. Dependabot secrets contain REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
 
-#1124 audited dimension 1. #1118 added dimension 4. This script checks
-all four and reports per-repo readiness.
+Dimension 4 (Dependabot-scope secrets) was originally included but
+DROPPED per #1131. Cerberus is the agent fence -- it gates PRs created
+by an agent acting under user credentials. Dependabot PRs have a
+separate governance path via tools/dependabot_review.py and do not
+go through Cerberus. The Dependabot scope's emptiness is therefore not
+a readiness blocker; the noisy auto-reviewer failure on dependabot PRs
+is fixed by the workflow-level skip landed in #1131.
+
+The Dependabot-scope check is still reported in the TSV for visibility,
+but no longer factors into the READY/NOT_READY verdict.
 
 Output:
   - audit_fleet_auto_merge_readiness_results.tsv (one row per repo)
   - Summary printed listing every NOT_READY repo with the failing dims
 
-Issue: #1128 | Related: #1124 (protection audit), #1118 (dependabot scope)
+Issue: #1128 | Related: #1131 (architectural correction), #1124 (protection)
 """
 
 from __future__ import annotations
@@ -206,14 +213,15 @@ def audit_one(repo_obj: dict, pat: str) -> RepoReadiness:
     if not has_act:
         r.failures.append("actions_secrets_incomplete")
 
-    # 4. Dependabot secrets
+    # 4. Dependabot secrets -- reported in TSV but NOT a failure per #1131.
+    # Cerberus skips dependabot PRs at the workflow level; this scope is
+    # informational only.
     has_dep, err = check_secrets(name, "dependabot", pat)
     r.dependabot_secrets_complete = has_dep
     if err:
-        r.error = err
-        return r
-    if not has_dep:
-        r.failures.append("dependabot_secrets_incomplete")
+        # An error querying dependabot scope shouldn't change the verdict;
+        # it's not a readiness dimension.
+        r.dependabot_secrets_complete = None
 
     return r
 

--- a/tools/land_1131_auto_reviewer_skip_dependabot.py
+++ b/tools/land_1131_auto_reviewer_skip_dependabot.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Land the #1131 auto-reviewer.yml dependabot-skip fix via classic-PAT Contents API.
+
+THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
+
+The fix is a one-condition expansion to `.github/workflows/auto-reviewer.yml`
+in AssemblyZero. The fine-grained PAT cannot push workflow files (no
+`workflow` scope, intentionally per ADR-0216). Lands via the GitHub
+Contents API using an in-process classic PAT.
+
+The change makes auto-reviewer.yml SKIP dependabot PRs. Architectural
+rationale in #1131:
+
+- Cerberus is the AGENT fence -- breaks the self-authorization loop for
+  PRs created by an agent acting under user credentials.
+- Dependabot has its own governance: tools/dependabot_review.py runs
+  tests + approves under the user's credentials.
+- Running auto-reviewer.yml on dependabot PRs causes a noisy failure
+  (Dependabot-scope secrets missing) and doesn't serve any architectural
+  purpose.
+
+What this script does:
+
+  1. Reads `.github/workflows/auto-reviewer.yml` from origin/main via
+     Contents API.
+  2. Applies the #1131 fix: expands the existing `if:` on the auto-review
+     job to also require `github.event.pull_request.user.login != 'dependabot[bot]'`.
+  3. Validates the patch is idempotent (refuse if already applied).
+  4. Creates a branch from main HEAD via API.
+  5. PUTs the patched file (CRLF-normalised per the 2026-04-30 memory).
+  6. Opens a PR with `Closes #1131` in title and body.
+  7. Polls mergeable_state until clean or unstable (the auto-reviewer
+     check itself runs on THIS PR and now skips dependabot, but this
+     PR isn't dependabot, so the check should pass normally).
+  8. Squash-merges via API.
+
+Issue: #1131 | Related: #1104 / PR #1115 (precedent), ADR-0216
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+REPO = f"{GITHUB_USER}/AssemblyZero"
+GH_API = "https://api.github.com"
+WORKFLOW_PATH = ".github/workflows/auto-reviewer.yml"
+ISSUE_NUMBER = 1131
+BRANCH = f"{ISSUE_NUMBER}-auto-reviewer-skip-dependabot"
+
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 900
+
+# The old `if:` -- existing single-line condition.
+OLD_IF = (
+    "    if: github.event_name == 'pull_request' "
+    "|| github.event_name == 'workflow_call'"
+)
+
+# The new `if:` -- adds the dependabot skip condition.
+NEW_IF = (
+    "    # #1131: skip dependabot PRs. Cerberus is the agent fence; dependabot\n"
+    "    # has its own governance via tools/dependabot_review.py.\n"
+    "    if: (github.event_name == 'pull_request' "
+    "|| github.event_name == 'workflow_call') "
+    "&& github.event.pull_request.user.login != 'dependabot[bot]'"
+)
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _api(method: str, url: str, pat: str, **kw: Any) -> requests.Response:
+    return requests.request(method, url, headers=_headers(pat), timeout=HTTP_TIMEOUT_S, **kw)
+
+
+def read_workflow(pat: str) -> tuple[str, str]:
+    r = _api("GET", f"{GH_API}/repos/{REPO}/contents/{WORKFLOW_PATH}?ref=main", pat)
+    if r.status_code >= 300:
+        sys.exit(f"GET contents failed: {r.status_code} {r.text[:300]}")
+    data = r.json()
+    return base64.b64decode(data["content"]).decode("utf-8"), data["sha"]
+
+
+def apply_patch(content: str) -> str | None:
+    """Apply the #1131 fix. Returns patched text, or None if already applied."""
+    if "dependabot[bot]" in content and "#1131" in content:
+        return None  # already patched
+    if OLD_IF not in content:
+        sys.exit(
+            "ERROR: expected `if:` block not found in workflow file. The "
+            "file has drifted since this script was written -- re-derive "
+            "the patch from current content."
+        )
+    return content.replace(OLD_IF, NEW_IF)
+
+
+def main_head_sha(pat: str) -> str:
+    r = _api("GET", f"{GH_API}/repos/{REPO}/git/refs/heads/main", pat)
+    if r.status_code >= 300:
+        sys.exit(f"GET main ref failed: {r.status_code}")
+    return r.json()["object"]["sha"]
+
+
+def create_branch(pat: str, main_sha: str) -> None:
+    r = _api(
+        "POST", f"{GH_API}/repos/{REPO}/git/refs", pat,
+        json={"ref": f"refs/heads/{BRANCH}", "sha": main_sha},
+    )
+    if r.status_code == 422:
+        print(f"  branch {BRANCH} already exists, reusing")
+        return
+    if r.status_code >= 300:
+        sys.exit(f"POST branch failed: {r.status_code} {r.text[:300]}")
+
+
+def get_blob_sha_on_branch(pat: str) -> str | None:
+    r = _api("GET", f"{GH_API}/repos/{REPO}/contents/{WORKFLOW_PATH}?ref={BRANCH}", pat)
+    if r.status_code >= 300:
+        return None
+    return r.json()["sha"]
+
+
+def put_file(pat: str, new_content: str, blob_sha: str) -> None:
+    new_bytes = new_content.replace("\r\n", "\n").encode("utf-8")
+    payload = {
+        "message": f"fix: auto-reviewer skips dependabot PRs (Closes #{ISSUE_NUMBER})",
+        "content": base64.b64encode(new_bytes).decode("ascii"),
+        "branch": BRANCH,
+        "sha": blob_sha,
+    }
+    r = _api("PUT", f"{GH_API}/repos/{REPO}/contents/{WORKFLOW_PATH}", pat, json=payload)
+    if r.status_code >= 300:
+        sys.exit(f"PUT contents failed: {r.status_code} {r.text[:300]}")
+
+
+def open_pr(pat: str) -> int:
+    body = (
+        f"Closes #{ISSUE_NUMBER}\n\n"
+        "Adds a single `if:` condition to `.github/workflows/auto-reviewer.yml` "
+        "so the auto-review job skips dependabot PRs entirely.\n\n"
+        "Architectural rationale:\n"
+        "- Cerberus is the agent fence -- breaks the self-authorization loop "
+        "for PRs created by an agent acting under user credentials\n"
+        "- Dependabot has its own governance via `tools/dependabot_review.py` "
+        "(tests + approves under the user's creds, accruing to the user's profile)\n"
+        "- Running auto-reviewer on dependabot PRs causes a noisy failure "
+        "(Dependabot-scope secrets missing) and serves no architectural purpose\n\n"
+        "Fleet-wide impact is automatic because consumer repos reference "
+        "`@main` of this reusable workflow.\n"
+    )
+    r = _api(
+        "POST", f"{GH_API}/repos/{REPO}/pulls", pat,
+        json={
+            "title": f"fix: auto-reviewer skips dependabot PRs (Closes #{ISSUE_NUMBER})",
+            "head": BRANCH,
+            "base": "main",
+            "body": body,
+        },
+    )
+    if r.status_code >= 300:
+        existing = _api(
+            "GET", f"{GH_API}/repos/{REPO}/pulls?head={GITHUB_USER}:{BRANCH}&state=open", pat,
+        )
+        if existing.status_code == 200 and existing.json():
+            pr_n = existing.json()[0]["number"]
+            print(f"  PR #{pr_n} already exists, reusing")
+            return pr_n
+        sys.exit(f"POST PR failed: {r.status_code} {r.text[:300]}")
+    return r.json()["number"]
+
+
+def wait_for_mergeable(pat: str, pr_n: int) -> None:
+    deadline = time.time() + MERGEABLE_TIMEOUT_S
+    while time.time() < deadline:
+        r = _api("GET", f"{GH_API}/repos/{REPO}/pulls/{pr_n}", pat)
+        if r.status_code >= 300:
+            time.sleep(POLL_INTERVAL_S)
+            continue
+        state = r.json().get("mergeable_state")
+        print(f"  PR #{pr_n}: mergeable_state={state}")
+        if state in ("clean", "unstable"):
+            return
+        time.sleep(POLL_INTERVAL_S)
+    sys.exit(f"Timed out waiting for PR #{pr_n} to be mergeable")
+
+
+def squash_merge(pat: str, pr_n: int) -> None:
+    r = _api("PUT", f"{GH_API}/repos/{REPO}/pulls/{pr_n}/merge", pat,
+             json={"merge_method": "squash"})
+    if r.status_code >= 300:
+        sys.exit(f"PUT merge failed: {r.status_code} {r.text[:300]}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Land #1131 auto-reviewer dependabot-skip fix.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Write the patched YAML to a tempfile + diff path; no API writes.")
+    args = parser.parse_args()
+
+    if args.dry_run:
+        local = Path(__file__).resolve().parents[1] / WORKFLOW_PATH
+        if not local.is_file():
+            print("Dry-run requires the workflow file in the current worktree.",
+                  file=sys.stderr)
+            return 1
+        content = local.read_text(encoding="utf-8", errors="replace")
+        new_content = apply_patch(content)
+        if new_content is None:
+            print("Already patched. No change needed.")
+            return 0
+        import tempfile
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", suffix=".yml",
+            prefix="auto-reviewer-1131-patched-", delete=False,
+        )
+        tmp.write(new_content)
+        tmp.close()
+        print(f"Patched YAML: {tmp.name}")
+        print(f"Diff: diff -u '{local}' '{tmp.name}'")
+        return 0
+
+    with classic_pat_session() as pat:
+        print("1. Reading current workflow file from main...")
+        content, _ = read_workflow(pat)
+
+        print("2. Applying patch...")
+        new_content = apply_patch(content)
+        if new_content is None:
+            print("   Already patched. Nothing to do.")
+            return 0
+
+        print(f"3. Creating branch {BRANCH}...")
+        main_sha = main_head_sha(pat)
+        create_branch(pat, main_sha)
+
+        print(f"4. PUTting patched file via Contents API on {BRANCH}...")
+        branch_blob_sha = get_blob_sha_on_branch(pat)
+        if branch_blob_sha is None:
+            sys.exit("Failed to read blob sha on new branch -- aborting")
+        put_file(pat, new_content, branch_blob_sha)
+
+        print("5. Opening PR...")
+        pr_n = open_pr(pat)
+        print(f"   PR #{pr_n} -- https://github.com/{REPO}/pull/{pr_n}")
+
+        print("6. Waiting for mergeable_state...")
+        wait_for_mergeable(pat, pr_n)
+
+        print("7. Squash-merging...")
+        squash_merge(pat, pr_n)
+
+    print(f"\nDone. #{ISSUE_NUMBER} fix landed via PR #{pr_n}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1131

## The architectural correction

Cerberus is the **agent fence** -- breaks the self-authorization loop where an agent (acting under user creds) would otherwise approve and merge its own PRs. Branch protection requires 1 approving review; Cerberus posts that review as a separate GitHub App identity so an agent can't satisfy the requirement itself.

**Cerberus is not for dependabot.** Dependabot has its own governance: \`tools/dependabot_review.py\` runs tests, approves under your credentials (accruing to your profile per #1091), and merges. No agent self-auth risk to fence against.

I was solving the wrong layer with #1118 / PR #1119 (Dependabot-scope secrets deploy). The right fix is at the workflow level: auto-reviewer.yml just skips dependabot PRs entirely.

## What this PR adds

1. **\`tools/land_1131_auto_reviewer_skip_dependabot.py\`** -- classic-PAT one-shot that expands the existing \`if:\` on the auto-review job to also require \`github.event.pull_request.user.login != 'dependabot[bot]'\`. Same delivery pattern as #1104 / PR #1115. User runs the script; it opens a PR that closes #1131.

2. **\`tools/audit_fleet_auto_merge_readiness.py\` update** -- drops Dependabot-scope secrets as a readiness dimension. Still reported in the TSV for visibility but no longer flagged as NOT_READY. The audit re-run after the landing script merges will show 49+ READY repos with only the comp-environ + gh-galaxy-quest workflow gap remaining.

3. **Tests updated** -- the prior \`test_audit_one_repo_missing_dependabot_secrets_classified_not_ready\` is now \`...still_classified_ready\` with the assertion inverted. Regression guard against re-introducing Dependabot scope as a blocker.

## Diff preview (from --dry-run)

\`\`\`diff
@@ -41,7 +41,9 @@
   auto-review:
     runs-on: ubuntu-latest
     # Only run on PRs, not on the PR created by the App itself (prevent loops)
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
+    # #1131: skip dependabot PRs. Cerberus is the agent fence; dependabot
+    # has its own governance via tools/dependabot_review.py.
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_call') && github.event.pull_request.user.login != 'dependabot[bot]'
\`\`\`

## How to use after merge

\`\`\`bash
cd /c/Users/mcwiz/Projects/AssemblyZero
git pull

# 1) Preview the patch
poetry run python tools/land_1131_auto_reviewer_skip_dependabot.py --dry-run

# 2) Land (opens a PR that closes #1131 and squash-merges itself)
poetry run python tools/land_1131_auto_reviewer_skip_dependabot.py

# 3) Re-run the readiness audit to confirm everything is READY except
#    the genuine workflow-file gaps (comp-environ, gh-galaxy-quest)
poetry run python tools/audit_fleet_auto_merge_readiness.py
\`\`\`

## Cleanup deferred to followup

- \`deploy_cerberus_secrets.py\` docstring should be updated to note Dependabot-scope capability is unnecessary for Cerberus. The capability stays (#1119 is harmless and may serve future non-Cerberus Dependabot-scope secrets); the doc just needs to stop framing it as a Cerberus prerequisite. Not in this PR to keep scope tight.

## Test plan
- [x] 19 tests passing (5 #1131-specific landing-script tests, 14 readiness-audit tests with Dependabot-blocker assertions inverted)
- [x] Dry-run smoke against live workflow file produces exactly the expected diff
- [x] \`poetry run ruff check --isolated\` -- clean
- [x] OLD_IF byte-string regression guard: the script's expected source pattern literally appears in the current workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)