### PR TITLE
fix(repo_drift_check): failures always reach stderr; distinct exit codes per failure class (Closes #1566)

### DIFF
--- a/tests/unit/test_repo_drift_check.py
+++ b/tests/unit/test_repo_drift_check.py
@@ -289,12 +289,14 @@ def test_main_emits_json_when_flag_passed(tmp_path, monkeypatch, capsys):
     handoff.write_text("Worked in /c/Users/mcwiz/Projects/real-repo today.", encoding="utf-8")
 
     rc = repo_drift_check.main(["--handoff", str(handoff), "--json"])
-    captured = capsys.readouterr().out
-    parsed = json.loads(captured)
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
     assert parsed["names_extracted"] == ["real-repo"]
     assert parsed["repos"][0]["status"] == "not_git"
-    # not_git is treated as an error status in main()'s exit-code logic
-    assert rc == 2
+    # #1566: non-fetch check failures exit 3 (fetch_error is 2); the
+    # failure detail reaches stderr even in --json mode.
+    assert rc == 3
+    assert "could not be checked" in captured.err
 
 
 def test_main_filters_filename_false_positives_via_dir_check(tmp_path, monkeypatch, capsys):
@@ -325,3 +327,53 @@ def test_main_returns_1_when_handoff_path_missing(tmp_path, capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "not found" in err
+
+
+# ---- #1566: --quiet must never silence check failures ----
+
+def _error_report():
+    return {
+        "repos": [
+            {"name": "alpha", "status": "fetch_error", "behind": 0, "ahead": 0,
+             "branch": "main", "error": "authentication failed"},
+            {"name": "beta", "status": "in_sync", "behind": 0, "ahead": 0,
+             "branch": "main"},
+        ]
+    }
+
+
+def test_stdout_report_omits_error_repos():
+    """Errors are stderr's job; a stdout consumer must never see a failed
+    check rendered as part of the answer."""
+    out = repo_drift_check.format_text_report(_error_report(), quiet=True)
+    assert "alpha" not in out
+    assert "fetch_error" not in out
+
+
+def test_error_report_names_repo_status_and_detail():
+    err = repo_drift_check.format_error_report(_error_report())
+    assert "could not be checked" in err
+    assert "alpha: fetch_error (authentication failed)" in err
+    assert "beta" not in err
+
+
+def test_main_quiet_fetch_error_exits_2_with_stderr_detail(tmp_path, monkeypatch, capsys):
+    """The 2026-06-09 incident shape: quiet mode, every fetch failing.
+    Exit must be 2 and stderr must say why — never empty-and-ambiguous."""
+    fake_root = tmp_path / "Projects"
+    (fake_root / "real-repo").mkdir(parents=True)
+    monkeypatch.setattr(repo_drift_check, "PROJECTS_ROOT", fake_root)
+    monkeypatch.setattr(
+        repo_drift_check, "check_repo_drift",
+        lambda name: {"name": name, "status": "fetch_error", "behind": 0,
+                      "ahead": 0, "branch": "main", "error": "auth token invalid"},
+    )
+
+    handoff = tmp_path / "h.md"
+    handoff.write_text("Worked in /c/Users/mcwiz/Projects/real-repo today.", encoding="utf-8")
+
+    rc = repo_drift_check.main(["--handoff", str(handoff), "--quiet"])
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert captured.out == ""
+    assert "auth token invalid" in captured.err

--- a/tools/repo_drift_check.py
+++ b/tools/repo_drift_check.py
@@ -212,11 +212,17 @@ def check_repo_drift(name: str) -> dict:
 
 
 def format_text_report(report: dict, quiet: bool) -> str:
+    """Render the ANSWER (drift / in-sync) for stdout.
+
+    #1566: error repos are deliberately NOT part of this report — "couldn't
+    do my job" belongs on stderr (see format_error_report), so a caller
+    capturing stdout under --quiet can never mistake a failed check for a
+    clean one.
+    """
     lines = []
     drift_repos = [r for r in report["repos"] if r["status"] == "drift"]
-    error_repos = [r for r in report["repos"] if r["status"] not in ("in_sync", "drift")]
 
-    if quiet and not drift_repos and not error_repos:
+    if quiet and not drift_repos:
         return ""
 
     if not report["repos"]:
@@ -232,13 +238,6 @@ def format_text_report(report: dict, quiet: bool) -> str:
                 parts.append(f"{r['ahead']} ahead of origin/{r['branch']}")
             lines.append(f"  {r['name']}: {' / '.join(parts)} -- pull before any local work")
 
-    if error_repos:
-        if lines:
-            lines.append("")
-        lines.append("Repos that could not be checked:")
-        for r in error_repos:
-            lines.append(f"  {r['name']}: {r['status']} ({r.get('error', 'no detail')})")
-
     if not quiet:
         in_sync = [r for r in report["repos"] if r["status"] == "in_sync"]
         if in_sync:
@@ -246,6 +245,25 @@ def format_text_report(report: dict, quiet: bool) -> str:
                 lines.append("")
             lines.append(f"In sync ({len(in_sync)}): {', '.join(r['name'] for r in in_sync)}")
 
+    return "\n".join(lines)
+
+
+def format_error_report(report: dict) -> str:
+    """Render repos that could NOT be checked, for stderr.
+
+    #1566: emitted unconditionally — --quiet must never silence "the check
+    itself failed". The 2026-06-09 incident: an invalidated gh token made
+    every fetch fail, --quiet produced empty stdout, and the caller
+    reported "no drift" when the true state was "unknown for every repo".
+    """
+    error_repos = [
+        r for r in report["repos"] if r["status"] not in ("in_sync", "drift")
+    ]
+    if not error_repos:
+        return ""
+    lines = ["Repos that could not be checked:"]
+    for r in error_repos:
+        lines.append(f"  {r['name']}: {r['status']} ({r.get('error', 'no detail')})")
     return "\n".join(lines)
 
 
@@ -278,8 +296,23 @@ def main(argv: list[str] | None = None) -> int:
         if text:
             print(text)
 
-    has_errors = any(r["status"] not in ("in_sync", "drift") for r in report["repos"])
-    return 2 if has_errors else 0
+    # #1566: failures to CHECK always reach stderr, in every mode — --quiet
+    # only quiets the answer, never the "I couldn't do my job" signal.
+    error_text = format_error_report(report)
+    if error_text:
+        print(error_text, file=sys.stderr)
+
+    # #1566: distinct exit codes so callers can dispatch on failure class:
+    #   0 = checked, clean or drift (the report is the answer)
+    #   1 = usage error (bad handoff path)
+    #   2 = fetch failed for at least one repo (network/auth — state UNKNOWN)
+    #   3 = other check failures only (missing dir, not a git repo, rev-list)
+    statuses = {r["status"] for r in report["repos"]}
+    if "fetch_error" in statuses:
+        return 2
+    if statuses - {"in_sync", "drift"}:
+        return 3
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The incident this fixes: a Windows update invalidated the gh token, every `git fetch` failed, and `--quiet` produced empty stdout with exit 2 — which the calling agent read as *no drift*. The true state was *unknown for every repo*. The drift check exists specifically to catch inherited-stale-state (#1077); a check that fails silently reintroduces that failure mode while creating the impression it was checked.

## The design change

**stdout is for the answer; stderr is for "I couldn't do my job."**

- `format_text_report` (stdout) now renders only drift/in-sync — error repos are no longer part of the answer, so a stdout consumer under `--quiet` can never mistake a failed check for a clean one.
- New `format_error_report` renders could-not-check repos with status and detail, emitted to **stderr unconditionally** — in quiet mode, verbose mode, and `--json` mode alike.
- Exit codes dispatch by failure class: **0** checked (clean or drift — the report is the answer), **1** usage error, **2** fetch failed for any repo (network/auth — state UNKNOWN), **3** other check failures only (missing dir, not a git repo, rev-list).

The issue's fourth ask (onboard-side: re-run without `--quiet` to expose the failure) is satisfied by design rather than by procedure — the first run now exposes it. One existing test updated for the 2→3 reclassification of `not_git`; three new tests, including a reproduction of the incident shape asserting exit 2, empty stdout, and the auth detail on stderr.

Full unit suite: **5,666 passed**.

Closes #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)