### PR TITLE
fix(lint): marker-7 explanatory-paragraph hedge for 'auto-loaded' / 'ADR 0219' / 'universal CLAUDE.md'

### DIFF
--- a/tests/test_lint_per_repo_claude_md.py
+++ b/tests/test_lint_per_repo_claude_md.py
@@ -187,6 +187,55 @@ def test_marker_7_universal_dupe_no_override(tmp_path: Path) -> None:
     assert any(f.marker == 7 for f in result.findings)
 
 
+def test_marker_7_skipped_in_explanatory_todo(tmp_path: Path) -> None:
+    """#1307: 'merge sequence' near 'auto-loaded' is descriptive, not drift. (Tests are careful to avoid the word 'override' in appended content — the existing override-proximity hedge would mask this test otherwise.)"""
+    content = lean_template() + (
+        "\n\n## Project Notes\n\n"
+        "_TODO: Document repo specifics. The universal CLAUDE.md (auto-loaded) "
+        "covers fleet-wide rules like the merge sequence and banned commands._\n"
+    )
+    repo = make_repo(tmp_path, "explanatory-todo", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 7 for f in result.findings), \
+        f"M7 should be skipped due to 'auto-loaded' proximity; findings: {[(f.marker, f.description) for f in result.findings]}"
+
+
+def test_marker_7_skipped_near_adr_0219(tmp_path: Path) -> None:
+    """#1307: 'enforce_admins true' near 'ADR 0219' is descriptive."""
+    content = lean_template() + (
+        "\n\n## Notes\n\n"
+        "Per ADR 0219, fleet rules like enforce_admins=true on branch protection "
+        "live in the universal layer, not here.\n"
+    )
+    repo = make_repo(tmp_path, "adr-0219-mention", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 7 for f in result.findings)
+
+
+def test_marker_7_skipped_near_universal_claude_md(tmp_path: Path) -> None:
+    """#1307: 'banned commands' near 'universal CLAUDE.md' is descriptive."""
+    content = lean_template() + (
+        "\n\n## Workflow\n\n"
+        "The universal CLAUDE.md is authoritative on banned commands.\n"
+    )
+    repo = make_repo(tmp_path, "universal-mention", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert not any(f.marker == 7 for f in result.findings)
+
+
+def test_marker_7_still_fires_when_explanation_keywords_absent(tmp_path: Path) -> None:
+    """#1307 regression guard: M7 must STILL fire when 'merge sequence' appears without any explanatory keywords nearby."""
+    content = lean_template() + (
+        "\n\n## How To Merge\n\n"
+        "Step 1: poll mergeable_state. Step 2: gh pr merge --squash. Step 3: clean up.\n"
+        "This is the standard merge sequence we use on every PR in this repo.\n"
+    )
+    repo = make_repo(tmp_path, "no-hedge", content)
+    result = detect_drift(repo / "CLAUDE.md", repo)
+    assert any(f.marker == 7 for f in result.findings), \
+        "M7 must still fire when 'merge sequence' appears without override/auto-loaded/ADR 0219/universal CLAUDE.md nearby"
+
+
 def test_marker_7_skipped_when_override_nearby(tmp_path: Path) -> None:
     """Aletheia-style: 'merge sequence override' must not trip marker 7."""
     content = lean_template() + (

--- a/tools/lint_per_repo_claude_md.py
+++ b/tools/lint_per_repo_claude_md.py
@@ -147,6 +147,15 @@ UNIVERSAL_DUPE_PATTERNS: list[re.Pattern[str]] = [
 OVERRIDE_PROXIMITY_CHARS = 200
 RE_OVERRIDE = re.compile(r"override", re.IGNORECASE)
 
+# #1307: second hedge — explanatory-paragraph exception. A paragraph that
+# names the auto-load mechanism, ADR 0219, or the universal CLAUDE.md is
+# explaining what lives elsewhere, not restating it. Same proximity window
+# as the override hedge.
+RE_EXPLANATORY = re.compile(
+    r"auto-loaded|ADR\s*0219|universal\s+CLAUDE\.md",
+    re.IGNORECASE,
+)
+
 STUB_LINE_THRESHOLD = 20
 
 
@@ -318,14 +327,21 @@ def detect_drift(claude_md: Path, repo_root: Path) -> RepoResult:
             window_start = max(0, m.start() - OVERRIDE_PROXIMITY_CHARS)
             window_end = m.end() + OVERRIDE_PROXIMITY_CHARS
             window = text[window_start:window_end]
-            if not RE_OVERRIDE.search(window):
-                result.findings.append(Finding(
-                    7, "WARNING",
-                    f"May duplicate universal CLAUDE.md content "
-                    f"(pattern: {pattern.pattern!r})",
-                    _match_excerpt(text, m),
-                ))
-                break  # one finding per pattern is enough
+            # Existing hedge: "override" qualifier nearby = legitimate per-repo override
+            if RE_OVERRIDE.search(window):
+                continue
+            # #1307 hedge: explanatory keyword nearby ("auto-loaded" / "ADR 0219" /
+            # "universal CLAUDE.md") = paragraph is describing what lives elsewhere,
+            # not restating it
+            if RE_EXPLANATORY.search(window):
+                continue
+            result.findings.append(Finding(
+                7, "WARNING",
+                f"May duplicate universal CLAUDE.md content "
+                f"(pattern: {pattern.pattern!r})",
+                _match_excerpt(text, m),
+            ))
+            break  # one finding per pattern is enough
 
     # Marker 9: hardcoded mcwiz paths. Skip the Project Identifiers block —
     # the literal Windows path there is scaffolder-emitted (load-bearing),


### PR DESCRIPTION
## Summary

Implements #1307. Adds a second hedge to the marker-7 (universal CLAUDE.md duplication) detector so explanatory TODO blocks that name the auto-load mechanism, ADR 0219, or the universal CLAUDE.md don't trip as false positives.

## Mechanism

Existing hedge: skip M7 when ``override`` is within ±200 chars (legitimate per-repo override, like Aletheia's merge-sequence override).

New hedge: ALSO skip M7 when any of these is within ±200 chars:
- ``auto-loaded``
- ``ADR 0219`` (any whitespace tolerated)
- ``universal CLAUDE.md`` (any whitespace tolerated)

A paragraph that names the auto-load mechanism, the governing ADR, or the universal file is by construction describing what lives elsewhere — not restating it. The scaffolder TODO blocks pre-#1291 named the phrases explicitly while telling the agent NOT to restate them — clean intent, wrong words. Marker 7 was firing on them spuriously.

## TDD

- 4 new tests: positive for each explanatory keyword (3) + regression guard ensuring M7 still fires when neither override NOR any explanatory keyword is nearby (1)
- Test setup careful to avoid lean_template's ``overrides`` word triggering the existing hedge (which would mask the test of the new hedge)
- All 40 lint tests pass; 7 scaffolder-lint integration tests pass

## Effect on the fleet

This is defense-in-depth — the 3 originally-affected repos (Chiron / Heuriskon / dependabot-honeypot) already PASS lint today because they were regenerated under the post-#1291 lean template. The hedge prevents future scaffolder template edits that mention these words inside a TODO from tripping M7.

## Test plan

- [x] ``poetry run pytest tests/test_lint_per_repo_claude_md.py`` — 40 passed
- [x] ``poetry run pytest tests/test_scaffolder_lint_integration.py`` — 7 passed
- [x] All existing M7 tests (no_override, override_nearby) still pass — no regression
- [x] New regression-guard test confirms M7 still fires when no hedge keyword is nearby

Closes #1307

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)