### PR TITLE
fix: backfill_assemblyzero_flag.py precise safety check (Closes #1222)

### DIFF
--- a/tests/test_backfill_assemblyzero_flag.py
+++ b/tests/test_backfill_assemblyzero_flag.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
 
 from backfill_assemblyzero_flag import (
     SKIP_REPOS,
+    current_branch,
     discover_repos,
     flip_file,
+    is_safe_to_backfill,
+    is_unleashed_json_clean,
     needs_flip,
 )
 
@@ -163,3 +167,113 @@ class TestDiscoverRepos:
 def test_skip_repos_contains_assemblyzero():
     """Defensive: AssemblyZero must always be in SKIP_REPOS."""
     assert "AssemblyZero" in SKIP_REPOS
+
+
+# ===========================================================================
+# #1222 — precise safety check (replaces coarse working-tree check)
+# ===========================================================================
+
+
+class TestIsUnleashedJsonClean:
+    """T300-T320: is_unleashed_json_clean."""
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T300_returns_true_when_porcelain_empty(self, mock_run, tmp_path):
+        """git status --porcelain returns empty → clean."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        assert is_unleashed_json_clean(tmp_path) is True
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T310_returns_false_when_modified(self, mock_run, tmp_path):
+        """M .unleashed.json → dirty."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=" M .unleashed.json\n", stderr="",
+        )
+        assert is_unleashed_json_clean(tmp_path) is False
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T315_returns_false_when_untracked(self, mock_run, tmp_path):
+        """?? .unleashed.json → dirty (file exists locally, not in git)."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="?? .unleashed.json\n", stderr="",
+        )
+        assert is_unleashed_json_clean(tmp_path) is False
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T320_returns_false_on_git_error(self, mock_run, tmp_path):
+        """Non-zero exit (not a git repo, etc.) → not safe."""
+        mock_run.return_value = MagicMock(returncode=128, stdout="", stderr="not a git repo")
+        assert is_unleashed_json_clean(tmp_path) is False
+
+
+class TestCurrentBranch:
+    """T400-T420: current_branch."""
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T400_returns_branch_name(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="main\n", stderr="")
+        assert current_branch(tmp_path) == "main"
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T410_returns_feature_branch(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="feature-foo\n", stderr="",
+        )
+        assert current_branch(tmp_path) == "feature-foo"
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T420_returns_none_on_error(self, mock_run, tmp_path):
+        mock_run.return_value = MagicMock(
+            returncode=128, stdout="", stderr="not a git repo",
+        )
+        assert current_branch(tmp_path) is None
+
+
+class TestIsSafeToBackfill:
+    """T500-T530: is_safe_to_backfill (the precise replacement for the
+    coarse working-tree check). Per #1222, only .unleashed.json clean +
+    on main matter."""
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T500_safe_when_on_main_and_clean(self, mock_run, tmp_path):
+        """on main, .unleashed.json clean → safe."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),       # porcelain check
+            MagicMock(returncode=0, stdout="main\n", stderr=""),  # branch check
+        ]
+        ok, reason = is_safe_to_backfill(tmp_path)
+        assert ok is True
+        assert reason == ""
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T510_unsafe_when_unleashed_json_dirty_on_main(self, mock_run, tmp_path):
+        """on main, .unleashed.json modified → not safe."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M .unleashed.json\n", stderr=""),
+        ]
+        ok, reason = is_safe_to_backfill(tmp_path)
+        assert ok is False
+        assert ".unleashed.json" in reason
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T520_unsafe_when_on_feature_branch_clean(self, mock_run, tmp_path):
+        """on feature-branch, .unleashed.json clean → not safe (other agent owns)."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="", stderr=""),
+            MagicMock(returncode=0, stdout="feature-foo\n", stderr=""),
+        ]
+        ok, reason = is_safe_to_backfill(tmp_path)
+        assert ok is False
+        assert "feature-foo" in reason
+        assert "main" in reason
+
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T530_unsafe_when_on_feature_branch_and_dirty(self, mock_run, tmp_path):
+        """on feature-branch, .unleashed.json dirty → not safe (dirty fires first)."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=" M .unleashed.json\n", stderr=""),
+        ]
+        ok, reason = is_safe_to_backfill(tmp_path)
+        assert ok is False
+        # Implementation short-circuits on dirty before checking branch.
+        assert ".unleashed.json" in reason

--- a/tools/backfill_assemblyzero_flag.py
+++ b/tools/backfill_assemblyzero_flag.py
@@ -144,11 +144,57 @@ def run(cmd: list[str], cwd: Path | None = None, check: bool = False) -> subproc
 
 
 def is_working_tree_clean(repo_path: Path) -> bool:
-    """True iff `git status --porcelain` returns no output."""
+    """True iff `git status --porcelain` returns no output.
+
+    Kept for backwards-compatibility; callers should prefer
+    is_safe_to_backfill which checks only what actually matters for
+    this script's scope.
+    """
     r = run(["git", "status", "--porcelain"], cwd=repo_path)
     if r.returncode != 0:
         return False
     return r.stdout.strip() == ""
+
+
+def is_unleashed_json_clean(repo_path: Path) -> bool:
+    """True iff `.unleashed.json` has no pending changes (staged or worktree).
+
+    Other untracked or modified files don't matter — this script only
+    stages `.unleashed.json`, so they're inert. (#1222)
+    """
+    r = run(
+        ["git", "status", "--porcelain", "--", ".unleashed.json"],
+        cwd=repo_path,
+    )
+    if r.returncode != 0:
+        return False
+    return r.stdout.strip() == ""
+
+
+def current_branch(repo_path: Path) -> str | None:
+    """Return the current branch name, or None on error."""
+    r = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_path)
+    if r.returncode != 0:
+        return None
+    return r.stdout.strip() or None
+
+
+def is_safe_to_backfill(repo_path: Path) -> tuple[bool, str]:
+    """Precise safety check for the backfill. Returns (ok, reason_if_not).
+
+    Two predicates (#1222):
+      1. `.unleashed.json` has no pending changes
+      2. Currently on `main` branch (avoid disrupting active feature branches)
+
+    Other untracked/modified files are not blockers — the script only
+    stages `.unleashed.json` so they're never picked up.
+    """
+    if not is_unleashed_json_clean(repo_path):
+        return False, ".unleashed.json has uncommitted changes"
+    branch = current_branch(repo_path)
+    if branch != "main":
+        return False, f"on branch '{branch}' (not main; agent in another session may own)"
+    return True, ""
 
 
 def gh_owner_of(repo_path: Path) -> str | None:
@@ -191,9 +237,9 @@ def process_repo(repo_path: Path, dry_run: bool) -> RepoResult:
     if dry_run:
         return RepoResult(name, "NEEDS_FLIP", "would set assemblyZero=true")
 
-    if not is_working_tree_clean(repo_path):
-        return RepoResult(name, "SKIPPED_DIRTY",
-                          "working tree has uncommitted changes")
+    safe, reason = is_safe_to_backfill(repo_path)
+    if not safe:
+        return RepoResult(name, "SKIPPED_UNSAFE", reason)
     repo_full = gh_owner_of(repo_path)
     if not repo_full:
         return RepoResult(name, "SKIPPED_NO_GH", "no github.com origin remote")


### PR DESCRIPTION
## Summary

Original \`is_working_tree_clean()\` was too coarse — flagged a repo as dirty on ANY untracked file. Apply runs skipped every active repo.

Replaced with two precise predicates: \`.unleashed.json\` itself is clean AND on \`main\` branch. Combined into \`is_safe_to_backfill()\` returning \`(bool, reason)\`. Orchestration now returns \`SKIPPED_UNSAFE\` with the specific reason.

11 new tests cover the four branch×dirty cases plus the underlying helpers. 24/24 pass.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)