### PR TITLE
fix(finalize): strip CommonMark indented code blocks before checkbox regex (Closes #1476)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -303,6 +303,12 @@ def validate_lld_final(content: str, open_questions_resolved: bool = False) -> l
             section_no_blocks = re.sub(
                 r"```[\s\S]*?```", "", open_questions_section
             )
+            # Closes #1476: also strip CommonMark indented code blocks
+            # (any line beginning with 4 spaces) so example checkbox syntax
+            # shown in indented documentation does not trip the regex either.
+            section_no_blocks = re.sub(
+                r"^ {4}.*$", "", section_no_blocks, flags=re.MULTILINE
+            )
             if re.search(r"^- \[ \]", section_no_blocks, re.MULTILINE):
                 errors.append("Unresolved open questions remain")
 

--- a/tests/unit/test_finalize_structured_output.py
+++ b/tests/unit/test_finalize_structured_output.py
@@ -213,6 +213,38 @@ class TestOpenQuestionsCheckboxIgnoresCodeBlocks:
             "Unresolved open questions remain" in i for i in issues
         ), f"got: {issues}"
 
+    def test_unchecked_inside_indented_block_does_not_trigger(self):
+        """CommonMark 4-space-indented code blocks: example checkbox syntax
+        in an indented block does NOT trip the regex. Closes #1476."""
+        content = (
+            "# LLD\n\n"
+            "## Open Questions\n\n"
+            "All resolved. The format for tracking is:\n\n"
+            "    - [ ] Example unchecked question (indented = code block)\n"
+            "    - [x] Example resolved question\n\n"
+            "## Next Section\n"
+        )
+        issues = validate_lld_final(content, open_questions_resolved=False)
+        assert not any(
+            "Unresolved open questions remain" in i for i in issues
+        ), f"got: {issues}"
+
+    def test_unchecked_in_indented_block_with_real_unchecked_outside_still_triggers(self):
+        """Mixed: indented-block example AND a real unchecked item. Closes #1476."""
+        content = (
+            "# LLD\n\n"
+            "## Open Questions\n\n"
+            "Format example:\n\n"
+            "    - [ ] example only (indented = code block)\n\n"
+            "Real questions:\n\n"
+            "- [ ] Actual question that needs answering\n\n"
+            "## Next Section\n"
+        )
+        issues = validate_lld_final(content, open_questions_resolved=False)
+        assert any(
+            "Unresolved open questions remain" in i for i in issues
+        ), f"got: {issues}"
+
 
 class TestDetectOpenQuestionsReturnType:
     """Verify FinalizeQuestionsResult TypedDict structure."""


### PR DESCRIPTION
## Summary

Adds a second `re.sub` after the fenced-block strip from #1471: any line beginning with 4 spaces (CommonMark indented code block) is removed from the Open Questions section before the unchecked-checkbox regex runs. Drafts that document the section format with indented example checkbox syntax no longer falsely trigger "Unresolved open questions remain."

The original deferral was named in #1470's explicit non-claims as "Indented (4-space) code blocks per CommonMark are not handled by the proposed fix." Tracking gap closed with #1476.

Closes #1476

## Test plan

- [x] `test_unchecked_inside_indented_block_does_not_trigger` — positive case
- [x] `test_unchecked_in_indented_block_with_real_unchecked_outside_still_triggers` — mixed case
- [x] 30/30 pass in `test_finalize_structured_output.py`