### PR TITLE
fix(gemini): bound every call — wall-clock budget, tree-kill, spawn-failure retry (Closes #1874, Closes #1872, Closes #1873)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -14,6 +14,8 @@ import os
 import re
 import shutil
 import subprocess
+
+from assemblyzero.utils.process import kill_process_tree
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -68,6 +70,27 @@ QUOTA_EXHAUSTED_PATTERNS = [
     "429",
     "Resource has been exhausted",
 ]
+
+# #1874: a per-attempt timeout is not a bound on a call. A timeout classifies
+# as capacity, which backs off and retries the SAME credential, so the real
+# worst case was MAX_RETRIES_PER_CREDENTIAL x credentials x per-attempt
+# timeout. A 15-second-nominal test-plan review sat 17.5 minutes that way
+# (hardening run 11, 2026-07-28) and had to be killed by hand. The budget
+# below bounds ONE invoke() end to end, retries and rotation included.
+AGY_CALL_TIMEOUT_SECONDS = 300.0
+MAX_TOTAL_INVOKE_SECONDS = 600.0
+MIN_ATTEMPT_SECONDS = 20.0
+
+# #1872: Windows process-creation failures. A child that dies with one of
+# these never got to run — desktop-heap / DLL-init pressure on a busy
+# machine, not a credential problem. Twice in 30 minutes on 2026-07-28 these
+# were reported as "All credentials failed" while preflight showed 4/4
+# healthy seconds later.
+SPAWN_FAILURE_EXIT_CODES = (
+    3221225794,  # 0xC0000142 STATUS_DLL_INIT_FAILED
+    3221225781,  # 0xC0000135 STATUS_DLL_NOT_FOUND
+    3221225477,  # 0xC0000005 access violation during process init
+)
 
 CAPACITY_PATTERNS = [
     "MODEL_CAPACITY_EXHAUSTED",
@@ -268,6 +291,15 @@ def get_credential_status() -> dict:
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[=>]")
 
 
+def _is_spawn_failure(error_text: str) -> bool:
+    """True when an error string carries a Windows process-creation code.
+
+    Issue #1872: these mean the child never started. That is transient
+    machine pressure and deserves a backoff, not a credential write-off.
+    """
+    return any(str(code) in error_text for code in SPAWN_FAILURE_EXIT_CODES)
+
+
 def _strip_ansi(text: str) -> str:
     """Strip ANSI/VT control sequences from agy's pseudo-console output and
     normalize newlines. agy renders to a TTY, so the captured stream carries
@@ -341,6 +373,7 @@ class GeminiClient:
         self,
         system_instruction: str,
         content: str,
+        timeout_seconds: float = AGY_CALL_TIMEOUT_SECONDS,
     ) -> tuple[bool, str, str]:
         """Invoke the governance model via the Antigravity CLI (agy).
 
@@ -378,7 +411,7 @@ class GeminiClient:
         # the response to a plain pipe (verified with a 39,954-char prompt).
         # Small prompts keep the proven PTY path below.
         if len(full_prompt) > 30000:
-            return self._invoke_via_stdin(full_prompt)
+            return self._invoke_via_stdin(full_prompt, timeout_seconds)
 
         try:
             from winpty import PtyProcess
@@ -393,7 +426,7 @@ class GeminiClient:
         try:
             with tempfile.TemporaryDirectory() as tmp_cwd:
                 proc = PtyProcess.spawn(argv, cwd=tmp_cwd, dimensions=(60, 1000))
-                deadline = time.time() + 300  # 5 minute timeout
+                deadline = time.time() + timeout_seconds
                 timed_out = True
                 while time.time() < deadline:
                     try:
@@ -413,7 +446,13 @@ class GeminiClient:
                         proc.terminate(force=True)
                     except Exception:
                         pass
-                    return False, "", "agy CLI timeout (300s)"
+                    # #1874: terminate() ends the console host, not the
+                    # grandchildren agy spawned under it.
+                    try:
+                        kill_process_tree(proc.pid)
+                    except Exception:
+                        pass
+                    return False, "", f"agy CLI timeout ({timeout_seconds:.0f}s)"
                 try:
                     exit_status = proc.exitstatus
                 except Exception:
@@ -439,7 +478,11 @@ class GeminiClient:
             return True, text, ""
         return False, "", "agy returned no output"
 
-    def _invoke_via_stdin(self, full_prompt: str) -> tuple[bool, str, str]:
+    def _invoke_via_stdin(
+        self,
+        full_prompt: str,
+        timeout_seconds: float = AGY_CALL_TIMEOUT_SECONDS,
+    ) -> tuple[bool, str, str]:
         """Invoke agy with the prompt on stdin (#1772).
 
         For prompts beyond the Windows argv ceiling. `agy --model X` with
@@ -455,29 +498,47 @@ class GeminiClient:
         import tempfile
 
         try:
-            with tempfile.TemporaryDirectory() as tmp_cwd:
-                result = subprocess.run(
+            # #1874: Popen, not subprocess.run. run()'s own timeout kills only
+            # the root process on Windows and then drains the pipes with an
+            # unbounded communicate() — agy's grandchildren hold those handles,
+            # so the call hangs indefinitely instead of raising at the timeout.
+            # ignore_cleanup_errors: a just-killed child can still hold the
+            # temp cwd for a moment; that must not fail the call.
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_cwd:
+                proc = subprocess.Popen(
                     [self._agy_cli, "--model", self.model],
-                    input=full_prompt,
-                    capture_output=True,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                     text=True,
                     encoding="utf-8",
                     errors="replace",
-                    timeout=300,
                     cwd=tmp_cwd,
                 )
-        except subprocess.TimeoutExpired:
-            return False, "", "agy CLI timeout (300s, stdin path)"
+                try:
+                    stdout, stderr = proc.communicate(
+                        input=full_prompt, timeout=timeout_seconds
+                    )
+                except subprocess.TimeoutExpired:
+                    kill_process_tree(proc.pid)
+                    try:
+                        proc.communicate(timeout=10)
+                    except (subprocess.TimeoutExpired, OSError, ValueError):
+                        pass
+                    return False, "", (
+                        f"agy CLI timeout ({timeout_seconds:.0f}s, stdin path)"
+                    )
+                returncode = proc.returncode
         except OSError as e:
             return False, "", f"agy stdin invocation failed: {e}"
 
-        text = _strip_ansi(result.stdout or "").strip()
+        text = _strip_ansi(stdout or "").strip()
 
         # #1765 boundaries, mirrored from the PTY path.
-        if result.returncode != 0:
-            detail = (result.stderr or "").strip() or text
+        if returncode != 0:
+            detail = (stderr or "").strip() or text
             return False, "", (
-                f"agy exited {result.returncode} (stdin path): {detail[:400]}"
+                f"agy exited {returncode} (stdin path): {detail[:400]}"
             )
         first_line = text.splitlines()[0].strip() if text else ""
         if first_line.startswith("Error:"):
@@ -561,6 +622,7 @@ class GeminiClient:
 
         initial_credential = available[0]
         errors: list[str] = []
+        budget_exhausted = False
 
         for cred in available:
             rotation_occurred = cred.name != initial_credential.name
@@ -578,6 +640,23 @@ class GeminiClient:
             attempt = 0
 
             while attempt < MAX_RETRIES_PER_CREDENTIAL:
+                # #1874: the ceiling covers the whole call. Without it, each
+                # attempt is bounded but the sequence is not — retries and
+                # rotations multiply into tens of minutes.
+                remaining = self._remaining_budget(start_time)
+                if remaining < MIN_ATTEMPT_SECONDS:
+                    budget_exhausted = True
+                    errors.append(
+                        f"{cred.name}: call budget of "
+                        f"{MAX_TOTAL_INVOKE_SECONDS:.0f}s exhausted"
+                    )
+                    print(
+                        f"    [LLM] provider=gemini model={self.model}: "
+                        f"call budget of {MAX_TOTAL_INVOKE_SECONDS:.0f}s "
+                        f"exhausted — halting instead of retrying"
+                    )
+                    break
+
                 attempt += 1
                 total_attempts += 1
 
@@ -586,7 +665,9 @@ class GeminiClient:
                     if cred.cred_type == "oauth":
                         # OAuth: use CLI subprocess
                         success, response_text, error_msg = self._invoke_via_cli(
-                            system_instruction, content
+                            system_instruction,
+                            content,
+                            timeout_seconds=min(AGY_CALL_TIMEOUT_SECONDS, remaining),
                         )
                         if success:
                             # Update state on success
@@ -630,6 +711,16 @@ class GeminiClient:
                     status_code = classified.status_code
                     error_type = self._error_type_from_classified(classified)
 
+                    # #1872: a child that never started is machine pressure,
+                    # not a bad credential. Route it into the backoff-and-
+                    # retry-same-credential path instead of writing the
+                    # credential off and reporting "all credentials failed".
+                    if (
+                        error_type == GeminiErrorType.UNKNOWN
+                        and _is_spawn_failure(error_str)
+                    ):
+                        error_type = GeminiErrorType.CAPACITY_EXHAUSTED
+
                     if error_type == GeminiErrorType.CAPACITY_EXHAUSTED:
                         # 529/503: Backoff and retry same credential
                         delay = self._backoff_delay(attempt)
@@ -646,7 +737,8 @@ class GeminiClient:
                             f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
                             f"{status_code or 503} capacity exhausted (retrying in {delay:.0f}s)"
                         )
-                        time.sleep(delay)
+                        # #1874: a backoff must not sleep past the budget.
+                        time.sleep(min(delay, max(0.0, self._remaining_budget(start_time))))
                         continue
 
                     elif error_type == GeminiErrorType.QUOTA_EXHAUSTED:
@@ -703,7 +795,10 @@ class GeminiClient:
                                 f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
                                 f"transient error (status={status_code}), retrying in {delay:.0f}s"
                             )
-                            time.sleep(delay)
+                            # #1874: a backoff must not sleep past the budget.
+                            time.sleep(
+                                min(delay, max(0.0, self._remaining_budget(start_time)))
+                            )
                             continue
 
                         # Non-retryable or last attempt: Log and try next credential
@@ -728,6 +823,10 @@ class GeminiClient:
                     f"{cred.name}: Capacity exhausted after "
                     f"{MAX_RETRIES_PER_CREDENTIAL} retries (503/529)"
                 )
+
+            # #1874: budget is per call, so stop rotating too.
+            if budget_exhausted:
+                break
 
         # All credentials failed
         duration_ms = int((time.time() - start_time) * 1000)
@@ -926,6 +1025,11 @@ class GeminiClient:
     def _backoff_delay(self, attempt: int) -> float:
         """Calculate exponential backoff delay."""
         return min(BACKOFF_BASE_SECONDS * (2**attempt), BACKOFF_MAX_SECONDS)
+
+    @staticmethod
+    def _remaining_budget(start_time: float) -> float:
+        """Seconds left in this invoke()'s wall-clock budget (#1874)."""
+        return MAX_TOTAL_INVOKE_SECONDS - (time.time() - start_time)
 
     def _parse_reset_time(self, error_output: str) -> Optional[float]:
         """Parse quota reset time from error message (returns hours)."""

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -50,6 +50,7 @@ from assemblyzero.core.errors import (
     classify_anthropic_error,
 )
 from assemblyzero.core.text_sanitizer import strip_emoji
+from assemblyzero.utils.process import kill_process_tree
 
 
 _PYDANTIC_WARNING_RE = re.compile(
@@ -342,26 +343,12 @@ class LLMProvider(ABC):
 def _kill_process_tree(pid: int) -> None:
     """Kill a process and all its children.
 
-    On Windows, uses taskkill /T (tree-kill) to terminate the entire
-    process group.  On Unix, kills the process group via os.killpg.
     Issue #526: subprocess.run timeout on Windows only kills the root
     process â€” grandchildren keep pipes open for hundreds of seconds.
+    Issue #1874: the primitive now lives in assemblyzero.utils.process so
+    the Gemini/agy transport kills tree-wise the same way this one does.
     """
-    try:
-        if sys.platform == "win32":
-            env = os.environ.copy()
-            env["PYTHONWARNINGS"] = "ignore"
-            subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(pid)],
-                capture_output=True,
-                timeout=10,
-                env=env,
-            )
-        else:
-            os.killpg(os.getpgid(pid), 9)
-    except (ProcessLookupError, OSError, subprocess.TimeoutExpired):
-        # Process already dead â€” that's fine
-        pass
+    kill_process_tree(pid)
 
 
 class ClaudeCLIProvider(LLMProvider):

--- a/assemblyzero/utils/process.py
+++ b/assemblyzero/utils/process.py
@@ -1,0 +1,43 @@
+"""Process-tree control shared by every subprocess-spawning provider.
+
+Issue #526 established that a Windows ``subprocess`` timeout kills only the
+root process: grandchildren keep the inherited pipe handles open, so the
+drain that follows the kill blocks for as long as they live. Issue #1874
+found the same hazard unfixed on the Gemini/agy transport, where it turned a
+15-second-nominal review into a 17.5-minute hang.
+
+The primitive lives here so both transports kill the same way.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def kill_process_tree(pid: int) -> None:
+    """Kill a process and every descendant it spawned.
+
+    On Windows this shells out to ``taskkill /T``; elsewhere it signals the
+    process group. Never raises: a process that is already gone is the
+    outcome the caller wanted.
+
+    Args:
+        pid: Process id of the tree root.
+    """
+    try:
+        if sys.platform == "win32":
+            env = os.environ.copy()
+            env["PYTHONWARNINGS"] = "ignore"
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                timeout=10,
+                env=env,
+            )
+        else:
+            os.killpg(os.getpgid(pid), 9)
+    except (ProcessLookupError, OSError, subprocess.TimeoutExpired):
+        # Already dead — that's fine.
+        pass

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -776,9 +776,18 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 transient=_classify_halt_transience(sub_result),
             )
     except subprocess.CalledProcessError as exc:
+        # #1873: stderr alone is empty when the git child dies before it can
+        # write (the machine-pressure spawn failures of #1872), which left
+        # the run record saying only "Git worktree error: ". Carry the
+        # command, the exit code, and both streams so a blank-stderr death
+        # is still diagnosable from the log.
+        detail = (exc.stderr or "").strip() or (exc.stdout or "").strip() or "no output"
         result = _make_stage_result(
             status="failed",
-            error_message=f"Git worktree error: {exc.stderr}",
+            error_message=(
+                f"Git worktree error (exit {exc.returncode}): {detail[:400]} "
+                f"[cmd: {' '.join(str(a) for a in exc.cmd) if isinstance(exc.cmd, (list, tuple)) else exc.cmd}]"
+            ),
             duration_seconds=time.monotonic() - start_time,
             attempts=1,
         )

--- a/tests/unit/test_gemini_call_bounds.py
+++ b/tests/unit/test_gemini_call_bounds.py
@@ -1,0 +1,138 @@
+"""Bounds on a single Gemini call: wall clock, tree-kill, spawn-failure retry.
+
+Hardening run 11 (2026-07-28) had a test-plan review with a ~15 second
+nominal run 17.5 minutes before it was killed by hand. Two independent
+defects made that possible, and both are pinned here:
+
+- #1874: nothing bounded the CALL. Per-attempt timeouts exist, but a timeout
+  classifies as capacity, which backs off and retries the same credential,
+  so the sequence multiplied into tens of minutes. On Windows the stdin
+  transport could not even honour its own timeout: subprocess.run kills the
+  root process and then drains pipes with an unbounded communicate(), which
+  agy's surviving grandchildren held open.
+- #1872: a child that never started (STATUS_DLL_INIT_FAILED and kin) was
+  written off as a dead credential instead of retried.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from assemblyzero.core import gemini_client as gc
+
+
+class TestSpawnFailureDetection:
+    """#1872: process-creation failures are transient, not credential death."""
+
+    def test_dll_init_failure_recognised(self):
+        assert gc._is_spawn_failure("agy exited 3221225794 (stdin path): ") is True
+
+    def test_dll_not_found_recognised(self):
+        assert gc._is_spawn_failure("agy exited 3221225781") is True
+
+    def test_ordinary_error_is_not_a_spawn_failure(self):
+        assert gc._is_spawn_failure("agy exited 1: model not found") is False
+
+    def test_empty_text_is_not_a_spawn_failure(self):
+        assert gc._is_spawn_failure("") is False
+
+    def test_spawn_failure_maps_to_a_retryable_type(self):
+        """The retry loop backs off on CAPACITY_EXHAUSTED; UNKNOWN writes the
+        credential off. A spawn failure must land on the former."""
+        assert (
+            gc.GeminiErrorType.CAPACITY_EXHAUSTED
+            in gc.GeminiErrorType.__members__.values()
+        )
+        # The classification hop itself is exercised in the invoke() path;
+        # here we pin that the code the client reports IS matched.
+        assert gc._is_spawn_failure(
+            f"agy exited {gc.SPAWN_FAILURE_EXIT_CODES[0]} (stdin path)"
+        )
+
+
+class TestCallBudget:
+    """#1874: one invoke() has a wall-clock ceiling covering all retries."""
+
+    def test_budget_shrinks_as_time_passes(self):
+        with patch.object(gc.time, "time", return_value=1000.0):
+            remaining = gc.GeminiClient._remaining_budget(start_time=940.0)
+        assert remaining == gc.MAX_TOTAL_INVOKE_SECONDS - 60.0
+
+    def test_budget_goes_negative_when_overrun(self):
+        with patch.object(gc.time, "time", return_value=2000.0):
+            remaining = gc.GeminiClient._remaining_budget(start_time=1000.0)
+        assert remaining < 0
+
+    def test_budget_is_smaller_than_worst_case_retry_sequence(self):
+        """The regression in one line: the old worst case was
+        retries x credentials x per-attempt timeout, with nothing capping the
+        product. The budget must be well under even a single credential's
+        share of that."""
+        single_credential_worst_case = (
+            gc.MAX_RETRIES_PER_CREDENTIAL * gc.AGY_CALL_TIMEOUT_SECONDS
+        )
+        assert gc.MAX_TOTAL_INVOKE_SECONDS < single_credential_worst_case
+
+    def test_floor_leaves_room_for_a_real_attempt(self):
+        assert 0 < gc.MIN_ATTEMPT_SECONDS < gc.AGY_CALL_TIMEOUT_SECONDS
+
+
+class TestStdinTransportTimeout:
+    """#1874: the stdin path kills the TREE and returns, never hangs."""
+
+    def _client(self):
+        client = gc.GeminiClient.__new__(gc.GeminiClient)
+        client._agy_cli = "agy"
+        client.model = "3.1-pro"
+        return client
+
+    def test_timeout_kills_the_process_tree(self):
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="agy", timeout=30)
+
+        with patch.object(gc.subprocess, "Popen", return_value=proc), \
+             patch.object(gc, "kill_process_tree") as killer:
+            ok, text, err = self._client()._invoke_via_stdin("prompt", timeout_seconds=30)
+
+        killer.assert_called_once_with(4242)
+        assert ok is False
+        assert "timeout" in err.lower()
+        assert text == ""
+
+    def test_timeout_message_reports_the_budget_it_was_given(self):
+        proc = MagicMock()
+        proc.pid = 1
+        proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="agy", timeout=45)
+
+        with patch.object(gc.subprocess, "Popen", return_value=proc), \
+             patch.object(gc, "kill_process_tree"):
+            _ok, _text, err = self._client()._invoke_via_stdin("p", timeout_seconds=45)
+
+        assert "45s" in err
+
+    def test_successful_call_returns_stdout(self):
+        proc = MagicMock()
+        proc.pid = 7
+        proc.communicate.return_value = ("the response", "")
+        proc.returncode = 0
+
+        with patch.object(gc.subprocess, "Popen", return_value=proc):
+            ok, text, err = self._client()._invoke_via_stdin("p", timeout_seconds=60)
+
+        assert ok is True
+        assert text == "the response"
+        assert err == ""
+
+    def test_nonzero_exit_surfaces_code_and_detail(self):
+        proc = MagicMock()
+        proc.pid = 7
+        proc.communicate.return_value = ("", "boom")
+        proc.returncode = 3221225794
+
+        with patch.object(gc.subprocess, "Popen", return_value=proc):
+            ok, _text, err = self._client()._invoke_via_stdin("p", timeout_seconds=60)
+
+        assert ok is False
+        assert "3221225794" in err
+        # and that message is what #1872's detector keys on
+        assert gc._is_spawn_failure(err) is True

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -263,15 +263,24 @@ class TestInvokeViaStdin:
         client._agy_cli = "/fake/agy"
         return client
 
-    @patch("assemblyzero.core.gemini_client.subprocess.run")
+    @staticmethod
+    def _proc(stdout="", stderr="", returncode=0):
+        """A Popen double. #1874 moved this path off subprocess.run, whose
+        Windows timeout kills the root and then drains pipes unbounded."""
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.communicate.return_value = (stdout, stderr)
+        proc.returncode = returncode
+        return proc
+
+    @patch("assemblyzero.core.gemini_client.subprocess.Popen")
     def test_oversize_prompt_routes_to_stdin_path(
-        self, mock_run, temp_credentials_file, temp_state_file
+        self, mock_popen, temp_credentials_file, temp_state_file
     ):
         """_invoke_via_cli must route >30K prompts to stdin — never reject
         them, never put them in argv."""
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="A fine review.\n", stderr=""
-        )
+        proc = self._proc(stdout="A fine review.\n")
+        mock_popen.return_value = proc
         client = self._client(temp_credentials_file, temp_state_file)
 
         big_content = "x" * 31000
@@ -279,47 +288,52 @@ class TestInvokeViaStdin:
 
         assert ok is True
         assert "fine review" in text
-        argv = mock_run.call_args[0][0]
+        argv = mock_popen.call_args[0][0]
         assert "-p" not in argv, "oversize prompt must NOT ride argv"
         assert argv[0] == "/fake/agy"
         assert argv[1:3] == ["--model", "gemini-3.1-pro-high"]
-        kwargs = mock_run.call_args[1]
-        assert len(kwargs["input"]) > 31000  # full composed prompt on stdin
-        assert kwargs["cwd"], "stdin path must keep temp-cwd isolation"
+        assert mock_popen.call_args[1]["cwd"], "stdin path keeps temp-cwd isolation"
+        sent = proc.communicate.call_args[1]["input"]
+        assert len(sent) > 31000  # full composed prompt on stdin
 
-    @patch("assemblyzero.core.gemini_client.subprocess.run")
+    @patch("assemblyzero.core.gemini_client.subprocess.Popen")
     def test_stdin_nonzero_exit_is_failure(
-        self, mock_run, temp_credentials_file, temp_state_file
+        self, mock_popen, temp_credentials_file, temp_state_file
     ):
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="", stderr="Error: invalid --model"
+        mock_popen.return_value = self._proc(
+            stderr="Error: invalid --model", returncode=1
         )
         client = self._client(temp_credentials_file, temp_state_file)
         ok, text, err = client._invoke_via_stdin("p" * 31000)
         assert ok is False
         assert "agy exited 1" in err
 
-    @patch("assemblyzero.core.gemini_client.subprocess.run")
+    @patch("assemblyzero.core.gemini_client.subprocess.Popen")
     def test_stdin_error_banner_is_failure(
-        self, mock_run, temp_credentials_file, temp_state_file
+        self, mock_popen, temp_credentials_file, temp_state_file
     ):
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout="Error: something odd\n", stderr=""
-        )
+        mock_popen.return_value = self._proc(stdout="Error: something odd\n")
         client = self._client(temp_credentials_file, temp_state_file)
         ok, text, err = client._invoke_via_stdin("p" * 31000)
         assert ok is False
         assert "agy error output" in err
 
-    @patch("assemblyzero.core.gemini_client.subprocess.run")
+    @patch("assemblyzero.core.gemini_client.kill_process_tree")
+    @patch("assemblyzero.core.gemini_client.subprocess.Popen")
     def test_stdin_timeout_is_failure(
-        self, mock_run, temp_credentials_file, temp_state_file
+        self, mock_popen, mock_kill, temp_credentials_file, temp_state_file
     ):
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="agy", timeout=300)
+        proc = self._proc()
+        proc.communicate.side_effect = subprocess.TimeoutExpired(
+            cmd="agy", timeout=300
+        )
+        mock_popen.return_value = proc
         client = self._client(temp_credentials_file, temp_state_file)
         ok, text, err = client._invoke_via_stdin("p" * 31000)
         assert ok is False
         assert "timeout" in err.lower()
+        # #1874: the whole tree dies, not just the root holding the pipes
+        mock_kill.assert_called_once_with(4242)
 
 
 class TestErrorClassification:
@@ -404,7 +418,7 @@ class TestRotationLogic:
 
         credentials_tried = []
 
-        def mock_invoke_via_cli(system_instruction, content):
+        def mock_invoke_via_cli(system_instruction, content, timeout_seconds=None):
             # Count each _invoke_via_cli call — one per credential tried
             credentials_tried.append(len(credentials_tried))
             return (False, "", "429 TerminalQuotaError: exhausted")
@@ -433,7 +447,7 @@ class TestRotationLogic:
 
         attempts = [0]
 
-        def mock_invoke_via_cli(system_instruction, content):
+        def mock_invoke_via_cli(system_instruction, content, timeout_seconds=None):
             attempts[0] += 1
             if attempts[0] < 3:
                 return (False, "", "529 MODEL_CAPACITY_EXHAUSTED")
@@ -461,7 +475,7 @@ class TestRotationLogic:
             state_file=temp_state_file,
         )
 
-        def mock_invoke_via_cli(system_instruction, content):
+        def mock_invoke_via_cli(system_instruction, content, timeout_seconds=None):
             return (False, "", "429 TerminalQuotaError: exhausted")
 
         with patch.object(client, "_invoke_via_cli", side_effect=mock_invoke_via_cli):


### PR DESCRIPTION
Three faces of unbounded/opaque subprocess behaviour, all seen live in hardening run 11 (boostgauge #96 campaign, 2026-07-28).

**#1874 — nothing bounded a call.** A test-plan review with a ~15 second nominal ran 17.5 minutes before it was killed by hand. Two independent causes:

- Per-attempt timeouts are not a bound on the sequence. A timeout classifies as capacity, which backs off and retries the SAME credential, so the worst case was retries x credentials x per-attempt timeout — up to an hour. invoke() now carries a 600s wall-clock budget covering every retry and rotation: each attempt gets min(per-call timeout, remaining), backoffs never sleep past the budget, and exhaustion halts honestly instead of rotating onward.
- The stdin transport could not honour its own timeout. subprocess.run kills only the root process on Windows and then drains pipes with an unbounded communicate(); agy's grandchildren hold those handles, so TimeoutExpired never arrives. That path is now Popen + communicate(timeout) + kill_process_tree + a bounded drain — the same treatment #526 gave the Claude transport. The PTY path also tree-kills now, since terminate() ends the console host but not what it spawned.

**#1872 — a child that never started was written off as a dead credential.** Windows process-creation failures (0xC0000142 STATUS_DLL_INIT_FAILED and kin) hit twice in 30 minutes while preflight showed 4/4 healthy seconds later. They now route into backoff-and-retry-same-credential instead of 'All credentials failed'.

**#1873 — 'Git worktree error: ' with no detail.** exc.stderr is empty when the git child dies before it can write; the record now carries the exit code, both streams, and the command.

The tree-kill primitive moved to assemblyzero/utils/process.py so both transports kill the same way (llm_provider keeps its private name so existing callers and tests are untouched).

Tests: 13 new cases pinning budget arithmetic, spawn-failure detection, and the stdin transport's kill-the-tree-and-return behaviour; the four stdin tests move to the Popen contract; three rotation mocks learn the new timeout_seconds kwarg. Full unit suite 5728 passed. Notably the gemini suite now runs in ~1s instead of sleeping 84s — that sleeping was a TypeError being retried as a transient, filed separately as #1875. Ruff: findings in these files are pre-existing (verified against HEAD), none introduced.

Closes #1874
Closes #1872
Closes #1873