### PR TITLE
feat(tools): token-ledger from local Claude session jsonls (Closes #1111)

### DIFF
--- a/tests/test_claude_usage_compute.py
+++ b/tests/test_claude_usage_compute.py
@@ -1,0 +1,442 @@
+"""Tests for tools/claude_usage_compute.py (#1111)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "claude_usage_compute", TOOLS_DIR / "claude_usage_compute.py",
+)
+ledger = importlib.util.module_from_spec(_spec)
+sys.modules["claude_usage_compute"] = ledger
+_spec.loader.exec_module(ledger)
+
+
+# ---- detect_family ----
+
+
+class TestDetectFamily:
+    def test_opus(self):
+        assert ledger.detect_family("claude-opus-4-7") == "opus"
+
+    def test_sonnet(self):
+        assert ledger.detect_family("claude-sonnet-4-6") == "sonnet"
+
+    def test_haiku(self):
+        assert ledger.detect_family("claude-haiku-4-5-20251001") == "haiku"
+
+    def test_unknown(self):
+        assert ledger.detect_family("claude-3-mystery") == "unknown"
+
+    def test_empty(self):
+        assert ledger.detect_family("") == "unknown"
+
+    def test_case_insensitive(self):
+        assert ledger.detect_family("CLAUDE-OPUS-4-7") == "opus"
+
+
+# ---- parse_timestamp ----
+
+
+class TestParseTimestamp:
+    def test_z_suffix(self):
+        ts = ledger.parse_timestamp("2026-04-19T14:53:54.033Z")
+        assert ts is not None
+        assert ts.tzinfo is not None
+
+    def test_offset(self):
+        ts = ledger.parse_timestamp("2026-04-19T14:53:54+00:00")
+        assert ts is not None
+
+    def test_garbage_returns_none(self):
+        assert ledger.parse_timestamp("not a timestamp") is None
+
+    def test_none_returns_none(self):
+        assert ledger.parse_timestamp(None) is None
+
+    def test_int_returns_none(self):
+        assert ledger.parse_timestamp(1234567890) is None
+
+
+# ---- extract_record ----
+
+
+def _assistant_event(
+    ts: str = "2026-04-19T14:53:54.033Z",
+    session: str = "sess-abc",
+    model: str = "claude-opus-4-7",
+    input_tokens: int = 100,
+    output_tokens: int = 200,
+    cache_read: int = 1000,
+    cache_create: int = 500,
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "sessionId": session,
+        "message": {
+            "model": model,
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_input_tokens": cache_read,
+                "cache_creation_input_tokens": cache_create,
+            },
+        },
+    }
+
+
+class TestExtractRecord:
+    def test_full_extraction(self):
+        rec = ledger.extract_record(_assistant_event())
+        assert rec is not None
+        assert rec.session_id == "sess-abc"
+        assert rec.model == "claude-opus-4-7"
+        assert rec.family == "opus"
+        assert rec.input_tokens == 100
+        assert rec.output_tokens == 200
+        assert rec.cache_read_input_tokens == 1000
+        assert rec.cache_creation_input_tokens == 500
+        assert rec.total_tokens == 1800
+
+    def test_user_message_skipped(self):
+        evt = {"type": "user", "message": {"content": "hi"}}
+        assert ledger.extract_record(evt) is None
+
+    def test_missing_usage_block(self):
+        evt = _assistant_event()
+        del evt["message"]["usage"]
+        assert ledger.extract_record(evt) is None
+
+    def test_missing_message(self):
+        assert ledger.extract_record({"type": "assistant"}) is None
+
+    def test_missing_timestamp_returns_none(self):
+        evt = _assistant_event()
+        del evt["timestamp"]
+        assert ledger.extract_record(evt) is None
+
+    def test_missing_token_fields_default_to_zero(self):
+        """Tolerance: partial usage blocks don't crash."""
+        evt = _assistant_event()
+        evt["message"]["usage"] = {"input_tokens": 50}  # only one field
+        rec = ledger.extract_record(evt)
+        assert rec is not None
+        assert rec.input_tokens == 50
+        assert rec.output_tokens == 0
+        assert rec.cache_read_input_tokens == 0
+        assert rec.cache_creation_input_tokens == 0
+
+
+# ---- iter_session_jsonls ----
+
+
+class TestIterSessionJsonls:
+    def test_picks_up_top_level_jsonls(self, tmp_path):
+        proj_a = tmp_path / "proj-a"
+        proj_a.mkdir()
+        (proj_a / "session1.jsonl").write_text("")
+        (proj_a / "session2.jsonl").write_text("")
+        # Non-jsonl ignored
+        (proj_a / "notes.txt").write_text("")
+        files = ledger.iter_session_jsonls(tmp_path)
+        names = sorted(p.name for p in files)
+        assert names == ["session1.jsonl", "session2.jsonl"]
+
+    def test_skips_subagent_subdir(self, tmp_path):
+        """#1111 explicitly excludes subagent jsonls -- they double-count
+        tokens already attributed to the parent session."""
+        proj = tmp_path / "proj-x"
+        proj.mkdir()
+        (proj / "parent.jsonl").write_text("")
+        subagents = proj / "subagents"
+        subagents.mkdir()
+        (subagents / "agent-1.jsonl").write_text("")
+        (subagents / "agent-2.jsonl").write_text("")
+        files = ledger.iter_session_jsonls(tmp_path)
+        names = sorted(p.name for p in files)
+        assert names == ["parent.jsonl"]
+
+    def test_missing_root_returns_empty(self, tmp_path):
+        nonexistent = tmp_path / "nonexistent"
+        assert ledger.iter_session_jsonls(nonexistent) == []
+
+    def test_handles_multiple_projects(self, tmp_path):
+        for name in ("proj-1", "proj-2", "proj-3"):
+            p = tmp_path / name
+            p.mkdir()
+            (p / "session.jsonl").write_text("")
+        files = ledger.iter_session_jsonls(tmp_path)
+        assert len(files) == 3
+
+
+# ---- iter_records (jsonl parsing) ----
+
+
+class TestIterRecords:
+    def test_parses_assistant_events(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        lines = [
+            json.dumps(_assistant_event(ts="2026-04-19T14:00:00Z", model="claude-opus-4-7")),
+            json.dumps({"type": "user", "message": {"content": "hi"}}),  # skipped
+            json.dumps(_assistant_event(ts="2026-04-19T14:05:00Z", model="claude-sonnet-4-6")),
+        ]
+        jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        records = ledger.iter_records(jsonl)
+        assert len(records) == 2
+        assert records[0].family == "opus"
+        assert records[1].family == "sonnet"
+
+    def test_skips_corrupt_lines(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(
+            json.dumps(_assistant_event()) + "\n"
+            "THIS IS NOT JSON\n"
+            + json.dumps(_assistant_event(session="sess-2")) + "\n",
+            encoding="utf-8",
+        )
+        records = ledger.iter_records(jsonl)
+        assert len(records) == 2
+
+    def test_skips_blank_lines(self, tmp_path):
+        jsonl = tmp_path / "session.jsonl"
+        jsonl.write_text(
+            "\n\n" + json.dumps(_assistant_event()) + "\n\n",
+            encoding="utf-8",
+        )
+        records = ledger.iter_records(jsonl)
+        assert len(records) == 1
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        records = ledger.iter_records(tmp_path / "nonexistent.jsonl")
+        assert records == []
+
+
+# ---- most_recent_sunday ----
+
+
+class TestMostRecentSunday:
+    def test_sunday_returns_same_day_midnight(self):
+        # 2026-04-12 was a Sunday
+        ref = datetime(2026, 4, 12, 14, 30, tzinfo=timezone.utc)
+        sun = ledger.most_recent_sunday(ref)
+        assert sun.weekday() == 6  # Sunday
+        assert sun.hour == 0
+        assert sun.day == 12
+
+    def test_monday_returns_previous_sunday(self):
+        # 2026-04-13 was a Monday
+        ref = datetime(2026, 4, 13, 9, 0, tzinfo=timezone.utc)
+        sun = ledger.most_recent_sunday(ref)
+        assert sun.weekday() == 6
+        assert sun.day == 12  # Sunday before
+
+    def test_saturday_returns_previous_sunday(self):
+        # 2026-04-18 was a Saturday
+        ref = datetime(2026, 4, 18, 23, 59, tzinfo=timezone.utc)
+        sun = ledger.most_recent_sunday(ref)
+        assert sun.weekday() == 6
+        assert sun.day == 12
+
+    def test_non_utc_reference_normalized(self):
+        # Local timezone reference -- function should normalize to UTC first
+        ref = datetime(2026, 4, 13, 1, 0, tzinfo=timezone(timedelta(hours=5)))  # Mon 01:00 +05:00 = Sun 20:00 UTC
+        sun = ledger.most_recent_sunday(ref)
+        # ref in UTC is 2026-04-12 20:00 (still Sunday)
+        assert sun.day == 12
+
+
+# ---- aggregation ----
+
+
+def _mk_record(family: str = "opus", session: str = "s1", tokens: int = 100,
+               ts: datetime | None = None) -> ledger.UsageRecord:
+    return ledger.UsageRecord(
+        timestamp=ts or datetime(2026, 4, 19, tzinfo=timezone.utc),
+        session_id=session,
+        model=f"claude-{family}-4-7",
+        family=family,
+        input_tokens=tokens // 4,
+        output_tokens=tokens // 4,
+        cache_read_input_tokens=tokens // 4,
+        cache_creation_input_tokens=tokens // 4,
+    )
+
+
+class TestByFamily:
+    def test_aggregates_per_family(self):
+        records = [
+            _mk_record("opus", tokens=400),
+            _mk_record("opus", tokens=800),
+            _mk_record("sonnet", tokens=200),
+        ]
+        totals = ledger.by_family(records)
+        assert totals["opus"].total_tokens == 1200
+        assert totals["opus"].message_count == 2
+        assert totals["sonnet"].total_tokens == 200
+        assert totals["sonnet"].message_count == 1
+
+    def test_empty_returns_empty(self):
+        assert ledger.by_family([]) == {}
+
+
+class TestBySession:
+    def test_aggregates_per_session(self):
+        records = [
+            _mk_record(session="s1", tokens=100,
+                       ts=datetime(2026, 4, 19, 14, tzinfo=timezone.utc)),
+            _mk_record(session="s1", tokens=200,
+                       ts=datetime(2026, 4, 19, 15, tzinfo=timezone.utc)),
+            _mk_record(session="s2", tokens=300,
+                       ts=datetime(2026, 4, 20, 10, tzinfo=timezone.utc)),
+        ]
+        totals = ledger.by_session(records)
+        assert totals["s1"].total_tokens == 300
+        assert totals["s1"].message_count == 2
+        assert totals["s1"].first_message.hour == 14
+        assert totals["s1"].last_message.hour == 15
+        assert totals["s2"].total_tokens == 300
+
+
+class TestCurrentSessionRecord:
+    def test_picks_most_recent_session(self):
+        records = [
+            _mk_record(session="old", tokens=100,
+                       ts=datetime(2026, 4, 19, tzinfo=timezone.utc)),
+            _mk_record(session="new", tokens=200,
+                       ts=datetime(2026, 4, 20, tzinfo=timezone.utc)),
+        ]
+        current = ledger.current_session_record(records)
+        assert current is not None
+        assert current.session_id == "new"
+
+    def test_empty_records_returns_none(self):
+        assert ledger.current_session_record([]) is None
+
+
+# ---- caps + payload ----
+
+
+class TestComputeCapsPayload:
+    def test_no_cap_omits_pct(self):
+        totals = {"opus": ledger.FamilyTotals(family="opus", total_tokens=500, message_count=1)}
+        payload = ledger.compute_caps_payload(totals, caps={})
+        assert "pct_used" not in payload["opus"]
+
+    def test_with_cap_computes_pct(self):
+        totals = {"opus": ledger.FamilyTotals(family="opus", total_tokens=500, message_count=1)}
+        payload = ledger.compute_caps_payload(totals, caps={"opus": 1000})
+        assert payload["opus"]["pct_used"] == 50.0
+        assert payload["opus"]["cap"] == 1000
+
+    def test_zero_cap_omits_pct(self):
+        totals = {"opus": ledger.FamilyTotals(family="opus", total_tokens=500, message_count=1)}
+        payload = ledger.compute_caps_payload(totals, caps={"opus": 0})
+        assert "pct_used" not in payload["opus"]
+
+
+class TestBuildPayload:
+    def test_records_outside_week_are_filtered(self):
+        now = datetime(2026, 4, 15, 12, tzinfo=timezone.utc)  # Wednesday
+        # week_start = Sunday 2026-04-12
+        records = [
+            _mk_record(family="opus", tokens=400,
+                       ts=datetime(2026, 4, 14, tzinfo=timezone.utc)),  # in-week
+            _mk_record(family="opus", tokens=800,
+                       ts=datetime(2026, 4, 1, tzinfo=timezone.utc)),  # too old
+        ]
+        payload = ledger.build_payload(records, caps={}, now=now)
+        assert payload["week_records"] == 1
+        assert payload["by_family_week"]["opus"]["total_tokens"] == 400
+
+    def test_current_session_uses_full_history_not_filtered_week(self):
+        """current_session picks across ALL records (most recent message),
+        not just the week. A user who hasn't run claude in 30 days should
+        still see their last session."""
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        records = [
+            _mk_record(session="old", tokens=400,
+                       ts=datetime(2026, 4, 1, tzinfo=timezone.utc)),  # outside week
+        ]
+        payload = ledger.build_payload(records, caps={}, now=now)
+        assert payload["current_session"] is not None
+        assert payload["current_session"]["session_id"] == "old"
+
+    def test_empty_records_safe(self):
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        payload = ledger.build_payload([], caps={}, now=now)
+        assert payload["total_records"] == 0
+        assert payload["week_records"] == 0
+        assert payload["by_family_week"] == {}
+        assert payload["current_session"] is None
+
+    def test_divergence_placeholder_present(self):
+        """The divergence field is a placeholder per the #1111 plan -- it
+        documents the intent until calibration data exists."""
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        payload = ledger.build_payload([], caps={}, now=now)
+        assert "divergence_placeholder" in payload
+
+
+# ---- main() integration ----
+
+
+class TestMainIntegration:
+    def test_main_writes_to_output_file(self, tmp_path, capsys):
+        # Build a fake projects root
+        projects = tmp_path / "projects"
+        proj = projects / "test-proj"
+        proj.mkdir(parents=True)
+        jsonl = proj / "session.jsonl"
+        jsonl.write_text(
+            json.dumps(_assistant_event()) + "\n",
+            encoding="utf-8",
+        )
+        out_file = tmp_path / "ledger.jsonl"
+        rc = ledger.main([
+            "--projects-root", str(projects),
+            "--output", str(out_file),
+        ])
+        assert rc == 0
+        assert out_file.exists()
+        # One line of valid JSON
+        lines = out_file.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["total_records"] == 1
+
+    def test_main_prints_to_stdout_when_no_output(self, tmp_path, capsys):
+        projects = tmp_path / "projects"
+        projects.mkdir()
+        rc = ledger.main(["--projects-root", str(projects)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["total_records"] == 0
+
+    def test_main_with_caps_computes_pct(self, tmp_path, capsys):
+        projects = tmp_path / "projects"
+        proj = projects / "p"
+        proj.mkdir(parents=True)
+        # 1800 total tokens (100+200+1000+500) on opus
+        (proj / "s.jsonl").write_text(
+            json.dumps(_assistant_event(
+                ts=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )) + "\n",
+            encoding="utf-8",
+        )
+        rc = ledger.main([
+            "--projects-root", str(projects),
+            "--cap-opus", "10000",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        family = parsed["by_family_week"]["opus"]
+        assert family["cap"] == 10000
+        assert family["pct_used"] == 18.0

--- a/tools/claude_usage_compute.py
+++ b/tools/claude_usage_compute.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Token-ledger: derive Claude Code usage from local session jsonls (Closes #1111).
+
+Why this exists -- the existing `tools/claude-usage-scraper.py` drives an
+interactive PTY into `claude /status` to read the TUI's quota %. That's
+the only place the % surfaces. The token data underneath, though, is sitting
+on disk in `~/.claude/projects/<encoded>/*.jsonl` -- every assistant message
+has a `usage` block:
+
+    {
+      "input_tokens": 5,
+      "output_tokens": 555,
+      "cache_read_input_tokens": 16446,
+      "cache_creation_input_tokens": 19382,
+      "model": "claude-opus-4-7"
+    }
+
+Walking those jsonls and aggregating gives us an INDEPENDENT token ledger
+that we control. We don't have to calibrate cleanly to /status's reported
+percentages -- Anthropic changes the quota algorithm without notice (caps
+shift; weighting changes between input/output/cache; etc.) and any
+hard-coded constants drift over time.
+
+What we DO get is parallel-signal detection: side-by-side with the existing
+`~/.claude-usage-quota.jsonl` scraped data, the **divergence** between
+(our derived %) and (the TUI's reported %) IS the signal that Anthropic
+shifted their algorithm. We don't have to match their numbers; we just
+have to track when they change relative to us.
+
+What this tool produces:
+
+  - Aggregate token counts by session (using sessionId from the jsonl
+    events).
+  - Aggregate by current week (since most recent Sunday 00:00 UTC).
+  - Per-model-family breakdown (sonnet / opus / haiku).
+  - Optional cap-based percentages (--cap-opus, --cap-sonnet, --cap-haiku).
+  - JSON output (default to stdout; `--output file` to append a row).
+
+Out of scope (per #1111 body):
+
+  - Calibrating to /status's percentages. Caps are user-configurable.
+  - Plan-tier auto-detection (Max vs Team vs Enterprise) -- user supplies caps.
+  - Replacing the existing scraper outright. Both should run in parallel
+    during a calibration window so we have ground truth to compare against.
+
+Files walked:
+
+  - Glob: ~/.claude/projects/*/*.jsonl   (top-level session files)
+  - Excluded: ~/.claude/projects/*/subagents/*.jsonl (subset of parent session)
+
+Issue: #1111 | Companion: tools/claude-usage-scraper.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+
+# Model family detection -- substring match on the message.model field.
+# Order matters: more specific first.
+MODEL_FAMILY_PATTERNS = (
+    ("opus", "opus"),
+    ("sonnet", "sonnet"),
+    ("haiku", "haiku"),
+)
+UNKNOWN_FAMILY = "unknown"
+
+
+@dataclass
+class UsageRecord:
+    """One assistant message's accounting fields."""
+    timestamp: datetime
+    session_id: str
+    model: str
+    family: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_input_tokens
+            + self.cache_creation_input_tokens
+        )
+
+
+@dataclass
+class FamilyTotals:
+    family: str
+    total_tokens: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+    message_count: int = 0
+
+
+@dataclass
+class SessionTotals:
+    session_id: str
+    total_tokens: int = 0
+    message_count: int = 0
+    first_message: datetime | None = None
+    last_message: datetime | None = None
+
+
+def detect_family(model: str) -> str:
+    """Return 'opus' / 'sonnet' / 'haiku' / 'unknown' from a model id."""
+    if not model:
+        return UNKNOWN_FAMILY
+    lower = model.lower()
+    for needle, family in MODEL_FAMILY_PATTERNS:
+        if needle in lower:
+            return family
+    return UNKNOWN_FAMILY
+
+
+def parse_timestamp(raw: Any) -> datetime | None:
+    """Parse a Claude-Code-style timestamp (ISO 8601 with Z suffix)."""
+    if not isinstance(raw, str):
+        return None
+    # Python's fromisoformat is permissive enough on 3.11+ but Z suffix
+    # needs swap to +00:00.
+    text = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def extract_record(event: dict) -> UsageRecord | None:
+    """Pull a UsageRecord from one assistant-message event, or None
+    if the event isn't a usage-bearing assistant message.
+    """
+    if event.get("type") != "assistant":
+        return None
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    timestamp = parse_timestamp(event.get("timestamp"))
+    if timestamp is None:
+        return None
+    model = str(message.get("model") or "")
+    session_id = str(event.get("sessionId") or "")
+    return UsageRecord(
+        timestamp=timestamp,
+        session_id=session_id,
+        model=model,
+        family=detect_family(model),
+        input_tokens=int(usage.get("input_tokens") or 0),
+        output_tokens=int(usage.get("output_tokens") or 0),
+        cache_read_input_tokens=int(usage.get("cache_read_input_tokens") or 0),
+        cache_creation_input_tokens=int(usage.get("cache_creation_input_tokens") or 0),
+    )
+
+
+def iter_session_jsonls(projects_root: Path) -> list[Path]:
+    """List top-level session jsonls (skip subagents/ subdirs).
+
+    Subagent jsonls duplicate counts already attributed to their parent
+    session; including them would double-count tokens.
+    """
+    if not projects_root.is_dir():
+        return []
+    out: list[Path] = []
+    for proj_dir in projects_root.iterdir():
+        if not proj_dir.is_dir():
+            continue
+        # Only top-level .jsonl in this project's dir (NOT subagents/)
+        for jsonl in proj_dir.glob("*.jsonl"):
+            if jsonl.is_file():
+                out.append(jsonl)
+    return out
+
+
+def iter_records(path: Path) -> list[UsageRecord]:
+    """Stream a single jsonl, returning every usage-bearing assistant
+    message as a UsageRecord. Corrupt lines are skipped silently
+    (the cost-of-best-effort vs. crashing on transient I/O is bounded).
+    """
+    records: list[UsageRecord] = []
+    try:
+        with path.open(encoding="utf-8") as fp:
+            for line in fp:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                rec = extract_record(event)
+                if rec is not None:
+                    records.append(rec)
+    except OSError:
+        # File disappeared mid-read or permissions changed; nothing to do.
+        pass
+    return records
+
+
+def collect_all_records(projects_root: Path) -> list[UsageRecord]:
+    out: list[UsageRecord] = []
+    for jsonl in iter_session_jsonls(projects_root):
+        out.extend(iter_records(jsonl))
+    return out
+
+
+def most_recent_sunday(reference: datetime) -> datetime:
+    """Return the most recent Sunday 00:00 UTC at or before `reference`."""
+    ref_utc = reference.astimezone(timezone.utc)
+    # Python: Monday=0 ... Sunday=6
+    weekday = ref_utc.weekday()  # 0=Mon, 6=Sun
+    days_since_sunday = (weekday + 1) % 7  # 0 when ref is Sunday
+    midnight = ref_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight - timedelta(days=days_since_sunday)
+
+
+def filter_to_window(
+    records: list[UsageRecord],
+    since: datetime,
+) -> list[UsageRecord]:
+    return [r for r in records if r.timestamp >= since]
+
+
+def by_family(records: list[UsageRecord]) -> dict[str, FamilyTotals]:
+    totals: dict[str, FamilyTotals] = {}
+    for r in records:
+        t = totals.setdefault(r.family, FamilyTotals(family=r.family))
+        t.total_tokens += r.total_tokens
+        t.input_tokens += r.input_tokens
+        t.output_tokens += r.output_tokens
+        t.cache_read_input_tokens += r.cache_read_input_tokens
+        t.cache_creation_input_tokens += r.cache_creation_input_tokens
+        t.message_count += 1
+    return totals
+
+
+def by_session(records: list[UsageRecord]) -> dict[str, SessionTotals]:
+    totals: dict[str, SessionTotals] = {}
+    for r in records:
+        t = totals.setdefault(r.session_id, SessionTotals(session_id=r.session_id))
+        t.total_tokens += r.total_tokens
+        t.message_count += 1
+        if t.first_message is None or r.timestamp < t.first_message:
+            t.first_message = r.timestamp
+        if t.last_message is None or r.timestamp > t.last_message:
+            t.last_message = r.timestamp
+    return totals
+
+
+def current_session_record(records: list[UsageRecord]) -> SessionTotals | None:
+    """Pick the session with the most recent message as 'current'."""
+    sessions = by_session(records)
+    if not sessions:
+        return None
+    return max(
+        sessions.values(),
+        key=lambda s: (s.last_message or datetime.min.replace(tzinfo=timezone.utc)),
+    )
+
+
+def compute_caps_payload(
+    family_totals: dict[str, FamilyTotals],
+    caps: dict[str, int],
+) -> dict[str, dict[str, Any]]:
+    """For each family in the totals, attach pct_used if a cap was supplied.
+
+    Out: { family: { total_tokens, cap, pct_used, message_count, ... } }
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for family, totals in family_totals.items():
+        entry: dict[str, Any] = {
+            "total_tokens": totals.total_tokens,
+            "input_tokens": totals.input_tokens,
+            "output_tokens": totals.output_tokens,
+            "cache_read_input_tokens": totals.cache_read_input_tokens,
+            "cache_creation_input_tokens": totals.cache_creation_input_tokens,
+            "message_count": totals.message_count,
+        }
+        cap = caps.get(family)
+        if cap and cap > 0:
+            entry["cap"] = cap
+            entry["pct_used"] = round(100.0 * totals.total_tokens / cap, 2)
+        out[family] = entry
+    return out
+
+
+def build_payload(
+    records: list[UsageRecord],
+    caps: dict[str, int],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Aggregate `records` into the output JSON shape."""
+    now = now or datetime.now(timezone.utc)
+    week_start = most_recent_sunday(now)
+
+    week_records = filter_to_window(records, week_start)
+    week_family_totals = by_family(week_records)
+    current = current_session_record(records)
+
+    payload: dict[str, Any] = {
+        "computed_at": now.isoformat().replace("+00:00", "Z"),
+        "week_start": week_start.isoformat().replace("+00:00", "Z"),
+        "total_records": len(records),
+        "week_records": len(week_records),
+        "by_family_week": compute_caps_payload(week_family_totals, caps),
+        "current_session": None,
+        "divergence_placeholder": (
+            "TODO #1111: compare against ~/.claude-usage-quota.jsonl latest "
+            "scraped row. Until calibration window completes this field is "
+            "informational only."
+        ),
+    }
+
+    if current is not None:
+        payload["current_session"] = {
+            "session_id": current.session_id,
+            "total_tokens": current.total_tokens,
+            "message_count": current.message_count,
+            "first_message": current.first_message.isoformat().replace("+00:00", "Z")
+                if current.first_message else None,
+            "last_message": current.last_message.isoformat().replace("+00:00", "Z")
+                if current.last_message else None,
+        }
+
+    return payload
+
+
+def parse_caps_args(args: argparse.Namespace) -> dict[str, int]:
+    caps: dict[str, int] = {}
+    for family in ("opus", "sonnet", "haiku"):
+        val = getattr(args, f"cap_{family}", None)
+        if val and val > 0:
+            caps[family] = val
+    return caps
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.strip().split("\n")[0],
+    )
+    parser.add_argument(
+        "--projects-root", type=Path, default=PROJECTS_ROOT,
+        help=f"Override the Claude projects root (default: {PROJECTS_ROOT})",
+    )
+    parser.add_argument(
+        "--cap-opus", type=int, default=0,
+        help="Opus weekly cap (tokens). 0 = don't compute percentages.",
+    )
+    parser.add_argument(
+        "--cap-sonnet", type=int, default=0,
+        help="Sonnet weekly cap (tokens).",
+    )
+    parser.add_argument(
+        "--cap-haiku", type=int, default=0,
+        help="Haiku weekly cap (tokens).",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None,
+        help="Append the JSON payload as one line to this file (JSONL). "
+             "If omitted, prints to stdout as pretty JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    records = collect_all_records(args.projects_root)
+    caps = parse_caps_args(args)
+    payload = build_payload(records, caps)
+
+    if args.output:
+        # Append as one JSON line for ledger-style consumption.
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("a", encoding="utf-8") as fp:
+            fp.write(json.dumps(payload, default=str) + "\n")
+        print(f"Appended ledger row to {args.output}", file=sys.stderr)
+    else:
+        print(json.dumps(payload, indent=2, default=str))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New `tools/claude_usage_compute.py` — an **independent token-ledger** built from the per-session jsonls in `~/.claude/projects/`. Every assistant message has a `message.usage` block; walking those gives us a token count we control, parallel to whatever the `/status` TUI reports.

## Why

The existing `tools/claude-usage-scraper.py` drives an interactive PTY into `claude /status` to read the TUI's quota percentage. That's the only place that percentage surfaces — but the underlying token data is sitting on disk in a stable schema (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `model`, `timestamp`, `sessionId`).

We don't need to *match* Anthropic's numbers (caps shift, weighting changes — the issue body documents this). We just need a parallel signal that catches algorithm changes faster than "oh, my quota burned out earlier than expected." When our derived % and the TUI's reported % diverge, that *is* the signal.

## What's in this PR

- `iter_session_jsonls(projects_root)` — top-level `*.jsonl` only; skips `subagents/` subdir (double-count avoidance).
- `iter_records(path)` — stream parse, skip blank/corrupt lines, extract usage from assistant messages with timestamps.
- `most_recent_sunday(reference)` — week-window anchor.
- `by_family()` / `by_session()` — aggregations.
- `compute_caps_payload()` — optional `pct_used` per family if a cap is supplied.
- `build_payload()` — top-level JSON shape.
- CLI: `--projects-root`, `--cap-opus/sonnet/haiku`, `--output` (JSONL ledger append).

## Smoke run

```
$ poetry run python tools/claude_usage_compute.py
{
  "computed_at": "2026-05-12T16:57:34Z",
  "week_start": "2026-05-10T00:00:00Z",
  "total_records": 32920,
  "week_records": 8385,
  "by_family_week": {
    "opus": { "total_tokens": 3206161240, "message_count": 8371, ... },
    "sonnet": { "total_tokens": 274054, "message_count": 9, ... },
    ...
  },
  "current_session": { ... },
  "divergence_placeholder": "..."
}
```

## Test plan

- [x] 44 tests pass
- [x] Detects opus/sonnet/haiku via case-insensitive substring match
- [x] Subagent jsonls explicitly excluded (regression guard included)
- [x] Corrupt-line and blank-line resilience
- [x] Week filtering uses most-recent-Sunday-00:00-UTC anchor; non-UTC reference normalized
- [x] `current_session` reads full history (not week-filtered) so stale-but-real sessions still surface
- [x] `--cap-opus 10000` against a known 1800-token fixture produces `pct_used: 18.0`
- [x] Smoke run against real `~/.claude/projects/` succeeded — 32,920 records, sensible aggregates

## Out of scope (per #1111 body)

- Calibrating to `/status`'s percentages — caps stay user-configurable
- Plan-tier auto-detection — user supplies caps
- Replacing the scraper outright — run both in parallel during a calibration window

The `divergence_placeholder` field documents the intent to add divergence detection against `~/.claude-usage-quota.jsonl` once we have calibration data.

Closes #1111