### PR TITLE
fix(scaffolder): pin claude-opus-4-7[1M] in .unleashed.json defaults (#1392)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -718,7 +718,7 @@ class TestMainLocalWorkflow:
         # #1060: deprecated and ignored by /onboard; should not be emitted.
         assert "pickupThresholdMinutes" not in config["onboard"]
         # Sanity: still has the rest of the structure.
-        assert config["claude"]["model"] == "opus"
+        assert config["claude"]["model"] == "claude-opus-4-7[1M]"
         assert config["claude"]["effort"] == "max"
         assert config["onboard"]["auto"] is True
 

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -1087,8 +1087,11 @@ Use `/audit` to verify structure compliance with AssemblyZero standards.
 def create_unleashed_json(project_path: Path) -> None:
     """Create .unleashed.json with standard wrapper configuration.
 
-    Sets model=opus, effort=max so unleashed wrappers pass the correct
-    CLI flags. Without this file, wrappers fall back to tool defaults.
+    Sets model=claude-opus-4-7[1M], effort=max so unleashed wrappers pass
+    the correct CLI flags. Without this file, wrappers fall back to tool
+    defaults. The explicit model literal (not the bare "opus" alias) pins
+    to 4.7[1M] — the alias would resolve to LATEST in Claude CLI and
+    bypass the user's pin.
 
     `assemblyZero` defaults to True (#1059): repos created by this tool
     are by definition AssemblyZero-managed, so /onboard should load
@@ -1104,7 +1107,7 @@ def create_unleashed_json(project_path: Path) -> None:
     content = json.dumps({
         "profile": "default",
         "claude": {
-            "model": "opus",
+            "model": "claude-opus-4-7[1M]",
             "effort": "max"
         },
         "assemblyZero": True,
@@ -2516,7 +2519,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     # Step 11b: Create .unleashed.json (wrapper configuration)
     print("\n11b. Creating .unleashed.json...")
     create_unleashed_json(project_path)
-    print("  Created .unleashed.json (model=opus, effort=max)")
+    print("  Created .unleashed.json (model=claude-opus-4-7[1M], effort=max)")
 
     # Step 11b2: Bootstrap Python project (#1058) — pyproject.toml,
     # pytest, pytest-cov, conftest.py. Required for AZ implementation


### PR DESCRIPTION
## Summary

- Scaffolder wrote `"model": "opus"` literal — Claude CLI's `--model opus` resolves to latest (Opus 4.8 today), bypassing the user-level `~/.claude/settings.json` pin
- Switch the literal to `"claude-opus-4-7[1M]"` so newly scaffolded repos pin correctly from birth
- Updated `test_new_repo_setup.py::test_..._creates_pickup_settings_..._minutes_field` assertion to the new literal
- Updated docstring + success-print to match

## Test plan

- [x] Local edit verified
- [ ] CI: `tests/test_new_repo_setup.py` passes with new assertion

## Pair

Companion wrapper-level fix at unleashed#670 maps `MODEL_MAP["opus"] -> "claude-opus-4-7[1M]"` so the 3 already-scaffolded stale repos (Chiron, dependabot-honeypot, Heuriskon) auto-correct.

Closes #1392