### PR TITLE
fix(orchestrator): triage artifacts validate as any non-empty file (Closes #1430)

### DIFF
--- a/assemblyzero/workflows/orchestrator/artifacts.py
+++ b/assemblyzero/workflows/orchestrator/artifacts.py
@@ -139,7 +139,12 @@ def validate_artifact(path: Path, artifact_type: str) -> bool:
       - File is non-empty
       - For lld: contains '## 1. Context' heading
       - For spec: contains '## 1. Overview' heading
-      - For triage: contains '##' heading (any h2)
+      - For triage: any non-empty file (#1430) — briefs are narrative by
+        nature, they exist as provenance + skip-marker, and no downstream
+        stage parses their structure (the lld stage reads the issue body
+        from GitHub directly). The old any-h2 requirement forced voice
+        compromises on operator-authored briefs while validating nothing
+        a consumer relied on.
     """
     if artifact_type == "impl":
         # For implementation, just check directory exists
@@ -158,6 +163,8 @@ def validate_artifact(path: Path, artifact_type: str) -> bool:
     if artifact_type == "spec":
         return "## 1. Overview" in content
     if artifact_type == "triage":
-        return "## " in content
+        # Non-empty is sufficient (#1430); the size check above already ran.
+        # Guard only against whitespace-only files.
+        return bool(content.strip())
 
     return True

--- a/tests/unit/test_orchestrator_artifacts.py
+++ b/tests/unit/test_orchestrator_artifacts.py
@@ -5,7 +5,6 @@ Issue #305: End-to-End Orchestration Workflow (Issue → Code)
 
 import pytest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
 
 from assemblyzero.workflows.orchestrator.artifacts import (
     detect_existing_artifacts,
@@ -134,6 +133,21 @@ class TestValidateArtifact:
         empty_file = tmp_path / "empty.md"
         empty_file.write_text("")
         assert validate_artifact(empty_file, "triage") is False
+
+    def test_narrative_brief_without_headings_is_valid_triage(self, tmp_path):
+        """#1430: briefs are narrative provenance, not structured input —
+        an operator-voice brief with no markdown headings must pass."""
+        brief = tmp_path / "issue-brief.md"
+        brief.write_text(
+            "The user wants the gauge to feel like a real tachometer.\n"
+            "No h2 anywhere in this file, and that is fine.\n"
+        )
+        assert validate_artifact(brief, "triage") is True
+
+    def test_whitespace_only_triage_is_invalid(self, tmp_path):
+        brief = tmp_path / "issue-brief.md"
+        brief.write_text("   \n\n\t\n")
+        assert validate_artifact(brief, "triage") is False
 
     def test_impl_checks_directory(self, tmp_path):
         impl_dir = tmp_path / "worktree"


### PR DESCRIPTION
The triage check required any h2 anywhere — a structural demand with no consumer behind it. Briefs are narrative by nature: they exist as provenance and skip-marker, and the downstream lld stage reads the issue body from GitHub directly (`stages.py`), never the brief. Meanwhile the check had real cost: an operator-voice brief with no headings failed validation, `should_skip_stage` returned False, triage ran anyway and halted on "No brief file specified" — and the workaround was promoting a P.S. paragraph to an h2, a voice compromise the issue documents.

## Change

`validate_artifact(path, "triage")` now accepts any non-empty file, with one refinement over the issue's literal proposal: **whitespace-only content still rejects** (the existing size check passes a file of spaces, which is empty in every way that matters).

The lld (`## 1. Context`) and spec (`## 1. Overview`) structural checks are untouched, per the issue's explicit scope — those headings are real contracts with downstream parsing.

## Verification

Two new tests: a heading-free narrative brief in operator voice passes; a whitespace-only file fails. Existing empty-file test unchanged and still green. Orchestrator suites: 68 passed; full unit suite green. Also clears the touched test file's 2 pre-existing unused-import findings (auto-fixable).

Leaves #1429 (`--from-stage`) open as the proper fix for skip-when-issue-exists.

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)