### PR TITLE
fix(new-repo): verify_pr_sentinel_installation uses classic_pat_session per ADR-0216 (Closes #1274)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -907,45 +907,68 @@ class TestVerifyWorkflowContent:
 
 
 class TestVerifyPrSentinelInstallation:
-    """T300-T302: verify_pr_sentinel_installation (#1202)."""
+    """T300-T302: verify_pr_sentinel_installation (#1202, refactored #1274).
 
-    @patch("new_repo_setup.run_command")
-    def test_T300_pass_when_repo_in_installation(self, mock_run):
+    Post-#1274: function uses requests + classic PAT (not gh CLI). Tests
+    mock requests.get with status-code/json-shaped responses.
+    """
+
+    @patch("new_repo_setup.requests.get")
+    def test_T300_pass_when_repo_in_installation(self, mock_get):
         """Worker installation found AND covers the new repo → (True, ...)."""
-        mock_run.side_effect = [
-            # /user/installations filter → installation id
-            MagicMock(returncode=0, stdout="12345\n", stderr=""),
-            # /user/installations/12345/repositories → list of full_names
-            MagicMock(
-                returncode=0,
-                stdout="martymcenroe/some-other\nmartymcenroe/repo-name\n",
-                stderr="",
-            ),
-        ]
-        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        installations_resp = MagicMock(status_code=200)
+        installations_resp.json.return_value = {
+            "installations": [
+                {"app_slug": "pr-sentinel-mm", "id": 12345},
+            ],
+        }
+        repos_resp = MagicMock(status_code=200)
+        repos_resp.json.return_value = {
+            "repositories": [
+                {"full_name": "martymcenroe/some-other"},
+                {"full_name": "martymcenroe/repo-name"},
+            ],
+        }
+        mock_get.side_effect = [installations_resp, repos_resp]
+        ok, msg = verify_pr_sentinel_installation(
+            "martymcenroe", "repo-name", "fake-pat",
+        )
         assert ok is True
         assert "covers" in msg
 
-    @patch("new_repo_setup.run_command")
-    def test_T301_warn_when_installation_missing(self, mock_run):
+    @patch("new_repo_setup.requests.get")
+    def test_T301_warn_when_installation_missing(self, mock_get):
         """No pr-sentinel-mm in /user/installations → (False, 'not found')."""
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"installations": [
+            {"app_slug": "some-other-app", "id": 99},
+        ]}
+        mock_get.return_value = resp
+        ok, msg = verify_pr_sentinel_installation(
+            "martymcenroe", "repo-name", "fake-pat",
+        )
         assert ok is False
         assert "not found" in msg
 
-    @patch("new_repo_setup.run_command")
-    def test_T302_warn_when_repo_not_in_installation_repos(self, mock_run):
+    @patch("new_repo_setup.requests.get")
+    def test_T302_warn_when_repo_not_in_installation_repos(self, mock_get):
         """Installation exists but doesn't cover the new repo → App scope drift warning."""
-        mock_run.side_effect = [
-            MagicMock(returncode=0, stdout="12345\n", stderr=""),
-            MagicMock(
-                returncode=0,
-                stdout="martymcenroe/some-other-only\n",
-                stderr="",
-            ),
-        ]
-        ok, msg = verify_pr_sentinel_installation("martymcenroe", "repo-name")
+        installations_resp = MagicMock(status_code=200)
+        installations_resp.json.return_value = {
+            "installations": [
+                {"app_slug": "pr-sentinel-mm", "id": 12345},
+            ],
+        }
+        repos_resp = MagicMock(status_code=200)
+        repos_resp.json.return_value = {
+            "repositories": [
+                {"full_name": "martymcenroe/some-other-only"},
+            ],
+        }
+        mock_get.side_effect = [installations_resp, repos_resp]
+        ok, msg = verify_pr_sentinel_installation(
+            "martymcenroe", "repo-name", "fake-pat",
+        )
         assert ok is False
         assert "does NOT cover" in msg or "drift" in msg.lower()
 

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1843,7 +1843,7 @@ def verify_workflow_content_on_origin(
 
 
 def verify_pr_sentinel_installation(
-    github_user: str, repo_name: str,
+    github_user: str, repo_name: str, pat: str,
 ) -> tuple[bool, str]:
     """Best-effort check that pr-sentinel-mm Cloudflare Worker covers this repo.
 
@@ -1852,49 +1852,82 @@ def verify_pr_sentinel_installation(
     drifted from 'All repositories', the check never fires and every PR sits
     blocked. Catches that at creation time instead of when the first PR opens.
 
-    Uses gh CLI's authenticated user-to-server token (fine-grained PAT is
-    sufficient for /user/installations) — no classic PAT needed.
+    Uses the in-process classic PAT per ADR-0216 (#1274). The
+    /user/installations endpoint requires elevated scope that the
+    fine-grained PAT deliberately lacks; prior versions of this function
+    shelled out via gh and reliably 403'd on every run.
+
+    Args:
+        github_user: GitHub username (org or user account that owns the repo).
+        repo_name: Repository name (no owner prefix).
+        pat: Classic PAT from classic_pat_session(). Passed in the
+            Authorization header; never reaches env or argv.
     """
+    headers = {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
     # Step 1: find the pr-sentinel-mm installation id on the user account.
     try:
-        r = run_command(
-            ["gh", "api", "/user/installations", "--jq",
-             '.installations[] | select(.app_slug == "pr-sentinel-mm") | .id'],
-            check=False,
+        r = requests.get(
+            "https://api.github.com/user/installations",
+            headers=headers, timeout=30,
         )
-    except (subprocess.TimeoutExpired, OSError) as e:
+    except requests.RequestException as e:
         return False, f"could not query /user/installations: {e}"
-    if r.returncode != 0:
-        # 403 / 401 / 404 — token doesn't have the right scope or API is
-        # unavailable. Surface but don't fail the verification — this is
-        # an advisory check.
-        return False, f"gh api /user/installations failed: {(r.stderr or '').strip()[:200]}"
-    out = (r.stdout or "").strip().splitlines()
-    if not out or not out[0].strip():
+    if r.status_code != 200:
+        return False, (
+            f"GET /user/installations failed: {r.status_code} "
+            f"{r.text[:200]}"
+        )
+    try:
+        installations = r.json().get("installations", [])
+    except ValueError as e:
+        return False, f"could not parse /user/installations: {e}"
+    sentinel = next(
+        (inst for inst in installations if inst.get("app_slug") == "pr-sentinel-mm"),
+        None,
+    )
+    if sentinel is None:
         return False, "pr-sentinel-mm not found in /user/installations"
-    installation_id = out[0].strip()
+    installation_id = sentinel.get("id")
+    if installation_id is None:
+        return False, "pr-sentinel-mm installation has no id field"
 
     # Step 2: list repositories covered by this installation; confirm the
-    # new repo is in the list. --paginate handles users with many repos.
-    try:
-        r = run_command(
-            ["gh", "api", f"/user/installations/{installation_id}/repositories",
-             "--paginate", "--jq", ".repositories[].full_name"],
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        return False, f"could not query installation repos: {e}"
-    if r.returncode != 0:
-        return False, (
-            f"gh api installation/{installation_id}/repositories failed: "
-            f"{(r.stderr or '').strip()[:200]}"
-        )
-    covered = set((r.stdout or "").strip().splitlines())
+    # new repo is in the list. GitHub paginates installation repositories
+    # at 100 per page; loop until exhausted.
     full_name = f"{github_user}/{repo_name}"
-    if full_name in covered:
-        return True, f"installation {installation_id} covers this repo"
+    page = 1
+    while True:
+        try:
+            r = requests.get(
+                f"https://api.github.com/user/installations/{installation_id}/repositories",
+                headers=headers,
+                params={"per_page": 100, "page": page},
+                timeout=30,
+            )
+        except requests.RequestException as e:
+            return False, f"could not query installation repos: {e}"
+        if r.status_code != 200:
+            return False, (
+                f"GET /user/installations/{installation_id}/repositories "
+                f"failed: {r.status_code} {r.text[:200]}"
+            )
+        try:
+            repos = r.json().get("repositories", [])
+        except ValueError as e:
+            return False, f"could not parse installation repos: {e}"
+        for repo in repos:
+            if repo.get("full_name") == full_name:
+                return True, f"installation {installation_id} covers this repo"
+        if len(repos) < 100:
+            break  # last page
+        page += 1
     return False, (
-        f"installation {installation_id} does NOT cover {full_name} — "
+        f"installation {installation_id} does NOT cover {full_name} -- "
         "App scope may have drifted from 'All repositories'"
     )
 
@@ -2726,6 +2759,23 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         else:
                             print(f"  [FAIL] Cerberus secrets missing: {missing}")
 
+                    # pr-sentinel installation check -- elevated; needs the
+                    # classic PAT (the /user/installations endpoint is NOT
+                    # accessible to the fine-grained PAT). Inside the
+                    # with-block, shares pat -- no extra pinentry. (#1274)
+                    gh_checks_total += 1
+                    ok, msg = verify_pr_sentinel_installation(
+                        github_user, repo_name_lower, pat,
+                    )
+                    if ok:
+                        print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
+                        gh_checks_passed += 1
+                    else:
+                        print(f"  [WARN] pr-sentinel-mm Worker: {msg}")
+                        print("         If pr-sentinel checks don't appear on the first PR,")
+                        print("         the App's installation scope likely drifted from "
+                              "'All repositories'.")
+
         except FileNotFoundError as e:
             print(f"\n  ERROR: classic PAT not configured: {e}")
             print("  Local scaffold preserved. Set up classic PAT per ADR-0216 /")
@@ -2736,20 +2786,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
             print(f"\n  ERROR: gpg decrypt failed: {e}")
             print("  Re-enter passphrase carefully and re-run.")
 
-        # pr-sentinel installation check -- non-elevated, no classic PAT
-        # needed. Runs OUTSIDE the with-block; pat is already out of scope.
         if github_created:
-            gh_checks_total += 1
-            ok, msg = verify_pr_sentinel_installation(github_user, repo_name_lower)
-            if ok:
-                print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
-                gh_checks_passed += 1
-            else:
-                print(f"  [WARN] pr-sentinel-mm Worker: {msg}")
-                print("         If pr-sentinel checks don't appear on the first PR,")
-                print("         the App's installation scope likely drifted from "
-                      "'All repositories'.")
-
             print(f"\nGitHub-side verification: {gh_checks_passed}/{gh_checks_total} checks passed")
 
             if gh_checks_passed < gh_checks_total:


### PR DESCRIPTION
Closes #1274

## What

Same shape as #1268: a verification function that shelled out via ``gh`` with the fine-grained PAT and reliably 403'd on every run because the endpoint requires elevated scope. Refactored to use ``requests`` + classic PAT in-process. Call site moved inside the existing elevated with-block.

## Observed 2026-05-25 during dependabot-honeypot creation

```
[WARN] pr-sentinel-mm Worker: gh api /user/installations failed:
gh: Resource not accessible by personal access token (HTTP 403)
```

The check uses ``GET /user/installations`` (and then ``/user/installations/{id}/repositories``) to confirm the ``pr-sentinel-mm`` App covers the new repo. Both endpoints need admin scope the fine-grained PAT deliberately lacks. The prior comment claiming "fine-grained PAT is sufficient" was wrong.

## Changes

| Change | Detail |
|---|---|
| ``verify_pr_sentinel_installation`` signature | Adds ``pat: str`` parameter |
| Auth path | ``requests.get`` with ``Authorization: token {pat}`` instead of ``gh api`` shell-out |
| Pagination | Explicit ``while`` loop on ``per_page=100`` / ``page+=1`` until <100 returned (was relying on ``gh api --paginate``) |
| Call site | Moved from AFTER the ``with classic_pat_session() as pat:`` block to INSIDE it — pat shared with other elevated ops, no extra pinentry |
| GitHub-side-verification summary | Moved out of the with-block so it prints after the elevated batch concludes |
| Tests T300-T302 | Refactored to mock ``requests.get`` instead of ``run_command``; return status-code/json-shaped Response objects |

## Tests

75 pass (was 58 before today's series; 17 new in #1273, 0 net change here apart from refactoring 3 existing tests).

## Manual verification (operator)

Next ``new_repo_setup.py NAME --cerberus-pem-gpg ...`` run should show:

```
[PASS] pr-sentinel-mm Worker: installation N covers this repo
```

Instead of the 403 WARN.

## Related

- ADR-0216 — in-process classic PAT pattern
- AZ#1268 / PR #1270 — companion fix for step 13 (same shape)
- 2026-05-25 dependabot-honeypot creation — where this surfaced