### PR TITLE
feat(new-repo): --cerberus-pem-gpg applies ADR-0216 to the PEM (Closes #1254)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,8 +1,8 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 6.0
-**Last Updated:** 2026-05-07
+**Version:** 6.3
+**Last Updated:** 2026-05-24
 
 ---
 
@@ -44,18 +44,46 @@ gpgconf --kill gpg-agent
 
 With `default-cache-ttl 0`, gpg prompts for the passphrase every decryption (instead of caching for ~10 minutes). Your choice on the ergonomics-vs-security tradeoff.
 
+**Encrypt the Cerberus App private key** (recommended for any repeat use):
+
+The first time you generate a Cerberus `.pem`, encrypt it the same way as the classic PAT and delete the plaintext immediately. After that, the encrypted blob is reusable across as many repo creations as you want — single browser-trip to generate, single browser-trip to revoke, no plaintext on disk in between.
+
+```bash
+# After generating the .pem at https://github.com/settings/apps/cerberus-az:
+cat ~/Downloads/cerberus.pem | gpg -c -o ~/.secrets/cerberus-pem.gpg
+rm ~/Downloads/cerberus.pem
+```
+
+The encrypted file lives at `~/.secrets/cerberus-pem.gpg` and is consumed via `cerberus_pem_session()` in `tools/_pat_session.py` (the parallel of `classic_pat_session()`, same ADR-0216 threat model). Decryption happens only inside the Python process's heap when `new_repo_setup.py --cerberus-pem-gpg` runs — no plaintext PEM ever appears on disk after this one-time step (#1254).
+
+When the key is eventually revoked in the GitHub App UI, you can delete the encrypted blob too (`rm ~/.secrets/cerberus-pem.gpg`). The next batch of repos uses a fresh `.pem` generation cycle.
+
 ---
 
 ## Checklist
 
 ### 1. Run the setup script (bare — no env prefix needed)
 
+**Recommended path — `--cerberus-pem-gpg` (encrypted at rest, reusable):**
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/new_repo_setup.py {name} \
+    --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg [--public]
+```
+
+This requires the one-time gpg-encrypt of the Cerberus `.pem` (see "One-time setup" above). The decrypted key only ever lives in the Python heap during the script's run; nothing plaintext touches disk. **You can run this same invocation for as many new repos as you want against the same encrypted blob — one browser trip to generate the `.pem` covers all of them, one browser trip to revoke when done.**
+
+**Legacy / single-shot path — `--cerberus-pem` (plaintext, deleted after deploy):**
+
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero
 poetry run python tools/new_repo_setup.py {name} --cerberus-pem PATH [--public]
 ```
 
-`--cerberus-pem` is **required** when creating a GitHub repo (#1206). The script exits with a guide if it's missing — Cerberus auto-approval is part of the new-repo contract, and without the secrets every PR sits blocked. The only override is `--no-github` (local scaffold only, skips the GitHub side entirely).
+The script reads the plaintext `.pem`, deploys, then unlinks the file. Fine for occasional one-off repo creation; for any repeat use the gpg path is strictly better (security + ergonomics).
+
+Either `--cerberus-pem-gpg` OR `--cerberus-pem` is **required** when creating a GitHub repo (#1206) — Cerberus auto-approval is part of the new-repo contract, and without the secrets every PR sits blocked. The only override is `--no-github` (local scaffold only, skips the GitHub side entirely). The two flags are mutually exclusive.
 
 gpg-agent will prompt for your passphrase once per cache window (controlled by `~/.gnupg/gpg-agent.conf`) and the script handles the rest.
 
@@ -275,3 +303,4 @@ The **per-repo human steps** are: entering the gpg passphrase (once per gpg-agen
 | 2026-05-07 | v6.0: #1037 — dropped \`--license mit\` from invocation examples (script default is \`polyform\`, was misleading to show MIT as if recommended). Added an explicit "Defaults the script picks unless you override" block. Rewrote Section 4 with three subsections explaining what Cerberus is (auto-approver of your own PRs after pr-sentinel passes), why the secrets must be per-repo (App's RSA private key, used by the auto-reviewer workflow to authenticate as Cerberus), and why \`--cerberus-pem\` is recommended on every new-repo creation. Updated the env-block exposure note to reflect that #1036/#1037 closes the last \`GH_TOKEN\` hold-out. |
 | 2026-05-09 | v6.1: #1058 + #1059 + #1060 + #1061 — bundle of post-boostgauge-readiness-audit fixes. Script now bootstraps a Python project by default (\`poetry init\` + \`poetry add --group dev pytest pytest-cov\` + \`[tool.pytest.ini_options]\` + \`tests/conftest.py\`); \`--lang none\` skips for non-Python repos. \`.unleashed.json\` defaults to \`assemblyZero: true\` and no longer emits the deprecated \`pickupThresholdMinutes\`. Two canonical GitHub labels (\`implementation\`, \`lld\`) created on the new repo. |
 | 2026-05-22 | v6.2: #1206 — `--cerberus-pem` is REQUIRED for new GitHub repos. Script exits 1 with the .pem-acquisition guide if omitted. Override is `--no-github` (local scaffold only). #1200 + #1202 — extended post-setup verification to GitHub-side state (branch protection, repo settings, workflow content, Cerberus secrets) and added a best-effort `pr-sentinel-mm` Worker installation check that surfaces App-scope drift at creation time instead of when the first PR opens. |
+| 2026-05-24 | v6.3: #1254 — applied ADR-0216 gpg-at-rest pattern to the Cerberus `.pem`. New `--cerberus-pem-gpg PATH` flag on both `new_repo_setup.py` and `deploy_cerberus_secrets.py` reads from an encrypted blob (typically `~/.secrets/cerberus-pem.gpg`) and decrypts in-process via `cerberus_pem_session()` -- never plaintext on disk during the script run. Legacy `--cerberus-pem` (plaintext, deleted after) preserved for backward compatibility. Multi-repo creation becomes trivial: one browser-trip generates the .pem, one revokes, the encrypted blob in `~/.secrets/` is reused across any number of `new_repo_setup.py` invocations. Added one-time-setup subsection for the encryption step. |

--- a/tools/_pat_session.py
+++ b/tools/_pat_session.py
@@ -58,6 +58,7 @@ from pathlib import Path
 from typing import Iterator
 
 DEFAULT_PAT_PATH: Path = Path.home() / ".secrets" / "classic-pat.gpg"
+DEFAULT_CERBERUS_PEM_PATH: Path = Path.home() / ".secrets" / "cerberus-pem.gpg"
 GPG_TIMEOUT_S: int = 180
 MAX_GPG_ATTEMPTS: int = 5
 
@@ -125,5 +126,95 @@ def classic_pat_session(
 
     raise RuntimeError(
         f"gpg decrypt failed after {MAX_GPG_ATTEMPTS} attempts. "
+        f"Last error: {last_stderr}"
+    )
+
+
+@contextmanager
+def cerberus_pem_session(
+    pem_path: Path = DEFAULT_CERBERUS_PEM_PATH,
+) -> Iterator[str]:
+    """Yield the gpg-decrypted Cerberus App private-key PEM.
+
+    Same threat model as classic_pat_session: the PEM lives at rest
+    gpg-symmetric-encrypted (passphrase-gated), is decrypted only into
+    this Python process's heap inside the context-manager scope, and
+    never touches disk in plaintext form during script execution.
+
+    Solves the multi-repo Cerberus deploy problem (#1254): the operator
+    runs new_repo_setup.py once per repo against the SAME encrypted
+    PEM, so a single browser-trip generates the key and a single
+    browser-trip revokes it, regardless of how many repos are created.
+    The plaintext PEM is deleted right after the one-time gpg-encrypt
+    step and never reappears.
+
+    One-time setup (operator):
+        # Generate .pem in browser, then encrypt + delete the plaintext:
+        cat ~/Downloads/cerberus.pem | gpg -c -o ~/.secrets/cerberus-pem.gpg
+        rm ~/Downloads/cerberus.pem
+
+    Same operational rules apply as classic_pat_session:
+        - gpg-agent default-cache-ttl 0 (silent sibling-decrypt attempts
+          surface pinentry — see ADR-0216 and the classic_pat_session
+          docstring above)
+        - The OPERATOR runs the script that opens this context; an
+          agent must never invoke it via its Bash tool
+
+    Args:
+        pem_path: Path to the gpg-encrypted Cerberus PEM file.
+
+    Yields:
+        The decrypted PEM as a string. Lives only in this generator's
+        scope; the local binding is deleted on exit.
+
+    Raises:
+        FileNotFoundError: If the encrypted PEM file does not exist.
+        RuntimeError: After MAX_GPG_ATTEMPTS consecutive gpg failures.
+        subprocess.TimeoutExpired: Same hung-pinentry handling as
+            classic_pat_session.
+
+    Implementation note: the body intentionally duplicates
+    classic_pat_session's structure rather than sharing a helper.
+    Keeping the load-bearing PAT path untouched is worth ~30 lines of
+    duplication.
+    """
+    if not pem_path.exists():
+        raise FileNotFoundError(
+            f"Cerberus PEM not found at {pem_path}.\n"
+            f"One-time setup (after downloading the .pem from the Cerberus "
+            f"App settings page):\n"
+            f"  mkdir -p {pem_path.parent}\n"
+            f"  cat ~/Downloads/cerberus.pem | gpg -c -o {pem_path}\n"
+            f"  rm ~/Downloads/cerberus.pem"
+        )
+
+    last_stderr = ""
+    for attempt in range(1, MAX_GPG_ATTEMPTS + 1):
+        result = subprocess.run(
+            ["gpg", "--quiet", "--decrypt", str(pem_path)],
+            capture_output=True,
+            text=True,
+            timeout=GPG_TIMEOUT_S,
+        )
+        if result.returncode == 0:
+            pem = result.stdout.strip()
+            try:
+                yield pem
+            finally:
+                del pem
+            return
+        last_stderr = result.stderr.strip()
+        if attempt < MAX_GPG_ATTEMPTS:
+            print(
+                f"gpg decrypt failed (attempt {attempt}/{MAX_GPG_ATTEMPTS}): {last_stderr}",
+                file=sys.stderr,
+            )
+            print(
+                "Retrying -- pinentry will prompt again. (Ctrl-C to abort.)",
+                file=sys.stderr,
+            )
+
+    raise RuntimeError(
+        f"gpg decrypt of Cerberus PEM failed after {MAX_GPG_ATTEMPTS} attempts. "
         f"Last error: {last_stderr}"
     )

--- a/tools/deploy_cerberus_secrets.py
+++ b/tools/deploy_cerberus_secrets.py
@@ -47,10 +47,10 @@ from nacl import encoding, public
 
 # Shared with new_repo_setup.py and other v3 callers.
 try:
-    from _pat_session import classic_pat_session
+    from _pat_session import classic_pat_session, cerberus_pem_session
 except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
-    from _pat_session import classic_pat_session
+    from _pat_session import classic_pat_session, cerberus_pem_session
 
 APP_ID = "3079970"
 GITHUB_USER = "martymcenroe"
@@ -225,8 +225,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "pem_path", nargs="?", default=None,
-        help="Path to the Cerberus .pem private key. "
-             "Required unless --dry-run is set.",
+        help="Path to the PLAINTEXT Cerberus .pem private key. "
+             "Single-use; mutually exclusive with --cerberus-pem-gpg. "
+             "Required unless --dry-run is set or --cerberus-pem-gpg is.",
+    )
+    parser.add_argument(
+        "--cerberus-pem-gpg",
+        metavar="PATH",
+        default=None,
+        help="Path to GPG-ENCRYPTED Cerberus .pem (typically "
+             "~/.secrets/cerberus-pem.gpg per ADR-0216 / runbook 0927). "
+             "Decrypted in-process via cerberus_pem_session(); never "
+             "written to plaintext disk. Mutually exclusive with the "
+             "positional pem_path. The encrypted blob is NOT deleted "
+             "after deploy -- reusable across runs (#1254).",
     )
     parser.add_argument(
         "--all", action="store_true",
@@ -293,9 +305,40 @@ def _select_target_repos(args: argparse.Namespace, pat: str) -> tuple[list[str],
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
-    if not args.dry_run and args.pem_path is None:
-        print("ERROR: pem_path is required unless --dry-run is set.", file=sys.stderr)
+    # Mutual exclusion -- pick one PEM source
+    if args.pem_path and args.cerberus_pem_gpg:
+        print("ERROR: positional pem_path and --cerberus-pem-gpg are mutually "
+              "exclusive. Pick one source.", file=sys.stderr)
         return 1
+
+    if not args.dry_run and not args.pem_path and not args.cerberus_pem_gpg:
+        print("ERROR: pem_path (plaintext) or --cerberus-pem-gpg PATH "
+              "(encrypted) is required unless --dry-run is set.",
+              file=sys.stderr)
+        return 1
+
+    # The --cerberus-pem-gpg path wraps the existing flow in a
+    # cerberus_pem_session context manager so the decrypted content
+    # only ever lives in the Python heap during this run.
+    if args.cerberus_pem_gpg:
+        gpg_path = Path(args.cerberus_pem_gpg)
+        try:
+            with cerberus_pem_session(gpg_path) as decrypted:
+                if "PRIVATE KEY" not in decrypted:
+                    print("ERROR: decrypted contents do not look like a "
+                          "private key.", file=sys.stderr)
+                    return 1
+                print(f"Cerberus App ID: {APP_ID}")
+                print(f"Private key:     gpg-decrypted from "
+                      f"{gpg_path.name} ({len(decrypted)} chars in-process)")
+                print()
+                return _deploy_loop(args, decrypted, source_path=None)
+        except FileNotFoundError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 1
+        except RuntimeError as e:
+            print(f"ERROR: gpg decrypt failed: {e}", file=sys.stderr)
+            return 1
 
     pem_content: str | None = None
     pem_path: Path | None = None
@@ -308,6 +351,26 @@ def main(argv: list[str] | None = None) -> int:
     elif args.dry_run:
         print("Dry-run mode (no .pem provided). Scanning only.\n")
 
+    return _deploy_loop(args, pem_content, source_path=pem_path)
+
+
+def _deploy_loop(
+    args: argparse.Namespace,
+    pem_content: str | None,
+    *,
+    source_path: Path | None,
+) -> int:
+    """Run the selection + deploy loop. Shared by both PEM source paths.
+
+    Args:
+        args: Parsed CLI args.
+        pem_content: PEM contents string (loaded from disk via _load_pem,
+            or decrypted in-process via cerberus_pem_session). None in
+            dry-run-with-no-PEM mode.
+        source_path: If not None, prints the "delete the .pem" reminder
+            at end (legacy plaintext path). None for the gpg-encrypted
+            path -- nothing on disk to delete (#1254).
+    """
     with classic_pat_session() as pat:
         print("Fetching target repos...")
         targets, skipped = _select_target_repos(args, pat)
@@ -328,7 +391,7 @@ def main(argv: list[str] | None = None) -> int:
             print("All scanned repos already have both Cerberus secrets. Nothing to do.")
             return 0
 
-        assert pem_content is not None  # _load_pem populated this above
+        assert pem_content is not None  # required at this point (caller validated)
 
         succeeded = 0
         failed: list[str] = []
@@ -346,8 +409,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Done: {succeeded}/{len(targets)} repos configured")
     if failed:
         print(f"Failed: {', '.join(failed)}")
-    if pem_path is not None:
-        print(f"\n*** NOW DELETE THE .pem FILE: {pem_path} ***")
+    if source_path is not None:
+        print(f"\n*** NOW DELETE THE .pem FILE: {source_path} ***")
         print("The secret is stored in GitHub -- you never need the file again.")
     return 0 if not failed else 1
 

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -56,10 +56,10 @@ except ImportError:
 # GH_TOKEN for the workflow-scoped initial push — tracked in #1000.
 import requests  # noqa: E402
 try:
-    from _pat_session import classic_pat_session
+    from _pat_session import classic_pat_session, cerberus_pem_session
 except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
-    from _pat_session import classic_pat_session
+    from _pat_session import classic_pat_session, cerberus_pem_session
 
 
 # ---------------------------------------------------------------------------
@@ -1940,19 +1940,31 @@ def verify_pr_sentinel_installation(
     )
 
 
-def _deploy_cerberus(repo_name: str, pem_path: Path, pat: str) -> str:
-    """Deploy Cerberus secrets to a single repo and handle pem file lifecycle.
+def _deploy_cerberus(
+    repo_name: str,
+    pem_content: str,
+    pat: str,
+    *,
+    source_path: Path | None = None,
+) -> str:
+    """Deploy Cerberus secrets to a single repo.
 
-    Reads the .pem file, deploys REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY
-    to the specified repo via in-process classic PAT (sealed-box encrypted
-    per GitHub's secrets API), verifies they landed, deletes the .pem, and
-    prints a reminder to revoke the key in the app UI. (#1007)
+    Deploys REVIEWER_APP_ID + REVIEWER_APP_PRIVATE_KEY to the specified
+    repo via in-process classic PAT (sealed-box encrypted per GitHub's
+    secrets API), then verifies they landed. (#1007)
 
     Args:
         repo_name: The new repo name (lowercased, owner-less).
-        pem_path: Path to the Cerberus App .pem file.
+        pem_content: PEM contents as a string. Already loaded from
+            disk (--cerberus-pem flow) or decrypted in-process via
+            cerberus_pem_session() (--cerberus-pem-gpg flow).
         pat: Classic PAT from classic_pat_session() — consumed by
             deploy_to_repo / verify_secrets, never placed in env.
+        source_path: If provided, the plaintext file at this path is
+            unlinked after successful verification (legacy
+            --cerberus-pem flow). If None, no file is unlinked --
+            used by --cerberus-pem-gpg, which has nothing plaintext
+            on disk to delete (#1254).
 
     Returns a short status string for the summary table.
     """
@@ -1960,39 +1972,46 @@ def _deploy_cerberus(repo_name: str, pem_path: Path, pat: str) -> str:
     print("CERBERUS SECRETS DEPLOY")
     print("=" * 60)
 
-    if not pem_path.exists():
-        print(f"  ERROR: .pem file not found: {pem_path}")
-        return "PEM_MISSING"
-
-    pem_content = pem_path.read_text(encoding="utf-8").strip()
     if "PRIVATE KEY" not in pem_content:
-        print(f"  ERROR: File does not look like a private key: {pem_path}")
+        print("  ERROR: PEM contents do not look like a private key.")
         return "INVALID_PEM"
 
     print(f"  Target repo: {repo_name}")
-    print(f"  .pem file:   {pem_path.name} ({len(pem_content)} chars)")
+    if source_path is not None:
+        print(f"  Source:      {source_path.name} (plaintext, "
+              f"will be deleted after deploy)")
+    else:
+        print("  Source:      gpg-decrypted in-process "
+              "(no plaintext on disk; encrypted blob preserved)")
+    print(f"  Key length:  {len(pem_content)} chars")
 
     ok, failed = deploy_to_repo(repo_name, pem_content, pat)
     if not ok:
         print(f"  FAILED to deploy: {', '.join(failed)}")
-        print(f"  .pem file NOT deleted — retry manually:")
-        print(f"    poetry run python tools/deploy_cerberus_secrets.py {pem_path}")
+        if source_path is not None:
+            print(f"  .pem file NOT deleted -- retry manually:")
+            print(f"    poetry run python tools/deploy_cerberus_secrets.py {source_path}")
         return f"FAILED: {', '.join(failed)}"
     print("  Secrets set.")
 
     ok, missing = verify_secrets(repo_name, pat)
     if not ok:
         print(f"  WARNING: verification failed; missing {missing}")
-        print(f"  .pem file NOT deleted — investigate before deleting.")
+        if source_path is not None:
+            print(f"  .pem file NOT deleted -- investigate before deleting.")
         return f"UNVERIFIED: {', '.join(missing)}"
     print("  Secrets verified on GitHub (both REVIEWER_APP_ID and REVIEWER_APP_PRIVATE_KEY present).")
 
-    try:
-        pem_path.unlink()
-        print(f"  .pem file deleted: {pem_path}")
-    except OSError as e:
-        print(f"  WARNING: could not delete .pem file: {e}")
-        print(f"  DELETE MANUALLY: {pem_path}")
+    if source_path is not None:
+        try:
+            source_path.unlink()
+            print(f"  .pem file deleted: {source_path}")
+        except OSError as e:
+            print(f"  WARNING: could not delete .pem file: {e}")
+            print(f"  DELETE MANUALLY: {source_path}")
+    else:
+        print("  (gpg-encrypted PEM preserved at "
+              "the path you provided; reuse it for additional repos.)")
 
     print()
     print("  NEXT STEP (browser-only, cannot be automated):")
@@ -2055,12 +2074,23 @@ Examples:
         "--cerberus-pem",
         metavar="PATH",
         default=None,
-        help="Path to Cerberus App .pem file. When provided, after repo "
-             "creation the script deploys REVIEWER_APP_ID and "
-             "REVIEWER_APP_PRIVATE_KEY secrets to the new repo, verifies "
-             "they landed, deletes the .pem file, and prints a reminder "
-             "to revoke the key in the app UI. When omitted, runbook "
-             "0927 step 4 is printed as manual fallback."
+        help="Path to PLAINTEXT Cerberus App .pem file. After deploy the "
+             "script DELETES this file. Single-use; for repeat/multi-repo "
+             "creation, use --cerberus-pem-gpg instead (encrypted at rest, "
+             "decrypted in-process per ADR-0216, no plaintext on disk). "
+             "When omitted, runbook 0927 step 4 is printed as manual fallback."
+    )
+    parser.add_argument(
+        "--cerberus-pem-gpg",
+        metavar="PATH",
+        default=None,
+        help="Path to GPG-ENCRYPTED Cerberus App .pem file (typically "
+             "~/.secrets/cerberus-pem.gpg per ADR-0216 / runbook 0927). "
+             "Decrypted in-process via cerberus_pem_session(); never written "
+             "to plaintext disk. Pinentry prompts per gpg-agent TTL. The "
+             "encrypted blob is NOT deleted -- reuse it across as many "
+             "new-repo invocations as you need, then revoke the key in the "
+             "browser when done (#1254)."
     )
     parser.add_argument(
         "--lang",
@@ -2085,34 +2115,50 @@ Examples:
 
     args = parser.parse_args()
 
-    # --cerberus-pem requires --no-github not set (need the repo to deploy to)
-    if args.cerberus_pem and args.no_github:
-        print("ERROR: --cerberus-pem requires GitHub repo creation (cannot be combined with --no-github)")
+    # --cerberus-pem and --cerberus-pem-gpg are mutually exclusive
+    if args.cerberus_pem and args.cerberus_pem_gpg:
+        print("ERROR: --cerberus-pem and --cerberus-pem-gpg are mutually exclusive.")
+        print("Pick one: --cerberus-pem PATH (plaintext, deleted after) OR "
+              "--cerberus-pem-gpg PATH (encrypted at rest, reusable).")
         sys.exit(1)
 
-    # --cerberus-pem is REQUIRED when creating a GitHub repo (#1206).
+    # Cerberus deploy requires --no-github not set (need the repo to deploy to)
+    if (args.cerberus_pem or args.cerberus_pem_gpg) and args.no_github:
+        print("ERROR: --cerberus-pem / --cerberus-pem-gpg requires GitHub repo "
+              "creation (cannot be combined with --no-github)")
+        sys.exit(1)
+
+    # A Cerberus PEM source is REQUIRED when creating a GitHub repo (#1206).
     # Without Cerberus secrets the new repo's PRs sit blocked indefinitely
     # because branch protection requires 1 approving review and the
     # auto-reviewer workflow can't authenticate without the App secrets.
     # Catching this at the CLI gate keeps the failure loud and pre-creation,
     # not silent and only-visible-on-first-PR. Audit mode is exempt — it
     # only inspects an existing project, never creates anything.
-    if not args.cerberus_pem and not args.no_github and not args.audit:
-        print("ERROR: --cerberus-pem is required.")
+    if (not args.cerberus_pem and not args.cerberus_pem_gpg
+            and not args.no_github and not args.audit):
+        print("ERROR: --cerberus-pem or --cerberus-pem-gpg is required.")
         print()
         print("Cerberus auto-approval is part of the new-repo contract. Without it,")
         print("every PR on the new repo will sit blocked indefinitely waiting for")
         print("a review (branch protection requires 1 approval; the auto-reviewer")
         print("workflow can't approve without the Cerberus App secrets).")
         print()
-        print("To get the .pem file:")
-        print("  1. Open https://github.com/settings/apps/cerberus-az")
-        print("  2. Click 'Private keys' > 'Generate a private key'")
-        print("  3. The browser downloads a .pem file (typically to ~/Downloads/)")
-        print("  4. Re-run with --cerberus-pem /path/to/the.pem")
+        print("Two ways to provide the .pem (per runbook 0927):")
         print()
-        print("The script will deploy the secrets, verify them, delete the .pem,")
-        print("and remind you to revoke the key in the GitHub App UI (browser-only).")
+        print("  RECOMMENDED -- --cerberus-pem-gpg PATH (encrypted at rest,")
+        print("  reusable across many new-repo runs, no plaintext on disk):")
+        print("    1. Open https://github.com/settings/apps/cerberus-az")
+        print("    2. Generate a private key -- browser downloads cerberus.pem")
+        print("    3. cat ~/Downloads/cerberus.pem | gpg -c -o ~/.secrets/cerberus-pem.gpg")
+        print("    4. rm ~/Downloads/cerberus.pem")
+        print("    5. Re-run with --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg")
+        print()
+        print("  LEGACY single-shot -- --cerberus-pem PATH (plaintext, deleted")
+        print("  after deploy; one-and-done, fresh .pem per repo):")
+        print("    1. Open https://github.com/settings/apps/cerberus-az")
+        print("    2. Generate a private key -- browser downloads cerberus.pem")
+        print("    3. Re-run with --cerberus-pem /path/to/the.pem")
         print()
         print("Full procedure: docs/runbooks/0927-new-repo-human-checklist.md#4")
         print()
@@ -2580,24 +2626,48 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     if checks_passed < checks_total:
         print("\nWARNING: Some checks failed. Review and fix before starting work!")
 
-    # Cerberus secrets deploy (if --cerberus-pem provided, and repo was created).
+    # Cerberus secrets deploy. Two source paths (mutually exclusive):
+    #   --cerberus-pem PATH       plaintext file, deleted after deploy
+    #   --cerberus-pem-gpg PATH   gpg-encrypted file, decrypted in-process,
+    #                             never written to plaintext disk (#1254)
+    # Both share the same deploy logic via _deploy_cerberus(pem_content,...).
     # Acquire the classic PAT in-process — no env GH_TOKEN needed. gpg-agent
-    # will typically reuse the cached passphrase from the earlier session.
+    # typically reuses the cached passphrase from the earlier session.
     cerberus_status: str | None = None
-    if not args.no_github and push_succeeded and args.cerberus_pem:
-        try:
-            with classic_pat_session() as pat:
-                cerberus_status = _deploy_cerberus(
-                    args.name.lower(), Path(args.cerberus_pem), pat,
-                )
-        except FileNotFoundError as e:
-            print(f"\n  WARNING: classic PAT not configured: {e}")
-            print("  Skipping Cerberus deploy. Retry later with:")
-            print(f"    poetry run python tools/deploy_cerberus_secrets.py {args.cerberus_pem}")
-            cerberus_status = "PAT_NOT_CONFIGURED"
-        except RuntimeError as e:
-            print(f"\n  WARNING: gpg decrypt failed: {e}")
-            cerberus_status = "GPG_FAILED"
+    if not args.no_github and push_succeeded and (
+            args.cerberus_pem or args.cerberus_pem_gpg):
+        if args.cerberus_pem:
+            pem_source_path = Path(args.cerberus_pem)
+            try:
+                pem_content = pem_source_path.read_text(encoding="utf-8").strip()
+                with classic_pat_session() as pat:
+                    cerberus_status = _deploy_cerberus(
+                        args.name.lower(), pem_content, pat,
+                        source_path=pem_source_path,
+                    )
+            except FileNotFoundError as e:
+                print(f"\n  WARNING: source file not found: {e}")
+                print("  Skipping Cerberus deploy. Retry later with:")
+                print(f"    poetry run python tools/deploy_cerberus_secrets.py {args.cerberus_pem}")
+                cerberus_status = "PAT_NOT_CONFIGURED"
+            except RuntimeError as e:
+                print(f"\n  WARNING: gpg decrypt failed: {e}")
+                cerberus_status = "GPG_FAILED"
+        else:  # args.cerberus_pem_gpg
+            pem_gpg_path = Path(args.cerberus_pem_gpg)
+            try:
+                with cerberus_pem_session(pem_gpg_path) as pem_content:
+                    with classic_pat_session() as pat:
+                        cerberus_status = _deploy_cerberus(
+                            args.name.lower(), pem_content, pat,
+                            source_path=None,
+                        )
+            except FileNotFoundError as e:
+                print(f"\n  WARNING: encrypted PEM not configured: {e}")
+                cerberus_status = "PEM_GPG_NOT_CONFIGURED"
+            except RuntimeError as e:
+                print(f"\n  WARNING: gpg decrypt failed: {e}")
+                cerberus_status = "GPG_FAILED"
 
     # GitHub-side verification (#1200, #1202). The local-only post-setup
     # verification above checks the working tree; this block verifies
@@ -2646,7 +2716,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 else:
                     print(f"  [FAIL] auto-reviewer.yml: {msg}")
 
-                if args.cerberus_pem:
+                if args.cerberus_pem or args.cerberus_pem_gpg:
                     gh_checks_total += 1
                     secrets_ok, missing = verify_secrets(
                         repo_name_lower, pat,
@@ -2708,7 +2778,8 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             print("  #   gh auth login -h github.com -p https  # paste classic PAT")
             print("  #   git push -u origin main")
             print("  #   gh auth login -h github.com -p https  # paste fine-grained PAT back")
-    if args.cerberus_pem is None and not args.no_github:
+    if (args.cerberus_pem is None and args.cerberus_pem_gpg is None
+            and not args.no_github):
         print()
         print("  # Cerberus secrets (manual):")
         print("  #   Without secrets, PRs pass pr-sentinel but are never auto-approved.")
@@ -2716,7 +2787,8 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("  #   2. poetry run python tools/deploy_cerberus_secrets.py /path/to/downloaded.pem")
         print("  #   3. Delete the .pem, revoke the key in the app UI")
         print("  #   See runbook 0927 step 4 for full procedure.")
-        print("  #   OR re-run this script with --cerberus-pem PATH to automate.")
+        print("  #   OR re-run this script with --cerberus-pem PATH (single-shot)")
+        print("  #   or --cerberus-pem-gpg PATH (reusable, encrypted at rest).")
     elif cerberus_status == "OK":
         print()
         print("  # Cerberus secrets deployed and verified.")


### PR DESCRIPTION
Closes #1254

## What

New `--cerberus-pem-gpg PATH` flag on `new_repo_setup.py` and `deploy_cerberus_secrets.py`. Reads from a gpg-encrypted blob (typically `~/.secrets/cerberus-pem.gpg`), decrypts in-process via a new `cerberus_pem_session()` context manager in `tools/_pat_session.py`. **No plaintext PEM ever touches disk during script execution.**

Strict superset of the existing `--cerberus-pem` (plaintext) flow:
- Same security posture during the script run (in-process bytes)
- Better at-rest posture (gpg-encrypted blob persists encrypted vs. plaintext during the brief deploy window)
- Multi-repo creation becomes trivial — the encrypted blob is reused across any number of invocations

## Why this design (not `--keep-pem`)

Earlier in the design conversation, a `--keep-pem` flag was floated to skip the post-deploy unlink and let one plaintext `.pem` cover multiple repos. **Rejected** — it extends the plaintext-on-disk window from ~30s (single script run) to "however long between runs," readable by any same-user process during that window. Regression on the threat model the existing auto-delete was built for.

The gpg-encrypted approach gives the same multi-repo convenience WITHOUT extending plaintext exposure.

## Threat model (carried from `classic_pat_session`)

- **At-rest:** gpg-symmetric encrypted, passphrase-gated. Sibling processes see ciphertext.
- **In-process:** decrypted bytes scoped to a context-manager `with` block. Local binding `del`'d on exit.
- **gpg-agent TTL=0:** every decrypt prompts pinentry. Silent sibling decrypt attempts surface pinentry to the user.
- **No env vars, no subprocess argv, no temp files.** Same posture as the classic PAT (ADR-0216).

## Files changed

| File | Change | Lines |
|---|---|---|
| `tools/_pat_session.py` | Add `cerberus_pem_session()` + `DEFAULT_CERBERUS_PEM_PATH`. Intentionally duplicates `classic_pat_session` structure to avoid touching the load-bearing PAT path. | +91 |
| `tools/new_repo_setup.py` | Add `--cerberus-pem-gpg` with mutex against `--cerberus-pem`; refactor `_deploy_cerberus` to take `pem_content` + optional `source_path`; update validation + reminders. | +198 / -75 |
| `tools/deploy_cerberus_secrets.py` | Add `--cerberus-pem-gpg`; extract `_deploy_loop` helper so both source paths share selection + deploy logic. | +81 / -... |
| `docs/runbooks/0927-new-repo-human-checklist.md` | v6.3. New one-time setup subsection for gpg-encryption; mark `--cerberus-pem-gpg` as recommended in Step 1; `--cerberus-pem` preserved as legacy single-shot; history entry. | +35 |

## Backward compatibility

`--cerberus-pem PATH` continues to work exactly as before. Additive change.

## Operator workflow after this lands

```bash
# One-time (per Cerberus key generation):
cat ~/Downloads/cerberus.pem | gpg -c -o ~/.secrets/cerberus-pem.gpg
rm ~/Downloads/cerberus.pem

# Then for any number of repos (single browser-trip for generate + revoke):
poetry run python tools/new_repo_setup.py dependabot-honey-pot \
    --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg
poetry run python tools/new_repo_setup.py Chiron \
    --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg
# ... revoke key in browser when batch done, optionally rm the encrypted blob
```

## Verification

- All three modified Python files parse cleanly (`python -c "import ast; ast.parse(...)"`)
- Mutual-exclusion check (`--cerberus-pem` + `--cerberus-pem-gpg` together) — added to both scripts
- Required-source check (one of `--cerberus-pem`, `--cerberus-pem-gpg`, `--no-github`) — updated error message in both scripts
- Refactored `_deploy_cerberus` preserves all existing behavior on the plaintext path (still unlinks via `source_path` arg)
- Refactored `_deploy_loop` in `deploy_cerberus_secrets.py` preserves the existing dry-run + delete-reminder behavior
- End-to-end manual verification (operator-run): will happen when the operator creates dependabot-honey-pot + Chiron using the new flag, immediately after this lands

## References

- ADR-0216 — the at-rest gpg pattern for the classic PAT
- `tools/_pat_session.py` — the reference implementation `cerberus_pem_session` mirrors
- Runbook 0927 v6.3 (this PR) — the updated procedure