### PR TITLE
fix(orchestrator): impl stage plumbs repo_root=worktree_path (Closes #1504)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -469,11 +469,16 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
 
         graph = create_impl_graph()
         app = graph.compile()
+        # Closes #1504: testing workflow writes files to repo_root. Plumb
+        # the worktree path here so generated implementation + tests land
+        # on the issue-{N} branch. original_repo_root stays as target_repo
+        # so load_lld.py's fallback (Issue #380) can find the LLD that
+        # lives on target_repo's main.
         sub_result = app.invoke({
             "issue_number": issue_number,
             "spec_path": spec_path,
             "worktree_path": str(worktree_path),
-            "repo_root": target_repo,
+            "repo_root": str(worktree_path),
             "original_repo_root": target_repo,
             "config_drafter": stage_cfg.get("drafter", ""),
             "config_reviewer": stage_cfg.get("reviewer", ""),

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -127,8 +127,13 @@ def test_impl_carves_worktree_from_target(mock_run, mock_create_graph):
     assert expected_wt in argv, f"worktree path is not a sibling of target: {argv}"
     assert "issue-5" in argv  # branch
 
-    # testing graph receives the target as repo_root / original_repo_root
-    assert captured["repo_root"] == EXTERNAL
+    # Closes #1504. The testing sub-workflow writes files relative to
+    # repo_root, so the impl stage must thread the worktree path under that
+    # key — otherwise generated files land on target_repo's main and the
+    # issue branch stays empty (pr stage then 422s with "No commits between
+    # main and issue-N"). original_repo_root stays as the target so the
+    # load_lld.py:815 fallback (Issue #380) can still find the LLD on main.
+    assert captured["repo_root"] == expected_wt
     assert captured["original_repo_root"] == EXTERNAL
     assert captured["worktree_path"] == expected_wt
 

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -126,6 +126,71 @@ class TestStageRunners:
             assert stage in STAGE_RUNNERS, f"Missing runner for stage: {stage}"
 
 
+class TestRunImplStageRepoRoot:
+    """Closes #1504. The impl stage carved a worktree but plumbed
+    repo_root=target_repo (not the worktree). Testing workflow wrote
+    files to target_repo; issue-{N} branch stayed empty; pr stage
+    halted with "No commits between main and issue-N."
+    """
+
+    @patch("assemblyzero.workflows.orchestrator.stages.run_command")
+    def test_impl_invokes_testing_with_repo_root_eq_worktree(
+        self, mock_run, tmp_path,
+    ):
+        from assemblyzero.workflows.orchestrator.stages import run_impl_stage
+
+        # subprocess.run is mocked; treat all calls as successful no-ops.
+        out = MagicMock()
+        out.stdout = ""
+        out.stderr = ""
+        out.returncode = 0
+        mock_run.return_value = out
+
+        config = get_default_config()
+        state = create_initial_state(
+            4,
+            config,
+            target_repo=str(tmp_path / "target"),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+        # spec_path needs to look real to the impl stage
+        state["spec_path"] = str(tmp_path / "spec.md")
+        (tmp_path / "spec.md").write_text("# spec")
+
+        captured: dict[str, dict] = {}
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                captured["payload"] = payload
+                # Pretend the testing workflow succeeded.
+                return {"error_message": ""}
+
+        class _StubGraph:
+            def compile(self) -> _StubApp:
+                return _StubApp()
+
+        with patch(
+            "assemblyzero.workflows.testing.graph.build_testing_workflow",
+            return_value=_StubGraph(),
+        ):
+            run_impl_stage(state)
+
+        payload = captured.get("payload", {})
+        worktree_path = payload.get("worktree_path", "")
+        repo_root = payload.get("repo_root", "")
+        original_repo_root = payload.get("original_repo_root", "")
+        assert worktree_path, "worktree_path must be set"
+        assert repo_root == worktree_path, (
+            f"repo_root must equal worktree_path so the testing workflow "
+            f"writes into the worktree; got repo_root={repo_root!r}, "
+            f"worktree_path={worktree_path!r}"
+        )
+        assert original_repo_root == str(tmp_path / "target"), (
+            "original_repo_root must remain the target_repo so the LLD "
+            "fallback at load_lld.py:815 can find the spec"
+        )
+
+
 class TestRunPrStage:
     """run_pr_stage must emit a pr-sentinel-compliant PR (Closes #1366).
 


### PR DESCRIPTION
## Summary

The impl stage carved a worktree but invoked the testing sub-workflow with `repo_root=target_repo`. Generated files landed in the operator's checkout, not the worktree. `issue-{N}` branch stayed empty. pr stage halted with "No commits between main and issue-N."

One-line fix: `repo_root=str(worktree_path)`. `original_repo_root=target_repo` is unchanged so the load_lld.py:815 fallback (Issue #380) still finds the LLD on main.

Closes #1504

## Test plan

- [x] `TestRunImplStageRepoRoot::test_impl_invokes_testing_with_repo_root_eq_worktree`
- [ ] End-to-end: smoke build iter09 should land the impl files on the issue-4 branch and reach pr stage with a non-empty diff.