### PR TITLE
feat: new_repo_setup.py — Pillar 1 confidence restoration (Closes #1200, #1202, #1206)

### DIFF
--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -31,16 +31,18 @@ Initialize a new project with the canonical AssemblyZero structure, enabling:
 
 ## Quick Start (Automated)
 
+> **`--cerberus-pem` is required** for any invocation that creates a GitHub repo (#1206). Download the .pem first from https://github.com/settings/apps/cerberus-az > Private keys > Generate, then pass its path to the script. The only override is `--no-github` (local scaffold only). Full procedure in [0927](0927-new-repo-human-checklist.md#4-deploy-cerberus-secrets-if-needed).
+
 ### Create a New Private Repository
 
 ```bash
-poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/new_repo_setup.py MyNewProject
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/new_repo_setup.py MyNewProject --cerberus-pem /c/Users/mcwiz/Downloads/cerberus-az.NNN.private-key.pem
 ```
 
 ### Create a Public Repository
 
 ```bash
-poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/new_repo_setup.py MyNewProject --public
+poetry run --directory /c/Users/mcwiz/Projects/AssemblyZero python /c/Users/mcwiz/Projects/AssemblyZero/tools/new_repo_setup.py MyNewProject --public --cerberus-pem /c/Users/mcwiz/Downloads/cerberus-az.NNN.private-key.pem
 ```
 
 ### Create Local Only (No GitHub)
@@ -270,3 +272,4 @@ The script automates all of this in one command.
 | 2.0 | 2026-01-29 | Automated with new_repo_setup.py, added 4 new dirs |
 | 2.1 | 2026-04-05 | Added `.unleashed.json` to file table (was in script/schema but missing from docs) |
 | 2.2 | 2026-04-05 | Added workflow files to file table. Updated post-setup: branch protection is now automated, Cerberus is the remaining human step. |
+| 2.3 | 2026-05-22 | `--cerberus-pem` is now **required** for GitHub-creating invocations (#1206). Quick Start examples updated to include the flag. Post-setup verification extended with GitHub-side checks (#1200) and `pr-sentinel-mm` Worker installation detection (#1202). |

--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -52,17 +52,19 @@ With `default-cache-ttl 0`, gpg prompts for the passphrase every decryption (ins
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
-poetry run python tools/new_repo_setup.py {name} [--public] [--cerberus-pem PATH]
+poetry run python tools/new_repo_setup.py {name} --cerberus-pem PATH [--public]
 ```
+
+`--cerberus-pem` is **required** when creating a GitHub repo (#1206). The script exits with a guide if it's missing — Cerberus auto-approval is part of the new-repo contract, and without the secrets every PR sits blocked. The only override is `--no-github` (local scaffold only, skips the GitHub side entirely).
 
 gpg-agent will prompt for your passphrase once per cache window (controlled by `~/.gnupg/gpg-agent.conf`) and the script handles the rest.
 
 **Defaults the script picks unless you override:**
 - **License**: PolyForm Noncommercial 1.0.0. Pass `--license mit` if you want MIT instead.
 - **Visibility**: private. Pass `--public` to override.
-- **Cerberus secrets**: NOT deployed unless you pass `--cerberus-pem PATH` (see [Cerberus](#what-cerberus-is-and-why-you-want-it) below).
+- **Cerberus secrets**: deployed when `--cerberus-pem PATH` is provided (required for new GitHub repos per #1206 — see [Cerberus](#what-cerberus-is-and-why-you-want-it) below).
 
-**Before using `--cerberus-pem`**, download the `.pem`:
+**Before running the script**, download the `.pem`:
 
 1. Go to <https://github.com/settings/apps/cerberus-az> → **Private keys**
 2. Click **Generate a private key** — the browser downloads a `.pem` file (typically to `C:\Users\mcwiz\Downloads\`)
@@ -161,7 +163,7 @@ After step 3 the secret value lives in GitHub Actions encrypted storage. The loc
 
 The script can't auto-do steps 1 and 3 (browser-only). It needs a flag to know whether YOU did step 1 and where you put the .pem. That's what `--cerberus-pem PATH` is for.
 
-**Recommendation: always pass `--cerberus-pem` on first creation of a new repo.** Skipping it leaves auto-approval broken until you fix it (either by re-running with `--cerberus-pem` later, or running `tools/deploy_cerberus_secrets.py` standalone fleet-wide).
+**`--cerberus-pem` is REQUIRED on new GitHub repos (#1206).** The script exits 1 with the .pem-acquisition guide if you forget it. The only way to skip Cerberus deploy is `--no-github` (local scaffold only). For repos already created without the flag, the fallback path below (standalone `tools/deploy_cerberus_secrets.py`) still applies.
 
 Two procedural variants follow — **preferred** (integrated into `new_repo_setup.py`, what `--cerberus-pem` does) or **fallback** (standalone fleet-wide script when you want to deploy to many repos at once).
 
@@ -272,3 +274,4 @@ The **per-repo human steps** are: entering the gpg passphrase (once per gpg-agen
 | 2026-04-22 | v5.3: #1014 — made the \`--cerberus-pem\` path-format explicit. Git Bash Unix-style (\`/c/Users/mcwiz/Downloads/...\`) is preferred; noted MSYS translation and the Windows-style fallback with its quoting caveat. Concrete example given in the Step 1 block. |
 | 2026-05-07 | v6.0: #1037 — dropped \`--license mit\` from invocation examples (script default is \`polyform\`, was misleading to show MIT as if recommended). Added an explicit "Defaults the script picks unless you override" block. Rewrote Section 4 with three subsections explaining what Cerberus is (auto-approver of your own PRs after pr-sentinel passes), why the secrets must be per-repo (App's RSA private key, used by the auto-reviewer workflow to authenticate as Cerberus), and why \`--cerberus-pem\` is recommended on every new-repo creation. Updated the env-block exposure note to reflect that #1036/#1037 closes the last \`GH_TOKEN\` hold-out. |
 | 2026-05-09 | v6.1: #1058 + #1059 + #1060 + #1061 — bundle of post-boostgauge-readiness-audit fixes. Script now bootstraps a Python project by default (\`poetry init\` + \`poetry add --group dev pytest pytest-cov\` + \`[tool.pytest.ini_options]\` + \`tests/conftest.py\`); \`--lang none\` skips for non-Python repos. \`.unleashed.json\` defaults to \`assemblyZero: true\` and no longer emits the deprecated \`pickupThresholdMinutes\`. Two canonical GitHub labels (\`implementation\`, \`lld\`) created on the new repo. |
+| 2026-05-22 | v6.2: #1206 — `--cerberus-pem` is REQUIRED for new GitHub repos. Script exits 1 with the .pem-acquisition guide if omitted. Override is `--no-github` (local scaffold only). #1200 + #1202 — extended post-setup verification to GitHub-side state (branch protection, repo settings, workflow content, Cerberus secrets) and added a best-effort `pr-sentinel-mm` Worker installation check that surfaces App-scope drift at creation time instead of when the first PR opens. |

--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -728,3 +728,223 @@ class TestMainLocalWorkflow:
         with patch("sys.argv", ["new_repo_setup.py", "ForceProject", "--no-github", "--force"]):
             main()
         assert (tmp_path / "ForceProject").exists()
+
+
+# ===========================================================================
+# Pillar 1 — Required --cerberus-pem (#1206) + GitHub-side verification (#1200, #1202)
+# ===========================================================================
+
+import base64 as _base64  # noqa: E402
+
+from new_repo_setup import (  # noqa: E402
+    _CANONICAL_AUTO_REVIEWER_CALLER,
+    verify_branch_protection_on_origin,
+    verify_pr_sentinel_installation,
+    verify_repo_settings_on_origin,
+    verify_workflow_content_on_origin,
+)
+
+
+class TestCerberusPemRequired:
+    """T290-T292: --cerberus-pem is REQUIRED for new GitHub repos (#1206)."""
+
+    @patch("new_repo_setup.config")
+    def test_T290_missing_pem_without_no_github_exits_one(self, mock_config, tmp_path):
+        """Without --cerberus-pem and without --no-github, exit 1 BEFORE any creation."""
+        _setup_config_mock(mock_config, tmp_path)
+        with patch("sys.argv", ["new_repo_setup.py", "RequiredTest"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+        # Pre-flight must exit BEFORE creating the local directory.
+        assert not (tmp_path / "RequiredTest").exists()
+
+    @patch("new_repo_setup.config")
+    @patch("new_repo_setup.run_command")
+    def test_T291_no_github_bypasses_requirement(self, mock_run, mock_config, tmp_path):
+        """--no-github skips the requirement — local scaffold proceeds without --cerberus-pem."""
+        _setup_config_mock(mock_config, tmp_path)
+        mock_run.return_value = MagicMock(returncode=0)
+        with patch("sys.argv", ["new_repo_setup.py", "NoGitTest", "--no-github"]):
+            main()  # should NOT raise
+        assert (tmp_path / "NoGitTest").exists()
+
+    @patch("new_repo_setup.config")
+    def test_T292_cerberus_pem_plus_no_github_still_conflict(self, mock_config, tmp_path):
+        """Pre-existing conflict check still fires: --cerberus-pem + --no-github → exit 1."""
+        _setup_config_mock(mock_config, tmp_path)
+        with patch("sys.argv", [
+            "new_repo_setup.py", "ConflictTest", "--no-github", "--cerberus-pem", "/tmp/fake.pem",
+        ]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+
+
+class TestVerifyBranchProtection:
+    """T293-T295: verify_branch_protection_on_origin (#1200)."""
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T293_pass_when_all_dimensions_match(self, mock_req):
+        """enforce_admins=True, 1 review, pr-sentinel check present → (True, ...)."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "enforce_admins": {"enabled": True},
+            "required_pull_request_reviews": {"required_approving_review_count": 1},
+            "required_status_checks": {
+                "contexts": ["pr-sentinel / issue-reference"],
+            },
+        }
+        mock_req.return_value = mock_resp
+        ok, msg = verify_branch_protection_on_origin("owner", "repo", "pat")
+        assert ok is True
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T294_fail_when_enforce_admins_off(self, mock_req):
+        """enforce_admins=False → (False, msg) and msg names the dimension."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "enforce_admins": {"enabled": False},
+            "required_pull_request_reviews": {"required_approving_review_count": 1},
+            "required_status_checks": {
+                "contexts": ["pr-sentinel / issue-reference"],
+            },
+        }
+        mock_req.return_value = mock_resp
+        ok, msg = verify_branch_protection_on_origin("owner", "repo", "pat")
+        assert ok is False
+        assert "enforce_admins" in msg
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T295_fail_on_404(self, mock_req):
+        """404 → (False, 'no branch protection set on origin')."""
+        mock_resp = MagicMock(status_code=404, text="Not Found")
+        mock_req.return_value = mock_resp
+        ok, msg = verify_branch_protection_on_origin("owner", "repo", "pat")
+        assert ok is False
+        assert "no branch protection" in msg
+
+
+class TestVerifyRepoSettings:
+    """T296-T297: verify_repo_settings_on_origin (#1200)."""
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T296_pass_when_squash_only_no_wiki(self, mock_req):
+        """All settings match fleet standard → (True, ...)."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "has_wiki": False,
+            "has_projects": False,
+            "allow_merge_commit": False,
+            "allow_rebase_merge": False,
+            "allow_squash_merge": True,
+            "delete_branch_on_merge": True,
+        }
+        mock_req.return_value = mock_resp
+        ok, msg = verify_repo_settings_on_origin("owner", "repo", "pat")
+        assert ok is True
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T297_fail_when_wiki_enabled(self, mock_req):
+        """has_wiki=True → (False, msg) and msg names the violation."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "has_wiki": True,
+            "has_projects": False,
+            "allow_merge_commit": False,
+            "allow_rebase_merge": False,
+            "allow_squash_merge": True,
+            "delete_branch_on_merge": True,
+        }
+        mock_req.return_value = mock_resp
+        ok, msg = verify_repo_settings_on_origin("owner", "repo", "pat")
+        assert ok is False
+        assert "has_wiki" in msg
+
+
+class TestVerifyWorkflowContent:
+    """T298-T299: verify_workflow_content_on_origin — the #1193 regression test."""
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T298_pass_when_content_matches_canonical(self, mock_req):
+        """Origin content == _CANONICAL_AUTO_REVIEWER_CALLER → (True, ...)."""
+        encoded = _base64.b64encode(
+            _CANONICAL_AUTO_REVIEWER_CALLER.encode("utf-8")
+        ).decode("ascii")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"content": encoded}
+        mock_req.return_value = mock_resp
+        ok, msg = verify_workflow_content_on_origin("owner", "repo", "pat")
+        assert ok is True
+
+    @patch("new_repo_setup._request_with_retry")
+    def test_T299_fail_when_old_format_signature(self, mock_req):
+        """Origin content uses OLD caller format → (False, ...). The #1193 failure mode.
+
+        OLD format: `name: auto-reviewer` (lowercase), no permissions: block,
+        no with: required_checks input, secrets: inherit. Reusable workflow
+        fails with startup_failure.
+        """
+        old_format = (
+            "name: auto-reviewer\n"
+            "\n"
+            "on:\n"
+            "  pull_request:\n"
+            "    types: [opened, synchronize, reopened]\n"
+            "\n"
+            "jobs:\n"
+            "  review:\n"
+            "    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main\n"
+            "    secrets: inherit\n"
+        )
+        encoded = _base64.b64encode(old_format.encode("utf-8")).decode("ascii")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"content": encoded}
+        mock_req.return_value = mock_resp
+        ok, msg = verify_workflow_content_on_origin("owner", "repo", "pat")
+        assert ok is False
+        assert "differs from canonical" in msg
+
+
+class TestVerifyPrSentinelInstallation:
+    """T300-T302: verify_pr_sentinel_installation (#1202)."""
+
+    @patch("new_repo_setup.run_command")
+    def test_T300_pass_when_repo_in_installation(self, mock_run):
+        """Worker installation found AND covers the new repo → (True, ...)."""
+        mock_run.side_effect = [
+            # /user/installations filter → installation id
+            MagicMock(returncode=0, stdout="12345\n", stderr=""),
+            # /user/installations/12345/repositories → list of full_names
+            MagicMock(
+                returncode=0,
+                stdout="martymcenroe/some-other\nmartymcenroe/repo-name\n",
+                stderr="",
+            ),
+        ]
+        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        assert ok is True
+        assert "covers" in msg
+
+    @patch("new_repo_setup.run_command")
+    def test_T301_warn_when_installation_missing(self, mock_run):
+        """No pr-sentinel-mm in /user/installations → (False, 'not found')."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        assert ok is False
+        assert "not found" in msg
+
+    @patch("new_repo_setup.run_command")
+    def test_T302_warn_when_repo_not_in_installation_repos(self, mock_run):
+        """Installation exists but doesn't cover the new repo → App scope drift warning."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="12345\n", stderr=""),
+            MagicMock(
+                returncode=0,
+                stdout="martymcenroe/some-other-only\n",
+                stderr="",
+            ),
+        ]
+        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        assert ok is False
+        assert "does NOT cover" in msg or "drift" in msg.lower()

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -22,6 +22,7 @@ See: docs/standards/0009-canonical-project-structure.md
 """
 
 import argparse
+import base64
 import json
 import logging
 import os
@@ -1294,6 +1295,38 @@ def create_python_project(
     return True
 
 
+# Canonical auto-reviewer.yml caller content. Single source of truth used
+# by both create_github_workflows() (write at creation time) and
+# verify_workflow_content_on_origin() (post-setup verification). Lifted
+# to module scope so both paths compare against the same bytes — the
+# #1193 failure mode was exactly this kind of divergent-template drift.
+_CANONICAL_AUTO_REVIEWER_CALLER = '''\
+name: Auto Review
+
+# Caller workflow: invokes the reusable auto-reviewer from AssemblyZero.
+# Requires Cerberus secrets (REVIEWER_APP_ID, REVIEWER_APP_PRIVATE_KEY).
+# Deploy secrets fleet-wide: poetry run python tools/deploy_cerberus_secrets.py
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  checks: read
+
+jobs:
+  auto-review:
+    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
+    with:
+      required_checks: "issue-reference"
+    secrets:
+      REVIEWER_APP_ID: ${{ secrets.REVIEWER_APP_ID }}
+      REVIEWER_APP_PRIVATE_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+'''
+
+
 def create_github_workflows(project_path: Path, enable_pypi: bool = True) -> None:
     """Create GitHub Actions workflow files for PR governance + PyPI release.
 
@@ -1319,37 +1352,11 @@ def create_github_workflows(project_path: Path, enable_pypi: bool = True) -> Non
     workflows_dir = project_path / ".github" / "workflows"
     workflows_dir.mkdir(parents=True, exist_ok=True)
 
-    # auto-reviewer caller: invokes AssemblyZero's reusable workflow
-    auto_reviewer = '''\
-name: Auto Review
-
-# Caller workflow: invokes the reusable auto-reviewer from AssemblyZero.
-# Requires Cerberus secrets (REVIEWER_APP_ID, REVIEWER_APP_PRIVATE_KEY).
-# Deploy secrets fleet-wide: poetry run python tools/deploy_cerberus_secrets.py
-
-on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
-
-permissions:
-  pull-requests: write
-  checks: read
-
-jobs:
-  auto-review:
-    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
-    with:
-      required_checks: "issue-reference"
-    secrets:
-      REVIEWER_APP_ID: ${{ secrets.REVIEWER_APP_ID }}
-      REVIEWER_APP_PRIVATE_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
-'''
     # newline="" disables Python's Windows LF→CRLF translation. The
     # workflow file lands on disk with LF — same as every other repo
     # in the fleet, and matches what the Contents API upload sends.
     (workflows_dir / "auto-reviewer.yml").write_text(
-        auto_reviewer, encoding="utf-8", newline="",
+        _CANONICAL_AUTO_REVIEWER_CALLER, encoding="utf-8", newline="",
     )
 
     # release.yml (#1074): tag-triggered PyPI publish via OIDC Trusted
@@ -1760,6 +1767,179 @@ def audit_structure(project_path: Path, name: str) -> int:
         return 1
 
 
+# ---------------------------------------------------------------------------
+# Post-setup verification helpers (#1200, #1202)
+#
+# The pre-#1200 verification block only checked LOCAL filesystem state — same
+# blind spot as the boostgauge #1193 incident, where file presence was OK
+# but file CONTENT was wrong on origin. These helpers verify GitHub-side
+# state end-to-end. Each returns (passed: bool, message: str) so the caller
+# can decide how to format output.
+# ---------------------------------------------------------------------------
+
+
+def verify_branch_protection_on_origin(
+    github_user: str, repo_name: str, pat: str,
+) -> tuple[bool, str]:
+    """Verify branch protection on origin matches fleet standard.
+
+    Required for parity with configure_branch_protection(): enforce_admins
+    enabled, required_approving_review_count == 1, pr-sentinel/issue-reference
+    in required checks. Reading classic Branch Protection needs Admin scope
+    so this requires the classic PAT, not the fine-grained one.
+    """
+    try:
+        resp = _request_with_retry(
+            "GET",
+            f"{_GH_API}/repos/{github_user}/{repo_name}/branches/main/protection",
+            pat,
+        )
+    except requests.RequestException as e:
+        return False, f"network: {e}"
+    if resp.status_code == 404:
+        return False, "no branch protection set on origin"
+    if resp.status_code != 200:
+        return False, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    p = resp.json()
+    failures: list[str] = []
+    if not (p.get("enforce_admins") or {}).get("enabled"):
+        failures.append("enforce_admins not enabled")
+    reviews = p.get("required_pull_request_reviews") or {}
+    if reviews.get("required_approving_review_count") != 1:
+        actual = reviews.get("required_approving_review_count")
+        failures.append(f"required_approving_review_count={actual!r}, want 1")
+    checks = (p.get("required_status_checks") or {}).get("contexts") or []
+    if "pr-sentinel / issue-reference" not in checks:
+        failures.append(
+            f"'pr-sentinel / issue-reference' not in required checks ({checks!r})"
+        )
+    if failures:
+        return False, "; ".join(failures)
+    return True, "enforce_admins=on, 1 review, pr-sentinel check"
+
+
+def verify_repo_settings_on_origin(
+    github_user: str, repo_name: str, pat: str,
+) -> tuple[bool, str]:
+    """Verify repo settings match fleet standard (squash-only, no wiki/projects)."""
+    try:
+        resp = _request_with_retry(
+            "GET",
+            f"{_GH_API}/repos/{github_user}/{repo_name}",
+            pat,
+        )
+    except requests.RequestException as e:
+        return False, f"network: {e}"
+    if resp.status_code != 200:
+        return False, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    r = resp.json()
+    expected = {
+        "has_wiki": False,
+        "has_projects": False,
+        "allow_merge_commit": False,
+        "allow_rebase_merge": False,
+        "allow_squash_merge": True,
+        "delete_branch_on_merge": True,
+    }
+    failures = [
+        f"{k}={r.get(k)!r}, want {v!r}"
+        for k, v in expected.items()
+        if r.get(k) is not v
+    ]
+    if failures:
+        return False, "; ".join(failures)
+    return True, "squash-only, no wiki/projects, delete-branch-on-merge"
+
+
+def verify_workflow_content_on_origin(
+    github_user: str, repo_name: str, pat: str,
+) -> tuple[bool, str]:
+    """Verify .github/workflows/auto-reviewer.yml on origin matches canonical.
+
+    Catches the #1193 failure mode: file exists but content is wrong (e.g.,
+    the OLD caller format that triggers startup_failure). Byte-for-byte
+    compare against the same constant that create_github_workflows() writes,
+    after CRLF normalization (Contents API stores bytes verbatim).
+    """
+    try:
+        resp = _request_with_retry(
+            "GET",
+            f"{_GH_API}/repos/{github_user}/{repo_name}/contents/.github/workflows/auto-reviewer.yml",
+            pat,
+        )
+    except requests.RequestException as e:
+        return False, f"network: {e}"
+    if resp.status_code == 404:
+        return False, "auto-reviewer.yml not present on origin"
+    if resp.status_code != 200:
+        return False, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    encoded = (resp.json().get("content") or "").replace("\n", "")
+    try:
+        content = base64.b64decode(encoded).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as e:
+        return False, f"could not decode content: {e}"
+    if content.replace("\r\n", "\n") == _CANONICAL_AUTO_REVIEWER_CALLER:
+        return True, "content matches canonical NEW format"
+    return False, "content differs from canonical (#1193 failure mode)"
+
+
+def verify_pr_sentinel_installation(
+    github_user: str, repo_name: str,
+) -> tuple[bool, str]:
+    """Best-effort check that pr-sentinel-mm Cloudflare Worker covers this repo.
+
+    The Worker delivers the `pr-sentinel / issue-reference` check that branch
+    protection requires. If the Worker's GitHub App installation scope has
+    drifted from 'All repositories', the check never fires and every PR sits
+    blocked. Catches that at creation time instead of when the first PR opens.
+
+    Uses gh CLI's authenticated user-to-server token (fine-grained PAT is
+    sufficient for /user/installations) — no classic PAT needed.
+    """
+    # Step 1: find the pr-sentinel-mm installation id on the user account.
+    try:
+        r = run_command(
+            ["gh", "api", "/user/installations", "--jq",
+             '.installations[] | select(.app_slug == "pr-sentinel-mm") | .id'],
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return False, f"could not query /user/installations: {e}"
+    if r.returncode != 0:
+        # 403 / 401 / 404 — token doesn't have the right scope or API is
+        # unavailable. Surface but don't fail the verification — this is
+        # an advisory check.
+        return False, f"gh api /user/installations failed: {(r.stderr or '').strip()[:200]}"
+    out = (r.stdout or "").strip().splitlines()
+    if not out or not out[0].strip():
+        return False, "pr-sentinel-mm not found in /user/installations"
+    installation_id = out[0].strip()
+
+    # Step 2: list repositories covered by this installation; confirm the
+    # new repo is in the list. --paginate handles users with many repos.
+    try:
+        r = run_command(
+            ["gh", "api", f"/user/installations/{installation_id}/repositories",
+             "--paginate", "--jq", ".repositories[].full_name"],
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return False, f"could not query installation repos: {e}"
+    if r.returncode != 0:
+        return False, (
+            f"gh api installation/{installation_id}/repositories failed: "
+            f"{(r.stderr or '').strip()[:200]}"
+        )
+    covered = set((r.stdout or "").strip().splitlines())
+    full_name = f"{github_user}/{repo_name}"
+    if full_name in covered:
+        return True, f"installation {installation_id} covers this repo"
+    return False, (
+        f"installation {installation_id} does NOT cover {full_name} — "
+        "App scope may have drifted from 'All repositories'"
+    )
+
+
 def _deploy_cerberus(repo_name: str, pem_path: Path, pat: str) -> str:
     """Deploy Cerberus secrets to a single repo and handle pem file lifecycle.
 
@@ -1908,6 +2088,35 @@ Examples:
     # --cerberus-pem requires --no-github not set (need the repo to deploy to)
     if args.cerberus_pem and args.no_github:
         print("ERROR: --cerberus-pem requires GitHub repo creation (cannot be combined with --no-github)")
+        sys.exit(1)
+
+    # --cerberus-pem is REQUIRED when creating a GitHub repo (#1206).
+    # Without Cerberus secrets the new repo's PRs sit blocked indefinitely
+    # because branch protection requires 1 approving review and the
+    # auto-reviewer workflow can't authenticate without the App secrets.
+    # Catching this at the CLI gate keeps the failure loud and pre-creation,
+    # not silent and only-visible-on-first-PR. Audit mode is exempt — it
+    # only inspects an existing project, never creates anything.
+    if not args.cerberus_pem and not args.no_github and not args.audit:
+        print("ERROR: --cerberus-pem is required.")
+        print()
+        print("Cerberus auto-approval is part of the new-repo contract. Without it,")
+        print("every PR on the new repo will sit blocked indefinitely waiting for")
+        print("a review (branch protection requires 1 approval; the auto-reviewer")
+        print("workflow can't approve without the Cerberus App secrets).")
+        print()
+        print("To get the .pem file:")
+        print("  1. Open https://github.com/settings/apps/cerberus-az")
+        print("  2. Click 'Private keys' > 'Generate a private key'")
+        print("  3. The browser downloads a .pem file (typically to ~/Downloads/)")
+        print("  4. Re-run with --cerberus-pem /path/to/the.pem")
+        print()
+        print("The script will deploy the secrets, verify them, delete the .pem,")
+        print("and remind you to revoke the key in the GitHub App UI (browser-only).")
+        print()
+        print("Full procedure: docs/runbooks/0927-new-repo-human-checklist.md#4")
+        print()
+        print("Override: --no-github (skip GitHub repo entirely; local scaffold only).")
         sys.exit(1)
 
     # Validate name
@@ -2389,6 +2598,87 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         except RuntimeError as e:
             print(f"\n  WARNING: gpg decrypt failed: {e}")
             cerberus_status = "GPG_FAILED"
+
+    # GitHub-side verification (#1200, #1202). The local-only post-setup
+    # verification above checks the working tree; this block verifies
+    # origin state end-to-end — branch protection actually applied, repo
+    # settings actually applied, auto-reviewer.yml content matches the
+    # canonical NEW format (the #1193 failure mode), Cerberus secrets
+    # actually present, pr-sentinel Worker actually covers this repo.
+    # Boostgauge #1193 slipped through audits for ~10 days because nothing
+    # verified content on origin — same blind spot was here too.
+    gh_checks_passed = 0
+    gh_checks_total = 0
+    if not args.no_github and github_created:
+        print("\n" + "=" * 60)
+        print("GITHUB-SIDE VERIFICATION")
+        print("=" * 60)
+
+        try:
+            with classic_pat_session() as pat:
+                gh_checks_total += 1
+                ok, msg = verify_branch_protection_on_origin(
+                    github_user, repo_name_lower, pat,
+                )
+                if ok:
+                    print(f"  [PASS] Branch protection: {msg}")
+                    gh_checks_passed += 1
+                else:
+                    print(f"  [FAIL] Branch protection: {msg}")
+
+                gh_checks_total += 1
+                ok, msg = verify_repo_settings_on_origin(
+                    github_user, repo_name_lower, pat,
+                )
+                if ok:
+                    print(f"  [PASS] Repo settings: {msg}")
+                    gh_checks_passed += 1
+                else:
+                    print(f"  [FAIL] Repo settings: {msg}")
+
+                gh_checks_total += 1
+                ok, msg = verify_workflow_content_on_origin(
+                    github_user, repo_name_lower, pat,
+                )
+                if ok:
+                    print(f"  [PASS] auto-reviewer.yml: {msg}")
+                    gh_checks_passed += 1
+                else:
+                    print(f"  [FAIL] auto-reviewer.yml: {msg}")
+
+                if args.cerberus_pem:
+                    gh_checks_total += 1
+                    secrets_ok, missing = verify_secrets(
+                        repo_name_lower, pat,
+                    )
+                    if secrets_ok:
+                        print("  [PASS] Cerberus secrets present "
+                              "(REVIEWER_APP_ID, REVIEWER_APP_PRIVATE_KEY)")
+                        gh_checks_passed += 1
+                    else:
+                        print(f"  [FAIL] Cerberus secrets missing: {missing}")
+        except FileNotFoundError as e:
+            print(f"  [SKIP] classic PAT not configured: {e}")
+        except RuntimeError as e:
+            print(f"  [SKIP] gpg decrypt failed: {e}")
+
+        # pr-sentinel installation check — no classic PAT needed, fine-grained
+        # gh CLI auth is sufficient for /user/installations.
+        gh_checks_total += 1
+        ok, msg = verify_pr_sentinel_installation(github_user, repo_name_lower)
+        if ok:
+            print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
+            gh_checks_passed += 1
+        else:
+            print(f"  [WARN] pr-sentinel-mm Worker: {msg}")
+            print("         If pr-sentinel checks don't appear on the first PR,")
+            print("         the App's installation scope likely drifted from "
+                  "'All repositories'.")
+
+        print(f"\nGitHub-side verification: {gh_checks_passed}/{gh_checks_total} checks passed")
+
+        if gh_checks_passed < gh_checks_total:
+            print("\nWARNING: GitHub-side checks failed. Investigate before opening PRs!")
 
     # Final summary
     if not args.no_github:


### PR DESCRIPTION
## Summary

Pillar 1 of the new-repo creation confidence-restoration plan. Three issues, one bundled PR.

- **#1206** — Make \`--cerberus-pem\` REQUIRED for GitHub-creating invocations. Pre-flight exits 1 with a guide when missing (audit mode exempt; \`--no-github\` bypasses).
- **#1200** — Extend post-setup verification to GitHub-side state: branch protection, repo settings, auto-reviewer.yml content (byte-for-byte against module-level canonical), and Cerberus secrets presence.
- **#1202** — Best-effort \`pr-sentinel-mm\` Worker installation check. Surfaces App-scope drift at creation time instead of when the first PR opens.

## Key changes

| File | Change |
|------|--------|
| \`tools/new_repo_setup.py\` | Pre-flight \`--cerberus-pem\` requirement; new module constant \`_CANONICAL_AUTO_REVIEWER_CALLER\` (single source of truth shared by writer + verifier); 4 new verification helpers using in-process classic PAT; new GITHUB-SIDE VERIFICATION block in \`_create_repo\` |
| \`tests/test_new_repo_setup.py\` | 13 new tests across 5 new classes (TestCerberusPemRequired, TestVerifyBranchProtection, TestVerifyRepoSettings, TestVerifyWorkflowContent, TestVerifyPrSentinelInstallation) — including the explicit #1193 regression test on the OLD caller format signature |
| \`docs/runbooks/0927-new-repo-human-checklist.md\` | Invocation examples include \`--cerberus-pem\`; recommendation language replaced with required language; History v6.2 added |
| \`docs/runbooks/0901-new-project-setup.md\` | Quick Start examples include \`--cerberus-pem\`; History v2.3 added |

## Architecture note

The \`_CANONICAL_AUTO_REVIEWER_CALLER\` constant is the single source of truth for the embedded workflow template. Both \`create_github_workflows()\` (write at creation) and \`verify_workflow_content_on_origin()\` (read for post-setup verification) reference the SAME constant. Divergence between writer and verifier was the #1193 root cause (\`deploy_auto_reviewer_workflow.py\` shipped an outdated template that the audit tool couldn't catch).

## What this does NOT do

This PR is Pillar 1 only. The fleet-side consolidation work (delete \`deploy_auto_reviewer_workflow.py\`, add \`--repos\` to \`deploy_auto_reviewer_fleet.py\`, migrate fleet.py auth to in-process classic PAT) is Pillar 4 — tracked under #1193 + #1204 and is a separate PR.

## Test plan

- [x] 54 unit tests pass (13 new, all existing preserved)
- [x] Lint check: new code clean (pre-existing F541s in untouched code are out of scope)
- [x] Syntax check via \`python -c "import ast; ast.parse(...)\"\`
- [x] Branch protection / Cerberus / pr-sentinel verification logic exercised in unit tests with mocked \`_request_with_retry\` and \`run_command\`
- [x] #1193 regression test (OLD caller format → verify_workflow_content_on_origin returns False) included as T299
- [ ] Live test: next new-repo creation will exercise the new code paths end-to-end

Closes #1200
Closes #1202
Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)