### PR TITLE
fix(dependabot_review): disable pytest bytecode caching in audit worktrees (Closes #1371)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -387,3 +387,25 @@ class TestProcessPrDeferralStaleBranchPriority:
         assert result == "deferred"
         assert "REBASE" not in actions
         assert "RECREATE" not in actions
+
+
+class TestRunTestsDisablesBytecode:
+    """#1371: run_tests must disable Python bytecode caching so pytest does not
+    write __pycache__/*.pyc into the audit worktree. Untracked .pyc files dirty
+    the worktree and make `git worktree remove` (no --force) refuse, leaking it.
+    """
+
+    def test_run_tests_sets_pythondontwritebytecode(self, monkeypatch, tmp_path):
+        captured: dict = {}
+
+        def _capture(cmd, *args, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["env"] = kwargs.get("env")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+
+        dependabot_review.run_tests(tmp_path)
+
+        assert captured["env"] is not None, "run_tests must pass env to run()"
+        assert captured["env"].get("PYTHONDONTWRITEBYTECODE") == "1"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -62,6 +62,7 @@ Issue: #949 | Related: #692, #1116 | Runbook: 0911 v2.0
 import argparse
 import datetime
 import json
+import os
 import re
 import subprocess
 import sys
@@ -120,7 +121,8 @@ class PRInfo:
 
 def run(cmd: list[str], cwd: str | None = None,
         timeout: int | None = None,
-        quiet_on_failure: bool = False) -> subprocess.CompletedProcess:
+        quiet_on_failure: bool = False,
+        env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     """Run a subprocess and echo the command to stdout.
 
     `encoding="utf-8", errors="replace"` is mandatory on Windows.
@@ -153,6 +155,7 @@ def run(cmd: list[str], cwd: str | None = None,
             encoding="utf-8", errors="replace",
             timeout=timeout, check=False,
             creationflags=_CREATION_FLAGS,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         ts2 = datetime.datetime.now().strftime("%H:%M:%S")
@@ -319,8 +322,15 @@ def install_deps(worktree: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 def run_tests(worktree: Path) -> int:
+    # #1371: PYTHONDONTWRITEBYTECODE=1 stops Python from writing
+    # __pycache__/*.pyc next to the target repo's test files during the audit
+    # run. Without it, any target repo whose .gitignore lacks __pycache__/
+    # ends up with untracked .pyc files that dirty the audit worktree, making
+    # `git worktree remove` (no --force) refuse and leak the worktree.
+    pytest_env = os.environ.copy()
+    pytest_env["PYTHONDONTWRITEBYTECODE"] = "1"
     result = run(["poetry", "run", "pytest", "-q", "--tb=short"],
-                 cwd=str(worktree), timeout=PYTEST_TIMEOUT_S)
+                 cwd=str(worktree), timeout=PYTEST_TIMEOUT_S, env=pytest_env)
     print(f"  pytest exit code: {result.returncode}")
     return result.returncode
 


### PR DESCRIPTION
## What

`run_tests()` in `tools/dependabot_review.py` now sets `PYTHONDONTWRITEBYTECODE=1` when invoking pytest in the audit worktree.

## Why

When the dependabot review tool runs a target repo's tests inside a throwaway audit worktree, pytest's default bytecode caching writes `__pycache__/*.pyc` next to the test files. Any target repo whose `.gitignore` does not list `__pycache__/` then has untracked `.pyc` files in the worktree. `git worktree remove` (no `--force`) correctly refuses to delete a worktree containing untracked files — so the worktree leaks, and the next run for that PR number is blocked.

Concrete instance: the 2026-05-28 fleet sweep leaked 4 dispatch worktrees this way (`dispatch` is a fiction/publishing repo that happens to contain a few Python tool-scripts with tests, and never gitignored `__pycache__/`).

## The fix addresses the source, not the symptom

Disabling bytecode caching means no `.pyc` files are written at all → nothing for cleanup to trip on. This is deliberately **not** a more-aggressive cleanup: no `rm`, no `--force`, no `git clean`, no edit to any target repo's `.gitignore`. The `git worktree remove` refusal is a correct safety check and is left intact.

This also removes the underlying reason the banned `git restore .` band-aid (#1377) was added — `git restore` only resets tracked files and never helped with these untracked `.pyc`s anyway.

## Changes

- `run()` gains an optional `env` param, forwarded to `subprocess.run`.
- `run_tests()` copies `os.environ` and sets `PYTHONDONTWRITEBYTECODE=1`.
- New test `TestRunTestsDisablesBytecode` asserts `run_tests` passes `PYTHONDONTWRITEBYTECODE=1` to `run()`.

## Verification

- `poetry run pytest tests/tools/test_dependabot_review.py -q` → **24 passed** (was 23).
- `ruff check --isolated` on both changed files → clean. (The repo-level `ruff check` is unrelated-broken: ruff cannot parse `requires-python = "^3.10"` Poetry caret syntax in `pyproject.toml`.)

## Scope note

Cleanup of pre-existing leftover worktrees is out of scope (operator's call). After this lands, no new leftovers of this class appear.

Closes #1371