### PR TITLE
feat: new_repo_setup.py — surface PyPI runbook 0934 reminder when release.yml ships (Closes #1201)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -948,3 +948,63 @@ class TestVerifyPrSentinelInstallation:
         ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
         assert ok is False
         assert "does NOT cover" in msg or "drift" in msg.lower()
+
+
+# ===========================================================================
+# #1201 — PyPI 0934 reminder
+# ===========================================================================
+
+from new_repo_setup import _maybe_print_pypi_reminder  # noqa: E402
+
+
+class TestPypiReminder:
+    """T303-T306: _maybe_print_pypi_reminder fires only when release.yml shipped."""
+
+    def test_T303_prints_when_python_pypi_github(self, capsys):
+        """Default config (python + pypi + github) → reminder prints with repo-specific values."""
+        _maybe_print_pypi_reminder(
+            lang="python",
+            no_pypi=False,
+            no_github=False,
+            github_user="owner",
+            repo_name="myproject",
+        )
+        out = capsys.readouterr().out
+        assert "pending-publisher registration" in out
+        assert "myproject" in out
+        assert "owner" in out
+        assert "release.yml" in out
+        assert "0934" in out
+
+    def test_T304_silent_when_no_github(self, capsys):
+        """--no-github → no remote, reminder suppressed."""
+        _maybe_print_pypi_reminder(
+            lang="python",
+            no_pypi=False,
+            no_github=True,
+            github_user="owner",
+            repo_name="myproject",
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_T305_silent_when_lang_none(self, capsys):
+        """--lang none → no Python project, no release.yml shipped, no reminder."""
+        _maybe_print_pypi_reminder(
+            lang="none",
+            no_pypi=False,
+            no_github=False,
+            github_user="owner",
+            repo_name="myproject",
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_T306_silent_when_no_pypi(self, capsys):
+        """--no-pypi → release.yml explicitly suppressed, no reminder."""
+        _maybe_print_pypi_reminder(
+            lang="python",
+            no_pypi=True,
+            no_github=False,
+            github_user="owner",
+            repo_name="myproject",
+        )
+        assert capsys.readouterr().out == ""

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -2722,6 +2722,55 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("  # Cerberus secrets deployed and verified.")
         print("  # REMEMBER to revoke the key in the app UI (browser-only step).")
 
+    _maybe_print_pypi_reminder(
+        lang=args.lang,
+        no_pypi=args.no_pypi,
+        no_github=args.no_github,
+        github_user=github_user,
+        repo_name=args.name.lower(),
+    )
+
+
+def _maybe_print_pypi_reminder(
+    *,
+    lang: str,
+    no_pypi: bool,
+    no_github: bool,
+    github_user: str,
+    repo_name: str,
+) -> None:
+    """Print the PyPI 0934 reminder if release.yml shipped on this repo.
+
+    release.yml is deployed by create_github_workflows() when
+    enable_pypi == (lang == "python") and (not no_pypi). The first
+    `git push origin v0.1.0` tag will fail at the publish step unless
+    the user has done the one-time PyPI pending-publisher registration
+    first — runbook 0934 covers the browser step. Surface here so the
+    user can't miss it. (#1201)
+
+    No-op when:
+    - --no-github was passed (no remote to release from)
+    - --lang none was passed (no Python project, no release.yml shipped)
+    - --no-pypi was passed (explicit opt-out, release.yml suppressed)
+
+    Keyword-only args so callers must be explicit about the flag state.
+    """
+    if no_github or lang != "python" or no_pypi:
+        return
+    print()
+    print("  # PyPI publish needs ONE-TIME pending-publisher registration")
+    print("  # BEFORE the first tag push (otherwise release.yml fails):")
+    print("  #   1. https://pypi.org/manage/account/publishing/")
+    print("  #   2. Add new pending publisher:")
+    print(f"  #        Project name:     {repo_name}")
+    print(f"  #        Owner:            {github_user}")
+    print(f"  #        Repository name:  {repo_name}")
+    print("  #        Workflow filename: release.yml")
+    print("  #        Environment name:  pypi")
+    print("  #   3. Click Add. Then `git tag v0.1.0 && git push origin v0.1.0`.")
+    print("  # Full procedure: docs/runbooks/0934-pypi-trusted-publisher-setup.md")
+    print("  # Not publishing to PyPI? Delete .github/workflows/release.yml.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

After #1074 the script ships \`release.yml\` by default (\`--no-pypi\` is opt-out). But the FIRST \`git push origin v0.1.0\` tag will fail at the publish step unless the user has done the one-time PyPI pending-publisher registration first (per runbook 0934).

This PR surfaces the requirement at creation time so the user doesn't have to discover it through a failed first release.

## Behavior

When all three conditions hold:
- Not \`--no-github\`
- \`--lang python\` (default)
- Not \`--no-pypi\`

… the script prints a block after the final summary with:
- The exact PyPI form values (project name, owner, repo, workflow filename, environment name)
- A direct link to https://pypi.org/manage/account/publishing/
- Reference to runbook 0934 for the full procedure
- An opt-out hint (\"delete \`release.yml\` if not publishing\")

In all other cases (any of the three flags set otherwise), the block is suppressed.

## Architecture note

Extracted to \`_maybe_print_pypi_reminder()\` helper with keyword-only args. The conditional logic is now testable in isolation — no need to mock the entire main() github-creation flow to exercise the four gate combinations.

## Tests

4 new tests (T303-T306) covering all four flag combinations. All 58 tests in \`tests/test_new_repo_setup.py\` pass.

Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)