### PR TITLE
feat(spec): edit-script revisions — SEARCH/REPLACE blocks applied mechanically, drift impossible by construction (Closes #1528)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
@@ -1,0 +1,160 @@
+"""SEARCH/REPLACE edit-script revision for Implementation Specs (Closes #1528).
+
+The measured failure (boostgauge#96 hardening runs 4-5, posted to #1529):
+spec "revisions" are full regenerations — sizes oscillated 1,149 → 341 →
+1,407 lines across iterations, fixing one mechanical deficiency while
+losing another. The #1521/#1522 prompt fix asks the model to copy
+unflagged content "byte-identical"; the data proves models don't.
+
+This module makes drift impossible BY CONSTRUCTION: the revision model
+outputs only SEARCH/REPLACE edit blocks; AZ applies them mechanically to
+the existing draft. Content the model doesn't name cannot change.
+
+Per ADR 0224, parsing and application are small pure functions with unit
+tests. Any failure at any step (no blocks, unmatched SEARCH, ambiguous
+SEARCH) is reported to the caller, which falls back to the classic
+full-revision prompt — never worse than the pre-#1528 behavior.
+"""
+
+from __future__ import annotations
+
+import re
+
+# The aider-style conflict-marker format: robust for LLMs (no line numbers,
+# exact-text anchoring). Tolerates trailing whitespace after markers.
+_EDIT_BLOCK_RE = re.compile(
+    r"^<{7} SEARCH[ \t]*\r?\n(.*?)\r?\n={7}[ \t]*\r?\n(.*?)\r?\n>{7} REPLACE[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
+
+EDIT_SCRIPT_SYSTEM_PROMPT = (
+    "You are a precision patch engine. You NEVER rewrite documents — you "
+    "emit minimal, exact edit blocks that a machine applies. Your entire "
+    "response is edit blocks in the specified format; any prose outside "
+    "edit blocks is discarded."
+)
+
+
+def build_edit_script_prompt(
+    existing_draft: str,
+    review_feedback: str,
+    completeness_issues: list[str],
+    prior_completeness_breakdown: list[dict] | None = None,
+) -> str:
+    """Build the revision prompt that requests edit blocks, not a rewrite."""
+    sections: list[str] = []
+
+    sections.append(
+        "You are revising an Implementation Spec. Do NOT rewrite it. "
+        "Output ONLY edit blocks in EXACTLY this format:\n\n"
+        "<<<<<<< SEARCH\n"
+        "(exact lines copied verbatim from the CURRENT SPEC below)\n"
+        "=======\n"
+        "(replacement lines)\n"
+        ">>>>>>> REPLACE\n\n"
+        "Rules:\n"
+        "1. Each SEARCH text must be copied EXACTLY from the current spec "
+        "(character-for-character, including whitespace) and must occur "
+        "exactly ONCE in the spec. Keep SEARCH as small as practical "
+        "(typically 1-15 lines).\n"
+        "2. To INSERT new content, SEARCH for the nearest existing anchor "
+        "line(s) and REPLACE with those same anchor lines plus the new "
+        "content.\n"
+        "3. Emit one edit block per fix. Fix ALL listed deficiencies. "
+        "Touch NOTHING else — content you do not name in a SEARCH block "
+        "cannot and must not change.\n"
+        "4. No preamble, no explanation, no markdown fences around the "
+        "blocks — edit blocks only."
+    )
+
+    if completeness_issues:
+        issues_text = "## DEFICIENCIES TO FIX (mechanical validation)\n\n"
+        for issue in completeness_issues:
+            issues_text += f"- {issue}\n"
+        sections.append(issues_text)
+
+    if review_feedback:
+        sections.append(f"## REVIEWER FEEDBACK TO ADDRESS\n\n{review_feedback}")
+
+    if prior_completeness_breakdown:
+        history = "## PRIOR ITERATION FAILURES (do not repeat)\n\n"
+        for entry in prior_completeness_breakdown:
+            iteration = entry.get("iteration", "?")
+            failures = entry.get("failures", [])
+            history += f"- Iteration {iteration}: " + "; ".join(
+                str(f) for f in failures
+            ) + "\n"
+        sections.append(history)
+
+    sections.append(
+        "## CURRENT SPEC (the document you are patching)\n\n"
+        + existing_draft
+    )
+
+    return "\n\n".join(sections)
+
+
+def parse_edit_blocks(response: str) -> list[tuple[str, str]]:
+    """Extract (search, replace) pairs from a model response.
+
+    Tolerates the whole response being wrapped in a single markdown fence
+    (a common model tic). Returns [] when no well-formed blocks exist —
+    the caller falls back to classic regeneration.
+    """
+    if not response:
+        return []
+    text = response.strip()
+
+    # Unwrap a single whole-response code fence if present.
+    if text.startswith("```") and text.endswith("```"):
+        first_newline = text.find("\n")
+        if first_newline > 0:
+            inner = text[first_newline + 1 : -3].strip()
+            if "<<<<<<< SEARCH" in inner:
+                text = inner
+
+    return [(m.group(1), m.group(2)) for m in _EDIT_BLOCK_RE.finditer(text)]
+
+
+def apply_edit_blocks(
+    draft: str, blocks: list[tuple[str, str]]
+) -> tuple[str, list[str]]:
+    """Apply edit blocks sequentially to ``draft``.
+
+    Each SEARCH must match exactly once in the CURRENT text (edits apply
+    in order, so later blocks see earlier results). Returns
+    (patched_text, failures); failures is non-empty when any block could
+    not be applied — the caller must then discard the result and fall
+    back (partial application is never returned as success).
+    """
+    failures: list[str] = []
+    text = draft
+    for i, (search, replace) in enumerate(blocks, start=1):
+        count = text.count(search)
+        if count == 0:
+            failures.append(
+                f"block {i}: SEARCH text not found (model did not copy "
+                f"verbatim): {search[:80]!r}"
+            )
+        elif count > 1:
+            failures.append(
+                f"block {i}: SEARCH text ambiguous ({count} occurrences): "
+                f"{search[:80]!r}"
+            )
+        else:
+            text = text.replace(search, replace, 1)
+    return text, failures
+
+
+def unchanged_ratio(original: str, patched: str) -> float:
+    """Fraction of the original's lines that survive byte-identical.
+
+    Cheap stability telemetry for #1529: line-level containment, not a
+    true diff — good enough to show 'revision, not regeneration'.
+    """
+    original_lines = original.splitlines()
+    if not original_lines:
+        return 1.0
+    patched_set = set(patched.splitlines())
+    kept = sum(1 for line in original_lines if line in patched_set)
+    return kept / len(original_lines)

--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -39,6 +39,13 @@ from assemblyzero.workflows.implementation_spec.state import (
     ImplementationSpecState,
     PatternRef,
 )
+from assemblyzero.workflows.implementation_spec.nodes.edit_script import (
+    EDIT_SCRIPT_SYSTEM_PROMPT,
+    apply_edit_blocks,
+    build_edit_script_prompt,
+    parse_edit_blocks,
+    unchanged_ratio,
+)
 from assemblyzero.workflows.implementation_spec.nodes.retry_prompt_builder import (
     RetryContext,
     build_retry_prompt,
@@ -284,15 +291,73 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
     print(f"    Drafter: {drafter_spec}")
 
     # -------------------------------------------------------------------------
-    # Call drafter LLM
+    # #1528: Edit-script revision — the model emits SEARCH/REPLACE blocks
+    # which are applied mechanically, so unflagged content cannot drift
+    # (measured regenerations oscillated 1,149→341→1,407 lines; see #1529).
+    # Any failure falls through to the classic full-revision call below.
     # -------------------------------------------------------------------------
-    cost_before = get_cumulative_cost()
-    result = drafter.invoke(
-        system_prompt=DRAFTER_SYSTEM_PROMPT,
-        content=prompt,
-        timeout_seconds=600,  # 10 min — impl specs are large
-    )
-    node_cost_usd = get_cumulative_cost() - cost_before
+    edit_script_content: str | None = None
+    result = None
+    if is_revision and retry_count < 1 and not drafter_spec.startswith("mock:"):
+        cost_before = get_cumulative_cost()
+        edit_result = drafter.invoke(
+            system_prompt=EDIT_SCRIPT_SYSTEM_PROMPT,
+            content=build_edit_script_prompt(
+                existing_draft=existing_draft,
+                review_feedback=review_feedback,
+                completeness_issues=completeness_issues,
+                prior_completeness_breakdown=state.get(
+                    "prior_completeness_breakdown", []
+                ),
+            ),
+            timeout_seconds=600,
+        )
+        node_cost_usd = get_cumulative_cost() - cost_before
+        if edit_result.success:
+            blocks = parse_edit_blocks(edit_result.response or "")
+            if blocks:
+                patched, failures = apply_edit_blocks(existing_draft, blocks)
+                if not failures and patched != existing_draft:
+                    ratio = unchanged_ratio(existing_draft, patched)
+                    print(
+                        f"    [EDIT-SCRIPT] Applied {len(blocks)} edit(s); "
+                        f"{ratio:.0%} of prior spec preserved byte-identical "
+                        f"(#1528)"
+                    )
+                    edit_script_content = patched
+                    result = edit_result
+                else:
+                    reason = (
+                        "; ".join(failures)
+                        if failures
+                        else "edits produced no change"
+                    )
+                    print(
+                        f"    [EDIT-SCRIPT] Falling back to full revision: "
+                        f"{reason}"
+                    )
+            else:
+                print(
+                    "    [EDIT-SCRIPT] Falling back to full revision: "
+                    "no well-formed edit blocks in response"
+                )
+        else:
+            print(
+                f"    [EDIT-SCRIPT] Falling back to full revision: "
+                f"{edit_result.error_message}"
+            )
+
+    # -------------------------------------------------------------------------
+    # Call drafter LLM (classic full draft/revision path)
+    # -------------------------------------------------------------------------
+    if edit_script_content is None:
+        cost_before = get_cumulative_cost()
+        result = drafter.invoke(
+            system_prompt=DRAFTER_SYSTEM_PROMPT,
+            content=prompt,
+            timeout_seconds=600,  # 10 min — impl specs are large
+        )
+        node_cost_usd = get_cumulative_cost() - cost_before
 
     if not result.success:
         print(f"    ERROR: {result.error_message}")
@@ -306,12 +371,15 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
         print(f"    {msg}")
         return {"error_message": msg}
 
-    spec_content = result.response or ""
-
-    # -------------------------------------------------------------------------
-    # Strip preamble (safety: Claude sometimes adds text before the # heading)
-    # -------------------------------------------------------------------------
-    spec_content = _strip_preamble(spec_content)
+    if edit_script_content is not None:
+        # #1528: the patched draft IS the spec — no preamble to strip.
+        spec_content = edit_script_content
+    else:
+        spec_content = result.response or ""
+        # ---------------------------------------------------------------------
+        # Strip preamble (safety: Claude sometimes adds text before the # heading)
+        # ---------------------------------------------------------------------
+        spec_content = _strip_preamble(spec_content)
 
     # -------------------------------------------------------------------------
     # Save to audit trail

--- a/tests/unit/test_spec_edit_script.py
+++ b/tests/unit/test_spec_edit_script.py
@@ -1,0 +1,268 @@
+"""Tests for edit-script spec revisions (Closes #1528).
+
+Measured failure this fixes (boostgauge#96 hardening runs 4-5, data on
+#1529): spec revisions were full regenerations — 1,149 → 341 → 1,407
+lines across iterations. Edit blocks applied mechanically make unflagged
+drift impossible by construction.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.edit_script import (
+    apply_edit_blocks,
+    build_edit_script_prompt,
+    parse_edit_blocks,
+    unchanged_ratio,
+)
+
+SPEC = """# Implementation Spec: Config
+
+## Functions
+
+### load_config()
+Loads the config.
+
+### validate_config()
+Validates the config.
+
+## Test Plan
+
+- test_load_config
+"""
+
+
+def _block(search: str, replace: str) -> str:
+    return f"<<<<<<< SEARCH\n{search}\n=======\n{replace}\n>>>>>>> REPLACE"
+
+
+class TestParseEditBlocks:
+    def test_single_block(self):
+        response = _block("### load_config()", "### load_config(path)")
+        blocks = parse_edit_blocks(response)
+        assert blocks == [("### load_config()", "### load_config(path)")]
+
+    def test_multiple_blocks(self):
+        response = (
+            _block("a", "b") + "\n\n" + _block("c\nd", "c\nd\ne")
+        )
+        blocks = parse_edit_blocks(response)
+        assert len(blocks) == 2
+        assert blocks[1] == ("c\nd", "c\nd\ne")
+
+    def test_prose_response_yields_no_blocks(self):
+        assert parse_edit_blocks("Here is the revised spec:\n# Spec\n...") == []
+
+    def test_malformed_block_ignored(self):
+        # Missing the ======= divider
+        response = "<<<<<<< SEARCH\nfoo\n>>>>>>> REPLACE"
+        assert parse_edit_blocks(response) == []
+
+    def test_whole_response_fence_unwrapped(self):
+        response = "```\n" + _block("x", "y") + "\n```"
+        assert parse_edit_blocks(response) == [("x", "y")]
+
+    def test_empty_response(self):
+        assert parse_edit_blocks("") == []
+
+
+class TestApplyEditBlocks:
+    def test_single_edit_applies(self):
+        patched, failures = apply_edit_blocks(
+            SPEC, [("Loads the config.", "Loads the config from disk.")]
+        )
+        assert failures == []
+        assert "Loads the config from disk." in patched
+        # Everything else untouched
+        assert "### validate_config()" in patched
+
+    def test_insertion_via_anchor(self):
+        patched, failures = apply_edit_blocks(
+            SPEC,
+            [(
+                "- test_load_config",
+                "- test_load_config\n- test_validate_config",
+            )],
+        )
+        assert failures == []
+        assert "- test_validate_config" in patched
+
+    def test_sequential_edits_see_prior_results(self):
+        patched, failures = apply_edit_blocks(
+            SPEC,
+            [
+                ("Loads the config.", "Loads the config quickly."),
+                ("Loads the config quickly.", "Loads the config very quickly."),
+            ],
+        )
+        assert failures == []
+        assert "very quickly" in patched
+
+    def test_search_not_found_reports_failure(self):
+        patched, failures = apply_edit_blocks(SPEC, [("nonexistent text", "x")])
+        assert len(failures) == 1
+        assert "not found" in failures[0]
+
+    def test_ambiguous_search_reports_failure(self):
+        text = "line\nline\n"
+        patched, failures = apply_edit_blocks(text, [("line", "other")])
+        assert len(failures) == 1
+        assert "ambiguous" in failures[0]
+
+    def test_unchanged_content_is_byte_identical(self):
+        """The core #1528 guarantee: content not named in a SEARCH block
+        survives exactly — drift is structurally impossible."""
+        patched, failures = apply_edit_blocks(
+            SPEC, [("Validates the config.", "Validates the config strictly.")]
+        )
+        assert failures == []
+        untouched = SPEC.replace("Validates the config.", "")
+        for line in untouched.splitlines():
+            if line.strip():
+                assert line in patched
+
+
+class TestUnchangedRatio:
+    def test_identical_is_one(self):
+        assert unchanged_ratio(SPEC, SPEC) == 1.0
+
+    def test_full_rewrite_is_low(self):
+        assert unchanged_ratio(SPEC, "totally different\ncontent\n") < 0.2
+
+    def test_small_edit_is_high(self):
+        patched, _ = apply_edit_blocks(
+            SPEC, [("Loads the config.", "Loads it.")]
+        )
+        assert unchanged_ratio(SPEC, patched) > 0.85
+
+
+class TestBuildEditScriptPrompt:
+    def test_prompt_carries_deficiencies_and_draft(self):
+        prompt = build_edit_script_prompt(
+            existing_draft=SPEC,
+            review_feedback="Section X is vague.",
+            completeness_issues=["Functions missing input/output examples: f()"],
+            prior_completeness_breakdown=[{"iteration": 1, "failures": ["y"]}],
+        )
+        assert "<<<<<<< SEARCH" in prompt
+        assert "Functions missing input/output examples" in prompt
+        assert "Section X is vague." in prompt
+        assert "Iteration 1" in prompt
+        assert SPEC in prompt
+        assert "Touch NOTHING else" in prompt
+
+
+class TestGenerateSpecEditScriptIntegration:
+    """The revision path tries edit-script first and falls back safely."""
+
+    def _base_revision_state(self, tmp_path):
+        return {
+            "issue_number": 7,
+            "assemblyzero_root": str(tmp_path),
+            "repo_root": str(tmp_path),
+            "spec_draft": SPEC,
+            "completeness_issues": ["Functions missing examples: f()"],
+            "review_feedback": "",
+            "review_iteration": 1,
+            "max_iterations": 3,
+            "config_mock_mode": False,
+            "config_drafter": "gemini:3.1-pro",
+            "lld_content": "# LLD",
+            "audit_dir": "",
+        }
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.check_spec_size_or_raise", create=True)
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
+    @patch("assemblyzero.core.preflight.check_gemini_available")
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
+    def test_edit_blocks_patch_without_regeneration(
+        self, mock_get_provider, mock_preflight, mock_template, _sz, tmp_path
+    ):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
+
+        mock_template.return_value = "# Template"
+        mock_preflight.return_value = Mock(
+            passed=True, available_credentials=4, total_credentials=4, warnings=[]
+        )
+        drafter = MagicMock()
+        drafter.invoke.return_value = Mock(
+            success=True,
+            response=_block("Loads the config.", "Loads the config from disk."),
+            error_message=None,
+            input_tokens=10,
+            output_tokens=5,
+        )
+        mock_get_provider.return_value = drafter
+
+        result = generate_spec(self._base_revision_state(tmp_path))
+
+        assert result["error_message"] == ""
+        assert "Loads the config from disk." in result["spec_draft"]
+        # Unflagged content preserved byte-identical
+        assert "### validate_config()" in result["spec_draft"]
+        # Only ONE LLM call — the edit-script call; no regeneration
+        assert drafter.invoke.call_count == 1
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
+    @patch("assemblyzero.core.preflight.check_gemini_available")
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
+    def test_prose_response_falls_back_to_full_revision(
+        self, mock_get_provider, mock_preflight, mock_template, tmp_path
+    ):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
+
+        mock_template.return_value = "# Template"
+        mock_preflight.return_value = Mock(
+            passed=True, available_credentials=4, total_credentials=4, warnings=[]
+        )
+        drafter = MagicMock()
+        drafter.invoke.side_effect = [
+            Mock(  # edit-script attempt: prose, no blocks
+                success=True, response="I rewrote the spec:\n# Spec v2\n...",
+                error_message=None, input_tokens=1, output_tokens=1,
+            ),
+            Mock(  # classic full-revision call
+                success=True, response="# Spec v2 (classic)\n\ncontent",
+                error_message=None, input_tokens=1, output_tokens=1,
+            ),
+        ]
+        mock_get_provider.return_value = drafter
+
+        result = generate_spec(self._base_revision_state(tmp_path))
+
+        assert result["error_message"] == ""
+        assert result["spec_draft"].startswith("# Spec v2 (classic)")
+        assert drafter.invoke.call_count == 2
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
+    @patch("assemblyzero.core.preflight.check_gemini_available")
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
+    def test_unmatched_search_falls_back(
+        self, mock_get_provider, mock_preflight, mock_template, tmp_path
+    ):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
+
+        mock_template.return_value = "# Template"
+        mock_preflight.return_value = Mock(
+            passed=True, available_credentials=4, total_credentials=4, warnings=[]
+        )
+        drafter = MagicMock()
+        drafter.invoke.side_effect = [
+            Mock(  # edit-script attempt: block whose SEARCH isn't verbatim
+                success=True,
+                response=_block("text that is not in the spec", "replacement"),
+                error_message=None, input_tokens=1, output_tokens=1,
+            ),
+            Mock(
+                success=True, response="# Spec v3 (classic)\n\ncontent",
+                error_message=None, input_tokens=1, output_tokens=1,
+            ),
+        ]
+        mock_get_provider.return_value = drafter
+
+        result = generate_spec(self._base_revision_state(tmp_path))
+
+        assert result["error_message"] == ""
+        assert result["spec_draft"].startswith("# Spec v3 (classic)")
+        assert drafter.invoke.call_count == 2


### PR DESCRIPTION
Closes #1528

## Why now

#1529's decision rule triggered tonight: the boostgauge#96 hardening campaign delivered the first measured spec-stage runs since the #1521/#1522 prompt fix, and revisions are still full regenerations — 1,149 → 341 → 1,407 lines across iterations (run 4), then a different mechanical check failed at the budget ceiling (run 5). The revision loop is a lottery: each rewrite fixes one deficiency and loses another. Data posted on #1529.

## What

Revision requests now ask the drafter for **SEARCH/REPLACE edit blocks** (aider-style conflict markers) which AZ applies mechanically to the existing draft:

- New `nodes/edit_script.py` (pure functions per ADR 0224): prompt builder (deficiencies + verbatim-copy contract), parser (tolerates a whole-response fence), applier (exact-match, unique-occurrence, sequential; ANY failed block → the patch is discarded, never partially applied), and `unchanged_ratio` telemetry for #1529.
- `generate_spec` tries the edit-script call first on revisions; on ANY failure (LLM error, no blocks, unmatched/ambiguous SEARCH, no-op patch) it logs the reason and falls back to the classic full-revision prompt — never worse than pre-#1528. Mock-mode and retry-prune paths untouched.
- The structural guarantee: content the model does not name in a SEARCH block cannot change. 'Byte-identical unflagged content' stops being a prompt aspiration and becomes an applier property.

## Verification

- 19 new tests: parse (5), apply incl. the byte-identical guarantee (6), telemetry (3), prompt (1), and generate_spec integration (edit-path single-call patch; prose fallback; unmatched-SEARCH fallback).
- Full unit suite: 5574 passed, 0 failed.

Found/forced by the boostgauge#96 hardening campaign, runs 4-5. see #1529 (measurements), mirrors PR #1522 (the prompt-only attempt this supersedes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)