### PR TITLE
fix(backfill_assemblyzero_flag): replace `git restore --worktree` rollback

### DIFF
--- a/tests/test_backfill_assemblyzero_flag.py
+++ b/tests/test_backfill_assemblyzero_flag.py
@@ -286,3 +286,72 @@ class TestIsSafeToBackfill:
         assert ok is False
         # Implementation short-circuits on dirty before checking branch.
         assert ".unleashed.json" in reason
+
+
+class TestProcessRepoCommitFailureRollback:
+    """T540-T550: commit-failure rollback path (#1379).
+
+    Pins the no-`--worktree` behavior so the banned destroy-uncommitted-state
+    pattern can't regress. Verifies the rollback restores the original file
+    content via explicit write-back rather than `git restore --worktree`.
+    """
+
+    @patch("backfill_assemblyzero_flag.gh_owner_of")
+    @patch("backfill_assemblyzero_flag.is_safe_to_backfill")
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T540_commit_failure_rollback_never_uses_worktree_flag(
+            self, mock_run, mock_safe, mock_owner, tmp_path):
+        """No `git restore --worktree` call when commit fails (#1379)."""
+        from backfill_assemblyzero_flag import process_repo
+
+        # Set up a tmp "repo" with .unleashed.json missing the assemblyZero key
+        # (needs_flip will return True).
+        original_text = '{\n  "profile": "default"\n}\n'
+        (tmp_path / ".unleashed.json").write_text(original_text, encoding="utf-8")
+
+        mock_safe.return_value = (True, "")
+        mock_owner.return_value = "owner/repo"
+
+        def run_side_effect(cmd, **kwargs):
+            # All git calls succeed EXCEPT `git commit`, which simulates a
+            # pre-commit hook rejection.
+            if cmd[:2] == ["git", "commit"]:
+                return MagicMock(returncode=1, stdout="", stderr="hook rejected")
+            return MagicMock(returncode=0, stdout="", stderr="")
+        mock_run.side_effect = run_side_effect
+
+        result = process_repo(tmp_path, dry_run=False)
+
+        all_call_args = [call.args[0] for call in mock_run.call_args_list]
+        for cmd in all_call_args:
+            assert "--worktree" not in cmd, (
+                f"Banned `--worktree` flag appeared in rollback path: {cmd}"
+            )
+        assert result.status == "ERROR_COMMIT"
+
+    @patch("backfill_assemblyzero_flag.gh_owner_of")
+    @patch("backfill_assemblyzero_flag.is_safe_to_backfill")
+    @patch("backfill_assemblyzero_flag.run")
+    def test_T550_commit_failure_restores_original_file_bytes(
+            self, mock_run, mock_safe, mock_owner, tmp_path):
+        """Rollback restores .unleashed.json to its pre-flip content (#1379)."""
+        from backfill_assemblyzero_flag import process_repo
+
+        original_text = '{\n  "profile": "default"\n}\n'
+        (tmp_path / ".unleashed.json").write_text(original_text, encoding="utf-8")
+
+        mock_safe.return_value = (True, "")
+        mock_owner.return_value = "owner/repo"
+
+        def run_side_effect(cmd, **kwargs):
+            if cmd[:2] == ["git", "commit"]:
+                return MagicMock(returncode=1, stdout="", stderr="hook rejected")
+            return MagicMock(returncode=0, stdout="", stderr="")
+        mock_run.side_effect = run_side_effect
+
+        result = process_repo(tmp_path, dry_run=False)
+
+        assert result.status == "ERROR_COMMIT"
+        # The flip happened in-memory then was reverted via write-back.
+        # File content should match the original byte-for-byte.
+        assert (tmp_path / ".unleashed.json").read_text(encoding="utf-8") == original_text

--- a/tools/backfill_assemblyzero_flag.py
+++ b/tools/backfill_assemblyzero_flag.py
@@ -258,17 +258,25 @@ def process_repo(repo_path: Path, dry_run: bool) -> RepoResult:
         return RepoResult(name, "ERROR_BRANCH",
                           f"could not create branch: {r.stderr.strip()[:200]}")
 
-    # 3. Edit + commit
+    # 3. Edit + commit. Capture original bytes BEFORE flip so the rollback
+    # path can restore the working tree via explicit write-back rather than
+    # `git restore --worktree` (banned pattern B7 — destroys uncommitted
+    # state; see Projects/CLAUDE.md banned-commands table). Write-back is
+    # correct here: we are reverting OUR OWN edit from flip_file two lines
+    # below, not destroying pre-existing operator state. (#1379)
+    original_unleashed_bytes = unleashed.read_bytes()
     flip_file(unleashed)
     run(["git", "add", ".unleashed.json"], cwd=repo_path)
     r = run(["git", "commit", "-m", COMMIT_MESSAGE], cwd=repo_path)
     if r.returncode != 0:
         # Commit failed (e.g., pre-commit hook). Branch has no new commits,
-        # so branch tip == main tip. Restore the working-tree edit, return
-        # to main, then `git branch -d` (-D is banned per memory; -d works
-        # because branch is reachable from main with no extra commits).
-        run(["git", "restore", "--staged", "--worktree", ".unleashed.json"],
-            cwd=repo_path)
+        # so branch tip == main tip. Restore the working tree by writing
+        # back the captured original bytes, unstage via `git restore --staged`
+        # only (no `--worktree`), return to main, then `git branch -d` (-D is
+        # banned per memory; -d works because branch is reachable from main
+        # with no extra commits).
+        unleashed.write_bytes(original_unleashed_bytes)
+        run(["git", "restore", "--staged", ".unleashed.json"], cwd=repo_path)
         run(["git", "checkout", "main"], cwd=repo_path)
         run(["git", "branch", "-d", BRANCH_NAME], cwd=repo_path)
         return RepoResult(name, "ERROR_COMMIT",


### PR DESCRIPTION
## Summary

- Replaces `git restore --staged --worktree .unleashed.json` (banned pattern B7 — destroys uncommitted state) in `process_repo`'s commit-failure rollback path with explicit write-back of the captured original bytes plus `git restore --staged` to unstage.
- Even though the rollback is reverting `flip_file`'s OWN edit (not pre-existing operator state), the principle table in `Projects/CLAUDE.md` forbids the destroy-form regardless of provenance.

## Test plan

- [x] T540 pins the no-`--worktree` regression: mocks `git commit` to fail and asserts no `--worktree` token appears in any `run()` call during the rollback path.
- [x] T550 pins the behavior: rollback restores `.unleashed.json` byte-for-byte to its pre-flip content (verifies the write-back path actually works, not just that the banned flag is absent).
- [x] Full `tests/test_backfill_assemblyzero_flag.py` (27 tests = 25 existing + 2 new) passes.

Closes #1379