### PR TITLE
fix(spec): import_targets_exist honors src-layout for new files (Closes #1461)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -737,38 +737,61 @@ def check_import_targets_exist(
     )
 
 
+_SOURCE_ROOT_PREFIXES: tuple[str, ...] = ("", "src", "lib")
+
+
+def _candidate_matches_new_file(candidate: Path, new_file_paths: set[str]) -> bool:
+    """Suffix-match a candidate module path against the spec's Add file paths.
+
+    Honors src-layout: `chiron/provenance.py` matches `src/chiron/provenance.py`
+    in new_file_paths because the latter ends with `/` + the former.
+    Closes #1461.
+    """
+    cand_str = str(candidate).replace("\\", "/")
+    for new_path in new_file_paths:
+        np = new_path.replace("\\", "/")
+        if np == cand_str or np.endswith("/" + cand_str):
+            return True
+    return False
+
+
+def _candidate_exists_under_source_roots(
+    candidate: Path, repo_root: Path
+) -> bool:
+    """Probe `repo_root / {prefix} / candidate` for common source-root prefixes.
+
+    Handles src-layout, lib-layout, and flat-layout uniformly. Closes #1461.
+    """
+    for prefix in _SOURCE_ROOT_PREFIXES:
+        probe = (repo_root / prefix / candidate) if prefix else (repo_root / candidate)
+        if probe.exists():
+            return True
+    return False
+
+
 def _import_resolves(
     module_path: str, repo_root: Path, new_file_paths: set[str]
 ) -> bool:
-    """Check if an import resolves to an existing file or a new file in the spec."""
+    """Check if an import resolves to an existing file or a new file in the spec.
+
+    Recognizes both flat-layout (`chiron/provenance.py` at repo root) and
+    src-layout (`src/chiron/provenance.py`). Closes #1461.
+    """
     parts = module_path.split(".")
-
-    # Check as module file: a/b/c.py
-    file_path = Path(*parts).with_suffix(".py")
-    if (repo_root / file_path).exists():
-        return True
-    # Check if the spec is creating this file
-    if str(file_path).replace("\\", "/") in new_file_paths:
-        return True
-
-    # Check as package: a/b/c/__init__.py
-    package_path = Path(*parts) / "__init__.py"
-    if (repo_root / package_path).exists():
-        return True
-    if str(package_path).replace("\\", "/") in new_file_paths:
-        return True
-
-    # Check parent (from a.b import c — c might be a name inside a.b.py)
+    candidates: list[Path] = [
+        Path(*parts).with_suffix(".py"),
+        Path(*parts) / "__init__.py",
+    ]
     if len(parts) > 1:
-        parent_file = Path(*parts[:-1]).with_suffix(".py")
-        if (repo_root / parent_file).exists():
+        candidates.extend([
+            Path(*parts[:-1]).with_suffix(".py"),
+            Path(*parts[:-1]) / "__init__.py",
+        ])
+
+    for candidate in candidates:
+        if _candidate_exists_under_source_roots(candidate, repo_root):
             return True
-        if str(parent_file).replace("\\", "/") in new_file_paths:
-            return True
-        parent_pkg = Path(*parts[:-1]) / "__init__.py"
-        if (repo_root / parent_pkg).exists():
-            return True
-        if str(parent_pkg).replace("\\", "/") in new_file_paths:
+        if _candidate_matches_new_file(candidate, new_file_paths):
             return True
 
     return False

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1185,6 +1185,103 @@ class TestCompletenessChecks:
         assert result["passed"] is False
 
 
+class TestImportResolvesSourceLayouts:
+    """Tests for _import_resolves source-layout handling. Closes #1461.
+
+    Verifies the validator honors src-layout (`src/foo/bar.py`), lib-layout
+    (`lib/foo/bar.py`), and flat-layout (`foo/bar.py`) for both on-disk modules
+    and modules declared as Add files in the spec's Files Changed table.
+    """
+
+    def test_resolves_flat_layout_on_disk(self, tmp_path):
+        """Flat-layout: chiron.provenance → repo/chiron/provenance.py exists."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "chiron").mkdir()
+        (tmp_path / "chiron" / "provenance.py").write_text("")
+        assert _import_resolves("chiron.provenance", tmp_path, set()) is True
+
+    def test_resolves_src_layout_on_disk(self, tmp_path):
+        """Src-layout: chiron.provenance → repo/src/chiron/provenance.py exists."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "src" / "chiron").mkdir(parents=True)
+        (tmp_path / "src" / "chiron" / "provenance.py").write_text("")
+        assert _import_resolves("chiron.provenance", tmp_path, set()) is True
+
+    def test_resolves_lib_layout_on_disk(self, tmp_path):
+        """Lib-layout: foo.bar → repo/lib/foo/bar.py exists."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "lib" / "foo").mkdir(parents=True)
+        (tmp_path / "lib" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_resolves_new_file_flat_layout(self, tmp_path):
+        """Spec declares Add `chiron/provenance.py` — flat-layout match."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        new_files = {"chiron/provenance.py"}
+        assert _import_resolves("chiron.provenance", tmp_path, new_files) is True
+
+    def test_resolves_new_file_src_layout(self, tmp_path):
+        """Spec declares Add `src/chiron/provenance.py` — src-layout suffix match."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        new_files = {"src/chiron/provenance.py"}
+        assert _import_resolves("chiron.provenance", tmp_path, new_files) is True
+
+    def test_resolves_new_file_src_layout_windows_separators(self, tmp_path):
+        """Windows-style separators in new_file_paths must still match."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        new_files = {"src\\chiron\\provenance.py"}
+        assert _import_resolves("chiron.provenance", tmp_path, new_files) is True
+
+    def test_resolves_package_init(self, tmp_path):
+        """from foo.bar import X where foo/bar/__init__.py exists in src."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "src" / "foo" / "bar").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar" / "__init__.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_resolves_parent_module_src_layout(self, tmp_path):
+        """from foo.bar import Baz where foo/bar.py exists (Baz lives inside)."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar.Baz", tmp_path, set()) is True
+
+    def test_unresolvable_returns_false(self, tmp_path):
+        """Module that exists nowhere returns False."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        assert _import_resolves("nonexistent.module", tmp_path, set()) is False
+
+    def test_chiron_provenance_smoke_build_repro(self, tmp_path):
+        """Reproduction of the Chiron #4 smoke build failure: src-layout repo
+        with `src/chiron/` parent dir missing on disk but `src/chiron/provenance.py`
+        declared as Add in the LLD's Files Changed list. Must resolve.
+        """
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        # No on-disk files. Only the Add declaration.
+        new_files = {"src/chiron/provenance.py"}
+        assert _import_resolves("chiron.provenance", tmp_path, new_files) is True
+
+
 # =============================================================================
 # N4: Human Gate
 # =============================================================================


### PR DESCRIPTION
## Summary

- `_import_resolves` now honors src-layout (`src/foo/bar.py`), lib-layout (`lib/foo/bar.py`), and flat-layout (`foo/bar.py`) for both on-disk modules and modules declared as Add files in the spec's Files Changed table.
- Two new private helpers: `_candidate_matches_new_file` (suffix match against new_file_paths) and `_candidate_exists_under_source_roots` (probes `""`, `"src"`, `"lib"` prefixes).
- Empirical motivator: Chiron #4 smoke build (2026-05-31 12:21 → 12:37 CT) looped on `import_targets_exist` for 9 spec drafts because `chiron.provenance` resolved to `chiron/provenance.py` but the actual Add path was `src/chiron/provenance.py`. After this fix, the suffix match catches it cleanly.

Closes #1461

## Test plan

- [x] `tests/unit/test_implementation_spec_workflow.py::TestImportResolvesSourceLayouts` — 10/10 pass (covers all 3 layouts × on-disk + Add list, plus the Chiron #4 smoke repro)
- [x] `tests/unit/test_implementation_spec_workflow.py` — 159/159 pass (full file)
- [ ] End-to-end: re-fire Chiron #4 smoke build after merge; spec stage must advance past `import_targets_exist`.
