### PR TITLE
style(dependabot): drop extraneous f-string prefix (ruff F541) (Closes #1710)

### DIFF
--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -1137,7 +1137,7 @@ def process_repo(
             sub["errored"].append(f"{repo}#orphan-worktrees")
             return sub
         print(
-            f"  proceeding anyway because --ignore-orphans was set",
+            "  proceeding anyway because --ignore-orphans was set",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
Drops the extraneous `f` prefix on the `--ignore-orphans` proceed message in
`tools/dependabot_review.py` (the string has no `{}` placeholders). Cosmetic;
`ruff check tools/dependabot_review.py` goes from 1 error (F541) to clean.

Surfaced during the #1699 lint gate; kept separate per One-Issue-Per-Concern.

Closes #1710
