### PR TITLE
fix(dependabot_review): poll mergeable_state through 'blocked' until timeout; reclassify race-failures as deferred (Closes #1399)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -183,8 +183,10 @@ class TestCommentOnPr:
 
 
 class TestWaitForMergeable:
-    """Issue #971: accept 'unstable' in addition to 'clean', tolerate one
-    cycle of 'blocked' to absorb the Cerberus-arrival race."""
+    """Issue #971: accept 'unstable' in addition to 'clean'.
+    Issue #1399: poll through 'blocked' until MERGEABLE_TIMEOUT_S timeout
+    (was: bailed after the second poll, which silently failed every PR
+    where cerberus-az took longer than POLL_INTERVAL_S to arrive)."""
 
     def _stub_state(self, monkeypatch, states):
         """Make `run` return a sequence of mergeable_state values."""
@@ -213,14 +215,30 @@ class TestWaitForMergeable:
         self._stub_state(monkeypatch, ["dirty"])
         assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
 
-    def test_persistent_blocked_returns_false(self, monkeypatch):
-        """After tolerating one cycle, persistent blocked gives up."""
-        self._stub_state(monkeypatch, ["blocked", "blocked", "blocked"])
+    def test_persistent_blocked_returns_false_at_timeout(self, monkeypatch):
+        """#1399: persistent blocked polls until the full timeout, then
+        returns False. Pre-#1399 it bailed after poll #2 (~10s), which
+        silently failed every PR where cerberus took longer than one
+        POLL_INTERVAL_S to arrive (#84, #47 on 2026-05-29/30)."""
+        # Tiny timeout so the test exits quickly without burning 15 min.
+        monkeypatch.setattr(dependabot_review, "MERGEABLE_TIMEOUT_S", 0.01)
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="blocked", stderr=""),
+        )
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
         assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
 
     def test_blocked_then_clean_returns_true(self, monkeypatch):
         """Race tolerance: Cerberus arrives between two of our polls."""
         self._stub_state(monkeypatch, ["blocked", "clean"])
+        assert dependabot_review.wait_for_mergeable(1, "owner/repo") is True
+
+    def test_multiple_blocked_then_clean_returns_true(self, monkeypatch):
+        """#1399: blocked-blocked-blocked-clean now succeeds. Pre-#1399 it
+        would have bailed at poll #2 even though cerberus arrived at #4."""
+        self._stub_state(monkeypatch, ["blocked", "blocked", "blocked", "clean"])
         assert dependabot_review.wait_for_mergeable(1, "owner/repo") is True
 
     def test_pending_then_clean_returns_true(self, monkeypatch):
@@ -231,6 +249,14 @@ class TestWaitForMergeable:
     def test_default_timeout_is_900s(self):
         """Issue #971: bumped from 300 -> 900 to cover Cerberus tail."""
         assert dependabot_review.MERGEABLE_TIMEOUT_S == 900
+
+    def test_elapsed_time_is_logged(self, monkeypatch, capsys):
+        """#1399: each poll logs elapsed seconds so the operator can tell
+        cerberus-timing-tail from polling-logic bugs."""
+        self._stub_state(monkeypatch, ["clean"])
+        dependabot_review.wait_for_mergeable(1, "owner/repo")
+        out = capsys.readouterr().out
+        assert "elapsed" in out
 
 
 class TestIsPRBranchStale:
@@ -569,3 +595,93 @@ class TestExitCodeFiveIsPass:
     def test_constant_is_five(self):
         """Lock the named constant to pytest's documented exit code."""
         assert dependabot_review.PYTEST_EXIT_NO_TESTS_COLLECTED == 5
+
+
+class TestWaitForMergeableTimeoutDeferred:
+    """#1399: when wait_for_mergeable returns False due to timeout (state
+    still 'blocked' / 'behind' / 'unknown'), the caller must classify the
+    PR as DEFERRED, not ERRORED. The approval persists; the next run will
+    merge it. Pre-#1399 the tool returned 'errored', misclassifying healthy
+    in-flight PRs as failures (#84 round 1, #47 round 2)."""
+
+    def _stub_to_wait_for_mergeable(self, monkeypatch):
+        """Stub everything up to wait_for_mergeable; the test then patches
+        wait_for_mergeable + the final-state re-query to control the exit
+        path under test."""
+        monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
+                            lambda worktree, pr_number, repo: True)
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
+        monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
+        monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 0)
+        monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "approve_pr", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=42, title="bump foo", author_login="app/dependabot",
+            body="Updates `foo`", head_ref="dependabot/pip/foo",
+        )
+
+    def _stub_wait_then_final_state(self, monkeypatch, final_state):
+        """wait_for_mergeable returns False; the post-wait re-query returns
+        `final_state`."""
+        monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
+                            lambda pr, repo: False)
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda cmd, *a, **kw: subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout=f'"{final_state}"', stderr=""),
+        )
+
+    def test_blocked_after_timeout_returns_deferred(self, monkeypatch, capsys):
+        """The exact #84/#47 case: cerberus did not approve before timeout."""
+        self._stub_to_wait_for_mergeable(monkeypatch)
+        self._stub_wait_then_final_state(monkeypatch, "blocked")
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        assert result == "deferred", (
+            "blocked-at-timeout must be deferred, not errored (approval persists; "
+            "next run merges it)"
+        )
+        out = capsys.readouterr().out
+        assert "DEFER" in out
+        assert "#1399" in out
+
+    def test_behind_after_timeout_returns_deferred(self, monkeypatch):
+        """`behind` = base branch moved; still transient, recoverable."""
+        self._stub_to_wait_for_mergeable(monkeypatch)
+        self._stub_wait_then_final_state(monkeypatch, "behind")
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+        assert result == "deferred"
+
+    def test_unknown_after_timeout_returns_deferred(self, monkeypatch):
+        """`unknown` = GitHub still computing; also transient."""
+        self._stub_to_wait_for_mergeable(monkeypatch)
+        self._stub_wait_then_final_state(monkeypatch, "unknown")
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+        assert result == "deferred"
+
+    def test_dirty_returns_errored_with_rebase(self, monkeypatch):
+        """`dirty` = merge conflict, NOT transient. Existing behavior
+        preserved: errored + @dependabot rebase requested."""
+        self._stub_to_wait_for_mergeable(monkeypatch)
+        rebase_calls: list = []
+        monkeypatch.setattr(dependabot_review, "request_dependabot_rebase",
+                            lambda pr, repo: rebase_calls.append((pr, repo)))
+        self._stub_wait_then_final_state(monkeypatch, "dirty")
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+        assert result == "errored"
+        assert rebase_calls == [(42, "owner/repo")], (
+            "dirty path must still request @dependabot rebase"
+        )

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -421,24 +421,34 @@ def wait_for_mergeable(pr_number: int, repo: str) -> bool:
     on dependabot PRs even though the worker check passes; mergeable_state
     reports `unstable`, not `clean`. Branch protection is the actual gate.
 
-    Tolerates one cycle of `blocked` to absorb the Cerberus-arrival race
-    where the App posts approval between two of our polls.
+    Issue #1399: 'blocked' is NOT a terminal state. It usually means
+    cerberus-az has not approved yet (the body edit in inject_no_issue
+    invalidates cerberus's prior approval; cerberus then re-evaluates,
+    typically within 30s-300s but with a tail past 5+ minutes). Pre-#1399
+    the loop bailed after the SECOND poll of 'blocked' (~10s total), which
+    silently failed every PR where cerberus took longer than one
+    POLL_INTERVAL_S cycle to arrive — #84 and #47 on 2026-05-29/30 are
+    the documented cases. The fix: poll through 'blocked' until the full
+    MERGEABLE_TIMEOUT_S budget is exhausted. The caller reclassifies a
+    non-'dirty' timeout as deferred (not errored) since the approval
+    persists and the next run picks the PR up cleanly.
     """
-    deadline = time.time() + MERGEABLE_TIMEOUT_S
-    polled_at_least_once = False
+    start = time.time()
+    deadline = start + MERGEABLE_TIMEOUT_S
     while time.time() < deadline:
         result = run(["gh", "api", f"repos/{repo}/pulls/{pr_number}",
                       "--jq", ".mergeable_state"])
         state = (result.stdout or "").strip().strip('"')
-        print(f"  mergeable_state: {state}")
+        elapsed = int(time.time() - start)
+        print(f"  mergeable_state: {state} (elapsed {elapsed}s)")
         if state in ("clean", "unstable"):
             return True
         if state == "dirty":
             return False  # merge conflict; waiting won't help
-        if state == "blocked" and polled_at_least_once:
-            return False
-        polled_at_least_once = True
         time.sleep(POLL_INTERVAL_S)
+    elapsed = int(time.time() - start)
+    print(f"  mergeable_state: timed out after {elapsed}s "
+          f"(MERGEABLE_TIMEOUT_S={MERGEABLE_TIMEOUT_S})")
     return False
 
 
@@ -801,12 +811,24 @@ def _process_pr_inside_worktree(
             "--jq", ".mergeable_state",
         ])
         final_state = (final_state_result.stdout or "").strip().strip('"')
-        print(f"  ERROR: mergeable_state failed to reach 'clean' (got '{final_state}')")
         if final_state == "dirty":
-            print("  Merge conflict -- requesting @dependabot rebase. "
-                  "Approval persists; next run re-evaluates post-rebase.")
+            print(f"  ERROR: mergeable_state '{final_state}' -- merge conflict, "
+                  f"requesting @dependabot rebase. Approval persists; next run "
+                  f"re-evaluates post-rebase.")
             request_dependabot_rebase(pr.number, repo)
-        return "errored"
+            return "errored"
+        # #1399: blocked/behind/unknown after timeout = state is genuinely
+        # in-flight (cerberus arrival tail, required check still running,
+        # base branch lag, etc.), NOT a permanent failure. Classify as
+        # "deferred" so the summary shows "try again next run" instead of
+        # "investigate this error". The approval persists; the next run
+        # finds the PR mergeable and merges it. This is the actual fix
+        # for the #84 (2026-05-29) and #47 (2026-05-30) cases where the
+        # tool reported errored but a re-run merged the PR within seconds.
+        print(f"  DEFER: mergeable_state '{final_state}' after wait timeout -- "
+              f"likely cerberus-arrival tail or pending check. Approval "
+              f"persists; next run will re-evaluate. (See #1399.)")
+        return "deferred"
 
     if not squash_merge(pr.number, repo):
         print("  ERROR: merge failed")


### PR DESCRIPTION
## What

Two related fixes that stop `wait_for_mergeable` from misclassifying healthy in-flight PRs as failures:

1. **The polling loop now keeps polling through `blocked` state** until the full `MERGEABLE_TIMEOUT_S = 900s` budget is exhausted. Pre-this-PR it bailed after the **second** poll of `blocked` (~10 seconds), even though the timeout was set to 15 minutes.

2. **The caller reclassifies a non-`dirty` timeout as `deferred`**, not `errored`. The approval persists; the next run picks the PR up cleanly.

## Why

`wait_for_mergeable` had this code:

```python
if state == "blocked" and polled_at_least_once:
    return False
```

The "tolerate one cycle of blocked" heuristic was set in #971 to absorb a tiny cerberus-arrival race, but cerberus's actual arrival distribution has a tail — typically 30s-300s, occasionally longer. After 10 seconds the loop gave up; the caller then recorded the PR as `errored`. The operator looked at "errored=1" in the summary and thought something was broken, when in reality the PR was approved and would merge on a re-run.

Documented cases:
- **2026-05-29 ~23:55 Central:** PR #84 (`python-minor-patch` in dependabot-honeypot). Tool posted approval, `wait_for_mergeable` returned False after ~10s of `blocked`. Summary: `errored=1`. **Re-run merged it within seconds.**
- **2026-05-30 ~00:13 Central:** PR #47 (`eslint`). Identical pattern.

## Changes

`tools/dependabot_review.py`:
- `wait_for_mergeable`: removed the `polled_at_least_once` early-exit on `blocked`. Now polls through `blocked`/`behind`/`unknown` until `MERGEABLE_TIMEOUT_S` expires. `clean`/`unstable` still exit early as success; `dirty` still exits early as failure (merge conflict — waiting won't help). Each poll logs elapsed seconds; timeout logs elapsed + the configured limit, so the operator can tell cerberus-tail from polling-logic issues.
- `_process_pr_inside_worktree`: when `wait_for_mergeable` fails with state `blocked`/`behind`/`unknown`, return `"deferred"` (not `"errored"`) with a clear log line. `dirty` still returns `"errored"` and requests `@dependabot rebase` (existing behavior preserved exactly).

## Tests (`tests/tools/test_dependabot_review.py`)

- `test_persistent_blocked_returns_false_at_timeout`: replaces the prior test that asserted the bug. Uses `MERGEABLE_TIMEOUT_S = 0.01` so the test exits in milliseconds.
- `test_multiple_blocked_then_clean_returns_true`: `blocked, blocked, blocked, clean` now succeeds (pre-this-PR it would have bailed at poll #2).
- `test_elapsed_time_is_logged`: each poll output contains "elapsed".
- `TestWaitForMergeableTimeoutDeferred` (4 tests): blocked/behind/unknown at timeout → deferred; dirty → errored + rebase.

## Verification

- Full suite: **1 failed, 5809 passed**. The single failure is the pre-existing #1391 cerberus stale-assertion (unrelated).
- Pass count delta: **+6** = my 6 new tests. No regressions.
- `ruff check --isolated` clean on the changed file. (A pre-existing F541 at line 1023 in the unrelated `--ignore-orphans` print is not touched.)

## Operational expectation

After this lands, the next fleet drain should show:
- Lower `errored` count (the wait-race no longer marks PRs as errors).
- Higher `deferred` count (those PRs now correctly show as "try again next run").
- Same or higher `merged` count once the deferred PRs sweep through on subsequent runs.

Closes #1399
