### PR TITLE
fix(cleanup): inline ADR-0217 recipe in skill + post-flight check (#1557, #1558)

### DIFF
--- a/.claude/skills/cleanup.md
+++ b/.claude/skills/cleanup.md
@@ -208,8 +208,53 @@ Session: {SESSION_NAME}
    - Branch has NO worktree + remote gone: Orphan candidate
 
 2. **Auto-Delete Orphaned LOCAL Branches** (unless --no-auto-delete):
-   - Safety: Not main, **does NOT match `graveyard/*`**, remote shows `gone`, no worktree
-   - Action: `git -C ... branch -D {branch-name}`
+   - Safety: Not main, **does NOT match `graveyard/*`**, remote shows `gone`, no worktree.
+   - **Do NOT use `git branch -D`** — it is on the CLAUDE.md banned-commands list. Use the literal four-step ADR-0217 graft recipe inline. For each candidate branch, execute these exact commands. Do not invent alternatives:
+
+     ```bash
+     # Identify the orphan tip and find the matching squash commit on main.
+     # Search recent main commits for one whose content matches the branch tip
+     # (typically the squash commit referencing the PR for this branch).
+     ORPHAN_TIP=$(git -C {ROOT} rev-parse {BRANCH})
+     SQUASH_SHA=$(git -C {ROOT} log origin/main --format='%H' --grep="(#${PR_N})" -1)
+     # If you cannot identify a SQUASH_SHA whose `git diff $ORPHAN_TIP $SQUASH_SHA` is empty,
+     # the branch holds unique content not on main — leave it alone and surface in the report
+     # (it is a content orphan, not a squash-merge orphan).
+
+     # Pre-flight: content equivalence REQUIRED before applying the graft.
+     if [ -n "$(git -C {ROOT} diff $ORPHAN_TIP $SQUASH_SHA --stat 2>&1)" ]; then
+       echo "WARNING: branch {BRANCH} has unique content vs squash on main. Not auto-deleting. Surface for operator review."
+       continue
+     fi
+
+     # Capture pre-flight replace-ref count so the post-flight check (Step 5 of ADR-0217)
+     # can detect any residue.
+     PRE_REPLACE_COUNT=$(git -C {ROOT} replace --list | wc -l)
+
+     # ADR-0217 Step 1: parent of the squash commit on main
+     BASE_SHA=$(git -C {ROOT} rev-parse ${SQUASH_SHA}^)
+
+     # ADR-0217 Step 2: graft (orphan tip becomes second parent of squash)
+     # Benign GPG-signature warning on signed squash commits is expected per ADR-0217 Section 5.
+     git -C {ROOT} replace --graft $SQUASH_SHA $BASE_SHA $ORPHAN_TIP
+
+     # ADR-0217 Step 3: safe delete now succeeds (orphan is reachable via graft)
+     git -C {ROOT} branch -d {BRANCH}
+
+     # ADR-0217 Step 4: remove the temporary graft
+     git -C {ROOT} replace -d $SQUASH_SHA
+
+     # ADR-0217 Step 5 (post-flight): replace-ref count must match pre-flight.
+     # If anything remains, an earlier step deviated. Surface the residue.
+     POST_REPLACE_COUNT=$(git -C {ROOT} replace --list | wc -l)
+     if [ "$POST_REPLACE_COUNT" -ne "$PRE_REPLACE_COUNT" ]; then
+       echo "ERROR: replace-ref residue remains after ADR-0217 recipe for {BRANCH}. Inspect:"
+       git -C {ROOT} replace --list --format=long
+       # Do NOT proceed silently. Report this in the final summary as a blocking condition.
+     fi
+     ```
+
+   - If the squash SHA cannot be identified (e.g., the PR number was not embedded in the commit message), fall back to namespacing the branch into `graveyard/<date>/<branch>` per ADR-0217 Option G' rather than forcing.
 
 3. **CRITICAL: Delete Stale REMOTE Branches for Merged PRs:**
    - Get merged PRs: `gh pr list --repo {GITHUB_REPO} --state merged --limit 50 --json headRefName`
@@ -374,9 +419,33 @@ Capture PR number → `PR_N`.
 ```bash
 until [ "$(gh api repos/{GITHUB_REPO}/pulls/$PR_N --jq '.mergeable_state')" = "clean" ]; do sleep 10; done
 gh pr merge $PR_N --squash --repo {GITHUB_REPO}
+
+# Capture the orphan-to-be and the new squash SHA before checkout.
+ORPHAN_TIP=$(git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} rev-parse $BRANCH)
+
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} fetch origin
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} checkout main
-git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} pull --rebase
-git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} branch -D $BRANCH
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} merge origin/main --ff-only
+
+# After squash-merge, the just-merged PR appears as the new tip of origin/main.
+SQUASH_SHA=$(git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} rev-parse origin/main)
+
+# Content equivalence is guaranteed here (we squash-merged our own commit),
+# so the pre-flight diff check is informational rather than gating.
+
+# ADR-0217 four-step recipe (do NOT use `branch -D` — it's on the banned list).
+PRE_REPLACE_COUNT=$(git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} replace --list | wc -l)
+BASE_SHA=$(git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} rev-parse ${SQUASH_SHA}^)
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} replace --graft $SQUASH_SHA $BASE_SHA $ORPHAN_TIP
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} branch -d $BRANCH
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} replace -d $SQUASH_SHA
+
+# Step 5 post-flight: replace-ref count must match pre-flight.
+POST_REPLACE_COUNT=$(git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} replace --list | wc -l)
+if [ "$POST_REPLACE_COUNT" -ne "$PRE_REPLACE_COUNT" ]; then
+  echo "ERROR: replace-ref residue remains after cleanup branch self-delete. Inspect:"
+  git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} replace --list --format=long
+fi
 ```
 
 ### 4.9 — Direct-push fallback (unprotected main only)

--- a/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
+++ b/docs/adrs/0217-squash-merge-orphan-graft-cleanup.md
@@ -25,6 +25,10 @@ A deep-research investigation (full prompt at `Aletheia/data/deep-research-squas
 **For deleting a local branch ref orphaned by a squash-merge, when no-force policy applies, use the four-step `git replace --graft` decomposition:**
 
 ```bash
+# 0. (Pre-flight) Capture the replace-ref state so the post-flight check
+#    in step 5 can detect residue. Typically PRE is 0 for a clean repo.
+PRE_REPLACE_COUNT=$(git replace --list | wc -l)
+
 # 1. Identify the parent of the squash commit on main
 BASE_SHA=$(git rev-parse <SQUASH_SHA>^)
 
@@ -38,9 +42,21 @@ git branch -d <ORPHAN_BRANCH_NAME>
 
 # 4. Remove the temporary graft; original commit and main are restored to pristine state
 git replace -d <SQUASH_SHA>
+
+# 5. (Post-flight) Verify no residue. The replace-ref count must match the
+#    pre-flight count. If it does not, an earlier step deviated from the
+#    recipe — surface the residue and remove it manually before continuing.
+POST_REPLACE_COUNT=$(git replace --list | wc -l)
+if [ "$POST_REPLACE_COUNT" -ne "$PRE_REPLACE_COUNT" ]; then
+  echo "ERROR: replace-ref residue after ADR-0217 recipe. Inspect:"
+  git replace --list --format=long
+  # Identify the offending ref and remove with: git replace -d <SHA>
+fi
 ```
 
 After step 4: local main is unchanged, the squash commit's parents are restored to their original single-parent form, no replace refs remain, and the orphan local branch ref is gone. The orphan commit itself becomes unreachable from any ref and is collected by `git gc` on its normal schedule.
+
+After step 5: the recipe is verified to have run to completion with no residue. This step is the load-bearing detection of a specific failure mode observed in the wild: a subagent (or an operator running the recipe partially) creates a non-standard replace ref — e.g., mapping the orphan tip to a synthetic commit instead of grafting the squash commit — abandons the sequence before step 3 or step 4, and reports success. Step 4 only removes the exact key it was told about; it cannot detect residue at a different key. Step 5 closes that gap.
 
 ## 3. Alternatives Considered
 
@@ -171,6 +187,7 @@ The selected option is a "Level 3" tool: higher overhead than `-D`, used only wh
 | `core.useReplaceRefs` set to false locally | Method silently ineffective | Very Low (default is true) | 2 | Verify with `git config --get core.useReplaceRefs` before applying; falls back to leaving orphan alone |
 | Step 3 succeeds but step 4 fails | Replace ref lingers, distorting subsequent reads of the squash commit | Very Low | 2 | Step 4 is one command; if it fails, run it manually; check `git replace -l` after |
 | Operator types wrong SHAs (e.g., not actually content-equivalent) | Could leave a graft mapping unrelated commits | Low | 2 | Verify content equivalence with `git diff <ORPHAN_SHA> <SQUASH_SHA>` before step 2 (must return zero output) |
+| Subagent (or operator) deviates from the recipe and reports success — e.g., creates a non-standard replace ref mapping the orphan tip to a synthetic commit and skips the `branch -d` | Replace-ref residue persists; orphan branch is not deleted; cleanup report claims success | Medium (observed Hermes 2026-06-06) | 2 | Step 5 post-flight check (`git replace --list` count must match pre-flight). Any deviation is detected and surfaced; recipe consumers MUST run step 5 |
 
 **Residual Risk:** Minimal for properly verified inputs.
 
@@ -217,3 +234,4 @@ The selected option is a "Level 3" tool: higher overhead than `-D`, used only wh
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-04-28 | Claude Opus 4.7 | Initial draft after sandbox + real-repo validation |
+| 2026-06-06 | Claude Opus 4.7 | Added Step 5 post-flight verification + Security Risk row for subagent-deviation failure mode observed on Hermes `feat-first-contact-disclosure` cleanup. See AssemblyZero #1558. |


### PR DESCRIPTION
Closes #1557 and #1558. /cleanup skill no longer references `branch -D` anywhere; both squash-orphan handling phases run the literal ADR-0217 recipe with the new step 5 post-flight check. ADR Section 5 gains the subagent-deviation risk row.

Test plan: skill change is a documentation/instruction edit, no runtime to test. Verified `grep -n "branch -D" cleanup.md` finds only prohibitions, not instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)