### PR TITLE
fix(new_repo_setup): success-message lowercasing + Cerberus revoke advice (Closes #1535, Closes #1536)

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -1239,3 +1239,98 @@ class TestGitHubRepoNameCasePreservation:
             f"{gh_banner} (delta={delta}). The fix-anchor comment is no "
             "longer adjacent to the GitHub-side flow it explains."
         )
+
+    def test_no_late_args_name_lowercase_mutation(self):
+        """#1535: the regression-pin above missed three direct mutations of
+        `args.name` in the final-summary block (`args.name = args.name.lower()`)
+        because it only checked for the `repo_name_lower` variable name. This
+        pin catches the direct-mutation form.
+
+        Legitimate `.lower()` uses in the script that we must NOT flag:
+        - `name.lower()` inside `create_python_project` (line ~1252-1253) —
+          generating Python package + module names per PEP 503
+        - `args.name.lower().replace(\"-\", \"_\")` for module-name substitution
+          at line ~2550 (same intent as line 1253, in the config-file flow)
+
+        What we DO flag:
+        - `args.name = args.name.lower()` anywhere — assignment that overwrites
+          the operator's input case
+        - `args.name.lower()` passed as `repo_name=...` to anything (those
+          arguments flow into displayed URLs / paths and must preserve case)
+        """
+        from pathlib import Path
+        import re
+        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        content = script.read_text(encoding="utf-8")
+
+        # Direct mutation: `args.name = args.name.lower()`
+        assert "args.name = args.name.lower()" not in content, (
+            "regression #1535: a direct mutation `args.name = args.name.lower()` "
+            "is present. That overwrites the operator's input case after the "
+            "GitHub repo was already created with the verbatim case (#1533). "
+            "Display lines downstream will then show the lowercased form, "
+            "diverging from the local dir name and the actual GitHub repo."
+        )
+
+        # Inline `args.name.lower()` passed to a `repo_name=` kwarg
+        # (the PyPI reminder path). The kwarg is supposed to receive a name
+        # that matches the actual GitHub repo.
+        matches = re.findall(r"repo_name\s*=\s*args\.name\.lower\(\)", content)
+        assert not matches, (
+            "regression #1535: `repo_name=args.name.lower()` is present. "
+            "Pass `repo_name=args.name` so the displayed PyPI URL matches "
+            "the actual GitHub repo name."
+        )
+
+
+class TestCerberusPostDeployAdvice:
+    """#1536: the post-deploy success message must distinguish between
+    the plaintext flow (`--cerberus-pem`, .pem deleted, revoke-the-key
+    correct) and the encrypted-reusable flow (`--cerberus-pem-gpg`, blob
+    preserved, revoke-the-key catastrophic — would invalidate the
+    reusable encrypted file).
+
+    Bug pre-fix: a single `print(\"REMEMBER to revoke the key...\")` line
+    fired for both flows. The operator following it under the
+    encrypted-reusable flow would lose the ability to use the encrypted
+    PEM for subsequent new-repo runs.
+    """
+
+    def test_revoke_advice_only_present_in_plaintext_branch(self):
+        """The string 'REMEMBER to revoke' should only appear inside a
+        conditional that checks args.cerberus_pem (the plaintext flow)."""
+        from pathlib import Path
+        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        content = script.read_text(encoding="utf-8")
+        # The advisory text must exist (it's correct for the plaintext flow)
+        assert "REMEMBER to revoke the key in the app UI" in content
+        # And the encrypted-flow branch must have the NEGATING advice
+        assert "DO NOT revoke the key in the app UI" in content, (
+            "regression #1536: the encrypted-reusable flow "
+            "(--cerberus-pem-gpg) lost its do-not-revoke guidance. The "
+            "post-deploy success message must distinguish the two flows."
+        )
+
+    def test_anchor_comment_naming_issue_present(self):
+        """A comment naming #1536 should sit at the cerberus_status branch
+        so future agents understand why the two flows produce different
+        end-of-run advice."""
+        from pathlib import Path
+        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        content = script.read_text(encoding="utf-8")
+        assert "#1536" in content
+        # The #1536 anchor must be near the `elif cerberus_status == \"OK\":`
+        # branch (within a few hundred chars BEFORE the branch text — the
+        # anchor comment introduces the conditional).
+        branch_loc = content.find('elif cerberus_status == "OK":')
+        anchor = content.find("#1536")
+        assert branch_loc != -1 and anchor != -1
+        delta = branch_loc - anchor
+        # Comment may sit ON the same logical block as the branch, so the
+        # offset is small in either direction; just check they are within
+        # 800 chars of each other.
+        assert abs(delta) < 800, (
+            f"#1536 anchor at offset {anchor}; cerberus_status branch at "
+            f"{branch_loc} (delta={delta}). The fix-anchor comment is no "
+            "longer adjacent to the cerberus advice branch."
+        )

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -2981,7 +2981,9 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("\n" + "=" * 60)
         print("SUMMARY")
         print("=" * 60)
-        args.name = args.name.lower()
+        # Closes #1535: do NOT lowercase args.name here. The GitHub repo
+        # was created with the verbatim case (#1533); the summary must
+        # display the same value, not a mutated lowercased form.
         print("  Local scaffold:     OK")
         print(f"  GitHub repo:        {'OK' if github_created else 'FAILED'}")
         print(f"  Push:               {'OK' if push_succeeded else 'FAILED'}")
@@ -2995,7 +2997,9 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     print("\nNext steps:")
     print(f"  cd {project_path}")
     if not args.no_github:
-        args.name = args.name.lower()
+        # Closes #1535: print the verbatim case-preserved repo name, not
+        # a mutated lowercased form. The local dir on the `cd` line above
+        # and this URL must agree, both matching the actual GitHub repo.
         print(f"  # Repository: https://github.com/{github_user}/{args.name}")
         if not push_succeeded:
             print("  # IMPORTANT: Initial push failed.")
@@ -3023,9 +3027,26 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("  #   OR re-run this script with --cerberus-pem PATH (single-shot)")
         print("  #   or --cerberus-pem-gpg PATH (reusable, encrypted at rest).")
     elif cerberus_status == "OK":
+        # Closes #1536: the post-deploy advice depends on which Cerberus
+        # flow ran. The plaintext flow (--cerberus-pem) deletes the .pem
+        # after deploy, so revoking the GitHub-side key as belt-and-
+        # suspenders is correct — no on-disk credential survives this run.
+        # The encrypted-reusable flow (--cerberus-pem-gpg) intentionally
+        # keeps the encrypted blob for subsequent new-repo invocations;
+        # revoking the key would invalidate that blob — catastrophic for
+        # the documented design intent of the flag.
         print()
         print("  # Cerberus secrets deployed and verified.")
-        print("  # REMEMBER to revoke the key in the app UI (browser-only step).")
+        if args.cerberus_pem is not None:
+            print("  # The plaintext .pem was deleted by the script.")
+            print("  # REMEMBER to revoke the key in the app UI (browser-only step) —")
+            print("  # there is no on-disk credential to retire otherwise.")
+        else:  # args.cerberus_pem_gpg is not None
+            print(f"  # Encrypted PEM preserved at {args.cerberus_pem_gpg} for reuse.")
+            print("  # DO NOT revoke the key in the app UI — that would invalidate")
+            print("  # the encrypted blob you just kept. Revoke only when you want")
+            print("  # to retire this credential entirely (e.g., rotation per")
+            print("  # runbook 0930, AZ #1017).")
 
     # The internal function uses `no_pypi` (legacy parameter name); compute
     # it as "did the operator OPT IN via --pypi?" -- false = no_pypi=True =
@@ -3035,7 +3056,10 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         no_pypi=not args.pypi,
         no_github=args.no_github,
         github_user=github_user,
-        repo_name=args.name.lower(),
+        # Closes #1535: pass the case-preserved repo name. PyPI itself
+        # canonicalizes the PEP 503 form internally; the displayed URL
+        # in the reminder should match the actual GitHub repo name.
+        repo_name=args.name,
     )
 
 


### PR DESCRIPTION
## Summary

Two bugs in the final-summary block of `tools/new_repo_setup.py`, both observed today during the operator's `IEEE-LRP-SC5` creation run.

### Bug 1 — display-side lowercasing (parent: PR #1534)

PR #1534 removed the `repo_name_lower` variable but missed three direct mutations of `args.name` in the SUMMARY / Next-steps block:

| Line | Form |
|---|---|
| 2984 (pre-fix) | `args.name = args.name.lower()` |
| 2998 (pre-fix) | `args.name = args.name.lower()` |
| 3038 (pre-fix) | `repo_name=args.name.lower(),` |

The GitHub repo itself was created with the verbatim case (confirmed: `gh api repos/martymcenroe/IEEE-LRP-SC5 --jq .name` returns `IEEE-LRP-SC5`); only the success-message printing was wrong. Yesterday's regression pin only checked the variable name `repo_name_lower` — the direct-mutation forms slipped past the grep.

### Bug 2 — wrong-direction Cerberus advice

`elif cerberus_status == \"OK\":` emitted `REMEMBER to revoke the key in the app UI` regardless of which flow ran. Correct for `--cerberus-pem` (plaintext, single-use, .pem deleted post-deploy); catastrophic for `--cerberus-pem-gpg` (encrypted, reusable — revoking the key invalidates the encrypted blob the operator just kept for the next new-repo run).

## Fix

- Bug 1: drop the three lowercase mutations; let `args.name` flow through verbatim
- Bug 2: split the advice on which flag is non-None. Plaintext branch retains the revoke-the-key text. Encrypted branch emits explicit do-NOT-revoke guidance, naming the preserved file path

## Regression pins

89 tests pass (86 prior + 3 new). The new pins under `TestGitHubRepoNameCasePreservation` and `TestCerberusPostDeployAdvice`:

- `test_no_late_args_name_lowercase_mutation` — catches both `args.name = args.name.lower()` and `repo_name=args.name.lower()` patterns the previous narrow grep missed
- `test_revoke_advice_only_present_in_plaintext_branch` — asserts both the revoke and the do-NOT-revoke text are present in the script
- `test_anchor_comment_naming_issue_present` (for #1536) — keeps the rationale comment adjacent to the cerberus_status branch

## Note on the CLAUDE.md vocabulary section I added yesterday

The new section I added to `Projects/CLAUDE.md` says \"the PR body must contain `Closes #N` EXACTLY ONCE.\" That wording is wrong for multi-close PRs like this one — the universal rule elsewhere allows multiple `Closes` directives when scope is shared. Filing a tiny follow-up to fix the wording (\"exactly one per closed issue\"). Not in this PR.

Closes #1535
Closes #1536