### PR TITLE
fix(new-repo): default to no PyPI scaffold; --pypi to opt in (Closes #1269)

### DIFF
--- a/docs/runbooks/0934-pypi-trusted-publisher-setup.md
+++ b/docs/runbooks/0934-pypi-trusted-publisher-setup.md
@@ -2,15 +2,15 @@
 
 **Runbook 0934 — one-time per-repo browser steps to enable tag-push PyPI publishes from a repo bootstrapped by `tools/new_repo_setup.py` (#1074).**
 
-`new_repo_setup.py` deploys `release.yml` to every new Python repo by default. The workflow is wired to publish to PyPI via OIDC Trusted Publisher — no API token is stored in GitHub secrets. But OIDC trust requires a one-time registration on PyPI's side, and **PyPI's publisher-registration UI is browser-only**. There is no API. This runbook covers the human steps; the script handles everything else.
+`new_repo_setup.py` deploys `release.yml` to new Python repos **only when `--pypi` is passed** (as of #1269 — was default-on, now opt-in). The workflow is wired to publish to PyPI via OIDC Trusted Publisher — no API token is stored in GitHub secrets. But OIDC trust requires a one-time registration on PyPI's side, and **PyPI's publisher-registration UI is browser-only**. There is no API. This runbook covers the human steps; the script handles everything else.
 
-If you used `--no-pypi` when creating the repo, this runbook does not apply — the repo has no `release.yml` and won't try to publish.
+If you did NOT pass `--pypi` when creating the repo, this runbook does not apply — the repo has no `release.yml` and won't try to publish. To add PyPI publishing to an existing repo, re-run scaffolding or add `release.yml` manually.
 
 ---
 
 ## Prerequisites
 
-- Repo created via `tools/new_repo_setup.py <name>` (without `--no-pypi`).
+- Repo created via `tools/new_repo_setup.py <name> --pypi`.
 - The script's output should include `Created auto-reviewer.yml + release.yml (PyPI publish on tag)`.
 - `pyproject.toml` in the repo has `[tool.poetry.scripts]` and `[tool.poetry.urls]` blocks populated. Verify with `grep -A3 "tool.poetry.scripts" pyproject.toml`.
 - `.github/workflows/release.yml` exists and uses `environment: pypi` (this is the default; don't edit unless you know what you're doing).

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -2061,15 +2061,23 @@ Examples:
              "for non-Python projects. (#1058)"
     )
     parser.add_argument(
+        "--pypi",
+        action="store_true",
+        default=False,
+        help="Include the PyPI publishing scaffold (entry point, src/<pkg>/ "
+             "skeleton, [tool.poetry.scripts]/[urls] blocks, release.yml). "
+             "Default: OMITTED. Runbook 0934 describes the one-time "
+             "pending-publisher registration on PyPI that release.yml "
+             "expects. Pass this flag ONLY for repos you intend to "
+             "publish to PyPI. (#1269)"
+    )
+    parser.add_argument(
         "--no-pypi",
         action="store_true",
         default=False,
-        help="Skip the PyPI publishing scaffold (entry point, src/<pkg>/ "
-             "skeleton, [tool.poetry.scripts]/[urls] blocks, release.yml). "
-             "Default: include all of those — runbook 0934 then describes "
-             "the one-time browser step on PyPI's side to enable the first "
-             "tag-push publish. Pass this flag for internal-only packages "
-             "that won't ever publish to PyPI. (#1074)"
+        help="DEPRECATED -- this is now the default. Accepted as a no-op "
+             "for backward compatibility; will print a deprecation warning. "
+             "Use --pypi to opt INTO the PyPI scaffold. (#1269)"
     )
 
     args = parser.parse_args()
@@ -2080,6 +2088,16 @@ Examples:
         print("Pick one: --cerberus-pem PATH (plaintext, deleted after) OR "
               "--cerberus-pem-gpg PATH (encrypted at rest, reusable).")
         sys.exit(1)
+
+    # --pypi and --no-pypi are mutually exclusive (#1269)
+    if args.pypi and args.no_pypi:
+        print("ERROR: --pypi and --no-pypi are mutually exclusive.")
+        sys.exit(1)
+
+    # --no-pypi is now the default; emit deprecation notice if it's used
+    if args.no_pypi:
+        print("NOTE: --no-pypi is deprecated -- this is now the default. "
+              "The flag is a no-op; remove it from your invocation. (#1269)")
 
     # Cerberus deploy requires --no-github not set (need the repo to deploy to)
     if (args.cerberus_pem or args.cerberus_pem_gpg) and args.no_github:
@@ -2332,13 +2350,14 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     # Step 11b2: Bootstrap Python project (#1058) — pyproject.toml,
     # pytest, pytest-cov, conftest.py. Required for AZ implementation
     # workflow's red/green TDD phases. Skippable via --lang none.
-    # Step also installs PyPI publishing scaffold (#1074) unless --no-pypi.
-    enable_pypi = (args.lang == "python") and (not args.no_pypi)
+    # PyPI publishing scaffold (#1074) is OPT-IN via --pypi (#1269 --
+    # inverted from earlier opt-out via --no-pypi).
+    enable_pypi = (args.lang == "python") and args.pypi
     if args.lang == "python":
         if enable_pypi:
             print("\n11b2. Bootstrapping Python project (poetry init + pytest + PyPI scaffold)...")
         else:
-            print("\n11b2. Bootstrapping Python project (poetry init + pytest, --no-pypi)...")
+            print("\n11b2. Bootstrapping Python project (poetry init + pytest)...")
         if create_python_project(
             project_path,
             args.name,
@@ -2787,9 +2806,12 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("  # Cerberus secrets deployed and verified.")
         print("  # REMEMBER to revoke the key in the app UI (browser-only step).")
 
+    # The internal function uses `no_pypi` (legacy parameter name); compute
+    # it as "did the operator OPT IN via --pypi?" -- false = no_pypi=True =
+    # reminder suppressed; true = no_pypi=False = reminder fires. (#1269)
     _maybe_print_pypi_reminder(
         lang=args.lang,
-        no_pypi=args.no_pypi,
+        no_pypi=not args.pypi,
         no_github=args.no_github,
         github_user=github_user,
         repo_name=args.name.lower(),


### PR DESCRIPTION
Closes #1269

## What

Flips the PyPI publishing scaffold default in ``new_repo_setup.py``:

- **Before**: included by default; ``--no-pypi`` to opt out
- **After**: omitted by default; ``--pypi`` to opt in

## Why

Operator-stated 2026-05-25: PyPI publishing is rare across the fleet. Most new repos are private internal tools, browser extensions, scratch projects, honeypots, etc. None publish to PyPI. Defaulting to include the scaffold forces operators to remember ``--no-pypi`` for every new repo or scrub ``release.yml`` after the fact.

Surfaced concretely during dependabot-honeypot creation: a private repo whose entire purpose is generating dependabot PRs got handed a ``release.yml`` + ``[tool.poetry.scripts]`` + ``[tool.poetry.urls]`` scaffold. Zero chance of publish; pure cleanup tax.

## Changes

| Change | File |
|---|---|
| Add ``--pypi`` flag (opt-in) | ``tools/new_repo_setup.py`` |
| Mark ``--no-pypi`` deprecated (kept as no-op + deprecation notice on use) | ``tools/new_repo_setup.py`` |
| Mutex: ``--pypi`` + ``--no-pypi`` errors loudly | ``tools/new_repo_setup.py`` |
| ``enable_pypi`` derives from ``args.pypi``, not ``not args.no_pypi`` | ``tools/new_repo_setup.py`` |
| ``_maybe_print_pypi_reminder`` call site flips ``no_pypi=`` derivation (internal signature unchanged for test compat) | ``tools/new_repo_setup.py`` |
| Runbook 0934 updated: "deploys by default" → "deploys only with ``--pypi``" | ``docs/runbooks/0934-pypi-trusted-publisher-setup.md`` |

## Backward compatibility

- Existing ``--no-pypi`` invocations: still accepted, no-op, prints deprecation notice
- Existing ``--pypi``-free invocations: behavior CHANGES (no longer get PyPI scaffold). This is the intended fix.

## Tests

All 58 tests pass. ``_maybe_print_pypi_reminder``'s internal ``no_pypi=`` parameter is preserved; the call site computes ``no_pypi = not args.pypi`` so the function's contract is unchanged. Test assertions on ``no_pypi=True``/``False`` continue to hold.

## Operator usage after this PR

```bash
# Private repo (no publishing) -- default:
poetry run python tools/new_repo_setup.py dependabot-honeypot \
    --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg

# Public package -- opt in:
poetry run python tools/new_repo_setup.py my-cool-lib \
    --public --pypi --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg
```

## Related

- AZ#1269 — the issue this closes
- AZ#1268 / PR #1270 — companion fix (step 13 uses classic_pat_session); both unblock dependabot-honeypot creation
- AZ#1074 — original ``--no-pypi`` addition (this PR inverts the default per operator feedback)
- Runbook 0934 — updated inline