### PR TITLE
feat(telemetry): structured hallucination-event log at both LLD and spec stage (Closes #1812)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -28,6 +28,10 @@ from assemblyzero.workflows.implementation_spec.state import (
     ImplementationSpecState,
     PatternRef,
 )
+from assemblyzero.workflows.telemetry import (
+    build_hallucination_event,
+    record_hallucination_event,
+)
 
 
 # =============================================================================
@@ -153,6 +157,14 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_symbols)
     _log_check(check_symbols)
 
+    # Telemetry (#1812): record detector outcomes for the spec draft (every
+    # pass) and the LLD (first pass only). Record-only — the try/except
+    # guarantees telemetry can never alter validation_passed.
+    try:
+        _record_hallucination_telemetry(state, spec_draft, gathered_symbols)
+    except Exception as e:  # noqa: BLE001 — record-only contract
+        print(f"    [telemetry] WARNING: hallucination telemetry failed: {e}")
+
     # Collect issues from failed checks
     completeness_issues = [
         check["details"] for check in checks if not check["passed"]
@@ -192,6 +204,66 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
         "prior_completeness_breakdown": prior_breakdown,
         "error_message": "",
     }
+
+
+def _record_hallucination_telemetry(
+    state: ImplementationSpecState,
+    spec_draft: str,
+    gathered_symbols: list[str],
+) -> None:
+    """Emit hallucination-detector events for this validation pass (#1812).
+
+    Runs the shared detector against the spec draft on every pass, and
+    against the LLD once per run — on the first pass, before any revision
+    has bumped ``review_iteration`` past 0. The LLD does not change across
+    revision cycles, so one measurement per run is the honest count.
+
+    When no symbols were gathered, the detector cannot run; a ``skipped``
+    event is recorded instead of silence, so "not checked" is never
+    mistaken for "checked, clean".
+
+    Record-only: this function writes events and returns nothing. It is
+    called inside a try/except in the node; sink failures degrade to
+    warnings inside the telemetry module itself.
+    """
+    iteration: int = state.get("review_iteration", 0)  # type: ignore[assignment]
+    repo: str = state.get("repo_root", "")  # type: ignore[assignment]
+    issue: int = state.get("issue_number", 0)  # type: ignore[assignment]
+
+    audit_dir_str: str = state.get("audit_dir", "")  # type: ignore[assignment]
+    audit_dir = Path(audit_dir_str) if audit_dir_str else None
+    az_root_str: str = state.get("assemblyzero_root", "")  # type: ignore[assignment]
+    az_root = Path(az_root_str) if az_root_str else None
+
+    symbol_set = set(gathered_symbols)
+
+    artifacts: list[tuple[str, str]] = [("spec_draft", spec_draft)]
+    if iteration == 0:
+        lld_content: str = state.get("lld_content", "")  # type: ignore[assignment]
+        artifacts.insert(0, ("lld", lld_content))
+
+    for artifact_name, text in artifacts:
+        if not symbol_set:
+            event = build_hallucination_event(
+                repo=repo,
+                issue=issue,
+                artifact=artifact_name,
+                iteration=iteration,
+                symbols_checked=0,
+                flagged={},
+                skipped=True,
+            )
+        else:
+            flagged = detect_unknown_method_calls(text, symbol_set)
+            event = build_hallucination_event(
+                repo=repo,
+                issue=issue,
+                artifact=artifact_name,
+                iteration=iteration,
+                symbols_checked=len(symbol_set),
+                flagged=flagged,
+            )
+        record_hallucination_event(event, audit_dir, az_root)
 
 
 # =============================================================================
@@ -756,6 +828,54 @@ def check_import_targets_exist(
     )
 
 
+def detect_unknown_method_calls(
+    text: str,
+    symbol_set: set[str],
+) -> dict[str, list[str]]:
+    """Scan code fences in ``text`` for method calls absent from ``symbol_set``.
+
+    The detection core shared by :func:`check_api_symbols_exist` (which
+    gates the spec) and the hallucination telemetry (#1812, which records
+    the same signal for both the spec draft and the LLD, record-only).
+    Extracted so both consumers measure with the identical yardstick.
+
+    Args:
+        text: Markdown to scan. Only content inside ``` fences is examined.
+        symbol_set: Real symbol names extracted from the target repo.
+
+    Returns:
+        Mapping of unknown method name -> truncated example call sites.
+        Empty when every call resolves to a known or allowlisted symbol.
+    """
+    # Extract method/function call names from code fences only
+    code_block_re = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
+    # Match  <ident>.<method>(  —  the opening paren marks a call, not an annotation
+    method_call_re = re.compile(r"\b\w+\.(\w+)\s*\(")
+
+    flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
+
+    for block_match in code_block_re.finditer(text):
+        block_content = block_match.group(1)
+        for call_match in method_call_re.finditer(block_content):
+            method_name = call_match.group(1)
+
+            if method_name in symbol_set:
+                continue
+            if method_name in _API_SYMBOL_ALLOWLIST:
+                continue
+
+            # Capture the call site for the error message (truncated)
+            call_site = block_content[
+                max(0, call_match.start() - 10) : call_match.end() + 20
+            ].strip().replace("\n", " ")
+
+            if method_name not in flagged:
+                flagged[method_name] = []
+            flagged[method_name].append(call_site[:80])
+
+    return flagged
+
+
 def check_api_symbols_exist(
     spec: str,
     gathered_symbols: list[str],
@@ -801,32 +921,7 @@ def check_api_symbols_exist(
         )
 
     symbol_set: set[str] = set(gathered_symbols)
-
-    # Extract method/function call names from code fences only
-    code_block_re = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
-    # Match  <ident>.<method>(  —  the opening paren marks a call, not an annotation
-    method_call_re = re.compile(r"\b\w+\.(\w+)\s*\(")
-
-    flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
-
-    for block_match in code_block_re.finditer(spec):
-        block_content = block_match.group(1)
-        for call_match in method_call_re.finditer(block_content):
-            method_name = call_match.group(1)
-
-            if method_name in symbol_set:
-                continue
-            if method_name in _API_SYMBOL_ALLOWLIST:
-                continue
-
-            # Capture the call site for the error message (truncated)
-            call_site = block_content[
-                max(0, call_match.start() - 10) : call_match.end() + 20
-            ].strip().replace("\n", " ")
-
-            if method_name not in flagged:
-                flagged[method_name] = []
-            flagged[method_name].append(call_site[:80])
+    flagged = detect_unknown_method_calls(spec, symbol_set)
 
     if not flagged:
         return CompletenessCheck(

--- a/assemblyzero/workflows/telemetry/__init__.py
+++ b/assemblyzero/workflows/telemetry/__init__.py
@@ -1,0 +1,16 @@
+"""Workflow telemetry — structured, record-only instrumentation.
+
+Issue #1812: telemetry modules observe the pipeline; they never gate it.
+Nothing exported here may alter workflow control flow, and sink failures
+degrade to warnings — telemetry must never break the pipeline it measures.
+"""
+
+from assemblyzero.workflows.telemetry.hallucination_log import (
+    build_hallucination_event,
+    record_hallucination_event,
+)
+
+__all__ = [
+    "build_hallucination_event",
+    "record_hallucination_event",
+]

--- a/assemblyzero/workflows/telemetry/hallucination_log.py
+++ b/assemblyzero/workflows/telemetry/hallucination_log.py
@@ -1,0 +1,124 @@
+"""Structured hallucination-event log (#1812).
+
+Records every invented-API detection the pipeline makes, so the Tiphys fix
+(see #1688) lands against a live baseline instead of remembered incidents.
+Before this module, the deterministic detector's findings lived only in
+console output and in-run workflow state — the evidence died at process
+exit, and only unstructured review prose survived.
+
+Two sinks, both written per event:
+
+- A per-invocation JSON file saved through the existing ``save_audit_file``
+  mechanism into the run's ``audit_dir``, so it archives into lineage
+  beside the verdicts — durable, tracked, travels with the issue.
+- An append-only JSONL at ``data/telemetry/hallucination-log.jsonl`` under
+  the AssemblyZero root — machine-local, gitignored, the one-grep query
+  index.
+
+Record-only contract: nothing here may alter workflow control flow. Every
+sink failure degrades to a printed warning. A run with zero detections
+still records events (``passed: true``) — absence of evidence must be
+distinguishable from absence of instrumentation.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from assemblyzero.workflows.requirements.audit import (
+    next_file_number,
+    save_audit_file,
+)
+
+# Suffix for the per-invocation audit file (numbered NNN- by save_audit_file).
+AUDIT_SUFFIX = "hallucination-check.json"
+
+# Cumulative query index, relative to the AssemblyZero root. Lives under
+# data/ (gitignored, machine-local) by design — the durable copy is the
+# audit_dir file that lineage archival carries. data-g/ is not a dependency
+# here; #1598 remains open.
+JSONL_RELATIVE_PATH = Path("data") / "telemetry" / "hallucination-log.jsonl"
+
+
+def build_hallucination_event(
+    *,
+    repo: str,
+    issue: int,
+    artifact: str,
+    iteration: int,
+    symbols_checked: int,
+    flagged: dict[str, list[str]],
+    skipped: bool = False,
+) -> dict[str, Any]:
+    """Build one detector-invocation event. Pure — no I/O.
+
+    Args:
+        repo: Target repository root path (identifies the project).
+        issue: GitHub issue number the run is working.
+        artifact: What the detector scanned — ``"lld"`` or ``"spec_draft"``.
+        iteration: The run's review iteration (0 = first pass).
+        symbols_checked: Size of the real-symbol set compared against.
+        flagged: Detector output — method name -> example call sites.
+            Empty when nothing was flagged.
+        skipped: True when the detector could not run (no gathered
+            symbols). A skipped event is NOT a clean event — it records
+            that no check happened, which is the distinction the whole
+            instrument exists to preserve.
+
+    Returns:
+        The event dict, ready for either sink.
+    """
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "repo": repo,
+        "issue": issue,
+        "stage": "spec",
+        "artifact": artifact,
+        "iteration": iteration,
+        "symbols_checked": symbols_checked,
+        "flagged": flagged,
+        "passed": not flagged,
+        "skipped": skipped,
+    }
+
+
+def record_hallucination_event(
+    event: dict[str, Any],
+    audit_dir: Path | None,
+    assemblyzero_root: Path | None,
+) -> None:
+    """Write one event to both sinks. Never raises.
+
+    Either sink may be unavailable (fresh checkout, missing audit dir,
+    permissions); each failure is reported as a warning and swallowed.
+    Telemetry must never break the pipeline it observes.
+
+    Args:
+        event: Event from :func:`build_hallucination_event`.
+        audit_dir: The run's audit directory, or None to skip that sink.
+        assemblyzero_root: AssemblyZero repo root anchoring the JSONL
+            sink, or None to skip it.
+    """
+    if audit_dir is not None and audit_dir.exists():
+        try:
+            file_num = next_file_number(audit_dir)
+            save_audit_file(
+                audit_dir,
+                file_num,
+                AUDIT_SUFFIX,
+                json.dumps(event, indent=2) + "\n",
+            )
+        except OSError as e:
+            print(f"    [telemetry] WARNING: audit sink failed: {e}")
+
+    if assemblyzero_root is not None:
+        try:
+            jsonl_path = assemblyzero_root / JSONL_RELATIVE_PATH
+            jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event) + "\n")
+        except OSError as e:
+            print(f"    [telemetry] WARNING: JSONL sink failed: {e}")

--- a/tests/unit/test_hallucination_telemetry.py
+++ b/tests/unit/test_hallucination_telemetry.py
@@ -1,0 +1,265 @@
+"""Hallucination-event telemetry (#1812).
+
+Pins the record-only contract: the instrument measures invented-API calls
+in both the spec draft and the LLD, writes structured events to both
+sinks, and can never — under any failure — alter the completeness gate's
+verdict. Clean runs still write events, and "detector could not run" is
+recorded as ``skipped``, never as silence.
+
+Issue: #1812
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    detect_unknown_method_calls,
+    validate_completeness,
+)
+from assemblyzero.workflows.telemetry.hallucination_log import (
+    AUDIT_SUFFIX,
+    JSONL_RELATIVE_PATH,
+    build_hallucination_event,
+    record_hallucination_event,
+)
+
+# A method name no allowlist or repo will ever contain.
+FAKE_CALL = "frobnicate_the_widget"
+
+KNOWN_SYMBOLS = ["to_dict", "from_dict", "Question"]
+
+# Long enough to clear the node's empty-draft guard (>= 100 chars).
+_FILLER = "This spec describes the change in enough detail to validate. " * 3
+
+CLEAN_SPEC = (
+    "# Implementation Spec\n\n" + _FILLER + "\n"
+    "```python\nresult = question.to_dict()\n```\n"
+)
+HALLUCINATED_SPEC = (
+    "# Implementation Spec\n\n" + _FILLER + "\n"
+    f"```python\nresult = question.{FAKE_CALL}()\n```\n"
+)
+CLEAN_LLD = "# LLD\n\n```python\nobj = Question.from_dict(data)\n```\n"
+HALLUCINATED_LLD = f"# LLD\n\n```python\nobj = question.{FAKE_CALL}()\n```\n"
+
+
+def _read_jsonl(az_root):
+    path = az_root / JSONL_RELATIVE_PATH
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+@pytest.fixture
+def state(tmp_path):
+    """Minimal node state with live audit + JSONL sinks under tmp_path."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+    return {
+        "issue_number": 42,
+        "lld_content": HALLUCINATED_LLD,
+        "files_to_modify": [],
+        "pattern_references": [],
+        "spec_draft": CLEAN_SPEC,
+        "gathered_symbols": list(KNOWN_SYMBOLS),
+        "review_iteration": 0,
+        "repo_root": str(tmp_path),
+        "assemblyzero_root": str(tmp_path),
+        "audit_dir": str(audit_dir),
+        "error_message": "",
+    }
+
+
+# =============================================================================
+# The event builder — pure
+# =============================================================================
+
+
+class TestBuildEvent:
+
+    def test_flagged_event_fields(self):
+        event = build_hallucination_event(
+            repo="/r", issue=7, artifact="lld", iteration=2,
+            symbols_checked=447,
+            flagged={FAKE_CALL: [f"question.{FAKE_CALL}()"]},
+        )
+        assert event["stage"] == "spec"
+        assert event["artifact"] == "lld"
+        assert event["iteration"] == 2
+        assert event["symbols_checked"] == 447
+        assert event["passed"] is False
+        assert event["skipped"] is False
+        # Timestamp must parse as ISO-8601
+        datetime.fromisoformat(event["ts"])
+
+    def test_clean_event_passes(self):
+        event = build_hallucination_event(
+            repo="/r", issue=7, artifact="spec_draft", iteration=0,
+            symbols_checked=10, flagged={},
+        )
+        assert event["passed"] is True
+
+    def test_skipped_event_is_not_a_clean_event(self):
+        """'Not checked' must be distinguishable from 'checked, clean'."""
+        event = build_hallucination_event(
+            repo="/r", issue=7, artifact="spec_draft", iteration=0,
+            symbols_checked=0, flagged={}, skipped=True,
+        )
+        assert event["skipped"] is True
+        assert event["passed"] is True  # nothing flagged — but skipped says why
+
+
+# =============================================================================
+# The sinks — guarded
+# =============================================================================
+
+
+class TestRecordEvent:
+
+    def _event(self):
+        return build_hallucination_event(
+            repo="/r", issue=7, artifact="lld", iteration=0,
+            symbols_checked=3, flagged={},
+        )
+
+    def test_writes_numbered_audit_file(self, tmp_path):
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        record_hallucination_event(self._event(), audit, None)
+        files = list(audit.glob(f"*-{AUDIT_SUFFIX}"))
+        assert len(files) == 1
+        assert files[0].name.startswith("001-")
+        assert json.loads(files[0].read_text(encoding="utf-8"))["issue"] == 7
+
+    def test_appends_jsonl_creating_directories(self, tmp_path):
+        record_hallucination_event(self._event(), None, tmp_path)
+        record_hallucination_event(self._event(), None, tmp_path)
+        events = _read_jsonl(tmp_path)
+        assert len(events) == 2
+
+    def test_missing_audit_dir_skips_that_sink_without_error(self, tmp_path):
+        record_hallucination_event(
+            self._event(), tmp_path / "does-not-exist", tmp_path
+        )
+        assert len(_read_jsonl(tmp_path)) == 1
+
+    def test_sink_failure_is_swallowed(self, tmp_path, capsys):
+        """A broken sink degrades to a warning — never an exception."""
+        # data/ as a FILE makes the JSONL sink's mkdir raise.
+        (tmp_path / "data").write_text("in the way", encoding="utf-8")
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        record_hallucination_event(self._event(), audit, tmp_path)
+        assert "WARNING" in capsys.readouterr().out
+        # The other sink still wrote.
+        assert len(list(audit.glob(f"*-{AUDIT_SUFFIX}"))) == 1
+
+
+# =============================================================================
+# The shared detector
+# =============================================================================
+
+
+class TestDetectUnknownMethodCalls:
+
+    def test_flags_unknown_call_in_code_fence(self):
+        flagged = detect_unknown_method_calls(
+            HALLUCINATED_SPEC, set(KNOWN_SYMBOLS)
+        )
+        assert FAKE_CALL in flagged
+        assert FAKE_CALL in flagged[FAKE_CALL][0]
+
+    def test_known_symbol_not_flagged(self):
+        assert detect_unknown_method_calls(CLEAN_SPEC, set(KNOWN_SYMBOLS)) == {}
+
+    def test_allowlisted_builtin_not_flagged(self):
+        text = "```python\nitems.append(1)\nname.strip()\n```\n"
+        assert detect_unknown_method_calls(text, {"unrelated"}) == {}
+
+    def test_prose_outside_fences_ignored(self):
+        text = f"The design calls question.{FAKE_CALL}() in prose only.\n"
+        assert detect_unknown_method_calls(text, set(KNOWN_SYMBOLS)) == {}
+
+
+# =============================================================================
+# Node integration — the record-only contract
+# =============================================================================
+
+
+class TestNodeTelemetry:
+
+    def test_first_pass_records_lld_then_spec(self, state, tmp_path):
+        validate_completeness(state)
+        events = _read_jsonl(tmp_path)
+        assert [e["artifact"] for e in events] == ["lld", "spec_draft"]
+        assert all(e["issue"] == 42 and e["iteration"] == 0 for e in events)
+        # Both events also archived beside the run.
+        audit_files = list((tmp_path / "audit").glob(f"*-{AUDIT_SUFFIX}"))
+        assert len(audit_files) == 2
+
+    def test_revision_pass_records_spec_only(self, state, tmp_path):
+        state["review_iteration"] = 1
+        validate_completeness(state)
+        events = _read_jsonl(tmp_path)
+        assert [e["artifact"] for e in events] == ["spec_draft"]
+        assert events[0]["iteration"] == 1
+
+    def test_clean_run_still_writes_events(self, state, tmp_path):
+        """Absence of evidence must not look like absence of instrumentation."""
+        state["lld_content"] = CLEAN_LLD
+        validate_completeness(state)
+        events = _read_jsonl(tmp_path)
+        assert len(events) == 2
+        assert all(e["passed"] is True and e["skipped"] is False for e in events)
+
+    def test_no_gathered_symbols_records_skipped(self, state, tmp_path):
+        state["gathered_symbols"] = []
+        validate_completeness(state)
+        events = _read_jsonl(tmp_path)
+        assert len(events) == 2
+        assert all(e["skipped"] is True and e["symbols_checked"] == 0 for e in events)
+
+    def test_lld_hallucinations_never_affect_the_gate(self, state, tmp_path):
+        """The money test: LLD detection records, the gate ignores it."""
+        dirty = validate_completeness(dict(state))
+
+        clean_state = dict(state)
+        clean_state["lld_content"] = CLEAN_LLD
+        clean = validate_completeness(clean_state)
+
+        # Identical gating outcome regardless of LLD contents...
+        assert dirty["validation_passed"] == clean["validation_passed"]
+        assert dirty["completeness_issues"] == clean["completeness_issues"]
+        # ...while the telemetry saw the difference.
+        lld_events = [e for e in _read_jsonl(tmp_path) if e["artifact"] == "lld"]
+        assert [e["passed"] for e in lld_events] == [False, True]
+
+    def test_telemetry_failure_cannot_change_the_verdict(
+        self, state, tmp_path, monkeypatch, capsys
+    ):
+        baseline = validate_completeness(dict(state))
+
+        # The nodes package re-exports the function under the module's own
+        # name, so `import ... as vc` would grab the function. sys.modules
+        # is unambiguous.
+        import sys
+
+        vc = sys.modules[
+            "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+        ]
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("telemetry sink exploded")
+
+        monkeypatch.setattr(vc, "record_hallucination_event", boom)
+        result = validate_completeness(dict(state))
+
+        assert result["validation_passed"] == baseline["validation_passed"]
+        assert result["completeness_issues"] == baseline["completeness_issues"]
+        assert "telemetry" in capsys.readouterr().out.lower()


### PR DESCRIPTION
Measure first, then fix. This is the instrument that gives Tiphys (see #1688) a live before/after baseline instead of remembered incidents.

## The gap it closes

The pipeline's best hallucination signal — the deterministic spec-stage detector that compares every method call in the spec against the target repo's real, AST-extracted symbols — reported its findings to the console and in-run workflow state, and nowhere else. The audit trail preserved the final spec but not the per-iteration failures that shaped it. When the run ended, the evidence was gone; only unstructured review prose survived, and mining that is a day of grepping.

## What this adds

**A telemetry module** (`assemblyzero/workflows/telemetry/hallucination_log.py`) with a pure event builder and a guarded recorder. One structured event per detector invocation:

```json
{"ts": "...", "repo": "...", "issue": 42, "stage": "spec", "artifact": "lld",
 "iteration": 0, "symbols_checked": 447, "flagged": {"model_dump": ["question.model_dump()"]},
 "passed": false, "skipped": false}
```

**Two sinks, both written per event:**
- A numbered `NNN-hallucination-check.json` saved through the existing `save_audit_file` mechanism into the run's audit directory — it archives into lineage beside the verdicts, durable and versioned, travels with the issue.
- An append-only `data/telemetry/hallucination-log.jsonl` under the AssemblyZero root — machine-local, gitignored, the one-grep query index. (`data-g/` is not a dependency; #1598 remains open.)

**Two call sites, one detector.** The detection core is extracted *verbatim* from `check_api_symbols_exist` into `detect_unknown_method_calls`, so the gate and the telemetry measure with the identical yardstick — no second parser to drift. The node then records:
- the **spec draft**, every validation pass, keyed by iteration;
- the **LLD**, once per run — on the first pass, gated on `review_iteration == 0`, which is correct because the iteration counter increments only inside revision cycles (`generate_spec.py:201`) and the LLD is constant across them.

## The record-only contract, enforced twice

- Inside the module: every sink failure degrades to a printed warning; `record_hallucination_event` never raises.
- Inside the node: the whole emission is wrapped in try/except, so even a telemetry bug cannot alter `validation_passed`.

Two further deliberate decisions:
- **Clean runs still write events** (`passed: true`). Absence of evidence must be distinguishable from absence of instrumentation.
- **"Could not check" is its own state** (`skipped: true` when no symbols were gathered) — never conflated with "checked, clean".

## Verification

17 new tests in `tests/unit/test_hallucination_telemetry.py`. The two worth naming:

- **LLD hallucinations are recorded but provably ignored by the gate**: two runs differing only in LLD content produce byte-identical gating results, while the JSONL shows `passed: false` vs `passed: true` for the LLD events.
- **A forced telemetry explosion leaves the verdict unchanged**: `record_hallucination_event` is monkeypatched to raise; the node's result is compared field-by-field against baseline.

Full unit suite: **5,627 passed, 16 skipped, 5 xfailed**. `ruff check` clean on all touched files. The one pre-existing F841 in `validate_completeness.py` (`has_arrow`, unused) is deliberately untouched — tracked in #1813, because deleting it without reading the original heuristic's intent could silently endorse a weakened check.

## What this unlocks

Any spec-stage run now produces baseline numbers with zero extra effort — including the scratch-repo verification run (#1761). When Tiphys lands, "did it work" becomes a query, not an anecdote: LLD-stage `flagged` counts before versus after, per issue, per iteration, one grep away.

Closes #1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
