### PR TITLE
tooling: verify_gpg_agent_ttl.py + runbook 0938 (gpg-agent cache TTL=0)

### DIFF
--- a/docs/runbooks/0938-verify-gpg-agent-ttl.md
+++ b/docs/runbooks/0938-verify-gpg-agent-ttl.md
@@ -1,0 +1,57 @@
+# Verify GPG-Agent Cache TTL = 0
+
+Sanity check that the gpg-agent passphrase cache is disabled (TTL=0 on all four directives) per ADR-0216 §6.2, **before** running any classic-PAT `--execute` script. Both the on-disk config AND the running agent are verified, because file-correct-but-agent-stale is a real failure mode immediately after editing the conf without restarting the agent.
+
+Run in **Git Bash** on Windows (or any POSIX shell elsewhere).
+
+## Why this matters
+
+ADR-0216's in-process PAT model assumes the PAT exists only in Python heap during a script invocation. That guarantee dissolves the moment gpg-agent caches the passphrase — any sibling process under the same user account can then call `gpg --decrypt classic-pat.gpg` and silently obtain the decrypted PAT.
+
+With TTL=0, every classic-PAT script invocation pops a fresh pinentry. A sibling's silent decrypt attempt surfaces a pinentry dialog the user can refuse. Without TTL=0, that attempt is invisible.
+
+## Run the check
+
+```
+python tools/verify_gpg_agent_ttl.py
+```
+
+Exit 0 = pass. Exit non-zero = remediation steps printed to stdout. No third-party dependencies; uses only `gpgconf`, `shutil`, `subprocess`, and `pathlib`.
+
+Two layers are verified:
+
+| Layer | What's checked |
+|---|---|
+| 1. Conf file | `gpgconf --list-dirs homedir` reports the gpg home directory; the script reads `<homedir>/gpg-agent.conf` and confirms each of `default-cache-ttl`, `max-cache-ttl`, `default-cache-ttl-ssh`, `max-cache-ttl-ssh` is set to `0`. |
+| 2. Running agent | `gpgconf --list-options gpg-agent` is queried; the script parses the last colon-separated field per line (the current loaded value) and confirms all four directives report `0`. |
+
+A common failure mode is Layer 1 passing while Layer 2 fails: the conf file was edited but the running agent wasn't restarted, so it's still using the previous in-memory values. Remediation: `gpgconf --kill gpg-agent`. The next gpg invocation spawns a fresh agent that reads the updated conf.
+
+## When to run
+
+- **Before** any `--execute` invocation of a classic-PAT script (any tool that sources `tools/_pat_session.py`).
+- After a Windows reboot — the agent restarts; verify its loaded settings still match the conf.
+- After a GnuPG upgrade — package installers occasionally relocate the homedir or rewrite default config.
+- Any "did this drift?" suspicion before a destructive operation.
+
+## If the conf file is missing the directives
+
+If Layer 1 fails because the conf file doesn't declare the directives, append them and restart the agent:
+
+```
+cat >> ~/.gnupg/gpg-agent.conf <<'EOF'
+default-cache-ttl 0
+max-cache-ttl 0
+default-cache-ttl-ssh 0
+max-cache-ttl-ssh 0
+EOF
+gpgconf --kill gpg-agent
+```
+
+Then re-run the verification — both layers should now report 0.
+
+## Cross-references
+
+- ADR-0216 §6.2 — passphrase caching as a real-not-theoretical attack class
+- Runbook [0930](0930-gpg-and-classic-pat-rotation.md) — full gpg key + classic-PAT rotation lifecycle
+- `tools/_pat_session.py` — the classic-PAT context manager whose protection depends on this setting

--- a/tools/verify_gpg_agent_ttl.py
+++ b/tools/verify_gpg_agent_ttl.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""verify_gpg_agent_ttl.py -- confirm gpg-agent cache TTL=0 per ADR-0216 sec 6.2.
+
+Two-layer check:
+  1. gpg-agent.conf contains all four cache-ttl directives explicitly set to 0
+  2. The running gpg-agent reports current value 0 on all four
+
+Exit 0 = both layers pass.
+Exit 1 = at least one layer reports a non-compliant TTL; remediation printed.
+Exit 2 = infrastructure problem (gpgconf missing, homedir not found, etc.).
+
+Run from anywhere; the script touches no state. The conf file path is
+discovered via `gpgconf --list-dirs homedir`, so it works on any host where
+GnuPG is installed.
+
+See docs/runbooks/0938-verify-gpg-agent-ttl.md for the operator-facing guide.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+REQUIRED = (
+    "default-cache-ttl",
+    "max-cache-ttl",
+    "default-cache-ttl-ssh",
+    "max-cache-ttl-ssh",
+)
+
+
+def die(msg: str) -> NoReturn:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def _msys_to_windows(p: str) -> str:
+    """Convert MSYS-style /c/Users/... into Windows-native C:\\Users\\... .
+
+    gpgconf on Windows ships in the Git for Windows MSYS bundle and emits
+    POSIX-style paths (`/c/...`) regardless of the invoking shell. Python's
+    `pathlib.Path` on Windows does not recognize that drive-letter idiom,
+    so we normalize before constructing the Path.
+    """
+    if sys.platform != "win32":
+        return p
+    if len(p) >= 3 and p[0] == "/" and p[1].isalpha() and p[2] == "/":
+        return p[1].upper() + ":" + p[2:].replace("/", "\\")
+    return p
+
+
+def gpg_homedir() -> Path:
+    if not shutil.which("gpgconf"):
+        die("gpgconf not on PATH (need GnuPG; on Windows it ships with Git for Windows)")
+    out = subprocess.run(
+        ["gpgconf", "--list-dirs", "homedir"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if not out:
+        die("gpgconf --list-dirs homedir returned an empty path")
+    return Path(_msys_to_windows(out))
+
+
+def read_conf(conf_path: Path) -> dict[str, str]:
+    """Return {directive: value} parsed from gpg-agent.conf."""
+    if not conf_path.exists():
+        die(f"conf file does not exist: {conf_path}")
+    found: dict[str, str] = {}
+    for raw in conf_path.read_text(encoding="utf-8").splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#"):
+            continue
+        parts = s.split(None, 1)
+        if len(parts) != 2:
+            continue
+        directive, value = parts[0], parts[1].strip()
+        if directive in REQUIRED:
+            found[directive] = value
+    return found
+
+
+def query_running_agent() -> dict[str, str]:
+    """Return {option: current_value} from `gpgconf --list-options gpg-agent`.
+
+    Each line is colon-separated; the LAST field is the configured value
+    (empty string = unconfigured, agent uses compiled-in default).
+    """
+    out = subprocess.run(
+        ["gpgconf", "--list-options", "gpg-agent"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    found: dict[str, str] = {}
+    for line in out.splitlines():
+        parts = line.split(":")
+        if not parts:
+            continue
+        name = parts[0]
+        if name in REQUIRED:
+            found[name] = parts[-1]
+    return found
+
+
+def main() -> int:
+    home = gpg_homedir()
+    conf = home / "gpg-agent.conf"
+    failures: list[str] = []
+
+    print(f"gpg homedir: {home}")
+    print(f"conf file:   {conf}")
+    print()
+
+    print("[1/2] gpg-agent.conf:")
+    conf_vals = read_conf(conf)
+    for d in REQUIRED:
+        v = conf_vals.get(d)
+        if v == "0":
+            print(f"  OK    {d} = 0")
+        elif v is None:
+            print(f"  FAIL  {d} = (missing)")
+            failures.append(f"add `{d} 0` to {conf}")
+        else:
+            print(f"  FAIL  {d} = {v} (want 0)")
+            failures.append(f"change `{d} {v}` to `{d} 0` in {conf}")
+
+    print()
+    print("[2/2] running gpg-agent:")
+    agent_vals = query_running_agent()
+    for d in REQUIRED:
+        v = agent_vals.get(d)
+        if v == "0":
+            print(f"  OK    {d} = 0")
+        elif not v:
+            print(f"  FAIL  {d} = (unconfigured; agent uses non-zero default)")
+            failures.append(
+                "run `gpgconf --kill gpg-agent` so the next gpg call spawns a fresh "
+                "agent that reads the updated conf"
+            )
+        else:
+            print(f"  FAIL  {d} = {v} (want 0)")
+            failures.append(
+                "run `gpgconf --kill gpg-agent` so the next gpg call spawns a fresh "
+                "agent that reads the updated conf"
+            )
+
+    print()
+    if failures:
+        print("Remediation:")
+        for f in sorted(set(failures)):
+            print(f"  - {f}")
+        return 1
+
+    print("PASS: all four cache-TTL directives are 0 in both conf and running agent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- New: `tools/verify_gpg_agent_ttl.py` — two-layer check that gpg-agent cache TTL is 0 per ADR-0216 §6.2. Checks both the on-disk `gpg-agent.conf` AND the running agent's current loaded values, because file-correct-but-agent-stale is a real failure mode after `conf` edits without `gpgconf --kill gpg-agent`.
- New: `docs/runbooks/0938-verify-gpg-agent-ttl.md` — companion runbook (why this matters / when to run / remediation).
- Stdlib only, no third-party deps. Handles the MSYS `/c/Users/...` path idiom that Git-for-Windows `gpgconf` emits.

Exit codes: `0` pass, `1` TTL non-compliant + remediation printed, `2` infrastructure issue.

## Verification

Ran on the operator's machine before this PR — both layers PASS, exit 0:

```
gpg homedir: C:\Users\mcwiz\.gnupg
conf file:   C:\Users\mcwiz\.gnupg\gpg-agent.conf

[1/2] gpg-agent.conf:
  OK    default-cache-ttl = 0
  OK    max-cache-ttl = 0
  OK    default-cache-ttl-ssh = 0
  OK    max-cache-ttl-ssh = 0

[2/2] running gpg-agent:
  OK    default-cache-ttl = 0
  OK    max-cache-ttl = 0
  OK    default-cache-ttl-ssh = 0
  OK    max-cache-ttl-ssh = 0

PASS: all four cache-TTL directives are 0 in both conf and running agent.
```

## Why this matters

ADR-0216's in-process PAT model assumes the PAT exists only in Python heap during a script invocation. If gpg-agent caches the passphrase (TTL>0), any sibling process under the same user can call `gpg --decrypt classic-pat.gpg` and silently obtain the PAT while the cache is warm. TTL=0 forces pinentry every time, so sibling decrypt attempts surface a dialog the operator can refuse.

Now there's a one-command answer to "is this actually configured right on this host?" before running any classic-PAT `--execute` script.

## Cross-references

- ADR-0216 §6.2
- Runbook 0930 (sibling)
- Closes martymcenroe/unleashed#621 (operationally; the unleashed-side tracker for the same verification)

Closes #1252