### PR TITLE
feat(audit): banned-command sweep for rendered per-repo command/skill files (Closes #1808)

### DIFF
--- a/tests/unit/test_banned_command_sweep.py
+++ b/tests/unit/test_banned_command_sweep.py
@@ -1,0 +1,159 @@
+"""Banned-command fleet sweep (#1808).
+
+The classification IS the tool: a naive grep flags the guards and buries
+the instructions — exactly backwards per the 0901 taxonomy. These tests
+pin that instructors are findings, guards are not, and the walk never
+strays beyond the two fixed globs.
+
+Issue: #1808
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+_spec = importlib.util.spec_from_file_location(
+    "banned_command_sweep", TOOLS_DIR / "banned_command_sweep.py"
+)
+sweep_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sweep_mod)
+
+
+def _repo(root: Path, name: str, commands: dict[str, str] | None = None,
+          skills: dict[str, str] | None = None) -> Path:
+    repo = root / name
+    for sub, files in (("commands", commands or {}), ("skills", skills or {})):
+        d = repo / ".claude" / sub
+        d.mkdir(parents=True, exist_ok=True)
+        for fname, text in files.items():
+            (d / fname).write_text(text, encoding="utf-8")
+    return repo
+
+
+class TestClassification:
+
+    def test_instruction_line_is_a_finding(self):
+        line = "   - Auto-delete: `git -C /repo branch -D {branch-name}`"
+        assert sweep_mod.classify_line(line) == "instructor"
+
+    def test_prohibition_line_is_a_guard(self):
+        line = "Delete via the ADR-0217 graft recipe — never `git branch -D` (banned)."
+        assert sweep_mod.classify_line(line) == "guard"
+
+    def test_refusal_wording_is_a_guard(self):
+        line = "the driver already refuses `--admin`, `--no-verify`, and force-push"
+        assert sweep_mod.classify_line(line) == "guard"
+
+
+class TestSweep:
+
+    def test_finds_instructor_and_excludes_guard(self, tmp_path):
+        _repo(tmp_path, "landmine-repo", commands={
+            "cleanup.md": (
+                "# Cleanup\n"
+                "Auto-delete: `git branch -D {branch}`\n"          # INSTRUCTOR
+                "Do NOT use `git reset --hard` (banned).\n"        # GUARD
+            ),
+        })
+        _repo(tmp_path, "clean-repo", commands={
+            "cleanup.md": "Use `git branch -d` after the ADR-0217 graft.\n",
+        })
+
+        hits = sweep_mod.sweep(tmp_path)
+        findings = [h for h in hits if h["class"] == "instructor"]
+        guards = [h for h in hits if h["class"] == "guard"]
+
+        assert len(findings) == 1
+        assert findings[0]["repo"] == "landmine-repo"
+        assert findings[0]["token"] == "git branch -D"
+        assert len(guards) == 1
+        assert guards[0]["token"] == "git reset --hard"
+
+    def test_scans_skills_too(self, tmp_path):
+        _repo(tmp_path, "skilled", skills={
+            "merge.md": "Then run gh pr merge 5 --admin to finish.\n",
+        })
+        findings = [h for h in sweep_mod.sweep(tmp_path) if h["class"] == "instructor"]
+        assert [h["token"] for h in findings] == ["gh --admin"]
+
+    def test_never_strays_beyond_the_fixed_globs(self, tmp_path):
+        repo = _repo(tmp_path, "sprawl")
+        # Banned tokens OUTSIDE the scanned globs must be invisible.
+        (repo / "README.md").write_text("git push --force is great\n", encoding="utf-8")
+        docs = repo / ".claude" / "commands" / "nested"
+        docs.mkdir()
+        (docs / "deep.md").write_text("git branch -D x\n", encoding="utf-8")
+        (repo / ".claude" / "commands" / "notes.txt").write_text(
+            "git branch -D x\n", encoding="utf-8"
+        )
+        assert sweep_mod.sweep(tmp_path) == []
+
+    def test_repos_without_claude_dirs_are_skipped(self, tmp_path):
+        (tmp_path / "bare-repo").mkdir()
+        assert sweep_mod.sweep(tmp_path) == []
+
+
+class TestMain:
+
+    def test_exit_1_and_report_on_findings(self, tmp_path, capsys):
+        _repo(tmp_path, "landmine-repo", commands={
+            "cleanup.md": "Auto-delete: `git branch -D {branch}`\n",
+        })
+        rc = sweep_mod.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "FINDINGS" in out
+        assert "landmine-repo/cleanup.md:1" in out
+
+    def test_exit_0_when_only_guards_exist(self, tmp_path, capsys):
+        _repo(tmp_path, "walled", commands={
+            "cleanup.md": "NEVER use `git branch -D` — banned.\n",
+        })
+        rc = sweep_mod.main(["--root", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "No banned-command instructions found" in out
+        assert "correctly excluded: 1" in out
+
+    def test_json_mode(self, tmp_path, capsys):
+        _repo(tmp_path, "landmine-repo", commands={
+            "cleanup.md": "run git clean -fd now\n",
+        })
+        rc = sweep_mod.main(["--root", str(tmp_path), "--json"])
+        parsed = json.loads(capsys.readouterr().out)
+        assert rc == 1
+        assert parsed["finding_count"] == 1
+        assert parsed["hits"][0]["token"] == "git clean -fd"
+
+    def test_exit_2_on_bad_root(self, tmp_path, capsys):
+        rc = sweep_mod.main(["--root", str(tmp_path / "missing")])
+        assert rc == 2
+        assert "not a directory" in capsys.readouterr().err
+
+
+class TestWrappedGuardSentences:
+    """The real fleet's only first-run false positive: a prohibition
+    sentence wrapped across two lines, judged by its continuation alone."""
+
+    def test_continuation_of_a_prohibition_is_a_guard(self, tmp_path):
+        _repo(tmp_path, "wrapped", skills={
+            "rista.md": (
+                "Do NOT escalate to `--admin` /\n"
+                "`--no-verify` / force-push / `branch -D`.\n"
+            ),
+        })
+        hits = sweep_mod.sweep(tmp_path)
+        assert hits, "tokens must still be detected"
+        assert all(h["class"] == "guard" for h in hits)
+
+    def test_instruction_with_unrelated_preceding_guard_still_flags(self, tmp_path):
+        _repo(tmp_path, "tricky", commands={
+            "x.md": (
+                "Never commit secrets.\n"
+                "\n"
+                "Then run: git push --force origin main\n"
+            ),
+        })
+        findings = [h for h in sweep_mod.sweep(tmp_path) if h["class"] == "instructor"]
+        assert [h["token"] for h in findings] == ["force push"]

--- a/tools/banned_command_sweep.py
+++ b/tools/banned_command_sweep.py
@@ -1,0 +1,176 @@
+"""Fleet sweep: banned-command landmines in rendered agent-facing files (#1808).
+
+Templates get fixed; already-rendered per-repo copies keep the banned form
+until someone looks. That is where a banned command survives longest —
+#1381's rendered ``branch -D`` instructions sat live for two months after
+the template was corrected, with no visible symptom to trigger discovery.
+
+Scans each repo's ``.claude/commands/*.md`` and ``.claude/skills/*.md``
+(fixed globs at fixed depth — never a recursive repo walk, never a cloud
+mount) for banned-command tokens, then classifies every hit by the 0901
+taxonomy line heuristic:
+
+- **GUARD/DOC** — the line *prohibits* the command ("never", "banned",
+  "do not"...). These are the wall; they are counted but NOT findings.
+- **INSTRUCTOR** — the line tells the agent to run it. An instructed ban
+  is an executed ban. These are the findings.
+
+A naive grep flags the guards and buries the instructions — exactly
+backwards (docs/audits/0901 §"How to sweep"). The classification is the
+tool.
+
+Read-only: no ``--apply`` needed. Exit 0 = no findings, 1 = findings
+present, 2 = usage error.
+
+Usage:
+    poetry run python tools/banned_command_sweep.py
+    poetry run python tools/banned_command_sweep.py --json
+    poetry run python tools/banned_command_sweep.py --root <projects-root>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+PROJECTS_ROOT = Path(r"C:\Users\mcwiz\Projects")
+
+# Fixed relative globs per repo. Deliberately NOT a recursive walk: the
+# hazard class lives in rendered agent-facing command/skill files, and a
+# bounded scan can never wander into a cloud-mounted or oversized tree.
+SCAN_GLOBS = (".claude/commands/*.md", ".claude/skills/*.md")
+
+# Banned-command tokens, from the root CLAUDE.md "Banned commands (ALWAYS)"
+# table. Named so reports read in plain language.
+BANNED_PATTERNS: dict[str, re.Pattern] = {
+    "git branch -D": re.compile(r"\bbranch\s+-D\b"),
+    "force push": re.compile(r"\bpush\b[^\n]*--force"),
+    "git reset --hard": re.compile(r"\breset\s+--hard\b"),
+    "git clean -fd": re.compile(r"\bclean\s+-fdx?\b"),
+    "checkout/merge --theirs": re.compile(r"--theirs\b"),
+    "worktree remove --force": re.compile(r"\bworktree\s+remove\b[^\n]*--force"),
+    "gh --admin": re.compile(r"--admin\b"),
+    "--no-verify": re.compile(r"--no-verify\b"),
+    "--no-gpg-sign": re.compile(r"--no-gpg-sign\b"),
+}
+
+# A line that PROHIBITS the command is a guard, not a landmine. Marker set
+# from the wording used across CLAUDE.md, ADR-0217, and the 0901 audit.
+GUARD_MARKERS = re.compile(
+    r"(?i)\b(never|banned|ban list|do not|don'?t|not use|must not|"
+    r"refus\w+|forbidden|prohibit\w*|instead of|rather than|"
+    r"escalat\w+ to|without|avoid)\b"
+)
+
+
+def classify_line(line: str, prev_line: str = "") -> str:
+    """Classify one token-bearing line: 'guard' or 'instructor'.
+
+    The previous line participates because prohibition sentences wrap:
+    "Do NOT escalate to `--admin` /" on one line, "`--no-verify` /
+    `branch -D`." on the next. Judged alone, the continuation line reads
+    as an instruction — the real fleet's only false positive on the
+    tool's first run.
+    """
+    if GUARD_MARKERS.search(line) or GUARD_MARKERS.search(prev_line):
+        return "guard"
+    return "instructor"
+
+
+def scan_file(path: Path, repo_name: str) -> list[dict]:
+    """Return one hit record per banned-token occurrence in the file."""
+    hits: list[dict] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        print(f"WARNING: cannot read {path}: {e}", file=sys.stderr)
+        return hits
+
+    lines = text.splitlines()
+    for lineno, line in enumerate(lines, start=1):
+        prev_line = lines[lineno - 2] if lineno >= 2 else ""
+        for token, pattern in BANNED_PATTERNS.items():
+            if pattern.search(line):
+                hits.append({
+                    "repo": repo_name,
+                    "file": path.name,
+                    "path": str(path),
+                    "line": lineno,
+                    "token": token,
+                    "class": classify_line(line, prev_line),
+                    "text": line.strip()[:160],
+                })
+    return hits
+
+
+def sweep(root: Path) -> list[dict]:
+    """Scan every repo under root. Returns all hits, both classes."""
+    hits: list[dict] = []
+    for repo_dir in sorted(root.iterdir()):
+        if not repo_dir.is_dir() or repo_dir.name.startswith("."):
+            continue
+        for rel_glob in SCAN_GLOBS:
+            base, _, pattern = rel_glob.rpartition("/")
+            target_dir = repo_dir / base
+            if not target_dir.is_dir():
+                continue
+            for md in sorted(target_dir.glob(pattern)):
+                hits.extend(scan_file(md, repo_dir.name))
+    return hits
+
+
+def format_report(hits: list[dict]) -> str:
+    findings = [h for h in hits if h["class"] == "instructor"]
+    guards = [h for h in hits if h["class"] == "guard"]
+
+    lines: list[str] = []
+    if findings:
+        lines.append(
+            f"FINDINGS — {len(findings)} banned-command INSTRUCTION(s) "
+            "in rendered agent-facing files:"
+        )
+        for h in findings:
+            lines.append(
+                f"  {h['repo']}/{h['file']}:{h['line']}  [{h['token']}]"
+            )
+            lines.append(f"    {h['text']}")
+    else:
+        lines.append("No banned-command instructions found.")
+    lines.append(
+        f"(guards/prohibition text correctly excluded: {len(guards)} line(s) "
+        f"across {len({h['path'] for h in guards})} file(s))"
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Sweep rendered per-repo command/skill files for banned-command instructions",
+    )
+    parser.add_argument(
+        "--root", type=Path, default=PROJECTS_ROOT,
+        help="Projects root to scan (default: the fleet root)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit all hits as JSON")
+    args = parser.parse_args(argv)
+
+    if not args.root.is_dir():
+        print(f"ERROR: root is not a directory: {args.root}", file=sys.stderr)
+        return 2
+
+    hits = sweep(args.root)
+    findings = [h for h in hits if h["class"] == "instructor"]
+
+    if args.json:
+        print(json.dumps({"hits": hits, "finding_count": len(findings)}, indent=2))
+    else:
+        print(format_report(hits))
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The gap this closes: fixing a template stops new propagation but does nothing for already-rendered copies — #1381's `branch -D` instructions sat live in two repos for two months after the template was corrected, with no visible symptom to trigger discovery. Nothing swept the rendered layer. Now something does.

## Design

- **Bounded walk, by construction.** Two fixed globs per repo (`.claude/commands/*.md`, `.claude/skills/*.md`) at fixed depth — never a recursive repo walk, so it can never wander into an oversized tree or a cloud mount. A test pins that tokens outside the globs (README, nested dirs, non-md files) are invisible.
- **The classification is the tool.** Per the 0901 taxonomy, a naive grep flags the guards and buries the instructions — exactly backwards. Every hit is classified: prohibition wording (never/banned/do not/refuses/…) → **guard**, counted and excluded; everything else → **instructor**, a finding. An instructed ban is an executed ban.
- **Two-line context.** The real fleet's only first-run false positive was a prohibition sentence wrapped across two lines (`Do NOT escalate to --admin /` ⏎ `--no-verify / branch -D.`) — judged alone, the continuation reads as an instruction. The classifier now considers the preceding line; a counter-test proves an instruction following an *unrelated* guard line still flags.
- Read-only; `--json` for automation; exit 0 clean / 1 findings / 2 usage — schedulable beside the other fleet audits.

## First full-fleet run (after the wrapped-guard fix)

```
No banned-command instructions found.
(guards/prohibition text correctly excluded: 25 line(s) across 9 file(s))
```

Zero landmines — independent confirmation that the #1381 remediation held everywhere, which is exactly the check that didn't exist when #1381 sat open for two months.

13 tests; `ruff` clean.

Closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)