### PR TITLE
fix(orchestrator/stages): don't double-compile spec stage's graph (Closes #1454)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -327,8 +327,13 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
         stage_cfg = config.get("stages", {}).get("spec", {})
         gate_enabled = bool(config.get("gates", {}).get("spec", False))
 
-        graph = create_spec_graph()
-        app = graph.compile()
+        # create_implementation_spec_graph already returns CompiledStateGraph
+        # (see implementation_spec/graph.py:273 + line 370 `return graph.compile()`).
+        # Calling .compile() again raises AttributeError. Use the returned
+        # graph directly. Requirements + testing graph factories return the
+        # uncompiled StateGraph and still need .compile() — those stages are
+        # unchanged.
+        app = create_spec_graph()
         sub_result = app.invoke({
             "issue_number": issue_number,
             "lld_path": lld_path,

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -90,7 +90,17 @@ def test_lld_threads_target_repo(mock_detect, mock_create_graph):
 def test_spec_threads_repo_root(mock_detect, mock_create_graph):
     mock_detect.return_value = {k: None for k in ("triage", "lld", "spec", "impl", "pr")}
     captured: dict = {}
-    mock_create_graph.return_value = _capturing_graph(captured, {"spec_path": ""})
+    # create_implementation_spec_graph returns a CompiledStateGraph (already
+    # compiled) — see implementation_spec/graph.py:273 type hint. The
+    # orchestrator's run_spec_stage uses the returned graph directly without
+    # calling .compile() on it. Mock the factory to return an "app" mock
+    # whose .invoke captures the payload — matching production shape.
+    app = MagicMock()
+    def _invoke(payload):
+        captured.update(payload)
+        return {"spec_path": ""}
+    app.invoke.side_effect = _invoke
+    mock_create_graph.return_value = app
 
     run_spec_stage(_external_state())
 


### PR DESCRIPTION
Fix: `create_implementation_spec_graph()` returns CompiledStateGraph; stages.py was calling `.compile()` on it again. See #1454 for the full trace.

## Test plan
- [ ] CI green
- [ ] Spec stage no longer crashes with AttributeError

Closes #1454