### PR TITLE
fix(dependabot_review): treat pytest exit 5 (no tests collected) as pass (Closes #1397)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -460,3 +460,112 @@ class TestCleanupWorktreeNoGitRestore:
         self._run_cleanup(monkeypatch, tmp_path, dirt="")
         err = capsys.readouterr().err
         assert "dirty" not in err.lower()
+
+
+class TestExitCodeFiveIsPass:
+    """#1397: pytest exit 5 (no tests collected) is the normal result for
+    test-less repos (decorative-deps honeypots, scaffold stubs). The gate
+    must treat exit 5 as pass, not failure. A dep bump cannot turn N>0
+    tests into 0, so exit 5 reliably means "this repo has no test suite"
+    -- safe to merge for the dep-bump gate's purpose."""
+
+    def _stub_inner_pipeline(self, monkeypatch, exit_code):
+        """Stub everything _process_pr_inside_worktree calls except the gate,
+        so we can isolate the exit-code decision. Green-path helpers all
+        return success, so a non-deferred run reaches the green path."""
+        monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
+                            lambda worktree, pr_number, repo: True)
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
+        monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
+        monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: exit_code)
+        # Green-path stubs (only used when the gate doesn't defer).
+        monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "approve_pr", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
+                            lambda pr, repo, timeout=900: True)
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+        # Catch-all for the gh pr merge subprocess call on the green path.
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda cmd, *a, **kw: subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""),
+        )
+
+    def _track_review_comments(self, monkeypatch):
+        """Capture (pr, body) tuples for every review_comment_on_pr call so
+        we can assert the deferral comment was/wasn't posted."""
+        calls: list[tuple[int, str]] = []
+        monkeypatch.setattr(dependabot_review, "review_comment_on_pr",
+                            lambda pr, repo, body: calls.append((pr, body)) or True)
+        return calls
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=42, title="bump foo", author_login="app/dependabot",
+            body="Updates `foo`", head_ref="dependabot/pip/foo",
+        )
+
+    def test_exit_5_does_not_defer(self, monkeypatch, capsys):
+        """The bug: clean test-less PR with pytest exit 5 must NOT be deferred."""
+        self._stub_inner_pipeline(monkeypatch, exit_code=5)
+        calls = self._track_review_comments(monkeypatch)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        # The deferral path posts a review-comment containing "FAILED".
+        failed_comments = [body for _, body in calls if "FAILED" in body]
+        assert not failed_comments, (
+            f"exit 5 must NOT trigger the deferral review-comment; "
+            f"got: {failed_comments}"
+        )
+        # Result must not be 'deferred' -- we took the green path.
+        assert result != "deferred", f"exit 5 must not defer; got {result!r}"
+
+    def test_exit_5_logs_treating_as_pass(self, monkeypatch, capsys):
+        """The fix must log loudly so operators see why a no-tests repo passed."""
+        self._stub_inner_pipeline(monkeypatch, exit_code=5)
+        self._track_review_comments(monkeypatch)
+
+        dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        out = capsys.readouterr().out
+        assert "no tests collected" in out
+        assert "treating as PASS" in out
+
+    def test_exit_0_unchanged_green_path(self, monkeypatch):
+        """Exit 0 (tests passed) must continue to take the green path."""
+        self._stub_inner_pipeline(monkeypatch, exit_code=0)
+        calls = self._track_review_comments(monkeypatch)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        failed_comments = [body for _, body in calls if "FAILED" in body]
+        assert not failed_comments
+        assert result != "deferred"
+
+    def test_exit_1_still_defers(self, monkeypatch):
+        """Real test failure (exit 1) must still defer -- existing behavior."""
+        self._stub_inner_pipeline(monkeypatch, exit_code=1)
+        # Stub the deferral-only helpers we'd otherwise miss.
+        monkeypatch.setattr(dependabot_review, "is_pr_branch_stale",
+                            lambda pr, repo: False)
+        monkeypatch.setattr(dependabot_review, "count_packages", lambda body: 1)
+        calls = self._track_review_comments(monkeypatch)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        failed_comments = [body for _, body in calls if "FAILED (exit 1)" in body]
+        assert failed_comments, "exit 1 must still post the FAILED deferral comment"
+        assert result == "deferred"
+
+    def test_constant_is_five(self):
+        """Lock the named constant to pytest's documented exit code."""
+        assert dependabot_review.PYTEST_EXIT_NO_TESTS_COLLECTED == 5

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -104,6 +104,23 @@ POLL_INTERVAL_S = 10
 MERGEABLE_TIMEOUT_S = 900
 PYTEST_TIMEOUT_S = 1800
 POETRY_INSTALL_TIMEOUT_S = 600
+# Pytest exit codes since pytest 5.0 (2019):
+#   0 = all tests passed
+#   1 = a test failed
+#   2 = interrupted (Ctrl-C, etc.)
+#   3 = internal error
+#   4 = usage error
+#   5 = no tests collected
+# Exit 5 means the repo has no test suite (decorative-deps honeypot,
+# scaffold-only repos). A dependency bump cannot turn N>0 tests into 0,
+# so exit 5 reliably means "nothing to break" -- safe to treat as a
+# pass for the dep-bump gate. Pre-#1397 the gate was `if exit_code != 0`
+# which deferred every clean PR in any test-less repo (the honeypot
+# never merged a single dependabot PR in 7 months for this reason).
+# ADR 00001 sec 6 + the honeypot CLAUDE.md previously claimed
+# "pytest returns 0 when no tests collected" -- that was true on
+# pytest <5.0; doc fix tracked separately.
+PYTEST_EXIT_NO_TESTS_COLLECTED = 5
 
 
 @dataclass
@@ -719,6 +736,16 @@ def _process_pr_inside_worktree(
         return "deferred"
 
     exit_code = run_tests(worktree)
+
+    # #1397: exit 5 = "no tests collected" is a normal pytest result for
+    # test-less repos (decorative-deps honeypots, scaffold stubs), not a
+    # failure. A dep bump cannot turn N>0 tests into 0, so exit 5 means
+    # "this repo has no test suite" -- safe to treat as pass for the
+    # dep-bump gate. Log loudly so the run output reflects the decision.
+    if exit_code == PYTEST_EXIT_NO_TESTS_COLLECTED:
+        print("  pytest: no tests collected (exit 5) -- treating as PASS "
+              "(decorative-deps repo with no test suite)")
+        exit_code = 0
 
     if exit_code != 0:
         package_count = count_packages(pr.body)


### PR DESCRIPTION
## What

Adds a named `PYTEST_EXIT_NO_TESTS_COLLECTED = 5` and a 5-line guard before the existing test-gate so that pytest exit code 5 is treated as a pass instead of a failure.

## Why

The gate at `tools/dependabot_review.py:723` is `if exit_code != 0: defer`. Since pytest 5.0 (2019), pytest returns exit code **5** for *"no tests collected"* — a normal result for repos with no test suite, not a test failure. The strict `!= 0` gate treated every clean PR in any test-less repo (decorative-deps honeypots, scaffold-only repos) as a test failure and deferred it forever.

**Concrete impact: dependabot-honeypot has had ZERO `dependabot[bot]` PRs merge via the `/dependabot` pipeline in 7+ months of operation.** Every clean PR hit:

```
poetry install -> exit 0 (success)
pytest -q --tb=short -> exit 5 ("collected 0 items / no tests ran")
tool: "test suite FAILED (exit 5). Not approving, not merging."  ← wrong
```

Reproduced today on PR #85 (`rich 13.9.4 -> 15.0.0`, single-package). The 23 merged PRs in honeypot history are all agent-driven scaffolding/cleanup landings via the standard Cerberus path — none from the `/dependabot` tool.

ADR 00001 §6 and the honeypot `CLAUDE.md` both claimed *"pytest returns 0 when no tests collected"* — true on pytest <5.0; hasn't been true for six years. The tool inherited the wrong assumption. (Doc fix tracked separately per one-issue-per-concern.)

## Why it's safe

A dependency bump cannot turn N>0 tests into 0 tests. So if pytest reports "no tests collected" **after `poetry install` succeeded**, that reliably means the repo has no test suite — not "the upgrade broke the tests." For the dep-bump gate's purpose ("did this bump break anything testable?"), exit 5 is equivalent to "nothing to break" = pass.

Real failures (exit 1, 2, 3, 4) are unchanged — they still defer.

## Changes

- New constant `PYTEST_EXIT_NO_TESTS_COLLECTED = 5` with a comment table of all pytest exit codes for future reference.
- Before the existing gate, a 5-line guard: if `exit_code == 5`, print `"pytest: no tests collected (exit 5) -- treating as PASS"` and normalize to 0. The existing gate and green path then run unchanged.
- 5 new tests covering: exit 5 → green, exit 5 → logs the line, exit 0 → green (preserved), exit 1 → defers (preserved), constant value locked.

## Verification

- Full suite: **1 failed, 5803 passed**. The single failure is `tests/test_deploy_cerberus_secrets.py::test_main_returns_1_when_no_pem_and_no_dry_run` — pre-existing, tracked in #1391, unrelated.
- Pass count delta: **+5** (= my 5 new tests). No regressions.
- `ruff check --isolated` clean on the changed file. A pre-existing F541 at line 1001 (in the unrelated `--ignore-orphans` print) is not touched.

## Out of scope (follow-ups)

- ADR 00001 §6 + honeypot `CLAUDE.md` need their "pytest returns 0 when no tests collected" claim corrected — separate concern.
- 16 stale honeypot PRs still carry pre-cleanup manifests with Rust deps (jiter) and need `@dependabot rebase` to rebuild against current main — separate concern.

Closes #1397