### PR TITLE
refactor(tools): migrate 4 elevated-scope tools to in-process classic PAT (Closes #962, Closes #965, Closes #1236, Closes #961)

### DIFF
--- a/tools/fix_branch_protections.py
+++ b/tools/fix_branch_protections.py
@@ -1,31 +1,32 @@
 #!/usr/bin/env python3
 """Fix branch protections on repos identified by the GitHub Protection Audit.
 
-This script is designed to be run MANUALLY by the user with a classic token.
-The agent writes it; the user reviews it, auths with a classic token, runs it,
-then brings the agent back to analyze the results.
+Sets branch protection on repos with NO protection (A01 FAIL) and disables
+wikis on repos where it is an attack surface.  The protection payload matches
+the existing fleet standard: block force-push, block deletion, enforce_admins,
+require pr-sentinel / issue-reference status check.
+
+Both operations are privileged writes that 403 on the fleet's fine-grained
+PAT; they are sent via requests + the in-process classic-PAT pattern
+(ADR-0216, #962).  Read-only calls (listing repos, reading current protection)
+keep using the gh CLI with the fine-grained PAT.
+
+Defaults to DRY-RUN (prints the would-be protection payload per repo);
+pass --apply to PUT / PATCH for real (standard 0017).
+
+OPERATOR-RUN ONLY (ADR-0216 §6.1): run this yourself in your own Git Bash.
+NEVER let an agent invoke it via its Bash tool — the spawned Python process
+would be the agent's child and its heap is theoretically readable while the
+PAT is in scope.
 
 Usage:
-    1. Review this script (it only calls `gh api` — no token handling)
-    2. gh auth login → paste classic token (repo + admin:repo_hook + read:org)
-    3. poetry run python tools/fix_branch_protections.py
-    4. gh auth login → restore fine-grained PAT
-    5. Delete classic token
-
-What it does:
-    - Sets branch protection on repos with NO protection (A01 FAIL)
-    - Config matches existing protected repos: block force push, block deletion,
-      enforce_admins, require pr-sentinel status check
-    - Disables wiki on repos where it's an attack surface
-    - Saves results to docs/audits/github-protection/fix-TIMESTAMP.md
-
-What it does NOT do:
-    - Read, store, or transmit any token
-    - Modify any code or file content
-    - Push to any repo
-    - Access any secrets
+    poetry run python tools/fix_branch_protections.py            # dry-run
+    poetry run python tools/fix_branch_protections.py --apply    # mutate
 """
 
+from __future__ import annotations
+
+import argparse
 import json
 import subprocess
 import sys
@@ -33,7 +34,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
 GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
 
 # Repos with zero branch protection (A01 FAIL from audit-20260308-202639-classic.md)
 REPOS_NO_PROTECTION = [
@@ -58,6 +66,14 @@ REPOS_WIKI_CONTENT = [
 ]
 
 
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
 @dataclass
 class FixResult:
     repo: str
@@ -67,105 +83,41 @@ class FixResult:
     http_status: int | None = None
 
 
-def gh_api(method: str, endpoint: str, *args: str) -> tuple[int, str]:
-    """Call gh api and return (returncode, combined output)."""
-    cmd = ["gh", "api", "-X", method, endpoint, *args]
-    try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30
-        )
-        output = result.stdout or result.stderr or ""
-        # Try to extract HTTP status from error message
-        http_status = None
-        if "HTTP " in output:
-            for part in output.split("HTTP "):
-                if len(part) >= 3 and part[:3].isdigit():
-                    http_status = int(part[:3])
-                    break
-        return result.returncode, output.strip(), http_status
-    except subprocess.TimeoutExpired:
-        return 1, "TIMEOUT", None
-    except FileNotFoundError:
-        return 1, "gh CLI not found", None
-
-
-def detect_token_type() -> str:
-    """Detect whether current gh auth is classic or fine-grained."""
-    rc, output, _ = gh_api("GET", "/user")
-    if rc != 0:
-        return "unknown (auth failed)"
-    # Classic tokens return X-OAuth-Scopes header; fine-grained do not
-    rc2, output2, _ = gh_api("GET", "/rate_limit")
-    # Fine-grained PATs get 403 on admin endpoints classic can access
-    rc3, _, _ = gh_api(
-        "GET", f"/repos/{GITHUB_USER}/AssemblyZero/branches/main/protection"
-    )
-    if rc3 == 0:
-        return "classic"
-    return "fine-grained (cannot read branch protection — this script needs a classic token)"
+# ---------------------------------------------------------------------------
+# Read-only helpers — gh CLI / fine-grained PAT is sufficient
+# ---------------------------------------------------------------------------
 
 
 def get_default_branch(repo: str) -> str:
-    """Get the default branch name for a repo."""
+    """Return the default branch name for a repo (read-only, gh CLI)."""
     full_repo = f"{GITHUB_USER}/{repo}"
-    rc, output, _ = gh_api("GET", f"/repos/{full_repo}", "--jq", ".default_branch")
-    if rc == 0 and output.strip():
-        return output.strip()
-    return "main"  # fallback
-
-
-def set_branch_protection(repo: str) -> FixResult:
-    """Set branch protection matching the standard config."""
-    full_repo = f"{GITHUB_USER}/{repo}"
-    branch = get_default_branch(repo)
-    endpoint = f"/repos/{full_repo}/branches/{branch}/protection"
-
-    rc, output, http_status = gh_api(
-        "PUT", endpoint,
-        "-F", "required_pull_request_reviews[dismiss_stale_reviews]=false",
-        "-F", "required_pull_request_reviews[require_code_owner_reviews]=false",
-        "-F", "required_pull_request_reviews[required_approving_review_count]=0",
-        "-F", "enforce_admins=true",
-        "-F", "restrictions=null",
-        "-F", "required_status_checks[strict]=true",
-        "-f", "required_status_checks[contexts][]=pr-sentinel / issue-reference",
-        "-F", "allow_force_pushes=false",
-        "-F", "allow_deletions=false",
+    result = subprocess.run(
+        ["gh", "api", f"/repos/{full_repo}", "--jq", ".default_branch"],
+        capture_output=True, text=True, timeout=HTTP_TIMEOUT_S,
     )
-
-    if rc == 0:
-        return FixResult(
-            repo=full_repo,
-            action="set_branch_protection",
-            success=True,
-            detail=f"Protection on '{branch}': force-push blocked, deletion blocked, "
-                   "enforce_admins=true, required check=pr-sentinel / issue-reference",
-            http_status=200,
-        )
-    else:
-        return FixResult(
-            repo=full_repo,
-            action="set_branch_protection",
-            success=False,
-            detail=output[:200],
-            http_status=http_status,
-        )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return "main"
 
 
 def verify_branch_protection(repo: str) -> FixResult:
-    """Verify branch protection was actually set by reading it back."""
+    """Read back protection and verify key fields (read-only, gh CLI)."""
     full_repo = f"{GITHUB_USER}/{repo}"
     branch = get_default_branch(repo)
     endpoint = f"/repos/{full_repo}/branches/{branch}/protection"
 
-    rc, output, http_status = gh_api("GET", endpoint)
-    if rc != 0:
+    result = subprocess.run(
+        ["gh", "api", endpoint],
+        capture_output=True, text=True, timeout=HTTP_TIMEOUT_S,
+    )
+    output = result.stdout or result.stderr or ""
+
+    if result.returncode != 0:
         return FixResult(
             repo=full_repo,
             action="verify_branch_protection",
             success=False,
             detail=f"Could not read back protection: {output[:200]}",
-            http_status=http_status,
         )
 
     try:
@@ -198,21 +150,64 @@ def verify_branch_protection(repo: str) -> FixResult:
             action="verify_branch_protection",
             success=False,
             detail=f"Invalid JSON response: {output[:200]}",
-            http_status=http_status,
         )
 
 
-def disable_wiki(repo: str) -> FixResult:
-    """Disable wiki on a repo."""
-    full_repo = f"{GITHUB_USER}/{repo}"
-    endpoint = f"/repos/{full_repo}"
+# ---------------------------------------------------------------------------
+# Privileged writes — classic PAT required; pat passed in explicitly
+# ---------------------------------------------------------------------------
 
-    rc, output, http_status = gh_api(
-        "PATCH", endpoint,
-        "-F", "has_wiki=false",
+
+def set_branch_protection(repo: str, pat: str) -> FixResult:
+    """PUT branch protection via the classic PAT.  Returns (FixResult)."""
+    full_repo = f"{GITHUB_USER}/{repo}"
+    branch = get_default_branch(repo)
+    url = f"{GH_API}/repos/{full_repo}/branches/{branch}/protection"
+
+    payload = {
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 0,
+        },
+        "enforce_admins": True,
+        "restrictions": None,
+        "required_status_checks": {
+            "strict": True,
+            "contexts": ["pr-sentinel / issue-reference"],
+        },
+        "allow_force_pushes": False,
+        "allow_deletions": False,
+    }
+
+    resp = requests.put(url, headers=_gh_headers(pat), json=payload, timeout=HTTP_TIMEOUT_S)
+    if resp.status_code == 200:
+        return FixResult(
+            repo=full_repo,
+            action="set_branch_protection",
+            success=True,
+            detail=(
+                f"Protection on '{branch}': force-push blocked, deletion blocked, "
+                "enforce_admins=true, required check=pr-sentinel / issue-reference"
+            ),
+            http_status=200,
+        )
+    return FixResult(
+        repo=full_repo,
+        action="set_branch_protection",
+        success=False,
+        detail=resp.text[:200],
+        http_status=resp.status_code,
     )
 
-    if rc == 0:
+
+def disable_wiki(repo: str, pat: str) -> FixResult:
+    """PATCH has_wiki=false via the classic PAT.  Returns (FixResult)."""
+    full_repo = f"{GITHUB_USER}/{repo}"
+    url = f"{GH_API}/repos/{full_repo}"
+
+    resp = requests.patch(url, headers=_gh_headers(pat), json={"has_wiki": False}, timeout=HTTP_TIMEOUT_S)
+    if resp.status_code == 200:
         return FixResult(
             repo=full_repo,
             action="disable_wiki",
@@ -220,17 +215,21 @@ def disable_wiki(repo: str) -> FixResult:
             detail="Wiki disabled",
             http_status=200,
         )
-    else:
-        return FixResult(
-            repo=full_repo,
-            action="disable_wiki",
-            success=False,
-            detail=output[:200],
-            http_status=http_status,
-        )
+    return FixResult(
+        repo=full_repo,
+        action="disable_wiki",
+        success=False,
+        detail=resp.text[:200],
+        http_status=resp.status_code,
+    )
 
 
-def write_report(results: list[FixResult], token_type: str) -> Path:
+# ---------------------------------------------------------------------------
+# Report writer
+# ---------------------------------------------------------------------------
+
+
+def write_report(results: list[FixResult], dry_run: bool) -> Path:
     """Write results to a markdown audit file."""
     now = datetime.now(timezone.utc)
     timestamp = now.strftime("%Y%m%d-%H%M%S")
@@ -240,13 +239,14 @@ def write_report(results: list[FixResult], token_type: str) -> Path:
 
     successes = [r for r in results if r.success]
     failures = [r for r in results if not r.success]
+    run_mode = "DRY-RUN" if dry_run else "APPLIED"
 
     lines = [
         "# Branch Protection Fix Report",
         "",
         f"**Date:** {now.isoformat()}",
-        f"**Token type:** {token_type}",
-        f"**Script:** `tools/fix_branch_protections.py`",
+        f"**Mode:** {run_mode}",
+        "**Script:** `tools/fix_branch_protections.py`",
         "",
         "## Summary",
         "",
@@ -285,62 +285,94 @@ def write_report(results: list[FixResult], token_type: str) -> Path:
     return output_file
 
 
-def main():
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually apply branch-protection writes (default: dry-run preview).",
+    )
+    args = parser.parse_args()
+
     print("=" * 60)
     print("Branch Protection Fix Script")
+    if not args.apply:
+        print("  [DRY-RUN — pass --apply to mutate]")
     print("=" * 60)
-
-    # Detect token type
-    print("\nDetecting token type...")
-    token_type = detect_token_type()
-    print(f"  Token type: {token_type}")
-
-    if "fine-grained" in token_type or "unknown" in token_type:
-        print("\n  WARNING: This script requires a classic token with repo scope.")
-        print("  Run: gh auth login → paste classic token")
-        print("  Then re-run this script.")
-        sys.exit(1)
 
     results: list[FixResult] = []
 
-    # Phase 1: Set branch protection on unprotected repos
-    print(f"\nPhase 1: Setting branch protection on {len(REPOS_NO_PROTECTION)} repos...")
-    for repo in REPOS_NO_PROTECTION:
-        print(f"\n  [{repo}]")
-        result = set_branch_protection(repo)
-        results.append(result)
-        status = "OK" if result.success else f"FAIL: {result.detail[:80]}"
-        print(f"    set_branch_protection: {status}")
+    # -----------------------------------------------------------------------
+    # Phase 1: Branch protection on unprotected repos
+    # -----------------------------------------------------------------------
+    print(f"\nPhase 1: Branch protection on {len(REPOS_NO_PROTECTION)} repos...")
 
-        if result.success:
-            verify = verify_branch_protection(repo)
-            results.append(verify)
-            status = "OK" if verify.success else f"FAIL: {verify.detail[:80]}"
-            print(f"    verify: {status}")
+    if not args.apply:
+        for repo in REPOS_NO_PROTECTION:
+            branch = get_default_branch(repo)
+            full_repo = f"{GITHUB_USER}/{repo}"
+            print(f"\n  [{repo}]")
+            print(f"    would PUT /repos/{full_repo}/branches/{branch}/protection")
+            print(
+                "    payload: enforce_admins=true, allow_force_pushes=false, "
+                "allow_deletions=false, required_status_checks=[pr-sentinel / issue-reference], "
+                "required_approving_review_count=0, restrictions=null"
+            )
+    else:
+        with classic_pat_session() as pat:
+            for repo in REPOS_NO_PROTECTION:
+                print(f"\n  [{repo}]")
+                result = set_branch_protection(repo, pat)
+                results.append(result)
+                status = "OK" if result.success else f"FAIL: {result.detail[:80]}"
+                print(f"    set_branch_protection: {status}")
 
-    # Phase 2: Disable wikis on repos with content
-    print(f"\nPhase 2: Disabling wikis on {len(REPOS_WIKI_CONTENT)} repos...")
-    for repo in REPOS_WIKI_CONTENT:
-        print(f"\n  [{repo}]")
-        result = disable_wiki(repo)
-        results.append(result)
-        status = "OK" if result.success else f"FAIL: {result.detail[:80]}"
-        print(f"    disable_wiki: {status}")
+                if result.success:
+                    verify = verify_branch_protection(repo)
+                    results.append(verify)
+                    vstatus = "OK" if verify.success else f"FAIL: {verify.detail[:80]}"
+                    print(f"    verify: {vstatus}")
 
-    # Write report
-    report_path = write_report(results, token_type)
+    # -----------------------------------------------------------------------
+    # Phase 2: Disable wikis
+    # -----------------------------------------------------------------------
+    print(f"\nPhase 2: Wikis on {len(REPOS_WIKI_CONTENT)} repos...")
 
-    # Summary
-    successes = sum(1 for r in results if r.success)
-    failures = sum(1 for r in results if not r.success)
-    print("\n" + "=" * 60)
-    print(f"Done. {successes} succeeded, {failures} failed.")
-    print(f"Report saved to: {report_path}")
-    print("=" * 60)
+    if not args.apply:
+        for repo in REPOS_WIKI_CONTENT:
+            full_repo = f"{GITHUB_USER}/{repo}"
+            print(f"  would PATCH /repos/{full_repo} {{has_wiki: false}}")
+    else:
+        with classic_pat_session() as pat:
+            for repo in REPOS_WIKI_CONTENT:
+                print(f"\n  [{repo}]")
+                result = disable_wiki(repo, pat)
+                results.append(result)
+                status = "OK" if result.success else f"FAIL: {result.detail[:80]}"
+                print(f"    disable_wiki: {status}")
 
-    if failures:
-        sys.exit(2)
+    # -----------------------------------------------------------------------
+    # Report
+    # -----------------------------------------------------------------------
+    if args.apply and results:
+        report_path = write_report(results, dry_run=False)
+        successes = sum(1 for r in results if r.success)
+        failures = sum(1 for r in results if not r.success)
+        print("\n" + "=" * 60)
+        print(f"Done. {successes} succeeded, {failures} failed.")
+        print(f"Report saved to: {report_path}")
+        print("=" * 60)
+        return 1 if failures else 0
+    elif not args.apply:
+        print("\nDry-run complete. Pass --apply to apply the above changes.")
+        return 0
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/merge_sentinel_permissions_prs.py
+++ b/tools/merge_sentinel_permissions_prs.py
@@ -1,37 +1,55 @@
 #!/usr/bin/env python3
 """Merge all open pr-sentinel permissions PRs across the fleet.
 
-This script is designed to be run MANUALLY by the user with a classic token.
-The agent writes it; the user reviews it, auths with a classic token, runs it,
-then brings the agent back to analyze the results.
+Uses the in-process classic-PAT pattern (ADR-0216) for all privileged calls:
+  (a) DELETE .../branches/main/protection/enforce_admins  — disable admin enforcement
+  (b) PUT    .../pulls/{n}/merge  {"merge_method": "squash"}  — merge the PR
+  (c) POST   .../branches/main/protection/enforce_admins  — re-enable admin enforcement
+
+Step (c) runs in a try/finally block so admin enforcement is ALWAYS restored
+even if the merge fails.  Leaving enforce_admins disabled is a hard safety
+failure; the try/finally is non-negotiable.
+
+Defaults to DRY-RUN; pass --apply to mutate (standard 0017).
+
+OPERATOR-RUN ONLY (ADR-0216 §6.1): run this yourself in your own Git Bash.
+NEVER let an agent invoke it via its Bash tool — the spawned Python process
+would be the agent's child and its heap is theoretically readable while the
+PAT is in scope.
 
 Usage:
-    1. Review this script (it only calls `gh` — no token handling)
-    2. gh auth login → paste classic token (repo scope)
-    3. poetry run python tools/merge_sentinel_permissions_prs.py
-    4. gh auth login → restore fine-grained PAT
-    5. Delete classic token
-
-What it does:
-    - Finds all open PRs matching "add permissions block to pr-sentinel"
-    - For each PR: disables enforce_admins, merges with --squash, re-enables enforce_admins
-    - Saves results to docs/audits/github-protection/merge-sentinel-prs-TIMESTAMP.md
-
-What it does NOT do:
-    - Read, store, or transmit any token
-    - Modify any code or file content
-    - Access any secrets
+    poetry run python tools/merge_sentinel_permissions_prs.py            # dry-run
+    poetry run python tools/merge_sentinel_permissions_prs.py --apply    # execute
 """
 
+from __future__ import annotations
+
+import argparse
+import json
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
 GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
 PR_TITLE_PATTERN = "fix: add permissions block to pr-sentinel workflow"
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
 
 
 @dataclass
@@ -41,126 +59,124 @@ class MergeResult:
     success: bool
     detail: str
     protection_restored: bool = True
-
-
-def run_gh(*args: str, timeout: int = 30) -> tuple[int, str]:
-    """Run a gh CLI command and return (returncode, output)."""
-    cmd = ["gh", *args]
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-        output = (result.stdout or "") + (result.stderr or "")
-        return result.returncode, output.strip()
-    except subprocess.TimeoutExpired:
-        return 1, "TIMEOUT"
-    except FileNotFoundError:
-        return 1, "gh CLI not found"
-
-
-def detect_token_type() -> str:
-    """Detect whether current gh auth is classic or fine-grained."""
-    rc, output = run_gh("auth", "status")
-    if rc != 0:
-        return "unknown (auth failed)"
-    if "ghp_" in output:
-        return "classic"
-    if "github_pat_" in output:
-        return "fine-grained"
-    return "unknown"
+    errors: list[str] = field(default_factory=list)
 
 
 def find_open_prs() -> list[dict]:
     """Find all open PRs matching the sentinel permissions title pattern."""
-    rc, output = run_gh(
-        "search", "prs",
-        "--author", GITHUB_USER,
-        "--state", "open",
-        PR_TITLE_PATTERN,
-        "--limit", "100",
-        "--json", "repository,number,title,url",
-        timeout=60,
+    result = subprocess.run(
+        [
+            "gh", "search", "prs",
+            "--author", GITHUB_USER,
+            "--state", "open",
+            PR_TITLE_PATTERN,
+            "--limit", "100",
+            "--json", "repository,number,title,url",
+        ],
+        capture_output=True, text=True, timeout=60,
     )
-    if rc != 0:
+    if result.returncode != 0:
+        output = (result.stdout + result.stderr).strip()
         print(f"  ERROR searching for PRs: {output[:200]}")
         return []
-
-    import json
     try:
-        prs = json.loads(output)
+        return json.loads(result.stdout)
     except json.JSONDecodeError:
-        print(f"  ERROR parsing search results: {output[:200]}")
+        print(f"  ERROR parsing search results: {result.stdout[:200]}")
         return []
 
-    return prs
 
-
-def disable_enforce_admins(repo_full_name: str) -> bool:
-    """Disable enforce_admins on main branch protection."""
-    rc, output = run_gh(
-        "api", f"repos/{repo_full_name}/branches/main/protection/enforce_admins",
-        "-X", "DELETE",
-        timeout=15,
+def _disable_enforce_admins(repo_full_name: str, pat: str) -> tuple[bool, str]:
+    """DELETE enforce_admins via classic PAT. Returns (ok, detail)."""
+    resp = requests.delete(
+        f"{GH_API}/repos/{repo_full_name}/branches/main/protection/enforce_admins",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
     )
-    return rc == 0
+    # 204 No Content is the success response for DELETE enforce_admins
+    if resp.status_code in (200, 204):
+        return (True, "disabled")
+    return (False, f"HTTP {resp.status_code}: {resp.text[:160]}")
 
 
-def enable_enforce_admins(repo_full_name: str) -> bool:
-    """Re-enable enforce_admins on main branch protection."""
-    rc, output = run_gh(
-        "api", f"repos/{repo_full_name}/branches/main/protection/enforce_admins",
-        "-X", "POST",
-        timeout=15,
+def _enable_enforce_admins(repo_full_name: str, pat: str) -> tuple[bool, str]:
+    """POST enforce_admins via classic PAT. Returns (ok, detail)."""
+    resp = requests.post(
+        f"{GH_API}/repos/{repo_full_name}/branches/main/protection/enforce_admins",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
     )
-    return rc == 0
+    if resp.status_code in (200, 201):
+        return (True, "restored")
+    return (False, f"HTTP {resp.status_code}: {resp.text[:160]}")
 
 
-def merge_pr(repo_full_name: str, pr_number: int) -> MergeResult:
-    """Temporarily disable enforce_admins, merge PR, re-enable."""
-    # Step 1: Disable enforce_admins
-    if not disable_enforce_admins(repo_full_name):
-        return MergeResult(
-            repo=repo_full_name,
-            pr_number=pr_number,
-            success=False,
-            detail="Failed to disable enforce_admins",
-            protection_restored=True,  # never changed it
-        )
+def _merge_pr_rest(repo_full_name: str, pr_number: int, pat: str) -> tuple[bool, str]:
+    """PUT /pulls/{n}/merge via classic PAT. Returns (ok, detail).
 
-    # Step 2: Merge
-    rc, output = run_gh(
-        "pr", "merge", str(pr_number),
-        "--repo", repo_full_name,
-        "--squash",
-        "--delete-branch",
-        "--admin",
-        timeout=30,
+    The classic PAT merges through branch protection without --admin.
+    That is the entire point of ADR-0216 here.
+    """
+    resp = requests.put(
+        f"{GH_API}/repos/{repo_full_name}/pulls/{pr_number}/merge",
+        headers=_gh_headers(pat),
+        json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if resp.status_code in (200, 201):
+        sha = resp.json().get("sha", "")
+        return (True, f"squash-merged sha={sha[:10]}")
+    return (False, f"HTTP {resp.status_code}: {resp.text[:200]}")
+
+
+def merge_pr(repo_full_name: str, pr_number: int, pat: str) -> MergeResult:
+    """Disable enforce_admins, merge PR via REST, ALWAYS re-enable.
+
+    The try/finally ensures enforce_admins is restored even if the merge
+    call raises an exception.  Leaving a repo unprotected is a hard failure.
+    """
+    result = MergeResult(
+        repo=repo_full_name,
+        pr_number=pr_number,
+        success=False,
+        detail="",
     )
 
-    # Step 3: ALWAYS re-enable enforce_admins
-    restored = enable_enforce_admins(repo_full_name)
+    # Step (a): disable enforce_admins
+    ok, detail = _disable_enforce_admins(repo_full_name, pat)
+    if not ok:
+        result.detail = f"Failed to disable enforce_admins: {detail}"
+        result.protection_restored = True  # never changed it
+        return result
 
-    if rc == 0:
-        return MergeResult(
-            repo=repo_full_name,
-            pr_number=pr_number,
-            success=True,
-            detail="Merged successfully",
-            protection_restored=restored,
-        )
-    else:
-        return MergeResult(
-            repo=repo_full_name,
-            pr_number=pr_number,
-            success=False,
-            detail=output[:200],
-            protection_restored=restored,
-        )
+    # Steps (b) + (c) — try/finally guarantees (c) always runs
+    try:
+        # Step (b): merge via REST (no --admin)
+        ok, detail = _merge_pr_rest(repo_full_name, pr_number, pat)
+        if ok:
+            result.success = True
+            result.detail = detail
+        else:
+            result.detail = f"Merge failed: {detail}"
+    finally:
+        # Step (c): re-enable enforce_admins — unconditional
+        ok_restore, restore_detail = _enable_enforce_admins(repo_full_name, pat)
+        result.protection_restored = ok_restore
+        if not ok_restore:
+            result.errors.append(
+                f"CRITICAL: enforce_admins NOT restored: {restore_detail}"
+            )
+
+    return result
 
 
-def write_report(results: list[MergeResult], token_type: str) -> Path:
+def write_report(results: list[MergeResult]) -> Path:
     """Write results to a markdown audit file."""
     now = datetime.now(timezone.utc)
     timestamp = now.strftime("%Y%m%d-%H%M%S")
-    output_dir = Path(__file__).parent.parent / "docs" / "audits" / "github-protection"
+    output_dir = (
+        Path(__file__).parent.parent / "docs" / "audits" / "github-protection"
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
     output_file = output_dir / f"merge-sentinel-prs-{timestamp}.md"
 
@@ -172,10 +188,10 @@ def write_report(results: list[MergeResult], token_type: str) -> Path:
         "# Sentinel Permissions PR Merge Report",
         "",
         f"**Date:** {now.isoformat()}",
-        f"**Token type:** {token_type}",
-        f"**Script:** `tools/merge_sentinel_permissions_prs.py`",
+        "**Script:** `tools/merge_sentinel_permissions_prs.py`",
         f"**PR title pattern:** `{PR_TITLE_PATTERN}`",
-        f"**Method:** Temporarily disable enforce_admins, merge --admin --squash, re-enable",
+        "**Method:** in-process classic-PAT (ADR-0216): disable enforce_admins → "
+        "REST squash-merge → re-enable enforce_admins (try/finally)",
         "",
         "## Summary",
         "",
@@ -196,7 +212,9 @@ def write_report(results: list[MergeResult], token_type: str) -> Path:
         status = "SUCCESS" if r.success else "**FAILURE**"
         restored = "Yes" if r.protection_restored else "**NO**"
         detail = r.detail.replace("|", "\\|").replace("\n", " ")
-        lines.append(f"| {r.repo} | #{r.pr_number} | {status} | {restored} | {detail} |")
+        lines.append(
+            f"| {r.repo} | #{r.pr_number} | {status} | {restored} | {detail} |"
+        )
 
     if unrestored:
         lines.extend([
@@ -208,7 +226,8 @@ def write_report(results: list[MergeResult], token_type: str) -> Path:
         ])
         for r in unrestored:
             lines.append(
-                f"- **{r.repo}**: `gh api repos/{r.repo}/branches/main/protection/enforce_admins -X POST`"
+                f"- **{r.repo}**: "
+                f"`gh api repos/{r.repo}/branches/main/protection/enforce_admins -X POST`"
             )
 
     if failures:
@@ -224,90 +243,92 @@ def write_report(results: list[MergeResult], token_type: str) -> Path:
         "",
         "---",
         "",
-        f"*Generated by tools/merge_sentinel_permissions_prs.py on {now.strftime('%Y-%m-%d')}*",
+        f"*Generated by tools/merge_sentinel_permissions_prs.py on "
+        f"{now.strftime('%Y-%m-%d')}*",
     ])
 
     output_file.write_text("\n".join(lines), encoding="utf-8")
     return output_file
 
 
-def main():
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually merge PRs (default: dry-run preview).",
+    )
+    args = parser.parse_args()
+
     print("=" * 60)
     print("Merge Sentinel Permissions PRs")
     print("=" * 60)
 
-    # Detect token type
-    print("\nDetecting token type...")
-    token_type = detect_token_type()
-    print(f"  Token type: {token_type}")
-
-    if "fine-grained" in token_type:
-        print("\n  WARNING: This script requires a classic token with repo scope.")
-        print("  Run: gh auth login -h github.com -p https")
-        print("  Then re-run this script.")
-        sys.exit(1)
-
-    if "unknown" in token_type:
-        print("\n  WARNING: Could not detect token type. Proceeding anyway...")
-
-    # Find open PRs
+    # Find open PRs (read-only — fine-grained PAT via gh CLI is sufficient)
     print(f"\nSearching for open PRs matching: {PR_TITLE_PATTERN}")
     prs = find_open_prs()
     print(f"  Found {len(prs)} open PRs")
 
     if not prs:
         print("\n  No PRs to merge. Done.")
-        sys.exit(0)
+        return 0
 
-    # Dry-run preview
-    print(f"\nWill merge {len(prs)} PRs using enforce_admins toggle method:")
-    for pr in prs[:5]:
-        repo = pr.get("repository", {}).get("nameWithOwner", "unknown")
-        print(f"  - {repo} #{pr.get('number', '?')}")
-    if len(prs) > 5:
-        print(f"  ... and {len(prs) - 5} more")
+    if not args.apply:
+        print(
+            f"\nDRY-RUN (pass --apply to merge). Would process {len(prs)} PR(s):\n"
+        )
+        for pr in prs:
+            repo = pr.get("repository", {}).get("nameWithOwner", "unknown")
+            num = pr.get("number", "?")
+            title = pr.get("title", "")[:60]
+            print(f"  - {repo} #{num}  {title}")
+        print(
+            "\nFor each PR: disable enforce_admins → REST squash-merge → "
+            "re-enable enforce_admins (try/finally)"
+        )
+        return 0
 
-    print("\nFor each PR: disable enforce_admins → merge --admin --squash → re-enable enforce_admins")
-    print("Press Ctrl+C to abort.\n")
-    time.sleep(3)
-
-    # Merge each PR
+    # --apply: open classic-PAT session for the entire batch
     results: list[MergeResult] = []
-    print(f"Merging {len(prs)} PRs...\n")
+    print(f"\nMerging {len(prs)} PR(s) via classic-PAT (ADR-0216)...\n")
 
-    for i, pr in enumerate(prs, 1):
-        repo_name = pr.get("repository", {}).get("nameWithOwner", "unknown")
-        pr_number = pr.get("number", 0)
-        print(f"  [{i}/{len(prs)}] {repo_name} #{pr_number}")
+    with classic_pat_session() as pat:
+        for i, pr in enumerate(prs, 1):
+            repo_name = pr.get("repository", {}).get("nameWithOwner", "unknown")
+            pr_number = pr.get("number", 0)
+            print(f"  [{i}/{len(prs)}] {repo_name} #{pr_number}")
 
-        result = merge_pr(repo_name, pr_number)
-        results.append(result)
+            result = merge_pr(repo_name, pr_number, pat)
+            results.append(result)
 
-        status = "OK" if result.success else f"FAIL: {result.detail[:60]}"
-        restored = "" if result.protection_restored else " [PROTECTION NOT RESTORED!]"
-        print(f"    → {status}{restored}")
+            status = "OK" if result.success else f"FAIL: {result.detail[:60]}"
+            restored = (
+                "" if result.protection_restored else " [PROTECTION NOT RESTORED!]"
+            )
+            print(f"    -> {status}{restored}")
+            for err in result.errors:
+                print(f"    !! {err}")
 
-        # Brief pause to avoid rate limiting
-        if i < len(prs):
-            time.sleep(1)
+            if i < len(prs):
+                time.sleep(1)
 
-    # Write report
-    report_path = write_report(results, token_type)
+    # Write audit report
+    report_path = write_report(results)
 
-    # Summary
     successes = sum(1 for r in results if r.success)
     failures = sum(1 for r in results if not r.success)
     unrestored = sum(1 for r in results if not r.protection_restored)
+
     print("\n" + "=" * 60)
     print(f"Done. {successes} succeeded, {failures} failed.")
     if unrestored:
-        print(f"  ⚠️  {unrestored} repos have enforce_admins NOT restored — see report!")
+        print(f"  WARNING: {unrestored} repo(s) have enforce_admins NOT restored — see report!")
     print(f"Report saved to: {report_path}")
     print("=" * 60)
 
     if failures or unrestored:
-        sys.exit(2)
+        return 2
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/push_workflow_fixes.py
+++ b/tools/push_workflow_fixes.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-"""
-Push workflow file fixes that require the 'workflow' scope.
+"""Push workflow file fixes that require 'workflow' scope via the in-process classic-PAT pattern (ADR-0216).
 
-THIS SCRIPT MUST BE RUN BY THE USER, NOT BY AN AGENT.
-It pushes changes to .github/workflows/ files, which require a classic PAT
-with 'workflow' scope. The fine-grained PAT agents use cannot push these.
+Writing .github/workflows/*.yml requires a classic PAT with 'workflow' scope — the
+fleet's fine-grained PAT returns 403 for these paths. This tool decrypts the classic
+PAT in-process and calls the GitHub REST API directly via `requests`; it never sets
+os.environ, never passes the PAT via argv, never logs it.
 
-Usage:
-    1. Switch to classic PAT:  gh auth login -h github.com -p https
-    2. Run:  poetry run python tools/push_workflow_fixes.py
-    3. Switch back:  gh auth login -h github.com -p https  (paste fine-grained PAT)
+Defaults to DRY-RUN; pass --apply to mutate (standard 0017).
+
+OPERATOR-RUN ONLY (ADR-0216 §6.1): run this yourself in your own Git Bash. NEVER
+let an agent invoke it via its Bash tool — the spawned Python process would be the
+agent's child and its heap is theoretically readable while the PAT is in scope.
 
 What it does:
     Fix 1: Add missing permissions block to AssemblyZero's auto-reviewer-caller.yml
@@ -17,19 +18,47 @@ What it does:
     Fix 2: Change reusable auto-reviewer default from "pr-sentinel" to "issue-reference"
            (dependabot PRs use bare check run name, not composite workflow/job name)
     Fix 3: Deploy auto-reviewer caller to patent-general via PR
-           (has GitHub ruleset instead of classic branch protection, Contents API blocked on main)
+           (has GitHub ruleset instead of classic branch protection; uses Contents API)
     Fix 4: Enable auto-delete head branches on all repos (#752)
            (squash merges leave orphan branches — 48 found on career alone)
 
-Issue: #752, #748, #737, #736
+Issues: #752, #748, #737, #736
+
+Usage:
+    poetry run python tools/push_workflow_fixes.py            # dry-run (default)
+    poetry run python tools/push_workflow_fixes.py --apply    # execute all fixes
 """
 
+from __future__ import annotations
+
+import argparse
+import base64
+import json
 import subprocess
 import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
 
 
 def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
-    """Run a command and return the result."""
+    """Run a shell command (read-only ops only — fine-grained PAT via gh CLI)."""
     print(f"  $ {' '.join(cmd)}")
     result = subprocess.run(cmd, capture_output=True, text=True)
     if check and result.returncode != 0:
@@ -38,43 +67,11 @@ def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
     return result
 
 
-def verify_classic_pat() -> bool:
-    """Check that the current gh auth has workflow scope."""
-    result = run(["gh", "auth", "status"], check=False)
-    output = result.stdout + result.stderr
-    if "workflow" not in output.lower():
-        print("WARNING: Could not confirm 'workflow' scope on current PAT.")
-        print("This script requires a classic PAT with 'workflow' scope.")
-        response = input("Continue anyway? (y/N): ").strip().lower()
-        return response == "y"
-    return True
-
-
-def main():
-    print("=" * 60)
-    print("Push Workflow Fixes (requires classic PAT with workflow scope)")
-    print("=" * 60)
-    print()
-
-    # Verify we're in AssemblyZero
-    result = run(["git", "rev-parse", "--show-toplevel"], check=False)
-    toplevel = result.stdout.strip().replace("\\", "/")
-    if "AssemblyZero" not in toplevel:
-        print(f"ERROR: Must run from AssemblyZero repo, got: {toplevel}")
-        sys.exit(1)
-
-    # Check auth
-    print("Checking GitHub auth...")
-    if not verify_classic_pat():
-        print("Aborted.")
-        sys.exit(1)
-    print()
-
-    # Fix 1: AssemblyZero caller permissions
-    print("Fix 1: Add permissions block to auto-reviewer-caller.yml")
-    caller_path = ".github/workflows/auto-reviewer-caller.yml"
-
-    caller_content = """name: Auto Review
+# ---------------------------------------------------------------------------
+# Caller workflow content (written in Fix 1 locally; pushed to patent-general
+# in Fix 3 via the Contents API).
+# ---------------------------------------------------------------------------
+CALLER_CONTENT = """name: Auto Review
 
 # Caller workflow: invokes the reusable auto-reviewer from AssemblyZero.
 # Copy this file to .github/workflows/auto-reviewer.yml in each repo.
@@ -103,19 +100,25 @@ jobs:
       REVIEWER_APP_PRIVATE_KEY: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
 """
 
+
+# ---------------------------------------------------------------------------
+# Fix 1 + 2: local file writes (working tree only — no GitHub API needed)
+# ---------------------------------------------------------------------------
+
+def apply_fix1(caller_path: str) -> None:
+    """Write the permissions-annotated caller workflow to the local working tree."""
     with open(caller_path, "w", encoding="utf-8", newline="\n") as f:
-        f.write(caller_content)
+        f.write(CALLER_CONTENT)
     print(f"  Wrote {caller_path}")
 
-    # Fix 2: Reusable workflow default
-    print("Fix 2: Change auto-reviewer.yml default from 'pr-sentinel' to 'issue-reference'")
-    reusable_path = ".github/workflows/auto-reviewer.yml"
 
+def apply_fix2(reusable_path: str) -> None:
+    """Patch the reusable workflow default required_checks in the local working tree."""
     with open(reusable_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    old_default = "default: \"pr-sentinel\""
-    new_default = "default: \"issue-reference\""
+    old_default = 'default: "pr-sentinel"'
+    new_default = 'default: "issue-reference"'
 
     if old_default not in content:
         print(f"  WARNING: '{old_default}' not found in {reusable_path}")
@@ -126,158 +129,347 @@ jobs:
             f.write(content)
         print(f"  Updated {reusable_path}")
 
-    print()
 
-    # Fix 3: Deploy auto-reviewer to patent-general via PR
-    # patent-general has a GitHub ruleset (not classic branch protection)
-    # so the fleet deploy script can't push via Contents API to main.
-    # Instead: create branch, push file, create PR, wait for Cerberus, merge.
-    print("Fix 3: Deploy auto-reviewer caller to patent-general via PR")
+# ---------------------------------------------------------------------------
+# Fix 3: deploy auto-reviewer caller to patent-general via Contents API + PR
+# (privileged — workflow scope required; all GitHub API calls inside classic_pat_session)
+# ---------------------------------------------------------------------------
+
+def get_main_sha(pg_repo: str) -> str | None:
+    """Read-only: get the main branch SHA via gh CLI (fine-grained PAT is sufficient)."""
+    result = run(
+        ["gh", "api", f"repos/{pg_repo}/git/refs/heads/main", "--jq", ".object.sha"],
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def create_branch(pg_repo: str, branch: str, main_sha: str, pat: str) -> bool:
+    """POST /repos/{owner}/{repo}/git/refs — creates the feature branch."""
+    resp = requests.post(
+        f"{GH_API}/repos/{pg_repo}/git/refs",
+        headers=_gh_headers(pat),
+        json={"ref": f"refs/heads/{branch}", "sha": main_sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if resp.status_code in (201, 422):
+        # 422 = branch already exists from a prior attempt; treat as success
+        return True
+    print(f"  WARNING: create branch HTTP {resp.status_code}: {resp.text[:160]}")
+    return False
+
+
+def push_workflow_file(
+    pg_repo: str,
+    branch: str,
+    file_path: str,
+    content: str,
+    commit_message: str,
+    pat: str,
+) -> bool:
+    """PUT /repos/{owner}/{repo}/contents/{path} — write workflow file via Contents API.
+
+    CRLF-normalizes the content bytes before base64-encoding (ADR-0216 §6.3):
+    Windows checkouts have CRLF; the Contents API stores bytes verbatim, so
+    without normalization the whole file's line endings flip on origin.
+    """
+    # CRLF normalization (ADR-0216 §6.3) — must happen before base64 encoding
+    content_bytes = content.encode("utf-8").replace(b"\r\n", b"\n")
+    encoded = base64.b64encode(content_bytes).decode()
+
+    # Check whether the file already exists (to get its SHA for updates)
+    check_resp = requests.get(
+        f"{GH_API}/repos/{pg_repo}/contents/{file_path}",
+        headers=_gh_headers(pat),
+        params={"ref": branch},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    body: dict = {
+        "message": commit_message,
+        "content": encoded,
+        "branch": branch,
+    }
+    if check_resp.status_code == 200:
+        body["sha"] = check_resp.json()["sha"]
+
+    resp = requests.put(
+        f"{GH_API}/repos/{pg_repo}/contents/{file_path}",
+        headers=_gh_headers(pat),
+        json=body,
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if resp.status_code in (200, 201):
+        print("  Pushed workflow file to branch")
+        return True
+    print(f"  WARNING: push workflow file HTTP {resp.status_code}: {resp.text[:160]}")
+    return False
+
+
+def create_pr(
+    pg_repo: str,
+    branch: str,
+    title: str,
+    body: str,
+    pat: str,
+) -> str | None:
+    """POST /repos/{owner}/{repo}/pulls — returns PR number as string, or None."""
+    resp = requests.post(
+        f"{GH_API}/repos/{pg_repo}/pulls",
+        headers=_gh_headers(pat),
+        json={"title": title, "body": body, "head": branch, "base": "main"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if resp.status_code == 201:
+        pr_num = str(resp.json()["number"])
+        pr_url = resp.json()["html_url"]
+        print(f"  PR created: {pr_url}")
+        return pr_num
+    if resp.status_code == 422 and "already exists" in resp.text:
+        # PR already open from prior attempt — find it via gh CLI (read-only)
+        result = run(
+            ["gh", "pr", "list", "--repo", pg_repo, "--head", branch,
+             "--json", "number", "--jq", ".[0].number"],
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            pr_num = result.stdout.strip()
+            print(f"  PR already exists: #{pr_num}")
+            return pr_num
+    print(f"  WARNING: create PR HTTP {resp.status_code}: {resp.text[:160]}")
+    return None
+
+
+def wait_and_merge_pr(pg_repo: str, pr_num: str, pat: str) -> bool:
+    """Poll for Cerberus approval then merge via REST API (squash)."""
+    print("  Waiting for Cerberus approval...")
+    for attempt in range(12):
+        time.sleep(10)
+        result = run(
+            ["gh", "api", f"repos/{pg_repo}/pulls/{pr_num}/reviews",
+             "--jq", 'map(select(.state == "APPROVED")) | length'],
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip() not in ("", "0"):
+            print("  Cerberus approved. Merging...")
+            resp = requests.put(
+                f"{GH_API}/repos/{pg_repo}/pulls/{pr_num}/merge",
+                headers=_gh_headers(pat),
+                json={"merge_method": "squash"},
+                timeout=HTTP_TIMEOUT_S,
+            )
+            if resp.status_code == 200:
+                print("  Merged.")
+                return True
+            print(f"  WARNING: merge HTTP {resp.status_code}: {resp.text[:160]}")
+            return False
+        print(f"    Attempt {attempt + 1}/12...")
+    print("  WARNING: Cerberus did not approve within 2 minutes.")
+    print(f"  PR #{pr_num} on {pg_repo} is still open — merge manually.")
+    return False
+
+
+def apply_fix3_privileged(pat: str) -> None:
+    """All privileged GitHub API calls for Fix 3 — must run inside classic_pat_session."""
     pg_repo = "martymcenroe/patent-general"
     pg_branch = "ci/deploy-auto-reviewer"
+    wf_file_path = ".github/workflows/auto-reviewer.yml"
+    commit_msg = "ci: deploy auto-reviewer caller workflow (Closes #748)"
+    pr_title = "ci: deploy auto-reviewer caller workflow (Closes #748)"
+    pr_body = (
+        "Deploy Cerberus auto-reviewer caller workflow.\n\n"
+        "Closes martymcenroe/patent-general#748\n\n"
+        "See parent: martymcenroe/AssemblyZero#748"
+    )
 
-    import base64 as b64mod
-    import time
+    main_sha = get_main_sha(pg_repo)
+    if not main_sha:
+        print("  WARNING: Could not get patent-general main SHA. Skipping Fix 3.")
+        return
 
-    # Get main SHA
-    result = run(["gh", "api", f"repos/{pg_repo}/git/refs/heads/main",
-                  "--jq", ".object.sha"], check=False)
+    if not create_branch(pg_repo, pg_branch, main_sha, pat):
+        print("  WARNING: Could not create branch. Skipping Fix 3.")
+        return
+
+    if not push_workflow_file(pg_repo, pg_branch, wf_file_path, CALLER_CONTENT, commit_msg, pat):
+        print("  WARNING: Could not push workflow file. Skipping Fix 3.")
+        return
+
+    pr_num = create_pr(pg_repo, pg_branch, pr_title, pr_body, pat)
+    if not pr_num:
+        print("  WARNING: Could not create PR. Skipping merge.")
+        return
+
+    wait_and_merge_pr(pg_repo, pr_num, pat)
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: enable auto-delete-head-branches fleet-wide
+# (privileged — PATCH /repos/{owner}/{repo} needs classic PAT)
+# ---------------------------------------------------------------------------
+
+def list_repos() -> list[dict]:
+    """Read-only: list all non-fork repos via gh CLI."""
+    result = run(
+        ["gh", "repo", "list", GITHUB_USER, "--limit", "200",
+         "--json", "nameWithOwner,isFork", "--no-archived"],
+        check=False,
+    )
     if result.returncode != 0:
-        print(f"  WARNING: Could not get patent-general main SHA. Skipping.")
-    else:
-        main_sha = result.stdout.strip()
+        print(f"  WARNING: Could not list repos: {result.stderr[:100]}")
+        return []
+    return json.loads(result.stdout)
 
-        # Create branch (may already exist from prior attempt)
-        run(["gh", "api", f"repos/{pg_repo}/git/refs",
-             "-X", "POST", "-f", f"ref=refs/heads/{pg_branch}",
-             "-f", f"sha={main_sha}"], check=False)
 
-        # Push workflow file to branch
-        wf_content = b64mod.b64encode(caller_content.encode()).decode()
-        result = run([
-            "gh", "api", f"repos/{pg_repo}/contents/.github/workflows/auto-reviewer.yml",
-            "-X", "PUT",
-            "-f", "message=ci: deploy auto-reviewer caller workflow (#748)",
-            "-f", f"content={wf_content}",
-            "-f", f"branch={pg_branch}",
-        ], check=False)
+def enable_delete_branch_on_merge(repo_full: str, pat: str) -> tuple[bool, str]:
+    """PATCH /repos/{owner}/{repo} — enable delete_branch_on_merge. Returns (ok, detail)."""
+    resp = requests.patch(
+        f"{GH_API}/repos/{repo_full}",
+        headers=_gh_headers(pat),
+        json={"delete_branch_on_merge": True},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if resp.status_code == 200 and resp.json().get("delete_branch_on_merge"):
+        return (True, "enabled")
+    return (False, f"HTTP {resp.status_code}: {resp.text[:80]}")
 
-        if result.returncode != 0:
-            print(f"  WARNING: Could not push workflow file: {result.stderr[:100]}")
+
+def apply_fix4_privileged(repos: list[dict], pat: str) -> None:
+    """All privileged GitHub API calls for Fix 4 — must run inside classic_pat_session."""
+    enabled = 0
+    skipped = 0
+    failed = 0
+    for repo_info in repos:
+        name = repo_info["nameWithOwner"]
+        if repo_info.get("isFork"):
+            skipped += 1
+            continue
+        ok, detail = enable_delete_branch_on_merge(name, pat)
+        if ok:
+            enabled += 1
         else:
-            print("  Pushed workflow file to branch")
+            failed += 1
+            print(f"  FAIL: {name}: {detail}")
+    print(f"  Enabled: {enabled} | Skipped (forks): {skipped} | Failed: {failed}")
 
-            # Create PR
-            result = run([
-                "gh", "pr", "create",
-                "--repo", pg_repo,
-                "--head", pg_branch,
-                "--title", "ci: deploy auto-reviewer caller workflow (#748)",
-                "--body", "Deploy Cerberus auto-reviewer caller workflow.\n\nCloses martymcenroe/AssemblyZero#748",
-            ], check=False)
 
-            if result.returncode == 0:
-                pr_url = result.stdout.strip()
-                print(f"  PR created: {pr_url}")
+# ---------------------------------------------------------------------------
+# Local AssemblyZero git steps (working tree + commit — no GitHub API write scope needed)
+# ---------------------------------------------------------------------------
 
-                # Wait for Cerberus approval and merge
-                print("  Waiting for Cerberus approval...")
-                pr_num = pr_url.rstrip("/").split("/")[-1]
-                for attempt in range(12):
-                    time.sleep(10)
-                    result = run([
-                        "gh", "api", f"repos/{pg_repo}/pulls/{pr_num}/reviews",
-                        "--jq", 'map(select(.state == "APPROVED")) | length',
-                    ], check=False)
-                    if result.returncode == 0 and result.stdout.strip() != "0":
-                        print("  Cerberus approved. Merging...")
-                        run(["gh", "pr", "merge", pr_num,
-                             "--squash", "--repo", pg_repo], check=False)
-                        print("  Merged.")
-                        break
-                    print(f"    Attempt {attempt + 1}/12...")
-                else:
-                    print("  WARNING: Cerberus did not approve within 2 minutes.")
-                    print(f"  PR is open at {pr_url} — merge manually.")
-            else:
-                print(f"  WARNING: Could not create PR: {result.stderr[:100]}")
-
-    print()
-
-    # Stage, commit, push (AssemblyZero local changes only)
-    print("Staging and committing AssemblyZero workflow fixes...")
+def stage_and_commit_local(caller_path: str, reusable_path: str) -> None:
+    """Stage Fix 1 + Fix 2 changes and commit to the local AssemblyZero working tree."""
     run(["git", "add", caller_path, reusable_path])
 
-    # Check if there's anything to commit
     result = run(["git", "diff", "--cached", "--quiet"], check=False)
     if result.returncode == 0:
         print("  No local changes to commit (already pushed).")
-    else:
-        commit_msg = (
-            "fix: auto-reviewer — add caller permissions + fix dependabot check name (#748)\n"
-            "\n"
-            "Two fixes:\n"
-            "1. AssemblyZero's auto-reviewer-caller.yml was missing the permissions\n"
-            "   block (pull-requests: write, checks: read) that the fleet deploy\n"
-            "   script added to all other repos. Caused startup_failure on every\n"
-            "   AssemblyZero PR.\n"
-            "\n"
-            "2. Changed the default required_checks from 'pr-sentinel' to\n"
-            "   'issue-reference'. Dependabot PRs create check runs named\n"
-            "   'issue-reference' (bare), while normal PRs create\n"
-            "   'pr-sentinel / issue-reference' (composite). The contains()\n"
-            "   matcher finds 'issue-reference' in both forms.\n"
-            "\n"
-            "Closes #748\n"
-            "\n"
-            "Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
-        )
+        return
 
-        run(["git", "commit", "-m", commit_msg])
-
-        print()
-        print("Pushing to origin...")
-        result = run(["git", "push"], check=False)
-        if result.returncode != 0:
-            print("  Direct push failed, trying current branch...")
-            branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
-            run(["git", "push", "origin", branch])
-
-    # Fix 4: Enable auto-delete head branches on all repos (#752)
-    print("Fix 4: Enable auto-delete head branches fleet-wide")
-    import json as json_mod
-
-    result = run(["gh", "repo", "list", "martymcenroe",
-                  "--limit", "200", "--json", "nameWithOwner,isFork",
-                  "--no-archived"], check=False)
-    if result.returncode != 0:
-        print(f"  WARNING: Could not list repos: {result.stderr[:100]}")
-    else:
-        repos = json_mod.loads(result.stdout)
-        enabled = 0
-        skipped = 0
-        failed = 0
-        for repo_info in repos:
-            name = repo_info["nameWithOwner"]
-            if repo_info.get("isFork"):
-                skipped += 1
-                continue
-            r = run(["gh", "api", "-X", "PATCH", f"repos/{name}",
-                     "-F", "delete_branch_on_merge=true",
-                     "--jq", ".delete_branch_on_merge"], check=False)
-            if r.returncode == 0 and r.stdout.strip() == "true":
-                enabled += 1
-            else:
-                failed += 1
-                print(f"  FAIL: {name}: {r.stderr[:80]}")
-        print(f"  Enabled: {enabled} | Skipped (forks): {skipped} | Failed: {failed}")
+    commit_msg = (
+        "fix: auto-reviewer — add caller permissions + fix dependabot check name"
+        " (Closes #748)\n"
+        "\n"
+        "Two fixes:\n"
+        "1. AssemblyZero's auto-reviewer-caller.yml was missing the permissions\n"
+        "   block (pull-requests: write, checks: read) that the fleet deploy\n"
+        "   script added to all other repos. Caused startup_failure on every\n"
+        "   AssemblyZero PR.\n"
+        "\n"
+        "2. Changed the default required_checks from 'pr-sentinel' to\n"
+        "   'issue-reference'. Dependabot PRs create check runs named\n"
+        "   'issue-reference' (bare), while normal PRs create\n"
+        "   'pr-sentinel / issue-reference' (composite). The contains()\n"
+        "   matcher finds 'issue-reference' in both forms.\n"
+        "\n"
+        "Closes #748\n"
+        "\n"
+        "Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+    )
+    run(["git", "commit", "-m", commit_msg])
 
     print()
+    print("Pushing to origin...")
+    result = run(["git", "push"], check=False)
+    if result.returncode != 0:
+        print("  Direct push failed, trying current branch...")
+        branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+        run(["git", "push", "origin", branch])
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Execute all fixes (default: dry-run preview).",
+    )
+    args = parser.parse_args()
+
+    # Verify we're in the AssemblyZero repo
+    result = run(["git", "rev-parse", "--show-toplevel"], check=False)
+    toplevel = result.stdout.strip().replace("\\", "/")
+    if "AssemblyZero" not in toplevel:
+        print(f"ERROR: Must run from AssemblyZero repo, got: {toplevel}")
+        return 1
+
+    caller_path = ".github/workflows/auto-reviewer-caller.yml"
+    reusable_path = ".github/workflows/auto-reviewer.yml"
+    pg_repo = "martymcenroe/patent-general"
+
+    if not args.apply:
+        print("DRY-RUN (pass --apply to execute). Planned writes:")
+        print()
+        print(f"  Fix 1 (local write):  {caller_path}")
+        print(f"  Fix 2 (local write):  {reusable_path}")
+        print(f"  Fix 3 (Contents API): {pg_repo}/.github/workflows/auto-reviewer.yml")
+        print("           via branch:  ci/deploy-auto-reviewer → PR → squash merge")
+        print("  Fix 4 (PATCH repos):  delete_branch_on_merge=true on all non-fork repos")
+        return 0
+
     print("=" * 60)
-    print("DONE. Now switch back to the fine-grained PAT:")
-    print("  gh auth login -h github.com -p https")
+    print("Push Workflow Fixes")
     print("=" * 60)
+    print()
+
+    # Fix 1: local write (no classic PAT needed)
+    print("Fix 1: Add permissions block to auto-reviewer-caller.yml")
+    apply_fix1(caller_path)
+    print()
+
+    # Fix 2: local write (no classic PAT needed)
+    print("Fix 2: Change auto-reviewer.yml default from 'pr-sentinel' to 'issue-reference'")
+    apply_fix2(reusable_path)
+    print()
+
+    # Local git commit for Fix 1 + Fix 2 (fine-grained PAT can push non-workflow commits)
+    print("Staging and committing AssemblyZero workflow fixes...")
+    stage_and_commit_local(caller_path, reusable_path)
+    print()
+
+    # Fix 3 + Fix 4: privileged GitHub API writes — enter classic_pat_session once
+    repos = list_repos()  # read-only; fine-grained PAT fine here
+
+    with classic_pat_session() as pat:
+        # Fix 3: deploy auto-reviewer to patent-general via Contents API + PR
+        print("Fix 3: Deploy auto-reviewer caller to patent-general via PR")
+        apply_fix3_privileged(pat)
+        print()
+
+        # Fix 4: enable auto-delete head branches fleet-wide
+        print("Fix 4: Enable auto-delete head branches fleet-wide")
+        apply_fix4_privileged(repos, pat)
+        print()
+
+    print("=" * 60)
+    print("DONE.")
+    print("=" * 60)
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/test_governance_system.py
+++ b/tools/test_governance_system.py
@@ -5,7 +5,14 @@ Two modes:
   --mode local    Create real test PRs to verify happy/failure paths.
                   Works with fine-grained PAT. Targets a single repo.
   --mode audit    Fleet-wide branch protection comparison against canonical config.
-                  Requires classic PAT with repo + admin:repo_hook scopes.
+                  Uses the in-process classic-PAT pattern (ADR-0216) — decrypts
+                  the classic PAT in-process via gpg pinentry. Read-only; no
+                  --apply gate needed.
+
+OPERATOR-RUN ONLY for audit mode (ADR-0216 §6.1): run this yourself in your own
+Git Bash terminal. NEVER let an agent invoke --mode audit via its Bash tool —
+the spawned Python process would be the agent's child and its heap is
+theoretically readable while the PAT is in scope.
 
 Usage:
     # Local tests on a specific repo
@@ -14,10 +21,8 @@ Usage:
     # Local tests on AssemblyZero (default)
     poetry run python tools/test_governance_system.py --mode local
 
-    # Fleet-wide audit (requires classic PAT)
-    gh auth login -h github.com -p https   # classic PAT
+    # Fleet-wide audit (decrypts classic PAT via gpg pinentry — run yourself)
     poetry run python tools/test_governance_system.py --mode audit
-    gh auth login -h github.com -p https   # back to fine-grained
 
     # Dry run (show what would happen, don't create PRs)
     poetry run python tools/test_governance_system.py --mode local --dry-run
@@ -26,18 +31,27 @@ Issue: #887 | Related: #886
 Standard: 0016-pr-sentinel-system-architecture.md
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import subprocess
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
 
 GITHUB_USER = "martymcenroe"
 DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
 SENTINEL_HEALTH_URL = "https://pr-sentinel.mcwizard1.workers.dev/health"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
 
 # Canonical branch protection settings (from standard 0016)
 CANONICAL = {
@@ -55,6 +69,14 @@ CANONICAL = {
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
 
 @dataclass
 class TestResult:
@@ -95,16 +117,6 @@ def run_curl(url: str, timeout: int = 10) -> tuple[int, str]:
         return 0, result.stdout
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return 0, "TIMEOUT or curl not found"
-
-
-def detect_token_type() -> str:
-    """Detect whether current gh auth is classic or fine-grained."""
-    rc, output = run_gh("auth", "status")
-    if "ghp_" in (output or ""):
-        return "classic"
-    if "github_pat_" in (output or ""):
-        return "fine-grained"
-    return "unknown"
 
 
 def get_all_repos() -> list[str]:
@@ -637,7 +649,7 @@ def run_local_tests(repo: str, dry_run: bool = False) -> list[TestResult]:
     results = []
 
     print(f"\n{'=' * 60}")
-    print(f"Governance System Tests — Local Mode")
+    print("Governance System Tests — Local Mode")
     print(f"Repo: {repo}")
     print(f"{'=' * 60}")
 
@@ -696,37 +708,44 @@ def run_local_tests(repo: str, dry_run: bool = False) -> list[TestResult]:
 # Audit mode: fleet-wide branch protection comparison
 # ---------------------------------------------------------------------------
 
-def audit_repo_protection(repo: str) -> list[TestResult]:
-    """Audit a single repo's branch protection against canonical config."""
+def audit_repo_protection(repo: str, pat: str) -> list[TestResult]:
+    """Audit a single repo's branch protection against canonical config.
+
+    Uses the in-process classic PAT (ADR-0216) for the admin-protected
+    GET /repos/{owner}/{repo}/branches/main/protection endpoint.
+    The fine-grained PAT returns 403 on this endpoint.
+    """
     results = []
     prefix = repo.split("/")[-1]
 
-    # Read branch protection
-    rc, output = run_gh(
-        "api", f"repos/{repo}/branches/main/protection",
+    # Read branch protection via classic PAT (fine-grained returns 403 here)
+    resp = requests.get(
+        f"{GH_API}/repos/{repo}/branches/main/protection",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
     )
 
-    if rc != 0:
-        if "404" in output:
-            results.append(TestResult(
-                f"{prefix}/A01", "Branch protection exists",
-                "Protection configured", "No protection on main",
-                False, detail="HTTP 404",
-            ))
-        elif "403" in output:
-            results.append(TestResult(
-                f"{prefix}/A01", "Branch protection exists",
-                "Readable", "Token lacks admin scope (HTTP 403)",
-                False, detail="Need classic PAT",
-            ))
+    if resp.status_code == 404:
+        results.append(TestResult(
+            f"{prefix}/A01", "Branch protection exists",
+            "Protection configured", "No protection on main",
+            False, detail="HTTP 404",
+        ))
+        return results
+    if resp.status_code != 200:
+        results.append(TestResult(
+            f"{prefix}/A01", "Branch protection exists",
+            "Readable", f"HTTP {resp.status_code}: {resp.text[:120]}",
+            False,
+        ))
         return results
 
     try:
-        prot = json.loads(output)
-    except json.JSONDecodeError:
+        prot = resp.json()
+    except ValueError:
         results.append(TestResult(
             f"{prefix}/A01", "Branch protection exists",
-            "Valid JSON", f"Invalid response: {output[:100]}",
+            "Valid JSON", f"Invalid response: {resp.text[:100]}",
             False,
         ))
         return results
@@ -808,27 +827,34 @@ def audit_repo_protection(repo: str) -> list[TestResult]:
 
 
 def run_audit(repos: list[str]) -> list[TestResult]:
-    """Run fleet-wide audit."""
+    """Run fleet-wide audit.
+
+    OPERATOR-RUN ONLY (ADR-0216 §6.1): decrypts the classic PAT in-process.
+    Never invoke this from an agent Bash tool.
+    """
     results = []
 
     print(f"\n{'=' * 60}")
-    print(f"Governance System Audit — Fleet Mode")
+    print("Governance System Audit — Fleet Mode")
     print(f"Repos: {len(repos)}")
     print(f"{'=' * 60}\n")
 
-    for i, repo in enumerate(repos, 1):
-        print(f"  [{i}/{len(repos)}] {repo}...", end=" ")
-        repo_results = audit_repo_protection(repo)
-        results.extend(repo_results)
+    # Branch protection reads require the classic PAT (fine-grained returns 403).
+    # One classic_pat_session spans the whole fleet scan so pinentry fires once.
+    with classic_pat_session() as pat:
+        for i, repo in enumerate(repos, 1):
+            print(f"  [{i}/{len(repos)}] {repo}...", end=" ")
+            repo_results = audit_repo_protection(repo, pat)
+            results.extend(repo_results)
 
-        fails = sum(1 for r in repo_results if not r.passed)
-        if fails:
-            print(f"{'FAIL'} ({fails} issues)")
-        else:
-            print("OK")
+            fails = sum(1 for r in repo_results if not r.passed)
+            if fails:
+                print(f"{'FAIL'} ({fails} issues)")
+            else:
+                print("OK")
 
-        if i < len(repos):
-            time.sleep(0.3)
+            if i < len(repos):
+                time.sleep(0.3)
 
     return results
 
@@ -856,13 +882,13 @@ def write_report(results: list[TestResult], mode: str, repo: str | None) -> Path
     if repo:
         lines.append(f"**Repo:** {repo}")
     lines.extend([
-        f"**Script:** `tools/test_governance_system.py`",
-        f"**Standard:** 0016-pr-sentinel-system-architecture.md",
+        "**Script:** `tools/test_governance_system.py`",
+        "**Standard:** 0016-pr-sentinel-system-architecture.md",
         "",
         "## Summary",
         "",
-        f"| Result | Count |",
-        f"|--------|-------|",
+        "| Result | Count |",
+        "|--------|-------|",
         f"| PASS | {passed} |",
         f"| FAIL | {failed} |",
         f"| Total | {len(results)} |",
@@ -947,14 +973,6 @@ Examples:
         help="Infrastructure checks only, skip PR creation",
     )
     args = parser.parse_args()
-
-    token_type = detect_token_type()
-    print(f"Token type: {token_type}")
-
-    if args.mode == "audit" and "fine-grained" in token_type:
-        print("\nERROR: Audit mode requires classic PAT with repo + admin:repo_hook scopes.")
-        print("Run: gh auth login -h github.com -p https")
-        sys.exit(1)
 
     if args.mode == "local":
         results = run_local_tests(args.repo, dry_run=args.dry_run)


### PR DESCRIPTION
## Summary

Migrates the 4 remaining elevated-scope fleet tools to the in-process classic-PAT pattern (ADR-0216), matching the merged `enable_wikis.py` (#1474). Each performed a privileged GitHub op the fine-grained PAT can't do and relied on a manual `gh auth login` swap. All four now decrypt the classic PAT **in-process** (`classic_pat_session` + `requests`): the PAT lives only in the Python heap — never os.environ, argv, or logs — and each defaults to **dry-run** with an `--apply` gate (standard 0017) + the operator-run-only warning (§6.1). Read-only ops stay on the fine-grained PAT / gh CLI.

| Issue | Tool | Privileged op → classic PAT |
|---|---|---|
| #962 | `fix_branch_protections` | PUT branch-protection + PATCH repo |
| #965 | `test_governance_system` | audit-mode protection **reads** (local mode untouched; token-detection gate removed) |
| #1236 | `push_workflow_fixes` | Contents-API workflow writes (**CRLF-normalized**, §6.3) + branch/PR + repo PATCH; no force-push |
| #961 | `merge_sentinel_permissions_prs` | replaced the **banned** `gh pr merge --admin` with a REST merge (`PUT /pulls/{n}/merge`); disable→merge→re-enable `enforce_admins` in a **try/finally** so admin enforcement is ALWAYS restored even if the merge raises |

### Verification
ruff clean + `py_compile` on all 4; grep confirms **no `--admin` / `--force` / `--no-verify`** in executed code; #961's enforce_admins restore is in a finally block; #1236's CRLF normalization runs before base64. No test imports these tools. **Operator-run** — not executed by the agent (the classic-PAT decryption must happen in your process).

Closes #962, Closes #965, Closes #1236, Closes #961