### PR TITLE
feat(dependabot): refuse to run from a linked worktree (Closes #1699)

### DIFF
--- a/tests/tools/test_dependabot_worktree_guard.py
+++ b/tests/tools/test_dependabot_worktree_guard.py
@@ -1,0 +1,78 @@
+"""Integration tests for the dependabot_review worktree guard (#1699).
+
+dependabot_review.py creates its own audit worktrees off the main repo. Launched
+from inside a linked worktree, `--main-repo` (default cwd) silently points at the
+worktree and the tool operates on the wrong git dir. The guard is code-level, not
+memory-level. These tests exercise REAL `git worktree` state — the guard is a
+statement about git behaviour, so a mock would prove nothing.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "tools"))
+
+import dependabot_review as dr  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", check=True,
+    )
+
+
+def _init_repo(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main", str(path)],
+                   capture_output=True, check=True)
+    _git(path, "config", "user.email", "t@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "f.txt").write_text("x", encoding="utf-8")
+    _git(path, "add", "f.txt")
+    _git(path, "commit", "-m", "init")
+    return path
+
+
+@pytest.fixture
+def main_and_worktree(tmp_path):
+    repo = _init_repo(tmp_path / "repo")
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-b", "wt-branch", str(wt))
+    return repo, wt
+
+
+class TestIsLinkedWorktree:
+    def test_main_repo_not_flagged(self, main_and_worktree):
+        repo, _ = main_and_worktree
+        assert dr.is_linked_worktree(repo) is False
+
+    def test_linked_worktree_flagged(self, main_and_worktree):
+        _, wt = main_and_worktree
+        assert dr.is_linked_worktree(wt) is True
+
+    def test_non_git_dir_not_flagged(self, tmp_path):
+        # Must not false-positive on a plain directory; the separate
+        # `.git`-exists check owns the "not a repo" case.
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert dr.is_linked_worktree(plain) is False
+
+
+class TestGuardNotWorktree:
+    def test_guard_exits_on_worktree(self, main_and_worktree):
+        _, wt = main_and_worktree
+        with pytest.raises(SystemExit) as exc:
+            dr.guard_not_worktree(wt)
+        msg = str(exc.value).lower()
+        assert "worktree" in msg
+        assert "#1699" in str(exc.value)
+
+    def test_guard_passes_on_main(self, main_and_worktree):
+        repo, _ = main_and_worktree
+        # Must not raise.
+        dr.guard_not_worktree(repo)

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -1166,6 +1166,72 @@ def process_repo(
 
 
 # ---------------------------------------------------------------------------
+# Worktree guard (#1699)
+# ---------------------------------------------------------------------------
+
+def is_linked_worktree(repo: Path) -> bool:
+    """True if `repo` is a LINKED git worktree rather than a main working tree.
+
+    dependabot_review creates and tears down its own `dependabot-audit-N`
+    worktrees off the main repo. If it is itself launched from inside a linked
+    worktree, `--main-repo` (which defaults to cwd) silently points at the
+    worktree, and the tool starts adding worktrees-of-a-worktree and deleting
+    branches against the wrong git dir. The /dependabot skill's "do NOT invoke
+    from inside a worktree" rule was enforced by memory alone; this is the
+    code-level guard.
+
+    Detection is the canonical one: compare the per-worktree git dir
+    (`--absolute-git-dir`) to the shared common dir (`--git-common-dir`). In a
+    linked worktree the former is `…/.git/worktrees/<name>` and the latter is
+    `…/.git`; in the main working tree they resolve to the same path. A
+    `worktrees/` component in the git dir is a corroborating fallback.
+
+    Returns False (does NOT false-positive) when `repo` is not a git repo or
+    git is too old to answer -- the separate `.git`-exists check owns that case.
+    """
+    def _git_out(*args: str) -> tuple[int, str]:
+        try:
+            r = subprocess.run(
+                ["git", "-C", str(repo), *args],
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", check=False,
+            )
+        except OSError:
+            return 1, ""
+        return r.returncode, (r.stdout or "").strip()
+
+    rc_gd, git_dir = _git_out("rev-parse", "--absolute-git-dir")
+    rc_cd, common_dir = _git_out("rev-parse", "--git-common-dir")
+    if rc_gd != 0 or rc_cd != 0 or not git_dir or not common_dir:
+        return False
+
+    git_dir_p = Path(git_dir)
+    common_p = Path(common_dir)
+    if not common_p.is_absolute():
+        # `--git-common-dir` may be relative to the worktree cwd.
+        common_p = repo / common_p
+    try:
+        if git_dir_p.resolve() != common_p.resolve():
+            return True
+    except OSError:
+        pass
+    return "worktrees" in git_dir_p.parts
+
+
+def guard_not_worktree(main_repo: Path) -> None:
+    """Refuse to run when `main_repo` is a linked worktree (#1699). Exits."""
+    if is_linked_worktree(main_repo):
+        sys.exit(
+            f"REFUSING TO RUN: {main_repo} is a linked git worktree, not a main "
+            f"working tree.\n"
+            f"dependabot_review.py creates its own audit worktrees off the main "
+            f"repo and must be launched from the main working tree.\n"
+            f"cd into the main repo (the dir whose .git is a directory) and pass "
+            f"--main-repo <main-repo-path>, then re-run. (#1699)"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1213,6 +1279,12 @@ def main() -> None:
     main_repo = Path(args.main_repo).resolve()
     if not (main_repo / ".git").exists():
         sys.exit(f"Not a git repo: {main_repo}")
+
+    # #1699: a linked worktree also has a `.git` (a file, not a dir), so it
+    # passes the check above. Refuse here -- running from a worktree makes the
+    # tool add worktrees-of-a-worktree and delete branches against the wrong
+    # git dir. This replaces the memory-only "don't run from a worktree" rule.
+    guard_not_worktree(main_repo)
 
     # #1360: the orphan-worktree canary is now per-repo (inside
     # process_repo). Pre-#1360 there was a global canary here that


### PR DESCRIPTION
## Summary

The /dependabot skill's "do NOT invoke from inside a worktree" rule was enforced
by LLM memory alone. `dependabot_review.py` defaults `--main-repo` to cwd, and a
linked worktree still has a `.git` (a file), so it passed the existing
`.git`-exists check — a violation silently treated the worktree as the main repo
and the tool would add worktrees-of-a-worktree and delete branches against the
wrong git dir.

Adds a code-level guard:

- `is_linked_worktree(repo)` — compares `--absolute-git-dir` to
  `--git-common-dir` (canonical worktree detection); a `worktrees/` component is
  a corroborating fallback. Returns False for non-repos (doesn't false-positive).
- `guard_not_worktree(main_repo)` — called in `main()` right after the
  `.git`-exists check; exits with a clear message telling the operator to cd to
  the main repo.

## Tests

`tests/tools/test_dependabot_worktree_guard.py` — 5 REAL `git worktree`
integration tests (a mock would prove nothing about git behaviour): main repo not
flagged, linked worktree flagged, plain dir not flagged, guard exits on a
worktree, guard passes on main.

Verified live: running the tool with `--main-repo <a-real-worktree> --dry-run`
prints `REFUSING TO RUN … is a linked git worktree … (#1699)` and exits 1;
pointed at the main repo it passes the guard and proceeds to the dry-run.

Note: `ruff` reports one pre-existing F541 elsewhere in the file (unrelated to
this change; present on origin/main). Left untouched to keep this PR focused;
filing a separate issue.

Closes #1699
