### PR TITLE
fix: backfill_assemblyzero_flag.py — add No-Issue exemption to PR body (Closes #1226)

### DIFF
--- a/tests/test_backfill_assemblyzero_flag.py
+++ b/tests/test_backfill_assemblyzero_flag.py
@@ -169,6 +169,15 @@ def test_skip_repos_contains_assemblyzero():
     assert "AssemblyZero" in SKIP_REPOS
 
 
+def test_pr_body_has_no_issue_exemption():
+    """#1226: PR_BODY must contain the No-Issue: exemption tag so pr-sentinel
+    doesn't block cross-repo PRs that have no per-repo issue to close."""
+    from backfill_assemblyzero_flag import PR_BODY
+    assert "No-Issue:" in PR_BODY
+    # And the body should still reference the tracking issue for traceability
+    assert "AssemblyZero#" in PR_BODY
+
+
 # ===========================================================================
 # #1222 — precise safety check (replaces coarse working-tree check)
 # ===========================================================================

--- a/tools/backfill_assemblyzero_flag.py
+++ b/tools/backfill_assemblyzero_flag.py
@@ -75,6 +75,8 @@ PR_BODY = (
     f"- [x] No code changes; no tests affected\n"
     f"- [ ] After merge, next `/onboard` in this repo loads AZ rules\n\n"
     f"Refs AssemblyZero#{ISSUE_NUMBER}\n\n"
+    f"No-Issue: AssemblyZero fleet backfill — tracking issue is "
+    f"AssemblyZero#{ISSUE_NUMBER} (cross-repo; no per-repo issue needed)\n\n"
     f"🤖 Generated with [Claude Code](https://claude.com/claude-code)\n"
 )
 


### PR DESCRIPTION
## Summary

Per-repo PRs from the backfill had no \`Closes #N\` to a local issue. pr-sentinel blocked every one. Added the canonical \`No-Issue:\` exemption tag to PR_BODY.

Closes #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)