### PR TITLE
fix(speedrun_reset): attempt-branch aware sweep that never destroys work (Closes #1762)

### DIFF
--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -1,0 +1,200 @@
+"""
+Post-cut sweep behavior for tools/speedrun_reset.py.
+
+A CUT take leaves worktrees, work branches, and an open LLD PR behind. The
+reset tool predates the attempt-branch model (#1759/#1755), so this suite
+pins the two properties that model requires:
+
+- the sweep never touches the attempt branch it is standing on;
+- the sweep never destroys uncommitted work, and never escalates to (or
+  advertises) a force-delete when git refuses.
+
+Issue: #1762
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "tools"))
+
+from speedrun_reset import (
+    close_open_prs,
+    current_branch,
+    delete_local_branches,
+    remove_worktree,
+    worktree_is_dirty,
+)
+
+TOOL_SOURCE = (Path(__file__).parent.parent.parent / "tools" / "speedrun_reset.py").read_text(
+    encoding="utf-8"
+)
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestBranchSweepIsAttemptBranchAware:
+
+    def test_never_deletes_the_checked_out_branch(self, tmp_path):
+        """
+        The attempt branch is what the run stands on. Even if it somehow
+        matched the issue glob, deleting it would cut the branch out from
+        under the attempt.
+        """
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="  1234-lld\n* 1234-attempt\n")
+            if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+                return _completed(stdout="1234-attempt\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            deleted = delete_local_branches(tmp_path, 1234)
+
+        assert deleted == 1
+        deletions = [c for c in calls if c[:3] == ["git", "branch", "-d"]]
+        assert deletions == [["git", "branch", "-d", "1234-lld"]]
+
+    def test_attempt_branch_does_not_match_the_issue_glob(self, tmp_path):
+        """Enumeration is scoped to `{issue}-*`; `attempt-test-1` is not swept."""
+        with patch("speedrun_reset._run", return_value=_completed(stdout="")) as run:
+            delete_local_branches(tmp_path, 1234)
+        listing = run.call_args_list[0].args[0]
+        assert listing == ["git", "branch", "--list", "1234-*"]
+
+    def test_unmerged_branch_is_left_alone_without_suggesting_force_delete(
+        self, tmp_path, capsys
+    ):
+        def fake_run(cmd, cwd=None, check=False):
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="  1234-implementation\n")
+            if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+                return _completed(stdout="attempt-test-1\n")
+            if cmd[:3] == ["git", "branch", "-d"]:
+                return _completed(returncode=1, stderr="not fully merged")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            deleted = delete_local_branches(tmp_path, 1234)
+
+        assert deleted == 0
+        out = capsys.readouterr().out
+        assert "unmerged commits" in out
+        assert "-D" not in out, "must never advertise a force-delete to the operator"
+
+    def test_source_contains_no_force_delete_instruction(self):
+        """
+        Guard against reintroduction. The tool previously printed
+        `git branch -D` as a suggestion -- an instructed ban is an
+        executed ban.
+        """
+        assert "branch -D" not in TOOL_SOURCE
+        assert "worktree remove --force" not in TOOL_SOURCE
+
+
+class TestWorktreeSweepPreservesWork:
+
+    def test_dirty_worktree_is_left_in_place(self, tmp_path, capsys):
+        """git refused, and the tree holds work -- respect the refusal."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = tmp_path / "repo-1234"
+        worktree.mkdir()
+
+        def fake_run(cmd, cwd=None, check=False):
+            if cmd[:3] == ["git", "worktree", "remove"]:
+                return _completed(returncode=1, stderr="contains modified files")
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return _completed(stdout=" M src/thing.py\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            removed = remove_worktree(repo, 1234)
+
+        assert removed is False
+        assert worktree.exists(), "a worktree holding work must survive the sweep"
+        out = capsys.readouterr().out
+        assert "uncommitted work" in out
+
+    def test_unreadable_worktree_is_treated_as_holding_work(self, tmp_path):
+        """If status cannot be read, assume work is present rather than delete."""
+        with patch("speedrun_reset._run", return_value=_completed(returncode=128)):
+            assert worktree_is_dirty(tmp_path) is True
+
+    def test_clean_unregistered_directory_is_removed(self, tmp_path, capsys):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = tmp_path / "repo-1234"
+        worktree.mkdir()
+        (worktree / "leftover.txt").write_text("x", encoding="utf-8")
+
+        def fake_run(cmd, cwd=None, check=False):
+            if cmd[:3] == ["git", "worktree", "remove"]:
+                return _completed(returncode=1, stderr="is not a working tree")
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return _completed(stdout="")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            removed = remove_worktree(repo, 1234)
+
+        assert removed is True
+        assert not worktree.exists()
+
+    def test_successful_removal_prunes_stale_registration(self, tmp_path):
+        """
+        Without a prune, git keeps the path registered and the next
+        `worktree add` there fails as already-registered.
+        """
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        worktree = tmp_path / "repo-1234"
+        worktree.mkdir()
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            assert remove_worktree(repo, 1234) is True
+
+        assert ["git", "worktree", "prune"] in calls
+
+    def test_missing_worktree_is_not_an_error(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        assert remove_worktree(repo, 1234) is False
+
+
+class TestPrEnumerationIsBaseAgnostic:
+
+    def test_pr_search_does_not_filter_by_base_branch(self):
+        """
+        PRs raised during an attempt target the attempt branch, not main.
+        Filtering by base would make the sweep miss every one of them.
+        """
+        with patch("speedrun_reset._run", return_value=_completed(stdout="[]")) as run:
+            close_open_prs("owner/repo", 1234)
+        cmd = run.call_args.args[0]
+        assert "--base" not in cmd
+        assert "Closes #1234" in cmd
+
+
+class TestCurrentBranch:
+
+    def test_returns_branch_name(self, tmp_path):
+        with patch("speedrun_reset._run", return_value=_completed(stdout="attempt-test-1\n")):
+            assert current_branch(tmp_path) == "attempt-test-1"
+
+    def test_returns_empty_string_when_undetermined(self, tmp_path):
+        with patch("speedrun_reset._run", return_value=_completed(returncode=128)):
+            assert current_branch(tmp_path) == ""

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -92,31 +92,91 @@ def close_open_prs(repo: str, issue: int) -> int:
     return closed
 
 
+def worktree_is_dirty(worktree_path: Path) -> bool:
+    """
+    True if the worktree holds uncommitted work (tracked or untracked).
+
+    Returns True when the state cannot be read, so an unreadable worktree
+    is treated as "might hold work" rather than "safe to delete".
+    """
+    result = _run(["git", "status", "--porcelain"], cwd=worktree_path)
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
 def remove_worktree(repo_root: Path, issue: int) -> bool:
-    """Remove worktree at `{repo}-{issue}` if it exists."""
+    """
+    Remove the worktree at `{repo}-{issue}` if it exists.
+
+    A CUT take leaves a half-finished worktree behind, and that worktree
+    may hold uncommitted work. `git worktree remove` refuses in that case,
+    and that refusal is a signal to respect, not to route around: this
+    function never force-removes and never deletes a dirty directory. A
+    worktree holding work is reported and left for the operator (#1762).
+    """
     parent = repo_root.parent
     worktree_path = parent / f"{repo_root.name}-{issue}"
     if not worktree_path.exists():
         return False
+
     result = _run(
         ["git", "worktree", "remove", str(worktree_path)],
         cwd=repo_root,
     )
     if result.returncode == 0:
         print(f"  Removed worktree: {worktree_path}")
+        _prune_worktrees(repo_root)
         return True
-    # Worktree might exist but be unregistered in git's view. Try direct rmdir.
+
+    if worktree_is_dirty(worktree_path):
+        print(f"  SKIPPED worktree {worktree_path} — it holds uncommitted work.")
+        print("    Left in place. Inspect it, then remove it yourself once")
+        print("    you have salvaged anything worth keeping.")
+        return False
+
+    # Clean, but git would not remove it — typically a directory that is no
+    # longer registered as a worktree. Nothing uncommitted is at stake.
     try:
         shutil.rmtree(worktree_path)
-        print(f"  Removed worktree directory: {worktree_path}")
+        print(f"  Removed unregistered worktree directory: {worktree_path}")
+        _prune_worktrees(repo_root)
         return True
     except OSError as e:
         print(f"  WARNING: could not remove worktree {worktree_path}: {e}")
         return False
 
 
+def _prune_worktrees(repo_root: Path) -> None:
+    """
+    Drop stale worktree registrations.
+
+    Without this, git keeps the removed path registered and the next
+    `git worktree add` at that path fails as already-registered — the
+    exact state a reset is supposed to clear.
+    """
+    _run(["git", "worktree", "prune"], cwd=repo_root)
+
+
+def current_branch(repo_root: Path) -> str:
+    """Name of the branch the repo is checked out on, or '' if undetermined."""
+    result = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_root)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
 def delete_local_branches(repo_root: Path, issue: int) -> int:
-    """Delete local branches matching `{issue}-*` pattern. Returns count deleted."""
+    """
+    Safe-delete the pipeline branches for one issue. Returns count deleted.
+
+    Only `{issue}-*` branches are candidates — the per-stage work branches
+    the pipeline creates. The attempt branch itself (the integration branch
+    every pipeline PR targets under the #1755 model) is named for the
+    attempt, not the issue, so it never matches. The checked-out branch is
+    additionally excluded by name, so a reset can never delete the very
+    branch the attempt is standing on (#1762).
+    """
     result = _run(
         ["git", "branch", "--list", f"{issue}-*"],
         cwd=repo_root,
@@ -128,22 +188,26 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
         for line in result.stdout.splitlines()
         if line.strip()
     ]
+    active = current_branch(repo_root)
     deleted = 0
     for branch in branches:
         if not branch:
             continue
-        # Try safe-delete first; never use -D
+        if branch == active:
+            print(f"  Skipped branch {branch} (currently checked out).")
+            continue
         r = _run(["git", "branch", "-d", branch], cwd=repo_root)
         if r.returncode == 0:
             print(f"  Deleted local branch: {branch}")
             deleted += 1
         else:
-            # Branch wasn't merged. For speed-run reset, that's expected
-            # (we're discarding work). Use -d still — the user can decide
-            # if they want -D themselves. We don't auto-escalate.
+            # Safe-delete refused: the branch holds commits not reachable
+            # from HEAD. That refusal is the safety net working. Report it
+            # and move on -- never escalate to a force-delete, and never
+            # suggest one, per the banned-commands rule and ADR-0217.
             print(
-                f"  Skipped branch {branch} (not merged; "
-                f"reset with `git branch -D {branch}` if intentional)"
+                f"  Skipped branch {branch} (holds unmerged commits; "
+                f"left in place for review)."
             )
     return deleted
 


### PR DESCRIPTION
`speedrun_reset.py` predates the attempt-branch model (#1755 / #1759). The audit this issue asked for turned up one thing that was already right and three that were not.

## Already correct

**PR enumeration is base-agnostic.** `close_open_prs` searches for `Closes #{issue}` with no `--base` filter, so it finds PRs that target an attempt branch just as well as ones targeting `main`. Filtering by base would have made the sweep miss every PR raised during an attempt. A test now pins this so it does not acquire a base filter later.

## Three defects

**1. The worktree fallback destroyed uncommitted work.** When `git worktree remove` failed, the tool ran `shutil.rmtree` on the directory. But git refuses precisely when the worktree holds uncommitted work — so the fallback was routing around the refusal and deleting the work. That is the operation the banned-commands rule forbids, arriving under a different name than the flags on the list.

It now checks for uncommitted state first and leaves a worktree holding work in place, reported for the operator to salvage. A status that cannot be read counts as dirty — an unreadable worktree is treated as "might hold work", never as "safe to delete". The `rmtree` path survives only for a directory that is verifiably clean and no longer registered as a worktree, where nothing is at stake.

**2. Nothing pruned the worktree registry.** After a removal, git kept the path registered, so the next `git worktree add` at that path failed as already-registered — the exact state a reset exists to clear, and a known recurring snag in this repo's workflow notes. A `git worktree prune` now follows every successful removal.

**3. The tool advertised a force-delete.** On a safe-delete refusal it printed:

> `Skipped branch {branch} (not merged; reset with `git branch -D {branch}` if intentional)`

An instructed ban is an executed ban — this is the INSTRUCTOR landmine class named in `docs/audits/0901-banned-commands-cleanup-family-2026-06-22.md`, sitting in a tool rather than a skill file. It now reports that the branch holds unmerged commits and leaves it in place. A safe-delete refusal is the safety net working, not a problem to route around.

## Attempt-branch awareness

Branch enumeration stays scoped to `{issue}-*`, which is correct: those are the per-stage work branches the pipeline creates, while the attempt branch is named for the attempt and never matches. On top of that, the checked-out branch is now excluded by name, so a sweep can never delete the branch the attempt is standing on.

## Verification

- `tests/unit/test_speedrun_reset.py` — 12 new tests.
- One is a source-level guard asserting neither `branch -D` nor `worktree remove --force` appears anywhere in the tool, so the instruction cannot be reintroduced quietly.
- Full unit suite: **5610 passed, 16 skipped, 5 xfailed**. `ruff check` clean.

## Note on the runbook card

This issue mentions the deliverable doubling as the post-cut sweep card for the boostgauge runbook. The behavior is now well-defined enough to write that card against — a sweep either clears the state or names what it deliberately left behind — but the card itself lives in the runbook that its own issue tracks, so it is not written here.

Closes #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
