### PR TITLE
fix(verify_phases): accept PEP 420 namespace packages in src-layout cov target (Closes #1506)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -224,13 +224,27 @@ _COV_SOURCE_ROOT_PREFIXES: tuple[str, ...] = (
 )
 
 
+def _is_python_package_dir(d: Path) -> bool:
+    """True if `d` is a Python package — regular (`__init__.py`) or PEP 420
+    namespace (directory with `.py` files but no `__init__.py`)."""
+    try:
+        if not d.is_dir():
+            return False
+        if (d / "__init__.py").exists():
+            return True
+        return any(f.suffix == ".py" for f in d.iterdir() if f.is_file())
+    except (OSError, PermissionError):
+        return False
+
+
 def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
     """Convert a relative file path to the correct --cov target.
 
     For Python packages (top-level dir has ``__init__.py``), returns dotted
     module format (e.g., ``assemblyzero.utils.file_type``).
     For src-layout packages (``src/<pkg>/...``), strips the source-root
-    prefix and returns the dotted module form (Closes #1502).
+    prefix and returns the dotted module form (Closes #1502). The nested
+    package may be a regular or PEP 420 namespace package (Closes #1506).
     For standalone scripts (no ``__init__.py``, e.g., ``tools/``), returns
     the file path so pytest-cov measures the right file.
     """
@@ -245,13 +259,17 @@ def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
     )
 
     # src-layout package: top_level is a source-root prefix and the
-    # immediately-nested dir is a package.
+    # immediately-nested dir is a package. Accept BOTH regular packages
+    # (have __init__.py) and PEP 420 namespace packages (no __init__.py
+    # but the dir contains .py files). Without this, namespace-package
+    # src-layouts fall through to file-path form and pytest-cov reports
+    # 0% coverage (Closes #1506).
     is_src_layout_package = bool(
         top_level
         and top_level in _COV_SOURCE_ROOT_PREFIXES
         and len(rel.parts) > 1
         and repo_root is not None
-        and (repo_root / top_level / rel.parts[1] / "__init__.py").exists()
+        and _is_python_package_dir(repo_root / top_level / rel.parts[1])
     )
 
     rel_str = str(rel)

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -62,6 +62,41 @@ def test_real_src_layout_no_src_init(tmp_path: Path) -> None:
     assert result == "chiron.provenance"
 
 
+def test_src_layout_namespace_package(tmp_path: Path) -> None:
+    """Closes #1506. PEP 420 namespace package under src/: no __init__.py
+    anywhere, but src/<pkg>/<file>.py is importable as <pkg>.<file> via
+    Python 3.3+ namespace-package import. The cov target must be dotted
+    form, not file path — pytest-cov's path-style --cov= reports 0%
+    coverage on namespace packages because the module is imported as
+    <pkg>.<file>, not src.<pkg>.<file>.
+
+    Empirically reproduced 2026-06-01 on Chiron-4 iter09 smoke build:
+    --cov=src/chiron/provenance.py emits "Module ... was never imported"
+    and reports 0%; --cov=chiron.provenance reports 100% on the same
+    test invocation.
+    """
+    (tmp_path / "src" / "chiron").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "provenance.py").touch()
+    # No __init__.py anywhere — PEP 420 namespace package.
+
+    result = _path_to_cov_target("src/chiron/provenance.py", tmp_path)
+    assert result == "chiron.provenance"
+
+
+def test_src_layout_empty_subdir_falls_back_to_path(tmp_path: Path) -> None:
+    """Closes #1506. Guard against accidental over-acceptance: when
+    src/<subdir>/ exists but is EMPTY (no __init__.py, no .py files),
+    do NOT treat it as a namespace package — fall through to file path
+    form. Keeps the existing tools/-style "non-package dir" semantics
+    intact when an empty placeholder happens to be under src/."""
+    (tmp_path / "src" / "data").mkdir(parents=True)
+    # Empty dir: no .py, no __init__.py.
+
+    result = _path_to_cov_target("src/data/example.py", tmp_path)
+    # The directory exists but isn't a package — file-path fallback.
+    assert result == "src/data/example.py"
+
+
 def test_lib_layout_strips_prefix(tmp_path: Path) -> None:
     """Closes #1502. lib-layout variant."""
     (tmp_path / "lib" / "foo").mkdir(parents=True)


### PR DESCRIPTION
## Summary

`_path_to_cov_target` required `<src-root>/<pkg>/__init__.py` to exist for the src-layout dotted-form branch. That rejected PEP 420 namespace packages (no `__init__.py` anywhere), and the function fell through to file-path form. pytest-cov reported 0% even when all tests passed.

Empirically reproduced on Chiron #4 iter09 smoke build (`Chiron/data/smoke-build-overnight-iter09.log` line 155): `--cov=chiron.provenance` reports 100%; `--cov=src/chiron/provenance.py` reports 0% on the same test invocation. Halted the impl stage with `Coverage stagnant: 0.0% -> 0.0%`.

Fix: introduce `_is_python_package_dir()` that accepts BOTH regular packages (have `__init__.py`) and PEP 420 namespace packages (directory contains `.py` files without `__init__.py`). Use it in the src-layout detection. Scope intentionally narrow — only the src-layout branch relaxes; flat-layout and empty-subdir cases stay strict.

Closes #1506

## Test plan

- [x] `test_src_layout_namespace_package` — `src/chiron/provenance.py` with no `__init__.py` → `chiron.provenance`
- [x] `test_src_layout_empty_subdir_falls_back_to_path` — `src/data/` empty → `src/data/example.py` (defensive)
- [x] Existing 14 tests pass unchanged
- [ ] End-to-end: Chiron #4 iter10 should reach pr stage with non-zero coverage on the namespace-package src-layout