### PR TITLE
fix(dependabot_review): stop worker-thread sys.exit from truncating fleet summary (Closes #1370)

### DIFF
--- a/tests/test_dependabot_review.py
+++ b/tests/test_dependabot_review.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 # Load the tools/ script as a module without polluting sys.path.
 TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
 _spec = importlib.util.spec_from_file_location(
@@ -659,3 +661,142 @@ class TestProcessRepoPerRepoBehavior:
             f"process_pr received {target} as target_repo; expected "
             f"the foreign clone at {sibling}, not main_repo {main_repo}"
         )
+
+
+# ---- #1370: sys.exit in worker threads must not corrupt the fleet summary ----
+
+class TestWorktreeFailureDoesNotSysExit:
+    """#1370: create_audit_worktree returns (None, None) on failure instead
+    of sys.exit, and process_pr converts that to 'errored' without raising
+    SystemExit (which would escape main()'s worker-aggregation and truncate
+    the summary)."""
+
+    def test_create_audit_worktree_returns_none_on_failure(self, tmp_path, capsys):
+        main_repo = tmp_path / "repo"
+
+        def fake_run(cmd, *args, **kwargs):
+            # Simulate `git worktree add` failing (path already exists).
+            return _mk_completed(
+                returncode=128,
+                stderr="fatal: 'foo-dependabot-7' already exists",
+            )
+
+        with patch.object(dependabot_review, "run", side_effect=fake_run):
+            worktree, branch = dependabot_review.create_audit_worktree(main_repo, 7)
+
+        assert worktree is None
+        assert branch is None
+        err = capsys.readouterr().err
+        assert "could not create worktree" in err.lower()
+
+    def test_process_pr_returns_errored_without_systemexit(self, tmp_path):
+        """The headline #1370 contract: a worktree-add failure inside a
+        worker yields 'errored', NOT a propagating SystemExit."""
+        main_repo = tmp_path / "repo"
+        pr = dependabot_review.PRInfo(
+            number=127, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+        cleanup_called: list = []
+
+        with patch.object(dependabot_review, "verify_author", return_value=True), \
+             patch.object(dependabot_review, "create_audit_worktree",
+                          return_value=(None, None)), \
+             patch.object(dependabot_review, "cleanup_worktree",
+                          side_effect=lambda *a, **k: cleanup_called.append(a)):
+            # Must NOT raise SystemExit.
+            status = dependabot_review.process_pr(pr, "owner/repo", main_repo)
+
+        assert status == "errored"
+        # cleanup must NOT run on a None worktree (early return before finally).
+        assert cleanup_called == [], \
+            "cleanup_worktree must not be called when worktree creation failed"
+
+    def test_list_dependabot_prs_raises_catchable_exception_not_systemexit(self, tmp_path):
+        """#1370: list_dependabot_prs runs in workers too; on gh failure it
+        must raise a plain Exception (caught), never SystemExit."""
+        def fake_run(cmd, *args, **kwargs):
+            return _mk_completed(returncode=1, stderr="gh: API error")
+
+        with patch.object(dependabot_review, "run", side_effect=fake_run):
+            with pytest.raises(dependabot_review.PRListError):
+                dependabot_review.list_dependabot_prs("owner/repo")
+
+    def test_process_repo_records_pr_list_failure_as_errored(self, tmp_path):
+        """A PRListError for one repo is recorded as errored, sweep continues."""
+        main_repo = tmp_path / "AssemblyZero"
+        main_repo.mkdir()
+
+        with patch.object(dependabot_review, "resolve_target_repo_dir",
+                          return_value=main_repo), \
+             patch.object(dependabot_review, "check_for_orphan_worktrees",
+                          return_value=[]), \
+             patch.object(dependabot_review, "list_dependabot_prs",
+                          side_effect=dependabot_review.PRListError("boom")):
+            sub = dependabot_review.process_repo("owner/repo", main_repo)
+
+        assert sub["errored"] == ["owner/repo#pr-list-failed"]
+        assert sub["merged"] == []
+        assert sub["deferred"] == []
+
+
+class TestWorkerAggregationSurvivesBaseException:
+    """#1370: the as_completed aggregation must catch BaseException (not just
+    Exception) so a worker raising SystemExit doesn't drop the results of
+    workers that already completed. This reproduces the loop's contract."""
+
+    def test_systemexit_worker_does_not_drop_other_workers(self):
+        import concurrent.futures as cf
+
+        def good_worker(name):
+            return {"merged": [f"{name}#1"], "deferred": [], "errored": []}
+
+        def bad_worker(name):
+            raise SystemExit("could not create worktree")  # the #1370 trigger
+
+        repos = ["repoA", "repoB", "repoC"]
+        results = {"merged": [], "deferred": [], "errored": []}
+
+        with cf.ThreadPoolExecutor(max_workers=3) as ex:
+            futures = {
+                ex.submit(bad_worker if r == "repoB" else good_worker, r): r
+                for r in repos
+            }
+            for fut in cf.as_completed(futures):
+                repo = futures[fut]
+                try:
+                    sub = fut.result()
+                except KeyboardInterrupt:
+                    raise
+                except BaseException:
+                    sub = {"merged": [], "deferred": [], "errored": [repo]}
+                for k in ("merged", "deferred", "errored"):
+                    results[k].extend(sub[k])
+
+        # The two good workers' results survive; the bad one is recorded errored.
+        assert sorted(results["merged"]) == ["repoA#1", "repoC#1"]
+        assert results["errored"] == ["repoB"]
+
+    def test_keyboardinterrupt_still_propagates(self):
+        """Ctrl-C must NOT be swallowed by the BaseException catch -- it has
+        its own re-raise branch so __main__'s sys.exit(130) handler runs."""
+        import concurrent.futures as cf
+
+        def interrupt_worker():
+            raise KeyboardInterrupt()
+
+        raised = False
+        try:
+            with cf.ThreadPoolExecutor(max_workers=1) as ex:
+                fut = ex.submit(interrupt_worker)
+                for f in cf.as_completed({fut: "r"}):
+                    try:
+                        f.result()
+                    except KeyboardInterrupt:
+                        raise
+                    except BaseException:
+                        pass  # would WRONGLY swallow Ctrl-C if reached
+        except KeyboardInterrupt:
+            raised = True
+
+        assert raised, "KeyboardInterrupt must propagate, not be swallowed"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -212,6 +212,17 @@ def run_gh_with_body(args_pre: list[str], body: str) -> subprocess.CompletedProc
 # PR enumeration
 # ---------------------------------------------------------------------------
 
+class PRListError(Exception):
+    """#1370: raised by list_dependabot_prs when `gh pr list` fails.
+
+    Replaces a former sys.exit. list_dependabot_prs runs inside
+    ThreadPoolExecutor workers (process_repo) in --fleet mode; sys.exit
+    raised SystemExit (BaseException), which escaped main()'s
+    worker-aggregation `except Exception` and truncated the fleet
+    summary. A plain Exception is caught by process_repo, recorded as an
+    errored entry for that repo, and the sweep continues."""
+
+
 def list_dependabot_prs(repo: str) -> list[PRInfo]:
     result = run([
         "gh", "pr", "list", "--repo", repo,
@@ -220,7 +231,9 @@ def list_dependabot_prs(repo: str) -> list[PRInfo]:
         "--json", "number,title,author,body,headRefName",
     ])
     if result.returncode != 0:
-        sys.exit(f"Failed to list PRs: {result.stderr}")
+        raise PRListError(
+            f"Failed to list PRs for {repo}: {(result.stderr or '').strip()[:200]}"
+        )
     raw = json.loads(result.stdout or "[]")
     return [
         PRInfo(
@@ -256,18 +269,35 @@ def verify_author(pr: PRInfo) -> bool:
 # Worktree + env setup
 # ---------------------------------------------------------------------------
 
-def create_audit_worktree(target_repo: Path, pr_number: int) -> tuple[Path, str]:
+def create_audit_worktree(
+    target_repo: Path, pr_number: int
+) -> tuple[Path, str] | tuple[None, None]:
     """#1360: operate on `target_repo`'s git, not the script's invocation
     directory. Worktree path is `{target_repo.parent}/{target_repo.name}-
     dependabot-{N}`, hosted by `target_repo.git/worktrees/`. Pre-#1360
     this used a single main_repo (AssemblyZero) for every fleet repo's
-    PRs, polluting AZ's git objects."""
+    PRs, polluting AZ's git objects.
+
+    #1370: returns (None, None) on worktree-add failure instead of
+    sys.exit. This function runs inside ThreadPoolExecutor workers in
+    --fleet mode; sys.exit raises SystemExit (a BaseException, not
+    Exception), which escaped the worker-aggregation `except Exception`
+    in main() and silently truncated the fleet summary -- every PR
+    processed AFTER the failing one was dropped from the merged/deferred/
+    errored counts even though the work had completed. Returning a
+    sentinel lets process_pr record this PR as 'errored' and the sweep
+    continue to the next PR / repo, so the summary stays truthful."""
     worktree = target_repo.parent / f"{target_repo.name}-dependabot-{pr_number}"
     branch = f"dependabot-audit-{pr_number}"
     result = run(["git", "-C", str(target_repo), "worktree", "add",
                   str(worktree), "-b", branch, "main"])
     if result.returncode != 0:
-        sys.exit(f"Could not create worktree: {result.stderr}")
+        print(
+            f"  ERROR: could not create worktree at {worktree}: "
+            f"{(result.stderr or '').strip()[:200]}",
+            file=sys.stderr,
+        )
+        return None, None
     return worktree, branch
 
 
@@ -777,6 +807,12 @@ def process_pr(pr: PRInfo, repo: str, target_repo: Path) -> str:
         return "errored"
 
     worktree, branch = create_audit_worktree(target_repo, pr.number)
+    if worktree is None:
+        # #1370: worktree-add failed (e.g. an orphan already occupies the
+        # path). create_audit_worktree already printed the diagnostic.
+        # Record this PR as errored and let the sweep continue -- do NOT
+        # enter the cleanup try/finally below with a None worktree.
+        return "errored"
 
     try:
         return _process_pr_inside_worktree(pr, repo, worktree)
@@ -940,7 +976,15 @@ def process_repo(
             file=sys.stderr,
         )
 
-    prs = list_dependabot_prs(repo)
+    try:
+        prs = list_dependabot_prs(repo)
+    except PRListError as e:
+        # #1370: a PR-list failure for this repo must not abort the whole
+        # fleet sweep. Record it as errored and move on; other repos'
+        # results still aggregate into the summary.
+        print(f"  ERROR: {e}", file=sys.stderr)
+        sub["errored"].append(f"{repo}#pr-list-failed")
+        return sub
     if not prs:
         print(f"  No open dependabot PRs in {repo}.")
         return sub
@@ -1055,8 +1099,23 @@ def main() -> None:
                     repo = futures[future]
                     try:
                         sub = future.result()
-                    except Exception as e:
-                        print(f"\n  [ERROR] worker for {repo} raised: {e}")
+                    except KeyboardInterrupt:
+                        # Intentional Ctrl-C: let it propagate to __main__'s
+                        # handler (sys.exit(130)). The finally below still
+                        # prints the partial summary first.
+                        raise
+                    except BaseException as e:
+                        # #1370: catch BaseException, not just Exception. A
+                        # worker that raised SystemExit (e.g. a stray sys.exit
+                        # deep in a helper) previously escaped an
+                        # `except Exception` here, propagated out of the
+                        # as_completed loop, and dropped every worker that
+                        # hadn't been iterated yet -- truncating the summary
+                        # even though those workers had completed. Recording
+                        # the failing repo and continuing keeps the summary
+                        # truthful regardless of the exception class.
+                        print(f"\n  [ERROR] worker for {repo} raised: "
+                              f"{type(e).__name__}: {e}")
                         sub = {"merged": [], "deferred": [], "errored": [repo]}
                     for k in ("merged", "deferred", "errored"):
                         results[k].extend(sub[k])


### PR DESCRIPTION
## What

Removes two `sys.exit` calls that run inside `ThreadPoolExecutor` workers in `--fleet` mode, and widens the result-aggregation catch, so a single PR/repo failure no longer truncates (and silently falsifies) the end-of-run fleet summary.

## Why

In `--fleet` mode, repos are processed in worker threads and results aggregated via `as_completed`. Two helpers called `sys.exit` on failure:
- `create_audit_worktree` — when `git worktree add` fails (e.g. an orphan worktree already occupies the path)
- `list_dependabot_prs` — when `gh pr list` fails

`sys.exit` raises `SystemExit`, which is a **`BaseException`, not an `Exception`**. The aggregation loop caught only `except Exception`, so `SystemExit` propagated out of the `as_completed` loop and **dropped every worker that hadn't been iterated yet** — even though those workers had already finished (review comments posted, merges done). The summary then under-reported reality: the operator saw `0 reviews`, concluded the sweep did nothing, and re-ran — while 17+ review comments had actually been posted.

Concrete instance from the issue: 2026-05-28 19:23 Central — summary showed `merged=0 deferred=0 errored=1`, but the log showed honeypot (16 PRs), Talos #165, patent-general #171, Orpheus #85, RCA #84 all processed.

## Fix (defense-in-depth, three levels)

1. **`create_audit_worktree`** returns `(None, None)` on failure (prints a diagnostic, no `sys.exit`). **`process_pr`** early-returns `"errored"` before the cleanup `try/finally` (so cleanup never runs on a `None` worktree).
2. **`list_dependabot_prs`** raises `PRListError` (a plain `Exception`). **`process_repo`** catches it, records `<repo>#pr-list-failed` as errored, and continues.
3. The **`as_completed` aggregation** now catches `BaseException` — re-raising `KeyboardInterrupt` so intentional Ctrl-C still reaches `__main__`'s `sys.exit(130)` and the partial summary still prints. This makes the summary robust against *any* future worker-level `BaseException`, not just today's two call sites.

Main-thread `sys.exit` calls (`list_fleet_repos`, "not a git repo", the SIGINT handler) are **unchanged** — those are correct top-level exits and never run inside workers.

## Result

A single PR/repo failure is recorded as `errored` and the sweep continues; the Summary block and the review-event counter truthfully reflect every PR processed.

## Tests (`tests/test_dependabot_review.py`)

- `create_audit_worktree` returns `(None, None)` + prints diagnostic on failure
- `process_pr` returns `"errored"` without raising `SystemExit`, and does **not** call `cleanup_worktree` on a `None` worktree
- `list_dependabot_prs` raises `PRListError` (catchable), never `SystemExit`
- `process_repo` records a `PRListError` as `<repo>#pr-list-failed`
- the `as_completed` pattern aggregates surviving workers when one raises `SystemExit`, **and** still propagates `KeyboardInterrupt`

## Verification

- Full suite: **5798 passed, 1 failed**. The single failure is `tests/test_deploy_cerberus_secrets.py::test_main_returns_1_when_no_pem_and_no_dry_run` — **pre-existing**, tracked in #1391, unrelated to this change.
- Targeted file: 35 passed (was 29; +6 new tests).
- `ruff check --isolated` clean on changed regions. (A pre-existing F541 at line 975, in the unrelated `--ignore-orphans` print, is not touched by this PR.)

Closes #1370