### PR TITLE
fix(skill): dependabot.md references runbook 0911 v2.1 → v2.3

### DIFF
--- a/.claude/skills/dependabot.md
+++ b/.claude/skills/dependabot.md
@@ -24,7 +24,7 @@ Usage: `/dependabot [--help] [--dry-run] [--fleet]`
 
 The tool operates ONLY on PRs authored by `dependabot[bot]`. Any other author is refused at the author gate. Tests must exit 0; non-zero exit means the PR gets a `gh pr review --comment` posted (deferred PRs accrue Code Review credit too — #1091) and is left for human review. No LLM in the decision loop — decisions are pure exit-code / string-match.
 
-Reference: runbook `docs/runbooks/0911-dependabot-pr-audit.md` v2.1.
+Reference: runbook `docs/runbooks/0911-dependabot-pr-audit.md` v2.3.
 
 ---
 


### PR DESCRIPTION
## Summary

One-character version drift fix in `.claude/skills/dependabot.md:27`. Same stale `v2.1` reference was fixed on the Dependabot-Pipeline wiki page (`#1280`); this PR catches the skill copy.

Closes #1282

## Test plan
- [x] One-line edit
- [ ] `skill_sync.py` propagates to `~/.claude/skills/dependabot.md` + `~/.claude/commands/dependabot.md` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)