### PR TITLE
fix(spec): lexically normalize completeness failures before clustering (Closes #1479)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -99,6 +99,26 @@ Do not skip or abbreviate any section."""
 
 
 # =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _normalize_failure_text(text: str) -> str:
+    """Lexically normalize a completeness-failure message for clustering.
+
+    Collapses whitespace runs to a single space, strips leading/trailing
+    whitespace, lowercases, and trims trailing punctuation. Used by
+    `_build_revision_prompt` to detect recurring failures across iterations
+    even when the surface text differs by trivial lexical variation.
+    Closes #1479.
+    """
+    t = text.strip().lower()
+    t = re.sub(r"\s+", " ", t)
+    t = re.sub(r"[.,;:!?]+$", "", t)
+    return t
+
+
+# =============================================================================
 # Main Node
 # =============================================================================
 
@@ -621,20 +641,30 @@ def _build_revision_prompt(
             for failure in failures:
                 history += f"- {failure}\n"
             history += "\n"
-        # Synthesize the "tried K times" warning if any check repeats
+        # Synthesize the "tried K times" warning if any check repeats.
+        # Closes #1479: cluster by lexically-normalized text so near-duplicate
+        # failure messages (extra whitespace, trailing punctuation, case)
+        # collapse into a single recurring entry instead of slipping past as
+        # distinct.
         all_failures = [
             f
             for entry in prior_completeness_breakdown
             for f in entry.get("failures", [])
         ]
         from collections import Counter
-        repeat_counts = Counter(all_failures)
-        repeated = [f for f, n in repeat_counts.items() if n >= 2]
+        normalized_pairs = [(_normalize_failure_text(f), f) for f in all_failures]
+        repeat_counts = Counter(norm for norm, _ in normalized_pairs)
+        # Map each normalized key to the LATEST verbatim text (last occurrence
+        # wins) so the warning shows real wording, not the normalized form.
+        latest_verbatim: dict[str, str] = {}
+        for norm, verbatim in normalized_pairs:
+            latest_verbatim[norm] = verbatim
+        repeated = [norm for norm, n in repeat_counts.items() if n >= 2]
         if repeated:
             history += "### RECURRING FAILURES (your prior fixes did NOT work)\n\n"
-            for failure in repeated:
-                count = repeat_counts[failure]
-                history += f"- Tried {count} times: {failure}\n"
+            for norm in repeated:
+                count = repeat_counts[norm]
+                history += f"- Tried {count} times: {latest_verbatim[norm]}\n"
             history += (
                 "\n**Stop refining the prior approach. Change the spec's "
                 "structure or strategy fundamentally for these failures.**\n"

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1532,6 +1532,104 @@ class TestPriorCompletenessBreakdownInPrompt:
         assert "RECURRING FAILURES" not in prompt
 
 
+class TestNormalizeFailureText:
+    """Lexical normalization for clustering recurring failures. Closes #1479."""
+
+    def test_collapses_whitespace_runs(self):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            _normalize_failure_text,
+        )
+        assert (
+            _normalize_failure_text("check_X:  thing   missing")
+            == _normalize_failure_text("check_X: thing missing")
+        )
+
+    def test_strips_trailing_punctuation(self):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            _normalize_failure_text,
+        )
+        assert (
+            _normalize_failure_text("check_X: thing missing.")
+            == _normalize_failure_text("check_X: thing missing")
+        )
+        assert (
+            _normalize_failure_text("check_X: thing missing!")
+            == _normalize_failure_text("check_X: thing missing")
+        )
+
+    def test_case_insensitive(self):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            _normalize_failure_text,
+        )
+        assert (
+            _normalize_failure_text("Check_X: Thing Missing")
+            == _normalize_failure_text("check_x: thing missing")
+        )
+
+    def test_strips_leading_trailing_whitespace(self):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            _normalize_failure_text,
+        )
+        assert (
+            _normalize_failure_text("  check_X: thing missing  ")
+            == _normalize_failure_text("check_X: thing missing")
+        )
+
+
+class TestNormalizedRecurringClustering:
+    """Lexical normalization clusters near-duplicate failures into the
+    recurring-warning section. Closes #1479."""
+
+    def _make_revision_prompt(self, prior_breakdown):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            build_drafter_prompt,
+        )
+        return build_drafter_prompt(
+            lld_content="# LLD",
+            current_state={},
+            patterns=[],
+            existing_draft="# Current draft",
+            completeness_issues=["any current failure"],
+            prior_completeness_breakdown=prior_breakdown,
+        )
+
+    def test_whitespace_variants_cluster_as_recurring(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: thing  missing"]},
+            {"iteration": 1, "failures": ["check_X: thing missing"]},
+        ])
+        assert "RECURRING FAILURES" in prompt
+        assert "Tried 2 times" in prompt
+
+    def test_trailing_punctuation_variants_cluster(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: thing missing"]},
+            {"iteration": 1, "failures": ["check_X: thing missing."]},
+            {"iteration": 2, "failures": ["check_X: thing missing!"]},
+        ])
+        assert "RECURRING FAILURES" in prompt
+        assert "Tried 3 times" in prompt
+
+    def test_case_variants_cluster(self):
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: Thing Missing"]},
+            {"iteration": 1, "failures": ["check_x: thing missing"]},
+        ])
+        assert "RECURRING FAILURES" in prompt
+        assert "Tried 2 times" in prompt
+
+    def test_latest_verbatim_text_shown(self):
+        """The recurring warning surfaces the most recent verbatim wording,
+        not the normalized form (operators see real error text)."""
+        prompt = self._make_revision_prompt(prior_breakdown=[
+            {"iteration": 0, "failures": ["check_X: thing missing"]},
+            {"iteration": 1, "failures": ["check_X: thing missing."]},
+            {"iteration": 2, "failures": ["check_X: THING MISSING!"]},
+        ])
+        # The latest entry's verbatim text appears in the warning
+        assert "check_X: THING MISSING!" in prompt
+
+
 class TestValidateCompletenessAccumulatesPriorBreakdown:
     """N3 appends each failed iteration to prior_completeness_breakdown so
     N2 sees the full history. Closes #1465."""


### PR DESCRIPTION
## Summary

Extends PR #1466's recurring-failure detection with a normalization function:

- New module-level `_normalize_failure_text(text)`: collapses whitespace runs, strips leading/trailing whitespace, lowercases, trims trailing punctuation.
- The Counter inside `_build_revision_prompt` keys on normalized text; near-duplicate failures (whitespace, punctuation, case variants) cluster correctly.
- Real verbatim wording is preserved in the warning output — clustered on normalized, displayed as the latest verbatim entry per cluster.

The original deferral was named in #1465 non-claims; tracking gap closed with #1479.

Closes #1479

## Test plan

- [x] `TestNormalizeFailureText` — 4 cases (whitespace runs, trailing punctuation, case, leading/trailing whitespace)
- [x] `TestNormalizedRecurringClustering` — 4 cases (each variant type clusters, latest verbatim shown)
- [x] 174/174 pass in `test_implementation_spec_workflow.py`