### PR TITLE
feat(new-repo): --project-type branching for scaffolded CLAUDE.md + tests

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -17,8 +17,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
 
 from new_repo_setup import (
+    PROJECT_TYPES,
     SchemaValidationError,
+    _project_specific_context,
     audit_project_structure,
+    create_claude_md,
     create_structure,
     flatten_directories,
     flatten_files,
@@ -1031,3 +1034,142 @@ class TestPypiReminder:
             repo_name="myproject",
         )
         assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md emission per ADR 0219 (#1258) + --project-type branching (#1291)
+# Tests #1292 — assert lean shape + per-type stubs + no banned content.
+# ---------------------------------------------------------------------------
+
+# Phrases that MUST NOT appear in any scaffolded CLAUDE.md per ADR 0219 —
+# these belong to the universal CLAUDE.md, and restating them creates drift
+# on every universal-CLAUDE.md edit.
+BANNED_PHRASES = [
+    "merge sequence",
+    "Closes #N must appear in ALL THREE",
+    "enforce_admins",
+    "FIRST: Read AssemblyZero",
+    "banned commands",
+    "pr-sentinel / issue-reference",
+]
+
+
+class TestCreateClaudeMdLeanShape:
+    """ADR 0219 — emitted CLAUDE.md must be additive only, no duplicated content."""
+
+    def test_minimal_is_default_and_emits_todo_stub(self, tmp_path):
+        create_claude_md(tmp_path, "myrepo", "alice")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "## Project Identifiers" in text
+        assert "myrepo" in text
+        assert "alice/myrepo" in text
+        # default minimal emits the TODO block (not a typed stack note)
+        assert "**Stack:**" not in text
+        assert "TODO: Add tech stack" in text
+
+    def test_no_banned_universal_content_in_minimal(self, tmp_path):
+        create_claude_md(tmp_path, "myrepo", "alice")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        for phrase in BANNED_PHRASES:
+            assert phrase not in text, (
+                f"Banned phrase {phrase!r} found in scaffolded CLAUDE.md — "
+                f"ADR 0219 forbids restating universal CLAUDE.md content."
+            )
+
+    def test_no_banned_universal_content_in_any_project_type(self, tmp_path):
+        """Across all project types, no stub may restate universal content."""
+        for pt in PROJECT_TYPES:
+            target = tmp_path / pt
+            target.mkdir()
+            create_claude_md(target, f"sample-{pt}", "alice", pt)
+            text = (target / "CLAUDE.md").read_text(encoding="utf-8")
+            for phrase in BANNED_PHRASES:
+                assert phrase not in text, (
+                    f"Banned phrase {phrase!r} found in {pt!r} stub — "
+                    f"per ADR 0219 stubs must be ADDITIVE only."
+                )
+
+    def test_invalid_project_type_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown project_type"):
+            create_claude_md(tmp_path, "myrepo", "alice", "nonexistent-type")
+
+
+class TestProjectTypeStubs:
+    """Each project type emits a recognizable stack identifier + ADR 0219 ref."""
+
+    def test_python_stub_mentions_poetry_and_pytest(self):
+        text = _project_specific_context("python", "myrepo")
+        assert "**Stack:**" in text
+        assert "Poetry" in text
+        assert "pytest" in text
+        assert "src/myrepo/" in text
+        assert "ADR 0219" in text
+
+    def test_chrome_extension_stub_mentions_mv3(self):
+        text = _project_specific_context("chrome-extension", "myrepo")
+        assert "Manifest V3" in text
+        assert "jest" in text
+        assert "ADR 0219" in text
+
+    def test_pypi_stub_mentions_release_yml(self):
+        text = _project_specific_context("pypi", "myrepo")
+        assert "PyPI" in text
+        assert "release.yml" in text
+        assert "[tool.poetry.scripts]" in text
+        assert "runbook 0934" in text
+        assert "ADR 0219" in text
+
+    def test_cf_worker_stub_mentions_wrangler(self):
+        text = _project_specific_context("cf-worker", "myrepo")
+        assert "Cloudflare Worker" in text
+        assert "wrangler" in text
+        assert "ADR 0219" in text
+
+    def test_web_stub_mentions_deploy_targets(self):
+        text = _project_specific_context("web", "myrepo")
+        assert "Web (static or SPA)" in text
+        # at least one of the listed deploy targets
+        assert any(t in text for t in ("Cloudflare Pages", "GitHub Pages", "Netlify"))
+        assert "ADR 0219" in text
+
+    def test_minimal_stub_has_no_stack_line(self):
+        text = _project_specific_context("minimal", "myrepo")
+        assert "**Stack:**" not in text
+        assert "TODO: Add tech stack" in text
+        assert "ADR 0219" in text
+
+    def test_each_stub_includes_project_specific_context_header(self):
+        for pt in PROJECT_TYPES:
+            text = _project_specific_context(pt, "myrepo")
+            assert text.startswith("## Project-Specific Context"), pt
+
+    def test_each_typed_stub_includes_todo(self):
+        """Even typed stubs must leave a TODO — the stack note is a head start, not a finish."""
+        for pt in PROJECT_TYPES:
+            text = _project_specific_context(pt, "myrepo")
+            assert "TODO" in text, f"{pt} stub has no TODO marker"
+
+
+class TestProjectTypeBranchingCallSite:
+    """End-to-end: create_claude_md passes the project_type through to the stub."""
+
+    def test_python_call_site_emits_stack_line(self, tmp_path):
+        create_claude_md(tmp_path, "myrepo", "alice", "python")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "**Stack:** Python (Poetry)" in text
+
+    def test_cf_worker_call_site_emits_wrangler(self, tmp_path):
+        create_claude_md(tmp_path, "myrepo", "alice", "cf-worker")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "wrangler" in text
+
+    def test_chrome_extension_call_site_emits_mv3(self, tmp_path):
+        create_claude_md(tmp_path, "myrepo", "alice", "chrome-extension")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "Manifest V3" in text
+
+    def test_default_call_site_emits_minimal(self, tmp_path):
+        """No explicit project_type = minimal stub (TODO, no stack note)."""
+        create_claude_md(tmp_path, "myrepo", "alice")
+        text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "**Stack:**" not in text

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -414,25 +414,132 @@ def create_project_json(project_path: Path, name: str, github_user: str) -> None
     project_json_path.write_text(json.dumps(project_json, indent=2) + "\n", encoding='utf-8')
 
 
-def create_claude_md(project_path: Path, name: str, github_user: str) -> None:
+PROJECT_TYPES = ("minimal", "python", "chrome-extension", "pypi", "cf-worker", "web")
+
+
+def _project_specific_context(project_type: str, name: str) -> str:
+    """Return the "## Project-Specific Context" section for the given project type.
+
+    Each stub:
+      - Names the stack concretely so the next agent doesn't have to guess
+      - Leaves a TODO for project-specific additions
+      - References ADR 0219 explicitly so the boundary stays load-bearing
+
+    Stubs MUST be ADDITIVE only — no restating of universal CLAUDE.md content
+    (merge sequence, Closes #N rules, branch protection, banned commands,
+    GitHub CLI safety). Verified by tests/test_new_repo_setup.py.
+
+    Per #1291: default 'minimal' on operator silence — better to emit a blank
+    that the operator fills in than guess wrong for unrecognized types.
+    """
+    if project_type == "minimal":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            "_TODO: Add tech stack, architecture, file map, project-type-specific notes,\n"
+            "and any workflow overrides specific to this project. The universal\n"
+            "CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers\n"
+            "fleet-wide rules -- this file only adds what's true for THIS repo\n"
+            "specifically. Restating universal content here creates drift on every\n"
+            "universal-CLAUDE.md edit (ADR 0219)._\n"
+        )
+    if project_type == "python":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            f"**Stack:** Python (Poetry); pytest suite at `tests/`; source under `src/{name}/`.\n"
+            "\n"
+            "_TODO: Add architecture notes, key modules, project-specific gotchas, and\n"
+            "any workflow overrides. The universal CLAUDE.md (auto-loaded) covers\n"
+            "fleet-wide rules -- only add what's true for THIS repo specifically (ADR 0219)._\n"
+        )
+    if project_type == "chrome-extension":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            "**Stack:** Chrome extension, Manifest V3. Source under `extensions/` (or `src/`).\n"
+            "Tests via jest + jsdom. Build/bundle via the project's chosen tooling (esbuild,\n"
+            "webpack, or vite -- confirm in `package.json` scripts).\n"
+            "\n"
+            "_TODO: Add MV3 service-worker entry point, content-script layout,\n"
+            "message-passing notes, and the manifest version. The universal CLAUDE.md\n"
+            "(auto-loaded) covers fleet-wide rules -- only add what's true for THIS\n"
+            "repo specifically (ADR 0219)._\n"
+        )
+    if project_type == "pypi":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            f"**Stack:** Python (Poetry), published to PyPI. Source under `src/{name}/`,\n"
+            "entry points in `[tool.poetry.scripts]`, release via\n"
+            "`.github/workflows/release.yml` on tag push. Pending-publisher registration\n"
+            "on PyPI documented in runbook 0934.\n"
+            "\n"
+            "_TODO: Add public-API stability notes, versioning policy, and any\n"
+            "release-time checks the project requires. The universal CLAUDE.md\n"
+            "(auto-loaded) covers fleet-wide rules -- only add what's true for THIS\n"
+            "repo specifically (ADR 0219)._\n"
+        )
+    if project_type == "cf-worker":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            "**Stack:** Cloudflare Worker. Source under `src/`. Deploy via `wrangler`\n"
+            "(config in `wrangler.toml`). Local dev: `wrangler dev`. Secrets / env\n"
+            "via `wrangler secret put`.\n"
+            "\n"
+            "_TODO: Add the Worker's route map, KV/D1/R2 bindings, observability\n"
+            "notes, and the staging-vs-prod environment split. The universal\n"
+            "CLAUDE.md (auto-loaded) covers fleet-wide rules -- only add what's true\n"
+            "for THIS repo specifically (ADR 0219)._\n"
+        )
+    if project_type == "web":
+        return (
+            "## Project-Specific Context\n"
+            "\n"
+            "**Stack:** Web (static or SPA). Confirm the framework in `package.json`.\n"
+            "Deploy target documented in the project's own README (commonly Cloudflare\n"
+            "Pages, GitHub Pages, or Netlify for this fleet).\n"
+            "\n"
+            "_TODO: Add the routing structure, asset pipeline, and any deploy hooks\n"
+            "specific to this repo. The universal CLAUDE.md (auto-loaded) covers\n"
+            "fleet-wide rules -- only add what's true for THIS repo specifically\n"
+            "(ADR 0219)._\n"
+        )
+    raise ValueError(
+        f"Unknown project_type: {project_type!r}. "
+        f"Choose one of: {', '.join(PROJECT_TYPES)}"
+    )
+
+
+def create_claude_md(
+    project_path: Path,
+    name: str,
+    github_user: str,
+    project_type: str = "minimal",
+) -> None:
     """
     Create the project CLAUDE.md file.
 
-    Emits the lean per-repo template per ADR 0219 (#1258): identifiers and a
-    Project-Specific Context TODO stub. Everything else (merge sequence, PR
-    rules, branch protection, GitHub CLI safety) lives in the universal
-    CLAUDE.md auto-loaded by Claude Code's parent-directory traversal --
-    NOT restated here, to avoid drift on every universal-CLAUDE.md edit.
+    Emits the lean per-repo template per ADR 0219 (#1258): identifiers plus
+    a project-type-specific Project-Specific Context stub (per #1291).
+    Everything else (merge sequence, PR rules, branch protection, GitHub CLI
+    safety) lives in the universal CLAUDE.md auto-loaded by Claude Code's
+    parent-directory traversal -- NOT restated here, to avoid drift on every
+    universal-CLAUDE.md edit.
 
     Args:
         project_path: Path to the project root
         name: Project name
         github_user: GitHub username
+        project_type: One of PROJECT_TYPES. Default 'minimal' on operator
+            silence -- better to emit a TODO than guess wrong (#1291).
 
-    See: #1266 (minimum-viable slice), #1259 (parent refactor, remaining
-    scope: lint tool + project-type branching), #1258 (ADR 0219).
+    See: #1266 (minimum-viable slice), #1291 (project-type branching),
+    #1292 (test coverage), #1258 (ADR 0219).
     """
     projects_root_unix = config.projects_root_unix()
+    context_block = _project_specific_context(project_type, name)
 
     content = f"""# CLAUDE.md - {name} Project
 
@@ -445,16 +552,7 @@ You are a team member on the {name} project, not a tool.
 - **Project Root (Unix):** `{projects_root_unix}/{name}`
 - **Worktree Pattern:** `{name}-{{IssueID}}` (e.g., `{name}-45`)
 
-## Project-Specific Context
-
-_TODO: Add tech stack, architecture, file map, project-type-specific notes,
-and any workflow overrides specific to this project. The universal
-CLAUDE.md (auto-loaded by Claude Code's parent-directory traversal) covers
-all fleet-wide rules -- merge sequence, PR-issue references, branch
-protection, GitHub CLI safety, banned commands, etc. This file only adds
-what is true for THIS repo specifically. Restating universal content here
-creates drift on every universal-CLAUDE.md edit (ADR 0219)._
-"""
+{context_block}"""
     claude_md_path = project_path / "CLAUDE.md"
     claude_md_path.write_text(content, encoding='utf-8')
 
@@ -2094,6 +2192,18 @@ Examples:
              "for non-Python projects. (#1058)"
     )
     parser.add_argument(
+        "--project-type",
+        choices=list(PROJECT_TYPES),
+        default="minimal",
+        help="Project-type-specific stub for the scaffolded CLAUDE.md's "
+             "Project-Specific Context section. 'minimal' (default) emits a "
+             "TODO block. Other choices ('python', 'chrome-extension', 'pypi', "
+             "'cf-worker', 'web') emit a one-paragraph stack note plus a "
+             "type-specific TODO. Default is intentionally 'minimal' -- "
+             "better to leave a TODO than guess wrong for an unrecognized "
+             "type. (#1291; ADR 0219)"
+    )
+    parser.add_argument(
         "--pypi",
         action="store_true",
         default=False,
@@ -2347,7 +2457,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
     # Step 6: Create CLAUDE.md
     print("\n6. Creating CLAUDE.md...")
-    create_claude_md(project_path, args.name, github_user)
+    create_claude_md(project_path, args.name, github_user, args.project_type)
     print("  Created CLAUDE.md")
 
     # Step 7: Create GEMINI.md


### PR DESCRIPTION
## Summary

Adds `--project-type {minimal,python,chrome-extension,pypi,cf-worker,web}` to `tools/new_repo_setup.py` per #1291. Each typed stub emits a one-paragraph `**Stack:**` note plus a type-specific TODO; `minimal` (default) emits just the TODO. Default is intentionally `minimal` — better to leave a TODO than guess wrong for unrecognized types.

Paired with #1292 — 16 new tests under `tests/test_new_repo_setup.py` covering the lean-shape invariant, per-type stub content, and the call-site end-to-end.

## Test plan
- [x] `poetry run pytest tests/test_new_repo_setup.py` — 74/74 pass (16 new + 58 pre-existing)
- [x] `poetry run ruff check --isolated tools/new_repo_setup.py tests/test_new_repo_setup.py` — no new errors in edit zone (20 pre-existing lint warnings elsewhere are out of scope; tracked separately if relevant)
- [x] Tested invalid `project_type` raises `ValueError`
- [x] Banned-phrase scan across every stub: 0 hits

## Notes

The minimal stub's TODO was tightened (dropped the enumeration of universal-CLAUDE.md sections like "merge sequence, PR-issue references, branch protection, GitHub CLI safety, banned commands") because that enumeration was itself a mild restatement of universal content. The new banned-phrase tests caught it. Universal CLAUDE.md is now referenced abstractly as "fleet-wide rules" instead. This is exactly the kind of drift ADR 0219 + the lint tool (#1290, just shipped) are designed to surface — caught here in tests instead.

Closes #1291
Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)