### PR TITLE
fix(new_repo): refuse to scaffold over a live repo; run with stdin closed (Closes #1805, Closes #1806, Closes #1728)

### DIFF
--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -11,6 +11,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -26,6 +27,8 @@ from new_repo import (
     flatten_directories,
     flatten_files,
     load_structure_schema,
+    main,
+    validate_name,
     validate_paths_no_traversal,
     validate_template_files_exist,
 )
@@ -371,7 +374,7 @@ class TestIntegrity:
         """Raise error for missing template files."""
         schema = _minimal_schema()
         schema["files"]["README.md"]["template"] = "readme-template.md"
-        path = _write_schema(tmp_path, schema)
+        _write_schema(tmp_path, schema)
         template_dir = tmp_path / "templates"
         template_dir.mkdir()
         # Template file does NOT exist
@@ -387,15 +390,6 @@ class TestIntegrity:
 # ===========================================================================
 # TestMain — Issue #451: main() workflow coverage
 # ===========================================================================
-
-from unittest.mock import patch, MagicMock
-
-from new_repo import (
-    main,
-    validate_name,
-    get_github_username,
-    audit_structure,
-)
 
 
 class TestValidateName:

--- a/tests/unit/test_new_repo_pypi.py
+++ b/tests/unit/test_new_repo_pypi.py
@@ -13,7 +13,6 @@ import re
 import sys
 from pathlib import Path
 
-import pytest
 
 # Make tools/ importable. Mirrors the conftest pattern other AZ tests use.
 _TOOLS = Path(__file__).resolve().parent.parent.parent / "tools"

--- a/tests/unit/test_new_repo_safety.py
+++ b/tests/unit/test_new_repo_safety.py
@@ -1,0 +1,227 @@
+"""
+Safety guards for new_repo.py.
+
+Two failure modes, both diagnosed from real runs on 2026-07-25/26:
+
+- #1805: scaffolding a fresh local history against a name whose GitHub repo
+  already exists. The push is rejected, and every step gated on that push --
+  workflow upload, repo settings, the Cerberus secret deploy -- silently
+  skips. The visible symptom (a missing second pinentry prompt) reads as a
+  broken security flow when the real fault is scaffolding over a live repo.
+- #1806: a passphrase typed while pinentry lacks focus must land nowhere.
+  This process, and the children it spawns, must not be able to read it.
+
+Issues: #1805, #1806
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "tools"))
+
+from new_repo import (
+    _create_repo,
+    check_remote_repo_exists,
+    detach_stdin,
+    get_github_username,
+    main,
+    run_command,
+)
+
+TOOLS_DIR = Path(__file__).parent.parent.parent / "tools"
+
+
+def _completed(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ===========================================================================
+# #1805 — the existence oracle
+# ===========================================================================
+
+
+class TestCheckRemoteRepoExists:
+
+    def test_returns_metadata_when_repo_exists(self):
+        payload = '{"full_name": "u/r", "created_at": "2026-07-04T10:00:00Z", "private": true}'
+        with patch("new_repo.subprocess.run", return_value=_completed(0, payload)):
+            result = check_remote_repo_exists("u", "r")
+        assert result["full_name"] == "u/r"
+        assert result["created_at"] == "2026-07-04T10:00:00Z"
+
+    def test_returns_none_on_404(self):
+        """A 404 is the good case -- the name is free."""
+        with patch("new_repo.subprocess.run",
+                   return_value=_completed(1, stderr="gh: Not Found (HTTP 404)")):
+            assert check_remote_repo_exists("u", "r") is None
+
+    def test_auth_failure_raises_rather_than_reporting_absent(self):
+        """
+        The #1805 trap. An error that is NOT a 404 must never be read as
+        "repo does not exist" -- that would let the caller scaffold over a
+        live repo, which is the whole defect.
+        """
+        with patch("new_repo.subprocess.run",
+                   return_value=_completed(1, stderr="gh: Bad credentials (HTTP 401)")):
+            with pytest.raises(RuntimeError, match="401"):
+                check_remote_repo_exists("u", "r")
+
+    def test_missing_gh_cli_raises(self):
+        with patch("new_repo.subprocess.run", side_effect=FileNotFoundError()):
+            with pytest.raises(RuntimeError, match="gh"):
+                check_remote_repo_exists("u", "r")
+
+    def test_timeout_raises(self):
+        with patch("new_repo.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("gh", 30)):
+            with pytest.raises(RuntimeError, match="timed out"):
+                check_remote_repo_exists("u", "r")
+
+    def test_unparseable_response_raises(self):
+        with patch("new_repo.subprocess.run", return_value=_completed(0, "<html>")):
+            with pytest.raises(RuntimeError, match="unparseable"):
+                check_remote_repo_exists("u", "r")
+
+    def test_query_does_not_inherit_stdin(self):
+        with patch("new_repo.subprocess.run", return_value=_completed(0, "{}")) as run:
+            check_remote_repo_exists("u", "r")
+        assert run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+
+# ===========================================================================
+# #1805 — the refusal, which must precede any local write
+# ===========================================================================
+
+
+class TestCreateRepoRemotePreflight:
+
+    def _args(self, name="brandnew", no_github=False):
+        args = MagicMock()
+        args.name = name
+        args.no_github = no_github
+        return args
+
+    def test_refuses_and_writes_nothing_when_repo_exists(self, tmp_path, capsys):
+        target = tmp_path / "brandnew"
+        existing = {
+            "full_name": "u/brandnew",
+            "html_url": "https://github.com/u/brandnew",
+            "created_at": "2026-07-04T10:00:00Z",
+            "private": True,
+        }
+        with patch("new_repo.check_remote_repo_exists", return_value=existing):
+            with pytest.raises(SystemExit) as exc:
+                _create_repo(target, self._args(), "u")
+
+        assert exc.value.code == 1
+        assert not target.exists(), "no scaffold directory may be created"
+        out = capsys.readouterr().out
+        assert "already exists" in out
+        assert "2026-07-04" in out, "operator needs the creation date to recognize the repo"
+        assert "gh repo clone u/brandnew" in out, "refusal must name the safe alternative"
+
+    def test_refuses_when_existence_cannot_be_determined(self, tmp_path, capsys):
+        """Unknown is not absent. Refuse rather than scaffold on an unverified name."""
+        target = tmp_path / "brandnew"
+        with patch("new_repo.check_remote_repo_exists",
+                   side_effect=RuntimeError("Bad credentials")):
+            with pytest.raises(SystemExit) as exc:
+                _create_repo(target, self._args(), "u")
+
+        assert exc.value.code == 1
+        assert not target.exists()
+        out = capsys.readouterr().out
+        assert "Cannot determine" in out
+        assert "Bad credentials" in out
+
+    def test_no_github_skips_the_remote_check(self, tmp_path):
+        """--no-github never contacts GitHub, so there is nothing to pre-flight."""
+        target = tmp_path / "brandnew"
+        with patch("new_repo.check_remote_repo_exists") as check:
+            # Scaffolding proceeds past the guard and fails later for unrelated
+            # reasons (MagicMock args); we assert only that the guard abstained.
+            with pytest.raises(BaseException):
+                _create_repo(target, self._args(no_github=True), "u")
+        check.assert_not_called()
+
+
+# ===========================================================================
+# #1806 — a stray passphrase must land nowhere
+# ===========================================================================
+
+
+class TestDetachStdin:
+
+    def test_detached_stdin_reads_empty_and_never_echoes_input(self, tmp_path):
+        """
+        End-to-end proof in a real subprocess: fd 0 is what is under test,
+        and pytest owns fd 0 in-process.
+        """
+        script = tmp_path / "probe.py"
+        script.write_text(
+            "import sys\n"
+            "sys.path.insert(0, %r)\n"
+            "from new_repo import detach_stdin\n"
+            "detach_stdin()\n"
+            "sys.stdout.write('READ=' + repr(sys.stdin.read()))\n" % str(TOOLS_DIR),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            input="hunter2-not-a-real-passphrase\n",
+            capture_output=True, text=True, timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "READ=''" in result.stdout, "detached stdin must read as empty"
+        assert "hunter2" not in result.stdout, "typed input must never be echoed"
+
+    def test_returns_false_when_there_is_no_real_stdin(self):
+        fake = MagicMock()
+        fake.fileno.side_effect = ValueError("no fileno")
+        with patch("new_repo.sys.stdin", fake):
+            assert detach_stdin() is False
+
+    def test_main_detaches_stdin_before_parsing_arguments(self):
+        """A guard that runs after the risky work is not a guard."""
+        with patch("new_repo.detach_stdin") as detach:
+            with patch("new_repo.argparse.ArgumentParser.parse_args",
+                       side_effect=SystemExit(2)) as parse:
+                with pytest.raises(SystemExit):
+                    main()
+        assert detach.call_count == 1, "main() must detach stdin exactly once"
+        assert parse.called
+
+
+class TestSubprocessStdinIsolation:
+    """No child may inherit a terminal that a passphrase could land in."""
+
+    def test_run_command_passes_devnull(self):
+        completed = subprocess.CompletedProcess(
+            args=["git"], returncode=0, stdout="", stderr=""
+        )
+        with patch("new_repo.subprocess.run", return_value=completed) as run:
+            run_command(["git", "status"])
+        assert run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+    def test_get_github_username_passes_devnull(self):
+        completed = subprocess.CompletedProcess(
+            args=["gh"], returncode=0, stdout="octocat\n", stderr=""
+        )
+        with patch("new_repo.subprocess.run", return_value=completed) as run:
+            assert get_github_username() == "octocat"
+        assert run.call_args.kwargs["stdin"] is subprocess.DEVNULL
+
+    def test_no_new_repo_code_path_reads_stdin(self):
+        """
+        Belt and braces: assert the module never reads stdin directly.
+        The recon for #1806 found no such path; this keeps it that way.
+        """
+        source = (TOOLS_DIR / "new_repo.py").read_text(encoding="utf-8")
+        assert "input(" not in source.replace("_input(", ""), "new_repo must not call input()"
+        assert "sys.stdin.read" not in source

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -346,6 +346,41 @@ def validate_name(name: str) -> tuple[bool, str]:
     return True, ""
 
 
+def detach_stdin() -> bool:
+    """
+    Replace this process's stdin with the null device (#1806).
+
+    During a run, gpg's pinentry may fail to steal window focus. If the
+    operator types or pastes the passphrase while focus is wrong, those
+    keystrokes land on whatever holds the terminal -- which must never be
+    this process. After this call, anything typed at the controlling
+    terminal is discarded: it cannot be read, echoed, or logged here.
+
+    The passphrase belongs to pinentry's own dialog, which reads from its
+    own handle, not from the inherited terminal. If gpg is ever configured
+    with a tty-based pinentry, it will now fail loudly rather than quietly
+    accept a secret through the wrong channel -- that is the intended
+    trade, not a regression.
+
+    Returns:
+        True if stdin was detached, False if there was no real stdin to
+        detach (already closed, or no file descriptor -- e.g. under a test
+        harness that captures output).
+    """
+    try:
+        fd = sys.stdin.fileno()
+    except (AttributeError, ValueError, OSError):
+        # No real stdin -- nothing can be typed into it, so nothing to do.
+        return False
+
+    try:
+        with open(os.devnull, "rb") as devnull:
+            os.dup2(devnull.fileno(), fd)
+    except OSError:
+        return False
+    return True
+
+
 def get_github_username() -> str:
     """Get the authenticated GitHub username."""
     result = subprocess.run(
@@ -354,8 +389,56 @@ def get_github_username() -> str:
         text=True,
         check=True,
         timeout=60,
+        stdin=subprocess.DEVNULL,
     )
     return result.stdout.strip()
+
+
+def check_remote_repo_exists(github_user: str, name: str) -> dict[str, Any] | None:
+    """
+    Look up <github_user>/<name> on GitHub before anything local is written.
+
+    Runs through the `gh` CLI, which uses the already-configured
+    fine-grained PAT. That matters: this is a pre-flight check, and it must
+    not trigger a pinentry prompt for the classic PAT before the operator
+    even knows whether the run can proceed.
+
+    Args:
+        github_user: The authenticated GitHub account name.
+        name: The repository name being requested.
+
+    Returns:
+        The repo's JSON metadata if it exists, or None if GitHub reports it
+        does not.
+
+    Raises:
+        RuntimeError: If existence could not be determined -- an auth
+            failure, a network error, or a missing `gh`. The caller must
+            treat this as "unknown", never as "does not exist"; proceeding
+            on an unverified name is what #1805 is about.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{github_user}/{name}"],
+            capture_output=True, text=True, timeout=30, stdin=subprocess.DEVNULL,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("`gh` CLI not found on PATH") from e
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError("timed out querying GitHub") from e
+
+    if result.returncode == 0:
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"unparseable response from GitHub: {e}") from e
+
+    # A 404 is the answer we want: the name is free.
+    stderr = (result.stderr or "").lower()
+    if "404" in stderr or "not found" in stderr:
+        return None
+
+    raise RuntimeError(result.stderr.strip() or f"gh exited {result.returncode}")
 
 
 def run_command(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
@@ -370,7 +453,10 @@ def run_command(cmd: list[str], cwd: Path | None = None, check: bool = True) -> 
     Returns:
         CompletedProcess result
     """
-    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check, timeout=60)
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=check, timeout=60,
+        stdin=subprocess.DEVNULL,
+    )
 
 
 def create_directory_structure(project_path: Path) -> list[str]:
@@ -1809,7 +1895,7 @@ def configure_branch_protection(github_user: str, repo_name: str, pat: str) -> b
     try:
         check = subprocess.run(
             ["gh", "api", f"/repos/{github_user}/{repo_name}/branches/main"],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL,
         )
         if check.returncode != 0:
             print("    Remote branch 'main' not found — skipping branch protection.")
@@ -2315,7 +2401,7 @@ def _deploy_cerberus(
     if not ok:
         print(f"  FAILED to deploy: {', '.join(failed)}")
         if source_path is not None:
-            print(f"  .pem file NOT deleted -- retry manually:")
+            print("  .pem file NOT deleted -- retry manually:")
             print(f"    poetry run python tools/deploy_cerberus_secrets.py {source_path}")
         return f"FAILED: {', '.join(failed)}"
     print("  Secrets set.")
@@ -2324,7 +2410,7 @@ def _deploy_cerberus(
     if not ok:
         print(f"  WARNING: verification failed; missing {missing}")
         if source_path is not None:
-            print(f"  .pem file NOT deleted -- investigate before deleting.")
+            print("  .pem file NOT deleted -- investigate before deleting.")
         return f"UNVERIFIED: {', '.join(missing)}"
     print("  Secrets verified on GitHub (both REVIEWER_APP_ID and REVIEWER_APP_PRIVATE_KEY present).")
 
@@ -2348,6 +2434,11 @@ def _deploy_cerberus(
 
 
 def main():
+    # Detach stdin before anything else (#1806). A run prompts for a GPG
+    # passphrase via pinentry; if pinentry loses the focus race, keystrokes
+    # meant for it land on this terminal. From here on they go nowhere.
+    detach_stdin()
+
     parser = argparse.ArgumentParser(
         description="Scaffold a new repository with AssemblyZero structure",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -2566,7 +2657,7 @@ Examples:
         print(f"[ERROR] Repository creation failed: {e}")
         print(f"{'=' * 60}")
         print(f"\nPartial state may exist at: {project_path}")
-        print(f"Review and clean up manually if needed.")
+        print("Review and clean up manually if needed.")
         sys.exit(1)
 
 
@@ -2588,9 +2679,9 @@ def _diagnose_existing_path(project_path: Path) -> tuple[str, list[str]]:
     """
     if project_path.is_file():
         return ("file", [
-            f"Path is a regular file, not a directory.",
+            "Path is a regular file, not a directory.",
             f"Remove it: rm '{project_path}'",
-            f"Then re-run.",
+            "Then re-run.",
         ])
 
     git_path = project_path / ".git"
@@ -2602,21 +2693,21 @@ def _diagnose_existing_path(project_path: Path) -> tuple[str, list[str]]:
         except OSError:
             pass
         return ("stale_worktree", [
-            f"Directory contains a `.git` FILE — looks like a stale git-worktree leftover (#935).",
+            "Directory contains a `.git` FILE — looks like a stale git-worktree leftover (#935).",
             f"  .git contents: {registration or '(unreadable)'}",
             "Recovery options (try in this order):",
             f"  1. cd '{project_path}' && poetry env remove --all  # release venv file locks",
             f"  2. rm -rf '{project_path}'                          # may still fail if other locks remain",
             f"  3. powershell -c \"Get-Process | Where-Object {{ \\$_.Path -like '*{project_path.name}*' }}\"  # find lock-holder",
-            f"  4. If a stale Python process holds the lock: powershell -c \"Get-Process python | Stop-Process\" (carefully)",
-            f"  5. Reboot is the nuclear option.",
+            "  4. If a stale Python process holds the lock: powershell -c \"Get-Process python | Stop-Process\" (carefully)",
+            "  5. Reboot is the nuclear option.",
         ])
 
     if git_path.is_dir():
         return ("live_repo", [
-            f"Directory is an existing git repo (has a `.git` directory).",
-            f"This is NOT a leftover. Refusing to overwrite.",
-            f"Pick a different name for your new repo, or move/rename the existing repo first.",
+            "Directory is an existing git repo (has a `.git` directory).",
+            "This is NOT a leftover. Refusing to overwrite.",
+            "Pick a different name for your new repo, or move/rename the existing repo first.",
         ])
 
     try:
@@ -2625,7 +2716,7 @@ def _diagnose_existing_path(project_path: Path) -> tuple[str, list[str]]:
         entry_count = -1
     return ("unknown_dir", [
         f"Directory exists with {entry_count} entries but no `.git` of any kind.",
-        f"Either remove it (if not yours) or pick a different name:",
+        "Either remove it (if not yours) or pick a different name:",
         f"  rm -rf '{project_path}'  # if you confirm you don't need it",
     ])
 
@@ -2716,7 +2807,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     if project_path.exists():
         kind, recovery_lines = _diagnose_existing_path(project_path)
         print("\n" + "=" * 60)
-        print(f"[PRE-FLIGHT] Refusing to proceed: target path already exists")
+        print("[PRE-FLIGHT] Refusing to proceed: target path already exists")
         print("=" * 60)
         print(f"Path: {project_path}")
         print(f"Kind: {kind}")
@@ -2725,6 +2816,51 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print()
         print("No local files written, no GitHub repo created. Resolve the collision and re-run.")
         sys.exit(1)
+
+    # Pre-flight: refuse to proceed if the GitHub repo already exists (#1805).
+    # This must run BEFORE the scaffold. Detecting the collision later (at the
+    # create call, which 422s) is too late: by then a fresh initial commit
+    # exists locally, its history is unrelated to the live remote, the push is
+    # rejected, and every downstream step gated on that push -- workflow
+    # upload, repo settings, the Cerberus secret deploy -- silently skips. The
+    # visible symptom is a missing second pinentry prompt, which reads as a
+    # broken security flow when the real fault is scaffolding over a live repo.
+    if not args.no_github:
+        try:
+            existing = check_remote_repo_exists(github_user, args.name)
+        except RuntimeError as e:
+            print("\n" + "=" * 60)
+            print("[PRE-FLIGHT] Cannot determine whether the GitHub repo exists")
+            print("=" * 60)
+            print(f"Repo:   {github_user}/{args.name}")
+            print(f"Reason: {e}")
+            print()
+            print("Refusing to scaffold on an unverified name. Fix the cause")
+            print("(`gh auth status`, network) and re-run, or pass --no-github")
+            print("to scaffold locally only.")
+            print()
+            print("No local files written, no GitHub state changed.")
+            sys.exit(1)
+
+        if existing is not None:
+            created = str(existing.get("created_at", "unknown"))[:10]
+            print("\n" + "=" * 60)
+            print("[PRE-FLIGHT] Refusing to proceed: GitHub repo already exists")
+            print("=" * 60)
+            print(f"Repo:    {existing.get('html_url', f'{github_user}/{args.name}')}")
+            print(f"Created: {created}")
+            print(f"Private: {existing.get('private', 'unknown')}")
+            print()
+            print("Scaffolding now would build a fresh initial commit whose history")
+            print("is unrelated to that repo. The push would be rejected, and the")
+            print("Cerberus secret deploy would be skipped because it is gated on a")
+            print("successful push -- leaving a local directory that can never push.")
+            print()
+            print("Clone the existing repo instead:")
+            print(f"  gh repo clone {github_user}/{args.name}")
+            print()
+            print("No local files written, no GitHub state changed.")
+            sys.exit(1)
 
     # Step 1: Create directory
     print("\n1. Creating directory...")
@@ -3050,7 +3186,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         print("  Proceeding in rerun mode against existing repo.")
                         github_created = True
                     else:
-                        print(f"  ERROR: 422 from POST /user/repos but repo not found")
+                        print("  ERROR: 422 from POST /user/repos but repo not found")
                         print(f"  Response: {create_resp.text[:300]}")
                 else:
                     print(f"  ERROR: POST /user/repos returned {create_resp.status_code}")
@@ -3066,7 +3202,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                     remote_check = subprocess.run(
                         ["git", "remote", "get-url", "origin"],
                         cwd=str(project_path),
-                        capture_output=True, text=True,
+                        capture_output=True, text=True, stdin=subprocess.DEVNULL,
                     )
                     if remote_check.returncode != 0:
                         try:
@@ -3126,6 +3262,7 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         pull = subprocess.run(
                             ["git", "pull", "--rebase", "origin", "main"],
                             cwd=str(project_path), capture_output=True, text=True, timeout=60,
+                            stdin=subprocess.DEVNULL,
                         )
                         if pull.returncode == 0:
                             print("  Synced -- local is now at remote HEAD with workflows tracked.")


### PR DESCRIPTION
Three issues on the same two files, landed together because they share scope: two are safety guards on `new_repo.py` and the third is the lint debt already sitting in the files being edited.

## #1805 — refuse to scaffold over a live repo

`new_repo.py` learned that a repo already existed only when `POST /user/repos` returned 422 — at step 13a, long after the local scaffold and its initial commit existed. From there the run degraded in a way that pointed at the wrong culprit:

1. Fresh local history, unrelated to the live remote.
2. `git push -u origin main` rejected, so `push_succeeded` stayed `False`.
3. Workflow upload, repo settings, and the Cerberus secret deploy are all gated on `push_succeeded` — so they silently skipped.
4. The operator saw one pinentry prompt instead of two and reasonably concluded the security apparatus had misfired. It hadn't; the deploy was correctly gated off a failed push.

Now a pre-flight runs **before `mkdir`**, beside the existing local-path collision check, and hard-stops with the creation date and a `gh repo clone` command. Nothing local is written and no GitHub state changes.

The lookup goes through `gh api`, which uses the already-configured fine-grained PAT. That is deliberate: a pre-flight must not trigger a classic-PAT pinentry prompt before the operator even knows the run can proceed.

One design point worth flagging: **an error that is not a 404 raises rather than reporting "absent."** A 401, a network failure, or a missing `gh` means existence is *unknown*, and treating unknown as free is exactly the defect. Unknown refuses too, and says why.

## #1806 — a stray passphrase must land nowhere

`detach_stdin()` runs as the first statement in `main()`, replacing file descriptor 0 with the null device. Anything typed at the controlling terminal during a run is discarded — it cannot be read, echoed, or logged. All five `subprocess` call sites now pass `stdin=subprocess.DEVNULL` so no child inherits the terminal either.

The recon on this issue found no `input()` or `sys.stdin.read()` path, and a test now asserts that stays true rather than trusting the recon.

**Deliberate trade:** if gpg is ever configured with a tty-based pinentry, it will now fail loudly instead of quietly accepting a secret through the wrong channel. On this platform pinentry is a GUI dialog reading its own handle, so this should not arise — and failing loudly is the behavior the issue asks for.

## #1728 — lint debt

15 findings in `tools/new_repo.py` and 6 across `tests/unit/test_new_repo*.py`. The issue cites `tools/test_new_repo.py`, which does not exist; the tests live in `tests/unit/`. The unused-`os` import resolved itself once `detach_stdin()` needed it. The two mid-file import blocks in the test file were merged into the top block rather than suppressed.

## Verification

- `tests/unit/test_new_repo_safety.py` — 16 new tests, all passing.
- The stdin test is an end-to-end subprocess probe: it pipes a fake passphrase in and asserts stdin reads back empty and the input never appears in output. It runs as a real subprocess because fd 0 is the thing under test and pytest owns fd 0 in-process.
- One test asserts `detach_stdin()` is called before `parse_args` — a guard that runs after the risky work is not a guard.
- Full unit suite: **5598 passed, 16 skipped, 5 xfailed**.
- `ruff check` clean on all four files.

## Not included

The `--adopt` / `--rerun` flag from #1805's ask is deliberately out of scope, tracked in #1809. Adopting a live repo means reconciling a real remote against a fresh scaffold — which files win, whether to overwrite settings, whether to re-run the Cerberus deploy — and that writes to a live repo. Bundling that design into a safety fix would put operational-config behavior in the same change as a guard. The hard stop is what makes repo creation safe today.

Closes #1805, Closes #1806, Closes #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)
