### PR TITLE
fix(testing/N1): BLOCKED is not an error — empty error_message on revise verdict (Closes #1490)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -639,12 +639,18 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
             gemini_feedback = "\n".join(feedback_parts) if feedback_parts else _extract_feedback(verdict_content)
         else:
             gemini_feedback = _extract_feedback(verdict_content)
+        # Closes #1490: BLOCKED is an actionable verdict, not an error.
+        # Setting error_message previously short-circuited
+        # route_after_review's "revise" policy, forcing END instead of
+        # routing to N1_5_revise_test_plan. The BLOCKED state is already
+        # preserved in test_plan_status + gemini_feedback; error_message
+        # stays empty so the revision loop can fire.
         return {
             "test_plan_status": "BLOCKED",
             "test_plan_verdict": f"BLOCKED: {gemini_feedback[:200]}",
             "gemini_feedback": gemini_feedback,
             "file_counter": file_num,
-            "error_message": "Test plan review BLOCKED - requires LLD revision",
+            "error_message": "",
             "node_costs": node_costs,  # Issue #511
             "node_tokens": node_tokens,  # Issue #511
         }
@@ -744,10 +750,14 @@ def _mock_review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
 
     print(f"    [MOCK] Verdict: {test_plan_status}")
 
+    # Closes #1490: BLOCKED is an actionable verdict; do NOT set
+    # error_message (it short-circuits the revise routing). Both mock and
+    # real paths now report empty error_message and rely on
+    # test_plan_status + gemini_feedback for downstream decisions.
     return {
         "test_plan_status": test_plan_status,
         "test_plan_verdict": f"{test_plan_status}: {gemini_feedback[:200]}" if gemini_feedback else test_plan_status,
         "gemini_feedback": gemini_feedback,
         "file_counter": file_num,
-        "error_message": "" if test_plan_status == "APPROVED" else "Test plan review BLOCKED",
+        "error_message": "",
     }

--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -620,6 +620,37 @@ class TestNodeFunctions:
         # With <100% coverage, mock mode should BLOCK (mechanical check fails)
         assert result.get("test_plan_status") == "BLOCKED"
         assert "REQ-2" in result.get("gemini_feedback", "")
+        # Closes #1490: BLOCKED must NOT set error_message (it short-circuits
+        # route_after_review's revise routing to END).
+        assert result.get("error_message", "") == "", (
+            f"BLOCKED must leave error_message empty so revise routing fires; "
+            f"got: {result.get('error_message')!r}"
+        )
+
+    def test_route_after_review_routes_to_revise_on_blocked_without_error(self, tmp_path):
+        """When N1 returns BLOCKED with empty error_message and policy=revise
+        (the default), route_after_review must route to N1_5_revise_test_plan.
+        Closes #1490 — without the fix, the N1 node's own error_message
+        forced END before the revise branch could fire.
+        """
+        from assemblyzero.workflows.testing.graph import route_after_review
+
+        state: TestingWorkflowState = {
+            "issue_number": 42,
+            "repo_root": str(tmp_path),
+            "auto_mode": False,
+            "test_plan_status": "BLOCKED",
+            "error_message": "",  # post-#1490 N1 sets this empty on BLOCKED
+            "test_plan_policy": "revise",
+            "test_plan_revision_count": 0,
+        }
+
+        result = route_after_review(state)
+
+        assert result == "N1_5_revise_test_plan", (
+            f"BLOCKED + empty error_message + policy=revise must route to "
+            f"revise node; got {result!r}"
+        )
 
     def test_route_after_review_auto_mode_continues_on_blocked(self, tmp_path):
         """route_after_review continues to scaffold in auto mode even when BLOCKED."""


### PR DESCRIPTION
## Summary

`review_test_plan` was setting `error_message="Test plan review BLOCKED - requires LLD revision"` on the BLOCKED return paths. `route_after_review` checks `error` BEFORE `test_plan_status`, so the N1 node's own error_message short-circuited the default "revise" policy (intended per #1072 to route BLOCKED → `N1_5_revise_test_plan`).

Result on overnight smoke iter02: reviewer correctly flagged missing negative tests (REQ-2 type enforcement, REQ-7 from_dict edge cases), but the workflow terminated. Orchestrator's 3 retries re-ran the entire testing workflow against the same LLD+spec, hit the same BLOCKED, halted impl.

Both N1 returns (real + mock) now set `error_message=""` on BLOCKED. BLOCKED state stays in `test_plan_status` + `gemini_feedback`.

Closes #1490

## Test plan

- [x] `test_review_test_plan_mock_mode_partial_coverage` now asserts empty error_message on BLOCKED
- [x] `test_route_after_review_routes_to_revise_on_blocked_without_error` (new) asserts the revise routing fires
- [x] 291/291 pass in `test_testing_workflow.py`