### PR TITLE
test(deploy_cerberus_secrets): update assertion to match current error text (Closes #1391)

### DIFF
--- a/tests/test_deploy_cerberus_secrets.py
+++ b/tests/test_deploy_cerberus_secrets.py
@@ -130,7 +130,7 @@ def test_main_returns_1_when_no_pem_and_no_dry_run(capsys):
     rc = deploy_cerberus_secrets.main([])  # neither pem nor --dry-run
     assert rc == 1
     err = capsys.readouterr().err
-    assert "pem_path is required" in err
+    assert "pem_path (plaintext) or --cerberus-pem-gpg PATH (encrypted) is required" in err
 
 
 # ---- #1118: dual-scope (Actions + Dependabot) deployment ----


### PR DESCRIPTION
## Summary

`tests/test_deploy_cerberus_secrets.py::test_main_returns_1_when_no_pem_and_no_dry_run` asserted the old substring `"pem_path is required"`. The error text in `tools/deploy_cerberus_secrets.py:314-318` was reworded when `--cerberus-pem-gpg` was added in #1254. Updated the test to assert the current substring.

Test-only fix. Verified by running the single test locally: pass.

Closes #1391