### PR TITLE
fix(testing): adversarial tests land in the target repo, not AZ's own tests tree (Closes #1757)

### DIFF
--- a/assemblyzero/workflows/testing/adversarial_state.py
+++ b/assemblyzero/workflows/testing/adversarial_state.py
@@ -36,6 +36,11 @@ class AdversarialNodeState(TypedDict, total=False):
     lld_content: str
     test_files: list[str]
     issue_id: int
+    # #1757: root the generated tests in the target repo/worktree. Without
+    # this key LangGraph filters repo_root out of the node input (same trap
+    # as mock_mode — see adversarial_node.py) and the writer's CWD-relative
+    # default drops target-repo tests into AssemblyZero's own tests tree.
+    repo_root: str
 
     # Outputs (populated by adversarial node)
     adversarial_analysis: AdversarialAnalysis

--- a/assemblyzero/workflows/testing/nodes/adversarial_node.py
+++ b/assemblyzero/workflows/testing/nodes/adversarial_node.py
@@ -170,9 +170,19 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
             "generated_test_files": {},
         }
 
-    # Write test files
+    # Write test files. #1757: root them in the target repo/worktree —
+    # the writer's CWD-relative default would land target-repo tests in
+    # AssemblyZero's own tests/adversarial/ when workflows run from AZ.
     issue_id = state.get("issue_id", 0)
-    generated_files = write_adversarial_tests(analysis, issue_id)
+    repo_root = state.get("repo_root", "")
+    output_dir = (
+        os.path.join(repo_root, "tests", "adversarial")
+        if repo_root
+        else "tests/adversarial"
+    )
+    generated_files = write_adversarial_tests(
+        analysis, issue_id, output_dir=output_dir
+    )
 
     # Validate (AST no-mock scan, syntax, assertions)
     validation = validate_adversarial_tests(generated_files)

--- a/tests/unit/test_adversarial_node.py
+++ b/tests/unit/test_adversarial_node.py
@@ -97,6 +97,83 @@ class TestRunAdversarialNode:
     @patch(
         "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
     )
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.write_adversarial_tests"
+    )
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.validate_adversarial_tests"
+    )
+    def test_output_dir_rooted_in_repo_root(
+        self, mock_validate, mock_write, mock_client_cls, tmp_path
+    ):
+        """#1757: when state carries repo_root (the worktree), generated
+        tests are written under it — NOT under the process CWD, which is
+        the AssemblyZero checkout when workflows run from AZ."""
+        import os
+
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.generate_adversarial_tests.return_value = (
+            _make_valid_analysis_json()
+        )
+        mock_write.return_value = {}
+        mock_validate.return_value = {
+            "valid": True, "errors": [], "warnings": [], "mock_violations": [],
+        }
+
+        worktree = str(tmp_path / "boostgauge-7")
+        state = {
+            "implementation_files": ["/fake/module.py"],
+            "lld_content": "# Feature",
+            "test_files": [],
+            "issue_id": 7,
+            "repo_root": worktree,
+        }
+
+        run_adversarial_node(state)
+
+        assert mock_write.call_args.kwargs["output_dir"] == os.path.join(
+            worktree, "tests", "adversarial"
+        )
+
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
+    )
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.write_adversarial_tests"
+    )
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.validate_adversarial_tests"
+    )
+    def test_output_dir_cwd_relative_without_repo_root(
+        self, mock_validate, mock_write, mock_client_cls
+    ):
+        """Backward compatibility: states without repo_root keep the old
+        CWD-relative behavior (#1757)."""
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.generate_adversarial_tests.return_value = (
+            _make_valid_analysis_json()
+        )
+        mock_write.return_value = {}
+        mock_validate.return_value = {
+            "valid": True, "errors": [], "warnings": [], "mock_violations": [],
+        }
+
+        state = {
+            "implementation_files": ["/fake/module.py"],
+            "lld_content": "# Feature",
+            "test_files": [],
+            "issue_id": 7,
+        }
+
+        run_adversarial_node(state)
+
+        assert mock_write.call_args.kwargs["output_dir"] == "tests/adversarial"
+
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
+    )
     def test_quota_skip(self, mock_client_cls):
         """T020: On GeminiQuotaExhaustedError, sets skipped_reason and error verdict."""
         mock_client = MagicMock()


### PR DESCRIPTION
Closes #1757

## What

`write_adversarial_tests()` defaults to a CWD-relative `tests/adversarial` and the call site passed no `output_dir` — so when workflows run from the AssemblyZero checkout (the documented invocation), adversarial tests generated for a TARGET repo landed inside AssemblyZero's own tracked `tests/adversarial/` package, where AZ's pytest then collects them.

Root cause of un-fixability at the node: `AdversarialNodeState` didn't declare `repo_root`, so LangGraph filtered it out of the node input (same trap as the `mock_mode` note in `adversarial_node.py`).

## Fix

- Add `repo_root` to `AdversarialNodeState` inputs (parent `TestingWorkflowState` already carries it).
- Root `output_dir` at `<repo_root>/tests/adversarial` in the call site; CWD-relative behavior retained only when `repo_root` is absent (backward compatibility).

## Verification

- Two new unit tests: worktree-rooted output when `repo_root` present; CWD-relative fallback without it.
- Full unit suite: 5542 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)