### PR TITLE
refactor(enable_wikis): migrate to in-process classic PAT (Closes #1474)

### DIFF
--- a/tools/enable_wikis.py
+++ b/tools/enable_wikis.py
@@ -1,23 +1,60 @@
 #!/usr/bin/env python3
-"""Re-enable wikis on all repos.
+"""Re-enable wikis on all repos via the in-process classic-PAT pattern (ADR-0216).
+
+Enabling a wiki is a repo-settings PATCH (`Administration: write`) which the
+fleet's fine-grained PAT cannot perform — it returns 403 (verified 2026-05-31,
+#1474). This tool decrypts the classic PAT in-process and calls the GitHub REST
+API directly via `requests`; it never sets os.environ, never passes the PAT via
+argv, never logs it.
+
+Defaults to DRY-RUN; pass --apply to mutate (standard 0017).
+
+OPERATOR-RUN ONLY (ADR-0216 §6.1): run this yourself in your own Git Bash. NEVER
+let an agent invoke it via its Bash tool — the spawned Python process would be
+the agent's child and its heap is theoretically readable while the PAT is in
+scope.
 
 Usage:
-    poetry run python tools/enable_wikis.py
-
-Requires: gh CLI authenticated (fine-grained PAT is fine — needs repo metadata write).
+    poetry run python tools/enable_wikis.py            # dry-run (default)
+    poetry run python tools/enable_wikis.py --apply    # enable wikis
 """
 
+from __future__ import annotations
+
+import argparse
 import subprocess
 import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
 
 GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
 
 
-def get_all_repos() -> list[str]:
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_all_repos() -> list[tuple[str, bool]]:
+    """List repos + current wiki status.
+
+    Read-only — a fine-grained PAT via the gh CLI is sufficient here; only the
+    PATCH (enable_wiki) needs the classic PAT.
+    """
     result = subprocess.run(
         ["gh", "repo", "list", GITHUB_USER, "--limit", "200",
-         "--json", "name,hasWikiEnabled", "--jq", '.[] | "\(.name)\t\(.hasWikiEnabled)"'],
-        capture_output=True, text=True, check=True
+         "--json", "name,hasWikiEnabled",
+         "--jq", r'.[] | "\(.name)\t\(.hasWikiEnabled)"'],
+        capture_output=True, text=True, check=True,
     )
     repos = []
     for line in result.stdout.strip().split("\n"):
@@ -28,45 +65,60 @@ def get_all_repos() -> list[str]:
     return sorted(repos)
 
 
-def enable_wiki(repo: str) -> bool:
-    result = subprocess.run(
-        ["gh", "api", "-X", "PATCH", f"/repos/{GITHUB_USER}/{repo}",
-         "-F", "has_wiki=true"],
-        capture_output=True, text=True
+def enable_wiki(repo: str, pat: str) -> tuple[bool, str]:
+    """PATCH has_wiki=true via the classic PAT. Returns (ok, detail)."""
+    resp = requests.patch(
+        f"{GH_API}/repos/{GITHUB_USER}/{repo}",
+        headers=_gh_headers(pat),
+        json={"has_wiki": True},
+        timeout=HTTP_TIMEOUT_S,
     )
-    return result.returncode == 0
+    if resp.status_code == 200:
+        return (True, "enabled")
+    return (False, f"HTTP {resp.status_code}: {resp.text[:160]}")
 
 
-def main():
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually enable wikis (default: dry-run preview).",
+    )
+    args = parser.parse_args()
+
     print("Fetching repo list...")
     repos = get_all_repos()
-    print(f"Found {len(repos)} repos\n")
-
-    already_on = [name for name, enabled in repos if enabled]
     needs_fix = [name for name, enabled in repos if not enabled]
-
-    print(f"  Wiki already enabled: {len(already_on)}")
-    print(f"  Wiki disabled: {len(needs_fix)}\n")
+    print(f"Found {len(repos)} repos; {len(needs_fix)} with wiki disabled.\n")
 
     if not needs_fix:
         print("Nothing to do.")
-        return
+        return 0
+
+    if not args.apply:
+        print("DRY-RUN (pass --apply to enable). Would enable wikis on:")
+        for repo in needs_fix:
+            print(f"  - {repo}")
+        return 0
 
     succeeded = 0
     failed = []
-
-    for i, repo in enumerate(needs_fix, 1):
-        if enable_wiki(repo):
-            print(f"  [{i}/{len(needs_fix)}] {repo}: enabled")
-            succeeded += 1
-        else:
-            print(f"  [{i}/{len(needs_fix)}] {repo}: FAILED")
-            failed.append(repo)
+    with classic_pat_session() as pat:
+        for i, repo in enumerate(needs_fix, 1):
+            ok, detail = enable_wiki(repo, pat)
+            if ok:
+                print(f"  [{i}/{len(needs_fix)}] {repo}: {detail}")
+                succeeded += 1
+            else:
+                print(f"  [{i}/{len(needs_fix)}] {repo}: FAILED — {detail}")
+                failed.append(repo)
 
     print(f"\nDone: {succeeded}/{len(needs_fix)} wikis enabled")
     if failed:
         print(f"Failed: {', '.join(failed)}")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Migrates `tools/enable_wikis.py` to the in-process classic-PAT pattern (ADR-0216). Enabling a wiki is a repo-settings `PATCH` (`Administration: write`) the fine-grained PAT can't perform (403, verified 2026-05-31) — so the PATCH now runs via `classic_pat_session` + `requests` (PAT only in the Python heap; never os.environ / argv / logs). The repo-list read stays on the gh CLI (fine-grained is fine for reads).

Adds the standard-0017 `--apply` dry-run gate (**defaults to dry-run** now, vs the old immediate-apply) and the ADR-0216 §6.1 operator-run-only warning.

Verification: ruff clean, compiles. **Operator-run** — not executed by the agent (the classic-PAT decryption must happen in your process).

Closes #1474