### PR TITLE
fix(spec): extend import_targets_exist source-root coverage (Closes #1477)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -750,7 +750,9 @@ def check_import_targets_exist(
     )
 
 
-_SOURCE_ROOT_PREFIXES: tuple[str, ...] = ("", "src", "lib")
+_SOURCE_ROOT_PREFIXES: tuple[str, ...] = (
+    "", "src", "lib", "source", "python", "apps",
+)
 
 
 def _candidate_matches_new_file(candidate: Path, new_file_paths: set[str]) -> bool:
@@ -768,14 +770,52 @@ def _candidate_matches_new_file(candidate: Path, new_file_paths: set[str]) -> bo
     return False
 
 
+def _discover_pyproject_source_roots(repo_root: Path) -> tuple[str, ...]:
+    """Best-effort discovery of source roots from pyproject.toml.
+
+    Reads `[tool.poetry.packages]` (with `from = "X"`) and
+    `[tool.setuptools.packages.find]` (with `where = ["X"]`) entries.
+    Malformed pyproject files return (); the caller falls back to the
+    static prefix list. Closes #1477.
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.exists():
+        return ()
+    try:
+        import tomllib
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, ValueError, ImportError):
+        return ()
+    roots: list[str] = []
+    poetry_packages = (
+        data.get("tool", {}).get("poetry", {}).get("packages", [])
+    )
+    if isinstance(poetry_packages, list):
+        for pkg in poetry_packages:
+            if isinstance(pkg, dict):
+                src = pkg.get("from")
+                if isinstance(src, str) and src:
+                    roots.append(src)
+    setuptools_where = (
+        data.get("tool", {}).get("setuptools", {})
+            .get("packages", {}).get("find", {}).get("where", [])
+    )
+    if isinstance(setuptools_where, list):
+        for w in setuptools_where:
+            if isinstance(w, str) and w:
+                roots.append(w)
+    return tuple(roots)
+
+
 def _candidate_exists_under_source_roots(
     candidate: Path, repo_root: Path
 ) -> bool:
-    """Probe `repo_root / {prefix} / candidate` for common source-root prefixes.
-
-    Handles src-layout, lib-layout, and flat-layout uniformly. Closes #1461.
+    """Probe `repo_root / {prefix} / candidate` for common source-root prefixes
+    plus any prefixes discovered from `pyproject.toml`. Closes #1461, #1477.
     """
-    for prefix in _SOURCE_ROOT_PREFIXES:
+    discovered = _discover_pyproject_source_roots(repo_root)
+    all_prefixes = _SOURCE_ROOT_PREFIXES + discovered
+    for prefix in all_prefixes:
         probe = (repo_root / prefix / candidate) if prefix else (repo_root / candidate)
         if probe.exists():
             return True

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1282,6 +1282,87 @@ class TestImportResolvesSourceLayouts:
         assert _import_resolves("chiron.provenance", tmp_path, new_files) is True
 
 
+class TestImportResolvesExtendedSourceLayouts:
+    """Extended source-root coverage beyond src/lib/flat. Closes #1477.
+
+    Adds: source/, python/, apps/ as static prefixes; pyproject.toml
+    discovery for poetry [tool.poetry.packages] from= entries and
+    setuptools [tool.setuptools.packages.find] where= entries.
+    """
+
+    def test_resolves_source_layout(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "source" / "foo").mkdir(parents=True)
+        (tmp_path / "source" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_resolves_python_layout(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "python" / "foo").mkdir(parents=True)
+        (tmp_path / "python" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_resolves_apps_layout(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "apps" / "foo").mkdir(parents=True)
+        (tmp_path / "apps" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_pyproject_poetry_packages_discovered(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        # pyproject declares packages from "custom-src/"
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.poetry]\nname = "demo"\nversion = "0.1.0"\n'
+            'packages = [{include = "foo", from = "custom-src"}]\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "custom-src" / "foo").mkdir(parents=True)
+        (tmp_path / "custom-src" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_pyproject_setuptools_where_discovered(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.setuptools.packages.find]\nwhere = ["my-pkg-root"]\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "my-pkg-root" / "foo").mkdir(parents=True)
+        (tmp_path / "my-pkg-root" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_malformed_pyproject_falls_back_silently(self, tmp_path):
+        """Malformed pyproject doesn't raise; static prefixes still work."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            "this is not [valid toml",
+            encoding="utf-8",
+        )
+        # Static "src" prefix still resolves
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+    def test_missing_pyproject_doesnt_break_static_prefixes(self, tmp_path):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            _import_resolves,
+        )
+        (tmp_path / "src" / "foo").mkdir(parents=True)
+        (tmp_path / "src" / "foo" / "bar.py").write_text("")
+        assert _import_resolves("foo.bar", tmp_path, set()) is True
+
+
 # =============================================================================
 # N4: Human Gate
 # =============================================================================


### PR DESCRIPTION
## Summary

Extends `_candidate_exists_under_source_roots` from PR #1462:

1. Static prefix tuple gains `source`, `python`, `apps` — common conventions outside src/lib.
2. New `_discover_pyproject_source_roots(repo_root)` reads pyproject.toml and parses:
   - `[tool.poetry.packages]` entries with `from = "X"`
   - `[tool.setuptools.packages.find]` entries with `where = ["X"]`
   Discovered roots are appended to the static prefixes before probing.
3. Malformed pyprojects return empty tuple (no raise) — static prefix list still works.

The original deferral was named in #1461 non-claims; tracking gap closed with #1477.

Closes #1477

## Test plan

- [x] `TestImportResolvesExtendedSourceLayouts` — 7 cases (source/, python/, apps/, poetry packages from=, setuptools where=, malformed pyproject, missing pyproject)
- [x] 173/173 pass in `test_implementation_spec_workflow.py`