### PR TITLE
fix(tests): patch LLD_STATUS_FILE under tmp_path — unblock dependabot test gate

### DIFF
--- a/tests/unit/test_lld_tracking.py
+++ b/tests/unit/test_lld_tracking.py
@@ -34,6 +34,26 @@ from assemblyzero.workflows.requirements.audit import (
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "lld_tracking"
 
 
+@pytest.fixture(autouse=True)
+def _patch_lld_status_file(monkeypatch, tmp_path: Path) -> None:
+    """Redirect LLD_STATUS_FILE under tmp_path for test isolation.
+
+    PR #1156 made LLD_STATUS_FILE an absolute Path (~/.claude/assemblyzero/...).
+    The function `load_lld_tracking(target_repo)` uses `target_repo / LLD_STATUS_FILE`
+    which collapses to the absolute path (Python Path `/` semantics), so passing
+    `tmp_path` is silently ignored. The function reads from the user's real
+    ~/.claude file instead of the test's tmp_path.
+
+    This autouse fixture monkeypatches the constant to live under tmp_path,
+    restoring per-test isolation. Tests still write to `tmp_path/docs/lld/...`
+    so the original test write locations remain valid. (#1158)
+    """
+    monkeypatch.setattr(
+        "assemblyzero.workflows.requirements.audit.LLD_STATUS_FILE",
+        tmp_path / "docs" / "lld" / "lld-status.json",
+    )
+
+
 @pytest.fixture
 def lld_with_review() -> str:
     """Load sample LLD content that contains a Gemini review section."""

--- a/tests/unit/test_requirements_audit.py
+++ b/tests/unit/test_requirements_audit.py
@@ -17,6 +17,21 @@ import tempfile
 import shutil
 
 
+@pytest.fixture(autouse=True)
+def _patch_lld_status_file(monkeypatch, tmp_path: Path) -> None:
+    """Redirect LLD_STATUS_FILE under tmp_path for test isolation (#1158).
+
+    PR #1156 made the constant absolute (~/.claude/assemblyzero/lld-status.json);
+    `target_repo / LLD_STATUS_FILE` now silently ignores target_repo. Tests that
+    pass `tmp_path` were reading the user's real ~/.claude file instead of the
+    test's tmp_path. This fixture restores per-test isolation.
+    """
+    monkeypatch.setattr(
+        "assemblyzero.workflows.requirements.audit.LLD_STATUS_FILE",
+        tmp_path / "docs" / "lld" / "lld-status.json",
+    )
+
+
 class TestCreateAuditDir:
     """Tests for create_audit_dir function."""
 


### PR DESCRIPTION
## Summary

Adds an `autouse` fixture to `test_lld_tracking.py` and `test_requirements_audit.py` that monkeypatches `LLD_STATUS_FILE` under `tmp_path` for the test's lifetime. Restores per-test isolation that PR #1156 unintentionally broke.

## Why

PR #1156 (a23fa6e) changed `LLD_STATUS_FILE` from relative `docs/lld/lld-status.json` to absolute `~/.claude/assemblyzero/lld-status.json`. The caller pattern `target_repo / LLD_STATUS_FILE` at `audit.py:557` silently collapses to the absolute path (Python's Path `/` operator absorbs the left operand when the right is absolute), so the function ignores its `target_repo` argument.

The pre-existing tests passed `tmp_path` expecting isolation. After #1156 they read the user's real `~/.claude/...` file — failing on Windows (real data leaks in) and on Linux CI (file doesn't exist, returns empty cache when tests expect populated data).

**This blocks the dependabot merge gate.** Per `tools/dependabot_review.py`, `poetry run pytest` must exit 0 for approval+merge. With these 6 tests failing on main, every dependabot run skips every PR. PRs #1095 and #1097 currently stuck.

## What's preserved

No production code changes. #1156's caller-pattern-absorbs-target_repo design (consolidate writes from all target_repos into one absolute log) is intentional and preserved.

## Test plan
- [x] All 88 tests in both files pass locally (`poetry run pytest tests/unit/test_lld_tracking.py tests/unit/test_requirements_audit.py`)
- [ ] CI passes — full suite green
- [ ] Next dependabot run picks up PRs #1095 and #1097 (or other pending) and merges via test gate

Closes #1158