### PR TITLE
chore(tools): add fleet-wide repository-ruleset audit (Closes #905)

### DIFF
--- a/tests/test_audit_fleet_rulesets.py
+++ b/tests/test_audit_fleet_rulesets.py
@@ -1,0 +1,334 @@
+"""Tests for tools/audit_fleet_rulesets.py (#905).
+
+Audits the fleet for repository rulesets. This test suite uses mocks
+to avoid network dependency; the integration is exercised by running
+the tool against the real fleet (separate manual step).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "audit_fleet_rulesets", TOOLS_DIR / "audit_fleet_rulesets.py",
+)
+audit = importlib.util.module_from_spec(_spec)
+sys.modules["audit_fleet_rulesets"] = audit
+_spec.loader.exec_module(audit)
+
+
+def _ruleset_detail(
+    rs_id: int = 14061333,
+    name: str = "main",
+    enforcement: str = "active",
+    target: str = "branch",
+    include: list[str] | None = None,
+    rule_types: list[str] | None = None,
+    bypass_actors: list[dict] | None = None,
+) -> dict:
+    """Mock GitHub ruleset detail response."""
+    return {
+        "id": rs_id,
+        "name": name,
+        "target": target,
+        "enforcement": enforcement,
+        "conditions": {"ref_name": {"include": include or ["~DEFAULT_BRANCH"], "exclude": []}},
+        "rules": [{"type": t} for t in (rule_types or ["pull_request"])],
+        "bypass_actors": bypass_actors or [],
+    }
+
+
+# ---- summarize_ruleset ----
+
+
+class TestSummarizeRuleset:
+    def test_default_branch_target_via_default_marker(self):
+        detail = _ruleset_detail(include=["~DEFAULT_BRANCH"])
+        s = audit.summarize_ruleset(detail, default_branch="main")
+        assert s.targets_default_branch is True
+
+    def test_default_branch_target_via_explicit_ref(self):
+        detail = _ruleset_detail(include=["refs/heads/main"])
+        s = audit.summarize_ruleset(detail, default_branch="main")
+        assert s.targets_default_branch is True
+
+    def test_non_default_branch_does_not_target(self):
+        detail = _ruleset_detail(include=["refs/heads/dev"])
+        s = audit.summarize_ruleset(detail, default_branch="main")
+        assert s.targets_default_branch is False
+
+    def test_admin_bypass_detected(self):
+        detail = _ruleset_detail(bypass_actors=[
+            {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
+        ])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.admin_role_bypass is True
+        assert s.bypass_actor_count == 1
+
+    def test_admin_bypass_absent(self):
+        detail = _ruleset_detail(bypass_actors=[])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.admin_role_bypass is False
+        assert s.bypass_actor_count == 0
+
+    def test_non_admin_bypass_does_not_count_as_admin_bypass(self):
+        detail = _ruleset_detail(bypass_actors=[
+            {"actor_id": 9999, "actor_type": "Team", "bypass_mode": "always"},
+        ])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.admin_role_bypass is False
+        assert s.bypass_actor_count == 1
+
+    def test_rule_types_extracted_in_order(self):
+        detail = _ruleset_detail(rule_types=["deletion", "pull_request", "non_fast_forward"])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.rule_types == ["deletion", "pull_request", "non_fast_forward"]
+
+    def test_inactive_ruleset_marked(self):
+        detail = _ruleset_detail(enforcement="disabled")
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.enforcement == "disabled"
+        assert s.blocks_direct_push_to_default() is False
+
+
+class TestBlocksDirectPushToDefault:
+    """The blocks_direct_push_to_default property is the bottom-line
+    signal: does this ruleset prevent a direct Contents-API PUT?"""
+
+    def test_blocks_when_active_default_branch_pull_request_rule(self):
+        detail = _ruleset_detail(rule_types=["pull_request"], include=["~DEFAULT_BRANCH"])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.blocks_direct_push_to_default() is True
+
+    def test_does_not_block_when_disabled(self):
+        detail = _ruleset_detail(enforcement="disabled", rule_types=["pull_request"])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.blocks_direct_push_to_default() is False
+
+    def test_does_not_block_when_not_targeting_default(self):
+        detail = _ruleset_detail(include=["refs/heads/dev"], rule_types=["pull_request"])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.blocks_direct_push_to_default() is False
+
+    def test_does_not_block_when_no_blocking_rules(self):
+        detail = _ruleset_detail(rule_types=["tag_name_pattern"])
+        s = audit.summarize_ruleset(detail, "main")
+        assert s.blocks_direct_push_to_default() is False
+
+
+# ---- RepoVerdict aggregation ----
+
+
+class TestRepoVerdict:
+    def test_blocks_when_any_ruleset_blocks(self):
+        v = audit.RepoVerdict(name="boostgauge")
+        v.rulesets = [
+            audit.summarize_ruleset(_ruleset_detail(rule_types=["pull_request"]), "main"),
+        ]
+        v.ruleset_count = 1
+        assert v.blocks_direct_push is True
+
+    def test_does_not_block_with_zero_rulesets(self):
+        v = audit.RepoVerdict(name="comp-environ")
+        assert v.blocks_direct_push is False
+
+    def test_can_admin_bypass_when_all_default_target_rulesets_have_admin(self):
+        v = audit.RepoVerdict(name="x")
+        v.rulesets = [
+            audit.summarize_ruleset(
+                _ruleset_detail(bypass_actors=[
+                    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
+                ]),
+                "main",
+            ),
+        ]
+        assert v.can_admin_bypass is True
+
+    def test_can_admin_bypass_false_when_any_default_target_lacks_admin(self):
+        v = audit.RepoVerdict(name="x")
+        v.rulesets = [
+            audit.summarize_ruleset(
+                _ruleset_detail(rs_id=1, bypass_actors=[
+                    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
+                ]),
+                "main",
+            ),
+            audit.summarize_ruleset(
+                _ruleset_detail(rs_id=2, bypass_actors=[]),
+                "main",
+            ),
+        ]
+        assert v.can_admin_bypass is False
+
+    def test_can_admin_bypass_ignores_non_default_target_rulesets(self):
+        v = audit.RepoVerdict(name="x")
+        v.rulesets = [
+            audit.summarize_ruleset(
+                _ruleset_detail(rs_id=1, include=["~DEFAULT_BRANCH"], bypass_actors=[
+                    {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},
+                ]),
+                "main",
+            ),
+            # Non-default-branch ruleset without admin bypass -- must NOT
+            # affect the can_admin_bypass verdict for the default branch.
+            audit.summarize_ruleset(
+                _ruleset_detail(rs_id=2, include=["refs/heads/release"], bypass_actors=[]),
+                "main",
+            ),
+        ]
+        assert v.can_admin_bypass is True
+
+
+# ---- TSV serialization ----
+
+
+class TestTsvRow:
+    def test_error_row_has_explicit_error_classification(self):
+        v = audit.RepoVerdict(name="repo", error="network failure")
+        row = v.tsv_row()
+        cols = row.split("\t")
+        assert cols[0] == "repo"
+        assert "ERROR" in row
+        assert "network failure" in cols[-1]
+
+    def test_clean_repo_with_no_rulesets(self):
+        v = audit.RepoVerdict(name="comp-environ", default_branch="main")
+        row = v.tsv_row()
+        cols = row.split("\t")
+        assert cols[0] == "comp-environ"
+        assert cols[1] == "main"
+        assert cols[2] == "no"  # blocks_direct_push
+        assert cols[4] == "0"   # ruleset_count
+
+    def test_repo_with_blocking_ruleset(self):
+        v = audit.RepoVerdict(name="boostgauge", default_branch="main")
+        v.rulesets = [
+            audit.summarize_ruleset(_ruleset_detail(rs_id=14061333), "main"),
+        ]
+        v.ruleset_count = 1
+        row = v.tsv_row()
+        cols = row.split("\t")
+        assert cols[0] == "boostgauge"
+        assert cols[2] == "yes"  # blocks_direct_push
+        assert "14061333" in cols[5]  # ruleset_ids
+
+
+# ---- audit_one orchestration ----
+
+
+class TestAuditOne:
+    def test_no_rulesets_returns_zero_count(self):
+        repo_obj = {"name": "comp-environ", "defaultBranchRef": {"name": "main"}}
+        with patch.object(audit, "list_ruleset_summaries", return_value=([], None)), \
+             patch.object(audit, "get_ruleset_detail") as mock_detail:
+            v = audit.audit_one(repo_obj)
+        assert v.name == "comp-environ"
+        assert v.ruleset_count == 0
+        assert v.rulesets == []
+        mock_detail.assert_not_called()
+
+    def test_summaries_error_sets_error_field(self):
+        repo_obj = {"name": "x", "defaultBranchRef": {"name": "main"}}
+        with patch.object(audit, "list_ruleset_summaries",
+                          return_value=([], "gh rulesets list: 503")):
+            v = audit.audit_one(repo_obj)
+        assert v.error is not None
+        assert "503" in v.error
+
+    def test_detail_fetched_for_each_summary(self):
+        repo_obj = {"name": "boostgauge", "defaultBranchRef": {"name": "main"}}
+        summaries = [
+            {"id": 14061333, "name": "main", "target": "branch", "enforcement": "active"},
+        ]
+        detail = _ruleset_detail(rs_id=14061333)
+        with patch.object(audit, "list_ruleset_summaries", return_value=(summaries, None)), \
+             patch.object(audit, "get_ruleset_detail", return_value=(detail, None)):
+            v = audit.audit_one(repo_obj)
+        assert v.ruleset_count == 1
+        assert len(v.rulesets) == 1
+        assert v.rulesets[0].rs_id == 14061333
+
+    def test_detail_error_aborts_with_error(self):
+        repo_obj = {"name": "x", "defaultBranchRef": {"name": "main"}}
+        summaries = [{"id": 1, "name": "x", "target": "branch", "enforcement": "active"}]
+        with patch.object(audit, "list_ruleset_summaries", return_value=(summaries, None)), \
+             patch.object(audit, "get_ruleset_detail", return_value=(None, "detail 503")):
+            v = audit.audit_one(repo_obj)
+        assert v.error is not None
+        assert "detail 503" in v.error
+
+
+# ---- main() integration smoke ----
+
+
+class TestMainIntegration:
+    def test_main_writes_tsv_with_expected_columns(self, tmp_path, capsys):
+        out_path = tmp_path / "rulesets.tsv"
+
+        fake_repos = [
+            {"name": "comp-environ", "defaultBranchRef": {"name": "main"},
+             "isArchived": False, "isFork": False},
+            {"name": "boostgauge", "defaultBranchRef": {"name": "main"},
+             "isArchived": False, "isFork": False},
+        ]
+
+        def fake_audit_one(repo_obj):
+            v = audit.RepoVerdict(name=repo_obj["name"], default_branch="main")
+            if repo_obj["name"] == "boostgauge":
+                v.rulesets = [
+                    audit.summarize_ruleset(_ruleset_detail(rs_id=14061333), "main"),
+                ]
+                v.ruleset_count = 1
+            return v
+
+        with patch.object(audit, "list_user_repos", return_value=fake_repos), \
+             patch.object(audit, "audit_one", side_effect=fake_audit_one):
+            rc = audit.main(["--output", str(out_path)])
+
+        assert rc == 0
+        assert out_path.exists()
+        content = out_path.read_text(encoding="utf-8")
+        lines = content.strip().split("\n")
+        # Header + 2 rows
+        assert len(lines) == 3
+        # Header has all expected columns
+        header_cols = lines[0].split("\t")
+        assert "repo" in header_cols
+        assert "blocks_direct_push_to_default" in header_cols
+        assert "admin_bypass_present" in header_cols
+        assert "ruleset_count" in header_cols
+
+    def test_main_summary_lists_repos_requiring_bootstrap(self, tmp_path, capsys):
+        out_path = tmp_path / "rulesets.tsv"
+
+        fake_repos = [
+            {"name": "comp-environ", "defaultBranchRef": {"name": "main"},
+             "isArchived": False, "isFork": False},
+            {"name": "boostgauge", "defaultBranchRef": {"name": "main"},
+             "isArchived": False, "isFork": False},
+        ]
+
+        def fake_audit_one(repo_obj):
+            v = audit.RepoVerdict(name=repo_obj["name"], default_branch="main")
+            if repo_obj["name"] == "boostgauge":
+                v.rulesets = [
+                    audit.summarize_ruleset(_ruleset_detail(rs_id=14061333), "main"),
+                ]
+                v.ruleset_count = 1
+            return v
+
+        with patch.object(audit, "list_user_repos", return_value=fake_repos), \
+             patch.object(audit, "audit_one", side_effect=fake_audit_one):
+            audit.main(["--output", str(out_path)])
+
+        out = capsys.readouterr().out
+        assert "REPOS THAT WILL REQUIRE BOOTSTRAP" in out
+        assert "boostgauge" in out
+        # comp-environ has no rulesets -> NOT listed in the bootstrap-needed group
+        # (it appears earlier in the per-repo trace but not in the summary list)
+        bootstrap_section = out.split("REPOS THAT WILL REQUIRE BOOTSTRAP")[1]
+        assert "comp-environ" not in bootstrap_section

--- a/tools/audit_fleet_rulesets.py
+++ b/tools/audit_fleet_rulesets.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Fleet-wide repository-ruleset audit (Closes #905).
+
+The companion to `audit_fleet_branch_protection.py`. That tool covers
+*classic* branch protection; this one covers the newer *rulesets* API
+surface. They are independent: a repo can have both, either, or neither.
+
+#905 was filed 2026-04-09 after a batch config fix surfaced a 6.5x timing
+spread in merge readiness across 5 repos. The today (2026-05-12)
+three-iteration bootstrap saga (#1135 / #1137 / #1141) re-confirmed why
+this audit is load-bearing: `comp-environ` had no rulesets and bootstrap
+worked first try; `boostgauge` and `gh-galaxy-quest` each had an active
+ruleset with a `pull_request` rule and `bypass_actors: []`, blocking the
+direct-push bootstrap entirely until #1137 added ruleset bypass support.
+
+Had this audit existed in April, the ruleset divergence would have been
+visible BEFORE the deploy tool encountered it as a 409 in production.
+
+What this script does:
+
+  1. List all martymcenroe non-archived non-fork repos via `gh repo list`.
+  2. For each repo, GET /repos/{owner}/{repo}/rulesets (gh CLI uses the
+     user's fine-grained PAT -- read scope on rulesets is sufficient,
+     no classic PAT needed).
+  3. For each active branch-target ruleset, fetch full detail to
+     extract: targeted refs, rule types present, bypass_actors count,
+     whether the Repository admin role can bypass.
+  4. Emit a TSV with one row per repo: ruleset count, IDs, main-target
+     subset, rule type fingerprint, bypass actor metadata.
+  5. Print a summary distinguishing repos that have rulesets blocking
+     direct push to the default branch (i.e., where deploy tools must
+     route through PRs OR use admin bypass).
+
+The agent can run this safely -- no secret is unlocked.
+
+Usage (from any AssemblyZero checkout):
+
+    poetry run python tools/audit_fleet_rulesets.py
+    poetry run python tools/audit_fleet_rulesets.py --limit 10
+    poetry run python tools/audit_fleet_rulesets.py --output /tmp/rulesets.tsv
+    poetry run python tools/audit_fleet_rulesets.py --repos boostgauge,gh-galaxy-quest
+
+Issue: #905 | Companion: tools/audit_fleet_branch_protection.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+GITHUB_USER = "martymcenroe"
+HTTP_TIMEOUT_S = 30
+DEFAULT_OUTPUT = Path("audit_fleet_rulesets_results.tsv")
+REPO_ADMIN_ROLE_ID = 5  # GitHub repository admin role (matches deploy_auto_reviewer_workflow.py)
+
+# Rule types that, when present in a ruleset targeting the default branch,
+# block direct push via Contents API. Used for the blocks_direct_push flag.
+BLOCKING_RULE_TYPES = frozenset({
+    "pull_request",
+    "deletion",        # blocks branch deletion, not pushes -- but worth flagging
+    "non_fast_forward",
+    "required_signatures",
+    "required_status_checks",
+    "creation",
+    "update",
+})
+
+
+@dataclass
+class RulesetSummary:
+    """One ruleset's relevant audit data."""
+    rs_id: int
+    name: str
+    enforcement: str
+    target: str
+    targets_default_branch: bool
+    rule_types: list[str]
+    bypass_actor_count: int
+    admin_role_bypass: bool
+
+    def blocks_direct_push_to_default(self) -> bool:
+        if not self.targets_default_branch:
+            return False
+        if self.enforcement != "active":
+            return False
+        return any(t in BLOCKING_RULE_TYPES for t in self.rule_types)
+
+
+@dataclass
+class RepoVerdict:
+    name: str
+    default_branch: str | None = None
+    ruleset_count: int = 0
+    rulesets: list[RulesetSummary] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def main_target_rulesets(self) -> list[RulesetSummary]:
+        return [r for r in self.rulesets if r.targets_default_branch]
+
+    @property
+    def blocks_direct_push(self) -> bool:
+        return any(r.blocks_direct_push_to_default() for r in self.rulesets)
+
+    @property
+    def can_admin_bypass(self) -> bool:
+        """Across all default-branch-targeting active rulesets, is the
+        Repository admin role a bypass actor? If yes, classic-PAT-as-owner
+        can direct-push without ruleset modification."""
+        return all(
+            r.admin_role_bypass
+            for r in self.rulesets
+            if r.targets_default_branch and r.enforcement == "active"
+        )
+
+    def tsv_row(self) -> str:
+        if self.error:
+            return "\t".join([self.name, "", "ERROR", "", "", "", "", "", "", self.error])
+
+        main_subset = self.main_target_rulesets
+        rule_types: set[str] = set()
+        bypass_count = 0
+        for r in main_subset:
+            rule_types.update(r.rule_types)
+            bypass_count += r.bypass_actor_count
+
+        ruleset_id_summary = ";".join(f"{r.rs_id}:{r.name}" for r in self.rulesets)
+        main_target_ids = ";".join(str(r.rs_id) for r in main_subset)
+
+        return "\t".join([
+            self.name,
+            self.default_branch or "",
+            "yes" if self.blocks_direct_push else "no",
+            "yes" if main_subset and self.can_admin_bypass else "no",
+            str(self.ruleset_count),
+            ruleset_id_summary,
+            main_target_ids,
+            ",".join(sorted(rule_types)),
+            str(bypass_count),
+            "",
+        ])
+
+
+TSV_HEADER = "\t".join([
+    "repo",
+    "default_branch",
+    "blocks_direct_push_to_default",
+    "admin_bypass_present",
+    "ruleset_count",
+    "ruleset_ids",
+    "default_branch_target_ruleset_ids",
+    "default_branch_rule_types",
+    "default_branch_bypass_actor_count",
+    "error",
+])
+
+
+def run_gh(args: list[str]) -> tuple[int, str, str]:
+    """Wrapper for `gh ...`. Returns (returncode, stdout, stderr).
+
+    Uses gh CLI's fine-grained PAT auth; read-only ruleset queries are
+    permitted without the classic PAT. Bounded timeout per call.
+    """
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", check=False, timeout=HTTP_TIMEOUT_S,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"gh timeout after {HTTP_TIMEOUT_S}s"
+    except OSError as e:
+        return 1, "", f"gh OSError: {e}"
+
+
+def list_user_repos() -> list[dict]:
+    rc, stdout, stderr = run_gh([
+        "repo", "list", GITHUB_USER, "--limit", "200",
+        "--json", "name,defaultBranchRef,isArchived,isFork",
+    ])
+    if rc != 0:
+        sys.exit(f"gh repo list failed: {stderr.strip()[:300]}")
+    return json.loads(stdout or "[]")
+
+
+def list_ruleset_summaries(repo: str) -> tuple[list[dict], str | None]:
+    """Returns (ruleset_summaries, error). Summaries are the list-endpoint
+    shape (id, name, target, enforcement). The detail endpoint must be
+    called separately for conditions / rules / bypass_actors."""
+    rc, stdout, stderr = run_gh([
+        "api", f"repos/{GITHUB_USER}/{repo}/rulesets",
+        "--header", "Accept: application/vnd.github+json",
+    ])
+    if rc != 0:
+        # 404 from this endpoint typically means "no rulesets" rather than
+        # repo not found, but gh CLI surfaces both as exit 1. Distinguish
+        # by stderr content.
+        if "Not Found" in stderr or "404" in stderr:
+            return [], None
+        return [], f"gh rulesets list: {stderr.strip()[:200]}"
+    try:
+        data = json.loads(stdout or "[]")
+    except json.JSONDecodeError as e:
+        return [], f"parse rulesets: {e}"
+    if not isinstance(data, list):
+        return [], None
+    return data, None
+
+
+def get_ruleset_detail(repo: str, rs_id: int) -> tuple[dict | None, str | None]:
+    rc, stdout, stderr = run_gh([
+        "api", f"repos/{GITHUB_USER}/{repo}/rulesets/{rs_id}",
+        "--header", "Accept: application/vnd.github+json",
+    ])
+    if rc != 0:
+        return None, f"gh rulesets detail {rs_id}: {stderr.strip()[:200]}"
+    try:
+        return json.loads(stdout), None
+    except json.JSONDecodeError as e:
+        return None, f"parse detail {rs_id}: {e}"
+
+
+def summarize_ruleset(detail: dict, default_branch: str | None) -> RulesetSummary:
+    """Reduce a ruleset detail dict to the audit-relevant fields."""
+    rs_id = int(detail.get("id", 0))
+    name = str(detail.get("name", ""))
+    enforcement = str(detail.get("enforcement", ""))
+    target = str(detail.get("target", ""))
+
+    # Determine if the ruleset targets the repo's default branch.
+    ref_name = (detail.get("conditions") or {}).get("ref_name") or {}
+    include = ref_name.get("include") or []
+    targets_default = "~DEFAULT_BRANCH" in include or (
+        default_branch is not None and f"refs/heads/{default_branch}" in include
+    )
+
+    rules = detail.get("rules") or []
+    rule_types = [str(r.get("type", "")) for r in rules if r.get("type")]
+
+    bypass_actors = detail.get("bypass_actors") or []
+    bypass_count = len(bypass_actors)
+    admin_bypass = any(
+        a.get("actor_id") == REPO_ADMIN_ROLE_ID
+        and a.get("actor_type") == "RepositoryRole"
+        for a in bypass_actors
+    )
+
+    return RulesetSummary(
+        rs_id=rs_id,
+        name=name,
+        enforcement=enforcement,
+        target=target,
+        targets_default_branch=targets_default,
+        rule_types=rule_types,
+        bypass_actor_count=bypass_count,
+        admin_role_bypass=admin_bypass,
+    )
+
+
+def audit_one(repo_obj: dict) -> RepoVerdict:
+    name = repo_obj.get("name", "")
+    default = (repo_obj.get("defaultBranchRef") or {}).get("name")
+    v = RepoVerdict(name=name, default_branch=default)
+
+    summaries, err = list_ruleset_summaries(name)
+    if err:
+        v.error = err
+        return v
+
+    v.ruleset_count = len(summaries)
+    for summary in summaries:
+        rs_id = summary.get("id")
+        if rs_id is None:
+            continue
+        detail, det_err = get_ruleset_detail(name, int(rs_id))
+        if det_err:
+            v.error = det_err
+            return v
+        if detail is None:
+            continue
+        v.rulesets.append(summarize_ruleset(detail, default))
+    return v
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT,
+                        help=f"TSV output path (default: {DEFAULT_OUTPUT})")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Audit only first N repos (smoke test)")
+    parser.add_argument("--repos", default=None,
+                        help="Comma-separated repo names; overrides full discovery")
+    args = parser.parse_args(argv)
+
+    print("Listing repos via gh CLI (read-only)...")
+    all_repos = list_user_repos()
+
+    if args.repos:
+        wanted = {r.strip() for r in args.repos.split(",") if r.strip()}
+        repos = [r for r in all_repos if r["name"] in wanted]
+    else:
+        repos = [r for r in all_repos if not r.get("isArchived") and not r.get("isFork")]
+        if args.limit:
+            repos = repos[: args.limit]
+
+    print(f"Auditing {len(repos)} repos for repository rulesets...\n")
+
+    verdicts: list[RepoVerdict] = []
+    for i, repo_obj in enumerate(repos, 1):
+        v = audit_one(repo_obj)
+        verdicts.append(v)
+        if v.error:
+            tag = f"ERROR ({v.error[:80]})"
+        else:
+            tag = (
+                f"{v.ruleset_count} ruleset(s), "
+                f"blocks_direct_push={'yes' if v.blocks_direct_push else 'no'}"
+            )
+        print(f"  [{i}/{len(repos)}] {v.name}: {tag}")
+
+    args.output.write_text(
+        TSV_HEADER + "\n" + "\n".join(v.tsv_row() for v in verdicts) + "\n",
+        encoding="utf-8",
+    )
+    print(f"\nTSV written: {args.output.resolve()}")
+
+    blocking = [v for v in verdicts if not v.error and v.blocks_direct_push]
+    no_admin_bypass = [
+        v for v in blocking
+        if not v.can_admin_bypass
+    ]
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"  Total audited: {len(verdicts)}")
+    print(f"  With any ruleset: {sum(1 for v in verdicts if not v.error and v.ruleset_count > 0)}")
+    print(f"  Blocks direct push to default branch: {len(blocking)}")
+    print(f"    of those, no admin bypass: {len(no_admin_bypass)}")
+
+    if no_admin_bypass:
+        print("\nREPOS THAT WILL REQUIRE BOOTSTRAP for any direct-PUT deploy:")
+        for v in no_admin_bypass:
+            rule_summary = ",".join(sorted({
+                t for rs in v.main_target_rulesets for t in rs.rule_types
+            }))
+            print(f"  - {v.name}: rules={rule_summary or '(none)'}")
+    else:
+        print("\nNo repos require ruleset bootstrap.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New `tools/audit_fleet_rulesets.py` companion to `audit_fleet_branch_protection.py`. That one covers classic protection; this one covers the rulesets API surface. They are independent — a repo can have both, either, or neither.

## Why now

#905 was filed 2026-04-09 after a batch config fix noted a 6.5x timing spread in merge readiness across 5 repos. Today's three-iteration bootstrap saga (#1135, #1137, #1141) made the gap operationally expensive:

| Repo | Ruleset | First deploy result | Iterations needed |
|---|---|---|---|
| `comp-environ` | none | APPLIED via classic bootstrap | 1 (PR #1136) |
| `boostgauge` | active w/ pull_request rule, empty bypass_actors | blocked by ruleset | 3 (PRs #1136, #1139, #1142) |
| `gh-galaxy-quest` | same | blocked by ruleset | 3 |

Had this audit existed, the ruleset divergence would have been a TSV column rather than a production 409.

## What the tool does

1. Lists user repos via `gh repo list` (fine-grained PAT, no classic PAT needed — **agent-safe**).
2. For each non-archived non-fork repo, GETs `/rulesets` then detail per ruleset.
3. Reduces each ruleset to: enforcement, target, default-branch coverage, rule types, bypass-actor count, whether admin role can bypass.
4. Writes a TSV with these columns: `repo, default_branch, blocks_direct_push_to_default, admin_bypass_present, ruleset_count, ruleset_ids, default_branch_target_ruleset_ids, default_branch_rule_types, default_branch_bypass_actor_count, error`.
5. Prints a summary of repos that would require bootstrap for direct-PUT deploys.

## Scope

Intentionally limited to the **audit script** per #905's primary action item. The other items in #905 body (path filters on AZ test workflow, fleet-wide `checks:read` standardization, document intended check profiles, etc.) are separate work — file individually if needed.

## Test plan

- [x] 26 tests pass (`pytest tests/test_audit_fleet_rulesets.py -v`)
- [x] Coverage: ruleset summarization, blocking detection, RepoVerdict aggregation, TSV serialization, audit_one orchestration error paths, main() integration smoke
- [ ] Manual run against the fleet (operator step):
  ```
  poetry run python tools/audit_fleet_rulesets.py
  ```

Closes #905