### PR TITLE
fix(orchestrator): ride the implementation spec on the LLD PR (Closes #1625)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from assemblyzero.utils.shell import run_command
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import time
@@ -447,6 +448,86 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
     return update_stage_result(state, stage, result)
 
 
+def _ride_spec_on_lld_pr(
+    spec_path: str,
+    target_repo: str,
+    issue_number: int,
+) -> bool:
+    """Closes #1625. Mirror the implementation spec into the existing ``{N}-lld``
+    worktree and commit + push it, so the spec rides the LLD PR (which merges per
+    ADR 0221) and lands on target main instead of being orphaned on the working
+    tree.
+
+    Best-effort: never raises. If the ``{N}-lld`` worktree is absent (e.g. the
+    LLD stage was skipped because a pre-existing LLD was found, so there is no LLD
+    PR to ride), the spec is left on the working tree and a note is logged — the
+    terminal cleanup only deletes the working-tree copy after the LLD PR merges,
+    so an un-ridden spec stays put rather than being lost.
+
+    Returns True iff the spec was committed to the LLD worktree.
+    """
+    if not target_repo or not spec_path:
+        return False
+    from assemblyzero.workflows.requirements.git_operations import (
+        lld_worktree_path_for,
+    )
+
+    worktree = lld_worktree_path_for(target_repo, issue_number)
+    if not worktree.is_dir():
+        print(
+            f"    [spec] no LLD worktree at {worktree} — spec stays on the working "
+            f"tree (no LLD PR to ride); terminal cleanup will not delete it"
+        )
+        return False
+
+    src = Path(spec_path)
+    try:
+        rel = src.relative_to(Path(target_repo))
+    except ValueError:
+        return False
+
+    try:
+        dst = worktree / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+        add = run_command(
+            ["git", "add", str(rel)], cwd=str(worktree),
+            capture_output=True, text=True,
+        )
+        if add.returncode != 0:
+            print(f"    [spec] git add failed (non-fatal): {add.stderr.strip()}")
+            return False
+
+        msg = (
+            f"docs: add implementation spec for issue #{issue_number}\n\n"
+            f"Ref #{issue_number}"
+        )
+        commit = run_command(
+            ["git", "commit", "-m", msg], cwd=str(worktree),
+            capture_output=True, text=True,
+        )
+        if commit.returncode != 0:
+            detail = (commit.stderr or commit.stdout).strip()
+            print(f"    [spec] git commit failed/no-op (non-fatal): {detail}")
+            return False
+
+        push = run_command(
+            ["git", "push"], cwd=str(worktree),
+            capture_output=True, text=True,
+        )
+        if push.returncode != 0:
+            # Committed locally; the open LLD PR updates on the next push.
+            print(f"    [spec] commit OK, push failed (non-fatal): {push.stderr.strip()}")
+            return True
+
+        print(f"    [spec] implementation spec committed to the LLD PR (issue #{issue_number})")
+        return True
+    except OSError as e:
+        print(f"    [spec] spec mirror failed (non-fatal): {e}")
+        return False
+
+
 def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute implementation spec workflow.
 
@@ -498,6 +579,15 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
 
         spec_path = sub_result.get("spec_path", "")
         if spec_path and Path(spec_path).is_file():
+            # Closes #1625: the spec is a permanent artifact paired with the LLD;
+            # ride it on the LLD PR so it lands on target main (ADR 0221). The
+            # working-tree copy stays for the impl stage to read; the terminal
+            # cleanup removes it after the LLD PR merges.
+            _ride_spec_on_lld_pr(
+                spec_path=spec_path,
+                target_repo=state.get("target_repo", ""),
+                issue_number=issue_number,
+            )
             result = _make_stage_result(
                 status="passed",
                 artifact_path=spec_path,

--- a/tests/unit/test_spec_rides_lld_pr.py
+++ b/tests/unit/test_spec_rides_lld_pr.py
@@ -1,0 +1,117 @@
+"""Tests for the spec riding the LLD PR (Issue #1625).
+
+finalize_spec writes the implementation spec to the target working tree but does
+no git op, so the spec was orphaned. Per ADR 0221 the spec is a permanent artifact
+that rides the LLD PR: run_spec_stage mirrors it into the existing {N}-lld worktree
+and commits + pushes (the open LLD PR auto-updates). The terminal cleanup later
+removes the working-tree copy after the LLD PR merges.
+"""
+from unittest.mock import MagicMock, patch
+
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.config import get_default_config
+from assemblyzero.workflows.orchestrator.state import create_initial_state
+
+
+def _ok_run(cmd, **kw):
+    out = MagicMock()
+    out.returncode = 0
+    out.stdout = ""
+    out.stderr = ""
+    return out
+
+
+def test_ride_spec_commits_to_lld_worktree(tmp_path):
+    """When the {N}-lld worktree exists, the spec is mirrored in and add/commit/push run."""
+    target = tmp_path / "target"
+    drafts = target / "docs" / "lld" / "drafts"
+    drafts.mkdir(parents=True)
+    spec = drafts / "spec-0042-implementation-readiness.md"
+    spec.write_text("# spec")
+    worktree = tmp_path / "target-42-lld"  # == lld_worktree_path_for(target, 42)
+    worktree.mkdir()
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _ok_run(cmd, **kw)
+
+    with patch.object(stages, "run_command", side_effect=fake_run):
+        ok = stages._ride_spec_on_lld_pr(str(spec), str(target), 42)
+
+    assert ok is True
+    # spec mirrored into the worktree at the same relative path
+    assert (worktree / "docs" / "lld" / "drafts" / "spec-0042-implementation-readiness.md").exists()
+    joined = [" ".join(c) for c in calls]
+    assert any(c.startswith("git add") for c in joined), joined
+    assert any(c.startswith("git commit") for c in joined), joined
+    assert any(c.startswith("git push") for c in joined), joined
+
+
+def test_ride_spec_no_worktree_returns_false(tmp_path):
+    """No {N}-lld worktree (e.g. LLD stage skipped) → no-op, returns False, no raise."""
+    target = tmp_path / "target"
+    drafts = target / "docs" / "lld" / "drafts"
+    drafts.mkdir(parents=True)
+    spec = drafts / "spec-0042-implementation-readiness.md"
+    spec.write_text("# spec")
+    # deliberately do NOT create the worktree
+    ok = stages._ride_spec_on_lld_pr(str(spec), str(target), 42)
+    assert ok is False
+
+
+def test_ride_spec_commit_noop_returns_false(tmp_path):
+    """If git commit is a no-op (nothing staged), best-effort returns False."""
+    target = tmp_path / "target"
+    drafts = target / "docs" / "lld" / "drafts"
+    drafts.mkdir(parents=True)
+    spec = drafts / "spec-0042-implementation-readiness.md"
+    spec.write_text("# spec")
+    worktree = tmp_path / "target-42-lld"
+    worktree.mkdir()
+
+    def fake_run(cmd, **kw):
+        out = MagicMock()
+        out.stdout = ""
+        out.stderr = "nothing to commit"
+        out.returncode = 1 if "commit" in cmd else 0
+        return out
+
+    with patch.object(stages, "run_command", side_effect=fake_run):
+        ok = stages._ride_spec_on_lld_pr(str(spec), str(target), 42)
+    assert ok is False
+
+
+def test_spec_stage_rides_spec_on_lld_pr(tmp_path):
+    """run_spec_stage invokes _ride_spec_on_lld_pr on a successful spec."""
+    config = get_default_config()
+    config["skip_existing_spec"] = False  # force the workflow to run (don't skip)
+    state = create_initial_state(
+        42, config,
+        target_repo=str(tmp_path / "target"),
+        assemblyzero_root=str(tmp_path / "az"),
+    )
+    spec_file = tmp_path / "target" / "docs" / "lld" / "drafts" / "spec-0042-implementation-readiness.md"
+    spec_file.parent.mkdir(parents=True)
+    spec_file.write_text("# spec")
+
+    class _StubApp:
+        def invoke(self, payload):
+            return {"spec_path": str(spec_file), "error_message": ""}
+
+    rode: dict = {}
+
+    def fake_ride(spec_path, target_repo, issue_number):
+        rode["called"] = (spec_path, target_repo, issue_number)
+        return True
+
+    with patch(
+        "assemblyzero.workflows.implementation_spec.graph.create_implementation_spec_graph",
+        return_value=_StubApp(),
+    ), patch.object(stages, "_ride_spec_on_lld_pr", side_effect=fake_ride):
+        stages.run_spec_stage(state)
+
+    assert rode.get("called") == (str(spec_file), str(tmp_path / "target"), 42), (
+        "run_spec_stage must ride the spec on the LLD PR for a successful spec"
+    )


### PR DESCRIPTION
Closes #1625

Per ADR 0221, the implementation spec is a permanent artifact paired with the LLD. `run_spec_stage` now mirrors the spec into the existing `{N}-lld` worktree and commits + pushes it (`_ride_spec_on_lld_pr`), so it rides the LLD PR and lands on target `main` instead of being orphaned on the working tree.

Best-effort: never raises. If the `{N}-lld` worktree is absent (e.g. the LLD stage was skipped for a pre-existing LLD, so there is no LLD PR to ride), the spec is left on the working tree with a logged note — the terminal cleanup (follow-up, #1624) only deletes the working-tree copy after the LLD PR merges, so an un-ridden spec stays put rather than being lost. The working-tree copy also stays during the run so the impl stage can read it.

Files: `orchestrator/stages.py` (`_ride_spec_on_lld_pr` + wire into `run_spec_stage`). Tests: `tests/unit/test_spec_rides_lld_pr.py` (commits to worktree, no-worktree no-op, commit-noop, stage-invokes-helper). Full orchestrator-stages suite green; ruff clean.

Follow-up (PR-B): #1531 + #1624 + #1628 — the terminal cleanup stage that merges the LLD PR and removes the working-tree copies / worktrees.