### PR TITLE
chore(docs): sweep remaining new_repo_setup references to new_repo (Closes #1610)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -708,7 +708,7 @@ def find_similar_files(filename: str, repo_root: Path, max_results: int = 3) -> 
     Issue #300: Help drafter fix invalid paths by suggesting alternatives.
 
     Args:
-        filename: The filename to search for (e.g., "new_repo_setup.py").
+        filename: The filename to search for (e.g., "new_repo.py").
         repo_root: Path to repository root.
         max_results: Maximum number of suggestions to return.
 
@@ -718,14 +718,14 @@ def find_similar_files(filename: str, repo_root: Path, max_results: int = 3) -> 
     suggestions = []
 
     # Normalize filename: convert underscores to hyphens and vice versa
-    base_name = Path(filename).stem  # e.g., "new_repo_setup"
+    base_name = Path(filename).stem  # e.g., "new_repo"
     extension = Path(filename).suffix  # e.g., ".py"
 
     # Generate variants to search for
     variants = {
         base_name,
-        base_name.replace("_", "-"),  # new_repo_setup -> new-repo-setup
-        base_name.replace("-", "_"),  # new-repo-setup -> new_repo_setup
+        base_name.replace("_", "-"),  # new_repo -> new-repo-setup
+        base_name.replace("-", "_"),  # new-repo-setup -> new_repo
     }
 
     # Search common code directories (limit depth to avoid slowness)

--- a/docs/adrs/0214-fleet-wide-workflow-permissions-enforcement.md
+++ b/docs/adrs/0214-fleet-wide-workflow-permissions-enforcement.md
@@ -139,7 +139,7 @@ After these PRs are merged, the `permissions` block exists on `main` in every re
 - Human must perform 9 manual steps — documented in the script header and session instructions
 
 ### Neutral
-- The `permissions` block is now part of the pr-sentinel workflow template; new repos created via `new_repo_setup.py` already include it
+- The `permissions` block is now part of the pr-sentinel workflow template; new repos created via `new_repo.py` already include it
 - No code changes to any application — only workflow YAML and the merge operation itself
 
 ## 7. Implementation

--- a/docs/adrs/0216-in-process-classic-pat-decryption.md
+++ b/docs/adrs/0216-in-process-classic-pat-decryption.md
@@ -80,7 +80,7 @@ Five existing tools still use v2 (env-scoped) at time of writing — see issues 
 - `tools/merge_sentinel_permissions_prs.py`
 - `tools/fix_branch_protections.py`
 - `tools/deploy_auto_reviewer_fleet.py`
-- `tools/new_repo_setup.py` (privileged paths only)
+- `tools/new_repo.py` (privileged paths only)
 - `tools/test_governance_system.py` (audit mode only)
 
 Until those land, mixed v2/v3 usage is tolerated. New tools MUST start at v3.

--- a/docs/adrs/0219-claude-md-division-of-responsibility.md
+++ b/docs/adrs/0219-claude-md-division-of-responsibility.md
@@ -9,7 +9,7 @@
 
 ## Context
 
-The scaffolded per-repo `CLAUDE.md` (emitted by `tools/new_repo_setup.py:create_claude_md`) duplicated content already in the universal `CLAUDE.md` (`C:\Users\mcwiz\Projects\CLAUDE.md`, auto-loaded for every project). When the universal `CLAUDE.md` changes (example: 2026-05-24's merge-sequence discussion about `unstable` vs `clean` polling), all per-repo copies become subtly stale. The drift compounds with every universal-CLAUDE.md edit.
+The scaffolded per-repo `CLAUDE.md` (emitted by `tools/new_repo.py:create_claude_md`) duplicated content already in the universal `CLAUDE.md` (`C:\Users\mcwiz\Projects\CLAUDE.md`, auto-loaded for every project). When the universal `CLAUDE.md` changes (example: 2026-05-24's merge-sequence discussion about `unstable` vs `clean` polling), all per-repo copies become subtly stale. The drift compounds with every universal-CLAUDE.md edit.
 
 Drift evidence: per-repo audit in the private fleet tracker (unleashed#656) showed multiple repos with stale boilerplate inherited from old scaffolder versions, false claims about what universal `CLAUDE.md` contains, and broken references to nonexistent infrastructure (orchestrator gate, wrong report-filename format).
 

--- a/docs/runbooks/0926-branch-protection-setup.md
+++ b/docs/runbooks/0926-branch-protection-setup.md
@@ -15,7 +15,7 @@ Configure **classic Branch Protection** for a repo when the script flow cannot d
 
 **When to use the manual fallback:** after creating a new repo and pushing at least one commit, AND the script's branch-protection step has failed AND re-running it with the classic PAT is not viable.
 
-**Why classic, not Rulesets:** every script in the fleet (`tools/new_repo_setup.py`, `tools/fix_branch_protections.py`, `tools/deploy_auto_reviewer_fleet.py`, `tools/github_protection_audit.py`, `tools/remediate_patent_general_protection.py`, `tools/remediate_fleet_branch_protection.py`) uses the classic Branch Protection API (`PUT /repos/{O}/{R}/branches/main/protection`). All 48+ protected repos in the fleet use classic protection. Per #1203 Option A (2026-05-22), the lone Rulesets outlier (patent-general) was migrated to classic on 2026-05-23 for fleet uniformity. Manual steps should match the fleet, not create a new outlier.
+**Why classic, not Rulesets:** every script in the fleet (`tools/new_repo.py`, `tools/fix_branch_protections.py`, `tools/deploy_auto_reviewer_fleet.py`, `tools/github_protection_audit.py`, `tools/remediate_patent_general_protection.py`, `tools/remediate_fleet_branch_protection.py`) uses the classic Branch Protection API (`PUT /repos/{O}/{R}/branches/main/protection`). All 48+ protected repos in the fleet use classic protection. Per #1203 Option A (2026-05-22), the lone Rulesets outlier (patent-general) was migrated to classic on 2026-05-23 for fleet uniformity. Manual steps should match the fleet, not create a new outlier.
 
 ---
 
@@ -136,7 +136,7 @@ git checkout -- README.md
 - [0925 - Agent Token Setup](0925-agent-token-setup.md) — Why the fine-grained PAT can't do this directly
 - `docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md` — Patterns for the in-process classic PAT (preferred over manual fallback)
 - `tools/remediate_patent_general_protection.py` — Reference one-shot tool: shows the canonical `CLASSIC_PROTECTION_BODY` shape this manual procedure must match
-- `tools/new_repo_setup.py:configure_branch_protection()` — The canonical body the manual steps mirror
+- `tools/new_repo.py:configure_branch_protection()` — The canonical body the manual steps mirror
 
 ---
 

--- a/docs/runbooks/0933-workflow-readiness-audit.md
+++ b/docs/runbooks/0933-workflow-readiness-audit.md
@@ -46,7 +46,7 @@ For the target repo at `{target}`:
 
 | Surface | What to check | Source |
 |---|---|---|
-| Repo bootstrap | `git log --oneline | grep "initialize project with AssemblyZero"` | Indicates `new_repo_setup.py` ran |
+| Repo bootstrap | `git log --oneline | grep "initialize project with AssemblyZero"` | Indicates `new_repo.py` ran |
 | `CLAUDE.md` + `GEMINI.md` | Both present, ≥50 lines each | Files |
 | `.unleashed.json` | Present; `assemblyZero: true`; no deprecated `pickupThresholdMinutes` | File |
 | Security hooks | `.claude/hooks/secret-file-guard.sh` present | File |

--- a/docs/runbooks/0934-pypi-trusted-publisher-setup.md
+++ b/docs/runbooks/0934-pypi-trusted-publisher-setup.md
@@ -1,8 +1,8 @@
 # PyPI Trusted Publisher Setup
 
-**Runbook 0934 — one-time per-repo browser steps to enable tag-push PyPI publishes from a repo bootstrapped by `tools/new_repo_setup.py` (#1074).**
+**Runbook 0934 — one-time per-repo browser steps to enable tag-push PyPI publishes from a repo bootstrapped by `tools/new_repo.py` (#1074).**
 
-`new_repo_setup.py` deploys `release.yml` to new Python repos **only when `--pypi` is passed** (as of #1269 — was default-on, now opt-in). The workflow is wired to publish to PyPI via OIDC Trusted Publisher — no API token is stored in GitHub secrets. But OIDC trust requires a one-time registration on PyPI's side, and **PyPI's publisher-registration UI is browser-only**. There is no API. This runbook covers the human steps; the script handles everything else.
+`new_repo.py` deploys `release.yml` to new Python repos **only when `--pypi` is passed** (as of #1269 — was default-on, now opt-in). The workflow is wired to publish to PyPI via OIDC Trusted Publisher — no API token is stored in GitHub secrets. But OIDC trust requires a one-time registration on PyPI's side, and **PyPI's publisher-registration UI is browser-only**. There is no API. This runbook covers the human steps; the script handles everything else.
 
 If you did NOT pass `--pypi` when creating the repo, this runbook does not apply — the repo has no `release.yml` and won't try to publish. To add PyPI publishing to an existing repo, re-run scaffolding or add `release.yml` manually.
 
@@ -10,7 +10,7 @@ If you did NOT pass `--pypi` when creating the repo, this runbook does not apply
 
 ## Prerequisites
 
-- Repo created via `tools/new_repo_setup.py <name> --pypi`.
+- Repo created via `tools/new_repo.py <name> --pypi`.
 - The script's output should include `Created auto-reviewer.yml + release.yml (PyPI publish on tag)`.
 - `pyproject.toml` in the repo has `[tool.poetry.scripts]` and `[tool.poetry.urls]` blocks populated. Verify with `grep -A3 "tool.poetry.scripts" pyproject.toml`.
 - `.github/workflows/release.yml` exists and uses `environment: pypi` (this is the default; don't edit unless you know what you're doing).
@@ -123,7 +123,7 @@ If you want to test the publish path without polluting the real PyPI index:
 3. Register a separate pending publisher on https://test.pypi.org/manage/account/publishing/ with the same fields.
 4. Trigger via a different tag pattern (e.g., `pre-v*.*.*`).
 
-This is out of scope for the default `new_repo_setup.py` flow. If demand for it grows, file a follow-up issue to add a `--testpypi` flag.
+This is out of scope for the default `new_repo.py` flow. If demand for it grows, file a follow-up issue to add a `--testpypi` flag.
 
 ---
 
@@ -142,10 +142,10 @@ PyPI **does not allow re-uploading** the same version (filename collision). If a
 
 ## Maintenance
 
-When `release.yml` template in `tools/new_repo_setup.py` changes:
+When `release.yml` template in `tools/new_repo.py` changes:
 
 1. Update the template string in `create_github_workflows()`.
-2. Re-run `new_repo_setup.py` on a throwaway test repo to verify the new workflow lands correctly.
+2. Re-run `new_repo.py` on a throwaway test repo to verify the new workflow lands correctly.
 3. For repos already created with the old workflow, decide: leave them on the old version, or land a follow-up PR per repo to update `release.yml` (Contents API path per ADR-0216).
 4. Update this runbook if the publisher fields change (e.g., environment name, workflow filename).
 
@@ -157,6 +157,6 @@ When `release.yml` template in `tools/new_repo_setup.py` changes:
 - **OIDC + GitHub Actions:** https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
 - **PyPI publishing GitHub Action:** https://github.com/pypa/gh-action-pypi-publish
 - **AZ #1074** — issue that surfaced the need for this runbook.
-- **`tools/new_repo_setup.py`** — script that deploys `release.yml`.
+- **`tools/new_repo.py`** — script that deploys `release.yml`.
 - **Standard 0009** — canonical project structure (defines `src/<module>/` layout).
 - **Speed-run plan** — `boostgauge/docs/speedrun/0003-az-implementation-plan.md` §6.4 calls out the browser-only nature of this step.

--- a/docs/standards/0009-canonical-project-structure.md
+++ b/docs/standards/0009-canonical-project-structure.md
@@ -4,7 +4,7 @@
 **Created:** 2026-01-20
 **Applies to:** All projects under AssemblyZero governance
 
-> **Note on scope.** "All projects under AssemblyZero governance" means CHILD projects — repositories that AZ governs and bootstraps via `tools/new_repo_setup.py`. **AssemblyZero itself, the governance layer, uses a parallel 4-digit numbering scheme** (`docs/0003-file-inventory.md`, `docs/standards/0009-...`, `docs/runbooks/0901-...`). The dual scheme is intentional — it originated in the 2026-01-13 Aletheia/AgentOS extraction so docs that briefly existed in both repos were glance-able. This standard governs CHILD projects (5-digit). AZ's own 4-digit scheme is its own convention, separate from this document. See `docs/index.md` for the historical record.
+> **Note on scope.** "All projects under AssemblyZero governance" means CHILD projects — repositories that AZ governs and bootstraps via `tools/new_repo.py`. **AssemblyZero itself, the governance layer, uses a parallel 4-digit numbering scheme** (`docs/0003-file-inventory.md`, `docs/standards/0009-...`, `docs/runbooks/0901-...`). The dual scheme is intentional — it originated in the 2026-01-13 Aletheia/AgentOS extraction so docs that briefly existed in both repos were glance-able. This standard governs CHILD projects (5-digit). AZ's own 4-digit scheme is its own convention, separate from this document. See `docs/index.md` for the historical record.
 
 ---
 

--- a/docs/standards/0011-audit-decisions.md
+++ b/docs/standards/0011-audit-decisions.md
@@ -2,7 +2,7 @@
 
 **Status:** Active
 **Created:** 2026-01-29
-**Applies to:** Structure audits via `new_repo_setup.py --audit`
+**Applies to:** Structure audits via `new_repo.py --audit`
 
 ---
 

--- a/docs/standards/0016-pr-sentinel-system-architecture.md
+++ b/docs/standards/0016-pr-sentinel-system-architecture.md
@@ -188,7 +188,7 @@ Every repo MUST have these branch protection settings on `main`:
 | Configuration | Context value | How it gets there |
 |---------------|--------------|-------------------|
 | **Fleet majority (48 repos)** | `pr-sentinel / issue-reference` | Set by `deploy_auto_reviewer_fleet.py` or `fix_branch_protections.py` |
-| **AssemblyZero + Sextant** | `issue-reference` with `app_id: 15368` | Set manually or by `new_repo_setup.py` |
+| **AssemblyZero + Sextant** | `issue-reference` with `app_id: 15368` | Set manually or by `new_repo.py` |
 
 **Both configurations work** because:
 - The Cloudflare Worker posts a check named `pr-sentinel / issue-reference`
@@ -196,9 +196,9 @@ Every repo MUST have these branch protection settings on `main`:
 - Context `pr-sentinel / issue-reference` matches the Worker's check
 - Context `issue-reference` with app_id filter 15368 matches the Actions workflow's job name
 
-**Known contradiction:** Issue #748 says `new_repo_setup.py` should set `issue-reference`. The fleet deployment scripts set `pr-sentinel / issue-reference`. Both work. This needs resolution (see #886).
+**Known contradiction:** Issue #748 says `new_repo.py` should set `issue-reference`. The fleet deployment scripts set `pr-sentinel / issue-reference`. Both work. This needs resolution (see #886).
 
-**What `new_repo_setup.py` currently sets:** `pr-sentinel` (bare, no slash, no job name). This is **wrong** — it matches neither the Worker's check run name nor the Actions workflow's composite name. Tracked in #748 and #883.
+**What `new_repo.py` currently sets:** `pr-sentinel` (bare, no slash, no job name). This is **wrong** — it matches neither the Worker's check run name nor the Actions workflow's composite name. Tracked in #748 and #883.
 
 ### 3.2 The app_id Filter
 
@@ -243,7 +243,7 @@ Used for fleet-wide operations that require elevated access. Always scripted, al
 | `merge_sentinel_permissions_prs.py` | Merge workflow permission fix PRs | `repo` |
 | `push_workflow_fixes.py` | Push workflow file changes | `workflow` |
 | `github_protection_audit.py` | Audit branch protection fleet-wide | `repo` + `admin:repo_hook` + `read:org` (audit mode) |
-| `new_repo_setup.py` | Create new repos with protection | Optional classic PAT for admin scope |
+| `new_repo.py` | Create new repos with protection | Optional classic PAT for admin scope |
 
 **Protocol:** Switch to classic PAT, run the script, switch back to fine-grained PAT immediately. The classic PAT is never stored in environment variables or configuration files accessible to agents.
 
@@ -282,7 +282,7 @@ Full audit data: `data/branch-protection-audit.csv`
 | Auto-reviewer timeout | PR not approved after 10 min | Required check not found by substring match | Verify check run name contains `issue-reference` |
 | Missing Cerberus secrets | Auto-reviewer workflow fails | `REVIEWER_APP_ID` or `REVIEWER_APP_PRIVATE_KEY` not set | Run `deploy_cerberus_secrets.py` |
 | Wrong context in branch protection | Check passes but protection not satisfied | Context name doesn't match any posted check | Fix via classic PAT (see scripts in section 4) |
-| `new_repo_setup.py` sets wrong context | New repos have mismatched protection | Script sets `pr-sentinel` instead of `pr-sentinel / issue-reference` | Known bug, tracked in #748/#883 |
+| `new_repo.py` sets wrong context | New repos have mismatched protection | Script sets `pr-sentinel` instead of `pr-sentinel / issue-reference` | Known bug, tracked in #748/#883 |
 | Squash merge drops PR body | Issue not auto-closed after merge | Commit message lacks `Closes #N` | Tracked in #851 — commit messages must also contain the reference |
 | Agent death spiral | Agent polls merge in tight loop | `mergeable_state` stays `blocked`, agent doesn't diagnose | CLAUDE.md instructs: check PR body, issue state, then stop |
 
@@ -296,7 +296,7 @@ Full audit data: `data/branch-protection-audit.csv`
 | 2026-03-10 | Agent merged 4 PRs in 6-7 seconds; pr-sentinel passed but didn't register due to missing permissions block | Documented in dispatch paper | Led to adding `permissions:` to pr-sentinel.yml (#853) |
 | 2026-03-10 | Auto-reviewer timeout — exact match on `pr-sentinel` failed against `pr-sentinel / issue-reference` | #742 | Fix: substring `contains()` match |
 | 2026-03-10 | Dependabot PRs permanently queued — Worker skipped without creating check run | #749 | Fix: create passing check run for dependabot |
-| 2026-03-18 | `new_repo_setup.py` sets `required_approving_review_count=0` instead of 1 | #758, #748 | Runbook updated; script still needs fix (#883) |
+| 2026-03-18 | `new_repo.py` sets `required_approving_review_count=0` instead of 1 | #758, #748 | Runbook updated; script still needs fix (#883) |
 | 2026-03-20 | Agent referenced closed issues, causing pr-sentinel failure and merge loop | Documented in lessons-learned | Led to commit message enforcement (#851) |
 | 2026-04-06 | Agent deleted Sextant branch protection and merged PR without permission | Lessons learned 2026-04-06 | Led to #883, reinforced standard 0003 |
 | 2026-04-06 | 3-hour misdiagnosis: Sextant protection flagged as broken when it was working | #886 | Led to this document and #887 (test suite) |

--- a/docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md
+++ b/docs/standards/0017-classic-pat-fleet-tooling-reference-architecture.md
@@ -1,6 +1,6 @@
 # Classic-PAT Fleet Tooling Reference Architecture
 
-A cross-fleet playbook for writing Python tools that perform privileged GitHub operations using the in-process classic PAT pattern (ADR-0216). Derived from production experience with `sentinel_migrate.py`, `fleet_delete_pr_sentinel.py`, `merge_aletheia_603_audit_gate.py`, `fleet_set_delete_branch_on_merge.py`, and `new_repo_setup.py`.
+A cross-fleet playbook for writing Python tools that perform privileged GitHub operations using the in-process classic PAT pattern (ADR-0216). Derived from production experience with `sentinel_migrate.py`, `fleet_delete_pr_sentinel.py`, `merge_aletheia_603_audit_gate.py`, `fleet_set_delete_branch_on_merge.py`, and `new_repo.py`.
 
 This is not prescriptive about specific algorithms. It captures **patterns that worked**, **patterns that didn't**, and **decisions you'll face early** that are expensive to change later.
 
@@ -199,7 +199,7 @@ Three options, none clearly best:
 - **`tools/_gh_http.py`** (proposed, not yet built) — dedicated HTTP helper module
 - **`tools/_pat_session.py`** — co-locate with `classic_pat_session()`, since both deal with elevated GitHub calls
 
-For now, inline is acceptable. As more tools land that use the same helper, extracting becomes worthwhile. Tracked at #1022 for `new_repo_setup.py`'s migration.
+For now, inline is acceptable. As more tools land that use the same helper, extracting becomes worthwhile. Tracked at #1022 for `new_repo.py`'s migration.
 
 ---
 
@@ -358,7 +358,7 @@ NEVER. Even to /tmp, even with `chmod 600`, even briefly. The Sentinel hook will
 | **`merge_aletheia_603_audit_gate.py`** (2026-04-30) | One-shot land single PR via API | Idempotent, accepts unstable for self-ref, CRLF normalize, `--skip-N-nudge` | YES — best model for one-shot tools |
 | **`fleet_delete_pr_sentinel.py`** (older) | Fleet-wide file deletion + PR + merge | Per-repo try/except, no retry/backoff | Partial — copy structure, add retry from `fleet_set_delete_branch_on_merge.py` |
 | **`sentinel_migrate.py`** (older) | Branch protection updates | Simplest v3 example, no retry | Partial — read for structure only |
-| **`new_repo_setup.py`** (complex) | Full new-repo orchestration | Wrapping try/except, no retry on privileged calls | NO — read for context, but #1022 tracks robustness debt |
+| **`new_repo.py`** (complex) | Full new-repo orchestration | Wrapping try/except, no retry on privileged calls | NO — read for context, but #1022 tracks robustness debt |
 | **`merge_sentinel_permissions_prs.py`** | DEPRECATED v1 (gh auth swap) | — | NO — anti-example. Documented for context only. |
 
 ---
@@ -410,7 +410,7 @@ When spinning up a new tool that needs classic PAT:
 - `docs/runbooks/0930-gpg-and-classic-pat-rotation.md` — periodic rotation procedure
 - Issue #1016 — Phase 1 of post-ADR-0216 hardening: move gpg key to YubiKey
 - Issue #1017 — TODO: execute gpg+pat rotation per runbook 0930
-- Issue #1022 — port `_request_with_retry` into `new_repo_setup.py`
+- Issue #1022 — port `_request_with_retry` into `new_repo.py`
 - Root `CLAUDE.md` — "When `git push` Is Rejected For Workflow Scope" + "Gotchas (learned the hard way 2026-04-30)" sections
 - Blog draft `dispatch/drafts/2026-04-21-in-process-pat-decryption-from-AssemblyZero.md` — companion narrative
 

--- a/docs/standards/0018-issue-spec-quality.md
+++ b/docs/standards/0018-issue-spec-quality.md
@@ -94,7 +94,7 @@ An issue must satisfy all six to be considered ready for the LLD workflow. Each 
 |---|---|
 | `New module: assemblyzero/utils/retry.py` | `Add some retry logic` |
 | `Modify: docs/standards/0009-canonical-project-structure.md §3.2` | `Update the standards doc` |
-| `Touches: tools/new_repo_setup.py + a new release.yml template` | `Set up packaging` |
+| `Touches: tools/new_repo.py + a new release.yml template` | `Set up packaging` |
 
 **Count needed:** ≥ 1 named path/module/function. Generic references ("the workflow," "the codebase") do not count.
 

--- a/docs/standards/0019-lld-mechanical-validation.md
+++ b/docs/standards/0019-lld-mechanical-validation.md
@@ -178,9 +178,9 @@ The validator runs eleven structural checks. Nine are ERROR-severity (blocking);
 - `Parent directory does not exist for Add file: {path}`
 - `Parent directory does not exist for Add directory: {path}`
 
-**Suggestions (Issue #300):** When a `Modify` or `Delete` references a non-existent file, the validator searches `tools/`, `assemblyzero/`, `scripts/`, `src/`, `lib/`, `tests/` for files matching the basename — including underscore↔hyphen normalization (`new_repo_setup.py` ↔ `new-repo-setup.py`). Up to 3 suggestions surface in the error message.
+**Suggestions (Issue #300):** When a `Modify` or `Delete` references a non-existent file, the validator searches `tools/`, `assemblyzero/`, `scripts/`, `src/`, `lib/`, `tests/` for files matching the basename — including underscore↔hyphen normalization (`new_repo.py` ↔ `new-repo-setup.py`). Up to 3 suggestions surface in the error message.
 
-**Why it exists:** Hallucinated file paths are the #1 LLD failure mode. The drafter confidently writes `tools/new_repo_setup.py` when the actual file is `tools/new-repo-setup.py`, or invents an entirely fictional file. Filesystem-level validation catches this deterministically; the suggestion engine reduces revision-cycle iterations by pointing the drafter at the real path.
+**Why it exists:** Hallucinated file paths are the #1 LLD failure mode. The drafter confidently writes `tools/new_repo.py` when the actual file is `tools/new-repo-setup.py`, or invents an entirely fictional file. Filesystem-level validation catches this deterministically; the suggestion engine reduces revision-cycle iterations by pointing the drafter at the real path.
 
 ### 2.8 Check 8 — Placeholder Prefixes Match Reality (ERROR)
 


### PR DESCRIPTION
Completes the #1609 rename's documentation tail: every non-historical `new_repo_setup` reference becomes `new_repo`, exactly per the issue's inventory — 3 ADRs (0214/0216/0219), 3 runbooks (0926/0933/0934), 6 standards (0009/0011/0016/0017/0018/0019), and one code comment in `validate_mechanical.py`. Docs and comments only; nothing executable changes.

Deliberately untouched, per the issue's own scope note:
- **Historical point-in-time documents** (audits, lineage, lessons-learned, reports) — not rewritten.
- **`.claude/skills/workflow-status.md`** — the auto-mode classifier blocks agent edits to skill files; the one-word change is tracked in #1824 for operator-authorized landing.

Post-sweep verification: `grep -rln new_repo_setup` across `docs/` (excluding historical dirs) and `assemblyzero/` returns nothing; residuals are exactly the skill file and history.

Full unit suite: **5,666 passed** (the code comment is the only source-file touch).

Closes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)