### PR TITLE
fix: update_inventory_node requires explicit repo_path (#1155)

### DIFF
--- a/assemblyzero/nodes/inventory.py
+++ b/assemblyzero/nodes/inventory.py
@@ -22,13 +22,35 @@ def scan_docs_directory(docs_dir: Path) -> list[Path]:
 
 
 def update_inventory_node(state: dict[str, Any]) -> dict[str, Any]:
-    """LangGraph node execution: orchestrates the scan, diff, and update process."""
+    """LangGraph node execution: orchestrates the scan, diff, and update process.
+
+    Requires `state["repo_path"]`. A missing or empty repo_path raises
+    ValueError -- the previous default to "." (cwd) silently scanned
+    and WROTE to whatever directory the caller happened to be in,
+    which dirtied audit worktrees and blocked the dependabot review
+    tool's cleanup step (#1155). Callers that genuinely want to scan
+    cwd must now pass repo_path=Path.cwd() explicitly.
+    """
     print("[Inventory] Starting documentation inventory scan...")
 
+    # Validate required state BEFORE the try/except wrapper below. The
+    # except block exists to soften I/O errors during the scan (missing
+    # dirs, permission denied, etc.) and turn them into structured
+    # {"errors": [...]} return values. A missing repo_path is NOT a
+    # runtime I/O issue -- it's a caller bug (a test that forgot to
+    # set up state, a workflow graph that didn't wire the input). Fast
+    # fail with a clear message so callers see it instead of silently
+    # scribbling on cwd.
+    repo_path_str = state.get("repo_path")
+    if not repo_path_str:
+        raise ValueError(
+            "update_inventory_node requires 'repo_path' in state. "
+            "The previous default of '.' silently scanned and wrote to "
+            "the caller's cwd, which dirtied worktrees and broke "
+            "cleanup-by-removal (#1155). Pass an explicit Path."
+        )
+
     try:
-        # Resolve target repo docs path
-        # Fallback to local '.' if repo_path not strictly provided in state
-        repo_path_str = state.get("repo_path", ".")
         repo_path = Path(repo_path_str)
         docs_dir = repo_path / "docs"
         inventory_file = docs_dir / "0003-file-inventory.md"

--- a/tests/unit/test_inventory_node.py
+++ b/tests/unit/test_inventory_node.py
@@ -384,18 +384,30 @@ class TestGracefulFailure:
         # succeeds with 0 entries or fails gracefully with an error
         assert result["inventory_entries_added"] >= 0
 
-    def test_missing_repo_path_key_uses_default(self, tmp_path):
-        """If repo_path is missing from state, should use default '.'."""
-        state = {}
-        result = update_inventory_node(state)
+    def test_missing_repo_path_key_raises_value_error(self, tmp_path):
+        """Regression test for #1155: missing repo_path must raise instead
+        of silently defaulting to '.' and scribbling on the caller's cwd.
 
-        # Should not crash
-        assert isinstance(result, dict)
-        assert "errors" in result
+        Pre-fix behavior: state.get("repo_path", ".") meant `state = {}`
+        scanned the test runner's cwd, which inside a git worktree dirtied
+        docs/0003-file-inventory.md and blocked subsequent cleanup. Fix
+        flips the default to a hard failure.
+        """
+        state = {}
+
+        with pytest.raises(ValueError, match="repo_path"):
+            update_inventory_node(state)
+
+    def test_empty_repo_path_value_raises_value_error(self, tmp_path):
+        """Empty string repo_path is also a caller bug -- treat the same
+        as missing rather than coercing to cwd via Path("")."""
+        state = {"repo_path": ""}
+
+        with pytest.raises(ValueError, match="repo_path"):
+            update_inventory_node(state)
 
     def test_readonly_file_handled(self, tmp_path):
         """If inventory file is read-only, node should handle gracefully."""
-        import os
         import platform
 
         docs_dir = tmp_path / "docs"


### PR DESCRIPTION
## Summary

- Previous `state.get(\"repo_path\", \".\")` default silently scanned + wrote the caller's cwd, which dirtied audit worktrees and blocked `git worktree remove` cleanup in the dependabot review tool
- This morning's 06:00 fleet run left 2 orphan worktrees behind (#1095, #1097) because of exactly this. Cleaned them up by hand; this PR prevents recurrence
- Validation now raises `ValueError` if repo_path is missing or empty -- BEFORE the try/except so the error propagates instead of being absorbed
- Verified no production caller in `assemblyzero/` invokes the node; only tests reach it. Safe signature change

## Test plan

- [x] `poetry run pytest tests/unit/test_inventory_node.py` — 26 passed, 1 skipped (Windows-only chmod)
- [x] `poetry run ruff check --isolated` on both files — clean
- [x] Regression test added: `test_missing_repo_path_key_raises_value_error` and `test_empty_repo_path_value_raises_value_error`
- [ ] Tomorrow's 06:00 fleet run should leave NO orphan worktrees behind even when PRs defer

Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)