### PR TITLE
feat(hooks): bare-claude-guard.sh blocks 'claude <positional>' from agent shells (Closes #1734)

### DIFF
--- a/.claude/hooks/bare-claude-guard.sh
+++ b/.claude/hooks/bare-claude-guard.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# bare-claude-guard.sh — PreToolUse[Bash] hook (#1734).
+#
+# Blocks agent Bash commands that invoke `claude` with a POSITIONAL first
+# argument. Claude Code v2.x parses removed subcommands as prompts, so
+# `claude config list` silently forks a live auto-mode agent session in cwd
+# with prompt "config" — observed 2026-07-10: the forked session performed a
+# real handoff and spawned a wrapper window (full evidence in the wrapper
+# repo's tracker). A rule in a memory file is advice to a future model; this
+# hook is harness-executed enforcement.
+#
+# Allowed by construction:
+#   claude --help / --version / any flag-first invocation
+#   CLAUDECODE="" claude --print "..."      (sanctioned LLM-call pattern)
+#   prose containing the word claude        (echo claude config, git commit -m "claude x")
+#   hyphenated binaries                     (unleashed-claude-tool foo)
+#
+# Blocked:
+#   claude config list | claude doctor | claude "prompt" | cd x && claude foo
+#   VAR=val claude foo | $(claude foo) | ... | claude foo
+#
+# Known limitation (documented, accepted): a claude invocation prefixed by a
+# word-form wrapper the anchor list doesn't name (e.g. `time claude foo`)
+# passes this guard. The sentinel layer and the banned-pattern list remain
+# defense-in-depth; extend BLOCK_RE's anchor group if a new form shows up.
+#
+# PreToolUse protocol: exit 0 = allow; exit 2 = block, stderr shown to model.
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+
+# Anchor: start-of-line / ; & | ( / $( — then optional env-var assignments,
+# optional `command`/`exec`, then claude(.exe|.cmd) followed by a first arg
+# that does not start with a dash.
+BLOCK_RE='(^|[;&|(]|\$\()[[:space:]]*([A-Za-z_][A-Za-z_0-9]*=[^[:space:]]*[[:space:]]+)*(command[[:space:]]+|exec[[:space:]]+)?claude(\.exe|\.cmd)?[[:space:]]+[^-[:space:]]'
+
+if printf '%s' "$cmd" | grep -qE "$BLOCK_RE"; then
+    cat >&2 <<'MSG'
+BLOCKED by bare-claude-guard (#1734): `claude <word>` forks a live agent
+session — Claude Code parses removed subcommands as PROMPTS (a one-word
+accidental prompt has performed a real handoff before). Use flag-only forms
+(claude --help, claude --version) or the sanctioned LLM-call pattern
+(CLAUDECODE="" claude --print "..."). If you genuinely need a claude
+subcommand, ask the operator to run it in their own terminal.
+MSG
+    exit 2
+fi
+exit 0

--- a/tests/unit/test_bare_claude_guard.py
+++ b/tests/unit/test_bare_claude_guard.py
@@ -1,0 +1,79 @@
+"""Drive .claude/hooks/bare-claude-guard.sh with real PreToolUse JSON (#1734).
+
+Each case pipes a JSON payload through the actual bash script via subprocess
+(Git Bash is a hard dependency of this environment). exit 0 = allowed,
+exit 2 = blocked.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "bare-claude-guard.sh"
+
+
+def run_hook(command: str | None) -> subprocess.CompletedProcess:
+    payload = {"tool_name": "Bash"}
+    if command is not None:
+        payload["tool_input"] = {"command": command}
+    return subprocess.run(
+        ["bash", str(HOOK)], input=json.dumps(payload),
+        capture_output=True, text=True, timeout=15,
+    )
+
+
+BLOCKED = [
+    "claude config list 2>/dev/null | head -15",  # the 2026-07-10 incident, verbatim shape
+    "claude doctor",
+    'claude "tell me a joke"',
+    "cd /c/x && claude update",
+    "cd /c/x; claude mcp list",
+    "OUT=$(claude foo)",
+    "CLAUDECODE= claude config list",          # env prefix stepped over
+    "FOO=bar BAZ=qux claude anything",
+    "true | claude subcommand",
+    "exec claude repl",
+    "command claude plugin",
+    "claude.exe doctor",
+]
+
+ALLOWED = [
+    "claude --help",
+    "claude --version",
+    'CLAUDECODE="" claude --print "summarize this"',
+    "claude -p 'quick question'",
+    "echo claude config",                       # prose, not an invocation
+    'git commit -m "claude config cleanup"',
+    "unleashed-claude-tool foo",                # hyphenated binary
+    "grep -r claude tools/",
+    "ls",
+    "",
+]
+
+
+@pytest.mark.parametrize("cmd", BLOCKED)
+def test_blocked(cmd):
+    proc = run_hook(cmd)
+    assert proc.returncode == 2, f"should block: {cmd!r}\nstderr={proc.stderr}"
+    assert "bare-claude-guard" in proc.stderr
+
+
+@pytest.mark.parametrize("cmd", ALLOWED)
+def test_allowed(cmd):
+    proc = run_hook(cmd)
+    assert proc.returncode == 0, f"should allow: {cmd!r}\nstderr={proc.stderr}"
+
+
+def test_missing_tool_input_allows():
+    assert run_hook(None).returncode == 0
+
+
+def test_malformed_json_allows_fail_open():
+    proc = subprocess.run(
+        ["bash", str(HOOK)], input="not json at all",
+        capture_output=True, text=True, timeout=15,
+    )
+    assert proc.returncode == 0


### PR DESCRIPTION
## What

`.claude/hooks/bare-claude-guard.sh` + 24 subprocess tests. PreToolUse[Bash] hook that blocks agent commands invoking `claude` with a positional (non-flag) first argument, exit 2 with a pointed stderr message.

## Why

Claude Code v2.x parses removed subcommands as PROMPTS: on 2026-07-10 an agent probe `claude config list` forked a live auto-mode session whose one-word prompt led to a real handoff and a spawned wrapper window. A memory file is advice to a future model; a PreToolUse hook is harness-executed enforcement - the model's in-the-moment judgment is not part of the chain.

## Behavior

- Blocked: `claude config list`, `claude doctor`, `claude "prompt"`, `cd x && claude foo`, `VAR=v claude foo`, `$(claude foo)`, `exec claude repl`, `claude.exe doctor`.
- Allowed: `claude --help` / `--version` (flag-first), the sanctioned `CLAUDECODE="" claude --print "..."` LLM-call pattern, prose mentions (`echo claude config`, commit messages), hyphenated binaries (`unleashed-claude-tool`).
- Fails OPEN on missing/malformed input so a hook bug cannot brick every Bash call.
- Documented limitation: word-form wrappers outside the anchor list (`time claude foo`) pass; the sentinel layer remains defense-in-depth and the anchor group is trivially extensible.

## Verification

24/24 tests drive the real bash script via subprocess with PreToolUse-shaped JSON - the incident command is a verbatim blocked case.

Install (machine-local, operator settings, not a repo artifact): add a fourth command entry to the existing PreToolUse Bash matcher group in user settings.json pointing at this script. That wiring happens outside this PR.

Closes #1734
