### PR TITLE
fix(review): REVISE with no Tier 1 BLOCKING issues maps to APPROVED (Closes #1511)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -32,6 +32,49 @@ from assemblyzero.workflows.requirements.audit import (
 from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 
 
+# Closes #1511: lines under "## Tier 1: BLOCKING Issues" that mean "no
+# real issues" — boilerplate subcategory placeholders the reviewer emits
+# for Cost / Safety / Security / Legal when nothing is wrong.
+_TIER1_PLACEHOLDER_PATTERNS = (
+    "no issues found",
+    "no blocking issues found",
+)
+
+
+def _count_tier1_blocking_issues(rationale: str) -> int:
+    """Count real Tier 1 BLOCKING issues in the reviewer's rationale.
+
+    The reviewer emits a `## Tier 1: BLOCKING Issues` section containing
+    one subsection per concern category (Cost, Safety, Security, Legal).
+    When no blocking issues exist, each subcategory shows `- [ ] No issues
+    found.` — those are placeholders, not real issues.
+
+    Returns the count of real Tier 1 issue lines after filtering placeholders.
+    Returns 0 if the Tier 1 section is absent or all lines are placeholders.
+
+    Closes #1511.
+    """
+    tier1_match = re.search(
+        r"## Tier 1: BLOCKING Issues\s*\n(.*?)(?=\n## Tier 2|\Z)",
+        rationale,
+        re.DOTALL,
+    )
+    if not tier1_match:
+        return 0
+
+    tier1_section = tier1_match.group(1)
+    issue_lines = re.findall(
+        r"^\s*-\s*\[.\]\s*(.+)$", tier1_section, re.MULTILINE
+    )
+
+    real_issues = [
+        line.strip()
+        for line in issue_lines
+        if not any(p in line.lower() for p in _TIER1_PLACEHOLDER_PATTERNS)
+    ]
+    return len(real_issues)
+
+
 def _invoke_reviewer_with_feedback_schema(
     provider,
     prompt: str,
@@ -172,11 +215,41 @@ Follow the Review Instructions exactly. Be specific about what needs to change f
     # Backward compat: derive `structured` dict for any remaining callers
     structured = {"verdict": verdict_status, "rationale": feedback_result["rationale"]}
 
-    # Map REVISE -> BLOCKED for workflow purposes
-    if verdict_status == "REVISE":
-        lld_status = "BLOCKED"
-    elif verdict_status == "APPROVED":
+    # Closes #1511: REVISE means "there's something to address." Tier 1 =
+    # BLOCKING (must fix). Tier 2 = HIGH PRIORITY (should fix but not a
+    # release blocker). Conflating them halts pipelines when the writer
+    # has converged on Tier 1 but the reviewer still has Tier 2 polish
+    # items. When REVISE has zero Tier 1 issues AND the rationale is
+    # well-formed (has both Tier sections), treat as APPROVED — Tier 2
+    # feedback stays in the review log as known-issues but does not
+    # block the spec stage. Empty / malformed rationales (API failures,
+    # unparseable responses that map UNKNOWN → REVISE) stay BLOCKED.
+    rationale_text = feedback_result.get("rationale", "")
+    well_formed_rationale = (
+        "## Tier 1: BLOCKING Issues" in rationale_text
+        and "## Tier 2:" in rationale_text
+    )
+    if verdict_status == "APPROVED":
         lld_status = "APPROVED"
+    elif verdict_status == "REVISE":
+        tier1_count = _count_tier1_blocking_issues(rationale_text)
+        if well_formed_rationale and tier1_count == 0:
+            lld_status = "APPROVED"
+            print(
+                "    [VERDICT] REVISE with no Tier 1 BLOCKING issues — "
+                "treating as APPROVED (#1511). Tier 2 feedback retained "
+                "in review log as known issues."
+            )
+        elif well_formed_rationale:
+            lld_status = "BLOCKED"
+            print(
+                f"    [VERDICT] REVISE with {tier1_count} Tier 1 "
+                f"BLOCKING issue(s) — BLOCKED."
+            )
+        else:
+            # Malformed rationale (API failure, parser fallback): stay
+            # conservative — BLOCKED rather than silently approving.
+            lld_status = "BLOCKED"
     elif verdict_status == "DISCUSS":
         lld_status = "BLOCKED"
     else:

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -683,15 +683,30 @@ class TestReviewNodeAdditional:
 
     @patch("assemblyzero.workflows.requirements.nodes.review.get_provider")
     def test_review_handles_blocked_status(self, mock_get_provider, tmp_path):
-        """Test review correctly sets BLOCKED status."""
+        """REVISE verdict with explicit Tier 1 BLOCKING issues -> BLOCKED."""
         from assemblyzero.workflows.requirements.nodes.review import review
         from assemblyzero.workflows.requirements.state import create_initial_state
         import json as _json
 
+        # Closes #1511: rationale must include a non-empty Tier 1 BLOCKING
+        # section for REVISE to map to BLOCKED. REVISE with empty Tier 1
+        # now maps to APPROVED (Tier 2 stays as known-issues).
+        rationale_with_tier1 = (
+            "Missing required sections.\n\n"
+            "## Tier 1: BLOCKING Issues\n"
+            "### Safety\n"
+            "- [ ] **CRITICAL** - The draft is missing the Requirements "
+            "section entirely; downstream stages cannot proceed.\n"
+        )
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "REVISE", "rationale": "Missing required sections.", "feedback_items": ["Missing required sections."], "open_questions": []}),
+            content=_json.dumps({
+                "verdict": "REVISE",
+                "rationale": rationale_with_tier1,
+                "feedback_items": ["Missing required sections."],
+                "open_questions": [],
+            }),
             response="BLOCKED: Missing required sections.",
             error_message=None,
             input_tokens=0,
@@ -734,6 +749,177 @@ class TestReviewNodeAdditional:
 
         assert result.get("error_message", "") != ""
         assert "prompt" in result.get("error_message", "").lower()
+
+
+class TestTier1BlockingCounter:
+    """Closes #1511. _count_tier1_blocking_issues distinguishes real Tier 1
+    issues from the placeholder lines the reviewer emits when no blocking
+    issues exist."""
+
+    def test_count_returns_zero_when_no_tier1_section(self):
+        from assemblyzero.workflows.requirements.nodes.review import _count_tier1_blocking_issues
+        assert _count_tier1_blocking_issues("Plain prose with no tier markers") == 0
+
+    def test_count_returns_zero_when_all_placeholders(self):
+        from assemblyzero.workflows.requirements.nodes.review import _count_tier1_blocking_issues
+        rationale = (
+            "## Tier 1: BLOCKING Issues\n"
+            "No blocking issues found.\n"
+            "### Cost\n- [ ] No issues found.\n"
+            "### Safety\n- [ ] No issues found.\n"
+            "### Security\n- [ ] No issues found.\n"
+            "### Legal\n- [ ] No issues found.\n\n"
+            "## Tier 2: HIGH PRIORITY Issues\n"
+            "### Observability\n- [ ] Missing logging.\n"
+        )
+        assert _count_tier1_blocking_issues(rationale) == 0
+
+    def test_count_returns_one_for_single_real_issue(self):
+        from assemblyzero.workflows.requirements.nodes.review import _count_tier1_blocking_issues
+        rationale = (
+            "## Tier 1: BLOCKING Issues\n"
+            "### Safety\n"
+            "- [ ] **CRITICAL** - The CLI writes to arbitrary absolute paths.\n"
+            "\n## Tier 2: HIGH PRIORITY Issues\n"
+        )
+        assert _count_tier1_blocking_issues(rationale) == 1
+
+    def test_count_returns_two_for_multiple_real_issues(self):
+        from assemblyzero.workflows.requirements.nodes.review import _count_tier1_blocking_issues
+        rationale = (
+            "## Tier 1: BLOCKING Issues\n"
+            "### Safety\n"
+            "- [ ] **CRITICAL** - Worktree scope violation.\n"
+            "- [ ] **CRITICAL** - Destructive rmtree on output dir.\n"
+            "\n## Tier 2: HIGH PRIORITY Issues\n"
+        )
+        assert _count_tier1_blocking_issues(rationale) == 2
+
+    def test_count_mixed_placeholders_and_real_issues(self):
+        from assemblyzero.workflows.requirements.nodes.review import _count_tier1_blocking_issues
+        rationale = (
+            "## Tier 1: BLOCKING Issues\n"
+            "### Cost\n- [ ] No issues found.\n"
+            "### Safety\n- [ ] **CRITICAL** - Real safety issue.\n"
+            "### Security\n- [ ] No issues found.\n"
+            "### Legal\n- [ ] No issues found.\n\n"
+            "## Tier 2: HIGH PRIORITY Issues\n"
+        )
+        assert _count_tier1_blocking_issues(rationale) == 1
+
+
+class TestReviewReviseToApprovedOnEmptyTier1:
+    """Closes #1511. When the reviewer marks REVISE but lists no Tier 1
+    BLOCKING issues, the verdict means 'polish needed', not 'must fix to
+    proceed'. The pipeline should treat it as APPROVED so downstream
+    stages can run; Tier 2 feedback stays embedded as known-issues.
+
+    Note: patch target is the review module's local binding
+    (`...nodes.review.get_provider`), NOT the source module — review.py
+    binds `get_provider` at import time so patching the source has no
+    effect on review.py's reference.
+    """
+
+    @patch("assemblyzero.workflows.requirements.nodes.review.get_provider")
+    def test_revise_with_empty_tier1_maps_to_approved(self, mock_get_provider, tmp_path):
+        from assemblyzero.workflows.requirements.nodes.review import review
+        from assemblyzero.workflows.requirements.state import create_initial_state
+        import json as _json
+
+        rationale_no_tier1 = (
+            "Design is sound; some Tier 2 polish.\n\n"
+            "## Tier 1: BLOCKING Issues\n"
+            "No blocking issues found.\n"
+            "### Cost\n- [ ] No issues found.\n"
+            "### Safety\n- [ ] No issues found.\n\n"
+            "## Tier 2: HIGH PRIORITY Issues\n"
+            "### Observability\n- [ ] Missing logging strategy.\n"
+        )
+        mock_provider = Mock()
+        mock_provider.invoke.return_value = Mock(
+            success=True,
+            content=_json.dumps({
+                "verdict": "REVISE",
+                "rationale": rationale_no_tier1,
+                "feedback_items": ["Missing logging strategy."],
+                "open_questions": [],
+            }),
+            response="",
+            error_message=None,
+            input_tokens=0,
+            output_tokens=0,
+        )
+        mock_get_provider.return_value = mock_provider
+
+        prompt_dir = tmp_path / "docs" / "skills"
+        prompt_dir.mkdir(parents=True)
+        (prompt_dir / "0702c-LLD-Review-Prompt.md").write_text("# Prompt")
+
+        state = create_initial_state(
+            workflow_type="lld",
+            assemblyzero_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+        )
+        state["current_draft"] = "# Draft"
+        state["audit_dir"] = str(tmp_path / "audit")
+        Path(state["audit_dir"]).mkdir(parents=True)
+
+        result = review(state)
+
+        assert result.get("lld_status") == "APPROVED", (
+            "REVISE with zero Tier 1 BLOCKING issues should map to APPROVED "
+            "so the pipeline proceeds; Tier 2 stays as embedded known-issues."
+        )
+
+    @patch("assemblyzero.workflows.requirements.nodes.review.get_provider")
+    def test_revise_with_real_tier1_stays_blocked(self, mock_get_provider, tmp_path):
+        from assemblyzero.workflows.requirements.nodes.review import review
+        from assemblyzero.workflows.requirements.state import create_initial_state
+        import json as _json
+
+        rationale_with_tier1 = (
+            "Critical safety issue must be resolved.\n\n"
+            "## Tier 1: BLOCKING Issues\n"
+            "### Safety\n"
+            "- [ ] **CRITICAL** - CLI writes to arbitrary absolute paths.\n\n"
+            "## Tier 2: HIGH PRIORITY Issues\n"
+        )
+        mock_provider = Mock()
+        mock_provider.invoke.return_value = Mock(
+            success=True,
+            content=_json.dumps({
+                "verdict": "REVISE",
+                "rationale": rationale_with_tier1,
+                "feedback_items": ["CLI writes to arbitrary absolute paths."],
+                "open_questions": [],
+            }),
+            response="",
+            error_message=None,
+            input_tokens=0,
+            output_tokens=0,
+        )
+        mock_get_provider.return_value = mock_provider
+
+        prompt_dir = tmp_path / "docs" / "skills"
+        prompt_dir.mkdir(parents=True)
+        (prompt_dir / "0702c-LLD-Review-Prompt.md").write_text("# Prompt")
+
+        state = create_initial_state(
+            workflow_type="lld",
+            assemblyzero_root=str(tmp_path),
+            target_repo=str(tmp_path),
+            issue_number=42,
+        )
+        state["current_draft"] = "# Draft"
+        state["audit_dir"] = str(tmp_path / "audit")
+        Path(state["audit_dir"]).mkdir(parents=True)
+
+        result = review(state)
+
+        assert result.get("lld_status") == "BLOCKED", (
+            "REVISE with real Tier 1 BLOCKING issues must remain BLOCKED."
+        )
 
 
 class TestFinalizeNode:


### PR DESCRIPTION
## Summary

`review_node` previously mapped every REVISE verdict to `lld_status=BLOCKED`, conflating \"Tier 1 blocking issues\" with \"Tier 2 polish items.\" When the writer converges on Tier 1 but the reviewer keeps flagging Tier 2 (logging, edge-case coverage), the pipeline halts via the two-strike stagnation detector even though no real blocker remains.

Empirical: Chiron #37 iter05 had verdict #1 with Tier 1 empty + 2 Tier 2 items; verdict #2 had Tier 1 empty + 1 Tier 2 (writer fixed one between drafts). Both checkboxed REVISE → both BLOCKED → two-strike halt.

Fix: extract Tier 1 BLOCKING count from the rationale (helper filters out the placeholder \"No issues found\" lines). When REVISE has zero Tier 1 AND rationale is well-formed (both Tier sections present), map to APPROVED. Tier 2 feedback stays embedded as known-issues.

Conservative on edge cases — empty/malformed rationale (API failures, regex fallback paths) stays BLOCKED. Explicit Tier 1 issues stay BLOCKED. Only the specific REVISE+zero-Tier-1+well-formed combination upgrades.

Closes #1511

## Test plan

- [x] `TestTier1BlockingCounter` — 5 helper unit tests
- [x] `TestReviewReviseToApprovedOnEmptyTier1` — 2 integration tests (REVISE+empty → APPROVED; REVISE+Tier1 → BLOCKED)
- [x] Existing `test_review_handles_blocked_status` updated with realistic Tier 1 rationale
- [x] All 4348 unit tests pass
- [ ] End-to-end: Chiron #37 iter06 should reach spec stage; the writer is already converging on Tier 1 per iter05 evidence