### PR TITLE
fix(orchestrator/config): impl reviewer defaults to top-tier Gemini (Closes #1488)

### DIFF
--- a/assemblyzero/workflows/orchestrator/config.py
+++ b/assemblyzero/workflows/orchestrator/config.py
@@ -61,8 +61,12 @@ def get_default_config() -> OrchestratorConfig:
                 timeout_seconds=600,
             ),
             "impl": StageConfig(
+                # Closes #1488: reviewer was empty, which caused the testing
+                # sub-workflow's N1 (review test plan) to halt with
+                # "Invalid provider spec ''". Top-tier Gemini matches every
+                # other LLM-bearing stage and the operator preference (#1434).
                 drafter="gemini:3.1-pro-preview",
-                reviewer="",
+                reviewer="gemini:3.1-pro-preview",
                 max_revisions=3,
                 timeout_seconds=1800,
             ),

--- a/tests/unit/test_orchestrator_config.py
+++ b/tests/unit/test_orchestrator_config.py
@@ -46,6 +46,32 @@ class TestGetDefaultConfig:
         errors = validate_config(config)
         assert errors == []
 
+    def test_impl_stage_reviewer_not_empty(self):
+        """Closes #1488. The impl stage's testing sub-workflow N1 needs a
+        reviewer; empty string raises Invalid provider spec.
+        """
+        config = get_default_config()
+        assert config["stages"]["impl"]["reviewer"] != "", (
+            "impl reviewer must not be empty — testing N1 invokes "
+            "get_provider() which raises on empty spec"
+        )
+        # Top-tier-models preference (AZ #1434): every LLM-bearing reviewer
+        # uses gemini:3.1-pro-preview by default.
+        assert config["stages"]["impl"]["reviewer"] == "gemini:3.1-pro-preview"
+
+    def test_all_llm_bearing_stage_reviewers_are_top_tier(self):
+        """Closes #1488. triage/lld/spec/impl all need non-empty reviewers
+        per AZ #1434's top-tier-models rule. The pr stage is non-LLM
+        (gh pr create only), so its empty reviewer is correct.
+        """
+        config = get_default_config()
+        for stage in ("triage", "lld", "spec", "impl"):
+            assert config["stages"][stage]["reviewer"] != "", (
+                f"{stage} reviewer must not be empty"
+            )
+        # pr stage is intentionally LLM-less
+        assert config["stages"]["pr"]["reviewer"] == ""
+
 
 class TestLoadConfig:
     """Tests for load_config (T130)."""


### PR DESCRIPTION
## Summary

Set the impl stage's reviewer to `gemini:3.1-pro-preview` (was empty string). The testing sub-workflow's N1 (review test plan) called `get_provider('')` which raised `Invalid provider spec ''` and halted the smoke build at stage `impl`.

Empirical surface: overnight smoke build iteration #1 (`Chiron/data/smoke-build-overnight-iter01.log`) halted with this exact error after 3 retry attempts.

Closes #1488

## Test plan

- [x] `test_impl_stage_reviewer_not_empty` (specific to bug)
- [x] `test_all_llm_bearing_stage_reviewers_are_top_tier` (regression guard for triage/lld/spec/impl reviewers; pr stage stays LLM-less)
- [x] 15/15 pass in `test_orchestrator_config.py`