### PR TITLE
fix(orchestrator/triage): synthesize brief from GitHub issue body on fresh issue (Closes #1508)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -11,6 +11,10 @@ Each stage function:
 from __future__ import annotations
 
 from assemblyzero.utils.shell import run_command
+import json
+import os
+import subprocess
+import tempfile
 import time
 from pathlib import Path
 
@@ -147,6 +151,78 @@ def _classify_halt_transience(sub_result: dict) -> bool | None:
     return bool(plan.get("is_transient", False))
 
 
+def _fetch_issue_body_to_temp_brief(
+    issue_number: int,
+    target_repo: str,
+) -> tuple[str, str]:
+    """Closes #1508: fetch the GitHub issue body and write it to a temp file
+    so the triage workflow has a `brief_file` to feed `_load_brief`.
+
+    The triage sub-workflow (workflow_type=\"issue\") requires `brief_file`
+    in its state. When the operator pre-authored `docs/lineage/{N}/issue-brief.md`,
+    `detect_existing_artifacts` finds it and `should_skip_stage` returns
+    early — the sub-workflow is never invoked. When no such brief exists
+    (the fresh-external-issue case observed on Chiron #37), the
+    sub-workflow IS invoked but `_load_brief` short-circuits with
+    \"No brief file specified\" and the stage halts in 0 seconds.
+
+    This helper plugs the gap: synthesize a brief from the GitHub issue
+    body itself, write it to a temp file, and pass that file path as
+    `brief_file`. The operator-authored Michelle-voice brief still
+    overrides via `should_skip_stage` when present.
+
+    Returns:
+        (temp_path, error_message). Exactly one is non-empty.
+    """
+    if not target_repo:
+        return ("", "target_repo not specified — cannot resolve issue from gh")
+
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+            cwd=target_repo,
+        )
+    except subprocess.SubprocessError as exc:
+        return ("", f"gh issue view failed for #{issue_number}: {exc}")
+
+    if result.returncode != 0:
+        return ("", f"gh issue view #{issue_number} non-zero: {result.stderr.strip()}")
+    if not result.stdout:
+        return ("", f"empty response from gh issue view #{issue_number}")
+
+    try:
+        issue_data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return ("", f"failed to parse gh issue view JSON: {exc}")
+
+    issue_title = issue_data.get("title", "").strip()
+    issue_body = issue_data.get("body", "")
+    if not issue_body.strip():
+        return ("", f"issue #{issue_number} body is empty — no content to synthesize a brief from")
+
+    # Minimal brief: just the title + body. The triage sub-workflow's
+    # drafter/reviewer process this further; we are NOT pre-Michelle-voice
+    # rewriting here — the operator's hand-authored brief at
+    # docs/lineage/{N}/issue-brief.md remains the override path.
+    brief_content = f"# {issue_title}\n\n{issue_body}\n"
+
+    fd, temp_path = tempfile.mkstemp(
+        prefix=f"orchestrator-issue-{issue_number}-",
+        suffix=".md",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(brief_content)
+    except OSError as exc:
+        return ("", f"failed to write temp brief: {exc}")
+
+    return (temp_path, "")
+
+
 def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute issue triage workflow.
 
@@ -169,6 +245,27 @@ def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
         )
         return update_stage_result(state, stage, result)
 
+    # Closes #1508: when no operator-authored brief exists at
+    # docs/lineage/{N}/issue-brief.md, synthesize one from the GitHub issue
+    # body and pass it as `brief_file` so `_load_brief` doesn't halt with
+    # "No brief file specified."
+    brief_file, brief_err = _fetch_issue_body_to_temp_brief(
+        issue_number, state.get("target_repo", ""),
+    )
+    if brief_err:
+        result = _make_stage_result(
+            status="failed",
+            error_message=(
+                "Triage stage: cannot synthesize brief from GitHub issue — "
+                f"{brief_err}. Workaround: hand-author "
+                f"docs/lineage/{issue_number}/issue-brief.md in the target "
+                "repo and re-run."
+            ),
+            duration_seconds=time.monotonic() - start_time,
+            attempts=0,
+        )
+        return update_stage_result(state, stage, result)
+
     # Execute triage sub-workflow
     try:
         # Import here to avoid circular dependencies and allow mocking
@@ -186,6 +283,7 @@ def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
             "workflow_type": "issue",
             "target_repo": state.get("target_repo", ""),
             "assemblyzero_root": state.get("assemblyzero_root", ""),
+            "brief_file": brief_file,  # Closes #1508
             "config_drafter": stage_cfg.get("drafter", ""),
             "config_reviewer": stage_cfg.get("reviewer", ""),
             "config_effort": stage_cfg.get("effort", ""),

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -59,10 +59,14 @@ def _external_state():
 # --- stage threading -------------------------------------------------------
 
 
+@patch("assemblyzero.workflows.orchestrator.stages._fetch_issue_body_to_temp_brief")
 @patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")
 @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
-def test_triage_threads_target_repo(mock_detect, mock_create_graph):
+def test_triage_threads_target_repo(mock_detect, mock_create_graph, mock_fetch):
     mock_detect.return_value = {k: None for k in ("triage", "lld", "spec", "impl", "pr")}
+    # #1508: the fresh-issue path now fetches the issue body and writes a
+    # temp brief. Mock the helper so the test doesn't shell out to gh.
+    mock_fetch.return_value = ("/fake/tmp/orchestrator-issue-5.md", "")
     captured: dict = {}
     mock_create_graph.return_value = _capturing_graph(captured, {"issue_brief_path": ""})
 
@@ -70,6 +74,8 @@ def test_triage_threads_target_repo(mock_detect, mock_create_graph):
 
     assert captured["target_repo"] == EXTERNAL
     assert captured["assemblyzero_root"] == AZ_ROOT
+    # #1508: brief_file is now threaded into the sub-workflow state
+    assert captured["brief_file"] == "/fake/tmp/orchestrator-issue-5.md"
 
 
 @patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -462,3 +462,117 @@ class TestRunStageNodeRetrySkip:
 
         assert call_count["n"] == 1
         assert result["stage_results"]["triage"]["status"] == "passed"
+
+
+class TestTriageBriefSynthesis:
+    """#1508: Triage stage synthesizes a brief from the GitHub issue body
+    when no operator-authored brief exists at docs/lineage/{N}/issue-brief.md.
+
+    Pre-fix: the triage sub-workflow's `_load_brief` halted with "No brief
+    file specified" in 0 seconds because `brief_file` wasn't threaded into
+    the sub-workflow state. This hit every external smoke build on a fresh
+    issue with no pre-authored brief (first observed on Chiron #37).
+    """
+
+    @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
+    @patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")
+    @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
+    def test_triage_fetches_issue_body_when_no_brief_exists(
+        self, mock_detect, mock_create_graph, mock_subprocess,
+    ):
+        """When no brief on disk: fetch issue body, write temp brief, pass it
+        as `brief_file` to the sub-workflow."""
+        import json as _json
+
+        # No existing artifact at docs/lineage/{N}/issue-brief.md
+        mock_detect.return_value = {k: None for k in ("triage", "lld", "spec", "impl", "pr")}
+
+        # Mock `gh issue view` returning a non-empty body
+        gh_result = MagicMock()
+        gh_result.returncode = 0
+        gh_result.stdout = _json.dumps({
+            "title": "Fresh issue from GitHub",
+            "body": "Body content the operator never pre-authored a Michelle-voice brief for.",
+        })
+        gh_result.stderr = ""
+        mock_subprocess.return_value = gh_result
+
+        # Capture what the sub-workflow receives
+        captured: dict = {}
+        app = MagicMock()
+        def _invoke(payload):
+            captured.update(payload)
+            return {"issue_brief_path": "/fake/produced/brief.md"}
+        app.invoke.side_effect = _invoke
+        graph = MagicMock()
+        graph.compile.return_value = app
+        mock_create_graph.return_value = graph
+
+        state = create_initial_state(
+            37, get_default_config(),
+            target_repo="/fake/projects/Chiron",
+            assemblyzero_root="/fake/projects/AssemblyZero",
+        )
+
+        result = run_triage_stage(state)
+
+        # gh was called for the right issue against the right cwd
+        gh_call = mock_subprocess.call_args
+        assert gh_call is not None
+        args = gh_call[0][0]
+        assert args[:4] == ["gh", "issue", "view", "37"]
+        assert gh_call[1]["cwd"] == "/fake/projects/Chiron"
+
+        # brief_file was threaded into the sub-workflow state
+        assert "brief_file" in captured
+        assert captured["brief_file"]  # non-empty path
+        # The temp brief file actually contains the synthesized brief
+        with open(captured["brief_file"], encoding="utf-8") as f:
+            content = f.read()
+        assert "Fresh issue from GitHub" in content
+        assert "Body content the operator never pre-authored" in content
+
+        # Stage no longer halts at the pre-fix "No brief file specified"
+        # gate. Final status reflects the sub-workflow's return — in this
+        # test the mocked brief_path doesn't exist on disk so the stage
+        # registers as failed-after-sub-workflow rather than failed-pre-fetch.
+        # The important assertion is the brief_file threading above; status
+        # here would only be "passed" with a real produced file.
+        triage_result = result["stage_results"]["triage"]
+        if triage_result["status"] == "failed":
+            # Verify it's the post-sub-workflow failure, NOT the
+            # cannot-synthesize-brief halt from the bug or the missing-
+            # brief_file pre-fix halt.
+            err = triage_result.get("error_message", "")
+            assert "cannot synthesize brief" not in err
+            assert "No brief file specified" not in err
+
+    @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
+    @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
+    def test_triage_fails_gracefully_when_gh_issue_fetch_errors(
+        self, mock_detect, mock_subprocess,
+    ):
+        """When gh fails (issue doesn't exist, network, etc.): stage halts
+        with a clear error pointing at the workaround, NOT silently calls
+        the sub-workflow with empty brief_file."""
+        mock_detect.return_value = {k: None for k in ("triage", "lld", "spec", "impl", "pr")}
+
+        gh_result = MagicMock()
+        gh_result.returncode = 1
+        gh_result.stdout = ""
+        gh_result.stderr = "GraphQL: Could not resolve to an Issue"
+        mock_subprocess.return_value = gh_result
+
+        state = create_initial_state(
+            99999, get_default_config(),
+            target_repo="/fake/projects/Chiron",
+            assemblyzero_root="/fake/projects/AssemblyZero",
+        )
+
+        result = run_triage_stage(state)
+
+        assert result["stage_results"]["triage"]["status"] == "failed"
+        err = result["stage_results"]["triage"]["error_message"]
+        assert "cannot synthesize brief" in err
+        # Points the operator at the workaround
+        assert "docs/lineage/99999/issue-brief.md" in err


### PR DESCRIPTION
## Summary

`run_triage_stage` invoked the requirements sub-workflow with `workflow_type=\"issue\"` but did NOT thread `brief_file`. `_load_brief` short-circuited with `"No brief file specified"`. Stage halted in 0s. Hit every external smoke build on a fresh issue with no operator-pre-authored brief (first observed on Chiron #37).

## Why this was hidden

Chiron #4 had an operator-authored brief at `docs/lineage/4/issue-brief.md` from a prior session. `should_skip_stage` returned early at the artifact-detection gate and the sub-workflow was never invoked. The empty-`brief_file` path only ran when no brief existed at all.

## Fix (Option A from the issue body — labeled "smallest blast radius")

New helper `_fetch_issue_body_to_temp_brief` fetches the GitHub issue body via `gh issue view`, synthesizes a minimal `# title \n\n body` brief, writes it to a tempfile, and `run_triage_stage` passes that path as `brief_file` to the sub-workflow.

The operator-authored Michelle-voice brief at `docs/lineage/{N}/issue-brief.md` continues to override via `should_skip_stage` when present. We are NOT pre-Michelle-voice rewriting in this helper — that remains the operator's job when they want the higher-fidelity brief.

When the fetch itself fails (issue doesn't exist, network, empty body), the stage halts with a clear error message that points the operator at the workaround: \"hand-author docs/lineage/{N}/issue-brief.md and re-run.\"

## Tests

3 changes (4372 total unit tests pass):

- `test_triage_fetches_issue_body_when_no_brief_exists` — mocks `gh issue view`, verifies `brief_file` is threaded into the captured sub-workflow payload, and the temp file's content matches what gh returned
- `test_triage_fails_gracefully_when_gh_issue_fetch_errors` — gh returns non-zero → stage = \"failed\" with an operator-actionable error pointing at the workaround
- `test_triage_threads_target_repo` (updated) — pre-existing repo-threading test now also asserts `brief_file` appears in the captured payload

## Not done in this PR

- Option B (cross-cutting `_load_brief` fallback to `_load_issue`) — deferred
- Option C (status quo + docs) — explicitly NOT pursued
- Pre-Michelle-voice rewriting of the fetched issue body — operator's call when desired

Closes #1508