### PR TITLE
fix(new_repo_setup): default --cerberus-pem-gpg to ~/.secrets/cerberus-pem.gpg

### DIFF
--- a/tests/test_new_repo_setup.py
+++ b/tests/test_new_repo_setup.py
@@ -749,8 +749,16 @@ from new_repo_setup import (  # noqa: E402
 
 
 class TestCerberusPemRequired:
-    """T290-T292: --cerberus-pem is REQUIRED for new GitHub repos (#1206)."""
+    """T290-T292: --cerberus-pem is REQUIRED for new GitHub repos (#1206).
 
+    The DEFAULT_CERBERUS_PEM_GPG patch in T290 forces the default-PEM-fallback
+    branch (#1543) to miss, so the test continues to exercise the exit-1 path
+    even on a developer machine that has the real encrypted PEM at the
+    canonical location.
+    """
+
+    @patch("new_repo_setup.DEFAULT_CERBERUS_PEM_GPG",
+           Path("/nonexistent-for-T290/cerberus-pem.gpg"))
     @patch("new_repo_setup.config")
     def test_T290_missing_pem_without_no_github_exits_one(self, mock_config, tmp_path):
         """Without --cerberus-pem and without --no-github, exit 1 BEFORE any creation."""
@@ -782,6 +790,27 @@ class TestCerberusPemRequired:
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
+
+    @patch("new_repo_setup.config")
+    def test_T292b_default_gpg_fallback_used_when_neither_flag_passed(
+            self, mock_config, tmp_path, capsys):
+        """When neither flag passed AND DEFAULT_CERBERUS_PEM_GPG exists → fallback fires (#1543).
+
+        Uses an invalid name so the script exits AFTER the fallback prints its
+        confirmation line but BEFORE any GitHub creation logic is reached.
+        """
+        _setup_config_mock(mock_config, tmp_path)
+        fake_pem = tmp_path / "fake-cerberus-pem.gpg"
+        fake_pem.write_bytes(b"fake encrypted blob")
+        with patch("new_repo_setup.DEFAULT_CERBERUS_PEM_GPG", fake_pem):
+            # "bad/name" fails validate_name's regex, exiting 1 — but AFTER the
+            # default-fallback block, so the confirmation line still prints.
+            with patch("sys.argv", ["new_repo_setup.py", "bad/name"]):
+                with pytest.raises(SystemExit):
+                    main()
+        captured = capsys.readouterr().out
+        assert "Using Cerberus PEM:" in captured
+        assert str(fake_pem) in captured
 
 
 class TestVerifyBranchProtection:

--- a/tools/new_repo_setup.py
+++ b/tools/new_repo_setup.py
@@ -86,6 +86,13 @@ class SchemaValidationError(Exception):
 # Default schema location: co-located with standard 0009
 _DEFAULT_SCHEMA_PATH = Path(__file__).parent.parent / "docs" / "standards" / "0009-structure-schema.json"
 
+# Canonical location for the encrypted Cerberus App private key per
+# ADR-0216 / runbook 0927. When neither --cerberus-pem nor --cerberus-pem-gpg
+# is passed, main() falls back to this path so repeat invocations don't need
+# to retype the flag every time. Tests patch this constant to a non-existent
+# path to exercise the missing-PEM error branch (#1543).
+DEFAULT_CERBERUS_PEM_GPG = Path.home() / ".secrets" / "cerberus-pem.gpg"
+
 
 def load_structure_schema(schema_path: Path | None = None) -> dict:
     """Load and validate the project structure schema from JSON file.
@@ -2289,36 +2296,29 @@ Examples:
     # Catching this at the CLI gate keeps the failure loud and pre-creation,
     # not silent and only-visible-on-first-PR. Audit mode is exempt — it
     # only inspects an existing project, never creates anything.
+    #
+    # When neither flag was passed, fall back to the canonical encrypted-PEM
+    # location (#1543). Repeat invocations don't need to retype the flag.
+    # The default is only applied when neither flag was explicitly passed,
+    # so the mutual-exclusion check above still catches both-flags-passed.
+    if (not args.cerberus_pem and not args.cerberus_pem_gpg
+            and not args.no_github and not args.audit
+            and DEFAULT_CERBERUS_PEM_GPG.exists()):
+        args.cerberus_pem_gpg = str(DEFAULT_CERBERUS_PEM_GPG)
+        print(f"Using Cerberus PEM: {DEFAULT_CERBERUS_PEM_GPG} "
+              "(encrypted, in-process decryption)")
+
     if (not args.cerberus_pem and not args.cerberus_pem_gpg
             and not args.no_github and not args.audit):
-        print("ERROR: --cerberus-pem or --cerberus-pem-gpg is required.")
+        print(f"ERROR: Cerberus encrypted PEM not found at {DEFAULT_CERBERUS_PEM_GPG}")
         print()
-        print("Cerberus auto-approval is part of the new-repo contract. Without it,")
-        print("every PR on the new repo will sit blocked indefinitely waiting for")
-        print("a review (branch protection requires 1 approval; the auto-reviewer")
-        print("workflow can't approve without the Cerberus App secrets).")
+        print("The new-repo workflow needs a Cerberus App key to wire up auto-approval.")
+        print("Without it, every PR on the new repo sits blocked waiting for a review.")
         print()
-        print("Two ways to provide the .pem (per runbook 0927):")
-        print()
-        print("  RECOMMENDED -- --cerberus-pem-gpg PATH (encrypted at rest,")
-        print("  reusable across many new-repo runs, no plaintext on disk):")
-        print("    1. Open https://github.com/settings/apps/cerberus-az")
-        print("    2. Generate a private key -- in the browser's Save-As dialog,")
-        print("       target ~/.secrets/cerberus.pem (NOT ~/Downloads/, which is")
-        print("       often OneDrive-synced; mkdir -p ~/.secrets first if needed)")
-        print("    3. gpg -c -o ~/.secrets/cerberus-pem.gpg ~/.secrets/cerberus.pem")
-        print("    4. rm ~/.secrets/cerberus.pem")
-        print("    5. Re-run with --cerberus-pem-gpg ~/.secrets/cerberus-pem.gpg")
-        print("       (See runbook 0927 'Hygiene surfaces' table for the full")
-        print("       audit gate — clipboard, Recycle Bin, browser history.)")
-        print()
-        print("  LEGACY single-shot -- --cerberus-pem PATH (plaintext, deleted")
-        print("  after deploy; one-and-done, fresh .pem per repo):")
-        print("    1. Open https://github.com/settings/apps/cerberus-az")
-        print("    2. Generate a private key -- browser downloads cerberus.pem")
-        print("    3. Re-run with --cerberus-pem /path/to/the.pem")
-        print()
-        print("Full procedure: docs/runbooks/0927-new-repo-human-checklist.md#4")
+        print("Options:")
+        print("  - Encrypted key elsewhere?  --cerberus-pem-gpg /path/to/cerberus-pem.gpg")
+        print("  - One-shot plaintext?       --cerberus-pem /path/to/cerberus.pem")
+        print("  - First-time setup?         See docs/runbooks/0927-new-repo-human-checklist.md#4")
         print()
         print("Override: --no-github (skip GitHub repo entirely; local scaffold only).")
         sys.exit(1)


### PR DESCRIPTION
## Summary

- Default `--cerberus-pem-gpg` to `~/.secrets/cerberus-pem.gpg` (the canonical location per ADR-0216 / runbook 0927) when neither PEM flag is passed. Repeat new-repo runs no longer need to retype the flag.
- A one-line confirmation prints when the fallback fires: `Using Cerberus PEM: <path> (encrypted, in-process decryption)`.
- Trim the missing-PEM error wall from 22 lines to 9. It now names the default path that was checked and lists three short options (encrypted key elsewhere, one-shot plaintext, first-time setup → runbook 0927). The multi-step create-from-scratch walkthrough is removed from the error and left in the runbook.

## What this fixes

The operator hit `tools/new_repo_setup.py Maieutics` today and got a 22-line error that walked them through creating an encrypted PEM they already had at `~/.secrets/cerberus-pem.gpg`. The flag *should* default to the canonical location.

## Test plan

- [x] `tests/test_new_repo_setup.py::TestCerberusPemRequired` — all 4 pass (3 existing + 1 new T292b)
- [x] T290 patches `DEFAULT_CERBERUS_PEM_GPG` to a non-existent path so the exit-1 branch is still exercised even on developer machines that have the real encrypted PEM at the canonical location
- [x] T292b asserts the fallback fires and the confirmation line prints when the default exists
- [x] Full `tests/test_new_repo_setup.py` (81 tests) passes
- [x] Module-level constant resolves to `C:\Users\mcwiz\.secrets\cerberus-pem.gpg` on operator's machine; `.exists()` returns True

Closes #1543