### PR TITLE
feat(dependabot_review): --limit N for calibrated daily harvests (Closes #1339)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -842,3 +842,99 @@ class TestRunLog:
         log.close()
         tee.write("still works\n")  # must not raise
         tee.flush()
+
+
+# ---- #1339: --limit N calibrated harvest ----
+
+class TestPRBudget:
+
+    def test_caps_at_limit(self):
+        budget = dependabot_review.PRBudget(3)
+        grants = [budget.try_acquire() for _ in range(5)]
+        assert grants == [True, True, True, False, False]
+        assert budget.exhausted is True
+        assert budget.used == 3
+
+    def test_thread_safety_never_overshoots(self):
+        import threading as _threading
+        budget = dependabot_review.PRBudget(50)
+        granted = []
+        lock = _threading.Lock()
+
+        def worker():
+            for _ in range(20):
+                if budget.try_acquire():
+                    with lock:
+                        granted.append(1)
+
+        threads = [_threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(granted) == 50, "budget must never overshoot under races"
+
+
+class TestProcessRepoWithBudget:
+
+    def _prs(self, numbers):
+        return [
+            dependabot_review.PRInfo(
+                number=n, title=f"bump {n}", author_login="app/dependabot",
+                body="", head_ref=f"dependabot/{n}",
+            )
+            for n in numbers
+        ]
+
+    def _wire(self, monkeypatch, tmp_path, numbers):
+        processed = []
+        monkeypatch.setattr(
+            dependabot_review, "resolve_target_repo_dir",
+            lambda repo, main: tmp_path,
+        )
+        monkeypatch.setattr(
+            dependabot_review, "check_for_orphan_worktrees", lambda t: [],
+        )
+        monkeypatch.setattr(
+            dependabot_review, "list_dependabot_prs",
+            lambda repo: self._prs(numbers),
+        )
+        monkeypatch.setattr(
+            dependabot_review, "process_pr",
+            lambda pr, repo, target: processed.append(pr.number) or "merged",
+        )
+        return processed
+
+    def test_oldest_first_and_budget_cutoff(self, monkeypatch, tmp_path):
+        """gh lists newest-first; the drain must be FIFO — and the limit
+        must cut deterministically at the oldest N."""
+        processed = self._wire(monkeypatch, tmp_path, [12, 5, 9])
+        budget = dependabot_review.PRBudget(2)
+        sub = dependabot_review.process_repo(
+            "o/r", tmp_path, budget=budget,
+        )
+        assert processed == [5, 9], "oldest two, in FIFO order"
+        assert sub["merged"] == ["o/r#5", "o/r#9"]
+        assert sub["limit_skipped"] == ["o/r#12"], "the skip is named, never silent"
+
+    def test_no_budget_processes_all_oldest_first(self, monkeypatch, tmp_path):
+        processed = self._wire(monkeypatch, tmp_path, [12, 5, 9])
+        sub = dependabot_review.process_repo("o/r", tmp_path)
+        assert processed == [5, 9, 12]
+        assert sub["limit_skipped"] == []
+
+    def test_result_dict_always_carries_limit_skipped_key(self, monkeypatch, tmp_path):
+        """Aggregators iterate a fixed key tuple — the key must exist on
+        every return path, including the no-PRs early return."""
+        monkeypatch.setattr(
+            dependabot_review, "resolve_target_repo_dir",
+            lambda repo, main: tmp_path,
+        )
+        monkeypatch.setattr(
+            dependabot_review, "check_for_orphan_worktrees", lambda t: [],
+        )
+        monkeypatch.setattr(
+            dependabot_review, "list_dependabot_prs", lambda repo: [],
+        )
+        sub = dependabot_review.process_repo("o/r", tmp_path)
+        assert set(sub) == {"merged", "deferred", "errored", "limit_skipped"}

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -67,6 +67,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import tomllib
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -190,6 +191,50 @@ class PRInfo:
     author_login: str
     body: str
     head_ref: str
+
+
+class PRBudget:
+    """Thread-safe cap on PRs processed per run (#1339).
+
+    The honeypot produces 30-50+ open PRs at once; an uncapped sweep is a
+    ~60-contribution single-day spike that rescales the operator's entire
+    contribution graph. ``--limit N`` turns the drain into a calibrated
+    daily harvest.
+
+    A PR consumes budget when processing STARTS, regardless of outcome —
+    merged and deferred PRs each generate a review event (the unit the
+    operator is budgeting), and an errored attempt already spent the
+    attempt. Thread-safe by construction even though the limit path runs
+    sequentially today, so a future parallel+limit combination cannot
+    silently overshoot.
+    """
+
+    def __init__(self, limit: int):
+        self._limit = limit
+        self._lock = threading.Lock()
+        self._used = 0
+
+    def try_acquire(self) -> bool:
+        """Reserve one PR slot; False when the budget is spent."""
+        with self._lock:
+            if self._used < self._limit:
+                self._used += 1
+                return True
+            return False
+
+    @property
+    def exhausted(self) -> bool:
+        with self._lock:
+            return self._used >= self._limit
+
+    @property
+    def used(self) -> int:
+        with self._lock:
+            return self._used
+
+    @property
+    def limit(self) -> int:
+        return self._limit
 
 
 # ---------------------------------------------------------------------------
@@ -1139,6 +1184,7 @@ def process_repo(
     main_repo: Path,
     dry_run: bool = False,
     ignore_orphans: bool = False,
+    budget: PRBudget | None = None,
 ) -> dict[str, list[str]]:
     """Process all dependabot PRs in one repo, sequentially.
 
@@ -1152,10 +1198,16 @@ def process_repo(
     Cross-repo parallelism is the caller's responsibility.
 
     Returns a per-repo result dict with the same shape as the
-    aggregate (merged / deferred / errored lists of `repo#N` strings).
-    Empty lists when no PRs are open.
+    aggregate (merged / deferred / errored / limit_skipped lists of
+    `repo#N` strings). Empty lists when no PRs are open.
+
+    #1339: PRs process oldest-first (ascending PR number) — FIFO drains
+    the queue tail, and under ``--limit`` it makes selection deterministic
+    instead of inheriting gh's newest-first listing order.
     """
-    sub: dict[str, list[str]] = {"merged": [], "deferred": [], "errored": []}
+    sub: dict[str, list[str]] = {
+        "merged": [], "deferred": [], "errored": [], "limit_skipped": [],
+    }
     print(f"\n{'=' * 60}")
     print(f"REPO: {repo}")
     print(f"{'=' * 60}")
@@ -1218,7 +1270,12 @@ def process_repo(
               f"({count_packages(pr.body)} packages)")
     if dry_run:
         return sub
-    for pr in prs:
+    for pr in sorted(prs, key=lambda p: p.number):
+        if budget is not None and not budget.try_acquire():
+            # #1339: budget spent — remaining PRs are untouched, recorded
+            # visibly (no silent caps), and left for the next harvest.
+            sub["limit_skipped"].append(f"{repo}#{pr.number}")
+            continue
         status = process_pr(pr, repo, target_repo)
         sub[status].append(f"{repo}#{pr.number}")
     return sub
@@ -1334,6 +1391,18 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--limit", type=int, default=0,
+        help=(
+            "#1339: process at most N PRs this run (0 = unlimited, the "
+            "default). Merged, deferred, and errored attempts all consume "
+            "budget; remaining PRs are reported as limit-skipped and left "
+            "for the next harvest. Selection is deterministic: repos in "
+            "name order, PRs oldest-first — so consecutive limited runs "
+            "drain the queue FIFO. Implies sequential processing "
+            "(--workers is ignored)."
+        ),
+    )
+    parser.add_argument(
         "--no-run-log", action="store_true",
         help=(
             "#1403: by default every run tees its full output to a "
@@ -1374,9 +1443,20 @@ def main() -> None:
     else:
         repos = [args.repo]
 
+    # #1339: calibrated harvest. gh's repo listing orders by recent push
+    # (non-deterministic run to run), so a limited run sorts repos by name
+    # — with oldest-first PRs inside process_repo, consecutive limited
+    # runs drain the fleet queue FIFO, deterministically.
+    if args.limit < 0:
+        sys.exit(f"--limit must be >= 0, got {args.limit}")
+    budget = PRBudget(args.limit) if args.limit > 0 else None
+    if budget:
+        repos = sorted(repos)
+        print(f"Harvest limit: {budget.limit} PR(s) this run (sequential).")
+
     # Aggregate results across repos.
     results: dict[str, list[str]] = {
-        "merged": [], "deferred": [], "errored": [],
+        "merged": [], "deferred": [], "errored": [], "limit_skipped": [],
     }
 
     # Wrap the worker dispatch + summary print in try/finally so the
@@ -1393,7 +1473,7 @@ def main() -> None:
         # Issue #1093: parallelize across repos in --fleet mode. Single-
         # repo mode (or --workers=1) keeps the sequential path. Within a
         # repo, processing is always sequential.
-        if args.fleet and args.workers > 1 and not args.dry_run:
+        if args.fleet and args.workers > 1 and not args.dry_run and not budget:
             print(f"\nProcessing {len(repos)} repo(s) with {args.workers} "
                   f"worker(s)...")
             with ThreadPoolExecutor(max_workers=args.workers) as executor:
@@ -1425,15 +1505,24 @@ def main() -> None:
                         # truthful regardless of the exception class.
                         print(f"\n  [ERROR] worker for {repo} raised: "
                               f"{type(e).__name__}: {e}")
-                        sub = {"merged": [], "deferred": [], "errored": [repo]}
-                    for k in ("merged", "deferred", "errored"):
+                        sub = {"merged": [], "deferred": [],
+                               "errored": [repo], "limit_skipped": []}
+                    for k in ("merged", "deferred", "errored", "limit_skipped"):
                         results[k].extend(sub[k])
         else:
             for repo in repos:
+                # #1339: once the budget is spent, later repos are not even
+                # enumerated — their queues are untouched, next harvest's
+                # name-ordered pass reaches them deterministically.
+                if budget is not None and budget.exhausted:
+                    print(f"\n  Harvest limit reached — skipping {repo} "
+                          f"(queue untouched).")
+                    continue
                 sub = process_repo(
                     repo, main_repo, args.dry_run, args.ignore_orphans,
+                    budget=budget,
                 )
-                for k in ("merged", "deferred", "errored"):
+                for k in ("merged", "deferred", "errored", "limit_skipped"):
                     results[k].extend(sub[k])
     finally:
         # Dry-run skips the result-aggregation summary -- it only
@@ -1461,6 +1550,11 @@ def main() -> None:
             print(f"  Deferred (test failures / install errors, worktree retained): "
                   f"{results['deferred']}")
             print(f"  Errored:  {results['errored']}")
+            if results["limit_skipped"]:
+                # #1339: no silent caps — every PR the limit left behind
+                # is named, so "covered everything" can never be misread.
+                print(f"  Limit-skipped (left for next harvest): "
+                      f"{results['limit_skipped']}")
             print(
                 f"  Review events created: {approved_events} APPROVED "
                 f"+ {commented_events} COMMENTED = {total_events} total"


### PR DESCRIPTION
`--limit 15` turns the all-you-can-eat fleet drain into a calibrated harvest: at most N PRs processed per run, the rest named and left for tomorrow. The issue's math: an uncapped honeypot sweep is ~60 contributions in one day against a ~260 calibrated max — and GitHub's relative scaling means one spike day dims every other day on the graph.

## Semantics

- **Budget = attempts, not merges.** Merged, deferred, and errored PRs all consume budget — merged and deferred each generate a review event (the unit being budgeted), and an errored attempt already spent the attempt.
- **Deterministic selection**, per the issue's acceptance. Two sources of nondeterminism had to go: `gh repo list` orders by recent push, and `gh pr list` returns newest-first. A limited run sorts repos by name and processes PRs **oldest-first** within each repo — so consecutive `--limit N` runs drain the fleet queue FIFO, exactly the issue's suggested policy. Oldest-first now applies to unlimited runs too (an unconditional improvement over inheriting gh's listing order).
- **`--limit` implies sequential.** Cross-repo parallelism plus a global cap means scheduling decides which PRs win — the opposite of deterministic. A capped run is short; losing parallelism costs little. The budget class is thread-safe anyway, so a future parallel+limit combination cannot silently overshoot — a 10-thread race test proves it.
- **No silent caps.** Every limit-skipped PR is listed by name in the summary, and repos past the exhaustion point are skipped with a message, queues untouched.
- `--limit 0` (default) = unlimited: today's behavior, unchanged — the parallel path still runs exactly as before.

## Verification

5 new tests: budget cap sequence, the 10-thread overshoot race, FIFO order + deterministic cutoff (`[12, 5, 9]` with limit 2 processes exactly 5 and 9, names 12 as skipped), unlimited ordering, and the result-dict key contract on every return path. Full unit suite: **5,688 passed**.

The issue's bonus goal is unlocked: with the cap in place, the scheduled 06:00 fleet task can be safely re-enabled at whatever N fits the daily budget — that re-enable is the operator's call, not part of this PR.

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)