### PR TITLE
chore(orchestrator/config): switch default drafter/reviewer to gemini:2.5-flash (Closes #1432)

### DIFF
--- a/assemblyzero/workflows/orchestrator/config.py
+++ b/assemblyzero/workflows/orchestrator/config.py
@@ -37,26 +37,30 @@ def get_default_config() -> OrchestratorConfig:
         skip_existing_lld=True,
         skip_existing_spec=True,
         stages={
+            # #1432: Default to Gemini drafter/reviewer to bypass the Claude
+            # json_schema crash (#1431) and reduce default-config cost.
+            # Operator-confirmed 2026-05-30: "i don't think it matters which
+            # llm writes and which reviews or even if one does both."
             "triage": StageConfig(
-                drafter="claude:opus-4.5",
-                reviewer="claude:opus",
+                drafter="gemini:2.5-flash",
+                reviewer="gemini:2.5-flash",
                 max_revisions=3,
                 timeout_seconds=300,
             ),
             "lld": StageConfig(
-                drafter="claude:opus-4.5",
-                reviewer="claude:opus",
+                drafter="gemini:2.5-flash",
+                reviewer="gemini:2.5-flash",
                 max_revisions=5,
                 timeout_seconds=600,
             ),
             "spec": StageConfig(
-                drafter="claude:opus-4.5",
-                reviewer="claude:opus",
+                drafter="gemini:2.5-flash",
+                reviewer="gemini:2.5-flash",
                 max_revisions=3,
                 timeout_seconds=600,
             ),
             "impl": StageConfig(
-                drafter="claude:opus-4.5",
+                drafter="gemini:2.5-flash",
                 reviewer="",
                 max_revisions=3,
                 timeout_seconds=1800,


### PR DESCRIPTION
## Summary

- Changes `get_default_config()` in `assemblyzero/workflows/orchestrator/config.py`: drafter/reviewer for triage, lld, spec → `gemini:2.5-flash` (was `claude:opus-4.5` / `claude:opus`); impl drafter → `gemini:2.5-flash` (was `claude:opus-4.5`).
- Bypasses the Claude json_schema crash (#1431) so the orchestrator's default config can complete LLD without overrides.
- Operator-confirmed flexibility on LLM choice: "i don't think it matters which llm writes and which reviews or even if one does both."

## Test plan

- [ ] CI / pr-sentinel green
- [ ] After merge, a fresh `poetry run python tools/orchestrate.py --issue 4 --repo /c/Users/mcwiz/Projects/Chiron --no-gate-pr` does NOT hit the `'list' object has no attribute 'get'` crash at LLD
- [ ] The sibling Claude bug (#1431) remains open for proper fix

Closes #1432