### PR TITLE
fix(import_validator): map PyPI dist names to import names (Closes #1518)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/import_validator.py
@@ -21,6 +21,74 @@ _KNOWN_THIRD_PARTY: frozenset[str] = frozenset({
 })
 
 
+# Closes #1518: PyPI package names frequently differ from import names.
+# `pip install pyyaml` installs the `yaml` module; `pip install Pillow`
+# installs `PIL`. The validator must map declared deps to the top-level
+# names they actually expose. Seed the common cases that bite real
+# projects; extend as new ones surface.
+_PYPI_TO_IMPORT_NAMES: dict[str, frozenset[str]] = {
+    "pyyaml": frozenset({"yaml"}),
+    "python_dateutil": frozenset({"dateutil"}),
+    "python_jose": frozenset({"jose"}),
+    "pillow": frozenset({"PIL"}),
+    "beautifulsoup4": frozenset({"bs4"}),
+    "opencv_python": frozenset({"cv2"}),
+    "opencv_python_headless": frozenset({"cv2"}),
+    "scikit_learn": frozenset({"sklearn"}),
+    "scikit_image": frozenset({"skimage"}),
+    "protobuf": frozenset({"google", "google.protobuf"}),
+    "msgpack_python": frozenset({"msgpack"}),
+    "attrs": frozenset({"attr", "attrs"}),
+    "snowflake_connector_python": frozenset({"snowflake"}),
+    "google_cloud_storage": frozenset({"google"}),
+    "google_cloud_bigquery": frozenset({"google"}),
+    "google_cloud_pubsub": frozenset({"google"}),
+}
+
+
+def _import_names_for_pypi(pypi_name_normalized: str) -> set[str]:
+    """Return the import-time top-level name(s) a PyPI dist exposes.
+
+    Closes #1518. The validator must recognize both the PyPI distribution
+    name and any top-level module name the dist installs as. Tries:
+
+    1. Hardcoded mapping for well-known mismatches.
+    2. importlib.metadata.top_level.txt of the locally-installed dist
+       (authoritative when the venv has the package installed; opportunistic).
+    3. Fallback: the normalized PyPI name itself (matches when import name
+       == PyPI name, the common case).
+
+    Returns a set that always contains the normalized PyPI name plus any
+    additional import names discovered.
+    """
+    names: set[str] = {pypi_name_normalized}
+
+    hardcoded = _PYPI_TO_IMPORT_NAMES.get(pypi_name_normalized)
+    if hardcoded:
+        names.update(hardcoded)
+
+    try:
+        import importlib.metadata as md
+        for dist in md.distributions():
+            dist_name = dist.metadata.get("Name", "")
+            if not dist_name:
+                continue
+            if _normalize_package_name(dist_name) != pypi_name_normalized:
+                continue
+            top_level = dist.read_text("top_level.txt") or ""
+            for line in top_level.splitlines():
+                module = line.strip()
+                if module:
+                    names.add(module)
+            break
+    except Exception:
+        # importlib.metadata may not work in every env (e.g. fresh worktree
+        # before poetry install); fall back to the hardcoded map.
+        pass
+
+    return names
+
+
 def _read_third_party_packages(repo_root: Path) -> set[str]:
     """Extract third-party package names from pyproject.toml.
 
@@ -52,26 +120,34 @@ def _read_third_party_packages(repo_root: Path) -> set[str]:
 
     packages: set[str] = set()
 
+    def _register(pypi_name: str) -> None:
+        """Register a PyPI dep + every top-level import name it exposes.
+        Closes #1518."""
+        normalized = _normalize_package_name(pypi_name)
+        if not normalized:
+            return
+        packages.update(_import_names_for_pypi(normalized))
+
     # Poetry: [tool.poetry.dependencies] and [tool.poetry.group.*.dependencies]
     poetry = data.get("tool", {}).get("poetry", {})
     for dep_name in poetry.get("dependencies", {}):
-        packages.add(_normalize_package_name(dep_name))
+        _register(dep_name)
     for group in poetry.get("group", {}).values():
         for dep_name in group.get("dependencies", {}):
-            packages.add(_normalize_package_name(dep_name))
+            _register(dep_name)
 
     # PEP 621: [project] dependencies = ["pypdf>=5.0.0", ...]
     project = data.get("project", {})
     for spec in project.get("dependencies", []):
         name = _extract_package_name_from_pep508(spec)
         if name:
-            packages.add(_normalize_package_name(name))
+            _register(name)
     # PEP 621: [project.optional-dependencies]
     for group_specs in project.get("optional-dependencies", {}).values():
         for spec in group_specs:
             name = _extract_package_name_from_pep508(spec)
             if name:
-                packages.add(_normalize_package_name(name))
+                _register(name)
 
     # PEP 735: [dependency-groups] dev = ["pytest>=9.0.3", ...]
     for group_specs in data.get("dependency-groups", {}).values():
@@ -82,7 +158,7 @@ def _read_third_party_packages(repo_root: Path) -> set[str]:
                 continue
             name = _extract_package_name_from_pep508(spec)
             if name:
-                packages.add(_normalize_package_name(name))
+                _register(name)
 
     return packages
 

--- a/tests/unit/test_import_validator.py
+++ b/tests/unit/test_import_validator.py
@@ -241,6 +241,93 @@ def test_absolute_imports_still_validated(tmp_path):
     assert any("nonexistent" in b for b in bad)
 
 
+def test_pyyaml_dep_recognizes_yaml_import(tmp_path):
+    """Closes #1518. PyYAML installs the `yaml` top-level module; declaring
+    pyyaml in deps must register `yaml` so `import yaml` is recognized."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = ["pyyaml>=6.0"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "yaml" in pkgs, f"Expected yaml import name from pyyaml dep, got {pkgs}"
+
+
+def test_pillow_dep_recognizes_pil_import(tmp_path):
+    """Closes #1518. Pillow → PIL (case-insensitive normalize)."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = ["Pillow>=10"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "PIL" in pkgs, f"Expected PIL import name from Pillow dep, got {pkgs}"
+
+
+def test_beautifulsoup4_dep_recognizes_bs4_import(tmp_path):
+    """Closes #1518. beautifulsoup4 → bs4."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = ["beautifulsoup4>=4.12"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "bs4" in pkgs
+
+
+def test_unmapped_pypi_name_still_normalizes(tmp_path):
+    """Closes #1518 regression: package names not in the mapping table
+    still go through the normal hyphen→underscore normalize path."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        _read_third_party_packages,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = ["pytest-cov>=7"]\n'
+    )
+    pkgs = _read_third_party_packages(tmp_path)
+    assert "pytest_cov" in pkgs
+
+
+def test_chiron_iter10_full_import_validation(tmp_path):
+    """Closes #1518. Verbatim iter10 shape: pyproject with pypdf + pyyaml,
+    code does `import yaml` — must pass validation, not flag yaml as
+    unresolvable."""
+    from assemblyzero.workflows.testing.nodes.implementation.import_validator import (
+        validate_imports,
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "chiron"\n'
+        'dependencies = [\n'
+        '    "pypdf>=5.0.0",\n'
+        '    "pyyaml>=6.0",\n'
+        ']\n'
+    )
+    code = (
+        '"""CLI entry."""\n'
+        'import argparse\n'
+        'import logging\n'
+        'from pathlib import Path\n'
+        '\n'
+        'import yaml\n'
+        '\n'
+        'def main(): pass\n'
+    )
+    valid, bad = validate_imports(code, "src/chiron/corpus/cli.py", tmp_path)
+    assert valid is True, f"Expected valid, got bad={bad!r}"
+
+
 def test_chiron_iter06_repro(tmp_path):
     """Verbatim shape from iter06 halt: src/chiron/provenance.py exists
     on disk, test file does `from chiron.provenance import Citation`,


### PR DESCRIPTION
## Summary

PyPI distribution names and Python import names differ for ~15 common packages: pyyaml→yaml, Pillow→PIL, beautifulsoup4→bs4, opencv-python→cv2, scikit-learn→sklearn, protobuf→google, etc. The validator only normalized hyphens to underscores; declaring `pyyaml` in deps never registered the `yaml` import name.

Empirical: Chiron #37 iter10 halted at impl with `Unresolvable imports: yaml (line 9)` even though pyyaml>=6.0 was correctly declared in `[project] dependencies`.

Fix: hardcoded `_PYPI_TO_IMPORT_NAMES` map for the common cases + opportunistic `importlib.metadata` fallback for locally-installed dists. `_register()` helper registers PyPI name + every exposed import name for every dep across Poetry/PEP 621/PEP 735.

Closes #1518

## Test plan

- [x] 5 new tests covering pyyaml→yaml, Pillow→PIL, beautifulsoup4→bs4, regression for unmapped names, full Chiron iter10 repro
- [x] 4367 unit tests pass (was 4362)
- [ ] End-to-end: Chiron #37 iter11 should clear the impl stage and progress to PR