### PR TITLE
feat: timestamps + completion marker + scope mypy tests (unblocks AZ #1095/#1097) (#1181)

### DIFF
--- a/tests/unit/test_retry_prompt_builder.py
+++ b/tests/unit/test_retry_prompt_builder.py
@@ -15,7 +15,6 @@ import pytest
 
 from assemblyzero.workflows.implementation_spec.nodes.retry_prompt_builder import (
     SNIPPET_MAX_LINES,
-    PrunedRetryPrompt,
     RetryContext,
     _build_tier1_prompt,
     _build_tier2_prompt,
@@ -566,7 +565,17 @@ class TestTypeAnnotations:
     """Tests for type annotation completeness (T160, T170)."""
 
     def test_mypy_retry_prompt_builder(self) -> None:
-        """T160: mypy reports zero errors on retry_prompt_builder module."""
+        """T160: mypy reports zero errors on retry_prompt_builder module.
+
+        Uses --follow-imports=skip so mypy checks only the target file's
+        own annotations, not the transitive import graph. Without that,
+        --strict descends into the entire AZ codebase, finds 219 type
+        errors across 59 files in dependencies the target module doesn't
+        own, and the test fails permanently. The test's name and intent
+        ("reports zero errors on retry_prompt_builder module") matches
+        the --follow-imports=skip scope; the original invocation was
+        accidentally checking the whole world.
+        """
         module_path = (
             Path(__file__).parent.parent.parent
             / "assemblyzero"
@@ -576,7 +585,11 @@ class TestTypeAnnotations:
             / "retry_prompt_builder.py"
         )
         result = subprocess.run(
-            [sys.executable, "-m", "mypy", str(module_path), "--strict", "--ignore-missing-imports"],
+            [
+                sys.executable, "-m", "mypy", str(module_path),
+                "--strict", "--ignore-missing-imports",
+                "--follow-imports=skip",
+            ],
             capture_output=True,
             text=True,
         )
@@ -585,7 +598,11 @@ class TestTypeAnnotations:
         )
 
     def test_mypy_lld_section_extractor(self) -> None:
-        """T170: mypy reports zero errors on lld_section_extractor module."""
+        """T170: mypy reports zero errors on lld_section_extractor module.
+
+        See test_mypy_retry_prompt_builder for the rationale on
+        --follow-imports=skip. Same scope-creep fix.
+        """
         module_path = (
             Path(__file__).parent.parent.parent
             / "assemblyzero"
@@ -593,7 +610,11 @@ class TestTypeAnnotations:
             / "lld_section_extractor.py"
         )
         result = subprocess.run(
-            [sys.executable, "-m", "mypy", str(module_path), "--strict", "--ignore-missing-imports"],
+            [
+                sys.executable, "-m", "mypy", str(module_path),
+                "--strict", "--ignore-missing-imports",
+                "--follow-imports=skip",
+            ],
             capture_output=True,
             text=True,
         )

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -52,6 +52,7 @@ Issue: #949 | Related: #692, #1116 | Runbook: 0911 v2.0
 """
 
 import argparse
+import datetime
 import json
 import re
 import subprocess
@@ -136,7 +137,8 @@ def run(cmd: list[str], cwd: str | None = None,
     existence of a file in the fleet enumeration -- a 404 just means
     "this repo doesn't have pyproject.toml", not "something broke").
     """
-    print(f"  $ {' '.join(cmd)}")
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    print(f"  [{ts}] $ {' '.join(cmd)}")
     try:
         result = subprocess.run(
             cmd, cwd=cwd, capture_output=True, text=True,
@@ -145,17 +147,19 @@ def run(cmd: list[str], cwd: str | None = None,
             creationflags=_CREATION_FLAGS,
         )
     except subprocess.TimeoutExpired:
-        print(f"  TIMEOUT after {timeout}s")
+        ts2 = datetime.datetime.now().strftime("%H:%M:%S")
+        print(f"  [{ts2}] TIMEOUT after {timeout}s")
         return subprocess.CompletedProcess(cmd, returncode=124, stdout="", stderr="TIMEOUT")
     if result.returncode != 0 and not quiet_on_failure:
         stderr = (result.stderr or "").strip()
         stdout = (result.stdout or "").strip()
+        ts3 = datetime.datetime.now().strftime("%H:%M:%S")
         if stderr:
-            print(f"  [exit {result.returncode}] stderr: {stderr[:500]}")
+            print(f"  [{ts3}] [exit {result.returncode}] stderr: {stderr[:500]}")
         elif stdout:
-            print(f"  [exit {result.returncode}] stdout: {stdout[:500]}")
+            print(f"  [{ts3}] [exit {result.returncode}] stdout: {stdout[:500]}")
         else:
-            print(f"  [exit {result.returncode}] (no output)")
+            print(f"  [{ts3}] [exit {result.returncode}] (no output)")
     return result
 
 
@@ -911,6 +915,21 @@ def main() -> None:
     print(
         f"  Review events created: {approved_events} APPROVED "
         f"+ {commented_events} COMMENTED = {total_events} total"
+    )
+
+    # Self-marked completion line. The PowerShell wrapper's OK/EXIT
+    # marker write proved unreliable in the scheduled-task context
+    # (Status:Ready, Last Result:0, but no | OK | line ever lands).
+    # Printing a marker as the last line of the python tool's output
+    # bypasses that -- cmd /c >> $LogFile captures it reliably, since
+    # we already know the per-line streaming works. morning_status_tool
+    # can grep for this marker as a secondary completion signal.
+    end_stamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(
+        f"\n=== {end_stamp} | FLEET-COMPLETE | "
+        f"merged={len(results['merged'])} "
+        f"deferred={len(results['deferred'])} "
+        f"errored={len(results['errored'])} ==="
     )
 
 


### PR DESCRIPTION
## Summary

- **The langchain bumps in AZ #1095/#1097 are innocent.** A pre-existing test (`test_mypy_retry_prompt_builder`) fails on bare main because `mypy --strict` chases the import graph and the AZ codebase has 219 pre-existing type errors across 59 files. Add `--follow-imports=skip` so it actually does what its name claims (check one file). Both mypy tests pass after the fix.
- **Timestamps** on every `$ <cmd>` echo in `run()` and on failure-output lines. 3 workers interleaving 470 lines was unscannable without them.
- **Self-printed completion marker** at end of main: `=== {ts} | FLEET-COMPLETE | merged=N deferred=M errored=K ===`. The PowerShell wrapper's `| OK | exit 0` keeps disappearing in scheduled-task context (mystery); python prints reliably, cmd /c >> captures reliably.

## Test plan

- [x] 54/54 tests in `test_retry_prompt_builder.py` pass
- [x] Dry-run of fleet tool shows `[HH:MM:SS]` prefix on each `$ cmd`
- [x] ruff clean
- [ ] After merge: trigger task. Log lines should be timestamped. Final line should be the FLEET-COMPLETE marker. AZ #1095/#1097 should produce pytest exit 0 (since the only failing test is now fixed) → approved + merged.

Closes #1181

🤖 Generated with [Claude Code](https://claude.com/claude-code)