### PR TITLE
fix(dependabot_review): strip VIRTUAL_ENV before poetry subprocess calls

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -957,3 +957,109 @@ class TestInstallDepsDevGroupConditional:
         assert called == [], (
             "install_deps must not invoke poetry when pyproject is absent"
         )
+
+
+class TestCleanSubprocessEnv:
+    """#1415: strip poetry-activation hints (VIRTUAL_ENV, POETRY_ACTIVE) so
+    subprocess `poetry` calls resolve the venv per cwd. The tool is invoked
+    via `poetry run python tools/dependabot_review.py`, so the inherited env
+    has those vars pointing at AZ's venv -- if they leak through, every
+    audit runs in AZ's venv instead of the target repo's."""
+
+    def test_strips_virtual_env(self, monkeypatch):
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/some/venv/path")
+        env = dependabot_review._clean_subprocess_env()
+        assert "VIRTUAL_ENV" not in env
+
+    def test_strips_poetry_active(self, monkeypatch):
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        env = dependabot_review._clean_subprocess_env()
+        assert "POETRY_ACTIVE" not in env
+
+    def test_strips_both_when_both_set(self, monkeypatch):
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/some/venv/path")
+        monkeypatch.setenv("POETRY_ACTIVE", "1")
+        env = dependabot_review._clean_subprocess_env()
+        assert "VIRTUAL_ENV" not in env
+        assert "POETRY_ACTIVE" not in env
+
+    def test_preserves_other_env_vars(self, monkeypatch):
+        """PATH and other env must still be present so subprocess can run."""
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/some/venv/path")
+        monkeypatch.setenv("MY_TEST_VAR", "preserved")
+        env = dependabot_review._clean_subprocess_env()
+        assert "VIRTUAL_ENV" not in env
+        assert env.get("MY_TEST_VAR") == "preserved"
+        assert "PATH" in env
+
+    def test_no_op_when_neither_set(self, monkeypatch):
+        """Doesn't crash if neither var is in the env (idempotent)."""
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("POETRY_ACTIVE", raising=False)
+        env = dependabot_review._clean_subprocess_env()
+        assert "VIRTUAL_ENV" not in env
+        assert "POETRY_ACTIVE" not in env
+
+
+class TestInstallDepsStripsVirtualEnv:
+    """#1415: install_deps must pass a cleaned env to poetry so the target's
+    venv is resolved, not AZ's."""
+
+    def test_install_deps_passes_clean_env_to_run(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/AZ/venv/that/should/not/leak")
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.poetry]\nname = "x"\nversion = "0.1.0"\n', encoding="utf-8",
+        )
+        captured: dict = {}
+
+        def _capture(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+        assert dependabot_review.install_deps(tmp_path) is True
+
+        assert captured["env"] is not None, (
+            "install_deps must pass env= to run() so VIRTUAL_ENV is stripped"
+        )
+        assert "VIRTUAL_ENV" not in captured["env"], (
+            "VIRTUAL_ENV must be stripped before poetry install — otherwise "
+            "poetry uses AZ venv instead of the target's"
+        )
+
+
+class TestRunTestsStripsVirtualEnv:
+    """#1415: run_tests must pass a cleaned env to pytest so the target's
+    venv is used, not AZ's. Composes with #1371's PYTHONDONTWRITEBYTECODE."""
+
+    def test_run_tests_strips_virtual_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/AZ/venv/that/should/not/leak")
+        captured: dict = {}
+
+        def _capture(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+        dependabot_review.run_tests(tmp_path)
+
+        assert captured["env"] is not None
+        assert "VIRTUAL_ENV" not in captured["env"], (
+            "VIRTUAL_ENV must be stripped before pytest — otherwise pytest "
+            "runs in AZ venv and target tests see foreign deps (sqlalchemy "
+            "via langgraph-checkpoint-sqlite was the recurring case)"
+        )
+
+    def test_run_tests_still_sets_pythondontwritebytecode(self, monkeypatch, tmp_path):
+        """Compose with #1371: env stripping must not remove the bytecode-
+        suppression that prevents __pycache__/*.pyc dirtying the worktree."""
+        captured: dict = {}
+
+        def _capture(cmd, *args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(dependabot_review, "run", _capture)
+        dependabot_review.run_tests(tmp_path)
+
+        assert captured["env"].get("PYTHONDONTWRITEBYTECODE") == "1"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -337,6 +337,27 @@ def evict_poetry_venv(worktree: Path) -> None:
     run(["poetry", "env", "remove", "--all"], cwd=str(worktree))
 
 
+def _clean_subprocess_env() -> dict[str, str]:
+    """Return os.environ minus poetry-activation hints.
+
+    The tool is invoked via `poetry run python tools/dependabot_review.py`,
+    which sets VIRTUAL_ENV (and sometimes POETRY_ACTIVE) in this process'
+    environment pointing at AssemblyZero's own venv. If those leak into the
+    subprocess env when we shell out to `poetry install` / `poetry run
+    pytest` against a TARGET repo's worktree, poetry treats the venv as
+    already-activated and skips per-cwd resolution -- every audit then runs
+    in AZ's venv instead of the target's own.
+
+    Symptom that surfaced this: sqlalchemy/sqlite tracebacks in pytest
+    output for dispatch/Talos/patent-general (none of which depend on
+    sqlalchemy), all routed through `assemblyzero-tools-{hash}` venv paths.
+    """
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env.pop("POETRY_ACTIVE", None)
+    return env
+
+
 def _has_dev_group(pyproject: Path) -> bool:
     """Return True iff pyproject.toml declares a `dev` poetry group.
 
@@ -380,7 +401,8 @@ def install_deps(worktree: Path) -> bool:
     cmd = ["poetry", "install", "--no-root"]
     if _has_dev_group(pyproject):
         cmd.extend(["--with", "dev"])
-    result = run(cmd, cwd=str(worktree), timeout=POETRY_INSTALL_TIMEOUT_S)
+    result = run(cmd, cwd=str(worktree), timeout=POETRY_INSTALL_TIMEOUT_S,
+                 env=_clean_subprocess_env())
     return result.returncode == 0
 
 
@@ -394,7 +416,7 @@ def run_tests(worktree: Path) -> int:
     # run. Without it, any target repo whose .gitignore lacks __pycache__/
     # ends up with untracked .pyc files that dirty the audit worktree, making
     # `git worktree remove` (no --force) refuse and leak the worktree.
-    pytest_env = os.environ.copy()
+    pytest_env = _clean_subprocess_env()
     pytest_env["PYTHONDONTWRITEBYTECODE"] = "1"
     result = run(["poetry", "run", "pytest", "-q", "--tb=short"],
                  cwd=str(worktree), timeout=PYTEST_TIMEOUT_S, env=pytest_env)


### PR DESCRIPTION
## Summary

- Tool is invoked via ``poetry run python tools/dependabot_review.py``, which sets VIRTUAL_ENV pointing at AZ's venv
- ``install_deps`` and ``run_tests`` shelled out to ``poetry`` without stripping VIRTUAL_ENV → poetry treated AZ's venv as already-activated and skipped per-cwd resolution
- Every audit was running in AZ's venv (``assemblyzero-tools-hxm2LnMb-py3.14``) instead of the target repo's own
- Symptom: sqlalchemy/sqlite errors in pytest output for dispatch/Talos/patent-general (none depend on sqlalchemy; AZ does via ``langgraph-checkpoint-sqlite``)

## Fix

- New helper ``_clean_subprocess_env()`` returns ``os.environ.copy()`` minus ``VIRTUAL_ENV`` and ``POETRY_ACTIVE``
- ``install_deps`` passes ``env=_clean_subprocess_env()`` to its ``run()`` call
- ``run_tests`` builds its env from ``_clean_subprocess_env()`` then adds ``PYTHONDONTWRITEBYTECODE=1`` (preserves #1371 behavior)

## Verification

- Looked up ``poetry env info --path`` from AZ root → ``...assemblyzero-tools-hxm2LnMb-py3.14``
- Same path-hash appears in every failing pytest traceback for dispatch / Talos / patent-general in today's 10:53 drain
- ``ls ~/AppData/Local/pypoetry/Cache/virtualenvs/`` shows 46 ``assemblyzero-tools-*`` venvs and zero ``dispatch-*`` / ``talos-*`` / ``patent-general-*`` venvs → target venvs have never been created

## Test plan

- [x] 5 new tests for ``_clean_subprocess_env`` (strips VIRTUAL_ENV, strips POETRY_ACTIVE, strips both, preserves other env, idempotent)
- [x] 1 test for ``install_deps`` strips VIRTUAL_ENV
- [x] 2 tests for ``run_tests`` (strips VIRTUAL_ENV, still sets PYTHONDONTWRITEBYTECODE)
- [x] All 70 tests pass (62 pre-existing + 8 new)

Closes #1415