### PR TITLE
feat(dependabot_review): tee every run to a timestamped log file by default (Closes #1403)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -800,3 +800,45 @@ class TestWorkerAggregationSurvivesBaseException:
             raised = True
 
         assert raised, "KeyboardInterrupt must propagate, not be swallowed"
+
+
+# ---- #1403: per-run log file ----
+
+class TestRunLog:
+    """Manual drains previously left no record beyond terminal scrollback."""
+
+    def test_creates_timestamped_log_and_tees_stdout(self, tmp_path, capsys, monkeypatch):
+        import sys as _sys
+        orig_out, orig_err = _sys.stdout, _sys.stderr
+        try:
+            log_path = dependabot_review.setup_run_log(tmp_path / "runs")
+            assert log_path is not None
+            print("hello drain")
+            _sys.stdout.flush()
+            content = log_path.read_text(encoding="utf-8")
+        finally:
+            _sys.stdout, _sys.stderr = orig_out, orig_err
+        assert "hello drain" in content
+        assert log_path.parent.name == "runs"
+        # Terminal output unchanged: capsys still saw the line.
+        assert "hello drain" in capsys.readouterr().out
+
+    def test_unwritable_log_dir_degrades_to_terminal_only(self, tmp_path, capsys):
+        import sys as _sys
+        blocker = tmp_path / "blocked"
+        blocker.write_text("a file where the dir should be", encoding="utf-8")
+        orig_out, orig_err = _sys.stdout, _sys.stderr
+        try:
+            log_path = dependabot_review.setup_run_log(blocker / "runs")
+        finally:
+            _sys.stdout, _sys.stderr = orig_out, orig_err
+        assert log_path is None
+        assert "terminal-only" in capsys.readouterr().err
+
+    def test_tee_survives_closed_logfile(self, tmp_path):
+        import io
+        log = io.StringIO()
+        tee = dependabot_review._Tee(io.StringIO(), log)
+        log.close()
+        tee.write("still works\n")  # must not raise
+        tee.flush()

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -75,6 +75,65 @@ from pathlib import Path
 
 GITHUB_USER = "martymcenroe"
 DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
+
+# #1403: per-run log directory, anchored to the AssemblyZero repo the tool
+# lives in — NOT the cwd, and NOT a hidden home directory. The issue's
+# original sketch said ~/.assemblyzero/, but the 2026-07-26 hidden-spaces
+# rule bans agent artifacts in invisible locations; data/ is the house
+# convention (speedrun run-log, hallucination telemetry) — operator-visible
+# in the Projects tree, machine-local, gitignored.
+RUN_LOG_DIR = Path(__file__).resolve().parent.parent / "data" / "dependabot-runs"
+
+
+class _Tee:
+    """Mirror a stream to a log file. Terminal output stays unchanged.
+
+    #1403: manual drains had no record — the operator's terminal
+    scrollback was the only log, and days were spent reconstructing runs
+    from partial pastes. Every failure here degrades silently to
+    terminal-only; logging must never break the drain.
+    """
+
+    def __init__(self, stream, logfile):
+        self._stream = stream
+        self._logfile = logfile
+
+    def write(self, text: str) -> int:
+        try:
+            self._logfile.write(text)
+        except (OSError, ValueError):
+            pass  # log file gone/closed — terminal keeps working
+        return self._stream.write(text)
+
+    def flush(self) -> None:
+        try:
+            self._logfile.flush()
+        except (OSError, ValueError):
+            pass
+        self._stream.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+
+def setup_run_log(log_dir: Path = RUN_LOG_DIR):
+    """Open a timestamped per-run log and tee stdout/stderr into it.
+
+    Returns the log path, or None when the log could not be created (the
+    run proceeds terminal-only — a warning says so).
+    """
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        log_path = log_dir / f"{stamp}.log"
+        logfile = open(log_path, "a", encoding="utf-8")  # noqa: SIM115 — lives for the process
+    except OSError as e:
+        print(f"WARNING: run log unavailable ({e}); continuing terminal-only",
+              file=sys.stderr)
+        return None
+    sys.stdout = _Tee(sys.stdout, logfile)
+    sys.stderr = _Tee(sys.stderr, logfile)
+    return log_path
 # Windows-only creationflag that isolates each child subprocess in its
 # own process group. Without this, parent + child share a console
 # group, so a child-side console event (e.g. pytest dying during
@@ -1274,7 +1333,20 @@ def main() -> None:
             "the orphans first or they accumulate."
         ),
     )
+    parser.add_argument(
+        "--no-run-log", action="store_true",
+        help=(
+            "#1403: by default every run tees its full output to a "
+            "timestamped file under data/dependabot-runs/ in AssemblyZero "
+            "(manual drains previously left no record). Pass this to skip."
+        ),
+    )
     args = parser.parse_args()
+
+    # #1403: open the run log FIRST so every subsequent line is recorded.
+    run_log_path = None if args.no_run_log else setup_run_log()
+    if run_log_path:
+        print(f"Run log: {run_log_path}")
 
     main_repo = Path(args.main_repo).resolve()
     if not (main_repo / ".git").exists():
@@ -1408,6 +1480,10 @@ def main() -> None:
                 f"deferred={len(results['deferred'])} "
                 f"errored={len(results['errored'])} ==="
             )
+            # #1403: repeat the log path at the very end — after a long
+            # drain the opening line is thousands of lines up-scroll.
+            if run_log_path:
+                print(f"Full run log: {run_log_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Manual drains left no record — the operator's terminal scrollback was the only log of what merged, deferred, or errored, and the issue documents days spent reconstructing runs from partial pastes. Scheduled runs had the PowerShell wrapper's tee; manual runs had nothing.

## What changed

- `setup_run_log()` opens `data/dependabot-runs/YYYY-MM-DD_HHMMSS.log` and wraps stdout/stderr in a tee before anything else prints. Terminal output is byte-identical; the file gets the same stream.
- The log path prints at the **start and again after the summary** — after a long drain, the opening line is thousands of lines up-scroll.
- `--no-run-log` opts out.

## One deliberate deviation, flagged

The issue's sketch (May 30) proposed `~/.assemblyzero/dependabot-runs/`. The hidden-spaces rule the operator decreed on 2026-07-26 bans exactly that pattern — agent work products in invisible OS locations. The log therefore lands in AssemblyZero's **visible, gitignored `data/`** directory, beside the speedrun run-log and hallucination telemetry that already live there. Same machine-local semantics, operator-visible in the Projects tree.

## Failure contract

Logging can never break a drain: an unwritable log dir degrades to terminal-only with a stderr warning, and a logfile handle that dies mid-run is swallowed while the terminal keeps streaming. Three tests pin this — tee mirrors to file with terminal unchanged, unwritable dir degrades gracefully, and writes to a closed logfile don't raise.

Full unit suite green.

Closes #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)