### PR TITLE
fix: Claude-DependabotFleet silent failure (#1163)

### DIFF
--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -96,11 +96,23 @@ class PRInfo:
 
 def run(cmd: list[str], cwd: str | None = None,
         timeout: int | None = None) -> subprocess.CompletedProcess:
-    """Run a subprocess and echo the command to stdout."""
+    """Run a subprocess and echo the command to stdout.
+
+    `encoding="utf-8", errors="replace"` is mandatory on Windows.
+    Default `text=True` decodes with the system locale (cp1252 on most
+    Windows installs), which crashes in `_readerthread` if any
+    subprocess emits a non-cp1252 byte (e.g. `git worktree list` output,
+    `gh pr` body containing an em-dash, pytest output with a non-ASCII
+    test name). The reader thread crash leaves stdout silently empty,
+    so the caller sees CompletedProcess with no output and proceeds as
+    if the command succeeded -- which is catastrophic on the merge path.
+    UTF-8 + replace tolerates any byte stream without crashing.
+    """
     print(f"  $ {' '.join(cmd)}")
     try:
         return subprocess.run(
             cmd, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
             timeout=timeout, check=False,
         )
     except subprocess.TimeoutExpired:

--- a/tools/run_dependabot_fleet.ps1
+++ b/tools/run_dependabot_fleet.ps1
@@ -26,6 +26,12 @@
 
 $ErrorActionPreference = 'Continue'
 
+# Force UTF-8 for Python stdout/stderr so em-dashes and other non-ASCII
+# characters in tool output don't crash the cp1252 default codec. Also
+# applies to subprocess output captured via Tee-Object below.
+$env:PYTHONIOENCODING = 'utf-8'
+$env:PYTHONUTF8 = '1'
+
 $LogFile = 'C:\Users\mcwiz\Projects\dependabot-fleet.log'
 $RepoRoot = 'C:\Users\mcwiz\Projects\AssemblyZero'
 $Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
@@ -38,11 +44,17 @@ Set-Location -Path $RepoRoot
 Add-Content -Path $LogFile -Value "$Timestamp | START | dependabot --fleet"
 
 try {
-    # Capture both stdout and stderr to the log. The tool prints a
-    # detailed per-PR trace; the log is the durable record.
-    $output = & poetry run python tools/dependabot_review.py --fleet 2>&1
+    # Stream subprocess output to the log line-by-line. The previous
+    # design buffered all output into `$output = & ...` and only flushed
+    # to the log after the subprocess returned, which meant a hung
+    # subprocess (e.g. gh waiting on an unanswerable auth prompt in the
+    # scheduled-task context) produced a "START with no completion"
+    # log forever. Tee-Object writes each line as produced so partial
+    # output survives subprocess failure and the operator can see WHERE
+    # it died.
+    & poetry run python tools/dependabot_review.py --fleet 2>&1 |
+        Tee-Object -FilePath $LogFile -Append
     $exitCode = $LASTEXITCODE
-    $output | Add-Content -Path $LogFile
 
     $endStamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     if ($exitCode -eq 0) {


### PR DESCRIPTION
## Summary

- `Claude-DependabotFleet` scheduled task ran daily but logged only `START` entries with no completion for 2+ days — dependabot PRs rotted up to 90 days
- Two compounding bugs: PowerShell wrapper buffered all subprocess output until return (lost on hang/crash), and Python tool's `run()` helper used cp1252 default decoding which crashed `_readerthread` on non-Latin bytes from `gh`/`git`/`pytest` output
- Wrapper now streams via `Tee-Object` and exports `PYTHONIOENCODING=utf-8`. Python `run()` passes `encoding="utf-8", errors="replace"`. Pre-fix dry-run reproduced the `UnicodeDecodeError`; post-fix completes cleanly

## Test plan

- [x] `poetry run pytest tests/tools/test_dependabot_review.py tests/test_dependabot_review.py` — 40/40 pass
- [x] `poetry run ruff check --isolated tools/dependabot_review.py` — clean
- [x] `poetry run python tools/dependabot_review.py --fleet --dry-run` — completes cleanly, enumerates 16 Poetry repos and 8 open dependabot PRs without UnicodeDecodeError
- [ ] After merge, user triggers `Claude-DependabotFleet` manually to verify streaming log captures end-to-end output

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)