### PR TITLE
fix(gemini_client): --sandbox requires Docker; switch to --approval-mode plan + --skip-trust (Closes #1436)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -363,7 +363,10 @@ class GeminiClient:
                 gemini_md_path.rename(gemini_md_backup)
                 gemini_md_renamed = True
 
-            # Use stdin to pass the prompt to avoid agentic file reading
+            # Use stdin to pass the prompt to avoid agentic file reading.
+            # --approval-mode plan = read-only (replaces --sandbox which required
+            # Docker/Podman — broken on machines without either). --skip-trust
+            # prevents the workspace-trust prompt in headless invocations.
             result = subprocess.run(
                 [
                     self._gemini_cli,
@@ -373,7 +376,9 @@ class GeminiClient:
                     self.model,
                     "--output-format",
                     "text",
-                    "--sandbox",  # Disable agentic features
+                    "--approval-mode",
+                    "plan",  # Read-only; no Docker requirement
+                    "--skip-trust",  # No workspace-trust prompt
                 ],
                 input=full_prompt,
                 capture_output=True,


### PR DESCRIPTION
## Summary

- Replaces `--sandbox` (requires Docker/Podman) with `--approval-mode plan` (read-only, no Docker requirement).
- Adds `--skip-trust` to prevent workspace-trust prompts in headless invocations.
- Unblocks OAuth Gemini calls on Windows / any Docker-less machine.

## Test plan

- [ ] CI / pr-sentinel green
- [ ] After merge: re-firing the Chiron #4 smoke build doesn't hit `GEMINI_SANDBOX is true but failed to determine command for sandbox` — instead, the OAuth credential successfully reaches Gemini and the LLD drafter call returns text.

Closes #1436