### PR TITLE
fix(import_validator): recognize PEP 621 deps + skip relative imports (Closes #1515, #1516)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
@@ -24,8 +24,16 @@ _KNOWN_THIRD_PARTY: frozenset[str] = frozenset({
 def _read_third_party_packages(repo_root: Path) -> set[str]:
     """Extract third-party package names from pyproject.toml.
 
-    Reads [tool.poetry.dependencies] and [tool.poetry.group.*.dependencies]
-    to build a set of top-level import names.
+    Reads three pyproject layouts:
+    - `[tool.poetry.dependencies]` + `[tool.poetry.group.*.dependencies]`
+      (Poetry, legacy).
+    - `[project] dependencies = [...]` + `[project.optional-dependencies]`
+      (PEP 621, canonical).
+    - `[dependency-groups]` (PEP 735, used by uv / hatch / modern tooling).
+
+    Closes #1515: previously only the Poetry tables were read, so every
+    external repo using PEP 621 lost its declared dependencies and every
+    third-party import got misclassified as "unresolvable internal."
     """
     pyproject = repo_root / "pyproject.toml"
     if not pyproject.exists():
@@ -44,17 +52,62 @@ def _read_third_party_packages(repo_root: Path) -> set[str]:
 
     packages: set[str] = set()
 
-    # Main dependencies
+    # Poetry: [tool.poetry.dependencies] and [tool.poetry.group.*.dependencies]
     poetry = data.get("tool", {}).get("poetry", {})
     for dep_name in poetry.get("dependencies", {}):
         packages.add(_normalize_package_name(dep_name))
-
-    # Group dependencies (dev, test, etc.)
     for group in poetry.get("group", {}).values():
         for dep_name in group.get("dependencies", {}):
             packages.add(_normalize_package_name(dep_name))
 
+    # PEP 621: [project] dependencies = ["pypdf>=5.0.0", ...]
+    project = data.get("project", {})
+    for spec in project.get("dependencies", []):
+        name = _extract_package_name_from_pep508(spec)
+        if name:
+            packages.add(_normalize_package_name(name))
+    # PEP 621: [project.optional-dependencies]
+    for group_specs in project.get("optional-dependencies", {}).values():
+        for spec in group_specs:
+            name = _extract_package_name_from_pep508(spec)
+            if name:
+                packages.add(_normalize_package_name(name))
+
+    # PEP 735: [dependency-groups] dev = ["pytest>=9.0.3", ...]
+    for group_specs in data.get("dependency-groups", {}).values():
+        if not isinstance(group_specs, list):
+            continue
+        for spec in group_specs:
+            if not isinstance(spec, str):
+                continue
+            name = _extract_package_name_from_pep508(spec)
+            if name:
+                packages.add(_normalize_package_name(name))
+
     return packages
+
+
+def _extract_package_name_from_pep508(spec: str) -> str:
+    """Extract the package name from a PEP 508 dependency spec.
+
+    Handles common forms:
+    - `"pypdf"` -> `"pypdf"`
+    - `"pypdf>=5.0.0"` -> `"pypdf"`
+    - `"pytest (>=9.0.3,<10.0.0)"` -> `"pytest"`  (Poetry whitespace form)
+    - `"pytest-cov[extra]>=7"` -> `"pytest-cov"`
+
+    Returns empty string on malformed input rather than raising.
+    """
+    if not spec or not isinstance(spec, str):
+        return ""
+    # Strip whitespace, then take the part before any version/extras marker.
+    s = spec.strip()
+    # Cut on the first occurrence of any spec-terminator char.
+    for ch in (" ", "[", "(", ">", "<", "=", "!", "~", ";"):
+        idx = s.find(ch)
+        if idx > 0:
+            s = s[:idx]
+    return s.strip()
 
 
 def _normalize_package_name(name: str) -> str:
@@ -101,6 +154,13 @@ def validate_imports(
             for alias in node.names:
                 imports.append((alias.name, node.lineno))
         elif isinstance(node, ast.ImportFrom):
+            # Closes #1516: relative imports (level > 0, e.g. `from .chunker
+            # import X`) are intra-package by definition. Without knowing
+            # the importing file's package the validator can't resolve them
+            # against repo_root paths; Python's import machinery will catch
+            # genuine misses at test/runtime, so skip rather than flag.
+            if node.level and node.level > 0:
+                continue
             if node.module:
                 imports.append((node.module, node.lineno))
 

--- a/tests/unit/test_import_validator.py
+++ b/tests/unit/test_import_validator.py
@@ -94,6 +94,153 @@ def test_unresolvable_returns_false(tmp_path):
     assert _resolve_internal_import("nonexistent.module", tmp_path) is False
 
 
+def test_pep621_dependencies_recognized(tmp_path):
+    """Closes #1515. PEP 621 [project] dependencies must be recognized
+    as third-party. Without this, every PEP 621 repo's deps get flagged
+    as 'unresolvable internal' imports."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = [\n'
+        '    "pypdf>=5.0.0",\n'
+        '    "pyyaml>=6.0",\n'
+        ']\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "pypdf" in pkgs
+    assert "pyyaml" in pkgs
+
+
+def test_pep621_optional_dependencies_recognized(tmp_path):
+    """Closes #1515. [project.optional-dependencies] also recognized."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = []\n'
+        '[project.optional-dependencies]\n'
+        'extras = ["rich>=13"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "rich" in pkgs
+
+
+def test_pep735_dependency_groups_recognized(tmp_path):
+    """Closes #1515. [dependency-groups] (PEP 735, uv/hatch) recognized."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = []\n'
+        '[dependency-groups]\n'
+        'dev = ["pytest (>=9.0.3,<10.0.0)"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "pytest" in pkgs
+
+
+def test_chiron_iter07_pyproject_repro(tmp_path):
+    """Closes #1515. Verbatim Chiron #37 iter07 pyproject shape:
+    PEP 621 [project] with pypdf + pyyaml. Validator must pick them up."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'version = "0.1.0"\n'
+        'dependencies = [\n'
+        '    "pypdf>=5.0.0",\n'
+        '    "pyyaml>=6.0",\n'
+        ']\n'
+    )
+    (tmp_path / "src" / "chiron" / "corpus").mkdir(parents=True)
+    (tmp_path / "src" / "chiron" / "corpus" / "__init__.py").write_text("")
+
+    code = (
+        '"""Extract MPEP PDFs."""\n'
+        'from pathlib import Path\n'
+        'from typing import Iterator\n'
+        '\n'
+        'import pypdf\n'
+        'import yaml\n'
+        '\n'
+        'def extract(path: Path) -> Iterator[str]:\n'
+        '    return iter([])\n'
+    )
+    valid, bad = validate_imports(code, "src/chiron/corpus/extractor.py", tmp_path)
+    # pypdf is in deps; yaml is not (the package is "pyyaml" but imports as "yaml")
+    # so yaml would still be flagged — that's a separate concern about
+    # import-name-vs-package-name (not part of #1515).
+    assert "pypdf" not in [b.split()[0] for b in bad], (
+        f"pypdf should be recognized via PEP 621 deps; got bad={bad!r}"
+    )
+
+
+def test_relative_imports_skipped_single_dot(tmp_path):
+    """Closes #1516. `from .chunker import X` must not be flagged."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    code = (
+        '"""Module using relative imports."""\n'
+        'from .chunker import chunk_by_section\n'
+        '\n'
+        'def go():\n'
+        '    return chunk_by_section\n'
+    )
+    valid, bad = validate_imports(code, "src/chiron/corpus/extractor.py", tmp_path)
+    assert valid is True, f"relative import should be skipped, got bad={bad!r}"
+    assert bad == []
+
+
+def test_relative_imports_skipped_double_dot(tmp_path):
+    """Closes #1516. `from ..foo import Y` must not be flagged."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    code = (
+        '"""Module using double-dot relative imports."""\n'
+        'from ..provenance import Citation\n'
+        '\n'
+        'def go():\n'
+        '    return Citation\n'
+    )
+    valid, bad = validate_imports(code, "src/chiron/corpus/extractor.py", tmp_path)
+    assert valid is True, f"double-dot relative should be skipped, got bad={bad!r}"
+    assert bad == []
+
+
+def test_relative_dot_only_skipped(tmp_path):
+    """Closes #1516. `from . import bar` must not be flagged."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    code = "from . import chunker\n\ndef go():\n    return chunker\n"
+    valid, bad = validate_imports(code, "src/chiron/corpus/extractor.py", tmp_path)
+    assert valid is True, f"dot-only relative should be skipped, got bad={bad!r}"
+    assert bad == []
+
+
+def test_absolute_imports_still_validated(tmp_path):
+    """Closes #1516. Regression guard: absolute imports of nonexistent
+    modules must still be flagged (the fix only skips relative imports)."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    code = "from nonexistent.module import X\n\ndef go(): pass\n"
+    valid, bad = validate_imports(code, "src/chiron/corpus/extractor.py", tmp_path)
+    assert valid is False, "absolute nonexistent import must be flagged"
+    assert any("nonexistent" in b for b in bad)
+
+
 def test_chiron_iter06_repro(tmp_path):
     """Verbatim shape from iter06 halt: src/chiron/provenance.py exists
     on disk, test file does `from chiron.provenance import Citation`,


### PR DESCRIPTION
## Summary

Two related defects in the impl-stage import validator, surfaced by Chiron #37 iter07. Same file, scoped fix in one PR.

**#1515:** `_read_third_party_packages` only read `[tool.poetry.*]` tables. Modern repos using PEP 621 (`[project] dependencies`) or PEP 735 (`[dependency-groups]`) returned empty; every third-party import got flagged as 'unresolvable internal.' Empirical: Chiron #37 iter07 added `pypdf>=5.0.0` to PEP 621 deps via the impl stage's earlier pyproject step, then immediately failed validation on `import pypdf` in the next file.

**#1516:** `validate_imports` ignored `node.level` on `ast.ImportFrom`. `from .chunker import X` got captured as top-level name `chunker` and flagged. Relative imports are intra-package by definition.

Both fixes are local to `import_validator.py`. Closes #1515 and #1516.

## Test plan

- [x] 8 new tests in `test_import_validator.py` covering PEP 621 + PEP 735 + relative-import variants + regression guard
- [x] 4362 unit tests pass (was 4354 + 8 new)
- [ ] End-to-end: Chiron #37 iter08 should clear the impl-stage import validator and progress through file generation