### PR TITLE
feat(tools): lint_per_repo_claude_md.py — drift detector for per-repo CLAUDE.md

### DIFF
--- a/tests/test_lint_per_repo_claude_md.py
+++ b/tests/test_lint_per_repo_claude_md.py
@@ -1,0 +1,284 @@
+"""Tests for tools/lint_per_repo_claude_md.py (#1290)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from lint_per_repo_claude_md import (  # noqa: E402
+    detect_drift,
+    format_json,
+    format_text,
+    load_allowlist,
+    load_unleashed_assemblyzero,
+    scan_fleet,
+)
+
+
+# ────────────────────────────────────────────────────────────────────
+# Fixture helpers
+# ────────────────────────────────────────────────────────────────────
+
+
+def make_repo(tmp_path: Path, name: str, claude_md: str | None,
+              unleashed: dict | None = None) -> Path:
+    """Create a fake repo dir with optional CLAUDE.md and .unleashed.json."""
+    repo = tmp_path / name
+    repo.mkdir()
+    if claude_md is not None:
+        (repo / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+    if unleashed is not None:
+        (repo / ".unleashed.json").write_text(json.dumps(unleashed), encoding="utf-8")
+    return repo
+
+
+def lean_template(name: str = "test-repo") -> str:
+    """Return a 25-line lean CLAUDE.md per ADR 0219 (passes all detectors)."""
+    return f"""# CLAUDE.md - {name} Project
+
+You are a team member on the {name} project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/{name}`
+- **Project Root (Windows):** `C:\\Users\\someone\\Projects\\{name}`
+- **Project Root (Unix):** `/c/Users/someone/Projects/{name}`
+- **Worktree Pattern:** `{name}-{{IssueID}}`
+
+## Project-Specific Context
+
+_TODO: Add tech stack, architecture, file map, project-type-specific notes,
+and any workflow overrides specific to this project. The universal CLAUDE.md
+(auto-loaded) covers all fleet-wide rules; this file only adds what is true
+for THIS repo specifically._
+
+## Notes
+
+- Some specific note here
+- Another note
+- Filler to clear the stub threshold
+- More filler
+- Even more filler so we exceed 20 lines
+"""
+
+
+# ────────────────────────────────────────────────────────────────────
+# Marker tests
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_lean_template_passes(tmp_path: Path) -> None:
+    """Lean reference template per ADR 0219 must trip zero detectors."""
+    # Note: lean template uses C:\Users\someone\ NOT mcwiz, so marker 9 doesn't fire
+    repo = make_repo(tmp_path, "lean-repo", lean_template("lean-repo"))
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert result.status == "PASS", f"Expected PASS, got {result.status}, findings: {[(f.marker, f.description) for f in result.findings]}"
+    assert result.findings == []
+
+
+def test_marker_1_false_az_rules_list(tmp_path: Path) -> None:
+    content = lean_template() + """
+
+## False claim
+
+The AssemblyZero/CLAUDE.md file contains bash-command rules and visible self-check
+patterns plus worktree isolation and decision-making protocol.
+"""
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert result.status == "DRIFT"
+    assert any(f.marker == 1 for f in result.findings)
+
+
+def test_marker_2_orchestrator_gate(tmp_path: Path) -> None:
+    content = lean_template() + """
+
+## PRE-MERGE GATE
+
+Wait for orchestrator review before merging.
+"""
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 2 for f in result.findings)
+
+
+def test_marker_3_wrong_report_format(tmp_path: Path) -> None:
+    content = lean_template() + "\n\nReport filenames are `1{IssueID}-foo.md`.\n"
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 3 for f in result.findings)
+
+
+def test_marker_4_session_logs_as_source(tmp_path: Path) -> None:
+    content = lean_template() + (
+        "\n\nFor cross-session continuity, read docs/session-logs/ first.\n"
+    )
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 4 for f in result.findings)
+
+
+def test_marker_5_first_read_az(tmp_path: Path) -> None:
+    content = lean_template() + "\n\n## FIRST: Read AssemblyZero Core Rules\n"
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 5 for f in result.findings)
+
+
+def test_marker_6_az_refs_when_opted_out(tmp_path: Path) -> None:
+    content = lean_template() + "\n\nThis repo references AssemblyZero workflows.\n"
+    repo = make_repo(
+        tmp_path, "opted-out", content,
+        unleashed={"assemblyZero": False},
+    )
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 6 for f in result.findings)
+
+
+def test_marker_6_skipped_when_no_unleashed_json(tmp_path: Path) -> None:
+    """No .unleashed.json = no signal; marker 6 should NOT fire even with AZ refs."""
+    content = lean_template() + "\n\nThis repo references AssemblyZero workflows.\n"
+    repo = make_repo(tmp_path, "no-config", content)  # no .unleashed.json
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 6 for f in result.findings)
+
+
+def test_marker_6_skipped_when_opted_in(tmp_path: Path) -> None:
+    """assemblyZero=true => AZ refs are legitimate, marker 6 must not fire."""
+    content = lean_template() + "\n\nUses AssemblyZero workflows for X.\n"
+    repo = make_repo(
+        tmp_path, "opted-in", content,
+        unleashed={"assemblyZero": True},
+    )
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 6 for f in result.findings)
+
+
+def test_marker_7_universal_dupe_no_override(tmp_path: Path) -> None:
+    """Phrases like 'merge sequence' without nearby 'override' qualifier fire."""
+    content = lean_template() + (
+        "\n\n## Process\n\nFollow the standard merge sequence on every PR.\n"
+    )
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 7 for f in result.findings)
+
+
+def test_marker_7_skipped_when_override_nearby(tmp_path: Path) -> None:
+    """Aletheia-style: 'merge sequence override' must not trip marker 7."""
+    content = lean_template() + (
+        "\n\n## Override\n\n"
+        "This repo overrides the universal merge sequence — use tools/merge_pr.py instead.\n"
+    )
+    repo = make_repo(tmp_path, "aletheia-like", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 7 for f in result.findings)
+
+
+def test_marker_8_stub_under_threshold(tmp_path: Path) -> None:
+    content = "# CLAUDE.md\n\nStub.\n"  # 3 lines
+    repo = make_repo(tmp_path, "stub", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert result.status == "STUB"
+    assert any(f.marker == 8 for f in result.findings)
+
+
+def test_marker_9_hardcoded_mcwiz_path(tmp_path: Path) -> None:
+    content = lean_template() + "\n\nSee C:\\Users\\mcwiz\\Projects\\X\\foo.md\n"
+    repo = make_repo(tmp_path, "drifted", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 9 for f in result.findings)
+
+
+def test_missing_claude_md(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, "empty", None)  # no CLAUDE.md
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert result.status == "MISSING"
+    assert result.findings == []
+
+
+# ────────────────────────────────────────────────────────────────────
+# Helper / config tests
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_load_unleashed_missing(tmp_path: Path) -> None:
+    repo = tmp_path / "norepo"
+    repo.mkdir()
+    assert load_unleashed_assemblyzero(repo) is None
+
+
+def test_load_unleashed_present(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, "r", lean_template(), unleashed={"assemblyZero": True})
+    assert load_unleashed_assemblyzero(repo) is True
+
+
+def test_load_unleashed_missing_key(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, "r", lean_template(), unleashed={"other": "thing"})
+    assert load_unleashed_assemblyzero(repo) is None
+
+
+def test_load_allowlist_strips_comments_and_blanks(tmp_path: Path) -> None:
+    allow = tmp_path / "allow.txt"
+    allow.write_text("# comment\nrepo-a\n\nrepo-b\n# another comment\n", encoding="utf-8")
+    assert load_allowlist(allow) == {"repo-a", "repo-b"}
+
+
+def test_load_allowlist_none_returns_empty() -> None:
+    assert load_allowlist(None) == set()
+
+
+def test_load_allowlist_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_allowlist(tmp_path / "nonexistent.txt")
+
+
+# ────────────────────────────────────────────────────────────────────
+# scan_fleet integration
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_scan_fleet_mixed(tmp_path: Path) -> None:
+    """Mixed fleet: one pass, one stub, one missing, one allowlisted."""
+    make_repo(tmp_path, "good", lean_template("good"))
+    make_repo(tmp_path, "stubby", "# Tiny\n")
+    make_repo(tmp_path, "noclaude", None)
+    make_repo(tmp_path, "skipme", "# Whatever\n" * 50)
+    (tmp_path / ".hidden").mkdir()  # hidden dir; should be ignored
+
+    results = scan_fleet(tmp_path, {"skipme"})
+    status_by_name = {r.repo_name: r.status for r in results}
+    assert status_by_name["good"] == "PASS"
+    assert status_by_name["stubby"] == "STUB"
+    assert status_by_name["noclaude"] == "MISSING"
+    assert status_by_name["skipme"] == "SKIPPED"
+    assert ".hidden" not in status_by_name
+
+
+# ────────────────────────────────────────────────────────────────────
+# Output formatting
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_format_text_summary(tmp_path: Path) -> None:
+    make_repo(tmp_path, "good", lean_template())
+    make_repo(tmp_path, "stub", "# tiny\n")
+    results = scan_fleet(tmp_path, set())
+    out = format_text(results)
+    assert "good: PASS" in out
+    assert "stub: STUB" in out
+    assert "Summary:" in out
+
+
+def test_format_json_is_valid(tmp_path: Path) -> None:
+    make_repo(tmp_path, "good", lean_template())
+    results = scan_fleet(tmp_path, set())
+    parsed = json.loads(format_json(results))
+    assert isinstance(parsed, list)
+    assert parsed[0]["repo"] == "good"
+    assert parsed[0]["status"] == "PASS"
+    assert parsed[0]["findings"] == []

--- a/tools/lint_per_repo_claude_md.py
+++ b/tools/lint_per_repo_claude_md.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""tools/lint_per_repo_claude_md.py — Drift detector for per-repo CLAUDE.md files.
+
+Surfaced by #1290 (split from #1259). ADR 0219 (#1258) sets the rule for what
+may and may not appear in a per-repo CLAUDE.md. This tool flags drift without
+acting on it (read-only audit) so per-repo remediation can be triaged
+deliberately.
+
+The 9 drift markers (severity in parens):
+
+  1 [ERROR]   False AssemblyZero/CLAUDE.md rules list (the fabricated list
+              signature observed in gh-link-auditor pre-#328 and boostgauge)
+  2 [ERROR]   PRE-MERGE GATE references nonexistent orchestrator
+  3 [ERROR]   Wrong report filename format ("1{IssueID}" vs "10{IssueID:04d}")
+  4 [WARNING] docs/session-logs/ named as cross-session source (should be
+              data/handoff-log.md)
+  5 [ERROR]   "FIRST: Read AssemblyZero Core Rules" or any variant (per ADR
+              0219 Consequence #2, auto-load handles inheritance)
+  6 [WARNING] References AssemblyZero in a repo whose .unleashed.json has
+              "assemblyZero": false (drift; AZ refs are only legitimate when
+              the repo opts in). If .unleashed.json doesn't exist at all, we
+              skip this marker — no signal to determine intent.
+  7 [WARNING] May duplicate universal CLAUDE.md content (matches phrases
+              like "merge sequence" / "enforce_admins" / "banned commands"
+              WITHOUT a nearby "override" qualifier). Advisory: legitimate
+              per-repo workflow overrides ARE allowed and use the same
+              phrases, so this marker hedges via the "override" check.
+  8 [ERROR]   Stub (line count < 20)
+  9 [WARNING] Hardcoded C:\\Users\\mcwiz\\... path (should be parameterized
+              via config.projects_root())
+
+Heuristic notes:
+
+- Markers 6 + 7 are WARNING (not ERROR) because both have legitimate
+  override paths (Aletheia overrides the merge-sequence rule deliberately
+  per its CLAUDE.md). Operator decides whether each WARNING is real drift.
+- Marker 7 specifically checks that "override" doesn't appear within ±200
+  chars of any match. Designed to NOT false-positive on Aletheia's
+  documented override.
+
+Output:
+
+  - text (default): one line per repo + summary + marker totals
+  - json: machine-readable, designed for piping into per-repo issue filers
+
+Exit codes:
+
+  0  — all repos pass (no drift, no missing, no stub)
+  1  — argument error (projects root not found, allowlist unreadable)
+  2  — one or more repos have drift / missing / stub status
+
+Usage:
+
+  poetry run python tools/lint_per_repo_claude_md.py
+  poetry run python tools/lint_per_repo_claude_md.py --json
+  poetry run python tools/lint_per_repo_claude_md.py --allowlist allowlist.txt
+
+Related:
+
+  - ADR 0219 (#1258) — the rule this enforces
+  - #1259 (parent, split into per-concern issues)
+  - #1290 — this tool
+  - unleashed#656 — private fleet audit queue (downstream consumer)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Import AssemblyZero config for projects-root resolution.
+try:
+    from assemblyzero_config import config
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from assemblyzero_config import config
+
+# ────────────────────────────────────────────────────────────────────
+# Detector regexes
+# ────────────────────────────────────────────────────────────────────
+
+# Marker 1: the fabricated AZ-rules-list signature observed in drifted repos.
+# Targets the "claims AZ/CLAUDE.md contains <X>" pattern where <X> is one of
+# the false-claim items historically listed.
+RE_FALSE_AZ_RULES = re.compile(
+    r"AssemblyZero[/\\]CLAUDE\.md.*"
+    r"(bash-command rules|visible self-check|worktree isolation|"
+    r"decision-making protocol)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Marker 2: PRE-MERGE GATE references nonexistent orchestrator wait.
+RE_ORCHESTRATOR_GATE = re.compile(
+    r"PRE[-_ ]MERGE GATE.*orchestrator|"
+    r"wait for orchestrator.*review",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Marker 3: wrong report filename format.
+# Real format is 10{IssueID:04d}; wrong is 1{IssueID}. We match the bare
+# wrong pattern (e.g. "1{IssueID}" in a path or string template).
+RE_WRONG_REPORT_FORMAT = re.compile(
+    r"`?1\{IssueID\}|1\{issue_id\}",
+    re.IGNORECASE,
+)
+
+# Marker 4: docs/session-logs/ named as cross-session source.
+RE_SESSION_LOGS_AS_SOURCE = re.compile(
+    r"docs/session-logs/.*(cross.session|previous session|continuity)|"
+    r"(cross.session|previous session|continuity).*docs/session-logs/",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Marker 5: "FIRST: Read AssemblyZero Core Rules" or variant.
+RE_FIRST_READ_AZ = re.compile(
+    r"FIRST[:\s]+Read AssemblyZero|"
+    r"FIRST.*read.*AssemblyZero.*(rules|CLAUDE)",
+    re.IGNORECASE,
+)
+
+# Marker 9: hardcoded user-specific paths.
+RE_HARDCODED_MCWIZ = re.compile(r"C:[\\/]Users[\\/]mcwiz[\\/]")
+
+# Marker 7: phrases that indicate restated universal-CLAUDE.md content.
+# These are ADVISORY — legitimate per-repo overrides use the same phrases
+# (e.g., Aletheia overrides the merge sequence), so we hedge via the
+# "override" proximity check below.
+UNIVERSAL_DUPE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"merge sequence", re.IGNORECASE),
+    re.compile(r"Closes #N must appear in ALL THREE", re.IGNORECASE),
+    re.compile(r"enforce_admins.*?true", re.IGNORECASE),
+    re.compile(r"\bbanned commands\b", re.IGNORECASE),
+]
+
+# How far to look on either side of a dupe match for the "override" qualifier
+# that legitimizes the restatement.
+OVERRIDE_PROXIMITY_CHARS = 200
+RE_OVERRIDE = re.compile(r"override", re.IGNORECASE)
+
+STUB_LINE_THRESHOLD = 20
+
+
+# ────────────────────────────────────────────────────────────────────
+# Data classes
+# ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Finding:
+    marker: int
+    severity: str  # 'ERROR' | 'WARNING'
+    description: str
+    evidence: Optional[str] = None  # short excerpt from the file
+
+
+@dataclass
+class RepoResult:
+    repo_name: str
+    claude_md_path: Path
+    status: str  # 'PASS' | 'DRIFT' | 'MISSING' | 'STUB' | 'SKIPPED'
+    line_count: int = 0
+    findings: list[Finding] = field(default_factory=list)
+    unleashed_assemblyzero: Optional[bool] = None  # from .unleashed.json
+
+
+# ────────────────────────────────────────────────────────────────────
+# Detectors
+# ────────────────────────────────────────────────────────────────────
+
+
+def load_unleashed_assemblyzero(repo_root: Path) -> Optional[bool]:
+    """Read `.unleashed.json:assemblyZero`. Returns None if file or key missing."""
+    cfg = repo_root / ".unleashed.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    val = data.get("assemblyZero")
+    return val if isinstance(val, bool) else None
+
+
+def _match_excerpt(text: str, m: re.Match[str], context: int = 60) -> str:
+    """Return a short excerpt around a regex match for evidence display."""
+    start = max(0, m.start() - context)
+    end = min(len(text), m.end() + context)
+    excerpt = text[start:end].replace("\n", " ").strip()
+    return f"...{excerpt}..."
+
+
+def detect_drift(claude_md: Path, repo_root: Path) -> RepoResult:
+    """Run all 9 detectors against a single CLAUDE.md and return findings."""
+    result = RepoResult(
+        repo_name=repo_root.name,
+        claude_md_path=claude_md,
+        status="PASS",
+    )
+
+    if not claude_md.exists():
+        result.status = "MISSING"
+        return result
+
+    text = claude_md.read_text(encoding="utf-8", errors="replace")
+    result.line_count = len(text.splitlines())
+    result.unleashed_assemblyzero = load_unleashed_assemblyzero(repo_root)
+
+    # Marker 8: stub (line count < 20). Don't return early — continue
+    # detection on stub files; multiple markers can coexist.
+    if result.line_count < STUB_LINE_THRESHOLD:
+        result.findings.append(Finding(
+            8, "ERROR",
+            f"Stub (line count {result.line_count} < {STUB_LINE_THRESHOLD})",
+        ))
+
+    # Marker 1: false AZ-rules-list signature.
+    m = RE_FALSE_AZ_RULES.search(text)
+    if m:
+        result.findings.append(Finding(
+            1, "ERROR",
+            "False AssemblyZero/CLAUDE.md rules list",
+            _match_excerpt(text, m),
+        ))
+
+    # Marker 2: PRE-MERGE GATE / orchestrator wait.
+    m = RE_ORCHESTRATOR_GATE.search(text)
+    if m:
+        result.findings.append(Finding(
+            2, "ERROR",
+            "PRE-MERGE GATE references nonexistent orchestrator",
+            _match_excerpt(text, m),
+        ))
+
+    # Marker 3: wrong report filename format.
+    m = RE_WRONG_REPORT_FORMAT.search(text)
+    if m:
+        result.findings.append(Finding(
+            3, "ERROR",
+            "Wrong report filename format (1{IssueID} vs 10{IssueID:04d})",
+            _match_excerpt(text, m),
+        ))
+
+    # Marker 4: docs/session-logs/ as cross-session source.
+    m = RE_SESSION_LOGS_AS_SOURCE.search(text)
+    if m:
+        result.findings.append(Finding(
+            4, "WARNING",
+            "docs/session-logs/ named as cross-session source "
+            "(should be data/handoff-log.md)",
+            _match_excerpt(text, m),
+        ))
+
+    # Marker 5: "FIRST: Read AssemblyZero..."
+    m = RE_FIRST_READ_AZ.search(text)
+    if m:
+        result.findings.append(Finding(
+            5, "ERROR",
+            'Tells agent to "FIRST: Read AssemblyZero..." '
+            "(per ADR 0219 Consequence #2, auto-load handles inheritance)",
+            _match_excerpt(text, m),
+        ))
+
+    # Marker 6: AZ refs in a repo that has explicitly opted OUT of AZ
+    # workflow. Skip if .unleashed.json doesn't exist at all (no signal).
+    if result.unleashed_assemblyzero is False:
+        m = re.search(r"\bAssemblyZero\b", text)
+        if m:
+            result.findings.append(Finding(
+                6, "WARNING",
+                "References AssemblyZero but .unleashed.json:assemblyZero=false",
+                _match_excerpt(text, m),
+            ))
+
+    # Marker 7: duplication of universal-CLAUDE.md content. Each pattern is
+    # checked; for each match, we look ±200 chars for an "override"
+    # qualifier. Only fire if no override is nearby — legitimate per-repo
+    # overrides (Aletheia's documented merge-sequence override) won't trip.
+    for pattern in UNIVERSAL_DUPE_PATTERNS:
+        for m in pattern.finditer(text):
+            window_start = max(0, m.start() - OVERRIDE_PROXIMITY_CHARS)
+            window_end = m.end() + OVERRIDE_PROXIMITY_CHARS
+            window = text[window_start:window_end]
+            if not RE_OVERRIDE.search(window):
+                result.findings.append(Finding(
+                    7, "WARNING",
+                    f"May duplicate universal CLAUDE.md content "
+                    f"(pattern: {pattern.pattern!r})",
+                    _match_excerpt(text, m),
+                ))
+                break  # one finding per pattern is enough
+
+    # Marker 9: hardcoded mcwiz paths.
+    m = RE_HARDCODED_MCWIZ.search(text)
+    if m:
+        result.findings.append(Finding(
+            9, "WARNING",
+            "Hardcoded C:\\Users\\mcwiz\\... path "
+            "(should be parameterized via config.projects_root())",
+            _match_excerpt(text, m),
+        ))
+
+    # Decide final status. STUB takes precedence over DRIFT for display
+    # (an under-threshold file is more fundamentally broken than a drifted
+    # one), but stub-AND-drifted files keep both findings.
+    if result.line_count < STUB_LINE_THRESHOLD:
+        result.status = "STUB"
+    elif result.findings:
+        result.status = "DRIFT"
+
+    return result
+
+
+# ────────────────────────────────────────────────────────────────────
+# Fleet scan + output
+# ────────────────────────────────────────────────────────────────────
+
+
+def load_allowlist(allowlist_path: Optional[Path]) -> set[str]:
+    """Load repo names to skip. Blank lines and # comments ignored."""
+    if allowlist_path is None:
+        return set()
+    if not allowlist_path.exists():
+        raise FileNotFoundError(f"Allowlist file not found: {allowlist_path}")
+    out: set[str] = set()
+    for raw in allowlist_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line)
+    return out
+
+
+def scan_fleet(
+    projects_root: Path,
+    allowlist: set[str],
+) -> list[RepoResult]:
+    """Scan every {projects_root}/*/CLAUDE.md (one level deep) and return results."""
+    results: list[RepoResult] = []
+    for repo_dir in sorted(projects_root.iterdir()):
+        if not repo_dir.is_dir():
+            continue
+        if repo_dir.name.startswith("."):
+            continue
+        if repo_dir.name in allowlist:
+            results.append(RepoResult(
+                repo_name=repo_dir.name,
+                claude_md_path=repo_dir / "CLAUDE.md",
+                status="SKIPPED",
+            ))
+            continue
+        claude_md = repo_dir / "CLAUDE.md"
+        results.append(detect_drift(claude_md, repo_dir))
+    return results
+
+
+def format_text(results: list[RepoResult]) -> str:
+    lines: list[str] = []
+    for r in results:
+        if r.status == "PASS":
+            tag = "PASS"
+        elif r.status == "MISSING":
+            tag = "MISSING"
+        elif r.status == "SKIPPED":
+            tag = "SKIPPED (allowlisted)"
+        elif r.status == "STUB":
+            marker_ids = ",".join(str(f.marker) for f in r.findings)
+            tag = f"STUB({r.line_count} lines; markers: {marker_ids})"
+        elif r.status == "DRIFT":
+            marker_ids = ",".join(str(f.marker) for f in r.findings)
+            errs = sum(1 for f in r.findings if f.severity == "ERROR")
+            warns = sum(1 for f in r.findings if f.severity == "WARNING")
+            tag = f"DRIFT(markers: {marker_ids}; E:{errs}/W:{warns})"
+        else:
+            tag = r.status
+        lines.append(f"{r.repo_name}: {tag}")
+    # Summary
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    lines.append("")
+    lines.append(
+        f"Summary: {counts.get('PASS', 0)} pass, "
+        f"{counts.get('DRIFT', 0)} drift, "
+        f"{counts.get('MISSING', 0)} missing, "
+        f"{counts.get('STUB', 0)} stub, "
+        f"{counts.get('SKIPPED', 0)} skipped "
+        f"(total {len(results)})"
+    )
+    # Marker totals
+    marker_totals: dict[int, int] = {}
+    for r in results:
+        for f in r.findings:
+            marker_totals[f.marker] = marker_totals.get(f.marker, 0) + 1
+    if marker_totals:
+        lines.append(
+            "Marker counts: "
+            + ", ".join(f"M{k}={v}" for k, v in sorted(marker_totals.items()))
+        )
+    return "\n".join(lines)
+
+
+def format_json(results: list[RepoResult]) -> str:
+    out = []
+    for r in results:
+        out.append({
+            "repo": r.repo_name,
+            "status": r.status,
+            "line_count": r.line_count,
+            "unleashed_assemblyzero": r.unleashed_assemblyzero,
+            "findings": [
+                {
+                    "marker": f.marker,
+                    "severity": f.severity,
+                    "description": f.description,
+                    "evidence": f.evidence,
+                }
+                for f in r.findings
+            ],
+            "claude_md_path": str(r.claude_md_path),
+        })
+    return json.dumps(out, indent=2)
+
+
+# ────────────────────────────────────────────────────────────────────
+# CLI
+# ────────────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Drift detector for per-repo CLAUDE.md files (ADR 0219).",
+    )
+    parser.add_argument(
+        "--projects-root",
+        type=Path,
+        default=None,
+        help="Override projects root (default from config.projects_root())",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=None,
+        help="File with line-separated repo names to skip "
+             "(blank lines and # comments ignored)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    projects_root = args.projects_root or Path(config.projects_root())
+    if not projects_root.exists():
+        print(f"ERROR: projects root not found: {projects_root}", file=sys.stderr)
+        return 1
+
+    try:
+        allowlist = load_allowlist(args.allowlist)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    results = scan_fleet(projects_root, allowlist)
+
+    if args.format == "json":
+        print(format_json(results))
+    else:
+        print(format_text(results))
+
+    has_drift = any(
+        r.status in ("DRIFT", "STUB", "MISSING") for r in results
+    )
+    return 2 if has_drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New tool `tools/lint_per_repo_claude_md.py` implementing the 9 drift markers from #1290 (split from #1259, gated by ADR 0219 #1258). Read-only audit — flags drift, never mutates.

## What it does

| Marker | Severity | Detects |
|---|---|---|
| 1 | ERROR | False AssemblyZero/CLAUDE.md rules list |
| 2 | ERROR | PRE-MERGE GATE orchestrator wait |
| 3 | ERROR | Wrong report filename format (1{IssueID}) |
| 4 | WARNING | docs/session-logs/ named as cross-session source |
| 5 | ERROR | "FIRST: Read AssemblyZero..." |
| 6 | WARNING | AZ refs in repo with `.unleashed.json:assemblyZero=false` |
| 7 | WARNING | May duplicate universal-CLAUDE.md content |
| 8 | ERROR | Stub (line count < 20) |
| 9 | WARNING | Hardcoded `C:\Users\mcwiz\...` paths |

Markers 6 + 7 hedge against false positives:
- **Marker 6** only fires if `.unleashed.json` exists AND `assemblyZero: false`. If `.unleashed.json` is absent (no signal), the marker is skipped — fresh repos don't get false-flagged.
- **Marker 7** uses an "override" proximity check (±200 chars) — Aletheia's documented merge-sequence override won't trip it.

## Verification

- **23-test pytest suite** — every marker has a positive case; markers 6 + 7 have negative cases proving the hedges work
- **Smoke test against the live fleet** (92 entries under `Projects/`): 8 pass, 21 drift, 55 missing, 8 stub. Tool correctly identifies the patent-general drift on marker 5 that ADR 0219 already flagged as the next remediation.

Closes #1290

## Test plan
- [x] `poetry run pytest tests/test_lint_per_repo_claude_md.py -v` — 23/23 pass
- [x] `poetry run ruff check --isolated tools/lint_per_repo_claude_md.py tests/test_lint_per_repo_claude_md.py` — clean
- [x] `poetry run python tools/lint_per_repo_claude_md.py` — full fleet scan, no crashes
- [x] `poetry run python tools/lint_per_repo_claude_md.py --format json | python -c "json.load(sys.stdin)"` — JSON output is parseable

🤖 Generated with [Claude Code](https://claude.com/claude-code)