### PR TITLE
fix(requirements): wire scan_patterns output into the drafter prompt (Closes #1816)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
@@ -79,6 +79,7 @@ def _empty_codebase_context() -> dict[str, Any]:
         "related_code": {},
         "dependency_summary": "",
         "directory_tree": "",
+        "code_patterns": {},
     }
 
 
@@ -161,7 +162,14 @@ def analyze_codebase(state: dict) -> dict:
     # ------------------------------------------------------------------
     # Step 3: Scan code patterns
     # ------------------------------------------------------------------
+    # #1816: this result was computed and discarded since the original #401
+    # build, despite #401's acceptance explicitly listing "existing code
+    # patterns are injected into the drafter prompt". Wired in: detected
+    # fields only ("unknown" values carry no signal and are dropped).
     pattern_analysis = scan_patterns(file_contents)
+    code_patterns: dict[str, str] = {
+        k: v for k, v in pattern_analysis.items() if v and v != "unknown"
+    }
 
     # ------------------------------------------------------------------
     # Step 4: Detect frameworks
@@ -245,6 +253,7 @@ def analyze_codebase(state: dict) -> dict:
         "related_code": related_code,
         "dependency_summary": dependency_summary,
         "directory_tree": directory_tree,
+        "code_patterns": code_patterns,
     }
 
     logger.info(

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -592,6 +592,22 @@ def _format_codebase_context(ctx: dict) -> str:
         conv_lines = "\n".join(f"- {c}" for c in conventions)
         parts.append(f"### Coding Conventions\n\n{conv_lines}")
 
+    # #1816: detected code patterns (scan_patterns output, wired in per
+    # #401's original acceptance — "existing code patterns are injected").
+    code_patterns = ctx.get("code_patterns", {})
+    if code_patterns:
+        labels = {
+            "naming_convention": "Naming convention",
+            "state_pattern": "State management",
+            "node_pattern": "Node/function style",
+            "test_pattern": "Test framework",
+            "import_style": "Import style",
+        }
+        pattern_lines = "\n".join(
+            f"- {labels.get(k, k)}: {v}" for k, v in code_patterns.items()
+        )
+        parts.append(f"### Detected Code Patterns\n\n{pattern_lines}")
+
     frameworks = ctx.get("frameworks", [])
     if frameworks:
         fw_lines = "\n".join(f"- {f}" for f in frameworks)

--- a/tests/unit/test_analyze_codebase.py
+++ b/tests/unit/test_analyze_codebase.py
@@ -29,18 +29,8 @@ from assemblyzero.workflows.requirements.nodes.analyze_codebase import (
     _search_for_file,
 )
 from assemblyzero.utils.codebase_reader import (
-    FileReadResult,
     is_sensitive_file,
     read_file_with_budget,
-    read_files_within_budget,
-    parse_project_metadata,
-    SENSITIVE_PATTERNS,
-)
-from assemblyzero.utils.pattern_scanner import (
-    PatternAnalysis,
-    scan_patterns,
-    detect_frameworks,
-    extract_conventions_from_claude_md,
 )
 
 
@@ -57,6 +47,7 @@ _CODEBASE_CONTEXT_KEYS = {
     "related_code",
     "dependency_summary",
     "directory_tree",
+    "code_patterns",  # #1816: scan_patterns output, wired in per #401
 }
 
 
@@ -1338,3 +1329,39 @@ class TestExtractModuleDocstringLong:
         result = _extract_module_docstring(content)
         assert len(result) <= 120
         assert result.endswith("...")
+
+class TestCodePatternsWiredIn:
+    """#1816: scan_patterns output must reach the drafter, per #401's
+    original acceptance ("existing code patterns are injected")."""
+
+    def test_context_carries_detected_patterns(self, mock_repo, directory_tree):
+        state = {
+            "repo_path": str(mock_repo),
+            "issue_text": "Improve the reader module",
+            "directory_tree": directory_tree,
+        }
+        ctx = analyze_codebase(state)["codebase_context"]
+        assert "code_patterns" in ctx
+        # Only detected values ride along -- never the "unknown" filler.
+        assert "unknown" not in ctx["code_patterns"].values()
+
+    def test_formatter_renders_detected_patterns(self):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            _format_codebase_context,
+        )
+
+        section = _format_codebase_context(
+            {"code_patterns": {"state_pattern": "TypedDict", "test_pattern": "pytest"}}
+        )
+        assert "### Detected Code Patterns" in section
+        assert "State management: TypedDict" in section
+        assert "Test framework: pytest" in section
+
+    def test_formatter_omits_section_when_nothing_detected(self):
+        from assemblyzero.workflows.requirements.nodes.generate_draft import (
+            _format_codebase_context,
+        )
+
+        assert "Detected Code Patterns" not in _format_codebase_context(
+            {"code_patterns": {}}
+        )


### PR DESCRIPTION
`pattern_analysis = scan_patterns(file_contents)` had been computed and discarded since the file's first commit — while #401's acceptance criteria explicitly listed *'existing code patterns are injected into the drafter prompt'*. Same born-dead class as #1813's `has_arrow`, but the archaeology points the opposite way: this signal was designed to be consumed, so the fix is **wiring it in**, not deleting it.

## What changed

- The five detected patterns (naming convention, state management, node/function style, test framework, import style) now travel in `codebase_context["code_patterns"]`, with `"unknown"` values filtered out — undetected is no-signal, not content.
- `_format_codebase_context` renders them as a `### Detected Code Patterns` subsection with plain-English labels. As an h3 it rides inside the codebase-analysis block, which keeps it correctly *sacrificial* under prompt truncation — repo conventions are useful context, not ground truth; the truncation-immune slot stays reserved for the Tiphys interface surface (#1688).
- The empty-context fallback and the test suite's expected-key pin both gain the new key.
- Housekeeping in the touched test file: its 8 pre-existing unused-import findings cleared (all auto-fixable — no intent question, unlike #1813/#1816 themselves).

## Verification

Three new tests: detected patterns reach the context with no "unknown" filler; the formatter renders labeled lines; an empty detection renders no section at all. Full unit suite: **5,666 passed**.

Closes #1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)