### PR TITLE
Fix ruff F401/F841/F811 errors in test files

### DIFF
--- a/tests/integration/test_orchestrator_graph.py
+++ b/tests/integration/test_orchestrator_graph.py
@@ -11,12 +11,9 @@ from unittest.mock import patch, MagicMock
 from assemblyzero.workflows.orchestrator.config import get_default_config
 from assemblyzero.workflows.orchestrator.graph import (
     ConcurrentOrchestrationError,
-    OrchestrationResult,
     orchestrate,
 )
 from assemblyzero.workflows.orchestrator.resume import (
-    LOCK_DIR,
-    STATE_DIR,
     load_orchestration_state,
     save_orchestration_state,
 )
@@ -131,7 +128,7 @@ class TestStatePersistence:
         config = get_default_config()
         state = create_initial_state(305, config)
 
-        path1 = save_orchestration_state(state)
+        save_orchestration_state(state)
         # Modify and save again
         state_dict = dict(state)
         state_dict["current_stage"] = "lld"

--- a/tests/unit/test_issue_248.py
+++ b/tests/unit/test_issue_248.py
@@ -12,14 +12,10 @@ This tests the behavior where:
 7. The 0702c prompt includes question instructions
 """
 
-import re
 from pathlib import Path
 
 import pytest
 
-from assemblyzero.workflows.requirements.nodes.generate_draft import (
-    validate_draft_structure,
-)
 from assemblyzero.workflows.requirements.nodes.review import (
     _check_open_questions_status,
     _draft_has_open_questions,

--- a/tests/unit/test_testing_workflow.py
+++ b/tests/unit/test_testing_workflow.py
@@ -6,9 +6,7 @@ Issue #93: N8 Documentation Node
 """
 
 import subprocess
-import tempfile
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1588,7 +1586,7 @@ class TestVerifyPhasesModule:
             mock_run.return_value.stdout = "1 passed\nTOTAL 100 10 90%"
             mock_run.return_value.stderr = ""
 
-            result = run_pytest(
+            run_pytest(
                 [str(test_file)],
                 coverage_module="mymodule",
                 coverage_target=80,
@@ -2944,7 +2942,6 @@ class TestPatternsModule:
 
     def test_get_mock_guidance_with_types(self):
         """get_mock_guidance returns combined guidance."""
-        from assemblyzero.workflows.testing.knowledge.patterns import get_mock_guidance
 
         result = get_mock_guidance(["unit", "browser"])
 
@@ -2952,7 +2949,6 @@ class TestPatternsModule:
 
     def test_get_mock_guidance_no_guidance(self):
         """get_mock_guidance handles types without guidance."""
-        from assemblyzero.workflows.testing.knowledge.patterns import get_mock_guidance
 
         result = get_mock_guidance(["e2e"])
 
@@ -3018,7 +3014,6 @@ class TestAuditModuleExtras:
 
     def test_create_testing_audit_dir(self, tmp_path):
         """create_testing_audit_dir creates proper structure."""
-        from assemblyzero.workflows.testing.audit import create_testing_audit_dir
 
         result = create_testing_audit_dir(42, tmp_path)
 
@@ -3379,7 +3374,6 @@ class TestReviewTestPlanFullCoverage:
 
         # Mock the imports to fail
         import sys
-        original_modules = sys.modules.copy()
 
         # Try to trigger import error by patching at different level
         with patch.dict(sys.modules, {"assemblyzero.core.gemini_client": None}):
@@ -3737,8 +3731,7 @@ class TestFinalizeFullCoverage:
         result = finalize(state)
 
         assert result.get("error_message") == ""
-        # LLD should be archived
-        archived = result.get("archived_files", [])
+        # LLD should be archived — result.get("archived_files", []) intentionally unused
         # May or may not archive depending on path structure
 
 


### PR DESCRIPTION
Closes #1638, closes #1652

Fixes pre-existing ruff errors in 3 test files:
- Remove unused imports from test_orchestrator_graph.py (F401)
- Remove unused path1 variable (F841)
- Remove unused imports from test_issue_248.py (F401)
- Remove unused imports, redefinitions, dead variables from test_testing_workflow.py (F401/F811/F841)