### PR TITLE
fix: drop hardcoded mcwiz path from AssemblyZero/CLAUDE.md line 3 (M9 lint cleanup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - AssemblyZero
 
-Universal rules are in `C:\Users\mcwiz\Projects\CLAUDE.md` (auto-loaded for all projects).
+Universal rules at `Projects/CLAUDE.md` are auto-loaded for all projects.
 
 AssemblyZero is the canonical source for core rules, tools, and workflow.
 Fix things in AssemblyZero, not in local project copies. Tools execute from `AssemblyZero/tools/`, not copied locally.


### PR DESCRIPTION
## Summary

Single-line fix to ``AssemblyZero/CLAUDE.md`` line 3 — replaces the absolute Windows path with a relative reference. Resolves per-repo lint marker M9.

## Diff

```
-Universal rules are in \`C:\Users\mcwiz\Projects\CLAUDE.md\` (auto-loaded for all projects).
+Universal rules at \`Projects/CLAUDE.md\` are auto-loaded for all projects.
```

## Test plan

- [x] ``poetry run python tools/lint_per_repo_claude_md.py`` reports ``AssemblyZero-1350: PASS``, 0 findings (previously ``DRIFT M=9 E:0/W:1``)
- [x] No content removed — just rephrased to drop the absolute path
- [x] Lines 16-26 (Unix-style ``/c/Users/mcwiz/...`` paths in code blocks) untouched — those don't trigger M9 (regex requires literal ``C:`` prefix)

Closes #1350

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)