### PR TITLE
feat(orchestrator/retry+drafter): revise-with-context — retry iterates on prior draft (Closes #1443)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -201,6 +201,12 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
         stage_cfg = config.get("stages", {}).get("lld", {})
         gate_enabled = bool(config.get("gates", {}).get("lld", False))
 
+        # #1443: Revise-with-context. On retry, state carries the prior
+        # attempt's draft and reviewer feedback so the drafter can iterate
+        # instead of starting fresh.
+        previous_draft_path = state.get("previous_lld_draft_path", "")
+        previous_verdict_text = state.get("previous_lld_verdict_text", "")
+
         graph = create_requirements_graph()
         app = graph.compile()
         sub_result = app.invoke({
@@ -213,10 +219,26 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
             "config_effort": stage_cfg.get("effort", ""),
             "config_gates_draft": gate_enabled,
             "config_gates_verdict": gate_enabled,
+            "previous_draft_path": previous_draft_path,
+            "previous_verdict_text": previous_verdict_text,
         })
 
         lld_path = sub_result.get("lld_path", "")
         review_verdict = sub_result.get("review_verdict", "")
+
+        # #1443: Capture this attempt's outputs onto orchestrator state so
+        # the NEXT retry (if any) sees them as previous_*. We snapshot the
+        # sub-workflow's current_verdict (actionable feedback) and the LLD
+        # path so retry can revise rather than regenerate.
+        state = dict(state)
+        if lld_path:
+            state["previous_lld_draft_path"] = lld_path
+        verdict_for_next = sub_result.get("current_verdict", "") or sub_result.get(
+            "verdict_text", ""
+        )
+        if verdict_for_next:
+            state["previous_lld_verdict_text"] = verdict_for_next
+        state = OrchestrationState(**state)
 
         if lld_path and Path(lld_path).is_file():
             if review_verdict.upper() == "APPROVED":

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -54,6 +54,18 @@ class OrchestrationState(TypedDict, total=False):
     # Error handling
     error_message: str
 
+    # #1443: Revise-with-context — carried across retries within a stage so
+    # the sub-workflow's drafter can iterate on the prior attempt instead of
+    # regenerating from scratch. The orchestrator's stage runner populates
+    # these from the failed sub_result; the runner reads them on the next
+    # attempt and threads them into the sub-workflow's app.invoke().
+    previous_lld_draft_path: str
+    previous_lld_verdict_text: str
+    previous_triage_brief_path: str
+    previous_triage_verdict_text: str
+    previous_spec_draft_path: str
+    previous_spec_verdict_text: str
+
 
 STAGE_ORDER: list[str] = ["triage", "lld", "spec", "impl", "pr"]
 

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -181,6 +181,55 @@ Use the template structure provided. Include all sections. Be specific about:
 - Data structures
 - Error handling approach"""
 
+    # #1443: Revise-with-context — when the orchestrator's stage runner has
+    # populated previous_draft_path and/or previous_verdict_text (set on retry
+    # of a stage that previously failed), augment the system prompt so the
+    # drafter REVISES instead of regenerating. Without this, each retry rolls
+    # dice on a fresh prompt and can't converge on what the reviewer / human
+    # flagged.
+    previous_draft_path = state.get("previous_draft_path", "")
+    previous_verdict_text = state.get("previous_verdict_text", "")
+    if previous_draft_path or previous_verdict_text:
+        previous_draft_text = ""
+        if previous_draft_path:
+            try:
+                previous_draft_text = Path(previous_draft_path).read_text(
+                    encoding="utf-8"
+                )
+            except OSError:
+                previous_draft_text = (
+                    f"(unable to read previous draft at {previous_draft_path})"
+                )
+        system_prompt += (
+            "\n\n========================================================\n"
+            "REVISION MODE — you have a prior attempt to learn from.\n"
+            "========================================================\n\n"
+            "This stage previously failed. Do NOT regenerate from scratch. "
+            "Produce a revision that:\n"
+            "  - Addresses every concrete reviewer-flagged issue below\n"
+            "  - Preserves content the reviewer did NOT flag\n"
+            "  - Keeps the same overall document shape (sections, ordering)\n"
+            "  - Improves the issues; does not paraphrase the whole document\n\n"
+        )
+        if previous_draft_text:
+            system_prompt += (
+                "PRIOR DRAFT (begin):\n"
+                "```markdown\n"
+                f"{previous_draft_text}\n"
+                "```\n"
+                "PRIOR DRAFT (end).\n\n"
+            )
+        if previous_verdict_text:
+            system_prompt += (
+                "REVIEWER FEEDBACK ON PRIOR DRAFT (begin):\n\n"
+                f"{previous_verdict_text}\n\n"
+                "REVIEWER FEEDBACK (end).\n\n"
+            )
+        system_prompt += (
+            "Now produce the revised document. Emit ONLY the revised markdown, "
+            "starting with the # title — same rules as before.\n"
+        )
+
     # Call drafter
     print(f"    Drafter: {drafter_spec}")
 

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -181,6 +181,13 @@ class RequirementsWorkflowState(TypedDict, total=False):
     context_files: list[str]
     context_content: str
 
+    # #1443: Revise-with-context — populated by orchestrator on retry so the
+    # drafter can iterate on the prior attempt instead of starting fresh.
+    # Empty on first attempt; non-empty when the orchestrator's stage runner
+    # captures a prior failed sub_result and passes it into the next invoke.
+    previous_draft_path: str
+    previous_verdict_text: str
+
     # Workflow tracking
     audit_dir: str
     file_counter: int


### PR DESCRIPTION
## Summary

- Orchestrator captures prior LLD attempt's draft path and reviewer verdict text onto state, threads them into the next retry's sub-workflow invoke.
- Drafter's system prompt enters REVISION MODE when previous_draft_path / previous_verdict_text are non-empty: prior draft + reviewer feedback are pasted in with explicit instructions to revise (not regenerate) and preserve un-flagged content.
- OrchestrationState + RequirementsWorkflowState schemas grow optional previous_* fields.
- Triage / spec / impl scaffolding present in state schema; runner wiring deferred to follow-ups (LLD is the immediate smoke-build need).
- Behavior is unchanged when previous_* are empty (first attempt or non-retry context).

## Test plan

- [ ] CI / pr-sentinel green
- [ ] First LLD attempt unchanged (previous_* fields empty)
- [ ] On orchestrator retry of LLD stage, sub-workflow drafter receives the prior draft path and verdict text as state inputs; resulting system prompt contains 'REVISION MODE' block
- [ ] Manually-observed convergence: retry draft retains structurally-valid sections from the prior attempt; only revises sections the reviewer flagged

Closes #1443