### PR TITLE
chore(banned-list): replace `--force` worktree-removal at three sites

### DIFF
--- a/docs/audits/0834-audit-worktree-hygiene.md
+++ b/docs/audits/0834-audit-worktree-hygiene.md
@@ -127,14 +127,24 @@ git worktree remove /path/to/worktree
 git branch -d branch-name  # -d = safe delete (fails if unmerged)
 ```
 
-### Force Removal (CAUTION)
+### When `git worktree remove` Refuses
 
-Only after confirming no valuable changes:
+`git worktree remove --force` and `git branch -D` are **banned** fleet-wide
+(see `Projects/CLAUDE.md` banned-commands table). Resolve via gentler
+means:
 
 ```bash
-git worktree remove --force /path/to/worktree
-git branch -D branch-name  # -D = force delete even if unmerged
+# 1. Cleans admin metadata for dead refs; often unblocks the next remove.
+git worktree prune
+
+# 2. Retry the plain remove.
+git worktree remove /path/to/worktree
 ```
+
+If `branch -d` refuses on a squash-merge orphan (different SHA from
+the squash commit on main), use the ADR-0217 `git replace --graft`
+recipe — never `branch -D`. If the branch still refuses to delete, it
+has unmerged work: investigate, do not force.
 
 ---
 

--- a/docs/lineage/active/94-lld-n1/002-draft.md
+++ b/docs/lineage/active/94-lld-n1/002-draft.md
@@ -382,8 +382,12 @@ def fix_broken_links(findings: list[Finding], repo_root: str, dry_run: bool) -> 
 def fix_stale_worktrees(findings: list[Finding], repo_root: str, dry_run: bool) -> list[FixAction]:
     """Prune stale worktrees.
 
-    Executes `git worktree remove <path>` for each stale worktree.
-    Falls back to `git worktree remove --force <path>` if needed.
+    Executes `git worktree remove <path>` for each stale worktree. On
+    failure, runs `git worktree prune` (cleans admin metadata for dead
+    refs) and retries once. If the second attempt still fails, surfaces
+    the unremoved worktree via a Finding for operator review — never
+    escalates to `--force` (banned pattern B10; see
+    `Projects/CLAUDE.md` banned-commands table).
     """
     ...
 

--- a/docs/lineage/active/94-lld/002-draft.md
+++ b/docs/lineage/active/94-lld/002-draft.md
@@ -372,8 +372,12 @@ def fix_broken_links(findings: list[Finding], repo_root: str, dry_run: bool) -> 
 def fix_stale_worktrees(findings: list[Finding], repo_root: str, dry_run: bool) -> list[FixAction]:
     """Prune stale worktrees.
 
-    Executes `git worktree remove <path>` for each stale worktree.
-    Falls back to `git worktree remove --force <path>` if needed.
+    Executes `git worktree remove <path>` for each stale worktree. On
+    failure, runs `git worktree prune` (cleans admin metadata for dead
+    refs) and retries once. If the second attempt still fails, surfaces
+    the unremoved worktree via a Finding for operator review — never
+    escalates to `--force` (banned pattern B10; see
+    `Projects/CLAUDE.md` banned-commands table).
     """
     ...
 

--- a/tests/test_backup_universal_claude_md.py
+++ b/tests/test_backup_universal_claude_md.py
@@ -1,0 +1,75 @@
+"""Pin tests for tools/backup_universal_claude_md.py.
+
+Issue: #1380 — replace `git worktree remove --force` with the no-force
+`_try_remove_worktree` helper at both call sites (pre-run leftover
+cleanup + finally-block cleanup).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TOOL_PATH = (
+    Path(__file__).parent.parent / "tools" / "backup_universal_claude_md.py"
+)
+
+
+def _find_subprocess_calls(tree: ast.AST) -> list[tuple[int, list[str]]]:
+    """Return [(lineno, [string-arg, ...]), ...] for every Call node whose
+    arguments include literal strings — covers both `_git("worktree", ...)`
+    and `subprocess.run(["git", ...])` forms.
+    """
+    found: list[tuple[int, list[str]]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        literals: list[str] = []
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                literals.append(arg.value)
+            elif isinstance(arg, ast.List):
+                for elt in arg.elts:
+                    if (isinstance(elt, ast.Constant)
+                            and isinstance(elt.value, str)):
+                        literals.append(elt.value)
+        if literals:
+            found.append((node.lineno, literals))
+    return found
+
+
+class TestNoForceFlagInWorktreeCalls:
+    """#1380: --force must never reach a git worktree subprocess call."""
+
+    def test_no_force_arg_passed_to_worktree_call(self):
+        """No Call node has both 'worktree' and '--force' as string args."""
+        tree = ast.parse(TOOL_PATH.read_text(encoding="utf-8"))
+        for lineno, literals in _find_subprocess_calls(tree):
+            if "worktree" in literals and "--force" in literals:
+                pytest.fail(
+                    f"Banned: subprocess call at line {lineno} passes both "
+                    f"'worktree' and '--force'. Use _try_remove_worktree() "
+                    f"instead (no-force helper). Args: {literals}"
+                )
+
+    def test_helper_function_is_defined(self):
+        """_try_remove_worktree must exist and not pass --force itself."""
+        tree = ast.parse(TOOL_PATH.read_text(encoding="utf-8"))
+        helper_funcs = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "_try_remove_worktree"
+        ]
+        assert len(helper_funcs) == 1, (
+            "_try_remove_worktree helper missing — the no-force replacement "
+            "for `git worktree remove --force` (#1380)"
+        )
+        # Walk just the helper's body and confirm no --force string literal
+        for node in ast.walk(helper_funcs[0]):
+            if (isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and node.value == "--force"):
+                pytest.fail(
+                    "_try_remove_worktree contains a '--force' string literal "
+                    "— the helper exists to AVOID --force; it must not use it."
+                )

--- a/tools/backup_universal_claude_md.py
+++ b/tools/backup_universal_claude_md.py
@@ -59,6 +59,21 @@ def _git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProce
     )
 
 
+def _try_remove_worktree(worktree: Path) -> subprocess.CompletedProcess:
+    """Remove a worktree without `--force` (banned pattern B10).
+
+    Tries plain `git worktree remove`. If that fails, runs `git worktree
+    prune` to clean up admin metadata for dead refs, then retries once.
+    Returns the final CompletedProcess; the caller decides how to react
+    to a non-zero returncode (surface failure, never force). (#1380)
+    """
+    r = _git("worktree", "remove", str(worktree), cwd=AZ_ROOT, check=False)
+    if r.returncode == 0:
+        return r
+    _git("worktree", "prune", cwd=AZ_ROOT, check=False)
+    return _git("worktree", "remove", str(worktree), cwd=AZ_ROOT, check=False)
+
+
 def fetch_canonical_from_origin() -> bytes | None:
     """Return the current canonical file bytes from origin/main, or None
     if it doesn't exist on origin yet (first-snapshot case).
@@ -100,8 +115,15 @@ def open_backup_pr(source_bytes: bytes, prior_canonical_len: int | None) -> tupl
     worktree = Path(f"C:/Users/mcwiz/Projects/AssemblyZero-backup-{date_tag}")
 
     if worktree.exists():
-        # Leftover from a previous failed run; remove it
-        _git("worktree", "remove", "--force", str(worktree), cwd=AZ_ROOT, check=False)
+        # Leftover from a previous failed run; remove via the no-force
+        # helper. If even prune+retry can't free it, abort the run rather
+        # than escalate to --force (banned pattern B10).
+        r = _try_remove_worktree(worktree)
+        if r.returncode != 0:
+            log("error", reason="could not remove leftover worktree",
+                worktree=str(worktree),
+                stderr=r.stderr.strip()[:300])
+            return None, branch
 
     _git("fetch", "origin", "main", cwd=AZ_ROOT)
     _git("worktree", "add", str(worktree), "-b", branch, "origin/main", cwd=AZ_ROOT)
@@ -161,8 +183,15 @@ def open_backup_pr(source_bytes: bytes, prior_canonical_len: int | None) -> tupl
                 return int(line.rstrip("/").rsplit("/", 1)[-1]), branch
         return None, branch
     finally:
-        # Always remove the worktree; the branch lives on origin
-        _git("worktree", "remove", "--force", str(worktree), cwd=AZ_ROOT, check=False)
+        # Always attempt to remove the worktree; the branch lives on origin.
+        # No --force (banned pattern B10); if the no-force helper can't
+        # free it, log loudly so the next run's pre-flight surfaces the
+        # leftover state.
+        r = _try_remove_worktree(worktree)
+        if r.returncode != 0:
+            log("warning", reason="worktree cleanup failed in finally",
+                worktree=str(worktree),
+                stderr=r.stderr.strip()[:300])
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

Three banned-list cleanups from audit `docs/audits/0900-banned-commands-fleet-audit-2026-05-29.md`:

| Site | Issue | Before | After |
|---|---|---|---|
| `tools/backup_universal_claude_md.py:104,165` | #1380 | `_git("worktree", "remove", "--force", ...)` × 2 | `_try_remove_worktree()` helper (plain remove → `git worktree prune` + retry → log loudly) |
| `docs/audits/0834-audit-worktree-hygiene.md:130-137` | #1386 | "Force Removal (CAUTION)" section teaching `--force` + `branch -D` | "When `git worktree remove` Refuses" section teaching `prune` + retry + ADR-0217 graft, cross-linking universal CLAUDE.md as canonical |
| `docs/lineage/active/94-lld/002-draft.md:376` + `94-lld-n1/002-draft.md:386` | #1388 | `fix_stale_worktrees` docstring "Falls back to ... --force" | Same docstring rewritten to prune+retry+surface — Janitor implementation can't ship the banned fallback |

## Test plan

- [x] `tests/test_backup_universal_claude_md.py` (new file) — 2 AST-walking pin tests:
  - `test_no_force_arg_passed_to_worktree_call` — fails if any `Call` node has both `'worktree'` and `'--force'` as string args
  - `test_helper_function_is_defined` — fails if `_try_remove_worktree` is missing or itself contains a `'--force'` literal
- [x] `tools/backup_universal_claude_md.py` AST-parses cleanly
- [x] Static grep confirms remaining `--force` occurrences are all in comments/docstrings documenting why it's banned

## Risk

Pre-existing behavior was "if removal fails, force it through." New behavior: "if removal fails, prune+retry; if still fails, log and continue (finally-block) or abort (pre-run cleanup)." Worst case if my helper's logic is wrong: nightly backup leaves a leftover worktree, which next run's pre-flight either cleans up or surfaces. No silent data loss possible.

Closes #1380, Closes #1386, Closes #1388