### PR TITLE
feat(orchestrator): terminal cleanup stage — merge LLD PR, delete landed copies, remove worktrees (Closes #1531, Closes #1624, Closes #1628)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -397,6 +397,11 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
         state = dict(state)
         if lld_path:
             state["previous_lld_draft_path"] = lld_path
+        # #1531: capture the LLD PR URL so the terminal cleanup stage can merge it
+        # (landing the LLD + spec on target main per ADR 0221).
+        lld_pr_url = sub_result.get("final_lld_pr_url", "")
+        if lld_pr_url:
+            state["lld_pr_url"] = lld_pr_url
         verdict_for_next = sub_result.get("current_verdict", "") or sub_result.get(
             "verdict_text", ""
         )
@@ -807,6 +812,165 @@ def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
     return update_stage_result(state, stage, result)
 
 
+def _merge_lld_pr(pr_url: str, timeout_s: int, notes: list[str]) -> bool:
+    """Closes #1531. Poll the LLD PR until mergeable, then squash-merge it (landing
+    the LLD + spec on target main per ADR 0221). Best-effort; returns True iff the PR
+    is now merged. Bounded by ``timeout_s``; on timeout the PR is left open and
+    deferred to manual ``/cleanup``. No ``--admin``, no force.
+    """
+    deadline = time.monotonic() + max(0, timeout_s)
+    last = ""
+    while True:
+        view = run_command(
+            ["gh", "pr", "view", pr_url, "--json", "state,mergeStateStatus",
+             "--jq", "[.state, .mergeStateStatus] | @tsv"],
+            capture_output=True, text=True,
+        )
+        if view.returncode == 0:
+            cols = (view.stdout or "").strip().split("\t")
+            pr_state = cols[0] if cols and cols[0] else ""
+            last = cols[1] if len(cols) > 1 else last
+            if pr_state == "MERGED":
+                return True
+            if last == "CLEAN":
+                merge = run_command(
+                    ["gh", "pr", "merge", pr_url, "--squash"],
+                    capture_output=True, text=True,
+                )
+                if merge.returncode == 0:
+                    return True
+                notes.append(f"LLD PR merge attempt failed: {(merge.stderr or '').strip()[:160]}")
+        else:
+            notes.append(f"LLD PR view failed: {(view.stderr or '').strip()[:160]}")
+        if time.monotonic() >= deadline:
+            notes.append(
+                f"LLD PR not merged within {timeout_s}s (last merge-state="
+                f"{last or '?'}); deferred to manual /cleanup"
+            )
+            return False
+        time.sleep(15)
+
+
+def _delete_landed_working_copies(target_repo: str, issue_number: int, notes: list[str]) -> None:
+    """Closes #1624. Delete the LLD + spec working-tree copies from the target after
+    they have landed on main via the merged LLD PR. Scoped to the LLD and spec
+    artifacts only — never ``lld-status.json`` or anything else.
+    """
+    base = Path(target_repo)
+    patterns = [
+        f"docs/lld/active/LLD-{issue_number:03d}.md",
+        f"docs/lld/active/LLD-{issue_number:03d}-*.md",
+        f"docs/lld/active/LLD-{issue_number}.md",
+        f"docs/lld/active/LLD-{issue_number}-*.md",
+        f"docs/lld/drafts/spec-{issue_number:04d}.md",
+        f"docs/lld/drafts/spec-{issue_number:04d}-*.md",
+        f"docs/lld/drafts/spec-{issue_number}.md",
+        f"docs/lld/drafts/spec-{issue_number}-*.md",
+    ]
+    matched = set()
+    for pat in patterns:
+        matched.update(base.glob(pat))
+    removed = []
+    for p in sorted(matched):
+        try:
+            if p.is_file():
+                p.unlink()
+                removed.append(str(p.relative_to(base)))
+        except OSError as e:
+            notes.append(f"could not delete {p}: {e}")
+    if removed:
+        notes.append(f"removed landed working-tree copies: {', '.join(removed)}")
+
+
+def _remove_orchestrator_worktrees(
+    target_repo: str, issue_number: int, lld_merged: bool, notes: list[str],
+) -> None:
+    """Closes #1628. Remove the LLD and impl worktrees the orchestrator created,
+    reusing cleanup_helpers (plain ``git worktree remove``, no ``--force``; ``git
+    branch -d``, never ``-D``). The impl branch is left intact (its PR is merged by
+    the normal review flow); a squash-merged LLD branch that ``-d`` refuses is left
+    for ``/cleanup``'s ADR-0217 graft. Worktree-removal failures (dirty worktree)
+    are logged as residue, never force-removed.
+    """
+    from assemblyzero.workflows.requirements.git_operations import lld_worktree_path_for
+    from assemblyzero.workflows.testing.nodes.cleanup_helpers import (
+        delete_local_branch,
+        get_worktree_branch,
+        remove_worktree,
+    )
+
+    if target_repo:
+        lld_wt = lld_worktree_path_for(target_repo, issue_number)
+        if Path(lld_wt).is_dir():
+            branch = None
+            try:
+                branch = get_worktree_branch(lld_wt)
+            except Exception:
+                branch = None
+            try:
+                remove_worktree(lld_wt)
+                notes.append(f"removed LLD worktree {lld_wt}")
+                if lld_merged and branch:
+                    try:
+                        delete_local_branch(branch)
+                    except Exception as e:
+                        notes.append(f"LLD branch -d left for /cleanup (squash orphan): {e}")
+            except Exception as e:
+                notes.append(f"LLD worktree not removed (residue left, no --force): {e}")
+
+    impl_wt = worktree_path_for(issue_number, target_repo or None)
+    if Path(impl_wt).is_dir():
+        try:
+            remove_worktree(impl_wt)
+            notes.append(f"removed impl worktree {impl_wt}")
+        except Exception as e:
+            notes.append(f"impl worktree not removed (residue left, no --force): {e}")
+
+
+def run_cleanup_stage(state: OrchestrationState) -> OrchestrationState:
+    """Terminal stage (#1531 + #1624 + #1628): merge the LLD PR (landing LLD + spec
+    on target main), delete the now-redundant LLD/spec working-tree copies, and
+    remove the LLD + impl worktrees.
+
+    Best-effort housekeeping: always returns ``passed`` so a cleanup hiccup never
+    fails an otherwise-successful run. Residue is logged and deferred to manual
+    ``/cleanup``.
+    """
+    stage = "cleanup"
+    issue_number = state["issue_number"]
+    start_time = time.monotonic()
+
+    target_repo = state.get("target_repo", "")
+    lld_pr_url = state.get("lld_pr_url", "")
+    config = state.get("config", {})
+    merge_timeout = config.get("cleanup_merge_timeout_s", 600)
+    notes: list[str] = []
+
+    lld_merged = False
+    if lld_pr_url:
+        lld_merged = _merge_lld_pr(lld_pr_url, merge_timeout, notes)
+    else:
+        notes.append("no LLD PR URL in state — skipping LLD merge")
+
+    # #1624: only delete the working-tree copies once the content is safely on main.
+    if lld_merged and target_repo:
+        _delete_landed_working_copies(target_repo, issue_number, notes)
+
+    # #1628: remove the worktrees (LLD branch -d attempted only if its PR merged).
+    _remove_orchestrator_worktrees(target_repo, issue_number, lld_merged, notes)
+
+    for note in notes:
+        print(f"    [cleanup] {note}")
+
+    result = _make_stage_result(
+        status="passed",
+        artifact_path=lld_pr_url if lld_merged else "",
+        duration_seconds=time.monotonic() - start_time,
+        attempts=1,
+    )
+    return update_stage_result(state, stage, result)
+
+
 # Map stage names to their runner functions
 STAGE_RUNNERS: dict[str, callable] = {
     "triage": run_triage_stage,
@@ -814,4 +978,5 @@ STAGE_RUNNERS: dict[str, callable] = {
     "spec": run_spec_stage,
     "impl": run_impl_stage,
     "pr": run_pr_stage,
+    "cleanup": run_cleanup_stage,
 }

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -31,7 +31,7 @@ class OrchestrationState(TypedDict, total=False):
     """Full orchestration pipeline state."""
 
     issue_number: int
-    current_stage: str  # "triage", "lld", "spec", "impl", "pr", "done"
+    current_stage: str  # "triage", "lld", "spec", "impl", "pr", "cleanup", "done"
 
     # Repo targeting (Issue #1374)
     target_repo: str  # Where the work happens (outputs, worktree, gh CLI)
@@ -43,6 +43,7 @@ class OrchestrationState(TypedDict, total=False):
     spec_path: str
     worktree_path: str
     pr_url: str
+    lld_pr_url: str  # Issue #1531: the LLD PR, captured so the terminal cleanup stage can merge it
 
     # Progress tracking
     stage_results: dict[str, StageResult]
@@ -72,7 +73,10 @@ class OrchestrationState(TypedDict, total=False):
     previous_spec_verdict_text: str
 
 
-STAGE_ORDER: list[str] = ["triage", "lld", "spec", "impl", "pr"]
+# Issue #1628: a terminal "cleanup" stage runs after "pr" — it merges the LLD PR
+# (#1531), deletes the now-redundant working-tree LLD/spec copies (#1624), and
+# removes the LLD + impl worktrees (#1628). Best-effort housekeeping.
+STAGE_ORDER: list[str] = ["triage", "lld", "spec", "impl", "pr", "cleanup"]
 
 # Maps stage name to the state key that holds its artifact path
 _STAGE_ARTIFACT_KEY: dict[str, str] = {
@@ -124,6 +128,7 @@ def create_initial_state(
         spec_path="",
         worktree_path="",
         pr_url="",
+        lld_pr_url="",
         stage_results={},
         stage_attempts={stage: 0 for stage in STAGE_ORDER},
         started_at=now,

--- a/tests/integration/test_orchestrator_graph.py
+++ b/tests/integration/test_orchestrator_graph.py
@@ -62,6 +62,9 @@ def mock_all_stages():
         "spec": make_mock_runner("spec", "impl-spec.md"),
         "impl": make_mock_runner("impl", "../AssemblyZero-305"),
         "pr": make_mock_runner("pr", "https://github.com/test/pull/1"),
+        # Issue #1628: the terminal cleanup stage is now part of STAGE_ORDER, so the
+        # "mock all stages" fixture must include it or the pipeline never reaches "done".
+        "cleanup": make_mock_runner("cleanup", "cleanup"),
     }
 
     with patch("assemblyzero.workflows.orchestrator.graph.STAGE_RUNNERS", runners), \

--- a/tests/unit/test_cleanup_stage.py
+++ b/tests/unit/test_cleanup_stage.py
@@ -1,0 +1,224 @@
+"""Tests for the terminal cleanup stage (Issues #1531 + #1624 + #1628).
+
+run_cleanup_stage runs after the pr stage and (best-effort): merges the LLD PR
+(#1531, landing LLD + spec on target main), deletes the now-redundant LLD/spec
+working-tree copies once merged (#1624, scoped — never lld-status.json), and removes
+the LLD + impl worktrees (#1628, plain `git worktree remove`, no --force). It always
+returns "passed" so cleanup never fails an otherwise-successful run.
+"""
+from unittest.mock import MagicMock, patch
+
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.config import get_default_config
+from assemblyzero.workflows.orchestrator.state import STAGE_ORDER, create_initial_state
+
+
+def _resp(returncode=0, stdout="", stderr=""):
+    out = MagicMock()
+    out.returncode = returncode
+    out.stdout = stdout
+    out.stderr = stderr
+    return out
+
+
+def _state(tmp_path, **overrides):
+    config = get_default_config()
+    state = create_initial_state(
+        42, config,
+        target_repo=str(tmp_path / "target"),
+        assemblyzero_root=str(tmp_path / "az"),
+    )
+    state.update(overrides)
+    return state
+
+
+# ---- wiring ----
+
+def test_cleanup_registered_in_order_and_runners():
+    assert STAGE_ORDER[-1] == "cleanup", "cleanup must be the terminal stage"
+    assert stages.STAGE_RUNNERS.get("cleanup") is stages.run_cleanup_stage
+
+
+# ---- run_cleanup_stage orchestration ----
+
+def test_cleanup_merges_deletes_removes_when_lld_pr_present(tmp_path):
+    state = _state(tmp_path, lld_pr_url="https://github.com/o/r/pull/9")
+    with patch.object(stages, "_merge_lld_pr", return_value=True) as m_merge, \
+         patch.object(stages, "_delete_landed_working_copies") as m_del, \
+         patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
+        new_state = stages.run_cleanup_stage(state)
+    m_merge.assert_called_once()
+    m_del.assert_called_once()
+    m_rm.assert_called_once()
+    assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+    assert new_state["current_stage"] == "done"
+
+
+def test_cleanup_no_lld_pr_skips_merge_and_delete(tmp_path):
+    state = _state(tmp_path)  # lld_pr_url == "" from create_initial_state
+    with patch.object(stages, "_merge_lld_pr") as m_merge, \
+         patch.object(stages, "_delete_landed_working_copies") as m_del, \
+         patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
+        new_state = stages.run_cleanup_stage(state)
+    m_merge.assert_not_called()
+    m_del.assert_not_called()
+    m_rm.assert_called_once()  # worktrees still removed
+    assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+
+def test_cleanup_unmerged_lld_skips_delete_but_passes(tmp_path):
+    """Gate: if the LLD PR did not merge, the working-tree copies are NOT deleted
+    (they would be lost), but the stage still passes and worktrees are still removed."""
+    state = _state(tmp_path, lld_pr_url="https://github.com/o/r/pull/9")
+    with patch.object(stages, "_merge_lld_pr", return_value=False), \
+         patch.object(stages, "_delete_landed_working_copies") as m_del, \
+         patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
+        new_state = stages.run_cleanup_stage(state)
+    m_del.assert_not_called()
+    m_rm.assert_called_once()
+    assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+
+# ---- _merge_lld_pr ----
+
+def test_merge_lld_pr_merges_when_clean():
+    notes = []
+
+    def fake_run(cmd, **kw):
+        if "view" in cmd:
+            return _resp(stdout="OPEN\tCLEAN\n")
+        return _resp()  # merge succeeds
+
+    with patch.object(stages, "run_command", side_effect=fake_run):
+        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 600, notes)
+    assert ok is True
+
+
+def test_merge_lld_pr_already_merged_no_merge_call():
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _resp(stdout="MERGED\tCLEAN\n")
+
+    with patch.object(stages, "run_command", side_effect=fake_run):
+        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 600, [])
+    assert ok is True
+    assert all("merge" not in c for c in calls), "must not attempt merge when already MERGED"
+
+
+def test_merge_lld_pr_timeout_returns_false():
+    notes = []
+
+    def fake_run(cmd, **kw):
+        return _resp(stdout="OPEN\tBLOCKED\n")  # never CLEAN
+
+    # timeout_s=0 → exits after the first check without sleeping
+    with patch.object(stages, "run_command", side_effect=fake_run):
+        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 0, notes)
+    assert ok is False
+    assert any("not merged within" in n for n in notes)
+
+
+# ---- _delete_landed_working_copies ----
+
+def test_delete_landed_working_copies_is_scoped(tmp_path):
+    """Deletes the LLD + spec copies but NOT lld-status.json (or anything else)."""
+    target = tmp_path
+    active = target / "docs" / "lld" / "active"
+    active.mkdir(parents=True)
+    drafts = target / "docs" / "lld" / "drafts"
+    drafts.mkdir(parents=True)
+    lld = active / "LLD-042.md"
+    lld.write_text("lld")
+    spec = drafts / "spec-0042-implementation-readiness.md"
+    spec.write_text("spec")
+    status = target / "docs" / "lld" / "lld-status.json"
+    status.write_text("{}")
+
+    notes = []
+    stages._delete_landed_working_copies(str(target), 42, notes)
+
+    assert not lld.exists(), "LLD copy must be deleted"
+    assert not spec.exists(), "spec copy must be deleted"
+    assert status.exists(), "lld-status.json must NOT be deleted (mutable tracking file)"
+
+
+# ---- _remove_orchestrator_worktrees ----
+
+def test_remove_worktrees_removes_both_and_deletes_merged_lld_branch(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    lld_wt = tmp_path / "target-42-lld"
+    lld_wt.mkdir()
+    impl_wt = tmp_path / "target-42"
+    impl_wt.mkdir()
+
+    removed = []
+
+    with patch("assemblyzero.workflows.requirements.git_operations.lld_worktree_path_for", return_value=lld_wt), \
+         patch.object(stages, "worktree_path_for", return_value=impl_wt), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.remove_worktree",
+               side_effect=lambda p: removed.append(str(p)) or True), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.get_worktree_branch", return_value="42-lld"), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.delete_local_branch") as m_del:
+        stages._remove_orchestrator_worktrees(str(target), 42, lld_merged=True, notes=[])
+
+    assert str(lld_wt) in removed and str(impl_wt) in removed, "both worktrees must be removed"
+    m_del.assert_called_once_with("42-lld"), "merged LLD branch -d attempted"
+
+
+def test_remove_worktrees_skips_lld_branch_delete_when_unmerged(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    lld_wt = tmp_path / "target-42-lld"
+    lld_wt.mkdir()
+    impl_wt = tmp_path / "target-42"
+    impl_wt.mkdir()
+
+    with patch("assemblyzero.workflows.requirements.git_operations.lld_worktree_path_for", return_value=lld_wt), \
+         patch.object(stages, "worktree_path_for", return_value=impl_wt), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.remove_worktree", return_value=True), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.get_worktree_branch", return_value="42-lld"), \
+         patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.delete_local_branch") as m_del:
+        stages._remove_orchestrator_worktrees(str(target), 42, lld_merged=False, notes=[])
+
+    m_del.assert_not_called(), "must not delete LLD branch when its PR did not merge"
+
+
+# ---- run_lld_stage captures the LLD PR url ----
+
+def test_lld_stage_captures_lld_pr_url(tmp_path):
+    config = get_default_config()
+    config["skip_existing_lld"] = False  # force the workflow to run
+    state = create_initial_state(
+        42, config,
+        target_repo=str(tmp_path / "target"),
+        assemblyzero_root=str(tmp_path / "az"),
+    )
+    lld_file = tmp_path / "target" / "docs" / "lld" / "active" / "LLD-042.md"
+    lld_file.parent.mkdir(parents=True)
+    lld_file.write_text("# LLD\n\nAPPROVED")
+
+    class _App:
+        def invoke(self, payload):
+            return {
+                "final_lld_path": str(lld_file),
+                "final_verdict": "APPROVED",
+                "final_lld_pr_url": "https://github.com/o/r/pull/9",
+            }
+
+    class _Graph:
+        def compile(self):
+            return _App()
+
+    with patch(
+        "assemblyzero.workflows.requirements.graph.create_requirements_graph",
+        return_value=_Graph(),
+    ):
+        new_state = stages.run_lld_stage(state)
+
+    assert new_state.get("lld_pr_url") == "https://github.com/o/r/pull/9", (
+        "run_lld_stage must capture final_lld_pr_url into orchestration state for the "
+        "terminal cleanup stage to merge"
+    )

--- a/tests/unit/test_orchestrator_state.py
+++ b/tests/unit/test_orchestrator_state.py
@@ -68,8 +68,12 @@ class TestGetNextStage:
     def test_impl_to_pr(self):
         assert get_next_stage("impl") == "pr"
 
-    def test_pr_to_done(self):
-        assert get_next_stage("pr") == "done"
+    def test_pr_to_cleanup(self):
+        # Issue #1628: a terminal cleanup stage now follows pr.
+        assert get_next_stage("pr") == "cleanup"
+
+    def test_cleanup_to_done(self):
+        assert get_next_stage("cleanup") == "done"
 
     def test_done_stays_done(self):
         assert get_next_stage("done") == "done"
@@ -141,7 +145,8 @@ class TestUpdateStageResult:
         new_state = update_stage_result(OrchestrationState(**state_at_lld), "lld", result)
         assert new_state["current_stage"] == "lld"
 
-    def test_pr_passed_sets_done_and_completed(self):
+    def test_pr_passed_advances_to_cleanup(self):
+        # Issue #1628: pr is no longer terminal — the cleanup stage follows it.
         config = get_default_config()
         state = create_initial_state(305, config)
         state_at_pr = dict(state)
@@ -154,9 +159,25 @@ class TestUpdateStageResult:
             attempts=1,
         )
         new_state = update_stage_result(OrchestrationState(**state_at_pr), "pr", result)
+        assert new_state["current_stage"] == "cleanup"
+        assert new_state["completed_at"] == ""
+        assert new_state["pr_url"] == "https://github.com/martymcenroe/AssemblyZero/pull/312"
+
+    def test_cleanup_passed_sets_done_and_completed(self):
+        config = get_default_config()
+        state = create_initial_state(305, config)
+        state_at_cleanup = dict(state)
+        state_at_cleanup["current_stage"] = "cleanup"
+        result = StageResult(
+            status="passed",
+            artifact_path="",
+            error_message="",
+            duration_seconds=1.0,
+            attempts=1,
+        )
+        new_state = update_stage_result(OrchestrationState(**state_at_cleanup), "cleanup", result)
         assert new_state["current_stage"] == "done"
         assert new_state["completed_at"] != ""
-        assert new_state["pr_url"] == "https://github.com/martymcenroe/AssemblyZero/pull/312"
 
     def test_does_not_mutate_original_state(self):
         config = get_default_config()


### PR DESCRIPTION
Closes #1531
Closes #1624
Closes #1628

Per ADR 0221: a new terminal `cleanup` stage (after `pr` in `STAGE_ORDER`) closes the orchestrator's zero-debris loop.

**#1531 — merge the LLD PR.** `run_lld_stage` captures `lld_pr_url`; the cleanup stage polls it to mergeable and `gh pr merge --squash` (no `--admin`, no force), landing the LLD + spec on target `main`. Bounded by `cleanup_merge_timeout_s` (default 600s); on timeout the PR is left open and deferred to manual `/cleanup`.

**#1624 — delete the redundant working-tree copies.** After the LLD PR merges, the LLD + spec working-tree copies are deleted — scoped to those artifacts only (never `lld-status.json`). Gated on merge success so an un-landed copy is never lost.

**#1628 — remove the worktrees.** The LLD + impl worktrees are removed reusing `cleanup_helpers` (plain `git worktree remove`, no `--force`). The impl branch is left for the normal review/merge flow; a squash-merged LLD branch that `-d` refuses is left for `/cleanup`'s ADR-0217 graft. Removal failures (dirty worktree) are logged as residue, never force-removed.

Best-effort: the stage always returns `passed` so a cleanup hiccup never fails an otherwise-successful run.

Files: `orchestrator/state.py` (`lld_pr_url` + `cleanup` in `STAGE_ORDER`), `orchestrator/stages.py` (capture + `run_cleanup_stage` + helpers + `STAGE_RUNNERS`). Tests: `tests/unit/test_cleanup_stage.py` (10) + updated the `mock_all_stages` integration fixture for the new stage. Full orchestrator unit + integration suites green; ruff clean on changed files.

Completes Phase 2 — with #1625 (PR #1636), the orchestrator lands LLD/spec/reports on main and leaves no untracked files, stashes, stale branches, or worktrees (ADR 0221 north star).