### PR TITLE
fix(spec-workflow): honest failure propagation — no verdicts from failed LLM calls (Closes #1868, Closes #1869)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/graph.py
+++ b/assemblyzero/workflows/implementation_spec/graph.py
@@ -106,6 +106,29 @@ def route_after_analyze(
     return "N2_generate_spec"
 
 
+def route_after_generate_spec(
+    state: ImplementationSpecState,
+) -> Literal["N3_validate_completeness", "HALT"]:
+    """Route after N2: generate_spec.
+
+    Routes to:
+    - N3_validate_completeness: Draft generated
+    - HALT: Drafter LLM failed (Issue #1869 — the previous unconditional
+      edge let error_message ride through N3's vacuous pass into N5, which
+      reset it to "", severing the error chain and fueling the run-11
+      recursion loop)
+
+    Args:
+        state: Current workflow state.
+
+    Returns:
+        Next node name.
+    """
+    if state.get("error_message"):
+        return "HALT"
+    return "N3_validate_completeness"
+
+
 def route_after_validation(
     state: ImplementationSpecState,
 ) -> Literal["N4_human_gate", "N5_review_spec", "N2_generate_spec", "HALT"]:
@@ -326,8 +349,15 @@ def create_implementation_spec_graph() -> CompiledStateGraph:
         },
     )
 
-    # N2 -> N3 (always proceeds to validation after generation)
-    graph.add_edge(N2_GENERATE_SPEC, N3_VALIDATE_COMPLETENESS)
+    # N2 -> N3 or HALT (Issue #1869: drafter failure must not reach review)
+    graph.add_conditional_edges(
+        N2_GENERATE_SPEC,
+        route_after_generate_spec,
+        {
+            "N3_validate_completeness": N3_VALIDATE_COMPLETENESS,
+            "HALT": HALT,
+        },
+    )
 
     # N3 -> N4 or N5 or N2 or HALT (based on validation result and config)
     graph.add_conditional_edges(

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -91,11 +91,20 @@ def _invoke_reviewer_with_spec_schema(
     provider,
     prompt: str,
     system: str,
-) -> ReviewSpecResult:
+) -> tuple[ReviewSpecResult | None, str]:
     """Call spec reviewer with REVIEW_SPEC_SCHEMA and parse structured response.
 
     Issue #775: Uses response_schema for Gemini, json_schema for all other
     providers (including FallbackProvider which wraps ClaudeCLIProvider).
+
+    Issue #1868 / #1843: the payload lives on LLMCallResult.response — the
+    old `result.content` read a field that never existed, so every parse ran
+    against the stringified dataclass and fell back to regex. A failed call
+    or empty response returns (None, error): an infrastructure failure must
+    never be parsed into a verdict.
+
+    Returns:
+        (parsed result, "") on success; (None, error description) on failure.
     """
     from assemblyzero.core.llm_provider import GeminiProvider
 
@@ -106,8 +115,13 @@ def _invoke_reviewer_with_spec_schema(
         schema_kwargs["json_schema"] = REVIEW_SPEC_SCHEMA
 
     result = provider.invoke(system, prompt, **schema_kwargs)
-    raw = result.content if hasattr(result, "content") else str(result)
-    return parse_structured_review_spec(raw)
+    if not getattr(result, "success", False):
+        detail = getattr(result, "error_message", None) or "LLM call failed with no error detail"
+        return None, str(detail)
+    raw = getattr(result, "response", None) or ""
+    if not raw.strip():
+        return None, "LLM call returned an empty response"
+    return parse_structured_review_spec(raw), ""
 
 
 # =============================================================================
@@ -234,7 +248,7 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
     # provider, then parses via parse_structured_review_spec.
     # -------------------------------------------------------------------------
     cost_before = get_cumulative_cost()
-    spec_result = _invoke_reviewer_with_spec_schema(
+    spec_result, invoke_error = _invoke_reviewer_with_spec_schema(
         reviewer, review_content, REVIEWER_SYSTEM_PROMPT
     )
     node_cost_usd = get_cumulative_cost() - cost_before
@@ -247,10 +261,20 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         print(f"    {msg}")
         return {"error_message": msg}
 
-    response = ""  # Raw text no longer primary; structured result is authoritative
+    # Issue #1868: a failed call is an error, not a verdict — the old path
+    # laundered it into REVISE and the graph looped to the recursion limit.
+    if invoke_error or spec_result is None:
+        msg = f"Spec review LLM call failed: {invoke_error or 'no result'}"
+        print(f"    ERROR: {msg}")
+        return {"error_message": msg}
+
     verdict_status = spec_result["verdict"]
     if verdict_status == "UNKNOWN":
-        verdict_status = "REVISE"
+        # Issue #1868: unparseable review = review infrastructure failure.
+        # Synthesizing a REVISE from noise steered revise cycles blind.
+        msg = "Spec review response yielded no extractable verdict"
+        print(f"    ERROR: {msg}")
+        return {"error_message": msg}
     feedback = spec_result["rationale"]
     if not feedback and spec_result["feedback_items"]:
         feedback = "\n".join(f"- {item}" for item in spec_result["feedback_items"])

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -95,7 +95,9 @@ def _invoke_reviewer_with_feedback_schema(
         schema_kwargs["json_schema"] = FEEDBACK_SCHEMA
 
     result = provider.invoke(system, prompt, **schema_kwargs)
-    raw = result.content if hasattr(result, "content") else str(result)
+    # Issue #1843: the payload lives on .response — `.content` never existed,
+    # so parses ran against the stringified dataclass and always fell back.
+    raw = getattr(result, "response", None) or ""
     return parse_structured_feedback(raw)
 
 

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -3257,3 +3257,23 @@ class TestDrafterSystemPrompt:
 
         assert "MUST trace" in DRAFTER_SYSTEM_PROMPT
         assert "side effects" in DRAFTER_SYSTEM_PROMPT
+
+
+class TestRouteAfterGenerateSpec:
+    """Issue #1869: a drafter failure halts — it must not ride through N3's
+    vacuous pass into N5, which resets error_message and severs the chain."""
+
+    def test_error_routes_to_halt(self):
+        from assemblyzero.workflows.implementation_spec.graph import (
+            route_after_generate_spec,
+        )
+
+        state = {"error_message": "Drafter failed: All credentials failed"}
+        assert route_after_generate_spec(state) == "HALT"
+
+    def test_clean_state_routes_to_validation(self):
+        from assemblyzero.workflows.implementation_spec.graph import (
+            route_after_generate_spec,
+        )
+
+        assert route_after_generate_spec({}) == "N3_validate_completeness"

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -329,8 +329,7 @@ class TestReviewNode:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "All requirements met.", "feedback_items": [], "open_questions": []}),
-            response="## Verdict: APPROVED\n\nAll requirements met.",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "All requirements met.", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -370,8 +369,7 @@ class TestReviewNode:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
-            response="APPROVED",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -407,8 +405,7 @@ class TestReviewNode:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "REVISE", "rationale": "Missing tests", "feedback_items": ["Missing tests"], "open_questions": []}),
-            response="BLOCKED: Missing tests",
+            response=_json.dumps({"verdict": "REVISE", "rationale": "Missing tests", "feedback_items": ["Missing tests"], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -654,8 +651,7 @@ class TestReviewNodeAdditional:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "Issue looks good.", "feedback_items": [], "open_questions": []}),
-            response="[x] **APPROVED** - Issue looks good.",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "Issue looks good.", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -701,13 +697,12 @@ class TestReviewNodeAdditional:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({
+            response=_json.dumps({
                 "verdict": "REVISE",
                 "rationale": rationale_with_tier1,
                 "feedback_items": ["Missing required sections."],
                 "open_questions": [],
             }),
-            response="BLOCKED: Missing required sections.",
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -838,13 +833,12 @@ class TestReviewReviseToApprovedOnEmptyTier1:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({
+            response=_json.dumps({
                 "verdict": "REVISE",
                 "rationale": rationale_no_tier1,
                 "feedback_items": ["Missing logging strategy."],
                 "open_questions": [],
             }),
-            response="",
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -888,13 +882,12 @@ class TestReviewReviseToApprovedOnEmptyTier1:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({
+            response=_json.dumps({
                 "verdict": "REVISE",
                 "rationale": rationale_with_tier1,
                 "feedback_items": ["CLI writes to arbitrary absolute paths."],
                 "open_questions": [],
             }),
-            response="",
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -1817,8 +1810,7 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
-            response="APPROVED",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -1882,8 +1874,7 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=False,
-            content="",
-            response=None,
+            response="",
             error_message="API error",
         )
         mock_get_provider.return_value = mock_provider
@@ -1920,8 +1911,7 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
-            response="APPROVED",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -1955,8 +1945,7 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "DISCUSS", "rationale": "Need clarification on requirements", "feedback_items": ["Need clarification on requirements"], "open_questions": []}),
-            response="[x] **DISCUSS** - Need clarification on requirements",
+            response=_json.dumps({"verdict": "DISCUSS", "rationale": "Need clarification on requirements", "feedback_items": ["Need clarification on requirements"], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -1991,8 +1980,7 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "REVISE", "rationale": "Missing error handling section", "feedback_items": ["Missing error handling section"], "open_questions": []}),
-            response="[X] **REVISE** - Missing error handling section",
+            response=_json.dumps({"verdict": "REVISE", "rationale": "Missing error handling section", "feedback_items": ["Missing error handling section"], "open_questions": []}),
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -2026,7 +2014,6 @@ class TestReviewNodeCoverage:
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content="Some random response without clear verdict markers",
             response="Some random response without clear verdict markers",
             error_message=None,
             input_tokens=0,

--- a/tests/unit/test_review_spec_structured_output.py
+++ b/tests/unit/test_review_spec_structured_output.py
@@ -17,10 +17,18 @@ from assemblyzero.core.verdict_schema import (
 )
 
 
-def _make_mock_provider(response_content: str):
-    """Create a mock provider that returns the given content."""
-    mock_result = MagicMock()
-    mock_result.content = response_content
+def _make_mock_provider(response_content: str, success: bool = True, error_message: str = ""):
+    """Create a mock provider whose invoke returns an LLMCallResult-shaped result.
+
+    Issue #1868/#1843: the payload field is `.response` — the old mock set
+    `.content`, which a MagicMock happily grew, so tests passed while
+    production read a nonexistent field and stringified the dataclass.
+    Explicit spec'd fields keep the mock honest.
+    """
+    mock_result = MagicMock(spec=["success", "response", "error_message"])
+    mock_result.success = success
+    mock_result.response = response_content
+    mock_result.error_message = error_message
     mock_provider = MagicMock()
     mock_provider.invoke.return_value = mock_result
     return mock_provider
@@ -56,10 +64,49 @@ class TestInvokeReviewerWithSpecSchema:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["verdict"] == "APPROVED"
         assert result["rationale"] == "Spec is complete"
+        assert result["source"] == "structured"
+
+    def test_failed_call_returns_error_not_verdict(self):
+        """Issue #1868: LLM failure surfaces as (None, error) — never a verdict."""
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            _invoke_reviewer_with_spec_schema,
+        )
+
+        provider = _make_mock_provider(
+            "", success=False, error_message="agy exited 3221225794"
+        )
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        assert result is None
+        assert "3221225794" in err
+
+    def test_empty_response_returns_error_not_verdict(self):
+        """Issue #1868: an empty response is a failure, not a parseable verdict."""
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            _invoke_reviewer_with_spec_schema,
+        )
+
+        provider = _make_mock_provider("   ", success=True)
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        assert result is None
+        assert "empty" in err.lower()
+
+    def test_payload_read_from_response_field(self):
+        """Issue #1843: the payload is LLMCallResult.response — a result object
+        without a `content` attribute must still parse structured."""
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            _invoke_reviewer_with_spec_schema,
+        )
+
+        raw = json.dumps({"verdict": "APPROVED", "rationale": "ok", "feedback_items": []})
+        provider = _make_mock_provider(raw)
+        # spec'd mock has no .content — the old code would stringify it
+        assert not hasattr(provider.invoke.return_value, "content")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        assert err == ""
         assert result["source"] == "structured"
 
     def test_passes_json_schema_to_non_gemini_provider(self):
@@ -95,8 +142,10 @@ class TestInvokeReviewerWithSpecSchema:
             "rationale": "ok",
             "feedback_items": [],
         })
-        mock_result = MagicMock()
-        mock_result.content = raw
+        mock_result = MagicMock(spec=["success", "response", "error_message"])
+        mock_result.success = True
+        mock_result.response = raw
+        mock_result.error_message = ""
         gemini_provider = MagicMock(spec=GeminiProvider)
         gemini_provider.invoke.return_value = mock_result
 
@@ -117,7 +166,7 @@ class TestInvokeReviewerWithSpecSchema:
         raw = "[X] **APPROVED**\n\nRationale: Looks good"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["verdict"] == "APPROVED"
         assert result["source"] == "regex_fallback"
@@ -135,7 +184,7 @@ class TestInvokeReviewerWithSpecSchema:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["verdict"] == "REVISE"
         assert result["feedback_items"] == ["Add diff for section 6"]
@@ -153,7 +202,7 @@ class TestInvokeReviewerWithSpecSchema:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["verdict"] == "BLOCKED"
         assert result["source"] == "structured"
@@ -324,7 +373,7 @@ class TestReviewSpecResultPropagation:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["feedback_items"] == items
 
@@ -341,7 +390,7 @@ class TestReviewSpecResultPropagation:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "structured"
 
@@ -354,7 +403,7 @@ class TestReviewSpecResultPropagation:
         raw = "[X] **REVISE**\n\nRationale: missing tests"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "regex_fallback"
 
@@ -371,7 +420,7 @@ class TestReviewSpecResultPropagation:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["feedback_items"] == []
 
@@ -389,7 +438,7 @@ class TestFallbackBehavior:
         raw = "[X] **REVISE**\n\n## Required Changes\n- Fix error handling"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "regex_fallback"
         mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=review_spec")
@@ -407,22 +456,23 @@ class TestFallbackBehavior:
         })
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "structured"
 
-    def test_empty_response_returns_unknown_or_revise(self):
-        """Empty provider response returns fallback result."""
+    def test_empty_response_is_an_error_not_a_verdict(self):
+        """Issue #1868: an empty response no longer synthesizes a fallback
+        verdict — it surfaces as an invoke error so routing halts honestly."""
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             _invoke_reviewer_with_spec_schema,
         )
 
         provider = _make_mock_provider("")
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
-        assert result["source"] == "regex_fallback"
-        assert result["verdict"] in {"UNKNOWN", "REVISE"}
+        assert result is None
+        assert err != ""
 
     def test_feedback_items_extracted_via_fallback(self):
         """Feedback items extracted from markdown via regex fallback."""
@@ -438,7 +488,7 @@ class TestFallbackBehavior:
         )
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "regex_fallback"
         assert "Fix error handling" in result["feedback_items"]
@@ -458,7 +508,7 @@ class TestFallbackBehavior:
         )
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
         assert result["source"] == "regex_fallback"
         assert "Update section 6" in result["feedback_items"]

--- a/tests/unit/test_review_structured_output.py
+++ b/tests/unit/test_review_structured_output.py
@@ -16,9 +16,12 @@ from assemblyzero.core.verdict_schema import (
 
 
 def _make_mock_provider(response_content: str):
-    """Create a mock provider that returns the given content."""
-    mock_result = MagicMock()
-    mock_result.content = response_content
+    """Create a mock provider whose result carries the payload on .response
+    (the real LLMCallResult field — Issue #1843 mock-drift repair)."""
+    mock_result = MagicMock(spec=["success", "response", "error_message"])
+    mock_result.success = True
+    mock_result.response = response_content
+    mock_result.error_message = ""
     mock_provider = MagicMock()
     mock_provider.invoke.return_value = mock_result
     return mock_provider
@@ -103,8 +106,10 @@ class TestInvokeReviewerWithFeedbackSchema:
             "open_questions": [],
             "resolved_issues": [],
         })
-        mock_result = MagicMock()
-        mock_result.content = raw
+        mock_result = MagicMock(spec=["success", "response", "error_message"])
+        mock_result.success = True
+        mock_result.response = raw
+        mock_result.error_message = ""
         gemini_provider = MagicMock(spec=GeminiProvider)
         gemini_provider.invoke.return_value = mock_result
 

--- a/tests/unit/test_wave1_token_savings.py
+++ b/tests/unit/test_wave1_token_savings.py
@@ -200,8 +200,7 @@ No blocking issues found.
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "LLD looks good overall.", "feedback_items": [], "open_questions": []}),
-            response=full_verdict,
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "LLD looks good overall.", "feedback_items": [], "open_questions": []}),
             error_message=None,
             input_tokens=100,
             output_tokens=200,
@@ -247,8 +246,7 @@ No blocking issues found.
         mock_provider = Mock()
         mock_provider.invoke.return_value = Mock(
             success=True,
-            content=_json.dumps({"verdict": "APPROVED", "rationale": "Looks good", "feedback_items": ["Consider caching"], "open_questions": []}),
-            response="raw prose",
+            response=_json.dumps({"verdict": "APPROVED", "rationale": "Looks good", "feedback_items": ["Consider caching"], "open_questions": []}),
             error_message=None,
             input_tokens=100,
             output_tokens=200,


### PR DESCRIPTION
Fixes the run-11 recursion-loop incident end to end (boostgauge #96 campaign, 2026-07-28). When agy began failing transiently (exit 3221225794), the spec workflow spun to LangGraph's 10000-recursion limit because failure was laundered at three layers:

- _invoke_reviewer_with_spec_schema read result.content — a field LLMCallResult never had — so every parse ran against the stringified dataclass and fell back to regex. On a failed call the fallback synthesized 'Verdict: REVISE' and the router looped. The helper now reads .response, and returns (None, error) on call failure or empty response. UNKNOWN after a successful parse also surfaces as error_message: never a verdict from noise. This is also the root cause behind the 100% structured-parse fallback rate documented on #1843 (the requirements-review helper had the identical .content bug — payload fix applied there too; #1843 stays open for the remaining contract questions at the other parse sites).
- review_spec now returns error_message on invoke failure instead of a synthesized verdict, so route_after_review's HALT branch actually fires.
- The N2->N3 edge was unconditional, so generate_spec's honest 'Drafter failed' error_message rode through N3's vacuous pass into N5, which reset it to '' — chain severed. New route_after_generate_spec halts on error like every other node's router.

Also repairs the mock-drift that hid all of this: the test mock set .content on a bare MagicMock, which grows any attribute — tests passed while production stringified dataclasses. The mock is now spec'd to the real fields.

Tests: 244 passing across the affected suites — new cases for failed-call, empty-response, payload-from-.response, and both router branches; two legacy tests updated from the old synthesize-a-verdict contract to the new halt contract. Ruff: remaining findings are pre-existing unused imports in untouched lines; one dead assignment inside the edited region removed.

Sibling: #1870 (vacuous N3 validation) stays open — the conditional edge prevents the empty-draft case reaching it from failures, but it remains the last line of defense.

Closes #1868
Closes #1869