### PR TITLE
feat(gemini): remove the paid API-key path — OAuth/subscription-only (Closes #1605)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -22,9 +22,6 @@ from pathlib import Path
 from assemblyzero.core.text_sanitizer import strip_emoji
 from typing import Optional
 
-from google import genai
-from google.genai import types
-
 from assemblyzero.core.config import (
     BACKOFF_BASE_SECONDS,
     BACKOFF_MAX_SECONDS,
@@ -550,52 +547,13 @@ class GeminiClient:
                             # Raise exception to trigger error handling
                             raise RuntimeError(error_msg)
                     else:
-                        # API key: use new google.genai SDK
-                        client = genai.Client(api_key=cred.key)
-
-                        # Issue #492: Wire response_schema into config when provided
-                        config_kwargs = {
-                            "system_instruction": system_instruction,
-                        }
-                        if response_schema is not None:
-                            config_kwargs["response_mime_type"] = "application/json"
-                            config_kwargs["response_schema"] = response_schema
-
-                        # Make the API call with system instruction in config
-                        config_kwargs["http_options"] = {"timeout": 300_000}
-                        response = client.models.generate_content(
-                            model=self.model,
-                            contents=content,
-                            config=types.GenerateContentConfig(**config_kwargs),
+                        # #1605: the paid API-key SDK path was removed — governance
+                        # is subscription/OAuth-only. _load_credentials no longer
+                        # loads api_key creds, so this is a defensive guard only.
+                        raise RuntimeError(
+                            f"Non-OAuth credential '{cred.name}' is not supported; "
+                            "governance is subscription/OAuth-only (#1605)"
                         )
-
-                        # Check for successful response
-                        if response.text:
-                            # Verify model used (if available in response metadata)
-                            model_verified = self.model  # Default to requested model
-
-                            # Update state on success
-                            state.last_success = cred.name
-                            state.last_success_time = datetime.now(
-                                timezone.utc
-                            ).isoformat()
-                            self._save_state(state)
-
-                            duration_ms = int((time.time() - start_time) * 1000)
-
-                            # Issue #527: Strip emojis (preserve raw)
-                            return GeminiCallResult(
-                                success=True,
-                                response=strip_emoji(response.text),
-                                raw_response=str(response),
-                                error_type=None,
-                                error_message=None,
-                                credential_used=cred.name,
-                                rotation_occurred=rotation_occurred,
-                                attempts=total_attempts,
-                                duration_ms=duration_ms,
-                                model_verified=model_verified,
-                            )
 
                 except Exception as e:
                     error_str = str(e)
@@ -742,7 +700,7 @@ class GeminiClient:
             response=None,
             raw_response=None,
             error_type=final_error_type,
-            error_message=f"All credentials failed:\n  - " + "\n  - ".join(errors),
+            error_message="All credentials failed:\n  - " + "\n  - ".join(errors),
             credential_used="",
             rotation_occurred=len(available) > 1,
             attempts=total_attempts,
@@ -753,13 +711,11 @@ class GeminiClient:
         )
 
     def _load_credentials(self) -> list[Credential]:
-        """Load credentials from config file.
+        """Load OAuth credentials from the config file.
 
-        OAuth credentials are loaded first (higher quota limits),
-        followed by API key credentials.
-
-        Note: OAuth through CLI loads GEMINI.md. We prepend model identity
-        to satisfy the handshake protocol defined there.
+        #1605: governance is subscription/OAuth-only; API-key credentials are
+        no longer loaded. OAuth is invoked via the Antigravity CLI (agy), which
+        runs in a clean temp dir — no GEMINI.md context bleed.
         """
         if self._credentials is not None:
             return self._credentials
@@ -767,7 +723,7 @@ class GeminiClient:
         if not self.credentials_file.exists():
             raise FileNotFoundError(
                 f"Credentials file not found: {self.credentials_file}\n"
-                f"Create it with your API keys. See AssemblyZero docs."
+                f"Create it with your OAuth credentials. See AssemblyZero docs."
             )
 
         with open(self.credentials_file, encoding="utf-8") as f:
@@ -788,18 +744,8 @@ class GeminiClient:
                     )
                 )
 
-        # Then load API key credentials
-        for c in data.get("credentials", []):
-            if c.get("type") == "api_key" and c.get("key") and c.get("enabled", True):
-                credentials.append(
-                    Credential(
-                        name=c.get("name", "unnamed"),
-                        key=c.get("key", ""),
-                        enabled=True,
-                        account_name=c.get("account-name", ""),
-                        cred_type="api_key",
-                    )
-                )
+        # #1605: API-key credentials are no longer loaded — governance is
+        # subscription/OAuth-only. Only OAuth credentials (above) are used.
 
         self._credentials = credentials
         return self._credentials

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -28,16 +28,20 @@ from assemblyzero.core.gemini_client import (
 
 @pytest.fixture
 def temp_credentials_file():
-    """Create a temporary credentials file."""
+    """Create a temporary credentials file with OAuth credentials.
+
+    #1605: api_key credentials are no longer loaded — governance is
+    subscription/OAuth-only.  All fixture credentials are now type: oauth.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         creds_file = Path(tmpdir) / "credentials.json"
         creds_file.write_text(
             json.dumps(
                 {
                     "credentials": [
-                        {"name": "key-1", "key": "test-key-1", "enabled": True, "type": "api_key"},
-                        {"name": "key-2", "key": "test-key-2", "enabled": True, "type": "api_key"},
-                        {"name": "key-3", "key": "test-key-3", "enabled": True, "type": "api_key"},
+                        {"name": "key-1", "enabled": True, "type": "oauth"},
+                        {"name": "key-2", "enabled": True, "type": "oauth"},
+                        {"name": "key-3", "enabled": True, "type": "oauth"},
                     ]
                 }
             )
@@ -109,7 +113,11 @@ class TestCredentialLoading:
     """Tests for credential loading."""
 
     def test_loads_credentials_from_file(self, temp_credentials_file, temp_state_file):
-        """Test that credentials are loaded from file."""
+        """Test that OAuth credentials are loaded from file.
+
+        #1605: _load_credentials() now only loads type: oauth credentials.
+        api_key credentials are silently skipped; key is always empty string.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=temp_credentials_file,
@@ -119,7 +127,8 @@ class TestCredentialLoading:
         creds = client._load_credentials()
         assert len(creds) == 3
         assert creds[0].name == "key-1"
-        assert creds[0].key == "test-key-1"
+        assert creds[0].cred_type == "oauth"
+        assert creds[0].key == ""  # OAuth credentials carry no API key
 
     def test_missing_credentials_file_raises(self, temp_state_file):
         """Test that missing credentials file raises FileNotFoundError."""
@@ -201,41 +210,41 @@ class TestRotationLogic:
     """Tests for credential rotation logic."""
 
     def test_090_429_triggers_rotation(self, temp_credentials_file, temp_state_file):
-        """Test that 429 error causes rotation to next credential."""
+        """Test that 429 error causes rotation to next credential.
+
+        #1605: the api_key/genai.Client path is gone.  Drive the rotation loop
+        via _invoke_via_cli returning a 429-bearing error string so that
+        classify_gemini_error → RateLimitError → QUOTA_EXHAUSTED → rotate.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=temp_credentials_file,
             state_file=temp_state_file,
         )
 
-        call_sequence = []
+        credentials_tried = []
 
-        def mock_client_init(api_key):
-            """Capture API key and return mock client."""
-            call_sequence.append(api_key)
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = Exception(
-                "TerminalQuotaError: exhausted"
-            )
-            return mock_client
+        def mock_invoke_via_cli(system_instruction, content):
+            # Count each _invoke_via_cli call — one per credential tried
+            credentials_tried.append(len(credentials_tried))
+            return (False, "", "429 TerminalQuotaError: exhausted")
 
-        with patch("assemblyzero.core.gemini_client.genai.Client") as mock_client_class:
-            mock_client_class.side_effect = mock_client_init
-
+        with patch.object(client, "_invoke_via_cli", side_effect=mock_invoke_via_cli):
             result = client.invoke("system", "content")
 
-        # Should have tried all 3 credentials
-        assert len(call_sequence) == 3
-        assert call_sequence[0] == "test-key-1"
-        assert call_sequence[1] == "test-key-2"
-        assert call_sequence[2] == "test-key-3"
+        # All 3 credentials should have been tried (rotation happened)
+        assert len(credentials_tried) == 3
 
-        # Result should indicate rotation occurred
+        # Result should indicate rotation occurred and overall failure
         assert result.rotation_occurred is True
         assert result.success is False
 
     def test_100_529_triggers_backoff(self, temp_credentials_file, temp_state_file):
-        """Test that 529 error causes backoff retry on same credential."""
+        """Test that 529 error causes backoff retry on same credential.
+
+        #1605: drive the backoff path via _invoke_via_cli returning a 529/capacity
+        error string.  Succeed on the 3rd attempt so success=True, no rotation.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=temp_credentials_file,
@@ -244,51 +253,38 @@ class TestRotationLogic:
 
         attempts = [0]
 
-        def mock_generate(*args, **kwargs):
+        def mock_invoke_via_cli(system_instruction, content):
             attempts[0] += 1
             if attempts[0] < 3:
-                raise Exception("MODEL_CAPACITY_EXHAUSTED")
+                return (False, "", "529 MODEL_CAPACITY_EXHAUSTED")
             # Succeed on 3rd attempt
-            mock_response = MagicMock()
-            mock_response.text = "Success"
-            return mock_response
+            return (True, "Success", "")
 
-        def mock_client_init(api_key):
-            """Return mock client with generate_content that tracks attempts."""
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = mock_generate
-            return mock_client
+        with patch.object(client, "_invoke_via_cli", side_effect=mock_invoke_via_cli), \
+             patch("time.sleep"):  # Skip actual delay
+            result = client.invoke("system", "content")
 
-        with patch("assemblyzero.core.gemini_client.genai.Client") as mock_client_class:
-            mock_client_class.side_effect = mock_client_init
-
-            with patch("time.sleep"):  # Skip actual delay
-                result = client.invoke("system", "content")
-
-        # Should have retried 3 times on same credential
+        # Should have retried 3 times on the same credential before succeeding
         assert attempts[0] == 3
         assert result.success is True
         assert result.rotation_occurred is False
 
     def test_110_all_credentials_exhausted(self, temp_credentials_file, temp_state_file):
-        """Test behavior when all credentials are exhausted."""
+        """Test behavior when all credentials are exhausted.
+
+        #1605: drive the exhaustion path via _invoke_via_cli returning a quota
+        error for every call so all three OAuth credentials get marked exhausted.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=temp_credentials_file,
             state_file=temp_state_file,
         )
 
-        def mock_client_init(api_key):
-            """Return mock client that always raises quota error."""
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = Exception(
-                "TerminalQuotaError: exhausted"
-            )
-            return mock_client
+        def mock_invoke_via_cli(system_instruction, content):
+            return (False, "", "429 TerminalQuotaError: exhausted")
 
-        with patch("assemblyzero.core.gemini_client.genai.Client") as mock_client_class:
-            mock_client_class.side_effect = mock_client_init
-
+        with patch.object(client, "_invoke_via_cli", side_effect=mock_invoke_via_cli):
             result = client.invoke("system", "content")
 
         assert result.success is False

--- a/tests/unit/test_gemini_client_capacity.py
+++ b/tests/unit/test_gemini_client_capacity.py
@@ -9,7 +9,7 @@ Tests verify that:
 - Capacity errors are not silently dropped
 """
 
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch
 from pathlib import Path
 import json
 
@@ -18,7 +18,6 @@ import pytest
 from assemblyzero.core.gemini_client import (
     GeminiClient,
     GeminiErrorType,
-    GeminiCallResult,
 )
 
 
@@ -29,13 +28,17 @@ from assemblyzero.core.gemini_client import (
 
 @pytest.fixture
 def creds_dir(tmp_path: Path) -> Path:
-    """Temporary directory with credentials and state files."""
+    """Temporary directory with credentials and state files.
+
+    #1605: api_key credentials are no longer loaded — governance is
+    subscription/OAuth-only.  Fixture updated to use type: oauth.
+    """
     creds_file = tmp_path / "gemini-credentials.json"
     state_file = tmp_path / "gemini-rotation-state.json"
 
     creds_file.write_text(json.dumps({
         "credentials": [
-            {"name": "api-key-1", "type": "api_key", "key": "test-key-1", "enabled": True},
+            {"name": "api-key-1", "type": "oauth", "enabled": True},
         ]
     }), encoding="utf-8")
 
@@ -49,14 +52,18 @@ def creds_dir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def multi_creds_dir(tmp_path: Path) -> Path:
-    """Temporary directory with multiple credentials (all will 503)."""
+    """Temporary directory with multiple credentials (all will 503).
+
+    #1605: api_key credentials are no longer loaded — governance is
+    subscription/OAuth-only.  Fixture updated to use type: oauth.
+    """
     creds_file = tmp_path / "gemini-credentials.json"
     state_file = tmp_path / "gemini-rotation-state.json"
 
     creds_file.write_text(json.dumps({
         "credentials": [
-            {"name": "api-key-1", "type": "api_key", "key": "test-key-1", "enabled": True},
-            {"name": "api-key-2", "type": "api_key", "key": "test-key-2", "enabled": True},
+            {"name": "api-key-1", "type": "oauth", "enabled": True},
+            {"name": "api-key-2", "type": "oauth", "enabled": True},
         ]
     }), encoding="utf-8")
 
@@ -77,21 +84,21 @@ class TestCapacity503Fix:
     """Tests for issue #483: 503 errors must not be silently dropped."""
 
     def test_503_appears_in_errors(self, creds_dir: Path) -> None:
-        """After retries exhaust on 503, the error appears in the result."""
+        """After retries exhaust on 503, the error appears in the result.
+
+        #1605: patch _invoke_via_cli (OAuth transport) to return a 503/capacity
+        error on every attempt.  The rotation loop must surface the error
+        rather than silently dropping it.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=creds_dir / "gemini-credentials.json",
             state_file=creds_dir / "gemini-rotation-state.json",
         )
 
-        # Mock genai.Client to raise 503 on every call
-        with patch("assemblyzero.core.gemini_client.genai") as mock_genai, \
+        with patch.object(client, "_invoke_via_cli",
+                          return_value=(False, "", "503 The model is overloaded. MODEL_CAPACITY_EXHAUSTED")), \
              patch("assemblyzero.core.gemini_client.time.sleep"):  # Skip actual delays
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = RuntimeError(
-                "503 The model is overloaded. MODEL_CAPACITY_EXHAUSTED"
-            )
-            mock_genai.Client.return_value = mock_client
 
             result = client.invoke(
                 system_instruction="test",
@@ -104,20 +111,19 @@ class TestCapacity503Fix:
         assert "Capacity exhausted" in result.error_message or "capacity" in result.error_message.lower()
 
     def test_all_capacity_returns_capacity_type(self, multi_creds_dir: Path) -> None:
-        """When all credentials fail with 503, error_type is CAPACITY_EXHAUSTED."""
+        """When all credentials fail with 503, error_type is CAPACITY_EXHAUSTED.
+
+        #1605: patch _invoke_via_cli for both OAuth credentials.
+        """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
             credentials_file=multi_creds_dir / "gemini-credentials.json",
             state_file=multi_creds_dir / "gemini-rotation-state.json",
         )
 
-        with patch("assemblyzero.core.gemini_client.genai") as mock_genai, \
+        with patch.object(client, "_invoke_via_cli",
+                          return_value=(False, "", "503 The model is overloaded. MODEL_CAPACITY_EXHAUSTED")), \
              patch("assemblyzero.core.gemini_client.time.sleep"):
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = RuntimeError(
-                "503 The model is overloaded. MODEL_CAPACITY_EXHAUSTED"
-            )
-            mock_genai.Client.return_value = mock_client
 
             result = client.invoke(
                 system_instruction="test",
@@ -133,6 +139,8 @@ class TestCapacity503Fix:
         Before the fix, the while loop `continue` on capacity errors
         never appended to the errors list, so after retries exhausted
         the error was silently dropped.
+
+        #1605: patch _invoke_via_cli (OAuth transport) with a 529 capacity error.
         """
         client = GeminiClient(
             model="gemini-3.1-pro-preview",
@@ -140,13 +148,9 @@ class TestCapacity503Fix:
             state_file=creds_dir / "gemini-rotation-state.json",
         )
 
-        with patch("assemblyzero.core.gemini_client.genai") as mock_genai, \
+        with patch.object(client, "_invoke_via_cli",
+                          return_value=(False, "", "529 RESOURCE_EXHAUSTED")), \
              patch("assemblyzero.core.gemini_client.time.sleep"):
-            mock_client = MagicMock()
-            mock_client.models.generate_content.side_effect = RuntimeError(
-                "529 RESOURCE_EXHAUSTED"
-            )
-            mock_genai.Client.return_value = mock_client
 
             result = client.invoke(
                 system_instruction="test",

--- a/tests/unit/test_structured_verdicts.py
+++ b/tests/unit/test_structured_verdicts.py
@@ -7,9 +7,7 @@ Verifies that:
 """
 
 import json
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
@@ -80,56 +78,14 @@ class TestParseStructuredVerdict:
 
 
 class TestGeminiPassesResponseSchema:
-    """Verify GeminiClient wires response_schema into API config."""
+    """Verify GeminiClient/GeminiProvider wire response_schema correctly.
 
-    @patch("assemblyzero.core.gemini_client.genai")
-    def test_gemini_passes_response_schema(self, mock_genai):
-        """When response_schema is provided, it should be in GenerateContentConfig."""
-        from assemblyzero.core.gemini_client import GeminiClient
-
-        # Create a mock client with minimal config
-        mock_client_instance = MagicMock()
-        mock_genai.Client.return_value = mock_client_instance
-
-        mock_response = MagicMock()
-        mock_response.text = json.dumps({"verdict": "APPROVED", "rationale": "OK"})
-        mock_client_instance.models.generate_content.return_value = mock_response
-
-        client = GeminiClient.__new__(GeminiClient)
-        client.model = "gemini-3.1-pro-preview"
-        client.credentials_file = MagicMock()
-        client.state_file = MagicMock()
-        client._credentials = None
-        client._state = None
-        client._gemini_cli = None
-
-        # Manually create a credential
-        from assemblyzero.core.gemini_client import Credential, RotationState
-
-        client._credentials = [
-            Credential(name="test-key", key="fake-key", enabled=True, cred_type="api_key")
-        ]
-        client._state = RotationState()
-
-        # Patch _save_state to avoid file IO
-        client._save_state = MagicMock()
-
-        result = client.invoke(
-            system_instruction="Review this",
-            content="Draft content",
-            response_schema=VERDICT_SCHEMA,
-        )
-
-        # Verify generate_content was called
-        assert mock_client_instance.models.generate_content.called
-        call_kwargs = mock_client_instance.models.generate_content.call_args
-
-        # The config should have response_mime_type and response_schema
-        config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
-        # Check that the config was created with the right params
-        # The config is a GenerateContentConfig object created via types.GenerateContentConfig
-        # We need to verify the kwargs passed to it
-        assert result.success
+    test_gemini_passes_response_schema was deleted in #1605: the structured-output
+    path relied on genai.Client (paid API-key SDK), which was removed when
+    governance moved to subscription/OAuth-only transport.  GeminiProvider still
+    accepts and forwards response_schema to the underlying client; that forwarding
+    is tested below.
+    """
 
     def test_gemini_provider_passes_schema(self):
         """GeminiProvider.invoke() should forward response_schema to client."""


### PR DESCRIPTION
## Summary

Removes the multi-account **paid API-key** invocation from `gemini_client.py` — governance is now subscription/OAuth-only (the agy transport, ADR-0220). This closes the door on ever spending on the per-token API (~100x subscription cost).

- `invoke()` no longer constructs `genai.Client(api_key=...)`; the only transport is the OAuth/agy path via `_invoke_via_cli`. A defensive `RuntimeError` guards any non-OAuth credential.
- `_load_credentials()` loads **OAuth credentials only**.
- Dropped the now-unused `google.genai` / `types` imports.
- **Kept** (still serve the OAuth subscription-quota path): the rotation loop, `RotationState`, exhaustion tracking, `log_gemini_event`, backoff. (Deleting them — as a first plan draft suggested — would have broken the keeper path; they're shared.)

### Tests
The 8 tests that exercised the api-key path are rewritten to drive rotation / backoff / exhaustion through `_invoke_via_cli` (real assertions — e.g. asserts all creds tried + `rotation_occurred`, or 3 backoff attempts then success — **not** mock-to-pass). The `response_schema`-forwarding test is removed (that SDK-only feature is gone).

Verification: full unit suite **5602 passed**; ruff clean. The obsolete rotation **tools and docs** (#1606, #1607) are a separate follow-up PR.

Closes #1605