### PR TITLE
fix(spec-drafter): test assertions must trace to specified behavior (Closes #1860)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -104,6 +104,13 @@ separators. Compare pathlib.Path objects (path == Path.home() / ".app" / \
 "cfg.json"), never separator-laden strings — monkeypatching sys.platform \
 does NOT change pathlib's flavour, so on Windows str(path) renders with \
 backslashes and endswith("dir/file.json") can never pass (Issue #1841)
+- Every assertion in test code MUST trace to behavior this spec's own \
+requirements/behavior sections specify. NEVER assert side effects the \
+behavior sections do not name — e.g., if CLI flags are specified as \
+runtime precedence over the config file, do NOT assert that a CLI \
+override is persisted back to disk. An assertion without a specified \
+behavior behind it makes the spec self-contradictory and unwinnable \
+(Issue #1860)
 
 STRUCTURE:
 Follow the provided template exactly. Include ALL sections. \

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -3248,3 +3248,12 @@ class TestDrafterSystemPrompt:
 
         assert "platform-independent" in DRAFTER_SYSTEM_PROMPT
         assert "sys.platform" in DRAFTER_SYSTEM_PROMPT
+
+    def test_assertion_traceability_requirement_present(self):
+        """Issue #1860: spec test assertions must trace to specified behavior."""
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            DRAFTER_SYSTEM_PROMPT,
+        )
+
+        assert "MUST trace" in DRAFTER_SYSTEM_PROMPT
+        assert "side effects" in DRAFTER_SYSTEM_PROMPT


### PR DESCRIPTION
Hardening run 10 halted at impl 33/34: the spec's test section asserted CLI overrides persist to disk while the spec's own behavior sections (and boostgauge#7's acceptance criteria) specify runtime precedence only — a self-contradiction no implementation can satisfy. Second spec-test defect class in three runs (sibling of #1841's platform assertions).

Fix: DRAFTER_SYSTEM_PROMPT quality requirement — every test assertion must trace to behavior the spec's own requirements/behavior sections specify; never assert unspecified side effects. Prompt-content test added; 200/200 module tests pass.

Closes #1860