### PR TITLE
fix(orchestrator): skip retry on non-transient stage halts (Closes #1463)

### DIFF
--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -109,8 +109,10 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
             return dict(new_state)
         if status == "blocked":
             return dict(new_state)
-        # failed — retry
-        if attempt < max_retries:
+        # failed — retry only when the failure is transient or unmarked
+        # (preserve current behavior for non-halt failures). Closes #1463.
+        transient = stage_result.get("transient", True)
+        if attempt < max_retries and transient:
             print(
                 f"[ORCHESTRATOR] Stage '{current_stage}' failed (attempt {attempt}/{max_retries}). "
                 f"Retrying in {retry_delay}s..."
@@ -119,6 +121,13 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
             stage_result["attempts"] = attempt
             time.sleep(retry_delay)
             last_state = new_state
+        else:
+            if not transient:
+                print(
+                    f"[ORCHESTRATOR] Stage '{current_stage}' halted non-transient — "
+                    f"skipping retry. Use the sub-workflow's Resume hint above."
+                )
+            break
 
     # All retries exhausted — update attempt count
     final_results = dict(new_state.get("stage_results", {}))

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -86,15 +86,33 @@ def _make_stage_result(
     error_message: str = "",
     duration_seconds: float = 0.0,
     attempts: int = 0,
+    transient: bool | None = None,
 ) -> StageResult:
-    """Helper to create a StageResult."""
-    return StageResult(
+    """Helper to create a StageResult.
+
+    transient: Pass False to mark this failure as non-transient so the
+    orchestrator's retry loop skips it (Closes #1463). Pass True to force
+    a retry attempt. Leave None to use the retry-default (current behavior:
+    retry up to max_retries). Only meaningful for status="failed" results.
+    """
+    result: StageResult = StageResult(
         status=status,
         artifact_path=artifact_path,
         error_message=error_message,
         duration_seconds=duration_seconds,
         attempts=attempts,
     )
+    if transient is not None:
+        result["transient"] = transient
+    return result
+
+
+def _is_non_transient_halt(sub_result: dict) -> bool:
+    """Sub-workflow halts write a recovery_plan_path. Non-transient by default
+    since the resume command — not a 10-second retry — is the recovery path.
+    Closes #1463.
+    """
+    return bool(sub_result.get("recovery_plan_path", ""))
 
 
 def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
@@ -159,6 +177,7 @@ def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
+                transient=False if _is_non_transient_halt(sub_result) else None,
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -285,6 +304,7 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
+                transient=False if _is_non_transient_halt(sub_result) else None,
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -361,6 +381,7 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
+                transient=False if _is_non_transient_halt(sub_result) else None,
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -442,6 +463,7 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
+                transient=False if _is_non_transient_halt(sub_result) else None,
             )
     except subprocess.CalledProcessError as exc:
         result = _make_stage_result(

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -20,6 +20,11 @@ class StageResult(TypedDict, total=False):
     error_message: str
     duration_seconds: float
     attempts: int
+    # When False, the orchestrator's retry loop skips this stage — the failure
+    # is known not to resolve on retry (e.g. sub-workflow halted with a
+    # non-transient recovery plan). When True or absent, the retry loop runs
+    # as today. Closes #1463.
+    transient: bool
 
 
 class OrchestrationState(TypedDict, total=False):

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -178,3 +178,167 @@ class TestRunPrStage:
         pushed_argv = push_calls[0].args[0]
         assert worktree_branch in pushed_argv
         assert f"issue-{issue}" not in pushed_argv
+
+
+class TestMakeStageResultTransient:
+    """Tests for transient field plumbing through _make_stage_result. Closes #1463."""
+
+    def test_transient_omitted_by_default(self):
+        from assemblyzero.workflows.orchestrator.stages import _make_stage_result
+
+        result = _make_stage_result(status="failed", error_message="boom")
+        assert "transient" not in result
+
+    def test_transient_false_recorded(self):
+        from assemblyzero.workflows.orchestrator.stages import _make_stage_result
+
+        result = _make_stage_result(status="failed", transient=False)
+        assert result["transient"] is False
+
+    def test_transient_true_recorded(self):
+        from assemblyzero.workflows.orchestrator.stages import _make_stage_result
+
+        result = _make_stage_result(status="failed", transient=True)
+        assert result["transient"] is True
+
+
+class TestIsNonTransientHalt:
+    """Tests for the sub-workflow halt detection helper. Closes #1463."""
+
+    def test_recovery_plan_path_set_means_halt(self):
+        from assemblyzero.workflows.orchestrator.stages import _is_non_transient_halt
+
+        assert _is_non_transient_halt({"recovery_plan_path": "/tmp/recovery.json"}) is True
+
+    def test_no_recovery_plan_path_means_not_halt(self):
+        from assemblyzero.workflows.orchestrator.stages import _is_non_transient_halt
+
+        assert _is_non_transient_halt({}) is False
+        assert _is_non_transient_halt({"recovery_plan_path": ""}) is False
+
+    def test_other_state_fields_ignored(self):
+        from assemblyzero.workflows.orchestrator.stages import _is_non_transient_halt
+
+        assert _is_non_transient_halt({"error_message": "foo"}) is False
+
+
+class TestRunStageNodeRetrySkip:
+    """Tests that _run_stage_node skips retry on non-transient failures.
+
+    Closes #1463. The smoke build burned ~24 Gemini calls retrying a halt
+    that printed `Transient: No`; the retry loop now reads the transient
+    field and breaks out instead of running the sub-workflow twice more.
+    """
+
+    def _make_state(self):
+        config = get_default_config()
+        state = create_initial_state(305, config)
+        state["current_stage"] = "triage"
+        return state
+
+    def test_non_transient_failure_skips_retry(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        call_count = {"n": 0}
+
+        def fake_runner(s):
+            call_count["n"] += 1
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "failed",
+                    "error_message": "halted",
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                    "transient": False,
+                }
+            }
+            return new_state
+
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": fake_runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"):
+            result = graph_mod._run_stage_node(self._make_state())
+
+        assert call_count["n"] == 1, "non-transient failure must not be retried"
+        assert result["stage_results"]["triage"]["status"] == "failed"
+
+    def test_transient_failure_retries_up_to_max(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        call_count = {"n": 0}
+
+        def fake_runner(s):
+            call_count["n"] += 1
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "failed",
+                    "error_message": "transient",
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                    "transient": True,
+                }
+            }
+            return new_state
+
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": fake_runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep"):
+            result = graph_mod._run_stage_node(self._make_state())
+
+        assert call_count["n"] == 3, "transient failure must retry up to max_retries"
+        assert result["stage_results"]["triage"]["status"] == "failed"
+
+    def test_failure_without_transient_field_retries_as_today(self):
+        """Backward-compat: absent transient field preserves the current
+        retry behavior so non-halt failure paths (e.g. gh CLI flakes) keep
+        their retry budget."""
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        call_count = {"n": 0}
+
+        def fake_runner(s):
+            call_count["n"] += 1
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "failed",
+                    "error_message": "no transient field",
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                }
+            }
+            return new_state
+
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": fake_runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep"):
+            result = graph_mod._run_stage_node(self._make_state())
+
+        assert call_count["n"] == 3, "absent transient field defaults to retry-as-today"
+        assert result["stage_results"]["triage"]["status"] == "failed"
+
+    def test_passed_status_does_not_retry(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        call_count = {"n": 0}
+
+        def fake_runner(s):
+            call_count["n"] += 1
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "passed",
+                    "artifact_path": "/tmp/brief.md",
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                }
+            }
+            return new_state
+
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": fake_runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"):
+            result = graph_mod._run_stage_node(self._make_state())
+
+        assert call_count["n"] == 1
+        assert result["stage_results"]["triage"]["status"] == "passed"


### PR DESCRIPTION
## Summary

- Adds optional `transient: bool` to `StageResult` (state.py). Absent = retry as today; present-and-False = skip retry.
- `_make_stage_result` (stages.py) accepts a `transient` kwarg; a new `_is_non_transient_halt` helper detects sub-workflow halts via `recovery_plan_path` presence.
- Each `status="failed"` emission site that has `sub_result` in scope now passes `transient=False if _is_non_transient_halt(sub_result) else None`. Except-clauses left unmarked (Python exceptions might be transient).
- Retry decision in `graph.py:113` becomes `if attempt < max_retries and transient`. Prints a descriptive line when skipping so operators always see the resume hint.
- Empirical motivator: Chiron #4 smoke build burned ~24 Gemini calls retrying a non-transient `import_targets_exist` halt three times. With this fix the first halt bubbles up immediately; resume command appears once.

Closes #1463

## Test plan

- [x] `tests/unit/test_orchestrator_stages.py::TestMakeStageResultTransient` — 3/3 pass
- [x] `tests/unit/test_orchestrator_stages.py::TestIsNonTransientHalt` — 3/3 pass
- [x] `tests/unit/test_orchestrator_stages.py::TestRunStageNodeRetrySkip` — 4/4 pass (non-transient skip, transient retry-to-max, absent-field backward-compat, passed-no-retry)
- [x] Full orchestrator family: `test_orchestrator_stages`, `_state`, `_artifacts`, `_config`, `_repo_targeting` — 58/58 pass
- [ ] End-to-end: paired with #1462 (the validator fix), the smoke build's next failure produces 1 halt + 1 resume hint instead of 3 retries + ~24 wasted Gemini calls.
