### PR TITLE
chore(GEMINI.md): remove blocking session-handshake/ACK

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,7 +1,5 @@
 # Gemini Operational Protocols - AssemblyZero
 
-## 1. Session Initialization (The Handshake)
-
 ## 2. Core Rules
 
 **Read `CLAUDE.md` in this repository.** Those rules apply to ALL agents:


### PR DESCRIPTION
Removes the `## Session Initialization (The Handshake)` section from GEMINI.md. It instructs the agent to emit an `ACK` and HALT until the user replies, which blocks the Antigravity CLI (`agy`) on auto-load. Operator-confirmed by direct test.

No-Issue: remove the blocking Gemini session-handshake/ACK from GEMINI.md -- it halts Antigravity CLI (agy) on auto-load. Operator-confirmed by direct test that agy prompts the ACK in repos that still carry it. Fleet consistency cleanup.