### PR TITLE
docs: deprecate RAG references — superseded by Tiphys (Closes #1690)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,11 @@ All workflows are LangGraph `StateGraph` instances with typed state and SQLite c
 | **TDD Implementation** | 13 | Spec → code + tests + PR |
 | **Scout** | Variable | External intelligence gathering |
 
-### Codebase & Document Intelligence (RAG)
+### Codebase & Document Intelligence (⚠ RAG retired 2026-07-06 → Tiphys)
 
-AssemblyZero uses a local RAG system built on ChromaDB and `all-MiniLM-L6-v2` embeddings:
+> **Retired (ADR-0223).** The vector-RAG system below was removed — a *similarity* engine aimed at a *ground-truth* problem (grounding the design in real interface signatures). LLD codebase-grounding is now **Tiphys**: deterministic AST extraction of the real interface surface, no embeddings. The description below is historical.
+
+AssemblyZero previously used a local RAG system built on ChromaDB and `all-MiniLM-L6-v2` embeddings:
 - **Document retrieval** (The Librarian) — injects relevant ADRs, standards, and past LLDs into design prompts
 - **Codebase retrieval** (Hex) — AST-based Python indexing with vector search for implementation context
 - **Duplicate detection** (The Historian) — checks for similar past issues before drafting

--- a/docs/0003-file-inventory.md
+++ b/docs/0003-file-inventory.md
@@ -299,6 +299,8 @@ These tools live outside AZ but operate fleet-wide. The user invokes them from t
 
 ## 4. RAG Subsystem (`assemblyzero/rag/`) - 14 files
 
+> **⚠ REMOVED 2026-07-06 (ADR-0223).** This subsystem no longer exists — RAG was retired and `assemblyzero/rag/` deleted. The rows below are kept as a historical inventory record. LLD grounding is now Tiphys (AZ #1688).
+
 | File | Status | Description |
 |------|--------|-------------|
 | `__init__.py` | Stable | Public API, singleton factories (`get_store`, `get_query_engine`) |

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -73,6 +73,8 @@ graph LR
 
 ## RAG Data Flow
 
+> **⚠ Retired 2026-07-06 (ADR-0223).** The vector-RAG data flow below (ChromaDB + local embeddings, the `assemblyzero/rag/` subsystem) was removed. LLD codebase-grounding is now **Tiphys** (deterministic interface-map, no embeddings). Preserved for depth.
+
 The RAG subsystem has two distinct phases: **indexing** (batch, manual) and **retrieval** (per-query, automatic).
 
 ### Indexing Phase


### PR DESCRIPTION
Follow-on to the RAG retirement (#1689, ADR-0223). Corrects the high-visibility repo docs that still described the removed RAG subsystem as live — README RAG section, `docs/architecture/data-flow.md` RAG data-flow, and the `docs/0003-file-inventory.md` RAG subsystem header — with a banner pointing to Tiphys; original content preserved for depth. Wiki handled separately (direct push).

Closes #1690