### PR TITLE
refactor(new-repo): emit lean per-repo CLAUDE.md template per ADR 0219 (Closes #1266)

### DIFF
--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -418,32 +418,25 @@ def create_claude_md(project_path: Path, name: str, github_user: str) -> None:
     """
     Create the project CLAUDE.md file.
 
+    Emits the lean per-repo template per ADR 0219 (#1258): identifiers and a
+    Project-Specific Context TODO stub. Everything else (merge sequence, PR
+    rules, branch protection, GitHub CLI safety) lives in the universal
+    CLAUDE.md auto-loaded by Claude Code's parent-directory traversal --
+    NOT restated here, to avoid drift on every universal-CLAUDE.md edit.
+
     Args:
         project_path: Path to the project root
         name: Project name
         github_user: GitHub username
+
+    See: #1266 (minimum-viable slice), #1259 (parent refactor, remaining
+    scope: lint tool + project-type branching), #1258 (ADR 0219).
     """
     projects_root_unix = config.projects_root_unix()
 
     content = f"""# CLAUDE.md - {name} Project
 
 You are a team member on the {name} project, not a tool.
-
-## CRITICAL: Read these BEFORE any PR work
-
-The root file `C:\\Users\\mcwiz\\Projects\\CLAUDE.md` is **auto-loaded** for every project. It contains the universal rules. Two sections are non-negotiable — skipping them wastes hours:
-
-1. **"Merging PRs (Universal)"** — exact `gh` command sequence. Never `--admin` (branch protection has `enforce_admins: true`). Never `gh pr review --approve` on your own PR (GitHub blocks self-approval). Never ask the human to approve manually — **Cerberus-AZ auto-approves after pr-sentinel passes**, typically 10-30 seconds after checks go green.
-
-2. **"PR Issue References (Mandatory)"** — `Closes #N` must appear in **ALL THREE** places: commit message, PR title, AND PR body. `pr-sentinel` validates the **PR body specifically**; the commit message alone will NOT pass the check.
-
-If a merge shows `mergeable_state: blocked`, do NOT retry blindly. Check the PR body for `Closes #N` pointing to an **OPEN** issue. Fix with:
-
-```bash
-gh pr edit {{NUMBER}} --body "...Closes #N..." --repo {github_user}/{name}
-```
-
----
 
 ## Project Identifiers
 
@@ -452,49 +445,15 @@ gh pr edit {{NUMBER}} --body "...Closes #N..." --repo {github_user}/{name}
 - **Project Root (Unix):** `{projects_root_unix}/{name}`
 - **Worktree Pattern:** `{name}-{{IssueID}}` (e.g., `{name}-45`)
 
----
+## Project-Specific Context
 
-## Branch Protection Contract (main)
-
-| Setting | Value | What it means for you |
-|---------|-------|----------------------|
-| `enforce_admins` | `true` | `--admin` bypass will fail. Do not try. |
-| `required_approving_review_count` | `1` | Cerberus-AZ provides this automatically after pr-sentinel passes. |
-| `required_status_checks` | `pr-sentinel / issue-reference` | Must conclude `success` before merge. |
-| `allow_force_pushes` | `false` | `git push --force` to main will fail. |
-
-### Merge sequence — use this exact flow
-
-```bash
-# 1. Poll mergeable_state until clean
-#    Do NOT use `gh pr checks --watch` — it returns GraphQL 403 with the fine-grained PAT.
-while [ "$(gh api repos/{github_user}/{name}/pulls/$PR --jq '.mergeable_state')" != "clean" ]; do sleep 10; done
-
-# 2. Merge (Cerberus auto-approves after pr-sentinel passes — no separate approval poll needed)
-gh pr merge $PR --squash --repo {github_user}/{name}
-```
-
----
-
-## GitHub CLI Safety
-
-- ALWAYS use `--repo {github_user}/{name}` explicitly — never rely on default repo inference
-- NEVER use `--admin` — will 403
-- NEVER use `gh pr review --approve` on your own PR — GitHub blocks self-approval
-- NEVER use `--no-verify` — if a hook fails, diagnose the root cause instead
-- NEVER reference a **closed** issue in `Closes #N` — create a new issue first if needed
-
----
-
-## Session Logging
-
-At end of session, append a summary to `docs/session-logs/YYYY-MM-DD.md`.
-
----
-
-## You Are Not Alone
-
-Other agents may work on this project. Check `docs/session-logs/` for recent context before starting work.
+_TODO: Add tech stack, architecture, file map, project-type-specific notes,
+and any workflow overrides specific to this project. The universal
+CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers
+all fleet-wide rules -- merge sequence, PR-issue references, branch
+protection, GitHub CLI safety, banned commands, etc. This file only adds
+what is true for THIS repo specifically. Restating universal content here
+creates drift on every universal-CLAUDE.md edit (ADR 0219)._
 """
     claude_md_path = project_path / "CLAUDE.md"
     claude_md_path.write_text(content, encoding='utf-8')


### PR DESCRIPTION
Closes #1266

## What

Replaces the 80-line scaffolded CLAUDE.md template in ``tools/new_repo_setup.py:create_claude_md`` with the 15-line lean template specified in ADR 0219 (#1258). Stops propagating the drift markers documented in the private fleet audit to every newly-created repo.

One file, +17 / -58 lines.

## Why this is the slice that ships now

Operator has a backlog of new repos (dependabot-honeypot, Chiron, more). The full #1259 scope (template + lint tool + project-type branching + tests + runbook) is larger; this PR ships ONLY the template change so new-repo creation can resume immediately without inheriting drift. Lint tool + project-type branching land in a follow-up under #1259.

## The lean template

```markdown
# CLAUDE.md - {name} Project

You are a team member on the {name} project, not a tool.

## Project Identifiers

- **Repository:** `{github_user}/{name}`
- **Project Root (Windows):** `{project_path}`
- **Project Root (Unix):** `{projects_root_unix}/{name}`
- **Worktree Pattern:** `{name}-{{IssueID}}` (e.g., `{name}-45`)

## Project-Specific Context

_TODO: Add tech stack, architecture, file map, project-type-specific notes,
and any workflow overrides specific to this project. The universal
CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers
all fleet-wide rules -- merge sequence, PR-issue references, branch
protection, GitHub CLI safety, banned commands, etc. This file only adds
what is true for THIS repo specifically. Restating universal content here
creates drift on every universal-CLAUDE.md edit (ADR 0219)._
```

## Removed (and where each piece actually lives)

| Removed from per-repo template | Lives in | Why |
|---|---|---|
| "CRITICAL: Read these BEFORE any PR work" + hardcoded universal path | Universal CLAUDE.md (auto-loaded) | Per ADR 0219 Consequence #2, parent CLAUDE.md is auto-loaded by Claude Code; telling agent to "read" it is noise that implies a choice |
| Inline merge sequence bash | Universal CLAUDE.md | Duplication was the drift target we discussed for the `unstable` polling case |
| Branch Protection Contract table | Universal CLAUDE.md | Same |
| GitHub CLI Safety rules | Universal CLAUDE.md | Same |
| Session Logging pointing at `docs/session-logs/` | Universal CLAUDE.md handoff procedures (real path is `data/handoff-log.md`) | Per private fleet audit, session-logs path is wrong; the universal file covers the right mechanism |

## Verification

Manual test in a temp dir:

```
=== emitted 898 chars ===
# CLAUDE.md - TestRepo Project
[... lean template ...]

11/11 checks passed:
  PASS: has Project Identifiers
  PASS: has Project-Specific Context
  PASS: name interpolated
  PASS: github_user interpolated
  PASS: no CRITICAL: Read section
  PASS: no BP table
  PASS: no Cerberus reference
  PASS: no Session Logging section
  PASS: no session-logs path
  PASS: no enforce_admins reference
  PASS: no all-caps emphasis
```

Tests: `tests/test_new_repo_setup.py:692` only asserts `(project / "CLAUDE.md").exists()` — no content assertions to update.

## Backward compatibility

Only affects NEWLY-created repos. Existing per-repo CLAUDE.md files are untouched; their remediation is tracked separately in the private fleet audit issue (per-repo PRs per the audit's punch list).

## Related

- ADR 0219 (#1258) — division of responsibility, the rule this implements
- #1259 — parent refactor (remaining scope: lint tool + project-type branching + runbook update + test additions for the project-type matrix)
- #1262 / #1263 — universal CLAUDE.md backup task (ensures the auto-loaded universal has a versioned audit trail)
- Private fleet audit — per-repo remediation queue (separate work, blocked on lint tool from #1259)