### PR TITLE
feat(_pat_session): announce which secret pinentry wants (Closes #1853)

### DIFF
--- a/docs/adrs/0216-in-process-classic-pat-decryption.md
+++ b/docs/adrs/0216-in-process-classic-pat-decryption.md
@@ -39,7 +39,14 @@ The remaining attack surface is essentially: an attacker with `ptrace` privilege
 
 Concretely, the rule:
 
-- The PAT is decrypted by `subprocess.run(["gpg", "--quiet", "--decrypt", str(pat_path)], ...)` inside the calling Python process. `gpg-agent` prompts for the passphrase on first call (then caches per its TTL).
+- The PAT is decrypted by `subprocess.run(["gpg", "--quiet", "--decrypt", str(pat_path)], ...)` inside the calling Python process. `gpg-agent` prompts for the passphrase on **every** call — caching is a hard precondition to have DISABLED (`default-cache-ttl 0`, `max-cache-ttl 0`; see section 5 and the module docstring). While a passphrase is cached, any same-user sibling process can silently decrypt the file, which dissolves this ADR's central guarantee. An earlier revision of this line read "then caches per its TTL", which contradicted that requirement and is corrected here (#1853).
+- **Every decrypt announces its purpose on the console before pinentry appears** (#1853). The operator holds several distinct passphrases, and gpg's pinentry dialog names neither the secret nor the operation — so an unannounced prompt is ambiguous, and a wrong guess burns a retry. `_announce_decrypt()` prints the secret's human name, its path, the caller's stated reason, and the attempt counter to stderr immediately before each `gpg` invocation. Callers SHOULD pass `reason=` describing what the elevated scope is for on that run:
+
+  ```python
+  with classic_pat_session(reason="land Seshat CI workflow") as pat:
+  ```
+
+  The console is the load-bearing surface here, not the dialog: gpg symmetric decryption offers no dependable lever on pinentry's own text. The banner carries the secret's NAME only and must never carry secret material — `tests/tools/test_pat_session.py` asserts this.
 - The decrypted PAT is yielded as a local variable inside a context-manager scope (`with ... as pat:`).
 - The caller passes `pat` into `requests`/`pygithub` calls directly. **Never set `os.environ["GH_TOKEN"] = pat`. Never pass the PAT via subprocess argv. Never log it.**
 - When the `with` block exits, the local binding is `del`'d. (Python strings are immutable, so this is symbolic — the bytes may persist in the heap until garbage collection. The primary protection is process scope: the OS reclaims the address space when the script exits.)

--- a/tests/tools/test_pat_session.py
+++ b/tests/tools/test_pat_session.py
@@ -152,3 +152,137 @@ class TestClassicPatSession:
     def test_default_path_is_secrets_dir(self):
         assert _pat_session.DEFAULT_PAT_PATH.name == "classic-pat.gpg"
         assert _pat_session.DEFAULT_PAT_PATH.parent.name == ".secrets"
+
+
+class TestDecryptAnnouncement:
+    """Issue #1853. The operator holds several distinct passphrases and
+    pinentry's dialog names neither the secret nor the operation, so each
+    decrypt must announce itself on the console FIRST."""
+
+    def test_announce_names_secret_path_and_reason(self, capsys):
+        _pat_session._announce_decrypt(
+            _pat_session.SECRET_CLASSIC_PAT,
+            Path("/x/classic-pat.gpg"),
+            "land Seshat CI workflow",
+            1,
+            5,
+        )
+        err = capsys.readouterr().err
+        assert _pat_session.SECRET_CLASSIC_PAT in err
+        assert "classic-pat.gpg" in err
+        assert "land Seshat CI workflow" in err
+        assert "1 of 5" in err
+
+    def test_announce_omits_reason_line_when_unstated(self, capsys):
+        _pat_session._announce_decrypt(
+            _pat_session.SECRET_CLASSIC_PAT, Path("/x/a.gpg"), None, 1, 5
+        )
+        assert "used for" not in capsys.readouterr().err
+
+    def test_announce_is_ascii_only(self, capsys):
+        """Prints into Git Bash, cmd, and Windows Terminal — box-drawing
+        characters do not survive all three."""
+        _pat_session._announce_decrypt(
+            _pat_session.SECRET_CERBERUS_PEM, Path("/x/a.gpg"), "rotate", 2, 5
+        )
+        capsys.readouterr().err.encode("ascii")  # raises if non-ASCII
+
+    def test_announce_goes_to_stderr_not_stdout(self, capsys):
+        _pat_session._announce_decrypt(
+            _pat_session.SECRET_CLASSIC_PAT, Path("/x/a.gpg"), "r", 1, 5
+        )
+        captured = capsys.readouterr()
+        assert captured.out == "", "banner must not pollute stdout — callers pipe it"
+        assert _pat_session.SECRET_CLASSIC_PAT in captured.err
+
+    def test_announce_happens_before_gpg_runs(self, tmp_path, monkeypatch):
+        """The whole point: the operator must know which passphrase is wanted
+        BEFORE pinentry appears, not after."""
+        order: list[str] = []
+        pat_file = tmp_path / "classic-pat.gpg"
+        pat_file.write_bytes(b"fake gpg blob")
+
+        monkeypatch.setattr(
+            _pat_session,
+            "_announce_decrypt",
+            lambda *a, **k: order.append("announce"),
+        )
+        monkeypatch.setattr(
+            _pat_session.subprocess,
+            "run",
+            lambda *a, **k: (
+                order.append("gpg"),
+                _make_completed_process(stdout=FAKE_PAT),
+            )[1],
+        )
+
+        with _pat_session.classic_pat_session(pat_file):
+            pass
+
+        assert order == ["announce", "gpg"]
+
+    def test_banner_never_contains_the_secret(self, tmp_path, monkeypatch, capsys):
+        pat_file = tmp_path / "classic-pat.gpg"
+        pat_file.write_bytes(b"fake gpg blob")
+        monkeypatch.setattr(
+            _pat_session.subprocess,
+            "run",
+            mock.Mock(return_value=_make_completed_process(stdout=FAKE_PAT)),
+        )
+
+        with _pat_session.classic_pat_session(pat_file, reason="a run"):
+            pass
+
+        captured = capsys.readouterr()
+        assert FAKE_PAT not in captured.err
+        assert FAKE_PAT not in captured.out
+
+    def test_retry_announces_each_attempt_with_counter(self, tmp_path, monkeypatch, capsys):
+        pat_file = tmp_path / "classic-pat.gpg"
+        pat_file.write_bytes(b"fake gpg blob")
+        monkeypatch.setattr(
+            _pat_session.subprocess,
+            "run",
+            mock.Mock(return_value=_make_completed_process(stderr="bad passphrase", returncode=2)),
+        )
+
+        with pytest.raises(RuntimeError):
+            with _pat_session.classic_pat_session(pat_file):
+                pass
+
+        err = capsys.readouterr().err
+        for n in range(1, _pat_session.MAX_GPG_ATTEMPTS + 1):
+            assert f"{n} of {_pat_session.MAX_GPG_ATTEMPTS}" in err
+
+    def test_each_session_names_its_own_secret(self, tmp_path, monkeypatch, capsys):
+        """A shared banner that always said 'PAT' would defeat the purpose."""
+        monkeypatch.setattr(
+            _pat_session.subprocess,
+            "run",
+            mock.Mock(return_value=_make_completed_process(stdout="payload")),
+        )
+        cases = [
+            (_pat_session.cerberus_pem_session, "cerberus-pem.gpg", _pat_session.SECRET_CERBERUS_PEM),
+            (_pat_session.pr_sentinel_app_session, "pr-sentinel-app.gpg", _pat_session.SECRET_PR_SENTINEL_APP),
+        ]
+        for fn, filename, expected in cases:
+            f = tmp_path / filename
+            f.write_bytes(b"fake gpg blob")
+            with fn(f):
+                pass
+            err = capsys.readouterr().err
+            assert expected in err
+            assert _pat_session.SECRET_CLASSIC_PAT not in err
+
+    def test_reason_is_backward_compatible_keyword(self, tmp_path, monkeypatch):
+        """Existing callers pass only the path positionally; adding `reason`
+        must not break them."""
+        monkeypatch.setattr(
+            _pat_session.subprocess,
+            "run",
+            mock.Mock(return_value=_make_completed_process(stdout=FAKE_PAT)),
+        )
+        pat_file = tmp_path / "classic-pat.gpg"
+        pat_file.write_bytes(b"fake gpg blob")
+        with _pat_session.classic_pat_session(pat_file) as pat:
+            assert pat == FAKE_PAT

--- a/tools/_pat_session.py
+++ b/tools/_pat_session.py
@@ -55,10 +55,59 @@ DEFAULT_PR_SENTINEL_APP_PATH: Path = Path.home() / ".secrets" / "pr-sentinel-app
 GPG_TIMEOUT_S: int = 180
 MAX_GPG_ATTEMPTS: int = 5
 
+# Human names for each secret this module decrypts (#1853). The operator holds
+# several DISTINCT passphrases; gpg's pinentry dialog names neither the secret
+# nor the operation, so without an announcement the prompt is ambiguous and a
+# wrong guess burns a retry. These are display strings only -- never secret
+# material.
+SECRET_CLASSIC_PAT: str = "GitHub classic PAT (admin scope)"
+SECRET_CERBERUS_PEM: str = "Cerberus App private key (PEM)"
+SECRET_PR_SENTINEL_APP: str = "pr-sentinel App credential (App ID + PEM)"
+
+
+def _announce_decrypt(
+    secret_name: str,
+    path: Path,
+    reason: str | None,
+    attempt: int,
+    max_attempts: int,
+) -> None:
+    """Print to stderr WHICH secret pinentry is about to ask for (#1853).
+
+    The console is the reliable surface for this: gpg symmetric decryption
+    offers no dependable lever on the pinentry dialog's own text, so the
+    operator's cue has to arrive before the dialog appears.
+
+    Deliberately ASCII-only -- this prints into Git Bash, cmd, and Windows
+    Terminal, and box-drawing characters do not survive all three.
+
+    Receives and prints only the secret's NAME, its path, and the caller's
+    stated reason. Never secret material.
+
+    Args:
+        secret_name: One of the SECRET_* display constants above.
+        path: The encrypted file about to be decrypted.
+        reason: Caller's description of what the elevated scope is for on
+            this run, e.g. "land Seshat CI workflow". None if unstated.
+        attempt: 1-based attempt counter.
+        max_attempts: Total attempts before giving up.
+    """
+    bar = "=" * 64
+    print(bar, file=sys.stderr)
+    print("PASSPHRASE NEEDED -- pinentry is about to prompt", file=sys.stderr)
+    print(f"  secret   : {secret_name}", file=sys.stderr)
+    print(f"  file     : {path}", file=sys.stderr)
+    if reason:
+        print(f"  used for : {reason}", file=sys.stderr)
+    if max_attempts > 1:
+        print(f"  attempt  : {attempt} of {max_attempts}", file=sys.stderr)
+    print(bar, file=sys.stderr)
+
 
 @contextmanager
 def classic_pat_session(
     pat_path: Path = DEFAULT_PAT_PATH,
+    reason: str | None = None,
 ) -> Iterator[str]:
     """Yield the gpg-decrypted classic PAT.
 
@@ -69,6 +118,10 @@ def classic_pat_session(
 
     Args:
         pat_path: Path to the gpg-encrypted PAT file.
+        reason: What the elevated scope is for on this run, e.g.
+            "land Seshat CI workflow". Printed on the pre-prompt banner so
+            the operator can tell which of several passphrases pinentry is
+            asking for (#1853).
 
     Yields:
         The decrypted PAT as a string. Lives only in this generator's scope.
@@ -93,6 +146,7 @@ def classic_pat_session(
 
     last_stderr = ""
     for attempt in range(1, MAX_GPG_ATTEMPTS + 1):
+        _announce_decrypt(SECRET_CLASSIC_PAT, pat_path, reason, attempt, MAX_GPG_ATTEMPTS)
         result = subprocess.run(
             ["gpg", "--quiet", "--decrypt", str(pat_path)],
             capture_output=True,
@@ -126,6 +180,7 @@ def classic_pat_session(
 @contextmanager
 def cerberus_pem_session(
     pem_path: Path = DEFAULT_CERBERUS_PEM_PATH,
+    reason: str | None = None,
 ) -> Iterator[str]:
     """Yield the gpg-decrypted Cerberus App private-key PEM.
 
@@ -161,6 +216,9 @@ def cerberus_pem_session(
 
     Args:
         pem_path: Path to the gpg-encrypted Cerberus PEM file.
+        reason: What this decrypt is for on this run. Printed on the
+            pre-prompt banner so the operator can tell which of several
+            passphrases pinentry is asking for (#1853).
 
     Yields:
         The decrypted PEM as a string. Lives only in this generator's
@@ -189,6 +247,7 @@ def cerberus_pem_session(
 
     last_stderr = ""
     for attempt in range(1, MAX_GPG_ATTEMPTS + 1):
+        _announce_decrypt(SECRET_CERBERUS_PEM, pem_path, reason, attempt, MAX_GPG_ATTEMPTS)
         result = subprocess.run(
             ["gpg", "--quiet", "--decrypt", str(pem_path)],
             capture_output=True,
@@ -222,6 +281,7 @@ def cerberus_pem_session(
 @contextmanager
 def pr_sentinel_app_session(
     bundle_path: Path = DEFAULT_PR_SENTINEL_APP_PATH,
+    reason: str | None = None,
 ) -> Iterator[str]:
     """Yield the gpg-decrypted pr-sentinel App credential bundle.
 
@@ -249,6 +309,9 @@ def pr_sentinel_app_session(
 
     Args:
         bundle_path: Path to the gpg-encrypted credential bundle.
+        reason: What this permission boost is for on this run. Printed on
+            the pre-prompt banner so the operator can tell which of several
+            passphrases pinentry is asking for (#1853).
 
     Yields:
         Decrypted bundle text (App ID line + PEM). Deleted on exit.
@@ -275,6 +338,7 @@ def pr_sentinel_app_session(
 
     last_stderr = ""
     for attempt in range(1, MAX_GPG_ATTEMPTS + 1):
+        _announce_decrypt(SECRET_PR_SENTINEL_APP, bundle_path, reason, attempt, MAX_GPG_ATTEMPTS)
         result = subprocess.run(
             ["gpg", "--quiet", "--decrypt", str(bundle_path)],
             capture_output=True,


### PR DESCRIPTION
The operator holds several distinct passphrases across the gpg-encrypted secrets this module handles. gpg's pinentry dialog names neither the secret nor the operation, so the prompt was ambiguous — and a wrong guess burns a retry.

## What it looks like now

```
================================================================
PASSPHRASE NEEDED -- pinentry is about to prompt
  secret   : GitHub classic PAT (admin scope)
  file     : C:\Users\mcwiz\.secrets\classic-pat.gpg
  used for : land the CI workflow in <owner>/<repo>
  attempt  : 1 of 5
================================================================
```

Printed to stderr immediately **before** each gpg invocation, in all three session functions. Callers pass `reason=` to state what the elevated scope is for on that run.

The console is the load-bearing surface here, not the dialog: gpg symmetric decryption offers no dependable lever on pinentry's own text, so the cue has to arrive before the dialog appears.

## Respecting the module's conventions

`_pat_session.py` states that its three decrypt loops deliberately duplicate rather than share an implementation, because keeping the load-bearing PAT path untouched is worth the duplication. The announcement is therefore an **additive printer** called from each body — not a refactor of the decrypt loops.

`reason` is a keyword argument with a default. Every existing caller (`deploy_cerberus_secrets.py`, `new_repo.py` ×2) passes only the path positionally, so this is backward compatible.

## ADR correction

ADR-0216 section 3 said gpg-agent "prompts for the passphrase on first call (then caches per its TTL)". That contradicted the ADR's own hard precondition of `default-cache-ttl 0` — while a passphrase is cached, any same-user sibling process can silently decrypt the file, which dissolves the central guarantee. Corrected, and the announcement rule documented alongside it.

## Tests

10 new, 18 total in the file, all passing. Beyond the happy path they assert that the banner:

- precedes the gpg call (ordering spy, not inference)
- goes to stderr, never stdout
- stays ASCII — it prints into Git Bash, cmd, and Windows Terminal, and box-drawing characters do not survive all three
- names a **different** secret per function (a shared banner that always said "PAT" would defeat the purpose)
- **never contains secret material**

ruff: clean

Closes #1853