### PR TITLE
docs: Pillar 2 — fix 0901 LICENSE row + clarify 0009 parent-child architecture (Closes #1198, #1208)

### DIFF
--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -110,7 +110,7 @@ MyNewProject/
 | `CLAUDE.md` | Claude agent instructions |
 | `GEMINI.md` | Gemini agent instructions |
 | `README.md` | Project overview |
-| `LICENSE` | MIT License |
+| `LICENSE` | PolyForm Noncommercial 1.0.0 (default; pass `--license mit` for MIT) |
 | `.gitignore` | Standard ignore patterns |
 | `.unleashed.json` | Unleashed wrapper configuration (model, effort, onboard settings) |
 | `.github/workflows/auto-reviewer.yml` | Cerberus auto-approval caller workflow |
@@ -273,3 +273,4 @@ The script automates all of this in one command.
 | 2.1 | 2026-04-05 | Added `.unleashed.json` to file table (was in script/schema but missing from docs) |
 | 2.2 | 2026-04-05 | Added workflow files to file table. Updated post-setup: branch protection is now automated, Cerberus is the remaining human step. |
 | 2.3 | 2026-05-22 | `--cerberus-pem` is now **required** for GitHub-creating invocations (#1206). Quick Start examples updated to include the flag. Post-setup verification extended with GitHub-side checks (#1200) and `pr-sentinel-mm` Worker installation detection (#1202). |
+| 2.4 | 2026-05-22 | Fixed `Files Created` table — `LICENSE` row was documented as MIT but the script defaults to PolyForm Noncommercial 1.0.0 (#1198). |

--- a/docs/standards/0009-canonical-project-structure.md
+++ b/docs/standards/0009-canonical-project-structure.md
@@ -4,6 +4,8 @@
 **Created:** 2026-01-20
 **Applies to:** All projects under AssemblyZero governance
 
+> **Note on scope.** "All projects under AssemblyZero governance" means CHILD projects — repositories that AZ governs and bootstraps via `tools/new_repo_setup.py`. **AssemblyZero itself, the governance layer, uses a parallel 4-digit numbering scheme** (`docs/0003-file-inventory.md`, `docs/standards/0009-...`, `docs/runbooks/0901-...`). The dual scheme is intentional — it originated in the 2026-01-13 Aletheia/AgentOS extraction so docs that briefly existed in both repos were glance-able. This standard governs CHILD projects (5-digit). AZ's own 4-digit scheme is its own convention, separate from this document. See `docs/index.md` for the historical record.
+
 ---
 
 ## Purpose


### PR DESCRIPTION
## Summary

Two small documentation fixes that emerged from today's new-repo creation audit pass.

### #1198 — Runbook 0901 \`Files Created\` table

The LICENSE row said \"MIT License\" but the script defaults to PolyForm Noncommercial 1.0.0. Updated the row to match the actual default and note the override flag.

### #1208 — Standard 0009 parent-child architecture clarification

Added an explicit note that 0009's \"All projects under AssemblyZero governance\" means CHILD projects, not AZ itself. AssemblyZero uses a parallel 4-digit numbering scheme; this standard governs child projects (5-digit). Prevents the misread that triggered #1199 and #1205 today.

## Files

- \`docs/runbooks/0901-new-project-setup.md\` (LICENSE row + History v2.4)
- \`docs/standards/0009-canonical-project-structure.md\` (parent-child note)

## Test plan

- [x] No code changes
- [x] No tests affected
- [x] Diff is a 1-line table edit + a one-paragraph addition

Closes #1198
Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)