### PR TITLE
fix(requirements/graph): gate verdict-revise loop on verdict_count (Closes #1509)

### DIFF
--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -312,11 +312,15 @@ def route_after_review(
         return "N4_human_gate_verdict"
 
     # If UNANSWERED, loop back to review (not draft - this is a review followup)
-    # But respect max_iterations to prevent infinite loops
+    # But respect max_iterations to prevent infinite loops.
+    # Closes #1509: gate on verdict_count (incremented exactly once per N3
+    # review in review.py:86), NOT iteration_count (bumped by N1, Ponder,
+    # N1B etc. on every state-touching node — exhausts max before the
+    # first revise round can fire).
     if open_questions_status == "UNANSWERED":
-        iteration_count = state.get("iteration_count", 0)
+        verdict_count = state.get("verdict_count", 0)
         max_iterations = state.get("max_iterations", 3)
-        if iteration_count >= max_iterations:
+        if verdict_count >= max_iterations:
             print(f"    [ROUTING] Max iterations ({max_iterations}) reached with unanswered questions - going to human gate")
             return "N4_human_gate_verdict"
         print("    [ROUTING] Open questions unanswered - looping back to drafter for revision")
@@ -342,10 +346,15 @@ def route_after_review(
                     emit("workflow.halt_and_plan", repo=state.get("repo_root", ""), metadata={"reason": "stagnation", "issue": state.get("issue_number")})
                     return "HALT"
 
-            # Check max iterations before looping back
-            iteration_count = state.get("iteration_count", 0)
+            # Check max iterations before looping back.
+            # Closes #1509: gate on verdict_count (one increment per N3
+            # review) so the revise loop can actually fire. iteration_count
+            # is bumped by N1, Ponder, N1B, etc. and exhausts the cap on
+            # the first forward pass — that gated the revise loop closed
+            # before the first reviewer verdict could trigger a re-draft.
+            verdict_count = state.get("verdict_count", 0)
             max_iterations = state.get("max_iterations", 3)
-            if iteration_count >= max_iterations:
+            if verdict_count >= max_iterations:
                 # Max iterations reached - finalize with current status
                 return "N5_finalize"
             return "N1_generate_draft"

--- a/tests/unit/test_open_questions_loop.py
+++ b/tests/unit/test_open_questions_loop.py
@@ -197,22 +197,23 @@ class TestRouteAfterReviewOpenQuestions:
         assert route_after_review(state) == "N4_human_gate_verdict"
 
     def test_unanswered_loops_to_drafter(self):
-        """UNANSWERED should loop back to N1 if under max iterations."""
+        """UNANSWERED should loop back to N1 if verdict_count < max."""
         from assemblyzero.workflows.requirements.graph import route_after_review
 
+        # Closes #1509: gate is on verdict_count, not iteration_count.
         state = {
             "error_message": "",
             "config_gates_verdict": False,
             "lld_status": "APPROVED",
             "open_questions_status": "UNANSWERED",
-            "iteration_count": 5,
+            "verdict_count": 5,
             "max_iterations": 20,
         }
 
         assert route_after_review(state) == "N1_generate_draft"
 
     def test_unanswered_at_max_iterations_goes_to_gate(self):
-        """UNANSWERED at max iterations should go to human gate."""
+        """UNANSWERED at verdict_count >= max should go to human gate."""
         from assemblyzero.workflows.requirements.graph import route_after_review
 
         state = {
@@ -220,7 +221,7 @@ class TestRouteAfterReviewOpenQuestions:
             "config_gates_verdict": False,
             "lld_status": "APPROVED",
             "open_questions_status": "UNANSWERED",
-            "iteration_count": 20,
+            "verdict_count": 20,
             "max_iterations": 20,
         }
 

--- a/tests/unit/test_requirements_graph.py
+++ b/tests/unit/test_requirements_graph.py
@@ -303,32 +303,60 @@ class TestGraphRoutingExtended:
         assert result == "HALT"
 
     def test_route_from_review_to_finalize_on_max_iterations(self):
-        """Test routing from review to finalize when max iterations reached."""
+        """Test routing from review to finalize when verdict_count >= max."""
         from assemblyzero.workflows.requirements.graph import route_after_review
 
+        # Closes #1509: gate is on verdict_count (one per N3 review),
+        # not iteration_count (bumped by N1, Ponder, N1B too).
         state = {
             "error_message": "",
             "config_gates_verdict": False,
             "lld_status": "BLOCKED",
-            "iteration_count": 20,
+            "verdict_count": 20,
             "max_iterations": 20,
         }
         result = route_after_review(state)
         assert result == "N5_finalize"
 
     def test_route_from_review_to_draft_when_under_max_iterations(self):
-        """Test routing from review to draft when under max iterations."""
+        """Test routing from review to draft when verdict_count < max."""
         from assemblyzero.workflows.requirements.graph import route_after_review
 
         state = {
             "error_message": "",
             "config_gates_verdict": False,
             "lld_status": "BLOCKED",
-            "iteration_count": 5,
+            "verdict_count": 5,
             "max_iterations": 20,
         }
         result = route_after_review(state)
         assert result == "N1_generate_draft"
+
+    def test_route_from_review_ignores_high_iteration_count_regression_1509(self):
+        """Regression for #1509. High iteration_count must NOT block the
+        revise loop — only verdict_count (number of reviewer verdicts
+        received) gates the cap. Before the fix, iteration_count was bumped
+        to ~3-4 by N1 + Ponder + N1B before the first review even
+        completed, exhausting the default cap of 3 and skipping the loop
+        entirely. The empirical surface: Chiron #37 iter02-04 each ran
+        exactly one N1+N3 and finalized BLOCKED without ever revising.
+        """
+        from assemblyzero.workflows.requirements.graph import route_after_review
+
+        state = {
+            "error_message": "",
+            "config_gates_verdict": False,
+            "lld_status": "BLOCKED",
+            "iteration_count": 999,  # pathologically high — must not gate
+            "verdict_count": 1,      # only one review done; loop must fire
+            "max_iterations": 3,
+        }
+        result = route_after_review(state)
+        assert result == "N1_generate_draft", (
+            "high iteration_count must not pre-emptively gate the revise "
+            "loop closed; only verdict_count >= max_iterations does. "
+            "See #1509 for the empirical surface."
+        )
 
     def test_route_from_human_gate_verdict_to_end(self):
         """Test routing from human gate verdict to END for unknown next_node."""
@@ -368,16 +396,17 @@ class TestGraphRoutingExtended:
         assert result == "END"
 
     def test_route_from_review_uses_default_max_iterations(self):
-        """Test routing from review uses default max_iterations of 20."""
+        """Test routing from review uses default max_iterations of 3."""
         from assemblyzero.workflows.requirements.graph import route_after_review
 
-        # No max_iterations set, should use default of 20
+        # No max_iterations set in state — function defaults to 3.
+        # verdict_count of 19 is well past the default, so finalize.
         state = {
             "error_message": "",
             "config_gates_verdict": False,
             "lld_status": "BLOCKED",
-            "iteration_count": 19,
-            # max_iterations not set - should default to 20
+            "verdict_count": 19,
+            # max_iterations not set - should default to 3
         }
         result = route_after_review(state)
         assert result == "N5_finalize"  # Over default max of 3


### PR DESCRIPTION
## Summary

`route_after_review`'s verdict-revise loop and open-questions loop both checked `iteration_count >= max_iterations` to decide whether to route back to `N1_generate_draft`. But `iteration_count` is bumped by `N1`, `Ponder`, `N1B`, and the human gates on every state-touching forward pass — so by the time the FIRST `N3_review` completes, `iteration_count` is already at or past the default cap of 3. The revise loop never fires.

Empirical surface: Chiron #37 iter02/03/04 each ran exactly one N1+N3 and finalized BLOCKED on first REVISE verdict. Without the in-graph loop, the writer never saw prior verdict feedback. Reviewer kept flagging legitimate Tier 1 concerns; writer kept regenerating the same gaps.

Fix: gate both loops on `verdict_count` (incremented exactly once per N3 call in `review.py:86` — the right semantic for "reviewer verdicts received"). Two-line change in `graph.py`. `iteration_count` stays for the short mechanical-validation loops in `route_after_generate_draft` and `route_after_validate_test_plan`.

Closes #1509

## Test plan

- [x] Existing `test_route_from_review_to_finalize_on_max_iterations` updated to `verdict_count` semantics
- [x] Existing `test_route_from_review_to_draft_when_under_max_iterations` updated
- [x] New `test_route_from_review_ignores_high_iteration_count_regression_1509` — `iteration_count=999, verdict_count=1, max=3` must still loop back. Would have failed before the fix.
- [x] All 23 `test_requirements_graph` tests pass
- [ ] End-to-end: Chiron #37 iter05 should see the revise loop fire across multiple N3 reviews within a single orchestrator invocation, converging toward APPROVED or hitting `max_iterations=3` cleanly