### PR TITLE
fix(llm_provider/ClaudeCLIProvider): defensive isinstance check for non-dict JSON response (Closes #1431)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -581,23 +581,39 @@ class ClaudeCLIProvider(LLMProvider):
                 try:
                     response_data = json.loads(stdout)
 
-                    # Issue #779: When --json-schema is used, claude -p puts the
-                    # structured output in "structured_output" (dict), not "result"
-                    # (which is empty). Serialize it back to JSON string so
-                    # downstream consumers (parse_structured_verdict) can parse it.
-                    structured_out = response_data.get("structured_output")
-                    if structured_out is not None and active_schema:
-                        response_text = json.dumps(structured_out)
+                    # #1431: Defensive — claude -p sometimes returns a top-level
+                    # JSON array (rare; observed under certain --json-schema /
+                    # error conditions). Calling .get() on a list raises
+                    # AttributeError that the bare-except below swallows with a
+                    # cryptic "'list' object has no attribute 'get'" message.
+                    # Treat any non-dict shape as "use raw stdout" so the call
+                    # still completes with a useful response and the raw bytes
+                    # are preserved for debugging.
+                    if not isinstance(response_data, dict):
+                        logger.warning(
+                            "claude -p returned non-dict JSON (type=%s); "
+                            "falling back to raw stdout. stdout[:500]=%r",
+                            type(response_data).__name__, stdout[:500]
+                        )
+                        response_text = stdout.strip()
                     else:
-                        response_text = response_data.get("result", "")
+                        # Issue #779: When --json-schema is used, claude -p puts the
+                        # structured output in "structured_output" (dict), not "result"
+                        # (which is empty). Serialize it back to JSON string so
+                        # downstream consumers (parse_structured_verdict) can parse it.
+                        structured_out = response_data.get("structured_output")
+                        if structured_out is not None and active_schema:
+                            response_text = json.dumps(structured_out)
+                        else:
+                            response_text = response_data.get("result", "")
 
-                    # Extract usage from claude -p JSON
-                    usage = response_data.get("usage", {})
-                    input_tokens = usage.get("input_tokens", 0)
-                    output_tokens = usage.get("output_tokens", 0)
-                    cache_read_tokens = usage.get("cache_read_input_tokens", 0)
-                    cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
-                    cost_usd = response_data.get("total_cost_usd", 0.0)
+                        # Extract usage from claude -p JSON
+                        usage = response_data.get("usage", {})
+                        input_tokens = usage.get("input_tokens", 0)
+                        output_tokens = usage.get("output_tokens", 0)
+                        cache_read_tokens = usage.get("cache_read_input_tokens", 0)
+                        cache_creation_tokens = usage.get("cache_creation_input_tokens", 0)
+                        cost_usd = response_data.get("total_cost_usd", 0.0)
 
                 except json.JSONDecodeError:
                     # Fall back to raw stdout if not valid JSON


### PR DESCRIPTION
## Summary

- Adds `isinstance(response_data, dict)` defensive check in `ClaudeCLIProvider.invoke()` at `llm_provider.py:582-`. When `claude -p` returns a non-dict top-level JSON (rare; observed under `--json-schema` error/edge conditions), the call now falls back to raw stdout and logs the actual response shape — instead of crashing with `'list' object has no attribute 'get'` swallowed via the bare-except 50 lines down.
- Restores the operator's Max-subscription Claude CLI path as a usable drafter/reviewer (the SDK / AnthropicProvider path is not an acceptable alternative — see CLAUDE.md "User has Max subscription").
- Default-config switch to use Claude again is a SEPARATE follow-up, not in this PR.

## Test plan

- [ ] CI / pr-sentinel green
- [ ] An LLM call that previously returned a non-dict JSON no longer raises `AttributeError`; instead returns `success=True` with `response=raw_stdout` and a logged warning naming the unexpected shape
- [ ] Existing dict-response code path unchanged

Closes #1431