### PR TITLE
feat(gemini_client): migrate governance OAuth transport to Antigravity (agy) (Closes #1595)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -11,8 +11,8 @@ Ported from tools/gemini-rotate.py for programmatic use.
 
 import json
 import os
+import re
 import shutil
-import subprocess
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -263,6 +263,21 @@ def get_credential_status() -> dict:
 
 
 # =============================================================================
+# Antigravity CLI (agy) output handling
+# =============================================================================
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[=>]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI/VT control sequences from agy's pseudo-console output and
+    normalize newlines. agy renders to a TTY, so the captured stream carries
+    color codes and CR/LF that must be removed before the response is parsed."""
+    return _ANSI_RE.sub("", text).replace("\r\n", "\n").replace("\r", "")
+
+
+# =============================================================================
 # Gemini Client
 # =============================================================================
 
@@ -307,20 +322,21 @@ class GeminiClient:
         self.state_file = state_file
         self._credentials: Optional[list[Credential]] = None
         self._state: Optional[RotationState] = None
-        self._gemini_cli = self._find_gemini_cli()
+        self._agy_cli = self._find_agy_cli()
 
-    def _find_gemini_cli(self) -> Optional[str]:
-        """Find the gemini CLI executable."""
-        cli = shutil.which("gemini")
+    def _find_agy_cli(self) -> Optional[str]:
+        """Find the Antigravity CLI (agy) executable.
+
+        Replaces the retired Gemini CLI (#1335); agy is the subscription
+        (OAuth) governance transport.
+        """
+        cli = shutil.which("agy")
         if cli:
             return cli
-        # Try common locations on Windows
-        npm_gemini = Path.home() / "AppData" / "Roaming" / "npm" / "gemini.cmd"
-        if npm_gemini.exists():
-            return str(npm_gemini)
-        npm_gemini_unix = Path.home() / "AppData" / "Roaming" / "npm" / "gemini"
-        if npm_gemini_unix.exists():
-            return str(npm_gemini_unix)
+        # Default Windows install location (agy is not always on PATH).
+        candidate = Path.home() / "AppData" / "Local" / "agy" / "bin" / "agy.exe"
+        if candidate.exists():
+            return str(candidate)
         return None
 
     def _invoke_via_cli(
@@ -328,111 +344,83 @@ class GeminiClient:
         system_instruction: str,
         content: str,
     ) -> tuple[bool, str, str]:
-        """
-        Invoke Gemini via CLI (for OAuth credentials).
+        """Invoke the governance model via the Antigravity CLI (agy).
 
-        The CLI doesn't have a --system flag, so we prepend the system
-        instruction to the content with clear delineation.
+        This is the subscription/OAuth transport (#1335), replacing the retired
+        Gemini CLI. Two things differ from a normal subprocess call:
 
-        IMPORTANT: The CLI loads GEMINI.md from the working directory, which
-        contains handshake instructions that interfere with governance reviews.
-        We temporarily rename GEMINI.md during the call to avoid this.
+        1. agy renders its response ONLY to a TTY — a piped stdout receives
+           nothing (exit 0, empty stream). So we run agy under a pseudo-console
+           via pywinpty and strip ANSI control codes from the captured output.
+        2. agy is run in a clean temp working directory so no repo GEMINI.md /
+           AGENTS.md / .gemini context bleeds into the governance review. This
+           also retires the old GEMINI.md-rename workaround (and the .bak debris
+           it produced) entirely.
 
-        We also use --sandbox mode to disable agentic features.
+        The prompt rides in argv (agy `-p <prompt>`); Windows caps a command
+        line at ~32767 chars, so an oversized prompt is rejected explicitly
+        rather than truncated silently.
 
         Returns:
             Tuple of (success, response_text, error_message)
         """
-        if not self._gemini_cli:
-            return False, "", "Gemini CLI not found"
+        if not self._agy_cli:
+            return False, "", "Antigravity CLI (agy) not found"
 
-        # Combine system instruction and content
+        # Combine system instruction and content (agy has no --system flag).
         full_prompt = (
             f"You are {self.model}.\n\n"
             f"<system_instruction>\n{system_instruction}\n</system_instruction>\n\n"
             f"<user_content>\n{content}\n</user_content>"
         )
 
-        gemini_md_path = Path.cwd() / "GEMINI.md"
-        gemini_md_backup = Path.cwd() / "GEMINI.md.bak"
-        gemini_md_renamed = False
-
-        # #1436 (extended): If a prior invocation crashed before its finally
-        # block restored GEMINI.md, a stale .bak is sitting where we want to
-        # write. On Windows, Path.rename() fails when the target exists
-        # (WinError 183), making every subsequent OAuth call fail. Park any
-        # stale .bak out of the way at the start of each call. Use a
-        # timestamped suffix so the operator can still recover the parked
-        # content if needed; subsequent runs will park their own .bak with
-        # a different timestamp.
-        if gemini_md_backup.exists():
-            import datetime as _dt
-            stale_park = gemini_md_backup.with_suffix(
-                f".bak.stale-{_dt.datetime.now(_dt.timezone.utc).strftime('%Y%m%dT%H%M%S')}"
+        # Windows CreateProcess command-line limit is 32767 chars; leave headroom.
+        if len(full_prompt) > 30000:
+            return False, "", (
+                f"prompt too large for agy argv ({len(full_prompt)} chars > 30000); "
+                f"stdin-based invocation is a follow-up"
             )
-            try:
-                gemini_md_backup.replace(stale_park)
-            except OSError:
-                pass
 
         try:
-            # Temporarily rename GEMINI.md to prevent CLI from loading it.
-            # Use Path.replace() instead of Path.rename() — replace() is the
-            # cross-platform "atomic move that overwrites if target exists"
-            # primitive. Path.rename() refuses to overwrite on Windows
-            # (WinError 183). The stale-bak cleanup above means there should
-            # be no .bak to overwrite by the time we reach here, but
-            # replace() is the safer primitive regardless.
-            if gemini_md_path.exists():
-                gemini_md_path.replace(gemini_md_backup)
-                gemini_md_renamed = True
+            from winpty import PtyProcess
+        except ImportError as e:
+            return False, "", f"pywinpty unavailable for agy invocation: {e}"
 
-            # Use stdin to pass the prompt to avoid agentic file reading.
-            # --approval-mode plan = read-only (replaces --sandbox which required
-            # Docker/Podman — broken on machines without either). --skip-trust
-            # prevents the workspace-trust prompt in headless invocations.
-            result = subprocess.run(
-                [
-                    self._gemini_cli,
-                    "--prompt",
-                    "-",  # Read from stdin
-                    "--model",
-                    self.model,
-                    "--output-format",
-                    "text",
-                    "--approval-mode",
-                    "plan",  # Read-only; no Docker requirement
-                    "--skip-trust",  # No workspace-trust prompt
-                ],
-                input=full_prompt,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                timeout=120,  # 2 minute timeout
-            )
+        import tempfile
 
-            if result.returncode == 0 and result.stdout:
-                return True, result.stdout.strip(), ""
-            else:
-                error_msg = (
-                    result.stderr.strip() or result.stdout.strip() or "Unknown error"
-                )
-                return False, "", error_msg
+        argv = [self._agy_cli, "-p", full_prompt, "--model", self.model]
+        chunks: list[str] = []
+        try:
+            with tempfile.TemporaryDirectory() as tmp_cwd:
+                proc = PtyProcess.spawn(argv, cwd=tmp_cwd, dimensions=(60, 1000))
+                deadline = time.time() + 300  # 5 minute timeout
+                timed_out = True
+                while time.time() < deadline:
+                    try:
+                        data = proc.read(4096)
+                    except EOFError:
+                        timed_out = False
+                        break
+                    if data:
+                        chunks.append(data)
+                    elif not proc.isalive():
+                        timed_out = False
+                        break
+                    else:
+                        time.sleep(0.05)
+                if timed_out:
+                    try:
+                        proc.terminate(force=True)
+                    except Exception:
+                        pass
+                    return False, "", "agy CLI timeout (300s)"
+        except Exception as e:  # pywinpty raises assorted OS/runtime errors
+            return False, "", f"agy CLI invocation failed: {e}"
 
-        except subprocess.TimeoutExpired:
-            return False, "", "CLI timeout (120s)"
-        except FileNotFoundError:
-            return False, "", f"Gemini CLI not found: {self._gemini_cli}"
-        except OSError as e:
-            return False, "", str(e)
-        finally:
-            # Restore GEMINI.md using replace() for Windows-safe atomic
-            # overwrite of the path we moved it FROM.
-            if gemini_md_renamed and gemini_md_backup.exists():
-                try:
-                    gemini_md_backup.replace(gemini_md_path)
-                except OSError:
-                    pass
+        text = _strip_ansi("".join(chunks)).strip()
+        if text:
+            return True, text, ""
+        return False, "", "agy returned no output"
 
     def invoke(
         self,

--- a/docs/adrs/0220-antigravity-cli-migration.md
+++ b/docs/adrs/0220-antigravity-cli-migration.md
@@ -1,80 +1,77 @@
 # ADR 0220: Antigravity (`agy`) CLI migration for the governance Gemini client
 
-- **Status:** Proposed — primary path actionable now; CLI port blocked (see #1595)
+- **Status:** Accepted — implemented (#1595)
 - **Date:** 2026-06-13
-- **Related:** #1335 (this spike), #1595 (CLI port, blocked), #1596 (legacy reviewer bug), #1334/#1563 (scaffolder GEMINI.md), #1590 (GEMINI.md ACK removal)
+- **Related:** #1335 (spike), #1595 (this migration), #1596 (legacy reviewer bug), #1334/#1563 (scaffolder GEMINI.md), #1590 (GEMINI.md ACK removal)
 
 ## Context
 
 The Gemini CLI retires **2026-06-18** for AI Pro/Ultra and free tiers. Antigravity
-CLI (`agy`) is the subscription replacement. A prior session already removed the
-GEMINI.md handshake/ACK section fleet-wide (#1590) because `agy` trips on it on
-auto-load. This ADR covers the remaining governance-code question: does AssemblyZero's
-LLD/spec/test-plan review pipeline depend on the retiring `gemini` binary, and what is
-the migration?
+CLI (`agy`) is the subscription replacement. **Governance runs on the subscription
+(OAuth) quota only — the paid Gemini API is not used (it is ~100x the cost).** So when
+the Gemini CLI dies, the OAuth transport in `GeminiClient` breaks and there is no
+API-key fallback; the `agy` migration is the sole path and the deadline is hard.
+
+A prior session already removed the GEMINI.md handshake/ACK section fleet-wide (#1590)
+because `agy` trips on it on auto-load.
 
 ## Findings
 
-**1. The live review path does reach the `gemini` CLI.** The requirements, spec, and
-testing workflows review via `get_provider(config_reviewer)` with default spec
-`gemini:3.1-pro-preview` (`workflows/requirements/nodes/review.py:136`,
-`workflows/testing/nodes/review_test_plan.py:491`,
-`workflows/implementation_spec/nodes/review_spec.py`). That resolves to
-`GeminiProvider` → `GeminiClient(model="gemini-3.1-pro-preview")`. `GeminiClient` has
-two transports: an **OAuth** path that shells out to the `gemini` binary
-(`_invoke_via_cli`) and an **api_key** path that calls the `google.genai` SDK directly
-(`genai.Client`). Only the OAuth/CLI path breaks on 2026-06-18.
+**1. The live review path reaches the CLI.** The requirements, spec, and testing
+workflows review via `get_provider(config_reviewer)`, default spec `gemini:3.1-pro-preview`
+→ `GeminiProvider` → `GeminiClient`. For subscription/OAuth credentials, `GeminiClient`
+shells out to the CLI (`_invoke_via_cli`).
 
-**2. `agy`'s interface differs from `gemini`'s** (observed, `agy` v1.0.8):
+**2. `agy`'s interface differs from `gemini`'s** (`agy` v1.0.8): binary `agy`
+(`~/AppData/Local/agy/bin/agy.exe`, not always on PATH); prompt via `-p <prompt>`;
+`--model <id>`; no `--output-format`; `--sandbox` for restricted mode. `-p -` reads the
+prompt from stdin.
 
-| Concern | `gemini` (current) | `agy` (target) |
-|---|---|---|
-| binary lookup | `shutil.which("gemini")` + npm `.cmd` | `agy` (`~/AppData/Local/agy/bin/agy.exe`; on PATH after `agy install`) |
-| prompt input | `--prompt -` (stdin) | `--print "<prompt>"` (**argument**, not stdin) |
-| model flag | `--model <id>` | `--model <id>` |
-| output format | `--output-format text` | (none) |
-| read-only mode | `--approval-mode plan` `--skip-trust` | `--sandbox` |
+**3. `agy` renders its response only to a TTY — SOLVED.** Called with a piped stdout it
+exits 0 with empty output (the model call still happens — the log shows successful
+keyring auth and `streamGenerateContent` to `daily-cloudcode-pa.googleapis.com` — but
+nothing reaches the pipe). The fix: run `agy` under a **pseudo-console via `pywinpty`**
+(already a fleet dependency), capture the stream, and strip ANSI/VT codes. Verified
+end-to-end: a long JSON governance verdict round-trips intact and parses.
 
-**3. `agy` print mode produces no output as a headless subprocess.** `agy --print "..."`
-returns exit 0 with **empty stdout and stderr** when invoked from a non-TTY subprocess
-(tested twice from a clean temp dir, with and without `--sandbox`/`--model`).
-`GeminiClient` treats `returncode == 0 and not stdout` as failure, so a naive port would
-make every governance review fail. **This blocks the CLI port** (#1595) until `agy`
-emits output under `subprocess.run(capture_output=True)` — probably an auth/TTY issue
-the operator must resolve (`agy login` is a credential prompt the agent must not trigger).
-
-**4. The api_key path is the deadline-safe answer.** `GeminiClient`'s `genai.Client`
-transport does not touch the CLI and is unaffected by the CLI retirement. If
-`~/.assemblyzero/gemini-credentials.json` includes a Gemini **API key**, governance keeps
-working past 2026-06-18 with **zero code change**. The `agy` CLI port is only needed to
-keep using **subscription (OAuth)** quota instead of paid API keys.
+**4. Subscription-only — there is no API-key fallback.** `GeminiClient` also has a
+`genai.Client` (API-key) transport, but it is not used in governance because the paid
+API is ~100x the subscription cost. The CLI migration is therefore mandatory, not
+optional.
 
 **5. A legacy path is incoherent (#1596).** `config.REVIEWER_MODEL = "claude-opus-4-6"`,
 yet `nodes/lld_reviewer.py:88` calls `GeminiClient(model=REVIEWER_MODEL)`, which raises
-on any non-`gemini-` model. These `nodes/` modules appear superseded by the
-`get_provider` abstraction; tracked separately.
+on a non-`gemini-` model. These `nodes/` modules look superseded by `get_provider`;
+tracked separately.
 
 ## Decision
 
-1. **Deadline mitigation (do first, no code):** ensure a Gemini API-key credential is
-   configured so the `genai.Client` transport carries governance through the CLI
-   retirement. Verify by running a review with OAuth credentials disabled.
-2. **`agy` CLI port (#1595):** apply the interface translation in the table above — but
-   only after the operator confirms `agy --print` returns output when called as a
-   subprocess. Blocked until then. Needed only to preserve subscription quota.
-3. **Legacy cleanup (#1596):** determine whether `review_lld_node` / the designer node
-   are still wired into any graph; delete if dead, fix the model wiring if live.
+Migrate `GeminiClient._invoke_via_cli` (#1595) to drive `agy` via a `pywinpty`
+pseudo-console:
+
+- `_find_agy_cli` locates `agy` (PATH, then the default Windows install path).
+- `_invoke_via_cli` spawns `agy -p <full_prompt> --model <id>` under a pseudo-console
+  (wide terminal so long JSON does not wrap), reads to EOF, and `_strip_ansi`-cleans the
+  result. A 5-minute timeout terminates a hung call.
+- `agy` runs in a **clean temp working directory**, so no repo `GEMINI.md` / `AGENTS.md`
+  / `.gemini` bleeds into the governance review. This retires the old GEMINI.md-rename
+  workaround and the `.bak` debris it produced.
+- The prompt rides in argv; Windows caps a command line at ~32767 chars, so a prompt
+  over 30000 is rejected explicitly (stdin-based invocation for oversized prompts is a
+  follow-up).
 
 ## Consequences
 
-- Governance is **not** at hard risk on 2026-06-18 provided an API key exists (decision 1).
-- The subscription-quota cost saving from OAuth is paused until #1595 unblocks.
-- `agy`'s headless behavior is the single open question gating the CLI port; it cannot be
-  resolved agent-side (no credential-prompt access).
+- Governance survives the 2026-06-18 CLI retirement on the subscription quota, no code
+  changes to callers.
+- New hard dependency on `pywinpty` for the OAuth transport (Windows). The api-key
+  transport is unchanged and untouched.
+- Oversized prompts (>30 KB argv) fail loudly pending a stdin-based path.
+- Legacy `nodes/lld_reviewer.py` / `designer.py` cleanup remains open (#1596).
 
-## Fleet artifacts reviewed (per #1335 question 7)
+## Fleet artifacts
 
-Touched/identified: `gemini_client.py` (#1595), `nodes/lld_reviewer.py` + `nodes/designer.py`
-(#1596), GEMINI.md fleet templates (#1590, done). `tools/gemini_model_check.py` and
-`docs/prompts/gemini-rotation-instructions.md` (already retired in #1221) are unaffected by
-the CLI retirement — they concern model IDs and the API path, not the binary.
+Touched: `gemini_client.py` (#1595, done), GEMINI.md fleet templates (#1590, done).
+Open: `nodes/lld_reviewer.py` + `nodes/designer.py` (#1596). `tools/gemini_model_check.py`
+and the retired `gemini-rotation-instructions.md` (#1221) are unaffected — they concern
+model IDs, not the binary.

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -11,18 +11,18 @@ Issue #605: Systemic Model Refresh — Gemini 3.1, Claude 4.6
 """
 
 import json
+import sys
 import tempfile
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from assemblyzero.core.gemini_client import (
-    Credential,
-    GeminiCallResult,
     GeminiClient,
     GeminiErrorType,
-    RotationState,
+    _strip_ansi,
 )
 
 
@@ -350,3 +350,81 @@ class TestResetTimeParsing:
 
         result = client._parse_reset_time("Some random error message")
         assert result is None
+
+
+# ── Antigravity (agy) CLI transport (#1335) ──────────────────────────
+
+
+class _FakeAgyProc:
+    """Minimal pywinpty PtyProcess stand-in: replays chunks then EOFErrors."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.terminated = False
+
+    def read(self, _size):
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise EOFError
+
+    def isalive(self):
+        return bool(self._chunks)
+
+    def terminate(self, force=False):
+        self.terminated = True
+
+
+def _fake_winpty(chunks):
+    """A fake `winpty` module whose PtyProcess.spawn yields the given chunks.
+
+    Lets the agy pseudo-console path be tested without real pywinpty (so the
+    tests run on Linux CI, where winpty is not installed).
+    """
+    mod = types.ModuleType("winpty")
+    mod.PtyProcess = MagicMock()
+    mod.PtyProcess.spawn.return_value = _FakeAgyProc(chunks)
+    return mod
+
+
+def test_strip_ansi_removes_codes_and_normalizes_newlines():
+    assert _strip_ansi("\x1b[32mOK\x1b[0m\r\n") == "OK\n"
+    assert _strip_ansi("a\r\nb\r\n") == "a\nb\n"
+    assert _strip_ansi("plain") == "plain"
+
+
+def test_find_agy_cli_uses_path():
+    with patch("assemblyzero.core.gemini_client.shutil.which", return_value="/usr/bin/agy"):
+        client = GeminiClient(model="gemini-3.1-pro-preview")
+    assert client._agy_cli == "/usr/bin/agy"
+
+
+def test_invoke_via_cli_agy_not_found():
+    client = GeminiClient(model="gemini-3.1-pro-preview")
+    client._agy_cli = None
+    ok, resp, err = client._invoke_via_cli("sys", "content")
+    assert ok is False and resp == "" and "not found" in err.lower()
+
+
+def test_invoke_via_cli_rejects_oversized_prompt():
+    client = GeminiClient(model="gemini-3.1-pro-preview")
+    client._agy_cli = "agy"
+    ok, resp, err = client._invoke_via_cli("sys", "x" * 31000)
+    assert ok is False and "too large" in err
+
+
+def test_invoke_via_cli_strips_ansi_and_returns_text():
+    client = GeminiClient(model="gemini-3.1-pro-preview")
+    client._agy_cli = "agy"
+    chunks = ['\x1b[32m{"verdict":"APPROVE"}\x1b[0m\r\n']
+    with patch.dict(sys.modules, {"winpty": _fake_winpty(chunks)}):
+        ok, resp, err = client._invoke_via_cli("sys", "content")
+    assert ok is True and err == ""
+    assert resp == '{"verdict":"APPROVE"}'
+
+
+def test_invoke_via_cli_empty_output_is_failure():
+    client = GeminiClient(model="gemini-3.1-pro-preview")
+    client._agy_cli = "agy"
+    with patch.dict(sys.modules, {"winpty": _fake_winpty([])}):
+        ok, resp, err = client._invoke_via_cli("sys", "content")
+    assert ok is False and "no output" in err


### PR DESCRIPTION
## Why

The Gemini CLI retires **2026-06-18**. AZ governance runs on the **subscription/OAuth quota only** — the paid Gemini API is ~100x the cost and is not used — so there is no API-key fallback. The `agy` (Antigravity) CLI is the sole path, and the deadline is hard.

## The hard part (and the fix)

`agy` renders its response **only to a TTY**. Called with a piped stdout it exits 0 with empty output (the model call still happens — agy's log shows keyring auth + `streamGenerateContent` to the subscription endpoint — but nothing reaches the pipe). That's why a naive `subprocess.run` port produced nothing.

`_invoke_via_cli` now:
- drives `agy -p <prompt> --model <id>` under a **`pywinpty` pseudo-console** (already a fleet dependency), reads to EOF, and strips ANSI/VT codes;
- runs agy in a **clean temp working directory**, so no repo `GEMINI.md` / `AGENTS.md` / `.gemini` bleeds into the review — this also **retires the GEMINI.md-rename workaround and the `.bak` debris** it caused;
- uses a wide pseudo-terminal so long JSON verdicts don't wrap;
- rejects prompts over 30 000 chars explicitly (Windows argv limit; stdin path is a follow-up).

`_find_agy_cli` locates agy on PATH or the default Windows install location.

## Verified

End-to-end through `GeminiClient._invoke_via_cli` against real agy: a long JSON governance verdict round-trips intact and parses (`verdict=APPROVE`). Full `tests/unit`: **5585 passed, 0 failed**. 6 new unit tests cover `_strip_ansi`, agy discovery, and the not-found / oversized / empty-output / pty-capture paths (winpty faked so they run on Linux CI). The api-key transport is untouched.

ADR 0220 updated to reflect the implemented migration and correct the cost framing.

Closes #1595