### PR TITLE
fix(impl-validator): honor src-layout in _resolve_internal_import (Closes #1500)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
@@ -140,34 +140,42 @@ def validate_imports(
     return len(bad_imports) == 0, bad_imports
 
 
+# Closes #1500: src-layout repos place importable modules under a
+# source-root prefix (src/ is canonical; lib/, source/, python/, apps/ are
+# common alternatives — same list as the spec-stage validator extended in
+# #1477). The earlier resolver only checked repo_root/Path(*parts), which
+# missed every external target that uses src-layout.
+_SOURCE_ROOT_PREFIXES: tuple[str, ...] = (
+    "", "src", "lib", "source", "python", "apps",
+)
+
+
 def _resolve_internal_import(module_path: str, repo_root: Path) -> bool:
     """Check if an internal import resolves to a file or package on disk.
 
-    Handles both:
-    - `import assemblyzero.utils.foo` -> assemblyzero/utils/foo.py or foo/__init__.py
-    - `from assemblyzero.utils import foo` -> same resolution
+    Handles both flat-layout and src-layout (and lib/source/python/apps
+    variants). Mirrors the spec-stage validator at
+    assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+    (PR #1462 + #1477). Closes #1500.
     """
     parts = module_path.split(".")
-
-    # Try as a module file: assemblyzero/utils/foo.py
-    file_path = repo_root / Path(*parts).with_suffix(".py")
-    if file_path.exists():
-        return True
-
-    # Try as a package: assemblyzero/utils/foo/__init__.py
-    package_path = repo_root / Path(*parts) / "__init__.py"
-    if package_path.exists():
-        return True
-
-    # Try parent module (for `from assemblyzero.utils import foo`):
-    # The import might target a name inside a module, not a submodule file.
-    # Check if the parent path resolves.
+    candidates: list[Path] = [
+        Path(*parts).with_suffix(".py"),
+        Path(*parts) / "__init__.py",
+    ]
     if len(parts) > 1:
-        parent_file = repo_root / Path(*parts[:-1]).with_suffix(".py")
-        if parent_file.exists():
-            return True
-        parent_package = repo_root / Path(*parts[:-1]) / "__init__.py"
-        if parent_package.exists():
-            return True
+        candidates.extend([
+            Path(*parts[:-1]).with_suffix(".py"),
+            Path(*parts[:-1]) / "__init__.py",
+        ])
+
+    for candidate in candidates:
+        for prefix in _SOURCE_ROOT_PREFIXES:
+            probe = (
+                repo_root / prefix / candidate if prefix
+                else repo_root / candidate
+            )
+            if probe.exists():
+                return True
 
     return False

--- a/tests/unit/test_import_validator.py
+++ b/tests/unit/test_import_validator.py
@@ -1,0 +1,120 @@
+"""Tests for impl-stage import validator. Closes #1500.
+
+The impl-stage validator at
+assemblyzero/workflows/testing/nodes/implementation/import_validator.py
+resolves internal imports against on-disk module paths. The earlier
+version only checked repo_root/Path(*parts), missing src-layout repos
+where chiron.provenance lives at src/chiron/provenance.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_resolves_flat_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "chiron").mkdir()
+    (tmp_path / "chiron" / "provenance.py").write_text("")
+    assert _resolve_internal_import("chiron.provenance", tmp_path) is True
+
+
+def test_resolves_src_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "src" / "chiron").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "provenance.py").write_text("")
+    assert _resolve_internal_import("chiron.provenance", tmp_path) is True
+
+
+def test_resolves_lib_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "lib" / "foo").mkdir(parents=True)
+    (tmp_path / "lib" / "foo" / "bar.py").write_text("")
+    assert _resolve_internal_import("foo.bar", tmp_path) is True
+
+
+def test_resolves_source_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "source" / "foo").mkdir(parents=True)
+    (tmp_path / "source" / "foo" / "bar.py").write_text("")
+    assert _resolve_internal_import("foo.bar", tmp_path) is True
+
+
+def test_resolves_python_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "python" / "foo").mkdir(parents=True)
+    (tmp_path / "python" / "foo" / "bar.py").write_text("")
+    assert _resolve_internal_import("foo.bar", tmp_path) is True
+
+
+def test_resolves_apps_layout(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "apps" / "foo").mkdir(parents=True)
+    (tmp_path / "apps" / "foo" / "bar.py").write_text("")
+    assert _resolve_internal_import("foo.bar", tmp_path) is True
+
+
+def test_resolves_src_layout_via_init(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "src" / "foo" / "bar").mkdir(parents=True)
+    (tmp_path / "src" / "foo" / "bar" / "__init__.py").write_text("")
+    assert _resolve_internal_import("foo.bar", tmp_path) is True
+
+
+def test_resolves_parent_module_src_layout(tmp_path):
+    """`from chiron.provenance import Citation` resolves when
+    src/chiron/provenance.py exists (Citation lives inside).
+    """
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    (tmp_path / "src" / "chiron").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "provenance.py").write_text("class Citation: ...")
+    assert _resolve_internal_import("chiron.provenance.Citation", tmp_path) is True
+
+
+def test_unresolvable_returns_false(tmp_path):
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _resolve_internal_import,
+    )
+    assert _resolve_internal_import("nonexistent.module", tmp_path) is False
+
+
+def test_chiron_iter06_repro(tmp_path):
+    """Verbatim shape from iter06 halt: src/chiron/provenance.py exists
+    on disk, test file does `from chiron.provenance import Citation`,
+    validator must accept.
+    """
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    (tmp_path / "src" / "chiron").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "provenance.py").write_text(
+        '"""Citation provenance value object."""\nclass Citation: pass\n'
+    )
+    test_code = (
+        '"""Tests for chiron.provenance."""\n'
+        "import pytest\n"
+        "\n"
+        "from chiron.provenance import Citation\n"
+        "\n"
+        "def test_citation_is_immutable():\n"
+        "    pass\n"
+    )
+    valid, bad = validate_imports(test_code, "tests/unit/test_provenance.py", tmp_path)
+    assert valid is True, f"Expected valid, got bad={bad!r}"
+    assert bad == []


### PR DESCRIPTION
## Summary

Parallel fix to PR #1462 in a different file. The impl-stage import validator probed only `repo_root/Path(*parts)` for internal modules. Src-layout repos (Chiron: `src/chiron/provenance.py` for the module `chiron.provenance`) tripped `Unresolvable imports: chiron.provenance` even after the impl stage had successfully written the target file to disk, halting impl on the next generated test file that imported it.

Extended `_resolve_internal_import` to iterate `_SOURCE_ROOT_PREFIXES = ("", "src", "lib", "source", "python", "apps")` — mirroring #1477's list.

Closes #1500

## Test plan

- [x] `tests/unit/test_import_validator.py` — 10 cases (flat, src, lib, source, python, apps layouts; \_\_init\_\_ package; parent module; nonexistent; verbatim Chiron iter06 repro)