### PR TITLE
chore(tools): commit accumulated one-shot landing scripts (Closes #1702, Closes #1703, Closes #1704)

### DIFF
--- a/tools/hermes_add_ci_workflow.py
+++ b/tools/hermes_add_ci_workflow.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Land Hermes .github/workflows/ci.yml via the classic-PAT Contents API.
+
+martymcenroe/Hermes#536.
+
+Hermes has no CI workflow that runs its vitest suites -- PRs merge on the
+auto-reviewer's issue-reference check alone, with no test verification. This
+tool adds `.github/workflows/ci.yml` (root + dashboard vitest jobs, Node 22,
+non-blocking).
+
+WHY A SCRIPT INSTEAD OF `git push`:
+The fine-grained PAT used for normal Hermes work cannot create or update files
+under `.github/workflows/` (GitHub rejects it: "without `workflow` scope").
+ADR-0216 (in-process classic-PAT decryption) is the sanctioned path: the
+classic PAT is gpg-decrypted inside THIS Python process, used for REST calls,
+and never written to env / argv / disk. The change lands via the Contents API
+(PUT) + a PR + an API squash-merge.
+
+REQUIRED CLASSIC-PAT SCOPES: repo (full) + workflow.
+
+OPERATIONAL RULE (ADR-0216, load-bearing):
+    The OPERATOR runs this script in their own Git Bash. An agent must NEVER
+    invoke it via its Bash tool -- the spawned Python process would be the
+    agent's child and its heap (holding the decrypted PAT for a few seconds)
+    is theoretically agent-readable.
+
+    Also confirm ~/.gnupg/gpg-agent.conf has `default-cache-ttl 0` /
+    `max-cache-ttl 0` (then `gpgconf --kill gpg-agent`) so a sibling process
+    cannot silently decrypt the PAT while a passphrase is cached.
+
+USAGE (run from the AssemblyZero repo so poetry resolves `requests`):
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/hermes_add_ci_workflow.py            # dry-run
+    poetry run python tools/hermes_add_ci_workflow.py --apply    # land it
+
+Default is dry-run (prints the plan, no mutations). `--apply` performs the
+mutation. The source contains no command from the universal CLAUDE.md
+"Banned commands (ALWAYS)" table (no force-push, no --admin, no git reset),
+so the canonical `--apply` gate applies -- NOT `--execute`.
+
+Idempotent: skips if ci.yml already exists on main; skips if an open PR with
+the same title already exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+OWNER = "martymcenroe"
+REPO = "Hermes"
+GH_API = "https://api.github.com"
+WORKFLOW_PATH = ".github/workflows/ci.yml"
+BRANCH = "536-ci-workflow"
+ISSUE_NUMBER = 536
+PR_TITLE = "ci: run the vitest suites on push and PR (Closes #536)"
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 900
+
+# The workflow file content. Defined inline as a Python str (LF line endings),
+# so there is no CRLF-from-Windows-working-tree hazard (ADR-0216 gotcha #3).
+CI_YML = """name: CI
+
+# Runs the vitest suites on every push to main and every PR targeting main.
+# NON-BLOCKING by default (not a required status check); making it gating is a
+# separate branch-protection follow-up (#644). Playwright e2e is intentionally
+# excluded -- `npm test` runs `vitest run` only, never `test:e2e`.
+#
+# Added via tools/hermes_add_ci_workflow.py (classic-PAT Contents API,
+# ADR-0216) because fine-grained PATs cannot push .github/workflows/*.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  root-tests:
+    name: Root suite (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+
+  dashboard-tests:
+    name: Dashboard suite (vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+      - run: npm ci
+      - run: npm test
+"""
+
+PR_BODY = """## Summary
+
+Adds `.github/workflows/ci.yml` so the vitest suites actually run in CI on
+every push to `main` and every PR targeting `main`. Until now Hermes had no
+test-running workflow -- PRs merged on the auto-reviewer's `issue-reference`
+check alone, with no test verification (the resume claim of "N tests in CI"
+had no real source of truth).
+
+## Jobs
+- **Root suite (vitest)** -- `npm ci` + `npm test` (`vitest run`) at repo root.
+- **Dashboard suite (vitest)** -- `npm ci` + `npm test` in `dashboard/`.
+
+Both pin Node 22 (the repo has no `.nvmrc`/engines). Playwright e2e is excluded
+-- `npm test` runs `vitest run` only.
+
+## Non-blocking for now
+Not added to branch protection as a required check yet -- a green run across
+real PRs should be observed before it gates merges, to avoid a flaky-on-arrival
+required check wedging the queue. follow-up: #644.
+
+## How this landed
+Via the classic-PAT Contents API (ADR-0216), because fine-grained PATs cannot
+push files under `.github/workflows/`. Script: `tools/hermes_add_ci_workflow.py`
+in AssemblyZero.
+
+Closes #536
+"""
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def file_exists_on_main(pat: str) -> bool:
+    r = requests.get(
+        f"{GH_API}/repos/{OWNER}/{REPO}/contents/{WORKFLOW_PATH}",
+        params={"ref": "main"},
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 404:
+        return False
+    r.raise_for_status()
+    return True
+
+
+def find_open_pr(pat: str) -> int | None:
+    r = requests.get(
+        f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+        params={"state": "open", "per_page": 100},
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    for pr in r.json():
+        if pr.get("title", "") == PR_TITLE or pr.get("head", {}).get("ref") == BRANCH:
+            return pr["number"]
+    return None
+
+
+def main_head_sha(pat: str) -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{OWNER}/{REPO}/git/refs/heads/main",
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def create_branch(sha: str, pat: str) -> None:
+    r = requests.post(
+        f"{GH_API}/repos/{OWNER}/{REPO}/git/refs",
+        headers=_headers(pat),
+        json={"ref": f"refs/heads/{BRANCH}", "sha": sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 422:
+        # Ref already exists from a prior partial run -- reuse it.
+        print(f"  branch {BRANCH} already exists, reusing")
+        return
+    r.raise_for_status()
+
+
+def put_file(pat: str) -> None:
+    content_b64 = base64.b64encode(CI_YML.encode("utf-8")).decode("ascii")
+    r = requests.put(
+        f"{GH_API}/repos/{OWNER}/{REPO}/contents/{WORKFLOW_PATH}",
+        headers=_headers(pat),
+        json={
+            "message": "ci: add vitest CI workflow (Closes #536)",
+            "content": content_b64,
+            "branch": BRANCH,
+        },
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+
+
+def create_pr(pat: str) -> int:
+    r = requests.post(
+        f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+        headers=_headers(pat),
+        json={"title": PR_TITLE, "head": BRANCH, "base": "main", "body": PR_BODY},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["number"]
+
+
+def wait_for_mergeable(pr_number: int, pat: str) -> str:
+    """Poll until mergeable. Accepts 'clean' OR 'unstable'.
+
+    'unstable' matters here: the new ci.yml runs on its own PR, so while those
+    non-required jobs are pending/failing the state is 'unstable' -- which a
+    squash merge still accepts (ADR-0216 gotcha #4, self-referential check).
+    'blocked' is a WAIT state, NOT terminal: right after the PR opens it just
+    means Cerberus-AZ has not posted its approving review yet (typically
+    10-30s, occasionally minutes). Keep polling THROUGH 'blocked' until
+    'clean'/'unstable' or the timeout. Only 'dirty' (a real merge conflict)
+    fails immediately -- waiting cannot resolve a conflict.
+
+    BUGFIX: an earlier version returned on the FIRST 'blocked' (after ~10s) and
+    left the PR open + unmerged -- it bailed before Cerberus ever approved.
+    That was the failure on PR #648.
+    """
+    deadline = time.time() + MERGEABLE_TIMEOUT_S
+    last = "unknown"
+    while time.time() < deadline:
+        r = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{pr_number}",
+            headers=_headers(pat),
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        last = r.json().get("mergeable_state") or "unknown"
+        if last in ("clean", "unstable"):
+            return last
+        if last == "dirty":
+            return last
+        print(f"  mergeable_state={last}, waiting {POLL_INTERVAL_S}s for Cerberus approval...")
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+def merge_pr(pr_number: int, pat: str) -> str:
+    r = requests.put(
+        f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{pr_number}/merge",
+        headers=_headers(pat),
+        json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json().get("sha", "")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the mutation. Default is dry-run (plan only).",
+    )
+    args = parser.parse_args()
+
+    with classic_pat_session() as pat:
+        if file_exists_on_main(pat):
+            print(f"{WORKFLOW_PATH} already exists on main -- nothing to do.")
+            return 0
+
+        existing = find_open_pr(pat)
+        if existing is not None:
+            if not args.apply:
+                print(f"Open PR #{existing} already adds this workflow. "
+                      f"Re-run with --apply to wait for it to become mergeable and merge it.")
+                return 0
+            # RESUME: a prior run opened the PR + pushed the file but did not
+            # merge (e.g. the pre-bugfix early-bail on 'blocked'). Finish it.
+            print(f"Resuming: open PR #{existing} already exists -- waiting for mergeable...")
+            state = wait_for_mergeable(existing, pat)
+            if state not in ("clean", "unstable"):
+                print(f"  PR #{existing} not mergeable (state={state}). Retained for manual review.")
+                return 1
+            merge_sha = merge_pr(existing, pat)
+            print(f"  PR #{existing} squash-merged at {merge_sha[:8]}  OK")
+            return 0
+
+        if not args.apply:
+            print("DRY-RUN (no changes). Would:")
+            print(f"  1. branch {BRANCH} from main HEAD")
+            print(f"  2. PUT {WORKFLOW_PATH} ({len(CI_YML)} bytes) via Contents API")
+            print(f"  3. open PR '{PR_TITLE}'")
+            print("  4. wait for mergeable (clean/unstable), then squash-merge")
+            print("Re-run with --apply to land it.")
+            return 0
+
+        print(f"Landing {WORKFLOW_PATH} on {OWNER}/{REPO}...")
+        sha = main_head_sha(pat)
+        create_branch(sha, pat)
+        put_file(pat)
+        pr_number = create_pr(pat)
+        print(f"  opened PR #{pr_number}")
+
+        state = wait_for_mergeable(pr_number, pat)
+        if state not in ("clean", "unstable"):
+            print(f"  PR #{pr_number} not mergeable (state={state}). "
+                  f"Branch + PR retained for manual review.")
+            return 1
+
+        merge_sha = merge_pr(pr_number, pat)
+        print(f"  PR #{pr_number} squash-merged at {merge_sha[:8]}  OK")
+        print()
+        print("Done. Pull main locally:  git checkout main && git pull")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/land_career_lint_workflow.py
+++ b/tools/land_career_lint_workflow.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""One-shot: land career/.github/workflows/lint.yml via the classic-PAT Contents API (career #1236).
+
+The fine-grained PAT lacks `workflow` scope, so a normal `git push` of a
+`.github/workflows/*` file is rejected. This lands it the ADR-0216 way: the
+classic PAT is gpg-decrypted in-process, consumed by `requests` directly (never
+via gh / env / argv), and used to create a branch + commit the file + open a PR,
+then squash-merge after pr-sentinel + Cerberus pass.
+
+Run from AssemblyZero (for the poetry env + `_pat_session`):
+
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/land_career_lint_workflow.py            # live
+    poetry run python tools/land_career_lint_workflow.py --dry-run  # print the plan
+
+The encrypted classic PAT must exist at ~/.secrets/classic-pat.gpg (ADR-0216).
+Idempotent: reuses the branch/PR if a prior run was interrupted. Delete this
+one-shot after it succeeds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+OWNER = "martymcenroe"
+REPO = "career"
+GH_API = "https://api.github.com"
+BRANCH = "ci/1236-lint-workflow"
+FILE_PATH = ".github/workflows/lint.yml"
+HTTP_TIMEOUT_S = 30
+
+# LF-only (the Contents API stores bytes verbatim -- never ship CRLF, per ADR-0216).
+LINT_YML = (
+    "name: lint\n"
+    "on:\n"
+    "  pull_request:\n"
+    "  push:\n"
+    "    branches: [main]\n"
+    "jobs:\n"
+    "  lint:\n"
+    "    runs-on: ubuntu-latest\n"
+    "    defaults:\n"
+    "      run:\n"
+    "        working-directory: dashboard\n"
+    "    steps:\n"
+    "      - uses: actions/checkout@v4\n"
+    "      - uses: actions/setup-node@v4\n"
+    "        with:\n"
+    "          node-version: 20\n"
+    "          cache: npm\n"
+    "          cache-dependency-path: dashboard/package-lock.json\n"
+    "      - run: npm ci\n"
+    "      - run: npm run lint\n"
+    "      - run: npm run typecheck\n"
+)
+
+COMMIT_MSG = "ci: add lint + typecheck workflow (Closes #1236)"
+PR_TITLE = "ci: add lint + typecheck workflow (Closes #1236)"
+PR_BODY = (
+    "Adds `.github/workflows/lint.yml` -- server-side `npm run lint` + "
+    "`npm run typecheck` enforcement on pull requests and push-to-main. This is "
+    "the enforcement layer on top of the local lint rule that landed in #1183, "
+    "so a push that skips local lint is still caught pre-merge.\n\n"
+    "Landed via the in-process classic-PAT Contents API pattern (ADR-0216) "
+    "because the fine-grained PAT deliberately lacks `workflow` scope.\n\n"
+    "Verified locally from `dashboard/`: `npm run lint` 0 errors (warnings only), "
+    "`npm run typecheck` clean -- so the workflow is green on `main` from the start.\n\n"
+    "Closes #1236"
+)
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--dry-run", action="store_true", help="Print the plan; make no writes.")
+    args = ap.parse_args()
+
+    if args.dry_run:
+        print(f"DRY-RUN: branch {BRANCH} -> commit {FILE_PATH} -> PR (Closes #1236) -> squash-merge.")
+        print("--- lint.yml ---")
+        print(LINT_YML)
+        return 0
+
+    with classic_pat_session() as pat:
+        h = _headers(pat)
+
+        # 1. Base SHA of main.
+        r = requests.get(f"{GH_API}/repos/{OWNER}/{REPO}/git/ref/heads/main", headers=h, timeout=HTTP_TIMEOUT_S)
+        r.raise_for_status()
+        base_sha = r.json()["object"]["sha"]
+        print(f"main @ {base_sha[:8]}")
+
+        # 2. Create the branch (idempotent: 422 == already exists).
+        r = requests.post(
+            f"{GH_API}/repos/{OWNER}/{REPO}/git/refs",
+            headers=h,
+            json={"ref": f"refs/heads/{BRANCH}", "sha": base_sha},
+            timeout=HTTP_TIMEOUT_S,
+        )
+        if r.status_code == 422:
+            print(f"branch {BRANCH} already exists -- reusing")
+        else:
+            r.raise_for_status()
+            print(f"created branch {BRANCH}")
+
+        # 3. Commit the file via the Contents API (PUT). Include the existing blob
+        #    sha if the file is already present on the branch (resumed run).
+        content_b64 = base64.b64encode(LINT_YML.encode("utf-8")).decode("ascii")
+        existing = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+            headers=h, params={"ref": BRANCH}, timeout=HTTP_TIMEOUT_S,
+        )
+        put_body = {"message": COMMIT_MSG, "content": content_b64, "branch": BRANCH}
+        if existing.status_code == 200:
+            put_body["sha"] = existing.json()["sha"]
+        r = requests.put(
+            f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+            headers=h, json=put_body, timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        print(f"committed {FILE_PATH} to {BRANCH}")
+
+        # 4. Open the PR (reuse an existing open one for the branch).
+        prs = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+            headers=h, params={"head": f"{OWNER}:{BRANCH}", "state": "open"}, timeout=HTTP_TIMEOUT_S,
+        )
+        prs.raise_for_status()
+        if prs.json():
+            pr = prs.json()[0]
+            print(f"reusing PR #{pr['number']}")
+        else:
+            r = requests.post(
+                f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+                headers=h,
+                json={"title": PR_TITLE, "head": BRANCH, "base": "main", "body": PR_BODY},
+                timeout=HTTP_TIMEOUT_S,
+            )
+            r.raise_for_status()
+            pr = r.json()
+            print(f"opened PR #{pr['number']}")
+        num = pr["number"]
+
+        # 5. Wait for `clean` (required check pr-sentinel green + Cerberus approval).
+        #    lint is NOT a required check, so a transient `unstable` while it runs
+        #    is fine -- we only merge on `clean`. `dirty` is a conflict; stop.
+        for i in range(48):
+            r = requests.get(f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{num}", headers=h, timeout=HTTP_TIMEOUT_S)
+            r.raise_for_status()
+            state = r.json().get("mergeable_state")
+            print(f"[{i}] mergeable_state={state}")
+            if state == "clean":
+                break
+            if state == "dirty":
+                print("PR is dirty (merge conflict) -- resolve manually.")
+                return 1
+            time.sleep(10)
+        else:
+            print(f"Timed out waiting for `clean` -- inspect PR #{num} and merge manually if it looks good.")
+            return 1
+
+        # 6. Squash-merge (no --admin; branch protection is satisfied by `clean`).
+        r = requests.put(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{num}/merge",
+            headers=h, json={"merge_method": "squash"}, timeout=HTTP_TIMEOUT_S,
+        )
+        if not r.ok:
+            print(f"merge failed: {r.status_code} {r.text[:300]}")
+            return 1
+        print(f"MERGED PR #{num} -- lint.yml is live on main. You can delete tools/land_career_lint_workflow.py now.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/land_career_test_ci.py
+++ b/tools/land_career_test_ci.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Land the career repo's test-runner CI workflow via the in-process classic PAT.
+
+career #1262. The fine-grained PAT the agent uses cannot push files under
+`.github/workflows/` (it lacks the `workflow` scope — see root CLAUDE.md
+"When git push Is Rejected For Workflow Scope"). So the workflow file is landed
+here through the GitHub Contents API using the admin-scope classic PAT, which
+this process gpg-decrypts in-heap per ADR-0216 (#959): the PAT lives only as a
+local variable inside the `with classic_pat_session()` block, is consumed by
+`requests` directly, and is never written to env, argv, disk, or a log.
+
+What it does (idempotent):
+  1. If `.github/workflows/test.yml` already exists on main -> report + exit 0.
+  2. Create branch `ci/test-workflow-1262` from main.
+  3. PUT the workflow file on that branch via the Contents API.
+  4. Open a PR ("Closes #1262"), poll until mergeable, squash-merge.
+  5. Delete the remote branch. Local git is never touched (API only).
+
+Usage (RUN THIS YOURSELF in your own Git Bash — never via an agent's Bash tool,
+per the _pat_session operational rule):
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/land_career_test_ci.py            # live
+    poetry run python tools/land_career_test_ci.py --dry-run  # preview, no writes
+
+Requires ~/.secrets/classic-pat.gpg (one-time setup in _pat_session docstring)
+and gpg-agent default-cache-ttl 0 (so a sibling's silent decrypt surfaces
+pinentry).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+OWNER = "martymcenroe"
+REPO = "career"
+GH_API = "https://api.github.com"
+BRANCH = "ci/test-workflow-1262"
+FILE_PATH = ".github/workflows/test.yml"
+HTTP_TIMEOUT_S = 30
+MERGE_POLL_ATTEMPTS = 30
+MERGE_POLL_SLEEP_S = 10
+
+# LF-only on purpose (authored with \n) — the Contents API stores bytes verbatim,
+# so CRLF would land CRLF on origin. npm ci because dashboard/ has a package-lock.
+# SCOPE: src/ + cli/ ONLY — the self-contained unit/driver tests. tests/api/* are
+# live integration tests that hit the PRODUCTION API and require a key absent from
+# CI, so the full `npm test` would be red (35 × HTTP 401) or pollute prod
+# (career #1262 finding 2026-06-16). Those stay a local/manual concern.
+WORKFLOW_YAML = """name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      # src/ + cli/ only — tests/api/* hit prod + need a key (career #1262).
+      - run: npx vitest run src/ cli/
+"""
+
+PR_TITLE = "ci: run the self-contained vitest suite on push + PR (Closes #1262)"
+PR_BODY = (
+    "Closes #1262\n\n"
+    "Adds a GitHub Actions workflow that runs the self-contained vitest tests "
+    "(`vitest run src/ cli/`) on every push and pull request, with Playwright "
+    "Chromium for the driver fixtures. Landed via the classic-PAT Contents API "
+    "because the fine-grained PAT cannot push `.github/workflows/`.\n\n"
+    "Scope: `tests/api/*` are excluded — they are live integration tests that hit "
+    "the production API and require a key absent from CI, so the full `npm test` "
+    "would be red (35 × HTTP 401) or write to prod (career #1262 finding).\n"
+)
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def file_exists_on_main(pat: str) -> bool:
+    r = requests.get(
+        f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+        params={"ref": "main"},
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 200:
+        return True
+    if r.status_code == 404:
+        return False
+    r.raise_for_status()
+    return False
+
+
+def main_sha(pat: str) -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{OWNER}/{REPO}/git/ref/heads/main",
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def ensure_branch(pat: str, sha: str) -> None:
+    r = requests.post(
+        f"{GH_API}/repos/{OWNER}/{REPO}/git/refs",
+        headers=_headers(pat),
+        json={"ref": f"refs/heads/{BRANCH}", "sha": sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 422 and "already exists" in r.text.lower():
+        print(f"  branch {BRANCH} already exists — reusing")
+        return
+    r.raise_for_status()
+    print(f"  created branch {BRANCH} @ {sha[:8]}")
+
+
+def put_file(pat: str) -> None:
+    content_b64 = base64.b64encode(WORKFLOW_YAML.encode("utf-8")).decode("ascii")
+    r = requests.put(
+        f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+        headers=_headers(pat),
+        json={
+            "message": "ci: add vitest test-runner workflow (Closes #1262)",
+            "content": content_b64,
+            "branch": BRANCH,
+        },
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    print(f"  committed {FILE_PATH} on {BRANCH}")
+
+
+def open_pr(pat: str) -> int:
+    r = requests.post(
+        f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+        headers=_headers(pat),
+        json={"title": PR_TITLE, "head": BRANCH, "base": "main", "body": PR_BODY},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    num = r.json()["number"]
+    print(f"  opened PR #{num}")
+    return num
+
+
+def wait_mergeable(pat: str, num: int) -> bool:
+    for i in range(1, MERGE_POLL_ATTEMPTS + 1):
+        r = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{num}",
+            headers=_headers(pat),
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        state = r.json().get("mergeable_state")
+        print(f"  [{i}/{MERGE_POLL_ATTEMPTS}] mergeable_state={state}")
+        if state in ("clean", "unstable"):
+            # `unstable` = mergeable, but a NON-required check is pending/failing.
+            # This PR adds tests.yml (on: push), which fires on the feature-branch
+            # push and shows as a non-required pending check on the PR, parking it
+            # at `unstable` for the whole CI run — it never reaches `clean` inside a
+            # sane poll budget. By the time the state is `unstable`, required review
+            # + checks (Cerberus approval) are already satisfied, so merging is safe.
+            # Mirrors fleet_delete_pr_sentinel.py + root CLAUDE.md gotcha #4.
+            return True
+        if state == "dirty":
+            return False
+        time.sleep(MERGE_POLL_SLEEP_S)
+    return False
+
+
+def merge_pr(pat: str, num: int) -> None:
+    r = requests.put(
+        f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{num}/merge",
+        headers=_headers(pat),
+        json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    print(f"  merged PR #{num}")
+
+
+def delete_branch(pat: str) -> None:
+    r = requests.delete(
+        f"{GH_API}/repos/{OWNER}/{REPO}/git/refs/heads/{BRANCH}",
+        headers=_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code in (204, 422, 404):
+        print(f"  cleaned up remote branch {BRANCH}")
+        return
+    r.raise_for_status()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--dry-run", action="store_true", help="Preview without any writes.")
+    args = ap.parse_args()
+
+    if args.dry_run:
+        print("DRY-RUN — would land this workflow at "
+              f"{OWNER}/{REPO}:{FILE_PATH} via branch {BRANCH} + PR (Closes #1262):\n")
+        print(WORKFLOW_YAML)
+        return 0
+
+    with classic_pat_session() as pat:
+        if file_exists_on_main(pat):
+            print(f"{FILE_PATH} already exists on main — nothing to do.")
+            return 0
+        print(f"Landing {FILE_PATH} in {OWNER}/{REPO} ...")
+        ensure_branch(pat, main_sha(pat))
+        put_file(pat)
+        num = open_pr(pat)
+        if not wait_mergeable(pat, num):
+            print(f"PR #{num} did not reach a clean mergeable state. "
+                  f"Inspect it on GitHub; the branch + file are committed.",
+                  file=sys.stderr)
+            return 1
+        merge_pr(pat, num)
+        delete_branch(pat)
+        print("Done. Test CI is live; #1262 closed by the merge.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Commits three classic-PAT Contents-API landing scripts (ADR-0216) that landed `.github/workflows/*` files in external repos and were left uncommitted on the AZ working tree across multiple sessions. Surfaced in a /cleanup working-tree audit.

- `tools/hermes_add_ci_workflow.py` — Hermes#536 CI workflow
- `tools/land_career_lint_workflow.py` — career#1236 lint workflow
- `tools/land_career_test_ci.py` — career#1262 test CI

Kept as `tools/` references, consistent with the fleet's other committed landing scripts. All three ruff-clean (one `F401` auto-fixed). Staged set verified to be exactly these three files.

Closes #1702
Closes #1703
Closes #1704