### PR TITLE
feat(handoff): force why-per-file in 'Files to Read First' + ban auto-loaded snapshots

### DIFF
--- a/.claude/skills/handoff.md
+++ b/.claude/skills/handoff.md
@@ -177,10 +177,16 @@ archive_path: {from the Step 5.4B archive call result, or omit if archive failed
 
 ## Files to Read First
 
-{Ordered list of files the next session should read to get oriented:}
-1. `{plan file}` — the master plan
-2. `{key file}` — because...
-3. ...
+For each file: ONE sentence describing what signal the next session gets that auto-loaded files (universal CLAUDE.md, repo CLAUDE.md, MEMORY.md) don't already provide. If you can't articulate that, don't list it.
+
+**Do NOT include:**
+- The universal CLAUDE.md, repo CLAUDE.md, or MEMORY.md (auto-loaded — listing them implies the agent has a choice)
+- Snapshots / audit-trail copies of any of the above (e.g. `docs/canonical/*`)
+- Files the next session will Read on-demand anyway (list the spec, not the target the spec changes)
+
+Format:
+1. `{path}` — **{one-line signal the next session gets}**
+2. ...
 ```
 
 ### Step 2B: Memory Line Check


### PR DESCRIPTION
## Summary

Replace the loose `— because...` placeholder in `/handoff`'s "Files to Read First" block with a structured "what signal does this give the next session" rule + an explicit exclusion list (auto-loaded CLAUDE.md files, their snapshots, on-demand-read targets).

## Why

Yesterday's handoff (2026-05-25 17:16) listed `docs/canonical/universal-CLAUDE.md` as a "Files to Read First" entry. Today's pickup session read it. The file is an audit-trail snapshot generated by AZ#1263 — its content is already auto-loaded by Claude Code from the universal CLAUDE.md. Reading the snapshot returned zero incremental signal.

The current template format (`— because...`) accepts a description (`initial snapshot from AZ#1263`) as easily as a justification, so the author wrote what they had rather than what the next session needed. The new shape forces the author to articulate the SIGNAL or drop the entry, and the exclusion list catches the class of failure (audit artifacts, mirrors of auto-loaded files).

## Honest scope

This fixes the **author side**. It does NOT fix the structural **reader-side** bluffing problem (LLMs skipping files and producing confident answers from incomplete reads). Reader-side fix lives in #1255.

Closes #1276

## Test plan
- [x] Diff is a single-block edit in `.claude/skills/handoff.md`
- [ ] `skill_sync.py` propagates the change after merge (manual: run from AssemblyZero next session)
- [ ] Next `/handoff` run demonstrates the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)