### PR TITLE
test: fix 3 pre-existing failures outside tests/unit/ (unblocks dependabot tool) (#1183)

### DIFF
--- a/tests/test_fleet_readiness.py
+++ b/tests/test_fleet_readiness.py
@@ -213,8 +213,22 @@ def test_deploy_skips_repo_that_already_has_workflow():
 
 
 def test_deploy_puts_when_missing():
+    # Test was missing two mocks. deploy.main probes BOTH classic
+    # branch protection AND repository rulesets before deciding the
+    # repo is "permissive" enough for a direct PUT. Without those
+    # mocks the live GitHub API got hit with the fake "pat" string
+    # and returned 401. Returning non-strict-protection + empty
+    # rulesets sends deploy.main down the direct-PUT path -- which
+    # is the path this test exercises (put_workflow called once
+    # per repo, no bootstrap toggle).
+    non_strict_protection = (
+        {"enforce_admins": {"enabled": False}, "required_pull_request_reviews": None},
+        None,
+    )
     with patch.object(deploy, "classic_pat_session") as mock_ctx, \
          patch.object(deploy, "get_default_branch", return_value="main"), \
+         patch.object(deploy, "get_protection", return_value=non_strict_protection), \
+         patch.object(deploy, "list_blocking_rulesets", return_value=([], None)), \
          patch.object(deploy, "workflow_status", return_value=(False, None)), \
          patch.object(deploy, "put_workflow", return_value=(True, None)) as mock_put:
         mock_ctx.return_value.__enter__.return_value = "pat"

--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -427,9 +427,17 @@ class TestPythonBootstrap:
         project = tmp_path / "TestProject"
         project.mkdir()
         # poetry init normally writes this; with mocked run_command,
-        # we pre-create it so the append step has a target.
+        # we pre-create it so the append step has a target. Must
+        # include `description = ""` because create_python_project
+        # anchors its `packages` directive injection on that line --
+        # poetry init always emits it (even with --description "")
+        # but the mocked run_command skips the actual poetry call,
+        # so the fixture has to include it explicitly.
         (project / "pyproject.toml").write_text(
-            "[tool.poetry]\nname = \"testproject\"\nversion = \"0.1.0\"\n",
+            "[tool.poetry]\n"
+            "name = \"testproject\"\n"
+            "version = \"0.1.0\"\n"
+            "description = \"\"\n",
             encoding="utf-8",
         )
         from new_repo_setup import create_python_project

--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -639,7 +639,16 @@ class TestNodeFunctions:
         assert result == "N2_scaffold_tests"
 
     def test_route_after_review_stops_on_blocked_without_auto(self, tmp_path):
-        """route_after_review stops at end when BLOCKED without auto mode."""
+        """route_after_review stops at end when BLOCKED under strict policy.
+
+        Issue #1072 changed the default `test_plan_policy` from "strict"
+        (END on BLOCKED) to "revise" (try revisions before ending). The
+        original test asserted the legacy "end" behavior without setting
+        policy explicitly, which now incorrectly hits the revise path
+        and returns "N1_5_revise_test_plan". Setting policy="strict"
+        restores the original test intent: verify that BLOCKED+non-auto
+        under strict policy ends the workflow.
+        """
         from assemblyzero.workflows.testing.graph import route_after_review
 
         state: TestingWorkflowState = {
@@ -648,11 +657,12 @@ class TestNodeFunctions:
             "auto_mode": False,  # Not auto mode - should stop
             "test_plan_status": "BLOCKED",
             "error_message": "",
+            "test_plan_policy": "strict",  # legacy END-on-BLOCKED behavior
         }
 
         result = route_after_review(state)
 
-        # Without auto mode, BLOCKED should end the workflow
+        # strict policy: BLOCKED ends the workflow
         assert result == "end"
 
     def test_scaffold_tests_creates_files(self, tmp_path):


### PR DESCRIPTION
## Summary

The dependabot review tool's `pytest` invocation hits 3 stale top-level tests that AZ's CI doesn't gate on. All three are test bugs (incomplete mock list, missing fixture fields, stale assertion against changed-by-design behavior). Production code untouched.

1. `test_deploy_puts_when_missing` — patch list forgot `get_protection` + `list_blocking_rulesets`; deploy.main hit live GH with fake `\"pat\"` and 401'd. Add the missing mocks.
2. `test_T280_happy_path_writes_artifacts` — fixture pyproject.toml missing `description = \"\"`; create_python_project anchors injection on that line. Add it to the fixture.
3. `test_route_after_review_stops_on_blocked_without_auto` — #1072 changed default test_plan_policy from \"strict\" to \"revise\"; test wasn't updated. Add `test_plan_policy=\"strict\"` to state.

## Test plan

- [x] All 3 specific tests pass
- [x] Full bare-pytest run on main: 5565 passed, 13 skipped, 47 deselected, 5 xfailed -- 0 failures
- [ ] Next dependabot fleet run on AZ #1095/#1097 should now produce exit 0 from the test gate

Closes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)