### PR TITLE
feat(tools): pat_smoke_test.py - operator-run classic-PAT verification (Closes #1745)

### DIFF
--- a/tests/unit/test_pat_smoke_test.py
+++ b/tests/unit/test_pat_smoke_test.py
@@ -1,0 +1,47 @@
+"""Unit tests for tools/pat_smoke_test.py's pure verdict (#1745)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from pat_smoke_test import evaluate  # noqa: E402
+
+
+def test_happy_path_all_pass():
+    ok, lines = evaluate(200, "martymcenroe", "repo, workflow",
+                         "2026-10-09 05:00:00 UTC")
+    assert ok
+    assert sum(1 for line in lines if line.startswith("PASS")) == 4
+
+
+def test_bad_status_fails_fast_with_encrypt_hint():
+    ok, lines = evaluate(401, "", "", "")
+    assert not ok
+    assert len(lines) == 1
+    assert "re-check the encrypt step" in lines[0]
+
+
+def test_wrong_login_fails():
+    ok, lines = evaluate(200, "somebody-else", "repo", "")
+    assert not ok
+    assert any("wrong token" in line for line in lines)
+
+
+def test_missing_repo_scope_fails():
+    ok, lines = evaluate(200, "martymcenroe", "gist, read:org", "")
+    assert not ok
+    assert any("repo (full)" in line for line in lines)
+
+
+def test_scope_match_is_exact_token_not_substring():
+    # "repo:status" alone must NOT satisfy the full-repo requirement.
+    ok, lines = evaluate(200, "martymcenroe", "repo:status", "")
+    assert not ok
+
+
+def test_non_expiring_token_notes_not_fails():
+    ok, lines = evaluate(200, "martymcenroe", "repo", "")
+    assert ok
+    assert any(line.startswith("NOTE") for line in lines)

--- a/tools/pat_smoke_test.py
+++ b/tools/pat_smoke_test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify the encrypted classic PAT end-to-end. OPERATOR-RUN ONLY (#1745).
+
+One read-only GET proves the whole chain: the gpg file decrypts (pinentry
+surfacing is itself the zero-TTL agent-config check), the decrypted token
+authenticates, it belongs to the expected account, it carries the `repo`
+scope the fleet tooling needs, and its expiration is what the operator
+chose. Built after a rotation "verification" step pointed at a tool that
+never touches the classic PAT and therefore verified nothing.
+
+Per the ADR-0216 threat model the OPERATOR runs this in their own shell —
+never an agent (the decrypted token lives briefly in this process's heap).
+
+Usage (from AssemblyZero, in Git Bash):
+    poetry run python tools/pat_smoke_test.py
+
+Exit 0 with PASS lines, or exit 1 with the specific failure.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+EXPECTED_LOGIN = "martymcenroe"
+REQUIRED_SCOPE = "repo"
+API = "https://api.github.com/user"
+HTTP_TIMEOUT_S = 30
+
+
+def evaluate(status: int, login: str, scopes_header: str,
+             expiration_header: str) -> tuple[bool, list[str]]:
+    """Pure verdict: (ok, report lines). Unit-tested; no I/O."""
+    lines: list[str] = []
+    ok = True
+
+    if status == 200:
+        lines.append(f"PASS  token authenticates (HTTP {status})")
+    else:
+        lines.append(f"FAIL  HTTP {status} from GET /user -- token invalid, "
+                     f"revoked, or malformed (re-check the encrypt step)")
+        return False, lines
+
+    if login == EXPECTED_LOGIN:
+        lines.append(f"PASS  account: {login}")
+    else:
+        ok = False
+        lines.append(f"FAIL  account is {login!r}, expected {EXPECTED_LOGIN!r} "
+                     f"-- wrong token in the file?")
+
+    scopes = [s.strip() for s in scopes_header.split(",") if s.strip()]
+    if REQUIRED_SCOPE in scopes:
+        lines.append(f"PASS  scopes: {', '.join(scopes)}")
+    else:
+        ok = False
+        lines.append(f"FAIL  scope '{REQUIRED_SCOPE}' missing (has: "
+                     f"{scopes_header or 'none'}) -- recreate the token with "
+                     f"repo (full) checked")
+
+    if expiration_header:
+        lines.append(f"PASS  expires: {expiration_header} -- put it in the calendar")
+    else:
+        lines.append("NOTE  no expiration header (non-expiring token)")
+
+    return ok, lines
+
+
+def main() -> int:
+    with classic_pat_session() as pat:
+        resp = requests.get(
+            API,
+            headers={
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=HTTP_TIMEOUT_S,
+        )
+    login = ""
+    try:
+        login = resp.json().get("login", "")
+    except ValueError:
+        pass
+    ok, lines = evaluate(
+        resp.status_code,
+        login,
+        resp.headers.get("X-OAuth-Scopes", ""),
+        resp.headers.get("github-authentication-token-expiration", ""),
+    )
+    print("\n".join(lines))
+    print("\nRESULT: " + ("PASS -- rotation verified" if ok else "FAIL -- see above"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Dedicated rotation-verification tool: classic_pat_session -> GET /user; PASS/FAIL on status, account, exact repo scope token, plus the expiration header for the operator's calendar. Read-only; operator-run per ADR-0216. Exists because the runbook's prior live-fire step pointed at a tool that never decrypts the classic PAT. 6 unit tests on the pure verdict. Closes #1745