### PR TITLE
docs: align gh-reviews alias name in runbooks 0936 + 0937 (Closes #1249)

### DIFF
--- a/docs/runbooks/0936-gh-cli-aliases.md
+++ b/docs/runbooks/0936-gh-cli-aliases.md
@@ -23,7 +23,7 @@ These are different mechanisms with different invocation patterns. A name like `
 |---|---|---|---|
 | `co` | `gh co <pr>` | `gh pr checkout` shortcut | built-in `gh` shortcut |
 | `gh-count` | `gh gh-count` | Today's contribution breakdown (commits, issues, PRs, reviews, repos) | `automation-scripts/tools/gh_daily_contributions.py` |
-| `reviews` | `gh reviews` | All-time review count + 12-month breakdown + projection to 1% graph spoke | `automation-scripts/tools/gh_review_projection.py` |
+| `gh-reviews` | `gh gh-reviews` | All-time review count + 12-month breakdown + projection to 1% graph spoke | `automation-scripts/tools/gh_review_projection.py` |
 
 ### Shell aliases (inspect with `alias` or `type`)
 
@@ -78,5 +78,5 @@ The orphaned aliases are tracked for cleanup in AZ#1245.
 - AZ#1244 — work that produced this runbook
 - AZ#1245 — orphaned dotfiles aliases cleanup (follow-up)
 - `automation-scripts/tools/gh_daily_contributions.py` — `gh-count` implementation
-- `automation-scripts/tools/gh_review_projection.py` — `gh reviews` implementation
+- `automation-scripts/tools/gh_review_projection.py` — `gh gh-reviews` implementation
 - `~/.bash_profile` SECTION 0 — dotfiles auto-sync mechanism

--- a/docs/runbooks/0937-gh-cli-scripts.md
+++ b/docs/runbooks/0937-gh-cli-scripts.md
@@ -17,7 +17,7 @@ The tool is stdlib + the `gh` CLI only — no third-party deps. Tools shell out 
 | Tool | Invoked as | What it reports |
 |---|---|---|
 | `tools/gh_daily_contributions.py` | `gh gh-count` | Today's contribution breakdown (commits, issues, PRs, reviews, repos) |
-| `tools/gh_review_projection.py` | `gh reviews` | All-time review count, 12-month state, current pace, projection to 1% graph spoke |
+| `tools/gh_review_projection.py` | `gh gh-reviews` | All-time review count, 12-month state, current pace, projection to 1% graph spoke |
 
 When adding a new sibling tool: update this table, update the alias inventory in 0936, then `gh alias set <name> '!...'`.
 
@@ -131,7 +131,7 @@ This recipe catches:
 
 - [`0936-gh-cli-aliases.md`](0936-gh-cli-aliases.md) — alias mechanism, inventory, dotfiles divergence trap
 - AZ#1247 — work that produced this runbook
-- AZ#1244 — parent (gh reviews + projection tool ship)
+- AZ#1244 — parent (`gh gh-reviews` + projection tool ship)
 - `automation-scripts#49` — original tool ship
 - `automation-scripts#51` — denominator-fix issue + analysis
 - `automation-scripts/tools/gh_review_projection.py` — reference implementation of the math + verification recipe


### PR DESCRIPTION
Closes #1249

## Drift

The `gh reviews` work in AZ#1244 shipped with the alias named `reviews`, inconsistent with the existing `gh-count` (named `gh-count`, invoked as `gh gh-count`). The operator caught the inconsistency: `gh gh-reviews` returned `unknown command` on 2026-05-24.

## Changes

Both runbook inventory tables updated:

```diff
- | `reviews`   | `gh reviews`    | All-time review count + 12-month breakdown + projection to 1% graph spoke |
+ | `gh-reviews`| `gh gh-reviews` | All-time review count + 12-month breakdown + projection to 1% graph spoke |
```

Plus the in-body reference at the bottom of 0936 (`gh reviews implementation` → `gh gh-reviews implementation`) and the cross-reference line in 0937 (`gh reviews + projection tool ship` → `\`gh gh-reviews\` + projection tool ship`).

Four edits across two files, four lines changed.

## Companion work

- Local `gh` CLI alias: renamed via `gh alias delete reviews && gh alias set gh-reviews '!...'` — operator-local config, no commit needed
- Tool docstring: martymcenroe/automation-scripts PR #54 (filed alongside) adds explicit `Invocation: gh gh-reviews` documentation to the script's module docstring, which previously didn't reference the alias name at all
- Dotfiles orphan removal: martymcenroe/dotfiles PR #45 (closes AZ#1245)

## Verification

```bash
$ gh gh-reviews
GitHub review-projection for @martymcenroe  (as of 2026-05-24)
... [full output]
```

Confirmed live before this PR shipped.