### PR TITLE
feat: tools/backfill_assemblyzero_flag.py — fleet backfill for .unleashed.json (Closes #1212)

### DIFF
--- a/tests/test_backfill_assemblyzero_flag.py
+++ b/tests/test_backfill_assemblyzero_flag.py
@@ -1,0 +1,165 @@
+"""Tests for tools/backfill_assemblyzero_flag.py.
+
+Issue: #1212
+
+Covers the file-handling and discovery helpers in isolation. The PR
+orchestration (process_repo, poll_mergeable) is exercised via integration —
+this test module does NOT spawn real git/gh subprocesses.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
+
+from backfill_assemblyzero_flag import (
+    SKIP_REPOS,
+    discover_repos,
+    flip_file,
+    needs_flip,
+)
+
+
+# ===========================================================================
+# needs_flip
+# ===========================================================================
+
+
+class TestNeedsFlip:
+    """T010-T040."""
+
+    def test_T010_missing_file_returns_false(self, tmp_path):
+        """File doesn't exist → caller has nothing to do; return False."""
+        assert needs_flip(tmp_path / "nonexistent.json") is False
+
+    def test_T020_missing_field_returns_true(self, tmp_path):
+        """File present, no assemblyZero key → needs flip."""
+        p = tmp_path / ".unleashed.json"
+        p.write_text(json.dumps({"profile": "default"}) + "\n", encoding="utf-8")
+        assert needs_flip(p) is True
+
+    def test_T030_false_value_returns_true(self, tmp_path):
+        """File present, assemblyZero=false → needs flip."""
+        p = tmp_path / ".unleashed.json"
+        p.write_text(
+            json.dumps({"profile": "default", "assemblyZero": False}) + "\n",
+            encoding="utf-8",
+        )
+        assert needs_flip(p) is True
+
+    def test_T040_true_value_returns_false(self, tmp_path):
+        """File present, assemblyZero=true → already aligned, no flip."""
+        p = tmp_path / ".unleashed.json"
+        p.write_text(
+            json.dumps({"profile": "default", "assemblyZero": True}) + "\n",
+            encoding="utf-8",
+        )
+        assert needs_flip(p) is False
+
+    def test_T050_invalid_json_returns_false(self, tmp_path):
+        """Unparseable JSON → return False (caller decides what to do)."""
+        p = tmp_path / ".unleashed.json"
+        p.write_text("{not valid json!!", encoding="utf-8")
+        assert needs_flip(p) is False
+
+
+# ===========================================================================
+# flip_file
+# ===========================================================================
+
+
+class TestFlipFile:
+    """T100-T120."""
+
+    def test_T100_sets_field_from_false_to_true(self, tmp_path):
+        p = tmp_path / ".unleashed.json"
+        p.write_text(
+            json.dumps({"profile": "default", "assemblyZero": False}) + "\n",
+            encoding="utf-8",
+        )
+        flip_file(p)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert data["assemblyZero"] is True
+
+    def test_T110_adds_field_when_missing(self, tmp_path):
+        p = tmp_path / ".unleashed.json"
+        p.write_text(
+            json.dumps({"profile": "default", "claude": {"model": "opus"}}) + "\n",
+            encoding="utf-8",
+        )
+        flip_file(p)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert data["assemblyZero"] is True
+        # other fields preserved
+        assert data["profile"] == "default"
+        assert data["claude"]["model"] == "opus"
+
+    def test_T120_idempotent_when_already_true(self, tmp_path):
+        p = tmp_path / ".unleashed.json"
+        original = {"profile": "default", "assemblyZero": True}
+        p.write_text(json.dumps(original) + "\n", encoding="utf-8")
+        flip_file(p)
+        data = json.loads(p.read_text(encoding="utf-8"))
+        assert data["assemblyZero"] is True
+
+
+# ===========================================================================
+# discover_repos
+# ===========================================================================
+
+
+class TestDiscoverRepos:
+    """T200-T230."""
+
+    def test_T200_finds_repos_with_unleashed_json(self, tmp_path):
+        """Discovery returns dirs containing .unleashed.json."""
+        (tmp_path / "RepoA").mkdir()
+        (tmp_path / "RepoA" / ".unleashed.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "RepoB").mkdir()
+        (tmp_path / "RepoB" / ".unleashed.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "RepoC").mkdir()  # no .unleashed.json
+
+        found = discover_repos(tmp_path)
+        names = [p.name for p in found]
+        assert "RepoA" in names
+        assert "RepoB" in names
+        assert "RepoC" not in names
+
+    def test_T210_skips_assemblyzero(self, tmp_path):
+        """AssemblyZero (the governance layer) is always excluded."""
+        (tmp_path / "AssemblyZero").mkdir()
+        (tmp_path / "AssemblyZero" / ".unleashed.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "OtherRepo").mkdir()
+        (tmp_path / "OtherRepo" / ".unleashed.json").write_text("{}", encoding="utf-8")
+
+        found = discover_repos(tmp_path)
+        names = [p.name for p in found]
+        assert "AssemblyZero" not in names
+        assert "OtherRepo" in names
+
+    def test_T220_returns_empty_when_projects_root_missing(self, tmp_path):
+        nonexistent = tmp_path / "does-not-exist"
+        assert discover_repos(nonexistent) == []
+
+    def test_T230_skips_non_directories(self, tmp_path):
+        """A file in projects-root (not a dir) is ignored."""
+        (tmp_path / "Repo").mkdir()
+        (tmp_path / "Repo" / ".unleashed.json").write_text("{}", encoding="utf-8")
+        (tmp_path / "loose-file.txt").write_text("not a repo", encoding="utf-8")
+
+        found = discover_repos(tmp_path)
+        names = [p.name for p in found]
+        assert "Repo" in names
+        assert "loose-file.txt" not in names
+
+
+# ===========================================================================
+# Module-level invariants
+# ===========================================================================
+
+
+def test_skip_repos_contains_assemblyzero():
+    """Defensive: AssemblyZero must always be in SKIP_REPOS."""
+    assert "AssemblyZero" in SKIP_REPOS

--- a/tools/backfill_assemblyzero_flag.py
+++ b/tools/backfill_assemblyzero_flag.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Fleet backfill: set .unleashed.json assemblyZero=true across existing AZ-managed repos.
+
+`tools/new_repo_setup.py` started defaulting `.unleashed.json` to
+`assemblyZero: true` after #1059 (commit f85ee2ef1). Repos created
+before that change have the field missing or set to false, which means
+`/onboard` does NOT load AssemblyZero's CLAUDE.md and gemini rotation
+instructions when those sessions start. This script backfills the flag.
+
+Discovery:
+    Walks ~/Projects/* for directories that contain .unleashed.json.
+
+For each repo found:
+    - dry-run: classify as NEEDS_FLIP / ALREADY_TRUE / SKIPPED_DIRTY / etc.
+    - apply: if NEEDS_FLIP, branch + edit + commit + push + open PR +
+      poll mergeable + squash merge + clean up local branch. PR
+      references this issue via `Refs #1212` (does NOT close it — this
+      script closes it once after a successful --apply run summarizes
+      across all repos).
+
+Safety:
+    - Skips repos with uncommitted working-tree changes (avoids stepping
+      on in-progress work).
+    - Skips AssemblyZero itself (it's the governance layer, not a
+      governed project — and its .unleashed.json already has the right
+      value).
+    - Dry-run is the default. --apply is required to actually mutate.
+
+Auth:
+    Fine-grained PAT sufficient (file edit + standard git push + gh PR
+    operations). Does NOT need classic PAT.
+
+Usage:
+    poetry run python tools/backfill_assemblyzero_flag.py            # dry-run, all repos
+    poetry run python tools/backfill_assemblyzero_flag.py --apply    # apply across all
+    poetry run python tools/backfill_assemblyzero_flag.py --repos A,B  # limit scope
+
+Issue: #1212 | Carryover from: #1059
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+ISSUE_NUMBER = 1212
+PROJECTS_ROOT = Path("C:/Users/mcwiz/Projects")
+SKIP_REPOS = {"AssemblyZero"}  # governance layer; not a governed project
+BRANCH_NAME = f"chore-{ISSUE_NUMBER}-set-assemblyzero-flag"
+COMMIT_MESSAGE = (
+    f"chore: set .unleashed.json assemblyZero=true (Refs #{ISSUE_NUMBER})\n"
+    f"\n"
+    f"Backfill from AZ #{ISSUE_NUMBER}. `tools/new_repo_setup.py` defaults\n"
+    f"to assemblyZero=true since #1059; this aligns existing repos that\n"
+    f"predate that change so /onboard correctly loads AZ rules.\n"
+    f"\n"
+    f"Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\n"
+)
+PR_BODY = (
+    f"## Summary\n\n"
+    f"One-line config change: set `.unleashed.json` `assemblyZero` field to `true`.\n\n"
+    f"## Why\n\n"
+    f"AssemblyZero #{ISSUE_NUMBER} fleet backfill. `tools/new_repo_setup.py` "
+    f"in AssemblyZero defaults `.unleashed.json` to `assemblyZero: true` since "
+    f"#1059. Existing repos that predate that change have the field missing or "
+    f"`false`, which means `/onboard` skips loading AssemblyZero's CLAUDE.md / "
+    f"gemini rotation instructions for sessions in this repo. Setting the flag "
+    f"aligns this repo with the fleet default.\n\n"
+    f"## Test plan\n\n"
+    f"- [x] One-line config edit\n"
+    f"- [x] No code changes; no tests affected\n"
+    f"- [ ] After merge, next `/onboard` in this repo loads AZ rules\n\n"
+    f"Refs AssemblyZero#{ISSUE_NUMBER}\n\n"
+    f"🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
+)
+
+MERGEABLE_POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 900
+
+
+@dataclass
+class RepoResult:
+    name: str
+    status: str  # NEEDS_FLIP, ALREADY_TRUE, NO_UNLEASHED_JSON, SKIPPED_DIRTY, etc.
+    detail: str = ""
+
+
+def needs_flip(unleashed_path: Path) -> bool:
+    """True iff the .unleashed.json is missing assemblyZero or has it False.
+
+    Returns False when the field is present and True (already aligned).
+    Returns False when the file is missing or unreadable (caller decides).
+    """
+    if not unleashed_path.exists():
+        return False
+    try:
+        data = json.loads(unleashed_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    return data.get("assemblyZero", False) is not True
+
+
+def flip_file(unleashed_path: Path) -> None:
+    """Set assemblyZero=true in .unleashed.json, preserving the rest.
+
+    Preserves field ordering by re-emitting with the same json.dumps
+    settings new_repo_setup.py uses (indent=2, trailing newline).
+    """
+    data = json.loads(unleashed_path.read_text(encoding="utf-8"))
+    data["assemblyZero"] = True
+    unleashed_path.write_text(
+        json.dumps(data, indent=2) + "\n", encoding="utf-8",
+    )
+
+
+def discover_repos(projects_root: Path) -> list[Path]:
+    """List repo paths under projects_root that contain .unleashed.json.
+
+    Filters out the AssemblyZero governance layer (SKIP_REPOS) and
+    non-directory entries. Returns sorted for deterministic output.
+    """
+    repos: list[Path] = []
+    if not projects_root.exists():
+        return repos
+    for entry in sorted(projects_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in SKIP_REPOS:
+            continue
+        if (entry / ".unleashed.json").exists():
+            repos.append(entry)
+    return repos
+
+
+def run(cmd: list[str], cwd: Path | None = None, check: bool = False) -> subprocess.CompletedProcess:
+    """Run a subprocess; capture text output; default check=False."""
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=check, timeout=120,
+    )
+
+
+def is_working_tree_clean(repo_path: Path) -> bool:
+    """True iff `git status --porcelain` returns no output."""
+    r = run(["git", "status", "--porcelain"], cwd=repo_path)
+    if r.returncode != 0:
+        return False
+    return r.stdout.strip() == ""
+
+
+def gh_owner_of(repo_path: Path) -> str | None:
+    """Read the gh remote and return 'owner/repo' string, or None if not gh-tracked."""
+    r = run(["git", "remote", "get-url", "origin"], cwd=repo_path)
+    if r.returncode != 0:
+        return None
+    url = r.stdout.strip()
+    if "github.com" not in url:
+        return None
+    suffix = url.split("github.com", 1)[1].lstrip(":/")
+    if suffix.endswith(".git"):
+        suffix = suffix[:-4]
+    return suffix
+
+
+def poll_mergeable(repo_full: str, pr_number: int) -> bool:
+    """Poll the PR's mergeable_state until 'clean' or timeout. True on clean."""
+    deadline = time.time() + MERGEABLE_TIMEOUT_S
+    while time.time() < deadline:
+        r = run(
+            ["gh", "api", f"repos/{repo_full}/pulls/{pr_number}",
+             "--jq", ".mergeable_state"],
+        )
+        state = (r.stdout or "").strip()
+        if state == "clean":
+            return True
+        time.sleep(MERGEABLE_POLL_INTERVAL_S)
+    return False
+
+
+def process_repo(repo_path: Path, dry_run: bool) -> RepoResult:
+    """Classify a repo; if --apply and NEEDS_FLIP, run the per-repo PR flow."""
+    name = repo_path.name
+    unleashed = repo_path / ".unleashed.json"
+    if not unleashed.exists():
+        return RepoResult(name, "NO_UNLEASHED_JSON")
+    if not needs_flip(unleashed):
+        return RepoResult(name, "ALREADY_TRUE")
+    if dry_run:
+        return RepoResult(name, "NEEDS_FLIP", "would set assemblyZero=true")
+
+    if not is_working_tree_clean(repo_path):
+        return RepoResult(name, "SKIPPED_DIRTY",
+                          "working tree has uncommitted changes")
+    repo_full = gh_owner_of(repo_path)
+    if not repo_full:
+        return RepoResult(name, "SKIPPED_NO_GH", "no github.com origin remote")
+
+    # --- PR flow ---
+    # 1. Ensure on main and current
+    run(["git", "checkout", "main"], cwd=repo_path)
+    run(["git", "fetch", "origin"], cwd=repo_path)
+    run(["git", "merge", "--ff-only", "origin/main"], cwd=repo_path)
+
+    # 2. Branch
+    r = run(["git", "checkout", "-b", BRANCH_NAME], cwd=repo_path)
+    if r.returncode != 0:
+        return RepoResult(name, "ERROR_BRANCH",
+                          f"could not create branch: {r.stderr.strip()[:200]}")
+
+    # 3. Edit + commit
+    flip_file(unleashed)
+    run(["git", "add", ".unleashed.json"], cwd=repo_path)
+    r = run(["git", "commit", "-m", COMMIT_MESSAGE], cwd=repo_path)
+    if r.returncode != 0:
+        # Commit failed (e.g., pre-commit hook). Branch has no new commits,
+        # so branch tip == main tip. Restore the working-tree edit, return
+        # to main, then `git branch -d` (-D is banned per memory; -d works
+        # because branch is reachable from main with no extra commits).
+        run(["git", "restore", "--staged", "--worktree", ".unleashed.json"],
+            cwd=repo_path)
+        run(["git", "checkout", "main"], cwd=repo_path)
+        run(["git", "branch", "-d", BRANCH_NAME], cwd=repo_path)
+        return RepoResult(name, "ERROR_COMMIT",
+                          f"commit failed: {r.stderr.strip()[:200]}")
+
+    # 4. Push
+    r = run(["git", "push", "-u", "origin", BRANCH_NAME], cwd=repo_path)
+    if r.returncode != 0:
+        # Branch has a local commit that didn't reach origin. Do NOT
+        # delete it — that would lose work. Leave for user investigation.
+        run(["git", "checkout", "main"], cwd=repo_path)
+        return RepoResult(name, "ERROR_PUSH",
+                          f"push failed (local branch {BRANCH_NAME} retained for investigation): "
+                          f"{r.stderr.strip()[:200]}")
+
+    # 5. Open PR
+    title = f"chore: set .unleashed.json assemblyZero=true (Refs AssemblyZero#{ISSUE_NUMBER})"
+    r = run(
+        ["gh", "pr", "create", "--repo", repo_full,
+         "--head", BRANCH_NAME, "--base", "main",
+         "--title", title, "--body", PR_BODY],
+        cwd=repo_path,
+    )
+    if r.returncode != 0:
+        return RepoResult(name, "ERROR_PR_CREATE",
+                          f"gh pr create failed: {r.stderr.strip()[:200]}")
+    pr_url = (r.stdout or "").strip().splitlines()[-1]
+    pr_number_str = pr_url.rsplit("/", 1)[-1]
+    try:
+        pr_number = int(pr_number_str)
+    except ValueError:
+        return RepoResult(name, "ERROR_PR_PARSE",
+                          f"could not parse PR number from {pr_url!r}")
+
+    # 6. Wait for clean
+    if not poll_mergeable(repo_full, pr_number):
+        return RepoResult(name, "ERROR_NOT_MERGEABLE",
+                          f"PR #{pr_number} did not reach 'clean' in {MERGEABLE_TIMEOUT_S}s")
+
+    # 7. Squash merge
+    r = run(["gh", "pr", "merge", str(pr_number), "--squash", "--repo", repo_full],
+            cwd=repo_path)
+    if r.returncode != 0:
+        return RepoResult(name, "ERROR_MERGE",
+                          f"merge failed: {r.stderr.strip()[:200]}")
+
+    # 8. Cleanup local
+    run(["git", "checkout", "main"], cwd=repo_path)
+    run(["git", "fetch", "origin"], cwd=repo_path)
+    run(["git", "merge", "--ff-only", "origin/main"], cwd=repo_path)
+    run(["git", "branch", "-d", BRANCH_NAME], cwd=repo_path)
+
+    return RepoResult(name, "MERGED", f"PR #{pr_number}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.strip().split("\n")[0])
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually run the PR flow. Default is dry-run.")
+    parser.add_argument("--repos",
+                        help="Comma-separated repo names to limit scope. "
+                             "Default: all repos with .unleashed.json under "
+                             f"{PROJECTS_ROOT}.")
+    args = parser.parse_args(argv)
+
+    all_repos = discover_repos(PROJECTS_ROOT)
+    if args.repos:
+        wanted = {r.strip() for r in args.repos.split(",") if r.strip()}
+        all_repos = [r for r in all_repos if r.name in wanted]
+
+    if not all_repos:
+        print("No repos with .unleashed.json found (after filters).")
+        return 0
+
+    print(f"Mode: {'APPLY' if args.apply else 'DRY-RUN'}")
+    print(f"Scanned: {len(all_repos)} repo(s) under {PROJECTS_ROOT}")
+    print()
+
+    results: list[RepoResult] = []
+    for repo in all_repos:
+        print(f"--- {repo.name} ---")
+        result = process_repo(repo, dry_run=not args.apply)
+        results.append(result)
+        if result.detail:
+            print(f"  {result.status}: {result.detail}")
+        else:
+            print(f"  {result.status}")
+
+    print()
+    print("=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    by_status: dict[str, int] = {}
+    for r in results:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    for status, count in sorted(by_status.items()):
+        print(f"  {status}: {count}")
+
+    needs_flip_count = by_status.get("NEEDS_FLIP", 0)
+    merged_count = by_status.get("MERGED", 0)
+    errors = sum(1 for r in results if r.status.startswith("ERROR_"))
+
+    if not args.apply and needs_flip_count > 0:
+        print(f"\n{needs_flip_count} repo(s) would be flipped. Re-run with --apply.")
+    if args.apply:
+        print(f"\nMerged: {merged_count} | Errors: {errors}")
+        if errors:
+            print("Errors per repo:")
+            for r in results:
+                if r.status.startswith("ERROR_"):
+                    print(f"  {r.name}: {r.detail}")
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Carryover from #1059. \`tools/new_repo_setup.py\` defaults \`.unleashed.json\` to \`assemblyZero: true\` for newly-created repos; existing repos that predate that default have the field missing or false. Without it, \`/onboard\` skips AZ rules for sessions in those repos.

This PR adds the fleet backfill script. After merge, agent runs it (dry-run for your approval, then --apply across the fleet).

## Behavior

- Default: dry-run, lists affected repos
- \`--apply\`: per-repo PR flow (branch + edit + commit + push + PR + poll + squash merge + cleanup)
- \`--repos A,B\`: limit scope
- Skips: AssemblyZero (governance layer), repos without \`.unleashed.json\`, repos with dirty working tree, repos without github.com origin

## Safety

- Fine-grained PAT sufficient (no classic PAT)
- \`git branch -d\` only (banned \`-D\` never appears); on commit failure the staged working tree is restored so \`-d\` works cleanly; on push failure the local branch is RETAINED for investigation (deleting would lose work)
- \`Refs AssemblyZero#1212\` on per-repo PRs (does not close the issue from each PR — this PR closes via \`Closes\`)

## Tests

13 unit tests covering \`needs_flip\`, \`flip_file\`, \`discover_repos\`. All pass.

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)