### PR TITLE
feat(spec): catch hallucinated target-repo API calls in N3 validation (Closes #1527)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -254,6 +254,12 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
     # Issue #490: Compute repo structure once, cache in state
     repo_structure = get_repo_structure(str(repo_root))
 
+    # Closes #1527: Extract symbol names from all gathered Python file content.
+    # Runs over the full current_content (before excerpt trimming) so that
+    # methods defined deep in a class body are captured.
+    gathered_symbols = _extract_symbols_from_files(updated_files)
+    print(f"    Gathered {len(gathered_symbols)} target-repo symbols for API check")
+
     return {
         "current_state_snapshots": current_state_snapshots,
         "pattern_references": pattern_references,
@@ -261,6 +267,7 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
         "import_dependencies": import_dependencies,
         "files_to_modify": updated_files,
         "repo_structure": repo_structure,
+        "gathered_symbols": gathered_symbols,
         "error_message": "",
     }
 
@@ -953,6 +960,50 @@ def _extract_import_dependencies(
         lines.append(f"- **{filename}** imports: {import_list}")
 
     return "\n".join(lines)
+
+
+def _extract_symbols_from_files(files: list[FileToModify]) -> list[str]:
+    """Extract class and function/method names from gathered Python files.
+
+    Closes #1527: Produces the symbol set that N3's API-hallucination check
+    uses to detect method calls on target-repo classes that don't actually
+    exist.
+
+    Uses Python ``ast`` when the content is valid Python.  Falls back to
+    two simple regexes (``^\\s*def (\\w+)`` / ``^\\s*class (\\w+)``) for
+    content that fails to parse (partial snippets, syntax errors).
+
+    Args:
+        files: Updated list of FileToModify entries with current_content set.
+
+    Returns:
+        Sorted, deduplicated list of identifier names.
+    """
+    symbols: set[str] = set()
+
+    _def_re = re.compile(r"^\s*def\s+(\w+)", re.MULTILINE)
+    _cls_re = re.compile(r"^\s*class\s+(\w+)", re.MULTILINE)
+
+    for file_spec in files:
+        content = file_spec.get("current_content")
+        path = file_spec.get("path", "")
+
+        if not content or not path.endswith(".py"):
+            continue
+
+        try:
+            tree = ast.parse(content)
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                    symbols.add(node.name)
+        except SyntaxError:
+            # Fallback: regex-based extraction for partial/broken files
+            for m in _def_re.finditer(content):
+                symbols.add(m.group(1))
+            for m in _cls_re.finditer(content):
+                symbols.add(m.group(1))
+
+    return sorted(symbols)
 
 
 def _names_similar(name_a: str, name_b: str) -> bool:

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -147,6 +147,12 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_imports)
     _log_check(check_imports)
 
+    # Check 7: Spec must not call methods absent from target repo (Issue #1527)
+    gathered_symbols: list[str] = state.get("gathered_symbols", [])  # type: ignore[assignment]
+    check_symbols = check_api_symbols_exist(spec_draft, gathered_symbols)
+    checks.append(check_symbols)
+    _log_check(check_symbols)
+
     # Collect issues from failed checks
     completeness_issues = [
         check["details"] for check in checks if not check["passed"]
@@ -748,6 +754,184 @@ def check_import_targets_exist(
         passed=True,
         details=f"All {len(checked)} import targets validated.",
     )
+
+
+def check_api_symbols_exist(
+    spec: str,
+    gathered_symbols: list[str],
+) -> CompletenessCheck:
+    """Spec must not call methods absent from the target project's gathered symbols.
+
+    Closes #1527: Catches hallucinated API calls like ``question.model_dump()``
+    and ``Question.model_validate(...)`` when the target class is a plain
+    dataclass that exposes only ``to_dict`` / ``from_dict``.
+
+    Strategy:
+    - Scan only inside code fences (``` blocks) to avoid prose false positives.
+    - Extract method/attribute calls of the form ``<ident>.<method>(`` (the
+      opening paren ensures we capture method *calls*, not attribute accesses
+      in prose or type annotations).
+    - Flag any method name that is (a) absent from ``gathered_symbols`` AND
+      (b) not in the false-positive allowlist of common Python builtins, stdlib
+      idioms, dunder methods, and well-known third-party conventions.
+
+    Conservative design:
+    - Only flags method CALLS (trailing ``(``), not bare attribute access.
+    - Only scans inside code fences.
+    - Has a broad allowlist to keep false positives low.
+    - Skips the check when ``gathered_symbols`` is empty (N1 didn't gather any
+      Python content, so we have nothing to check against).
+
+    Args:
+        spec: Implementation Spec markdown content.
+        gathered_symbols: Sorted list of identifier names extracted by N1 from
+            the target repo's gathered .py files.
+
+    Returns:
+        CompletenessCheck with pass/fail result and details.
+    """
+    if not gathered_symbols:
+        return CompletenessCheck(
+            check_name="api_symbols_exist",
+            passed=True,
+            details=(
+                "No gathered symbols from target repo — "
+                "API symbol check skipped (N1 found no Python files to analyze)."
+            ),
+        )
+
+    symbol_set: set[str] = set(gathered_symbols)
+
+    # Extract method/function call names from code fences only
+    code_block_re = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
+    # Match  <ident>.<method>(  —  the opening paren marks a call, not an annotation
+    method_call_re = re.compile(r"\b\w+\.(\w+)\s*\(")
+
+    flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
+
+    for block_match in code_block_re.finditer(spec):
+        block_content = block_match.group(1)
+        for call_match in method_call_re.finditer(block_content):
+            method_name = call_match.group(1)
+
+            if method_name in symbol_set:
+                continue
+            if method_name in _API_SYMBOL_ALLOWLIST:
+                continue
+
+            # Capture the call site for the error message (truncated)
+            call_site = block_content[
+                max(0, call_match.start() - 10) : call_match.end() + 20
+            ].strip().replace("\n", " ")
+
+            if method_name not in flagged:
+                flagged[method_name] = []
+            flagged[method_name].append(call_site[:80])
+
+    if not flagged:
+        return CompletenessCheck(
+            check_name="api_symbols_exist",
+            passed=True,
+            details=(
+                f"All method calls in spec code fences are present in the "
+                f"target repo's gathered symbols ({len(symbol_set)} symbols checked)."
+            ),
+        )
+
+    # Build a readable summary of the flagged calls
+    flag_items: list[str] = []
+    for method_name, sites in sorted(flagged.items()):
+        site_preview = sites[0] if sites else ""
+        flag_items.append(f"`{method_name}` (e.g. `{site_preview}`)")
+
+    flag_list = "; ".join(flag_items[:5])
+    suffix = f" (and {len(flagged) - 5} more)" if len(flagged) > 5 else ""
+
+    return CompletenessCheck(
+        check_name="api_symbols_exist",
+        passed=False,
+        details=(
+            f"Spec calls methods not found in the target project's gathered "
+            f"symbols: {flag_list}{suffix}. These may be hallucinated APIs "
+            f"(e.g., pydantic methods on a plain dataclass). Verify these "
+            f"symbols exist in the target repo or replace with the actual API "
+            f"the target class exposes."
+        ),
+    )
+
+
+# Allowlist of method/function names that are NEVER flagged as hallucinated.
+# Covers: Python builtins, common stdlib idioms, dunder methods, and a small
+# set of near-universal third-party conventions.
+_API_SYMBOL_ALLOWLIST: frozenset[str] = frozenset({
+    # ---- dunder / special methods ----
+    "__init__", "__repr__", "__str__", "__eq__", "__lt__", "__le__",
+    "__gt__", "__ge__", "__ne__", "__hash__", "__bool__", "__len__",
+    "__iter__", "__next__", "__contains__", "__getitem__", "__setitem__",
+    "__delitem__", "__enter__", "__exit__", "__call__", "__class__",
+    "__dict__", "__doc__", "__module__", "__slots__", "__annotations__",
+    "__new__",
+    # ---- built-in type methods — dict ----
+    "get", "items", "keys", "values", "update", "pop", "setdefault",
+    "copy", "clear", "fromkeys",
+    # ---- built-in type methods — list ----
+    "append", "extend", "insert", "remove", "reverse", "sort", "count",
+    # ---- built-in type methods — str ----
+    "strip", "lstrip", "rstrip", "split", "rsplit", "splitlines",
+    "join", "replace", "startswith", "endswith", "upper", "lower",
+    "title", "capitalize", "format", "encode", "decode", "find",
+    "rfind", "rindex", "partition", "rpartition", "zfill",
+    "center", "ljust", "rjust",
+    # ---- built-in type methods — set ----
+    "add", "discard", "difference", "intersection", "union",
+    "issubset", "issuperset",
+    # ---- built-in type methods — bytes / bytearray ----
+    "hex", "fromhex",
+    # ---- pathlib ----
+    "read_text", "write_text", "read_bytes", "write_bytes", "mkdir",
+    "exists", "is_file", "is_dir", "glob", "rglob", "unlink", "rename",
+    "stat", "open", "parent", "name", "stem", "suffix", "relative_to",
+    "resolve",
+    # ---- json / stdlib ----
+    "loads", "dumps", "load", "dump",
+    # ---- logging ----
+    "info", "debug", "warning", "error", "exception", "critical",
+    "getLogger",
+    # ---- common built-ins ----
+    "close", "flush", "read", "write", "seek", "tell", "readline",
+    "readlines", "writelines",
+    # ---- subprocess / os ----
+    "run", "check_output", "check_call", "Popen", "communicate",
+    "getenv",
+    # ---- typing / dataclasses ----
+    "field", "fields", "asdict", "astuple",
+    # ---- collections ----
+    "deque", "OrderedDict", "defaultdict", "Counter",
+    # ---- itertools / functools ----
+    "chain", "product", "combinations", "permutations", "partial",
+    "reduce", "wraps",
+    # ---- datetime ----
+    "now", "utcnow", "strftime", "strptime", "isoformat",
+    # ---- re / regex ----
+    "match", "search", "findall", "finditer", "sub", "subn", "compile",
+    "fullmatch", "group", "groups", "groupdict", "start", "end", "span",
+    # ---- enum ----
+    "value",
+    # ---- contextlib ----
+    "contextmanager",
+    # ---- uuid ----
+    "uuid4", "UUID",
+    # ---- hashlib ----
+    "sha256", "md5", "hexdigest", "digest",
+    # ---- asyncio ----
+    "gather", "sleep", "create_task", "ensure_future", "get_event_loop",
+    "run_until_complete",
+    # ---- threading ----
+    "Thread", "Lock", "Event", "set", "wait",
+    # ---- common pytest/mock patterns ----
+    "assert_called", "assert_called_once", "assert_called_with",
+    "assert_any_call", "call_count", "called",
+})
 
 
 _SOURCE_ROOT_PREFIXES: tuple[str, ...] = (

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -186,3 +186,9 @@ class ImplementationSpecState(TypedDict, total=False):
     # messages produce identical revisions and the loop never converges.
     # Each entry: {"iteration": int, "failures": list[str]}.
     prior_completeness_breakdown: list[dict]
+
+    # Closes #1527: Symbol names (class names + function/method names) extracted
+    # from all gathered .py files by N1. Used by N3 to detect hallucinated API
+    # calls that reference methods not defined in the target project.
+    # Stored as list (not set) because TypedDict values must be serializable.
+    gathered_symbols: list[str]

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -2844,3 +2844,364 @@ class TestGraphExecutesEndToEnd:
         assert "N0_load_lld" in nodes_visited
         # Workflow should have stopped (error routes to END)
         assert final_state.get("error_message"), "Expected error but got none"
+
+
+# =============================================================================
+# Tests for Issue #1527: API symbol hallucination checker
+# =============================================================================
+
+
+class TestCheckApiSymbolsExist:
+    """Tests for check_api_symbols_exist — the hallucinated-API checker.
+
+    Regression case from issue #1527: spec-writer emitted
+    ``question.model_dump()`` and ``Question.model_validate(...)``
+    against a plain dataclass that only defines ``to_dict`` / ``from_dict``.
+    """
+
+    def _check(self, spec: str, symbols: list[str]):
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            check_api_symbols_exist,
+        )
+        return check_api_symbols_exist(spec, symbols)
+
+    # ------------------------------------------------------------------
+    # Regression case: the documented failure from issue #1527
+    # ------------------------------------------------------------------
+
+    def test_regression_1527_model_dump_flagged(self):
+        """model_dump / model_validate not in gathered symbols → flagged.
+
+        Target: Question is a dataclass with only to_dict / from_dict.
+        Spec emits pydantic calls → check must fail with both names.
+        """
+        gathered_symbols = ["Question", "to_dict", "from_dict"]
+
+        spec = (
+            "# Implementation Spec\n\n"
+            "## 6.1 Serialize question\n\n"
+            "```python\n"
+            "yaml_data = yaml.safe_dump(question.model_dump(), allow_unicode=True)\n"
+            "return Question.model_validate(parsed_dict)\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+
+        assert result["passed"] is False, (
+            "model_dump and model_validate are not in gathered symbols "
+            "and must be flagged"
+        )
+        details = result["details"]
+        assert "model_dump" in details, f"model_dump not mentioned in details: {details}"
+        assert "model_validate" in details, f"model_validate not mentioned in details: {details}"
+
+    # ------------------------------------------------------------------
+    # Negative case: all calls are real symbols → passes
+    # ------------------------------------------------------------------
+
+    def test_negative_real_symbols_pass(self):
+        """Spec calling only symbols present in gathered set → passes."""
+        gathered_symbols = ["Question", "to_dict", "from_dict", "Editor", "load"]
+
+        spec = (
+            "# Implementation Spec\n\n"
+            "## 5. Implementation\n\n"
+            "```python\n"
+            "data = question.to_dict()\n"
+            "q = Question.from_dict(parsed)\n"
+            "editor = Editor()\n"
+            "editor.load(path)\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is True, (
+            f"All calls are real symbols — should pass. Details: {result['details']}"
+        )
+
+    # ------------------------------------------------------------------
+    # False-positive guard: common Python/stdlib methods never flagged
+    # ------------------------------------------------------------------
+
+    def test_false_positive_builtin_dict_methods_not_flagged(self):
+        """Built-in dict methods (get, items, keys) must not be flagged."""
+        gathered_symbols = ["MyClass", "process"]
+
+        spec = (
+            "# Spec\n\n"
+            "```python\n"
+            "value = config.get('key', None)\n"
+            "for k, v in mapping.items():\n"
+            "    result[k] = v\n"
+            "keys = config.keys()\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is True, (
+            f".get()/.items()/.keys() are stdlib — must not be flagged. "
+            f"Details: {result['details']}"
+        )
+
+    def test_false_positive_list_methods_not_flagged(self):
+        """Built-in list methods (append, extend, sort) must not be flagged."""
+        gathered_symbols = ["Parser"]
+
+        spec = (
+            "# Spec\n\n"
+            "```python\n"
+            "results.append(item)\n"
+            "output.extend(batch)\n"
+            "items.sort(key=lambda x: x.name)\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is True, (
+            f"List methods are stdlib — must not be flagged. Details: {result['details']}"
+        )
+
+    def test_false_positive_str_methods_not_flagged(self):
+        """Built-in str methods (strip, split, format) must not be flagged."""
+        gathered_symbols = ["Tokenizer"]
+
+        spec = (
+            "# Spec\n\n"
+            "```python\n"
+            "text = raw.strip()\n"
+            "parts = line.split(',')\n"
+            "msg = template.format(name=name)\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is True, (
+            f"Str methods are stdlib — must not be flagged. Details: {result['details']}"
+        )
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_empty_gathered_symbols_skips_check(self):
+        """No gathered symbols → check skips (nothing to compare against)."""
+        spec = "```python\nfoo.model_dump()\n```\n"
+        result = self._check(spec, [])
+        assert result["passed"] is True
+        assert "skipped" in result["details"].lower()
+
+    def test_no_code_fences_passes(self):
+        """Spec with no code fences → no calls to check → passes."""
+        gathered_symbols = ["MyClass"]
+        spec = "# Spec\n\nSome prose: question.model_dump() mentioned here.\n"
+        result = self._check(spec, gathered_symbols)
+        # Prose outside code fences must NOT be scanned
+        assert result["passed"] is True, (
+            "Calls in prose (not code fences) must not be flagged. "
+            f"Details: {result['details']}"
+        )
+
+    def test_dunder_methods_not_flagged(self):
+        """Dunder methods like __init__ / __repr__ are in the allowlist."""
+        gathered_symbols = ["Widget"]
+
+        spec = (
+            "# Spec\n\n"
+            "```python\n"
+            "obj = Widget.__new__(Widget)\n"
+            "s = item.__repr__()\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is True, (
+            f"Dunders are allowlisted — must not be flagged. Details: {result['details']}"
+        )
+
+    def test_mixed_real_and_hallucinated_flags_only_hallucinated(self):
+        """When spec mixes real and fake methods, only fake ones are flagged."""
+        gathered_symbols = ["Question", "to_dict", "validate"]
+
+        spec = (
+            "# Spec\n\n"
+            "```python\n"
+            "data = question.to_dict()         # real\n"
+            "q = Question.from_orm(row)        # hallucinated — from_orm not in symbols\n"
+            "question.validate(ctx)            # real\n"
+            "```\n"
+        )
+
+        result = self._check(spec, gathered_symbols)
+        assert result["passed"] is False
+        assert "from_orm" in result["details"]
+        assert "to_dict" not in result["details"]
+        assert "validate" not in result["details"]
+
+
+class TestExtractSymbolsFromFiles:
+    """Tests for _extract_symbols_from_files used in N1."""
+
+    def test_extracts_class_and_function_names(self):
+        """AST extraction captures class names and all function/method names."""
+        from assemblyzero.workflows.implementation_spec.state import FileToModify
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _extract_symbols_from_files,
+        )
+
+        content = (
+            "from dataclasses import dataclass\n\n"
+            "@dataclass(frozen=True)\n"
+            "class Question:\n"
+            "    stem: str\n\n"
+            "    def to_dict(self) -> dict:\n"
+            "        return {'stem': self.stem}\n\n"
+            "    @classmethod\n"
+            "    def from_dict(cls, data: dict) -> 'Question':\n"
+            "        return cls(stem=data['stem'])\n"
+        )
+
+        files: list[FileToModify] = [
+            FileToModify(
+                path="src/quiz/models.py",
+                change_type="Modify",
+                description="Target file",
+                current_content=content,
+            )
+        ]
+
+        symbols = _extract_symbols_from_files(files)
+        assert "Question" in symbols
+        assert "to_dict" in symbols
+        assert "from_dict" in symbols
+
+    def test_skips_non_python_files(self):
+        """Non-.py files are ignored."""
+        from assemblyzero.workflows.implementation_spec.state import FileToModify
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _extract_symbols_from_files,
+        )
+
+        files: list[FileToModify] = [
+            FileToModify(
+                path="config.yaml",
+                change_type="Modify",
+                description="Config",
+                current_content="key: value\n",
+            )
+        ]
+
+        symbols = _extract_symbols_from_files(files)
+        assert symbols == []
+
+    def test_skips_files_with_no_content(self):
+        """Files with None or empty current_content are skipped."""
+        from assemblyzero.workflows.implementation_spec.state import FileToModify
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _extract_symbols_from_files,
+        )
+
+        files: list[FileToModify] = [
+            FileToModify(
+                path="new_module.py",
+                change_type="Add",
+                description="New file",
+                current_content=None,
+            )
+        ]
+
+        symbols = _extract_symbols_from_files(files)
+        assert symbols == []
+
+    def test_fallback_regex_on_syntax_error(self):
+        """Broken Python falls back to regex, still extracts def/class names."""
+        from assemblyzero.workflows.implementation_spec.state import FileToModify
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _extract_symbols_from_files,
+        )
+
+        # Deliberately broken Python (missing colon on class)
+        broken_content = (
+            "class BrokenClass\n"
+            "    def my_method(self):\n"
+            "        pass\n"
+        )
+
+        files: list[FileToModify] = [
+            FileToModify(
+                path="broken.py",
+                change_type="Modify",
+                description="Broken file",
+                current_content=broken_content,
+            )
+        ]
+
+        symbols = _extract_symbols_from_files(files)
+        # At minimum the method should be found via regex fallback
+        assert "my_method" in symbols
+
+    def test_gathered_symbols_stored_in_state(self, tmp_path):
+        """N1 analyze_codebase populates gathered_symbols in returned state."""
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            analyze_codebase,
+        )
+
+        # Create a target repo with a Python file containing known symbols
+        src_dir = tmp_path / "src" / "quiz"
+        src_dir.mkdir(parents=True)
+        (src_dir / "models.py").write_text(
+            "@dataclass\nclass Question:\n    def to_dict(self): ...\n    def from_dict(cls, d): ...\n",
+            encoding="utf-8",
+        )
+
+        state = {
+            "repo_root": str(tmp_path),
+            "lld_content": "",
+            "files_to_modify": [
+                {
+                    "path": "src/quiz/models.py",
+                    "change_type": "Modify",
+                    "description": "Target model",
+                    "current_content": None,
+                }
+            ],
+        }
+
+        result = analyze_codebase(state)
+
+        gathered = result.get("gathered_symbols", [])
+        assert "Question" in gathered, f"Question not in gathered_symbols: {gathered}"
+        assert "to_dict" in gathered, f"to_dict not in gathered_symbols: {gathered}"
+        assert "from_dict" in gathered, f"from_dict not in gathered_symbols: {gathered}"
+
+
+class TestApiSymbolCheckInValidateCompleteness:
+    """Integration: validate_completeness wires check_api_symbols_exist."""
+
+    def test_validate_completeness_uses_gathered_symbols(self, base_state, sample_spec_complete):
+        """validate_completeness populates the api_symbols_exist check."""
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+
+        base_state["spec_draft"] = sample_spec_complete
+        base_state["files_to_modify"] = [
+            {
+                "path": "assemblyzero/workflows/test/graph.py",
+                "change_type": "Modify",
+                "description": "Update graph",
+                "current_content": "def create_graph(): pass\n",
+            }
+        ]
+        base_state["pattern_references"] = []
+        # gathered_symbols set to non-empty — create_graph is real
+        base_state["gathered_symbols"] = ["create_graph"]
+
+        result = validate_completeness(base_state)
+        # The sample_spec_complete doesn't call any hallucinated APIs on
+        # target-repo objects, so this check should not be the cause of failure
+        # (other checks may fail; we only verify the symbol check ran)
+        checks_run = result.get("completeness_issues", [])
+        details_blob = " ".join(checks_run)
+        # Hallucinated-API check details must NOT appear when symbols are valid
+        assert "api_symbols_exist" not in details_blob or "model_dump" not in details_blob


### PR DESCRIPTION
## Summary

- N1 (`analyze_codebase`) now extracts class/function/method names from all gathered Python files using AST (with regex fallback for syntax errors) and stores them as `gathered_symbols` in workflow state.
- N3 (`validate_completeness`) adds a new check `check_api_symbols_exist`: scans spec code fences for `.method(...)` call patterns, flags any method absent from `gathered_symbols` that is also not in a broad false-positive allowlist (builtins, stdlib, dunder methods, common itertools/pathlib/logging idioms).
- `ImplementationSpecState` gains a `gathered_symbols: list[str]` field.

Catches the documented regression: `question.model_dump()` and `Question.model_validate(...)` against a plain `@dataclass` that only exposes `to_dict`/`from_dict`. Both pydantic methods are absent from gathered symbols and not in the allowlist → flagged, validation blocked.

## Test plan

- [x] Regression case: `gathered_symbols = {Question, to_dict, from_dict}`, spec calls `model_dump`/`model_validate` → both flagged, check fails
- [x] Negative case: spec calls only real symbols → check passes
- [x] False-positive guards: `.get()`, `.items()`, `.keys()` (dict), `.append()`, `.sort()` (list), `.strip()`, `.split()` (str) → not flagged
- [x] Dunder methods (`__new__`, `__repr__`) → not flagged
- [x] Mixed: real+hallucinated → only hallucinated flagged
- [x] Empty `gathered_symbols` → check skips conservatively
- [x] Prose outside code fences → not scanned
- [x] `_extract_symbols_from_files` AST extraction unit tests
- [x] Regex fallback on syntax-broken Python
- [x] N1→state integration: `analyze_codebase` populates `gathered_symbols`
- [x] 197/197 existing tests pass, 15 new tests pass
- [x] `ruff check` on changed files: 0 new errors (3 pre-existing in unchanged code)

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)