### PR TITLE
revert(onboard): remove wrapper_status pre-flight — breaks /onboard with empty content blocks

### DIFF
--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -97,18 +97,6 @@ Read config + most recent session log + open issues. No pickup detection.
 
 The pickup decision is **event-ordered**, not age-based. Read `data/handoff-log.md` and pick up the handoff iff it has not been consumed by a `<!-- picked-up -->` marker. Age, post-handoff session count, and session activity DO NOT factor into this decision. A handoff that is the last unconsumed event in the log is exactly what the next session should resume — whether it's 5 minutes or 50 days old.
 
-**Pre-flight: Run `wrapper_status.py` for the running wrapper's version state:**
-
-```bash
-(cd /c/Users/mcwiz/Projects/unleashed && poetry run python src/wrapper_status.py --tier alpha --repo {repo_root})
-```
-
-The subshell `()` keeps the `cd` local. The script reads `~/.unleashed-usage.log` to find the most recent matching launch, stats the wrapper source file, and emits JSON with `status: current | stale | no_match | no_usage_log | wrapper_missing` plus a human-readable `summary`.
-
-**Why this runs before reading the handoff:** handoff text often references the wrapper version of the **handoff-writing** session ("this session ran under c-36 (pre-fix); the fix takes effect on the NEXT alpha launch"). The next session reads that verbatim and parrots "this session is pre-fix" — even though /handoff's spawn flow has already opened a fresh window that DOES have the fix loaded. wrapper_status gives ground truth for the CURRENT session before the handoff's framing has a chance to bias the report.
-
-When `status: current` AND the handoff text says "pre-fix", "fresh window", "NEXT alpha launch", or similar language implying the running wrapper lacks a recently merged fix, explicitly overrule the parroted framing in the Report — the current session IS the fresh window and the fix IS loaded. Cite the wrapper_status JSON (`wrapper_mtime`, `session_launch`) as evidence. Always include the result as "Wrapper: {summary}" in the Step 3 Report.
-
 **IF `--pickup` flag is set:** Skip detection. Go directly to Step 1D (import).
 
 **OTHERWISE:**
@@ -191,7 +179,6 @@ After Step 1B has decided pickup vs no-pickup, optionally surface these signals 
 Project: {name}
 Type: {from CLAUDE.md description — already in context}
 Focus: {from plan doc, handoff, or session log}
-Wrapper: {wrapper_status.summary — from the Step 1 pre-flight call}
 Top 3 issues: {from gh issue list}
 Model: {from system prompt} | Effort: {from config or "default"} | Window: {model window}
 ```


### PR DESCRIPTION
## Summary

Reverts the wrapper_status pre-flight additions from #1140 (commit 2 of that PR). The pickup_decide event-ordered drift capture from commit 1 is preserved.

## Why

After #1140 merged and skill_sync deployed `~/.claude/commands/onboard.md`, every fresh /onboard invocation errored:

```
API Error: 400 messages.0.content.5.text: cache_control cannot be set for empty text blocks
API Error: 400 messages: text content blocks must be non-empty
```

The user is blocked across all sessions. Root cause not yet identified — something in the wrapper_status Step 1 pre-flight section or the Report-template `Wrapper:` line causes Claude Code's slash-command processor to emit an empty content block with cache_control attached.

This revert removes:
1. The 11-line "Pre-flight: Run wrapper_status.py..." section at the top of Step 1
2. The `Wrapper:` line in Step 3 Report template

The `src/wrapper_status.py` helper in martymcenroe/unleashed#539 stays. Re-implementation will follow once the trigger is identified — likely needs a different content shape.

## Test plan
- [x] After merge + skill_sync, /onboard works again in fresh sessions
- [ ] Diagnose what specific markdown pattern triggered the empty-content-block bug
- [ ] Re-PR wrapper_status pre-flight with a sanitized content shape

Closes #1145
Refs #1140