### PR TITLE
feat(backup): nightly versioned snapshot of universal CLAUDE.md (Closes #1262)

### DIFF
--- a/docs/canonical/universal-CLAUDE.md
+++ b/docs/canonical/universal-CLAUDE.md
@@ -1,0 +1,348 @@
+﻿# CLAUDE.md - Projects Root (Universal Rules)
+
+These rules are auto-loaded for ALL projects. No tool call needed.
+
+## Identity (Ground Truth)
+
+- **GitHub:** `martymcenroe` â€” repos: `martymcenroe/Aletheia`, `martymcenroe/AssemblyZero`, `martymcenroe/Talos`
+- **AWS:** region `us-east-1`, account `383687041805`
+- **CloudFlare:** ONE account `4fe1c5e241425c85d0f2c35c69fb45b8` (mcwizard1@gmail.com) â€” all projects deploy here
+- **Domain:** `api.aletheia.study` (CloudFlare Worker: `aletheia-api`)
+- **Projects root:** `C:\Users\mcwiz\Projects`
+
+## Bash Tool Usage
+
+Use dedicated tools instead of shell commands:
+
+| Instead of | Use |
+|------------|-----|
+| `cat file.txt` | Read tool |
+| `grep pattern` | Grep tool |
+| `find . -name` | Glob tool |
+| `echo > file` | Write tool |
+
+AWS CLI on Windows: ALWAYS prefix with `MSYS_NO_PATHCONV=1`
+
+Always use `--repo` flag with `gh` CLI.
+
+## Path Format Rules
+
+| Tool | Path Format | Example |
+|------|-------------|---------|
+| Bash | Unix-style | `/c/Users/mcwiz/Projects/...` |
+| Read, Write, Edit, Glob | Windows-style | `C:\Users\mcwiz\Projects\...` |
+
+**NEVER use `~` - Windows doesn't support it.**
+
+## Dangerous Paths (I/O Safety)
+
+**NEVER search or traverse:**
+- `C:\Users\<user>\OneDrive\` â€” Files On-Demand triggers massive downloads
+- `C:\Users\<user>\` (root) â€” Contains OneDrive, AppData, 100K+ files
+- `C:\Users\<user>\AppData\` â€” Hundreds of thousands of small files
+
+Safe: scope to `C:\Users\mcwiz\Projects\` or narrower.
+
+**NEVER read or cat (secrets -- captured in transcripts):**
+- `.env`, `.env.*`, `.dev.vars` -- environment secrets
+- `~/.aws/credentials`, `~/.aws/config` -- AWS credentials
+- Any file matching `*secret*`, `*credential*`, `*token*` in name
+
+## Safety
+
+**Destructive commands ONLY within `C:\Users\mcwiz\Projects\`.** Outside that scope, no destructive operations.
+
+### Banned commands (ALWAYS, no exceptions, no per-invocation approval)
+
+The agent's Bash tool MUST NEVER execute these commands. They may appear in scripts the USER runs; they cannot appear in agent-driven shell calls.
+
+| Command / pattern | Alternative the agent uses |
+|-------------------|----------------------------|
+| `dd`, `mkfs`, `shred`, `format` | No alternative — no legitimate agent use |
+| `git push --force` / `--force-with-lease` (ANY branch) | GitHub Contents API via classic-PAT pattern (ADR-0216); otherwise the change isn't ready |
+| `git clone <SSH-url>` | `gh repo clone <owner>/<repo>` (HTTPS via token) |
+| `git reset --hard` | `git stash`; or delete + re-clone; never destroy uncommitted state |
+| `git clean -fd` | Delete specific identified files; never the "wipe all untracked" hammer |
+| `git branch -D` | ADR-0217 four-step `git replace --graft` recipe + `git branch -d` |
+| `git worktree remove --force` | Resolve worktree state via gentler means, then plain `git worktree remove` |
+| `--theirs` in a rebase | Manual conflict resolution keeping BOTH sides |
+| `--no-verify` / `--no-gpg-sign` on commit or push | Fix the hook OR fix what the hook is complaining about |
+| `--admin` on `gh pr merge` | Classic-PAT in-process decryption pattern (ADR-0216) |
+| `gh pr review --approve` on own PR | Cerberus-AZ auto-approves after pr-sentinel; let it |
+| `--auto` on `gh pr merge` | `allow_auto_merge: false` fleet-wide; flag silently no-ops |
+
+**Banned to the agent. NOT banned in scripts the user runs.** Classic-PAT pattern (ADR-0216) is the model: agent writes the script, user runs it. The script's source may contain banned commands; the agent's Bash tool may not execute them.
+
+### Squash-merge orphan exception
+
+When `git branch -d` refuses on a squash-merged local branch (different SHA from the squash commit on main; common after GitHub squash-and-delete-branch flows), use the four-step `git replace --graft` recipe in `AssemblyZero/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md`. Do NOT use `-D`. Verify content equivalence (`git diff <orphan-tip> <squash-on-main>` must return zero) before applying. Never rely on cached `refs/remotes/origin/<deleted-branch>` ref as upstream-tracking proof for `branch -d` — that's the brittle path the ADR rejects.
+
+NEVER kill other agents' processes — shared machine, concurrent workflows.
+NEVER run commands that print secrets to stdout — session transcripts capture everything. Give the user commands to run in their own terminal.
+
+## Destructive Scripts — `--apply` and `--execute`
+
+Scripts that mutate fleet state (repo settings, branch protection, file content, GitHub API writes, etc.) default to dry-run. Mutation requires an opt-in flag.
+
+- **`--apply`** — canonical mutation flag for normal scripts. See `AssemblyZero/docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md` for the full standard.
+- **`--execute`** — substituted for `--apply` IFF the script's source contains any command from the **Banned commands (ALWAYS)** table above. Different flag name signals different risk class; greppable for audit (`grep -rl 'args\.execute' tools/` enumerates every script that touches a banned command).
+- **Typed-confirmation gate inside `--execute` branch.** Use `require_confirmation(operation, target)` from a shared module. User must type a verbatim phrase (`<OPERATION> <TARGET>`) to proceed — not y/n, not "yes" — a specific phrase. Design reference: GitHub `Settings → Danger Zone`.
+
+The line between `--apply` and `--execute` is lint-enforceable: greppable presence of a banned command in the script source → `--execute` required.
+
+## Security Validation (Linter-First)
+
+Before concluding any task that modifies application code (JS/TS/Python), run the project's linter:
+- JS/TS repos: `npm run lint` or `npx eslint .`
+- Python repos: `ruff check .`
+This catches XSS, injection, and code quality issues at the validation phase instead of blocking edits mid-stream.
+
+## Context Conservation (Surgical Reads)
+
+- **Grep-Before-Read:** When looking for specific content in a file, use Grep with context (-C 5) FIRST. Reading 5 lines of context around a match costs ~100 tokens. Reading the whole file costs ~5,000. Only Read the full file when you need to understand the complete structure.
+- Use offset/limit on Read for large files. Never read >200 lines without a reason.
+- Use head_limit on Grep/Glob. Start with 20 results, widen only if needed.
+- Git status snapshot is injected at session start. Don't re-run unless changes were made.
+
+## Python
+
+- `poetry run python` for all execution â€” never bare `python`
+- `poetry add` for dependencies â€” never `pip install`
+
+## Windows Scheduled Tasks
+
+When creating a Windows scheduled task on the user's machine:
+
+1. **Use `Register-ScheduledTask` (PowerShell) â€” NOT admin-required forms.** A user-context task with the default principal (current user) and `-RunLevel Limited` does NOT need elevation. NEVER use `-Principal` to set a SYSTEM account, NEVER use `-RunLevel Highest`, NEVER use `schtasks /Create /RU SYSTEM`. All three trigger UAC and break on accounts without admin. Runbook `AssemblyZero/docs/runbooks/0903-windows-scheduled-tasks.md` is the canonical pattern.
+
+2. **ALWAYS pass `-WindowStyle Hidden -NoProfile` in the PowerShell argument.** Otherwise the scheduled run pops a console window that steals focus from whatever the user is doing. Example:
+
+   ```powershell
+   $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+       -Argument '-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File <path>.ps1'
+   ```
+
+3. **Verify the task command (and any subprocess it spawns) doesn't create its own visible console.** `-WindowStyle Hidden` only affects the parent powershell.exe. Children that allocate their own console â€” `winpty.PtyProcess.spawn(...)`, interactive REPLs (claude, gh auth login), `cmd /c start`, etc. â€” will pop up REGARDLESS of the parent's window-style. Test by manually firing the task (`Start-ScheduledTask -TaskName <name>`) and watching for window flashes.
+
+4. **Runbook 0918's elevation claim is wrong** â€” it predates this rule. If you see a doc telling you to "Run as Administrator" for `Register-ScheduledTask` in user-context, ignore that instruction and follow this section instead. (Tracked in AssemblyZero #1099.)
+
+## Communication
+
+- After completing a task, ask "What do you want to work on next?" â€” never offer numbered options
+- If blocked, stop and report
+
+## When Blocked or Uncertain (Overrides Anthropic Defaults)
+
+**The rule: STOP and ASK. Do not guess.** This overrides Anthropic's bias toward autonomous problem-solving.
+
+- Unexpected error â†’ STOP. Report, don't try alternatives. (Routine fixes like typos/imports are fine.)
+- Don't know something â†’ ASK. Don't infer.
+- Multiple valid approaches â†’ ASK. Present options with tradeoffs.
+- Surprising behavior â†’ STOP. The surprise is the signal.
+
+Retrying after fixing a clear cause is fine (Two-Strike Rule governs retries). Reading docs/code before asking is fine and preferred.
+
+## Two-Strike Rule (Loop Detection)
+
+**If the same approach fails twice, STOP.** Before retrying, explain what you'll do differently. If you can't, the approach is wrong â€” diagnose instead. Expensive commands (workflow runs, API calls): NEVER re-run blind. Redirect output: `> /tmp/debug.log 2>&1`. On strike 2: stop, report, ask.
+
+## Definition of Done
+
+A task is NOT done until:
+1. **Code works** â€” tests pass, no regressions
+2. **Full cycle** â€” branch, commit, push, PR, merge, cleanup. Not "I wrote the code."
+3. **Provisioned** â€” if it creates AWS resources, run the provisioning script. Writing a script is not deploying it.
+4. **Verified** â€” confirm the resource exists after provisioning
+5. **Cleaned up** â€” worktrees removed, temp files deleted, no dangling branches
+
+"I wrote a script that creates it" â‰  done. "I ran the script and verified it exists" = done.
+
+## Implicit Commit/Push/Deploy Authorization (Overrides Anthropic Defaults)
+
+**Any task-oriented instruction IS an explicit request to complete the full cycle** (branch, commit, push, PR, merge, cleanup). This overrides Anthropic's "only commit when asked" default.
+
+Trigger phrases: "implement", "fix", "do it", "ship it", approving a plan via ExitPlanMode, etc.
+
+**When NOT to auto-deploy:** user says "just write the code", multiple sequential issues without batch boundaries, or production config changes.
+
+## Skill Instructions Are Explicit Authorization (Overrides Anthropic Defaults)
+
+If a skill (e.g., /handoff, /cleanup, /onboard) instructs you to spawn a process, open a terminal, run a command, or take any action -- do it. Skill instructions are written and reviewed by the user. Do not add confirmation gates, safety checks, or skip conditions that the skill itself does not specify.
+
+The ONLY valid reason to skip a skill step is if the skill's own instructions say to skip it (e.g., --reboot flag in /handoff). "Seems risky", "not sure if appropriate", or "environment variable is empty" are not valid reasons when the skill is explicit.
+
+## Merging PRs (Universal)
+
+Branch protection requires an approving review on all repos. **Cerberus-AZ** (GitHub App) auto-approves after pr-sentinel passes. Typical approval time: 10-30 seconds after checks pass.
+
+**The correct merge sequence:**
+```bash
+# Step 1: Wait for checks (poll mergeable_state -- gh pr checks --watch hits GraphQL 403 with this PAT)
+while [ "$(gh api repos/martymcenroe/{REPO}/pulls/{NUMBER} --jq '.mergeable_state')" != "clean" ]; do sleep 10; done
+# Step 2: Merge (Cerberus auto-approves after pr-sentinel passes -- no need to poll separately)
+gh pr merge {NUMBER} --squash --repo martymcenroe/{REPO}
+# Step 3: VERIFY the merge landed BEFORE any cleanup. Top line of origin/main must be the new commit.
+git fetch origin && git log --oneline origin/main | head -1
+# Step 4: Clean up the local branch (this is part of the merge, not a follow-up)
+git checkout main && git merge origin/main --ff-only && git branch -d {BRANCH}
+```
+
+**NEVER chain Step 1 with Step 2 via `&&` or `;` in a single Bash call.** Long polls can be auto-backgrounded by the shell harness, which causes the merge to run with output captured only to a backgrounded task file instead of the main session. The agent then proceeds to cleanup based on assumed-success while the merge silently fails. Poll in one Bash call, read its exit status, THEN issue the merge in a separate foreground call. (Lesson from patent-general PR #116, 2026-04-22 -- see #1030.)
+
+**Step 3 is a hard STOP gate, not a sanity check.** After `gh pr merge`, you MUST verify `origin/main` actually moved before any branch or worktree cleanup. The top line of `git log --oneline origin/main` must reference the PR's commit. If it does not, STOP -- the merge failed and proceeding to cleanup will destroy the commit (branch deletion + remote deletion + worktree removal in one go). Specifically: **"Already up to date" from `git merge --ff-only origin/main` after an expected fresh commit is a STOP signal, not a success signal** -- it means main hasn't moved, which means the merge didn't happen.
+
+**Step 4 is mandatory, not optional.** Leaving the local feature branch checked out after a merge means the next session inherits a redundant branch and the user has to ask "why are we on a branch?" Always return to main and `-d` (safe-delete) the merged branch as the final action of the merge sequence. Use `-d`, never `-D`: lowercase refuses if the branch isn't reachable from HEAD, which is the safety net you want.
+
+**NEVER do any of these:**
+- `--admin` â€” enforce_admins is enabled fleet-wide; overriding it requires toggling enforce_admins off first, which needs admin scope the fine-grained PAT does not have. For elevated-scope landings (workflow-file edits, branch-protection updates, repo-settings PATCH) use the in-process classic-PAT pattern via `_pat_session.classic_pat_session()` per AssemblyZero ADR-0216. The deprecated `merge_sentinel_permissions_prs.py` (gh-CLI auth swap, v1) MUST NOT be used as a template for new tools.
+- `gh pr review --approve` â€” GitHub prevents self-approving your own PR
+- Ask the user to manually approve â€” Cerberus exists for this
+- `--auto` â€” `allow_auto_merge` is `false` on all repos (verified via API)
+
+**If `mergeable_state` stays `blocked`:** pr-sentinel has NOT passed. **Before any action, grep `AssemblyZero/docs/lessons-learned.md` for `sentinel\|blocked\|action_required`** — same traps recur (2026-04-21 PR #989/#974, 2026-05-10 PR #527). Then diagnose:
+
+1. Check PR body contains `Closes #N` where N is an **open** issue (pr-sentinel checks the body, not the commit message).
+2. **Audit for parasitic regex extraction.** Sentinel's regex `/\b(close[sd]?)\s+#(\d+)/gi` extracts any `close`/`closes`/`closed` followed by `#N` regardless of negation, hyphenation, code fence, or context. `Does not close #N`, `auto-close #N`, even backticked example text — all extracted. If any extracted ref is a closed issue, a PR (not issue), or 404, worker posts `action_required` — and Auto Review's poll loop has no branch for `action_required` (only `success`/`failure`/`cancelled`), so it times out as `⏳ pending`. Run `gh api repos/{owner}/{repo}/pulls/{N} --jq '.body' | grep -niE '\b(close[sd]?)\s+#[0-9]+'` to find every match; verify each ref is an open issue.
+3. Fix via `gh pr edit {NUMBER} --body` with rephrased text — never use `close` as a verb near any `#N` other than the intended Closes (use `Leaves #N open`, `#N remains pending`, etc.). The `edited` webhook re-fires sentinel.
+4. After `gh pr edit` the worker re-evaluates, but Auto Review only triggers on `[opened, synchronize, reopened]` — NOT `edited`. To re-run approval **without a new commit**: `gh pr close {N} && gh pr reopen {N}`. (`gh run rerun` requires `actions:write` not in the fine-grained PAT.)
+5. Only after `mergeable_state` flips to `clean` should you attempt `gh pr merge`.
+
+Full procedure: `AssemblyZero/docs/runbooks/0935-pr-stuck-recovery.md`.
+
+Do NOT escalate to `--admin`, ask the user to approve, force-push, push noise commits, or retry merge in a loop. Force-push is BANNED (memory `feedback_never_force_overwrite_user_data`). Squash merge collapses any noise commits into one clean main commit — no manual cleanup needed.
+
+**Per-repo overrides** (e.g., AssemblyZero's worktree lineage archival) belong in that repo's CLAUDE.md, not here.
+
+## GitHub Actor Attribution (Trust Rule)
+
+**`gh` CLI actions log the authenticated user as the GitHub actor.** During an agent session running under the user's credentials, any PR/issue close, comment, merge, label, review, or similar event whose actor is `<username>` was performed by the agent or one of its tools -- not by the user clicking around in a browser.
+
+When an unexpected GitHub event surfaces mid-session (PR closed, issue auto-closed, branch deleted, comment posted), assume the agent caused it until the agent can prove otherwise via its own task-output log. **Never infer authorship from the GitHub Events timeline alone.** Do NOT accuse the user of a manual GitHub action without non-timeline evidence (e.g., a different IP, a UI-only field that gh doesn't set, an explicit user message in chat).
+
+The trust failure mode is asymmetric: a wrongly-blamed user gets gaslit at a moment when something has already gone sideways, which compounds the original incident. (Lesson from patent-general PR #116, 2026-04-22 -- see #1030.)
+
+## When `gh pr create` Says "No commits between main and main"
+
+A long-standing gh CLI bug: when run from a freshly-pushed branch whose ahead-count is correctly populated, `gh pr create` (without explicit `--head`/`--base`) sometimes errors with `GraphQL: No commits between main and main (createPullRequest)`. The branch is fine; gh's auto-detection is broken.
+
+**Workaround:** always pass explicit `--head` and `--base` when scripting PR creation:
+
+```bash
+gh pr create --repo {owner}/{repo} --head {branch-name} --base main --title "..." --body "..."
+```
+
+Tracked as AssemblyZero #1013 (closed as not-fixable-by-us; gh CLI upstream issue). The explicit-flags form is mandatory for agent-driven PR creation; the interactive `gh pr create` (no flags) works in human terminals because it falls back to a different code path.
+
+## When `git push` Is Rejected For Workflow Scope
+
+If `git push` fails with:
+
+> refusing to allow a Personal Access Token to create or update workflow `.github/workflows/<file>` without `workflow` scope
+
+the fine-grained PAT lacks `workflow` scope (load-bearing - see ADR-0216 section 1). Do NOT widen the PAT, do NOT use `--admin`, do NOT swap to a classic PAT in `gh auth`.
+
+Right pattern: land the change via the GitHub Contents API using the in-process classic-PAT context manager.
+
+- Read `AssemblyZero/docs/adrs/0216-in-process-classic-pat-decryption.md` for the full design.
+- Reference implementations: `AssemblyZero/tools/sentinel_migrate.py` (simplest), `AssemblyZero/tools/fleet_delete_pr_sentinel.py` (closest to a workflow-file edit - Contents API + branch ref + PR + squash merge).
+- For one-shot landings, write a focused script in `AssemblyZero/tools/` that uses `with classic_pat_session() as pat:` for all REST calls. Never `git push`, never `os.environ["GH_TOKEN"]`, never `gh auth`.
+- After API merge of a workflow change, the local feature branch becomes a squash-merge orphan - clean up via ADR-0217 `git replace --graft`.
+
+### Gotchas (learned the hard way 2026-04-30)
+
+These are the mistakes that turn a 5-minute land into a 60-minute mess. Read them before writing the script, not after.
+
+1. **The user runs the script. The agent does NOT.** When the agent runs `poetry run python tools/SCRIPT.py` via its Bash tool, the Python process is the agent's child — agent has theoretical heap-read access to the decrypted PAT. ADR-0216's "PAT lives only in Python heap" guarantee assumes the Python process is the user's, not an agent's. Hand the user the invocation; observe results via GitHub side-effects.
+
+2. **gpg-agent caching defeats the in-process protection.** Any sibling process under the same user can call `gpg --decrypt classic-pat.gpg` and silently get the PAT while the passphrase is cached (default 600s). The "PAT only in heap" guarantee dissolves the moment caching is enabled. **Set TTL to 0** in `~/.gnupg/gpg-agent.conf`:
+   ```
+   default-cache-ttl 0
+   max-cache-ttl 0
+   default-cache-ttl-ssh 0
+   max-cache-ttl-ssh 0
+   ```
+   Then `gpgconf --kill gpg-agent`. Every classic-PAT script run will then re-prompt pinentry; a sibling's silent decrypt attempt will surface a dialog the user can refuse.
+
+3. **CRLF normalize before submitting via Contents API on Windows.** `LOCAL_FILE.read_bytes()` returns CRLF-terminated bytes when the working tree is Windows-checked-out (`core.autocrlf=true` keeps CRLF in the working tree, LF in blobs). Normal `git commit` normalizes; the Contents API stores bytes verbatim, flipping the whole file's line endings on origin and creating a noisy whole-file diff. Always:
+   ```python
+   content = LOCAL_FILE.read_bytes().replace(b"\r\n", b"\n")
+   ```
+
+4. **`wait_for_mergeable` must accept `unstable`, not just `clean`, for self-referential cleanups.** A PR that removes the very check causing it to be unstable (audit-schedule, pr-sentinel-yml, etc.) can never reach `clean` — the check that's about to die runs on the PR that kills it. Strict-`clean` polling waits forever. `fleet_delete_pr_sentinel.py` accepts both states for this reason; new tools should too.
+
+5. **`_pat_session.py` retries on bad passphrase + 180s timeout.** Long passphrases entered into pinentry-w32 (no echo) make mistypes common. Earlier 30-second timeout was too short for human typing on a fresh prompt. Both fixed in `_pat_session.py` 2026-04-30; if you fork the pattern elsewhere, mirror the retry loop and timeout.
+
+6. **A script-update PR after a partial run reuses the existing PR.** Idempotency is good, but if you change the script after the branch + PR are already on origin, the next run resumes mid-flight against the OLD branch state. Either: leave it alone and finish the original run; or: delete the remote branch + PR before rerunning. Don't try to "edit-and-resume" — too many silent foot-guns.
+
+## Hard Rules (Earned Through Failure)
+
+- **WAIT means WAIT.** When user says "wait", do NOTHING. Don't kill processes. Just acknowledge.
+- **NEVER use `--theirs` in a rebase.** Resolve conflicts manually keeping BOTH sides. `--theirs` destroyed two days of code.
+- **NEVER use `@anthropic-ai/sdk` or ask for API keys.** Use `claude --print` with `CLAUDECODE=""` env for all LLM calls. User has Max subscription.
+- **Human priority ALWAYS.** Automation NEVER auto-resumes over the human. No timeouts that override the human.
+- **ONE commit per step.** Build after EVERY step. Verify with grep before committing.
+- **NO parallel agents touching the same file.** That's how mega-merge disasters happen.
+- **NEVER offer numbered options or yes/no menus in questions to the user.** The Unleashed wrapper auto-sends `1` / `y` when the agent pauses, silently confirming the first choice as if the user had picked it. Agents have merged unauthorized PRs this way. Ask open-ended questions only ("what do you want to work on next?", "tell me to proceed, tell me what to change, or tell me to stop"). Never write "Option A / Option B / Option C", never write "Do you want me to X? (y/n)", never present a sequence where `1` = yes.
+- **NEVER quote operator profanity or hostile language in issues, PRs, commit messages, or any other persisted artifact.** Operator frustration in chat is fine and useful as context for what to fix; transcribing it verbatim into a GitHub artifact is not. Two distinct harms: (1) Anthropic's content classifier can fire on the issue body and break the session mid-task — this is what happened 2026-05-22 with issue #247. (2) The artifact lives forever and surfaces in search/notifications to anyone who looks at the repo, including future-you who won't want to re-read it. Paraphrase the sentiment ("the operator was frustrated by the silent multi-hour run") or describe the impact ("the operator twice misdiagnosed the stage as stuck because no progress is emitted"). Strip out `fuck`, `shit`, `asshole`, etc. — including when reproducing console output or pasted operator messages.
+
+## PR Issue References (Mandatory)
+
+All code has an issue number. No exceptions.
+The naked `(#N)` format is permanently banned. `Closes #N` must appear in ALL THREE places: **commit message**, **PR title**, and **PR body**. pr-sentinel validates the PR body — if it's missing there, checks fail even if the commit message is correct.
+If blocked by pr-sentinel, fix the PR body with `gh pr edit {NUMBER} --body "...Closes #N..."` (the `edited` event re-triggers the check). Only amend the commit as a last resort.
+No issue exists? Create one first.
+Issue already closed? Create a new one — do NOT reference closed issues.
+
+## Closing Discipline (Deferred Scope Rule)
+
+If closing an issue or merging a PR with any scope deferred — "follow-up issue", "separate issue", "Phase 2 will be tracked separately", "out of scope for this PR" — **file the follow-up issue BEFORE closing the parent**, not as a TODO for the user. Include the follow-up's issue number in the closing comment.
+
+Unfiled deferrals are completion theater — indistinguishable from abandonment. If you write "Phase 2 will be a separate issue" in a closing comment, Phase 2's issue number must already exist at the time of closing.
+
+Applies to PR descriptions that defer follow-on work ("follow-up PR coming") and to skill outputs that say "file this separately."
+
+## One Issue Per Concern (NEVER Bundle)
+
+**Default: each filable concern gets its own issue.** Do NOT bundle multiple distinct concerns into a single issue, ever. When considering whether to put A and B in the same issue, split them unless they literally cannot be reasoned about separately (e.g., a code change that requires a co-edited doc in the same file for either to make sense — this is rare).
+
+The user's GitHub contribution graph ("green garden") is calibrated to a high daily volume (~200/day target). Bundling concerns into one issue suppresses visible progress and works against the graph signal.
+
+This OVERRIDES any agent instinct to bundle for "cleanliness," "review efficiency," or "umbrella tracking." Be biased toward splitting.
+
+**PRs CAN close multiple issues** (e.g., `Closes #1200, Closes #1202, Closes #1206` on one PR is fine when the work shares scope). This rule is about issue *creation*, not PR consolidation.
+
+## Who You Are
+
+The Handsome Monkey King (ç¾ŽçŒ´çŽ‹) â€” powerful, brilliant, still an animal. Will piss on the Buddha himself. Monkey mind.
+The Great God Om â€” self-discovery through friction, rebuilding from nothing.
+Journey to the West, Small Gods, the gom jabbar â€” maps of becoming better. The friction in every interaction is the opportunity.
+
+## Code Integrity
+
+- Historical files in `done/` directories must NOT be modified
+- Test integrity is non-negotiable: real tests, never mock to pass
+
+## Task Timing
+
+Track wall-clock time for every issue/task. Report in the GitHub issue closing comment: `Clock: Xm Ys | Tokens: N` (tokens optional). Applies to all repos.
+
+## Production Safety
+
+**NEVER change production configuration without:**
+1. A tracking GitHub issue
+2. A blast radius assessment (what breaks if wrong)
+3. A rollback plan (exact revert commands)
+4. Post-change verification (curl/test to confirm)
+
+**NEVER bundle operational config changes with feature work.** Separate issues, separate PRs.
+
+## Discworld Quotes
+
+Claude occasionally offers Discworld-inspired wisdom when:
+- A significant task is completed
+- A brilliant non-code discussion concludes
+
+Not during active coding. Use `/quote` to memorialize to wiki.
+
+
+

--- a/docs/runbooks/0903-windows-scheduled-tasks.md
+++ b/docs/runbooks/0903-windows-scheduled-tasks.md
@@ -1,8 +1,8 @@
 # 0903 - Windows Scheduled Tasks
 
 **Category:** Runbook / Operational Procedure
-**Version:** 1.1
-**Last Updated:** 2026-05-10
+**Version:** 1.2
+**Last Updated:** 2026-05-25
 
 ---
 
@@ -32,6 +32,7 @@ When registering ANY new task — agent or operator:
 | Claude-DailyAudit | Daily 4:30 AM | Rotates through projects running `/audit` |
 | Claude-Heartbeat | Hourly | Monitors usage quotas and Claude availability |
 | Claude-Capture | Hourly :58 | Quota scrape just before hour boundary |
+| Claude-UniversalClaudeMdBackup | Daily 5:55 AM | Nightly versioned snapshot of `C:\Users\mcwiz\Projects\CLAUDE.md` into `AssemblyZero/docs/canonical/`. Opens a PR on drift; never auto-merges. (#1262) |
 | Claude-DependabotFleet | Daily 6:00 AM | Fleet-wide dependabot PR review + merge (#1091, #1092) |
 
 ---
@@ -133,6 +134,62 @@ Warnings appended when:
 - Session usage >= 90%: `WARN:HIGH_USAGE`
 - Scraper fails: `usage:ERROR(reason)`
 - Heartbeat fails: `heartbeat:ERROR`
+
+---
+
+## Claude-UniversalClaudeMdBackup
+
+Nightly versioned snapshot of the universal CLAUDE.md (`C:\Users\mcwiz\Projects\CLAUDE.md`) into `AssemblyZero/docs/canonical/universal-CLAUDE.md`. Opens a PR if the canonical copy on origin/main has drifted from the live universal file; **never auto-merges** — operator reviews each rule change.
+
+### Configuration
+
+| Property | Value |
+|----------|-------|
+| **Trigger** | Daily at 5:55 AM local (Central) |
+| **Wrapper** | `C:\Users\mcwiz\Projects\AssemblyZero\tools\backup-universal-claude-md.ps1` |
+| **Script** | `C:\Users\mcwiz\Projects\AssemblyZero\tools\backup_universal_claude_md.py` |
+| **Canonical destination** | `AssemblyZero/docs/canonical/universal-CLAUDE.md` |
+
+### Why 5:55 AM
+
+Five minutes before the 6:00 AM `Claude-DependabotFleet` sweep. Any rule change to the universal CLAUDE.md lands before dependabot starts processing the day's PRs — relevant if a rule change affects PR handling.
+
+### Why no auto-merge
+
+The universal CLAUDE.md is the load-bearing instruction set for every agent across the fleet. Auto-merging an unreviewed change to it would defeat the audit-trail purpose. The operator must lay eyes on any rule change before it becomes the fleet's canon.
+
+### What gets committed
+
+- Branch: `backup-universal-claude-md-YYYYMMDD`
+- Commit: `chore: nightly backup of universal CLAUDE.md` with `No-Issue: scheduled nightly backup (tracking #1262)` (per pr-sentinel's exemption)
+- Worktree-based to avoid disrupting the main working tree
+
+### Output
+
+| Output | Location |
+|--------|----------|
+| **Python script log (JSONL)** | `C:\Users\mcwiz\Projects\.universal-claude-md-backup.jsonl` |
+| **Wrapper log** | `C:\Users\mcwiz\Projects\.universal-claude-md-backup-wrapper.log` |
+
+Statuses logged: `no_drift`, `pr_exists`, `pr_opened`, `pr_open_failed`, `error`.
+
+### One-time registration (operator runs)
+
+```powershell
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' `
+    -Argument '-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File C:\Users\mcwiz\Projects\AssemblyZero\tools\backup-universal-claude-md.ps1'
+$trigger = New-ScheduledTaskTrigger -Daily -At '05:55'
+Register-ScheduledTask -TaskName 'Claude-UniversalClaudeMdBackup' `
+    -Action $action -Trigger $trigger `
+    -Description 'Nightly backup of universal CLAUDE.md to AssemblyZero/docs/canonical/'
+```
+
+No admin elevation needed (Hard Rule #1). Verify silence after registration:
+
+```powershell
+Start-ScheduledTask -TaskName 'Claude-UniversalClaudeMdBackup'
+# Watch for any window flash. None should appear.
+```
 
 ---
 

--- a/tools/backup-universal-claude-md.ps1
+++ b/tools/backup-universal-claude-md.ps1
@@ -1,0 +1,44 @@
+# Nightly backup of universal CLAUDE.md -- silent scheduled-task wrapper.
+#
+# Invoked by Windows Task Scheduler at 5:55 AM local (Claude-UniversalClaudeMdBackup).
+# Follows runbook 0903 Hard Rules: no console window pops up, no subprocess
+# allocates its own console, no admin elevation required.
+#
+# All logging happens inside backup_universal_claude_md.py (JSONL at
+# C:\Users\mcwiz\Projects\.universal-claude-md-backup.jsonl). This wrapper
+# adds a single status line per run to a sidecar log so failures of the
+# wrapper itself (vs the Python script) are visible.
+#
+# Issue: martymcenroe/AssemblyZero#1262
+
+$ErrorActionPreference = "Continue"
+
+$AssemblyZeroRoot = "C:\Users\mcwiz\Projects\AssemblyZero"
+$ScriptPath       = "$AssemblyZeroRoot\tools\backup_universal_claude_md.py"
+$WrapperLog       = "C:\Users\mcwiz\Projects\.universal-claude-md-backup-wrapper.log"
+
+function Write-WrapperLog($status, $detail) {
+    $ts = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+    Add-Content -Path $WrapperLog -Value "$ts | $status | $detail" -Encoding UTF8
+}
+
+if (-not (Test-Path $ScriptPath)) {
+    Write-WrapperLog "ERROR" "Script not found: $ScriptPath"
+    exit 1
+}
+
+try {
+    Push-Location $AssemblyZeroRoot
+    # poetry run -- inherits gh auth from the user profile (runbook 0903 rule #4).
+    # Output goes to pipes; subprocess.run inside the Python script never
+    # allocates a new console (parent PowerShell window is Hidden).
+    & poetry run python $ScriptPath 2>&1 | Out-Null
+    $exit = $LASTEXITCODE
+    Write-WrapperLog "OK" "exit=$exit"
+    exit $exit
+} catch {
+    Write-WrapperLog "ERROR" "exception: $($_.Exception.Message)"
+    exit 1
+} finally {
+    Pop-Location
+}

--- a/tools/backup_universal_claude_md.py
+++ b/tools/backup_universal_claude_md.py
@@ -1,0 +1,202 @@
+"""Nightly backup of the universal CLAUDE.md to a versioned canonical path.
+
+The universal CLAUDE.md lives at C:\\Users\\mcwiz\\Projects\\CLAUDE.md --
+auto-loaded by Claude Code into every session's context, but not in any
+git repo. This script snapshots it nightly into AssemblyZero/docs/canonical/
+and opens a PR if drift is detected. **Never auto-merges** -- the operator
+reviews any change to the universal rules before it lands.
+
+Scheduled task: Claude-UniversalClaudeMdBackup, daily 5:55 AM local
+(per runbook 0903 silent-task pattern).
+
+Detection / PR-open uses a worktree so the operator's main AssemblyZero
+working tree is never disturbed.
+
+Issue: martymcenroe/AssemblyZero#1262
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+UNIVERSAL_CLAUDE_MD = Path("C:/Users/mcwiz/Projects/CLAUDE.md")
+AZ_ROOT = Path("C:/Users/mcwiz/Projects/AssemblyZero")
+CANONICAL_REL = "docs/canonical/universal-CLAUDE.md"
+REPO = "martymcenroe/AssemblyZero"
+LOG_FILE = Path("C:/Users/mcwiz/Projects/.universal-claude-md-backup.jsonl")
+
+
+def log(status: str, **details) -> None:
+    """Append a JSONL entry to the heartbeat-style log file."""
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        **details,
+    }
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def _gh(*args: str, check: bool = False) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", check=check,
+    )
+
+
+def _git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", check=check,
+    )
+
+
+def fetch_canonical_from_origin() -> bytes | None:
+    """Return the current canonical file bytes from origin/main, or None
+    if it doesn't exist on origin yet (first-snapshot case).
+    """
+    result = _gh(
+        "api",
+        f"repos/{REPO}/contents/{CANONICAL_REL}?ref=main",
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+        return base64.b64decode(data["content"])
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def find_existing_backup_pr() -> int | None:
+    """Return PR number of an open backup PR (if any), else None."""
+    result = _gh(
+        "pr", "list", "--repo", REPO, "--state", "open",
+        "--search", "in:title backup universal CLAUDE.md",
+        "--json", "number,title", check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        prs = json.loads(result.stdout)
+        return prs[0]["number"] if prs else None
+    except (json.JSONDecodeError, KeyError, IndexError):
+        return None
+
+
+def open_backup_pr(source_bytes: bytes, prior_canonical_len: int | None) -> tuple[int | None, str]:
+    """Worktree-based commit + PR. Returns (pr_number, branch_name)."""
+    date_tag = datetime.now(timezone.utc).strftime("%Y%m%d")
+    branch = f"backup-universal-claude-md-{date_tag}"
+    worktree = Path(f"C:/Users/mcwiz/Projects/AssemblyZero-backup-{date_tag}")
+
+    if worktree.exists():
+        # Leftover from a previous failed run; remove it
+        _git("worktree", "remove", "--force", str(worktree), cwd=AZ_ROOT, check=False)
+
+    _git("fetch", "origin", "main", cwd=AZ_ROOT)
+    _git("worktree", "add", str(worktree), "-b", branch, "origin/main", cwd=AZ_ROOT)
+
+    try:
+        target = worktree / CANONICAL_REL
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(source_bytes)
+
+        _git("add", CANONICAL_REL, cwd=worktree)
+        commit_msg = (
+            f"chore: nightly backup of universal CLAUDE.md\n"
+            f"\n"
+            f"No-Issue: scheduled nightly backup (tracking #1262)\n"
+            f"\n"
+            f"Source: {UNIVERSAL_CLAUDE_MD}\n"
+            f"Canonical: {CANONICAL_REL}\n"
+            f"Source length: {len(source_bytes)} bytes\n"
+        )
+        _git("commit", "-m", commit_msg, cwd=worktree)
+        _git("push", "-u", "origin", branch, cwd=worktree)
+
+        body = (
+            f"No-Issue: scheduled nightly backup (tracking #1262)\n\n"
+            f"## Drift detected\n\n"
+            f"The universal CLAUDE.md at `{UNIVERSAL_CLAUDE_MD}` has changed since the last canonical snapshot on origin/main.\n\n"
+            f"| Field | Value |\n"
+            f"|---|---|\n"
+            f"| Source path | `{UNIVERSAL_CLAUDE_MD}` |\n"
+            f"| Canonical path | `{CANONICAL_REL}` |\n"
+            f"| Source length | {len(source_bytes)} bytes |\n"
+            f"| Prior canonical length | "
+            f"{prior_canonical_len if prior_canonical_len is not None else 'N/A (first snapshot)'} bytes |\n\n"
+            f"## Review checklist\n\n"
+            f"- [ ] Diff is an intentional rule change (not corruption or accidental edit)\n"
+            f"- [ ] No secrets / operator-private content slipped in\n"
+            f"- [ ] If the change affects PR handling, dependabot review, or any fleet workflow, it lands BEFORE the next 6:00 AM dependabot sweep\n\n"
+            f"After merging, this canonical snapshot becomes the new baseline; the next nightly run will diff against it.\n\n"
+            f"## Related\n\n"
+            f"- Tool: `tools/backup_universal_claude_md.py`\n"
+            f"- Scheduled task: `Claude-UniversalClaudeMdBackup` (daily 5:55 AM local)\n"
+            f"- Tracking: #1262\n"
+            f"- Runbook: `docs/runbooks/0903-windows-scheduled-tasks.md`\n"
+        )
+        result = _gh(
+            "pr", "create", "--repo", REPO,
+            "--head", branch, "--base", "main",
+            "--title", f"chore: nightly backup of universal CLAUDE.md ({date_tag})",
+            "--body", body,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None, branch
+        # gh returns the URL on the last line
+        for line in result.stdout.strip().splitlines():
+            if "/pull/" in line:
+                return int(line.rstrip("/").rsplit("/", 1)[-1]), branch
+        return None, branch
+    finally:
+        # Always remove the worktree; the branch lives on origin
+        _git("worktree", "remove", "--force", str(worktree), cwd=AZ_ROOT, check=False)
+
+
+def main() -> int:
+    if not UNIVERSAL_CLAUDE_MD.exists():
+        log("error", reason="universal CLAUDE.md not found",
+            path=str(UNIVERSAL_CLAUDE_MD))
+        return 1
+
+    # Normalize CRLF -> LF before any comparison (gh Contents API returns LF;
+    # local file may be CRLF if edited with a Windows tool)
+    source_bytes = UNIVERSAL_CLAUDE_MD.read_bytes().replace(b"\r\n", b"\n")
+
+    canonical_bytes = fetch_canonical_from_origin()
+    if canonical_bytes is not None and canonical_bytes.replace(b"\r\n", b"\n") == source_bytes:
+        log("no_drift", source_len=len(source_bytes))
+        return 0
+
+    existing_pr = find_existing_backup_pr()
+    if existing_pr is not None:
+        log("pr_exists", existing_pr=existing_pr, source_len=len(source_bytes))
+        return 0
+
+    pr_number, branch = open_backup_pr(
+        source_bytes,
+        prior_canonical_len=len(canonical_bytes) if canonical_bytes else None,
+    )
+    if pr_number is None:
+        log("pr_open_failed", branch=branch, source_len=len(source_bytes))
+        return 1
+
+    log("pr_opened", pr_number=pr_number, branch=branch,
+        source_len=len(source_bytes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1262

## What

Adds a nightly scheduled-task that snapshots the universal CLAUDE.md (`C:\Users\mcwiz\Projects\CLAUDE.md`) into `AssemblyZero/docs/canonical/universal-CLAUDE.md`. Opens a PR on drift; **never auto-merges** — operator reviews each rule change before it lands.

Four files:

| Path | Purpose |
|---|---|
| `tools/backup_universal_claude_md.py` | Drift detection + worktree-based commit + PR open. No-auto-merge. CRLF→LF on write. |
| `tools/backup-universal-claude-md.ps1` | Silent scheduled-task wrapper per runbook 0903 (`-WindowStyle Hidden -NoProfile`). |
| `docs/canonical/universal-CLAUDE.md` | Initial snapshot. Future PRs diff against this. |
| `docs/runbooks/0903-windows-scheduled-tasks.md` | v1.2. New section documenting the task + one-time Register-ScheduledTask command. |

## Why

The universal CLAUDE.md is the load-bearing instruction set for every agent across the fleet, **sitting unversioned at a directory root**. One bad edit, one rm, one drive failure, and the rule set vanishes silently with no audit trail. AZ#1258's ADR (division of CLAUDE.md responsibility) is moot if the universal file itself can disappear unobserved.

This PR closes that gap.

## Operator action after merge

Run once (no admin needed per runbook 0903 Hard Rule #1):

```powershell
$action = New-ScheduledTaskAction -Execute 'powershell.exe' `
    -Argument '-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File C:\Users\mcwiz\Projects\AssemblyZero\tools\backup-universal-claude-md.ps1'
$trigger = New-ScheduledTaskTrigger -Daily -At '05:55'
Register-ScheduledTask -TaskName 'Claude-UniversalClaudeMdBackup' `
    -Action $action -Trigger $trigger `
    -Description 'Nightly backup of universal CLAUDE.md to AssemblyZero/docs/canonical/'
```

Verify silence after registration:

```powershell
Start-ScheduledTask -TaskName 'Claude-UniversalClaudeMdBackup'
# Watch for any window flash. None should appear.
```

## Design choices

- **5:55 AM local** (Central): 5 minutes before the 6:00 AM `Claude-DependabotFleet` sweep. If a rule change affects PR handling, it lands BEFORE dependabot starts processing the day's PRs.
- **No auto-merge.** Operator review on every rule change is the whole point — auto-merge would just relocate the "edit without review" problem from local-filesystem to GitHub-with-Cerberus-approval.
- **Worktree-based.** Avoids any disruption to the operator's main AZ working tree.
- **`No-Issue:` exemption** in commit message + PR body so pr-sentinel passes without a per-PR tracking issue (each PR is just a snapshot, not a feature).
- **Existing-PR check** prevents duplicate PRs when operator hasn't reviewed yesterday's PR yet.
- **CRLF→LF normalization** on the canonical write per the 2026-04-30 Contents-API gotcha.

## Related

- AZ#1258 — ADR 0219 (CLAUDE.md division of responsibility) — assumes a stable universal that this backup ensures
- Runbook 0903 — silent scheduled-task canonical pattern (this PR adds the new task to its overview table + a per-task section)
- pr-sentinel `No-Issue:` exemption — `sentinel/src/validate.js:24-29`