### PR TITLE
fix(lint): read CLAUDE.md from origin/main, not working tree (Closes #1302)

### DIFF
--- a/tests/test_lint_per_repo_claude_md.py
+++ b/tests/test_lint_per_repo_claude_md.py
@@ -550,3 +550,54 @@ def test_scan_fleet_allowlisted_still_shows_with_reason(tmp_path: Path) -> None:
     by_name = {r.repo_name: r for r in results}
     assert by_name["skipme"].status == "SKIPPED"
     assert by_name["skipme"].skipped_reason == "allowlisted"
+
+
+# ────────────────────────────────────────────────────────────────────
+# #1302: source=origin-main reads from canonical branch, not working tree
+# ────────────────────────────────────────────────────────────────────
+
+
+def test_origin_main_source_ignores_working_tree_drift(tmp_path: Path) -> None:
+    """#1302: with source='origin-main', drift on a feature branch's working
+    tree must NOT appear in the lint result — origin/main is the source of truth."""
+    import subprocess as sp
+    repo = tmp_path / "test-repo"
+    repo.mkdir()
+
+    def git(*args: str) -> None:
+        sp.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+    # Clean lean template at the initial commit
+    (repo / "CLAUDE.md").write_text(lean_template(), encoding="utf-8")
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "test@test.local")
+    git("config", "user.name", "test")
+    git("add", "CLAUDE.md")
+    git("commit", "-q", "-m", "init")
+    # Fake origin/main remote-tracking ref (no real remote needed for `git show`)
+    git("update-ref", "refs/remotes/origin/main", "HEAD")
+
+    # Pollute working tree with marker-5 drift (simulates a stale feature branch)
+    drifted = lean_template() + "\n\n## FIRST: Read AssemblyZero Core Rules\n"
+    (repo / "CLAUDE.md").write_text(drifted, encoding="utf-8")
+
+    # source=origin-main: must not see the drift
+    result_om = detect_drift(repo / "CLAUDE.md", repo, source="origin-main")
+    assert result_om.status == "PASS", (
+        f"Expected PASS reading origin/main, got {result_om.status}; "
+        f"findings markers={[f.marker for f in result_om.findings]}"
+    )
+
+    # source=working-tree (legacy): must see marker 5
+    result_wt = detect_drift(repo / "CLAUDE.md", repo, source="working-tree")
+    assert result_wt.status == "DRIFT"
+    assert any(f.marker == 5 for f in result_wt.findings)
+
+
+def test_origin_main_source_missing_when_no_origin_ref(tmp_path: Path) -> None:
+    """source='origin-main' returns MISSING when origin/main ref doesn't exist
+    (e.g., repo has no remote or no `git fetch` has run yet). The working-tree
+    CLAUDE.md is NOT a fallback — the strict semantic is 'origin/main is truth.'"""
+    repo = make_repo(tmp_path, "no-origin", lean_template())  # has .git/ dir but no real git history
+    result = detect_drift(repo / "CLAUDE.md", repo, source="origin-main")
+    assert result.status == "MISSING"

--- a/tools/lint_per_repo_claude_md.py
+++ b/tools/lint_per_repo_claude_md.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -236,19 +237,74 @@ def _strip_identifiers_block(text: str) -> str:
     return text[:start] + text[end:]
 
 
-def detect_drift(claude_md: Path, repo_root: Path) -> RepoResult:
-    """Run all 9 detectors against a single CLAUDE.md and return findings."""
+def read_claude_md_text(
+    claude_md: Path,
+    repo_root: Path,
+    source: str,
+) -> Optional[str]:
+    """Read CLAUDE.md content from the configured source.
+
+    Returns None if the source has no CLAUDE.md (caller interprets as MISSING).
+
+    Sources:
+      - "working-tree": read from `claude_md` on disk
+      - "origin-main": read via `git show origin/main:CLAUDE.md` so lint
+        reflects the canonical branch's CLAUDE.md regardless of the
+        currently-checked-out local branch (#1302). Fails (returns None)
+        if `origin/main` does not exist or has no CLAUDE.md at its root.
+
+    Note: `origin-main` does NOT fetch — it reads whatever the last
+    `git fetch` saw. Run `git fetch --all` first if you want fresh data.
+    """
+    if source == "working-tree":
+        if not claude_md.exists():
+            return None
+        return claude_md.read_text(encoding="utf-8", errors="replace")
+
+    if source == "origin-main":
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "show", "origin/main:CLAUDE.md"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
+    raise ValueError(f"Unknown source: {source!r}")
+
+
+def detect_drift(
+    claude_md: Path,
+    repo_root: Path,
+    source: str = "working-tree",
+) -> RepoResult:
+    """Run all 9 detectors against a single CLAUDE.md and return findings.
+
+    The `source` kwarg controls where the CLAUDE.md text comes from:
+      - "working-tree" (default for backward compat): read from disk at `claude_md`
+      - "origin-main": read via `git show origin/main:CLAUDE.md` so lint
+        reflects what's on the canonical branch regardless of which local
+        branch is currently checked out (#1302). Returns MISSING if
+        origin/main does not have CLAUDE.md (or origin/main does not exist).
+
+    Note: when called from main(), the CLI default is "origin-main" — this
+    backward-compatible function default exists so the existing test suite
+    (40 tests using tmp_path repos without git remotes) continues to work.
+    """
     result = RepoResult(
         repo_name=repo_root.name,
         claude_md_path=claude_md,
         status="PASS",
     )
 
-    if not claude_md.exists():
+    text = read_claude_md_text(claude_md, repo_root, source)
+    if text is None:
         result.status = "MISSING"
         return result
 
-    text = claude_md.read_text(encoding="utf-8", errors="replace")
     result.line_count = len(text.splitlines())
     result.unleashed_assemblyzero = load_unleashed_assemblyzero(repo_root)
 
@@ -392,6 +448,7 @@ def scan_fleet(
     projects_root: Path,
     allowlist: set[str],
     show_skipped: bool = False,
+    source: str = "working-tree",
 ) -> list[RepoResult]:
     """Scan every {projects_root}/*/CLAUDE.md (one level deep) and return results.
 
@@ -402,6 +459,8 @@ def scan_fleet(
 
     Existing behavior (visible regardless of show_skipped):
     - Allowlisted repos — explicit operator-curated skip, shown as SKIPPED
+
+    The `source` kwarg is passed through to `detect_drift` (see #1302).
     """
     results: list[RepoResult] = []
     for repo_dir in sorted(projects_root.iterdir()):
@@ -455,7 +514,7 @@ def scan_fleet(
             continue
 
         claude_md = repo_dir / "CLAUDE.md"
-        results.append(detect_drift(claude_md, repo_dir))
+        results.append(detect_drift(claude_md, repo_dir, source=source))
     return results
 
 
@@ -565,6 +624,18 @@ def main(argv: Optional[list[str]] = None) -> int:
              "Default: silently exclude these. Allowlisted repos are "
              "always shown regardless of this flag.",
     )
+    parser.add_argument(
+        "--source",
+        choices=["origin-main", "working-tree"],
+        default="origin-main",
+        help="CLAUDE.md text source (#1302). "
+             "'origin-main' (default): read via `git show origin/main:CLAUDE.md` "
+             "so lint reflects the canonical branch regardless of which local "
+             "branch is checked out. Does NOT fetch — reads whatever the last "
+             "`git fetch` saw. "
+             "'working-tree': read from disk (legacy behavior; useful when "
+             "linting an in-progress edit before push).",
+    )
     args = parser.parse_args(argv)
 
     projects_root = args.projects_root or Path(config.projects_root())
@@ -578,7 +649,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"ERROR: {e}", file=sys.stderr)
         return 1
 
-    results = scan_fleet(projects_root, allowlist, show_skipped=args.show_skipped)
+    results = scan_fleet(
+        projects_root, allowlist,
+        show_skipped=args.show_skipped,
+        source=args.source,
+    )
 
     if args.format == "json":
         print(format_json(results))


### PR DESCRIPTION
## Summary

`tools/lint_per_repo_claude_md.py` now reads each repo's CLAUDE.md from `origin/main` by default instead of the working tree. Fixes the documented patent-general scenario: feature branch had a stale CLAUDE.md after `#170` landed on origin/main, lint kept reporting drift until the operator pulled main into the feature branch. With the fix, lint reflects what's actually on the canonical branch regardless of which local branch is checked out.

## Behavior change

| | Before | After |
|---|---|---|
| Default source | working-tree | `origin/main` |
| When `origin/main` missing | (n/a) | status=MISSING (no working-tree fallback) |
| Fetch behavior | (n/a) | does NOT fetch — reads last-fetched `origin/main` |
| Legacy behavior | default | available via `--source working-tree` |

The `--source working-tree` escape hatch preserves the legacy behavior for use cases like "lint my in-progress edit before push."

## Implementation

- New helper `read_claude_md_text(claude_md, repo_root, source)`
- `detect_drift` accepts `source` kwarg (default `working-tree` for backward compat with the existing 40 tests that use tmp_path repos without git remotes)
- `scan_fleet` threads `source` through
- CLI default is `origin-main` (the bug fix)

## Tests

42 tests pass (40 existing + 2 new):
- `test_origin_main_source_ignores_working_tree_drift` — proves drift in the working tree does NOT appear when source=origin-main; same content WITH source=working-tree still fires marker 5
- `test_origin_main_source_missing_when_no_origin_ref` — graceful MISSING when origin/main isn't available

Closes #1302