### PR TITLE
fix(orchestrator): read recovery plan to classify halt transience (Closes #1478)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -111,8 +111,40 @@ def _is_non_transient_halt(sub_result: dict) -> bool:
     """Sub-workflow halts write a recovery_plan_path. Non-transient by default
     since the resume command — not a 10-second retry — is the recovery path.
     Closes #1463.
+
+    Kept for backward compatibility; new call sites should prefer
+    _classify_halt_transience (Closes #1478) which reads the recovery plan
+    JSON for the actual is_transient classification.
     """
     return bool(sub_result.get("recovery_plan_path", ""))
+
+
+def _classify_halt_transience(sub_result: dict) -> bool | None:
+    """Read the sub-workflow's recovery plan JSON and classify transience.
+
+    Returns:
+        - True  -> halt is transient (quota exhausted, capacity, 5xx/429
+                   classes per core/recovery_plan.py:TRANSIENT_ERROR_TYPES)
+                   -> retry per existing retry loop
+        - False -> halt occurred but is non-transient (code bug, exhausted
+                   iterations, etc.) -> skip retry
+        - None  -> no halt detected (no recovery_plan_path); leave the
+                   StageResult.transient field unset -> preserve current
+                   behavior for non-halt failures (e.g. gh CLI flakes)
+
+    Closes #1478.
+    """
+    import json
+    plan_path = sub_result.get("recovery_plan_path", "")
+    if not plan_path:
+        return None
+    try:
+        plan = json.loads(Path(plan_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # Halt occurred but plan unreadable. Conservatively non-transient —
+        # the operator's resume hint is still the right recovery path.
+        return False
+    return bool(plan.get("is_transient", False))
 
 
 def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
@@ -177,7 +209,7 @@ def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
-                transient=False if _is_non_transient_halt(sub_result) else None,
+                transient=_classify_halt_transience(sub_result),
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -304,7 +336,7 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
-                transient=False if _is_non_transient_halt(sub_result) else None,
+                transient=_classify_halt_transience(sub_result),
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -381,7 +413,7 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
-                transient=False if _is_non_transient_halt(sub_result) else None,
+                transient=_classify_halt_transience(sub_result),
             )
     except Exception as exc:
         result = _make_stage_result(
@@ -463,7 +495,7 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 error_message=error_msg,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
-                transient=False if _is_non_transient_halt(sub_result) else None,
+                transient=_classify_halt_transience(sub_result),
             )
     except subprocess.CalledProcessError as exc:
         result = _make_stage_result(

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -222,6 +222,61 @@ class TestIsNonTransientHalt:
         assert _is_non_transient_halt({"error_message": "foo"}) is False
 
 
+class TestClassifyHaltTransience:
+    """Reads the recovery plan JSON to classify transience. Closes #1478."""
+
+    def test_no_recovery_plan_returns_none(self):
+        from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+
+        assert _classify_halt_transience({}) is None
+        assert _classify_halt_transience({"recovery_plan_path": ""}) is None
+
+    def test_transient_true_in_plan_returns_true(self, tmp_path):
+        from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+        import json
+
+        plan = tmp_path / "rp.json"
+        plan.write_text(json.dumps({
+            "error_type": "quota_exhausted",
+            "is_transient": True,
+        }), encoding="utf-8")
+        assert _classify_halt_transience({"recovery_plan_path": str(plan)}) is True
+
+    def test_transient_false_in_plan_returns_false(self, tmp_path):
+        from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+        import json
+
+        plan = tmp_path / "rp.json"
+        plan.write_text(json.dumps({
+            "error_type": "max_iterations_reached",
+            "is_transient": False,
+        }), encoding="utf-8")
+        assert _classify_halt_transience({"recovery_plan_path": str(plan)}) is False
+
+    def test_unreadable_plan_conservatively_returns_false(self, tmp_path):
+        """If the halt happened but the plan file is missing or malformed,
+        treat as non-transient (skip retry) — the operator's resume hint
+        is still the right recovery path."""
+        from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+
+        missing = tmp_path / "missing.json"
+        assert _classify_halt_transience({"recovery_plan_path": str(missing)}) is False
+
+        bad = tmp_path / "bad.json"
+        bad.write_text("not valid json{", encoding="utf-8")
+        assert _classify_halt_transience({"recovery_plan_path": str(bad)}) is False
+
+    def test_is_transient_missing_defaults_to_false(self, tmp_path):
+        """A recovery plan without an is_transient field is treated as
+        non-transient (conservative default)."""
+        from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+        import json
+
+        plan = tmp_path / "rp.json"
+        plan.write_text(json.dumps({"error_type": "unknown"}), encoding="utf-8")
+        assert _classify_halt_transience({"recovery_plan_path": str(plan)}) is False
+
+
 class TestRunStageNodeRetrySkip:
     """Tests that _run_stage_node skips retry on non-transient failures.
 


### PR DESCRIPTION
## Summary

Extends PR #1464. Replaces the binary `_is_non_transient_halt` (treats every halt as non-transient) with `_classify_halt_transience(sub_result) -> bool | None` which reads the recovery plan JSON:
- **True** when `is_transient: True` (quota exhausted, capacity, 5xx/429) → retry per existing loop
- **False** when `is_transient: False` (code bugs, max-iterations) → skip retry
- **None** when no halt detected → leave field unset, preserve pre-#1464 behavior for non-halt failures

Each `status="failed"` emission site updated to use the new classifier. `_is_non_transient_halt` kept for backward compatibility with #1464 tests.

The original deferral was named in #1463 non-claims; tracking gap closed with #1478.

Closes #1478

## Test plan

- [x] `TestClassifyHaltTransience` — 5 cases (no plan, transient=True, transient=False, unreadable plan, missing is_transient field)
- [x] 26/26 pass in `test_orchestrator_stages.py`