### PR TITLE
feat(tools): verify_encrypted_secret.py -- diagnostic for gpg-encrypted PEM/PAT blobs (Closes #1272)

### DIFF
--- a/tests/tools/test_verify_encrypted_secret.py
+++ b/tests/tools/test_verify_encrypted_secret.py
@@ -1,0 +1,147 @@
+"""Unit tests for tools/verify_encrypted_secret.py.
+
+Tests the type-detection + checker functions against fixture content.
+Does NOT invoke gpg (decryption is the script's I/O boundary; we test the
+content-classification logic that runs after decrypt).
+
+Issue: martymcenroe/AssemblyZero#1272
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(_TOOLS))
+
+from verify_encrypted_secret import (  # noqa: E402
+    check_pat,
+    check_pem,
+    check_text,
+    infer_type,
+)
+
+
+_VALID_PEM_LINES = [
+    "-----BEGIN RSA PRIVATE KEY-----",
+] + [
+    "A" * 64 for _ in range(25)
+] + [
+    "-----END RSA PRIVATE KEY-----",
+]
+VALID_PEM = "\n".join(_VALID_PEM_LINES) + "\n"
+
+VALID_PKCS8_PEM_LINES = [
+    "-----BEGIN PRIVATE KEY-----",
+] + ["B" * 64 for _ in range(25)] + [
+    "-----END PRIVATE KEY-----",
+]
+VALID_PKCS8_PEM = "\n".join(VALID_PKCS8_PEM_LINES) + "\n"
+
+INVALID_PEM_NO_HEADERS = "just some random text\nwith multiple lines\n"
+
+INVALID_PEM_TOO_SHORT = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    "AAAA\n"
+    "-----END RSA PRIVATE KEY-----\n"
+)
+
+VALID_CLASSIC_PAT = "0123456789abcdef" * 2 + "01234567"  # 40 chars
+assert len(VALID_CLASSIC_PAT) == 40
+
+VALID_FINEGRAINED_PAT = "github_pat_" + "A" * 60  # 71 chars
+
+INVALID_PAT_WRONG_CHARS = "this is not a real token, has spaces and uppercase"
+INVALID_PAT_MULTILINE = "ghp_AAAA1234567890ABCDEFGHIJ_klmnopqrstuvwxyz\nextra line"
+
+
+class TestInferType:
+    def test_pem_in_name(self):
+        assert infer_type(Path("/x/cerberus-pem.gpg")) == "pem"
+        assert infer_type(Path("/x/PEM-blob.gpg")) == "pem"
+
+    def test_pat_in_name(self):
+        assert infer_type(Path("/x/classic-pat.gpg")) == "pat"
+        assert infer_type(Path("/x/PAT.gpg")) == "pat"
+
+    def test_pem_wins_over_pat(self):
+        assert infer_type(Path("/x/pem-and-pat.gpg")) == "pem"
+
+    def test_fallback_text(self):
+        assert infer_type(Path("/x/secret.gpg")) == "text"
+        assert infer_type(Path("/x/notes.gpg")) == "text"
+
+
+class TestCheckPem:
+    def test_valid_rsa_pkcs1(self):
+        ok, details = check_pem(VALID_PEM)
+        assert ok, f"valid PEM rejected: {details}"
+        assert details["has_begin_marker"]
+        assert details["has_end_marker"]
+        assert details["size_in_typical_range"]
+        assert details["line_count_in_typical_range"]
+
+    def test_valid_pkcs8(self):
+        ok, _ = check_pem(VALID_PKCS8_PEM)
+        assert ok
+
+    def test_no_headers_rejected(self):
+        ok, details = check_pem(INVALID_PEM_NO_HEADERS)
+        assert not ok
+        assert not details["has_begin_marker"]
+        assert not details["has_end_marker"]
+
+    def test_too_short_rejected(self):
+        ok, details = check_pem(INVALID_PEM_TOO_SHORT)
+        assert not ok
+        assert details["has_begin_marker"]
+        assert details["has_end_marker"]
+        assert not details["size_in_typical_range"]
+
+    def test_empty_rejected(self):
+        ok, _ = check_pem("")
+        assert not ok
+
+
+class TestCheckPat:
+    def test_classic_pat_valid(self):
+        ok, details = check_pat(VALID_CLASSIC_PAT)
+        assert ok
+        assert details["is_single_line"]
+        assert details["matches_classic_pat_pattern"]
+        assert details["char_count"] == 40
+
+    def test_classic_pat_with_trailing_newline(self):
+        ok, _ = check_pat(VALID_CLASSIC_PAT + "\n")
+        assert ok
+
+    def test_finegrained_pat_valid(self):
+        ok, details = check_pat(VALID_FINEGRAINED_PAT)
+        assert ok
+        assert details["matches_finegrained_pat_pattern"]
+
+    def test_wrong_chars_rejected(self):
+        ok, _ = check_pat(INVALID_PAT_WRONG_CHARS)
+        assert not ok
+
+    def test_multiline_rejected(self):
+        ok, details = check_pat(INVALID_PAT_MULTILINE)
+        assert not ok
+        assert not details["is_single_line"]
+
+    def test_empty_rejected(self):
+        ok, _ = check_pat("")
+        assert not ok
+
+
+class TestCheckText:
+    def test_nonempty_valid(self):
+        ok, details = check_text("any content")
+        assert ok
+        assert details["non_empty"]
+
+    def test_empty_rejected(self):
+        ok, details = check_text("")
+        assert not ok
+        assert not details["non_empty"]

--- a/tools/verify_encrypted_secret.py
+++ b/tools/verify_encrypted_secret.py
@@ -1,0 +1,189 @@
+"""Verify a gpg-encrypted secret blob without exposing key material.
+
+Decrypts in-process (single pinentry prompt), then reports structural
+metadata only -- byte count, line count, first/last lines, type-specific
+checks. The decrypted content never reaches stdout/stderr and never lands
+on disk. Follows the same threat-model posture as
+``tools/_pat_session.py`` (ADR-0216).
+
+Supported types:
+    pem  -- PEM-encoded private key (RSA, EC, generic)
+    pat  -- single-line PAT / token (classic or fine-grained)
+    text -- generic text blob (just metadata, no semantic checks)
+
+Type is auto-detected from the filename if ``--type`` is not given:
+    "*pem*" -> pem
+    "*pat*" -> pat
+    else    -> text
+
+Exit codes:
+    0  verdict is VALID for the chosen type
+    1  verdict is INVALID (one or more type checks failed)
+    2  file not found / decrypt failed / argparse error
+
+Usage:
+    poetry run python tools/verify_encrypted_secret.py PATH [--type TYPE]
+
+Issue: martymcenroe/AssemblyZero#1272
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+GPG_TIMEOUT_S = 180
+
+# RSA-2048 PEMs land around 1700 bytes; RSA-4096 around 3300. A generous
+# 1500-4000 range catches both with margin for line-ending variance.
+PEM_TYPICAL_BYTES = (1500, 4000)
+PEM_TYPICAL_LINES = (20, 60)
+
+# Classic PAT: 40-char lowercase hex. Fine-grained: "ghp_" or "github_pat_"
+# prefix followed by 36+ alphanumerics/underscores. Both should be a
+# single line; total length 40-100.
+PAT_CLASSIC = re.compile(r"^[a-f0-9]{40}$")
+PAT_FINEGRAINED = re.compile(r"^(ghp_|github_pat_)[A-Za-z0-9_]{36,}$")
+PAT_BYTE_RANGE = (40, 100)
+
+
+def _decrypt(path: Path) -> str:
+    """Decrypt the gpg blob in-process. Single pinentry prompt.
+
+    Exits with code 2 if decrypt fails -- caller never gets ciphertext.
+    """
+    result = subprocess.run(
+        ["gpg", "--quiet", "--decrypt", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=GPG_TIMEOUT_S,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: gpg decrypt failed: {result.stderr.strip()}",
+              file=sys.stderr)
+        sys.exit(2)
+    return result.stdout
+
+
+def infer_type(path: Path) -> str:
+    """Auto-detect the secret type from the filename."""
+    name = path.name.lower()
+    if "pem" in name:
+        return "pem"
+    if "pat" in name:
+        return "pat"
+    return "text"
+
+
+def check_pem(content: str) -> tuple[bool, dict]:
+    """Check the decrypted content looks like a PEM private key."""
+    lines = content.splitlines()
+    has_begin = any("BEGIN" in l and "PRIVATE KEY" in l for l in lines)
+    has_end = any("END" in l and "PRIVATE KEY" in l for l in lines)
+    size_ok = PEM_TYPICAL_BYTES[0] <= len(content) <= PEM_TYPICAL_BYTES[1]
+    lines_ok = PEM_TYPICAL_LINES[0] <= len(lines) <= PEM_TYPICAL_LINES[1]
+    return (
+        has_begin and has_end and size_ok and lines_ok,
+        {
+            "has_begin_marker": has_begin,
+            "has_end_marker": has_end,
+            "size_in_typical_range": size_ok,
+            "line_count_in_typical_range": lines_ok,
+        },
+    )
+
+
+def check_pat(content: str) -> tuple[bool, dict]:
+    """Check the decrypted content looks like a GitHub PAT."""
+    stripped = content.strip()
+    lines = stripped.splitlines()
+    is_single_line = len(lines) == 1
+    classic = bool(PAT_CLASSIC.fullmatch(stripped))
+    fine_grained = bool(PAT_FINEGRAINED.fullmatch(stripped))
+    size_ok = PAT_BYTE_RANGE[0] <= len(stripped) <= PAT_BYTE_RANGE[1]
+    return (
+        is_single_line and (classic or fine_grained) and size_ok,
+        {
+            "is_single_line": is_single_line,
+            "char_count": len(stripped),
+            "matches_classic_pat_pattern": classic,
+            "matches_finegrained_pat_pattern": fine_grained,
+        },
+    )
+
+
+def check_text(content: str) -> tuple[bool, dict]:
+    """Generic check: non-empty."""
+    return (
+        len(content) > 0,
+        {"non_empty": len(content) > 0},
+    )
+
+
+CHECKERS = {
+    "pem": check_pem,
+    "pat": check_pat,
+    "text": check_text,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a gpg-encrypted secret blob without exposing key material. "
+            "Decrypts in-process, reports metadata + type-specific checks, "
+            "never prints the decrypted content."
+        ),
+    )
+    parser.add_argument(
+        "path",
+        help="Path to the gpg-encrypted file (e.g. ~/.secrets/cerberus-pem.gpg)",
+    )
+    parser.add_argument(
+        "--type",
+        choices=list(CHECKERS),
+        default=None,
+        help="Secret type. Auto-detected from filename if omitted: "
+             "'*pem*' -> pem, '*pat*' -> pat, else text.",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.path).expanduser()
+    if not path.exists():
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        return 2
+
+    secret_type = args.type or infer_type(path)
+
+    print(f"File:         {path}")
+    print(f"Type:         {secret_type}")
+    print()
+
+    content = _decrypt(path)
+    lines = content.splitlines()
+
+    print(f"Total bytes:  {len(content)}")
+    print(f"Line count:   {len(lines)}")
+    print(f"First line:   {lines[0] if lines else '(empty)'}")
+    print(f"Last line:    {lines[-1] if lines else '(empty)'}")
+    print()
+
+    ok, details = CHECKERS[secret_type](content)
+    print(f"Type-specific checks ({secret_type}):")
+    for k, v in details.items():
+        print(f"  {k}: {v}")
+    print()
+
+    if ok:
+        print("VERDICT: VALID")
+        return 0
+    print("VERDICT: INVALID -- one or more checks failed.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1272

## What

New ``tools/verify_encrypted_secret.py`` -- promotes the ad-hoc gpg-decrypt + python-one-liner diagnostic (from the 2026-05-25 Cerberus PEM incident) into a small standalone tool.

```bash
poetry run python tools/verify_encrypted_secret.py ~/.secrets/cerberus-pem.gpg
```

Output:

```
File:         /c/Users/mcwiz/.secrets/cerberus-pem.gpg
Type:         pem

Total bytes:  1679
Line count:   27
First line:   -----BEGIN RSA PRIVATE KEY-----
Last line:    -----END RSA PRIVATE KEY-----

Type-specific checks (pem):
  has_begin_marker: True
  has_end_marker: True
  size_in_typical_range: True
  line_count_in_typical_range: True

VERDICT: VALID
```

## Behavior

- **Single pinentry prompt per invocation** (one gpg decrypt call)
- **Decrypted content never reaches stdout/stderr** -- only metadata + boolean checks
- **Type auto-detected from filename**: ``*pem*`` -> pem, ``*pat*`` -> pat, else text. ``--type`` overrides
- **Exit codes**: 0 (valid), 1 (invalid), 2 (file/decrypt error)

## Type-specific checks

| Type | Checks |
|---|---|
| ``pem`` | BEGIN/END PRIVATE KEY markers, byte count 1500-4000 (RSA-2048 through RSA-4096 with margin), line count 20-60 |
| ``pat`` | Single line, 40-100 chars, matches classic (``[a-f0-9]{40}``) OR fine-grained (``(ghp_\|github_pat_)[A-Za-z0-9_]{36,}``) |
| ``text`` | Non-empty (no semantic checks) |

## Tests

17 tests covering ``infer_type`` + the three checker functions. No gpg invocation in tests -- decryption is the script's I/O boundary; we test the content-classification logic that runs after decrypt.

## Threat-model posture (matches ADR-0216)

- Decrypted bytes only in Python heap, scope-bounded
- gpg subprocess uses ``capture_output=True``; no console exposure of plaintext
- No env vars, no subprocess argv carrying secret content

## Out of scope (follow-ups, separate issues if wanted)

- ``gh`` CLI alias: ``gh alias set verify-secret '!cd ~/Projects/AssemblyZero && poetry run python tools/verify_encrypted_secret.py'``
- Documentation cross-reference in runbook 0927 / 0930 as the canonical post-encrypt verification step

## Related

- 2026-05-25 incident -- Cerberus deploy failed with "PEM contents do not look like a private key" because the encrypted blob contained the wrong file content; ad-hoc diagnostic surfaced the issue
- ADR-0216 -- in-process classic PAT pattern; this tool follows the same posture