### PR TITLE
fix(lint): marker 9 ignores hardcoded paths inside Project Identifiers block

### DIFF
--- a/tests/test_lint_per_repo_claude_md.py
+++ b/tests/test_lint_per_repo_claude_md.py
@@ -10,6 +10,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
 from lint_per_repo_claude_md import (  # noqa: E402
+    _strip_identifiers_block,
     detect_drift,
     format_json,
     format_text,
@@ -192,6 +193,125 @@ def test_marker_9_hardcoded_mcwiz_path(tmp_path: Path) -> None:
     repo = make_repo(tmp_path, "drifted", content)
     result = detect_drift(repo / "CLAUDE.md", repo)
     assert any(f.marker == 9 for f in result.findings)
+
+
+def test_marker_9_skipped_when_only_in_identifiers(tmp_path: Path) -> None:
+    """Scaffolder-emitted path in Identifiers block must NOT trip marker 9 (#1300)."""
+    content = """# CLAUDE.md - test Project
+
+You are a team member on the test project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/test`
+- **Project Root (Windows):** `C:\\Users\\mcwiz\\Projects\\test`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/test`
+- **Worktree Pattern:** `test-{IssueID}`
+
+## Project-Specific Context
+
+Filler so we clear stub threshold.
+More filler.
+Even more.
+Filler line.
+Another line.
+And another.
+And more.
+Last filler.
+"""
+    repo = make_repo(tmp_path, "ident-only", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 9 for f in result.findings), (
+        f"Marker 9 fired on Identifiers-only path: {[(f.marker, f.description) for f in result.findings]}"
+    )
+
+
+def test_marker_9_fires_outside_identifiers_even_when_also_inside(tmp_path: Path) -> None:
+    """Identifiers + body occurrence => marker 9 fires (on the body one)."""
+    content = """# CLAUDE.md - test Project
+
+You are a team member on the test project, not a tool.
+
+## Project Identifiers
+
+- **Repository:** `martymcenroe/test`
+- **Project Root (Windows):** `C:\\Users\\mcwiz\\Projects\\test`
+- **Project Root (Unix):** `/c/Users/mcwiz/Projects/test`
+- **Worktree Pattern:** `test-{IssueID}`
+
+## Notes
+
+For more info see `C:\\Users\\mcwiz\\Projects\\SomeOther\\bar.md` in the body.
+Filler to clear stub threshold.
+More filler.
+And more.
+"""
+    repo = make_repo(tmp_path, "both", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 9 for f in result.findings)
+
+
+def test_marker_9_fires_when_no_identifiers_heading(tmp_path: Path) -> None:
+    """No `## Project Identifiers` heading => no exception, marker 9 fires on any match."""
+    content = """# CLAUDE.md - test Project
+
+Body content with no Identifiers heading.
+
+See `C:\\Users\\mcwiz\\Projects\\X\\foo.md` for details.
+Filler to clear stub threshold.
+More filler.
+And more.
+And more lines.
+Even more.
+"""
+    repo = make_repo(tmp_path, "no-ident", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 9 for f in result.findings)
+
+
+def test_strip_identifiers_block_removes_section(tmp_path: Path) -> None:
+    text = """# Title
+
+Body before.
+
+## Project Identifiers
+
+- a
+- b
+- c
+
+## Next Section
+
+Body after.
+"""
+    out = _strip_identifiers_block(text)
+    assert "## Project Identifiers" not in out
+    assert "- a" not in out
+    assert "Body before" in out
+    assert "Body after" in out
+    assert "## Next Section" in out
+
+
+def test_strip_identifiers_block_no_heading_returns_unchanged(tmp_path: Path) -> None:
+    text = "# Title\n\nBody with no Identifiers heading.\n"
+    assert _strip_identifiers_block(text) == text
+
+
+def test_strip_identifiers_block_at_eof(tmp_path: Path) -> None:
+    """Identifiers block at EOF (no following h2) is stripped to EOF."""
+    text = """# Title
+
+Body before.
+
+## Project Identifiers
+
+- a
+- b
+"""
+    out = _strip_identifiers_block(text)
+    assert "## Project Identifiers" not in out
+    assert "- a" not in out
+    assert "Body before" in out
 
 
 def test_missing_claude_md(tmp_path: Path) -> None:

--- a/tools/lint_per_repo_claude_md.py
+++ b/tools/lint_per_repo_claude_md.py
@@ -125,6 +125,12 @@ RE_FIRST_READ_AZ = re.compile(
 # Marker 9: hardcoded user-specific paths.
 RE_HARDCODED_MCWIZ = re.compile(r"C:[\\/]Users[\\/]mcwiz[\\/]")
 
+# Project Identifiers block boundaries — used by marker 9 to skip the
+# scaffolder-emitted literal path in the Identifiers section, which is
+# load-bearing (it IS the project root on this dev machine) and not drift.
+RE_IDENTIFIERS_HEADING = re.compile(r"^## Project Identifiers\s*$", re.MULTILINE)
+RE_NEXT_H2 = re.compile(r"^## ", re.MULTILINE)
+
 # Marker 7: phrases that indicate restated universal-CLAUDE.md content.
 # These are ADVISORY — legitimate per-repo overrides use the same phrases
 # (e.g., Aletheia overrides the merge sequence), so we hedge via the
@@ -191,6 +197,32 @@ def _match_excerpt(text: str, m: re.Match[str], context: int = 60) -> str:
     end = min(len(text), m.end() + context)
     excerpt = text[start:end].replace("\n", " ").strip()
     return f"...{excerpt}..."
+
+
+def _strip_identifiers_block(text: str) -> str:
+    """Return text with the `## Project Identifiers` section removed.
+
+    Used by marker 9 to ignore the scaffolder-emitted literal Windows path
+    that appears in every per-repo CLAUDE.md's Identifiers block (e.g.
+    `C:\\Users\\mcwiz\\Projects\\boostgauge`). That literal IS the project
+    root on this dev machine — load-bearing, not drift. Marker 9 should
+    only fire on `C:\\Users\\mcwiz\\...` occurrences OUTSIDE this block
+    (in body prose, example commands, etc.).
+
+    If the file has no `## Project Identifiers` heading, returns the
+    original text unchanged (no exception to apply).
+
+    Block boundaries: starts at the `## Project Identifiers` line, ends
+    at the next `## ` heading or EOF.
+    """
+    m = RE_IDENTIFIERS_HEADING.search(text)
+    if not m:
+        return text
+    start = m.start()
+    rest = text[m.end():]
+    next_m = RE_NEXT_H2.search(rest)
+    end = m.end() + next_m.start() if next_m else len(text)
+    return text[:start] + text[end:]
 
 
 def detect_drift(claude_md: Path, repo_root: Path) -> RepoResult:
@@ -293,14 +325,18 @@ def detect_drift(claude_md: Path, repo_root: Path) -> RepoResult:
                 ))
                 break  # one finding per pattern is enough
 
-    # Marker 9: hardcoded mcwiz paths.
-    m = RE_HARDCODED_MCWIZ.search(text)
+    # Marker 9: hardcoded mcwiz paths. Skip the Project Identifiers block —
+    # the literal Windows path there is scaffolder-emitted (load-bearing),
+    # not drift. Only fires on occurrences OUTSIDE the Identifiers block.
+    text_excl_identifiers = _strip_identifiers_block(text)
+    m = RE_HARDCODED_MCWIZ.search(text_excl_identifiers)
     if m:
         result.findings.append(Finding(
             9, "WARNING",
-            "Hardcoded C:\\Users\\mcwiz\\... path "
-            "(should be parameterized via config.projects_root())",
-            _match_excerpt(text, m),
+            "Hardcoded C:\\Users\\mcwiz\\... path outside Project "
+            "Identifiers block (should be parameterized via "
+            "config.projects_root())",
+            _match_excerpt(text_excl_identifiers, m),
         ))
 
     # Decide final status. STUB takes precedence over DRIFT for display


### PR DESCRIPTION
## Summary

Marker 9 previously fired on the literal `C:\Users\mcwiz\Projects\{name}` in every per-repo CLAUDE.md's `## Project Identifiers` section — the **scaffolder's own emission**. That made every successfully-cleaned repo permanently show `DRIFT(markers: 9; E:0/W:1)`.

This PR adds an Identifiers-block exception: the helper `_strip_identifiers_block(text)` removes the section before running the marker 9 regex. Marker 9 still fires on body / quoted commands / examples — just not on the scaffolder's emission.

## Fleet impact

Tested on the live fleet of 92 entries:

| Metric | Before | After |
|---|---|---|
| boostgauge status | `DRIFT(markers: 9; E:0/W:1)` | `PASS` |
| Total PASS | 8 | 9 |
| Total DRIFT | 21 | 20 |
| Marker 9 occurrences | 22 | 18 |

The 4 silenced occurrences were all Identifiers-only false-positives (boostgauge + 3 others I don't need to enumerate — same shape).

## Test plan

- [x] `poetry run pytest tests/test_lint_per_repo_claude_md.py -v` — 29/29 pass (+6 new tests covering the exception + helper)
- [x] Smoke-tested against live fleet — boostgauge flips PASS; no other repo's status changes unexpectedly
- [x] Existing `test_marker_9_hardcoded_mcwiz_path` still passes (the lean_template helper uses `C:\Users\someone\...` so the synthetic mcwiz string is OUTSIDE the Identifiers block, still triggering the marker)

Closes #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)