### PR TITLE
feat(dependabot): JS/npm test gate + enumerate fleet by open dependabot PRs (Closes #1839)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -502,18 +502,19 @@ class TestExitCodeFiveIsPass:
         return success, so a non-deferred run reaches the green path."""
         monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
                             lambda worktree, pr_number, repo: True)
-        # #1400: force the Python gate ON so these exit-code tests actually
-        # exercise the install/test path they are testing. (#1400 added a
-        # pr_touches_python check that would otherwise skip the gate when
-        # the stubbed `run` returns empty diff output.)
-        monkeypatch.setattr(dependabot_review, "pr_touches_python",
-                            lambda pr, repo: True)
+        # #1400/#1839: force the Python gate ON (and the npm gate OFF) so
+        # these exit-code tests exercise the install/test path they are
+        # testing, regardless of what the stubbed `run` returns for the
+        # changed-files listing.
+        monkeypatch.setattr(dependabot_review, "_pr_changed_files",
+                            lambda pr, repo: ["pyproject.toml"])
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
         monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: exit_code)
         # Green-path stubs (only used when the gate doesn't defer).
         monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
-        monkeypatch.setattr(dependabot_review, "approve_pr", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "approve_pr",
+                            lambda pr, repo, gate_desc: True)
         monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
                             lambda pr, repo, timeout=900: True)
         monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
@@ -621,7 +622,8 @@ class TestWaitForMergeableTimeoutDeferred:
         monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 0)
         monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
-        monkeypatch.setattr(dependabot_review, "approve_pr", lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "approve_pr",
+                            lambda pr, repo, gate_desc: True)
         monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
 
     def _pr(self):
@@ -787,7 +789,7 @@ class TestPipelineSkippedForNonPythonPR:
         monkeypatch.setattr(dependabot_review, "inject_no_issue",
                             lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "approve_pr",
-                            lambda pr, repo: True)
+                            lambda pr, repo, gate_desc: True)
         monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
                             lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "squash_merge",
@@ -804,8 +806,8 @@ class TestPipelineSkippedForNonPythonPR:
         """The headline #1400 contract: docker-only PR never invokes
         install_deps or run_tests."""
         self._stub_green_path(monkeypatch)
-        monkeypatch.setattr(dependabot_review, "pr_touches_python",
-                            lambda pr, repo: False)
+        monkeypatch.setattr(dependabot_review, "_pr_changed_files",
+                            lambda pr, repo: ["Dockerfile"])
         install_called = []
         tests_called = []
         monkeypatch.setattr(dependabot_review, "install_deps",
@@ -825,14 +827,14 @@ class TestPipelineSkippedForNonPythonPR:
         )
         assert result == "merged"
         out = capsys.readouterr().out
-        assert "skipping poetry install + pytest gate" in out
+        assert "skipping install/test gates" in out
         assert "#1400" in out
 
     def test_python_pr_still_runs_install_and_test(self, monkeypatch):
         """Existing behavior preserved for Python PRs."""
         self._stub_green_path(monkeypatch)
-        monkeypatch.setattr(dependabot_review, "pr_touches_python",
-                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "_pr_changed_files",
+                            lambda pr, repo: ["poetry.lock"])
         install_called = []
         tests_called = []
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
@@ -1228,3 +1230,344 @@ class TestProcessRepoSkipsUnchanged:
         assert processed == [9]
         assert sub["merged"] == ["o/r#9"]
         assert sub["skipped_unchanged"] == []
+
+
+class TestJsManifestDirs:
+    """#1839: pure predicate mapping changed files to npm gate dirs."""
+
+    def test_root_package_json(self):
+        assert dependabot_review._js_manifest_dirs(["package.json"]) == ["."]
+
+    def test_subdir_lockfile(self):
+        assert dependabot_review._js_manifest_dirs(
+            ["dashboard/package-lock.json"]) == ["dashboard"]
+
+    def test_dedup_and_sort(self):
+        files = ["web/package.json", "web/package-lock.json",
+                 "api/package.json", "README.md"]
+        assert dependabot_review._js_manifest_dirs(files) == ["api", "web"]
+
+    def test_node_modules_excluded(self):
+        assert dependabot_review._js_manifest_dirs(
+            ["web/node_modules/foo/package.json"]) == []
+
+    def test_yarn_and_pnpm_locks_recognized(self):
+        assert dependabot_review._js_manifest_dirs(
+            ["a/yarn.lock", "b/pnpm-lock.yaml"]) == ["a", "b"]
+
+    def test_unrelated_files_empty(self):
+        assert dependabot_review._js_manifest_dirs(
+            ["Dockerfile", ".github/workflows/ci.yml", "src/x.py"]) == []
+
+
+class TestNpmTestScript:
+    """#1839: what counts as a runnable npm test script."""
+
+    def _write(self, tmp_path, obj):
+        (tmp_path / "package.json").write_text(
+            json.dumps(obj), encoding="utf-8")
+
+    def test_missing_package_json(self, tmp_path):
+        assert dependabot_review._npm_test_script(tmp_path) is None
+
+    def test_no_scripts_section(self, tmp_path):
+        self._write(tmp_path, {"name": "x"})
+        assert dependabot_review._npm_test_script(tmp_path) is None
+
+    def test_npm_init_placeholder_counts_as_none(self, tmp_path):
+        self._write(tmp_path, {"scripts": {
+            "test": 'echo "Error: no test specified" && exit 1'}})
+        assert dependabot_review._npm_test_script(tmp_path) is None
+
+    def test_blank_script_counts_as_none(self, tmp_path):
+        self._write(tmp_path, {"scripts": {"test": "   "}})
+        assert dependabot_review._npm_test_script(tmp_path) is None
+
+    def test_real_script_returned(self, tmp_path):
+        self._write(tmp_path, {"scripts": {"test": "vitest run"}})
+        assert dependabot_review._npm_test_script(tmp_path) == "vitest run"
+
+    def test_malformed_json_counts_as_none(self, tmp_path):
+        (tmp_path / "package.json").write_text("{not json", encoding="utf-8")
+        assert dependabot_review._npm_test_script(tmp_path) is None
+
+
+class TestRunJsGate:
+    """#1839: npm install + test per touched dir, node_modules cleanup."""
+
+    def _pkg(self, d, script="run-my-tests", lock=True):
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "package.json").write_text(
+            json.dumps({"scripts": {"test": script}}), encoding="utf-8")
+        if lock:
+            (d / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def _stub_run(self, monkeypatch, calls, test_exit=0, install_exit=0):
+        def _fake(cmd, *args, **kwargs):
+            calls.append({"cmd": list(cmd), "cwd": kwargs.get("cwd"),
+                          "env": kwargs.get("env")})
+            rc = test_exit if cmd[-1] == "test" else install_exit
+            return subprocess.CompletedProcess(args=cmd, returncode=rc,
+                                               stdout="", stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+
+    def test_no_test_script_fails_gate(self, monkeypatch, tmp_path):
+        (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        ok, desc = dependabot_review.run_js_gate(tmp_path, ["."])
+        assert ok is False
+        assert "no runnable npm test script" in desc
+        assert calls == [], "no npm subprocess may run without a test script"
+
+    def test_lockfile_uses_npm_ci_then_test(self, monkeypatch, tmp_path):
+        self._pkg(tmp_path)
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        ok, desc = dependabot_review.run_js_gate(tmp_path, ["."])
+        assert ok is True
+        assert "npm test passed" in desc
+        assert calls[0]["cmd"][1:] == ["ci"]
+        assert calls[1]["cmd"][1:] == ["test"]
+
+    def test_no_lockfile_falls_back_to_install_no_package_lock(
+            self, monkeypatch, tmp_path):
+        self._pkg(tmp_path, lock=False)
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        ok, _ = dependabot_review.run_js_gate(tmp_path, ["."])
+        assert ok is True
+        assert calls[0]["cmd"][1:] == ["install", "--no-package-lock"]
+
+    def test_test_failure_fails_gate(self, monkeypatch, tmp_path):
+        self._pkg(tmp_path)
+        calls: list = []
+        self._stub_run(monkeypatch, calls, test_exit=1)
+        ok, desc = dependabot_review.run_js_gate(tmp_path, ["."])
+        assert ok is False
+        assert "npm test FAILED (exit 1)" in desc
+
+    def test_install_failure_fails_gate_without_running_tests(
+            self, monkeypatch, tmp_path):
+        self._pkg(tmp_path)
+        calls: list = []
+        self._stub_run(monkeypatch, calls, install_exit=1)
+        ok, desc = dependabot_review.run_js_gate(tmp_path, ["."])
+        assert ok is False
+        assert "npm install failed" in desc
+        assert len(calls) == 1
+
+    def test_subdir_runs_in_subdir(self, monkeypatch, tmp_path):
+        self._pkg(tmp_path / "dashboard")
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        ok, desc = dependabot_review.run_js_gate(tmp_path, ["dashboard"])
+        assert ok is True
+        assert calls[0]["cwd"] == str(tmp_path / "dashboard")
+        assert "'dashboard'" in desc
+
+    def test_node_modules_removed_after_gate(self, monkeypatch, tmp_path):
+        self._pkg(tmp_path)
+        nm = tmp_path / "node_modules" / "leftover"
+        nm.mkdir(parents=True)
+        (nm / "file.js").write_text("x", encoding="utf-8")
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        dependabot_review.run_js_gate(tmp_path, ["."])
+        assert not (tmp_path / "node_modules").exists(), (
+            "node_modules must be removed -- git worktree remove (no "
+            "--force) refuses on untracked files"
+        )
+
+    def test_node_modules_removed_even_on_failure(self, monkeypatch, tmp_path):
+        self._pkg(tmp_path)
+        (tmp_path / "node_modules").mkdir()
+        calls: list = []
+        self._stub_run(monkeypatch, calls, test_exit=1)
+        dependabot_review.run_js_gate(tmp_path, ["."])
+        assert not (tmp_path / "node_modules").exists()
+
+    def test_env_strips_virtual_env(self, monkeypatch, tmp_path):
+        """Compose with #1415: npm subprocesses get the cleaned env too."""
+        monkeypatch.setenv("VIRTUAL_ENV", "C:/AZ/venv/should/not/leak")
+        self._pkg(tmp_path)
+        calls: list = []
+        self._stub_run(monkeypatch, calls)
+        dependabot_review.run_js_gate(tmp_path, ["."])
+        assert calls, "gate must have invoked npm"
+        assert all("VIRTUAL_ENV" not in c["env"] for c in calls)
+
+
+class TestProcessPrJsFlow:
+    """#1839: gate selection inside _process_pr_inside_worktree."""
+
+    def _stub_green_path(self, monkeypatch):
+        monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
+                            lambda worktree, pr_number, repo: True)
+        monkeypatch.setattr(dependabot_review, "inject_no_issue",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "squash_merge",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=99, title="bump chalk", author_login="app/dependabot",
+            body="", head_ref="dependabot/npm_and_yarn/chalk-6")
+
+    def test_npm_only_pr_runs_js_gate_not_python(self, monkeypatch):
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(
+            dependabot_review, "_pr_changed_files",
+            lambda pr, repo: ["dashboard/package.json",
+                              "dashboard/package-lock.json"])
+        approvals: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "approve_pr",
+            lambda pr, repo, gate_desc: approvals.append(gate_desc) or True)
+        installs, tests, js = [], [], []
+        monkeypatch.setattr(dependabot_review, "install_deps",
+                            lambda wt: installs.append(wt) or True)
+        monkeypatch.setattr(dependabot_review, "run_tests",
+                            lambda wt: tests.append(wt) or 0)
+        monkeypatch.setattr(
+            dependabot_review, "run_js_gate",
+            lambda wt, dirs: js.append(dirs) or
+            (True, "npm test passed (exit 0) in 'dashboard'"))
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"))
+
+        assert result == "merged"
+        assert installs == [] and tests == []
+        assert js == [["dashboard"]]
+        assert approvals and "npm test passed" in approvals[0]
+
+    def test_js_gate_failure_defers_with_reason(self, monkeypatch):
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(dependabot_review, "_pr_changed_files",
+                            lambda pr, repo: ["package.json"])
+        monkeypatch.setattr(
+            dependabot_review, "run_js_gate",
+            lambda wt, dirs: (False, "no runnable npm test script in '.' -- "
+                              "not auto-merging unverified (#1839)"))
+        reviews: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "review_comment_on_pr",
+            lambda pr, repo, body: reviews.append(body) or True)
+        monkeypatch.setattr(dependabot_review, "is_pr_branch_stale",
+                            lambda pr, repo: False)
+        approvals: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "approve_pr",
+            lambda pr, repo, gate_desc: approvals.append(gate_desc) or True)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"))
+
+        assert result == "deferred"
+        assert approvals == []
+        assert reviews and "no runnable npm test script" in reviews[0]
+
+    def test_grouped_pr_runs_both_gates(self, monkeypatch):
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(
+            dependabot_review, "_pr_changed_files",
+            lambda pr, repo: ["poetry.lock", "web/package.json"])
+        approvals: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "approve_pr",
+            lambda pr, repo, gate_desc: approvals.append(gate_desc) or True)
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv",
+                            lambda wt: None)
+        monkeypatch.setattr(dependabot_review, "install_deps",
+                            lambda wt: True)
+        monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 0)
+        js: list = []
+        monkeypatch.setattr(
+            dependabot_review, "run_js_gate",
+            lambda wt, dirs: js.append(dirs) or
+            (True, "npm test passed (exit 0) in 'web'"))
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"))
+
+        assert result == "merged"
+        assert js == [["web"]]
+        assert "pytest passed (exit 0)" in approvals[0]
+        assert "npm test passed" in approvals[0]
+
+    def test_python_failure_short_circuits_js_gate(self, monkeypatch):
+        self._stub_green_path(monkeypatch)
+        monkeypatch.setattr(
+            dependabot_review, "_pr_changed_files",
+            lambda pr, repo: ["poetry.lock", "web/package.json"])
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv",
+                            lambda wt: None)
+        monkeypatch.setattr(dependabot_review, "install_deps",
+                            lambda wt: True)
+        monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 1)
+        js: list = []
+        monkeypatch.setattr(dependabot_review, "run_js_gate",
+                            lambda wt, dirs: js.append(dirs) or (True, "x"))
+        monkeypatch.setattr(dependabot_review, "review_comment_on_pr",
+                            lambda pr, repo, body: True)
+        monkeypatch.setattr(dependabot_review, "is_pr_branch_stale",
+                            lambda pr, repo: False)
+
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "owner/repo", Path("/tmp/wt"))
+
+        assert result == "deferred"
+        assert js == [], "js gate must not run when the Python gate failed"
+
+
+class TestListFleetReposByOpenPrs:
+    """#1839: fleet = repos with open dependabot PRs, intersected with the
+    user's non-archived non-fork repos, sorted."""
+
+    def test_intersection_sorted_archived_excluded(self, monkeypatch):
+        def _fake(cmd, *args, **kwargs):
+            if cmd[1] == "repo" and cmd[2] == "list":
+                payload = [
+                    {"name": "beta", "nameWithOwner": "o/beta",
+                     "isArchived": False, "isFork": False},
+                    {"name": "alpha", "nameWithOwner": "o/alpha",
+                     "isArchived": False, "isFork": False},
+                    {"name": "old", "nameWithOwner": "o/old",
+                     "isArchived": True, "isFork": False},
+                    {"name": "fork", "nameWithOwner": "o/fork",
+                     "isArchived": False, "isFork": True},
+                ]
+            else:
+                payload = [
+                    {"repository": {"nameWithOwner": "o/beta"}},
+                    {"repository": {"nameWithOwner": "o/alpha"}},
+                    {"repository": {"nameWithOwner": "o/alpha"}},
+                    {"repository": {"nameWithOwner": "o/old"}},
+                    {"repository": {"nameWithOwner": "o/fork"}},
+                ]
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=json.dumps(payload), stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        assert dependabot_review.list_fleet_repos("o") == ["o/alpha", "o/beta"]
+
+
+class TestApprovePrGateDesc:
+    """#1839: the approval body names the gate that actually ran."""
+
+    def test_gate_desc_lands_in_review_body(self, monkeypatch):
+        captured: dict = {}
+
+        def _fake(cmd, *args, **kwargs):
+            captured["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0,
+                                               stdout="", stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        assert dependabot_review.approve_pr(
+            5, "o/r", "npm test passed (exit 0) in '.'") is True
+        body = captured["cmd"][captured["cmd"].index("--body") + 1]
+        assert "gate: npm test passed (exit 0) in '.'" in body
+        assert body.startswith(dependabot_review.REVIEW_BODY_PREFIX)

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -5,8 +5,13 @@ Hard gates (no LLM in the loop):
 
 1. Author gate: every PR must be authored by `dependabot[bot]`. Any other
    author is a hard refusal — the script will not approve or merge it.
-2. Test gate: `poetry run pytest` must exit 0. Non-zero exit means the PR
-   is commented on and left for human review; no approval, no merge.
+2. Test gate, per ecosystem the PR touches (#1839): Python-relevant
+   changes run `poetry install` + `poetry run pytest` (exit 0, or 5 for
+   test-less repos per #1397); npm-relevant changes run `npm ci` /
+   `npm install` + `npm test` (exit 0) in each touched manifest
+   directory. Non-zero exit means the PR is commented on and left for
+   human review; no approval, no merge. PRs touching neither ecosystem
+   (docker, github-actions) skip the gate (#1400).
 
 For each open dependabot-authored PR:
 
@@ -64,6 +69,8 @@ import datetime
 import json
 import os
 import re
+import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -165,6 +172,10 @@ POLL_INTERVAL_S = 10
 MERGEABLE_TIMEOUT_S = 900
 PYTEST_TIMEOUT_S = 1800
 POETRY_INSTALL_TIMEOUT_S = 600
+# #1839: npm install can be slow on first run (puppeteer-class postinstall
+# downloads); test budget mirrors pytest's.
+NPM_INSTALL_TIMEOUT_S = 900
+NPM_TEST_TIMEOUT_S = 1800
 # Pytest exit codes since pytest 5.0 (2019):
 #   0 = all tests passed
 #   1 = a test failed
@@ -537,6 +548,113 @@ def run_tests(worktree: Path) -> int:
     return result.returncode
 
 
+def _npm_cmd() -> str:
+    """npm on Windows is npm.cmd; CreateProcess does not apply PATHEXT,
+    so a bare "npm" argv entry is unresolvable. shutil.which does apply
+    it and returns the full shim path."""
+    return shutil.which("npm") or "npm"
+
+
+def _npm_test_script(pkg_dir: Path) -> str | None:
+    """The package.json "test" script, or None when nothing is runnable.
+
+    npm init's placeholder ("Error: no test specified" && exit 1) counts
+    as no script -- running it can only exit 1 with a message that would
+    then be misreported as a test failure instead of the real condition,
+    which is "this package declares no tests".
+    """
+    pkg = pkg_dir / "package.json"
+    if not pkg.exists():
+        return None
+    try:
+        with pkg.open("rb") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    script = (data.get("scripts") or {}).get("test")
+    if not isinstance(script, str) or not script.strip():
+        return None
+    if "no test specified" in script:
+        return None
+    return script
+
+
+def _remove_node_modules(pkg_dir: Path) -> None:
+    """#1839: the audit must delete what it created. `git worktree
+    remove` (no --force; the force flag is banned) refuses on untracked
+    files, and node_modules always lands in-tree. Windows needs the
+    chmod-and-retry handler for readonly files (esbuild/sharp binaries,
+    nested .git objects)."""
+    nm = pkg_dir / "node_modules"
+    if not nm.exists():
+        return
+
+    def _onexc(func, path, exc):
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    try:
+        shutil.rmtree(nm, onexc=_onexc)
+    except OSError as e:
+        print(f"  WARNING: could not fully remove {nm}: {e} -- worktree "
+              f"cleanup will likely refuse; manual cleanup needed.",
+              file=sys.stderr)
+
+
+def run_js_gate(worktree: Path, js_dirs: list[str]) -> tuple[bool, str]:
+    """#1839: install + test gate for npm ecosystems, one pass per
+    touched manifest directory.
+
+    Per directory: `npm ci` when an npm lockfile exists (ci never writes
+    the lockfile; it errors when manifest and lock are out of sync),
+    else `npm install --no-package-lock` (yarn/pnpm repos still gate
+    installability from package.json, and no untracked lockfile is
+    generated). Then `npm test`, gated on exit code. A directory with no
+    runnable test script fails the gate -- do not auto-merge unverified
+    (martymcenroe/dependabot-honeypot#171 point 4). node_modules is
+    removed on every exit path so worktree cleanup stays force-free.
+
+    Returns (ok, desc); desc goes verbatim into the review body.
+    """
+    npm = _npm_cmd()
+    parts: list[str] = []
+    for d in js_dirs:
+        pkg_dir = worktree if d == "." else worktree / d
+        try:
+            if not (pkg_dir / "package.json").exists():
+                parts.append(f"'{d}': package.json absent on PR branch; "
+                             f"nothing to gate")
+                continue
+            if _npm_test_script(pkg_dir) is None:
+                return False, (
+                    f"no runnable npm test script in '{d}' -- not "
+                    f"auto-merging unverified (#1839)"
+                )
+            has_npm_lock = any(
+                (pkg_dir / lf).exists()
+                for lf in ("package-lock.json", "npm-shrinkwrap.json")
+            )
+            install_cmd = ([npm, "ci"] if has_npm_lock
+                           else [npm, "install", "--no-package-lock"])
+            result = run(install_cmd, cwd=str(pkg_dir),
+                         timeout=NPM_INSTALL_TIMEOUT_S,
+                         env=_clean_subprocess_env())
+            if result.returncode != 0:
+                return False, (f"npm install failed "
+                               f"(exit {result.returncode}) in '{d}'")
+            result = run([npm, "test"], cwd=str(pkg_dir),
+                         timeout=NPM_TEST_TIMEOUT_S,
+                         env=_clean_subprocess_env())
+            print(f"  npm test exit code ('{d}'): {result.returncode}")
+            if result.returncode != 0:
+                return False, (f"npm test FAILED "
+                               f"(exit {result.returncode}) in '{d}'")
+            parts.append(f"npm test passed (exit 0) in '{d}'")
+        finally:
+            _remove_node_modules(pkg_dir)
+    return True, "; ".join(parts) if parts else "npm gate: nothing to run"
+
+
 # ---------------------------------------------------------------------------
 # PR mutation (only after both gates pass)
 # ---------------------------------------------------------------------------
@@ -556,12 +674,16 @@ def inject_no_issue(pr: PRInfo, repo: str) -> bool:
     return result.returncode == 0
 
 
-def approve_pr(pr_number: int, repo: str) -> bool:
+def approve_pr(pr_number: int, repo: str, gate_desc: str) -> bool:
+    """#1839: the review body states WHICH gate actually ran. The prior
+    fixed text claimed "test suite passed (exit 0)" even on the #1400
+    skip path where no test ran -- a false audit record for npm/docker/
+    actions PRs."""
     result = run([
         "gh", "pr", "review", str(pr_number), "--repo", repo, "--approve",
         "--body",
-        f"{REVIEW_BODY_PREFIX} — test suite passed "
-        "(exit 0). Deterministic gate; no LLM in loop. "
+        f"{REVIEW_BODY_PREFIX} — gate: {gate_desc}. "
+        "Deterministic gate; no LLM in loop. "
         "Author and exit-code gates enforced.",
     ])
     return result.returncode == 0
@@ -786,33 +908,34 @@ _PYTHON_RELEVANT_FILES = frozenset({
 })
 
 
-def pr_touches_python(pr_number: int, repo: str) -> bool:
-    """#1400: True iff the PR's diff includes any Python-relevant file.
+# #1839: npm lockfiles + manifest. A dependabot npm bump always touches
+# package.json and/or one of these lockfiles; their parent directory is
+# where the JS gate runs (fleet npm manifests are mostly subdirectories --
+# /dashboard, /das, /web -- not repo roots).
+_JS_LOCKFILES = frozenset({
+    "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
+})
+_JS_MANIFEST_FILES = _JS_LOCKFILES | frozenset({"package.json"})
 
-    Used by _process_pr_inside_worktree to decide whether to run the
-    `poetry install` + `pytest` gate. A PR that does not touch any Python
-    file or manifest cannot break the Python venv by construction --
-    running the Python gate on it is wasted work AND creates false
-    negatives when the worktree's lockfile has any pre-existing issue
-    unrelated to the PR (the bug that bit honeypot's docker PRs #52, #53,
-    #55 on 2026-05-29/30 -- their branches predate the LLM-cleanup
-    martymcenroe/dependabot-honeypot#67/#71/#72/#76 and still carry the
-    jiter manifest, but the docker bump itself cannot have caused that).
 
-    Conservative on failure: if `gh pr diff` cannot list the changed
-    files, return True so the Python gate still runs (no false-pass).
+def _pr_changed_files(pr_number: int, repo: str) -> list[str] | None:
+    """Changed-file paths for the PR, or None when gh cannot list them.
+
+    Single source for both ecosystem predicates -- one `gh pr diff`
+    call per PR feeds _touches_python and _js_manifest_dirs.
     """
     result = run(
         ["gh", "pr", "diff", str(pr_number), "--repo", repo, "--name-only"],
         quiet_on_failure=True,
     )
     if result.returncode != 0:
-        print(f"  WARNING: could not list PR #{pr_number} changed files "
-              f"(gh pr diff --name-only failed); running Python gate as "
-              f"the safe default (#1400).",
-              file=sys.stderr)
-        return True
-    files = [f.strip() for f in (result.stdout or "").splitlines() if f.strip()]
+        return None
+    return [f.strip() for f in (result.stdout or "").splitlines() if f.strip()]
+
+
+def _touches_python(files: list[str]) -> bool:
+    """#1400 predicate, pure part: any Python source, manifest, or
+    lockfile anywhere in the changed-file list."""
     for f in files:
         # Any *.py file anywhere in the repo.
         if f.endswith(".py"):
@@ -825,6 +948,43 @@ def pr_touches_python(pr_number: int, repo: str) -> bool:
         if basename.startswith("requirements") and basename.endswith(".txt"):
             return True
     return False
+
+
+def _js_manifest_dirs(files: list[str]) -> list[str]:
+    """#1839: repo-relative directories ('.' for root) holding a touched
+    npm manifest or lockfile. Sorted and deduped. Vendored trees under
+    node_modules are ignored -- dependabot never edits them, and a stray
+    checked-in vendor dir must not trigger an install there."""
+    dirs: set[str] = set()
+    for f in files:
+        parts = f.split("/")
+        if "node_modules" in parts[:-1]:
+            continue
+        if parts[-1] in _JS_MANIFEST_FILES:
+            dirs.add("/".join(parts[:-1]) or ".")
+    return sorted(dirs)
+
+
+def pr_touches_python(pr_number: int, repo: str) -> bool:
+    """#1400: True iff the PR's diff includes any Python-relevant file.
+
+    A PR that does not touch any Python file or manifest cannot break
+    the Python venv by construction -- running the Python gate on it is
+    wasted work AND creates false negatives when the worktree's lockfile
+    has any pre-existing issue unrelated to the PR (the bug that bit
+    honeypot's docker PRs #52, #53, #55 on 2026-05-29/30).
+
+    Conservative on failure: if `gh pr diff` cannot list the changed
+    files, return True so the Python gate still runs (no false-pass).
+    """
+    files = _pr_changed_files(pr_number, repo)
+    if files is None:
+        print(f"  WARNING: could not list PR #{pr_number} changed files "
+              f"(gh pr diff --name-only failed); running Python gate as "
+              f"the safe default (#1400).",
+              file=sys.stderr)
+        return True
+    return _touches_python(files)
 
 
 # ---------------------------------------------------------------------------
@@ -991,6 +1151,18 @@ def _process_pr_inside_worktree(
         print("  ERROR: gh pr checkout failed")
         return "errored"
 
+    files = _pr_changed_files(pr.number, repo)
+    if files is None:
+        print(f"  WARNING: could not list PR #{pr.number} changed files "
+              f"(gh pr diff --name-only failed); running Python gate as "
+              f"the safe default (#1400).", file=sys.stderr)
+    touches_py = True if files is None else _touches_python(files)
+    js_dirs = [] if files is None else _js_manifest_dirs(files)
+
+    gate_descs: list[str] = []
+    exit_code = 0
+    defer_reason = ""
+
     # #1400: only run the Python gate (poetry install + pytest) when the
     # PR actually touches a Python file or manifest. A Dockerfile-only
     # bump, an npm bump, or a github-actions workflow pin cannot break
@@ -998,7 +1170,7 @@ def _process_pr_inside_worktree(
     # PRs is wasted work and creates false-negative deferrals when the
     # PR's branch has any pre-existing lockfile issue (e.g. honeypot's
     # docker PRs #52/#53/#55 carried the pre-cleanup jiter manifest).
-    if pr_touches_python(pr.number, repo):
+    if touches_py:
         evict_poetry_venv(worktree)
 
         if not install_deps(worktree):
@@ -1023,19 +1195,32 @@ def _process_pr_inside_worktree(
         if exit_code == PYTEST_EXIT_NO_TESTS_COLLECTED:
             print("  pytest: no tests collected (exit 5) -- treating as PASS "
                   "(decorative-deps repo with no test suite)")
+            gate_descs.append("pytest: no tests collected (exit 5, treated "
+                              "as pass per #1397)")
             exit_code = 0
-    else:
-        # #1400: PR did not touch any Python-relevant file. Skip the Python
-        # gate entirely and treat as pass for the dep-bump gate. The PR
-        # can only have changed Docker / npm / workflow / docs content;
-        # those cannot break a Python venv. Eventual follow-up: add
-        # ecosystem-specific gates here (npm test, docker build, etc.)
-        # if/when needed -- the honeypot's decorative-deps purpose means
-        # "skip gate, pass through" is currently the right semantic.
-        print(f"  PR #{pr.number} touches no Python-relevant files -- "
-              f"skipping poetry install + pytest gate (#1400). "
+        elif exit_code == 0:
+            gate_descs.append("pytest passed (exit 0)")
+        else:
+            defer_reason = f"test suite FAILED (exit {exit_code})"
+
+    # #1839: npm gate for every touched manifest directory, after the
+    # Python gate -- a grouped PR touching both ecosystems must pass both.
+    if exit_code == 0 and js_dirs:
+        js_ok, js_desc = run_js_gate(worktree, js_dirs)
+        gate_descs.append(js_desc)
+        if not js_ok:
+            exit_code = 1
+            defer_reason = js_desc
+
+    if not touches_py and not js_dirs:
+        # #1400: PR touches neither ecosystem -- docker / workflow / docs
+        # content cannot break a venv or an npm tree. Skip the gates and
+        # pass through; the review body says so truthfully (#1839).
+        print(f"  PR #{pr.number} touches no Python- or npm-relevant files "
+              f"-- skipping install/test gates (#1400). "
               f"Treating as PASS for the dep-bump gate.")
-        exit_code = 0
+        gate_descs.append("no Python- or npm-relevant files changed; "
+                          "install/test gates skipped (#1400)")
 
     if exit_code != 0:
         package_count = count_packages(pr.body)
@@ -1045,8 +1230,8 @@ def _process_pr_inside_worktree(
         # user has audited the PR; the credit should reflect that.
         review_comment_on_pr(
             pr.number, repo,
-            f"{REVIEW_BODY_PREFIX} -- test suite "
-            f"FAILED (exit {exit_code}). Not approving, not merging. "
+            f"{REVIEW_BODY_PREFIX} -- {defer_reason}. "
+            f"Not approving, not merging. "
             f"Re-run locally via `gh pr checkout` if needed; the PR's Actions "
             f"output is the forensic record.",
         )
@@ -1072,7 +1257,7 @@ def _process_pr_inside_worktree(
     # Small wait for pr-sentinel to re-evaluate the edited body
     time.sleep(5)
 
-    if not approve_pr(pr.number, repo):
+    if not approve_pr(pr.number, repo, "; ".join(gate_descs)):
         print("  ERROR: approve failed")
         return "errored"
 
@@ -1192,11 +1377,16 @@ def resolve_target_repo_dir(repo_full: str, default_parent: Path) -> Path | None
 def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
     """List user-owned repos that we should attempt to process.
 
-    Returns repos as 'owner/name' strings. Filters to repos where this
-    tool can actually run the test gate — i.e., repos with a
-    `pyproject.toml` on `main`. Non-Poetry repos (npm, Cargo, etc.)
-    are omitted because the existing test gate can't validate them.
-    Future per-language test runners can lift this filter.
+    #1839: the fleet is the WORK QUEUE -- repos with at least one open
+    dependabot PR -- intersected with the user's non-archived, non-fork
+    repos. Pre-#1839 this probed each repo for a root `pyproject.toml`
+    (the gate was Poetry-only), which excluded exactly the JS repos the
+    gate can now handle (~47 of the fleet's 84 open dependabot PRs on
+    2026-07-28) and burned one API probe per repo. With per-ecosystem
+    gate selection in _process_pr_inside_worktree, any repo with open
+    PRs is processable; repos with nothing open have nothing to do.
+
+    Returned sorted for deterministic ordering run to run.
     """
     result = run([
         "gh", "repo", "list", user,
@@ -1206,33 +1396,25 @@ def list_fleet_repos(user: str = GITHUB_USER) -> list[str]:
     if result.returncode != 0:
         sys.exit(f"Failed to list fleet repos: {result.stderr}")
     repos = json.loads(result.stdout or "[]")
+    allowed = {
+        r["nameWithOwner"] for r in repos
+        if not r.get("isArchived") and not r.get("isFork")
+    }
 
-    candidates: list[str] = []
-    for r in repos:
-        if r.get("isArchived") or r.get("isFork"):
-            continue
-        candidates.append(r["nameWithOwner"])
+    search = run([
+        "gh", "search", "prs",
+        "--author", "app/dependabot",
+        "--state", "open",
+        "--owner", user,
+        "--limit", str(FLEET_REPO_LIMIT),
+        "--json", "repository",
+    ])
+    if search.returncode != 0:
+        sys.exit(f"Failed to search open dependabot PRs: {search.stderr}")
+    rows = json.loads(search.stdout or "[]")
+    with_open_prs = {row["repository"]["nameWithOwner"] for row in rows}
 
-    # Filter to repos that have a pyproject.toml on main. Non-Python
-    # repos would defer every PR (poetry run pytest fails) which is a
-    # waste — and would file failure-path review-comments on PRs the
-    # user can't actually approve. Skip silently instead.
-    processable: list[str] = []
-    for repo in candidates:
-        # 404 = "no pyproject.toml in this repo" = "not a Python repo we
-        # can run pytest in". That's the FILTER signal, not an error;
-        # suppress the stderr noise for these calls.
-        check = run(
-            [
-                "gh", "api", f"repos/{repo}/contents/pyproject.toml",
-                "--jq", ".name",
-            ],
-            quiet_on_failure=True,
-        )
-        if check.returncode == 0 and check.stdout.strip():
-            processable.append(repo)
-
-    return processable
+    return sorted(with_open_prs & allowed)
 
 
 # ---------------------------------------------------------------------------
@@ -1431,10 +1613,10 @@ def main() -> None:
     parser.add_argument(
         "--fleet", action="store_true",
         help=(
-            "Process dependabot PRs across ALL user-owned repos with a "
-            "pyproject.toml on main, not just --repo. Multiplies review-"
-            "event volume across the fleet. Mutually exclusive with "
-            "--repo (--fleet wins). (#1091)"
+            "Process dependabot PRs across ALL user-owned repos with open "
+            "dependabot PRs — every ecosystem, not just Poetry (#1839). "
+            "Multiplies review-event volume across the fleet. Mutually "
+            "exclusive with --repo (--fleet wins). (#1091)"
         ),
     )
     parser.add_argument(
@@ -1507,9 +1689,10 @@ def main() -> None:
 
     # Issue #1091: fleet mode enumerates user-owned Poetry repos.
     if args.fleet:
-        print(f"Fleet mode — enumerating {GITHUB_USER}'s Python repos...")
+        print(f"Fleet mode — enumerating {GITHUB_USER}'s repos with open "
+              f"dependabot PRs (#1839)...")
         repos = list_fleet_repos()
-        print(f"  Found {len(repos)} Poetry-based repo(s) to scan.")
+        print(f"  Found {len(repos)} repo(s) with open dependabot PRs.")
     else:
         repos = [args.repo]
 


### PR DESCRIPTION
Closes #1839

## Problem

Per martymcenroe/dependabot-honeypot#171: `--fleet` enumerated Poetry repos only, so pure-JS repos — Hermes(13), sextant(8), career(8), data-harvest(7), sentinel(6), Clio(5), ~47 of the fleet's 84 open dependabot PRs — were never processed. Meanwhile npm PRs in mixed repos (unleashed /das + /dashboard, chiron /web, Heuriskon, Aletheia) merged through the #1400 skip path with **no JS gate**, and the fixed approval text claimed "test suite passed (exit 0)" when no test had run.

## Changes

- **Per-PR gate selection** from a single `gh pr diff --name-only` call: Python-relevant files run the existing poetry/pytest gate; touched `package.json`/npm lockfiles run the new JS gate; PRs touching neither (docker, actions) skip per #1400. A grouped PR touching both ecosystems must pass both.
- **JS gate, per touched manifest directory** (fleet npm manifests are mostly subdirs): `npm ci` when an npm lockfile exists (never writes the lockfile), else `npm install --no-package-lock` (yarn/pnpm repos, no untracked lockfile generated); then `npm test`, gated on exit code. **No runnable test script → defer** — do not auto-merge unverified (per the honeypot issue's point 4; npm-init's "no test specified" placeholder counts as no script). Defer-once semantics via #1838.
- **`node_modules` removed on every exit path** — `git worktree remove` (no `--force`) refuses on untracked files; Windows readonly handler included. npm resolved via `shutil.which` (npm.cmd is not CreateProcess-resolvable).
- **Fleet enumeration**: repos with ≥1 open dependabot PR (`gh search prs`) ∩ non-archived/non-fork owned repos, sorted for deterministic ordering. The pyproject probe (one API call per repo) is retired.
- **Truthful attestation**: `approve_pr` takes a `gate_desc` naming what actually ran ("pytest passed (exit 0)", "npm test passed (exit 0) in 'dashboard'", "gates skipped (#1400)"); deferral reviews name the specific failing gate.

## Tests

27 new tests: manifest-dir predicate, test-script detection (incl. npm-init placeholder), JS gate matrix (ci vs install fallback, failure paths, subdir cwd, node_modules cleanup on success AND failure, #1415 env stripping), flow-level gate selection (npm-only, grouped both-gates, python-failure short-circuit, defer-with-reason), search-based enumeration, and the gate-desc attestation. Full file: 109 passed. `ruff check` clean.

## Companions

- Prerequisite already on main: #1838 (unchanged-head deferral skip — JS repos without test scripts defer once, not daily).
- dependabot-honeypot needs its exit-0 test script before the next drain (martymcenroe/dependabot-honeypot#207) or its npm wedge defers.
