### PR TITLE
fix(testing): exit-2 import-error red signal + ASCII-only routing logs (Closes #1492, Closes #1493)

### DIFF
--- a/assemblyzero/workflows/testing/framework_detector.py
+++ b/assemblyzero/workflows/testing/framework_detector.py
@@ -153,7 +153,8 @@ def detect_framework_from_project(project_root: str) -> TestFramework | None:
         if os.path.isfile(os.path.join(project_root, filename)):
             if framework not in detected:
                 detected.append(framework)
-                logger.info("Found config file %s → %s", filename, framework.value)
+                # Closes #1493: ASCII-only log (Windows cp1252).
+                logger.info("Found config file %s -> %s", filename, framework.value)
 
     # Check package.json scripts
     package_json_path = os.path.join(project_root, "package.json")

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -187,12 +187,14 @@ def route_after_review(
             return "N2_scaffold_tests"
         # Strict policy preserves the original END-on-BLOCKED behavior.
         if policy == "strict":
-            print("    [STRICT] BLOCKED → END (test_plan_policy=strict)")
+            # Closes #1493: ASCII-only print (Windows cp1252).
+            print("    [STRICT] BLOCKED -> END (test_plan_policy=strict)")
             return "end"
         # Default revise policy: try to fix the test plan up to N cycles.
         if revision_count < MAX_REVISION_CYCLES:
+            # Closes #1493: ASCII-only print (Windows cp1252).
             print(
-                f"    [REVISE] BLOCKED → N1.5 revise cycle "
+                f"    [REVISE] BLOCKED -> N1.5 revise cycle "
                 f"{revision_count + 1}/{MAX_REVISION_CYCLES}"
             )
             return "N1_5_revise_test_plan"

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -154,16 +154,28 @@ def _classify_import_errors(
     """
     # Convert file paths to dotted module names for matching
     # e.g., "assemblyzero/utils/foo.py" -> "assemblyzero.utils.foo"
+    # Closes #1492: also strip common source-root prefixes so src-layout
+    # repos (src/chiron/provenance.py -> chiron.provenance per Python
+    # import resolution) match the names pytest actually reports.
+    # Aligned with #1477's source-root list in implementation_spec.
+    _SOURCE_ROOT_DOTTED = ("src.", "lib.", "source.", "python.", "apps.")
     expected_dotted: set[str] = set()
     for path in expected_module_paths:
         dotted = path.replace("/", ".").replace("\\", ".")
         if dotted.endswith(".py"):
             dotted = dotted[:-3]
+        # Add raw form (flat-layout repos)
         expected_dotted.add(dotted)
-        # Also add each parent package so "from assemblyzero.utils import foo" matches
-        parts = dotted.split(".")
-        for i in range(1, len(parts)):
-            expected_dotted.add(".".join(parts[:i]))
+        # Also add the source-root-stripped form (src-layout, lib-layout, etc.)
+        for prefix in _SOURCE_ROOT_DOTTED:
+            if dotted.startswith(prefix):
+                expected_dotted.add(dotted[len(prefix):])
+        # And each parent package of every form recorded so far so that
+        # "from assemblyzero.utils import foo" matches as expected.
+        for form in list(expected_dotted):
+            parts = form.split(".")
+            for i in range(1, len(parts)):
+                expected_dotted.add(".".join(parts[:i]))
 
     # Parse ModuleNotFoundError / ImportError from pytest output
     # Patterns: "ModuleNotFoundError: No module named 'X'"
@@ -389,9 +401,40 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "error_message": "",
         }
 
+    if exit_code == EXIT_INTERRUPTED:
+        # Closes #1492: exit 2 is documented as "interrupted by user", but
+        # pytest also returns 2 when collection fails because of
+        # ImportError on a module that doesn't exist yet — i.e. the
+        # expected red signal at the start of TDD. Classify the output
+        # first; route to N4_implement_code if the missing module is one
+        # the spec said it would Add. Only END on genuine interruption.
+        files_to_modify_for_red = state.get("files_to_modify", [])
+        expected_modules_for_red = [
+            f["path"] for f in files_to_modify_for_red
+            if f.get("path", "").endswith(".py")
+        ]
+        exp_count_red, unexp_count_red, _ = _classify_import_errors(
+            output, expected_modules_for_red
+        )
+        if exp_count_red > 0 and unexp_count_red == 0:
+            print(
+                f"    [EXIT CODE {exit_code}] ImportError on expected module(s) "
+                f"-> valid red signal, routing to implementation"
+            )
+            return {
+                "red_phase_output": output,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "next_node": "N4_implement_code",
+                "error_message": "",
+            }
+        # Fall through to the generic interrupted handler below.
+
     if exit_code in (EXIT_INTERRUPTED, EXIT_INTERNALERROR):
         reason = describe_exit_code(exit_code)
-        print(f"    [EXIT CODE {exit_code}] {reason} — stopping workflow")
+        # Closes #1493: ASCII-only print, no Unicode arrows. Windows cp1252
+        # otherwise raises UnicodeEncodeError mid-stream.
+        print(f"    [EXIT CODE {exit_code}] {reason} -- stopping workflow")
 
         return {
             "red_phase_output": output,

--- a/tests/test_testing_workflow.py
+++ b/tests/test_testing_workflow.py
@@ -627,6 +627,38 @@ class TestNodeFunctions:
             f"got: {result.get('error_message')!r}"
         )
 
+    def test_route_after_review_log_messages_ascii_only(self, tmp_path, capsys):
+        """Closes #1493. Windows cp1252 raises UnicodeEncodeError on
+        non-ASCII characters in print(). Assert the BLOCKED routing log
+        lines stay ASCII for both policies.
+        """
+        from assemblyzero.workflows.testing.graph import route_after_review
+
+        for policy, expected_route in (
+            ("revise", "N1_5_revise_test_plan"),
+            ("strict", "end"),
+        ):
+            ascii_state: TestingWorkflowState = {
+                "issue_number": 42,
+                "repo_root": str(tmp_path),
+                "auto_mode": False,
+                "test_plan_status": "BLOCKED",
+                "error_message": "",
+                "test_plan_policy": policy,
+                "test_plan_revision_count": 0,
+            }
+            capsys.readouterr()  # clear
+            result = route_after_review(ascii_state)
+            assert result == expected_route
+            out = capsys.readouterr().out
+            try:
+                out.encode("cp1252")
+            except UnicodeEncodeError as e:
+                raise AssertionError(
+                    f"route_after_review printed non-cp1252 chars "
+                    f"under policy={policy}: {e}; output={out!r}"
+                )
+
     def test_route_after_review_routes_to_revise_on_blocked_without_error(self, tmp_path):
         """When N1 returns BLOCKED with empty error_message and policy=revise
         (the default), route_after_review must route to N1_5_revise_test_plan.

--- a/tests/unit/test_exit_code_verify_phases.py
+++ b/tests/unit/test_exit_code_verify_phases.py
@@ -112,6 +112,66 @@ class TestRedPhaseExitCodeRouting:
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.Path.exists", return_value=True)
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_exit_2_with_expected_import_error_routes_to_implement(
+        self, mock_pytest, mock_exists,
+    ):
+        """Closes #1492. Exit code 2 with ImportError on a module the spec
+        is creating (a file in files_to_modify) is the EXPECTED red signal
+        at the start of TDD — the implementation doesn't exist yet. Route
+        to N4_implement_code instead of END.
+        """
+        # Simulated pytest output: ImportError for the module being built.
+        result_mock = _make_pytest_result(
+            EXIT_INTERRUPTED, passed=0, failed=0, errors=0,
+        )
+        result_mock["stdout"] = (
+            "collected 0 items / 1 error\n"
+            "ImportError while importing test module "
+            "'tests/test_issue_4.py'.\n"
+            "ModuleNotFoundError: No module named 'chiron.provenance'\n"
+        )
+        mock_pytest.return_value = result_mock
+        state = _make_state(
+            files_to_modify=[
+                {"path": "src/chiron/provenance.py", "change_type": "Add"},
+                {"path": "tests/test_issue_4.py", "change_type": "Add"},
+            ],
+        )
+        result = verify_red_phase(state)
+
+        assert result["next_node"] == "N4_implement_code", (
+            f"exit 2 + expected ImportError must route to N4; got {result}"
+        )
+        assert result["pytest_exit_code"] == EXIT_INTERRUPTED
+        assert result["error_message"] == ""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.Path.exists", return_value=True)
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_exit_2_without_import_error_still_stops(
+        self, mock_pytest, mock_exists,
+    ):
+        """Closes #1492. Genuine interruption (no ImportError pattern in
+        output) preserves the old END behavior. Protects against
+        false-positives that could mask a real Ctrl-C.
+        """
+        result_mock = _make_pytest_result(
+            EXIT_INTERRUPTED, passed=0, failed=0, errors=0,
+        )
+        # Output looks like a user-triggered abort; no import error pattern.
+        result_mock["stdout"] = "KeyboardInterrupt\n"
+        mock_pytest.return_value = result_mock
+        state = _make_state(
+            files_to_modify=[
+                {"path": "src/chiron/provenance.py", "change_type": "Add"},
+            ],
+        )
+        result = verify_red_phase(state)
+
+        assert result["next_node"] == "end"
+        assert result["pytest_exit_code"] == EXIT_INTERRUPTED
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.Path.exists", return_value=True)
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_exit_3_stops_workflow(self, mock_pytest, mock_exists):
         """Exit code 3 (internal error) stops the workflow."""
         mock_pytest.return_value = _make_pytest_result(


### PR DESCRIPTION
## Summary

Two co-blocking smoke-build bugs from Chiron #4 overnight iter03, bundled because they surface in the same impl-stage retry sequence.

**#1492** - verify_red_phase routed pytest exit 2 to END. Exit 2 is also returned when collection fails because of ImportError on a module the spec is creating (TDD red signal at start). Now: classify import errors; route to N4_implement_code if all errors are for expected modules. Fall through to END for genuine interruption.

Also extended `_classify_import_errors` to handle src-layout: pytest reports `chiron.provenance` but the spec's file path is `src/chiron/provenance.py`. Prefix-stripping mirrors #1477's source-root list.

**#1493** - testing/graph.py and framework_detector.py emit Unicode arrow (U+2192) in print/logger.info. Windows cp1252 raises UnicodeEncodeError; orchestrator catches as stage failure. Replaced with ASCII `->`.

Closes #1492
Closes #1493

## Test plan

- [x] `test_exit_2_with_expected_import_error_routes_to_implement` - the new red-signal path
- [x] `test_exit_2_without_import_error_still_stops` - preserves END for genuine interruption
- [x] `test_route_after_review_log_messages_ascii_only` - cp1252-encode check
- [x] 316/316 pass across `test_exit_code_verify_phases` + `test_testing_workflow`