### PR TITLE
fix(lld-template+drafter): teach the prompt to emit (REQ-N) suffix on test scenarios (Closes #1438)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -169,6 +169,12 @@ CRITICAL FORMATTING RULES:
 - Output ONLY the raw markdown content
 - First line MUST be the title starting with #
 
+CRITICAL — REQUIREMENT/TEST MAPPING (failure to follow halts the workflow):
+- Section 3 (Requirements) MUST be a plain numbered markdown list (1. 2. 3. ...). NO REQ-ID prefixes, NO tables, NO bullets.
+- Section 10.1 (Test Scenarios) MUST be a markdown table. Each scenario's `Scenario` column MUST end with `(REQ-N)` where N is the requirement number from Section 3 the scenario covers. Example: `| 010 | Happy path object creation (REQ-1) | Auto | ... |`
+- EVERY requirement in Section 3 MUST be covered by at least one test scenario via the `(REQ-N)` suffix. A mechanical validator counts coverage by regex-matching `(REQ-N)` patterns in Section 10.1 against the numbered list in Section 3. Missing coverage halts the workflow.
+- Multiple scenarios may cover the same requirement (e.g. two error-case scenarios both ending in `(REQ-2)`). That's fine. What's NOT fine: a requirement with zero matching `(REQ-N)` references.
+
 Use the template structure provided. Include all sections. Be specific about:
 - Files to be created/modified
 - Function signatures

--- a/docs/templates/0102-feature-lld-template.md
+++ b/docs/templates/0102-feature-lld-template.md
@@ -296,9 +296,11 @@ sequenceDiagram
 
 | ID | Scenario | Type | Input | Expected Output | Pass Criteria |
 |----|----------|------|-------|-----------------|---------------|
-| 010 | {Happy path} | Auto | {input} | {output} | {criteria} |
-| 020 | {Edge case} | Auto | {input} | {output} | {criteria} |
-| 030 | {Error case} | Auto | {input} | {output} | {criteria} |
+| 010 | {Happy path} (REQ-1) | Auto | {input} | {output} | {criteria} |
+| 020 | {Edge case} (REQ-2) | Auto | {input} | {output} | {criteria} |
+| 030 | {Error case} (REQ-2) | Auto | {input} | {output} | {criteria} |
+
+**CRITICAL — coverage mapping:** Every scenario's `Scenario` column MUST end with `(REQ-N)` where N is the requirement number from Section 3 the scenario covers. Multiple scenarios may cover the same requirement (e.g. `(REQ-2)` for both error cases above). **Every requirement listed in Section 3 MUST be covered by at least one scenario.** Mechanical validation rejects the LLD if coverage is incomplete; the `(REQ-N)` suffix is how the validator maps tests to requirements.
 
 *Note: Use 3-digit IDs with gaps of 10 (010, 020, 030...) to allow insertions.*
 


### PR DESCRIPTION
## Summary

- Template Section 10.1 example rows now show `(REQ-1)`, `(REQ-2)` suffixes + a CRITICAL note explaining the validator's coverage-mapping mechanism.
- Drafter system prompt for `workflow_type=lld` includes an explicit hard rule about the `(REQ-N)` requirement with a verbatim example.
- Both anchored against the validator's actual regex behavior (no validator changes).

## Test plan

- [ ] CI / pr-sentinel green
- [ ] After merge, re-running the Chiron #4 smoke build's LLD stage produces test scenarios with `(REQ-N)` suffixes that pass mechanical validation

Closes #1438