### PR TITLE
fix(dependabot): skip re-audit of PRs already deferred at an unchanged head SHA (Closes #1838)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -9,6 +9,7 @@ notes). The fix routes large bodies through `--body-file <tempfile>`.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -1063,3 +1064,167 @@ class TestRunTestsStripsVirtualEnv:
         dependabot_review.run_tests(tmp_path)
 
         assert captured["env"].get("PYTHONDONTWRITEBYTECODE") == "1"
+
+
+class TestAlreadyDeferredAtHead:
+    """#1838: skip re-audit when a tool-authored deferral review exists at
+    the PR's current head SHA. Standing deferrals were re-audited (and
+    re-commented) every scheduled run; under --limit 15 they consumed the
+    entire daily budget before fresh PRs were reached."""
+
+    HEAD = "abc123def4567890abc123def4567890abc123de"
+
+    def _pr(self, head_oid=None):
+        return dependabot_review.PRInfo(
+            number=42, title="bump x", author_login="app/dependabot",
+            body="", head_ref="dependabot/pip/x-1.0",
+            head_oid=self.HEAD if head_oid is None else head_oid,
+        )
+
+    def _review(self, *, user="martymcenroe", state="COMMENTED",
+                commit_id=None, body=None):
+        return {
+            "user": user,
+            "state": state,
+            "commit_id": self.HEAD if commit_id is None else commit_id,
+            "body": (
+                dependabot_review.REVIEW_BODY_PREFIX
+                + " -- test suite FAILED (exit 1). Not approving, not merging."
+            ) if body is None else body,
+        }
+
+    def _stub(self, monkeypatch, reviews, returncode=0, raw=None):
+        def _fake(cmd, *args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode,
+                stdout=raw if raw is not None else json.dumps(reviews),
+                stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+
+    def test_matching_deferral_review_skips(self, monkeypatch):
+        self._stub(monkeypatch, [self._review()])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is True
+
+    def test_commit_mismatch_reaudits(self, monkeypatch):
+        """A rebase/new push moves the head SHA -- must re-audit (#994)."""
+        self._stub(monkeypatch, [self._review(commit_id="0" * 40)])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_approved_review_does_not_skip(self, monkeypatch):
+        """An APPROVED review at head is the green path, not a deferral --
+        the #1399 timeout-deferral case must keep retrying the merge."""
+        self._stub(monkeypatch, [self._review(state="APPROVED")])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_foreign_reviewer_does_not_skip(self, monkeypatch):
+        self._stub(monkeypatch, [self._review(user="cerberus-az[bot]")])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_non_tool_body_does_not_skip(self, monkeypatch):
+        self._stub(monkeypatch, [self._review(body="LGTM, nice bump")])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_gh_failure_is_conservative(self, monkeypatch):
+        self._stub(monkeypatch, [], returncode=1)
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_bad_json_is_conservative(self, monkeypatch):
+        self._stub(monkeypatch, [], raw="not-json{")
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_missing_head_oid_reaudits_without_api_call(self, monkeypatch):
+        """PRInfo from an older listing (no headRefOid) must not skip and
+        must not spend an API call."""
+        called = []
+
+        def _fake(*args, **kwargs):
+            called.append(args)
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="[]", stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(head_oid=""), "o/r") is False
+        assert called == []
+
+
+class TestListPRsCarriesHeadOid:
+    """#1838: the PR listing must request headRefOid and map it onto
+    PRInfo.head_oid so the skip check has a SHA to compare against."""
+
+    def test_head_oid_requested_and_mapped(self, monkeypatch):
+        captured: dict = {}
+        payload = [{
+            "number": 7, "title": "t", "author": {"login": "app/dependabot"},
+            "body": None, "headRefName": "dependabot/npm_and_yarn/x-2",
+            "headRefOid": "feedbeef" * 5,
+        }]
+
+        def _fake(cmd, *args, **kwargs):
+            captured["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps(payload), stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        prs = dependabot_review.list_dependabot_prs("o/r")
+        assert "headRefOid" in " ".join(captured["cmd"])
+        assert prs[0].head_oid == "feedbeef" * 5
+
+    def test_missing_oid_field_maps_to_empty(self, monkeypatch):
+        payload = [{
+            "number": 7, "title": "t", "author": {"login": "app/dependabot"},
+            "body": "", "headRefName": "h",
+        }]
+
+        def _fake(cmd, *args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps(payload), stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        assert dependabot_review.list_dependabot_prs("o/r")[0].head_oid == ""
+
+
+class TestProcessRepoSkipsUnchanged:
+    """#1838: the skip happens BEFORE budget accounting and before any
+    worktree work; skipped PRs land in skipped_unchanged, visibly."""
+
+    def _wire(self, monkeypatch, tmp_path, deferred_at_head):
+        pr = dependabot_review.PRInfo(
+            number=9, title="bump y", author_login="app/dependabot",
+            body="", head_ref="h", head_oid="cafe1234" * 5)
+        monkeypatch.setattr(dependabot_review, "resolve_target_repo_dir",
+                            lambda repo, parent: tmp_path)
+        monkeypatch.setattr(dependabot_review, "check_for_orphan_worktrees",
+                            lambda t: [])
+        monkeypatch.setattr(dependabot_review, "list_dependabot_prs",
+                            lambda repo: [pr])
+        monkeypatch.setattr(dependabot_review, "already_deferred_at_head",
+                            lambda p, repo: deferred_at_head)
+        processed: list[int] = []
+        monkeypatch.setattr(
+            dependabot_review, "process_pr",
+            lambda p, repo, target: processed.append(p.number) or "merged")
+        return processed
+
+    def test_unchanged_pr_is_skipped_and_budget_untouched(
+            self, monkeypatch, tmp_path):
+        processed = self._wire(monkeypatch, tmp_path, deferred_at_head=True)
+        budget = dependabot_review.PRBudget(5)
+        sub = dependabot_review.process_repo("o/r", tmp_path, budget=budget)
+        assert sub["skipped_unchanged"] == ["o/r#9"]
+        assert processed == []
+        assert budget.used == 0, (
+            "skip must happen BEFORE budget.try_acquire -- a skipped PR "
+            "consuming budget recreates the starvation #1838 fixes"
+        )
+
+    def test_changed_pr_still_processes(self, monkeypatch, tmp_path):
+        processed = self._wire(monkeypatch, tmp_path, deferred_at_head=False)
+        sub = dependabot_review.process_repo("o/r", tmp_path)
+        assert processed == [9]
+        assert sub["merged"] == ["o/r#9"]
+        assert sub["skipped_unchanged"] == []

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -182,6 +182,11 @@ POETRY_INSTALL_TIMEOUT_S = 600
 # "pytest returns 0 when no tests collected" -- that was true on
 # pytest <5.0; doc fix tracked separately.
 PYTEST_EXIT_NO_TESTS_COLLECTED = 5
+# #1838: shared prefix for every review body this tool posts. Both the
+# posting sites (approve + deferral reviews) and the skip-detection in
+# already_deferred_at_head key on this string -- if it drifts, the skip
+# silently disarms and standing deferrals go back to daily re-audits.
+REVIEW_BODY_PREFIX = "Automated review via tools/dependabot_review.py"
 
 
 @dataclass
@@ -191,6 +196,9 @@ class PRInfo:
     author_login: str
     body: str
     head_ref: str
+    # #1838: current head SHA (headRefOid). "" when the listing did not
+    # provide one; every consumer must treat "" as "unknown, re-audit".
+    head_oid: str = ""
 
 
 class PRBudget:
@@ -350,7 +358,7 @@ def list_dependabot_prs(repo: str) -> list[PRInfo]:
         "gh", "pr", "list", "--repo", repo,
         "--author", "app/dependabot",
         "--state", "open",
-        "--json", "number,title,author,body,headRefName",
+        "--json", "number,title,author,body,headRefName,headRefOid",
     ])
     if result.returncode != 0:
         raise PRListError(
@@ -364,6 +372,7 @@ def list_dependabot_prs(repo: str) -> list[PRInfo]:
             author_login=r["author"]["login"],
             body=r["body"] or "",
             head_ref=r["headRefName"],
+            head_oid=r.get("headRefOid") or "",
         )
         for r in raw
     ]
@@ -551,7 +560,7 @@ def approve_pr(pr_number: int, repo: str) -> bool:
     result = run([
         "gh", "pr", "review", str(pr_number), "--repo", repo, "--approve",
         "--body",
-        "Automated review via tools/dependabot_review.py — test suite passed "
+        f"{REVIEW_BODY_PREFIX} — test suite passed "
         "(exit 0). Deterministic gate; no LLM in loop. "
         "Author and exit-code gates enforced.",
     ])
@@ -711,6 +720,57 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
     if not pr_base or not main_head:
         return False  # Conservative: don't trigger rebase on uncertain state
     return pr_base != main_head
+
+
+def already_deferred_at_head(pr: PRInfo, repo: str) -> bool:
+    """#1838: True iff this tool already posted a deferral review at the
+    PR's CURRENT head SHA.
+
+    The scheduled harvest re-audited every standing deferral daily -- full
+    worktree + install + test cycle, a duplicate COMMENTED review, and a
+    budget slot (#1339). On 2026-07-28, 30 of 37 processed PRs were
+    re-deferrals; under --limit 15 (#1836) the sorted repo order spends
+    the entire daily budget on them before reaching fresh PRs.
+
+    A deferral review whose commit_id equals the current head means
+    nothing changed since the last audit -- re-running the gate is
+    guaranteed to reproduce the same result. Dependabot rebases and
+    pushes move the head SHA, so real changes still re-audit (#994
+    semantics preserved). #1399 mergeable-timeout deferrals post no
+    review, so they correctly keep retrying; errored PRs post no review
+    either and also retry.
+
+    per_page=100 covers the worst observed backlog (~60 daily deferral
+    reviews on Talos#169); once this skip is active, deferral reviews
+    stop accumulating, so the count is self-limiting.
+
+    Conservative on ANY failure: return False (re-audit). A wasted audit
+    is recoverable; a wrongly-skipped PR never merges.
+    """
+    if not pr.head_oid:
+        return False
+    result = run(
+        ["gh", "api", f"repos/{repo}/pulls/{pr.number}/reviews?per_page=100",
+         "--jq",
+         "[.[] | {user: .user.login, state: .state, "
+         "commit_id: .commit_id, body: .body}]"],
+        quiet_on_failure=True,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        reviews = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return False
+    for rv in reviews:
+        if (
+            rv.get("user") == GITHUB_USER
+            and rv.get("state") == "COMMENTED"
+            and (rv.get("body") or "").startswith(REVIEW_BODY_PREFIX)
+            and rv.get("commit_id") == pr.head_oid
+        ):
+            return True
+    return False
 
 
 # #1400: file patterns that mean "this PR could affect the Python test
@@ -947,7 +1007,7 @@ def _process_pr_inside_worktree(
             # path also accrues to the user's Code Review profile stat.
             review_comment_on_pr(
                 pr.number, repo,
-                "Automated review via tools/dependabot_review.py -- "
+                f"{REVIEW_BODY_PREFIX} -- "
                 "`poetry install` failed. See the PR's Actions output for the "
                 "captured stderr; re-run locally via `gh pr checkout` if needed.",
             )
@@ -985,7 +1045,7 @@ def _process_pr_inside_worktree(
         # user has audited the PR; the credit should reflect that.
         review_comment_on_pr(
             pr.number, repo,
-            f"Automated review via tools/dependabot_review.py -- test suite "
+            f"{REVIEW_BODY_PREFIX} -- test suite "
             f"FAILED (exit {exit_code}). Not approving, not merging. "
             f"Re-run locally via `gh pr checkout` if needed; the PR's Actions "
             f"output is the forensic record.",
@@ -1198,8 +1258,9 @@ def process_repo(
     Cross-repo parallelism is the caller's responsibility.
 
     Returns a per-repo result dict with the same shape as the
-    aggregate (merged / deferred / errored / limit_skipped lists of
-    `repo#N` strings). Empty lists when no PRs are open.
+    aggregate (merged / deferred / errored / limit_skipped /
+    skipped_unchanged lists of `repo#N` strings). Empty lists when no
+    PRs are open.
 
     #1339: PRs process oldest-first (ascending PR number) — FIFO drains
     the queue tail, and under ``--limit`` it makes selection deterministic
@@ -1207,6 +1268,7 @@ def process_repo(
     """
     sub: dict[str, list[str]] = {
         "merged": [], "deferred": [], "errored": [], "limit_skipped": [],
+        "skipped_unchanged": [],
     }
     print(f"\n{'=' * 60}")
     print(f"REPO: {repo}")
@@ -1271,6 +1333,14 @@ def process_repo(
     if dry_run:
         return sub
     for pr in sorted(prs, key=lambda p: p.number):
+        # #1838: a PR already deferred at this exact head SHA cannot
+        # produce a different result -- skip before spending a budget
+        # slot, building a worktree, or posting a duplicate review.
+        if already_deferred_at_head(pr, repo):
+            print(f"  SKIP #{pr.number}: already deferred at current head "
+                  f"{pr.head_oid[:9]} -- unchanged since last audit (#1838)")
+            sub["skipped_unchanged"].append(f"{repo}#{pr.number}")
+            continue
         if budget is not None and not budget.try_acquire():
             # #1339: budget spent — remaining PRs are untouched, recorded
             # visibly (no silent caps), and left for the next harvest.
@@ -1457,6 +1527,7 @@ def main() -> None:
     # Aggregate results across repos.
     results: dict[str, list[str]] = {
         "merged": [], "deferred": [], "errored": [], "limit_skipped": [],
+        "skipped_unchanged": [],
     }
 
     # Wrap the worker dispatch + summary print in try/finally so the
@@ -1506,8 +1577,10 @@ def main() -> None:
                         print(f"\n  [ERROR] worker for {repo} raised: "
                               f"{type(e).__name__}: {e}")
                         sub = {"merged": [], "deferred": [],
-                               "errored": [repo], "limit_skipped": []}
-                    for k in ("merged", "deferred", "errored", "limit_skipped"):
+                               "errored": [repo], "limit_skipped": [],
+                               "skipped_unchanged": []}
+                    for k in ("merged", "deferred", "errored", "limit_skipped",
+                              "skipped_unchanged"):
                         results[k].extend(sub[k])
         else:
             for repo in repos:
@@ -1522,7 +1595,8 @@ def main() -> None:
                     repo, main_repo, args.dry_run, args.ignore_orphans,
                     budget=budget,
                 )
-                for k in ("merged", "deferred", "errored", "limit_skipped"):
+                for k in ("merged", "deferred", "errored", "limit_skipped",
+                          "skipped_unchanged"):
                     results[k].extend(sub[k])
     finally:
         # Dry-run skips the result-aggregation summary -- it only
@@ -1555,6 +1629,12 @@ def main() -> None:
                 # is named, so "covered everything" can never be misread.
                 print(f"  Limit-skipped (left for next harvest): "
                       f"{results['limit_skipped']}")
+            if results["skipped_unchanged"]:
+                # #1838: standing deferrals with an unchanged head are not
+                # re-audited; they create no review events and burn no
+                # budget. A rebase or new push re-audits them.
+                print(f"  Skipped (already deferred at unchanged head): "
+                      f"{results['skipped_unchanged']}")
             print(
                 f"  Review events created: {approved_events} APPROVED "
                 f"+ {commented_events} COMMENTED = {total_events} total"
@@ -1572,7 +1652,8 @@ def main() -> None:
                 f"\n=== {end_stamp} | FLEET-COMPLETE | "
                 f"merged={len(results['merged'])} "
                 f"deferred={len(results['deferred'])} "
-                f"errored={len(results['errored'])} ==="
+                f"errored={len(results['errored'])} "
+                f"skipped_unchanged={len(results['skipped_unchanged'])} ==="
             )
             # #1403: repeat the log path at the very end — after a long
             # drain the opening line is thousands of lines up-scroll.


### PR DESCRIPTION
Closes #1838

## Problem

The scheduled fleet harvest (Claude-DependabotFleet, daily 06:00) re-audits every standing deferral: the 2026-07-28 run finished `merged=5 deferred=30 errored=2`, and the same ~30 PRs (dispatch x6, Talos x8, Aletheia x6, IEEE-LRP-SC5 x5, Orpheus x3, AssemblyZero#1753, patent-general#189) get a full worktree + install + test cycle plus a duplicate COMMENTED review every morning. With `--limit 15` (#1836) active, budget-mode's name-sorted repo order spends the entire daily budget on re-deferrals before ever reaching dependabot-honeypot or dispatch.

## Fix

- `PRInfo` carries `head_oid` (`headRefOid`) from the PR listing.
- New `already_deferred_at_head()`: true iff a review by the invoking user with state COMMENTED, a body starting with the tool's marker prefix, and `commit_id` equal to the current head SHA exists. Conservative on any lookup failure: re-audit.
- `process_repo` skips such PRs **before** budget accounting, into a new visible `skipped_unchanged` category (Summary + FLEET-COMPLETE line). No worktree, no review event, no budget.
- Review bodies now share `REVIEW_BODY_PREFIX` so posting and detection cannot drift apart.
- A rebase or new push moves the head SHA and re-audits normally (#994 preserved); #1399 timeout-deferrals and errored PRs post no review and still retry.

## Tests

18 new tests: the detection matrix (state / user / body-prefix / SHA / failure modes), headRefOid mapping, and process_repo ordering (the skip lands before `budget.try_acquire`; `budget.used` stays 0). Full file: 82 passed. `ruff check` clean.

sibling: #1836 (limit cap), #1339 (PRBudget), #1091 (review-credit design). Surfaced verifying martymcenroe/dependabot-honeypot#166; enables martymcenroe/dependabot-honeypot#171.
