### PR TITLE
fix(dependabot): UTF-8 stdout/stderr so non-ASCII subprocess output cannot abort a drain (Closes #1876)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -1571,3 +1571,108 @@ class TestApprovePrGateDesc:
         body = captured["cmd"][captured["cmd"].index("--body") + 1]
         assert "gate: npm test passed (exit 0) in '.'" in body
         assert body.startswith(dependabot_review.REVIEW_BODY_PREFIX)
+
+
+# vitest/jest and pytest benchmark tables emit these routinely; cp1252
+# cannot encode any of them.
+NON_ASCII_LINE = "  | ✓ src/x.test.ts (3 tests) │ ── 456ms"
+
+
+class _Cp1252Stream:
+    """stdout double whose encoding cannot represent non-ASCII -- the
+    exact 2026-07-28 career-run condition (#1876)."""
+
+    encoding = "cp1252"
+
+    def __init__(self):
+        self.written: list[str] = []
+
+    def write(self, text: str) -> int:
+        text.encode("cp1252")  # raises UnicodeEncodeError like the real one
+        self.written.append(text)
+        return len(text)
+
+    def flush(self) -> None:
+        pass
+
+
+class TestForceUtf8Streams:
+    """#1876: the tool must not depend on its launcher's env for
+    encoding correctness."""
+
+    def test_reconfigures_each_stream_to_utf8_replace(self):
+        calls: list[dict] = []
+
+        class _Stream:
+            def reconfigure(self, **kw):
+                calls.append(kw)
+
+        dependabot_review._force_utf8_streams([_Stream(), _Stream()])
+        assert len(calls) == 2
+        assert all(c == {"encoding": "utf-8", "errors": "replace"}
+                   for c in calls)
+
+    def test_stream_without_reconfigure_does_not_raise(self):
+        """A test double or already-wrapped stream must be tolerated --
+        _Tee.write's fallback covers that case."""
+        dependabot_review._force_utf8_streams([object()])
+
+    def test_reconfigure_failure_is_swallowed(self):
+        class _Stream:
+            def reconfigure(self, **kw):
+                raise ValueError("detached buffer")
+
+        dependabot_review._force_utf8_streams([_Stream()])
+
+    def test_reconfigured_stream_accepts_non_ascii(self):
+        """End-to-end intent: after reconfigure, the write that crashed
+        the career run succeeds."""
+        import io
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        with pytest.raises(UnicodeEncodeError):
+            stream.write(NON_ASCII_LINE)
+            stream.flush()
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        dependabot_review._force_utf8_streams([stream])
+        stream.write(NON_ASCII_LINE)
+        stream.flush()
+
+
+class TestTeeSurvivesUndecodableTerminal:
+    """#1876: a failed *print* must never abort the drain."""
+
+    def test_write_does_not_raise_on_unicode_error(self, tmp_path):
+        logfile = (tmp_path / "run.log").open("w", encoding="utf-8")
+        tee = dependabot_review._Tee(_Cp1252Stream(), logfile)
+        tee.write(NON_ASCII_LINE)  # must not raise
+        logfile.close()
+
+    def test_faithful_text_still_reaches_the_log(self, tmp_path):
+        log_path = tmp_path / "run.log"
+        logfile = log_path.open("w", encoding="utf-8")
+        tee = dependabot_review._Tee(_Cp1252Stream(), logfile)
+        tee.write(NON_ASCII_LINE)
+        logfile.close()
+        assert NON_ASCII_LINE in log_path.read_text(encoding="utf-8"), (
+            "the run log is UTF-8 and must keep the exact text even when "
+            "the terminal can only render a lossy version"
+        )
+
+    def test_terminal_gets_lossy_render_not_nothing(self, tmp_path):
+        logfile = (tmp_path / "run.log").open("w", encoding="utf-8")
+        stream = _Cp1252Stream()
+        tee = dependabot_review._Tee(stream, logfile)
+        tee.write(NON_ASCII_LINE)
+        logfile.close()
+        assert stream.written, "output must degrade, not disappear"
+        assert "src/x.test.ts (3 tests)" in stream.written[0], (
+            "the ASCII substance of the line must survive the fallback"
+        )
+
+    def test_ascii_write_is_unaffected(self, tmp_path):
+        logfile = (tmp_path / "run.log").open("w", encoding="utf-8")
+        stream = _Cp1252Stream()
+        tee = dependabot_review._Tee(stream, logfile)
+        assert tee.write("plain ascii line") == len("plain ascii line")
+        logfile.close()
+        assert stream.written == ["plain ascii line"]

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -111,7 +111,19 @@ class _Tee:
             self._logfile.write(text)
         except (OSError, ValueError):
             pass  # log file gone/closed — terminal keeps working
-        return self._stream.write(text)
+        try:
+            return self._stream.write(text)
+        except UnicodeEncodeError:
+            # #1876: the terminal's encoding cannot represent this text
+            # (cp1252 console + vitest/jest box-drawing or check marks).
+            # Degrade to a lossy render rather than let a *print* abort
+            # the drain -- the log copy written above is UTF-8 and keeps
+            # the faithful text. Belt-and-suspenders behind
+            # _force_utf8_streams(), which normally prevents this.
+            enc = getattr(self._stream, "encoding", None) or "ascii"
+            return self._stream.write(
+                text.encode(enc, "replace").decode(enc, "replace")
+            )
 
     def flush(self) -> None:
         try:
@@ -122,6 +134,34 @@ class _Tee:
 
     def __getattr__(self, name):
         return getattr(self._stream, name)
+
+
+def _force_utf8_streams(streams=None) -> None:
+    """#1876: make stdout/stderr UTF-8 regardless of how the tool was
+    launched.
+
+    `run()` captures subprocess output with errors="replace", so the
+    captured str is always valid -- but ECHOING it crashed with
+    UnicodeEncodeError when the console encoding was the Windows locale
+    default (cp1252) and the subprocess emitted non-ASCII (vitest/jest
+    box-drawing, pytest benchmark tables). The exception escaped
+    process_repo's sequential path and killed the whole drain, printing
+    an all-zero Summary that hid the PR's real outcome.
+
+    tools/run_dependabot_fleet.ps1 sets PYTHONIOENCODING/PYTHONUTF8, so
+    the scheduled task never hit this -- correctness depended on the
+    launcher, leaving every manual run (including the /dependabot skill)
+    unprotected. #1839 widened the exposure: before it the tool never
+    ran npm, so JS output never reached the echo path.
+    """
+    for stream in (streams if streams is not None
+                   else (sys.stdout, sys.stderr)):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            # Not a reconfigurable TextIOWrapper (already wrapped, or a
+            # test double). _Tee.write's fallback covers this case.
+            pass
 
 
 def setup_run_log(log_dir: Path = RUN_LOG_DIR):
@@ -1663,6 +1703,10 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+
+    # #1876: UTF-8 the streams BEFORE _Tee wraps them, so both the
+    # terminal and the run log can carry subprocess output verbatim.
+    _force_utf8_streams()
 
     # #1403: open the run log FIRST so every subsequent line is recorded.
     run_log_path = None if args.no_run_log else setup_run_log()


### PR DESCRIPTION
Closes #1876

## Problem

Verifying #1839's JS gate end-to-end, a manual run against `martymcenroe/career` PR #927 (/dashboard, vitest) died mid-PR:

```
File "tools/dependabot_review.py", line 321, in run
    print(f"  | {line}")
UnicodeEncodeError: 'charmap' codec can't encode characters in position 13-34
```

`run()` captures subprocess output with `errors="replace"`, so the captured text was always valid — the crash was the **echo** to a cp1252 console. The exception escaped `_process_pr_inside_worktree` → `process_repo` → `main`'s sequential loop (which has no per-repo guard on that path), killing the whole run: exit 1 with an all-zero Summary (`merged=0 deferred=0 errored=0`) even though the gate had already run and produced a real result.

The scheduled task never hit this because `run_dependabot_fleet.ps1` sets `PYTHONIOENCODING`/`PYTHONUTF8` — so correctness depended on the launcher, leaving every manual invocation (including the `/dependabot` skill) unprotected. #1839 widened the exposure sharply: before it the tool never ran npm, so vitest/jest box-drawing never reached the echo path.

## Fix

- **`_force_utf8_streams()`** reconfigures `sys.stdout`/`sys.stderr` to `utf-8` / `errors="replace"` as the first action in `main()`, before `_Tee` wraps them. The tool is now self-sufficient regardless of how it is launched.
- **`_Tee.write` degrades instead of propagating** on `UnicodeEncodeError` — lossy render to the terminal, faithful UTF-8 to the run log. A failed *print* must never abort a drain.

## Tests

8 new. The reconfigure test is self-validating: it asserts a raw cp1252 `TextIOWrapper` **does** raise on the exact vitest-style line, then that the same write succeeds after `_force_utf8_streams`. The `_Tee` tests use a cp1252 stream double that raises like the real one, and assert three things separately — the write does not raise, the log keeps the exact text, and the terminal still gets the ASCII substance rather than nothing. Full file: 117 passed. `ruff check` clean.

## Cleanup note

The crash was a good validation of the cleanup contract: despite an unexpected exception mid-gate, `run_js_gate`'s `finally` removed `node_modules` and `process_pr`'s `finally` removed the worktree and audit branch. Verified afterward — no leaked state anywhere in the fleet.

sibling: #1839 (the JS gate this surfaced under), #1838; encoding-hardening lineage #1176/#1177, #1403.
