### PR TITLE
feat: migrate legacy flat-layout lineage into per-run subdirs (Closes #1480)

### DIFF
--- a/tests/unit/test_migrate_lineage.py
+++ b/tests/unit/test_migrate_lineage.py
@@ -1,0 +1,157 @@
+"""Tests for the flat-to-run-scoped lineage migration tool.
+
+Closes #1480.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _make_flat_layout(repo_root: Path) -> None:
+    """Create a flat-layout lineage directory: docs/lineage/done/4-lld/001-issue.md."""
+    flat = repo_root / "docs" / "lineage" / "done" / "4-lld"
+    flat.mkdir(parents=True)
+    (flat / "001-issue.md").write_text("issue\n")
+    (flat / "002-draft.md").write_text("draft\n")
+    (flat / "003-verdict.md").write_text("verdict\n")
+
+
+def _make_run_scoped_layout(repo_root: Path) -> None:
+    """Create an already-run-scoped lineage dir that should NOT be touched."""
+    rs = repo_root / "docs" / "lineage" / "done" / "5-lld" / "2026-05-31T17-27-26Z"
+    rs.mkdir(parents=True)
+    (rs / "001-issue.md").write_text("scoped issue\n")
+
+
+def test_plan_moves_finds_flat_files(tmp_path):
+    from tools.migrate_lineage_flat_to_run_scoped import plan_moves
+
+    _make_flat_layout(tmp_path)
+    moves = plan_moves(tmp_path)
+
+    assert len(moves) == 3
+    for src, dst in moves:
+        assert "legacy" in str(dst.parent)
+        assert dst.name == src.name
+
+
+def test_plan_moves_ignores_run_scoped_subdirs(tmp_path):
+    from tools.migrate_lineage_flat_to_run_scoped import plan_moves
+
+    _make_run_scoped_layout(tmp_path)
+    moves = plan_moves(tmp_path)
+    assert moves == []
+
+
+def test_plan_moves_handles_mixed_layout(tmp_path):
+    from tools.migrate_lineage_flat_to_run_scoped import plan_moves
+
+    _make_flat_layout(tmp_path)
+    _make_run_scoped_layout(tmp_path)
+    moves = plan_moves(tmp_path)
+    # Only the 3 flat files; the run-scoped ones are untouched.
+    assert len(moves) == 3
+    for src, _ in moves:
+        assert "4-lld" in str(src)
+
+
+def test_plan_moves_returns_empty_when_no_lineage_dir(tmp_path):
+    from tools.migrate_lineage_flat_to_run_scoped import plan_moves
+
+    # tmp_path has no docs/lineage/
+    moves = plan_moves(tmp_path)
+    assert moves == []
+
+
+def test_apply_moves_relocates_files(tmp_path):
+    from tools.migrate_lineage_flat_to_run_scoped import apply_moves, plan_moves
+
+    _make_flat_layout(tmp_path)
+    moves = plan_moves(tmp_path)
+    apply_moves(moves)
+
+    flat = tmp_path / "docs" / "lineage" / "done" / "4-lld"
+    legacy = flat / "legacy"
+    # Originals removed
+    assert not (flat / "001-issue.md").exists()
+    # Moved into legacy/
+    assert (legacy / "001-issue.md").read_text() == "issue\n"
+    assert (legacy / "002-draft.md").read_text() == "draft\n"
+    assert (legacy / "003-verdict.md").read_text() == "verdict\n"
+
+
+def test_idempotent_apply(tmp_path):
+    """Running --apply twice is safe; second run finds no flat files."""
+    from tools.migrate_lineage_flat_to_run_scoped import apply_moves, plan_moves
+
+    _make_flat_layout(tmp_path)
+    apply_moves(plan_moves(tmp_path))
+    # Second plan finds nothing to do
+    second_plan = plan_moves(tmp_path)
+    assert second_plan == []
+
+
+def test_dry_run_does_not_move(tmp_path, capsys):
+    """`main()` without --apply leaves the filesystem unchanged."""
+    from tools.migrate_lineage_flat_to_run_scoped import main
+
+    _make_flat_layout(tmp_path)
+    rc = main(["--repo", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DRY-RUN" in out
+    assert "001-issue.md" in out
+    # Files still in their original flat location
+    flat = tmp_path / "docs" / "lineage" / "done" / "4-lld"
+    assert (flat / "001-issue.md").exists()
+
+
+def test_apply_via_main(tmp_path, capsys):
+    """`main(['--apply'])` actually moves the files."""
+    from tools.migrate_lineage_flat_to_run_scoped import main
+
+    _make_flat_layout(tmp_path)
+    rc = main(["--repo", str(tmp_path), "--apply"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "APPLY" in out
+    # Files moved into legacy/
+    legacy = tmp_path / "docs" / "lineage" / "done" / "4-lld" / "legacy"
+    assert (legacy / "001-issue.md").exists()
+
+
+def test_active_subtree_also_migrated(tmp_path):
+    """Both active/ and done/ subtrees are walked."""
+    from tools.migrate_lineage_flat_to_run_scoped import plan_moves
+
+    active = tmp_path / "docs" / "lineage" / "active" / "9-lld"
+    active.mkdir(parents=True)
+    (active / "001-draft.md").write_text("a")
+    done = tmp_path / "docs" / "lineage" / "done" / "10-lld"
+    done.mkdir(parents=True)
+    (done / "001-issue.md").write_text("b")
+
+    moves = plan_moves(tmp_path)
+    assert len(moves) == 2
+    state_dirs = {m[0].parent.parent.name for m in moves}
+    assert state_dirs == {"active", "done"}
+
+
+def test_nonexistent_repo_returns_nonzero(tmp_path, capsys):
+    from tools.migrate_lineage_flat_to_run_scoped import main
+
+    rc = main(["--repo", str(tmp_path / "nope")])
+    assert rc != 0
+    assert "ERROR" in capsys.readouterr().out
+
+
+def test_empty_repo_prints_no_migration_needed(tmp_path, capsys):
+    from tools.migrate_lineage_flat_to_run_scoped import main
+
+    (tmp_path / "README.md").write_text("noise")  # not a lineage repo
+    rc = main(["--repo", str(tmp_path)])
+    assert rc == 0
+    assert "no migration needed" in capsys.readouterr().out

--- a/tools/migrate_lineage_flat_to_run_scoped.py
+++ b/tools/migrate_lineage_flat_to_run_scoped.py
@@ -1,0 +1,139 @@
+"""Migrate legacy flat-layout lineage files into per-run subdirectories.
+
+Closes #1480.
+
+PR #1468 introduced per-run subdirectories for new lineage writes:
+    docs/lineage/{active,done}/{N}-{type}/{run_id}/NNN-*.md
+
+Lineage that landed before that PR is flat:
+    docs/lineage/{active,done}/{N}-{type}/NNN-*.md
+
+This tool walks both `active/` and `done/`, finds each `{N}-{type}/` issue
+directory, detects any flat NNN-*.md files at its top level, and moves them
+into a synthetic `legacy/` run-id subdirectory:
+    docs/lineage/{active,done}/{N}-{type}/legacy/NNN-*.md
+
+The `legacy` run-id is filesystem-safe and visually distinct from real
+timestamp run-ids (which contain `T` and end in `Z`), so a reader can tell
+at a glance which files predate PR #1468.
+
+The tool defaults to dry-run (preview). Pass `--apply` to actually move.
+Idempotent: a second `--apply` invocation finds no flat files and exits
+without changes.
+
+This tool does NOT commit the moves. Run it, review `git status`, then
+commit or revert.
+
+Usage:
+    poetry run python tools/migrate_lineage_flat_to_run_scoped.py --repo <path>
+    poetry run python tools/migrate_lineage_flat_to_run_scoped.py --repo <path> --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+from pathlib import Path
+
+LEGACY_RUN_ID = "legacy"
+NNN_PREFIX = re.compile(r"^\d{3}-")
+
+
+def find_flat_files(issue_dir: Path) -> list[Path]:
+    """Return NNN-*.md files at the top level of an issue directory.
+
+    Files inside any subdirectory (whether `legacy/` or a real run-id like
+    `2026-05-31T17-27-26Z/`) are excluded — those are already run-scoped.
+    """
+    if not issue_dir.is_dir():
+        return []
+    flat: list[Path] = []
+    for child in issue_dir.iterdir():
+        if child.is_file() and NNN_PREFIX.match(child.name):
+            flat.append(child)
+    return sorted(flat)
+
+
+def plan_moves(repo_root: Path) -> list[tuple[Path, Path]]:
+    """Walk active/ and done/ to compute all (src, dst) move pairs.
+
+    Returns an empty list if no migration is needed. Skips repos that don't
+    have a `docs/lineage/` directory at all.
+    """
+    lineage_root = repo_root / "docs" / "lineage"
+    if not lineage_root.is_dir():
+        return []
+    moves: list[tuple[Path, Path]] = []
+    for state_dir_name in ("active", "done"):
+        state_dir = lineage_root / state_dir_name
+        if not state_dir.is_dir():
+            continue
+        for issue_dir in sorted(state_dir.iterdir()):
+            if not issue_dir.is_dir():
+                continue
+            for src in find_flat_files(issue_dir):
+                dst = issue_dir / LEGACY_RUN_ID / src.name
+                moves.append((src, dst))
+    return moves
+
+
+def apply_moves(moves: list[tuple[Path, Path]]) -> None:
+    """Execute each (src, dst) move via shutil.move, creating parent dirs."""
+    for src, dst in moves:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Migrate legacy flat-layout docs/lineage/ files into per-run "
+            "subdirectories under a synthetic 'legacy/' run-id. Closes #1480."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        type=Path,
+        help="Path to the target repository (containing docs/lineage/).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Actually move files. Without --apply, runs in dry-run mode "
+            "and prints the planned moves without touching the filesystem."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo.resolve()
+    if not repo_root.is_dir():
+        print(f"[ERROR] repo path does not exist or is not a directory: {repo_root}")
+        return 2
+
+    moves = plan_moves(repo_root)
+    if not moves:
+        print(f"[OK] no migration needed for {repo_root}")
+        return 0
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] {len(moves)} flat lineage file(s) to migrate under {repo_root}")
+    for src, dst in moves:
+        rel_src = src.relative_to(repo_root)
+        rel_dst = dst.relative_to(repo_root)
+        print(f"    {rel_src}  ->  {rel_dst}")
+
+    if args.apply:
+        apply_moves(moves)
+        print(f"[OK] {len(moves)} file(s) moved. Review `git status` and commit.")
+    else:
+        print("[DRY-RUN] pass --apply to actually move the files above.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

New tool `tools/migrate_lineage_flat_to_run_scoped.py` for backward-migrating legacy flat-layout lineage files into per-run subdirectories.

- Defaults to dry-run; `--apply` executes.
- Walks both `docs/lineage/active/` and `docs/lineage/done/`.
- Synthesizes a `legacy/` run-id for pre-#1468 flat files; already run-scoped subdirs left alone.
- Idempotent; does not git commit.

The original deferral was named in #1467 non-claims; tracking gap closed with #1480.

Closes #1480

## Test plan

- [x] 11/11 pass in `tests/unit/test_migrate_lineage.py`
- [ ] Operator runs against Chiron, Heuriskon, AZ in dry-run; reviews plan; runs with `--apply`; reviews `git status`; commits or reverts.