### PR TITLE
fix(spec): persist cumulative completeness-failure history across revisions (Closes #1465)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -228,6 +228,9 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
             project_context=state.get("project_context", ""),
             import_dependencies=state.get("import_dependencies", ""),
             repo_structure=state.get("repo_structure", ""),
+            prior_completeness_breakdown=(
+                state.get("prior_completeness_breakdown", []) if is_revision else []
+            ),
         )
 
     # -------------------------------------------------------------------------
@@ -355,6 +358,7 @@ def build_drafter_prompt(
     project_context: str = "",
     import_dependencies: str = "",
     repo_structure: str = "",
+    prior_completeness_breakdown: list[dict] | None = None,
 ) -> str:
     """Build the prompt for Claude spec generation.
 
@@ -391,6 +395,8 @@ def build_drafter_prompt(
         completeness_issues = []
     if files_to_modify is None:
         files_to_modify = []
+    if prior_completeness_breakdown is None:
+        prior_completeness_breakdown = []
 
     is_revision = bool(existing_draft and (review_feedback or completeness_issues))
 
@@ -407,6 +413,7 @@ def build_drafter_prompt(
             repo_root=repo_root,
             files_to_modify=files_to_modify,
             repo_structure=repo_structure,
+            prior_completeness_breakdown=prior_completeness_breakdown,
         )
     else:
         return _build_initial_prompt(
@@ -517,6 +524,7 @@ def _build_revision_prompt(
     repo_root: str,
     files_to_modify: list,
     repo_structure: str = "",
+    prior_completeness_breakdown: list[dict] | None = None,
 ) -> str:
     """Build prompt for spec revision based on feedback.
 
@@ -593,6 +601,45 @@ def _build_revision_prompt(
             issues_text += f"```\n{repo_structure}\n```\n"
 
         sections.append(issues_text)
+
+    # Closes #1465: Cumulative prior-iteration failures. Show the drafter the
+    # full history of which checks failed in which iterations, so identical
+    # error messages don't yield identical revisions. If the same check has
+    # failed K times, the drafter is told explicitly: "your last K attempts
+    # did NOT fix this — try a fundamentally different approach."
+    if prior_completeness_breakdown:
+        history = "## PRIOR ITERATION HISTORY (DO NOT REPEAT)\n\n"
+        history += (
+            "Each entry shows checks that failed in a prior iteration. "
+            "If the same failure recurs across multiple iterations, your "
+            "earlier fixes did NOT work — change approach, do not minor-tweak:\n\n"
+        )
+        for entry in prior_completeness_breakdown:
+            iteration = entry.get("iteration", "?")
+            failures = entry.get("failures", [])
+            history += f"### Iteration {iteration} failures\n"
+            for failure in failures:
+                history += f"- {failure}\n"
+            history += "\n"
+        # Synthesize the "tried K times" warning if any check repeats
+        all_failures = [
+            f
+            for entry in prior_completeness_breakdown
+            for f in entry.get("failures", [])
+        ]
+        from collections import Counter
+        repeat_counts = Counter(all_failures)
+        repeated = [f for f, n in repeat_counts.items() if n >= 2]
+        if repeated:
+            history += "### RECURRING FAILURES (your prior fixes did NOT work)\n\n"
+            for failure in repeated:
+                count = repeat_counts[failure]
+                history += f"- Tried {count} times: {failure}\n"
+            history += (
+                "\n**Stop refining the prior approach. Change the spec's "
+                "structure or strategy fundamentally for these failures.**\n"
+            )
+        sections.append(history)
 
     # Review feedback (from N5 Gemini review)
     if review_feedback:

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -168,9 +168,22 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
         for issue in completeness_issues:
             print(f"      - {issue[:120]}...")
 
+    # Closes #1465: Persist this iteration's failures into a cumulative
+    # breakdown so the next N2 revision sees "we already tried fixing this
+    # K times" history. Without it, identical failure text yields identical
+    # revisions and the spec-revision loop never converges.
+    prior_breakdown = list(state.get("prior_completeness_breakdown", []))
+    if not validation_passed:
+        iteration = state.get("review_iteration", 0)
+        prior_breakdown.append({
+            "iteration": iteration,
+            "failures": list(completeness_issues),
+        })
+
     return {
         "completeness_issues": completeness_issues,
         "validation_passed": validation_passed,
+        "prior_completeness_breakdown": prior_breakdown,
         "error_message": "",
     }
 

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -179,3 +179,10 @@ class ImplementationSpecState(TypedDict, total=False):
     previous_attempt_snippet: str | None
     target_file: str
     completed_files: list[str]
+
+    # Closes #1465: Cumulative N3 completeness failures across iterations so
+    # the drafter sees "iteration K failed on these checks" history, not just
+    # the current iteration's failures. Without this, identical failure
+    # messages produce identical revisions and the loop never converges.
+    # Each entry: {"iteration": int, "failures": list[str]}.
+    prior_completeness_breakdown: list[dict]

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1480,6 +1480,144 @@ class TestBuildDrafterPrompt:
         assert "Similar node" in prompt
 
 
+class TestPriorCompletenessBreakdownInPrompt:
+    """Cumulative prior-iteration failures appear in revision prompt. Closes #1465."""
+
+    def _make_revision_prompt(self, prior_breakdown):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            build_drafter_prompt,
+        )
+        # Revision mode requires existing_draft + (review_feedback OR completeness_issues)
+        return build_drafter_prompt(
+            lld_content="# LLD",
+            current_state={},
+            patterns=[],
+            existing_draft="# Current draft",
+            completeness_issues=["import_targets_exist: chiron.provenance"],
+            prior_completeness_breakdown=prior_breakdown,
+        )
+
+    def test_empty_prior_breakdown_no_history_section(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[])
+        assert "PRIOR ITERATION HISTORY" not in prompt
+
+    def test_single_prior_iteration_renders_history(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: thing missing"]},
+        ])
+        assert "PRIOR ITERATION HISTORY" in prompt
+        assert "Iteration 0" in prompt
+        assert "check_X: thing missing" in prompt
+
+    def test_recurring_failure_synthesizes_warning(self):
+        """When the same failure appears in >=2 prior iterations, the prompt
+        explicitly tells the drafter prior fixes did not work and to change
+        approach — not just retry a minor tweak."""
+        same = "check_X: thing missing"
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": [same]},
+            {"iteration": 1, "failures": [same]},
+            {"iteration": 2, "failures": [same]},
+        ])
+        assert "RECURRING FAILURES" in prompt
+        assert "Tried 3 times" in prompt
+        assert "Change approach" in prompt or "change the spec" in prompt.lower()
+
+    def test_distinct_failures_do_not_trigger_recurring_section(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: A"]},
+            {"iteration": 1, "failures": ["check_Y: B"]},
+        ])
+        assert "PRIOR ITERATION HISTORY" in prompt
+        assert "RECURRING FAILURES" not in prompt
+
+
+class TestValidateCompletenessAccumulatesPriorBreakdown:
+    """N3 appends each failed iteration to prior_completeness_breakdown so
+    N2 sees the full history. Closes #1465."""
+
+    def test_first_failure_creates_first_breakdown_entry(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+        state = {
+            "spec_draft": "# Spec\n" + ("content " * 30),
+            "files_to_modify": [{
+                "path": "src/chiron/provenance.py",
+                "change_type": "Add", "description": "Add module",
+                "current_content": "",
+            }],
+            "pattern_references": [],
+            "repo_root": str(tmp_path),
+            "review_iteration": 0,
+            "prior_completeness_breakdown": [],
+        }
+        result = validate_completeness(state)
+        breakdown = result.get("prior_completeness_breakdown", [])
+        assert result["validation_passed"] is False
+        assert len(breakdown) == 1
+        assert breakdown[0]["iteration"] == 0
+        assert len(breakdown[0]["failures"]) > 0
+
+    def test_subsequent_failure_appends_without_dropping_prior(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+        prior = [{"iteration": 0, "failures": ["old failure"]}]
+        state = {
+            "spec_draft": "# Spec\n" + ("content " * 30),
+            "files_to_modify": [{
+                "path": "src/chiron/provenance.py",
+                "change_type": "Add", "description": "Add module",
+                "current_content": "",
+            }],
+            "pattern_references": [],
+            "repo_root": str(tmp_path),
+            "review_iteration": 1,
+            "prior_completeness_breakdown": prior,
+        }
+        result = validate_completeness(state)
+        breakdown = result.get("prior_completeness_breakdown", [])
+        assert len(breakdown) == 2
+        assert breakdown[0] == {"iteration": 0, "failures": ["old failure"]}
+        assert breakdown[1]["iteration"] == 1
+
+    def test_passing_validation_does_not_append(self, tmp_path):
+        """When N3 passes, the breakdown is unchanged (passing iterations
+        aren't part of the failure history)."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+        prior = [{"iteration": 0, "failures": ["earlier failure"]}]
+        # A long substantive spec with no Modify files passes most checks
+        # (the import check is the harshest gate; with no Add files in the
+        # spec and no imports declared, the test passes the bar — but only
+        # for the purpose of this test we use a draft that will pass).
+        # Easiest: use the existing sample_spec_complete pattern from
+        # base_state fixtures. For unit isolation, give it an empty files
+        # list and a basic but >100-char draft.
+        state = {
+            "spec_draft": "# Implementation Spec\n\n## Overview\n\n"
+                          "This spec does nothing structural; no Modify, "
+                          "no Add. " + ("filler " * 20),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": str(tmp_path),
+            "review_iteration": 1,
+            "prior_completeness_breakdown": prior,
+        }
+        result = validate_completeness(state)
+        # Even if validation_passed varies (it depends on other checks),
+        # the contract is: prior_breakdown is only appended on failure.
+        breakdown = result.get("prior_completeness_breakdown", [])
+        if result["validation_passed"]:
+            assert breakdown == prior
+        else:
+            # On failure the new entry is appended; original prior still present
+            assert breakdown[0] == prior[0]
+            assert len(breakdown) == 2
+
+
 class TestPromptProjectContext:
     """Tests for Issue #409: project context and import deps in prompt."""
 


### PR DESCRIPTION
## Summary

- Adds `prior_completeness_breakdown: list[dict]` to `ImplementationSpecState` (each entry: `{iteration, failures}`).
- N3 (`validate_completeness`) appends current iteration's failures on every failed validation, persisting the history across iterations.
- N2 (`generate_spec`) threads the breakdown through `build_drafter_prompt` → `_build_revision_prompt`, which renders a new `## PRIOR ITERATION HISTORY (DO NOT REPEAT)` section. When the same failure recurs across ≥2 iterations, a `### RECURRING FAILURES` subsection synthesizes the warning explicitly.
- Drafter now sees: "Iterations 0, 1, 2 all failed on `chiron.provenance` — change approach." Without this, identical failure text yielded identical revisions and the loop never converged.

Closes #1465

## Test plan

- [x] `TestPriorCompletenessBreakdownInPrompt` — 4/4 pass (empty, single, recurring, distinct)
- [x] `TestValidateCompletenessAccumulatesPriorBreakdown` — 3/3 pass (first failure, append, no-append on pass)
- [x] `tests/unit/test_implementation_spec_workflow.py` — 166/166 total
