### PR TITLE
chore: untrack data/ session-state files; drop from /cleanup allowlist (Closes #1644, Closes #1645)

### DIFF
--- a/.claude/skills/cleanup.md
+++ b/.claude/skills/cleanup.md
@@ -350,9 +350,10 @@ Content:
 - `docs/session-logs/*.md`
 - `docs/lessons-learned.md`
 - `data/session-index.jsonl`
-- `data/pickup-status.json`
 - `.claude/commands/*.md` (AssemblyZero only — skill sync)
 - `.claude/hooks/*.sh` (AssemblyZero only — hook sync)
+
+> Note: `data/pickup-status.json` and `data/handoff-marker-status.json` are intentionally excluded — they are ephemeral session state covered by the global `/data/` gitignore ban (see Secret-Agent-Man#20). Do not add them back to this allowlist; `git add` on them is a no-op anyway since they are globally ignored.
 
 **DENIED patterns** (NEVER staged, even if changed — report only so user handles separately):
 - Credentials: `*.env*`, `*.dev.vars*`, `*.pem`, `*.key`, anything matching `*secret*`, `*credential*`, `*token*` in filename
@@ -400,7 +401,6 @@ git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} checkout -b $BRANCH
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add docs/session-logs/ 2>/dev/null
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add docs/lessons-learned.md 2>/dev/null
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add data/session-index.jsonl 2>/dev/null
-git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add data/pickup-status.json 2>/dev/null
 # AssemblyZero only (skill + hook sync):
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add .claude/commands/ 2>/dev/null
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add .claude/hooks/ 2>/dev/null
@@ -465,7 +465,7 @@ fi
 
 If 4.2 detected no protection:
 ```bash
-git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl data/pickup-status.json 2>/dev/null
+git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl 2>/dev/null
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} commit -m "chore: session cleanup {DATE} — {SESSION_NAME}"
 git -C /c/Users/mcwiz/Projects/{PROJECT_NAME} push
 ```

--- a/.claude/templates/commands/cleanup.md.template
+++ b/.claude/templates/commands/cleanup.md.template
@@ -189,7 +189,8 @@ If no session log tool exists, manually append to the current day's session log.
 - `docs/session-logs/*.md`
 - `docs/lessons-learned.md`
 - `data/session-index.jsonl`
-- `data/pickup-status.json`
+
+> `data/pickup-status.json` and `data/handoff-marker-status.json` are intentionally excluded — ephemeral session state under the global `/data/` gitignore ban (see Secret-Agent-Man#20).
 
 **DENIED patterns** (NEVER staged, even if changed):
 - Credentials: `*.env*`, `*.dev.vars*`, `*.pem`, `*.key`, anything matching `*secret*`, `*credential*`, `*token*` in filename
@@ -225,7 +226,7 @@ gh issue create --repo {{GITHUB_REPO}} \
 
 BRANCH="cleanup-[DATE]-[session-slug]"
 git -C {{PROJECT_ROOT}} checkout -b $BRANCH
-git -C {{PROJECT_ROOT}} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl data/pickup-status.json 2>/dev/null
+git -C {{PROJECT_ROOT}} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl 2>/dev/null
 git -C {{PROJECT_ROOT}} commit -m "chore: session cleanup [DATE] (Closes #${ISSUE_N})"
 git -C {{PROJECT_ROOT}} push -u origin $BRANCH
 
@@ -245,7 +246,7 @@ git -C {{PROJECT_ROOT}} branch -D $BRANCH
 ### 4.9 — Direct-push fallback (unprotected main)
 
 ```bash
-git -C {{PROJECT_ROOT}} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl data/pickup-status.json 2>/dev/null
+git -C {{PROJECT_ROOT}} add docs/session-logs/ docs/lessons-learned.md data/session-index.jsonl 2>/dev/null
 git -C {{PROJECT_ROOT}} commit -m "chore: session cleanup [DATE]"
 git -C {{PROJECT_ROOT}} push
 ```

--- a/data/handoff-marker-status.json
+++ b/data/handoff-marker-status.json
@@ -1,8 +1,0 @@
-{
-  "status": "ok",
-  "marker": "park",
-  "timestamp": "2026-06-02 17:06:25",
-  "handoff_timestamp": "2026-06-02 17:04:30",
-  "repo": "AssemblyZero",
-  "message": "Marked handoff from 2026-06-02 17:04:30 as park at 2026-06-02 17:06:25"
-}

--- a/data/pickup-status.json
+++ b/data/pickup-status.json
@@ -1,7 +1,0 @@
-{
-  "status": "ok",
-  "timestamp": "2026-06-22 14:10:32",
-  "handoff_timestamp": "2026-06-22 14:01:57",
-  "repo": "AssemblyZero",
-  "message": "Marked handoff from 2026-06-22 14:01:57 as picked up at 2026-06-22 14:10:32"
-}


### PR DESCRIPTION
## Summary

`data/pickup-status.json` and `data/handoff-marker-status.json` are ephemeral session state (unleashed marker scripts), covered by the global `/data/` gitignore ban but committed before the ban so still tracked. `git rm --cached` untracks them; the global ban keeps them out thereafter. Also drops `data/pickup-status.json` from the /cleanup commit-allowlist (skill + template) so cleanup stops staging it.

Survey: 3 of 75 repos affected (AZ here; career and patent-general queued separately while their trees are mid-flight).

Closes #1644, Closes #1645
Ref a private tracking repo, item #20