### PR TITLE
feat(dependabot_review): skip Python install + pytest gate for PRs that touch no Python files (Closes #1400)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -501,6 +501,12 @@ class TestExitCodeFiveIsPass:
         return success, so a non-deferred run reaches the green path."""
         monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
                             lambda worktree, pr_number, repo: True)
+        # #1400: force the Python gate ON so these exit-code tests actually
+        # exercise the install/test path they are testing. (#1400 added a
+        # pr_touches_python check that would otherwise skip the gate when
+        # the stubbed `run` returns empty diff output.)
+        monkeypatch.setattr(dependabot_review, "pr_touches_python",
+                            lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
         monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: exit_code)
@@ -685,3 +691,159 @@ class TestWaitForMergeableTimeoutDeferred:
         assert rebase_calls == [(42, "owner/repo")], (
             "dirty path must still request @dependabot rebase"
         )
+
+
+class TestPrTouchesPython:
+    """#1400: pr_touches_python decides whether to run the Python gate
+    (poetry install + pytest). True iff the PR's diff contains any Python
+    file (*.py) or Python manifest (pyproject.toml, poetry.lock, etc.).
+    Conservative: returns True if the diff query fails (no false-pass)."""
+
+    def _stub_diff(self, monkeypatch, files, returncode=0):
+        """Make `run` return the given file list as gh pr diff --name-only output."""
+        stdout = "\n".join(files) + ("\n" if files else "")
+
+        def _capture(cmd, *args, **kwargs):
+            assert "diff" in cmd and "--name-only" in cmd, (
+                f"pr_touches_python must shell out to gh pr diff --name-only; saw {cmd}"
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout=stdout, stderr="",
+            )
+
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+
+    def test_python_source_file_is_relevant(self, monkeypatch):
+        self._stub_diff(monkeypatch, ["src/foo.py"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_pyproject_toml_is_relevant(self, monkeypatch):
+        self._stub_diff(monkeypatch, ["pyproject.toml", "poetry.lock"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_requirements_txt_is_relevant(self, monkeypatch):
+        self._stub_diff(monkeypatch, ["requirements.txt"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_requirements_dev_txt_is_relevant(self, monkeypatch):
+        """requirements-dev.txt, requirements/base.txt etc. all count."""
+        self._stub_diff(monkeypatch, ["requirements-dev.txt"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_setup_py_is_relevant(self, monkeypatch):
+        self._stub_diff(monkeypatch, ["setup.py"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_dockerfile_only_is_not_relevant(self, monkeypatch):
+        """The exact #52/#53/#55 honeypot case: docker bump alone."""
+        self._stub_diff(monkeypatch, ["Dockerfile"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is False
+
+    def test_package_json_only_is_not_relevant(self, monkeypatch):
+        """npm bump should NOT trigger the Python gate."""
+        self._stub_diff(monkeypatch, ["package.json", "package-lock.json"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is False
+
+    def test_workflow_only_is_not_relevant(self, monkeypatch):
+        self._stub_diff(monkeypatch, [".github/workflows/ci.yml"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is False
+
+    def test_empty_diff_is_not_relevant(self, monkeypatch):
+        """Edge case: empty diff (unlikely for dependabot but defensive)."""
+        self._stub_diff(monkeypatch, [])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is False
+
+    def test_mixed_diff_with_one_python_file_is_relevant(self, monkeypatch):
+        """A single .py file in the diff is enough to trigger the gate."""
+        self._stub_diff(monkeypatch, ["Dockerfile", "src/util.py", "README.md"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+    def test_gh_diff_failure_returns_true_conservatively(self, monkeypatch, capsys):
+        """If gh pr diff fails, default to running the Python gate (no
+        false-pass). A WARNING is logged so the operator sees why."""
+        self._stub_diff(monkeypatch, [], returncode=1)
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+        err = capsys.readouterr().err
+        assert "could not list" in err.lower()
+        assert "#1400" in err
+
+    def test_nested_pyproject_is_relevant(self, monkeypatch):
+        """Monorepo pattern: pyproject.toml at any depth, not just root."""
+        self._stub_diff(monkeypatch, ["services/api/pyproject.toml"])
+        assert dependabot_review.pr_touches_python(1, "owner/repo") is True
+
+
+class TestPipelineSkippedForNonPythonPR:
+    """#1400: _process_pr_inside_worktree skips poetry install + pytest
+    when the PR touches no Python files. Goes straight to the green path
+    (inject_no_issue -> approve -> merge)."""
+
+    def _stub_green_path(self, monkeypatch):
+        """Stub the green-path helpers as success no-ops, so we can run
+        the function without hitting the network."""
+        monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
+                            lambda worktree, pr_number, repo: True)
+        monkeypatch.setattr(dependabot_review, "inject_no_issue",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "approve_pr",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "squash_merge",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=52, title="bump alpine", author_login="app/dependabot",
+            body="", head_ref="dependabot/docker/alpine-3.23.4",
+        )
+
+    def test_non_python_pr_skips_install_and_test(self, monkeypatch, capsys):
+        """The headline #1400 contract: docker-only PR never invokes
+        install_deps or run_tests."""
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(dependabot_review, "pr_touches_python",
+                            lambda pr, repo: False)
+        install_called = []
+        tests_called = []
+        monkeypatch.setattr(dependabot_review, "install_deps",
+                            lambda wt: install_called.append(wt) or True)
+        monkeypatch.setattr(dependabot_review, "run_tests",
+                            lambda wt: tests_called.append(wt) or 0)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        assert install_called == [], (
+            "install_deps must NOT be called when PR touches no Python files"
+        )
+        assert tests_called == [], (
+            "run_tests must NOT be called when PR touches no Python files"
+        )
+        assert result == "merged"
+        out = capsys.readouterr().out
+        assert "skipping poetry install + pytest gate" in out
+        assert "#1400" in out
+
+    def test_python_pr_still_runs_install_and_test(self, monkeypatch):
+        """Existing behavior preserved for Python PRs."""
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(dependabot_review, "pr_touches_python",
+                            lambda pr, repo: True)
+        install_called = []
+        tests_called = []
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
+        monkeypatch.setattr(dependabot_review, "install_deps",
+                            lambda wt: install_called.append(wt) or True)
+        monkeypatch.setattr(dependabot_review, "run_tests",
+                            lambda wt: tests_called.append(wt) or 0)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"),
+        )
+
+        assert len(install_called) == 1, "install_deps must run for Python PRs"
+        assert len(tests_called) == 1, "run_tests must run for Python PRs"
+        assert result == "merged"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -567,6 +567,60 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
     return pr_base != main_head
 
 
+# #1400: file patterns that mean "this PR could affect the Python test
+# environment" -- standard manifests, lockfiles, and any Python source.
+# Order matters only for readability; we check every changed file.
+_PYTHON_RELEVANT_FILES = frozenset({
+    "pyproject.toml",
+    "poetry.lock",
+    "setup.py",
+    "setup.cfg",
+    "Pipfile",
+    "Pipfile.lock",
+})
+
+
+def pr_touches_python(pr_number: int, repo: str) -> bool:
+    """#1400: True iff the PR's diff includes any Python-relevant file.
+
+    Used by _process_pr_inside_worktree to decide whether to run the
+    `poetry install` + `pytest` gate. A PR that does not touch any Python
+    file or manifest cannot break the Python venv by construction --
+    running the Python gate on it is wasted work AND creates false
+    negatives when the worktree's lockfile has any pre-existing issue
+    unrelated to the PR (the bug that bit honeypot's docker PRs #52, #53,
+    #55 on 2026-05-29/30 -- their branches predate the LLM-cleanup
+    martymcenroe/dependabot-honeypot#67/#71/#72/#76 and still carry the
+    jiter manifest, but the docker bump itself cannot have caused that).
+
+    Conservative on failure: if `gh pr diff` cannot list the changed
+    files, return True so the Python gate still runs (no false-pass).
+    """
+    result = run(
+        ["gh", "pr", "diff", str(pr_number), "--repo", repo, "--name-only"],
+        quiet_on_failure=True,
+    )
+    if result.returncode != 0:
+        print(f"  WARNING: could not list PR #{pr_number} changed files "
+              f"(gh pr diff --name-only failed); running Python gate as "
+              f"the safe default (#1400).",
+              file=sys.stderr)
+        return True
+    files = [f.strip() for f in (result.stdout or "").splitlines() if f.strip()]
+    for f in files:
+        # Any *.py file anywhere in the repo.
+        if f.endswith(".py"):
+            return True
+        # Any known Python manifest/lockfile at any path depth.
+        basename = f.rsplit("/", 1)[-1]
+        if basename in _PYTHON_RELEVANT_FILES:
+            return True
+        # requirements.txt, requirements-dev.txt, requirements/*.txt, etc.
+        if basename.startswith("requirements") and basename.endswith(".txt"):
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
@@ -731,30 +785,50 @@ def _process_pr_inside_worktree(
         print("  ERROR: gh pr checkout failed")
         return "errored"
 
-    evict_poetry_venv(worktree)
+    # #1400: only run the Python gate (poetry install + pytest) when the
+    # PR actually touches a Python file or manifest. A Dockerfile-only
+    # bump, an npm bump, or a github-actions workflow pin cannot break
+    # the Python venv by construction; running the Python gate on those
+    # PRs is wasted work and creates false-negative deferrals when the
+    # PR's branch has any pre-existing lockfile issue (e.g. honeypot's
+    # docker PRs #52/#53/#55 carried the pre-cleanup jiter manifest).
+    if pr_touches_python(pr.number, repo):
+        evict_poetry_venv(worktree)
 
-    if not install_deps(worktree):
-        print("  ERROR: poetry install failed")
-        # Issue #1091: post as a formal review-comment so the failure
-        # path also accrues to the user's Code Review profile stat.
-        review_comment_on_pr(
-            pr.number, repo,
-            "Automated review via tools/dependabot_review.py -- "
-            "`poetry install` failed. See the PR's Actions output for the "
-            "captured stderr; re-run locally via `gh pr checkout` if needed.",
-        )
-        return "deferred"
+        if not install_deps(worktree):
+            print("  ERROR: poetry install failed")
+            # Issue #1091: post as a formal review-comment so the failure
+            # path also accrues to the user's Code Review profile stat.
+            review_comment_on_pr(
+                pr.number, repo,
+                "Automated review via tools/dependabot_review.py -- "
+                "`poetry install` failed. See the PR's Actions output for the "
+                "captured stderr; re-run locally via `gh pr checkout` if needed.",
+            )
+            return "deferred"
 
-    exit_code = run_tests(worktree)
+        exit_code = run_tests(worktree)
 
-    # #1397: exit 5 = "no tests collected" is a normal pytest result for
-    # test-less repos (decorative-deps honeypots, scaffold stubs), not a
-    # failure. A dep bump cannot turn N>0 tests into 0, so exit 5 means
-    # "this repo has no test suite" -- safe to treat as pass for the
-    # dep-bump gate. Log loudly so the run output reflects the decision.
-    if exit_code == PYTEST_EXIT_NO_TESTS_COLLECTED:
-        print("  pytest: no tests collected (exit 5) -- treating as PASS "
-              "(decorative-deps repo with no test suite)")
+        # #1397: exit 5 = "no tests collected" is a normal pytest result for
+        # test-less repos (decorative-deps honeypots, scaffold stubs), not a
+        # failure. A dep bump cannot turn N>0 tests into 0, so exit 5 means
+        # "this repo has no test suite" -- safe to treat as pass for the
+        # dep-bump gate. Log loudly so the run output reflects the decision.
+        if exit_code == PYTEST_EXIT_NO_TESTS_COLLECTED:
+            print("  pytest: no tests collected (exit 5) -- treating as PASS "
+                  "(decorative-deps repo with no test suite)")
+            exit_code = 0
+    else:
+        # #1400: PR did not touch any Python-relevant file. Skip the Python
+        # gate entirely and treat as pass for the dep-bump gate. The PR
+        # can only have changed Docker / npm / workflow / docs content;
+        # those cannot break a Python venv. Eventual follow-up: add
+        # ecosystem-specific gates here (npm test, docker build, etc.)
+        # if/when needed -- the honeypot's decorative-deps purpose means
+        # "skip gate, pass through" is currently the right semantic.
+        print(f"  PR #{pr.number} touches no Python-relevant files -- "
+              f"skipping poetry install + pytest gate (#1400). "
+              f"Treating as PASS for the dep-bump gate.")
         exit_code = 0
 
     if exit_code != 0:


### PR DESCRIPTION
## What

The tool no longer runs `poetry install --no-root --with dev` + `pytest` on PRs that do not touch any Python file or manifest. A Dockerfile-only bump, an npm bump, or a github-actions workflow pin now goes straight to the green path (inject_no_issue → approve → merge) with a clear log line.

## Why

Hardcoding the Python pipeline on every PR produced false-negative deferrals on multi-ecosystem repos. Concrete cases from this evening's honeypot drains:

- **#52** (alpine docker bump), **#53** (node docker bump), **#55** (python base image docker bump) — every run deferred with `"poetry install failed"`. A Dockerfile-only change cannot break `poetry install` by construction, but the PRs' branches predate the LLM-cleanup (martymcenroe/dependabot-honeypot#67/#71/#72/#76) so their stale lockfiles still carry `jiter`, which fails to build on Windows + Python 3.14. The PR was not the problem; the stale branch was. But the tool blamed the PR.

The principle: **a dependency bump can only break what its own ecosystem can break.** Docker bumps cannot break Python imports; npm bumps cannot break a Python venv. The tool was forced into a choice between (a) deferring correct PRs because of unrelated state, or (b) ignoring failures (losing the gate). Picking the gate per-PR avoids both.

## Changes

**New function `pr_touches_python(pr_number, repo)`**: shells out to `gh pr diff <N> --repo <R> --name-only` and returns True iff any changed file is Python-relevant. Recognizes: `*.py` at any depth; `pyproject.toml` / `poetry.lock` / `setup.py` / `setup.cfg` / `Pipfile` / `Pipfile.lock` (root or nested); `requirements*.txt`. Conservative on failure — returns True (so the gate still runs) and logs a WARNING.

**`_process_pr_inside_worktree` wraps the install/test block** in `if pr_touches_python(...):`. The else branch logs `"PR #N touches no Python-relevant files -- skipping poetry install + pytest gate (#1400). Treating as PASS for the dep-bump gate."` and falls through to the green path. Existing behavior for Python PRs is exactly preserved.

## Tests (`tests/tools/test_dependabot_review.py`)

**`TestPrTouchesPython` (12 tests)** — file-pattern coverage:
- `*.py` file at any depth → True
- `pyproject.toml` / `poetry.lock` / `setup.py` (root or nested) → True
- `requirements.txt` / `requirements-dev.txt` → True
- `Dockerfile` only → False (the headline #52/#53/#55 case)
- `package.json` / `package-lock.json` only → False (npm)
- `.github/workflows/*.yml` only → False (gha)
- empty diff → False
- mixed diff with one `.py` → True
- `gh pr diff` failure → True (conservative) + WARNING logged

**`TestPipelineSkippedForNonPythonPR` (2 tests)** — end-to-end behavior:
- non-Python PR: `install_deps` and `run_tests` are **never** called; result = `"merged"`
- Python PR: `install_deps` and `run_tests` each called exactly once (existing behavior preserved)

Also updated the #1397 `TestExitCodeFiveIsPass._stub_inner_pipeline` to force `pr_touches_python = True` so those exit-code tests continue to exercise the install/test path they are testing (the full-suite run caught this regression and I fixed it in the same PR).

## Verification

- Full suite: **1 failed, 5823 passed**. The single failure is the pre-existing #1391 cerberus stale-assertion, unrelated.
- Pass count delta: **+14** = my 14 new tests. No regressions.
- `ruff check --isolated` clean on the changed file. (A pre-existing F541 at line ~1077 in the unrelated `--ignore-orphans` print is not touched.)

## Operational expectation

After this lands, the next honeypot drain should:
- Merge the docker PRs (#52, #53, #55) directly — they skip the broken Python gate and go straight through.
- Merge npm/gha PRs the same way.
- Still defer Python PRs whose install or tests fail (existing safety preserved).

## Out of scope (future)

- Ecosystem-specific gates (npm test, docker build, etc.) plug in at the same decision point — separate issues when needed.

Closes #1400
