### PR TITLE
feat(tools): fleet_remove_claude_model.py sweeps the dead claude.model key (Closes #1730)

### DIFF
--- a/tests/unit/test_fleet_remove_claude_model.py
+++ b/tests/unit/test_fleet_remove_claude_model.py
@@ -1,0 +1,250 @@
+"""Unit tests for tools/fleet_remove_claude_model.py (#1730).
+
+A scripted fake runner stands in for gh — no live GitHub. The fake maps
+(method, path-prefix) to canned CompletedProcess results and records every
+call so tests can assert exactly which mutations were (not) attempted.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from fleet_remove_claude_model import (  # noqa: E402
+    compute_new_content,
+    find_existing_pr,
+    process_repo,
+    wait_for_mergeable,
+)
+
+
+def b64(text: str) -> str:
+    return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+
+CONFIG_WITH_MODEL = (
+    '{\n'
+    '  "profile": "default",\n'
+    '  "claude": {\n'
+    '    "model": "opus",\n'
+    '    "effort": "max"\n'
+    '  },\n'
+    '  "assemblyZero": true\n'
+    '}\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_new_content — the pure edit
+# ---------------------------------------------------------------------------
+
+class TestComputeNewContent:
+    def test_removes_only_model_preserving_siblings_and_order(self):
+        out = compute_new_content(b64(CONFIG_WITH_MODEL))
+        cfg = json.loads(out)
+        assert "model" not in cfg["claude"]
+        assert cfg["claude"]["effort"] == "max"
+        assert list(cfg.keys()) == ["profile", "claude", "assemblyZero"]
+
+    def test_house_style_indent_lf_trailing_newline(self):
+        out = compute_new_content(b64(CONFIG_WITH_MODEL))
+        assert out.endswith("}\n")
+        assert "\r" not in out
+        assert '  "profile"' in out  # 2-space indent
+
+    def test_none_when_model_absent(self):
+        cfg = '{\n  "claude": {\n    "effort": "max"\n  }\n}\n'
+        assert compute_new_content(b64(cfg)) is None
+
+    def test_none_when_no_claude_block(self):
+        assert compute_new_content(b64('{\n  "profile": "default"\n}\n')) is None
+
+    def test_none_when_claude_is_not_a_dict(self):
+        assert compute_new_content(b64('{\n  "claude": "opus"\n}\n')) is None
+
+    def test_claude_block_retained_when_model_was_only_key(self):
+        cfg = '{\n  "claude": {\n    "model": "opus"\n  }\n}\n'
+        out = compute_new_content(b64(cfg))
+        assert json.loads(out)["claude"] == {}
+
+    def test_contents_api_wrapped_base64_accepted(self):
+        # The Contents API returns base64 with embedded newlines.
+        wrapped = "\n".join(
+            b64(CONFIG_WITH_MODEL)[i:i + 20]
+            for i in range(0, len(b64(CONFIG_WITH_MODEL)), 20)
+        )
+        out = compute_new_content(wrapped)
+        assert "model" not in json.loads(out)["claude"]
+
+    def test_non_ascii_preserved_unescaped(self):
+        cfg = '{\n  "claude": {\n    "model": "opus"\n  },\n  "note": "café"\n}\n'
+        out = compute_new_content(b64(cfg))
+        assert "café" in out
+        assert "\\u" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fake gh runner
+# ---------------------------------------------------------------------------
+
+class FakeRunner:
+    """Maps (method, path-substring) -> response; records every gh argv."""
+
+    def __init__(self, routes: list[tuple[str, str, int, object]]):
+        self.routes = routes
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *, timeout=0, input=None):
+        self.calls.append(list(cmd))
+        path = cmd[2]
+        method = "GET"
+        if "-X" in cmd:
+            method = cmd[cmd.index("-X") + 1]
+        for m, frag, rc, body in self.routes:
+            if m == method and frag in path:
+                stdout = body if isinstance(body, str) else json.dumps(body)
+                stderr = "HTTP 404: Not Found" if rc != 0 else ""
+                return subprocess.CompletedProcess(cmd, rc, stdout, stderr)
+        raise AssertionError(f"unrouted gh call: {method} {path}")
+
+    def mutations(self) -> list[list[str]]:
+        return [c for c in self.calls if "-X" in c]
+
+
+REPO_META = {"default_branch": "main"}
+CONTENTS = {"content": b64(CONFIG_WITH_MODEL), "sha": "abc123"}
+
+
+# ---------------------------------------------------------------------------
+# process_repo — skip paths and dry-run safety
+# ---------------------------------------------------------------------------
+
+class TestSkipPaths:
+    def test_missing_repo_skips(self):
+        r = FakeRunner([("GET", "repos/martymcenroe/ghost", 1, "")])
+        assert "not found" in process_repo(r, "ghost", apply=True)
+        assert r.mutations() == []
+
+    def test_missing_config_file_skips(self):
+        r = FakeRunner([
+            ("GET", "/contents/", 1, ""),
+            ("GET", "repos/martymcenroe/bare", 0, REPO_META),
+        ])
+        assert ".unleashed.json" in process_repo(r, "bare", apply=True)
+        assert r.mutations() == []
+
+    def test_model_already_absent_skips(self):
+        clean = {"content": b64('{\n  "claude": {\n    "effort": "max"\n  }\n}\n'),
+                 "sha": "abc"}
+        r = FakeRunner([
+            ("GET", "/contents/", 0, clean),
+            ("GET", "repos/martymcenroe/done", 0, REPO_META),
+        ])
+        assert "already absent" in process_repo(r, "done", apply=True)
+        assert r.mutations() == []
+
+    def test_open_pr_from_prior_run_skips(self):
+        r = FakeRunner([
+            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/pulls?state=open", 0,
+             [{"number": 7, "head": {"ref": "5-remove-claude-model"}}]),
+            ("GET", "repos/martymcenroe/mid", 0, REPO_META),
+        ])
+        assert "open PR #7" in process_repo(r, "mid", apply=True)
+        assert r.mutations() == []
+
+    def test_dry_run_issues_no_mutating_calls(self):
+        r = FakeRunner([
+            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/pulls?state=open", 0, []),
+            ("GET", "repos/martymcenroe/live", 0, REPO_META),
+        ])
+        out = process_repo(r, "live", apply=False)
+        assert out.startswith("dry-run")
+        assert r.mutations() == []
+
+
+# ---------------------------------------------------------------------------
+# process_repo — happy path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+    def _runner(self) -> FakeRunner:
+        return FakeRunner([
+            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/pulls?state=open", 0, []),
+            ("POST", "/issues", 0, {"number": 41}),
+            ("GET", "/git/ref/heads/main", 0, {"object": {"sha": "f" * 40}}),
+            ("POST", "/git/refs", 0, {}),
+            ("PUT", "/contents/", 0, {}),
+            ("POST", "/pulls", 0, {"number": 42}),
+            ("PUT", "/pulls/42/merge", 0, {"merged": True}),
+            ("GET", "/pulls/42", 0,
+             {"mergeable_state": "clean", "merged": True,
+              "merge_commit_sha": "deadbeefcafe"}),
+            ("GET", "repos/martymcenroe/live", 0, REPO_META),
+        ])
+
+    def test_full_cycle_reports_issue_pr_and_squash(self):
+        out = process_repo(self._runner(), "live", apply=True)
+        assert out == "merged: issue #41, PR #42, squash deadbeef"
+
+    def test_branch_named_after_issue(self):
+        r = self._runner()
+        process_repo(r, "live", apply=True)
+        ref_calls = [c for c in r.calls if c[2].endswith("/git/refs")]
+        assert len(ref_calls) == 1  # branch created exactly once
+
+    def test_no_force_tokens_in_any_gh_argv(self):
+        r = self._runner()
+        process_repo(r, "live", apply=True)
+        banned = {"-D", "--force", "--force-with-lease", "--admin", "--no-verify"}
+        for call in r.calls:
+            assert not banned.intersection(call), call
+
+    def test_unstable_state_is_mergeable(self):
+        r = self._runner()
+        r.routes.insert(0, ("GET", "/pulls/42", 0,
+                            {"mergeable_state": "unstable", "merged": True,
+                             "merge_commit_sha": "deadbeefcafe"}))
+        out = process_repo(r, "live", apply=True)
+        assert out.startswith("merged:")
+
+
+# ---------------------------------------------------------------------------
+# wait_for_mergeable — bounded poll
+# ---------------------------------------------------------------------------
+
+class TestWaitForMergeable:
+    def test_dirty_short_circuits(self):
+        r = FakeRunner([("GET", "/pulls/9", 0, {"mergeable_state": "dirty"})])
+        assert wait_for_mergeable(r, "x", 9) == "dirty"
+
+    def test_timeout_reports_last_state(self):
+        r = FakeRunner([("GET", "/pulls/9", 0, {"mergeable_state": "blocked"})])
+        clock = iter([0, 5, 10, 999]).__next__
+        out = wait_for_mergeable(r, "x", 9, timeout_s=12,
+                                 sleep=lambda s: None, clock=clock)
+        assert out == "timeout:blocked"
+
+
+# ---------------------------------------------------------------------------
+# find_existing_pr
+# ---------------------------------------------------------------------------
+
+def test_find_existing_pr_matches_suffix_only():
+    r = FakeRunner([
+        ("GET", "/pulls?state=open", 0,
+         [{"number": 3, "head": {"ref": "other-branch"}},
+          {"number": 4, "head": {"ref": "12-remove-claude-model"}}]),
+    ])
+    assert find_existing_pr(r, "x") == 4
+
+
+def test_find_existing_pr_none_when_no_match():
+    r = FakeRunner([("GET", "/pulls?state=open", 0, [])])
+    assert find_existing_pr(r, "x") is None

--- a/tools/fleet_remove_claude_model.py
+++ b/tools/fleet_remove_claude_model.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Fleet-wide removal of the inert `.unleashed.json` `claude.model` key.
+
+AssemblyZero #1730.
+
+The Claude wrapper no longer reads `claude.model` — model choice belongs to
+Claude Code's native settings hierarchy (the operator's /model default in
+user settings; a committed `.claude/settings.json` for a deliberate per-repo
+pin). Any `claude.model` left in a repo's `.unleashed.json` is dead config
+that misleads readers into thinking it decides something. The scaffolder
+stopped minting the key in #1727; this tool sweeps the existing fleet.
+
+For each named repo this tool:
+
+  1. Skips if the repo or its `.unleashed.json` does not exist on origin.
+  2. Skips if `claude.model` is absent (idempotent re-runs).
+  3. Skips if an open PR from a prior run exists (idempotent).
+  4. Files a per-repo issue describing the change.
+  5. Creates a branch from the default-branch HEAD.
+  6. Removes ONLY the `claude.model` key via the Contents API — key order,
+     sibling fields, 2-space indent, LF endings, trailing newline preserved.
+  7. Opens a PR carrying `Closes #N` for that repo's issue.
+  8. Polls `mergeable_state` until clean/unstable, then squash-merges.
+  9. Verifies the merge actually landed before reporting success.
+
+All GitHub access goes through the ambient `gh` CLI auth: `.unleashed.json`
+is a plain contents path, so no elevated scopes are needed (contrast
+`fleet_set_permission_mode.py`, which predates that distinction and uses the
+classic-PAT session). Every `gh` call goes through an injectable runner so
+the logic is unit-testable with a scripted fake — no live GitHub required.
+
+Generated issue/PR bodies carry no cross-repo references: each repo's
+artifacts describe the change in that repo only.
+
+Usage:
+    poetry run python tools/fleet_remove_claude_model.py --repos a,b,c
+    poetry run python tools/fleet_remove_claude_model.py --repos a,b,c --apply
+
+Dry-run is the default: prints the per-repo plan and the exact resulting
+JSON, takes no action. `--apply` mutates.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import time
+from typing import Any, Callable, Optional
+
+GITHUB_USER = "martymcenroe"
+TARGET_PATH = ".unleashed.json"
+BRANCH_SUFFIX = "remove-claude-model"
+HTTP_TIMEOUT_S = 60
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 300
+MAX_REPOS_PER_RUN = 100
+
+# Mergeable states that never resolve by waiting (mirrors tracked_pr_land).
+TERMINAL_BAD_STATES = {"dirty", "draft"}
+# States good enough to merge: `unstable` means non-required checks are still
+# running; required ones passed (fleet merges gate on a single required check).
+MERGEABLE_OK_STATES = {"clean", "unstable"}
+
+ISSUE_TITLE = "Remove inert claude.model from .unleashed.json"
+
+ISSUE_BODY = """## Context
+
+The Claude wrapper no longer reads `claude.model` from `.unleashed.json` —
+model choice belongs to Claude Code's native settings hierarchy (the
+operator's `/model` default; a committed `.claude/settings.json` for a
+deliberate per-repo pin). This repo's `.unleashed.json` still carries the
+key, where it is dead config that misleads readers.
+
+## Scope
+
+Remove ONLY `claude.model`. Sibling fields (`effort`, `permissionMode`,
+`onboard`, etc.) are preserved, as are key order, indent, and line endings.
+No behavior change: the wrapper ignores the key at every version still in
+service.
+
+Filed and processed automatically by `tools/fleet_remove_claude_model.py`
+in AssemblyZero.
+"""
+
+PR_BODY_TEMPLATE = """## Summary
+
+Removes the inert `claude.model` key from `.unleashed.json`. The Claude
+wrapper no longer reads it; model choice belongs to Claude Code's native
+settings hierarchy. Sibling fields, key order, indent, and line endings are
+preserved. No behavior change.
+
+Filed and processed automatically by `tools/fleet_remove_claude_model.py`
+in AssemblyZero.
+
+Closes #{issue_number}
+"""
+
+
+class GhError(RuntimeError):
+    """A gh api call failed in a way the caller did not expect."""
+
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def run(cmd: list[str], *, timeout: int = HTTP_TIMEOUT_S,
+        input: Optional[str] = None) -> subprocess.CompletedProcess:
+    """Default runner. UTF-8 + replace-errors so gh output never crashes on
+    the Windows cp1252 default console encoding."""
+    return subprocess.run(
+        cmd, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", check=False, timeout=timeout, input=input,
+    )
+
+
+def gh_api(runner: Runner, path: str, *, method: str = "GET",
+           payload: Optional[dict] = None, ok_404: bool = False) -> Optional[Any]:
+    """One gh api call. Returns parsed JSON, or None on 404 when ok_404."""
+    cmd = ["gh", "api", path]
+    if method != "GET":
+        cmd += ["-X", method]
+    kwargs: dict[str, Any] = {}
+    if payload is not None:
+        cmd += ["--input", "-"]
+        kwargs["input"] = json.dumps(payload)
+    proc = runner(cmd, timeout=HTTP_TIMEOUT_S, **kwargs)
+    if proc.returncode != 0:
+        if ok_404 and "404" in (proc.stderr or ""):
+            return None
+        raise GhError(f"gh api {method} {path} failed: {proc.stderr.strip()[:300]}")
+    out = (proc.stdout or "").strip()
+    return json.loads(out) if out else {}
+
+
+def compute_new_content(current_b64: str) -> Optional[str]:
+    """New `.unleashed.json` text with `claude.model` removed.
+
+    Returns None when there is nothing to do (no claude block / no model
+    key). Preserves key order and sibling fields; emits the fleet house
+    style: 2-space indent, LF-only, trailing newline, non-ASCII unescaped.
+    """
+    raw = base64.b64decode(current_b64).decode("utf-8")
+    cfg = json.loads(raw)
+    claude = cfg.get("claude")
+    if not isinstance(claude, dict) or "model" not in claude:
+        return None
+    del claude["model"]
+    return json.dumps(cfg, indent=2, ensure_ascii=False) + "\n"
+
+
+def find_existing_pr(runner: Runner, repo: str) -> Optional[int]:
+    """Open PR from a prior run of this tool, if any."""
+    prs = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/pulls?state=open&per_page=50")
+    for pr in prs or []:
+        if pr.get("head", {}).get("ref", "").endswith(BRANCH_SUFFIX):
+            return pr["number"]
+    return None
+
+
+def wait_for_mergeable(runner: Runner, repo: str, pr_number: int,
+                       *, timeout_s: int = MERGEABLE_TIMEOUT_S,
+                       interval_s: int = POLL_INTERVAL_S,
+                       sleep: Callable[[float], None] = time.sleep,
+                       clock: Callable[[], float] = time.monotonic) -> str:
+    """Poll mergeable_state until an OK state, a terminal-bad state, or timeout."""
+    deadline = clock() + timeout_s
+    state = "unknown"
+    while clock() < deadline:
+        pr = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/pulls/{pr_number}")
+        state = pr.get("mergeable_state") or "unknown"
+        if state in MERGEABLE_OK_STATES:
+            return state
+        if state in TERMINAL_BAD_STATES:
+            return state
+        print(f"  PR #{pr_number} mergeable_state={state} -> wait")
+        sleep(interval_s)
+    return f"timeout:{state}"
+
+
+def process_repo(runner: Runner, repo: str, apply: bool) -> str:
+    """Run the full cycle for one repo. Returns a one-line outcome."""
+    print(f"\n=== {repo} ===")
+
+    meta = gh_api(runner, f"repos/{GITHUB_USER}/{repo}", ok_404=True)
+    if meta is None:
+        return "skip: repo not found on origin"
+    default_branch = meta.get("default_branch", "main")
+
+    info = gh_api(
+        runner,
+        f"repos/{GITHUB_USER}/{repo}/contents/{TARGET_PATH}?ref={default_branch}",
+        ok_404=True,
+    )
+    if info is None:
+        return f"skip: no {TARGET_PATH} on {default_branch}"
+
+    new_content = compute_new_content(info["content"])
+    if new_content is None:
+        return "skip: claude.model already absent"
+
+    existing = find_existing_pr(runner, repo)
+    if existing is not None:
+        return f"skip: open PR #{existing} from a prior run"
+
+    if not apply:
+        print(new_content, end="")
+        return "dry-run: would file issue, branch, edit, PR, merge"
+
+    issue = gh_api(
+        runner, f"repos/{GITHUB_USER}/{repo}/issues", method="POST",
+        payload={"title": ISSUE_TITLE, "body": ISSUE_BODY},
+    )
+    issue_number = issue["number"]
+    print(f"  issue #{issue_number}")
+
+    head = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/git/ref/heads/{default_branch}")
+    head_sha = head["object"]["sha"]
+    branch = f"{issue_number}-{BRANCH_SUFFIX}"
+    gh_api(
+        runner, f"repos/{GITHUB_USER}/{repo}/git/refs", method="POST",
+        payload={"ref": f"refs/heads/{branch}", "sha": head_sha},
+    )
+    print(f"  branch {branch} @ {head_sha[:8]}")
+
+    title = f"chore: remove inert claude.model from .unleashed.json (Closes #{issue_number})"
+    gh_api(
+        runner, f"repos/{GITHUB_USER}/{repo}/contents/{TARGET_PATH}", method="PUT",
+        payload={
+            "message": title,
+            "content": base64.b64encode(new_content.encode("utf-8")).decode("ascii"),
+            "sha": info["sha"],
+            "branch": branch,
+        },
+    )
+    print(f"  {TARGET_PATH} updated on {branch}")
+
+    pr = gh_api(
+        runner, f"repos/{GITHUB_USER}/{repo}/pulls", method="POST",
+        payload={
+            "title": title,
+            "head": branch,
+            "base": default_branch,
+            "body": PR_BODY_TEMPLATE.format(issue_number=issue_number),
+        },
+    )
+    pr_number = pr["number"]
+    print(f"  PR #{pr_number}")
+
+    state = wait_for_mergeable(runner, repo, pr_number)
+    if state not in MERGEABLE_OK_STATES:
+        return (f"STUCK: PR #{pr_number} mergeable_state={state} -- "
+                f"branch + issue retained for human review")
+
+    gh_api(
+        runner, f"repos/{GITHUB_USER}/{repo}/pulls/{pr_number}/merge", method="PUT",
+        payload={"merge_method": "squash"},
+    )
+
+    merged = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/pulls/{pr_number}")
+    if not merged.get("merged"):
+        return f"STUCK: PR #{pr_number} merge reported but merged=false -- verify by hand"
+    sha = (merged.get("merge_commit_sha") or "")[:8]
+    return f"merged: issue #{issue_number}, PR #{pr_number}, squash {sha}"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--repos", required=True,
+                        help="Comma-separated owner-less repo names to sweep")
+    parser.add_argument("--apply", action="store_true",
+                        help="Mutate. Default is dry-run: print plan, take no action.")
+    parser.add_argument("--limit", type=int, default=MAX_REPOS_PER_RUN)
+    args = parser.parse_args(argv)
+
+    repos = [r.strip() for r in args.repos.split(",") if r.strip()]
+    if not repos:
+        print("no repos given", file=sys.stderr)
+        return 2
+    repos = repos[: args.limit]
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"fleet_remove_claude_model [{mode}] over {len(repos)} repo(s)")
+
+    outcomes: dict[str, str] = {}
+    for repo in repos:
+        try:
+            outcomes[repo] = process_repo(run, repo, args.apply)
+        except (GhError, KeyError, json.JSONDecodeError) as exc:
+            outcomes[repo] = f"ERROR: {exc}"
+        print(f"  -> {outcomes[repo]}")
+
+    print("\n===== summary =====")
+    stuck = 0
+    for repo, outcome in outcomes.items():
+        print(f"{repo}: {outcome}")
+        if outcome.startswith(("STUCK", "ERROR")):
+            stuck += 1
+    return 1 if stuck else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

`tools/fleet_remove_claude_model.py` + 21 unit tests. Sweeps the dead `claude.model` key out of `.unleashed.json` across the fleet: the Claude wrapper no longer reads it, and the scaffolder stopped minting it in #1727, so what remains in existing repos is inert config that misleads readers.

## Design

Follows the `fleet_set_permission_mode.py` architecture with three deliberate differences:

- **Ambient `gh` CLI auth instead of the classic-PAT session.** `.unleashed.json` is a plain contents path; no elevated scopes are needed, so the tool is safe to run unattended.
- **Injectable runner** — the whole cycle is unit-tested with a scripted fake (skip paths, dry-run mutation-safety, happy path, bounded poll, no-force-token guard). No live GitHub in tests.
- **No cross-repo references in generated issue/PR bodies** — each repo's artifacts describe the change in that repo only.

Per-repo cycle: idempotent skips (repo/file missing, key already absent, open PR from a prior run) -> per-repo issue -> branch from default-branch HEAD -> Contents-API edit preserving key order, siblings, 2-space indent, LF endings, trailing newline -> PR carrying the issue reference -> `mergeable_state` poll bounded at 300s (clean/unstable proceed; dirty/draft short-circuit) -> squash merge -> post-merge `merged=true` verification before reporting success.

Dry-run is the default and prints the exact resulting JSON per repo; `--apply` mutates. No banned/force flags are representable in any generated `gh` argv (tested).

## Verification

- 21/21 tests pass; ruff clean on both files.

Closes #1730
