### PR TITLE
fix(scaffolder): python stub is layout-agnostic, doesn't claim src/{name}/

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -1102,8 +1102,22 @@ class TestProjectTypeStubs:
         assert "**Stack:**" in text
         assert "Poetry" in text
         assert "pytest" in text
-        assert "src/myrepo/" in text
         assert "ADR 0219" in text
+
+    def test_python_stub_stack_line_is_layout_agnostic(self):
+        """#1304: Python stub's Stack line doesn't hardcode src/{name}/.
+
+        The Stack line names Poetry + pytest + tests/ but defers source layout
+        to the TODO block so script-collection repos (e.g. automation-scripts)
+        don't get a factually wrong claim. The TODO MAY mention src/{name}/ as
+        one example shape, but the Stack line itself must not claim it.
+        """
+        text = _project_specific_context("python", "myrepo")
+        stack_line = next(
+            line for line in text.splitlines() if line.startswith("**Stack:**")
+        )
+        assert "src/myrepo/" not in stack_line
+        assert "src/" not in stack_line
 
     def test_chrome_extension_stub_mentions_mv3(self):
         text = _project_specific_context("chrome-extension", "myrepo")

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -455,11 +455,14 @@ def _project_specific_context(project_type: str, name: str) -> str:
         return (
             "## Project-Specific Context\n"
             "\n"
-            f"**Stack:** Python (Poetry); pytest suite at `tests/`; source under `src/{name}/`.\n"
+            "**Stack:** Python (Poetry); pytest suite at `tests/`. Layout details in\n"
+            "the TODO block below.\n"
             "\n"
-            "_TODO: Add architecture notes, key modules, project-specific gotchas, and\n"
-            "any workflow overrides. The universal CLAUDE.md (auto-loaded) covers\n"
-            "fleet-wide rules -- only add what's true for THIS repo specifically (ADR 0219)._\n"
+            "_TODO: Add source layout (single-package under `src/{name}/`, script\n"
+            "collection in `tools/`, or another shape), architecture notes, key modules,\n"
+            "project-specific gotchas, and any workflow overrides. The universal CLAUDE.md\n"
+            "(auto-loaded) covers fleet-wide rules -- only add what's true for THIS repo\n"
+            "specifically (ADR 0219)._\n"
         )
     if project_type == "chrome-extension":
         return (


### PR DESCRIPTION
## Summary

- Drops the ``source under \`src/{name}/\``` claim from the python project-type stub's Stack line (Option A from #1304).
- Layout details deferred to the TODO block, which now lists ``src/{name}/``, ``tools/`` collection, and "another shape" as examples.
- Adds a regression-guard test ensuring the Stack line stays layout-agnostic.

## Why

Surfaced during automation-scripts CLAUDE.md cleanup (automation-scripts#55 / #56). The python stub from #1291 hardcoded a single-package layout (``src/{name}/``) which was factually wrong for script-collection repos like automation-scripts (no ``src/automation_scripts/`` package). The repo's CLAUDE.md had to be written from scratch by hand to avoid the wrong claim.

Likely affects other fleet repos (dotfiles, data-harvest, etc.). Option A keeps the stub honest by not guessing the layout.

## Test plan

- [x] ``poetry run pytest tests/test_new_repo_setup.py -q`` -- 75 passed (74 existing + 1 new)
- [x] ``poetry run pytest tests/test_scaffolder_lint_integration.py -q`` -- 7 passed
- [x] Updated test asserts Poetry + pytest + tests/ + ADR 0219 still mentioned
- [x] New ``test_python_stub_stack_line_is_layout_agnostic`` asserts no ``src/`` substring in the Stack line

Closes #1304

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)