### PR TITLE
fix(orchestrator): triage passes-through for existing issues — no issue-authoring workflow, no duplicate GitHub issues (Closes #1770)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -327,57 +327,38 @@ def run_triage_stage(state: OrchestrationState) -> OrchestrationState:
         )
         return update_stage_result(state, stage, result)
 
-    # Execute triage sub-workflow
+    # Closes #1770: `orchestrate --issue N` means the issue ALREADY EXISTS,
+    # so triage's product — a brief distilled from the issue — is exactly
+    # what the synthesizer above just produced (#1508 fetch + #1530
+    # summary). The previous code invoked the issue-AUTHORING workflow
+    # here, which (a) filed a duplicate GitHub issue per attempt via its
+    # finalize (`gh issue create`, no existing-issue guard) and (b) then
+    # failed on `sub_result['issue_brief_path']`, a key no code path sets —
+    # triage could never pass without a pre-existing skip artifact.
+    # Persist the synthesized brief to the canonical skip-artifact location
+    # so resume/re-runs skip via detect_existing_artifacts, and pass.
+    canonical_brief = (
+        Path(state.get("target_repo", "."))
+        / "docs" / "lineage" / str(issue_number) / "issue-brief.md"
+    )
+    artifact_path = brief_file
     try:
-        # Import here to avoid circular dependencies and allow mocking
-        from assemblyzero.workflows.requirements.graph import create_requirements_graph
-
-        # #1440: Plumb orchestrator config into the sub-workflow state.
-        config = state.get("config", {})
-        stage_cfg = config.get("stages", {}).get("triage", {})
-        gate_enabled = bool(config.get("gates", {}).get("triage", False))
-
-        graph = create_requirements_graph()
-        app = graph.compile()
-        sub_result = app.invoke({
-            "issue_number": issue_number,
-            "workflow_type": "issue",
-            "target_repo": state.get("target_repo", ""),
-            "assemblyzero_root": state.get("assemblyzero_root", ""),
-            "brief_file": brief_file,  # Closes #1508
-            "config_drafter": stage_cfg.get("drafter", ""),
-            "config_reviewer": stage_cfg.get("reviewer", ""),
-            "config_effort": stage_cfg.get("effort", ""),
-            "config_gates_draft": gate_enabled,
-            "config_gates_verdict": gate_enabled,
-        })
-
-        # Check for artifact
-        brief_path = sub_result.get("issue_brief_path", "")
-        if brief_path and Path(brief_path).is_file():
-            result = _make_stage_result(
-                status="passed",
-                artifact_path=brief_path,
-                duration_seconds=time.monotonic() - start_time,
-                attempts=1,
-            )
-        else:
-            error_msg = sub_result.get("error_message", "Triage workflow completed but no artifact produced")
-            result = _make_stage_result(
-                status="failed",
-                error_message=error_msg,
-                duration_seconds=time.monotonic() - start_time,
-                attempts=1,
-                transient=_classify_halt_transience(sub_result),
-            )
-    except Exception as exc:
-        result = _make_stage_result(
-            status="failed",
-            error_message=f"Triage stage error: {exc}",
-            duration_seconds=time.monotonic() - start_time,
-            attempts=1,
+        canonical_brief.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(brief_file, canonical_brief)
+        artifact_path = str(canonical_brief)
+    except OSError as exc:
+        # Non-fatal: the temp brief still serves this run; only the
+        # skip-on-rerun convenience is lost.
+        _stages_logger.warning(
+            "Triage: could not persist brief to %s: %s", canonical_brief, exc
         )
 
+    result = _make_stage_result(
+        status="passed",
+        artifact_path=artifact_path,
+        duration_seconds=time.monotonic() - start_time,
+        attempts=1,
+    )
     return update_stage_result(state, stage, result)
 
 

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -60,22 +60,29 @@ def _external_state():
 
 
 @patch("assemblyzero.workflows.orchestrator.stages._fetch_issue_body_to_temp_brief")
-@patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")
 @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
-def test_triage_threads_target_repo(mock_detect, mock_create_graph, mock_fetch):
+def test_triage_threads_target_repo(mock_detect, mock_fetch, tmp_path):
+    """#1770: triage no longer invokes the issue-authoring sub-workflow.
+    target_repo threading now shows up as (a) the repo handed to the gh
+    fetch helper and (b) the canonical brief persisted under the TARGET
+    repo — never the orchestrator's own cwd."""
     mock_detect.return_value = {k: None for k in ("triage", "lld", "spec", "impl", "pr")}
-    # #1508: the fresh-issue path now fetches the issue body and writes a
-    # temp brief. Mock the helper so the test doesn't shell out to gh.
-    mock_fetch.return_value = ("/fake/tmp/orchestrator-issue-5.md", "")
-    captured: dict = {}
-    mock_create_graph.return_value = _capturing_graph(captured, {"issue_brief_path": ""})
+    temp_brief = tmp_path / "orchestrator-issue-5.md"
+    temp_brief.write_text("## Summary\nsynthesized\n", encoding="utf-8")
+    mock_fetch.return_value = (str(temp_brief), "")
 
-    run_triage_stage(_external_state())
+    target = tmp_path / "external-target"
+    target.mkdir()
+    state = create_initial_state(
+        5, get_default_config(), target_repo=str(target), assemblyzero_root=AZ_ROOT
+    )
 
-    assert captured["target_repo"] == EXTERNAL
-    assert captured["assemblyzero_root"] == AZ_ROOT
-    # #1508: brief_file is now threaded into the sub-workflow state
-    assert captured["brief_file"] == "/fake/tmp/orchestrator-issue-5.md"
+    result = run_triage_stage(state)
+
+    assert mock_fetch.call_args[0] == (5, str(target))
+    assert result["stage_results"]["triage"]["status"] == "passed"
+    canonical = target / "docs" / "lineage" / "5" / "issue-brief.md"
+    assert canonical.is_file(), "brief must persist under the target repo"
 
 
 @patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -116,6 +116,61 @@ class TestRunTriageStage:
         assert new_state["stage_results"]["triage"]["status"] == "skipped"
         assert new_state["current_stage"] == "lld"
 
+    @patch("assemblyzero.workflows.orchestrator.stages._fetch_issue_body_to_temp_brief")
+    @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
+    def test_existing_issue_passes_without_authoring_workflow(
+        self, mock_detect, mock_fetch, tmp_path
+    ):
+        """#1770: `--issue N` means the issue exists — triage persists the
+        synthesized brief to the canonical location and passes. It must NOT
+        invoke the issue-authoring workflow (which filed a duplicate GitHub
+        issue per attempt) and must not depend on `issue_brief_path` (a key
+        nothing sets)."""
+        mock_detect.return_value = {
+            "triage": None, "lld": None, "spec": None, "impl": None, "pr": None,
+        }
+        temp_brief = tmp_path / "temp-brief.md"
+        temp_brief.write_text(
+            "# feat: config file\n\n## Summary\nA config file.\n\n"
+            "## Issue detail\nBody.\n",
+            encoding="utf-8",
+        )
+        mock_fetch.return_value = (str(temp_brief), "")
+
+        target = tmp_path / "boostgauge"
+        target.mkdir()
+
+        config = get_default_config()
+        state = create_initial_state(7, config, target_repo=str(target))
+
+        new_state = run_triage_stage(state)
+
+        assert new_state["stage_results"]["triage"]["status"] == "passed"
+        canonical = target / "docs" / "lineage" / "7" / "issue-brief.md"
+        assert canonical.is_file(), "brief must persist to the skip-artifact path"
+        assert "## Summary" in canonical.read_text(encoding="utf-8")
+        assert new_state["stage_results"]["triage"]["artifact_path"] == str(canonical)
+
+    @patch("assemblyzero.workflows.orchestrator.stages._fetch_issue_body_to_temp_brief")
+    @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
+    def test_brief_synthesis_failure_still_fails_stage(
+        self, mock_detect, mock_fetch, tmp_path
+    ):
+        """An unreachable/empty issue still fails triage loudly (#1770
+        preserves the #1508 error path)."""
+        mock_detect.return_value = {
+            "triage": None, "lld": None, "spec": None, "impl": None, "pr": None,
+        }
+        mock_fetch.return_value = ("", "issue #7 body is empty")
+
+        config = get_default_config()
+        state = create_initial_state(7, config, target_repo=str(tmp_path))
+
+        new_state = run_triage_stage(state)
+
+        assert new_state["stage_results"]["triage"]["status"] == "failed"
+        assert "empty" in new_state["stage_results"]["triage"]["error_message"]
+
 
 class TestStageRunners:
     """Tests for STAGE_RUNNERS mapping."""
@@ -597,13 +652,17 @@ class TestTriageBriefSynthesis:
     """
 
     @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
-    @patch("assemblyzero.workflows.requirements.graph.create_requirements_graph")
     @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")
     def test_triage_fetches_issue_body_when_no_brief_exists(
-        self, mock_detect, mock_create_graph, mock_subprocess,
+        self, mock_detect, mock_subprocess, tmp_path
     ):
-        """When no brief on disk: fetch issue body, write temp brief, pass it
-        as `brief_file` to the sub-workflow."""
+        """When no brief on disk: fetch the issue body, synthesize a brief,
+        persist it to the canonical skip-artifact path, and PASS.
+
+        #1770 rewrote the tail of this flow: the issue-authoring
+        sub-workflow is no longer invoked from triage (it filed duplicate
+        GitHub issues and its result was checked against a key nothing
+        sets), so this test now pins the persist-and-pass contract."""
         import json as _json
 
         # No existing artifact at docs/lineage/{N}/issue-brief.md
@@ -619,55 +678,35 @@ class TestTriageBriefSynthesis:
         gh_result.stderr = ""
         mock_subprocess.return_value = gh_result
 
-        # Capture what the sub-workflow receives
-        captured: dict = {}
-        app = MagicMock()
-        def _invoke(payload):
-            captured.update(payload)
-            return {"issue_brief_path": "/fake/produced/brief.md"}
-        app.invoke.side_effect = _invoke
-        graph = MagicMock()
-        graph.compile.return_value = app
-        mock_create_graph.return_value = graph
-
+        target = tmp_path / "target-repo"
+        target.mkdir()
         state = create_initial_state(
             37, get_default_config(),
-            target_repo="/fake/projects/Chiron",
+            target_repo=str(target),
             assemblyzero_root="/fake/projects/AssemblyZero",
         )
 
         result = run_triage_stage(state)
 
         # gh was called for the right issue against the right cwd
-        gh_call = mock_subprocess.call_args
-        assert gh_call is not None
-        args = gh_call[0][0]
+        gh_calls = [
+            c for c in mock_subprocess.call_args_list
+            if c[0][0][:3] == ["gh", "issue", "view"]
+        ]
+        assert gh_calls, "gh issue view must be called"
+        args = gh_calls[0][0][0]
         assert args[:4] == ["gh", "issue", "view", "37"]
-        assert gh_call[1]["cwd"] == "/fake/projects/Chiron"
+        assert gh_calls[0][1]["cwd"] == str(target)
 
-        # brief_file was threaded into the sub-workflow state
-        assert "brief_file" in captured
-        assert captured["brief_file"]  # non-empty path
-        # The temp brief file actually contains the synthesized brief
-        with open(captured["brief_file"], encoding="utf-8") as f:
-            content = f.read()
+        # #1770: stage passes; brief persisted to the canonical location
+        triage_result = result["stage_results"]["triage"]
+        assert triage_result["status"] == "passed"
+        canonical = target / "docs" / "lineage" / "37" / "issue-brief.md"
+        assert canonical.is_file()
+        content = canonical.read_text(encoding="utf-8")
         assert "Fresh issue from GitHub" in content
         assert "Body content the operator never pre-authored" in content
-
-        # Stage no longer halts at the pre-fix "No brief file specified"
-        # gate. Final status reflects the sub-workflow's return — in this
-        # test the mocked brief_path doesn't exist on disk so the stage
-        # registers as failed-after-sub-workflow rather than failed-pre-fetch.
-        # The important assertion is the brief_file threading above; status
-        # here would only be "passed" with a real produced file.
-        triage_result = result["stage_results"]["triage"]
-        if triage_result["status"] == "failed":
-            # Verify it's the post-sub-workflow failure, NOT the
-            # cannot-synthesize-brief halt from the bug or the missing-
-            # brief_file pre-fix halt.
-            err = triage_result.get("error_message", "")
-            assert "cannot synthesize brief" not in err
-            assert "No brief file specified" not in err
+        assert triage_result["artifact_path"] == str(canonical)
 
     @patch("assemblyzero.workflows.orchestrator.stages.subprocess.run")
     @patch("assemblyzero.workflows.orchestrator.stages.detect_existing_artifacts")


### PR DESCRIPTION
Closes #1770

## What

`orchestrate --issue N` means the issue already exists — but triage invoked the issue-AUTHORING workflow (whose finalize runs `gh issue create` with no existing-issue guard: three duplicate issues filed on the target during hardening run 2, since closed) and then judged success by `sub_result['issue_brief_path']`, a key no code path has ever set — so triage could never pass without a pre-existing skip artifact.

Now: the brief synthesized from the issue body (#1508 fetch + #1530 summary) is persisted to the canonical skip-artifact location `docs/lineage/{N}/issue-brief.md` in the target repo and the stage passes with it. The issue-authoring sub-workflow is no longer invoked from triage. Re-runs skip via `detect_existing_artifacts`. Saves ~3 LLM calls per pipeline run.

## Verification

- 2 new tests (pass-through persists canonical brief; synthesis failure still fails loudly) + 2 legacy tests updated from the old invoke-the-workflow contract to the new one (gh threading assertions preserved).
- Full unit suite: 5550 passed, 0 failed.
- Evidence trail: boostgauge#96 run-2 report; duplicates boostgauge#97–#99 closed.

Found by the boostgauge#96 hardening campaign, run 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)