### PR TITLE
fix(new_repo): pr-sentinel check verifies via App JWT; unverifiable is skip, not fail (Closes #1822)

### DIFF
--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -737,6 +737,9 @@ import base64 as _base64  # noqa: E402
 
 from new_repo import (  # noqa: E402
     _CANONICAL_AUTO_REVIEWER_CALLER,
+    _mint_github_app_jwt,
+    _parse_sentinel_app_bundle,
+    run_pr_sentinel_check,
     verify_branch_protection_on_origin,
     verify_pr_sentinel_installation,
     verify_repo_settings_on_origin,
@@ -935,70 +938,182 @@ class TestVerifyWorkflowContent:
 
 
 class TestVerifyPrSentinelInstallation:
-    """T300-T302: verify_pr_sentinel_installation (#1202, refactored #1274).
+    """T300-T302: verify_pr_sentinel_installation (#1202, #1274, #1822).
 
-    Post-#1274: function uses requests + classic PAT (not gh CLI). Tests
-    mock requests.get with status-code/json-shaped responses.
+    Post-#1822: the function authenticates AS the App (JWT) and probes
+    GET /repos/{owner}/{repo}/installation — 200 = installed, 404 = not.
+    The old /user/installations flow was rejected 403 for any PAT, so the
+    check could never pass; these tests mock the new endpoint only.
     """
 
     @patch("new_repo.requests.get")
-    def test_T300_pass_when_repo_in_installation(self, mock_get):
-        """Worker installation found AND covers the new repo → (True, ...)."""
-        installations_resp = MagicMock(status_code=200)
-        installations_resp.json.return_value = {
-            "installations": [
-                {"app_slug": "pr-sentinel-mm", "id": 12345},
-            ],
-        }
-        repos_resp = MagicMock(status_code=200)
-        repos_resp.json.return_value = {
-            "repositories": [
-                {"full_name": "martymcenroe/some-other"},
-                {"full_name": "martymcenroe/repo-name"},
-            ],
-        }
-        mock_get.side_effect = [installations_resp, repos_resp]
+    def test_T300_pass_when_app_installed_on_repo(self, mock_get):
+        """200 from /repos/{o}/{r}/installation → (True, covers)."""
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = {"id": 12345}
+        mock_get.return_value = resp
         ok, msg = verify_pr_sentinel_installation(
-            "martymcenroe", "repo-name", "fake-pat",
+            "martymcenroe", "repo-name", "fake-jwt",
         )
         assert ok is True
         assert "covers" in msg
+        # Bearer auth with the App JWT, not a PAT token header.
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer fake-jwt"
 
     @patch("new_repo.requests.get")
-    def test_T301_warn_when_installation_missing(self, mock_get):
-        """No pr-sentinel-mm in /user/installations → (False, 'not found')."""
-        resp = MagicMock(status_code=200)
-        resp.json.return_value = {"installations": [
-            {"app_slug": "some-other-app", "id": 99},
-        ]}
+    def test_T301_fail_when_app_not_installed(self, mock_get):
+        """404 → (False, NOT installed / scope drift)."""
+        resp = MagicMock(status_code=404, text="Not Found")
         mock_get.return_value = resp
         ok, msg = verify_pr_sentinel_installation(
-            "martymcenroe", "repo-name", "fake-pat",
+            "martymcenroe", "repo-name", "fake-jwt",
         )
         assert ok is False
-        assert "not found" in msg
+        assert "NOT installed" in msg
+        assert "drift" in msg.lower()
 
     @patch("new_repo.requests.get")
-    def test_T302_warn_when_repo_not_in_installation_repos(self, mock_get):
-        """Installation exists but doesn't cover the new repo → App scope drift warning."""
-        installations_resp = MagicMock(status_code=200)
-        installations_resp.json.return_value = {
-            "installations": [
-                {"app_slug": "pr-sentinel-mm", "id": 12345},
-            ],
-        }
-        repos_resp = MagicMock(status_code=200)
-        repos_resp.json.return_value = {
-            "repositories": [
-                {"full_name": "martymcenroe/some-other-only"},
-            ],
-        }
-        mock_get.side_effect = [installations_resp, repos_resp]
+    def test_T302_fail_on_unexpected_http_status(self, mock_get):
+        """Non-200/404 (e.g. 401 bad JWT) → (False, HTTP detail)."""
+        resp = MagicMock(status_code=401, text="Bad credentials")
+        mock_get.return_value = resp
         ok, msg = verify_pr_sentinel_installation(
-            "martymcenroe", "repo-name", "fake-pat",
+            "martymcenroe", "repo-name", "fake-jwt",
         )
         assert ok is False
-        assert "does NOT cover" in msg or "drift" in msg.lower()
+        assert "401" in msg
+
+
+class TestSentinelAppBundleAndJwt:
+    """T310-T313: _parse_sentinel_app_bundle + _mint_github_app_jwt (#1822)."""
+
+    @staticmethod
+    def _test_pem() -> str:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        return key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+    def test_T310_parse_valid_bundle(self):
+        """App ID line + PEM body parses into the pair."""
+        pem = self._test_pem()
+        app_id, parsed_pem = _parse_sentinel_app_bundle(f"123456\n{pem}")
+        assert app_id == "123456"
+        assert "PRIVATE KEY" in parsed_pem
+
+    def test_T311_parse_rejects_non_numeric_app_id(self):
+        """Line 1 must be the numeric App ID."""
+        with pytest.raises(ValueError, match="numeric App ID"):
+            _parse_sentinel_app_bundle("not-a-number\n-----BEGIN PRIVATE KEY-----\nx\n")
+
+    def test_T312_parse_rejects_missing_pem(self):
+        """A bare App ID with no PEM body is malformed."""
+        with pytest.raises(ValueError):
+            _parse_sentinel_app_bundle("123456")
+
+    def test_T313_minted_jwt_has_app_claims_and_valid_signature(self):
+        """JWT: three segments, iss = App ID, iat backdated, RS256-verifiable."""
+        import base64
+        import json
+
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        pem = self._test_pem()
+        token = _mint_github_app_jwt("123456", pem)
+        header_b64, payload_b64, sig_b64 = token.split(".")
+
+        def unb64(seg: str) -> bytes:
+            return base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4))
+
+        header = json.loads(unb64(header_b64))
+        payload = json.loads(unb64(payload_b64))
+        assert header == {"alg": "RS256", "typ": "JWT"}
+        assert payload["iss"] == "123456"
+        assert payload["exp"] - payload["iat"] == 600  # -60s iat, +540s exp
+        # Signature must verify against the key's public half.
+        pub = serialization.load_pem_private_key(
+            pem.encode(), password=None,
+        ).public_key()
+        pub.verify(  # raises InvalidSignature on mismatch
+            unb64(sig_b64),
+            f"{header_b64}.{payload_b64}".encode(),
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+
+
+class TestRunPrSentinelCheck:
+    """T314-T317: run_pr_sentinel_check three-state dispatch (#1822).
+
+    "skip" outcomes must NOT count toward the GitHub-side denominator —
+    that is the whole point of the fix: an unperformable check must not
+    produce the WARNING banner.
+    """
+
+    def test_T314_skip_when_bundle_not_provisioned(self, tmp_path):
+        """Missing encrypted bundle → ('skip', not attempted)."""
+        outcome, msg = run_pr_sentinel_check(
+            "martymcenroe", "repo-name", tmp_path / "absent.gpg",
+        )
+        assert outcome == "skip"
+        assert "not provisioned" in msg
+        assert "not attempted" in msg
+
+    @patch("new_repo.pr_sentinel_app_session")
+    def test_T315_skip_when_decrypt_declined(self, mock_session, tmp_path):
+        """Operator cancels pinentry (RuntimeError) → ('skip', ...)."""
+        mock_session.side_effect = RuntimeError(
+            "decrypt declined by operator (pinentry cancelled)"
+        )
+        outcome, msg = run_pr_sentinel_check(
+            "martymcenroe", "repo-name", tmp_path / "any.gpg",
+        )
+        assert outcome == "skip"
+        assert "declined" in msg
+
+    @patch("new_repo.verify_pr_sentinel_installation")
+    @patch("new_repo._mint_github_app_jwt")
+    @patch("new_repo._parse_sentinel_app_bundle")
+    @patch("new_repo.pr_sentinel_app_session")
+    def test_T316_pass_when_verified(
+        self, mock_session, mock_parse, mock_mint, mock_verify,
+    ):
+        """Decrypt + mint + 200 probe → ('pass', ...)."""
+        mock_session.return_value.__enter__ = MagicMock(return_value="bundle")
+        mock_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_parse.return_value = ("123456", "PEM")
+        mock_mint.return_value = "jwt"
+        mock_verify.return_value = (True, "App installation covers this repo (id 1)")
+        outcome, msg = run_pr_sentinel_check(
+            "martymcenroe", "repo-name", Path("ignored.gpg"),
+        )
+        assert outcome == "pass"
+        assert "covers" in msg
+
+    @patch("new_repo.verify_pr_sentinel_installation")
+    @patch("new_repo._mint_github_app_jwt")
+    @patch("new_repo._parse_sentinel_app_bundle")
+    @patch("new_repo.pr_sentinel_app_session")
+    def test_T317_fail_when_app_absent(
+        self, mock_session, mock_parse, mock_mint, mock_verify,
+    ):
+        """Credential fine but App genuinely not installed → ('fail', ...)."""
+        mock_session.return_value.__enter__ = MagicMock(return_value="bundle")
+        mock_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_parse.return_value = ("123456", "PEM")
+        mock_mint.return_value = "jwt"
+        mock_verify.return_value = (False, "App is NOT installed on o/r")
+        outcome, msg = run_pr_sentinel_check(
+            "martymcenroe", "repo-name", Path("ignored.gpg"),
+        )
+        assert outcome == "fail"
+        assert "NOT installed" in msg
 
 
 # ===========================================================================

--- a/tools/_pat_session.py
+++ b/tools/_pat_session.py
@@ -51,6 +51,7 @@ from typing import Iterator
 
 DEFAULT_PAT_PATH: Path = Path.home() / ".secrets" / "classic-pat.gpg"
 DEFAULT_CERBERUS_PEM_PATH: Path = Path.home() / ".secrets" / "cerberus-pem.gpg"
+DEFAULT_PR_SENTINEL_APP_PATH: Path = Path.home() / ".secrets" / "pr-sentinel-app.gpg"
 GPG_TIMEOUT_S: int = 180
 MAX_GPG_ATTEMPTS: int = 5
 
@@ -215,4 +216,95 @@ def cerberus_pem_session(
     raise RuntimeError(
         f"gpg decrypt of Cerberus PEM failed after {MAX_GPG_ATTEMPTS} attempts. "
         f"Last error: {last_stderr}"
+    )
+
+
+@contextmanager
+def pr_sentinel_app_session(
+    bundle_path: Path = DEFAULT_PR_SENTINEL_APP_PATH,
+) -> Iterator[str]:
+    """Yield the gpg-decrypted pr-sentinel App credential bundle.
+
+    The bundle is one gpg-symmetric-encrypted file: the App ID on line 1,
+    the App's private-key PEM from line 2 onward. Same threat model as
+    classic_pat_session / cerberus_pem_session: encrypted at rest,
+    decrypted only into this process's heap inside the context-manager
+    scope, never on disk in plaintext during a run.
+
+    With gpg-agent at TTL 0 every decrypt surfaces pinentry, so each
+    decrypt IS the operator's per-run consent to this permission boost
+    (#1822). Deliberate deviation from the sibling sessions: a
+    user-CANCELLED pinentry aborts immediately with RuntimeError instead
+    of retrying — cancel means "I decline the boost", and callers report
+    the dependent check as unverifiable rather than failed. Genuine
+    decrypt failures (mistyped passphrase) still retry as usual.
+
+    One-time setup (operator, in their own shell; App ID from the App's
+    settings page, PEM freshly downloaded):
+        mkdir -p ~/.secrets
+        { echo <APP_ID>; cat <app>.private-key.pem; } \\
+            | gpg -c -o ~/.secrets/pr-sentinel-app.gpg
+        rm <app>.private-key.pem
+        # then walk the hygiene-surfaces audit gate (runbook 0927)
+
+    Args:
+        bundle_path: Path to the gpg-encrypted credential bundle.
+
+    Yields:
+        Decrypted bundle text (App ID line + PEM). Deleted on exit.
+
+    Raises:
+        FileNotFoundError: Bundle file absent — treat the dependent
+            check as unverifiable, not failed.
+        RuntimeError: Decrypt declined (pinentry cancel) or failed
+            after MAX_GPG_ATTEMPTS — same unverifiable treatment.
+
+    Implementation note: mirrors cerberus_pem_session's structure rather
+    than sharing a helper, per that function's stated convention — the
+    load-bearing PAT/PEM paths stay untouched.
+    """
+    if not bundle_path.exists():
+        raise FileNotFoundError(
+            f"pr-sentinel App credential not found at {bundle_path}.\n"
+            f"One-time setup (operator shell; App ID + downloaded PEM):\n"
+            f"  mkdir -p {bundle_path.parent}\n"
+            f"  {{ echo <APP_ID>; cat <app>.private-key.pem; }} "
+            f"| gpg -c -o {bundle_path}\n"
+            f"  rm <app>.private-key.pem"
+        )
+
+    last_stderr = ""
+    for attempt in range(1, MAX_GPG_ATTEMPTS + 1):
+        result = subprocess.run(
+            ["gpg", "--quiet", "--decrypt", str(bundle_path)],
+            capture_output=True,
+            text=True,
+            timeout=GPG_TIMEOUT_S,
+        )
+        if result.returncode == 0:
+            bundle = result.stdout.strip()
+            try:
+                yield bundle
+            finally:
+                del bundle
+            return
+        last_stderr = result.stderr.strip()
+        if "cancel" in last_stderr.lower():
+            # Pinentry cancel = operator declined the boost. No retry.
+            raise RuntimeError(
+                "decrypt declined by operator (pinentry cancelled)"
+            )
+        if attempt < MAX_GPG_ATTEMPTS:
+            print(
+                f"gpg decrypt failed (attempt {attempt}/{MAX_GPG_ATTEMPTS}): {last_stderr}",
+                file=sys.stderr,
+            )
+            print(
+                "Retrying -- pinentry will prompt again. (Ctrl-C to abort.)",
+                file=sys.stderr,
+            )
+
+    raise RuntimeError(
+        f"gpg decrypt of pr-sentinel App bundle failed after "
+        f"{MAX_GPG_ATTEMPTS} attempts. Last error: {last_stderr}"
     )

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -65,10 +65,18 @@ except ImportError:
 # GH_TOKEN for the workflow-scoped initial push — tracked in #1000.
 import requests  # noqa: E402
 try:
-    from _pat_session import classic_pat_session, cerberus_pem_session
+    from _pat_session import (
+        classic_pat_session,
+        cerberus_pem_session,
+        pr_sentinel_app_session,
+    )
 except ImportError:
     sys.path.insert(0, str(Path(__file__).parent))
-    from _pat_session import classic_pat_session, cerberus_pem_session
+    from _pat_session import (
+        classic_pat_session,
+        cerberus_pem_session,
+        pr_sentinel_app_session,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +101,13 @@ _DEFAULT_SCHEMA_PATH = Path(__file__).parent.parent / "docs" / "standards" / "00
 # to retype the flag every time. Tests patch this constant to a non-existent
 # path to exercise the missing-PEM error branch (#1543).
 DEFAULT_CERBERUS_PEM_GPG = Path.home() / ".secrets" / "cerberus-pem.gpg"
+
+# Canonical location for the encrypted pr-sentinel App credential bundle
+# (App ID on line 1, private-key PEM after), used by the installation
+# check (#1822). Absent file => the check reports "unverifiable" and is
+# excluded from the GitHub-side pass/fail denominator entirely — an
+# unperformable check must not produce a warning banner.
+DEFAULT_PR_SENTINEL_APP_GPG = Path.home() / ".secrets" / "pr-sentinel-app.gpg"
 
 
 def load_structure_schema(schema_path: Path | None = None) -> dict:
@@ -2262,94 +2277,144 @@ def verify_workflow_content_on_origin(
     return False, "content differs from canonical (#1193 failure mode)"
 
 
+def _parse_sentinel_app_bundle(bundle: str) -> tuple[str, str]:
+    """Split the decrypted sentinel App bundle into (app_id, pem).
+
+    Bundle format (see pr_sentinel_app_session): App ID on line 1, the
+    App's private-key PEM from line 2 onward.
+
+    Raises:
+        ValueError: Line 1 is not a numeric App ID, or no PEM follows.
+    """
+    lines = bundle.strip().splitlines()
+    if len(lines) < 2:
+        raise ValueError("bundle has fewer than 2 lines (App ID + PEM expected)")
+    app_id = lines[0].strip()
+    if not app_id.isdigit():
+        raise ValueError("bundle line 1 is not a numeric App ID")
+    pem = "\n".join(lines[1:]).strip() + "\n"
+    if "PRIVATE KEY" not in pem:
+        raise ValueError("bundle lines 2+ do not look like a private-key PEM")
+    return app_id, pem
+
+
+def _mint_github_app_jwt(app_id: str, pem: str) -> str:
+    """Mint a short-lived RS256 JWT authenticating AS the GitHub App.
+
+    Standard GitHub App JWT shape: iat backdated 60s for clock drift,
+    9-minute expiry (GitHub caps at 10), iss = the App ID. Signed with
+    the App's private key via `cryptography` (already a project
+    dependency) — no JWT library needed for the one fixed header shape
+    GitHub accepts. (#1822)
+    """
+    import base64 as _b64
+    import json as _json
+    import time as _time
+
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding as _padding
+
+    def _b64url(data: bytes) -> bytes:
+        return _b64.urlsafe_b64encode(data).rstrip(b"=")
+
+    now = int(_time.time())
+    header = _b64url(_json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _b64url(_json.dumps(
+        {"iat": now - 60, "exp": now + 540, "iss": app_id}
+    ).encode())
+    signing_input = header + b"." + payload
+    key = serialization.load_pem_private_key(pem.encode(), password=None)
+    signature = key.sign(signing_input, _padding.PKCS1v15(), hashes.SHA256())
+    return (signing_input + b"." + _b64url(signature)).decode()
+
+
 def verify_pr_sentinel_installation(
-    github_user: str, repo_name: str, pat: str,
+    github_user: str, repo_name: str, app_jwt: str,
 ) -> tuple[bool, str]:
-    """Best-effort check that pr-sentinel-mm Cloudflare Worker covers this repo.
+    """Check that the pr-sentinel App is installed on this repo.
 
-    The Worker delivers the `pr-sentinel / issue-reference` check that branch
-    protection requires. If the Worker's GitHub App installation scope has
-    drifted from 'All repositories', the check never fires and every PR sits
-    blocked. Catches that at creation time instead of when the first PR opens.
+    The Worker delivers the `pr-sentinel / issue-reference` check that
+    branch protection requires. If the App's installation scope has
+    drifted from 'All repositories', the check never fires and every PR
+    sits blocked. Catches that at creation time instead of when the
+    first PR opens.
 
-    Uses the in-process classic PAT per ADR-0216 (#1274). The
-    /user/installations endpoint requires elevated scope that the
-    fine-grained PAT deliberately lacks; prior versions of this function
-    shelled out via gh and reliably 403'd on every run.
+    Asks the question the honest way (#1822): authenticated AS the App
+    (JWT), `GET /repos/{owner}/{repo}/installation` returns 200 iff this
+    App is installed on the repo, 404 if it is not. The previous
+    /user/installations approach was rejected 403 for ANY personal
+    access token (auth-shape rejection — that endpoint requires a GitHub
+    App user access token), so the check structurally could not pass on
+    any run.
 
     Args:
-        github_user: GitHub username (org or user account that owns the repo).
+        github_user: GitHub username (org or user account owning the repo).
         repo_name: Repository name (no owner prefix).
-        pat: Classic PAT from classic_pat_session(). Passed in the
-            Authorization header; never reaches env or argv.
+        app_jwt: RS256 App JWT from _mint_github_app_jwt(). Bearer
+            header only; never reaches env or argv.
     """
     headers = {
-        "Authorization": f"token {pat}",
+        "Authorization": f"Bearer {app_jwt}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-
-    # Step 1: find the pr-sentinel-mm installation id on the user account.
+    full_name = f"{github_user}/{repo_name}"
     try:
         r = requests.get(
-            "https://api.github.com/user/installations",
+            f"https://api.github.com/repos/{full_name}/installation",
             headers=headers, timeout=30,
         )
     except requests.RequestException as e:
-        return False, f"could not query /user/installations: {e}"
-    if r.status_code != 200:
+        return False, f"could not query repo installation: {e}"
+    if r.status_code == 200:
+        try:
+            inst_id = r.json().get("id")
+        except ValueError:
+            inst_id = None
+        return True, f"App installation covers this repo (id {inst_id})"
+    if r.status_code == 404:
         return False, (
-            f"GET /user/installations failed: {r.status_code} "
-            f"{r.text[:200]}"
+            f"App is NOT installed on {full_name} -- installation scope "
+            "may have drifted from 'All repositories'"
         )
-    try:
-        installations = r.json().get("installations", [])
-    except ValueError as e:
-        return False, f"could not parse /user/installations: {e}"
-    sentinel = next(
-        (inst for inst in installations if inst.get("app_slug") == "pr-sentinel-mm"),
-        None,
-    )
-    if sentinel is None:
-        return False, "pr-sentinel-mm not found in /user/installations"
-    installation_id = sentinel.get("id")
-    if installation_id is None:
-        return False, "pr-sentinel-mm installation has no id field"
-
-    # Step 2: list repositories covered by this installation; confirm the
-    # new repo is in the list. GitHub paginates installation repositories
-    # at 100 per page; loop until exhausted.
-    full_name = f"{github_user}/{repo_name}"
-    page = 1
-    while True:
-        try:
-            r = requests.get(
-                f"https://api.github.com/user/installations/{installation_id}/repositories",
-                headers=headers,
-                params={"per_page": 100, "page": page},
-                timeout=30,
-            )
-        except requests.RequestException as e:
-            return False, f"could not query installation repos: {e}"
-        if r.status_code != 200:
-            return False, (
-                f"GET /user/installations/{installation_id}/repositories "
-                f"failed: {r.status_code} {r.text[:200]}"
-            )
-        try:
-            repos = r.json().get("repositories", [])
-        except ValueError as e:
-            return False, f"could not parse installation repos: {e}"
-        for repo in repos:
-            if repo.get("full_name") == full_name:
-                return True, f"installation {installation_id} covers this repo"
-        if len(repos) < 100:
-            break  # last page
-        page += 1
     return False, (
-        f"installation {installation_id} does NOT cover {full_name} -- "
-        "App scope may have drifted from 'All repositories'"
+        f"GET /repos/{full_name}/installation failed: "
+        f"{r.status_code} {r.text[:200]}"
     )
+
+
+def run_pr_sentinel_check(
+    github_user: str, repo_name: str, bundle_path: Path,
+) -> tuple[str, str]:
+    """Three-state pr-sentinel installation check (#1822).
+
+    Returns (outcome, message) with outcome one of:
+        "pass" -- App verified installed on the repo.
+        "fail" -- App verifiably NOT installed, or the authenticated
+                  probe errored: counts against the GitHub-side
+                  denominator (genuine investigate signal).
+        "skip" -- unverifiable, not attempted: credential bundle not
+                  provisioned, operator declined the pinentry boost, or
+                  bundle malformed. Excluded from the denominator so an
+                  unperformable check cannot cry wolf — an always-firing
+                  warning banner trains operators to ignore it, which
+                  then cannot alert on a genuine failure.
+    """
+    try:
+        with pr_sentinel_app_session(bundle_path) as bundle:
+            app_id, pem = _parse_sentinel_app_bundle(bundle)
+            app_jwt = _mint_github_app_jwt(app_id, pem)
+    except FileNotFoundError:
+        return "skip", (
+            f"encrypted App credential not provisioned ({bundle_path}); "
+            "check not attempted"
+        )
+    except RuntimeError as e:
+        return "skip", f"credential unavailable: {e}; check not attempted"
+    except ValueError as e:
+        return "skip", f"credential bundle malformed: {e}; check not attempted"
+    ok, msg = verify_pr_sentinel_installation(github_user, repo_name, app_jwt)
+    return ("pass" if ok else "fail"), msg
 
 
 def _deploy_cerberus(
@@ -2508,6 +2573,17 @@ Examples:
              "encrypted blob is NOT deleted -- reuse it across as many "
              "new-repo invocations as you need, then revoke the key in the "
              "browser when done (#1254)."
+    )
+    parser.add_argument(
+        "--sentinel-app-gpg",
+        metavar="PATH",
+        default=None,
+        help="Path to the GPG-ENCRYPTED pr-sentinel App credential bundle "
+             "(App ID on line 1, private-key PEM after; default "
+             "~/.secrets/pr-sentinel-app.gpg). Used by the installation "
+             "check; decrypted in-process, pinentry per run is the consent "
+             "event. If the file is absent or the decrypt is declined, the "
+             "check reports unverifiable and is NOT counted (#1822)."
     )
     parser.add_argument(
         "--lang",
@@ -3405,22 +3481,38 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
                         else:
                             print(f"  [FAIL] Cerberus secrets missing: {missing}")
 
-                    # pr-sentinel installation check -- elevated; needs the
-                    # classic PAT (the /user/installations endpoint is NOT
-                    # accessible to the fine-grained PAT). Inside the
-                    # with-block, shares pat -- no extra pinentry. (#1274)
-                    gh_checks_total += 1
-                    ok, msg = verify_pr_sentinel_installation(
-                        github_user, args.name, pat,
+                    # pr-sentinel installation check -- requires the App's
+                    # OWN credential (JWT); GitHub refuses /user/installations
+                    # to personal access tokens of any shape, so no PAT can
+                    # perform this check. Three-state per #1822: "skip" means
+                    # unverifiable/not attempted and is EXCLUDED from the
+                    # denominator -- no false warning banner. The decrypt
+                    # pinentry (TTL 0) is the operator's per-run consent to
+                    # this extra permission boost; cancelling it declines.
+                    sentinel_bundle = Path(
+                        args.sentinel_app_gpg or DEFAULT_PR_SENTINEL_APP_GPG
                     )
-                    if ok:
-                        print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
+                    if sentinel_bundle.exists():
+                        print("  pr-sentinel check: pinentry will prompt to "
+                              "decrypt the App credential (cancel to skip "
+                              "this check).")
+                    outcome, msg = run_pr_sentinel_check(
+                        github_user, args.name, sentinel_bundle,
+                    )
+                    if outcome == "pass":
+                        gh_checks_total += 1
                         gh_checks_passed += 1
-                    else:
-                        print(f"  [WARN] pr-sentinel-mm Worker: {msg}")
+                        print(f"  [PASS] pr-sentinel-mm Worker: {msg}")
+                    elif outcome == "fail":
+                        gh_checks_total += 1
+                        print(f"  [FAIL] pr-sentinel-mm Worker: {msg}")
                         print("         If pr-sentinel checks don't appear on the first PR,")
                         print("         the App's installation scope likely drifted from "
                               "'All repositories'.")
+                    else:
+                        print(f"  [SKIP] pr-sentinel-mm Worker: {msg}")
+                        print("         (not counted; the first PR doubles as the live "
+                              "sentinel verification)")
 
         except FileNotFoundError as e:
             print(f"\n  ERROR: classic PAT not configured: {e}")


### PR DESCRIPTION
Closes #1822

## Problem

`GET /user/installations` rejects any personal access token with 403 — it requires a GitHub App user access token — so the pr-sentinel installation check structurally could not pass, and every `new_repo.py` run ended with a false **WARNING: GitHub-side checks failed** banner regardless of actual sentinel health. An always-firing banner trains the operator to ignore it.

## Change

- **Honest probe:** `verify_pr_sentinel_installation` now authenticates AS the App — an RS256 JWT minted in-process (`cryptography`, already a dependency) — and calls `GET /repos/{owner}/{repo}/installation`: 200 = the App covers the repo, 404 = genuinely not installed (real FAIL).
- **Credential source:** gpg-encrypted bundle (App ID on line 1, private-key PEM after) at `~/.secrets/pr-sentinel-app.gpg`, decrypted via new `pr_sentinel_app_session()` in `_pat_session.py`. Pinentry at TTL 0 is the per-run consent event; cancelling pinentry means declining — immediate abort, no retry loop (deliberate deviation from the sibling sessions, documented in the docstring).
- **Three-state outcome:** `run_pr_sentinel_check` returns pass / fail / skip. **Skip** (bundle not provisioned, decrypt declined, malformed bundle) is excluded from the GitHub-side denominator — no warning banner for a check that could not be attempted. The console notes the first PR doubles as live sentinel verification.
- **`--sentinel-app-gpg`** flag overrides the bundle path.

## Tests

127 passed (`test_new_repo.py` + `test_new_repo_safety.py`); ruff clean on all three files.

- T300–T302 rewritten for the new probe (200 / 404 / unexpected-status, Bearer auth asserted)
- T310–T313: bundle parsing (valid, non-numeric App ID, missing PEM) and JWT shape — claims verified AND signature cryptographically verified against the key's public half
- T314–T317: three-state dispatch — not-provisioned → skip, pinentry-declined → skip, verified → pass, absent installation → fail

## Provisioning note

Until the encrypted bundle is provisioned (operator one-time step, documented in the session helper's file-not-found message), runs report `[SKIP] ... check not attempted` with no banner — which is the truthful description of today's reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)