### PR TITLE
feat(dependabot): enable_dependabot.py + new_repo_setup integration (#1331)

### DIFF
--- a/docs/runbooks/0901-new-project-setup.md
+++ b/docs/runbooks/0901-new-project-setup.md
@@ -1,8 +1,8 @@
 # 0901 - New Project Setup
 
 **Category:** Runbook / Operational Procedure
-**Version:** 2.2
-**Last Updated:** 2026-04-05
+**Version:** 2.6
+**Last Updated:** 2026-05-26
 
 ---
 
@@ -294,3 +294,4 @@ The script automates all of this in one command.
 | 2.3 | 2026-05-22 | `--cerberus-pem` is now **required** for GitHub-creating invocations (#1206). Quick Start examples updated to include the flag. Post-setup verification extended with GitHub-side checks (#1200) and `pr-sentinel-mm` Worker installation detection (#1202). |
 | 2.4 | 2026-05-22 | Fixed `Files Created` table — `LICENSE` row was documented as MIT but the script defaults to PolyForm Noncommercial 1.0.0 (#1198). |
 | 2.5 | 2026-05-23 | Multi-section sweep (#1210): `.claude/settings.json` row corrected (not empty — wires the hook); added rows for `.github/workflows/release.yml`, `.claude/hooks/secret-file-guard.sh`, `src/<module>/__init__.py`, `src/<module>/__main__.py`; Directory Structure tree includes `.github/workflows/` and `src/<module>/`; Command Reference adds `--no-pypi` flag and notes `--cerberus-pem` is required; Post-Setup Steps Section 1 rewritten — Cerberus is now automated, not a manual remaining step; added Section 1a for PyPI pending-publisher registration. |
+| 2.6 | 2026-05-26 | #1331 — Dependabot now enabled automatically at repo settings level (step 20 in the script). Without this step, the scaffolded `.github/dependabot.yml` was inert on private repos (defect confirmed on `dependabot-honeypot`). Companion tool `tools/enable_dependabot.py` backfills existing repos. See runbook 0927 v6.7 history entry for the under-the-hood table change. |

--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -1,7 +1,7 @@
 # 0927 - New Repo: Human Steps Checklist
 
 **Category:** Runbook / Operational Procedure
-**Version:** 6.6
+**Version:** 6.7
 **Last Updated:** 2026-05-26
 
 ---
@@ -182,6 +182,8 @@ gpg-agent will prompt for your passphrase once per cache window (controlled by `
 | 16 | `git pull --rebase` to sync local with the Contents-API commits | `gh auth` (read-only) |
 | 17 | **Configure repo settings (wiki/projects/merge strategy)** via PATCH | In-process classic PAT |
 | 18 | **Configure branch protection** via PUT | In-process classic PAT |
+| 19 | **Create canonical labels** (`implementation`, `lld`) | In-process classic PAT |
+| 20 | **Enable Dependabot** (security_and_analysis PATCH + vulnerability-alerts PUT + automated-security-fixes PUT) | In-process classic PAT (#1331) |
 | — | **Cerberus secrets** (if `--cerberus-pem` passed): sealed-box encrypt + PUT | In-process classic PAT (#1007) |
 
 Steps in **bold** require classic-PAT scopes. The PAT never enters the env block or subprocess argv — privileged calls share a `classic_pat_session()`, and gpg-agent caches the passphrase across sessions, so you'll typically see the prompt at most once per shell.
@@ -198,6 +200,7 @@ The script handles all of the following automatically:
 - **Canonical labels**: `implementation` and `lld` on the GitHub repo (#1061)
 - **Per-repo `CLAUDE.md` (lean shape per ADR 0219)**: `## Project Identifiers` block plus a project-type-specific `## Project-Specific Context` stub. The scaffolded file is intentionally short (~15-25 lines) and ADDITIVE only — no merge-sequence / branch-protection / PR-rules content; those live in the auto-loaded universal `CLAUDE.md`. Pass `--project-type {minimal,python,chrome-extension,pypi,cf-worker,web}` to pick the stub; default `minimal` is a pure TODO block. Per-repo drift is auditable via `tools/lint_per_repo_claude_md.py` (#1290). See [ADR 0219](../adrs/0219-claude-md-division-of-responsibility.md) for the full division-of-responsibility rule. (#1258, #1291, #1266)
 - Cerberus secrets deploy (if `--cerberus-pem` supplied)
+- **Enable Dependabot at repo settings level** (#1331): PATCH `security_and_analysis.dependabot_security_updates`, PUT `/vulnerability-alerts`, PUT `/automated-security-fixes`. Without this step the scaffolded `.github/dependabot.yml` is inert on private repos — Dependabot defaults to disabled and no PRs emit. The defect was confirmed 2026-05-26 on `dependabot-honeypot` (yml in place, 65 decorative deps pinned to ~12-18mo old versions, zero PRs after 11+ hours). The tool `tools/enable_dependabot.py` can also be run standalone to backfill existing repos.
 
 The script prints a summary showing what succeeded and what failed.
 
@@ -370,3 +373,4 @@ The **per-repo human steps** are: entering the gpg passphrase (once per gpg-agen
 | 2026-05-26 | v6.4: #1265 — rewrote "Encrypt the Cerberus App private key" subsection. Save-As pattern (target `~/.secrets/cerberus.pem` directly via browser Save-As dialog, bypassing `~/Downloads/`) is now primary; clipboard pattern documented as alternative for classic-PAT recipe parity. Added inline Hygiene Surfaces audit-gate table naming every surface the recipe touches (Downloads, browser history, Recycle Bin, clipboard, editor cache, gpg-agent) and which step closes it. Eliminates the "operator forgets a step" failure mode that compounds under stress. |
 | 2026-05-25 | v6.5: #1295 — removed all "revoke after deploy" instructions (lines 49, 128, 264, 283, 287 of prior version). Per `unleashed#658`: revoking the key on the App page removes only the public-half registration; every per-repo `REVIEWER_APP_PRIVATE_KEY` Actions secret becomes unusable (GitHub rejects JWTs signed by the revoked key) — silently breaks every repo holding the just-revoked key. Added "Three independent copies of the key" explanation. All revoke guidance now points at runbook 0939 for the canonical deploy-new → audit → revoke-old rotation pattern. Operator question that surfaced this: "i don't understand. i don't need a pem private key on github? then how does it work?" |
 | 2026-05-26 | v6.6: #1293 — documented the per-repo `CLAUDE.md` lean shape per ADR 0219 (#1258) in the "What the script handles automatically" block. Surfaced the new `--project-type` flag (#1291) and pointed at the drift-detector lint tool (#1290). Per-repo CLAUDE.md is now explicitly framed as ADDITIVE only — no restatement of universal-CLAUDE.md content — with the lint tool as the audit-gate that catches regressions. |
+| 2026-05-26 | v6.7: #1331 — added Step 20 to the under-the-hood table: Enable Dependabot at the repo settings level (PATCH `security_and_analysis.dependabot_security_updates`, PUT `/vulnerability-alerts`, PUT `/automated-security-fixes`). Without this step the scaffolded `.github/dependabot.yml` is inert on private repos (Dependabot defaults to disabled; no PRs emit). Defect confirmed 2026-05-26 on `dependabot-honeypot`. Companion tool `tools/enable_dependabot.py` runs the same enablement against existing repos (`--repo OWNER/NAME` or `--fleet`, `--apply` per std 0017). |

--- a/tests/test_enable_dependabot.py
+++ b/tests/test_enable_dependabot.py
@@ -1,0 +1,137 @@
+"""Tests for tools/enable_dependabot.py (#1331)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from enable_dependabot import (  # noqa: E402
+    EnableResult,
+    enable_dependabot_for_repo,
+    list_fleet_repos,
+)
+
+
+# ────────────────────────────────────────────────────────────────────
+# enable_dependabot_for_repo — dry-run path
+# ────────────────────────────────────────────────────────────────────
+
+
+def _mock_get_response(status_code: int = 200, sa: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = {"security_and_analysis": sa or {}}
+    r.text = ""
+    return r
+
+
+def _mock_put_or_patch_response(status_code: int = 204) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.text = ""
+    return r
+
+
+@patch("enable_dependabot.requests")
+def test_dry_run_makes_no_mutations(mock_requests: MagicMock) -> None:
+    """apply=False: GET happens for state read; NO PATCH / PUT calls."""
+    mock_requests.get.return_value = _mock_get_response(
+        sa={"dependabot_security_updates": {"status": "disabled"}}
+    )
+    result = enable_dependabot_for_repo("owner", "repo", pat="fake", apply=False)
+    assert result.ok is True
+    assert mock_requests.get.called
+    assert not mock_requests.patch.called
+    assert not mock_requests.put.called
+    for v in result.actions.values():
+        assert v.startswith("DRY-RUN")
+
+
+@patch("enable_dependabot.requests")
+def test_apply_makes_three_api_calls(mock_requests: MagicMock) -> None:
+    """apply=True: GET (state) + PATCH (security_and_analysis) + 2 PUTs."""
+    mock_requests.get.return_value = _mock_get_response(sa={})
+    mock_requests.patch.return_value = _mock_put_or_patch_response(200)
+    mock_requests.put.return_value = _mock_put_or_patch_response(204)
+    result = enable_dependabot_for_repo("owner", "repo", pat="fake", apply=True)
+    assert result.ok is True
+    assert mock_requests.get.call_count == 1
+    assert mock_requests.patch.call_count == 1
+    assert mock_requests.put.call_count == 2
+    assert all("DRY-RUN" not in v for v in result.actions.values())
+
+
+@patch("enable_dependabot.requests")
+def test_apply_records_http_status_per_action(mock_requests: MagicMock) -> None:
+    mock_requests.get.return_value = _mock_get_response(sa={})
+    mock_requests.patch.return_value = _mock_put_or_patch_response(200)
+    mock_requests.put.return_value = _mock_put_or_patch_response(204)
+    result = enable_dependabot_for_repo("owner", "repo", pat="fake", apply=True)
+    assert "HTTP 200" in result.actions["PATCH security_and_analysis.dependabot_security_updates"]
+    assert "HTTP 204" in result.actions["PUT vulnerability-alerts"]
+    assert "HTTP 204" in result.actions["PUT automated-security-fixes"]
+
+
+@patch("enable_dependabot.requests")
+def test_apply_marks_non_2xx_as_error(mock_requests: MagicMock) -> None:
+    """Non-success HTTP code on PATCH/PUT flips ok=False but doesn't crash."""
+    mock_requests.get.return_value = _mock_get_response(sa={})
+    mock_requests.patch.return_value = _mock_put_or_patch_response(403)
+    mock_requests.put.return_value = _mock_put_or_patch_response(204)
+    result = enable_dependabot_for_repo("owner", "repo", pat="fake", apply=True)
+    assert result.ok is False
+    assert "HTTP 403" in result.actions["PATCH security_and_analysis.dependabot_security_updates"]
+
+
+@patch("enable_dependabot.requests")
+def test_get_failure_returns_early(mock_requests: MagicMock) -> None:
+    """If GET /repos fails, return immediately with error — no further calls."""
+    mock_requests.get.return_value = _mock_get_response(status_code=404)
+    result = enable_dependabot_for_repo("owner", "nope", pat="fake", apply=True)
+    assert result.ok is False
+    assert "GET /repos" in result.actions
+    assert "HTTP 404" in result.actions["GET /repos"]
+    # No further mutations attempted
+    assert not mock_requests.patch.called
+    assert not mock_requests.put.called
+
+
+@patch("enable_dependabot.requests")
+def test_get_state_surfaced_in_result(mock_requests: MagicMock) -> None:
+    """The before-state from GET is preserved in EnableResult.before."""
+    sa = {
+        "dependabot_security_updates": {"status": "disabled"},
+        "secret_scanning": {"status": "enabled"},
+    }
+    mock_requests.get.return_value = _mock_get_response(sa=sa)
+    result = enable_dependabot_for_repo("owner", "repo", pat="fake", apply=False)
+    assert result.before == sa
+
+
+# ────────────────────────────────────────────────────────────────────
+# Fleet enumeration
+# ────────────────────────────────────────────────────────────────────
+
+
+@patch("enable_dependabot.subprocess")
+def test_list_fleet_excludes_forks_and_archives(mock_subprocess: MagicMock) -> None:
+    fake_stdout = """[
+        {"name": "live", "nameWithOwner": "u/live", "isArchived": false, "isFork": false},
+        {"name": "old", "nameWithOwner": "u/old", "isArchived": true, "isFork": false},
+        {"name": "fork", "nameWithOwner": "u/fork", "isArchived": false, "isFork": true},
+        {"name": "live2", "nameWithOwner": "u/live2", "isArchived": false, "isFork": false}
+    ]"""
+    mock_subprocess.run.return_value = MagicMock(returncode=0, stdout=fake_stdout, stderr="")
+    repos = list_fleet_repos("u")
+    assert repos == ["u/live", "u/live2"]
+
+
+@patch("enable_dependabot.subprocess")
+def test_list_fleet_exits_on_gh_failure(mock_subprocess: MagicMock) -> None:
+    mock_subprocess.run.return_value = MagicMock(returncode=1, stdout="", stderr="auth error")
+    with pytest.raises(SystemExit):
+        list_fleet_repos("u")

--- a/tools/enable_dependabot.py
+++ b/tools/enable_dependabot.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Enable Dependabot on existing repos via REST API (#1331).
+
+The defect this addresses: private repos created via runbooks 0901+0927
+land with `.github/dependabot.yml` in place but Dependabot itself
+disabled at the repo settings level. Result: yml is inert, no PRs emit,
+the wedge starves. Confirmed 2026-05-26 on `martymcenroe/dependabot-honeypot`
+— 11+ hours after yml landed + 65 decorative deps pinned to ~12-18mo old
+versions, zero dependabot PRs opened.
+
+What this tool does (per target repo):
+  1. GET /repos/{owner}/{repo} — read current security_and_analysis state
+  2. PATCH /repos/{owner}/{repo} with security_and_analysis enabling
+     Dependabot security updates
+  3. PUT /repos/{owner}/{repo}/vulnerability-alerts — enable alerts
+  4. PUT /repos/{owner}/{repo}/automated-security-fixes — enable
+     automated fixes
+
+Per ADR-0216: classic PAT decrypted in-process via classic_pat_session().
+The PAT lives only in this Python process's heap; never in env, never in
+subprocess argv, never via `gh auth`. **The OPERATOR runs this script,
+not the agent** — the in-process protection assumes the Python process is
+the operator's, not an agent's child.
+
+Per AssemblyZero standard 0017: `--apply` flag required to mutate. Default
+behavior is dry-run that reports what WOULD change.
+
+Usage:
+  poetry run python tools/enable_dependabot.py --repo OWNER/NAME
+  poetry run python tools/enable_dependabot.py --repo OWNER/NAME --apply
+  poetry run python tools/enable_dependabot.py --fleet
+  poetry run python tools/enable_dependabot.py --fleet --apply
+
+Exit codes:
+  0 — completed (dry-run or apply); all targets processed without errors
+  1 — argument or input error
+  2 — one or more per-repo errors during processing (partial state)
+
+Related:
+  - #1331 — this issue
+  - ADR-0216 — in-process classic PAT pattern
+  - runbook 0901 — new project setup (to be updated to call this)
+  - runbook 0927 — new repo human checklist (to be updated)
+  - sibling: companion integration in new_repo_setup.py for new-repo creation
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+
+try:
+    from _pat_session import classic_pat_session
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _pat_session import classic_pat_session
+
+
+GITHUB_USER = "martymcenroe"
+FLEET_REPO_LIMIT = 200
+HTTP_TIMEOUT_S = 30
+
+
+# ────────────────────────────────────────────────────────────────────
+# Public-API helper (the part new_repo_setup.py imports)
+# ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class EnableResult:
+    """Per-repo result. One per target."""
+    repo: str
+    before: dict[str, Any]  # `security_and_analysis` block from GET
+    actions: dict[str, str]  # endpoint -> "HTTP NNN" or "DRY-RUN" or "ERROR: ..."
+    ok: bool  # True iff all actions succeeded (or all were dry-run)
+
+
+def enable_dependabot_for_repo(
+    owner: str,
+    name: str,
+    pat: str,
+    apply: bool,
+) -> EnableResult:
+    """Enable Dependabot for one repo. Single-public function the
+    scaffolder + the CLI both call.
+
+    apply=False is a dry-run: reads current state, reports what would
+    change, makes NO mutations.
+    apply=True executes the three API calls.
+    """
+    repo = f"{owner}/{name}"
+    headers = {
+        "Authorization": f"token {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # Step 1: read current state. Always done, even in dry-run.
+    actions: dict[str, str] = {}
+    before: dict[str, Any] = {}
+    try:
+        r = requests.get(
+            f"https://api.github.com/repos/{owner}/{name}",
+            headers=headers, timeout=HTTP_TIMEOUT_S,
+        )
+        if r.status_code != 200:
+            return EnableResult(
+                repo=repo,
+                before={},
+                actions={"GET /repos": f"HTTP {r.status_code} — {r.text[:200]}"},
+                ok=False,
+            )
+        before = r.json().get("security_and_analysis") or {}
+    except requests.RequestException as e:
+        return EnableResult(
+            repo=repo,
+            before={},
+            actions={"GET /repos": f"ERROR: {e}"},
+            ok=False,
+        )
+
+    all_ok = True
+
+    # Step 2: PATCH security_and_analysis to enable dependabot_security_updates.
+    if apply:
+        try:
+            r = requests.patch(
+                f"https://api.github.com/repos/{owner}/{name}",
+                headers=headers,
+                json={
+                    "security_and_analysis": {
+                        "dependabot_security_updates": {"status": "enabled"},
+                    }
+                },
+                timeout=HTTP_TIMEOUT_S,
+            )
+            actions["PATCH security_and_analysis.dependabot_security_updates"] = (
+                f"HTTP {r.status_code}"
+            )
+            if r.status_code not in (200, 204):
+                actions["PATCH security_and_analysis.dependabot_security_updates"] += (
+                    f" — {r.text[:200]}"
+                )
+                all_ok = False
+        except requests.RequestException as e:
+            actions["PATCH security_and_analysis.dependabot_security_updates"] = (
+                f"ERROR: {e}"
+            )
+            all_ok = False
+    else:
+        actions["PATCH security_and_analysis.dependabot_security_updates"] = (
+            "DRY-RUN (would PATCH dependabot_security_updates.status=enabled)"
+        )
+
+    # Step 3: PUT /vulnerability-alerts (no body — toggle).
+    if apply:
+        try:
+            r = requests.put(
+                f"https://api.github.com/repos/{owner}/{name}/vulnerability-alerts",
+                headers=headers, timeout=HTTP_TIMEOUT_S,
+            )
+            actions["PUT vulnerability-alerts"] = f"HTTP {r.status_code}"
+            if r.status_code not in (204,):
+                actions["PUT vulnerability-alerts"] += f" — {r.text[:200]}"
+                all_ok = False
+        except requests.RequestException as e:
+            actions["PUT vulnerability-alerts"] = f"ERROR: {e}"
+            all_ok = False
+    else:
+        actions["PUT vulnerability-alerts"] = "DRY-RUN (would PUT)"
+
+    # Step 4: PUT /automated-security-fixes (no body — toggle).
+    if apply:
+        try:
+            r = requests.put(
+                f"https://api.github.com/repos/{owner}/{name}/automated-security-fixes",
+                headers=headers, timeout=HTTP_TIMEOUT_S,
+            )
+            actions["PUT automated-security-fixes"] = f"HTTP {r.status_code}"
+            if r.status_code not in (204,):
+                actions["PUT automated-security-fixes"] += f" — {r.text[:200]}"
+                all_ok = False
+        except requests.RequestException as e:
+            actions["PUT automated-security-fixes"] = f"ERROR: {e}"
+            all_ok = False
+    else:
+        actions["PUT automated-security-fixes"] = "DRY-RUN (would PUT)"
+
+    return EnableResult(repo=repo, before=before, actions=actions, ok=all_ok)
+
+
+# ────────────────────────────────────────────────────────────────────
+# Fleet enumeration
+# ────────────────────────────────────────────────────────────────────
+
+
+def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
+    """List user-owned, non-fork, non-archive repos as 'owner/name' strings.
+
+    Mirrors dependabot_review.py topology but does NOT filter to Poetry —
+    Dependabot version-updates can target any ecosystem (pip, npm, docker,
+    github-actions, cargo, etc.). Anything with `.github/dependabot.yml`
+    on `main` is a valid target. We let the API tell us which actually
+    have the yml; this function just enumerates the candidate set.
+    """
+    result = subprocess.run(
+        ["gh", "repo", "list", user,
+         "--limit", str(FLEET_REPO_LIMIT),
+         "--json", "name,nameWithOwner,isArchived,isFork"],
+        capture_output=True, text=True, timeout=60,
+    )
+    if result.returncode != 0:
+        sys.exit(f"Failed to list fleet repos: {result.stderr}")
+    repos = json.loads(result.stdout or "[]")
+    return [
+        r["nameWithOwner"] for r in repos
+        if not r.get("isArchived") and not r.get("isFork")
+    ]
+
+
+# ────────────────────────────────────────────────────────────────────
+# CLI
+# ────────────────────────────────────────────────────────────────────
+
+
+def _format_result(r: EnableResult, apply: bool) -> str:
+    """One-block summary per repo for human-readable output."""
+    lines = [f"=== {r.repo} ==="]
+    if r.before:
+        current = r.before.get("dependabot_security_updates", {}).get("status", "unknown")
+        lines.append(f"  Before: dependabot_security_updates = {current}")
+    else:
+        lines.append("  Before: (could not read state)")
+    for endpoint, status in r.actions.items():
+        lines.append(f"  {endpoint}: {status}")
+    if not r.ok:
+        lines.append("  >>> ERRORS encountered")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enable Dependabot on existing repos via REST API (#1331). "
+                    "Per ADR-0216 — operator runs, not the agent.",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--repo",
+        metavar="OWNER/NAME",
+        help="Single repo to enable (e.g., martymcenroe/dependabot-honeypot)",
+    )
+    group.add_argument(
+        "--fleet",
+        action="store_true",
+        help="All user-owned non-fork non-archive repos (mirrors dependabot_review.py)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate. Default: dry-run (reads state + reports what would change).",
+    )
+    parser.add_argument(
+        "--user",
+        default=GITHUB_USER,
+        help=f"GitHub user for --fleet enumeration (default: {GITHUB_USER})",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve targets.
+    if args.repo:
+        if "/" not in args.repo:
+            print(f"ERROR: --repo expects OWNER/NAME format, got {args.repo!r}", file=sys.stderr)
+            return 1
+        targets = [args.repo]
+    else:
+        targets = list_fleet_repos(args.user)
+
+    print(f"Targets: {len(targets)} repo(s)")
+    if not args.apply:
+        print("DRY-RUN MODE (no mutations will be made). Pass --apply to enable.")
+    print()
+
+    n_errored = 0
+    with classic_pat_session() as pat:
+        for target in targets:
+            owner, name = target.split("/", 1)
+            result = enable_dependabot_for_repo(owner, name, pat, args.apply)
+            print(_format_result(result, args.apply))
+            print()
+            if not result.ok:
+                n_errored += 1
+
+    if n_errored:
+        print(f"WARNING: {n_errored} of {len(targets)} repo(s) had errors")
+        return 2
+    if args.apply:
+        print(f"Done. {len(targets)} repo(s) processed.")
+    else:
+        print(f"Dry-run complete. {len(targets)} repo(s) inspected. Re-run with --apply to mutate.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -46,6 +46,14 @@ try:
     from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
 except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
+
+# Dependabot enablement (#1331) — runs at step 20, inside the same
+# classic_pat_session as steps 13-19 so it shares the in-process PAT.
+try:
+    from enable_dependabot import enable_dependabot_for_repo
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from enable_dependabot import enable_dependabot_for_repo
     from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
 
 # In-process classic PAT for privileged REST calls (ADR-0216).
@@ -2801,6 +2809,24 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     )
                     print(f"  {created}/{total} labels created or updated "
                           f"({', '.join(n for n, _, _ in _CANONICAL_LABELS)})")
+
+                    # Step 20: Enable Dependabot (#1331).
+                    # Private repos default to Dependabot DISABLED at the
+                    # repo settings level. Without this step, .github/
+                    # dependabot.yml is inert -- no PRs emit, wedge starves.
+                    # Confirmed defect 2026-05-26 on dependabot-honeypot.
+                    print("\n20. Enabling Dependabot (security updates, alerts, "
+                          "automated fixes)...")
+                    db_result = enable_dependabot_for_repo(
+                        github_user, repo_name_lower, pat, apply=True,
+                    )
+                    for endpoint, status in db_result.actions.items():
+                        print(f"  {endpoint}: {status}")
+                    if not db_result.ok:
+                        print("  WARNING: Dependabot enablement had errors. "
+                              "Re-run `tools/enable_dependabot.py --repo "
+                              f"{github_user}/{repo_name_lower} --apply` "
+                              "after diagnosing.")
 
                 # Cerberus secrets deploy. Inside the same with-block so it
                 # shares `pat` -- no extra pinentry. cerberus_pem_session


### PR DESCRIPTION
## Summary

Adds `tools/enable_dependabot.py` (backfill existing repos) and integrates the same enablement into `new_repo_setup.py` step 20 so new repos land with Dependabot already enabled at the repo settings level.

The defect being fixed (confirmed 2026-05-26 on dependabot-honeypot): private repos created via runbooks 0901+0927 landed with `.github/dependabot.yml` in place but Dependabot itself **disabled at the repo settings level**. Yml inert, no PRs emit. 11+ hours after seeding 65 decorative deps pinned 12-18mo old, zero PRs.

## Operator action required

This PR ships the tooling. The actual enablement of existing repos requires the operator to run the script (per ADR-0216 — the agent cannot run it via Bash tool because the in-process PAT protection assumes the Python process is the operator's). After this merges:

```bash
# Verify against dependabot-honeypot first
poetry run python tools/enable_dependabot.py \
    --repo martymcenroe/dependabot-honeypot --apply

# Then fleet-wide if happy
poetry run python tools/enable_dependabot.py --fleet --apply
```

Going forward, new repos created via `new_repo_setup.py` get Dependabot enabled automatically as step 20.

Closes #1331

## Test plan
- [x] `poetry run pytest tests/test_enable_dependabot.py -v` — 8/8 pass (dry-run no-mutations, apply makes 3 API calls, HTTP status capture, partial-failure flagging, GET-failure early-return, before-state surfacing, fleet enumeration filters, fleet failure exits)
- [x] `poetry run pytest tests/ -k "new_repo or enable_dependabot or scaffolder_lint or universal"` — 105/105 pass; no regressions
- [x] `import new_repo_setup` works (integration import doesn't crash)
- [ ] Operator runs against dependabot-honeypot post-merge to verify Dependabot actually starts emitting PRs (the API-surface assumption needs real-world verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)