### PR TITLE
fix(new_repo_setup): preserve case in GitHub repo name (Closes #1533)

### DIFF
--- a/docs/runbooks/0927-new-repo-human-checklist.md
+++ b/docs/runbooks/0927-new-repo-human-checklist.md
@@ -190,7 +190,7 @@ Steps in **bold** require classic-PAT scopes. The PAT never enters the env block
 
 The script handles all of the following automatically:
 - Local directory structure + all config files
-- GitHub repo creation (forced lowercase) + initial push of non-workflow files
+- GitHub repo creation (case preserved from the input name; #1533) + initial push of non-workflow files
 - Workflow file upload via Contents API (one PUT per file)
 - Repo settings: wiki disabled, projects disabled, squash-only merge, delete branch on merge
 - Branch protection: require PR (1 review), block force push, block deletion, enforce_admins, pr-sentinel check

--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -1187,3 +1187,55 @@ class TestProjectTypeBranchingCallSite:
         create_claude_md(tmp_path, "myrepo", "alice")
         text = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
         assert "**Stack:**" not in text
+
+
+class TestGitHubRepoNameCasePreservation:
+    """#1533: GitHub repo name preserves the operator's input case verbatim.
+
+    Pre-fix: line 2671 of the script unconditionally did
+    `repo_name_lower = args.name.lower()` before sending the name to GitHub.
+    Result: `Chiron` input produced `martymcenroe/chiron` on GitHub while the
+    local directory at `Projects/Chiron/` kept its case — asymmetric and
+    against the operator's intent.
+
+    The fix is structural (remove the variable; use `args.name` directly in
+    all 14 GitHub-side call sites). This regression pin asserts the variable
+    name is gone from the script so a future edit can't quietly reintroduce
+    the lowercase normalization. The fix-anchor comment naming the issue
+    must also be present.
+    """
+
+    def test_no_lowercased_repo_name_variable_in_script(self):
+        from pathlib import Path
+        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        content = script.read_text(encoding="utf-8")
+        assert "repo_name_lower" not in content, (
+            "regression: `repo_name_lower` was reintroduced. The GitHub repo "
+            "name must preserve the operator's input case verbatim — use "
+            "`args.name` in the GitHub-create / -PATCH / -GET paths instead. "
+            "See AssemblyZero #1533."
+        )
+
+    def test_fix_anchor_comment_naming_issue_present(self):
+        """The inline comment naming #1533 should remain at the GitHub-create
+        site so a future agent reading the code understands why no
+        lowercasing happens there."""
+        from pathlib import Path
+        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        content = script.read_text(encoding="utf-8")
+        assert "#1533" in content
+        # The comment must sit in the GitHub-side flow. Use the `GITHUB REMOTE`
+        # banner print as the canonical anchor for that flow — it appears
+        # exactly once and only inside the post-no-github-gate block.
+        gh_banner = content.find("GITHUB REMOTE (single classic-PAT")
+        anchor = content.find("#1533")
+        assert gh_banner != -1 and anchor != -1
+        # The comment naming #1533 should appear within ~600 chars BEFORE
+        # the banner (the comment explains why no lowercase happens at this
+        # gate; banner follows immediately after).
+        delta = gh_banner - anchor
+        assert 0 < delta < 600, (
+            f"#1533 comment is at offset {anchor}; GITHUB REMOTE banner at "
+            f"{gh_banner} (delta={delta}). The fix-anchor comment is no "
+            "longer adjacent to the GitHub-side flow it explains."
+        )

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -2668,7 +2668,13 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("\nWARNING: Some local checks failed. Review and fix before starting work!")
 
     if not args.no_github:
-        repo_name_lower = args.name.lower()
+        # Closes #1533: the GitHub repo name preserves the operator's input
+        # case verbatim. Prior code unconditionally lowercased here, which
+        # produced `martymcenroe/chiron` from `Chiron` input. GitHub's REST
+        # API is case-insensitive for lookup and case-preserved for display,
+        # so passing the verbatim case is correct in both directions.
+        # (The Python package name at line ~1252 stays lowercased — that is
+        # the separate PEP 503 packaging convention, not GitHub-side.)
 
         print("\n" + "=" * 60)
         print("GITHUB REMOTE (single classic-PAT session per ADR-0216)")
@@ -2693,29 +2699,29 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 # fine-grained PATs that lack Administration: write (per
                 # ADR-0216 the fine-grained PAT is intentionally lean; admin
                 # operations use the in-process classic PAT). (#1268)
-                print(f"\n13. Creating GitHub repository ({repo_name_lower})...")
+                print(f"\n13. Creating GitHub repository ({args.name})...")
                 create_resp = requests.post(
                     "https://api.github.com/user/repos",
                     headers=_api_headers,
                     json={
-                        "name": repo_name_lower,
+                        "name": args.name,
                         "private": not args.public,
                         "description": f"{args.name} project",
                     },
                     timeout=30,
                 )
                 if create_resp.status_code == 201:
-                    print(f"  Created: https://github.com/{github_user}/{repo_name_lower}")
+                    print(f"  Created: https://github.com/{github_user}/{args.name}")
                     github_created = True
                 elif create_resp.status_code == 422:
                     # 422 typically means "name already exists" -- check
                     # whether it's THIS user's repo (rerun mode) before failing.
                     check_resp = requests.get(
-                        f"https://api.github.com/repos/{github_user}/{repo_name_lower}",
+                        f"https://api.github.com/repos/{github_user}/{args.name}",
                         headers=_api_headers, timeout=30,
                     )
                     if check_resp.status_code == 200:
-                        print(f"  Already exists: https://github.com/{github_user}/{repo_name_lower}")
+                        print(f"  Already exists: https://github.com/{github_user}/{args.name}")
                         print("  Proceeding in rerun mode against existing repo.")
                         github_created = True
                     else:
@@ -2741,7 +2747,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         try:
                             run_command(
                                 ["git", "remote", "add", "origin",
-                                 f"https://github.com/{github_user}/{repo_name_lower}.git"],
+                                 f"https://github.com/{github_user}/{args.name}.git"],
                                 cwd=project_path,
                             )
                         except Exception as e:
@@ -2762,7 +2768,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 if github_created:
                     print("\n14. Starring repository...")
                     star_resp = requests.put(
-                        f"https://api.github.com/user/starred/{github_user}/{repo_name_lower}",
+                        f"https://api.github.com/user/starred/{github_user}/{args.name}",
                         headers=_api_headers, timeout=30,
                     )
                     if star_resp.status_code in (204, 304):
@@ -2774,7 +2780,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                 if github_created and push_succeeded:
                     print("\n15. Uploading workflow files via Contents API...")
                     success, count = _deploy_workflows_via_contents_api(
-                        project_path, github_user, repo_name_lower, pat,
+                        project_path, github_user, args.name, pat,
                     )
                     if success:
                         workflows_deployed = True
@@ -2803,7 +2809,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
                     # Step 17: Configure repo settings.
                     print("\n17. Configuring repo settings...")
-                    if configure_repo_settings(github_user, repo_name_lower, pat):
+                    if configure_repo_settings(github_user, args.name, pat):
                         print("  Repo settings configured:")
                         print("    - Wiki: disabled")
                         print("    - Projects: disabled")
@@ -2815,7 +2821,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
                     # Step 18: Configure branch protection.
                     print("\n18. Configuring branch protection...")
-                    if configure_branch_protection(github_user, repo_name_lower, pat):
+                    if configure_branch_protection(github_user, args.name, pat):
                         print("  Branch protection configured:")
                         print("    - Force push: blocked")
                         print("    - Deletion: blocked")
@@ -2830,7 +2836,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     # Step 19: Create canonical AZ workflow labels (#1061).
                     print("\n19. Creating canonical labels...")
                     created, total = create_canonical_labels(
-                        github_user, repo_name_lower
+                        github_user, args.name
                     )
                     print(f"  {created}/{total} labels created or updated "
                           f"({', '.join(n for n, _, _ in _CANONICAL_LABELS)})")
@@ -2843,14 +2849,14 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     print("\n20. Enabling Dependabot (security updates, alerts, "
                           "automated fixes)...")
                     db_result = enable_dependabot_for_repo(
-                        github_user, repo_name_lower, pat, apply=True,
+                        github_user, args.name, pat, apply=True,
                     )
                     for endpoint, status in db_result.actions.items():
                         print(f"  {endpoint}: {status}")
                     if not db_result.ok:
                         print("  WARNING: Dependabot enablement had errors. "
                               "Re-run `tools/enable_dependabot.py --repo "
-                              f"{github_user}/{repo_name_lower} --apply` "
+                              f"{github_user}/{args.name} --apply` "
                               "after diagnosing.")
 
                 # Cerberus secrets deploy. Inside the same with-block so it
@@ -2867,7 +2873,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                                 encoding="utf-8"
                             ).strip()
                             cerberus_status = _deploy_cerberus(
-                                repo_name_lower, pem_content, pat,
+                                args.name, pem_content, pat,
                                 source_path=pem_source_path,
                             )
                         except FileNotFoundError as e:
@@ -2878,7 +2884,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         try:
                             with cerberus_pem_session(pem_gpg_path) as pem_content:
                                 cerberus_status = _deploy_cerberus(
-                                    repo_name_lower, pem_content, pat,
+                                    args.name, pem_content, pat,
                                     source_path=None,
                                 )
                         except FileNotFoundError as e:
@@ -2897,7 +2903,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
                     gh_checks_total += 1
                     ok, msg = verify_branch_protection_on_origin(
-                        github_user, repo_name_lower, pat,
+                        github_user, args.name, pat,
                     )
                     if ok:
                         print(f"  [PASS] Branch protection: {msg}")
@@ -2907,7 +2913,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
                     gh_checks_total += 1
                     ok, msg = verify_repo_settings_on_origin(
-                        github_user, repo_name_lower, pat,
+                        github_user, args.name, pat,
                     )
                     if ok:
                         print(f"  [PASS] Repo settings: {msg}")
@@ -2917,7 +2923,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
 
                     gh_checks_total += 1
                     ok, msg = verify_workflow_content_on_origin(
-                        github_user, repo_name_lower, pat,
+                        github_user, args.name, pat,
                     )
                     if ok:
                         print(f"  [PASS] auto-reviewer.yml: {msg}")
@@ -2928,7 +2934,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     if args.cerberus_pem or args.cerberus_pem_gpg:
                         gh_checks_total += 1
                         secrets_ok, missing = verify_secrets(
-                            repo_name_lower, pat,
+                            args.name, pat,
                         )
                         if secrets_ok:
                             print("  [PASS] Cerberus secrets present "
@@ -2943,7 +2949,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     # with-block, shares pat -- no extra pinentry. (#1274)
                     gh_checks_total += 1
                     ok, msg = verify_pr_sentinel_installation(
-                        github_user, repo_name_lower, pat,
+                        github_user, args.name, pat,
                     )
                     if ok:
                         print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
@@ -2975,7 +2981,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("\n" + "=" * 60)
         print("SUMMARY")
         print("=" * 60)
-        repo_name_lower = args.name.lower()
+        args.name = args.name.lower()
         print("  Local scaffold:     OK")
         print(f"  GitHub repo:        {'OK' if github_created else 'FAILED'}")
         print(f"  Push:               {'OK' if push_succeeded else 'FAILED'}")
@@ -2989,8 +2995,8 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     print("\nNext steps:")
     print(f"  cd {project_path}")
     if not args.no_github:
-        repo_name_lower = args.name.lower()
-        print(f"  # Repository: https://github.com/{github_user}/{repo_name_lower}")
+        args.name = args.name.lower()
+        print(f"  # Repository: https://github.com/{github_user}/{args.name}")
         if not push_succeeded:
             print("  # IMPORTANT: Initial push failed.")
             print("  # Diagnose first -- the push uses git's credential helper")


### PR DESCRIPTION
## Summary

Script unconditionally lowercased `args.name` at line 2671 before sending it to the GitHub REST API. Local directory at line 2334 preserved case; GitHub repo got the lowercased version. Result: `Projects/Chiron/` locally, `martymcenroe/chiron` on GitHub.

Fix: drop the `repo_name_lower = args.name.lower()` line; swap all 14 downstream call sites to use `args.name` directly. The local-dir line already used `args.name` correctly — unchanged.

## Why the lowercase was there

Introduced as a side-effect of the classic-PAT-session refactor (squash `2622ae86a`, see PR #1270) with no inline comment. GitHub's REST API is case-insensitive for repo lookup and case-preserved for display, so the lowercasing was defensive but unnecessary.

## What stays lowercase (correctly)

The Python package name at line 1252 (`package_name = name.lower().replace(\"_\", \"-\")`) — that is the PEP 503 normalization, a separate surface from the GitHub repo name. Unchanged.

## Tests

86 pass (84 prior + 2 new regression pins under `TestGitHubRepoNameCasePreservation`):

- One pin asserts the variable name does not return to the script source
- One pin asserts the #1533 anchor comment stays adjacent to the GitHub-side flow it explains, so the rationale remains discoverable for future readers

## Runbook

`docs/runbooks/0927-new-repo-human-checklist.md:193` previously said \"(forced lowercase)\" — described the bug, not the intent. Now reads \"(case preserved from the input name; #1533)\".

## Not in this PR

- Renaming the existing `martymcenroe/chiron` on GitHub to `martymcenroe/Chiron` — operator-only manual step that breaks any existing clones; out of scope here
- Modifying line 1252's package-name normalization — correct per PEP 503

Closes #1533