### PR TITLE
feat(dependabot): scheduled fleet harvest passes --limit 15; header stops teaching the flashing registration (Closes #1836)

### DIFF
--- a/tools/run_dependabot_fleet.ps1
+++ b/tools/run_dependabot_fleet.ps1
@@ -2,18 +2,21 @@
 #
 # Designed to be called by Windows Task Scheduler. Logs to
 # C:\Users\mcwiz\Projects\dependabot-fleet.log so the operator can
-# see what happened across runs without opening a console.
+# see what happened across runs without opening a console. The tool
+# additionally writes its own per-run log under data/dependabot-runs/
+# in AssemblyZero (#1403).
 #
-# Setup (run once):
-#
-#     $action = New-ScheduledTaskAction `
-#       -Execute 'powershell.exe' `
-#       -Argument '-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File C:\Users\mcwiz\Projects\AssemblyZero\tools\run_dependabot_fleet.ps1'
-#     $trigger = New-ScheduledTaskTrigger -Daily -At 06:00
-#     Register-ScheduledTask `
-#       -TaskName 'Claude-DependabotFleet' `
-#       -Action $action -Trigger $trigger `
-#       -Description 'Daily fleet-wide dependabot PR review + merge (#1091, #1092)'
+# Registration (#1836): the Claude-DependabotFleet task does NOT launch
+# this script with powershell.exe directly. Launching powershell from a
+# scheduled task -- even with -WindowStyle Hidden -- flashes a console
+# on the interactive desktop, because Windows allocates the console for
+# a console-subsystem app BEFORE SW_HIDE takes effect (measured; see
+# AZ #1819). The task instead runs a silent wscript launcher (WshShell
+# .Run with window style 0 = SW_HIDE at CreateProcess) that invokes
+# this script; the launcher is generated and managed by the private
+# environment-tooling repo's converter. Do NOT re-register this task
+# with a direct powershell action -- that silently reintroduces the
+# console flash the launcher exists to prevent.
 #
 # Manual run:
 #
@@ -58,7 +61,12 @@ try {
     # PowerShell's pipeline mechanics. The OK/EXIT marker is then
     # written by PowerShell with explicit -Encoding utf8 so the same
     # encoding wire doesn't trip later writes. See #1176.
-    & cmd.exe /c "poetry run python tools\dependabot_review.py --fleet >> `"$LogFile`" 2>&1"
+    # #1836/#1339: --limit 15 caps the scheduled harvest at ~30
+    # contributions/day (15 review events + up to 15 merges) against the
+    # operator's ~260/day calibration. The uncapped 2026-07-28 run
+    # produced 35 review events in one morning; consecutive limited runs
+    # drain the queue FIFO instead.
+    & cmd.exe /c "poetry run python tools\dependabot_review.py --fleet --limit 15 >> `"$LogFile`" 2>&1"
     $exitCode = $LASTEXITCODE
 
     $endStamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'


### PR DESCRIPTION
The discovery that motivated this: `Claude-DependabotFleet` was believed disabled since the 2026-05-30 spike avoidance — but the silent-launcher remediation re-enabled it, and it fired **this morning, uncapped**: 5 merged + 30 deferred + 2 errored = **35 review events before 06:30**, per `data/dependabot-runs/2026-07-28_060002.log` (the #1403 run-log's first scheduled outing, incidentally working exactly as designed).

## Changes

- **`--limit 15`** on the wrapper's python invocation. The task's chain is: scheduled task → silent wscript launcher (SW_HIDE at CreateProcess) → this wrapper → the tool — so the wrapper edit caps every future 06:00 run with no task modification at all. With #1339's FIFO semantics, consecutive mornings drain the queue oldest-first at ~30 contributions/day against the ~260/day calibration.
- **The header's Setup block stopped teaching a regression.** It still documented the original direct-`powershell -WindowStyle Hidden` registration — the exact pattern the remediation work measured as flashing a console (Windows allocates the console before SW_HIDE applies; AZ #1819). Anyone following that comment would silently undo the launcher fix. The header now documents the real chain and forbids the direct registration.

## Silence verification (the operator's explicit ask)

Layered evidence, no live fire needed: the task action is a windowless GUI-subsystem host passing SW_HIDE at spawn (the #1819-endorsed complete fix, "measured on this machine, not assumed" per the launcher's own header); the private environment repo's remediation trail — the 13-task conversion, the does-it-actually-work verifier, and per-task effect probes naming this task — is all closed; and this morning's 25-minute run went unnoticed until this session read the log, which is what silence means operationally. A live manual fire was deliberately NOT run: it would execute another uncapped ~35-event harvest, and #1819 documents manual-fire eyeballing as false-negative-prone anyway.

Script-only change (the task runs it; no Python paths touched). Suite unaffected.

Closes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)