### PR TITLE
fix(dependabot_review): per-repo worktrees + per-repo canary

### DIFF
--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -480,3 +480,182 @@ class TestCheckForOrphanWorktrees:
                           side_effect=_fake_run_canary(branches, porcelain)):
             orphans = dependabot_review.check_for_orphan_worktrees(main_repo)
         assert orphans == []
+
+
+# ---- #1360: target-repo resolution + per-repo processing ----
+
+
+class TestResolveTargetRepoDir:
+    """#1360: each fleet repo's PRs must be processed against THAT repo's
+    local clone, not the script's invocation directory."""
+
+    def test_returns_default_parent_for_self_repo(self, tmp_path):
+        """When the fleet repo matches the script's working directory by
+        name, return that directory directly. This is the AZ-self path
+        when processing AssemblyZero's own dependabot PRs."""
+        default_parent = tmp_path / "AssemblyZero"
+        default_parent.mkdir()
+        (default_parent / ".git").mkdir()
+        resolved = dependabot_review.resolve_target_repo_dir(
+            "martymcenroe/AssemblyZero", default_parent,
+        )
+        assert resolved == default_parent
+
+    def test_returns_sibling_clone_when_present(self, tmp_path):
+        """For a foreign fleet repo (e.g., dispatch), look for a sibling
+        clone in `default_parent.parent / <repo_name>`."""
+        default_parent = tmp_path / "AssemblyZero"
+        default_parent.mkdir()
+        (default_parent / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        (sibling / ".git").mkdir()
+        resolved = dependabot_review.resolve_target_repo_dir(
+            "martymcenroe/dispatch", default_parent,
+        )
+        assert resolved == sibling
+
+    def test_returns_none_when_sibling_missing(self, tmp_path):
+        """If the sibling clone is missing, return None so the caller
+        skips the repo. Pre-#1360 the script silently used the script's
+        own .git as a fallback, polluting AZ's objects with foreign refs."""
+        default_parent = tmp_path / "AssemblyZero"
+        default_parent.mkdir()
+        (default_parent / ".git").mkdir()
+        resolved = dependabot_review.resolve_target_repo_dir(
+            "martymcenroe/dispatch", default_parent,
+        )
+        assert resolved is None
+
+    def test_returns_none_when_sibling_is_not_a_git_repo(self, tmp_path):
+        """A directory that exists but doesn't have a `.git` is not a
+        local clone — return None."""
+        default_parent = tmp_path / "AssemblyZero"
+        default_parent.mkdir()
+        (default_parent / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        # No .git inside `sibling`.
+        resolved = dependabot_review.resolve_target_repo_dir(
+            "martymcenroe/dispatch", default_parent,
+        )
+        assert resolved is None
+
+    def test_accepts_git_as_file_for_worktree_layouts(self, tmp_path):
+        """git worktrees use `.git` as a FILE (gitlink), not a directory.
+        The resolver must accept either form."""
+        default_parent = tmp_path / "AssemblyZero"
+        default_parent.mkdir()
+        (default_parent / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        (sibling / ".git").write_text("gitdir: ../other/.git/worktrees/foo\n")
+        resolved = dependabot_review.resolve_target_repo_dir(
+            "martymcenroe/dispatch", default_parent,
+        )
+        assert resolved == sibling
+
+
+class TestProcessRepoPerRepoBehavior:
+    """#1360: process_repo resolves the target repo per fleet entry and
+    skips the repo when the local clone is missing or has orphan
+    worktrees. Replaces the pre-#1360 fleet-wide abort on AZ state."""
+
+    def test_skips_repo_when_local_clone_missing(self, tmp_path, capsys):
+        main_repo = tmp_path / "AssemblyZero"
+        main_repo.mkdir()
+        (main_repo / ".git").mkdir()
+        # No `tmp_path / "dispatch"` exists -- resolver returns None.
+        sub = dependabot_review.process_repo("martymcenroe/dispatch", main_repo)
+        assert sub["merged"] == []
+        assert sub["deferred"] == []
+        assert sub["errored"] == ["martymcenroe/dispatch#missing-clone"]
+        err = capsys.readouterr().err
+        assert "SKIP: no local clone for martymcenroe/dispatch" in err
+
+    def test_skips_repo_when_orphan_worktrees_present(self, tmp_path, capsys):
+        """A clone exists but has paired audit-branch+worktree orphans
+        from a prior crashed run -- skip this repo with a clear log,
+        but DO NOT abort the rest of the fleet (#1358)."""
+        main_repo = tmp_path / "AssemblyZero"
+        main_repo.mkdir()
+        (main_repo / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        (sibling / ".git").mkdir()
+
+        # Mock the canary to return one orphan path.
+        with patch.object(
+            dependabot_review, "check_for_orphan_worktrees",
+            return_value=["/tmp/dispatch-dependabot-99"],
+        ), patch.object(dependabot_review, "list_dependabot_prs") as mock_list:
+            sub = dependabot_review.process_repo(
+                "martymcenroe/dispatch", main_repo, ignore_orphans=False,
+            )
+
+        # Should NOT have called list_dependabot_prs -- skipped before that.
+        mock_list.assert_not_called()
+        assert sub["errored"] == ["martymcenroe/dispatch#orphan-worktrees"]
+        err = capsys.readouterr().err
+        assert "SKIP: martymcenroe/dispatch this run" in err
+
+    def test_proceeds_past_orphans_with_ignore_orphans(self, tmp_path):
+        """`--ignore-orphans` still lets the repo proceed despite orphans."""
+        main_repo = tmp_path / "AssemblyZero"
+        main_repo.mkdir()
+        (main_repo / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        (sibling / ".git").mkdir()
+
+        with patch.object(
+            dependabot_review, "check_for_orphan_worktrees",
+            return_value=["/tmp/dispatch-dependabot-99"],
+        ), patch.object(
+            dependabot_review, "list_dependabot_prs", return_value=[],
+        ):
+            sub = dependabot_review.process_repo(
+                "martymcenroe/dispatch", main_repo, ignore_orphans=True,
+            )
+
+        # Reached list_dependabot_prs (returned [] -- no PRs), no skip recorded.
+        assert sub["errored"] == []
+        assert sub["merged"] == []
+        assert sub["deferred"] == []
+
+    def test_passes_target_repo_not_main_repo_to_process_pr(self, tmp_path):
+        """#1360 invariant: when processing a foreign repo's PR, the
+        third arg to process_pr is the foreign clone, NOT the script's
+        invocation directory. This is what stops AZ's .git from being
+        polluted with foreign PR heads."""
+        main_repo = tmp_path / "AssemblyZero"
+        main_repo.mkdir()
+        (main_repo / ".git").mkdir()
+        sibling = tmp_path / "dispatch"
+        sibling.mkdir()
+        (sibling / ".git").mkdir()
+
+        pr = dependabot_review.PRInfo(
+            number=42, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+        process_pr_calls: list[tuple] = []
+        def fake_process_pr(p, r, target):
+            process_pr_calls.append((p.number, r, target))
+            return "merged"
+
+        with patch.object(
+            dependabot_review, "check_for_orphan_worktrees", return_value=[],
+        ), patch.object(
+            dependabot_review, "list_dependabot_prs", return_value=[pr],
+        ), patch.object(dependabot_review, "process_pr", side_effect=fake_process_pr):
+            dependabot_review.process_repo("martymcenroe/dispatch", main_repo)
+
+        assert len(process_pr_calls) == 1
+        pr_num, repo, target = process_pr_calls[0]
+        assert pr_num == 42
+        assert repo == "martymcenroe/dispatch"
+        assert target == sibling, (
+            f"process_pr received {target} as target_repo; expected "
+            f"the foreign clone at {sibling}, not main_repo {main_repo}"
+        )

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -41,9 +41,17 @@ to stderr with the captured exit code and stderr -- the operator MUST
 investigate that path before the next run, because a leaked worktree
 breaks subsequent `git worktree add` for the same PR number.
 
-On startup, a canary lists pre-existing `*-dependabot-N` worktrees and
-refuses to proceed unless --ignore-orphans is passed (so accumulating
-debt is loud rather than silent).
+#1360: each fleet repo's PRs are processed in worktrees against THAT
+repo's local clone -- not against AssemblyZero's git (which pre-#1360
+hosted every fleet PR's content and accumulated foreign refs). Repos
+without a local clone at `~/Projects/<name>` are skipped with a clear
+diagnostic; no on-the-fly clone is created.
+
+Per-repo orphan canary (also #1360): before processing a repo, scan
+that repo's worktrees for leaked `dependabot-audit-N` pairs from prior
+crashed runs. If any are found the repo is skipped this run (or
+proceeds anyway with --ignore-orphans). Pre-#1360 a single global
+canary aborted the whole fleet on AssemblyZero's state alone.
 
 Usage:
     poetry run python tools/dependabot_review.py [--repo OWNER/REPO] [--dry-run]
@@ -245,10 +253,15 @@ def verify_author(pr: PRInfo) -> bool:
 # Worktree + env setup
 # ---------------------------------------------------------------------------
 
-def create_audit_worktree(main_repo: Path, pr_number: int) -> tuple[Path, str]:
-    worktree = main_repo.parent / f"{main_repo.name}-dependabot-{pr_number}"
+def create_audit_worktree(target_repo: Path, pr_number: int) -> tuple[Path, str]:
+    """#1360: operate on `target_repo`'s git, not the script's invocation
+    directory. Worktree path is `{target_repo.parent}/{target_repo.name}-
+    dependabot-{N}`, hosted by `target_repo.git/worktrees/`. Pre-#1360
+    this used a single main_repo (AssemblyZero) for every fleet repo's
+    PRs, polluting AZ's git objects."""
+    worktree = target_repo.parent / f"{target_repo.name}-dependabot-{pr_number}"
     branch = f"dependabot-audit-{pr_number}"
-    result = run(["git", "-C", str(main_repo), "worktree", "add",
+    result = run(["git", "-C", str(target_repo), "worktree", "add",
                   str(worktree), "-b", branch, "main"])
     if result.returncode != 0:
         sys.exit(f"Could not create worktree: {result.stderr}")
@@ -491,7 +504,7 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
 # Cleanup
 # ---------------------------------------------------------------------------
 
-def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
+def cleanup_worktree(target_repo: Path, worktree: Path, branch: str) -> bool:
     """Remove the audit worktree and its branch. Returns True iff both
     operations exited with status 0.
 
@@ -529,7 +542,7 @@ def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
     if worktree.exists():
         run(["git", "-C", str(worktree), "restore", "."])
 
-    wt_remove = run(["git", "-C", str(main_repo), "worktree", "remove", str(worktree)])
+    wt_remove = run(["git", "-C", str(target_repo), "worktree", "remove", str(worktree)])
     if wt_remove.returncode != 0:
         success = False
         print(
@@ -541,7 +554,7 @@ def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
             file=sys.stderr,
         )
 
-    br_delete = run(["git", "-C", str(main_repo), "branch", "-d", branch])
+    br_delete = run(["git", "-C", str(target_repo), "branch", "-d", branch])
     if br_delete.returncode != 0:
         success = False
         # branch -d failing post-worktree-remove-failure is expected (the
@@ -559,11 +572,11 @@ def cleanup_worktree(main_repo: Path, worktree: Path, branch: str) -> bool:
     return success
 
 
-def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
-    """#1133/#1357: enumerate pre-existing dependabot worktrees that match
-    BOTH the script's path pattern (`{main_name}-dependabot-N`) AND a
-    paired `dependabot-audit-N` branch. Returns list of orphan worktree
-    paths created by this script. Empty list = clean.
+def check_for_orphan_worktrees(target_repo: Path) -> list[str]:
+    """#1133/#1357/#1360: enumerate pre-existing dependabot worktrees in
+    `target_repo`'s git that match BOTH the script's path pattern
+    (`{target_name}-dependabot-N`) AND a paired `dependabot-audit-N`
+    branch. Returns list of orphan worktree paths. Empty list = clean.
 
     The branch is the strong-provenance signal. `create_audit_worktree`
     creates worktrees via `git worktree add ... -b dependabot-audit-N`,
@@ -573,14 +586,18 @@ def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
     path AND the matching branch; if the branch is missing, the worktree
     is not this script's orphan.
 
+    #1360: the canary is now per-repo — each fleet repo's git is scanned
+    separately rather than one global scan against AssemblyZero's git
+    that aborted the whole fleet on per-repo state.
+
     Before #1357 the canary matched on path name alone (`if prefix in
     Path(path).name`), which false-positived on any worktree whose name
-    happened to contain `{main_name}-dependabot-` regardless of origin.
+    happened to contain `{target_name}-dependabot-` regardless of origin.
     """
     # Provenance step: enumerate the script's own audit branches. If
     # none exist, there cannot be any real script orphans.
     branch_result = run([
-        "git", "-C", str(main_repo), "branch", "--list",
+        "git", "-C", str(target_repo), "branch", "--list",
         "--format=%(refname:short)", "dependabot-audit-*",
     ])
     if branch_result.returncode != 0:
@@ -598,11 +615,11 @@ def check_for_orphan_worktrees(main_repo: Path) -> list[str]:
         return []
 
     # Now pair worktrees against the audit-branch set.
-    result = run(["git", "-C", str(main_repo), "worktree", "list", "--porcelain"])
+    result = run(["git", "-C", str(target_repo), "worktree", "list", "--porcelain"])
     if result.returncode != 0:
         return []
     orphans: list[str] = []
-    prefix = f"{main_repo.name}-dependabot-"
+    prefix = f"{target_repo.name}-dependabot-"
     for line in result.stdout.splitlines():
         if not line.startswith("worktree "):
             continue
@@ -716,8 +733,12 @@ def _process_pr_inside_worktree(
     return "merged"
 
 
-def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
+def process_pr(pr: PRInfo, repo: str, target_repo: Path) -> str:
     """Process a single PR. Returns 'merged', 'deferred', or 'errored'.
+
+    #1360: `target_repo` is the local clone of the PR's repo. Pre-#1360
+    this was `main_repo` (always AssemblyZero), which forced foreign
+    PR content into AZ's git.
 
     #1133: cleanup is wrapped in try/finally so it runs on every exit
     path -- normal return, sub-helper return, OR exception (Ctrl-C,
@@ -730,12 +751,12 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
     if not verify_author(pr):
         return "errored"
 
-    worktree, branch = create_audit_worktree(main_repo, pr.number)
+    worktree, branch = create_audit_worktree(target_repo, pr.number)
 
     try:
         return _process_pr_inside_worktree(pr, repo, worktree)
     finally:
-        cleanup_ok = cleanup_worktree(main_repo, worktree, branch)
+        cleanup_ok = cleanup_worktree(target_repo, worktree, branch)
         if not cleanup_ok:
             # cleanup_worktree already printed the diagnostic. Add a
             # one-line WARNING for the operator who's scanning the
@@ -750,6 +771,33 @@ def process_pr(pr: PRInfo, repo: str, main_repo: Path) -> str:
 # ---------------------------------------------------------------------------
 # Fleet enumeration (Issue #1091)
 # ---------------------------------------------------------------------------
+
+def resolve_target_repo_dir(repo_full: str, default_parent: Path) -> Path | None:
+    """#1360: resolve the local clone path for a fleet repo.
+
+    Returns Path to the local clone, or None if not found. Lookup:
+
+    1. If `repo_full`'s short name matches the script's working-dir name
+       (`default_parent.name`), return `default_parent` itself — this is
+       the AZ-self path (or whatever repo the script runs from).
+    2. Sibling-clone path: `default_parent.parent / <short_name>` with a
+       `.git` directory or file inside.
+
+    When neither is present the caller skips the repo with a clear
+    diagnostic; the script does NOT silently fall back to hosting the
+    foreign PR in `default_parent.git` (which was the pre-#1360 design
+    that polluted AZ's `.git/objects` with every fleet repo's commits
+    and caused cleanup failures on foreign untracked-file paths).
+    """
+    repo_name = repo_full.split("/")[-1]
+    if repo_name == default_parent.name:
+        return default_parent
+    candidate = default_parent.parent / repo_name
+    git_path = candidate / ".git"
+    if git_path.exists():
+        return candidate
+    return None
+
 
 def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
     """List user-owned repos that we should attempt to process.
@@ -805,8 +853,14 @@ def process_repo(
     repo: str,
     main_repo: Path,
     dry_run: bool = False,
+    ignore_orphans: bool = False,
 ) -> dict[str, list[str]]:
     """Process all dependabot PRs in one repo, sequentially.
+
+    #1360: `main_repo` here is only used as a parent-dir hint for finding
+    the sibling clone of `repo`. The actual worktree machinery operates
+    on the target repo's git, not main_repo's. Skips the repo entirely
+    if no local clone is found.
 
     Within a repo, PR processing is sequential — each merge moves
     `main` and subsequent PRs need to test against the new HEAD.
@@ -820,6 +874,47 @@ def process_repo(
     print(f"\n{'=' * 60}")
     print(f"REPO: {repo}")
     print(f"{'=' * 60}")
+
+    # #1360: resolve the target repo's local clone. Required for per-repo
+    # worktree hosting (the foreign-PR-in-AZ-git pollution fix).
+    target_repo = resolve_target_repo_dir(repo, main_repo)
+    if target_repo is None:
+        repo_name = repo.split("/")[-1]
+        expected_path = main_repo.parent / repo_name
+        print(
+            f"  SKIP: no local clone for {repo} (looked at {expected_path}). "
+            f"Clone the repo locally and re-run.",
+            file=sys.stderr,
+        )
+        sub["errored"].append(f"{repo}#missing-clone")
+        return sub
+
+    # #1360/#1358: per-repo orphan canary. Pre-#1360 a global canary ran
+    # once against AssemblyZero's worktree list and aborted the whole
+    # fleet on per-repo state. Now each repo's git is scanned independently
+    # — an orphan on dispatch blocks only dispatch's PRs, AZ proceeds.
+    orphans = check_for_orphan_worktrees(target_repo)
+    if orphans:
+        print(
+            f"  WARNING: pre-existing dependabot worktrees on "
+            f"{target_repo.name}:",
+            file=sys.stderr,
+        )
+        for o in orphans:
+            print(f"    {o}", file=sys.stderr)
+        if not ignore_orphans:
+            print(
+                f"  SKIP: {repo} this run. Resolve the orphans, then re-run. "
+                f"Pass --ignore-orphans to override.",
+                file=sys.stderr,
+            )
+            sub["errored"].append(f"{repo}#orphan-worktrees")
+            return sub
+        print(
+            f"  proceeding anyway because --ignore-orphans was set",
+            file=sys.stderr,
+        )
+
     prs = list_dependabot_prs(repo)
     if not prs:
         print(f"  No open dependabot PRs in {repo}.")
@@ -831,7 +926,7 @@ def process_repo(
     if dry_run:
         return sub
     for pr in prs:
-        status = process_pr(pr, repo, main_repo)
+        status = process_pr(pr, repo, target_repo)
         sub[status].append(f"{repo}#{pr.number}")
     return sub
 
@@ -885,32 +980,13 @@ def main() -> None:
     if not (main_repo / ".git").exists():
         sys.exit(f"Not a git repo: {main_repo}")
 
-    # #1133: orphan-worktree canary BEFORE any new worktrees are created.
-    # If a prior run leaked state, refuse to proceed unless explicitly
-    # overridden -- accumulating orphans is what got us into the #1133
-    # situation in the first place.
-    orphans = check_for_orphan_worktrees(main_repo)
-    if orphans:
-        print(
-            f"\nWARNING: pre-existing dependabot worktrees detected on "
-            f"{main_repo.name}:",
-            file=sys.stderr,
-        )
-        for o in orphans:
-            print(f"  {o}", file=sys.stderr)
-        if not args.ignore_orphans:
-            print(
-                "\nThese are leftovers from prior runs that didn't reach "
-                "cleanup.\nAborting to prevent further pile-up. Investigate "
-                "the orphans, clean them up, then re-run. Pass "
-                "--ignore-orphans to override (not recommended).",
-                file=sys.stderr,
-            )
-            sys.exit(3)
-        print(
-            "  proceeding anyway because --ignore-orphans was set",
-            file=sys.stderr,
-        )
+    # #1360: the orphan-worktree canary is now per-repo (inside
+    # process_repo). Pre-#1360 there was a global canary here that
+    # aborted the whole fleet on AssemblyZero's worktree state; that
+    # blocked work across 16 repos every time AZ had even one orphan,
+    # and conflated foreign-repo worktrees (which pre-#1360 lived in
+    # AZ's namespace) with AZ's own orphans. See #1360 for the full
+    # investigation; #1358 closed by this same change.
 
     # Issue #1091: fleet mode enumerates user-owned Poetry repos.
     if args.fleet:
@@ -944,7 +1020,10 @@ def main() -> None:
                   f"worker(s)...")
             with ThreadPoolExecutor(max_workers=args.workers) as executor:
                 futures = {
-                    executor.submit(process_repo, repo, main_repo, args.dry_run): repo
+                    executor.submit(
+                        process_repo, repo, main_repo, args.dry_run,
+                        args.ignore_orphans,
+                    ): repo
                     for repo in repos
                 }
                 for future in as_completed(futures):
@@ -958,7 +1037,9 @@ def main() -> None:
                         results[k].extend(sub[k])
         else:
             for repo in repos:
-                sub = process_repo(repo, main_repo, args.dry_run)
+                sub = process_repo(
+                    repo, main_repo, args.dry_run, args.ignore_orphans,
+                )
                 for k in ("merged", "deferred", "errored"):
                     results[k].extend(sub[k])
     finally:


### PR DESCRIPTION
## Summary

Refactors the fleet sweep so each repo's PRs are processed against **that repo's own local clone**, not AssemblyZero's git. Pre-#1360 the script borrowed AZ's `.git/worktrees/` machinery to host PRs from every fleet repo (dispatch, honeypot, Aletheia, etc.), with two real consequences:

1. AZ's `.git/objects` accumulated commits from every fleet repo across every run.
2. Cleanup failed routinely when pytest left `__pycache__` files in foreign directory structures that AZ's `.gitignore` couldn't cover (because AZ didn't have those directories). Git's stderr suggests `--force`, which is permanently banned per `Projects/CLAUDE.md`.

Closes #1360. Closes #1358 (scope follow-up — the per-repo canary IS the scope fix).

## Changes

- `tools/dependabot_review.py`:
  - New `resolve_target_repo_dir(repo_full, default_parent)`: looks for the sibling clone at `default_parent.parent/<repo_name>`. Returns `None` if missing — caller skips the repo with a clear log; no on-the-fly clone.
  - `create_audit_worktree`, `cleanup_worktree`, `check_for_orphan_worktrees`, `process_pr`: parameter renamed `main_repo` → `target_repo`; functions operate on the target repo's git.
  - `process_repo`: resolves target_repo per fleet entry; runs the orphan canary against that target_repo only. Missing-clone and orphan cases are recorded as `errored#missing-clone` / `errored#orphan-worktrees` so they surface in the summary.
  - `main()`: removed the global startup canary. Per-repo canary in `process_repo` replaces it; an orphan on one repo no longer aborts the fleet.
  - Worktree naming shifts: `{target_repo.name}-dependabot-N` (e.g., `dispatch-dependabot-127`) instead of always `AssemblyZero-dependabot-N`.
- `tests/test_dependabot_review.py`:
  - 5 new tests for `resolve_target_repo_dir` (self-path, sibling-exists, sibling-missing, not-a-git-repo, `.git` as file for worktree layouts).
  - 4 new tests for `process_repo` per-repo behavior (skip on missing clone, skip on orphans, proceed with `--ignore-orphans`, and the #1360 invariant that `process_pr` receives target_repo not main_repo).
  - Existing 20 tests pass unchanged.

## Migration note

The five legacy AZ-named orphans on disk (`AssemblyZero-dependabot-{123-127}`) remain. They are inert under this PR:

- No paired `dependabot-audit-*` branches exist in AZ ⇒ canary skips them.
- New worktrees use per-repo naming ⇒ no collision possible except for AZ PRs whose number happens to match {123, 124, 125, 126, 127} — narrow window.

Cleanup of these legacy paths is deferred to operator discretion. (#1360 plan explicitly punts on AZ `.git/objects` GC.)

## Investigation reference

Full incident write-up and architectural rationale: #1360. The cross-repo pollution was discovered when a fleet run created a worktree at `AssemblyZero-dependabot-127` whose HEAD turned out to be dispatch's lxml PR (dispatch PR #127, dependabot[bot]), and the cleanup failure that surfaced this nearly led to the agent proposing deletion of the operator's book content — see [the #1357 incident notes](https://github.com/martymcenroe/AssemblyZero/issues/1357).

## Test plan

- [x] `poetry run pytest tests/test_dependabot_review.py -v` — 29 passed (20 existing + 9 new for #1360)
- [ ] After merge: next fleet sweep should use per-repo worktree naming. Foreign PRs no longer enter AZ's git. Existing five AZ-named legacy orphans remain inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)