### PR TITLE
fix(dependabot_review): cleanup contract covers exceptions + surfaces failures + startup canary (Closes #1133)

### DIFF
--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -159,3 +159,236 @@ def test_deferred_test_fail_path_calls_cleanup_worktree(tmp_path):
     assert status == "deferred"
     assert len(cleanup_called) == 1, \
         f"cleanup_worktree must be called exactly once on test-fail path, got {len(cleanup_called)}"
+
+
+# ---- #1133: cleanup contract hardening ----
+
+
+class TestCleanupWorktreeReturnsBool:
+    """#1133: cleanup_worktree now returns True on success, False on
+    failure (previously returned None and discarded exit codes silently)."""
+
+    def test_returns_true_when_all_subprocesses_succeed(self, tmp_path):
+        main_repo = tmp_path / "repo"
+        worktree = tmp_path / "repo-dependabot-42"
+        with patch.object(dependabot_review, "run", return_value=_mk_completed(0)):
+            result = dependabot_review.cleanup_worktree(
+                main_repo, worktree, "dependabot-audit-42",
+            )
+        assert result is True
+
+    def test_returns_false_when_worktree_remove_fails(self, tmp_path, capsys):
+        """The original #1133 bug: `git worktree remove` returns non-zero
+        on dirty worktrees, but the old code discarded the exit code."""
+        main_repo = tmp_path / "repo"
+        worktree = tmp_path / "repo-dependabot-42"
+
+        def fake_run(cmd, cwd=None, timeout=None):
+            joined = " ".join(cmd)
+            if "worktree remove" in joined:
+                return _mk_completed(1, stderr="fatal: 'foo' contains modified or untracked files")
+            return _mk_completed(0)
+
+        with patch.object(dependabot_review, "run", side_effect=fake_run):
+            result = dependabot_review.cleanup_worktree(
+                main_repo, worktree, "dependabot-audit-42",
+            )
+        assert result is False
+        # Loud diagnostic must hit stderr
+        err = capsys.readouterr().err
+        assert "CLEANUP FAILURE" in err
+        assert "worktree remove" in err
+        assert "modified or untracked" in err
+
+    def test_returns_false_when_branch_delete_fails(self, tmp_path, capsys):
+        main_repo = tmp_path / "repo"
+        worktree = tmp_path / "repo-dependabot-42"
+
+        def fake_run(cmd, cwd=None, timeout=None):
+            if "branch" in cmd and "-d" in cmd:
+                return _mk_completed(1, stderr="error: branch 'dependabot-audit-42' is not fully merged")
+            return _mk_completed(0)
+
+        with patch.object(dependabot_review, "run", side_effect=fake_run):
+            result = dependabot_review.cleanup_worktree(
+                main_repo, worktree, "dependabot-audit-42",
+            )
+        assert result is False
+        err = capsys.readouterr().err
+        assert "CLEANUP FAILURE" in err
+        assert "branch -d" in err
+
+    def test_branch_delete_failure_silent_when_worktree_remove_already_failed(
+        self, tmp_path, capsys,
+    ):
+        """When worktree remove fails, branch -d will likely also fail (the
+        branch is still attached to the leaked worktree). Avoid duplicate
+        CLEANUP FAILURE noise -- the worktree-remove failure is the root cause.
+        """
+        main_repo = tmp_path / "repo"
+        worktree = tmp_path / "repo-dependabot-42"
+
+        with patch.object(dependabot_review, "run",
+                          return_value=_mk_completed(1, stderr="some failure")):
+            dependabot_review.cleanup_worktree(
+                main_repo, worktree, "dependabot-audit-42",
+            )
+        err = capsys.readouterr().err
+        # Exactly ONE "CLEANUP FAILURE" header -- the worktree one.
+        # branch -d failure does not duplicate the message.
+        assert err.count("CLEANUP FAILURE") == 1
+
+
+class TestProcessPrTryFinallyContract:
+    """#1133: process_pr's cleanup_worktree call lives in `finally`, so it
+    runs on every exit path including exceptions raised mid-flight."""
+
+    def test_cleanup_called_when_inner_pipeline_raises(self, tmp_path):
+        """Pre-#1133 bug: if anything between worktree creation and a return
+        statement raised (KeyboardInterrupt, network error, subprocess timeout),
+        cleanup was skipped and the worktree leaked."""
+        main_repo = tmp_path / "repo"
+        main_repo.mkdir()
+        pr = dependabot_review.PRInfo(
+            number=99, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+
+        cleanup_calls: list[tuple] = []
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated mid-flight crash")
+
+        def fake_cleanup(main_repo_arg, worktree_arg, branch_arg):
+            cleanup_calls.append((main_repo_arg, worktree_arg, branch_arg))
+            return True
+
+        with patch.object(dependabot_review, "verify_author", return_value=True), \
+             patch.object(dependabot_review, "create_audit_worktree",
+                          return_value=(tmp_path / "repo-dependabot-99",
+                                        "dependabot-audit-99")), \
+             patch.object(dependabot_review, "checkout_pr_into_worktree",
+                          side_effect=boom), \
+             patch.object(dependabot_review, "cleanup_worktree",
+                          side_effect=fake_cleanup):
+            # Exception propagates -- but cleanup MUST run via finally
+            try:
+                dependabot_review.process_pr(pr, "owner/repo", main_repo)
+            except RuntimeError:
+                pass
+
+        assert len(cleanup_calls) == 1, (
+            "cleanup_worktree MUST run via finally even when inner pipeline "
+            "raises -- pre-#1133 design only covered explicit return paths"
+        )
+
+    def test_cleanup_warning_emitted_when_cleanup_returns_false(self, tmp_path, capsys):
+        """If cleanup_worktree returns False (failure), process_pr's finally
+        block emits a WARNING about leftover state."""
+        main_repo = tmp_path / "repo"
+        main_repo.mkdir()
+        pr = dependabot_review.PRInfo(
+            number=77, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+
+        with patch.object(dependabot_review, "verify_author", return_value=True), \
+             patch.object(dependabot_review, "create_audit_worktree",
+                          return_value=(tmp_path / "repo-dependabot-77",
+                                        "dependabot-audit-77")), \
+             patch.object(dependabot_review, "checkout_pr_into_worktree", return_value=False), \
+             patch.object(dependabot_review, "cleanup_worktree", return_value=False):
+            status = dependabot_review.process_pr(pr, "owner/repo", main_repo)
+
+        assert status == "errored"  # inner pipeline returned errored
+        err = capsys.readouterr().err
+        assert "WARNING: leftover state for PR #77" in err
+        assert "Manual cleanup required" in err
+
+    def test_cleanup_no_warning_when_cleanup_returns_true(self, tmp_path, capsys):
+        """Conversely: clean cleanup runs silently (no warning noise)."""
+        main_repo = tmp_path / "repo"
+        main_repo.mkdir()
+        pr = dependabot_review.PRInfo(
+            number=78, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+
+        with patch.object(dependabot_review, "verify_author", return_value=True), \
+             patch.object(dependabot_review, "create_audit_worktree",
+                          return_value=(tmp_path / "repo-dependabot-78",
+                                        "dependabot-audit-78")), \
+             patch.object(dependabot_review, "checkout_pr_into_worktree", return_value=False), \
+             patch.object(dependabot_review, "cleanup_worktree", return_value=True):
+            dependabot_review.process_pr(pr, "owner/repo", main_repo)
+
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+
+class TestCheckForOrphanWorktrees:
+    """#1133: startup canary that enumerates pre-existing dependabot worktrees."""
+
+    def test_returns_empty_when_no_orphans(self, tmp_path):
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+        )
+        with patch.object(dependabot_review, "run",
+                          return_value=_mk_completed(0, stdout=porcelain)):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []
+
+    def test_returns_orphan_paths(self, tmp_path):
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-dependabot-1095\n"
+            "HEAD def456\n"
+            "detached\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-dependabot-1097\n"
+            "HEAD ghi789\n"
+            "detached\n"
+            "\n"
+        )
+        with patch.object(dependabot_review, "run",
+                          return_value=_mk_completed(0, stdout=porcelain)):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert len(orphans) == 2
+        assert any("dependabot-1095" in o for o in orphans)
+        assert any("dependabot-1097" in o for o in orphans)
+
+    def test_ignores_non_dependabot_worktrees(self, tmp_path):
+        """Other feature-branch worktrees (e.g., AssemblyZero-1135-foo) are
+        NOT orphan dependabot worktrees and must not be flagged."""
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-1135-bootstrap\n"
+            "HEAD def456\n"
+            "branch refs/heads/1135-bootstrap\n"
+            "\n"
+        )
+        with patch.object(dependabot_review, "run",
+                          return_value=_mk_completed(0, stdout=porcelain)):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []
+
+    def test_returns_empty_on_subprocess_error(self, tmp_path):
+        """Diagnostic must not block the script: if `git worktree list` itself
+        fails, return [] so the operator's run can proceed."""
+        main_repo = tmp_path / "AssemblyZero"
+        with patch.object(dependabot_review, "run",
+                          return_value=_mk_completed(128, stderr="not a git repo")):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -31,11 +31,19 @@ For each open dependabot-authored PR:
     - Clean up worktree + audit branch
     - Move to next PR (one failure does not block the queue)
 
-Cleanup contract: zero persistent disk artifacts on ANY exit path. Every
-return from process_pr (merged / deferred / errored) must call
-cleanup_worktree before returning. If a future maintainer wants to
-inspect a failure, they re-create the worktree via `gh pr checkout` --
-the PR + Actions output captures everything else (#1116).
+Cleanup contract (#1116, hardened in #1133): zero persistent disk
+artifacts on ANY exit path -- normal return, deferred, errored, OR
+exception. Exit paths through `return` are covered by the try/finally
+wrapper in process_pr; exception paths are covered by the same finally
+block. If `git worktree remove` itself fails (e.g., the working tree
+went dirty mid-run), cleanup_worktree prints a CLEANUP FAILURE warning
+to stderr with the captured exit code and stderr -- the operator MUST
+investigate that path before the next run, because a leaked worktree
+breaks subsequent `git worktree add` for the same PR number.
+
+On startup, a canary lists pre-existing `*-dependabot-N` worktrees and
+refuses to proceed unless --ignore-orphans is passed (so accumulating
+debt is loud rather than silent).
 
 Usage:
     poetry run python tools/dependabot_review.py [--repo OWNER/REPO] [--dry-run]
@@ -378,35 +386,95 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
 # Cleanup
 # ---------------------------------------------------------------------------
 
-def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> None:
-    # `git branch -d` (lowercase, safe) is sufficient here because the audit
-    # branch is created from `main` by create_audit_worktree and never moves --
-    # checkout_pr_into_worktree uses `gh pr checkout --detach` (#1107), so the
-    # worktree's HEAD detaches without committing on the audit branch. After
-    # the dep PR is squash-merged, main fast-forwards past the original tip,
-    # leaving the audit branch fully reachable from main -> safe-delete works.
-    # `branch -D` is permanently banned per memory feedback_destructive_flag_scrutiny.
+def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
+    """Remove the audit worktree and its branch. Returns True iff both
+    operations exited with status 0.
+
+    `git branch -d` (lowercase, safe) is sufficient here because the audit
+    branch is created from `main` by create_audit_worktree and never moves --
+    checkout_pr_into_worktree uses `gh pr checkout --detach` (#1107), so the
+    worktree's HEAD detaches without committing on the audit branch. After
+    the dep PR is squash-merged, main fast-forwards past the original tip,
+    leaving the audit branch fully reachable from main -> safe-delete works.
+    `branch -D` is permanently banned per memory feedback_destructive_flag_scrutiny.
+
+    #1133: previously this function discarded subprocess exit codes, so
+    a dirty worktree (e.g., cascade detector having appended to a tracked
+    file -- pre-#1134) caused `git worktree remove` to fail silently and
+    leak the worktree. Now exit codes are inspected; failures are printed
+    LOUDLY to stderr with the captured stderr text so the operator can
+    diagnose. The bool return lets the caller decide whether to escalate;
+    process_pr's try/finally surfaces failures as a WARNING but does not
+    flip the PR processing result.
+    """
+    success = True
     evict_poetry_venv(worktree)
-    run(["git", "-C", str(main_repo), "worktree", "remove", str(worktree)])
-    run(["git", "-C", str(main_repo), "branch", "-d", branch])
+
+    wt_remove = run(["git", "-C", str(main_repo), "worktree", "remove", str(worktree)])
+    if wt_remove.returncode != 0:
+        success = False
+        print(
+            f"  CLEANUP FAILURE: `git worktree remove {worktree}` returned "
+            f"{wt_remove.returncode}\n"
+            f"  stderr: {wt_remove.stderr.strip()[:300] if wt_remove.stderr else '(none)'}\n"
+            f"  This worktree is now an ORPHAN. Investigate before next run "
+            f"-- a stuck worktree blocks `git worktree add` for the same PR.",
+            file=sys.stderr,
+        )
+
+    br_delete = run(["git", "-C", str(main_repo), "branch", "-d", branch])
+    if br_delete.returncode != 0:
+        success = False
+        # branch -d failing post-worktree-remove-failure is expected (the
+        # branch is still associated with the leaked worktree). Print
+        # diagnostically rather than crying wolf separately when the root
+        # cause is already surfaced above.
+        if wt_remove.returncode == 0:
+            print(
+                f"  CLEANUP FAILURE: `git branch -d {branch}` returned "
+                f"{br_delete.returncode}\n"
+                f"  stderr: {br_delete.stderr.strip()[:300] if br_delete.stderr else '(none)'}",
+                file=sys.stderr,
+            )
+
+    return success
+
+
+def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
+    """#1133: enumerate pre-existing dependabot worktrees so the operator
+    can be warned at startup. Returns list of orphan worktree paths
+    matching the `{main_name}-dependabot-N` pattern. Empty list = clean.
+    """
+    result = run(["git", "-C", str(main_repo), "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        # If we can't even list, return empty -- don't block the script on
+        # a diagnostic that itself errored.
+        return []
+    orphans: list[str] = []
+    prefix = f"{main_repo.name}-dependabot-"
+    for line in result.stdout.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        path = line[len("worktree "):].strip()
+        if prefix in Path(path).name:
+            orphans.append(path)
+    return orphans
 
 
 # ---------------------------------------------------------------------------
 # Per-PR processing
 # ---------------------------------------------------------------------------
 
-def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
-    """Process a single PR. Returns 'merged', 'deferred', or 'errored'."""
-    print(f"\n=== PR #{pr.number}: {pr.title} ===")
+def _process_pr_inside_worktree(
+    pr: PRInfo, repo: str, worktree: Path,
+) -> str:
+    """Inner pipeline that assumes the audit worktree has been created.
 
-    if not verify_author(pr):
-        return "errored"
-
-    worktree, branch = create_audit_worktree(main_repo, pr.number)
-
+    Returns 'merged', 'deferred', or 'errored'. Does NOT clean up --
+    cleanup is the caller's responsibility (process_pr's try/finally).
+    """
     if not checkout_pr_into_worktree(worktree, pr.number, repo):
         print("  ERROR: gh pr checkout failed")
-        cleanup_worktree(main_repo, worktree, branch)
         return "errored"
 
     evict_poetry_venv(worktree)
@@ -421,8 +489,6 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
             "`poetry install` failed. See the PR's Actions output for the "
             "captured stderr; re-run locally via `gh pr checkout` if needed.",
         )
-        # #1116: no retention. The PR + Actions output is the forensic record.
-        cleanup_worktree(main_repo, worktree, branch)
         return "deferred"
 
     exit_code = run_tests(worktree)
@@ -452,14 +518,11 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
             print(f"  Multi-package PR ({package_count} packages) -- "
                   f"requesting dependabot recreate")
             request_dependabot_recreate(pr.number, repo)
-        # #1116: no retention. The PR + Actions output is the forensic record.
-        cleanup_worktree(main_repo, worktree, branch)
         return "deferred"
 
     # ---- Green path ----
     if not inject_no_issue(pr, repo):
         print("  ERROR: inject No-Issue failed")
-        cleanup_worktree(main_repo, worktree, branch)
         return "errored"
 
     # Small wait for pr-sentinel to re-evaluate the edited body
@@ -467,21 +530,48 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
 
     if not approve_pr(pr.number, repo):
         print("  ERROR: approve failed")
-        cleanup_worktree(main_repo, worktree, branch)
         return "errored"
 
     if not wait_for_mergeable(pr.number, repo):
         print(f"  ERROR: mergeable_state never reached 'clean' within {MERGEABLE_TIMEOUT_S}s")
-        cleanup_worktree(main_repo, worktree, branch)
         return "errored"
 
     if not squash_merge(pr.number, repo):
         print("  ERROR: merge failed")
-        cleanup_worktree(main_repo, worktree, branch)
         return "errored"
 
-    cleanup_worktree(main_repo, worktree, branch)
     return "merged"
+
+
+def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
+    """Process a single PR. Returns 'merged', 'deferred', or 'errored'.
+
+    #1133: cleanup is wrapped in try/finally so it runs on every exit
+    path -- normal return, sub-helper return, OR exception (Ctrl-C,
+    subprocess timeout, network blip). The pre-#1133 design only
+    covered explicit return statements, so any exception leaked the
+    worktree.
+    """
+    print(f"\n=== PR #{pr.number}: {pr.title} ===")
+
+    if not verify_author(pr):
+        return "errored"
+
+    worktree, branch = create_audit_worktree(main_repo, pr.number)
+
+    try:
+        return _process_pr_inside_worktree(pr, repo, worktree)
+    finally:
+        cleanup_ok = cleanup_worktree(main_repo, worktree, branch)
+        if not cleanup_ok:
+            # cleanup_worktree already printed the diagnostic. Add a
+            # one-line WARNING for the operator who's scanning the
+            # summary -- this is a leaked worktree they need to address.
+            print(
+                f"  WARNING: leftover state for PR #{pr.number} at {worktree}. "
+                f"Manual cleanup required before next run.",
+                file=sys.stderr,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -601,11 +691,47 @@ def main() -> None:
                         help="Path to main repo (default: cwd)")
     parser.add_argument("--dry-run", action="store_true",
                         help="List PRs that would be processed; take no action")
+    parser.add_argument(
+        "--ignore-orphans", action="store_true",
+        help=(
+            "#1133: by default the script refuses to run if pre-existing "
+            "`*-dependabot-N` worktrees are detected (signal that a prior "
+            "run leaked state). Pass this to proceed anyway -- but resolve "
+            "the orphans first or they accumulate."
+        ),
+    )
     args = parser.parse_args()
 
     main_repo = Path(args.main_repo).resolve()
     if not (main_repo / ".git").exists():
         sys.exit(f"Not a git repo: {main_repo}")
+
+    # #1133: orphan-worktree canary BEFORE any new worktrees are created.
+    # If a prior run leaked state, refuse to proceed unless explicitly
+    # overridden -- accumulating orphans is what got us into the #1133
+    # situation in the first place.
+    orphans = check_for_orphan_worktrees(main_repo)
+    if orphans:
+        print(
+            f"\nWARNING: pre-existing dependabot worktrees detected on "
+            f"{main_repo.name}:",
+            file=sys.stderr,
+        )
+        for o in orphans:
+            print(f"  {o}", file=sys.stderr)
+        if not args.ignore_orphans:
+            print(
+                "\nThese are leftovers from prior runs that didn't reach "
+                "cleanup.\nAborting to prevent further pile-up. Investigate "
+                "the orphans, clean them up, then re-run. Pass "
+                "--ignore-orphans to override (not recommended).",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+        print(
+            "  proceeding anyway because --ignore-orphans was set",
+            file=sys.stderr,
+        )
 
     # Issue #1091: fleet mode enumerates user-owned Poetry repos.
     if args.fleet:


### PR DESCRIPTION
## Summary

Closes the two gaps in dependabot_review.py's cleanup discipline that surfaced during today's orphan-worktree investigation. #1116 added cleanup calls at every return path; this PR makes the contract cover **exceptions** and **silent subprocess failures** too.

## Changes

| Gap | Before | After |
|---|---|---|
| Exception paths | KeyboardInterrupt / timeout / network blip skipped cleanup | `process_pr` wraps inner pipeline in `try/finally`; cleanup runs exactly once on every exit |
| Silent failure | `git worktree remove` exit code discarded; dirty worktrees leaked invisibly | `cleanup_worktree` returns `bool`, prints `CLEANUP FAILURE` to stderr with exit code + stderr text; `process_pr` emits a one-line WARNING on cleanup failure |
| Accumulation | Orphans piled up across sessions silently | Startup canary `check_for_orphan_worktrees` enumerates pre-existing `{repo}-dependabot-N` worktrees; exits 3 unless `--ignore-orphans` is passed |

## Refactor approach

`process_pr` body extracted into `_process_pr_inside_worktree` (the inner pipeline that assumes the worktree exists and never calls cleanup). The 8 inline `cleanup_worktree` calls collapse into a single `finally` block. Net: more correct AND less code-duplication.

## Test plan

- [x] 40 tests pass (`pytest tests/test_dependabot_review.py tests/tools/test_dependabot_review.py -v`)
- [x] 11 new tests cover: bool returns, CLEANUP FAILURE stderr, exception-path cleanup, WARNING signaling, canary detection patterns, subprocess-error tolerance
- [x] All 29 prior tests preserved (refactor changed structure, not observable per-path behavior)
- [ ] After merge + a fresh dependabot run: any pre-existing orphans block the run with a clear error message; clean runs leave zero artifacts on disk

Closes #1133