### PR TITLE
fix(requirements): LLD workflow uses worktree + PR (Closes #1459)

### DIFF
--- a/assemblyzero/workflows/requirements/git_operations.py
+++ b/assemblyzero/workflows/requirements/git_operations.py
@@ -1,6 +1,13 @@
 """Git operations for requirements workflow.
 
 Encapsulates subprocess calls to git for committing and pushing files.
+
+#1459 (this PR): LLD outputs now flow through a per-issue worktree + PR
+rather than being committed directly to the target's current branch. The
+new helpers `lld_worktree_path_for`, `setup_lld_worktree`, and
+`commit_and_pr` mirror the impl-stage pattern at
+`orchestrator/stages.py:493-532`. `commit_and_push` is kept for the
+issue-workflow path which still commits to the operator's checkout.
 """
 
 from assemblyzero.utils.shell import run_command
@@ -15,19 +22,235 @@ class GitOperationError(Exception):
 
 def format_commit_message(workflow_type: str, issue_number: Optional[int] = None, slug: Optional[str] = None) -> str:
     """Format commit message based on workflow type.
-    
+
     Args:
         workflow_type: Either "lld" or "issue"
         issue_number: Issue number (required for lld workflow)
         slug: Issue slug (required for issue workflow)
-        
+
     Returns:
         Formatted commit message
     """
     if workflow_type == "lld":
-        return f"docs: add LLD-{issue_number} via requirements workflow\n\nRef #{issue_number}"
+        # Issue #238: LLDs reference, not close. The original issue stays open
+        # through the implementation phase; the impl PR closes it. Preserved
+        # across the worktree+PR rewire (#1459) — the LLD PR body uses
+        # `No-Issue:` for pr-sentinel rather than `Closes #N`.
+        return (
+            f"docs: add LLD-{issue_number} via requirements workflow\n\n"
+            f"Ref #{issue_number}"
+        )
     else:  # issue
         return f"docs: add lineage for {slug} via requirements workflow"
+
+
+def lld_worktree_path_for(target_repo: Path | str, issue_number: int) -> Path:
+    """Return the worktree path for an LLD workflow run.
+
+    Mirrors `orchestrator/artifacts.worktree_path_for` (impl stage) but with
+    a `-lld` suffix so the LLD worktree is distinct from any later impl
+    worktree for the same issue. Closes #1459.
+
+    Args:
+        target_repo: Path to the target repository.
+        issue_number: GitHub issue number.
+
+    Returns:
+        Sibling path: {target_parent}/{target_name}-{issue_number}-lld
+    """
+    repo = Path(target_repo)
+    return repo.parent / f"{repo.name}-{issue_number}-lld"
+
+
+def setup_lld_worktree(target_repo: Path | str, issue_number: int) -> tuple[Path, str]:
+    """Carve (or reuse) a worktree for the LLD workflow.
+
+    Branch name is ``{issue_number}-lld``. If the worktree path already
+    exists (e.g. a prior LLD run for the same issue), it is reused; we do
+    not re-create. Closes #1459.
+
+    Args:
+        target_repo: Path to the target repository.
+        issue_number: GitHub issue number.
+
+    Returns:
+        (worktree_path, branch_name)
+
+    Raises:
+        GitOperationError: If worktree creation fails.
+    """
+    target_repo = Path(target_repo)
+    worktree_path = lld_worktree_path_for(target_repo, issue_number)
+    branch_name = f"{issue_number}-lld"
+
+    if worktree_path.is_dir():
+        # Reuse existing worktree from a prior LLD run for the same issue.
+        return worktree_path, branch_name
+
+    result = run_command(
+        ["git", "-C", str(target_repo), "worktree", "add",
+         str(worktree_path), "-b", branch_name],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Branch may already exist from a prior aborted run; try without -b
+        result2 = run_command(
+            ["git", "-C", str(target_repo), "worktree", "add",
+             str(worktree_path), branch_name],
+            capture_output=True,
+            text=True,
+        )
+        if result2.returncode != 0:
+            raise GitOperationError(
+                f"Failed to create LLD worktree at {worktree_path}: "
+                f"{result.stderr or result2.stderr}"
+            )
+    return worktree_path, branch_name
+
+
+def commit_and_pr(
+    created_files: list[str],
+    worktree_path: Path | str,
+    target_repo: Path | str,
+    issue_number: int,
+    branch_name: str,
+) -> tuple[str, str]:
+    """Commit, push, and open a PR for LLD-workflow outputs.
+
+    Stages files relative to the worktree (the file paths in
+    ``created_files`` should be within ``worktree_path``), commits with a
+    ``Closes #N`` message, pushes the branch with --set-upstream, and
+    opens a PR via the gh CLI carrying ``Closes #N`` in both title and
+    body. Closes #1459.
+
+    Args:
+        created_files: List of absolute file paths inside the worktree.
+        worktree_path: Path to the LLD worktree.
+        target_repo: Path to the target repository (used for --repo).
+        issue_number: GitHub issue number for Closes #N.
+        branch_name: Branch checked out in the worktree.
+
+    Returns:
+        (commit_sha, pr_url). Empty strings if there was nothing to do.
+
+    Raises:
+        GitOperationError: If git or gh operation fails.
+    """
+    if not created_files:
+        return "", ""
+
+    worktree_path = Path(worktree_path)
+    target_repo = Path(target_repo)
+
+    # Stage files.
+    for file_path in created_files:
+        result = run_command(
+            ["git", "add", file_path],
+            cwd=str(worktree_path),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise GitOperationError(
+                f"Failed to stage {file_path} in worktree {worktree_path}: "
+                f"{result.stderr}"
+            )
+
+    # Commit.
+    commit_message = format_commit_message(
+        workflow_type="lld", issue_number=issue_number
+    )
+    result = run_command(
+        ["git", "commit", "-m", commit_message],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise GitOperationError(
+            f"Failed to commit in worktree {worktree_path}: {result.stderr}"
+        )
+
+    commit_sha = ""
+    if result.stdout:
+        parts = result.stdout.split()
+        if len(parts) >= 2:
+            commit_sha = parts[1].rstrip("]")
+
+    # Push branch with --set-upstream.
+    result = run_command(
+        ["git", "push", "--set-upstream", "origin", branch_name],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise GitOperationError(
+            f"Failed to push branch {branch_name}: {result.stderr}"
+        )
+
+    # Determine --repo argument from target_repo's origin remote so the PR
+    # lands in the right GitHub repo regardless of the operator's cwd.
+    repo_arg = _resolve_repo_arg(target_repo)
+
+    # Open PR. Issue #238 establishes that LLDs reference (not close) the
+    # issue — the impl PR is what closes it. pr-sentinel demands Closes #N
+    # OR a No-Issue: exemption; we use the latter with a specific reason so
+    # the issue stays open through the implementation phase. Closes #1459.
+    pr_title = (
+        f"docs: add LLD-{issue_number} via requirements workflow "
+        f"(Ref #{issue_number})"
+    )
+    pr_body = (
+        f"No-Issue: LLD design artifact for issue #{issue_number}; the "
+        f"issue remains open through the implementation phase, which is "
+        f"what closes it. Ref #{issue_number}.\n\n"
+        "LLD generated by the requirements workflow. Review the LLD "
+        "content under `docs/lld/active/` and merge to land it on main."
+    )
+    pr_cmd = ["gh", "pr", "create",
+              "--title", pr_title, "--body", pr_body,
+              "--base", "main", "--head", branch_name]
+    if repo_arg:
+        pr_cmd += ["--repo", repo_arg]
+    result = run_command(
+        pr_cmd,
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise GitOperationError(
+            f"Failed to create PR for {branch_name}: {result.stderr}"
+        )
+
+    pr_url = result.stdout.strip()
+    return commit_sha, pr_url
+
+
+def _resolve_repo_arg(target_repo: Path) -> str:
+    """Best-effort extract `{owner}/{repo}` from the target's origin remote.
+
+    Returns an empty string if the remote cannot be parsed; gh CLI will then
+    fall back to its own auto-detection. Closes #1459.
+    """
+    result = run_command(
+        ["git", "-C", str(target_repo), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return ""
+    url = result.stdout.strip()
+    # Handle https://github.com/owner/repo(.git) and git@github.com:owner/repo.git
+    for prefix in ("https://github.com/", "git@github.com:"):
+        if url.startswith(prefix):
+            tail = url[len(prefix):]
+            if tail.endswith(".git"):
+                tail = tail[:-4]
+            return tail
+    return ""
 
 
 def commit_and_push(

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -22,7 +22,12 @@ from assemblyzero.workflows.requirements.audit import (
     update_lld_status,
 )
 from assemblyzero.workflows.testing.audit import log_workflow_execution
-from ..git_operations import commit_and_push, GitOperationError
+from ..git_operations import (
+    GitOperationError,
+    commit_and_pr,
+    commit_and_push,
+    setup_lld_worktree,
+)
 from assemblyzero.core.verdict_schema import (
     FinalizeQuestionsResult,
     parse_structured_finalize_questions,
@@ -165,22 +170,78 @@ def _commit_and_push_files(state: Dict[str, Any]) -> Dict[str, Any]:
     slug = state.get("slug")
 
     try:
-        commit_sha = commit_and_push(
-            created_files=created_files,
-            workflow_type=workflow_type,
-            target_repo=target_repo,
-            issue_number=issue_number,
-            slug=slug,
-        )
-
-        if commit_sha:
-            state["commit_sha"] = commit_sha
+        if workflow_type == "lld" and issue_number:
+            # Closes #1459: LLD outputs flow through a per-issue worktree + PR
+            # instead of a direct push to the operator's checkout. Mirrors the
+            # impl stage's pattern at orchestrator/stages.py:493-532.
+            worktree_path, branch_name = setup_lld_worktree(
+                target_repo=target_repo, issue_number=issue_number,
+            )
+            # Mirror each created_file from the target_repo working tree into
+            # the worktree at its same relative path so the commit captures
+            # them on the LLD branch (rather than the operator's main).
+            worktree_files = _mirror_to_worktree(
+                created_files=created_files,
+                target_repo=Path(target_repo),
+                worktree_path=worktree_path,
+            )
+            commit_sha, pr_url = commit_and_pr(
+                created_files=worktree_files,
+                worktree_path=worktree_path,
+                target_repo=target_repo,
+                issue_number=issue_number,
+                branch_name=branch_name,
+            )
+            if commit_sha:
+                state["commit_sha"] = commit_sha
+            if pr_url:
+                state["final_lld_pr_url"] = pr_url
+                print(f"    LLD PR opened: {pr_url}")
+        else:
+            # Issue workflow remains on the legacy direct-push path.
+            commit_sha = commit_and_push(
+                created_files=created_files,
+                workflow_type=workflow_type,
+                target_repo=target_repo,
+                issue_number=issue_number,
+                slug=slug,
+            )
+            if commit_sha:
+                state["commit_sha"] = commit_sha
 
     except GitOperationError as e:
         # Log error but don't fail the workflow - files are already saved
         state["commit_error"] = str(e)
 
     return state
+
+
+def _mirror_to_worktree(
+    created_files: list[str],
+    target_repo: Path,
+    worktree_path: Path,
+) -> list[str]:
+    """Copy each file from its target_repo location into the worktree at the
+    same relative path. Returns the worktree-relative absolute paths.
+
+    Closes #1459. Files that aren't under target_repo are passed through
+    untouched (caller-supplied absolute paths outside the repo are unusual
+    but tolerated).
+    """
+    import shutil
+    out: list[str] = []
+    for f in created_files:
+        src = Path(f)
+        try:
+            rel = src.relative_to(target_repo)
+        except ValueError:
+            out.append(str(src))
+            continue
+        dst = worktree_path / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        out.append(str(dst))
+    return out
 
 
 def _detect_open_questions(content: str) -> FinalizeQuestionsResult:

--- a/tests/test_issue_162.py
+++ b/tests/test_issue_162.py
@@ -239,108 +239,101 @@ def test_080(tmp_path):
 # Integration Tests
 # -----------------
 
-def test_090(tmp_path):
-    """
-    Integration: LLD then implement | Auto-Live | Full workflow sequence
-    | Implementation finds LLD | Worktree contains LLD file
-    """
-    # TDD: Arrange
-    # Create a bare remote repo for push target
-    remote_path = tmp_path / "remote.git"
-    remote_path.mkdir()
-    subprocess.run(["git", "init", "--bare"], cwd=str(remote_path), check=True, capture_output=True)
+# test_090 (Issue #162 integration) was deleted with #1459. The LLD path
+# of _commit_and_push_files now dispatches to setup_lld_worktree +
+# commit_and_pr (worktree + PR) instead of direct push, which requires gh
+# CLI access and a real GitHub remote — out of scope for a unit-level
+# integration test. Mock-based coverage of the new dispatch lives in
+# tests/unit/test_requirements_nodes.py::TestFinalizeNodeAdditional
+# (test_commit_lld_dispatches_to_pr_path,
+#  test_commit_issue_workflow_uses_legacy_push,
+#  test_commit_lld_error_logged).
 
-    # Create a minimal git repo
-    work_path = tmp_path / "work"
-    work_path.mkdir()
-    subprocess.run(["git", "init"], cwd=str(work_path), check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(work_path), check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=str(work_path), check=True, capture_output=True)
-    subprocess.run(["git", "remote", "add", "origin", str(remote_path)], cwd=str(work_path), check=True, capture_output=True)
-    
-    # Create directory structure
-    lld_dir = work_path / "docs" / "lld" / "active"
-    lld_dir.mkdir(parents=True)
 
-    lineage_dir = work_path / "docs" / "lineage" / "active" / "162-lld"
-    lineage_dir.mkdir(parents=True)
+# Issue #1459 — LLD worktree + PR
+# --------------------------------
 
-    # Create LLD file
-    lld_file = lld_dir / "LLD-162.md"
-    lld_file.write_text("# LLD-162\n\nTest LLD content")
+def test_lld_worktree_path_for_appends_lld_suffix():
+    """Worktree path is `{parent}/{name}-{N}-lld`, distinct from impl's
+    `{parent}/{name}-{N}` so LLD and impl worktrees don't collide."""
+    from assemblyzero.workflows.requirements.git_operations import lld_worktree_path_for
 
-    # Create status file
-    status_file = work_path / "docs" / "lld" / "lld-status.json"
-    status_file.write_text('{"version": "1.0", "last_updated": "2024-01-01T00:00:00Z", "issues": {}}')
+    path = lld_worktree_path_for("/c/Users/x/Projects/Chiron", 4)
+    assert path.name == "Chiron-4-lld"
+    assert path.parent.name == "Projects"
 
-    # Create audit final file
-    final_file = lineage_dir / "001-final.md"
-    final_file.write_text("# LLD Finalized\n\nFinal content")
 
-    # Initial commit and push to set up tracking
-    subprocess.run(["git", "add", "."], cwd=str(work_path), check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "Initial"], cwd=str(work_path), check=True, capture_output=True)
-    # Get the current branch name (could be main or master depending on git config)
-    branch_result = subprocess.run(["git", "branch", "--show-current"], cwd=str(work_path), capture_output=True, text=True)
-    current_branch = branch_result.stdout.strip()
-    subprocess.run(["git", "push", "-u", "origin", current_branch], cwd=str(work_path), check=True, capture_output=True)
+def test_commit_and_pr_returns_empty_for_empty_created_files():
+    """No-op when nothing to commit (mirrors commit_and_push behavior)."""
+    from assemblyzero.workflows.requirements.git_operations import commit_and_pr
 
-    # Now modify the files to simulate the workflow creating new content
-    lld_file.write_text("# LLD-162\n\nUpdated LLD content after workflow")
-    status_file.write_text('{"version": "1.0", "last_updated": "2024-01-02T00:00:00Z", "issues": {"162": "APPROVED"}}')
-    final_file.write_text("# LLD Finalized\n\nUpdated final content")
-
-    # Create state
-    state = create_initial_state(
-        workflow_type="lld",
-        assemblyzero_root=str(work_path),
-        target_repo=str(work_path),
-        issue_number=162,
+    sha, url = commit_and_pr(
+        created_files=[],
+        worktree_path="/tmp/wt",
+        target_repo="/tmp/target",
+        issue_number=4,
+        branch_name="4-lld",
     )
-    state["audit_dir"] = str(lineage_dir)
-    state["current_draft"] = "# LLD-162\n\nTest content"
-    state["lld_status"] = "APPROVED"
-    state["created_files"] = [
-        "docs/lld/active/LLD-162.md",
-        "docs/lld/lld-status.json",
-        "docs/lineage/active/162-lld/001-final.md",
-    ]
+    assert sha == ""
+    assert url == ""
 
-    # TDD: Act
-    # Call the internal function that does commit/push
-    # This will actually commit and push (to local bare remote)
-    try:
-        updated_state = _commit_and_push_files(state)
-        commit_error = updated_state.get("commit_error", "")
-        if commit_error:
-            print(f"Commit error: {commit_error}")
-        # Success = no error message (empty string is OK, means no error)
-        commit_succeeded = not commit_error
-    except Exception as e:
-        print(f"Exception: {e}")
-        commit_succeeded = False
-        updated_state = {"commit_error": str(e)}
 
-    # TDD: Assert
-    assert commit_succeeded, f"Commit failed. State: {updated_state.get('commit_error', 'no error in state')}"
+def test_commit_and_pr_emits_no_issue_for_pr_body(tmp_path):
+    """The LLD PR body must contain `No-Issue:` (not `Closes #N`) so the
+    referenced issue stays open through the implementation phase.
+    Encodes the architectural decision from Issue #238."""
+    from unittest.mock import MagicMock, patch
+    from assemblyzero.workflows.requirements.git_operations import commit_and_pr
 
-    # Verify commit exists
-    log_result = subprocess.run(
-        ["git", "log", "--oneline"],
-        cwd=str(work_path),
-        capture_output=True,
-        text=True,
-    )
-    assert "docs: add LLD-162 via requirements workflow" in log_result.stdout
+    captured = {}
 
-    # Verify files are in git
-    ls_result = subprocess.run(
-        ["git", "ls-files"],
-        cwd=str(work_path),
-        capture_output=True,
-        text=True,
-    )
-    assert "docs/lld/active/LLD-162.md" in ls_result.stdout
+    def fake_run(cmd, *args, **kwargs):
+        out = MagicMock()
+        out.returncode = 0
+        if cmd[:1] == ["git"] and len(cmd) > 1 and cmd[1] == "add":
+            out.stdout = ""
+        elif cmd[:2] == ["git", "commit"]:
+            out.stdout = "[main abc123] commit message\n"
+        elif cmd[:2] == ["git", "push"]:
+            out.stdout = ""
+        elif cmd[:3] == ["gh", "pr", "create"]:
+            captured["pr_argv"] = list(cmd)
+            out.stdout = "https://github.com/owner/repo/pull/9999\n"
+        elif cmd[:1] == ["git"] and "remote" in cmd:
+            out.stdout = "https://github.com/owner/repo.git\n"
+        else:
+            out.stdout = ""
+        return out
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    wt = tmp_path / "repo-4-lld"
+    wt.mkdir()
+    file_in_wt = wt / "docs" / "lld" / "active" / "LLD-004.md"
+    file_in_wt.parent.mkdir(parents=True)
+    file_in_wt.write_text("# LLD")
+
+    with patch("assemblyzero.workflows.requirements.git_operations.run_command",
+               side_effect=fake_run):
+        sha, url = commit_and_pr(
+            created_files=[str(file_in_wt)],
+            worktree_path=wt,
+            target_repo=target,
+            issue_number=4,
+            branch_name="4-lld",
+        )
+
+    assert sha == "abc123"
+    assert url == "https://github.com/owner/repo/pull/9999"
+    pr_argv = captured["pr_argv"]
+    body = pr_argv[pr_argv.index("--body") + 1]
+    title = pr_argv[pr_argv.index("--title") + 1]
+    assert "No-Issue:" in body, f"PR body must contain No-Issue: — got {body!r}"
+    assert "Closes #4" not in body, f"LLD PR must NOT close — got {body!r}"
+    assert "Closes #4" not in title, f"LLD PR title must NOT close — got {title!r}"
+    assert "Ref #4" in title, f"PR title should reference — got {title!r}"
+    # The branch is pushed by its real name with --set-upstream
+    # (mirrors orchestrator/stages.py:493-509 pattern for impl stage).
 
 
 # Issue #238 - Ref instead of Closes

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1013,12 +1013,18 @@ class TestFinalizeNodeAdditional:
 
         assert result.get("final_lld_path") is None
 
-    @patch("assemblyzero.workflows.requirements.nodes.finalize.commit_and_push")
-    def test_commit_and_push_success(self, mock_commit, tmp_path):
-        """Test _commit_and_push_files sets commit_sha on success."""
+    @patch("assemblyzero.workflows.requirements.nodes.finalize.setup_lld_worktree")
+    @patch("assemblyzero.workflows.requirements.nodes.finalize.commit_and_pr")
+    @patch("assemblyzero.workflows.requirements.nodes.finalize._mirror_to_worktree")
+    def test_commit_lld_dispatches_to_pr_path(
+        self, mock_mirror, mock_commit_and_pr, mock_setup, tmp_path
+    ):
+        """LLD workflow now flows through worktree+PR. Closes #1459."""
         from assemblyzero.workflows.requirements.nodes.finalize import _commit_and_push_files
 
-        mock_commit.return_value = "abc123"
+        mock_setup.return_value = (tmp_path / "wt", "42-lld")
+        mock_mirror.return_value = ["mirrored/file1.md"]
+        mock_commit_and_pr.return_value = ("abc123", "https://example.com/pr/1")
 
         state = {
             "created_files": ["file1.md"],
@@ -1029,25 +1035,55 @@ class TestFinalizeNodeAdditional:
 
         result = _commit_and_push_files(state)
 
+        mock_setup.assert_called_once()
+        mock_commit_and_pr.assert_called_once()
         assert result.get("commit_sha") == "abc123"
+        assert result.get("final_lld_pr_url") == "https://example.com/pr/1"
 
     @patch("assemblyzero.workflows.requirements.nodes.finalize.commit_and_push")
-    def test_commit_and_push_error_logged(self, mock_commit, tmp_path):
-        """Test _commit_and_push_files logs error but doesn't fail."""
+    def test_commit_issue_workflow_uses_legacy_push(self, mock_commit, tmp_path):
+        """Issue workflow keeps the legacy direct-push behavior (no PR).
+        Closes #1459 — only the LLD path was rewired."""
+        from assemblyzero.workflows.requirements.nodes.finalize import _commit_and_push_files
+
+        mock_commit.return_value = "abc123"
+
+        state = {
+            "created_files": ["file1.md"],
+            "workflow_type": "issue",
+            "target_repo": str(tmp_path),
+            "slug": "my-feature",
+        }
+
+        result = _commit_and_push_files(state)
+
+        assert result.get("commit_sha") == "abc123"
+        mock_commit.assert_called_once()
+
+    @patch("assemblyzero.workflows.requirements.nodes.finalize.setup_lld_worktree")
+    @patch("assemblyzero.workflows.requirements.nodes.finalize.commit_and_pr")
+    @patch("assemblyzero.workflows.requirements.nodes.finalize._mirror_to_worktree")
+    def test_commit_lld_error_logged(
+        self, mock_mirror, mock_commit_and_pr, mock_setup, tmp_path
+    ):
+        """LLD-path PR failure is logged but doesn't fail the workflow."""
         from assemblyzero.workflows.requirements.nodes.finalize import _commit_and_push_files
         from assemblyzero.workflows.requirements.git_operations import GitOperationError
 
-        mock_commit.side_effect = GitOperationError("push failed")
+        mock_setup.return_value = (tmp_path / "wt", "42-lld")
+        mock_mirror.return_value = ["mirrored/file1.md"]
+        mock_commit_and_pr.side_effect = GitOperationError("pr failed")
 
         state = {
             "created_files": ["file1.md"],
             "workflow_type": "lld",
             "target_repo": str(tmp_path),
+            "issue_number": 42,
         }
 
         result = _commit_and_push_files(state)
 
-        assert "push failed" in result.get("commit_error", "")
+        assert "pr failed" in result.get("commit_error", "")
 
 
 class TestFinalizeLineageFiles:


### PR DESCRIPTION
## Summary

Ports the impl-stage worktree+PR pattern (`orchestrator/stages.py:493-532`) to the LLD path of the requirements workflow. After this lands, LLD outputs flow:

1. `setup_lld_worktree(target_repo, N)` carves a sibling worktree `{target_parent}/{name}-{N}-lld` on branch `{N}-lld`. Distinct from the impl stage's `{name}-{N}`, so both worktrees coexist for orchestrated runs.
2. Files written by the workflow under `target_repo/docs/...` are mirrored into the worktree before commit via `_mirror_to_worktree`.
3. `commit_and_pr` does `git add` + `git commit` + `git push --set-upstream` + `gh pr create` with `No-Issue:` in the PR body — preserving Issue #238's "LLDs reference, not close" rule. The issue stays open through the implementation phase, which is what closes it.
4. The issue-workflow path is unchanged (still legacy `commit_and_push` — no PR, no per-verdict gate exists for that path).

Closes #1459

## Test plan

- [x] `tests/unit/test_requirements_nodes.py::TestFinalizeNodeAdditional` — 3 new tests (LLD dispatches to PR path, issue keeps legacy push, LLD error logged)
- [x] `tests/test_issue_162.py` — 3 new tests (worktree path naming, commit_and_pr no-op on empty, PR body contains `No-Issue:` + no `Closes #N`)
- [x] 201/201 pass across `test_issue_162`, `test_requirements_nodes`, `test_requirements_audit`, `test_move_lineage`, `test_orchestrator_stages`
- [ ] End-to-end: paired with the seven other same-session fixes, the next Chiron #4 smoke build run produces an LLD PR (not a direct push to main) when the LLD reaches APPROVED.

## Decisions worth surfacing

- **`No-Issue:` in the LLD PR body** is the only way to satisfy pr-sentinel without auto-closing the referenced issue on merge (per universal CLAUDE.md the alternatives are `Closes #N` which closes, or a per-LLD tracking issue which doubles issue noise). The text is greppable: `gh pr list --search "No-Issue: LLD design artifact"`.
- **Worktree reuse on re-run.** If the operator re-fires the LLD workflow against the same issue while a `{name}-{N}-lld` worktree already exists, `setup_lld_worktree` reuses it rather than failing. The PR push then updates the branch with a new commit (pr-sentinel re-evaluates).
- **Test 090 deleted.** The old integration test exercised direct-push behavior that's now intentionally absent on the LLD path. Mock-based coverage in `test_requirements_nodes.py` replaces it.
