### PR TITLE
feat(cleanup): auto-remove orphan worktrees when PR merged + tree clean

### DIFF
--- a/.claude/skills/cleanup.md
+++ b/.claude/skills/cleanup.md
@@ -264,12 +264,25 @@ Session: {SESSION_NAME}
      - Action: `git -C ... push origin --delete {branch-name}`
    - This is NON-NEGOTIABLE. Merged PR branches MUST be deleted.
 
-4. **Verify No Orphaned Worktrees:**
+4. **Verify No Orphaned Worktrees — and auto-remove the safe ones (#1556):**
    - List worktrees: `git -C ... worktree list`
    - For each worktree (not main):
-     - Check if corresponding branch has an OPEN PR
-     - If PR is MERGED or CLOSED: worktree is orphaned → REPORT AS ERROR
-   - Worktrees for merged work MUST be removed manually (safety)
+     - Identify the worktree's branch (`git -C <worktree> branch --show-current`)
+     - Find the most recent PR for that branch: `gh pr list --repo {GITHUB_REPO} --state all --head <branch> --limit 1 --json number,state,mergedAt`
+     - **Auto-remove path** — fires when ALL three conditions are met:
+       - The PR exists AND its state is **MERGED**
+       - The worktree's `git -C <worktree> status --porcelain` returns empty (clean working tree, nothing uncommitted)
+       - The branch does NOT match `graveyard/*` → SKIP (graveyard branches are operator-parked; never auto-touch their worktrees)
+     - When auto-remove fires:
+       - Evict the worktree's cached poetry venv first (Windows file-lock mitigation, see below)
+       - Run plain `git -C {ROOT} worktree remove <worktree-path>` (no `--force` — banned per CLAUDE.md banned-commands table)
+       - On success: report `AUTO-REMOVE: <worktree> (PR #N merged, working tree was clean)`
+       - On failure (e.g., locked files, refs locked, or `worktree remove` refuses): report `AUTO-REMOVE FAILED: <worktree> — <stderr>`. Do NOT retry, do NOT escalate to `--force`, do NOT bypass.
+     - **Manual-handling path** — fires when:
+       - The PR is MERGED but the worktree has uncommitted changes (operator may have unmerged work) → REPORT as ORPHAN-WITH-UNCOMMITTED-STATE
+       - The PR is CLOSED unmerged → REPORT as ORPHAN-UNMERGED (the work may still be wanted)
+       - No PR association → REPORT as ORPHAN-NO-PR (could be carry-in or intentional state)
+     - In all manual-handling cases: report and let the operator decide; do not auto-remove
    - **Pre-removal poetry venv eviction (Windows file-lock mitigation):** Before calling `git worktree remove` on any worktree, run the following inside that worktree so its cached poetry virtualenv doesn't hold file locks:
      ```bash
      poetry env remove --all  # run from inside the worktree

--- a/.claude/templates/commands/cleanup.md.template
+++ b/.claude/templates/commands/cleanup.md.template
@@ -135,11 +135,33 @@ Run these commands simultaneously in a single message with multiple Bash tool ca
    b. If remote shows `gone` AND no worktree AND `--no-auto-delete` IS set:
       - Report: "ORPHAN: Branch {name} has no remote (--no-auto-delete set, skipping)"
 
-3. **Open PRs** - Should be 0. Flag if any exist.
+3. **Verify No Orphaned Worktrees — auto-remove safe ones (#1556):**
 
-4. **Stashes** - Document any stash entries found.
+   The workflow runners create worktrees at `~/Projects/<RepoName>-<issue>/`. When the associated PR merges and the working tree is clean, the worktree directory is filesystem residue and can be removed without losing work. This step closes that gap so worktree directories don't accumulate.
 
-5. **Permission Check** (Full mode only) - If the permission quick-check returned exit code 1:
+   - List worktrees: `git -C {{PROJECT_ROOT}} worktree list`
+   - For each worktree (not main):
+     - Identify the worktree's branch: `git -C <worktree> branch --show-current`
+     - Find the most recent PR for the branch: `gh pr list --repo {GITHUB_REPO} --state all --head <branch> --limit 1 --json number,state,mergedAt`
+     - **Auto-remove path** — fires when ALL three conditions are met:
+       - PR exists AND its state is **MERGED**
+       - `git -C <worktree> status --porcelain` returns empty (clean tree)
+       - Branch does NOT match `graveyard/*` (graveyard branches are operator-parked; never auto-touch)
+     - When auto-remove fires:
+       - Evict the worktree's cached poetry venv first (Windows file-lock mitigation; see Phase 2 note below)
+       - Run plain `git -C {{PROJECT_ROOT}} worktree remove <worktree-path>` (no `--force` — banned per CLAUDE.md banned-commands table)
+       - On success: report `AUTO-REMOVE: <worktree> (PR #N merged, working tree was clean)`
+       - On failure: report `AUTO-REMOVE FAILED: <worktree> — <stderr>`. Do NOT retry, do NOT escalate to `--force`, do NOT bypass.
+     - **Manual-handling path** — operator decides:
+       - PR is MERGED but working tree has uncommitted changes → REPORT `ORPHAN-WITH-UNCOMMITTED-STATE`
+       - PR is CLOSED unmerged → REPORT `ORPHAN-UNMERGED` (the work may still be wanted)
+       - No PR association → REPORT `ORPHAN-NO-PR` (could be carry-in)
+
+4. **Open PRs** - Should be 0. Flag if any exist.
+
+5. **Stashes** - Document any stash entries found.
+
+6. **Permission Check** (Full mode only) - If the permission quick-check returned exit code 1:
    - Report: "Stale permissions detected in settings.local.json"
    - Suggest: "Run `poetry run python tools/assemblyzero-permissions.py --clean --project {{PROJECT_NAME}}` to clean"
 


### PR DESCRIPTION
## Summary

Closes the filesystem-residue gap surfaced by the 2026-06-07 fleet graveyard survey (martymcenroe/a private tracking repo PR #3): the cleanup skill previously reported worktrees-with-merged-PRs as ORPHAN-ERROR and required manual cleanup. The conservative auto-remove path now fires when:

- PR for the worktree's branch is MERGED
- `git -C <worktree> status --porcelain` returns empty (no uncommitted state)
- Branch does NOT match `graveyard/*` (operator-parked, never auto-touch)

When all three hold, runs plain `git worktree remove` (no `--force`, per banned-commands table). On failure: report and stop — never escalate.

When any condition fails, surfaces as ORPHAN-WITH-UNCOMMITTED-STATE / ORPHAN-UNMERGED / ORPHAN-NO-PR for operator decision.

## Files

- `.claude/skills/cleanup.md` (Phase 2 step 4 expanded)
- `.claude/templates/commands/cleanup.md.template` (new Phase 2 step 3 + subsequent renumbering: Open PRs 3→4, Stashes 4→5, Permission Check 5→6)

Closes #1556