### PR TITLE
fix(tests): repair #1599 (verdict_count gate) and #1602 (mock_mode adversarial skip) (Closes #1599, Closes #1602)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/adversarial_node.py
+++ b/assemblyzero/workflows/testing/nodes/adversarial_node.py
@@ -67,20 +67,6 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
     """
     logger.info("[ADV] Starting adversarial test generation node")
 
-    # #1602: in mock_mode, skip the Gemini call entirely — mock runs must not
-    # require credentials. Return a clean "skipped" state so the workflow still
-    # proceeds to N8.
-    if state.get("mock_mode"):
-        logger.info("[ADV] mock_mode — skipping adversarial Gemini call")
-        return {
-            **state,
-            "adversarial_skipped_reason": "mock_mode",
-            "adversarial_verdict": "success",
-            "adversarial_test_count": 0,
-            "adversarial_error": None,
-            "generated_test_files": {},
-        }
-
     # Issue #547: Skip-on-resume — don't re-call Gemini if verdict already exists
     if state.get("adversarial_verdict") in ("success", "error") and state.get("adversarial_test_count", 0) > 0:
         logger.info("[ADV] Adversarial analysis already complete — skipping")
@@ -102,8 +88,25 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
     # Collect and trim context
     impl_context, lld_context, test_context = _collect_context(state)
 
-    # Invoke Gemini
-    client = AdversarialGeminiClient()
+    # Invoke Gemini. This node is non-blocking by design (route_after_adversarial
+    # always proceeds to N8). If no usable Gemini client can be constructed —
+    # mock_mode runs, or a credential-less environment such as CI — skip
+    # gracefully instead of crashing the whole TDD workflow (#1602). The
+    # mock_mode flag is NOT visible here: LangGraph filters the node input to
+    # AdversarialNodeState, which omits it, so we key off client-constructability
+    # rather than the flag.
+    try:
+        client = AdversarialGeminiClient()
+    except Exception as exc:  # noqa: BLE001 — non-blocking node: any ctor failure skips
+        logger.info("[ADV] No usable Gemini client — skipping adversarial: %s", exc)
+        return {
+            **state,
+            "adversarial_skipped_reason": f"no Gemini client available: {exc}",
+            "adversarial_verdict": "success",
+            "adversarial_test_count": 0,
+            "adversarial_error": None,
+            "generated_test_files": {},
+        }
 
     try:
         raw_response = client.generate_adversarial_tests(

--- a/assemblyzero/workflows/testing/nodes/adversarial_node.py
+++ b/assemblyzero/workflows/testing/nodes/adversarial_node.py
@@ -67,6 +67,20 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
     """
     logger.info("[ADV] Starting adversarial test generation node")
 
+    # #1602: in mock_mode, skip the Gemini call entirely — mock runs must not
+    # require credentials. Return a clean "skipped" state so the workflow still
+    # proceeds to N8.
+    if state.get("mock_mode"):
+        logger.info("[ADV] mock_mode — skipping adversarial Gemini call")
+        return {
+            **state,
+            "adversarial_skipped_reason": "mock_mode",
+            "adversarial_verdict": "success",
+            "adversarial_test_count": 0,
+            "adversarial_error": None,
+            "generated_test_files": {},
+        }
+
     # Issue #547: Skip-on-resume — don't re-call Gemini if verdict already exists
     if state.get("adversarial_verdict") in ("success", "error") and state.get("adversarial_test_count", 0) > 0:
         logger.info("[ADV] Adversarial analysis already complete — skipping")

--- a/tests/unit/test_adversarial_node.py
+++ b/tests/unit/test_adversarial_node.py
@@ -121,6 +121,35 @@ class TestRunAdversarialNode:
     @patch(
         "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
     )
+    def test_no_client_available_skips(self, mock_client_cls):
+        """#1602: if the Gemini client can't be constructed (no creds / mock env),
+        the non-blocking node skips gracefully instead of crashing the workflow.
+
+        Reproduces the CI failure: genai.Client() raises a ValueError at
+        construction when no api_key is present.
+        """
+        mock_client_cls.side_effect = ValueError(
+            "Missing key inputs argument! To use the Google AI API, provide "
+            "(`api_key`) arguments."
+        )
+
+        state = {
+            "implementation_files": ["/fake/module.py"],
+            "lld_content": "# LLD",
+            "test_files": [],
+            "issue_id": 352,
+        }
+
+        # Must NOT raise — the construction failure is caught and skipped.
+        result = run_adversarial_node(state)
+
+        assert result["adversarial_verdict"] == "success"
+        assert "no Gemini client available" in result["adversarial_skipped_reason"]
+        assert result["adversarial_test_count"] == 0
+
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
+    )
     def test_downgrade_skip(self, mock_client_cls):
         """T030: On GeminiModelDowngradeError, sets skipped_reason with Flash."""
         mock_client = MagicMock()

--- a/tests/unit/test_issue_248.py
+++ b/tests/unit/test_issue_248.py
@@ -289,7 +289,6 @@ def test_t040(mock_state_base):
     assert result == "N4_human_gate_verdict"
 
 
-@pytest.mark.xfail(reason="stale routing expectation N4_human_gate_verdict vs N1_generate_draft; see #1599", strict=False)
 def test_t050(mock_state_base):
     """
     test_max_iterations_respected | Terminates after limit
@@ -299,7 +298,9 @@ def test_t050(mock_state_base):
     # TDD: Arrange
     state = mock_state_base.copy()
     state["open_questions_status"] = "UNANSWERED"
-    state["iteration_count"] = 20
+    # #1599: the UNANSWERED max-iterations gate is on verdict_count (#1509),
+    # not iteration_count. Set verdict_count to the cap to exercise the halt.
+    state["verdict_count"] = 20
     state["max_iterations"] = 20
 
     # TDD: Act
@@ -463,7 +464,6 @@ def test_040(verdict_with_human_required, draft_with_open_questions, mock_state_
     assert route == "N4_human_gate_verdict", "Should escalate to human gate"
 
 
-@pytest.mark.xfail(reason="stale routing expectation N4_human_gate_verdict vs N1_generate_draft; see #1599", strict=False)
 def test_050(mock_state_base):
     """
     Max iterations respected | Auto | 20 loops without resolution |
@@ -472,7 +472,9 @@ def test_050(mock_state_base):
     # TDD: Arrange
     state = mock_state_base.copy()
     state["open_questions_status"] = "UNANSWERED"
-    state["iteration_count"] = 20
+    # #1599: the UNANSWERED max-iterations gate is on verdict_count (#1509),
+    # not iteration_count. Set verdict_count to the cap to exercise the halt.
+    state["verdict_count"] = 20
     state["max_iterations"] = 20
 
     # TDD: Act

--- a/tests/unit/test_testing_workflow.py
+++ b/tests/unit/test_testing_workflow.py
@@ -5,7 +5,6 @@ Issue #102: TDD Initialization
 Issue #93: N8 Documentation Node
 """
 
-import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -457,14 +456,6 @@ class TestWorkflowIntegration:
         assert "N7_finalize" in nodes
         assert "N8_document" in nodes
 
-    @pytest.mark.skipif(
-        not (
-            os.environ.get("GEMINI_API_KEY")
-            or os.environ.get("GOOGLE_API_KEY")
-            or (Path.home() / ".assemblyzero" / "gemini-credentials.json").exists()
-        ),
-        reason="mock_mode still constructs genai.Client (needs a key); see #1602",
-    )
     def test_workflow_mock_mode_completes(self, tmp_path):
         """Workflow completes in mock mode."""
         # Create minimal LLD file


### PR DESCRIPTION
## Summary

Two confirmed-still-valid test/CI bugs, fixed and verified.

- **#1599** — `route_after_review`'s UNANSWERED max-iterations gate is on `verdict_count` (per #1509), not `iteration_count`. `test_050`/`test_t050` set the wrong counter, so they were marked xfail. Now set `verdict_count` to the cap and drop the xfail marks; both pass.
- **#1602** — the testing workflow's adversarial node (N7.5) crashed the whole run when no Gemini client could be constructed (no credentials → `genai.Client()` ValueError). Since the node is **non-blocking** (`route_after_adversarial` always proceeds to N8), it now **catches a failed client construction and skips gracefully** — the same pattern it already uses for quota/downgrade errors. (A first attempt gated on `mock_mode` inside the node, but LangGraph filters the node input to `AdversarialNodeState`, which omits the flag, so that guard never fired — corrected here.) The credential-gated skipif on `test_workflow_mock_mode_completes` is removed, and a regression test patches the client constructor to raise (the exact CI failure mode).

**#1601 is intentionally NOT here** — its Linux failure is a *production* sanitizer bug (`_sanitize_path` calls `Path.resolve()` on a Windows-format path, which on Linux cwd-prefixes it), not a test-only fix. Left for an approach decision; details posted on the issue.

Verification: targeted + regression tests pass; full unit suite **5603 passed**; ruff clean on changed production code.

Closes #1599, Closes #1602