### PR TITLE
fix(speedrun_reset): branch sweep also matches issue-{N} (Closes #1862)

### DIFF
--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -87,11 +87,12 @@ class TestBranchSweepIsAttemptBranchAware:
         assert "7-lld" in deleted_branches
 
     def test_attempt_branch_does_not_match_the_issue_glob(self, tmp_path):
-        """Enumeration is scoped to `{issue}-*`; `attempt-test-1` is not swept."""
+        """Enumeration is scoped to `{issue}-*` and `issue-{N}` (#1862);
+        `attempt-test-1` is not swept."""
         with patch("speedrun_reset._run", return_value=_completed(stdout="")) as run:
             delete_local_branches(tmp_path, 1234)
         listing = run.call_args_list[0].args[0]
-        assert listing == ["git", "branch", "--list", "1234-*"]
+        assert listing == ["git", "branch", "--list", "1234-*", "issue-1234"]
 
     def test_unmerged_branch_is_left_alone_without_suggesting_force_delete(
         self, tmp_path, capsys

--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -64,6 +64,28 @@ class TestBranchSweepIsAttemptBranchAware:
         deletions = [c for c in calls if c[:3] == ["git", "branch", "-d"]]
         assert deletions == [["git", "branch", "-d", "1234-lld"]]
 
+    def test_impl_branch_issue_n_is_swept(self, tmp_path):
+        """#1862: the pipeline's issue-{N} impl branch is a candidate too."""
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="  issue-7\n  7-lld\n")
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _completed(stdout="hardening-run-11\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            deleted = delete_local_branches(tmp_path, 7)
+
+        assert deleted == 2
+        list_call = next(c for c in calls if c[:3] == ["git", "branch", "--list"])
+        assert "issue-7" in list_call
+        deleted_branches = [c[3] for c in calls if c[:3] == ["git", "branch", "-d"]]
+        assert "issue-7" in deleted_branches
+        assert "7-lld" in deleted_branches
+
     def test_attempt_branch_does_not_match_the_issue_glob(self, tmp_path):
         """Enumeration is scoped to `{issue}-*`; `attempt-test-1` is not swept."""
         with patch("speedrun_reset._run", return_value=_completed(stdout="")) as run:

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -190,15 +190,17 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
     """
     Safe-delete the pipeline branches for one issue. Returns count deleted.
 
-    Only `{issue}-*` branches are candidates — the per-stage work branches
-    the pipeline creates. The attempt branch itself (the integration branch
-    every pipeline PR targets under the #1755 model) is named for the
-    attempt, not the issue, so it never matches. The checked-out branch is
-    additionally excluded by name, so a reset can never delete the very
-    branch the attempt is standing on (#1762).
+    Candidates are the per-stage work branches the pipeline creates:
+    `{issue}-*` (e.g. `7-lld`) and the implementation branch `issue-{N}`
+    (e.g. `issue-7`, missed by the glob alone — #1862). The attempt branch
+    itself (the integration branch every pipeline PR targets under the
+    #1755 model) is named for the attempt, not the issue, so it never
+    matches. The checked-out branch is additionally excluded by name, so a
+    reset can never delete the very branch the attempt is standing on
+    (#1762).
     """
     result = _run(
-        ["git", "branch", "--list", f"{issue}-*"],
+        ["git", "branch", "--list", f"{issue}-*", f"issue-{issue}"],
         cwd=repo_root,
     )
     if result.returncode != 0:


### PR DESCRIPTION
Live evidence from runs 8-10 wipes: the pipeline's implementation branch is named issue-{N}, but the sweep listed only '{issue}-*' — so 7-lld was matched while issue-7 survived every reset and needed manual graveyard-renaming three times. The listing now includes 'issue-{issue}' exactly; checked-out-branch exclusion and safe-delete-only behavior (#1762) unchanged, and the suite's exact-listing assertion updated to the new contract. 19/19 module tests pass; ruff clean.

Closes #1862