### PR TITLE
fix(llm_provider): extract response from claude -p streaming-events array (Closes #1498)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -71,6 +71,53 @@ def _filter_stderr(stderr: str) -> str:
     return "\n".join(filtered).strip()
 
 
+def _extract_text_from_stream_events(events: object, raw_stdout: str) -> str:
+    """Extract the response text from claude -p's streaming-events array.
+
+    Claude CLI v2.1.x returns `[{type: "system", ...}, {type: "assistant",
+    message: {content: [{type: "text", text: "..."}]}}, {type: "result",
+    result: "..."}]` on `--output-format json`. Closes #1498.
+
+    Priority:
+    1. The `result` event's `result` field (canonical, full final text).
+    2. The first assistant message's text content (fallback if no result
+       event is present in the array — happens on some error paths).
+    3. The raw stdout (last resort, preserves the existing behavior for
+       unknown shapes).
+    """
+    if not isinstance(events, list):
+        return raw_stdout.strip()
+
+    # 1. result event
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "result":
+            result_text = event.get("result")
+            if isinstance(result_text, str) and result_text:
+                return result_text
+
+    # 2. assistant message content
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != "assistant":
+            continue
+        message = event.get("message", {})
+        if not isinstance(message, dict):
+            continue
+        for content in message.get("content", []) or []:
+            if not isinstance(content, dict):
+                continue
+            if content.get("type") == "text":
+                text = content.get("text", "")
+                if isinstance(text, str) and text:
+                    return text
+
+    # 3. last-resort raw stdout
+    return raw_stdout.strip()
+
+
 @dataclass
 class LLMCallResult:
     """Result of an LLM API call with full observability.
@@ -599,12 +646,23 @@ class ClaudeCLIProvider(LLMProvider):
                     # still completes with a useful response and the raw bytes
                     # are preserved for debugging.
                     if not isinstance(response_data, dict):
+                        # Closes #1498: Claude CLI v2.1.x returns a streaming-
+                        # events JSON array even on `--output-format json`.
+                        # Extract the actual response from the `result` event,
+                        # or fall back to assistant message content, before
+                        # last-resort raw stdout. The earlier behavior (just
+                        # stringify stdout) discarded a perfectly parseable
+                        # response and the downstream consumer couldn't find a
+                        # code block.
                         logger.warning(
                             "claude -p returned non-dict JSON (type=%s); "
-                            "falling back to raw stdout. stdout[:500]=%r",
+                            "attempting streaming-events extraction. "
+                            "stdout[:500]=%r",
                             type(response_data).__name__, stdout[:500]
                         )
-                        response_text = stdout.strip()
+                        response_text = _extract_text_from_stream_events(
+                            response_data, stdout
+                        )
                     else:
                         # Issue #779: When --json-schema is used, claude -p puts the
                         # structured output in "structured_output" (dict), not "result"

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -1678,6 +1678,100 @@ class TestResponseSchema:
         assert "response_schema" in sig.parameters
 
 
+class TestExtractTextFromStreamEvents:
+    """Closes #1498. Claude CLI v2.1.x returns streaming-events JSON arrays
+    on --output-format json. The provider must extract the actual response
+    text from the events list (priority: result event -> assistant message
+    -> raw stdout) instead of discarding the structure.
+    """
+
+    def test_extracts_from_result_event(self):
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        events = [
+            {"type": "system", "subtype": "init"},
+            {"type": "result", "result": "```python\nprint('hi')\n```"},
+        ]
+        result = _extract_text_from_stream_events(events, raw_stdout="ignored")
+        assert result == "```python\nprint('hi')\n```"
+
+    def test_falls_back_to_assistant_message_text(self):
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        events = [
+            {"type": "system", "subtype": "init"},
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "asst-text-here"}]},
+            },
+            # no result event
+        ]
+        result = _extract_text_from_stream_events(events, raw_stdout="ignored")
+        assert result == "asst-text-here"
+
+    def test_result_event_takes_priority_over_assistant(self):
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        events = [
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "asst"}]},
+            },
+            {"type": "result", "result": "canonical-result"},
+        ]
+        assert (
+            _extract_text_from_stream_events(events, raw_stdout="ignored")
+            == "canonical-result"
+        )
+
+    def test_falls_back_to_raw_stdout_when_no_extractable_event(self):
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        events = [
+            {"type": "system", "subtype": "init"},
+            {"type": "rate_limit_event"},
+        ]
+        result = _extract_text_from_stream_events(events, raw_stdout="raw-fallback")
+        assert result == "raw-fallback"
+
+    def test_non_list_falls_back_to_raw_stdout(self):
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        # Defensive: only lists carry the streaming-events shape.
+        result = _extract_text_from_stream_events(
+            "not a list", raw_stdout="raw-fallback"
+        )
+        assert result == "raw-fallback"
+
+    def test_smoke_build_iter05_repro(self):
+        """Verbatim shape from Chiron iter05's 091-response-...md."""
+        from assemblyzero.core.llm_provider import _extract_text_from_stream_events
+        code = (
+            "```python\n"
+            "from dataclasses import dataclass\n"
+            "\n"
+            "@dataclass(frozen=True)\n"
+            "class Citation:\n"
+            "    document: str\n"
+            "```"
+        )
+        events = [
+            {"type": "system", "subtype": "init", "cwd": "/tmp"},
+            {"type": "rate_limit_event", "rate_limit_info": {"status": "allowed"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [{"type": "text", "text": code}],
+                },
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": code,
+            },
+        ]
+        result = _extract_text_from_stream_events(events, raw_stdout="ignored")
+        assert "Citation" in result
+        assert "```python" in result
+
+
 class TestModuleLoggerDefined:
     """Regression for #1495. llm_provider used logger.warning at the
     #1431 defensive branch (non-dict JSON) but never imported logging or


### PR DESCRIPTION
## Summary

Claude CLI v2.1.x returns a streaming-events JSON array even on `--output-format json` (system/init -> rate_limit -> assistant -> result). The provider's #1431 defensive branch detected the non-dict shape but stringified raw stdout, so the downstream consumer couldn't find a code block and halted impl with "No code block after 2 attempts."

New helper `_extract_text_from_stream_events` walks the events array:
1. `result` event's `result` field (canonical)
2. First assistant message's text content (fallback)
3. Raw stdout (preserves the existing behavior for unknown shapes)

Closes #1498

## Test plan

- [x] `TestExtractTextFromStreamEvents` — 6 cases including the verbatim Chiron iter05 shape
- [x] 123/123 pass in `test_llm_provider.py`