### PR TITLE
feat(tools): effort eradication - scaffolder drops claude block, sweep tool generalized to --key (Closes #1732, Closes #1733)

### DIFF
--- a/tests/unit/test_fleet_remove_claude_key.py
+++ b/tests/unit/test_fleet_remove_claude_key.py
@@ -1,8 +1,8 @@
-"""Unit tests for tools/fleet_remove_claude_model.py (#1730).
+"""Unit tests for tools/fleet_remove_claude_key.py (#1730, generalized #1733).
 
 A scripted fake runner stands in for gh — no live GitHub. The fake maps
-(method, path-prefix) to canned CompletedProcess results and records every
-call so tests can assert exactly which mutations were (not) attempted.
+(method, path-substring) to canned CompletedProcess results and records
+every call so tests can assert exactly which mutations were (not) attempted.
 """
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
 
-from fleet_remove_claude_model import (  # noqa: E402
+from fleet_remove_claude_key import (  # noqa: E402
     compute_new_content,
     find_existing_pr,
     process_repo,
@@ -37,39 +37,56 @@ CONFIG_WITH_MODEL = (
     '}\n'
 )
 
+# Post-model-sweep shape: effort is the only claude key left.
+CONFIG_WITH_EFFORT = (
+    '{\n'
+    '  "profile": "default",\n'
+    '  "claude": {\n'
+    '    "effort": "max"\n'
+    '  },\n'
+    '  "assemblyZero": true\n'
+    '}\n'
+)
+
 
 # ---------------------------------------------------------------------------
-# compute_new_content — the pure edit
+# compute_new_content — the pure edit, both keys
 # ---------------------------------------------------------------------------
 
 class TestComputeNewContent:
     def test_removes_only_model_preserving_siblings_and_order(self):
-        out = compute_new_content(b64(CONFIG_WITH_MODEL))
+        out = compute_new_content(b64(CONFIG_WITH_MODEL), "model")
         cfg = json.loads(out)
         assert "model" not in cfg["claude"]
         assert cfg["claude"]["effort"] == "max"
         assert list(cfg.keys()) == ["profile", "claude", "assemblyZero"]
 
+    def test_removes_only_effort_preserving_siblings_and_order(self):
+        out = compute_new_content(b64(CONFIG_WITH_MODEL), "effort")
+        cfg = json.loads(out)
+        assert "effort" not in cfg["claude"]
+        assert cfg["claude"]["model"] == "opus"
+        assert list(cfg.keys()) == ["profile", "claude", "assemblyZero"]
+
+    def test_effort_removal_on_post_model_sweep_config_leaves_empty_block(self):
+        out = compute_new_content(b64(CONFIG_WITH_EFFORT), "effort")
+        assert json.loads(out)["claude"] == {}
+
     def test_house_style_indent_lf_trailing_newline(self):
-        out = compute_new_content(b64(CONFIG_WITH_MODEL))
+        out = compute_new_content(b64(CONFIG_WITH_EFFORT), "effort")
         assert out.endswith("}\n")
         assert "\r" not in out
         assert '  "profile"' in out  # 2-space indent
 
-    def test_none_when_model_absent(self):
-        cfg = '{\n  "claude": {\n    "effort": "max"\n  }\n}\n'
-        assert compute_new_content(b64(cfg)) is None
+    def test_none_when_key_absent(self):
+        assert compute_new_content(b64(CONFIG_WITH_EFFORT), "model") is None
 
     def test_none_when_no_claude_block(self):
-        assert compute_new_content(b64('{\n  "profile": "default"\n}\n')) is None
+        cfg = '{\n  "profile": "default"\n}\n'
+        assert compute_new_content(b64(cfg), "effort") is None
 
     def test_none_when_claude_is_not_a_dict(self):
-        assert compute_new_content(b64('{\n  "claude": "opus"\n}\n')) is None
-
-    def test_claude_block_retained_when_model_was_only_key(self):
-        cfg = '{\n  "claude": {\n    "model": "opus"\n  }\n}\n'
-        out = compute_new_content(b64(cfg))
-        assert json.loads(out)["claude"] == {}
+        assert compute_new_content(b64('{\n  "claude": "max"\n}\n'), "effort") is None
 
     def test_contents_api_wrapped_base64_accepted(self):
         # The Contents API returns base64 with embedded newlines.
@@ -77,12 +94,12 @@ class TestComputeNewContent:
             b64(CONFIG_WITH_MODEL)[i:i + 20]
             for i in range(0, len(b64(CONFIG_WITH_MODEL)), 20)
         )
-        out = compute_new_content(wrapped)
+        out = compute_new_content(wrapped, "model")
         assert "model" not in json.loads(out)["claude"]
 
     def test_non_ascii_preserved_unescaped(self):
-        cfg = '{\n  "claude": {\n    "model": "opus"\n  },\n  "note": "café"\n}\n'
-        out = compute_new_content(b64(cfg))
+        cfg = '{\n  "claude": {\n    "effort": "max"\n  },\n  "note": "café"\n}\n'
+        out = compute_new_content(b64(cfg), "effort")
         assert "café" in out
         assert "\\u" not in out
 
@@ -97,9 +114,11 @@ class FakeRunner:
     def __init__(self, routes: list[tuple[str, str, int, object]]):
         self.routes = routes
         self.calls: list[list[str]] = []
+        self.inputs: list = []  # index-aligned with calls: the stdin payloads
 
     def __call__(self, cmd, *, timeout=0, input=None):
         self.calls.append(list(cmd))
+        self.inputs.append(input)
         path = cmd[2]
         method = "GET"
         if "-X" in cmd:
@@ -116,17 +135,17 @@ class FakeRunner:
 
 
 REPO_META = {"default_branch": "main"}
-CONTENTS = {"content": b64(CONFIG_WITH_MODEL), "sha": "abc123"}
+CONTENTS_EFFORT = {"content": b64(CONFIG_WITH_EFFORT), "sha": "abc123"}
 
 
 # ---------------------------------------------------------------------------
-# process_repo — skip paths and dry-run safety
+# process_repo — skip paths and dry-run safety (driven with key=effort)
 # ---------------------------------------------------------------------------
 
 class TestSkipPaths:
     def test_missing_repo_skips(self):
         r = FakeRunner([("GET", "repos/martymcenroe/ghost", 1, "")])
-        assert "not found" in process_repo(r, "ghost", apply=True)
+        assert "not found" in process_repo(r, "ghost", apply=True, key="effort")
         assert r.mutations() == []
 
     def test_missing_config_file_skips(self):
@@ -134,48 +153,59 @@ class TestSkipPaths:
             ("GET", "/contents/", 1, ""),
             ("GET", "repos/martymcenroe/bare", 0, REPO_META),
         ])
-        assert ".unleashed.json" in process_repo(r, "bare", apply=True)
+        assert ".unleashed.json" in process_repo(r, "bare", apply=True, key="effort")
         assert r.mutations() == []
 
-    def test_model_already_absent_skips(self):
-        clean = {"content": b64('{\n  "claude": {\n    "effort": "max"\n  }\n}\n'),
-                 "sha": "abc"}
+    def test_key_already_absent_skips(self):
+        clean = {"content": b64('{\n  "claude": {}\n}\n'), "sha": "abc"}
         r = FakeRunner([
             ("GET", "/contents/", 0, clean),
             ("GET", "repos/martymcenroe/done", 0, REPO_META),
         ])
-        assert "already absent" in process_repo(r, "done", apply=True)
+        out = process_repo(r, "done", apply=True, key="effort")
+        assert "claude.effort already absent" in out
         assert r.mutations() == []
 
-    def test_open_pr_from_prior_run_skips(self):
+    def test_open_pr_from_prior_run_same_key_skips(self):
         r = FakeRunner([
-            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/contents/", 0, CONTENTS_EFFORT),
+            ("GET", "/pulls?state=open", 0,
+             [{"number": 7, "head": {"ref": "5-remove-claude-effort"}}]),
+            ("GET", "repos/martymcenroe/mid", 0, REPO_META),
+        ])
+        assert "open PR #7" in process_repo(r, "mid", apply=True, key="effort")
+        assert r.mutations() == []
+
+    def test_open_pr_for_other_key_does_not_block(self):
+        # A leftover model-sweep PR must not mask the effort sweep.
+        r = FakeRunner([
+            ("GET", "/contents/", 0, CONTENTS_EFFORT),
             ("GET", "/pulls?state=open", 0,
              [{"number": 7, "head": {"ref": "5-remove-claude-model"}}]),
             ("GET", "repos/martymcenroe/mid", 0, REPO_META),
         ])
-        assert "open PR #7" in process_repo(r, "mid", apply=True)
-        assert r.mutations() == []
+        out = process_repo(r, "mid", apply=False, key="effort")
+        assert out.startswith("dry-run")
 
     def test_dry_run_issues_no_mutating_calls(self):
         r = FakeRunner([
-            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/contents/", 0, CONTENTS_EFFORT),
             ("GET", "/pulls?state=open", 0, []),
             ("GET", "repos/martymcenroe/live", 0, REPO_META),
         ])
-        out = process_repo(r, "live", apply=False)
+        out = process_repo(r, "live", apply=False, key="effort")
         assert out.startswith("dry-run")
         assert r.mutations() == []
 
 
 # ---------------------------------------------------------------------------
-# process_repo — happy path
+# process_repo — happy path (key=effort)
 # ---------------------------------------------------------------------------
 
 class TestHappyPath:
     def _runner(self) -> FakeRunner:
         return FakeRunner([
-            ("GET", "/contents/", 0, CONTENTS),
+            ("GET", "/contents/", 0, CONTENTS_EFFORT),
             ("GET", "/pulls?state=open", 0, []),
             ("POST", "/issues", 0, {"number": 41}),
             ("GET", "/git/ref/heads/main", 0, {"object": {"sha": "f" * 40}}),
@@ -190,18 +220,20 @@ class TestHappyPath:
         ])
 
     def test_full_cycle_reports_issue_pr_and_squash(self):
-        out = process_repo(self._runner(), "live", apply=True)
+        out = process_repo(self._runner(), "live", apply=True, key="effort")
         assert out == "merged: issue #41, PR #42, squash deadbeef"
 
-    def test_branch_named_after_issue(self):
+    def test_branch_named_after_issue_and_key(self):
         r = self._runner()
-        process_repo(r, "live", apply=True)
-        ref_calls = [c for c in r.calls if c[2].endswith("/git/refs")]
-        assert len(ref_calls) == 1  # branch created exactly once
+        process_repo(r, "live", apply=True, key="effort")
+        ref_idx = [i for i, c in enumerate(r.calls) if c[2].endswith("/git/refs")]
+        assert len(ref_idx) == 1
+        payload = json.loads(r.inputs[ref_idx[0]])
+        assert payload["ref"] == "refs/heads/41-remove-claude-effort"
 
     def test_no_force_tokens_in_any_gh_argv(self):
         r = self._runner()
-        process_repo(r, "live", apply=True)
+        process_repo(r, "live", apply=True, key="effort")
         banned = {"-D", "--force", "--force-with-lease", "--admin", "--no-verify"}
         for call in r.calls:
             assert not banned.intersection(call), call
@@ -211,7 +243,7 @@ class TestHappyPath:
         r.routes.insert(0, ("GET", "/pulls/42", 0,
                             {"mergeable_state": "unstable", "merged": True,
                              "merge_commit_sha": "deadbeefcafe"}))
-        out = process_repo(r, "live", apply=True)
+        out = process_repo(r, "live", apply=True, key="effort")
         assert out.startswith("merged:")
 
 
@@ -233,18 +265,19 @@ class TestWaitForMergeable:
 
 
 # ---------------------------------------------------------------------------
-# find_existing_pr
+# find_existing_pr — key-scoped suffix matching
 # ---------------------------------------------------------------------------
 
-def test_find_existing_pr_matches_suffix_only():
+def test_find_existing_pr_matches_requested_key_only():
     r = FakeRunner([
         ("GET", "/pulls?state=open", 0,
-         [{"number": 3, "head": {"ref": "other-branch"}},
-          {"number": 4, "head": {"ref": "12-remove-claude-model"}}]),
+         [{"number": 3, "head": {"ref": "12-remove-claude-model"}},
+          {"number": 4, "head": {"ref": "13-remove-claude-effort"}}]),
     ])
-    assert find_existing_pr(r, "x") == 4
+    assert find_existing_pr(r, "x", "effort") == 4
+    assert find_existing_pr(r, "x", "model") == 3
 
 
 def test_find_existing_pr_none_when_no_match():
     r = FakeRunner([("GET", "/pulls?state=open", 0, [])])
-    assert find_existing_pr(r, "x") is None
+    assert find_existing_pr(r, "x", "effort") is None

--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -718,10 +718,10 @@ class TestMainLocalWorkflow:
         # #1060: deprecated and ignored by /onboard; should not be emitted.
         assert "pickupThresholdMinutes" not in config["onboard"]
         # Sanity: still has the rest of the structure.
-        # #1727: no model key — the Claude wrapper retired --model injection,
-        # so scaffolding one would be inert config that misleads readers.
-        assert "model" not in config["claude"]
-        assert config["claude"]["effort"] == "max"
+        # #1727/#1732: no claude block at all — the wrapper retired --model
+        # and --effort injection; scaffolding either would be inert config
+        # that misleads readers. The wrapper handles absence via .get().
+        assert "claude" not in config
         assert config["onboard"]["auto"] is True
 
     @patch("new_repo.config")

--- a/tools/fleet_remove_claude_key.py
+++ b/tools/fleet_remove_claude_key.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
-"""Fleet-wide removal of the inert `.unleashed.json` `claude.model` key.
+"""Fleet-wide removal of an inert `.unleashed.json` `claude.<key>` field.
 
-AssemblyZero #1730.
+AssemblyZero #1730 (model sweep), generalized in #1733 (`--key {model,effort}`).
 
-The Claude wrapper no longer reads `claude.model` — model choice belongs to
-Claude Code's native settings hierarchy (the operator's /model default in
-user settings; a committed `.claude/settings.json` for a deliberate per-repo
-pin). Any `claude.model` left in a repo's `.unleashed.json` is dead config
-that misleads readers into thinking it decides something. The scaffolder
-stopped minting the key in #1727; this tool sweeps the existing fleet.
+The Claude wrapper retired both `--model` and `--effort` injection: session
+shaping belongs to Claude Code's native settings hierarchy (the operator's
+`/model` and `effortLevel` user defaults; a committed `.claude/settings.json`
+for a deliberate per-repo pin). Any `claude.model` or `claude.effort` left in
+a repo's `.unleashed.json` is dead config that misleads readers into thinking
+it decides something. The scaffolder stopped minting the fields in #1727 and
+#1732; this tool sweeps the existing fleet, one key per run.
 
 For each named repo this tool:
 
   1. Skips if the repo or its `.unleashed.json` does not exist on origin.
-  2. Skips if `claude.model` is absent (idempotent re-runs).
-  3. Skips if an open PR from a prior run exists (idempotent).
+  2. Skips if `claude.<key>` is absent (idempotent re-runs).
+  3. Skips if an open PR from a prior run FOR THIS KEY exists (idempotent).
   4. Files a per-repo issue describing the change.
   5. Creates a branch from the default-branch HEAD.
-  6. Removes ONLY the `claude.model` key via the Contents API — key order,
-     sibling fields, 2-space indent, LF endings, trailing newline preserved.
+  6. Removes ONLY `claude.<key>` via the Contents API — key order, sibling
+     fields, 2-space indent, LF endings, trailing newline preserved.
   7. Opens a PR carrying `Closes #N` for that repo's issue.
   8. Polls `mergeable_state` until clean/unstable, then squash-merges.
   9. Verifies the merge actually landed before reporting success.
@@ -33,8 +34,8 @@ Generated issue/PR bodies carry no cross-repo references: each repo's
 artifacts describe the change in that repo only.
 
 Usage:
-    poetry run python tools/fleet_remove_claude_model.py --repos a,b,c
-    poetry run python tools/fleet_remove_claude_model.py --repos a,b,c --apply
+    poetry run python tools/fleet_remove_claude_key.py --key model  --repos a,b
+    poetry run python tools/fleet_remove_claude_key.py --key effort --repos a,b --apply
 
 Dry-run is the default: prints the per-repo plan and the exact resulting
 JSON, takes no action. `--apply` mutates.
@@ -51,7 +52,7 @@ from typing import Any, Callable, Optional
 
 GITHUB_USER = "martymcenroe"
 TARGET_PATH = ".unleashed.json"
-BRANCH_SUFFIX = "remove-claude-model"
+VALID_KEYS = ("model", "effort")
 HTTP_TIMEOUT_S = 60
 POLL_INTERVAL_S = 10
 MERGEABLE_TIMEOUT_S = 300
@@ -63,35 +64,43 @@ TERMINAL_BAD_STATES = {"dirty", "draft"}
 # running; required ones passed (fleet merges gate on a single required check).
 MERGEABLE_OK_STATES = {"clean", "unstable"}
 
-ISSUE_TITLE = "Remove inert claude.model from .unleashed.json"
+# Per-key rationale sentence used in generated issue/PR bodies.
+KEY_CONTEXT = {
+    "model": (
+        "model choice belongs to Claude Code's native settings hierarchy "
+        "(the operator's `/model` default; a committed "
+        "`.claude/settings.json` for a deliberate per-repo pin)"
+    ),
+    "effort": (
+        "effort belongs to the operator's `effortLevel` user setting "
+        "(a committed `.claude/settings.json` covers a deliberate "
+        "per-repo pin)"
+    ),
+}
 
-ISSUE_BODY = """## Context
+ISSUE_BODY_TEMPLATE = """## Context
 
-The Claude wrapper no longer reads `claude.model` from `.unleashed.json` —
-model choice belongs to Claude Code's native settings hierarchy (the
-operator's `/model` default; a committed `.claude/settings.json` for a
-deliberate per-repo pin). This repo's `.unleashed.json` still carries the
-key, where it is dead config that misleads readers.
+The Claude wrapper no longer reads `claude.{key}` from `.unleashed.json` —
+{context}. This repo's `.unleashed.json` still carries the key, where it is
+dead config that misleads readers.
 
 ## Scope
 
-Remove ONLY `claude.model`. Sibling fields (`effort`, `permissionMode`,
-`onboard`, etc.) are preserved, as are key order, indent, and line endings.
-No behavior change: the wrapper ignores the key at every version still in
-service.
+Remove ONLY `claude.{key}`. Sibling fields are preserved, as are key order,
+indent, and line endings. No behavior change: the wrapper ignores the key at
+every version still in service.
 
-Filed and processed automatically by `tools/fleet_remove_claude_model.py`
+Filed and processed automatically by `tools/fleet_remove_claude_key.py`
 in AssemblyZero.
 """
 
 PR_BODY_TEMPLATE = """## Summary
 
-Removes the inert `claude.model` key from `.unleashed.json`. The Claude
-wrapper no longer reads it; model choice belongs to Claude Code's native
-settings hierarchy. Sibling fields, key order, indent, and line endings are
-preserved. No behavior change.
+Removes the inert `claude.{key}` key from `.unleashed.json`. The Claude
+wrapper no longer reads it; {context}. Sibling fields, key order, indent,
+and line endings are preserved. No behavior change.
 
-Filed and processed automatically by `tools/fleet_remove_claude_model.py`
+Filed and processed automatically by `tools/fleet_remove_claude_key.py`
 in AssemblyZero.
 
 Closes #{issue_number}
@@ -103,6 +112,14 @@ class GhError(RuntimeError):
 
 
 Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def branch_suffix(key: str) -> str:
+    return f"remove-claude-{key}"
+
+
+def issue_title(key: str) -> str:
+    return f"Remove inert claude.{key} from .unleashed.json"
 
 
 def run(cmd: list[str], *, timeout: int = HTTP_TIMEOUT_S,
@@ -134,27 +151,27 @@ def gh_api(runner: Runner, path: str, *, method: str = "GET",
     return json.loads(out) if out else {}
 
 
-def compute_new_content(current_b64: str) -> Optional[str]:
-    """New `.unleashed.json` text with `claude.model` removed.
+def compute_new_content(current_b64: str, key: str) -> Optional[str]:
+    """New `.unleashed.json` text with `claude.<key>` removed.
 
-    Returns None when there is nothing to do (no claude block / no model
+    Returns None when there is nothing to do (no claude block / no such
     key). Preserves key order and sibling fields; emits the fleet house
     style: 2-space indent, LF-only, trailing newline, non-ASCII unescaped.
     """
     raw = base64.b64decode(current_b64).decode("utf-8")
     cfg = json.loads(raw)
     claude = cfg.get("claude")
-    if not isinstance(claude, dict) or "model" not in claude:
+    if not isinstance(claude, dict) or key not in claude:
         return None
-    del claude["model"]
+    del claude[key]
     return json.dumps(cfg, indent=2, ensure_ascii=False) + "\n"
 
 
-def find_existing_pr(runner: Runner, repo: str) -> Optional[int]:
-    """Open PR from a prior run of this tool, if any."""
+def find_existing_pr(runner: Runner, repo: str, key: str) -> Optional[int]:
+    """Open PR from a prior run of this tool FOR THIS KEY, if any."""
     prs = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/pulls?state=open&per_page=50")
     for pr in prs or []:
-        if pr.get("head", {}).get("ref", "").endswith(BRANCH_SUFFIX):
+        if pr.get("head", {}).get("ref", "").endswith(branch_suffix(key)):
             return pr["number"]
     return None
 
@@ -179,7 +196,7 @@ def wait_for_mergeable(runner: Runner, repo: str, pr_number: int,
     return f"timeout:{state}"
 
 
-def process_repo(runner: Runner, repo: str, apply: bool) -> str:
+def process_repo(runner: Runner, repo: str, apply: bool, key: str) -> str:
     """Run the full cycle for one repo. Returns a one-line outcome."""
     print(f"\n=== {repo} ===")
 
@@ -196,11 +213,11 @@ def process_repo(runner: Runner, repo: str, apply: bool) -> str:
     if info is None:
         return f"skip: no {TARGET_PATH} on {default_branch}"
 
-    new_content = compute_new_content(info["content"])
+    new_content = compute_new_content(info["content"], key)
     if new_content is None:
-        return "skip: claude.model already absent"
+        return f"skip: claude.{key} already absent"
 
-    existing = find_existing_pr(runner, repo)
+    existing = find_existing_pr(runner, repo, key)
     if existing is not None:
         return f"skip: open PR #{existing} from a prior run"
 
@@ -210,21 +227,24 @@ def process_repo(runner: Runner, repo: str, apply: bool) -> str:
 
     issue = gh_api(
         runner, f"repos/{GITHUB_USER}/{repo}/issues", method="POST",
-        payload={"title": ISSUE_TITLE, "body": ISSUE_BODY},
+        payload={
+            "title": issue_title(key),
+            "body": ISSUE_BODY_TEMPLATE.format(key=key, context=KEY_CONTEXT[key]),
+        },
     )
     issue_number = issue["number"]
     print(f"  issue #{issue_number}")
 
     head = gh_api(runner, f"repos/{GITHUB_USER}/{repo}/git/ref/heads/{default_branch}")
     head_sha = head["object"]["sha"]
-    branch = f"{issue_number}-{BRANCH_SUFFIX}"
+    branch = f"{issue_number}-{branch_suffix(key)}"
     gh_api(
         runner, f"repos/{GITHUB_USER}/{repo}/git/refs", method="POST",
         payload={"ref": f"refs/heads/{branch}", "sha": head_sha},
     )
     print(f"  branch {branch} @ {head_sha[:8]}")
 
-    title = f"chore: remove inert claude.model from .unleashed.json (Closes #{issue_number})"
+    title = f"chore: remove inert claude.{key} from .unleashed.json (Closes #{issue_number})"
     gh_api(
         runner, f"repos/{GITHUB_USER}/{repo}/contents/{TARGET_PATH}", method="PUT",
         payload={
@@ -242,7 +262,9 @@ def process_repo(runner: Runner, repo: str, apply: bool) -> str:
             "title": title,
             "head": branch,
             "base": default_branch,
-            "body": PR_BODY_TEMPLATE.format(issue_number=issue_number),
+            "body": PR_BODY_TEMPLATE.format(
+                key=key, context=KEY_CONTEXT[key], issue_number=issue_number,
+            ),
         },
     )
     pr_number = pr["number"]
@@ -267,6 +289,8 @@ def process_repo(runner: Runner, repo: str, apply: bool) -> str:
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--key", required=True, choices=VALID_KEYS,
+                        help="Which claude.<key> field to remove fleet-wide")
     parser.add_argument("--repos", required=True,
                         help="Comma-separated owner-less repo names to sweep")
     parser.add_argument("--apply", action="store_true",
@@ -281,12 +305,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     repos = repos[: args.limit]
 
     mode = "APPLY" if args.apply else "DRY-RUN"
-    print(f"fleet_remove_claude_model [{mode}] over {len(repos)} repo(s)")
+    print(f"fleet_remove_claude_key [{mode}] key={args.key} over {len(repos)} repo(s)")
 
     outcomes: dict[str, str] = {}
     for repo in repos:
         try:
-            outcomes[repo] = process_repo(run, repo, args.apply)
+            outcomes[repo] = process_repo(run, repo, args.apply, args.key)
         except (GhError, KeyError, json.JSONDecodeError) as exc:
             outcomes[repo] = f"ERROR: {exc}"
         print(f"  -> {outcomes[repo]}")

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -1096,7 +1096,7 @@ This document provides a complete inventory of files in the {name} project, orga
 ├── README.md                   # Project overview
 ├── LICENSE                     # PolyForm Noncommercial 1.0.0
 ├── .gitignore                  # Git ignore rules
-└── .unleashed.json             # Unleashed wrapper config (effort)
+└── .unleashed.json             # Unleashed wrapper config
 ```
 
 ---
@@ -1141,14 +1141,18 @@ Use `/audit` to verify structure compliance with AssemblyZero standards.
 def create_unleashed_json(project_path: Path) -> None:
     """Create .unleashed.json with standard wrapper configuration.
 
-    Sets effort=max. No "model" key is emitted (#1727): the Claude wrapper
-    retired --model injection entirely, so model choice belongs to Claude
-    Code's native settings hierarchy — the operator's /model default, or a
-    committed .claude/settings.json for a deliberate per-repo pin. A model
-    key here would be inert config that misleads readers. (History: the old
-    scaffold hardcoded "claude-opus-4-7[1M]", which forced every new repo
-    onto Opus 4.7 once 4.8 shipped; the interim scaffold wrote the bare
-    "opus" alias, which the wrapper deferred on.)
+    No "claude" block is emitted (#1727 model, #1732 effort): the Claude
+    wrapper retired --model and --effort injection entirely, so session
+    shaping belongs to Claude Code's native settings hierarchy — the
+    operator's /model and effortLevel user defaults, or a committed
+    .claude/settings.json for a deliberate per-repo pin. Any claude.*
+    scaffold value would be inert config that misleads readers. The wrapper
+    reads config.get('claude', {}), so absence is handled; fleet
+    permission-mode tooling creates the block on demand when it sets
+    permissionMode. (History: the old scaffold hardcoded
+    "claude-opus-4-7[1M]", which forced every new repo onto Opus 4.7 once
+    4.8 shipped; the interim scaffold wrote the bare "opus" alias plus
+    effort=max, both retired since.)
 
     `assemblyZero` defaults to True (#1059): repos created by this tool
     are by definition AssemblyZero-managed, so /onboard should load
@@ -1163,9 +1167,6 @@ def create_unleashed_json(project_path: Path) -> None:
     """
     content = json.dumps({
         "profile": "default",
-        "claude": {
-            "effort": "max"
-        },
         "assemblyZero": True,
         "onboard": {
             "auto": True,
@@ -2804,7 +2805,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     # Step 11b: Create .unleashed.json (wrapper configuration)
     print("\n11b. Creating .unleashed.json...")
     create_unleashed_json(project_path)
-    print("  Created .unleashed.json (effort=max; no model key -- #1727)")
+    print("  Created .unleashed.json (no claude block -- #1727/#1732)")
 
     # Step 11b2: Bootstrap Python project (#1058) — pyproject.toml,
     # pytest, pytest-cov, conftest.py. Required for AZ implementation


### PR DESCRIPTION
## What

Effort eradication, generator + tooling side. The Claude wrapper retired `--effort` injection the same way it retired `--model`: session shaping belongs to Claude Code's native settings (the operator's `effortLevel` user setting; a committed `.claude/settings.json` for a deliberate per-repo pin).

**Scaffolder (#1732):** `new_repo.py` no longer emits a `claude` block at all — with model (#1727) and now effort gone it would be empty. The wrapper reads `config.get('claude', {})` so absence is handled; fleet permission-mode tooling creates the block on demand. Docstring, directory-tree comment, and the step 11b print updated; `test_T265` now asserts no `claude` key.

**Sweep tool generalized (#1733):** `fleet_remove_claude_model.py` renamed via git mv to `fleet_remove_claude_key.py` with a required `--key {model,effort}`. Branch suffix (`N-remove-claude-<key>`), issue/PR templates (per-key rationale paragraph, still membrane-clean with no cross-repo references), the pure edit function, and prior-run PR detection are parameterized - a leftover model-sweep PR cannot mask an effort sweep (tested). `--key model` behavior is byte-equivalent to the original tool; idempotent skips make re-runs safe.

## Verification

- 126 tests pass (103 scaffolder + 23 sweep-tool, including new effort cases, key-scoped PR detection, branch-name payload assertion, dry-run mutation-safety, no-force-token guard).
- ruff: zero findings on the renamed tool and its tests; the 20 pre-existing findings in new_repo.py/test_new_repo.py remain tracked in #1728.

Next step after merge: run the effort sweep across the fleet (~70+ unique repos carry `claude.effort=max`), dry-run first.

Closes #1732, Closes #1733
