### PR TITLE
fix(test-gen): platform-independent path assertions in spec and impl prompts (Closes #1841)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -99,6 +99,11 @@ with realistic values (not just TypedDict definitions)
 - Change instructions MUST be specific enough to generate diffs \
 (line-level guidance, before/after snippets)
 - Pattern references MUST include file:line locations pointing to real code
+- Test code MUST be platform-independent: never assert on hardcoded path \
+separators. Compare pathlib.Path objects (path == Path.home() / ".app" / \
+"cfg.json"), never separator-laden strings — monkeypatching sys.platform \
+does NOT change pathlib's flavour, so on Windows str(path) renders with \
+backslashes and endswith("dir/file.json") can never pass (Issue #1841)
 
 STRUCTURE:
 Follow the provided template exactly. Include ALL sections. \

--- a/assemblyzero/workflows/testing/nodes/implementation/prompts.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/prompts.py
@@ -43,6 +43,21 @@ def build_stable_system_prompt(
 
 {lld_content}
 
+## Platform Correctness
+
+Generated code and tests run on Windows, macOS, and Linux. Both must be
+platform-independent (Issue #1841):
+
+- Never assert on hardcoded path separators. Compare `pathlib.Path` objects
+  (`assert path == Path.home() / ".app" / "cfg.json"`), never separator-laden
+  strings.
+- Monkeypatching `sys.platform` does NOT change `pathlib`'s flavour: on
+  Windows, `Path` still renders with backslashes, so
+  `str(path).endswith("dir/file.json")` can NEVER pass there.
+- If the specification's test code contains a platform-dependent assertion,
+  implement the platform-independent equivalent that preserves the same
+  behavioral claim — do not transcribe the broken assertion verbatim.
+
 """
 
     if path_enforcement_section:

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -3236,3 +3236,15 @@ class TestApiSymbolCheckInValidateCompleteness:
         details_blob = " ".join(checks_run)
         # Hallucinated-API check details must NOT appear when symbols are valid
         assert "api_symbols_exist" not in details_blob or "model_dump" not in details_blob
+
+
+class TestDrafterSystemPrompt:
+    """Issue #1841: spec drafter must demand platform-independent test code."""
+
+    def test_platform_independence_requirement_present(self):
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            DRAFTER_SYSTEM_PROMPT,
+        )
+
+        assert "platform-independent" in DRAFTER_SYSTEM_PROMPT
+        assert "sys.platform" in DRAFTER_SYSTEM_PROMPT

--- a/tests/unit/test_stable_system_prompt.py
+++ b/tests/unit/test_stable_system_prompt.py
@@ -68,6 +68,13 @@ class TestBuildStableSystemPrompt:
         assert "Additional Context" not in result
         assert "Tests That Must Pass" not in result
 
+    def test_contains_platform_correctness_guidance(self):
+        """Issue #1841: platform guidance must ride in every stable prompt."""
+        result = build_stable_system_prompt(lld_content="lld")
+        assert "Platform Correctness" in result
+        assert "sys.platform" in result
+        assert "path separators" in result
+
     def test_identical_across_files(self):
         """Two different files must produce the same stable system prompt."""
         kwargs = dict(


### PR DESCRIPTION
Hardening run 8 halted at impl: the spec authored a POSIX-branch path assertion with a hardcoded forward-slash separator, and N4 transcribed it verbatim through 3 iterations on a Windows runner where it can never pass (full evidence in the issue).

Two prompt anchors, one defect class:

- DRAFTER_SYSTEM_PROMPT (spec stage): new quality requirement — test code must be platform-independent; compare pathlib.Path objects, never separator-laden strings; monkeypatching sys.platform does not change pathlib's flavour.
- build_stable_system_prompt (N4 impl stage): new Platform Correctness section with the same rules plus a narrow deviation permission — when the spec's test code carries a platform-dependent assertion, implement the platform-independent equivalent that preserves the same behavioral claim.

Tests: prompt-content assertions in test_stable_system_prompt.py and a new TestDrafterSystemPrompt in test_implementation_spec_workflow.py (216 passing). Ruff: 13 pre-existing findings in untouched lines, none introduced.

Sibling issues from the same run: #1842 (feedback-loop non-convergence), #1843 (structured-parse fallback rate).

Closes #1841