### PR TITLE
fix(implementation_spec): review the final-iteration spec instead of discarding it with a synthesized BLOCKED (Closes #1775)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -153,14 +153,26 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
 
     # -------------------------------------------------------------------------
     # GUARD: Iteration bounds
+    #
+    # #1775: strictly GREATER than — the draft generated AT the final
+    # iteration still deserves its review. The iteration budget bounds
+    # REGENERATION, which the routing functions already enforce
+    # (route_after_validation and route_after_review both require
+    # review_iteration < max_iterations before re-entering N2), so
+    # reviewing here cannot loop: REVISE at max routes to HALT honestly,
+    # APPROVED finalizes. The old >= guard discarded a mechanically
+    # complete final spec unreviewed and synthesized a BLOCKED verdict
+    # no reviewer issued (boostgauge#96 hardening run 4).
     # -------------------------------------------------------------------------
-    if review_iteration >= max_iterations:
-        print(f"    [GUARD] Max iterations ({max_iterations}) reached")
+    if review_iteration > max_iterations:
+        print(f"    [GUARD] Iteration {review_iteration} exceeds budget ({max_iterations})")
         return {
             "review_verdict": "BLOCKED",
             "review_feedback": (
-                f"Maximum review iterations ({max_iterations}) exceeded. "
-                "Spec could not pass readiness review within allowed attempts."
+                f"Review iteration {review_iteration} exceeds the maximum "
+                f"({max_iterations}); the regeneration routing should have "
+                "halted earlier — treating as BLOCKED. The last generated "
+                "spec was NOT reviewed."
             ),
             "error_message": "",
         }

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -2044,16 +2044,47 @@ class TestReviewSpec:
         assert result["review_feedback"] != ""
 
     @patch("assemblyzero.workflows.implementation_spec.nodes.review_spec.get_provider")
-    def test_max_iterations_guard(self, mock_provider, base_state):
-        """Max iterations → BLOCKED without calling provider."""
+    def test_final_iteration_still_gets_reviewed(self, mock_provider, base_state):
+        """#1775: the draft generated AT the final iteration deserves its
+        review — the old >= guard discarded a mechanically complete final
+        spec unreviewed and synthesized BLOCKED (boostgauge#96 run 4).
+        Loop safety lives in the routing functions, which require
+        review_iteration < max_iterations before any regeneration."""
+        reviewer = Mock()
+        reviewer.invoke.return_value = Mock(
+            success=True,
+            response="## Verdict\n[X] **APPROVED** - Ready\n",
+            content="## Verdict\n[X] **APPROVED** - Ready\n",
+            error_message=None,
+            input_tokens=0,
+            output_tokens=0,
+        )
+        mock_provider.return_value = reviewer
+
         base_state["spec_draft"] = SAMPLE_SPEC_COMPLETE
+        base_state["lld_content"] = SAMPLE_LLD_APPROVED
         base_state["review_iteration"] = 3
         base_state["max_iterations"] = 3
 
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import review_spec
 
         result = review_spec(base_state)
+        assert result["review_verdict"] == "APPROVED"
+        mock_provider.assert_called_once()
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.review_spec.get_provider")
+    def test_over_budget_iteration_guard(self, mock_provider, base_state):
+        """Iterations BEYOND the budget (routing failure) still guard
+        BLOCKED without calling the provider (#1775)."""
+        base_state["spec_draft"] = SAMPLE_SPEC_COMPLETE
+        base_state["review_iteration"] = 4
+        base_state["max_iterations"] = 3
+
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import review_spec
+
+        result = review_spec(base_state)
         assert result["review_verdict"] == "BLOCKED"
+        assert "NOT reviewed" in result["review_feedback"]
         mock_provider.assert_not_called()
 
     @patch("assemblyzero.workflows.implementation_spec.nodes.review_spec.get_provider")


### PR DESCRIPTION
Closes #1775

## What

Hardening run 4 (boostgauge#96): the spec stage's third-iteration regeneration passed ALL 7 mechanical completeness checks (1,407 lines) — then the N5 entry guard (`review_iteration >= max_iterations`) fired BEFORE the review, discarded the final artifact unreviewed, and reported 'verdict BLOCKED' — a verdict no reviewer issued.

The iteration budget's real enforcement lives in the routing functions (`route_after_validation` and `route_after_review` both require `review_iteration < max_iterations` before re-entering generation — covered by existing tests, e.g. REVISE-at-max → HALT). So reviewing the final draft cannot loop: APPROVED finalizes, REVISE halts honestly. The N5 guard becomes strictly-greater-than (a routing-failure backstop) with an honest message.

## Verification

- New test: the final-iteration spec IS reviewed (provider called once, APPROVED honored).
- New test: beyond-budget iterations still guard BLOCKED without an LLM call, message states the spec was not reviewed.
- Full unit suite: 5555 passed, 0 failed.

Found by the boostgauge#96 hardening campaign, run 4 — which also delivered the #1529 drift measurements (posted there) implicating #1528 as the durable fix for revision instability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)