### PR TITLE
fix(hooks): bare-claude-guard masks quoted strings before matching (Closes #1739)

### DIFF
--- a/.claude/hooks/bare-claude-guard.sh
+++ b/.claude/hooks/bare-claude-guard.sh
@@ -30,12 +30,21 @@ input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -z "$cmd" ] && exit 0
 
+# #1739: mask quoted strings BEFORE matching — a regex cannot parse shell
+# quoting, and the guard's first live block was a false positive on prose
+# inside a quoted --comment argument. Quoted substrings become the bare
+# placeholder QSTR: real invocations are unquoted at command position and
+# still match; a quoted PROMPT (claude "do x") still matches because QSTR
+# itself is a non-flag positional. Residual documented hole: heredoc bodies
+# are not masked.
+residue=$(printf '%s' "$cmd" | sed -e "s/'[^']*'/QSTR/g" -e 's/"[^"]*"/QSTR/g')
+
 # Anchor: start-of-line / ; & | ( / $( — then optional env-var assignments,
 # optional `command`/`exec`, then claude(.exe|.cmd) followed by a first arg
 # that does not start with a dash.
 BLOCK_RE='(^|[;&|(]|\$\()[[:space:]]*([A-Za-z_][A-Za-z_0-9]*=[^[:space:]]*[[:space:]]+)*(command[[:space:]]+|exec[[:space:]]+)?claude(\.exe|\.cmd)?[[:space:]]+[^-[:space:]]'
 
-if printf '%s' "$cmd" | grep -qE "$BLOCK_RE"; then
+if printf '%s' "$residue" | grep -qE "$BLOCK_RE"; then
     cat >&2 <<'MSG'
 BLOCKED by bare-claude-guard (#1734): `claude <word>` forks a live agent
 session — Claude Code parses removed subcommands as PROMPTS (a one-word

--- a/tests/unit/test_bare_claude_guard.py
+++ b/tests/unit/test_bare_claude_guard.py
@@ -51,6 +51,11 @@ ALLOWED = [
     "grep -r claude tools/",
     "ls",
     "",
+    # #1739 regression: the guard's first live block was THIS false positive —
+    # quoted prose containing the incident command (with a paren anchor)
+    # inside a gh argument. Quoted strings are masked before matching now.
+    'gh issue close 756 --comment "text (CLAUDECODE= claude config list) more text"',
+    "git commit -m 'guard blocks claude doctor probes'",
 ]
 
 


### PR DESCRIPTION
First live block was a false positive: quoted prose inside a gh --comment argument matched the command-position regex. Quoted substrings are now masked to a bare QSTR placeholder before BLOCK_RE applies - real invocations and quoted prompts still block, quoted prose passes. The offending command shape is a regression test (26 total). Heredoc bodies remain a documented residual hole. Follow-up to #1734 / PR #1736. Closes #1739