### PR TITLE
fix(verify_phases): _path_to_cov_target recognizes real src-layout packages (Closes #1502)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -212,35 +212,63 @@ def _classify_import_errors(
     return expected_count, unexpected_count, unexpected_modules
 
 
+# Closes #1502: src-layout repos store importable packages under a
+# source-root prefix dir which is NOT itself a package. The earlier
+# is_package check only looked at top_level/__init__.py; for src-layout
+# that returned False and the function fell back to file-path form,
+# which pytest-cov measured as 0.0% (it expects module names or
+# discoverable directories, not file paths inside a nested layout).
+# Mirrors #1477's source-root list.
+_COV_SOURCE_ROOT_PREFIXES: tuple[str, ...] = (
+    "src", "lib", "source", "python", "apps",
+)
+
+
 def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
     """Convert a relative file path to the correct --cov target.
 
-    For Python packages (top-level dir has __init__.py), returns dotted
+    For Python packages (top-level dir has ``__init__.py``), returns dotted
     module format (e.g., ``assemblyzero.utils.file_type``).
-    For standalone scripts (no __init__.py, e.g., ``tools/``), returns
+    For src-layout packages (``src/<pkg>/...``), strips the source-root
+    prefix and returns the dotted module form (Closes #1502).
+    For standalone scripts (no ``__init__.py``, e.g., ``tools/``), returns
     the file path so pytest-cov measures the right file.
     """
     rel = Path(rel_path)
     top_level = rel.parts[0] if rel.parts else None
-    is_package = (
+
+    # Flat-layout package: repo_root/<top>/__init__.py exists.
+    is_flat_package = bool(
         top_level
         and repo_root
         and (repo_root / top_level / "__init__.py").exists()
+    )
+
+    # src-layout package: top_level is a source-root prefix and the
+    # immediately-nested dir is a package.
+    is_src_layout_package = bool(
+        top_level
+        and top_level in _COV_SOURCE_ROOT_PREFIXES
+        and len(rel.parts) > 1
+        and repo_root is not None
+        and (repo_root / top_level / rel.parts[1] / "__init__.py").exists()
     )
 
     rel_str = str(rel)
     if rel_str.endswith(".py"):
         rel_str = rel_str[:-3]
 
-    if is_package:
+    if is_flat_package or is_src_layout_package:
         module = rel_str.replace("/", ".").replace("\\", ".")
-        # Issue #387: Strip src. prefix for src-layout projects
-        if module.startswith("src."):
-            module = module[4:]
+        # Strip a known source-root prefix (Issue #387 / #1502).
+        for prefix in _COV_SOURCE_ROOT_PREFIXES:
+            if module.startswith(prefix + "."):
+                module = module[len(prefix) + 1:]
+                break
         return module
-    else:
-        # Return as a file path — pytest-cov accepts paths for non-package code
-        return str(rel).replace("\\", "/")
+
+    # Return as a file path — pytest-cov accepts paths for non-package code
+    return str(rel).replace("\\", "/")
 
 
 def run_pytest(

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -47,6 +47,40 @@ def test_src_layout_strips_prefix(tmp_path: Path) -> None:
     assert result == "mypackage.core"
 
 
+def test_real_src_layout_no_src_init(tmp_path: Path) -> None:
+    """Closes #1502. Real-world src-layout: src/ is NOT a package (no
+    src/__init__.py), but src/<pkg>/__init__.py exists. The cov target
+    must be the dotted form with the src prefix stripped, not the file
+    path (which pytest-cov misclassifies as 0% coverage).
+    """
+    (tmp_path / "src" / "chiron").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "__init__.py").touch()
+    (tmp_path / "src" / "chiron" / "provenance.py").touch()
+    # Deliberately do NOT create src/__init__.py — real src-layout shape.
+
+    result = _path_to_cov_target("src/chiron/provenance.py", tmp_path)
+    assert result == "chiron.provenance"
+
+
+def test_lib_layout_strips_prefix(tmp_path: Path) -> None:
+    """Closes #1502. lib-layout variant."""
+    (tmp_path / "lib" / "foo").mkdir(parents=True)
+    (tmp_path / "lib" / "foo" / "__init__.py").touch()
+    (tmp_path / "lib" / "foo" / "bar.py").touch()
+
+    result = _path_to_cov_target("lib/foo/bar.py", tmp_path)
+    assert result == "foo.bar"
+
+
+def test_source_layout_strips_prefix(tmp_path: Path) -> None:
+    """Closes #1502. source-layout variant."""
+    (tmp_path / "source" / "foo").mkdir(parents=True)
+    (tmp_path / "source" / "foo" / "__init__.py").touch()
+
+    result = _path_to_cov_target("source/foo/bar.py", tmp_path)
+    assert result == "foo.bar"
+
+
 # ---------------------------------------------------------------------------
 # _path_to_cov_target — standalone scripts (no __init__.py)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_path_to_cov_target` returned a file path for src-layout repos because `src/` itself isn't a package (no `src/__init__.py`). pytest-cov measured 0.0% coverage despite tests exercising the code, and N5 halted with "Coverage stagnant."

Added parallel src-layout package detection: `top_level` is one of `(src, lib, source, python, apps)` AND nested dir has `__init__.py`. Both branches share the same prefix-stripping loop.

Closes #1502

## Test plan

- [x] `test_real_src_layout_no_src_init` — the Chiron shape, no src/__init__.py
- [x] `test_lib_layout_strips_prefix`, `test_source_layout_strips_prefix`
- [x] Existing tests still pass (legacy src/__init__.py case + standalone scripts)
- [x] 15/15 pass