### PR TITLE
feat(lld): Tiphys — ground the LLD drafter in real interface signatures (Closes #1688)

### DIFF
--- a/assemblyzero/core/interface_surface.py
+++ b/assemblyzero/core/interface_surface.py
@@ -1,0 +1,582 @@
+"""Shared AST interface-surface extraction — Tiphys (#1688).
+
+Grounds the LLD drafter in the target repo's REAL public interface
+signatures so it stops inventing functions that don't exist. Interface
+lookup is a ground-truth problem, not a similarity problem: retrieval
+returns the *most similar* name, which is exactly how a plausible-but-wrong
+one gets fetched (see the RAG retirement, #1687). This module reads the
+actual AST instead.
+
+The three signature summarizers moved here from the implementation-spec
+stage (which keeps aliases), so the surface the LLD drafter sees and the
+symbol set the spec-stage gate checks come from one yardstick — same
+argument as the #1812 detector extraction: one measure, two consumers,
+drift impossible.
+
+Selection composite (operator-ratified 2026-07-26):
+
+- **Whole-surface mode** — small repos ship their entire public surface;
+  no selection, therefore no selection miss.
+- **Selection mode** — large repos: explicit path mentions in the issue
+  text (highest precision), then keyword-related files (a draft-one
+  heuristic, nothing more), then one-hop intra-repo import expansion
+  (designs touch a file *and its collaborators*).
+- The revision feedback loop (in generate_draft) re-extracts from the
+  draft's own Files Changed table, turning any draft-one selection miss
+  into a one-iteration transient.
+
+Failure contract: every public entry point degrades to an empty result
+with a logged warning. Tiphys degrading is not a pipeline failure — it is
+a measurable absence (#1812 records LLD-stage hallucination counts).
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+from pathlib import Path
+from typing import Callable
+
+from assemblyzero.utils.codebase_reader import is_sensitive_file
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Budgets and caps
+# ---------------------------------------------------------------------------
+
+# Per-file cap on a signature summary (chars). Summaries run ~2-3 KB by
+# construction (#373 pattern); the cap is a backstop for pathological files.
+PER_FILE_CHAR_CAP = 4_000
+
+# Total cap on the rendered surface (chars, ~6k tokens).
+TOTAL_CHAR_CAP = 24_000
+
+# Whole-surface mode is considered only when the repo has at most this many
+# candidate Python files; above it, selection mode runs without reading
+# everything first.
+WHOLE_SURFACE_MAX_FILES = 48
+
+# Selection mode: primary picks (explicit paths + keyword-related), then
+# one-hop import expansion.
+PRIMARY_SELECTION_CAP = 8
+IMPORT_EXPANSION_CAP = 8
+
+# Directories never walked for surface extraction.
+_EXCLUDED_DIR_NAMES = {
+    "tests", "test", "__pycache__", "node_modules",
+    "build", "dist", ".venv", "venv", "data", "docs",
+}
+
+# Prompt section heading. generate_draft renders under this title and the
+# truncation drop-list test asserts it is NOT in the sacrificial set.
+INTERFACE_SECTION_TITLE = "## Real Interface Surface"
+
+# Imperative framing resurrected from the retired RAG formatter (a7c4dc58^),
+# which survived review cycles for a reason.
+_SECTION_PREAMBLE = (
+    "These are the ACTUAL signatures of modules in the target repository,\n"
+    "extracted from the code itself. Use them exactly as declared.\n"
+    "DO NOT invent methods or functions that are not listed here.\n"
+    "If an interface you need is missing, state that explicitly in the\n"
+    "design instead of assuming it exists."
+)
+
+
+# ---------------------------------------------------------------------------
+# Signature summarizers (moved from implementation_spec, Issue #373 pattern)
+# ---------------------------------------------------------------------------
+
+
+def summarize_python_file(content: str) -> str:
+    """Extract imports and signatures from a Python file for compact context.
+
+    Issue #373 pattern: Instead of embedding full file bodies (~20KB+),
+    extract only what's needed: imports, class/function signatures, and
+    their docstrings. Reduces context from ~20KB to ~2-3KB.
+
+    Args:
+        content: Full Python file content.
+
+    Returns:
+        Compact summary with imports, signatures, and constants.
+    """
+    try:
+        tree = ast.parse(content)
+    except SyntaxError:
+        # If we can't parse it, return first 50 lines as fallback
+        lines = content.split("\n")
+        return "\n".join(lines[:50]) + "\n# ... (truncated, syntax error in original)\n"
+
+    parts: list[str] = []
+
+    # Extract module docstring
+    if (
+        tree.body
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    ):
+        docstring = tree.body[0].value.value
+        parts.append(f'"""{docstring}"""')
+
+    # Extract all imports
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            start = node.lineno - 1
+            end = node.end_lineno if node.end_lineno else start + 1
+            source_lines = content.split("\n")[start:end]
+            parts.append("\n".join(source_lines))
+
+    # Extract class and function signatures
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef):
+            parts.append(summarize_class(node, content))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            parts.append(summarize_function(node, content))
+
+    # Extract module-level constants/type aliases (simple assignments)
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.Assign):
+            start = node.lineno - 1
+            end = node.end_lineno if node.end_lineno else start + 1
+            source_lines = content.split("\n")[start:end]
+            line_text = "\n".join(source_lines)
+            # Only include short assignments (constants, not large data structures)
+            if len(line_text) < 200:
+                parts.append(line_text)
+
+    return "\n\n".join(parts)
+
+
+def summarize_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, source: str
+) -> str:
+    """Extract function signature and docstring.
+
+    Args:
+        node: AST function definition node.
+        source: Full source code of the file.
+
+    Returns:
+        Function signature with docstring summary.
+    """
+    start = node.lineno - 1
+    source_lines = source.split("\n")
+
+    # Find the end of the signature (the line with the colon)
+    sig_lines = []
+    for i in range(start, min(start + 10, len(source_lines))):
+        sig_lines.append(source_lines[i])
+        if source_lines[i].rstrip().endswith(":"):
+            break
+
+    sig = "\n".join(sig_lines)
+
+    # Get docstring if present
+    docstring = ast.get_docstring(node)
+    if docstring:
+        # Use only first 3 lines of docstring
+        doc_lines = docstring.split("\n")[:3]
+        indent = "    "
+        sig += f'\n{indent}"""{chr(10).join(doc_lines)}"""'
+
+    sig += "\n    ..."
+    return sig
+
+
+def summarize_class(node: ast.ClassDef, source: str) -> str:
+    """Extract class signature, docstring, and method signatures.
+
+    Args:
+        node: AST class definition node.
+        source: Full source code of the file.
+
+    Returns:
+        Class signature with docstring and method signatures.
+    """
+    source_lines = source.split("\n")
+    start = node.lineno - 1
+
+    # Get class def line
+    class_lines = []
+    for i in range(start, min(start + 5, len(source_lines))):
+        class_lines.append(source_lines[i])
+        if source_lines[i].rstrip().endswith(":"):
+            break
+
+    parts_inner = ["\n".join(class_lines)]
+
+    # Get class docstring
+    docstring = ast.get_docstring(node)
+    if docstring:
+        doc_lines = docstring.split("\n")[:3]
+        parts_inner.append(f'    """{chr(10).join(doc_lines)}"""')
+
+    # Get method signatures
+    for item in node.body:
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            parts_inner.append(summarize_function(item, source))
+
+    return "\n\n".join(parts_inner)
+
+
+# ---------------------------------------------------------------------------
+# The language seam: extractor dispatch by file extension. Python is the
+# only registered language; other extensions contribute nothing until an
+# extractor is registered here. This table IS the multi-language seam.
+# ---------------------------------------------------------------------------
+
+_EXTRACTORS: dict[str, Callable[[str], str]] = {
+    ".py": summarize_python_file,
+}
+
+
+# ---------------------------------------------------------------------------
+# File discovery and selection
+# ---------------------------------------------------------------------------
+
+
+def list_repo_python_files(repo_root: Path) -> list[Path]:
+    """Walk the repo for candidate Python files (whole-surface mode input).
+
+    Excludes hidden directories, test trees, caches, build/venv dirs, and
+    sensitive files. Sorted for determinism.
+
+    Args:
+        repo_root: Resolved absolute repository root.
+
+    Returns:
+        Sorted list of candidate .py paths; empty on any walk failure.
+    """
+    results: list[Path] = []
+    try:
+        for path in sorted(repo_root.rglob("*.py")):
+            if not path.is_file():
+                continue
+            rel_parts = path.relative_to(repo_root).parts
+            if any(
+                part.startswith(".") or part in _EXCLUDED_DIR_NAMES
+                for part in rel_parts[:-1]
+            ):
+                continue
+            if is_sensitive_file(path):
+                continue
+            results.append(path)
+    except OSError as e:
+        logger.warning("Interface surface walk failed under %s: %s", repo_root, e)
+        return []
+    return results
+
+
+def extract_explicit_paths(issue_text: str, repo_root: Path) -> list[Path]:
+    """Resolve path-shaped ``.py`` tokens from issue text to real repo files.
+
+    An issue that names ``assemblyzero/workflows/requirements/graph.py`` is
+    declaring its blast radius — the highest-precision selector available.
+
+    Args:
+        issue_text: The GitHub issue body.
+        repo_root: Resolved absolute repository root.
+
+    Returns:
+        Deduplicated, order-preserving list of existing in-repo paths.
+    """
+    if not issue_text:
+        return []
+
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for token in re.findall(r"[\w./\\-]+\.py\b", issue_text):
+        candidate = (repo_root / token.replace("\\", "/").lstrip("./")).resolve()
+        try:
+            candidate.relative_to(repo_root)
+        except ValueError:
+            continue
+        if candidate.is_file() and candidate not in seen and not is_sensitive_file(candidate):
+            seen.add(candidate)
+            found.append(candidate)
+    return found
+
+
+def resolve_import_targets(path: Path, repo_root: Path) -> list[Path]:
+    """One-hop import expansion: intra-repo modules imported by ``path``.
+
+    Resolves ``import a.b.c`` / ``from a.b import x`` / relative imports to
+    files under the repo root. Stdlib and third-party imports resolve to
+    nothing (no matching in-repo file) and are silently skipped.
+
+    Args:
+        path: Python file whose imports to resolve.
+        repo_root: Resolved absolute repository root.
+
+    Returns:
+        Deduplicated list of existing in-repo .py paths; empty on parse failure.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+
+    targets: list[Path] = []
+    seen: set[Path] = set()
+
+    def _add(dotted: str, anchor: Path) -> None:
+        base = anchor.joinpath(*dotted.split(".")) if dotted else anchor
+        for candidate in (base.with_suffix(".py"), base / "__init__.py"):
+            if candidate.is_file():
+                resolved = candidate.resolve()
+                try:
+                    resolved.relative_to(repo_root)
+                except ValueError:
+                    return
+                if resolved not in seen and resolved != path.resolve():
+                    seen.add(resolved)
+                    targets.append(resolved)
+                return
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                _add(alias.name, repo_root)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                _add(node.module or "", repo_root)
+            else:
+                # Relative import: anchor at the file's package, up (level-1)
+                anchor = path.parent
+                for _ in range(node.level - 1):
+                    anchor = anchor.parent
+                _add(node.module or "", anchor)
+
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_interface_map(
+    paths: list[Path],
+    repo_root: Path,
+    *,
+    per_file_char_cap: int = PER_FILE_CHAR_CAP,
+    total_char_cap: int = TOTAL_CHAR_CAP,
+) -> dict[str, str]:
+    """Summarize each file's interface surface, within budget.
+
+    Dispatches by extension through the language seam; unregistered
+    extensions contribute nothing. Unreadable files are skipped with a
+    warning. Once the total cap is reached, remaining files are dropped
+    (logged) rather than truncated mid-signature.
+
+    Args:
+        paths: Candidate files (absolute).
+        repo_root: Resolved absolute repository root (keys are made relative).
+        per_file_char_cap: Per-file summary cap.
+        total_char_cap: Total surface cap.
+
+    Returns:
+        Ordered mapping of repo-relative posix path -> signature summary.
+    """
+    surface: dict[str, str] = {}
+    total = 0
+    dropped = 0
+
+    for path in paths:
+        extractor = _EXTRACTORS.get(path.suffix)
+        if extractor is None:
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning("Interface surface: cannot read %s: %s", path, e)
+            continue
+
+        summary = extractor(content)
+        if len(summary) > per_file_char_cap:
+            summary = summary[:per_file_char_cap] + "\n# ... (truncated for budget)"
+
+        if total + len(summary) > total_char_cap:
+            dropped += 1
+            continue
+
+        try:
+            rel = path.resolve().relative_to(repo_root).as_posix()
+        except ValueError:
+            rel = path.name
+        surface[rel] = summary
+        total += len(summary)
+
+    if dropped:
+        logger.warning(
+            "Interface surface: dropped %d file(s) to fit %d-char budget",
+            dropped, total_char_cap,
+        )
+    return surface
+
+
+def build_interface_map(
+    repo_root: Path,
+    *,
+    issue_text: str = "",
+    related_paths: list[Path] | None = None,
+) -> dict[str, str]:
+    """Build the interface map for the LLD drafter (N0b entry point).
+
+    Size-adaptive: whole-surface mode when the entire repo fits the budget
+    (no selection, no selection miss); otherwise the selection composite —
+    explicit paths, keyword-related files, one-hop import expansion.
+
+    Never raises: any failure returns ``{}`` with a logged warning.
+
+    Args:
+        repo_root: Repository root (resolved inside).
+        issue_text: GitHub issue body, for explicit-path extraction.
+        related_paths: Keyword-matched paths N0b already computed.
+
+    Returns:
+        Repo-relative path -> signature summary; ``{}`` when unavailable.
+    """
+    try:
+        repo_root = Path(repo_root).resolve()
+        if not repo_root.is_dir():
+            return {}
+
+        all_py = list_repo_python_files(repo_root)
+        if not all_py:
+            return {}
+
+        # Mode 1: whole surface, when it fits.
+        if len(all_py) <= WHOLE_SURFACE_MAX_FILES:
+            whole = extract_interface_map(all_py, repo_root)
+            if len(whole) == len(
+                [p for p in all_py if p.suffix in _EXTRACTORS]
+            ):
+                logger.info(
+                    "Interface surface: whole-repo mode (%d files)", len(whole)
+                )
+                return whole
+            # Didn't fit — fall through to selection.
+
+        # Mode 2: selection composite.
+        primary: list[Path] = []
+        seen: set[Path] = set()
+        for p in extract_explicit_paths(issue_text, repo_root) + [
+            Path(rp) for rp in (related_paths or [])
+        ]:
+            try:
+                rp = Path(p).resolve()
+            except OSError:
+                continue
+            if rp.is_file() and rp.suffix == ".py" and rp not in seen:
+                seen.add(rp)
+                primary.append(rp)
+            if len(primary) >= PRIMARY_SELECTION_CAP:
+                break
+
+        expansion: list[Path] = []
+        for p in primary:
+            for target in resolve_import_targets(p, repo_root):
+                if target not in seen:
+                    seen.add(target)
+                    expansion.append(target)
+                if len(expansion) >= IMPORT_EXPANSION_CAP:
+                    break
+            if len(expansion) >= IMPORT_EXPANSION_CAP:
+                break
+
+        return extract_interface_map(primary + expansion, repo_root)
+    except Exception as e:  # noqa: BLE001 — never block the LLD
+        logger.warning("Interface surface extraction failed: %s", e)
+        return {}
+
+
+def build_interface_map_for_paths(
+    paths: list[str],
+    repo_root: Path,
+) -> dict[str, str]:
+    """Build the map for explicitly named files (revision feedback loop).
+
+    Used by generate_draft on revision passes: the draft's own Files
+    Changed table declares the blast radius, and this extracts signatures
+    for exactly those files plus their one-hop imports.
+
+    Never raises: any failure returns ``{}`` with a logged warning.
+
+    Args:
+        paths: Repo-relative path strings (from the Files Changed table).
+        repo_root: Repository root (resolved inside).
+
+    Returns:
+        Repo-relative path -> signature summary; ``{}`` when unavailable.
+    """
+    try:
+        repo_root = Path(repo_root).resolve()
+        if not repo_root.is_dir():
+            return {}
+
+        primary: list[Path] = []
+        seen: set[Path] = set()
+        for raw in paths:
+            candidate = (repo_root / str(raw).replace("\\", "/")).resolve()
+            try:
+                candidate.relative_to(repo_root)
+            except ValueError:
+                continue
+            if (
+                candidate.is_file()
+                and candidate.suffix == ".py"
+                and candidate not in seen
+                and not is_sensitive_file(candidate)
+            ):
+                seen.add(candidate)
+                primary.append(candidate)
+            if len(primary) >= PRIMARY_SELECTION_CAP:
+                break
+
+        expansion: list[Path] = []
+        for p in primary:
+            for target in resolve_import_targets(p, repo_root):
+                if target not in seen:
+                    seen.add(target)
+                    expansion.append(target)
+                if len(expansion) >= IMPORT_EXPANSION_CAP:
+                    break
+            if len(expansion) >= IMPORT_EXPANSION_CAP:
+                break
+
+        return extract_interface_map(primary + expansion, repo_root)
+    except Exception as e:  # noqa: BLE001 — never block the LLD
+        logger.warning("Interface surface (revision) extraction failed: %s", e)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def format_interface_map_section(interface_map: dict[str, str]) -> str:
+    """Render the interface map as the drafter-prompt section.
+
+    The section heading is deliberately ABSENT from generate_draft's
+    truncation drop list, and callers place it directly after the issue
+    content: ground truth that exists to prevent hallucination must not be
+    the first thing sacrificed under token pressure.
+
+    Args:
+        interface_map: Repo-relative path -> signature summary.
+
+    Returns:
+        Markdown section, or "" for an empty map.
+    """
+    if not interface_map:
+        return ""
+
+    parts = [INTERFACE_SECTION_TITLE, "", _SECTION_PREAMBLE, ""]
+    for rel_path, summary in interface_map.items():
+        parts.append(f"**{rel_path}**:\n```python\n{summary}\n```")
+    return "\n".join(parts)

--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -320,137 +320,15 @@ def extract_relevant_excerpt(
     return excerpt
 
 
-def _summarize_python_file(content: str) -> str:
-    """Extract imports and signatures from a Python file for compact context.
-
-    Issue #373 pattern: Instead of embedding full file bodies (~20KB+),
-    extract only what's needed: imports, class/function signatures, and
-    their docstrings. Reduces context from ~20KB to ~2-3KB.
-
-    Args:
-        content: Full Python file content.
-
-    Returns:
-        Compact summary with imports, signatures, and constants.
-    """
-    try:
-        tree = ast.parse(content)
-    except SyntaxError:
-        # If we can't parse it, return first 50 lines as fallback
-        lines = content.split("\n")
-        return "\n".join(lines[:50]) + "\n# ... (truncated, syntax error in original)\n"
-
-    parts: list[str] = []
-
-    # Extract module docstring
-    if (
-        tree.body
-        and isinstance(tree.body[0], ast.Expr)
-        and isinstance(tree.body[0].value, ast.Constant)
-        and isinstance(tree.body[0].value.value, str)
-    ):
-        docstring = tree.body[0].value.value
-        parts.append(f'"""{docstring}"""')
-
-    # Extract all imports
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            start = node.lineno - 1
-            end = node.end_lineno if node.end_lineno else start + 1
-            source_lines = content.split("\n")[start:end]
-            parts.append("\n".join(source_lines))
-
-    # Extract class and function signatures
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.ClassDef):
-            parts.append(_summarize_class(node, content))
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            parts.append(_summarize_function(node, content))
-
-    # Extract module-level constants/type aliases (simple assignments)
-    for node in ast.iter_child_nodes(tree):
-        if isinstance(node, ast.Assign):
-            start = node.lineno - 1
-            end = node.end_lineno if node.end_lineno else start + 1
-            source_lines = content.split("\n")[start:end]
-            line_text = "\n".join(source_lines)
-            # Only include short assignments (constants, not large data structures)
-            if len(line_text) < 200:
-                parts.append(line_text)
-
-    return "\n\n".join(parts)
-
-
-def _summarize_function(
-    node: ast.FunctionDef | ast.AsyncFunctionDef, source: str
-) -> str:
-    """Extract function signature and docstring.
-
-    Args:
-        node: AST function definition node.
-        source: Full source code of the file.
-
-    Returns:
-        Function signature with docstring summary.
-    """
-    start = node.lineno - 1
-    source_lines = source.split("\n")
-
-    # Find the end of the signature (the line with the colon)
-    sig_lines = []
-    for i in range(start, min(start + 10, len(source_lines))):
-        sig_lines.append(source_lines[i])
-        if source_lines[i].rstrip().endswith(":"):
-            break
-
-    sig = "\n".join(sig_lines)
-
-    # Get docstring if present
-    docstring = ast.get_docstring(node)
-    if docstring:
-        # Use only first 3 lines of docstring
-        doc_lines = docstring.split("\n")[:3]
-        indent = "    "
-        sig += f'\n{indent}"""{chr(10).join(doc_lines)}"""'
-
-    sig += "\n    ..."
-    return sig
-
-
-def _summarize_class(node: ast.ClassDef, source: str) -> str:
-    """Extract class signature, docstring, and method signatures.
-
-    Args:
-        node: AST class definition node.
-        source: Full source code of the file.
-
-    Returns:
-        Class signature with docstring and method signatures.
-    """
-    source_lines = source.split("\n")
-    start = node.lineno - 1
-
-    # Get class def line
-    class_lines = []
-    for i in range(start, min(start + 5, len(source_lines))):
-        class_lines.append(source_lines[i])
-        if source_lines[i].rstrip().endswith(":"):
-            break
-
-    parts_inner = ["\n".join(class_lines)]
-
-    # Get class docstring
-    docstring = ast.get_docstring(node)
-    if docstring:
-        doc_lines = docstring.split("\n")[:3]
-        parts_inner.append(f'    """{chr(10).join(doc_lines)}"""')
-
-    # Get method signatures
-    for item in node.body:
-        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            parts_inner.append(_summarize_function(item, source))
-
-    return "\n\n".join(parts_inner)
+# The three signature summarizers moved to core (Tiphys, #1688) so the LLD
+# stage and this spec stage extract with one yardstick. The `_`-prefixed
+# aliases preserve this module's historical import surface — internal
+# callers and existing tests are untouched.
+from assemblyzero.core.interface_surface import (  # noqa: E402
+    summarize_class as _summarize_class,
+    summarize_function as _summarize_function,
+    summarize_python_file as _summarize_python_file,
+)
 
 
 def _truncate_content(content: str, max_chars: int) -> str:

--- a/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.core.interface_surface import build_interface_map
 from assemblyzero.utils.codebase_reader import (
     is_sensitive_file,
     parse_project_metadata,
@@ -104,7 +105,7 @@ def analyze_codebase(state: dict) -> dict:
 
     if not repo_path_str or not str(repo_path_str).strip():
         logger.warning("No repo path provided, skipping codebase analysis")
-        return {"codebase_context": _empty_codebase_context()}
+        return {"codebase_context": _empty_codebase_context(), "interface_map": {}}
 
     repo_path = Path(repo_path_str)
     if not repo_path.exists():
@@ -112,7 +113,7 @@ def analyze_codebase(state: dict) -> dict:
             "Repo path does not exist: %s, skipping codebase analysis",
             repo_path,
         )
-        return {"codebase_context": _empty_codebase_context()}
+        return {"codebase_context": _empty_codebase_context(), "interface_map": {}}
 
     # Resolve to absolute to ensure consistent path handling
     repo_path = repo_path.resolve()
@@ -191,9 +192,14 @@ def analyze_codebase(state: dict) -> dict:
     # ------------------------------------------------------------------
     remaining_budget = max(0, _TOTAL_TOKEN_BUDGET - tokens_used)
     related_code: dict[str, str] = {}
+    # Full related list, pre-exclusion, kept for Tiphys interface extraction
+    # (Step 8b) — the name-based exclusion below exists only to avoid
+    # double-reading contents, which doesn't apply to signature extraction.
+    related_paths_all: list[Path] = []
 
     if issue_text and directory_tree:
         related_paths = _find_related_files(repo_path, issue_text, directory_tree)
+        related_paths_all = list(related_paths)
         # Exclude files already read as key files
         already_read = {Path(p).name for p in key_file_excerpts}
         related_paths = [
@@ -211,6 +217,23 @@ def analyze_codebase(state: dict) -> dict:
                     related_code[result["path"]] = result["content"]
 
     # ------------------------------------------------------------------
+    # Step 8b: Tiphys (#1688) — ground-truth interface surface.
+    # Size-adaptive: small repos ship their whole public surface (no
+    # selection, no selection miss); large repos use explicit-path +
+    # keyword selection with one-hop import expansion. Never blocks:
+    # any failure yields an empty map and the LLD proceeds as before.
+    # ------------------------------------------------------------------
+    interface_map: dict[str, str] = {}
+    try:
+        interface_map = build_interface_map(
+            repo_path,
+            issue_text=issue_text,
+            related_paths=related_paths_all,
+        )
+    except Exception:  # noqa: BLE001 — Tiphys must never block the LLD
+        logger.warning("Tiphys interface extraction failed", exc_info=True)
+
+    # ------------------------------------------------------------------
     # Step 9: Assemble CodebaseContext
     # ------------------------------------------------------------------
     context: dict[str, Any] = {
@@ -226,14 +249,15 @@ def analyze_codebase(state: dict) -> dict:
 
     logger.info(
         "Codebase analysis complete: %d key files, %d related files, "
-        "%d conventions, %d frameworks detected",
+        "%d conventions, %d frameworks detected, %d interface surfaces",
         len(key_file_excerpts),
         len(related_code),
         len(conventions),
         len(frameworks),
+        len(interface_map),
     )
 
-    return {"codebase_context": context}
+    return {"codebase_context": context, "interface_map": interface_map}
 
 
 def _select_key_files(repo_path: Path) -> list[Path]:

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -24,6 +24,10 @@ MAX_TOTAL_PROMPT_CHARS = 120_000
 # Warn at 80% of the cap
 PROMPT_SIZE_WARNING_THRESHOLD = 0.8
 
+from assemblyzero.core.interface_surface import (
+    build_interface_map_for_paths,
+    format_interface_map_section,
+)
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
 from assemblyzero.core.section_utils import (
@@ -41,6 +45,9 @@ from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 from assemblyzero.workflows.requirements.feedback_window import (
     build_feedback_block,
     render_feedback_markdown,
+)
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    parse_files_changed_table,
 )
 from assemblyzero.core.verdict_schema import (
     DRAFT_QUESTIONS_SCHEMA,
@@ -331,6 +338,12 @@ def _build_prompt(
     user_feedback = state.get("user_feedback", "")
     validation_errors = state.get("validation_errors", [])  # Issue #294
 
+    # Revision detection, computed early: Tiphys injection placement depends
+    # on it (Issue #294 originally defined this after input assembly).
+    is_revision = bool(
+        current_draft and (verdict_history or validation_errors or user_feedback)
+    )
+
     if workflow_type == "issue":
         input_content = state.get("brief_content", "")
         input_label = "Brief (user's ideation notes)"
@@ -345,6 +358,19 @@ def _build_prompt(
         if context_content:
             input_content += f"\n\n## Context\n\n{context_content}"
 
+        # Tiphys (#1688): real interface surface, placed BEFORE the
+        # codebase-context sections — _truncate_prompt sacrifices those
+        # first under token pressure, and ground truth that exists to
+        # prevent hallucination must not be the first thing dropped. On
+        # revision passes the refreshed surface rides in revision_context
+        # instead — never both.
+        if not is_revision:
+            interface_section = format_interface_map_section(
+                state.get("interface_map") or {}
+            )
+            if interface_section:
+                input_content += f"\n\n{interface_section}"
+
         # Issue #401: Inject codebase context from N0b analyze_codebase node
         codebase_ctx = state.get("codebase_context")
         if codebase_ctx and isinstance(codebase_ctx, dict):
@@ -355,10 +381,8 @@ def _build_prompt(
         input_content += f"\n\n**CRITICAL: This LLD is for GitHub Issue #{issue_number}. Use this exact issue number in all references.**"
         input_label = f"GitHub Issue #{issue_number}"
 
-    # Check if this is a revision (Gemini feedback, user feedback, OR validation errors)
-    # Issue #294: Include validation_errors to break infinite loop
-    is_revision = current_draft and (verdict_history or validation_errors or user_feedback)
-
+    # is_revision computed above, before input assembly (Issue #294 origin;
+    # moved for Tiphys injection placement).
     if is_revision:
         # Revision mode
         revision_context = ""
@@ -389,6 +413,32 @@ def _build_prompt(
                 revision_context += "- 'Modify' files MUST exist in the repository\n"
                 revision_context += "- 'Add' files must have existing parent directories\n"
                 revision_context += "- Use actual file names from the codebase, not generic names\n\n"
+
+        # Tiphys (#1688): revision feedback loop — the draft's own Files
+        # Changed table declares the change's actual blast radius; refresh
+        # signatures for exactly those files (plus one-hop imports). Any
+        # draft-one selection miss becomes a one-iteration transient. Falls
+        # back to the N0b-computed map when the table yields nothing.
+        refreshed_map: dict = {}
+        revision_target_repo = state.get("target_repo", "")
+        if revision_target_repo and current_draft:
+            try:
+                entries, _parse_errors = parse_files_changed_table(current_draft)
+                draft_paths = [
+                    e.get("path", "") for e in entries
+                    if e.get("path", "").endswith(".py")
+                ]
+                if draft_paths:
+                    refreshed_map = build_interface_map_for_paths(
+                        draft_paths, Path(revision_target_repo)
+                    )
+            except Exception:  # noqa: BLE001 — Tiphys must never block revision
+                logger.warning("Tiphys revision refresh failed", exc_info=True)
+        interface_section = format_interface_map_section(
+            refreshed_map or state.get("interface_map") or {}
+        )
+        if interface_section:
+            revision_context += interface_section + "\n\n"
 
         # Issue #497: Bounded feedback window replaces cumulative verdict history
         if verdict_history:

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -253,6 +253,9 @@ class RequirementsWorkflowState(TypedDict, total=False):
     # Codebase context (Issue #401)
     codebase_context: dict
 
+    # Tiphys: real interface surface for the drafter (Issue #1688)
+    interface_map: dict
+
     # Issue #476: API cost budget
     cost_budget_usd: float
 
@@ -378,6 +381,8 @@ def create_initial_state(
         "draft_number": 1,
         # Codebase context (Issue #401)
         "codebase_context": {},
+        # Tiphys: real interface surface (Issue #1688)
+        "interface_map": {},
         # Issue #476: API cost budget
         "cost_budget_usd": 0.0,
         # Issue #486: Halt-and-Plan

--- a/docs/lld/active/LLD-1688.md
+++ b/docs/lld/active/LLD-1688.md
@@ -1,0 +1,162 @@
+# 1688 - Feature: Tiphys — ground the LLD in real interface signatures
+
+<!-- Hand-authored 2026-07-26 per operator direction (no workflow dogfooding).
+Design settled in-session against code read at 20bfd794; baseline instrument
+(#1812) landed first so this feature's effect is measurable. -->
+
+## 1. Context & Goal
+
+* **Issue:** #1688
+* **Objective:** Put the target repo's *real* public interface signatures in front of the LLD drafter before it writes, so it stops inventing functions that don't exist.
+* **Status:** Draft — awaiting operator ratification before implementation
+* **Related Issues:** parent context #1688; baseline instrument #1812 (landed); in-vivo verification vehicle #1761; RAG retirement #1687 (landed); spec-stage gate #1527
+
+### Design decisions already ratified by the operator (2026-07-26)
+
+- Python-only extraction, with a documented seam for other languages. (Verified: the live target fleet's near-term pipeline repo is pure Python — tkinter/Win32, no TypeScript.)
+- Hand-built in-session; not dogfooded through the LLD workflow.
+- Instrument-first sequencing: #1812 landed before this, so LLD-stage hallucination counts are recorded per run. Success is a measured drop to zero, not an anecdote.
+- **Selection composite (ratified after risk discussion):** size-adaptive whole-repo surface; revision-pass feedback loop from the draft's own Files Changed table; explicit-path extraction; one-hop import expansion IN; keyword matching demoted to a draft-one heuristic for large repos. "Misses show up in telemetry" is a detection channel, not a mitigation — the composite above is the mitigation.
+
+### Open Questions
+
+None. The insertion-point and shared-utility questions the issue left open are resolved below with rationale.
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `assemblyzero/core/interface_surface.py` | Add | Shared AST interface-surface extraction: the three signature summarizers (moved from the spec stage) + `extract_interface_map()` + the extension-dispatch language seam |
+| `assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py` | Modify | Summarizers become thin aliases re-exporting from core — internal callers and existing test imports keep working unchanged |
+| `assemblyzero/workflows/requirements/nodes/analyze_codebase.py` | Modify | N0b gains Step 8b: build `interface_map` from explicit-path mentions + the already-computed related files |
+| `assemblyzero/workflows/requirements/state.py` | Modify | Add `interface_map: dict` beside `codebase_context`, default `{}` |
+| `assemblyzero/workflows/requirements/nodes/generate_draft.py` | Modify | Render the map as a `## Real Interface Surface` section placed directly after the issue content (excluded from `_truncate_prompt`'s drop list); on revision passes, refresh the map from the draft's Files Changed paths |
+| `tests/unit/test_interface_surface.py` | Add | New suite (see Section 10) |
+
+### 2.2 Dependencies
+
+None. Python `ast` (stdlib) only.
+
+### 2.3 Data Structures
+
+```python
+# state.py — beside codebase_context (Issue #401 block)
+interface_map: dict   # {relative_path: signature_summary_str}; {} = Tiphys unavailable
+```
+
+The summary string per file is the proven #373-pattern output: module docstring first line, imports, class/def signatures with docstring heads, short module constants — ~2-3 KB per file instead of ~20 KB of body.
+
+### 2.4 Design
+
+#### Insertion point: upgrade N0b in place (not a new N0c node)
+
+The issue offered both. N0b wins on three grounds:
+
+1. **Selection reuse is free.** N0b already computes `related_paths` via `_find_related_files` before converting them to whole-file excerpts. Tiphys needs exactly those paths; a separate node would recompute them or thread them through state.
+2. **No graph-shape change.** Adding a node alters the compiled graph and its checkpoint shape; this repo has been bitten by shared-structure changes rippling into untouched tests (STAGE_ORDER, 2026-06-22). An in-place upgrade has no resume/checkpoint migration surface.
+3. **Node bloat is contained** by putting all extraction logic in `core/interface_surface.py` — N0b gains ~15 lines: select, call, attach.
+
+#### File selection (Step 8b in N0b) — the size-adaptive composite
+
+Selection risk is regime-dependent, and the strategy adapts:
+
+**Mode 1 — whole-surface (small repos).** Walk the repo's Python files (excluding tests, hidden dirs, caches, build/venv dirs, and sensitive files). If the file count is small enough to consider (≤ 48) and the summarized surface fits the total budget, ship the **entire public interface surface** — no selection, therefore no miss. Greenfield and small repos (the speedrun regime, most fleet projects) live here permanently. An empty repo yields an empty map, correctly: with no interfaces to get wrong, invented API is design, not hallucination.
+
+**Mode 2 — selection (large repos).** When the surface can't fit, select, in priority order, deduped, primary cap 8:
+
+1. **Explicit path mentions** in the issue text — path-shaped tokens ending `.py` that resolve inside the repo. Highest precision; an issue that names `assemblyzero/workflows/requirements/graph.py` is declaring its blast radius.
+2. **The `related_paths` N0b already computed** (keyword match, ≤5 files) — honestly a draft-one heuristic, nothing more.
+
+Then **one-hop import expansion**: for every selected file, resolve its intra-repo imports and add their summaries (expansion cap 8 more; total budget still enforced). Designs touch a file *and its collaborators* — the "called into the neighboring module with an invented name" case is a large share of real hallucinations.
+
+Non-`.py` selections pass through the extractor's dispatch and contribute nothing (see seam).
+
+#### Revision feedback loop — the real fix for large-repo selection
+
+The first draft's **Files Changed table declares the change's actual blast radius**, and the mechanical validator already parses those paths. On every revision pass (`is_revision` — routinely forced by validation errors and review verdicts), re-extract signatures for **the files the draft itself named** (plus their one-hop imports) and render the refreshed surface into the revision prompt.
+
+This demotes keyword selection to draft-one-only: any selection miss becomes a one-iteration transient, corrected by the LLD's own stated intent, rather than a permanent blind spot. The selector we can't trust is replaced mid-run by the design's declaration.
+
+#### Extraction (`core/interface_surface.py`)
+
+- `summarize_python_file / summarize_class / summarize_function` — **moved** from `implementation_spec/nodes/analyze_codebase.py` with public names; the spec-stage module keeps `_`-prefixed aliases (`_summarize_python_file = summarize_python_file`) so its callers and the existing test imports at `test_implementation_spec_workflow.py:3080` are untouched. One yardstick, two consumers, no drift — same argument as the #1812 detector extraction.
+- `extract_interface_map(paths, repo_root, *, per_file_char_cap=4_000, total_char_cap=24_000) -> dict[str, str]` — reads each file, dispatches by extension, truncates per caps, skips unreadable/unparseable files with a logged warning. Syntax-error fallback (first-50-lines) is inherited from the summarizer as-is.
+- **The language seam** is a module-level dispatch table:
+
+```python
+# Pseudocode — the seam other languages plug into
+_EXTRACTORS: dict[str, Callable[[str], str]] = {
+    ".py": summarize_python_file,
+    # ".ts": summarize_typescript_file,  # future — see Section 8
+}
+```
+
+#### Rendering (`generate_draft.py`)
+
+New `_format_interface_map(interface_map) -> str` emitting:
+
+```markdown
+## Real Interface Surface
+
+These are the ACTUAL signatures of the modules this change touches,
+extracted from the code itself. Use them exactly as declared.
+DO NOT invent methods or functions that are not listed here.
+If an interface you need is missing, state that explicitly in the
+design instead of assuming it exists.
+
+**path/to/file.py**:
+```python
+{signature summary}
+```
+```
+
+The imperative framing resurrects the proven "DO NOT reinvent" language from the retired RAG formatter (`a7c4dc58^`), which survived review cycles for a reason.
+
+**Placement and truncation are load-bearing, not cosmetic.** `_truncate_prompt` (#508) drops sections under token pressure in a fixed order — and "Codebase Analysis" and "Related Code" are dropped *first*. Ground truth that exists to prevent hallucination must not be the first sacrifice:
+
+- The section is emitted **directly after the issue content**, before the `_format_codebase_context` sections — early position also shields it from last-resort tail hard-truncation.
+- Its heading is **deliberately absent from `drop_order`** — a test pins this.
+
+#### Failure semantics: never block the LLD
+
+Mirrors N0b's existing contract: any failure (missing repo, unreadable file, zero selections) yields `interface_map == {}` and the run proceeds exactly as today. Tiphys degrading is not a pipeline failure mode — it is a measurable absence: the #1812 telemetry will show LLD-stage hallucination counts not improving, which is the correct alarm channel.
+
+## 8. Out of Scope
+
+- **LLD-stage gating** on detected hallucinations. #1812 deliberately records without gating; whether to block LLDs is a decision to make on top of accumulated data, in its own issue.
+- **TypeScript/other-language extractors.** The seam is the deliverable; the fleet's near-term pipeline targets are Python.
+- **A separate N0c graph node** — rejected above with rationale.
+- **Resurrecting the retired RAG retrieval machinery.** Only its formatter *language* is reused.
+- **#1692's incidental RAG doc mentions** — unrelated docs tail, stays its own issue.
+
+## 10. Verification & Testing
+
+### Unit (new `tests/unit/test_interface_surface.py`)
+
+1. **Extraction**: classes, functions, async functions, dataclasses summarized; docstring heads present; syntax-error fallback; non-`.py` files yield nothing (seam behavior); per-file and total caps enforced.
+2. **Selection**: whole-surface mode triggers for small repos and includes every non-excluded module; explicit path in issue text resolves and wins; outside-repo and non-existent paths rejected; dedup against related files; primary cap at 8; one-hop import expansion resolves intra-repo imports (dotted module → file path, package `__init__` handling) and ignores stdlib/third-party; empty repo yields an empty map without error.
+2b. **Revision feedback**: Files Changed paths parsed from a draft's Section 2.1 table; revision prompt contains refreshed signatures for exactly those files plus their one-hop imports.
+3. **Move safety**: spec-stage aliases still importable from their historical module path; spec-stage `gathered_symbols` behavior unchanged.
+4. **Self-consistency of the two yardsticks**: every class/def name appearing in a file's interface summary is present in `_extract_symbols_from_files`' symbol set for the same file — the map the drafter sees and the set the gate checks cannot disagree.
+5. **Rendering**: section title, imperative framing, placement before codebase-analysis sections.
+6. **Truncation immunity**: build an oversized prompt; assert every `drop_order` section can be dropped while `## Real Interface Surface` survives.
+7. **Failure semantics**: each failure path yields `{}` and the node still returns `codebase_context` normally.
+
+### In vivo (the regression guard the issue names)
+
+The #1812 telemetry records `flagged` counts for the **LLD artifact** on every spec-stage run, zero extra effort. Acceptance: Tiphys-grounded LLDs show `artifact: "lld", passed: true` events — invented-call count zero — starting with the #1761 scratch-repo run. Pre-Tiphys events already accumulating form the *before* side.
+
+### Suite gate
+
+Full unit suite green (5,627 at design time); `ruff` clean on all touched files.
+
+## 11. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Prompt growth (~up to 24 KB) displaces other context on big issues | Interface section is capped, compact by construction (#373 pattern), and the sections it may displace are the ones truncation already sacrifices first — by design the *right* trade |
+| Keyword selection misses the actually-touched module | Eliminated for small repos (whole-surface mode sends everything); for large repos, a draft-one miss is corrected on the next pass by the revision feedback loop (signatures re-extracted from the draft's own Files Changed table), and import expansion covers the collaborator-module case. Non-zero LLD telemetry is the *detection* channel, not the mitigation |
+| Moving summarizers breaks spec-stage tests | Aliases preserve import paths; move-safety tests pin it; full suite gates the PR |
+| Drafter ignores the surface and hallucinates anyway | That is precisely what #1812 measures; if framing proves too weak, the recorded data justifies escalation (gating) as follow-up work |

--- a/tests/unit/test_interface_surface.py
+++ b/tests/unit/test_interface_surface.py
@@ -1,0 +1,401 @@
+"""Tiphys — shared interface-surface extraction (#1688).
+
+Pins the design's load-bearing properties:
+
+- the three summarizers moved to core ARE the spec stage's summarizers
+  (aliases, not copies — one yardstick, drift impossible);
+- whole-surface mode eliminates selection for small repos;
+- selection mode composes explicit paths + related files + one-hop
+  import expansion;
+- the revision feedback loop extracts from the draft's own Files Changed
+  paths;
+- the rendered section survives prompt truncation while every sacrificial
+  section is dropped;
+- every failure path degrades to an empty map — Tiphys can never block
+  an LLD.
+
+Issue: #1688
+"""
+
+import textwrap
+
+import pytest
+
+import assemblyzero.core.interface_surface as isurf
+from assemblyzero.core.interface_surface import (
+    INTERFACE_SECTION_TITLE,
+    build_interface_map,
+    build_interface_map_for_paths,
+    extract_explicit_paths,
+    extract_interface_map,
+    format_interface_map_section,
+    list_repo_python_files,
+    resolve_import_targets,
+    summarize_python_file,
+)
+
+MODELS_PY = textwrap.dedent(
+    '''
+    """Domain models."""
+
+    DEFAULT_LIMIT = 10
+
+
+    class Question:
+        """A question with plain-dataclass serialization."""
+
+        def to_dict(self) -> dict:
+            """Serialize."""
+            return {"secret_internal_detail": True}
+
+        @classmethod
+        def from_dict(cls, data: dict) -> "Question":
+            return cls()
+
+
+    async def fetch_question(qid: int) -> Question:
+        """Fetch by id."""
+        return Question()
+    '''
+).strip()
+
+SERVICE_PY = textwrap.dedent(
+    '''
+    """Service layer."""
+
+    import os
+    from pkg.models import Question
+
+
+    def serve(q: Question) -> dict:
+        """Serve a question."""
+        return q.to_dict()
+    '''
+).strip()
+
+RELATIVE_PY = textwrap.dedent(
+    '''
+    """Uses a relative import."""
+
+    from .models import Question
+
+
+    def relative_user() -> Question:
+        return Question()
+    '''
+).strip()
+
+UTIL_PY = '"""Utility."""\n\n\ndef helper() -> int:\n    return 1\n'
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A small fake repo exercising every selection surface."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "models.py").write_text(MODELS_PY, encoding="utf-8")
+    (pkg / "service.py").write_text(SERVICE_PY, encoding="utf-8")
+    (pkg / "relative_user.py").write_text(RELATIVE_PY, encoding="utf-8")
+    (pkg / "util.py").write_text(UTIL_PY, encoding="utf-8")
+    # Never walked:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_models.py").write_text("def test_x(): pass\n", encoding="utf-8")
+    hidden = tmp_path / ".hidden"
+    hidden.mkdir()
+    (hidden / "sneaky.py").write_text("def sneaky(): pass\n", encoding="utf-8")
+    return tmp_path
+
+
+# =============================================================================
+# Summarizers — moved, aliased, self-consistent
+# =============================================================================
+
+
+class TestSummarizers:
+
+    def test_summary_has_signatures_not_bodies(self):
+        summary = summarize_python_file(MODELS_PY)
+        assert "class Question:" in summary
+        assert "def to_dict(self) -> dict:" in summary
+        assert "async def fetch_question(qid: int) -> Question:" in summary
+        assert "DEFAULT_LIMIT = 10" in summary
+        assert '"""Domain models."""' in summary
+        # Implementation details must NOT ride along.
+        assert "secret_internal_detail" not in summary
+
+    def test_syntax_error_falls_back_to_head(self):
+        summary = summarize_python_file("def broken(:\n" * 3)
+        assert "truncated, syntax error" in summary
+
+    def test_spec_stage_aliases_are_the_core_functions(self):
+        """The move must be aliasing, not copying — one yardstick."""
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _summarize_class,
+            _summarize_function,
+            _summarize_python_file,
+        )
+
+        assert _summarize_python_file is isurf.summarize_python_file
+        assert _summarize_class is isurf.summarize_class
+        assert _summarize_function is isurf.summarize_function
+
+    def test_summary_names_subset_of_gate_symbols(self):
+        """Self-consistency of the funnel's two ends: every def/class name
+        the drafter is shown must exist in the symbol set the spec-stage
+        gate checks. If these ever disagree, Tiphys teaches names the gate
+        would then flag."""
+        from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+            _extract_symbols_from_files,
+        )
+
+        gate_symbols = set(
+            _extract_symbols_from_files(
+                [{"path": "pkg/models.py", "current_content": MODELS_PY}]
+            )
+        )
+        for name in ("Question", "to_dict", "from_dict", "fetch_question"):
+            summary = summarize_python_file(MODELS_PY)
+            assert name in summary
+            assert name in gate_symbols
+
+
+# =============================================================================
+# Discovery and selection
+# =============================================================================
+
+
+class TestListRepoPythonFiles:
+
+    def test_walk_includes_source_excludes_tests_and_hidden(self, repo):
+        rels = {p.relative_to(repo).as_posix() for p in list_repo_python_files(repo)}
+        assert "pkg/models.py" in rels
+        assert "pkg/util.py" in rels
+        assert not any(r.startswith("tests/") for r in rels)
+        assert not any(r.startswith(".hidden/") for r in rels)
+
+
+class TestExtractExplicitPaths:
+
+    def test_resolves_mentioned_file(self, repo):
+        issue = "Please refactor pkg/service.py to stop doing the thing."
+        paths = extract_explicit_paths(issue, repo)
+        assert [p.name for p in paths] == ["service.py"]
+
+    def test_backslash_form_resolves(self, repo):
+        paths = extract_explicit_paths(r"See pkg\models.py for details.", repo)
+        assert [p.name for p in paths] == ["models.py"]
+
+    def test_nonexistent_and_escaping_paths_rejected(self, repo):
+        issue = "Touch pkg/nope.py and also ../../outside/evil.py please."
+        assert extract_explicit_paths(issue, repo) == []
+
+
+class TestResolveImportTargets:
+
+    def test_absolute_intra_repo_import_resolves(self, repo):
+        targets = resolve_import_targets(repo / "pkg" / "service.py", repo)
+        assert [t.name for t in targets] == ["models.py"]
+
+    def test_relative_import_resolves(self, repo):
+        targets = resolve_import_targets(repo / "pkg" / "relative_user.py", repo)
+        assert [t.name for t in targets] == ["models.py"]
+
+    def test_stdlib_imports_resolve_to_nothing(self, repo):
+        only_stdlib = repo / "pkg" / "stdlib_only.py"
+        only_stdlib.write_text("import os\nimport json\n", encoding="utf-8")
+        assert resolve_import_targets(only_stdlib, repo) == []
+
+
+# =============================================================================
+# Extraction budgets
+# =============================================================================
+
+
+class TestExtractInterfaceMap:
+
+    def test_keys_are_repo_relative_posix(self, repo):
+        surface = extract_interface_map([repo / "pkg" / "models.py"], repo)
+        assert list(surface) == ["pkg/models.py"]
+
+    def test_per_file_cap_truncates_with_marker(self, repo):
+        surface = extract_interface_map(
+            [repo / "pkg" / "models.py"], repo, per_file_char_cap=40
+        )
+        assert "truncated for budget" in surface["pkg/models.py"]
+
+    def test_total_cap_drops_whole_files(self, repo):
+        surface = extract_interface_map(
+            [repo / "pkg" / "models.py", repo / "pkg" / "service.py"],
+            repo,
+            total_char_cap=len(summarize_python_file(MODELS_PY)) + 1,
+        )
+        assert "pkg/models.py" in surface
+        assert "pkg/service.py" not in surface
+
+    def test_non_python_contributes_nothing(self, repo):
+        readme = repo / "README.md"
+        readme.write_text("# hi", encoding="utf-8")
+        assert extract_interface_map([readme], repo) == {}
+
+
+# =============================================================================
+# Mode logic
+# =============================================================================
+
+
+class TestBuildInterfaceMap:
+
+    def test_small_repo_ships_whole_surface(self, repo):
+        """No selection, therefore no selection miss: even a file with no
+        keyword or import relationship to the issue is included."""
+        surface = build_interface_map(repo, issue_text="Something unrelated.")
+        assert "pkg/util.py" in surface
+        assert "pkg/models.py" in surface
+
+    def test_large_repo_selects_and_expands_imports(self, repo, monkeypatch):
+        monkeypatch.setattr(isurf, "WHOLE_SURFACE_MAX_FILES", 0)
+        surface = build_interface_map(
+            repo, issue_text="Refactor pkg/service.py return shape."
+        )
+        assert "pkg/service.py" in surface, "explicit path must be selected"
+        assert "pkg/models.py" in surface, "one-hop import must be expanded"
+        assert "pkg/util.py" not in surface, "unrelated file must not ride along"
+
+    def test_empty_repo_yields_empty_map(self, tmp_path):
+        assert build_interface_map(tmp_path) == {}
+
+    def test_missing_repo_yields_empty_map(self, tmp_path):
+        assert build_interface_map(tmp_path / "gone") == {}
+
+
+class TestBuildInterfaceMapForPaths:
+    """The revision feedback loop's extractor."""
+
+    def test_draft_declared_paths_plus_imports(self, repo):
+        surface = build_interface_map_for_paths(["pkg/service.py"], repo)
+        assert "pkg/service.py" in surface
+        assert "pkg/models.py" in surface
+
+    def test_escaping_and_missing_paths_skipped(self, repo):
+        surface = build_interface_map_for_paths(
+            ["../outside.py", "pkg/nope.py"], repo
+        )
+        assert surface == {}
+
+
+# =============================================================================
+# Rendering and prompt integration
+# =============================================================================
+
+
+class TestFormatSection:
+
+    def test_section_carries_imperative_framing(self, repo):
+        surface = build_interface_map(repo)
+        section = format_interface_map_section(surface)
+        assert section.startswith(INTERFACE_SECTION_TITLE)
+        assert "DO NOT invent methods" in section
+        assert "**pkg/models.py**:" in section
+
+    def test_empty_map_renders_nothing(self):
+        assert format_interface_map_section({}) == ""
+
+
+class TestPromptIntegration:
+
+    def _lld_state(self, repo, **overrides):
+        state = {
+            "issue_number": 77,
+            "issue_title": "Do the thing",
+            "issue_body": "Change pkg/service.py behavior.",
+            "context_content": "",
+            "target_repo": str(repo),
+            "interface_map": build_interface_map(repo),
+            "codebase_context": {"project_description": "A demo project."},
+            "current_draft": "",
+            "verdict_history": [],
+            "user_feedback": "",
+            "validation_errors": [],
+        }
+        state.update(overrides)
+        return state
+
+    def test_fresh_draft_places_surface_before_codebase_context(self, repo):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            _build_prompt,
+        )
+
+        prompt = _build_prompt(self._lld_state(repo), "TEMPLATE", "lld")
+        assert prompt.count(INTERFACE_SECTION_TITLE) == 1
+        assert prompt.index(INTERFACE_SECTION_TITLE) < prompt.index(
+            "## Codebase Analysis"
+        )
+
+    def test_revision_refreshes_from_files_changed_table(self, repo):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            _build_prompt,
+        )
+
+        draft = textwrap.dedent(
+            """
+            # 77 - Feature: Do the thing
+
+            ### 2.1 Files Changed
+
+            | File | Change Type | Description |
+            |------|-------------|-------------|
+            | `pkg/relative_user.py` | Modify | rewire |
+
+            ## 11 Acceptance
+            ## 12 Done
+            """
+        ).strip()
+        state = self._lld_state(
+            repo,
+            current_draft=draft,
+            validation_errors=["Section 2.3 missing"],
+            repo_structure="pkg/",
+            # A stale N0b map that does NOT contain relative_user.py — the
+            # refresh must supersede it.
+            interface_map={"pkg/util.py": "def helper() -> int:\n    ..."},
+        )
+        prompt = _build_prompt(state, "TEMPLATE", "lld")
+        # Exactly one surface section: refresh in revision context; the
+        # input-content injection must be suppressed on revisions.
+        assert prompt.count(INTERFACE_SECTION_TITLE) == 1
+        assert "relative_user" in prompt.split(INTERFACE_SECTION_TITLE)[1]
+        assert "def helper" not in prompt, "stale map must be superseded"
+
+    def test_revision_falls_back_to_state_map_without_table(self, repo):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            _build_prompt,
+        )
+
+        state = self._lld_state(
+            repo,
+            current_draft="# 77 - Feature: no table here\n\nProse only.",
+            validation_errors=["Section 2.1 not found"],
+            repo_structure="pkg/",
+        )
+        prompt = _build_prompt(state, "TEMPLATE", "lld")
+        assert prompt.count(INTERFACE_SECTION_TITLE) == 1
+
+    def test_truncation_sacrifices_codebase_context_not_the_surface(self, repo):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            MAX_TOTAL_PROMPT_CHARS,
+            _truncate_prompt,
+        )
+
+        surface_section = format_interface_map_section(build_interface_map(repo))
+        oversized = (
+            "## Issue\nDo the thing.\n\n"
+            + surface_section
+            + "\n\n## Codebase Analysis\n"
+            + ("filler " * (MAX_TOTAL_PROMPT_CHARS // 6))
+        )
+        assert len(oversized) > MAX_TOTAL_PROMPT_CHARS
+        result = _truncate_prompt(oversized)
+        assert INTERFACE_SECTION_TITLE in result
+        assert "## Codebase Analysis" not in result


### PR DESCRIPTION
Tiphys, the helmsman: the LLD drafter now sees the target repo's **real** public interface signatures before it writes, so it stops inventing functions that don't exist. Interface lookup is a ground-truth problem, not a similarity problem — retrieval returns the *most similar* name, which is exactly how a plausible-but-wrong one gets fetched with confidence attached; that's why RAG was retired (#1687) and why this reads the AST instead.

Design document: `docs/lld/active/LLD-1688.md`, hand-authored and operator-ratified in-session (insertion point, language scope, and the selection composite were each explicitly discussed and decided).

## What's in it

**One yardstick, two consumers.** The three #373-pattern signature summarizers *move* from the spec stage into `core/interface_surface.py`; the spec stage keeps `_`-prefixed aliases, and a test asserts the aliases **are** the core functions (`is`, not equal) — the surface the drafter is shown and the symbol set the spec-stage gate checks can never drift. A second test pins funnel self-consistency: every name in a file's summary exists in `_extract_symbols_from_files`' set for the same file.

**Size-adaptive selection (the ratified composite).** The original keyword-only selection risk was real, and "telemetry will show misses" is detection, not mitigation. So:

- **Whole-surface mode:** small repos (≤48 candidate files, surface fits 24 KB) ship their *entire* public interface — no selection, therefore no selection miss. The speedrun-class repo lives here permanently. A test proves an unrelated file still gets included.
- **Selection mode:** large repos select by explicit path mentions in the issue (highest precision — an issue that names `graph.py` is declaring its blast radius), then keyword-related files (honestly a draft-one heuristic), then **one-hop intra-repo import expansion** — designs touch a file *and its collaborators*, and the invented-name-on-the-neighbor case is a large share of real hallucinations. Absolute, `from`-style, and relative imports all resolve; stdlib/third-party resolve to nothing.
- **The revision feedback loop — the real fix for large repos:** on revision passes, `generate_draft` re-extracts signatures from the files named in **the draft's own Files Changed table** (via the mechanical validator's existing `parse_files_changed_table`) plus their imports. A draft-one selection miss becomes a one-iteration transient, corrected by the design's own declared blast radius. A test shows a stale pre-draft map being superseded by the refresh.

**Truncation-immune rendering.** The discovery that shaped this: `_truncate_prompt` (#508) sacrifices "Codebase Analysis" and "Related Code" *first* under token pressure — so ground truth riding inside the codebase context would be the first thing deleted exactly when prompts get large. The `## Real Interface Surface` section is separate, placed before the codebase-context sections, deliberately absent from the drop list, and framed with the retired RAG formatter's imperative language ("use exactly as declared; DO NOT invent methods not listed; if something is missing, *say so*"). A test builds an oversized prompt and proves truncation drops Codebase Analysis while the surface survives. Fresh drafts get the section in the input block; revisions get the refreshed section in the feedback block — a count test proves never both.

**Failure contract.** Every entry point degrades to an empty map with a logged warning. Tiphys can never block an LLD; a degraded Tiphys is a *measurable absence*, not a pipeline failure.

## Verification

- 27 new tests in `tests/unit/test_interface_surface.py` covering summarizer move-safety, funnel self-consistency, walk exclusions, explicit-path resolution (incl. backslash form and boundary escapes), import resolution (absolute/relative/stdlib), both budget caps, both selection modes, the revision refresh and its fallback, rendering, and truncation immunity.
- Full unit suite: **5,654 passed** (+27, nothing broken in either workflow).
- Lint: the new module is clean; two new E402s in `generate_draft.py` match that file's existing structural idiom (constants precede imports, so *every* import there is E402 — 8 pre-existing). A pre-existing dead-code find made during this work (`pattern_analysis` computed and discarded in N0b — same class as #1813) is deliberately untouched and tracked in #1816.

## The regression guard (why #1812 landed first)

The telemetry instrument records invented-call counts for the **LLD artifact** on every spec-stage run. Acceptance for Tiphys is empirical: Tiphys-grounded LLDs should log `artifact: "lld", passed: true` — zero invented calls — measured starting with the #1761 scratch-repo run, against the pre-Tiphys events as the before side. When someone asks "did Tiphys work," the answer is a grep, not an anecdote.

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)
