### PR TITLE
feat: two-tier mutation flag rule + _gate.py reference implementation + fleet audit

### DIFF
--- a/docs/audits/0853-fleet-mutation-flag-audit-2026-05-23.md
+++ b/docs/audits/0853-fleet-mutation-flag-audit-2026-05-23.md
@@ -1,0 +1,121 @@
+# 0853 - Fleet Mutation-Flag Audit (--apply / --execute compliance)
+
+**Auditor:** Claude Opus 4.7 (1M context), AssemblyZero session
+**Date:** 2026-05-23
+**Scope:** all `martymcenroe/*` repos under `C:\Users\mcwiz\Projects\` (58 GitHub repos + local-only meta dirs)
+**Trigger:** AZ #1230 mandatory-to-close clause (fleet audit + per-tool issues for non-conformant tools)
+**Issue:** [#1230](https://github.com/martymcenroe/AssemblyZero/issues/1230)
+
+## Rule audited
+
+Per `Projects/CLAUDE.md` § "Destructive Scripts — `--apply` and `--execute`" (codified 2026-05-23):
+
+- **`--apply`** — canonical mutation flag for normal scripts. Default mode is dry-run.
+- **`--execute`** — substituted for `--apply` IFF the script's source contains any command from the **Banned commands (ALWAYS)** table in `Projects/CLAUDE.md` § Safety.
+- **Typed-confirmation gate** inside the `--execute` branch via `require_confirmation(operation, target)` (AZ #1231; implementation: `tools/_gate.py`).
+
+## Methodology
+
+Per the Clio session comment on AZ #1231 + lessons from the morning's first-attempt failure (Grep tool defaults skipped `.gitignore`'d paths, hiding `Hermes/data/migrate-email.py`):
+
+1. **Enumerate the fleet.** `gh repo list martymcenroe --limit 200 --json name` → 58 GitHub repos. Locally there are also archived clones, wikis, and meta dirs.
+2. **Identify candidate tools.** `gh search code --owner martymcenroe '"--apply"' --limit 100` and `'"--execute"' --limit 100` across all extensions. Local cross-check via `Grep` tool with explicit per-repo paths.
+3. **Filter false positives.** Lineage docs, session captures, PTY logs, and docstring mentions that match the regex but are not real argparse declarations were excluded by inspecting context.
+4. **Inspect each real tool** for:
+   - Argparse flag name (`--apply` vs `--execute`)
+   - Operational use of any banned command (subprocess.run / os.system / explicit shell invocation of `git push --force`, `git reset --hard`, `git branch -D`, `git clean -fd`, `git worktree remove --force`, `--theirs`, `--no-verify`, `--no-gpg-sign`, `gh pr merge --admin`, `gh pr review --approve` on own PR, `gh pr merge --auto`, `dd`, `mkfs`, `shred`, `format`)
+5. **Decision matrix per tool:**
+
+   | Flag in use | Banned command present operationally? | Verdict |
+   |---|---|---|
+   | `--apply` | No | **conformant** |
+   | `--apply` | Yes | non-conformant: should rename to `--execute` and add gate |
+   | `--execute` | Yes | conformant (verify gate added once `_gate.py` ships) |
+   | `--execute` | No | non-conformant: should rename to `--apply` |
+
+## Results (15 candidate tools across 5 repos)
+
+### AssemblyZero/tools/ (7 tools, all `--apply`)
+
+| Tool | Flag | Banned cmd? | Verdict |
+|---|---|---|---|
+| `backfill_assemblyzero_flag.py` | `--apply` (L329) | no | **conformant** |
+| `backfill_canonical_labels.py` | `--apply` (L169) | no | **conformant** |
+| `deploy_auto_reviewer_workflow.py` | `--apply` (L567) | no (docstring mentions `gh pr merge --admin` as a non-use) | **conformant** |
+| `update-doc-refs.py` | `--apply` (L253) | no | **conformant** |
+| `remediate_fleet_branch_protection.py` | `--apply` (L190) + `--confirm-yes` belt-and-braces | no | **conformant** |
+| `remediate_patent_general_protection.py` | `--apply` (L153) | no | **conformant** (fixed today via #1228/PR #1229) |
+| `verdict-analyzer.py` | `args.apply` subcommand pattern (L146) | no | **conformant** |
+
+### Aletheia/tools/ (1 tool)
+
+| Tool | Flag | Banned cmd? | Verdict |
+|---|---|---|---|
+| `admin_subscriptions.py` | `--apply` (L191), also has explicit `--dry-run` default=True (L189) | no | **conformant** |
+
+### career/dashboard/scripts/ (2 TypeScript tools)
+
+| Tool | Flag | Banned cmd? | Verdict |
+|---|---|---|---|
+| `purge-stale-alerts.ts` | `--apply` (L169 `args.has("--apply")`) | no | **conformant** |
+| `triage-unknown-questions.ts` | `--apply` (L31 `process.argv.includes("--apply")`) | no | **conformant** |
+
+### unleashed/ (4 tools)
+
+| Tool | Flag | Banned cmd? | Verdict |
+|---|---|---|---|
+| `scripts/backfill_session_ts_utc.py` | `--apply` (L132) | no | **conformant** |
+| `scripts/migrate_plans_to_per_project.py` | `--apply` (L480) | no | **conformant** |
+| `src/fleet_branch_cleanup.py` | `--apply` (L332) | no (uses `git branch -d` lowercase per ADR-0217, not `-D`) | **conformant** |
+| `src/lock_sweep.py` | `--apply` (L193) | no | **conformant** |
+
+### Hermes (handed off to separate session)
+
+| Tool | Flag | Status |
+|---|---|---|
+| `data/migrate-email.py` | `--execute` (L657) | **handed off via Hermes#476** — `data/` is `.gitignore`d, hid the file from the morning's first audit pass; needs per-repo session to verify operational banned-command status and either retrofit with gate (if banned) or rename to `--apply` (if not banned) |
+
+## Summary
+
+| Category | Count |
+|---|---|
+| **Conformant tools (use `--apply`, no banned command)** | 14 |
+| **Non-conformant tools in AZ-audited fleet** | 0 |
+| **Hand-off (separate repo session)** | 1 (Hermes#476) |
+| **Per-tool issues filed** | 0 |
+
+## Audit verdict
+
+**The AZ-audited portion of the fleet (14 of 15 candidate tools across 4 repos) is fully conformant with the codified two-tier mutation-flag rule.** No per-tool issues filed.
+
+The lone outstanding candidate (`Hermes/data/migrate-email.py`) was identified during the morning's investigation that triggered AZ #1228/#1230/#1231; ownership transferred to Hermes#476 per the one-session-per-repo discipline.
+
+## Re-execution
+
+To re-run this audit:
+
+```bash
+# Fleet enumeration
+gh repo list martymcenroe --limit 200 --json name,visibility
+
+# Code search (GitHub-indexed)
+gh search code --owner martymcenroe '"--apply"' --limit 100
+gh search code --owner martymcenroe '"--execute"' --limit 100
+
+# Local filesystem (defeats gitignore + hidden-dir skips)
+for repo in /c/Users/mcwiz/Projects/*/; do
+    grep -rEn --include='*.py' --include='*.sh' --include='*.ts' --include='*.tsx' \
+        --exclude-dir=node_modules --exclude-dir=__pycache__ --exclude-dir=.git \
+        --exclude-dir=dist --exclude-dir=build --exclude-dir=.venv --exclude-dir=venv \
+        --exclude-dir=site-packages \
+        '"--execute"|"--apply"' "$repo" 2>/dev/null
+done
+```
+
+The default `Grep` tool exclusions (`.gitignore`-respect, hidden-dir skip) MUST be defeated for fleet audits. The morning's first-attempt failure that produced AZ #1230 was caused by trusting default exclusions and missing `Hermes/data/migrate-email.py` (gitignored under `data/`).
+
+## Audit Record
+
+| Date | Auditor | Findings | Issues Filed |
+|------|---------|----------|--------------|
+| 2026-05-23 | Claude Opus 4.7 | 14 conformant, 0 non-conformant in AZ-audited fleet; 1 handed off (Hermes#476) | 0 (none needed in AZ-audited fleet) |

--- a/docs/standards/0003-agent-prohibited-actions.md
+++ b/docs/standards/0003-agent-prohibited-actions.md
@@ -2,6 +2,10 @@
 
 Rules defining what AI agents must never do, regardless of user instructions.
 
+> **Authoritative source for banned commands:** `Projects/CLAUDE.md` § Safety "Banned commands (ALWAYS, no exceptions, no per-invocation approval)" table is the universal banned-commands list for all projects, codified 2026-05-23. The table below in §1.1 is the AZ-flavored summary; if it ever diverges from the CLAUDE.md root table, CLAUDE.md root wins.
+>
+> **For mutation-tool authoring:** see `docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md` § 3.1 "Mutation Flag Convention (the two-tier rule)" — defines when a tool that contains a banned command in source must use `--execute` (with typed-confirmation gate) instead of `--apply`.
+
 ## 1. Core Prohibitions
 
 ### 1.1 Git History Destruction

--- a/docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md
+++ b/docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md
@@ -90,9 +90,68 @@ Every fleet tool that imports `classic_pat_session()` should have:
 - [ ] **Distinct status categories** — at least: success, no-op, permission-denied, error
 - [ ] **Final summary** — counts per status
 - [ ] **Non-zero exit code** on any errors or permission-denied
-- [ ] **`--dry-run` flag** — list what would happen, take no action
+- [ ] **Mutation flag follows the two-tier rule** (Section 3.1 + `Projects/CLAUDE.md` § "Destructive Scripts — `--apply` and `--execute`"):
+  - Default behavior is dry-run (no flag = list-only, take no action)
+  - `--apply` is the opt-in mutation flag for normal scripts (no banned command in source)
+  - `--execute` is substituted for `--apply` IFF the script's source contains any command from the CLAUDE.md root § Safety **Banned commands (ALWAYS)** table
+- [ ] **For `--execute`-tier tools**: import `require_confirmation` from `tools/_gate.py` and call it after the dry-run preview prints, before any mutation. Per-target call if the tool loops over N targets — no batch shortcut. See AZ #1231 for the gate spec.
+- [ ] **CLI surface test** — at minimum, assert that every flag named in help text, `--help` output, dry-run print statements, and docstring usage examples is actually recognized by the argparse parser. Catches the #1228 class of bug where a tool advertised `--apply` to execute but only knew `--dry-run`.
 - [ ] **`--repos` (or similar) flag** — let the user run against a subset for testing
 - [ ] **Safety cap** — refuse to process > N targets in one run unless explicitly waived (prevents fat-finger fleet-wide damage)
+
+---
+
+## 3.1 Mutation Flag Convention (the two-tier rule)
+
+Codified in `Projects/CLAUDE.md` § "Destructive Scripts — `--apply` and `--execute`" (universal for all projects); this section is the AZ-canonical mirror.
+
+### The rule
+
+A fleet tool that mutates state defaults to dry-run. Opt-in mutation requires a flag whose name signals the tool's risk class:
+
+| Flag | When | Behavior on opt-in |
+|---|---|---|
+| **`--apply`** | Tool's source contains NO command from CLAUDE.md root § Safety "Banned commands (ALWAYS)" table | Tool performs mutation directly |
+| **`--execute`** | Tool's source contains ANY banned command (operationally executed via subprocess / os.system / equivalent) | Tool performs mutation only after `require_confirmation(operation, target)` succeeds |
+
+The name difference is itself the signal — `--apply` reads as routine, `--execute` reads as elevated. The rule is **lint-enforceable**: a tool that imports `subprocess` and runs `git push --force` MUST use `--execute`, and `grep -rl 'args\.execute' tools/` enumerates every script in the elevated tier.
+
+### The typed-confirmation gate (`--execute` tier only)
+
+`require_confirmation(operation, target)` lives in `tools/_gate.py`. It prompts the operator to type:
+
+```
+approve forbidden <operation> for <target>
+```
+
+verbatim, on stdin. Wrong input or EOF → exit code 2 + structured log line to `~/.cache/classic-pat-tools/gate-refusals.jsonl`. No retry loop. Gate placement in the tool's flow: after `--execute` parsed → after pre-flight `/user` check → after the dry-run preview is FULLY printed → visual divider → THEN gate prompt.
+
+Modeled on GitHub Settings → Danger Zone (type the repo name to confirm deletion). See AZ #1231 for full v1 specification and design rationale.
+
+### Why not just one flag for everything?
+
+Two reasons:
+
+1. **The name change is the signal.** An operator running `--execute` reads the flag and remembers "this one is the elevated kind." Single-flag schemes (e.g., always `--apply`) collapse the risk-class distinction into runtime behavior that the operator must trust the tool to know.
+2. **Lint-enforceability.** With the name tied to source content (banned-command presence), a CI check can grep tool source and verify the flag name matches the tool's risk class. A single-flag scheme has nothing to lint against.
+
+### Reference implementation
+
+- `tools/_gate.py` — the `require_confirmation()` function
+- `tests/test_gate.py` — coverage for correct-phrase / wrong-phrase / EOF / log-truncation / multi-target / stdin fallback / log-dir-auto-creation
+- `docs/audits/0853-fleet-mutation-flag-audit-2026-05-23.md` — fleet-wide audit verifying compliance (per AZ #1230)
+
+### Migration path for existing tools
+
+A tool that currently uses `--apply` but contains a banned command is non-conformant under this rule. Fix sequence:
+
+1. File a per-tool issue (one issue per concern, no bundling — per root CLAUDE.md "One Issue Per Concern")
+2. Rename `--apply` → `--execute` in the argparse declaration
+3. Add `from _gate import require_confirmation` and call it after the dry-run preview prints
+4. Update tool docstring usage examples
+5. Update any CLI surface test to assert `--execute` is the recognized flag
+
+The audit clause (`docs/audits/0853-...`) identified zero such migrations needed in the AZ-managed fleet as of 2026-05-23. The Hermes session owns the lone outstanding candidate (`Hermes#476`).
 
 ---
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,164 @@
+"""Tests for tools/_gate.py (AZ #1231 typed-confirmation gate).
+
+Covers:
+- Correct phrase → returns normally
+- Wrong phrase → sys.exit(2) + refusal log entry
+- EOF on stdin → sys.exit(2) + refusal log entry
+- Refusal log entry contains expected fields with got truncated
+- Multi-call (per-target loop simulation) preserves per-call state
+- gate_phrase() returns the canonical format
+- print_gate_phrase() prints the phrase and returns (no exit)
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+import _gate  # noqa: E402
+
+
+@pytest.fixture
+def tmp_log(tmp_path, monkeypatch):
+    """Redirect GATE_REFUSAL_LOG to a tmp path so tests don't pollute ~/.cache."""
+    log_path = tmp_path / "gate-refusals.jsonl"
+    monkeypatch.setattr(_gate, "GATE_REFUSAL_LOG", log_path)
+    return log_path
+
+
+def _read_log_records(log_path: Path) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_gate_phrase_format():
+    assert _gate.gate_phrase("rewrite-history", "martymcenroe/foo") == \
+        "approve forbidden rewrite-history for martymcenroe/foo"
+
+
+def test_correct_phrase_returns_normally(tmp_log, capsys):
+    phrase = _gate.gate_phrase("delete-protection", "martymcenroe/foo")
+    stream = io.StringIO(phrase + "\n")
+    _gate.require_confirmation("delete-protection", "martymcenroe/foo", stream=stream)
+    out = capsys.readouterr().out
+    assert "Confirmed. Proceeding." in out
+    assert _read_log_records(tmp_log) == []
+
+
+def test_wrong_phrase_exits_2(tmp_log, capsys):
+    stream = io.StringIO("wrong thing\n")
+    with pytest.raises(SystemExit) as exc:
+        _gate.require_confirmation("delete-protection", "martymcenroe/foo", stream=stream)
+    assert exc.value.code == _gate.EXIT_REFUSED == 2
+    out = capsys.readouterr().out
+    assert "Confirmation failed" in out
+    assert "Aborting. No changes made." in out
+
+
+def test_wrong_phrase_logs_refusal(tmp_log):
+    stream = io.StringIO("close enough\n")
+    with pytest.raises(SystemExit):
+        _gate.require_confirmation("force-push", "martymcenroe/foo", stream=stream)
+    records = _read_log_records(tmp_log)
+    assert len(records) == 1
+    record = records[0]
+    assert record["operation"] == "force-push"
+    assert record["target"] == "martymcenroe/foo"
+    assert record["expected"] == "approve forbidden force-push for martymcenroe/foo"
+    assert record["got"] == "close enough"
+    assert "ts" in record and isinstance(record["ts"], (int, float))
+
+
+def test_eof_exits_2_and_logs(tmp_log, capsys):
+    stream = io.StringIO("")
+    with pytest.raises(SystemExit) as exc:
+        _gate.require_confirmation("rewrite-history", "martymcenroe/foo", stream=stream)
+    assert exc.value.code == 2
+    records = _read_log_records(tmp_log)
+    assert len(records) == 1
+    assert records[0]["got"] == ""
+
+
+def test_got_truncated_to_80_chars_in_log(tmp_log):
+    long_garbage = "x" * 200
+    stream = io.StringIO(long_garbage + "\n")
+    with pytest.raises(SystemExit):
+        _gate.require_confirmation("delete-protection", "martymcenroe/foo", stream=stream)
+    records = _read_log_records(tmp_log)
+    assert len(records) == 1
+    got = records[0]["got"]
+    assert got.endswith("...")
+    assert len(got) == _gate.GOT_LOG_TRUNCATE + 3
+    assert got == "x" * _gate.GOT_LOG_TRUNCATE + "..."
+
+
+def test_trailing_whitespace_stripped(tmp_log, capsys):
+    phrase = _gate.gate_phrase("delete-protection", "martymcenroe/foo")
+    stream = io.StringIO(phrase + "\r\n")
+    _gate.require_confirmation("delete-protection", "martymcenroe/foo", stream=stream)
+    assert "Confirmed. Proceeding." in capsys.readouterr().out
+
+
+def test_multi_target_loop_each_prompt_independent(tmp_log, capsys):
+    """Simulate a per-target loop: 3 targets, all confirmed."""
+    targets = ["martymcenroe/a", "martymcenroe/b", "martymcenroe/c"]
+    for target in targets:
+        phrase = _gate.gate_phrase("set-protection", target)
+        stream = io.StringIO(phrase + "\n")
+        _gate.require_confirmation("set-protection", target, stream=stream)
+    out = capsys.readouterr().out
+    assert out.count("Confirmed. Proceeding.") == 3
+    assert _read_log_records(tmp_log) == []
+
+
+def test_multi_target_loop_one_refusal_logs_only_that_one(tmp_log):
+    """Simulate per-target loop where the middle target is refused."""
+    targets = ["martymcenroe/a", "martymcenroe/b", "martymcenroe/c"]
+    for i, target in enumerate(targets):
+        phrase = _gate.gate_phrase("set-protection", target)
+        text = phrase + "\n" if i != 1 else "no\n"
+        stream = io.StringIO(text)
+        if i == 1:
+            with pytest.raises(SystemExit):
+                _gate.require_confirmation("set-protection", target, stream=stream)
+            break
+        else:
+            _gate.require_confirmation("set-protection", target, stream=stream)
+    records = _read_log_records(tmp_log)
+    assert len(records) == 1
+    assert records[0]["target"] == "martymcenroe/b"
+    assert records[0]["got"] == "no"
+
+
+def test_print_gate_phrase_prints_and_returns(tmp_log, capsys):
+    """`--gate-print-only` support: prints the phrase, returns, does not exit."""
+    _gate.print_gate_phrase("rewrite-history", "martymcenroe/foo")
+    out = capsys.readouterr().out
+    assert out.strip() == "approve forbidden rewrite-history for martymcenroe/foo"
+
+
+def test_log_dir_created_if_missing(tmp_path, monkeypatch):
+    """Refusal log path should be created on first refusal even if parent dirs don't exist."""
+    deep_path = tmp_path / "deep" / "nested" / "missing" / "gate-refusals.jsonl"
+    monkeypatch.setattr(_gate, "GATE_REFUSAL_LOG", deep_path)
+    stream = io.StringIO("wrong\n")
+    with pytest.raises(SystemExit):
+        _gate.require_confirmation("delete-protection", "martymcenroe/foo", stream=stream)
+    assert deep_path.exists()
+    assert len(_read_log_records(deep_path)) == 1
+
+
+def test_stdin_fallback_when_no_stream(tmp_log, capsys, monkeypatch):
+    """If stream=None, falls back to input(). Verify input() is called and returns its value."""
+    phrase = _gate.gate_phrase("delete-protection", "martymcenroe/foo")
+    with patch("builtins.input", return_value=phrase) as mock_input:
+        _gate.require_confirmation("delete-protection", "martymcenroe/foo")
+    mock_input.assert_called_once()
+    assert "Confirmed. Proceeding." in capsys.readouterr().out

--- a/tools/_gate.py
+++ b/tools/_gate.py
@@ -1,0 +1,103 @@
+"""Typed-confirmation gate for elevated-risk fleet tools (AZ #1231).
+
+Tools whose source contains a command from the CLAUDE.md root "Banned
+commands (ALWAYS)" table use `--execute` (not `--apply`) as their
+opt-in mutation flag, per the two-tier rule codified in CLAUDE.md root
+section "Destructive Scripts — `--apply` and `--execute`".
+
+Such tools call `require_confirmation(operation, target)` after their
+dry-run preview and before any mutation. The operator must type:
+
+    approve forbidden <operation> for <target>
+
+verbatim, on stdin. No retry loop. Wrong input → exit code 2 + structured
+log line to ~/.cache/classic-pat-tools/gate-refusals.jsonl.
+
+Design: see AZ #1231 (v1 spec, Clio session comment for full reasoning).
+Reference: GitHub Settings → Danger Zone (type repo name to confirm).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+GATE_REFUSAL_LOG = Path.home() / ".cache" / "classic-pat-tools" / "gate-refusals.jsonl"
+GATE_PHRASE_PREFIX = "approve forbidden"
+GOT_LOG_TRUNCATE = 80
+EXIT_REFUSED = 2
+
+
+def gate_phrase(operation: str, target: str) -> str:
+    """The exact phrase the operator must type to confirm `operation` on `target`."""
+    return f"{GATE_PHRASE_PREFIX} {operation} for {target}"
+
+
+def require_confirmation(operation: str, target: str, *, stream=None) -> None:
+    """Prompt for the gate phrase. Return normally on match; sys.exit(2) on mismatch/EOF.
+
+    Args:
+        operation: imperative-hyphenated op token (e.g., "rewrite-history",
+            "delete-protection", "force-push"). Comes from a module-level
+            constant in the calling tool, not free-form operator input.
+        target: the repository or resource the operation acts on
+            (e.g., "martymcenroe/AssemblyZero" or "fleet").
+        stream: optional input source for testing (defaults to stdin via input()).
+
+    Behavior on refusal (wrong phrase or EOF):
+        - Append a JSONL record to GATE_REFUSAL_LOG with ts, operation, target,
+          expected phrase, and got (truncated to GOT_LOG_TRUNCATE chars).
+        - Print a clear error to stdout.
+        - sys.exit(EXIT_REFUSED) — does not return.
+    """
+    expected = gate_phrase(operation, target)
+
+    print()
+    print("=" * 70)
+    print(f"DANGER: about to perform '{operation}' on '{target}'")
+    print("This tool's source contains a command from the CLAUDE.md banned list.")
+    print()
+    print("Type the following EXACTLY to confirm (no abbreviations, no extra whitespace):")
+    print(f"  {expected}")
+    print()
+
+    try:
+        if stream is None:
+            got = input("> ").rstrip("\r\n")
+        else:
+            line = stream.readline()
+            if not line:
+                raise EOFError
+            got = line.rstrip("\r\n")
+    except EOFError:
+        got = ""
+
+    if got == expected:
+        print("Confirmed. Proceeding.")
+        return
+
+    got_truncated = got[:GOT_LOG_TRUNCATE] + ("..." if len(got) > GOT_LOG_TRUNCATE else "")
+    record = {
+        "ts": time.time(),
+        "operation": operation,
+        "target": target,
+        "expected": expected,
+        "got": got_truncated,
+    }
+    GATE_REFUSAL_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with GATE_REFUSAL_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record) + "\n")
+
+    print(f"Confirmation failed (expected '{expected}', got '{got_truncated}').")
+    print("Aborting. No changes made.")
+    sys.exit(EXIT_REFUSED)
+
+
+def print_gate_phrase(operation: str, target: str) -> None:
+    """For `--gate-print-only` support: print the expected phrase and return.
+
+    Tools that accept `--gate-print-only` should call this and exit 0 without
+    invoking require_confirmation(). Useful for runbook documentation.
+    """
+    print(gate_phrase(operation, target))


### PR DESCRIPTION
## Summary

- **`tools/_gate.py`** — `require_confirmation(operation, target)` typed-gate per AZ #1231 v1 spec. Prompts `approve forbidden <operation> for <target>`, exit 2 on mismatch/EOF, structured refusal log at `~/.cache/classic-pat-tools/gate-refusals.jsonl`. No retry loop.
- **`tests/test_gate.py`** — 12 tests, all passing locally: correct phrase, wrong phrase exits 2, EOF exits 2, refusal logged with truncated `got`, trailing whitespace stripped, multi-target loop independence, `print_gate_phrase` for `--gate-print-only` support, log-dir auto-creation, stdin fallback when `stream=None`.
- **`docs/standards/0017` § 3.1** — new "Mutation Flag Convention (the two-tier rule)" section mirrors the universal rule from `Projects/CLAUDE.md` § "Destructive Scripts — `--apply` and `--execute`" as the AZ-canonical authority. Authoring checklist updated with the two-tier rule, gate-import requirement for `--execute` tier, and CLI surface test requirement (catches the #1228 class of bug).
- **`docs/standards/0003`** — cross-reference to `Projects/CLAUDE.md` root as the authoritative source for the banned-commands table. Keeps 0003's AZ-specific sections (issue closure, comm rules, quota exhaustion, etc.) intact.
- **`docs/audits/0853-fleet-mutation-flag-audit-2026-05-23.md`** — fleet audit of 14 candidate tools across AssemblyZero, Aletheia, career, unleashed. All conformant; zero per-tool issues filed. Hermes/migrate-email.py handed off to Hermes#476 per the one-session-per-repo rule.

## Test plan
- [x] `poetry run pytest tests/test_gate.py -v` — 12 passed
- [x] `poetry run ruff check --isolated tools/_gate.py tests/test_gate.py` — all checks passed (project-level `ruff check .` is currently broken on a pre-existing pyproject.toml version-specifier issue, out of scope)
- [ ] First retrofit of an actual elevated-risk tool to use `_gate.require_confirmation()` — owned by the dependent issues (`Hermes#476` if migrate-email is elevated; `martymcenroe/unleashed#635` for the commit-message scrub script — Clio identified these as the first concrete use cases)

## Scope

This PR fully addresses **#1230** (standard tightening + fleet audit + per-tool issue filings). All 14 audited tools were conformant; no per-tool issues needed.

This PR **partially addresses #1231**: ships reference implementation + standard update (2 of 3 mandatory-to-close items). The remaining item ("at least one existing elevated-risk tool retrofitted") is owned by dependent per-repo issues — the AZ-managed fleet contains no elevated-tier tools today, so the first retrofit will land via `Hermes#476` or `martymcenroe/unleashed#635`.

Closes #1230