### PR TITLE
fix(dependabot_review): require audit-branch provenance in orphan canary

### DIFF
--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -326,8 +326,23 @@ class TestProcessPrTryFinallyContract:
         assert "WARNING" not in err
 
 
+def _fake_run_canary(branches_stdout: str, worktrees_stdout: str,
+                     branches_rc: int = 0, worktrees_rc: int = 0):
+    """Build a side_effect for `dependabot_review.run` that returns
+    different CompletedProcess values for the canary's two git calls:
+    `git branch --list dependabot-audit-*` and `git worktree list
+    --porcelain`. #1357.
+    """
+    def fake(cmd, *args, **kwargs):
+        if "branch" in cmd:
+            return _mk_completed(branches_rc, stdout=branches_stdout)
+        return _mk_completed(worktrees_rc, stdout=worktrees_stdout)
+    return fake
+
+
 class TestCheckForOrphanWorktrees:
-    """#1133: startup canary that enumerates pre-existing dependabot worktrees."""
+    """#1133/#1357: startup canary that enumerates pre-existing dependabot
+    worktrees created by this script (path pattern + paired audit branch)."""
 
     def test_returns_empty_when_no_orphans(self, tmp_path):
         main_repo = tmp_path / "AssemblyZero"
@@ -338,7 +353,7 @@ class TestCheckForOrphanWorktrees:
             "\n"
         )
         with patch.object(dependabot_review, "run",
-                          return_value=_mk_completed(0, stdout=porcelain)):
+                          side_effect=_fake_run_canary("", porcelain)):
             orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
         assert orphans == []
 
@@ -358,8 +373,10 @@ class TestCheckForOrphanWorktrees:
             "detached\n"
             "\n"
         )
+        # Paired audit branches exist -> both worktrees are real orphans.
+        branches = "dependabot-audit-1095\ndependabot-audit-1097\n"
         with patch.object(dependabot_review, "run",
-                          return_value=_mk_completed(0, stdout=porcelain)):
+                          side_effect=_fake_run_canary(branches, porcelain)):
             orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
         assert len(orphans) == 2
         assert any("dependabot-1095" in o for o in orphans)
@@ -380,15 +397,86 @@ class TestCheckForOrphanWorktrees:
             "\n"
         )
         with patch.object(dependabot_review, "run",
-                          return_value=_mk_completed(0, stdout=porcelain)):
+                          side_effect=_fake_run_canary("", porcelain)):
             orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
         assert orphans == []
 
     def test_returns_empty_on_subprocess_error(self, tmp_path):
-        """Diagnostic must not block the script: if `git worktree list` itself
-        fails, return [] so the operator's run can proceed."""
+        """Diagnostic must not block the script: if the first git call
+        (branch listing) itself fails, return [] so the operator's run
+        can proceed."""
         main_repo = tmp_path / "AssemblyZero"
         with patch.object(dependabot_review, "run",
                           return_value=_mk_completed(128, stderr="not a git repo")):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []
+
+    def test_ignores_unpaired_dependabot_worktrees(self, tmp_path):
+        """#1357 regression: worktrees matching the path pattern but with
+        NO paired `dependabot-audit-N` branch are not this script's
+        orphans. Pre-#1357 the canary flagged them anyway and aborted
+        the fleet sweep. Operator-incident shape: another agent's
+        worktrees happened to use `{repo}-dependabot-N` naming for
+        unrelated work; pre-fix canary couldn't tell them apart and
+        nearly led to deletion of unrelated active work."""
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-dependabot-123\n"
+            "HEAD def456\n"
+            "detached\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-dependabot-124\n"
+            "HEAD ghi789\n"
+            "detached\n"
+            "\n"
+        )
+        # No `dependabot-audit-*` branches -> no script-created orphans.
+        with patch.object(dependabot_review, "run",
+                          side_effect=_fake_run_canary("", porcelain)):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []
+
+    def test_ignores_audit_branch_with_no_worktree(self, tmp_path):
+        """A stray `dependabot-audit-N` branch with no matching worktree
+        is not what this canary flags. The canary's job is to surface
+        worktrees that will block `git worktree add` -- stale branches
+        are a different cleanup problem (`git branch -d`) and not in
+        scope here."""
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+        )
+        branches = "dependabot-audit-1095\n"
+        with patch.object(dependabot_review, "run",
+                          side_effect=_fake_run_canary(branches, porcelain)):
+            orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
+        assert orphans == []
+
+    def test_pairs_only_matching_n_suffix(self, tmp_path):
+        """Audit branch for N=1095 with a worktree for a different N
+        (1097) is not a match. Each orphan worktree must be paired to
+        its OWN audit branch."""
+        main_repo = tmp_path / "AssemblyZero"
+        porcelain = (
+            "worktree /c/Users/foo/Projects/AssemblyZero\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n"
+            "\n"
+            "worktree /c/Users/foo/Projects/AssemblyZero-dependabot-1097\n"
+            "HEAD def456\n"
+            "detached\n"
+            "\n"
+        )
+        # Branch is for 1095, worktree is for 1097 -- no pair.
+        branches = "dependabot-audit-1095\n"
+        with patch.object(dependabot_review, "run",
+                          side_effect=_fake_run_canary(branches, porcelain)):
             orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
         assert orphans == []

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -560,14 +560,46 @@ def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
 
 
 def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
-    """#1133: enumerate pre-existing dependabot worktrees so the operator
-    can be warned at startup. Returns list of orphan worktree paths
-    matching the `{main_name}-dependabot-N` pattern. Empty list = clean.
+    """#1133/#1357: enumerate pre-existing dependabot worktrees that match
+    BOTH the script's path pattern (`{main_name}-dependabot-N`) AND a
+    paired `dependabot-audit-N` branch. Returns list of orphan worktree
+    paths created by this script. Empty list = clean.
+
+    The branch is the strong-provenance signal. `create_audit_worktree`
+    creates worktrees via `git worktree add ... -b dependabot-audit-N`,
+    so the branch always exists when this script leaves a worktree behind.
+    `cleanup_worktree` deletes the branch via `git branch -d`. A real
+    leaked worktree from a crashed run therefore has BOTH the matching
+    path AND the matching branch; if the branch is missing, the worktree
+    is not this script's orphan.
+
+    Before #1357 the canary matched on path name alone (`if prefix in
+    Path(path).name`), which false-positived on any worktree whose name
+    happened to contain `{main_name}-dependabot-` regardless of origin.
     """
+    # Provenance step: enumerate the script's own audit branches. If
+    # none exist, there cannot be any real script orphans.
+    branch_result = run([
+        "git", "-C", str(main_repo), "branch", "--list",
+        "--format=%(refname:short)", "dependabot-audit-*",
+    ])
+    if branch_result.returncode != 0:
+        # Diagnostic-on-diagnostic failure: don't block the script.
+        return []
+    audit_ns: set[str] = set()
+    for raw in branch_result.stdout.splitlines():
+        name = raw.strip()
+        if not name.startswith("dependabot-audit-"):
+            continue
+        n_str = name[len("dependabot-audit-"):]
+        if n_str.isdigit():
+            audit_ns.add(n_str)
+    if not audit_ns:
+        return []
+
+    # Now pair worktrees against the audit-branch set.
     result = run(["git", "-C", str(main_repo), "worktree", "list", "--porcelain"])
     if result.returncode != 0:
-        # If we can't even list, return empty -- don't block the script on
-        # a diagnostic that itself errored.
         return []
     orphans: list[str] = []
     prefix = f"{main_repo.name}-dependabot-"
@@ -575,7 +607,11 @@ def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
         if not line.startswith("worktree "):
             continue
         path = line[len("worktree "):].strip()
-        if prefix in Path(path).name:
+        name = Path(path).name
+        if not name.startswith(prefix):
+            continue
+        n_str = name[len(prefix):]
+        if n_str in audit_ns:
             orphans.append(path)
     return orphans
 


### PR DESCRIPTION
## Summary

The startup canary in `tools/dependabot_review.py` (`check_for_orphan_worktrees`) was matching worktrees on path-name pattern alone, with no provenance check. Any worktree whose name happened to contain `{main_name}-dependabot-` — including from unrelated concurrent workflows — was flagged as an orphan, aborting the entire fleet sweep with `EXIT 3`.

This PR requires **both** path pattern match AND a paired `dependabot-audit-N` branch (the strong provenance signal — this branch is only ever created by `create_audit_worktree`). Worktrees from any other source are now ignored.

Closes #1357

## Why this matters

Operator-incident shape: another agent's worktrees happened to use the same `{repo}-dependabot-N` naming convention for unrelated active work. Pre-fix canary couldn't distinguish them from this script's leaks, and 58 dependabot PRs across 12+ repos were blocked because no fleet sweep could start. The investigation is captured in issue #1357.

## Changes

- `tools/dependabot_review.py`: `check_for_orphan_worktrees` now does a two-step check — enumerate `dependabot-audit-*` branches first, then pair worktrees against the audit-branch set by `N` suffix. Path match also tightened from `prefix in name` to `name.startswith(prefix)`.
- `tests/test_dependabot_review.py`: existing canary tests updated to inject matching audit branches via `side_effect` mock; three new regression tests for the false-positive class and inverse cases.

## Follow-up

#1358 tracks the scope problem (canary aborts fleet-wide on per-repo AZ state). Out of scope for this PR — this is the matching fix only.

## Test plan

- [x] `poetry run pytest tests/test_dependabot_review.py -v` — 20 passed (17 existing + 3 new)
- [ ] After merge: re-run the fleet sweep with the four incident worktrees (`AssemblyZero-dependabot-{123-126}`) still present. The canary should report empty orphans (because there are no `dependabot-audit-*` branches) and the sweep should proceed to fleet enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)