### PR TITLE
feat(skills): quote/rista land via tracked_pr_land; blog-draft wraps blog_draft.py (Closes #1742)

### DIFF
--- a/.claude/skills/blog-draft.md
+++ b/.claude/skills/blog-draft.md
@@ -8,6 +8,13 @@ scope: global
 
 Create a blog post draft in the dispatch repo, stamped with the source project.
 
+**This skill is a thin wrapper.** All deterministic work — project-anchor
+detection, date stamping, Windows-safe slug generation, model attribution from
+config, filename collision guard, template scaffolding — lives in tested Python
+(`blog_draft.py`, 36 tests). The skill runs the script and reports; it does NOT
+re-implement any of that logic in prose. If the scaffold ever looks wrong, fix
+the script, not this file.
+
 ## Usage
 
 ```
@@ -17,67 +24,28 @@ Create a blog post draft in the dispatch repo, stamped with the source project.
 
 ## Execution
 
-### Step 1: Extract Context
+### Step 1: Run the scaffolder
 
-1. Get the **source project** from the current working directory:
-   - Extract project name from path (e.g., `/c/Users/mcwiz/Projects/AssemblyZero` → `AssemblyZero`)
-
-2. Get **today's date** in YYYY-MM-DD format
-
-3. Generate **slug** from the title:
-   - Lowercase, replace spaces with hyphens, remove special characters
-   - Example: "My Amazing Discovery" → "my-amazing-discovery"
-
-### Step 2: Create Draft File
-
-**Location:** `C:\Users\mcwiz\Projects\dispatch\drafts\{date}-{slug}-from-{project}.md`
-
-**Template:**
-
-```markdown
----
-title: "{title}"
-source_project: {project}
-created: {date}
-status: draft
-tags: []
----
-
-# {title}
-
-*[Opening hook - what's the problem or insight?]*
-
----
-
-## The Context
-
-[What were you working on? What led to this?]
-
-## The Discovery/Solution
-
-[The meat of the post - what did you learn or build?]
-
-## Why It Matters
-
-[So what? Why should readers care?]
-
-## Try It Yourself
-
-[If applicable - how can readers use this?]
-
----
-
-*Built with Claude Opus 4.5. Source: {project}*
+```bash
+(cd /c/Users/mcwiz/Projects/unleashed && poetry run python src/blog_draft.py \
+  --title "{TITLE}" \
+  --project-path "{CURRENT_PROJECT_ROOT}")
 ```
 
-### Step 3: Report
+`{CURRENT_PROJECT_ROOT}` is the repo you are working in (the script anchors the
+draft's `source_project` to it). The script prints the created draft's full
+path; on a filename collision it refuses rather than overwriting — report that
+to the user instead of working around it.
 
-After creating the file, report:
-- Full path to the draft
-- Suggested next steps (fill in sections, run `/blog-review` when ready)
+### Step 2: Report
+
+- Full path to the created draft (clickable link + plain path per house style).
+- Suggested next steps: fill in the scaffold's sections, run `/blog-review` in
+  dispatch when ready.
 
 ## Notes
 
-- Drafts are **not committed** until explicitly requested
-- The dispatch repo has a `STYLE-GUIDE.md` - read it if tone guidance is needed
-- Use `/blog-review` in dispatch to get AI feedback on drafts
+- Drafts are **not committed** until explicitly requested.
+- The dispatch repo has a `STYLE-GUIDE.md` — read it if tone guidance is needed.
+- `--dry-run` previews without writing; `--date` overrides the stamp if the
+  user asks for a specific date.

--- a/.claude/skills/quote.md
+++ b/.claude/skills/quote.md
@@ -79,19 +79,37 @@ Read: `C:\Users\mcwiz\Projects\AssemblyZero\wiki\Claudes-World.md`
 
 Use Edit tool to insert the new entry before `## About This Page`.
 
-## Step 7: Commit to AssemblyZero
+## Step 7: Commit to AssemblyZero via the shared PR-lander
+
+Main is branch-protected — a direct `git push` from main is rejected, and the
+hand-rolled push/poll/merge sequence is the retired anti-pattern. File a
+tracking issue, branch with the edit, commit, and hand the whole
+push→PR→poll→merge→verify→graft cycle to the shared driver (bounded poll,
+verify-gate before any branch deletion, ADR-0217 graft hardcoded, squash SHA
+looked up by PR number, fail-safe protection probe):
 
 ```bash
+ISSUE_N=$(gh issue create --repo martymcenroe/AssemblyZero \
+  --title "docs(wiki): add quote to Claude's World {DATE}" \
+  --body "Auto-created by /quote to track the wiki-page commit." \
+  | grep -oE '[0-9]+$')
+BRANCH="quote-{DATE}-{slug}"
+git -C /c/Users/mcwiz/Projects/AssemblyZero checkout -b $BRANCH
 git -C /c/Users/mcwiz/Projects/AssemblyZero add wiki/Claudes-World.md
+git -C /c/Users/mcwiz/Projects/AssemblyZero commit -m "docs(wiki): add quote to Claude's World (Closes #${ISSUE_N})"
+(cd /c/Users/mcwiz/Projects/unleashed && poetry run python src/tracked_pr_land.py \
+  --repo /c/Users/mcwiz/Projects/AssemblyZero \
+  --branch $BRANCH \
+  --title "docs(wiki): add quote to Claude's World (Closes #${ISSUE_N})" \
+  --issue ${ISSUE_N} \
+  --body "Quote memorialized by /quote.
+
+Closes #${ISSUE_N}")
 ```
 
-```bash
-git -C /c/Users/mcwiz/Projects/AssemblyZero commit -m "docs(wiki): add quote to Claude's World"
-```
-
-```bash
-git -C /c/Users/mcwiz/Projects/AssemblyZero push
-```
+Exit `0` = merged, verified on origin/main, branch grafted + deleted. Non-zero =
+STOP and report the issue number, branch, and the driver's final `stage=…` line.
+Do NOT escalate to `--admin` / `--no-verify` / force-push / `branch -D`.
 
 ## Step 8: Sync Wiki Repo
 

--- a/.claude/skills/rista.md
+++ b/.claude/skills/rista.md
@@ -1,0 +1,159 @@
+---
+description: Inscribe names into the Well of Names (Kastalia) — the fleet's mythological-naming store
+allowed-tools: Bash, Read, Edit, Write, Glob
+scope: global
+---
+
+# Rista — the pen of the Well of Names
+
+`rista` (Old Norse *rísta*, "to carve runes"; Younger Futhark **ᚱᛁᛋᛏᛅ**) inscribes
+naming material into the fleet's **Well of Names**, which is itself named
+**Kastalia** (`dispatch/ideas/the-well-of-names.md`, on dispatch `main`). It is
+the `/quote`-analog for names: where `/quote` memorializes Discworld wisdom to
+Claude's World, `/rista` carves a drawn name — or a raw term — into the well so
+no future naming starts from a dry bucket or collides with a name already on the
+line.
+
+This skill **replaces** the old universal-CLAUDE.md hand-commit instruction for
+naming discussions. When a mythological name is discussed, run `/rista`.
+
+> Adopted into the canonical skills source 2026-07-11 (previously machine-local
+> only) with the landing sequence wired to the shared PR-lander.
+
+## Doctrine (non-negotiable)
+
+- **Native script always.** Greek in Greek (Κασταλία), Norse in runes (Younger
+  Futhark), Hebrew in Hebrew (דממה) — native form **plus** transliteration in
+  every entry. Do not invent rune/script spellings from memory beyond trivial
+  transliteration; verify first.
+- **Append-only.** Never rewrite an existing entry except to annotate a dedup.
+  The well is a record of what was set down as much as what was chosen.
+- **Every name keeps its losers.** An entry records the chosen name AND every
+  candidate set back down, each with its reasoning and state (in service /
+  drawn / set back down / reserve bucket). The set-down names are half the value.
+- **Isolation.** NEVER edit the operator's live `dispatch` checkout — it
+  routinely carries uncommitted work. All edits happen in an isolated worktree.
+
+## Modes
+
+**No arguments** — scan the recent conversation for a naming discussion (as
+`/quote` finds the quote) and inscribe the full outcome: chosen name, candidate
+set, reasoning, filed under the correct state and language mouth.
+
+**Arguments — keywords and/or quoted phrases**, e.g. `/rista funklein 'scintilla anime'`.
+Inscribe EACH term. Per term:
+- **Spelling / diacritic correction, silent but noted**: `funklein` → **Fünklein**;
+  `scintilla anime` → **scintilla animae**. Correct it; note the correction in the entry.
+- **Language detection** → route to the right mouth (Greek / Latin / German /
+  Norse / Hebrew / Spanish as of 2026-07-05). If the tongue is new, **create a
+  new language section** under "The well has many mouths".
+- Entry carries: term (native script where applicable + transliteration),
+  meaning/gloss, **provenance** (who raised it, in which conversation / repo /
+  session), **context** (one-line hook for why it surfaced), and the **date**.
+- **Dedup**: if the term already lives in the well, annotate/update the existing
+  entry instead of adding a duplicate.
+
+## Step 1 — Determine the inscription
+
+- **No-arg**: identify the naming discussion in the recent turns. Extract chosen
+  name, every candidate + reasoning, the state of each, and the target section
+  (a fleet guardian/gate/tool → a "Drawn for X" / "In service" section; a raw
+  word in another tongue → that language's mouth).
+- **Args**: parse each keyword and quoted phrase as a separate term to route.
+
+If nothing nameable is found, say so and stop — do not invent an entry.
+
+## Step 2 — Get the date
+
+Run plain `date` (the machine clock is US Central; do NOT use PowerShell — the
+operator's deny rules block it — and NEVER prefix `TZ=`, which returns UTC in Git
+Bash). Parse to `YYYY-MM-DD`.
+
+## Step 3 — Isolated worktree on dispatch main
+
+dispatch `main` is branch-protected and the live checkout has uncommitted work.
+Work only in a fresh worktree off `origin/main`:
+
+```bash
+git -C /c/Users/mcwiz/Projects/dispatch fetch origin -q
+git -C /c/Users/mcwiz/Projects/dispatch worktree add -b rista-<slug> \
+    /c/Users/mcwiz/Projects/dispatch-rista-<slug> origin/main
+```
+
+`<slug>` is a short kebab tag for the inscription (e.g. `kastalia`, `funklein`).
+
+## Step 4 — Inscribe (in the worktree, anchor-asserted)
+
+Read `dispatch-rista-<slug>/ideas/the-well-of-names.md`. Edit with the **Edit**
+tool using a unique anchor (a real existing line near the target section) — a
+silent `str.replace` no-op burned the prototype once, so every edit must change
+the file. Confirm the diff is non-empty before committing:
+
+```bash
+git -C /c/Users/mcwiz/Projects/dispatch-rista-<slug> diff --stat
+```
+
+Follow the well's existing formatting: `## The well's own name`, `## In service`,
+`## Drawn for <thing>`, and the `### <Language>` mouths under "The well has many
+mouths". New tongues get a new `### <Language> (native name)` mouth.
+
+## Step 5 — Land via the shared PR-lander
+
+File the tracking issue, commit IN the worktree, remove the worktree (the
+branch must not be checked out anywhere when the driver deletes it after
+merge), then hand the whole push→PR→poll→merge→verify→graft cycle to the
+shared driver. Do NOT hand-roll push / poll / merge / graft — the driver owns
+that cycle with a bounded poll, a verify-gate before any deletion, the
+ADR-0217 graft hardcoded, the squash SHA looked up by PR number, and a
+fail-safe protection probe:
+
+```bash
+# capture #N from the issue URL (or use the driver's --no-issue with an
+# operator-authorized reason)
+ISSUE_N=$(gh issue create --repo martymcenroe/dispatch \
+  --title "inscribe <term> into the Well of Names" --body "..." \
+  | grep -oE '[0-9]+$')
+git -C /c/Users/mcwiz/Projects/dispatch-rista-<slug> add ideas/the-well-of-names.md
+git -C /c/Users/mcwiz/Projects/dispatch-rista-<slug> commit -m "ideas(well-of-names): inscribe <term> (Closes #${ISSUE_N})"
+# Worktree out of the way FIRST — clean tree, plain remove (never --force):
+git -C /c/Users/mcwiz/Projects/dispatch worktree remove /c/Users/mcwiz/Projects/dispatch-rista-<slug>
+(cd /c/Users/mcwiz/Projects/unleashed && poetry run python src/tracked_pr_land.py \
+  --repo /c/Users/mcwiz/Projects/dispatch \
+  --branch rista-<slug> \
+  --title "ideas(well-of-names): inscribe <term> (Closes #${ISSUE_N})" \
+  --issue ${ISSUE_N} \
+  --body "Inscribed by /rista.
+
+Closes #${ISSUE_N}")
+```
+
+Exit `0` = merged, verified on dispatch `origin/main`, branch grafted +
+deleted — nothing left to clean. Non-zero = STOP and report the issue number,
+branch, and the driver's final `stage=…` line; never escalate to `--admin` /
+`--no-verify` / force-push / `branch -D`.
+
+## The `super` option (gated; operator-defined)
+
+`/rista super …` is reserved for a heightened inscription mode, gated behind an
+**active second confirmation** — a typed verbatim phrase (the `require_confirmation`
+Danger-Zone pattern), never y/n. Its semantics are deliberately unspecified until
+the operator defines them; until then, `super` prompts for the typed phrase and,
+lacking a defined behavior, asks the operator what `super` should do rather than
+guessing.
+
+## The well's mouths (as of 2026-07-05)
+
+Greek (ἑλληνικά, the main well) · Latin · German (Deutsch) · Norse (norrœnt, +
+runes) · Hebrew (עברית) · Spanish (español). Add a mouth when a new tongue
+arrives.
+
+## Rules
+
+- Native script + transliteration, always. Verify non-trivial scripts; never
+  invent rune spellings from memory.
+- Append-only; dedup by annotation, never by rewrite.
+- Worktree isolation, always; never touch the live dispatch checkout.
+- The skill commits its own writes (worktree → driver-landed PR); it does not
+  defer the commit to a later session.
+- No numbered/yes-no prompts to the operator (the session wrapper auto-fires
+  them); ask open-ended questions only.


### PR DESCRIPTION
## What

Three canonical skill sources, one theme: skills stop hand-rolling what the shared, tested PR-lander owns.

- **quote.md** - Step 7 previously committed and pushed DIRECTLY TO PROTECTED MAIN: broken since fleet-wide branch protection, and the hand-rolled push is the retired anti-pattern. Now: tracking issue -> branch -> commit -> `tracked_pr_land.py` with the standard failure protocol (stop and report; never `--admin`/`--no-verify`/force/`-D`). The wiki-repo sync step is unchanged (wiki pushes are unprotected by design).
- **rista.md** - ADOPTED into canonical sources: it existed only as a machine-local deployed copy, unversioned and outside skill_sync's coverage. Its Step 5 hand-rolled push/poll/merge + prose graft instructions are replaced by the driver, with the load-bearing ordering fix: the worktree is removed AFTER the commit and BEFORE the driver runs, so post-merge branch deletion cannot refuse on a checked-out branch.
- **blog-draft.md** - thin wrapper over `blog_draft.py` (36 tests). The skill ran its own date/slug/template logic in prose, drifting from the tested implementation (including a stale hardcoded model attribution). The script owns project-anchor, Windows-safe slug, model-from-config, and the collision guard; the skill runs it and reports.

cleanup.md needed no change - its quick-mode Step 4 and Phase 4.4 already call the driver.

## Deployment

skill_sync deployed all three to both user-level targets at edit time (live reload); this PR lands the canonical sources.

Closes #1742
