### PR TITLE
fix(dependabot_review): only pass --with dev when pyproject declares the group

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -847,3 +847,113 @@ class TestPipelineSkippedForNonPythonPR:
         assert len(install_called) == 1, "install_deps must run for Python PRs"
         assert len(tests_called) == 1, "run_tests must run for Python PRs"
         assert result == "merged"
+
+
+class TestHasDevGroup:
+    """#1406: detect whether pyproject.toml declares a `dev` poetry group so
+    install_deps can decide whether to pass `--with dev`. The flag was passed
+    unconditionally; the docstring claimed Poetry warns when the group is
+    absent, but Poetry actually errors out -- deferring every repo without a
+    dev group (e.g. patent-general) for a tool-level reason unrelated to the
+    dep upgrade."""
+
+    def _write(self, tmp_path, body):
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(body, encoding="utf-8")
+        return pyproject
+
+    def test_dep_groups_dev_present(self, tmp_path):
+        """PEP 735 [dependency-groups] dev = [...] (the AssemblyZero pattern)."""
+        pyproject = self._write(tmp_path, '[dependency-groups]\ndev = ["pytest>=8.0"]\n')
+        assert dependabot_review._has_dev_group(pyproject) is True
+
+    def test_poetry_group_dev_present(self, tmp_path):
+        """Poetry-native [tool.poetry.group.dev] section."""
+        pyproject = self._write(
+            tmp_path,
+            '[tool.poetry.group.dev]\noptional = false\n\n'
+            '[tool.poetry.group.dev.dependencies]\npytest = "^8.0"\n',
+        )
+        assert dependabot_review._has_dev_group(pyproject) is True
+
+    def test_poetry_group_dev_dependencies_only(self, tmp_path):
+        """Compact form: only [tool.poetry.group.dev.dependencies]."""
+        pyproject = self._write(
+            tmp_path,
+            '[tool.poetry.group.dev.dependencies]\npytest = "^8.0"\n',
+        )
+        assert dependabot_review._has_dev_group(pyproject) is True
+
+    def test_other_group_only_returns_false(self, tmp_path):
+        """A test group is not a dev group; PEP 735 docs group is not dev."""
+        pyproject = self._write(
+            tmp_path,
+            '[tool.poetry.group.test]\noptional = false\n\n'
+            '[dependency-groups]\ndocs = ["mkdocs"]\n',
+        )
+        assert dependabot_review._has_dev_group(pyproject) is False
+
+    def test_no_groups_returns_false(self, tmp_path):
+        """The patent-general case: pyproject exists, no dev group."""
+        pyproject = self._write(
+            tmp_path,
+            '[tool.poetry]\nname = "patent-general"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dependencies]\npython = "^3.11"\n',
+        )
+        assert dependabot_review._has_dev_group(pyproject) is False
+
+    def test_empty_pyproject_returns_false(self, tmp_path):
+        pyproject = self._write(tmp_path, "")
+        assert dependabot_review._has_dev_group(pyproject) is False
+
+
+class TestInstallDepsDevGroupConditional:
+    """#1406: install_deps must only pass --with dev when the group exists."""
+
+    def _stub_run(self, monkeypatch, captured, returncode=0):
+        def _capture(cmd, *args, **kwargs):
+            captured["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout="", stderr="",
+            )
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+
+    def test_with_dev_group_passes_flag(self, monkeypatch, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[dependency-groups]\ndev = ["pytest"]\n', encoding="utf-8",
+        )
+        captured: dict = {}
+        self._stub_run(monkeypatch, captured)
+
+        assert dependabot_review.install_deps(tmp_path) is True
+        assert "--with" in captured["cmd"]
+        assert "dev" in captured["cmd"]
+
+    def test_without_dev_group_omits_flag(self, monkeypatch, tmp_path):
+        """The patent-general case that motivated #1406."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.poetry]\nname = "x"\nversion = "0.1.0"\n', encoding="utf-8",
+        )
+        captured: dict = {}
+        self._stub_run(monkeypatch, captured)
+
+        assert dependabot_review.install_deps(tmp_path) is True
+        assert "--with" not in captured["cmd"], (
+            f"install_deps must NOT pass --with when pyproject has no dev "
+            f"group; got {captured['cmd']}"
+        )
+
+    def test_no_pyproject_returns_true_without_running_poetry(
+        self, monkeypatch, tmp_path,
+    ):
+        """Pre-existing behavior: no pyproject = not a poetry project = skip."""
+        called = []
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda *a, **kw: called.append(a) or subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""),
+        )
+        assert dependabot_review.install_deps(tmp_path) is True
+        assert called == [], (
+            "install_deps must not invoke poetry when pyproject is absent"
+        )

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -68,6 +68,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import tomllib
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -336,9 +337,24 @@ def evict_poetry_venv(worktree: Path) -> None:
     run(["poetry", "env", "remove", "--all"], cwd=str(worktree))
 
 
+def _has_dev_group(pyproject: Path) -> bool:
+    """Return True iff pyproject.toml declares a `dev` poetry group.
+
+    Recognizes [tool.poetry.group.dev] (Poetry-native) and
+    [dependency-groups] dev = [...] (PEP 735).
+    """
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    poetry_groups = data.get("tool", {}).get("poetry", {}).get("group", {})
+    if "dev" in poetry_groups:
+        return True
+    return "dev" in data.get("dependency-groups", {})
+
+
 def install_deps(worktree: Path) -> bool:
-    """Install project dependencies + the `dev` group so pytest is in the
-    venv. AssemblyZero declares pytest under PEP 735 `[dependency-groups]
+    """Install project dependencies, plus the `dev` group when present.
+
+    AssemblyZero declares pytest under PEP 735 `[dependency-groups]
     dev = [...]`, which `poetry install` (no flags) does NOT include by
     default -- the audit venv ends up without pytest and every test run
     fails with `ModuleNotFoundError: No module named 'pytest'` regardless
@@ -346,9 +362,10 @@ def install_deps(worktree: Path) -> bool:
     workflow already passes `--with dev` for the same reason; mirroring
     that here makes the audit venv match production.
 
-    `--with dev` is tolerant on repos that don't have a `dev` group:
-    Poetry warns rather than failing, so this is safe across the fleet
-    of varying repo layouts.
+    `--with dev` is only added when pyproject.toml actually declares the
+    group. Poetry errors out (does NOT warn) on `--with dev` when the
+    group is absent, so passing it unconditionally defers any repo that
+    has no dev group for a tool-level reason unrelated to the dep upgrade.
 
     `--no-root` skips installing the project itself, only its dependencies.
     Required for decorative-deps repos like dependabot-honeypot that have
@@ -357,10 +374,13 @@ def install_deps(worktree: Path) -> bool:
     sweep tests dep upgrades, not the project's own code, so installing
     the root is unnecessary in every case.
     """
-    if not (worktree / "pyproject.toml").exists():
+    pyproject = worktree / "pyproject.toml"
+    if not pyproject.exists():
         return True  # Not a poetry project
-    result = run(["poetry", "install", "--no-root", "--with", "dev"],
-                 cwd=str(worktree), timeout=POETRY_INSTALL_TIMEOUT_S)
+    cmd = ["poetry", "install", "--no-root"]
+    if _has_dev_group(pyproject):
+        cmd.extend(["--with", "dev"])
+    result = run(cmd, cwd=str(worktree), timeout=POETRY_INSTALL_TIMEOUT_S)
     return result.returncode == 0
 
 


### PR DESCRIPTION
## Summary

- `install_deps` was passing `poetry install --no-root --with dev` to every audit worktree
- Docstring claimed Poetry warns when the group is absent; Poetry actually errors out ("Group(s) not found: dev (via --with)") and the install fails
- Repos without a dev group (e.g. patent-general) were being deferred for a tool-level reason that has nothing to do with the dep upgrade — directly visible in the 2026-05-30 08:24 drain run

## Fix

- New helper `_has_dev_group(pyproject)` parses `pyproject.toml` with `tomllib`
- Recognizes both `[tool.poetry.group.dev]` (Poetry-native) and `[dependency-groups] dev = [...]` (PEP 735, the AssemblyZero pattern)
- `install_deps` only appends `--with dev` when the group is present

## Test plan

- [x] 6 new tests for `_has_dev_group` covering PEP 735, poetry-native, compact form, other-group-only, no-groups, empty file
- [x] 3 new tests for `install_deps` covering with-group / without-group / no-pyproject paths
- [x] All 62 tests in `tests/tools/test_dependabot_review.py` pass locally (53 pre-existing + 9 new)

Closes #1406