### PR TITLE
fix(finalize): strip code blocks before checkbox regex + move-to-done before commit (Closes #1457, Closes #1470)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -236,7 +236,13 @@ def validate_lld_final(content: str, open_questions_resolved: bool = False) -> l
 
         if match:
             open_questions_section = match.group(1)
-            if re.search(r"^- \[ \]", open_questions_section, re.MULTILINE):
+            # Closes #1470: strip fenced code blocks so example syntax inside
+            # backticks (`- [ ]` as documentation, not as a real checkbox) does
+            # not trip the regex.
+            section_no_blocks = re.sub(
+                r"```[\s\S]*?```", "", open_questions_section
+            )
+            if re.search(r"^- \[ \]", section_no_blocks, re.MULTILINE):
                 errors.append("Unresolved open questions remain")
 
     # Issue #775: Use structured detection for questions/TODOs (REQ-1)
@@ -476,6 +482,19 @@ def finalize(state: Dict[str, Any]) -> Dict[str, Any]:
             details=completion_details,
         )
 
+    # Closes #1457: move-to-done runs BEFORE the commit. Previously the commit
+    # captured lineage in active/ then this move relocated those files to done/,
+    # leaving the working tree dirty after every successful workflow run. With
+    # AZ #1458 (lineage no longer in created_files) the dirty-state was mostly
+    # defused, but the order is still wrong: post-commit working-tree mutation
+    # is incoherent. Moving first ensures that whatever lineage is committed —
+    # if any — lives at its final on-disk location.
+    if not state.get("error_message"):
+        audit_dir = Path(state.get("audit_dir", ""))
+        target_repo = Path(state.get("target_repo", "."))
+        if audit_dir.exists():
+            move_lineage_to_done(audit_dir, target_repo)
+
     # For LLD workflow, commit only on APPROVED — REVISE / BLOCKED outputs
     # are not project history and must not land on target main. Issue workflow
     # commits unconditionally (no per-verdict gate exists for that path).
@@ -486,13 +505,6 @@ def finalize(state: Dict[str, Any]) -> Dict[str, Any]:
     )
     if not state.get("error_message") and not lld_blocked:
         state = _commit_and_push_files(state)
-
-    # Issue #100: Move lineage from active/ to done/ on successful completion
-    if not state.get("error_message"):
-        audit_dir = Path(state.get("audit_dir", ""))
-        target_repo = Path(state.get("target_repo", "."))
-        if audit_dir.exists():
-            move_lineage_to_done(audit_dir, target_repo)
 
     # Cleanup source idea after successful issue creation
     if workflow_type == "issue" and not state.get("error_message"):

--- a/tests/unit/test_finalize_structured_output.py
+++ b/tests/unit/test_finalize_structured_output.py
@@ -157,6 +157,63 @@ class TestValidateLldFinalStructured:
         assert isinstance(issues, list)
 
 
+class TestOpenQuestionsCheckboxIgnoresCodeBlocks:
+    """The unchecked-checkbox regex must not match inside fenced code blocks.
+
+    Closes #1470. A draft that documents the Open Questions section format
+    by showing the `- [ ]` syntax in a code block was falsely flagging
+    "Unresolved open questions remain" even when all real checkboxes were
+    checked or resolved.
+    """
+
+    def test_unchecked_inside_fenced_block_does_not_trigger(self):
+        content = (
+            "# LLD\n\n"
+            "## Open Questions\n\n"
+            "All questions resolved. The format for tracking is:\n\n"
+            "```markdown\n"
+            "- [ ] Example unchecked question\n"
+            "- [x] Example resolved question\n"
+            "```\n\n"
+            "## Next Section\n"
+        )
+        issues = validate_lld_final(content, open_questions_resolved=False)
+        assert not any(
+            "Unresolved open questions remain" in i for i in issues
+        ), f"got: {issues}"
+
+    def test_real_unchecked_outside_block_still_triggers(self):
+        content = (
+            "# LLD\n\n"
+            "## Open Questions\n\n"
+            "- [ ] What is the timeout?\n\n"
+            "## Next Section\n"
+        )
+        issues = validate_lld_final(content, open_questions_resolved=False)
+        assert any(
+            "Unresolved open questions remain" in i for i in issues
+        ), f"got: {issues}"
+
+    def test_unchecked_in_block_with_real_unchecked_outside_still_triggers(self):
+        """Mixed case: code-block example AND a real unchecked item — the
+        real one must still trigger the error."""
+        content = (
+            "# LLD\n\n"
+            "## Open Questions\n\n"
+            "Format example:\n\n"
+            "```markdown\n"
+            "- [ ] example only\n"
+            "```\n\n"
+            "Real questions:\n\n"
+            "- [ ] Actual question that needs answering\n\n"
+            "## Next Section\n"
+        )
+        issues = validate_lld_final(content, open_questions_resolved=False)
+        assert any(
+            "Unresolved open questions remain" in i for i in issues
+        ), f"got: {issues}"
+
+
 class TestDetectOpenQuestionsReturnType:
     """Verify FinalizeQuestionsResult TypedDict structure."""
 

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1202,6 +1202,43 @@ class TestFinalizeLineageFiles:
 
         mock_commit.assert_called_once()
 
+    @patch("assemblyzero.workflows.requirements.nodes.finalize._commit_and_push_files")
+    @patch("assemblyzero.workflows.requirements.nodes.finalize.move_lineage_to_done")
+    def test_finalize_moves_to_done_before_commit(
+        self, mock_move, mock_commit, tmp_path
+    ):
+        """Move-to-done runs BEFORE the commit so post-commit working-tree
+        mutation doesn't leave the target repo dirty. Closes #1457."""
+        from assemblyzero.workflows.requirements.nodes.finalize import finalize
+        from assemblyzero.workflows.requirements.state import create_initial_state
+
+        mock_commit.side_effect = lambda s: s
+        call_order: list[str] = []
+        mock_move.side_effect = lambda *a, **kw: call_order.append("move")
+        mock_commit.side_effect = lambda s: (call_order.append("commit") or s)
+
+        target_repo = tmp_path / "repo"
+        target_repo.mkdir()
+        audit_dir = target_repo / "docs" / "lineage" / "active" / "77-lld"
+        audit_dir.mkdir(parents=True)
+
+        state = create_initial_state(
+            workflow_type="lld",
+            assemblyzero_root=str(tmp_path / "assemblyzero"),
+            target_repo=str(target_repo),
+            issue_number=77,
+        )
+        state["current_draft"] = "# LLD Content"
+        state["issue_title"] = "Feature"
+        state["lld_status"] = "APPROVED"
+        state["audit_dir"] = str(audit_dir)
+
+        finalize(state)
+
+        assert call_order == ["move", "commit"], (
+            f"Expected move-before-commit, got: {call_order}"
+        )
+
     def test_finalize_handles_empty_audit_dir(self, tmp_path):
         """Should handle case where audit_dir exists but is empty."""
         from assemblyzero.workflows.requirements.nodes.finalize import finalize


### PR DESCRIPTION
## Summary

Two co-located fixes in `finalize.py`:

- **#1470** — `validate_lld_final` strips fenced code blocks before applying the unchecked-checkbox regex. Drafts that document the Open Questions section format with a code-block example (` ```markdown\n- [ ] example\n``` `) no longer false-trigger "Unresolved open questions remain."
- **#1457** — `move_lineage_to_done` runs BEFORE `_commit_and_push_files` instead of after. Previously the commit captured lineage in `active/` then the post-commit move relocated those files to `done/`, leaving the target working tree dirty. Reordered so the commit (if any) reflects the final on-disk location.

Closes #1457
Closes #1470

## Scope note

[#1459 (architectural worktree+PR redesign for the LLD workflow)](https://github.com/martymcenroe/AssemblyZero/issues/1459) was approved as part of this PR's plan but is meaningfully larger work; deferred to a follow-up PR. The smaller fixes here address residual operator pain that earlier same-session PRs (#1460 lineage commit + #1462 src-layout + #1464 retry semantics + #1466 revise-context + #1468 run-scoped lineage + #1449 GEMINI.md self-heal) had not yet covered. Net effect: the next Chiron #4 smoke build run lands with all six fixes plus this one; #1459 is the architectural lift for a future session.

## Test plan

- [x] `TestOpenQuestionsCheckboxIgnoresCodeBlocks` — 3/3 pass (block-only no trigger, real outside triggers, mixed-still-triggers)
- [x] `test_finalize_moves_to_done_before_commit` — asserts call_order = ["move", "commit"]
- [x] `tests/unit/test_finalize_structured_output.py` + `test_requirements_nodes.py` — 113/113 pass
