### PR TITLE
fix(core): remap Pro aliases to agy's living catalog; reject CLI error banners at the transport boundary (Closes #1764, Closes #1765)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -306,7 +306,7 @@ class GeminiClient:
         if model in FORBIDDEN_MODELS:
             raise ValueError(
                 f"Model '{model}' is explicitly forbidden for governance. "
-                f"Allowed: gemini-3.1-pro-preview, gemini-3-flash-preview"
+                f"Allowed: Pro-tier models (e.g. gemini-3.1-pro-high; #1764)"
             )
         if not model.startswith("gemini-"):
             raise ValueError(
@@ -387,6 +387,7 @@ class GeminiClient:
 
         argv = [self._agy_cli, "-p", full_prompt, "--model", self.model]
         chunks: list[str] = []
+        exit_status = None
         try:
             with tempfile.TemporaryDirectory() as tmp_cwd:
                 proc = PtyProcess.spawn(argv, cwd=tmp_cwd, dimensions=(60, 1000))
@@ -411,10 +412,26 @@ class GeminiClient:
                     except Exception:
                         pass
                     return False, "", "agy CLI timeout (300s)"
+                try:
+                    exit_status = proc.exitstatus
+                except Exception:
+                    exit_status = None
         except Exception as e:  # pywinpty raises assorted OS/runtime errors
             return False, "", f"agy CLI invocation failed: {e}"
 
         text = _strip_ansi("".join(chunks)).strip()
+
+        # #1765: never hand a CLI error banner to callers as model output.
+        # An invalid --model (etc.) printed 'Error: ...' to the PTY and was
+        # laundered through draft -> review -> verdict as content. Nonzero
+        # exit is the primary signal; a first-line 'Error:' catches banners
+        # printed under a PTY with ambiguous status.
+        if exit_status not in (0, None):
+            return False, "", f"agy exited {exit_status}: {text[:400]}"
+        first_line = text.splitlines()[0].strip() if text else ""
+        if first_line.startswith("Error:"):
+            return False, "", f"agy error output: {text[:400]}"
+
         if text:
             return True, text, ""
         return False, "", "agy returned no output"

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1171,13 +1171,20 @@ class GeminiProvider(LLMProvider):
 
     # Model mapping from friendly names to actual model IDs
     # Issue #605: Gemini 3.1 (REQ-1) â€” removed deprecated 3.0 entries
+    # Issue #1764: agy retired the -preview IDs (catalog verified 2026-07-14
+    # via `agy models` + live probe). Pro-line aliases remap to the living
+    # gemini-3.1-pro-{low,high} so persisted states and older configs keep
+    # working instead of erroring at the CLI. Legacy flash/2.5 entries are
+    # untouched (already dead at the CLI; flash is forbidden for governance).
     MODEL_MAP = {
         "2.5-pro": "gemini-2.5-pro",
         "pro": "gemini-2.5-pro",
         "2.5-flash": "gemini-2.5-flash",
         "flash": "gemini-2.5-flash",
-        "3.1-pro-preview": "gemini-3.1-pro-preview",
-        "3.1-pro": "gemini-3.1-pro",
+        "3.1-pro-preview": "gemini-3.1-pro-high",  # superseded preview (#1764)
+        "3.1-pro": "gemini-3.1-pro-high",
+        "3.1-pro-high": "gemini-3.1-pro-high",
+        "3.1-pro-low": "gemini-3.1-pro-low",
         "3.1-flash-preview": "gemini-3.1-flash-preview",
     }
 

--- a/assemblyzero/core/preflight.py
+++ b/assemblyzero/core/preflight.py
@@ -106,7 +106,7 @@ def check_gemini_available(
 
 
 def check_gemini_reachable(
-    model: str = "gemini-3.1-pro-preview",
+    model: str = "gemini-3.1-pro-high",  # #1764: agy retired the -preview IDs
     credentials_file: Optional[Path] = None,
     state_file: Optional[Path] = None,
 ) -> PreflightResult:

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -142,6 +142,94 @@ class TestCredentialLoading:
             client._load_credentials()
 
 
+class _FakePty:
+    """Minimal PtyProcess stand-in for _invoke_via_cli boundary tests (#1765)."""
+
+    def __init__(self, chunks, exitstatus=0):
+        self._chunks = list(chunks)
+        self.exitstatus = exitstatus
+
+    @classmethod
+    def make_spawn(cls, chunks, exitstatus=0):
+        instance = cls(chunks, exitstatus)
+        spawner = MagicMock()
+        spawner.spawn.return_value = instance
+        return spawner, instance
+
+    def read(self, n):
+        if self._chunks:
+            return self._chunks.pop(0)
+        raise EOFError
+
+    def isalive(self):
+        return False
+
+    def terminate(self, force=False):
+        pass
+
+
+class TestInvokeViaCliErrorBoundary:
+    """#1765: CLI error banners must never be returned as model output.
+
+    Hardening-run evidence: an 'Error: invalid --model' banner was saved as
+    a draft and flowed through review and verdict as content.
+    """
+
+    def _client(self, temp_credentials_file, temp_state_file):
+        return GeminiClient(
+            model="gemini-3.1-pro-high",
+            credentials_file=temp_credentials_file,
+            state_file=temp_state_file,
+        )
+
+    def test_nonzero_exit_is_failure(self, temp_credentials_file, temp_state_file):
+        client = self._client(temp_credentials_file, temp_state_file)
+        banner = (
+            'Error: invalid --model "gemini-3.1-pro-preview": model '
+            "gemini-3.1-pro-preview is not recognized\nAvailable models:\n"
+        )
+        spawner, _ = _FakePty.make_spawn([banner], exitstatus=1)
+        with patch("winpty.PtyProcess", spawner):
+            ok, text, err = client._invoke_via_cli("sys", "content")
+        assert ok is False
+        assert text == ""
+        assert "agy exited 1" in err
+        assert "invalid --model" in err
+
+    def test_error_banner_with_clean_exit_is_failure(
+        self, temp_credentials_file, temp_state_file
+    ):
+        """agy can print errors under a PTY with ambiguous status — the
+        first-line 'Error:' shape alone must reject the output."""
+        client = self._client(temp_credentials_file, temp_state_file)
+        banner = "Error: something went sideways\ndetails...\n"
+        spawner, _ = _FakePty.make_spawn([banner], exitstatus=0)
+        with patch("winpty.PtyProcess", spawner):
+            ok, text, err = client._invoke_via_cli("sys", "content")
+        assert ok is False
+        assert text == ""
+        assert "agy error output" in err
+
+    def test_normal_output_still_succeeds(
+        self, temp_credentials_file, temp_state_file
+    ):
+        client = self._client(temp_credentials_file, temp_state_file)
+        spawner, _ = _FakePty.make_spawn(["## Draft\n\nA legitimate response.\n"])
+        with patch("winpty.PtyProcess", spawner):
+            ok, text, err = client._invoke_via_cli("sys", "content")
+        assert ok is True
+        assert "legitimate response" in text
+        assert err == ""
+
+    def test_empty_output_is_failure(self, temp_credentials_file, temp_state_file):
+        client = self._client(temp_credentials_file, temp_state_file)
+        spawner, _ = _FakePty.make_spawn([""])
+        with patch("winpty.PtyProcess", spawner):
+            ok, text, err = client._invoke_via_cli("sys", "content")
+        assert ok is False
+        assert "no output" in err
+
+
 class TestErrorClassification:
     """Tests for error classification."""
 

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -173,7 +173,17 @@ class TestInvokeViaCliErrorBoundary:
 
     Hardening-run evidence: an 'Error: invalid --model' banner was saved as
     a draft and flowed through review and verdict as content.
+
+    winpty is Windows-only and absent on the Linux CI runner, so these
+    tests stub the whole module in sys.modules rather than patching into
+    a real import.
     """
+
+    @staticmethod
+    def _patch_winpty(spawner):
+        return patch.dict(
+            sys.modules, {"winpty": types.SimpleNamespace(PtyProcess=spawner)}
+        )
 
     def _client(self, temp_credentials_file, temp_state_file):
         return GeminiClient(
@@ -189,7 +199,7 @@ class TestInvokeViaCliErrorBoundary:
             "gemini-3.1-pro-preview is not recognized\nAvailable models:\n"
         )
         spawner, _ = _FakePty.make_spawn([banner], exitstatus=1)
-        with patch("winpty.PtyProcess", spawner):
+        with self._patch_winpty(spawner):
             ok, text, err = client._invoke_via_cli("sys", "content")
         assert ok is False
         assert text == ""
@@ -204,7 +214,7 @@ class TestInvokeViaCliErrorBoundary:
         client = self._client(temp_credentials_file, temp_state_file)
         banner = "Error: something went sideways\ndetails...\n"
         spawner, _ = _FakePty.make_spawn([banner], exitstatus=0)
-        with patch("winpty.PtyProcess", spawner):
+        with self._patch_winpty(spawner):
             ok, text, err = client._invoke_via_cli("sys", "content")
         assert ok is False
         assert text == ""
@@ -215,7 +225,7 @@ class TestInvokeViaCliErrorBoundary:
     ):
         client = self._client(temp_credentials_file, temp_state_file)
         spawner, _ = _FakePty.make_spawn(["## Draft\n\nA legitimate response.\n"])
-        with patch("winpty.PtyProcess", spawner):
+        with self._patch_winpty(spawner):
             ok, text, err = client._invoke_via_cli("sys", "content")
         assert ok is True
         assert "legitimate response" in text
@@ -224,7 +234,7 @@ class TestInvokeViaCliErrorBoundary:
     def test_empty_output_is_failure(self, temp_credentials_file, temp_state_file):
         client = self._client(temp_credentials_file, temp_state_file)
         spawner, _ = _FakePty.make_spawn([""])
-        with patch("winpty.PtyProcess", spawner):
+        with self._patch_winpty(spawner):
             ok, text, err = client._invoke_via_cli("sys", "content")
         assert ok is False
         assert "no output" in err

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -186,11 +186,16 @@ class TestInvokeViaCliErrorBoundary:
         )
 
     def _client(self, temp_credentials_file, temp_state_file):
-        return GeminiClient(
+        client = GeminiClient(
             model="gemini-3.1-pro-high",
             credentials_file=temp_credentials_file,
             state_file=temp_state_file,
         )
+        # The Linux CI runner has no agy binary; _find_agy_cli() returns
+        # None there and _invoke_via_cli bails before the PTY layer these
+        # tests exercise. Force a fake path — the PTY itself is stubbed.
+        client._agy_cli = "/fake/agy"
+        return client
 
     def test_nonzero_exit_is_failure(self, temp_credentials_file, temp_state_file):
         client = self._client(temp_credentials_file, temp_state_file)

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -778,6 +778,22 @@ class TestGeminiProvider:
         provider = GeminiProvider(model="3.1-pro-preview")
         assert provider.model == "3.1-pro-preview"
 
+    def test_pro_aliases_resolve_to_living_catalog_ids(self):
+        """#1764: agy retired the -preview IDs. Every Pro-line alias must
+        resolve to a model the CLI actually serves (verified against
+        `agy models` 2026-07-14) — a dead ID turns every pipeline LLM call
+        into an error banner."""
+        assert GeminiProvider.MODEL_MAP["3.1-pro-preview"] == "gemini-3.1-pro-high"
+        assert GeminiProvider.MODEL_MAP["3.1-pro"] == "gemini-3.1-pro-high"
+        assert GeminiProvider.MODEL_MAP["3.1-pro-high"] == "gemini-3.1-pro-high"
+        assert GeminiProvider.MODEL_MAP["3.1-pro-low"] == "gemini-3.1-pro-low"
+
+    def test_pro_preview_alias_maps_to_high_model_id(self):
+        """The workflow default spec gemini:3.1-pro-preview must construct a
+        provider whose resolved model ID is servable (#1764)."""
+        provider = GeminiProvider(model="3.1-pro-preview")
+        assert provider._model_id == "gemini-3.1-pro-high"
+
     def test_valid_model_3_flash_preview(self):
         """Test creating provider with 3.1-flash-preview model."""
         provider = GeminiProvider(model="3.1-flash-preview")


### PR DESCRIPTION
Closes #1764, Closes #1765

## What

Hardening run 1 against boostgauge (boostgauge#96) halted in triage: every Gemini call errored because agy retired `gemini-3.1-pro-preview`, and — worse — the transport returned the CLI's error banner as if it were model output, which then flowed through draft → review → verdict as content.

- **#1764:** `GeminiProvider.MODEL_MAP` Pro-line aliases now resolve to the living catalog (`gemini-3.1-pro-high`/`-low`, verified via `agy models` + live probe 2026-07-14); `preflight.check_gemini_reachable` default updated; stale allowed-models message fixed. Every existing `gemini:3.1-pro-preview` config default keeps working through the alias (honest-rename sweep tracked in #1768).
- **#1765:** `_invoke_via_cli` now captures the PTY exit status — nonzero is a failure carrying the banner as error_message — and rejects first-line `Error:` output even on clean exit. Callers' existing classification/rotation handles the failure loudly instead of laundering it into lineage.

## Verification

- 4 new boundary tests (nonzero exit, error-banner-clean-exit, normal output, empty output) + 2 alias-resolution tests.
- Full unit suite: 5548 passed, 0 failed.
- Live probes: `agy -p 'Reply OK' --model gemini-3.1-pro-high` → OK, exit 0; bogus model → `Error:` banner, exit 1.

Found by the boostgauge#96 hardening campaign, run 1. Follow-ups filed: #1766 (verdict-path contradiction), #1767 (claude -p list JSON), #1768 (cosmetic rename sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)