### PR TITLE
fix(deploy_auto_reviewer_workflow): bootstrap also handles active repository rulesets (Closes #1137)

### DIFF
--- a/tests/test_deploy_auto_reviewer_workflow.py
+++ b/tests/test_deploy_auto_reviewer_workflow.py
@@ -139,6 +139,7 @@ def test_enable_enforce_admins_403_fails():
 def test_deploy_permissive_uses_direct_put_no_bootstrap():
     """No protection on the branch -> direct PUT, bootstrap_used=False."""
     with patch.object(deploy, "get_protection", return_value=(None, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "put_workflow", return_value=(True, None)) as mock_put, \
          patch.object(deploy, "disable_enforce_admins") as mock_disable, \
          patch.object(deploy, "enable_enforce_admins") as mock_enable:
@@ -153,10 +154,10 @@ def test_deploy_permissive_uses_direct_put_no_bootstrap():
 
 
 def test_deploy_protected_but_enforce_admins_off_uses_direct_put():
-    """Protected branch with enforce_admins=False -> still direct PUT.
-    Admin push bypasses required reviews/checks naturally."""
+    """Protected branch with enforce_admins=False AND no rulesets -> direct PUT."""
     prot = {"enforce_admins": {"enabled": False}}
     with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "put_workflow", return_value=(True, None)) as mock_put, \
          patch.object(deploy, "disable_enforce_admins") as mock_disable:
         ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
@@ -168,7 +169,7 @@ def test_deploy_protected_but_enforce_admins_off_uses_direct_put():
 
 
 def test_deploy_strict_uses_bootstrap_path():
-    """enforce_admins=True -> DELETE enforce_admins, PUT, POST enforce_admins."""
+    """enforce_admins=True, no rulesets -> DELETE enforce_admins, PUT, POST enforce_admins."""
     prot = {"enforce_admins": {"enabled": True}}
     call_order: list[str] = []
 
@@ -185,6 +186,7 @@ def test_deploy_strict_uses_bootstrap_path():
         return (True, None)
 
     with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "disable_enforce_admins", side_effect=record_disable), \
          patch.object(deploy, "put_workflow", side_effect=record_put), \
          patch.object(deploy, "enable_enforce_admins", side_effect=record_enable):
@@ -209,6 +211,7 @@ def test_deploy_strict_restoration_happens_even_when_put_fails():
         return _fn
 
     with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "disable_enforce_admins",
                       side_effect=record("disable", (True, None))), \
          patch.object(deploy, "put_workflow",
@@ -220,17 +223,16 @@ def test_deploy_strict_restoration_happens_even_when_put_fails():
     assert ok is False
     assert "blocked" in err
     assert bootstrap_used is True
-    # finally must have run -- enable_enforce_admins was called
     assert "enable" in call_order
     assert call_order.index("enable") > call_order.index("put")
 
 
 def test_deploy_strict_restoration_failure_is_surfaced(capsys):
-    """If the PUT succeeds but the restore fails, the restore error is
-    surfaced (load-bearing) and a recovery hint is printed to stderr."""
+    """If PUT succeeds but enforce_admins restore fails, surface restore error."""
     prot = {"enforce_admins": {"enabled": True}}
 
     with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "disable_enforce_admins", return_value=(True, None)), \
          patch.object(deploy, "put_workflow", return_value=(True, None)), \
          patch.object(deploy, "enable_enforce_admins",
@@ -238,23 +240,22 @@ def test_deploy_strict_restoration_failure_is_surfaced(capsys):
         ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
 
     assert ok is False
-    assert "PUT succeeded but enforce_admins restore failed" in err
+    assert "PUT succeeded but restoration failed" in err
     assert "502" in err
     assert bootstrap_used is True
-    # Recovery hint must be printed
     err_stream = capsys.readouterr().err
     assert "CRITICAL" in err_stream
     assert "protection/enforce_admins" in err_stream
 
 
 def test_deploy_strict_disable_fails_no_put_attempt():
-    """If we can't disable enforce_admins, never attempt the PUT --
-    restoration also doesn't run because there's nothing to restore."""
+    """If we can't disable enforce_admins, never attempt the PUT."""
     prot = {"enforce_admins": {"enabled": True}}
 
     with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "disable_enforce_admins",
-                      return_value=((False, "DELETE 403: forbidden"))), \
+                      return_value=(False, "DELETE 403: forbidden")), \
          patch.object(deploy, "put_workflow") as mock_put, \
          patch.object(deploy, "enable_enforce_admins") as mock_enable:
         ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
@@ -267,9 +268,9 @@ def test_deploy_strict_disable_fails_no_put_attempt():
 
 
 def test_deploy_get_protection_error_aborts_early():
-    """GET protection failure is fatal -- never touch enforce_admins
-    or attempt PUT when we can't even see the current state."""
+    """GET protection failure is fatal."""
     with patch.object(deploy, "get_protection", return_value=(None, "GET 503: upstream")), \
+         patch.object(deploy, "list_blocking_rulesets") as mock_lrs, \
          patch.object(deploy, "disable_enforce_admins") as mock_disable, \
          patch.object(deploy, "put_workflow") as mock_put, \
          patch.object(deploy, "enable_enforce_admins") as mock_enable:
@@ -278,9 +279,372 @@ def test_deploy_get_protection_error_aborts_early():
     assert ok is False
     assert "could not GET protection" in err
     assert bootstrap_used is False
+    mock_lrs.assert_not_called()
     mock_disable.assert_not_called()
     mock_put.assert_not_called()
     mock_enable.assert_not_called()
+
+
+def test_deploy_get_rulesets_error_aborts_early():
+    """GET rulesets failure is fatal -- never touch any protection state."""
+    with patch.object(deploy, "get_protection", return_value=(None, None)), \
+         patch.object(deploy, "list_blocking_rulesets",
+                      return_value=([], "GET rulesets 503")), \
+         patch.object(deploy, "disable_enforce_admins") as mock_disable, \
+         patch.object(deploy, "put_workflow") as mock_put, \
+         patch.object(deploy, "enable_enforce_admins") as mock_enable:
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is False
+    assert "could not GET rulesets" in err
+    assert bootstrap_used is False
+    mock_disable.assert_not_called()
+    mock_put.assert_not_called()
+    mock_enable.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #1137: ruleset bootstrap
+# ---------------------------------------------------------------------------
+
+def _fake_ruleset(rs_id: int, bypass_actors: list | None = None,
+                  target: str = "branch", include: list | None = None,
+                  enforcement: str = "active") -> dict:
+    return {
+        "id": rs_id,
+        "name": "main",
+        "target": target,
+        "enforcement": enforcement,
+        "conditions": {"ref_name": {"include": include or ["~DEFAULT_BRANCH"]}},
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            {"type": "pull_request", "parameters": {"required_approving_review_count": 0}},
+        ],
+        "bypass_actors": bypass_actors or [],
+    }
+
+
+def test_deploy_ruleset_only_uses_bypass_path():
+    """No classic strict protection but ruleset present -> add admin bypass,
+    PUT, restore bypass."""
+    rs = _fake_ruleset(14061333)
+    call_order: list[str] = []
+
+    def record_add(repo, rs_id, pat):
+        call_order.append(f"add:{rs_id}")
+        return (True, [], None)
+
+    def record_put(*args, **kwargs):
+        call_order.append("put")
+        return (True, None)
+
+    def record_restore(repo, rs_id, original, pat):
+        call_order.append(f"restore:{rs_id}")
+        return (True, None)
+
+    with patch.object(deploy, "get_protection", return_value=(None, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([rs], None)), \
+         patch.object(deploy, "add_admin_bypass", side_effect=record_add), \
+         patch.object(deploy, "put_workflow", side_effect=record_put), \
+         patch.object(deploy, "restore_bypass", side_effect=record_restore), \
+         patch.object(deploy, "disable_enforce_admins") as mock_disable, \
+         patch.object(deploy, "enable_enforce_admins") as mock_enable:
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is True
+    assert err is None
+    assert bootstrap_used is True
+    assert call_order == ["add:14061333", "put", "restore:14061333"]
+    # Classic toggles never fired
+    mock_disable.assert_not_called()
+    mock_enable.assert_not_called()
+
+
+def test_deploy_classic_plus_ruleset_combined():
+    """Both classic enforce_admins=True AND ruleset present -> both bypasses
+    applied (classic first), PUT, both restored in reverse order (ruleset first)."""
+    prot = {"enforce_admins": {"enabled": True}}
+    rs = _fake_ruleset(14061333)
+    call_order: list[str] = []
+
+    def record(name, result):
+        def _fn(*args, **kwargs):
+            call_order.append(name)
+            return result
+        return _fn
+
+    with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([rs], None)), \
+         patch.object(deploy, "disable_enforce_admins",
+                      side_effect=record("classic_disable", (True, None))), \
+         patch.object(deploy, "add_admin_bypass",
+                      side_effect=lambda *a, **k: (call_order.append("rs_add"), (True, [], None))[1]), \
+         patch.object(deploy, "put_workflow",
+                      side_effect=record("put", (True, None))), \
+         patch.object(deploy, "restore_bypass",
+                      side_effect=lambda *a, **k: (call_order.append("rs_restore"), (True, None))[1]), \
+         patch.object(deploy, "enable_enforce_admins",
+                      side_effect=record("classic_enable", (True, None))):
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is True
+    assert bootstrap_used is True
+    # Apply order: classic_disable -> rs_add -> put
+    # Restore order (reverse): rs_restore -> classic_enable
+    assert call_order == ["classic_disable", "rs_add", "put", "rs_restore", "classic_enable"]
+
+
+def test_deploy_ruleset_restoration_runs_even_on_put_failure():
+    """PUT fails inside bootstrap -> ruleset bypass still gets restored."""
+    rs = _fake_ruleset(14061333)
+    call_order: list[str] = []
+
+    with patch.object(deploy, "get_protection", return_value=(None, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([rs], None)), \
+         patch.object(deploy, "add_admin_bypass",
+                      side_effect=lambda *a, **k: (call_order.append("add"), (True, [], None))[1]), \
+         patch.object(deploy, "put_workflow",
+                      side_effect=lambda *a, **k: (call_order.append("put"), (False, "PUT 409: blocked"))[1]), \
+         patch.object(deploy, "restore_bypass",
+                      side_effect=lambda *a, **k: (call_order.append("restore"), (True, None))[1]):
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is False
+    assert "blocked" in err
+    assert bootstrap_used is True
+    assert call_order == ["add", "put", "restore"]
+
+
+def test_deploy_ruleset_restoration_failure_is_surfaced(capsys):
+    """PUT succeeds but bypass restore fails -> CRITICAL stderr + restore error
+    surfaced as load-bearing."""
+    rs = _fake_ruleset(14061333)
+
+    with patch.object(deploy, "get_protection", return_value=(None, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([rs], None)), \
+         patch.object(deploy, "add_admin_bypass", return_value=(True, [], None)), \
+         patch.object(deploy, "put_workflow", return_value=(True, None)), \
+         patch.object(deploy, "restore_bypass",
+                      return_value=(False, "PATCH ruleset 502")):
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is False
+    assert "PUT succeeded but restoration failed" in err
+    assert "ruleset 14061333" in err
+    assert "502" in err
+    err_stream = capsys.readouterr().err
+    assert "CRITICAL" in err_stream
+    assert "rulesets/14061333" in err_stream
+
+
+def test_deploy_ruleset_add_bypass_fails_unwinds_prior_state(capsys):
+    """If add_admin_bypass fails on the Nth ruleset, prior rulesets' bypasses
+    AND classic enforce_admins must be unwound before returning."""
+    prot = {"enforce_admins": {"enabled": True}}
+    rs1 = _fake_ruleset(111)
+    rs2 = _fake_ruleset(222)
+
+    call_order: list[str] = []
+    add_results = iter([(True, [], None), (False, None, "PATCH 403")])
+
+    def fake_add(repo, rs_id, pat):
+        call_order.append(f"add:{rs_id}")
+        return next(add_results)
+
+    with patch.object(deploy, "get_protection", return_value=(prot, None)), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([rs1, rs2], None)), \
+         patch.object(deploy, "disable_enforce_admins",
+                      side_effect=lambda *a, **k: (call_order.append("classic_disable"), (True, None))[1]), \
+         patch.object(deploy, "add_admin_bypass", side_effect=fake_add), \
+         patch.object(deploy, "put_workflow") as mock_put, \
+         patch.object(deploy, "restore_bypass",
+                      side_effect=lambda *a, **k: (call_order.append("rs_restore"), (True, None))[1]), \
+         patch.object(deploy, "enable_enforce_admins",
+                      side_effect=lambda *a, **k: (call_order.append("classic_enable"), (True, None))[1]):
+        ok, err, bootstrap_used = deploy.deploy_with_bootstrap("repo", "main", "pat")
+
+    assert ok is False
+    assert "could not add bypass to ruleset 222" in err
+    assert bootstrap_used is True
+    # Sequence: classic_disable -> add:111 (ok) -> add:222 (fails) ->
+    #           emergency_unwind: rs_restore(111) -> classic_enable
+    # PUT is never called.
+    assert call_order == ["classic_disable", "add:111", "add:222", "rs_restore", "classic_enable"]
+    mock_put.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# list_blocking_rulesets
+# ---------------------------------------------------------------------------
+
+def test_list_blocking_rulesets_skips_inactive():
+    """enforcement != 'active' rulesets are not blocking."""
+    summaries = [{"id": 1, "name": "x", "target": "branch", "enforcement": "disabled"}]
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, summaries)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert rulesets == []
+    assert err is None
+
+
+def test_list_blocking_rulesets_filters_by_target():
+    """target != 'branch' rulesets are skipped."""
+    summaries = [{"id": 1, "name": "x", "target": "tag", "enforcement": "active"}]
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, summaries)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert rulesets == []
+
+
+def test_list_blocking_rulesets_filters_by_ref_include():
+    """Ruleset targeting a different branch is not returned for ours."""
+    summaries = [{"id": 1, "name": "x", "target": "branch", "enforcement": "active"}]
+    detail = _fake_ruleset(1, include=["refs/heads/dev"])  # not main
+    responses = iter([
+        _fake_response(200, summaries),
+        _fake_response(200, detail),
+    ])
+    with patch.object(deploy.requests, "get",
+                      side_effect=lambda *a, **k: next(responses)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert rulesets == []
+
+
+def test_list_blocking_rulesets_includes_default_branch_match():
+    """Ruleset with ~DEFAULT_BRANCH include is captured."""
+    summaries = [{"id": 99, "name": "main", "target": "branch", "enforcement": "active"}]
+    detail = _fake_ruleset(99, include=["~DEFAULT_BRANCH"])
+    responses = iter([
+        _fake_response(200, summaries),
+        _fake_response(200, detail),
+    ])
+    with patch.object(deploy.requests, "get",
+                      side_effect=lambda *a, **k: next(responses)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert len(rulesets) == 1
+    assert rulesets[0]["id"] == 99
+
+
+def test_list_blocking_rulesets_includes_explicit_ref_match():
+    """Ruleset with refs/heads/main include is captured."""
+    summaries = [{"id": 99, "name": "main", "target": "branch", "enforcement": "active"}]
+    detail = _fake_ruleset(99, include=["refs/heads/main"])
+    responses = iter([
+        _fake_response(200, summaries),
+        _fake_response(200, detail),
+    ])
+    with patch.object(deploy.requests, "get",
+                      side_effect=lambda *a, **k: next(responses)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert len(rulesets) == 1
+
+
+def test_list_blocking_rulesets_404_means_empty_no_error():
+    """Repo with no rulesets surface (404) returns empty list, no error."""
+    with patch.object(deploy.requests, "get", return_value=_fake_response(404)):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert rulesets == []
+    assert err is None
+
+
+def test_list_blocking_rulesets_5xx_returns_error():
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(503, text="upstream")):
+        rulesets, err = deploy.list_blocking_rulesets("repo", "main", "pat")
+    assert rulesets == []
+    assert err is not None
+    assert "503" in err
+
+
+# ---------------------------------------------------------------------------
+# add_admin_bypass / restore_bypass
+# ---------------------------------------------------------------------------
+
+def test_add_admin_bypass_captures_existing_actors():
+    """GET ruleset returns existing bypass_actors -> PATCH adds admin to
+    the list AND returns the original for later restoration."""
+    existing = [{"actor_id": 9999, "actor_type": "Team", "bypass_mode": "always"}]
+    get_resp = _fake_response(200, {"bypass_actors": existing})
+    patch_resp = _fake_response(200)
+
+    captured: dict = {}
+
+    def fake_patch(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return patch_resp
+
+    with patch.object(deploy.requests, "get", return_value=get_resp), \
+         patch.object(deploy.requests, "patch", side_effect=fake_patch):
+        ok, original, err = deploy.add_admin_bypass("repo", 14061333, "pat")
+
+    assert ok is True
+    assert err is None
+    assert original == existing
+    # New list contains the original Team actor PLUS the admin role
+    sent_actors = captured["json"]["bypass_actors"]
+    assert len(sent_actors) == 2
+    assert any(a["actor_type"] == "Team" for a in sent_actors)
+    assert any(
+        a["actor_type"] == "RepositoryRole"
+        and a["actor_id"] == deploy.REPO_ADMIN_ROLE_ID
+        and a["bypass_mode"] == "always"
+        for a in sent_actors
+    )
+
+
+def test_add_admin_bypass_idempotent_when_already_present():
+    """If admin role is already a bypass_actor, no PATCH is sent."""
+    existing = [{
+        "actor_id": deploy.REPO_ADMIN_ROLE_ID,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "always",
+    }]
+    get_resp = _fake_response(200, {"bypass_actors": existing})
+
+    with patch.object(deploy.requests, "get", return_value=get_resp), \
+         patch.object(deploy.requests, "patch") as mock_patch:
+        ok, original, err = deploy.add_admin_bypass("repo", 14061333, "pat")
+
+    assert ok is True
+    assert err is None
+    assert original == existing
+    mock_patch.assert_not_called()
+
+
+def test_add_admin_bypass_get_failure_no_patch():
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(404, text="not found")), \
+         patch.object(deploy.requests, "patch") as mock_patch:
+        ok, original, err = deploy.add_admin_bypass("repo", 999, "pat")
+    assert ok is False
+    assert original is None
+    assert err is not None
+    mock_patch.assert_not_called()
+
+
+def test_restore_bypass_sends_original_list():
+    captured: dict = {}
+
+    def fake_patch(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _fake_response(200)
+
+    original = [{"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}]
+    with patch.object(deploy.requests, "patch", side_effect=fake_patch):
+        ok, err = deploy.restore_bypass("repo", 123, original, "pat")
+    assert ok is True
+    assert err is None
+    assert captured["json"]["bypass_actors"] == original
+
+
+def test_restore_bypass_failure_returns_error():
+    with patch.object(deploy.requests, "patch",
+                      return_value=_fake_response(502, text="upstream")):
+        ok, err = deploy.restore_bypass("repo", 123, [], "pat")
+    assert ok is False
+    assert err is not None
+    assert "502" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tools/deploy_auto_reviewer_workflow.py
+++ b/tools/deploy_auto_reviewer_workflow.py
@@ -15,22 +15,32 @@ What this script does:
      `.github/workflows/auto-reviewer.yml` on the default branch.
   3. Idempotent: skips repos that already have the file.
 
-#1135: bootstrap mode for STRICT-protected repos missing the workflow.
+#1135 + #1137: bootstrap mode for STRICT-protected repos missing the workflow.
 The original (pre-#1135) tool only worked when direct PUT to main was
-allowed -- on STRICT repos (1 review + status checks + enforce_admins)
-the PUT is refused with "Repository rule violations found". When a
-repo's classic branch protection has enforce_admins=True, the tool now:
+allowed -- on protected repos (classic protection with enforce_admins
+and/or active rulesets with pull_request rule) the PUT is refused
+with "Repository rule violations found".
 
-  a. DELETEs the enforce_admins sub-resource (admins can bypass)
-  b. PUTs the workflow file (succeeds because PAT identity == owner == admin)
-  c. POSTs the enforce_admins sub-resource (restores admin enforcement)
-  d. All wrapped in try/finally so step (c) runs even if (b) fails.
+Bootstrap covers two independent protection mechanisms:
 
-This is the sanctioned classic-PAT pattern per root CLAUDE.md
+CLASSIC PROTECTION (#1135) -- enforce_admins toggle:
+  a. DELETEs the enforce_admins sub-resource (admins bypass)
+  b. PUTs the workflow file (admin push succeeds)
+  c. POSTs the enforce_admins sub-resource (restores)
+
+RULESETS (#1137) -- bypass_actors toggle:
+  a. GETs each active ruleset targeting the branch
+  b. PATCHes ruleset to add Repository admin role (actor_id=5) to
+     bypass_actors with bypass_mode=always
+  c. After PUT, PATCHes ruleset to restore original bypass_actors
+
+Both dimensions are detected first, applied in sequence, and restored
+in reverse via try/finally so restoration runs even if PUT fails. This
+is the sanctioned classic-PAT pattern per root CLAUDE.md
 ("elevated-scope landings: workflow-file edits, branch-protection
 updates ... use in-process classic-PAT"). It is NOT the banned
 `--admin` flag (which is the `gh pr merge --admin` shortcut). The
-bypass window is one HTTP request, owner-only, atomic.
+bypass window is bounded to a single PUT, owner-role-scoped, atomic.
 
 The canonical CALLER file is:
 
@@ -232,64 +242,275 @@ def enable_enforce_admins(repo: str, branch: str,
     return True, None
 
 
+REPO_ADMIN_ROLE_ID = 5  # GitHub repository role: admin
+
+
+def list_blocking_rulesets(repo: str, branch: str,
+                           pat: str) -> tuple[list[dict], str | None]:
+    """List active rulesets targeting the given branch.
+
+    Returns (rulesets_with_details, error). Each item in the returned
+    list is the FULL ruleset detail dict (caller needs `id` and current
+    `bypass_actors`). Rulesets are filtered to those with:
+      - enforcement="active"
+      - target="branch"
+      - conditions.ref_name.include containing "~DEFAULT_BRANCH" or the
+        explicit "refs/heads/{branch}" entry
+
+    Empty list means no ruleset bootstrap is needed (or no rulesets exist).
+    """
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return [], f"network: {e}"
+    if r.status_code == 404:
+        # Repo has no rulesets surface at all -- treat as empty
+        return [], None
+    if r.status_code >= 300:
+        return [], f"GET rulesets {r.status_code}: {r.text[:200]}"
+
+    summaries = r.json()
+    if not isinstance(summaries, list):
+        return [], None
+
+    blocking: list[dict] = []
+    explicit_ref = f"refs/heads/{branch}"
+    for summary in summaries:
+        if summary.get("enforcement") != "active":
+            continue
+        if summary.get("target") != "branch":
+            continue
+        # Fetch full detail to get conditions + bypass_actors
+        rs_id = summary.get("id")
+        if rs_id is None:
+            continue
+        try:
+            rd = requests.get(
+                f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{rs_id}",
+                headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+            )
+        except requests.RequestException as e:
+            return [], f"network on ruleset {rs_id}: {e}"
+        if rd.status_code >= 300:
+            return [], f"GET ruleset {rs_id} -> {rd.status_code}: {rd.text[:200]}"
+        details = rd.json()
+        ref_name = (details.get("conditions") or {}).get("ref_name") or {}
+        include = ref_name.get("include") or []
+        if "~DEFAULT_BRANCH" in include or explicit_ref in include:
+            blocking.append(details)
+    return blocking, None
+
+
+def add_admin_bypass(repo: str, ruleset_id: int,
+                     pat: str) -> tuple[bool, list[dict] | None, str | None]:
+    """Add Repository admin role to a ruleset's bypass_actors.
+
+    Captures and returns the ORIGINAL bypass_actors so the caller can
+    restore exactly what was there (instead of assuming the list was
+    empty). Returns (success, original_bypass_actors, error).
+
+    On 404 / failure during the initial GET, original is None and the
+    PATCH is not attempted.
+    """
+    try:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return False, None, f"network: {e}"
+    if r.status_code >= 300:
+        return False, None, f"GET ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+
+    original = r.json().get("bypass_actors") or []
+    # Don't double-add if the admin role is already a bypass actor.
+    already_present = any(
+        a.get("actor_id") == REPO_ADMIN_ROLE_ID
+        and a.get("actor_type") == "RepositoryRole"
+        for a in original
+    )
+    if already_present:
+        return True, original, None  # No-op; caller restores to identical state
+
+    new_actors = list(original) + [{
+        "actor_id": REPO_ADMIN_ROLE_ID,
+        "actor_type": "RepositoryRole",
+        "bypass_mode": "always",
+    }]
+    try:
+        r = requests.patch(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
+            headers=_headers(pat),
+            json={"bypass_actors": new_actors},
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return False, original, f"network: {e}"
+    if r.status_code >= 300:
+        return False, original, f"PATCH ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+    return True, original, None
+
+
+def restore_bypass(repo: str, ruleset_id: int, original: list[dict],
+                   pat: str) -> tuple[bool, str | None]:
+    """Restore a ruleset's bypass_actors to the original list."""
+    try:
+        r = requests.patch(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
+            headers=_headers(pat),
+            json={"bypass_actors": original},
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return False, f"network: {e}"
+    if r.status_code >= 300:
+        return False, f"PATCH ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+    return True, None
+
+
 def deploy_with_bootstrap(repo: str, branch: str,
                           pat: str) -> tuple[bool, str | None, bool]:
     """Deploy auto-reviewer.yml to a repo, bootstrapping past strict
-    protection if necessary.
+    protection (classic + rulesets) if necessary.
 
     Returns (success, error, bootstrap_used). bootstrap_used is True
-    when enforce_admins was toggled. enforce_admins is always restored
-    on exit -- success OR failure -- via try/finally.
+    when any protection toggle (classic enforce_admins or ruleset
+    bypass_actors) was applied. Restoration always runs via try/finally.
 
-    If enforce_admins restoration ITSELF fails, the error message
-    includes a manual recovery command. Operator MUST run that command;
-    the repo is left with weakened protection until they do.
+    Restoration failures emit CRITICAL stderr messages with recovery
+    commands; if the PUT succeeded but any restoration failed, the
+    function returns the restoration error as load-bearing.
     """
+    # Probe both protection dimensions BEFORE touching anything.
     prot, err = get_protection(repo, branch, pat)
     if err:
         return False, f"could not GET protection: {err}", False
+    classic_strict = is_enforce_admins_on(prot)
 
-    if not is_enforce_admins_on(prot):
-        # Permissive branch -- direct PUT works
+    rulesets, err = list_blocking_rulesets(repo, branch, pat)
+    if err:
+        return False, f"could not GET rulesets: {err}", False
+    has_rulesets = bool(rulesets)
+
+    if not classic_strict and not has_rulesets:
+        # Permissive: direct PUT
         ok, put_err = put_workflow(repo, branch, None, pat)
         return ok, put_err, False
 
-    # Strict path: relax enforce_admins, PUT, restore.
-    print(f"  bootstrap: strict protection detected (enforce_admins=True)")
-    print(f"  bootstrap: disabling enforce_admins on {repo}/{branch}")
-    ok, disable_err = disable_enforce_admins(repo, branch, pat)
-    if not ok:
-        return False, f"could not disable enforce_admins: {disable_err}", False
+    # Bootstrap path
+    if classic_strict:
+        print(f"  bootstrap: classic protection strict (enforce_admins=True)")
+    if has_rulesets:
+        rs_ids = [rs.get("id") for rs in rulesets]
+        print(f"  bootstrap: {len(rulesets)} active ruleset(s) targeting {branch}: {rs_ids}")
 
+    classic_disabled = False
+    rs_originals: dict[int, list[dict]] = {}  # ruleset_id -> original bypass_actors
+
+    # Step 1: apply both bypasses (classic first so the unwind order is
+    # symmetric: rulesets restored first, classic last).
+    if classic_strict:
+        print(f"  bootstrap: disabling enforce_admins on {repo}/{branch}")
+        ok, disable_err = disable_enforce_admins(repo, branch, pat)
+        if not ok:
+            return False, f"could not disable enforce_admins: {disable_err}", False
+        classic_disabled = True
+
+    for rs in rulesets:
+        rs_id = rs["id"]
+        print(f"  bootstrap: adding admin bypass to ruleset {rs_id}")
+        ok, original, err = add_admin_bypass(repo, rs_id, pat)
+        if not ok:
+            # Unwind whatever was already applied via the finally block by
+            # raising into try.
+            # NOTE: rs_originals already captures what to restore;
+            # classic_disabled flag will trigger enforce_admins restore.
+            # Return into the outer flow by jumping to finally via the put
+            # never executing.
+            # We do this by setting put_ok=False with the bypass error and
+            # falling into the try/finally below.
+            # Simplest implementation: short-circuit by returning here only
+            # AFTER running the same unwind logic.
+            # Manually unwind here to keep the finally block focused on the
+            # PUT lifecycle.
+            crit = _emergency_unwind(repo, branch, pat, rs_originals, classic_disabled)
+            full_err = f"could not add bypass to ruleset {rs_id}: {err}"
+            if crit:
+                full_err += f"; unwind issues: {crit}"
+            return False, full_err, True
+        rs_originals[rs_id] = original or []
+
+    # Step 2: PUT inside try/finally so step 3 always runs.
     put_ok = False
     put_err: str | None = None
-    restore_err: str | None = None
+    restore_errs: list[str] = []
     try:
         put_ok, put_err = put_workflow(repo, branch, None, pat)
     finally:
-        # Restoration ALWAYS runs (try/finally), even if put_workflow raised.
-        # Avoid `return` from `finally` -- it would swallow exceptions; instead
-        # capture the result and decide what to surface after the block.
-        print(f"  bootstrap: restoring enforce_admins on {repo}/{branch}")
-        enable_ok, enable_err = enable_enforce_admins(repo, branch, pat)
-        if not enable_ok:
-            recovery_url = (
-                f"{GH_API}/repos/{GITHUB_USER}/{repo}/branches/{branch}"
-                "/protection/enforce_admins"
-            )
-            print(
-                f"  CRITICAL: failed to restore enforce_admins on {repo}!\n"
-                f"  Branch protection is currently WEAKENED on this repo.\n"
-                f"  Recovery: POST {recovery_url} with classic PAT.\n"
-                f"  Error: {enable_err}",
-                file=sys.stderr,
-            )
-            restore_err = enable_err
+        # Step 3: restore in reverse order -- rulesets first, then classic.
+        for rs_id, original in rs_originals.items():
+            print(f"  bootstrap: restoring bypass_actors on ruleset {rs_id}")
+            ok2, err2 = restore_bypass(repo, rs_id, original, pat)
+            if not ok2:
+                recovery = (
+                    f"PATCH {GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{rs_id} "
+                    f"with classic PAT: bypass_actors={original}"
+                )
+                print(
+                    f"  CRITICAL: failed to restore bypass_actors on ruleset {rs_id}!\n"
+                    f"  Ruleset is currently WEAKENED on {repo}.\n"
+                    f"  Recovery: {recovery}\n"
+                    f"  Error: {err2}",
+                    file=sys.stderr,
+                )
+                restore_errs.append(f"ruleset {rs_id}: {err2}")
+        if classic_disabled:
+            print(f"  bootstrap: restoring enforce_admins on {repo}/{branch}")
+            ok2, err2 = enable_enforce_admins(repo, branch, pat)
+            if not ok2:
+                recovery_url = (
+                    f"{GH_API}/repos/{GITHUB_USER}/{repo}/branches/{branch}"
+                    "/protection/enforce_admins"
+                )
+                print(
+                    f"  CRITICAL: failed to restore enforce_admins on {repo}!\n"
+                    f"  Branch protection is currently WEAKENED on this repo.\n"
+                    f"  Recovery: POST {recovery_url} with classic PAT.\n"
+                    f"  Error: {err2}",
+                    file=sys.stderr,
+                )
+                restore_errs.append(f"enforce_admins: {err2}")
 
-    # Restoration failure on top of PUT success is load-bearing -- surface it.
-    if put_ok and restore_err:
-        return False, f"PUT succeeded but enforce_admins restore failed: {restore_err}", True
+    if put_ok and restore_errs:
+        return False, f"PUT succeeded but restoration failed: {'; '.join(restore_errs)}", True
     return put_ok, put_err, True
+
+
+def _emergency_unwind(repo: str, branch: str, pat: str,
+                      rs_originals: dict[int, list[dict]],
+                      classic_disabled: bool) -> str | None:
+    """Best-effort unwind when bootstrap set-up itself fails partway.
+
+    Called when add_admin_bypass on the Nth ruleset fails: prior rulesets
+    have already been modified, classic protection may have been
+    weakened, and we never reached the try/finally that handles normal
+    restoration. This function restores any state that was already
+    applied. Returns a comma-joined error string if any restoration
+    fails, else None.
+    """
+    errs: list[str] = []
+    for rs_id, original in rs_originals.items():
+        ok, err = restore_bypass(repo, rs_id, original, pat)
+        if not ok:
+            errs.append(f"ruleset {rs_id}: {err}")
+    if classic_disabled:
+        ok, err = enable_enforce_admins(repo, branch, pat)
+        if not ok:
+            errs.append(f"enforce_admins: {err}")
+    return "; ".join(errs) if errs else None
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary

Completes the bootstrap-into-protected-repos coverage started in #1135.

The empirical re-run after PR #1136 landed unblocked `comp-environ` (no rulesets, only classic protection) but `boostgauge` and `gh-galaxy-quest` still failed:

```
FAILED: PUT 409: Repository rule violations found
Changes must be made through a pull request.
```

The classic `enforce_admins` toggle worked — note the absent `"Required status check 'pr-sentinel'"` line that was in the original pre-#1135 error. What remained: a separate ruleset's `pull_request` rule.

| Repo | Classic strict | Active ruleset | Pre-#1136 | Post-#1136 | Post this PR |
|---|---|---|---|---|---|
| `boostgauge` | yes | yes (14061333) | blocked | blocked | unblocked |
| `gh-galaxy-quest` | yes | yes (14063223) | blocked | blocked | unblocked |
| `comp-environ` | yes | no | blocked | unblocked | unblocked |

## Mechanism

- `list_blocking_rulesets(repo, branch, pat)` — enumerate active branch-targeting rulesets whose `conditions.ref_name.include` covers `~DEFAULT_BRANCH` or `refs/heads/{branch}`.
- `add_admin_bypass(repo, ruleset_id, pat)` — GET ruleset to capture existing `bypass_actors`, PATCH to add `{actor_id: 5, actor_type: "RepositoryRole", bypass_mode: "always"}`. **Captures original** for restoration (not assumed empty). Idempotent if admin role already present.
- `restore_bypass(repo, ruleset_id, original, pat)` — PATCH back to the captured original list.
- `deploy_with_bootstrap` now probes BOTH protection dimensions upfront, applies bypasses in sequence (classic first), runs PUT in try/finally, restores in **reverse** order (rulesets first, classic last). Each restoration failure emits a CRITICAL stderr message with a specific recovery PATCH command.
- `_emergency_unwind` handles the rare case where `add_admin_bypass` itself fails partway: any already-applied bypasses are reverted before returning. The PUT is never attempted in this path.

## Failure modes (all test-covered)

| Scenario | Behavior |
|---|---|
| Ruleset-only repo, PUT succeeds | Apply bypass → PUT → restore. `APPLIED (via bootstrap)`. |
| Classic + ruleset both strict | Apply classic + ruleset bypasses → PUT → restore in reverse. |
| PUT fails | Restoration still runs (try/finally). PUT error surfaced. |
| Restore fails (any dimension) | CRITICAL stderr + recovery URL. Load-bearing restore error. |
| Add bypass fails on Nth ruleset | Emergency unwind of prior bypasses + classic; PUT never attempted. |
| GET rulesets fails | Aborts early. No state change. |

## Test plan

- [x] 43 tests pass (18 new since #1135, all #1135 tests still green)
- [x] No `return` from `finally` (SyntaxWarning-free)
- [x] Bypass restoration preserves any pre-existing bypass_actors (not naively wiped to [])
- [x] Idempotent when admin role already in `bypass_actors` (no superfluous PATCH)
- [ ] After merge, user runs:
  ```
  poetry run python tools/deploy_auto_reviewer_workflow.py \
      --repos boostgauge,gh-galaxy-quest --apply --confirm-yes
  ```
  Expected: `APPLIED (via bootstrap)` for both; auto-reviewer.yml lands; ruleset `bypass_actors` returns to `[]`; classic `enforce_admins` returns to True.

Closes #1137