### PR TITLE
fix(impl-loop): skip-on-resume only on first pass — retries must regenerate (Closes #1842)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -272,6 +272,27 @@ def validate_files_to_modify(
     return errors
 
 
+def _should_skip_existing_file(
+    change_type: str, target_path: Path, iteration_count: int
+) -> bool:
+    """Issue #547 skip-on-resume, scoped by Issue #1842 to the first pass only.
+
+    Retry iterations (iteration_count > 0) exist to REWRITE files with the
+    test-failure feedback that build_single_file_prompt carries as
+    previous_error. The unscoped guard skipped every already-on-disk Add file,
+    so no retry ever called the model — N5 re-ran byte-identical files until
+    the stagnation detector halted the run (hardening runs 8/10/11, boostgauge
+    campaign 2026-07-28).
+    """
+    if iteration_count > 0:
+        return False
+    return (
+        change_type.lower() == "add"
+        and target_path.exists()
+        and target_path.stat().st_size > 0
+    )
+
+
 def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
     """N4: Generate implementation code file-by-file.
 
@@ -527,7 +548,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
 
         # Issue #547: Skip-on-resume — don't re-call Claude for files already on disk
         target_path = repo_root / filepath
-        if change_type.lower() == "add" and target_path.exists() and target_path.stat().st_size > 0:
+        if _should_skip_existing_file(change_type, target_path, iteration_count):
             existing_content = target_path.read_text(encoding="utf-8")
             print(f"        Skipped (already exists): {target_path}")
             completed_files.append((filepath, existing_content))

--- a/tests/unit/test_impl_skip_guard.py
+++ b/tests/unit/test_impl_skip_guard.py
@@ -1,0 +1,43 @@
+"""Issue #1842: the skip-on-resume guard must never fire on retry iterations.
+
+The #547 optimization skips Claude calls for Add files already on disk. On a
+test-failure retry every file is already on disk (iteration 0 wrote them), so
+the unscoped guard turned every retry into a no-op: previous_error was wired
+into the prompt but the prompt was never built, N5 re-ran identical files, and
+the stagnation detector halted the run. These tests pin the scoping.
+"""
+
+from assemblyzero.workflows.testing.nodes.implementation.orchestrator import (
+    _should_skip_existing_file,
+)
+
+
+class TestSkipOnResumeScoping:
+    def test_first_pass_skips_existing_file(self, tmp_path):
+        """Iteration 0 + file on disk = the #547 resume case. Skip."""
+        f = tmp_path / "config.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        assert _should_skip_existing_file("Add", f, iteration_count=0) is True
+
+    def test_retry_iteration_never_skips(self, tmp_path):
+        """Iteration >0 exists to rewrite files with failure feedback."""
+        f = tmp_path / "config.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        assert _should_skip_existing_file("Add", f, iteration_count=1) is False
+        assert _should_skip_existing_file("Add", f, iteration_count=2) is False
+
+    def test_first_pass_missing_file_not_skipped(self, tmp_path):
+        assert (
+            _should_skip_existing_file("Add", tmp_path / "new.py", iteration_count=0)
+            is False
+        )
+
+    def test_first_pass_empty_file_not_skipped(self, tmp_path):
+        f = tmp_path / "empty.py"
+        f.write_text("", encoding="utf-8")
+        assert _should_skip_existing_file("Add", f, iteration_count=0) is False
+
+    def test_modify_files_never_skipped(self, tmp_path):
+        f = tmp_path / "mod.py"
+        f.write_text("x = 1\n", encoding="utf-8")
+        assert _should_skip_existing_file("Modify", f, iteration_count=0) is False


### PR DESCRIPTION
Root cause found and verified for the campaign's dominant failure mode (runs 8, 10, and both 11-phase-2 rolls all stagnated at impl).

The #547 skip-on-resume guard skips the Claude call for any Add file already on disk. On iteration 0 no files exist; on every retry iteration ALL of them exist — iteration 0 just wrote them. So previous_error (correctly wired since #498) never reached a prompt: retry iterations called the model zero times, re-served identical files, N5 re-failed identically, and the stagnation detector halted the run. Run 8's log confirms: 25 'Skipped (already exists)' lines, and retry iteration 1 ran start-to-gate in the same second.

Fix: the guard is extracted to _should_skip_existing_file and scoped to iteration_count == 0 — the genuine crash-resume case #547 was built for. Retry iterations now rebuild every file with the failure summary in the prompt. Five unit tests pin the scoping (first-pass skip, retry never skips, missing/empty/Modify never skip). 53/53 across the new and orchestrator-stage suites; ruff: one pre-existing F541 in untouched code.

Closes #1842