### PR TITLE
chore(validate_completeness): remove born-dead has_arrow assignment (Closes #1813)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -503,9 +503,6 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
                 )
             )
             has_code_block = "```" in search_region
-            has_arrow = bool(
-                re.search(r"(?:->|=>|→|returns?\s*:)", search_region)
-            )
             has_concrete_values = bool(
                 re.search(
                     r'(?:\d+|"[^"]+"|True|False|None|\[.*\]|\{.*\})',


### PR DESCRIPTION
Removes the `has_arrow` assignment from `check_functions_have_io_examples` — three deleted lines, no behavior change.

## Why deletion is safe (the part that needed proving)

Deleting an unused ingredient from a safety check without knowing its intent is how checks get quietly weakened, so intent was settled first — full archaeology on the issue:

- **Born dead.** The variable appears in the file's first commit (`c70e93af`, 2026-02-16, the #304 workflow build) already computed and already unused, with the decision logic byte-identical to today's. `git log -S has_arrow` shows exactly one commit ever touched it. Nothing regressed; there is no historical version to restore.
- **Direction of the risk.** Wiring it in would have *added* a pass path, so its absence made the check stricter, not weaker. The only case it would uniquely admit — an arrow-notation example outside any code fence with none of the I/O keywords within 4,000 characters — is an example weak enough that failing it is arguably correct. (`has_input_output` already matches `returns?`, overlapping most of what the arrow pattern caught.)
- **Code matches documented intent.** The check's own comment describes two pass clauses; the code implements exactly those two. The variable was drafter litter from the original LLM-authored build, not a lost requirement.

## Verification

- Full unit suite: **5,627 passed** — identical count before and after, as a deletion of an unread variable must produce.
- `ruff check` on the file: fully clean for the first time (this was its last finding).

Closes #1813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
