### PR TITLE
refactor(core): remove AZ-rooted artifact-path properties from WorkspaceContext (Closes #1420)

### DIFF
--- a/assemblyzero/core/workspace_context.py
+++ b/assemblyzero/core/workspace_context.py
@@ -38,20 +38,12 @@ class WorkspaceContext:
             if not path.exists():
                 raise ValueError(f"{field_name} does not exist: {path}")
 
-    @property
-    def docs_dir(self) -> Path:
-        """Return assemblyzero_root / 'docs'."""
-        return self.assemblyzero_root / "docs"
-
-    @property
-    def lld_active_dir(self) -> Path:
-        """Return docs / 'lld' / 'active'."""
-        return self.docs_dir / "lld" / "active"
-
-    @property
-    def reports_dir(self) -> Path:
-        """Return docs / 'reports'."""
-        return self.docs_dir / "reports"
+    # docs_dir / lld_active_dir / reports_dir properties removed (#1420):
+    # they returned AssemblyZero-rooted paths with zero external callers,
+    # and any future consumer wiring a WRITE to them would land the write
+    # in the AssemblyZero repo instead of the target repo. Per-target
+    # artifact paths belong to the target repo, never derived from
+    # assemblyzero_root.
 
     @property
     def target_name(self) -> str:

--- a/tests/unit/test_workspace_context.py
+++ b/tests/unit/test_workspace_context.py
@@ -101,17 +101,12 @@ class TestWorkspaceContextProperties:
         repo.mkdir()
         return WorkspaceContext(assemblyzero_root=root, target_repo=repo)
 
-    def test_docs_dir(self, ctx) -> None:
-        """T060."""
-        assert ctx.docs_dir == ctx.assemblyzero_root / "docs"
-
-    def test_lld_active_dir(self, ctx) -> None:
-        """T070."""
-        assert ctx.lld_active_dir == ctx.assemblyzero_root / "docs" / "lld" / "active"
-
-    def test_reports_dir(self, ctx) -> None:
-        """T080."""
-        assert ctx.reports_dir == ctx.assemblyzero_root / "docs" / "reports"
+    def test_az_rooted_artifact_properties_removed(self, ctx) -> None:
+        """#1420: the AZ-rooted docs_dir/lld_active_dir/reports_dir
+        properties must stay gone — a future consumer writing through them
+        would write into AssemblyZero instead of the target repo."""
+        for name in ("docs_dir", "lld_active_dir", "reports_dir"):
+            assert not hasattr(ctx, name), f"{name} must not be reintroduced"
 
     def test_target_name(self, ctx) -> None:
         """T090."""


### PR DESCRIPTION
Removes `docs_dir` / `lld_active_dir` / `reports_dir` from `WorkspaceContext`. Re-verified on current main: the only references were the class's own internals and the tests exercising the properties directly — zero real callers.

The issue's hazard is the reason to delete rather than keep: the properties return **AssemblyZero-rooted** paths, so any future consumer wiring a write through them would write into the AssemblyZero repo instead of the target repo. Per-target artifact paths belong to the target, never derived from `assemblyzero_root` — a comment at the removal site says so, and a replacement guard test asserts the three names stay gone.

Full unit suite: 5,666 passed.

Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)