### PR TITLE
fix(deploy_auto_reviewer_workflow): ruleset bypass uses PUT not PATCH (Closes #1141)

### DIFF
--- a/tests/test_deploy_auto_reviewer_workflow.py
+++ b/tests/test_deploy_auto_reviewer_workflow.py
@@ -562,26 +562,25 @@ def test_list_blocking_rulesets_5xx_returns_error():
 # ---------------------------------------------------------------------------
 
 def test_add_admin_bypass_captures_existing_actors():
-    """GET ruleset returns existing bypass_actors -> PATCH adds admin to
+    """GET ruleset returns existing bypass_actors -> PUT adds admin to
     the list AND returns the original for later restoration."""
     existing = [{"actor_id": 9999, "actor_type": "Team", "bypass_mode": "always"}]
-    get_resp = _fake_response(200, {"bypass_actors": existing})
-    patch_resp = _fake_response(200)
-
+    get_body = _fake_ruleset(14061333, bypass_actors=existing)
     captured: dict = {}
 
-    def fake_patch(url, **kwargs):
+    def fake_put(url, **kwargs):
+        captured["url"] = url
         captured["json"] = kwargs.get("json")
-        return patch_resp
+        return _fake_response(200)
 
-    with patch.object(deploy.requests, "get", return_value=get_resp), \
-         patch.object(deploy.requests, "patch", side_effect=fake_patch):
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put", side_effect=fake_put):
         ok, original, err = deploy.add_admin_bypass("repo", 14061333, "pat")
 
     assert ok is True
     assert err is None
     assert original == existing
-    # New list contains the original Team actor PLUS the admin role
     sent_actors = captured["json"]["bypass_actors"]
     assert len(sent_actors) == 2
     assert any(a["actor_type"] == "Team" for a in sent_actors)
@@ -593,55 +592,191 @@ def test_add_admin_bypass_captures_existing_actors():
     )
 
 
+def test_add_admin_bypass_put_body_excludes_server_managed_fields():
+    """#1141: PUT body must contain only writable fields. Server-managed
+    fields (id, source, source_type, node_id, created_at, updated_at,
+    current_user_can_bypass, _links) must be stripped before PUT."""
+    get_body = {
+        "id": 14061333,
+        "name": "main",
+        "target": "branch",
+        "source_type": "Repository",
+        "source": "martymcenroe/boostgauge",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+        "rules": [{"type": "pull_request", "parameters": {"required_approving_review_count": 0}}],
+        "node_id": "RRS_xxx",
+        "created_at": "2026-03-18T07:36:50.271-05:00",
+        "updated_at": "2026-03-18T07:36:50.294-05:00",
+        "bypass_actors": [],
+        "current_user_can_bypass": "never",
+        "_links": {"self": {"href": "https://api.github.com/..."}},
+    }
+    captured: dict = {}
+
+    def fake_put(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _fake_response(200)
+
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put", side_effect=fake_put):
+        deploy.add_admin_bypass("repo", 14061333, "pat")
+
+    body = captured["json"]
+    # Must contain writable fields
+    assert "name" in body
+    assert "target" in body
+    assert "enforcement" in body
+    assert "conditions" in body
+    assert "rules" in body
+    assert "bypass_actors" in body
+    # Must NOT contain server-managed fields
+    for forbidden in ("id", "source", "source_type", "node_id", "created_at",
+                      "updated_at", "current_user_can_bypass", "_links"):
+        assert forbidden not in body, (
+            f"PUT body contained server-managed field {forbidden!r}; "
+            "would be rejected or echoed back incorrectly by GitHub"
+        )
+
+
+def test_add_admin_bypass_uses_put_method_not_patch():
+    """#1141 regression guard: GitHub returns 404 for PATCH on this endpoint.
+    add_admin_bypass MUST use PUT, not PATCH."""
+    get_body = _fake_ruleset(14061333)
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put",
+                      return_value=_fake_response(200)) as mock_put, \
+         patch.object(deploy.requests, "patch") as mock_patch:
+        deploy.add_admin_bypass("repo", 14061333, "pat")
+    mock_put.assert_called_once()
+    mock_patch.assert_not_called()
+
+
 def test_add_admin_bypass_idempotent_when_already_present():
-    """If admin role is already a bypass_actor, no PATCH is sent."""
+    """If admin role is already a bypass_actor, no PUT is sent."""
     existing = [{
         "actor_id": deploy.REPO_ADMIN_ROLE_ID,
         "actor_type": "RepositoryRole",
         "bypass_mode": "always",
     }]
-    get_resp = _fake_response(200, {"bypass_actors": existing})
+    get_body = _fake_ruleset(14061333, bypass_actors=existing)
 
-    with patch.object(deploy.requests, "get", return_value=get_resp), \
-         patch.object(deploy.requests, "patch") as mock_patch:
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put") as mock_put:
         ok, original, err = deploy.add_admin_bypass("repo", 14061333, "pat")
 
     assert ok is True
     assert err is None
     assert original == existing
-    mock_patch.assert_not_called()
+    mock_put.assert_not_called()
 
 
-def test_add_admin_bypass_get_failure_no_patch():
+def test_add_admin_bypass_get_failure_no_put():
     with patch.object(deploy.requests, "get",
                       return_value=_fake_response(404, text="not found")), \
-         patch.object(deploy.requests, "patch") as mock_patch:
+         patch.object(deploy.requests, "put") as mock_put:
         ok, original, err = deploy.add_admin_bypass("repo", 999, "pat")
     assert ok is False
     assert original is None
     assert err is not None
+    mock_put.assert_not_called()
+
+
+def test_restore_bypass_uses_put_method_not_patch():
+    """#1141 regression guard: PATCH returns 404 here; restore must use PUT."""
+    get_body = _fake_ruleset(14061333)
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put",
+                      return_value=_fake_response(200)) as mock_put, \
+         patch.object(deploy.requests, "patch") as mock_patch:
+        deploy.restore_bypass("repo", 14061333, [], "pat")
+    mock_put.assert_called_once()
     mock_patch.assert_not_called()
 
 
 def test_restore_bypass_sends_original_list():
+    """restore_bypass GETs current state then PUTs with original bypass_actors."""
+    get_body = _fake_ruleset(
+        14061333,
+        bypass_actors=[{"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}],
+    )
+    original_to_restore = [{"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}]
     captured: dict = {}
 
-    def fake_patch(url, **kwargs):
+    def fake_put(url, **kwargs):
         captured["json"] = kwargs.get("json")
         return _fake_response(200)
 
-    original = [{"actor_id": 1, "actor_type": "OrganizationAdmin", "bypass_mode": "always"}]
-    with patch.object(deploy.requests, "patch", side_effect=fake_patch):
-        ok, err = deploy.restore_bypass("repo", 123, original, "pat")
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put", side_effect=fake_put):
+        ok, err = deploy.restore_bypass("repo", 14061333, original_to_restore, "pat")
+
     assert ok is True
     assert err is None
-    assert captured["json"]["bypass_actors"] == original
+    assert captured["json"]["bypass_actors"] == original_to_restore
+    # And the full writable-fields shape is preserved (regression guard)
+    assert captured["json"].get("name") == "main"
+    assert captured["json"].get("target") == "branch"
 
 
-def test_restore_bypass_failure_returns_error():
-    with patch.object(deploy.requests, "patch",
-                      return_value=_fake_response(502, text="upstream")):
+def test_restore_bypass_put_body_excludes_server_managed_fields():
+    """#1141: same field-stripping requirement as add_admin_bypass."""
+    get_body = {
+        "id": 14061333,
+        "name": "main",
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"]}},
+        "rules": [{"type": "pull_request"}],
+        "source": "x/y",
+        "source_type": "Repository",
+        "node_id": "z",
+        "created_at": "...",
+        "updated_at": "...",
+        "current_user_can_bypass": "never",
+        "_links": {},
+        "bypass_actors": [],
+    }
+    captured: dict = {}
+
+    def fake_put(url, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return _fake_response(200)
+
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put", side_effect=fake_put):
+        deploy.restore_bypass("repo", 14061333, [], "pat")
+
+    body = captured["json"]
+    for forbidden in ("id", "source", "source_type", "node_id", "created_at",
+                      "updated_at", "current_user_can_bypass", "_links"):
+        assert forbidden not in body
+
+
+def test_restore_bypass_get_failure_no_put():
+    """If the pre-restore GET fails, no PUT attempt."""
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(503, text="upstream")), \
+         patch.object(deploy.requests, "put") as mock_put:
         ok, err = deploy.restore_bypass("repo", 123, [], "pat")
+    assert ok is False
+    assert err is not None
+    mock_put.assert_not_called()
+
+
+def test_restore_bypass_put_failure_returns_error():
+    get_body = _fake_ruleset(14061333)
+    with patch.object(deploy.requests, "get",
+                      return_value=_fake_response(200, get_body)), \
+         patch.object(deploy.requests, "put",
+                      return_value=_fake_response(502, text="upstream")):
+        ok, err = deploy.restore_bypass("repo", 14061333, [], "pat")
     assert ok is False
     assert err is not None
     assert "502" in err

--- a/tools/deploy_auto_reviewer_workflow.py
+++ b/tools/deploy_auto_reviewer_workflow.py
@@ -244,6 +244,28 @@ def enable_enforce_admins(repo: str, branch: str,
 
 REPO_ADMIN_ROLE_ID = 5  # GitHub repository role: admin
 
+# Fields from a GET ruleset response that are writable via PUT (the canonical
+# "Update a repository ruleset" endpoint). Other fields are server-managed
+# (id, source, source_type, node_id, created_at, updated_at,
+# current_user_can_bypass, _links) and must NOT be sent in the PUT body.
+RULESET_WRITABLE_FIELDS = ("name", "target", "enforcement", "conditions", "rules")
+
+
+def _ruleset_put_body(ruleset: dict, bypass_actors: list[dict]) -> dict:
+    """Build a PUT body for `Update a repository ruleset` from a GET response.
+
+    Copies only the writable fields (skipping server-managed ones) and
+    overwrites bypass_actors with the caller's value. GitHub returns 404
+    on PATCH against this endpoint (#1141) -- PUT is the only supported
+    update method.
+    """
+    body: dict = {}
+    for field in RULESET_WRITABLE_FIELDS:
+        if field in ruleset:
+            body[field] = ruleset[field]
+    body["bypass_actors"] = bypass_actors
+    return body
+
 
 def list_blocking_rulesets(repo: str, branch: str,
                            pat: str) -> tuple[list[dict], str | None]:
@@ -313,7 +335,11 @@ def add_admin_bypass(repo: str, ruleset_id: int,
     empty). Returns (success, original_bypass_actors, error).
 
     On 404 / failure during the initial GET, original is None and the
-    PATCH is not attempted.
+    PUT is not attempted.
+
+    #1141: uses PUT with the full ruleset body. PATCH is not a supported
+    method on this endpoint -- GitHub returns 404 (not 405) when method
+    and resource don't match.
     """
     try:
         r = requests.get(
@@ -325,7 +351,8 @@ def add_admin_bypass(repo: str, ruleset_id: int,
     if r.status_code >= 300:
         return False, None, f"GET ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
 
-    original = r.json().get("bypass_actors") or []
+    current = r.json()
+    original = current.get("bypass_actors") or []
     # Don't double-add if the admin role is already a bypass actor.
     already_present = any(
         a.get("actor_id") == REPO_ADMIN_ROLE_ID
@@ -340,34 +367,51 @@ def add_admin_bypass(repo: str, ruleset_id: int,
         "actor_type": "RepositoryRole",
         "bypass_mode": "always",
     }]
+    put_body = _ruleset_put_body(current, new_actors)
     try:
-        r = requests.patch(
+        r = requests.put(
             f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
             headers=_headers(pat),
-            json={"bypass_actors": new_actors},
+            json=put_body,
             timeout=HTTP_TIMEOUT_S,
         )
     except requests.RequestException as e:
         return False, original, f"network: {e}"
     if r.status_code >= 300:
-        return False, original, f"PATCH ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+        return False, original, f"PUT ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
     return True, original, None
 
 
 def restore_bypass(repo: str, ruleset_id: int, original: list[dict],
                    pat: str) -> tuple[bool, str | None]:
-    """Restore a ruleset's bypass_actors to the original list."""
+    """Restore a ruleset's bypass_actors to the original list.
+
+    #1141: GET to capture the current writable fields (in case they
+    changed between add and restore -- defensive), then PUT with the
+    original bypass_actors. PATCH is not supported on this endpoint.
+    """
     try:
-        r = requests.patch(
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException as e:
+        return False, f"network on GET: {e}"
+    if r.status_code >= 300:
+        return False, f"GET ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+    current = r.json()
+    put_body = _ruleset_put_body(current, original)
+    try:
+        r = requests.put(
             f"{GH_API}/repos/{GITHUB_USER}/{repo}/rulesets/{ruleset_id}",
             headers=_headers(pat),
-            json={"bypass_actors": original},
+            json=put_body,
             timeout=HTTP_TIMEOUT_S,
         )
     except requests.RequestException as e:
         return False, f"network: {e}"
     if r.status_code >= 300:
-        return False, f"PATCH ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
+        return False, f"PUT ruleset {ruleset_id} -> {r.status_code}: {r.text[:200]}"
     return True, None
 
 


### PR DESCRIPTION
## Summary

Third iteration of the bootstrap fix. After PR #1139 landed, the empirical re-run hit `PATCH ruleset 14061333 -> 404`. GET succeeded, PATCH didn't — GitHub returns 404 (not 405) when the endpoint+method combo isn't defined. "Update a repository ruleset" requires **PUT** with the full ruleset body.

| PR | Layer fixed | Verified by |
|---|---|---|
| #1136 | Classic protection (enforce_admins toggle) | comp-environ deployed successfully |
| #1139 | Added ruleset bypass support but used wrong HTTP method | (no live verification — tests passed via mocks) |
| **this PR** | PATCH → PUT with full ruleset body | regression-guarded by `test_*_uses_put_method_not_patch` |

## Why mocks didn't catch this

`test_add_admin_bypass_captures_existing_actors` mocked `requests.patch` and verified the body was sent — but mocks don't enforce that GitHub actually accepts PATCH. **The new tests assert HTTP method directly** (`test_*_uses_put_method_not_patch`): they patch `requests.patch` and assert it's NEVER called. That would have caught this bug.

## Mechanism

- `_ruleset_put_body(ruleset, bypass_actors)` constructs a PUT body containing only writable fields: `name`, `target`, `enforcement`, `conditions`, `rules`. Server-managed fields (`id`, `source`, `source_type`, `node_id`, `created_at`, `updated_at`, `current_user_can_bypass`, `_links`) are stripped — GitHub rejects or echoes them incorrectly.
- `add_admin_bypass`: GET → build PUT body with admin added to bypass_actors → **PUT** (was PATCH).
- `restore_bypass`: GET (defensive: capture current writable fields) → build PUT body with original bypass_actors → **PUT** (was PATCH).

## Test plan

- [x] 48 tests pass (5 new, regression guards on HTTP method choice and body shape)
- [x] PUT body assertion tests: name/target/enforcement/rules present; no server-managed fields
- [x] PATCH-not-called assertions on both add and restore paths
- [ ] After merge, user runs:
  ```
  poetry run python tools/deploy_auto_reviewer_workflow.py \
      --repos boostgauge,gh-galaxy-quest --apply --confirm-yes
  ```
  Expected: `APPLIED (via bootstrap)` for both. If it fails again, the new error (whatever it is) will be more diagnostic than the 404 was.

## What I'm less certain about

The PUT body shape is what GitHub's docs describe, but I'm extrapolating across the GET response shape. If GitHub rejects, say, `conditions.ref_name.exclude: []` (which the GET returned but PUT might not accept), we'll see a 422 with a specific field error — that's actionable. The 404 was opaque; a 422 won't be.

Closes #1141