### PR TITLE
fix(dependabot_review): remove banned git restore . from cleanup_worktree (Closes #1377)

### DIFF
--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -26,7 +26,7 @@ def test_cleanup_worktree_uses_safe_branch_d_not_capital_D(tmp_path):
     (worktree / "pyproject.toml").write_text("")  # so evict_poetry_venv runs
 
     calls: list[list[str]] = []
-    def fake_run(cmd, cwd=None, timeout=None):
+    def fake_run(cmd, *args, **kwargs):
         calls.append(cmd)
         return _mk_completed()
 
@@ -48,7 +48,7 @@ def test_cleanup_worktree_call_order_evict_remove_branch(tmp_path):
     (worktree / "pyproject.toml").write_text("")
 
     calls: list[list[str]] = []
-    def fake_run(cmd, cwd=None, timeout=None):
+    def fake_run(cmd, *args, **kwargs):
         calls.append(cmd)
         return _mk_completed()
 

--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -409,3 +409,54 @@ class TestRunTestsDisablesBytecode:
 
         assert captured["env"] is not None, "run_tests must pass env to run()"
         assert captured["env"].get("PYTHONDONTWRITEBYTECODE") == "1"
+
+
+class TestCleanupWorktreeNoGitRestore:
+    """#1377: cleanup_worktree must NOT use `git restore` (banned B7 pattern).
+    A dirty worktree is surfaced loudly and left for the non-`--force`
+    `git worktree remove` to refuse, never silently wiped.
+    """
+
+    def _run_cleanup(self, monkeypatch, tmp_path, dirt: str):
+        """Drive cleanup_worktree with a stubbed run() that reports `dirt`
+        (a git status --porcelain string) and otherwise succeeds. Returns
+        (result, list_of_commands_run)."""
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
+        commands: list[list[str]] = []
+
+        def _fake_run(cmd, *args, **kwargs):
+            commands.append(list(cmd))
+            stdout = ""
+            if "status" in cmd and "--porcelain" in cmd:
+                stdout = dirt
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(dependabot_review, "run", _fake_run)
+        result = dependabot_review.cleanup_worktree(tmp_path, tmp_path, "dependabot-audit-1")
+        return result, commands
+
+    def test_never_invokes_git_restore_when_clean(self, monkeypatch, tmp_path):
+        result, commands = self._run_cleanup(monkeypatch, tmp_path, dirt="")
+        assert result is True
+        assert not any("restore" in c for c in commands), \
+            f"cleanup_worktree must not call git restore; saw: {commands}"
+
+    def test_never_invokes_git_restore_when_dirty(self, monkeypatch, tmp_path):
+        # Even with a dirty tree, the banned restore must NOT appear.
+        result, commands = self._run_cleanup(
+            monkeypatch, tmp_path, dirt=" M docs/0003-file-inventory.md"
+        )
+        assert not any("restore" in c for c in commands), \
+            f"cleanup_worktree must not call git restore even when dirty; saw: {commands}"
+
+    def test_dirty_worktree_emits_warning(self, monkeypatch, tmp_path, capsys):
+        self._run_cleanup(monkeypatch, tmp_path, dirt=" M docs/0003-file-inventory.md")
+        err = capsys.readouterr().err
+        assert "dirty" in err.lower()
+        assert "docs/0003-file-inventory.md" in err
+        assert "do NOT add a `git restore`" in err
+
+    def test_clean_worktree_emits_no_dirty_warning(self, monkeypatch, tmp_path, capsys):
+        self._run_cleanup(monkeypatch, tmp_path, dirt="")
+        err = capsys.readouterr().err
+        assert "dirty" not in err.lower()

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -538,19 +538,34 @@ def cleanup_worktree(target_repo: Path, worktree: Path, branch: str) -> bool:
     success = True
     evict_poetry_venv(worktree)
 
-    # Defensive: discard any working-tree modifications before the
-    # worktree-remove attempt. Something in the audit run (still
-    # unidentified after #1155's inventory.py fix -- not gh pr checkout,
-    # not poetry install, not pytest collection in standalone testing)
-    # auto-modifies docs/0003-file-inventory.md inside the worktree.
-    # That dirties the worktree, making `git worktree remove` (no --force)
-    # refuse and leak the worktree. `git restore .` reverts working-tree
-    # changes to HEAD without touching the index or refs -- no --force,
-    # no --hard, just standard restore. Any commits that the audit run
-    # made (it doesn't make any; gh pr checkout uses --detach and we
-    # never commit on the audit branch) would be untouched.
+    # #1377: do NOT `git restore .` here. The two historical sources of
+    # worktree dirt are both fixed at the source now: the inventory-node
+    # cwd-write (#1155, raises instead of scribbling on cwd) and pytest
+    # bytecode caching (#1371, PYTHONDONTWRITEBYTECODE=1 in run_tests).
+    # `git restore <path>` is a banned working-tree-destroying pattern
+    # (Projects/CLAUDE.md) -- it silently discards any uncommitted change.
+    # If a worktree is unexpectedly dirty after those fixes, that is a NEW
+    # writer we want to SEE, not silently wipe. Surface it loudly and let
+    # the non-`--force` `git worktree remove` below refuse (its failure is
+    # already reported LOUDLY). The audit run makes no commits -- gh pr
+    # checkout uses --detach (#1107) -- so a dirty tree is always a bug to
+    # diagnose, never expected state.
     if worktree.exists():
-        run(["git", "-C", str(worktree), "restore", "."])
+        dirty = run(["git", "-C", str(worktree), "status", "--porcelain"],
+                    quiet_on_failure=True)
+        dirt = (dirty.stdout or "").strip()
+        if dirt:
+            print(
+                f"  CLEANUP WARNING: audit worktree {worktree} is dirty before "
+                f"removal. This is unexpected (the audit run commits nothing and "
+                f"the known dirt sources are fixed: #1155 inventory, #1371 .pyc). "
+                f"Investigate the writer -- do NOT add a `git restore`. "
+                f"`git worktree remove` (no --force) will refuse below if this "
+                f"dirt blocks it.\n"
+                f"  git status --porcelain:\n"
+                + "\n".join(f"    {line}" for line in dirt.splitlines()),
+                file=sys.stderr,
+            )
 
     wt_remove = run(["git", "-C", str(target_repo), "worktree", "remove", str(worktree)])
     if wt_remove.returncode != 0:


### PR DESCRIPTION
## What

`cleanup_worktree` in `tools/dependabot_review.py` ran `git restore .` before `git worktree remove`. This PR removes it and replaces it with a read-only, loud diagnostic.

## Why

`git restore <path>` is a banned working-tree-destroying pattern (`Projects/CLAUDE.md`, finding **B7** in the 0900 fleet audit) — it silently discards any uncommitted change. It was added to "defensively" clear worktree dirt that blocked `git worktree remove`. But the two historical sources of that dirt are both fixed at the source now, so the restore masks nothing:

- **inventory-node cwd-write** → fixed by #1155 (the node raises `ValueError` instead of defaulting to cwd and scribbling on `docs/0003-file-inventory.md`)
- **pytest bytecode `.pyc` files** → fixed by #1371 (`PYTHONDONTWRITEBYTECODE=1` in `run_tests`)

This was confirmed **empirically in #1378**: a full audit-style test run (5,788 tests) on a clean worktree off current `main` left `docs/0003-file-inventory.md` byte-identical, with zero tracked modifications and zero `.pyc` files. The `git restore .` had nothing to restore.

## The replacement (no silent destruction)

Instead of wiping, the cleanup now runs a **read-only** `git status --porcelain`. If the worktree is unexpectedly dirty, it prints a LOUD diagnostic naming the dirty files and instructing the operator to investigate the writer — explicitly *not* to re-add a `git restore`. The existing non-`--force` `git worktree remove` then refuses on genuine dirt (a failure that is already reported loudly with stderr). Net effect: a *future* unknown writer surfaces for diagnosis instead of being silently destroyed.

This preserves the safety check (`git worktree remove` without `--force` is correct) and removes the banned pattern.

## Changes

- Removed `run(["git", "-C", str(worktree), "restore", "."])` and its stale comment (the comment claimed an "unidentified" ongoing writer that #1155 already eliminated — #1378 documents this).
- Added a read-only dirt diagnostic (`git status --porcelain`, no mutation).
- New `TestCleanupWorktreeNoGitRestore`: asserts `git restore` is **never** invoked (clean OR dirty paths) and that dirt emits the warning.
- Widened two brittle run-stubs in `tests/test_dependabot_review.py` to accept `**kwargs` (the new status call passes `quiet_on_failure=True`; the fixed-signature stubs would otherwise raise `TypeError`). Assertions unchanged — `branch -d` usage and call order still verified.

## Verification

- Full suite: **5792 passed, 1 failed**. The single failure is `tests/test_deploy_cerberus_secrets.py::test_main_returns_1_when_no_pem_and_no_dry_run` — a **pre-existing** stale-assertion failure tracked in #1391, unrelated to this change (present on `main` before this PR).
- `tests/test_dependabot_review.py`: 29 passed (the two previously-failing cleanup tests now green).
- `ruff check --isolated` clean on changed regions. (A pre-existing F541 at line 939, in the unrelated orphan-canary path, is not touched by this PR.)

## Related

- Closes #1377 (B7 finding from the 0900 banned-commands fleet audit)
- Depends-on / enabled-by: #1371 (`.pyc`) and #1155 (inventory cwd-write) — both already merged
- Investigation: #1378 (empirically proved the dirt sources are gone)