### PR TITLE
fix(completeness): declaration-baseline subtraction for dead-flag string check (Closes #1864)

### DIFF
--- a/assemblyzero/workflows/testing/completeness/ast_analyzer.py
+++ b/assemblyzero/workflows/testing/completeness/ast_analyzer.py
@@ -233,8 +233,11 @@ def analyze_dead_cli_flags(
     except SyntaxError:
         return issues
 
-    # Phase 1: Find all add_argument calls and their flag names
+    # Phase 1: Find all add_argument calls, their flag names, and each
+    # call's own source segment. Occurrences of a flag name inside any
+    # declaration segment are declaration context, not consumption (#1864).
     declared_flags: list[tuple[str, int]] = []  # (flag_name, line_number)
+    decl_segments: list[str] = []  # lowercased add_argument call sources
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -242,6 +245,9 @@ def analyze_dead_cli_flags(
         # Match pattern: *.add_argument(...)
         if isinstance(node.func, ast.Attribute) and node.func.attr == "add_argument":
             flag_names = _extract_argparse_flag_names(node)
+            if flag_names:
+                segment = ast.get_source_segment(source_code, node) or ""
+                decl_segments.append(segment.lower())
             for flag_name in flag_names:
                 declared_flags.append((flag_name, node.lineno))
 
@@ -273,13 +279,19 @@ def analyze_dead_cli_flags(
         ):
             flag_referenced = True
 
-        # Check string references (getattr(args, 'flag_name'))
+        # Check string references (getattr(args, 'flag_name')). Baseline
+        # subtraction, not a fixed threshold (#1864): a hyphen-declared flag
+        # ('--no-topmost' -> dest no_topmost) never spells its normalized
+        # name in the declaration, so ANY occurrence outside declaration
+        # segments is consumption evidence — while an underscore-declared
+        # unconsumed flag's own declaration occurrence subtracts to zero.
         if not flag_referenced:
-            # Count occurrences - if more than just the declaration, it's used
-            occurrences = source_lower.count(flag_name.lower())
+            flag_lower = flag_name.lower()
+            decl_occ = sum(seg.count(flag_lower) for seg in decl_segments)
+            outside = source_lower.count(flag_lower) - decl_occ
             if corpus_text:
-                occurrences = max(occurrences, corpus_text.count(flag_name.lower()))
-            if occurrences > 1:
+                outside = max(outside, corpus_text.count(flag_lower) - decl_occ)
+            if outside > 0:
                 flag_referenced = True
 
         if not flag_referenced:

--- a/tests/unit/test_completeness_gate.py
+++ b/tests/unit/test_completeness_gate.py
@@ -213,6 +213,60 @@ class TestDeadCLIFlags:
         issues = analyze_dead_cli_flags(source, "broken.py")
         assert issues == []
 
+    def test_hyphen_flag_consumed_via_getattr_same_file(self) -> None:
+        """Issue #1864: --no-topmost + getattr(args, 'no_topmost') is alive.
+
+        The declaration spells the hyphen form, so the single normalized
+        occurrence in getattr must count as consumption on its own.
+        """
+        source = textwrap.dedent("""\
+            import argparse
+
+            def build_parser():
+                parser = argparse.ArgumentParser()
+                parser.add_argument('--no-topmost', action='store_true')
+                return parser
+
+            def apply(parsed_args, config):
+                if getattr(parsed_args, 'no_topmost', False):
+                    config.always_on_top = False
+                return config
+        """)
+        issues = analyze_dead_cli_flags(source, "config.py")
+        assert issues == []
+
+    def test_hyphen_flag_never_consumed_still_flagged(self) -> None:
+        """Issue #1864: hyphen-declared flag with zero consumption stays dead."""
+        source = textwrap.dedent("""\
+            import argparse
+
+            def build_parser():
+                parser = argparse.ArgumentParser()
+                parser.add_argument('--no-topmost', action='store_true')
+                return parser
+        """)
+        issues = analyze_dead_cli_flags(source, "config.py")
+        assert len(issues) == 1
+        assert issues[0]["category"] == CompletenessCategory.DEAD_CLI_FLAG
+
+    def test_help_text_mention_does_not_rescue_dead_flag(self) -> None:
+        """Issue #1864: a mention inside another declaration's help string
+        is declaration context, not consumption."""
+        source = textwrap.dedent("""\
+            import argparse
+
+            def build_parser():
+                parser = argparse.ArgumentParser()
+                parser.add_argument('--orphan', action='store_true')
+                parser.add_argument('--other', help='overrides orphan behavior')
+                args = parser.parse_args()
+                print(args.other)
+                return parser
+        """)
+        issues = analyze_dead_cli_flags(source, "cli.py")
+        orphan = [i for i in issues if "orphan" in i["description"]]
+        assert len(orphan) == 1
+
     def test_cross_file_consumption_suppresses_issue(self) -> None:
         """Issue #1857: flag defined in cli.py, read in app.py — alive."""
         cli_source = textwrap.dedent("""\


### PR DESCRIPTION
Hardening run 11 (instrumented) died at the gate on a second false-positive shape: --no-topmost defined at config.py:215 and consumed at line 234 via getattr(parsed_args, 'no_topmost', False). The AST check only sees attribute accesses, and the string fallback's count>1 threshold assumes the declaration contributes one occurrence of the normalized name — false for hyphen-declared flags, whose declaration spells no-topmost. One real consumption therefore read as 'just the declaration'.

Fix: capture each add_argument call's own source segment and subtract its occurrences — referenced iff occurrences outside declaration segments > 0, applied to both the single-file source and the #1858 corpus text. Hyphen-declared + getattr-consumed is alive on a single occurrence; underscore-declared unconsumed subtracts to zero and stays dead; a mention in another declaration's help string rescues nothing.

Tests: three new cases pinning each of those properties (the first is run 11's exact shape); 66/66 module tests pass. Ruff: 3 pre-existing unused imports in the test file, none introduced.

Closes #1864