### PR TITLE
test(ci): move scaffolder/tooling tests into tests/unit so CI runs them (Closes #1579)

### DIFF
--- a/tests/unit/test_fix_requires_python.py
+++ b/tests/unit/test_fix_requires_python.py
@@ -8,7 +8,7 @@ dry-run never touches the network.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "tools"))
 
 from fix_requires_python import (  # noqa: E402
     fix_repo,

--- a/tests/unit/test_new_repo_setup.py
+++ b/tests/unit/test_new_repo_setup.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "tools"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "tools"))
 
 from new_repo_setup import (
     PROJECT_TYPES,
@@ -34,8 +34,8 @@ from new_repo_setup import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-SCHEMA_PATH = Path(__file__).parent.parent / "docs" / "standards" / "0009-structure-schema.json"
-STANDARD_PATH = Path(__file__).parent.parent / "docs" / "standards" / "0009-canonical-project-structure.md"
+SCHEMA_PATH = Path(__file__).parent.parent.parent / "docs" / "standards" / "0009-structure-schema.json"
+STANDARD_PATH = Path(__file__).parent.parent.parent / "docs" / "standards" / "0009-canonical-project-structure.md"
 
 
 def _minimal_schema():
@@ -1236,7 +1236,7 @@ class TestGitHubRepoNameCasePreservation:
 
     def test_no_lowercased_repo_name_variable_in_script(self):
         from pathlib import Path
-        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo_setup.py"
         content = script.read_text(encoding="utf-8")
         assert "repo_name_lower" not in content, (
             "regression: `repo_name_lower` was reintroduced. The GitHub repo "
@@ -1250,7 +1250,7 @@ class TestGitHubRepoNameCasePreservation:
         site so a future agent reading the code understands why no
         lowercasing happens there."""
         from pathlib import Path
-        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo_setup.py"
         content = script.read_text(encoding="utf-8")
         assert "#1533" in content
         # The comment must sit in the GitHub-side flow. Use the `GITHUB REMOTE`
@@ -1289,7 +1289,7 @@ class TestGitHubRepoNameCasePreservation:
         """
         from pathlib import Path
         import re
-        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo_setup.py"
         content = script.read_text(encoding="utf-8")
 
         # Direct mutation: `args.name = args.name.lower()`
@@ -1329,7 +1329,7 @@ class TestCerberusPostDeployAdvice:
         """The string 'REMEMBER to revoke' should only appear inside a
         conditional that checks args.cerberus_pem (the plaintext flow)."""
         from pathlib import Path
-        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo_setup.py"
         content = script.read_text(encoding="utf-8")
         # The advisory text must exist (it's correct for the plaintext flow)
         assert "REMEMBER to revoke the key in the app UI" in content
@@ -1345,7 +1345,7 @@ class TestCerberusPostDeployAdvice:
         so future agents understand why the two flows produce different
         end-of-run advice."""
         from pathlib import Path
-        script = Path(__file__).resolve().parent.parent / "tools" / "new_repo_setup.py"
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo_setup.py"
         content = script.read_text(encoding="utf-8")
         assert "#1536" in content
         # The #1536 anchor must be near the `elif cerberus_status == \"OK\":`

--- a/tests/unit/test_new_repo_setup_pypi.py
+++ b/tests/unit/test_new_repo_setup_pypi.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 
 # Make tools/ importable. Mirrors the conftest pattern other AZ tests use.
-_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+_TOOLS = Path(__file__).resolve().parent.parent.parent / "tools"
 if str(_TOOLS) not in sys.path:
     sys.path.insert(0, str(_TOOLS))
 

--- a/tests/unit/test_scaffolder_lint_integration.py
+++ b/tests/unit/test_scaffolder_lint_integration.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
 
 from new_repo_setup import PROJECT_TYPES, create_claude_md  # noqa: E402
 from lint_per_repo_claude_md import detect_drift  # noqa: E402


### PR DESCRIPTION
## What this does

CI (`ci.yml`) runs `tools/test-gate.py` against `tests/unit/` and `tests/integration/` only. Four scaffolder/tooling test files lived at `tests/` root and never ran in CI — so the scaffolder's own correctness tests (including this week's #1334 / #1563 / #1573 / #1575 / #1577 coverage) were not CI-guarded, even though the scaffolder is the most defect-prone surface (see #1333).

Moved into `tests/unit/`:
- `test_new_repo_setup.py`
- `test_new_repo_setup_pypi.py`
- `test_scaffolder_lint_integration.py`
- `test_fix_requires_python.py`

Fixed the `__file__`-relative depth in each (`parent.parent` → `parent.parent.parent`, `parents[1]` → `parents[2]`) so they resolve `repo-root/tools` and `repo-root/docs` from the new location.

## Verified

`tests/unit/` now **4498 passing** (was 4372; +126 from the moved files). A regression in `new_repo_setup.py` / `fix_requires_python.py` now fails the `test` check.

## Scope

This closes the scaffolder/tooling slice. The systemic remainder — ~50 other test files at `tests/` root are also not in CI — is tracked in #1580 (needs a move-all-vs-CI-change decision; some root tests need network/secrets).

Closes #1579
