### PR TITLE
test(dependabot): key-set assertion learns skipped_unchanged (Closes #1850)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -937,4 +937,6 @@ class TestProcessRepoWithBudget:
             dependabot_review, "list_dependabot_prs", lambda repo: [],
         )
         sub = dependabot_review.process_repo("o/r", tmp_path)
-        assert set(sub) == {"merged", "deferred", "errored", "limit_skipped"}
+        assert set(sub) == {
+            "merged", "deferred", "errored", "limit_skipped", "skipped_unchanged",
+        }


### PR DESCRIPTION
Main CI went red at a232125c: PR #1840 added the skipped_unchanged key to dependabot_review's per-repo result dict but the exact-key-set test was not updated. The key is deliberate contract — initialized on every return path and iterated by both aggregators — so the assertion gains the key. 43/43 module tests pass locally. Every PR since a232125c inherits the failure through its merge ref; this restores a green baseline.

Closes #1850