### PR TITLE
feat(cleanup): graveyard/* skip in skill + Option G' refinement in ADR-0217

### DIFF
--- a/.claude/skills/cleanup.md
+++ b/.claude/skills/cleanup.md
@@ -203,11 +203,12 @@ Session: {SESSION_NAME}
 ## Phase 2: Conditional Fixes
 
 1. **Branches vs Worktrees** - Cross-reference:
+   - **Branch name matches `graveyard/*`: SKIP entirely.** These are operator-parked orphans per the ADR-0217 Option G refinement (namespace segregation). Never flag as orphan, never auto-delete. Surface only as a count in the Phase 5 report.
    - Branch HAS worktree: OK (active work)
    - Branch has NO worktree + remote gone: Orphan candidate
 
 2. **Auto-Delete Orphaned LOCAL Branches** (unless --no-auto-delete):
-   - Safety: Not main, remote shows `gone`, no worktree
+   - Safety: Not main, **does NOT match `graveyard/*`**, remote shows `gone`, no worktree
    - Action: `git -C ... branch -D {branch-name}`
 
 3. **CRITICAL: Delete Stale REMOTE Branches for Merged PRs:**
@@ -422,6 +423,7 @@ git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} branch -r
 | Worktrees | Only main / {list} |
 | Local Orphans Deleted | {count} branches / 0 |
 | **Remote Stale Deleted** | {count} branches / 0 |
+| Graveyard | {count} parked branches (skipped per ADR-0217 namespace segregation) |
 | **Orphan Worktrees** | None / **ERROR: {list}** |
 | Empty Worktree Dirs Deleted | {count} / 0 |
 | Stashes | None / {count} |

--- a/.claude/templates/commands/cleanup.md.template
+++ b/.claude/templates/commands/cleanup.md.template
@@ -112,6 +112,7 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
 
 1. **Branches vs Worktrees** - Cross-reference branch list against worktree list:
    - For each branch OTHER than main, check if it appears in the worktree list
+   - **Skip if the branch name matches `graveyard/*`** — these are operator-parked orphans per the ADR-0217 Option G refinement (namespace segregation). They persist intentionally; never flag them as orphans, never auto-delete them, do NOT include them in the orphan-deletion path. Surface only as a count in the report (see Phase 5).
    - If branch HAS a worktree: OK (active work - do NOT flag)
    - If branch has NO worktree: Flag as potential orphan
 
@@ -119,6 +120,7 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
 
    **Safety Criteria (ALL must be met to auto-delete):**
    - Branch is not `main`
+   - **Branch name does NOT match `graveyard/*`** (parked orphans, never auto-delete)
    - Remote tracking shows `gone` (was deleted on GitHub)
    - No worktree exists for this branch
 
@@ -256,6 +258,7 @@ Return a summary table:
 | Branches | Only main / {list} |
 | Worktrees | Only main / {list} |
 | Auto-Deleted | {count} branches / Skipped |
+| Graveyard | {count} parked branches (skipped per ADR-0217 namespace segregation) |
 | Stashes | None / {count} |
 | Permissions | Clean / Stale (Full mode only) |
 | Commit | Pushed / Failed |

--- a/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
+++ b/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
@@ -121,6 +121,37 @@ Local branch refs cost essentially nothing. If `-D` is forbidden and `--graft` i
 - `git branch --list` accumulates dead refs over time
 - Tooling that operates on the branch list (e.g., automated cleanup, branch counters) sees noise
 
+### Option G' — Refinement: Namespace segregation for parked orphans
+
+A refinement of Option G that addresses the noise problem without crossing into bypass territory. When the graft-equivalence check fails AND the rebase-and-retry path produces a non-empty remnant (so the branch genuinely holds content that isn't on main), rename the orphan into a `graveyard/` namespace:
+
+```bash
+git branch -m <orphan-branch-name> graveyard/<orphan-branch-name>
+```
+
+Or with a date prefix for easier aging:
+
+```bash
+git branch -m <orphan-branch-name> graveyard/$(date +%Y-%m-%d)/<orphan-branch-name>
+```
+
+The rename is a **non-destructive ref operation** — the tip stays at the same commit, no content is destroyed, no force flag is involved. The branch continues to exist; it is just relocated to a namespace the operator's tooling can filter out by default.
+
+**Pros over plain Option G:**
+- Visually segregates "intentional active work" from "stuck orphans" — `git branch --list` (without `-a` and without the namespace pattern) hides parked orphans
+- Automated cleanup tooling can be taught one line — "skip `graveyard/*`" — and stop re-surfacing the same noise every run
+- Periodic re-check is trivial: `git branch -d graveyard/*` over the whole namespace tries plain delete on every parked orphan; any whose underlying commit has since become reachable from main (e.g., via subsequent merges that pull in equivalent content) will succeed and be cleaned. The namespace is a holding area with a natural-decay sweep, not a permanent grave.
+- Optional `git branch --edit-description graveyard/<name>` records why it's parked, preserving operator intent for future review.
+
+**Cons (acknowledged — same shape as Option F):**
+- The branch ref persists; the underlying commit is held alive until manual cleanup
+- Accumulates over time without the periodic re-check discipline
+- GUI git clients (GitHub Desktop, GitKraken, GitLens) render branches with slashes as collapsible folders, so the namespace surfaces there — usually desirable as visual grouping, but worth flagging
+
+This is **not** the same as Option F (rejected). Option F proposed pushing the orphan to `refs/archive/<branch>` and reconfiguring upstream — that's an actual ref-class change plus an upstream reconfiguration. Option G' is a plain rename within `refs/heads/`, no upstream changes, no new ref class. It works on the safety surface the no-force policy is concerned with.
+
+**Validated:** first applied 2026-06-07 to `1443-revise-with-context`, where the rebase-and-retry produced a 14-line duplicate-code remnant. The `git branch -m` succeeded without any flag; the cleanup skill was updated the same session to skip `graveyard/*` in orphan detection.
+
 ## 4. Rationale
 
 Option A was selected because it is the only path that:


### PR DESCRIPTION
## Summary

Two related changes, one PR:

- **Cleanup skill** skips `graveyard/*` branches in orphan-candidate detection and auto-delete safety criteria; adds Graveyard row to the Phase 5 report. Touches the canonical template and the project-local skill copy.
- **ADR-0217** gains a new "Option G' — Refinement: Namespace segregation for parked orphans" subsection documenting the `git branch -m <orphan> graveyard/<orphan>` recipe, pros over plain Option G, acknowledged cons, distinction from rejected Option F, and the 2026-06-07 validation note.

(Adjacent open issue: #1381 — replacing the skill's existing `branch -D` calls with the ADR-0217 graft pattern. Out of scope for this PR; the graveyard skip stacks regardless of how the underlying `branch -d` vs `branch -D` discussion resolves.)

Closes #1553, Closes #1554