### PR TITLE
fix(new_repo): scaffold model=opus so new repos defer to the /model default (Closes #1724)

### DIFF
--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -718,7 +718,7 @@ class TestMainLocalWorkflow:
         # #1060: deprecated and ignored by /onboard; should not be emitted.
         assert "pickupThresholdMinutes" not in config["onboard"]
         # Sanity: still has the rest of the structure.
-        assert config["claude"]["model"] == "claude-opus-4-7[1M]"
+        assert config["claude"]["model"] == "opus"
         assert config["claude"]["effort"] == "max"
         assert config["onboard"]["auto"] is True
 

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -1141,11 +1141,12 @@ Use `/audit` to verify structure compliance with AssemblyZero standards.
 def create_unleashed_json(project_path: Path) -> None:
     """Create .unleashed.json with standard wrapper configuration.
 
-    Sets model=claude-opus-4-7[1M], effort=max so unleashed wrappers pass
-    the correct CLI flags. Without this file, wrappers fall back to tool
-    defaults. The explicit model literal (not the bare "opus" alias) pins
-    to 4.7[1M] — the alias would resolve to LATEST in Claude CLI and
-    bypass the user's pin.
+    Sets model="opus" (the bare family alias) and effort=max. The wrapper no
+    longer injects --model for the bare "opus" alias, so a new repo defers to
+    the operator's interactive /model default rather than being pinned to a
+    hardcoded version. (The old scaffold hardcoded "claude-opus-4-7[1M]", which
+    forced every new repo onto Opus 4.7 once 4.8 shipped and a --model flag
+    overrides the /model default.)
 
     `assemblyZero` defaults to True (#1059): repos created by this tool
     are by definition AssemblyZero-managed, so /onboard should load
@@ -1161,7 +1162,7 @@ def create_unleashed_json(project_path: Path) -> None:
     content = json.dumps({
         "profile": "default",
         "claude": {
-            "model": "claude-opus-4-7[1M]",
+            "model": "opus",
             "effort": "max"
         },
         "assemblyZero": True,
@@ -2802,7 +2803,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     # Step 11b: Create .unleashed.json (wrapper configuration)
     print("\n11b. Creating .unleashed.json...")
     create_unleashed_json(project_path)
-    print("  Created .unleashed.json (model=claude-opus-4-7[1M], effort=max)")
+    print("  Created .unleashed.json (model=opus, effort=max)")
 
     # Step 11b2: Bootstrap Python project (#1058) — pyproject.toml,
     # pytest, pytest-cov, conftest.py. Required for AZ implementation


### PR DESCRIPTION
## Summary

`tools/new_repo.py` hardcoded `"model": "claude-opus-4-7[1M]"` into every scaffolded `.unleashed.json`, so every new repo was born pinned to Opus 4.7 — and since a `--model` CLI flag overrides the operator's interactive `/model` default, that default could never win in a new repo. A fleet scan found 16 repos carrying this identical scaffolder-stamped pin.

## Change

Scaffold `"model": "opus"` (the bare family alias) instead. The wrapper no longer injects `--model` for the bare `"opus"` alias, so new repos defer to the operator's `/model` default and there is no hardcoded version string to bump at each Opus release.

- `tools/new_repo.py`: the `.unleashed.json` `model` value, the function docstring (which previously justified the explicit pin), and the "Created .unleashed.json (model=...)" print.
- `tests/unit/test_new_repo.py`: the assertion that checked the scaffolded model (now expects `"opus"`).

## Verification

`tests/unit/test_new_repo.py` + `test_scaffolder_lint_integration.py` pass (110 tests). Pre-existing `ruff` F401/F541 warnings in `new_repo.py` are unchanged (present on origin/main, unrelated to this change).

## Scope

Fixes the source so NEW repos are no longer pinned. The 16 existing repos need a separate config sweep to change their pinned value — handled separately.

Closes #1724
