### PR TITLE
feat(orchestrator): real summary atop auto-generated issue briefs (Closes #1530)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -29,6 +29,11 @@ from assemblyzero.workflows.orchestrator.state import (
     StageResult,
     update_stage_result,
 )
+from assemblyzero.core.llm_provider import get_provider
+
+import logging
+
+_stages_logger = logging.getLogger(__name__)
 
 
 def should_skip_stage(
@@ -152,6 +157,47 @@ def _classify_halt_transience(sub_result: dict) -> bool | None:
     return bool(plan.get("is_transient", False))
 
 
+def _synthesize_brief_summary(title: str, body: str) -> str:
+    """Closes #1530: generate a concise 2-4 sentence summary from an issue
+    title and body using the codebase's ClaudeCLIProvider (haiku model for
+    speed; subscription/OAuth, never API key).
+
+    Returns the summary text on success, or an empty string on any failure
+    (timeout, model error, empty response). Callers must treat an empty
+    return as "fall back to raw passthrough."
+    """
+    system_prompt = (
+        "You are a technical writer summarising GitHub issues for an engineering workflow. "
+        "Write 2-4 sentences: what the issue asks for, why it matters, and the rough scope "
+        "(e.g. single function, new module, config change). "
+        "Do not repeat the title. Write in plain English, no markdown headings, no bullet points."
+    )
+    content = f"Title: {title}\n\nBody:\n{body}"
+
+    try:
+        provider = get_provider("claude:haiku")
+        result = provider.invoke(
+            system_prompt=system_prompt,
+            content=content,
+            timeout_seconds=60,
+        )
+    except Exception as exc:
+        _stages_logger.warning(
+            "brief summary synthesis failed (provider error): %s — falling back to raw passthrough",
+            exc,
+        )
+        return ""
+
+    if not result.success or not result.response or not result.response.strip():
+        _stages_logger.warning(
+            "brief summary synthesis returned empty/failure (error=%s) — falling back to raw passthrough",
+            result.error_message,
+        )
+        return ""
+
+    return result.response.strip()
+
+
 def _fetch_issue_body_to_temp_brief(
     issue_number: int,
     target_repo: str,
@@ -205,11 +251,24 @@ def _fetch_issue_body_to_temp_brief(
     if not issue_body.strip():
         return ("", f"issue #{issue_number} body is empty — no content to synthesize a brief from")
 
-    # Minimal brief: just the title + body. The triage sub-workflow's
-    # drafter/reviewer process this further; we are NOT pre-Michelle-voice
-    # rewriting here — the operator's hand-authored brief at
-    # docs/lineage/{N}/issue-brief.md remains the override path.
-    brief_content = f"# {issue_title}\n\n{issue_body}\n"
+    # Closes #1530: prepend a concise auto-generated summary so the brief
+    # starts with substance rather than raw issue text.  If synthesis fails
+    # (timeout, model error, empty response) we fall back silently to the
+    # original title+body passthrough — orchestration must never halt here.
+    summary = _synthesize_brief_summary(issue_title, issue_body)
+    if summary:
+        brief_content = (
+            f"# {issue_title}\n\n"
+            f"## Summary\n{summary}\n\n"
+            f"## Issue detail\n{issue_body}\n"
+        )
+    else:
+        # Fallback: raw passthrough (preserves pre-#1530 behaviour)
+        _stages_logger.info(
+            "issue #%s brief synthesis: using raw passthrough (summary generation failed or returned empty)",
+            issue_number,
+        )
+        brief_content = f"# {issue_title}\n\n{issue_body}\n"
 
     fd, temp_path = tempfile.mkstemp(
         prefix=f"orchestrator-issue-{issue_number}-",

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -576,3 +576,161 @@ class TestTriageBriefSynthesis:
         assert "cannot synthesize brief" in err
         # Points the operator at the workaround
         assert "docs/lineage/99999/issue-brief.md" in err
+
+
+class TestSynthesizeBriefSummary:
+    """#1530: _synthesize_brief_summary prepends an AI-generated summary to
+    the auto-synthesized brief so issues start with a concise overview, not
+    raw GitHub issue text.
+
+    All tests mock the provider so no real API/CLI calls are made.
+    """
+
+    def _mock_provider(self, response: str | None = None, succeed: bool = True):
+        """Build a MagicMock LLMCallResult-returning provider."""
+        from assemblyzero.core.llm_provider import LLMCallResult
+
+        result = LLMCallResult(
+            success=succeed,
+            response=response,
+            raw_response=response,
+            error_message=None if succeed else "mock error",
+            provider="mock",
+            model_used="haiku",
+            duration_ms=10,
+            attempts=1,
+        )
+        provider = MagicMock()
+        provider.invoke.return_value = result
+        return provider
+
+    @patch("assemblyzero.workflows.orchestrator.stages.get_provider")
+    def test_returns_summary_on_success(self, mock_get_provider):
+        """When the model returns a non-empty response, the summary is returned."""
+        from assemblyzero.workflows.orchestrator.stages import _synthesize_brief_summary
+
+        expected = "This issue asks for a new summary section in the auto-synthesized brief."
+        mock_get_provider.return_value = self._mock_provider(response=expected)
+
+        result = _synthesize_brief_summary("Add summary to briefs", "Detailed description here.")
+        assert result == expected
+
+    @patch("assemblyzero.workflows.orchestrator.stages.get_provider")
+    def test_returns_empty_on_model_failure(self, mock_get_provider):
+        """When the model call fails, the function returns empty string (caller falls back)."""
+        from assemblyzero.workflows.orchestrator.stages import _synthesize_brief_summary
+
+        mock_get_provider.return_value = self._mock_provider(response=None, succeed=False)
+
+        result = _synthesize_brief_summary("Some issue", "Some body")
+        assert result == ""
+
+    @patch("assemblyzero.workflows.orchestrator.stages.get_provider")
+    def test_returns_empty_on_empty_response(self, mock_get_provider):
+        """When the model returns an empty/whitespace string, the function returns empty."""
+        from assemblyzero.workflows.orchestrator.stages import _synthesize_brief_summary
+
+        mock_get_provider.return_value = self._mock_provider(response="   ")
+
+        result = _synthesize_brief_summary("Some issue", "Some body")
+        assert result == ""
+
+    @patch("assemblyzero.workflows.orchestrator.stages.get_provider")
+    def test_returns_empty_on_provider_exception(self, mock_get_provider):
+        """When get_provider raises, the function returns empty (no crash)."""
+        from assemblyzero.workflows.orchestrator.stages import _synthesize_brief_summary
+
+        mock_get_provider.side_effect = RuntimeError("claude not found")
+
+        result = _synthesize_brief_summary("Some issue", "Some body")
+        assert result == ""
+
+    @patch("assemblyzero.workflows.orchestrator.stages.get_provider")
+    def test_uses_haiku_model(self, mock_get_provider):
+        """Provider is requested with 'claude:haiku' (fast/cheap for summaries)."""
+        from assemblyzero.workflows.orchestrator.stages import _synthesize_brief_summary
+
+        mock_get_provider.return_value = self._mock_provider(response="A summary.")
+        _synthesize_brief_summary("Title", "Body")
+
+        mock_get_provider.assert_called_once_with("claude:haiku")
+
+
+class TestFetchIssueBriefWithSummary:
+    """#1530: _fetch_issue_body_to_temp_brief writes a ## Summary section when
+    _synthesize_brief_summary returns non-empty, and falls back to the raw
+    title+body passthrough when synthesis fails.
+    """
+
+    def _make_gh_result(self, title: str, body: str) -> MagicMock:
+        import json as _json
+        gh = MagicMock()
+        gh.returncode = 0
+        gh.stdout = _json.dumps({"title": title, "body": body})
+        gh.stderr = ""
+        return gh
+
+    @patch("assemblyzero.workflows.orchestrator.stages._synthesize_brief_summary")
+    @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
+    def test_brief_contains_summary_section_when_synthesis_succeeds(
+        self, mock_subprocess, mock_synthesize,
+    ):
+        """When synthesis returns text, the temp brief contains ## Summary and ## Issue detail."""
+        from assemblyzero.workflows.orchestrator.stages import _fetch_issue_body_to_temp_brief
+
+        issue_body = "The raw issue body describing the change needed."
+        generated_summary = "This is the generated 2-sentence summary."
+        mock_subprocess.return_value = self._make_gh_result("My Issue Title", issue_body)
+        mock_synthesize.return_value = generated_summary
+
+        temp_path, err = _fetch_issue_body_to_temp_brief(42, "/fake/repo")
+        assert not err, f"unexpected error: {err}"
+        assert temp_path
+
+        content = Path(temp_path).read_text(encoding="utf-8")
+        assert "## Summary" in content, "brief must contain ## Summary section"
+        assert generated_summary in content, "generated summary text must be in brief"
+        assert "## Issue detail" in content, "brief must contain ## Issue detail section"
+        assert issue_body in content, "original issue body must be in ## Issue detail"
+
+    @patch("assemblyzero.workflows.orchestrator.stages._synthesize_brief_summary")
+    @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
+    def test_brief_falls_back_to_raw_when_synthesis_returns_empty(
+        self, mock_subprocess, mock_synthesize,
+    ):
+        """When synthesis returns empty string, the brief falls back to raw title+body passthrough."""
+        from assemblyzero.workflows.orchestrator.stages import _fetch_issue_body_to_temp_brief
+
+        issue_body = "The raw issue body."
+        mock_subprocess.return_value = self._make_gh_result("My Issue Title", issue_body)
+        mock_synthesize.return_value = ""  # synthesis failed
+
+        temp_path, err = _fetch_issue_body_to_temp_brief(42, "/fake/repo")
+        assert not err, f"unexpected error: {err}"
+        assert temp_path
+
+        content = Path(temp_path).read_text(encoding="utf-8")
+        # Raw passthrough: title + body, no ## Summary section
+        assert "## Summary" not in content, "raw passthrough must NOT include ## Summary"
+        assert "My Issue Title" in content
+        assert issue_body in content
+
+    @patch("assemblyzero.workflows.orchestrator.stages._synthesize_brief_summary")
+    @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
+    def test_issue_detail_section_labels_body_when_synthesis_succeeds(
+        self, mock_subprocess, mock_synthesize,
+    ):
+        """The ## Issue detail section must immediately precede the original body text."""
+        from assemblyzero.workflows.orchestrator.stages import _fetch_issue_body_to_temp_brief
+
+        issue_body = "Specific body text to locate in ## Issue detail."
+        mock_subprocess.return_value = self._make_gh_result("Title", issue_body)
+        mock_synthesize.return_value = "A concise summary."
+
+        temp_path, err = _fetch_issue_body_to_temp_brief(1530, "/fake/repo")
+        assert not err
+        content = Path(temp_path).read_text(encoding="utf-8")
+        # ## Issue detail section must appear before the body
+        detail_idx = content.index("## Issue detail")
+        body_idx = content.index(issue_body)
+        assert detail_idx < body_idx, "## Issue detail heading must precede the body text"


### PR DESCRIPTION
## Summary

Per your call — every issue gets a real summary at the top. When the orchestrator processes an issue and you haven't hand-written a brief, the auto-synthesized brief now leads with a generated `## Summary` (2-4 sentences: what it asks for, why, scope) above the full issue detail, instead of dumping the raw body.

- Summary generated via the existing `ClaudeCLIProvider` (`claude --print`, **subscription/OAuth only — no API key**).
- On any model failure / timeout / empty response → **falls back** to the original raw passthrough. A summary hiccup never breaks an orchestrated run.
- Your hand-authored brief (`docs/lineage/{N}/issue-brief.md`) still overrides — that path is untouched.

8 tests (success path, model-failure fallback, empty-response fallback, structure). Full unit suite **5618 passed**; ruff clean.

Closes #1530