### PR TITLE
fix(orchestrator): run-6 plumbing residuals — LLD-PR URL survives LangGraph, checkpoints get an upstream, worktree removal retries locks (Closes #1778, Closes #1780, Closes #1781)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -696,6 +696,21 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 capture_output=True,
                 text=True,
             )
+            # #1780: set upstream at creation so checkpoint pushes work.
+            # Without it every [CP:*] push fails until the pr stage's
+            # --set-upstream, losing the crash-resilience checkpoints
+            # exist for. Non-fatal (offline runs stay possible).
+            push_result = run_command(
+                ["git", "-C", str(worktree_path), "push", "-u", "origin", branch_name],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if push_result.returncode != 0:
+                print(
+                    f"    [WARN] could not push {branch_name} upstream: "
+                    f"{(push_result.stderr or '').strip()[:200]}"
+                )
 
         # Run implementation workflow
         from assemblyzero.workflows.testing.graph import build_testing_workflow as create_impl_graph
@@ -950,6 +965,23 @@ def _remove_orchestrator_worktrees(
         remove_worktree,
     )
 
+    def _remove_with_retry(path, attempts: int = 3, delay_s: float = 2.0) -> None:
+        # #1781: Windows file locks from just-finished child processes make
+        # the first removal attempt fail transiently — the identical command
+        # succeeds seconds later. Retry before declaring residue; never
+        # escalate to --force.
+        last_exc: Exception | None = None
+        for i in range(attempts):
+            try:
+                remove_worktree(path)
+                return
+            except Exception as e:  # noqa: BLE001 — re-raised after retries
+                last_exc = e
+                if i < attempts - 1:
+                    time.sleep(delay_s)
+        assert last_exc is not None
+        raise last_exc
+
     if target_repo:
         lld_wt = lld_worktree_path_for(target_repo, issue_number)
         if Path(lld_wt).is_dir():
@@ -959,7 +991,7 @@ def _remove_orchestrator_worktrees(
             except Exception:
                 branch = None
             try:
-                remove_worktree(lld_wt)
+                _remove_with_retry(lld_wt)
                 notes.append(f"removed LLD worktree {lld_wt}")
                 if lld_merged and branch:
                     try:
@@ -972,7 +1004,7 @@ def _remove_orchestrator_worktrees(
     impl_wt = worktree_path_for(issue_number, target_repo or None)
     if Path(impl_wt).is_dir():
         try:
-            remove_worktree(impl_wt)
+            _remove_with_retry(impl_wt)
             notes.append(f"removed impl worktree {impl_wt}")
         except Exception as e:
             notes.append(f"impl worktree not removed (residue left, no --force): {e}")

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -224,6 +224,10 @@ class RequirementsWorkflowState(TypedDict, total=False):
 
     # Output - LLD workflow
     final_lld_path: str
+    # #1778: MUST be declared or LangGraph strips it from the graph result
+    # and the orchestrator's cleanup stage never learns the LLD PR exists
+    # (silently skipping the merge). Set by finalize's worktree+PR path.
+    final_lld_pr_url: str
     lld_status: Literal["PENDING", "APPROVED", "BLOCKED"]
 
     # Error handling
@@ -406,6 +410,7 @@ def create_initial_state(
                 "context_files": context_files or [],
                 "context_content": "",
                 "final_lld_path": "",
+                "final_lld_pr_url": "",
                 "lld_status": "PENDING",
             }
         )

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -172,6 +172,107 @@ class TestRunTriageStage:
         assert "empty" in new_state["stage_results"]["triage"]["error_message"]
 
 
+class TestImplWorktreeUpstreamPush:
+    """#1780: the impl worktree branch is pushed -u at creation so
+    checkpoint pushes work (crash-resilience)."""
+
+    @patch("assemblyzero.workflows.orchestrator.stages.run_command")
+    def test_worktree_creation_pushes_upstream(self, mock_run, tmp_path):
+        from assemblyzero.workflows.orchestrator.stages import run_impl_stage
+
+        out = MagicMock()
+        out.stdout = ""
+        out.stderr = ""
+        out.returncode = 0
+        mock_run.return_value = out
+
+        config = get_default_config()
+        state = create_initial_state(
+            4,
+            config,
+            target_repo=str(tmp_path / "target"),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+        state["spec_path"] = str(tmp_path / "spec.md")
+        (tmp_path / "spec.md").write_text("# spec")
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                return {"error_message": ""}
+
+        class _StubGraph:
+            def compile(self) -> _StubApp:
+                return _StubApp()
+
+        with patch(
+            "assemblyzero.workflows.testing.graph.build_testing_workflow",
+            return_value=_StubGraph(),
+        ):
+            run_impl_stage(state)
+
+        push_calls = [
+            c for c in mock_run.call_args_list
+            if len(c.args[0]) >= 4 and c.args[0][3:4] == ["push"]
+            or ("push" in c.args[0] and "-u" in c.args[0])
+        ]
+        assert any(
+            "-u" in c.args[0] and "issue-4" in c.args[0] for c in push_calls
+        ), f"expected a push -u origin issue-4 at worktree creation; calls: {[c.args[0] for c in mock_run.call_args_list]}"
+
+
+class TestWorktreeRemovalRetry:
+    """#1781: transient Windows file locks — retry before declaring residue."""
+
+    @patch("assemblyzero.workflows.orchestrator.stages.time.sleep")
+    @patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.remove_worktree")
+    def test_lock_then_success_is_removed(self, mock_remove, mock_sleep, tmp_path):
+        from assemblyzero.workflows.orchestrator.stages import (
+            _remove_orchestrator_worktrees,
+        )
+
+        target = tmp_path / "boostgauge"
+        target.mkdir()
+        (tmp_path / "boostgauge-7-lld").mkdir()
+        (tmp_path / "boostgauge-7").mkdir()
+
+        # Each worktree: first attempt locked, second succeeds
+        mock_remove.side_effect = [
+            OSError("exit 128: file in use"), None,
+            OSError("exit 128: file in use"), None,
+        ]
+
+        notes: list[str] = []
+        _remove_orchestrator_worktrees(str(target), 7, lld_merged=False, notes=notes)
+
+        joined = "\n".join(notes)
+        assert "removed LLD worktree" in joined
+        assert "removed impl worktree" in joined
+        assert "residue" not in joined
+        assert mock_remove.call_count == 4
+
+    @patch("assemblyzero.workflows.orchestrator.stages.time.sleep")
+    @patch("assemblyzero.workflows.testing.nodes.cleanup_helpers.remove_worktree")
+    def test_persistent_lock_reports_residue_without_force(
+        self, mock_remove, mock_sleep, tmp_path
+    ):
+        from assemblyzero.workflows.orchestrator.stages import (
+            _remove_orchestrator_worktrees,
+        )
+
+        target = tmp_path / "boostgauge"
+        target.mkdir()
+        (tmp_path / "boostgauge-7").mkdir()
+
+        mock_remove.side_effect = OSError("exit 128: file in use")
+
+        notes: list[str] = []
+        _remove_orchestrator_worktrees(str(target), 7, lld_merged=False, notes=notes)
+
+        joined = "\n".join(notes)
+        assert "residue left, no --force" in joined
+        assert mock_remove.call_count == 3  # 3 attempts, then honest residue
+
+
 class TestStageRunners:
     """Tests for STAGE_RUNNERS mapping."""
 

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1358,6 +1358,29 @@ class TestFinalizeNodeAdditional:
         assert "detached HEAD" in result.get("commit_error", "")
 
 
+class TestFinalLldPrUrlDeclared:
+    """#1778: the PR URL key must be DECLARED in the state schema or
+    LangGraph strips it and the orchestrator's cleanup never merges the
+    LLD PR (fourth member of the undeclared-key family: #1757, #1770)."""
+
+    def test_declared_in_state_schema(self):
+        from assemblyzero.workflows.requirements.state import (
+            RequirementsWorkflowState,
+        )
+        assert "final_lld_pr_url" in RequirementsWorkflowState.__annotations__
+
+    def test_initialized_empty_for_lld_workflow(self):
+        from assemblyzero.workflows.requirements.state import create_initial_state
+
+        state = create_initial_state(
+            workflow_type="lld",
+            assemblyzero_root="/az",
+            target_repo="/target",
+            issue_number=7,
+        )
+        assert state["final_lld_pr_url"] == ""
+
+
 class TestFinalizeLineageFiles:
     """Tests for lineage files being excluded from created_files.
 


### PR DESCRIPTION
Closes #1778, Closes #1780, Closes #1781

## What (all found by boostgauge#96 hardening run 6 — the first end-to-end success)

- **#1778:** `final_lld_pr_url` is now DECLARED in `RequirementsWorkflowState` (and initialized) — LangGraph was stripping the undeclared key, so cleanup's `_merge_lld_pr` silently never fired (persisted state showed `lld_pr_url: ''` while the PR sat open). Fourth member of the undeclared-key family (#1757, #1770).
- **#1780:** the orchestrator's impl worktree branch is pushed `-u origin` at creation (mirroring the direct tool), so `[CP:*]` checkpoint pushes stop failing with 'no upstream branch' and crash-resilience is real. Non-fatal on push failure (offline runs unaffected).
- **#1781:** `_remove_orchestrator_worktrees` retries removal (3 attempts, 2s apart) before declaring residue — run 6's exit-128 failures were transient Windows file locks; the identical command succeeded manually minutes later. Never escalates to --force; persistent locks still report honest residue.

## Verification

- 5 new tests: state-schema declaration + initialization; push -u at worktree creation; lock-then-success removal; persistent-lock honest residue (3 attempts, no force).
- Full unit suite: 5579 passed, 0 failed.

Sibling filed for daylight decision (not fixed here): #1779 — impl-stage STAGNANT completeness halt was reported as stage PASSED and shipped a PR with unexecuted tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)