### PR TITLE
fix(speedrun_reset): sweep -lld worktree + relocate leftover artifacts (Closes #1848, Closes #1849)

### DIFF
--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -23,6 +23,7 @@ from speedrun_reset import (
     close_open_prs,
     current_branch,
     delete_local_branches,
+    relocate_lld_artifacts,
     remove_worktree,
     worktree_is_dirty,
 )
@@ -173,6 +174,109 @@ class TestWorktreeSweepPreservesWork:
         repo = tmp_path / "repo"
         repo.mkdir()
         assert remove_worktree(repo, 1234) is False
+
+    def test_lld_worktree_is_swept_too(self, tmp_path, capsys):
+        """#1848: the requirements workflow's -lld worktree is also debris."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        lld_worktree = tmp_path / "repo-1234-lld"
+        lld_worktree.mkdir()
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            assert remove_worktree(repo, 1234) is True
+
+        removed_paths = [
+            cmd[3] for cmd in calls if cmd[:3] == ["git", "worktree", "remove"]
+        ]
+        assert str(lld_worktree) in removed_paths
+
+    def test_both_worktrees_swept_in_one_call(self, tmp_path):
+        """#1848: base and -lld worktrees both targeted."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (tmp_path / "repo-1234").mkdir()
+        (tmp_path / "repo-1234-lld").mkdir()
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            assert remove_worktree(repo, 1234) is True
+
+        removed_paths = [
+            cmd[3] for cmd in calls if cmd[:3] == ["git", "worktree", "remove"]
+        ]
+        assert str(tmp_path / "repo-1234") in removed_paths
+        assert str(tmp_path / "repo-1234-lld") in removed_paths
+
+
+class TestArtifactRelocation:
+    """#1849: untracked LLD/spec artifacts must leave the docs/lld tree."""
+
+    def _make_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / "docs" / "lld" / "active").mkdir(parents=True)
+        (repo / "docs" / "lld" / "drafts").mkdir(parents=True)
+        return repo
+
+    def test_untracked_artifacts_relocated(self, tmp_path, capsys):
+        repo = self._make_repo(tmp_path)
+        lld = repo / "docs" / "lld" / "active" / "LLD-007.md"
+        lld.write_text("# LLD", encoding="utf-8")
+        spec = repo / "docs" / "lld" / "drafts" / "spec-0007-implementation-readiness.md"
+        spec.write_text("# spec", encoding="utf-8")
+
+        # git ls-files --error-unmatch: nonzero == untracked
+        with patch("speedrun_reset._run", return_value=_completed(returncode=1)):
+            moved = relocate_lld_artifacts(repo, 7)
+
+        assert moved == 2
+        dest = repo / "data" / "speedrun" / "reset-artifacts" / "issue-7"
+        assert (dest / "LLD-007.md").exists()
+        assert (dest / "spec-0007-implementation-readiness.md").exists()
+        assert not lld.exists()
+        assert not spec.exists()
+        # emptied drafts dir is itself debris
+        assert not (repo / "docs" / "lld" / "drafts").exists()
+
+    def test_tracked_artifact_left_alone(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+        lld = repo / "docs" / "lld" / "active" / "LLD-007.md"
+        lld.write_text("# LLD", encoding="utf-8")
+
+        # git ls-files --error-unmatch: zero == tracked, deliberate content
+        with patch("speedrun_reset._run", return_value=_completed(returncode=0)):
+            moved = relocate_lld_artifacts(repo, 7)
+
+        assert moved == 0
+        assert lld.exists()
+
+    def test_no_artifacts_is_not_an_error(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+        with patch("speedrun_reset._run", return_value=_completed(returncode=1)):
+            assert relocate_lld_artifacts(repo, 7) == 0
+
+    def test_collision_gets_numeric_suffix(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+        lld = repo / "docs" / "lld" / "active" / "LLD-007.md"
+        lld.write_text("# second run", encoding="utf-8")
+        dest_dir = repo / "data" / "speedrun" / "reset-artifacts" / "issue-7"
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "LLD-007.md").write_text("# first run", encoding="utf-8")
+
+        with patch("speedrun_reset._run", return_value=_completed(returncode=1)):
+            moved = relocate_lld_artifacts(repo, 7)
+
+        assert moved == 1
+        assert (dest_dir / "LLD-007.1.md").read_text(encoding="utf-8") == "# second run"
+        assert (dest_dir / "LLD-007.md").read_text(encoding="utf-8") == "# first run"
 
 
 class TestPrEnumerationIsBaseAgnostic:

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -4,11 +4,16 @@
 Performs the cleanup needed between attempts:
 
   1. Closes any open PR for the issue (without merging).
-  2. Removes the worktree at `{repo}-{issue}` if it exists.
+  2. Removes the worktrees at `{repo}-{issue}` and `{repo}-{issue}-lld`
+     if they exist (#1848).
   3. Deletes the local feature branch (safe-delete).
   4. Deletes `docs/lineage/active/{issue}-*/` directories.
-  5. Reopens the issue if it was closed.
-  6. Prints "spawn state restored" on success.
+  5. Relocates untracked LLD/spec artifacts out of the target repo's
+     docs/lld tree into `data/speedrun/reset-artifacts/` (#1849) — left
+     in place they make the next run resolve existing artifacts and
+     silently skip design generation.
+  6. Reopens the issue if it was closed.
+  7. Prints "spawn state restored" on success.
 
 Idempotent: safe to run multiple times. Each step is independently
 guarded — a missing PR / worktree / branch is not an error.
@@ -107,7 +112,24 @@ def worktree_is_dirty(worktree_path: Path) -> bool:
 
 def remove_worktree(repo_root: Path, issue: int) -> bool:
     """
-    Remove the worktree at `{repo}-{issue}` if it exists.
+    Remove the worktrees at `{repo}-{issue}` and `{repo}-{issue}-lld`.
+
+    The requirements workflow creates an `-lld` worktree alongside the
+    implementation worktree; both are pipeline debris after a cut take
+    (#1848). Returns True if at least one was removed.
+    """
+    parent = repo_root.parent
+    removed_any = False
+    for suffix in (f"{issue}", f"{issue}-lld"):
+        worktree_path = parent / f"{repo_root.name}-{suffix}"
+        if _remove_worktree_at(repo_root, worktree_path):
+            removed_any = True
+    return removed_any
+
+
+def _remove_worktree_at(repo_root: Path, worktree_path: Path) -> bool:
+    """
+    Remove one worktree directory if it exists.
 
     A CUT take leaves a half-finished worktree behind, and that worktree
     may hold uncommitted work. `git worktree remove` refuses in that case,
@@ -115,8 +137,6 @@ def remove_worktree(repo_root: Path, issue: int) -> bool:
     function never force-removes and never deletes a dirty directory. A
     worktree holding work is reported and left for the operator (#1762).
     """
-    parent = repo_root.parent
-    worktree_path = parent / f"{repo_root.name}-{issue}"
     if not worktree_path.exists():
         return False
 
@@ -230,6 +250,73 @@ def delete_lineage_dirs(repo_root: Path, issue: int) -> int:
     return deleted
 
 
+def _is_git_tracked(repo_root: Path, file_path: Path) -> bool:
+    """True when git tracks the file (deliberate repo content)."""
+    try:
+        rel = file_path.relative_to(repo_root)
+    except ValueError:
+        return False
+    result = _run(
+        ["git", "ls-files", "--error-unmatch", str(rel)], cwd=repo_root
+    )
+    return result.returncode == 0
+
+
+def relocate_lld_artifacts(repo_root: Path, issue: int) -> int:
+    """
+    Move untracked LLD/spec artifacts out of the target repo's docs tree.
+
+    The requirements/spec stages save `LLD-{NNN}.md` and `spec-{NNNN}-*.md`
+    into the target repo's primary checkout. Left in place, the next run
+    resolves them as existing artifacts and can silently skip design
+    generation — a wiped repo must not behave differently from a cold
+    start (#1849). The bytes are already preserved in the design PR's
+    commits, so working copies are relocated (never deleted) to
+    `data/speedrun/reset-artifacts/issue-{N}/` for inspection. Tracked
+    files are deliberate repo content and are left alone.
+    """
+    active = repo_root / "docs" / "lld" / "active"
+    drafts = repo_root / "docs" / "lld" / "drafts"
+    candidates: list[Path] = []
+    candidates.extend(active.glob(f"LLD-{issue:03d}.md"))
+    candidates.extend(active.glob(f"LLD-{issue}.md"))
+    candidates.extend(drafts.glob(f"spec-{issue:04d}-*.md"))
+    candidates.extend(drafts.glob(f"spec-{issue}-*.md"))
+
+    dest_dir = repo_root / "data" / "speedrun" / "reset-artifacts" / f"issue-{issue}"
+    seen: set[Path] = set()
+    moved = 0
+    for artifact in candidates:
+        if artifact in seen or not artifact.is_file():
+            continue
+        seen.add(artifact)
+        if _is_git_tracked(repo_root, artifact):
+            continue
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / artifact.name
+        counter = 1
+        while dest.exists():
+            dest = dest_dir / f"{artifact.stem}.{counter}{artifact.suffix}"
+            counter += 1
+        try:
+            shutil.move(str(artifact), str(dest))
+            print(
+                f"  Relocated artifact: {artifact.relative_to(repo_root)}"
+                f" -> {dest.relative_to(repo_root)}"
+            )
+            moved += 1
+        except OSError as e:
+            print(f"  WARNING: could not relocate {artifact}: {e}")
+
+    # An emptied drafts/ dir is itself pipeline debris; active/ keeps .gitkeep
+    try:
+        if drafts.exists() and not any(drafts.iterdir()):
+            drafts.rmdir()
+    except OSError:
+        pass
+    return moved
+
+
 def reopen_issue(repo: str, issue: int) -> bool:
     """Reopen the GitHub issue if it's currently closed."""
     result = _run([
@@ -257,12 +344,13 @@ def reopen_issue(repo: str, issue: int) -> bool:
 
 
 def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
-    """Run all six reset steps for one issue."""
+    """Run all reset steps for one issue."""
     print(f"\nResetting issue #{issue}:")
     close_open_prs(repo, issue)
     remove_worktree(repo_root, issue)
     delete_local_branches(repo_root, issue)
     delete_lineage_dirs(repo_root, issue)
+    relocate_lld_artifacts(repo_root, issue)
     reopen_issue(repo, issue)
 
 


### PR DESCRIPTION
Both gaps were found live during hardening runs 8 and 9 (boostgauge #96 campaign) and manually completed twice; this makes the wipe one command again.

- #1848: remove_worktree now sweeps {repo}-{issue} AND {repo}-{issue}-lld — the requirements workflow's design worktree was surviving every reset, pinning the {issue}-lld branch. Same guarded, never-forcing removal path for both (refactored to _remove_worktree_at; #1762 properties preserved and still pinned by the existing suite).
- #1849: new relocate_lld_artifacts step — untracked LLD-{NNN}.md / spec-{NNNN}-*.md left in the target repo's docs/lld tree are moved to data/speedrun/reset-artifacts/issue-{N}/ (never deleted; the bytes already live in the design PR's commits). Left in place they make the next run resolve existing artifacts and silently skip design generation, so a wiped repo behaves differently from the recorded take's cold start. Tracked files are deliberate content and are left alone; an emptied drafts/ dir is removed.

Tests: 8 new cases (both-worktrees sweep, -lld path, tracked-vs-untracked, collision suffix, empty-drafts removal); 18/18 module tests pass; ruff clean.

Closes #1848
Closes #1849