### PR TITLE
fix(llm_provider): define module-level logger (Closes #1495)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -18,6 +18,7 @@ falls back to the Anthropic API if an API key is configured in .env.
 """
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -25,6 +26,14 @@ import subprocess
 import sys
 import tempfile
 import time
+
+# Closes #1495: llm_provider.py uses logger.warning at line 593 for the
+# #1431 defensive non-dict-JSON branch, but no logger was ever defined at
+# module scope. Every call through that branch raised
+# `NameError: name 'logger' is not defined`, surfaced by the testing
+# workflow's N4 (implement_code) as "API error: name 'logger' is not
+# defined" -- halting the impl stage.
+logger = logging.getLogger(__name__)
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from dataclasses import dataclass, field

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -1676,3 +1676,25 @@ class TestResponseSchema:
         import inspect
         sig = inspect.signature(GeminiProvider.invoke)
         assert "response_schema" in sig.parameters
+
+
+class TestModuleLoggerDefined:
+    """Regression for #1495. llm_provider used logger.warning at the
+    #1431 defensive branch (non-dict JSON) but never imported logging or
+    defined logger at module scope. Every code path that touched that
+    branch raised NameError. The smoke-build empirical surface was the
+    testing N4 (implement_code) halting impl.
+    """
+
+    def test_module_defines_logger(self):
+        import assemblyzero.core.llm_provider as mod
+        assert hasattr(mod, "logger"), (
+            "llm_provider must define a module-level `logger` so the "
+            "#1431 logger.warning branch does not NameError"
+        )
+        import logging
+        assert isinstance(mod.logger, logging.Logger)
+
+    def test_logger_name_matches_module(self):
+        import assemblyzero.core.llm_provider as mod
+        assert mod.logger.name == "assemblyzero.core.llm_provider"


### PR DESCRIPTION
## Summary

`llm_provider.py` used `logger.warning` at line 593 (the #1431 defensive branch for non-dict JSON returned by `claude -p`) but never imported `logging` or defined `logger` at module scope. Every code path through that branch raised `NameError`, which the provider exception handler returned as a generic API error. The testing workflow's N4 (implement_code) saw this as "API error after 2 attempts: name 'logger' is not defined" and halted impl.

Added `import logging` + `logger = logging.getLogger(__name__)` at module scope.

Empirical surface: Chiron #4 smoke build iter04 (Chiron/data/smoke-build-overnight-iter04.log).

Closes #1495

A deferred follow-up issue [#1496](https://github.com/martymcenroe/AssemblyZero/issues/1496) tracks swapping the N4 writer from Claude to Gemini (per operator preference #1434). This PR keeps the Claude path mechanically working so the smoke build can progress past iter04; the architectural swap is its own filed-and-tracked issue.

## Test plan

- [x] `TestModuleLoggerDefined::test_module_defines_logger`
- [x] `TestModuleLoggerDefined::test_logger_name_matches_module`
- [x] 115/115 pass in `test_llm_provider.py`