### PR TITLE
feat(capacity): know both providers' quota state before starting a run (Closes #1883)

### DIFF
--- a/assemblyzero/core/capacity.py
+++ b/assemblyzero/core/capacity.py
@@ -1,0 +1,292 @@
+"""Cross-provider capacity state — know before you spend (Issue #1883).
+
+A pipeline run needs both providers: Gemini designs and reviews, Claude
+implements. Starting a run when either is exhausted guarantees a partial run
+that spends the healthy provider's quota to discover the dry one.
+
+Gemini already had half of this. Its rotation state records which credentials
+are exhausted and when they reset, and ``preflight.check_gemini_available()``
+reads that file with zero API calls — its docstring even states the intent:
+"Checks Gemini availability BEFORE spending money on Claude drafts." Claude
+had none of it: usage limits were detected at call time (``errors.py`` matches
+"usage limit" / "wait until") and then discarded.
+
+The ``claude`` CLI exposes no usage or quota subcommand, and the numbers in
+Claude Code's ``/usage`` belong to the harness, not to anything a pipeline can
+read. So the Claude side cannot poll — it learns from a failure and remembers
+it, exactly the way the Gemini side already works.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+from assemblyzero.core.config import CAPACITY_STATE_FILE
+
+# A recorded exhaustion whose reset time could not be parsed still has to
+# expire on its own — a block that never lifts would wedge the pipeline
+# harder than the quota did. Claude's subscription windows are hours long,
+# so an hour is a conservative retry point, not a guess at the real reset.
+UNKNOWN_RESET_COOLDOWN = timedelta(hours=1)
+
+
+@dataclass
+class ProviderCapacity:
+    """One provider's known capacity state."""
+
+    provider: str
+    available: bool
+    resets_at: Optional[datetime] = None
+    exhausted_at: Optional[datetime] = None
+    detail: str = ""
+
+    def wait_summary(self, now: Optional[datetime] = None) -> str:
+        """Human phrasing of the wait, for an operator staring at a console."""
+        if self.available:
+            return f"{self.provider}: available"
+        if not self.resets_at:
+            return f"{self.provider}: exhausted ({self.detail or 'reset time unknown'})"
+        now = now or datetime.now(timezone.utc)
+        minutes = max(0, int((self.resets_at - now).total_seconds() // 60))
+        local = self.resets_at.astimezone()
+        # Formatted by hand: %-I is glibc-only and %#I is Windows-only, so
+        # either one crashes on the other platform (the #1841 lesson).
+        hour = local.hour % 12 or 12
+        meridiem = "AM" if local.hour < 12 else "PM"
+        return (
+            f"{self.provider}: exhausted until "
+            f"{hour}:{local.minute:02d} {meridiem} ({minutes} min)"
+        )
+
+
+def _load_state(state_file: Optional[Path] = None) -> dict:
+    path = state_file or CAPACITY_STATE_FILE
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        # An unreadable capacity file must never block work — the whole
+        # point of this module is to prevent wasted runs, not create them.
+        return {}
+
+
+def _save_state(state: dict, state_file: Optional[Path] = None) -> None:
+    path = state_file or CAPACITY_STATE_FILE
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(state, handle, indent=2)
+        tmp.replace(path)
+    except OSError:
+        pass
+
+
+def parse_reset_time(message: str, now: Optional[datetime] = None) -> Optional[datetime]:
+    """Best-effort reset timestamp from a provider's usage-limit message.
+
+    The exact wording of Claude's limit message has never been captured in
+    this repo, so this reads the shapes that have been observed in the wild
+    and returns None rather than guessing. Callers persist the raw message
+    either way, so a future sample can sharpen this without losing history.
+
+    Handles: a trailing unix timestamp (``...limit reached|1751904000``), an
+    explicit ISO timestamp, ``reset(s) at 5pm`` / ``at 15:00``, and
+    ``in 3h20m`` / ``in 45 minutes``.
+    """
+    if not message:
+        return None
+    now = now or datetime.now(timezone.utc)
+
+    unix = re.search(r"\|\s*(\d{10})\b", message)
+    if unix:
+        try:
+            return datetime.fromtimestamp(int(unix.group(1)), tz=timezone.utc)
+        except (ValueError, OSError):
+            pass
+
+    iso = re.search(r"(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?)", message)
+    if iso:
+        try:
+            parsed = datetime.fromisoformat(iso.group(1).replace(" ", "T"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+
+    relative = re.search(r"in\s+(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)", message, re.IGNORECASE)
+    if relative and (relative.group(1) or relative.group(2)):
+        hours = int(relative.group(1) or 0)
+        minutes = int(relative.group(2) or 0)
+        return now + timedelta(hours=hours, minutes=minutes)
+
+    minutes_only = re.search(r"in\s+(\d+)\s*minutes?", message, re.IGNORECASE)
+    if minutes_only:
+        return now + timedelta(minutes=int(minutes_only.group(1)))
+
+    clock = re.search(
+        r"reset[s]?\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", message, re.IGNORECASE
+    )
+    if clock:
+        hour = int(clock.group(1))
+        minute = int(clock.group(2) or 0)
+        meridiem = (clock.group(3) or "").lower()
+        if meridiem == "pm" and hour != 12:
+            hour += 12
+        elif meridiem == "am" and hour == 12:
+            hour = 0
+        if 0 <= hour <= 23:
+            local_now = now.astimezone()
+            candidate = local_now.replace(
+                hour=hour, minute=minute, second=0, microsecond=0
+            )
+            if candidate <= local_now:
+                candidate += timedelta(days=1)
+            return candidate.astimezone(timezone.utc)
+
+    return None
+
+
+def record_exhaustion(
+    provider: str,
+    message: str,
+    state_file: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> ProviderCapacity:
+    """Remember that a provider reported exhaustion, and when it recovers.
+
+    Called from the failure path that already detects the condition. The raw
+    message is stored verbatim so an unparseable format can be diagnosed —
+    and a parser written for it — from real evidence rather than memory.
+    """
+    now = now or datetime.now(timezone.utc)
+    resets_at = parse_reset_time(message, now=now)
+
+    state = _load_state(state_file)
+    state[provider] = {
+        "exhausted_at": now.isoformat(),
+        "resets_at": resets_at.isoformat() if resets_at else None,
+        "source_message": (message or "")[:500],
+    }
+    _save_state(state, state_file)
+
+    return ProviderCapacity(
+        provider=provider,
+        available=False,
+        resets_at=resets_at,
+        exhausted_at=now,
+        detail=(message or "")[:200],
+    )
+
+
+def clear_exhaustion(provider: str, state_file: Optional[Path] = None) -> None:
+    """Forget a recorded exhaustion — a provider that just answered is fine."""
+    state = _load_state(state_file)
+    if provider in state:
+        del state[provider]
+        _save_state(state, state_file)
+
+
+def _claude_capacity(
+    state_file: Optional[Path] = None, now: Optional[datetime] = None
+) -> ProviderCapacity:
+    now = now or datetime.now(timezone.utc)
+    entry = _load_state(state_file).get("claude")
+    if not entry:
+        return ProviderCapacity(provider="claude", available=True)
+
+    def _dt(key: str) -> Optional[datetime]:
+        raw = entry.get(key)
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw)
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return None
+
+    exhausted_at = _dt("exhausted_at")
+    resets_at = _dt("resets_at")
+
+    # No parsed reset time: expire the record on its own so a stale entry
+    # can never wedge the pipeline permanently.
+    effective_reset = resets_at or (
+        (exhausted_at + UNKNOWN_RESET_COOLDOWN) if exhausted_at else None
+    )
+    if effective_reset is None or now >= effective_reset:
+        return ProviderCapacity(provider="claude", available=True)
+
+    return ProviderCapacity(
+        provider="claude",
+        available=False,
+        resets_at=effective_reset,
+        exhausted_at=exhausted_at,
+        detail=entry.get("source_message", "")[:200],
+    )
+
+
+def _gemini_capacity(now: Optional[datetime] = None) -> ProviderCapacity:
+    """Derive Gemini's state from the rotation state that already tracks it."""
+    from assemblyzero.core.preflight import check_gemini_available
+
+    now = now or datetime.now(timezone.utc)
+    result = check_gemini_available()
+    if result.passed and result.available_credentials > 0:
+        return ProviderCapacity(provider="gemini", available=True)
+
+    detail = ", ".join(result.warnings) if result.warnings else ""
+    if result.exhausted_names:
+        detail = f"exhausted credentials: {', '.join(result.exhausted_names)}"
+    return ProviderCapacity(
+        provider="gemini",
+        available=False,
+        detail=detail or "no credentials available",
+    )
+
+
+def check_capacity(
+    providers: Optional[list[str]] = None,
+    state_file: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> dict[str, ProviderCapacity]:
+    """Read-only capacity status for each provider. Zero API calls.
+
+    Args:
+        providers: Provider names to check. Defaults to both.
+        state_file: Override for the capacity state file (tests).
+        now: Override for the clock (tests).
+
+    Returns:
+        Mapping of provider name to its ProviderCapacity.
+    """
+    names = providers or ["claude", "gemini"]
+    now = now or datetime.now(timezone.utc)
+    statuses: dict[str, ProviderCapacity] = {}
+    for name in names:
+        if name == "claude":
+            statuses[name] = _claude_capacity(state_file=state_file, now=now)
+        elif name == "gemini":
+            statuses[name] = _gemini_capacity(now=now)
+        else:
+            statuses[name] = ProviderCapacity(provider=name, available=True)
+    return statuses
+
+
+def blocked_providers(
+    providers: Optional[list[str]] = None,
+    state_file: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> list[ProviderCapacity]:
+    """Just the providers that cannot serve a run right now."""
+    return [
+        status
+        for status in check_capacity(providers, state_file=state_file, now=now).values()
+        if not status.available
+    ]

--- a/assemblyzero/core/config.py
+++ b/assemblyzero/core/config.py
@@ -43,6 +43,11 @@ CREDENTIALS_FILE = Path.home() / ".assemblyzero" / "gemini-credentials.json"
 ROTATION_STATE_FILE = Path.home() / ".assemblyzero" / "gemini-rotation-state.json"
 GEMINI_API_LOG_FILE = Path.home() / ".assemblyzero" / "gemini-api.jsonl"
 
+# Issue #1883: cross-provider capacity state. Gemini's exhaustion already
+# lives in ROTATION_STATE_FILE; Claude's was detected and then forgotten, so
+# a run could start with Claude dry and burn Gemini quota finding out.
+CAPACITY_STATE_FILE = Path.home() / ".assemblyzero" / "provider-capacity.json"
+
 # =============================================================================
 # Retry Configuration
 # =============================================================================

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -597,6 +597,16 @@ class ClaudeCLIProvider(LLMProvider):
                     # Check for non-retryable errors (like usage limits)
                     retryable = not is_non_retryable_error(error_msg)
 
+                    # #1883: remember the exhaustion instead of discarding it.
+                    # The claude CLI has no usage subcommand, so a failure is
+                    # the only signal there is — dropping it meant the next
+                    # run started blind and burned Gemini quota finding out.
+                    if _is_capacity_message(error_msg):
+                        from assemblyzero.core.capacity import record_exhaustion
+
+                        recorded = record_exhaustion("claude", error_msg)
+                        print(f"    [CAPACITY] {recorded.wait_summary()}")
+
                     call_result = LLMCallResult(
                         success=False,
                         response=None,
@@ -682,6 +692,13 @@ class ClaudeCLIProvider(LLMProvider):
 
                 # Issue #527: Strip emojis from response (preserve raw_response)
                 response_text = strip_emoji(response_text)
+
+                # #1883: a provider that just answered is not exhausted. This
+                # is what makes the gate self-healing when a reset time was
+                # unparseable or the window ended early.
+                from assemblyzero.core.capacity import clear_exhaustion
+
+                clear_exhaustion("claude")
 
                 call_result = LLMCallResult(
                     success=True,
@@ -977,6 +994,22 @@ class AnthropicProvider(LLMProvider):
             )
             log_llm_call(call_result)
             return call_result
+
+
+def _is_capacity_message(error_msg: str | None) -> bool:
+    """True when an error says the subscription is out of capacity (#1883).
+
+    Narrower than is_non_retryable_error, which also covers billing and auth
+    failures — recording those as "exhausted until" would block runs for a
+    condition that no amount of waiting fixes.
+    """
+    if not error_msg:
+        return False
+    lower = error_msg.lower()
+    return any(
+        pattern in lower
+        for pattern in ("usage limit", "usage has been exhausted", "wait until")
+    )
 
 
 def is_non_retryable_error(error_msg: str | None) -> bool:

--- a/tests/unit/test_capacity_gate.py
+++ b/tests/unit/test_capacity_gate.py
@@ -1,0 +1,195 @@
+"""Cross-provider capacity state (#1883).
+
+A run needs Gemini for design/review and Claude for implementation. Starting
+one while either is exhausted spends the healthy provider's quota to discover
+the dry one. Gemini already recorded its exhaustion with reset times; Claude
+detected usage limits and threw the knowledge away.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from assemblyzero.core import capacity
+from assemblyzero.core.capacity import (
+    UNKNOWN_RESET_COOLDOWN,
+    ProviderCapacity,
+    check_capacity,
+    clear_exhaustion,
+    parse_reset_time,
+    record_exhaustion,
+)
+
+NOW = datetime(2026, 7, 29, 17, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def state_file(tmp_path):
+    return tmp_path / "provider-capacity.json"
+
+
+class TestParseResetTime:
+    """The Claude message format has never been captured, so parse the shapes
+    seen in the wild and return None rather than guess."""
+
+    def test_trailing_unix_timestamp(self):
+        stamp = int(datetime(2026, 7, 29, 22, 0, tzinfo=timezone.utc).timestamp())
+        parsed = parse_reset_time(f"Claude AI usage limit reached|{stamp}")
+        assert parsed == datetime(2026, 7, 29, 22, 0, tzinfo=timezone.utc)
+
+    def test_iso_timestamp(self):
+        parsed = parse_reset_time("limit resets 2026-07-29T22:30:00")
+        assert parsed.hour == 22 and parsed.minute == 30
+
+    def test_relative_hours_and_minutes(self):
+        parsed = parse_reset_time("Your quota will reset in 2h30m", now=NOW)
+        assert parsed == NOW + timedelta(hours=2, minutes=30)
+
+    def test_relative_minutes_only(self):
+        parsed = parse_reset_time("try again in 45 minutes", now=NOW)
+        assert parsed == NOW + timedelta(minutes=45)
+
+    def test_clock_time_with_meridiem(self):
+        parsed = parse_reset_time("Your limit will reset at 5pm", now=NOW)
+        assert parsed is not None
+        assert parsed.astimezone().hour == 17
+
+    def test_unparseable_returns_none_rather_than_guessing(self):
+        assert parse_reset_time("Claude usage limit reached.") is None
+
+    def test_empty_returns_none(self):
+        assert parse_reset_time("") is None
+
+
+class TestRecordAndClear:
+    def test_record_persists_reset_and_raw_message(self, state_file):
+        message = "Claude usage limit reached. Your limit will reset in 1h0m"
+        result = record_exhaustion("claude", message, state_file=state_file, now=NOW)
+
+        assert result.available is False
+        assert result.resets_at == NOW + timedelta(hours=1)
+
+        stored = json.loads(state_file.read_text(encoding="utf-8"))["claude"]
+        # the raw message survives so an unparseable format is diagnosable
+        assert stored["source_message"] == message
+        assert stored["resets_at"] is not None
+
+    def test_record_keeps_raw_message_even_when_unparseable(self, state_file):
+        record_exhaustion("claude", "some new wording", state_file=state_file, now=NOW)
+        stored = json.loads(state_file.read_text(encoding="utf-8"))["claude"]
+        assert stored["resets_at"] is None
+        assert stored["source_message"] == "some new wording"
+
+    def test_clear_removes_the_record(self, state_file):
+        record_exhaustion("claude", "usage limit", state_file=state_file, now=NOW)
+        clear_exhaustion("claude", state_file=state_file)
+        status = check_capacity(["claude"], state_file=state_file, now=NOW)["claude"]
+        assert status.available is True
+
+
+class TestClaudeCapacityWindow:
+    def test_exhausted_before_reset(self, state_file):
+        record_exhaustion(
+            "claude", "reset in 0h30m", state_file=state_file, now=NOW
+        )
+        status = check_capacity(["claude"], state_file=state_file, now=NOW)["claude"]
+        assert status.available is False
+
+    def test_available_after_reset_passes(self, state_file):
+        record_exhaustion(
+            "claude", "reset in 0h30m", state_file=state_file, now=NOW
+        )
+        later = NOW + timedelta(hours=1)
+        status = check_capacity(["claude"], state_file=state_file, now=later)["claude"]
+        assert status.available is True
+
+    def test_unparseable_record_expires_on_its_own(self, state_file):
+        """A block that never lifts would wedge the pipeline harder than the
+        quota did."""
+        record_exhaustion("claude", "no time here", state_file=state_file, now=NOW)
+
+        during = check_capacity(["claude"], state_file=state_file, now=NOW)["claude"]
+        assert during.available is False
+
+        after = NOW + UNKNOWN_RESET_COOLDOWN + timedelta(minutes=1)
+        assert check_capacity(["claude"], state_file=state_file, now=after)[
+            "claude"
+        ].available is True
+
+    def test_missing_state_file_means_available(self, tmp_path):
+        status = check_capacity(
+            ["claude"], state_file=tmp_path / "nope.json", now=NOW
+        )["claude"]
+        assert status.available is True
+
+    def test_corrupt_state_file_does_not_block_work(self, state_file):
+        state_file.write_text("{ not json", encoding="utf-8")
+        status = check_capacity(["claude"], state_file=state_file, now=NOW)["claude"]
+        assert status.available is True
+
+
+class TestCapacityMessageDetection:
+    """Narrower than is_non_retryable_error: billing and auth failures must
+    NOT be recorded as 'exhausted until', since waiting never fixes them."""
+
+    def test_usage_limit_is_capacity(self):
+        from assemblyzero.core.llm_provider import _is_capacity_message
+
+        assert _is_capacity_message("Claude usage limit reached") is True
+
+    def test_billing_failure_is_not_capacity(self):
+        from assemblyzero.core.llm_provider import _is_capacity_message
+
+        assert _is_capacity_message("Your credit balance is too low") is False
+
+    def test_auth_failure_is_not_capacity(self):
+        from assemblyzero.core.llm_provider import _is_capacity_message
+
+        assert _is_capacity_message("invalid api key") is False
+
+    def test_empty_is_not_capacity(self):
+        from assemblyzero.core.llm_provider import _is_capacity_message
+
+        assert _is_capacity_message(None) is False
+
+
+class TestWaitSummary:
+    def test_available_summary(self):
+        assert "available" in ProviderCapacity("claude", True).wait_summary()
+
+    def test_exhausted_summary_is_platform_portable(self):
+        """Formatted by hand — %-I is glibc-only, %#I is Windows-only."""
+        status = ProviderCapacity(
+            provider="claude",
+            available=False,
+            resets_at=NOW + timedelta(minutes=45),
+        )
+        summary = status.wait_summary(now=NOW)
+        assert "45 min" in summary
+        assert "AM" in summary or "PM" in summary
+
+    def test_unknown_reset_summary_says_so(self):
+        status = ProviderCapacity("claude", False, detail="reset time unknown")
+        assert "unknown" in status.wait_summary()
+
+
+class TestBlockedProviders:
+    def test_lists_only_the_dry_ones(self, state_file, monkeypatch):
+        monkeypatch.setattr(
+            capacity,
+            "_gemini_capacity",
+            lambda now=None: ProviderCapacity("gemini", True),
+        )
+        record_exhaustion("claude", "reset in 0h30m", state_file=state_file, now=NOW)
+
+        blocked = capacity.blocked_providers(state_file=state_file, now=NOW)
+        assert [status.provider for status in blocked] == ["claude"]
+
+    def test_empty_when_both_healthy(self, state_file, monkeypatch):
+        monkeypatch.setattr(
+            capacity,
+            "_gemini_capacity",
+            lambda now=None: ProviderCapacity("gemini", True),
+        )
+        assert capacity.blocked_providers(state_file=state_file, now=NOW) == []

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -121,6 +121,14 @@ Examples:
     parser.add_argument("--gate-pr", action="store_true", default=None, help="Enable human gate before PR")
     parser.add_argument("--no-gate-pr", action="store_true", help="Disable human gate before PR")
     parser.add_argument(
+        "--ignore-capacity",
+        action="store_true",
+        help=(
+            "Start even when a provider is recorded as exhausted (#1883). "
+            "The record may be stale if the quota window ended early."
+        ),
+    )
+    parser.add_argument(
         "--base-branch",
         type=str,
         default=None,
@@ -159,6 +167,31 @@ Examples:
 
     print(f"[ORCHESTRATOR] Starting pipeline for issue #{args.issue}")
     print(f"[ORCHESTRATOR] Target repo: {target_repo}")
+
+    # #1883: a run needs BOTH providers — Gemini designs and reviews, Claude
+    # implements. Starting one while either is exhausted spends the healthy
+    # provider's quota just to discover the dry one, and on a recorded take
+    # that is a dead run. Read-only, zero API calls.
+    if not args.dry_run and not args.ignore_capacity:
+        from assemblyzero.core.capacity import blocked_providers
+
+        blocked = blocked_providers()
+        if blocked:
+            print("\n" + "=" * 58)
+            # ASCII only: the Windows console renders an em-dash as a
+            # replacement char, and this banner is read under pressure.
+            print("  RUN NOT STARTED - provider capacity exhausted")
+            print("=" * 58)
+            for status in blocked:
+                print(f"  {status.wait_summary()}")
+                if status.detail:
+                    print(f"    detail: {status.detail[:160]}")
+            print(
+                "\n  Nothing was spent. Re-run after the reset above, or pass\n"
+                "  --ignore-capacity to start anyway."
+            )
+            print("=" * 58 + "\n")
+            sys.exit(2)
     if args.dry_run:
         print("[ORCHESTRATOR] DRY RUN -- no stages will execute")
     if args.resume_from:


### PR DESCRIPTION
A run needs both providers — Gemini designs and reviews, Claude implements. Starting one while either is exhausted spends the healthy provider's quota just to discover the dry one, and on a recorded take that is a dead run.

Gemini already had half of this: its rotation state records exhausted credentials with reset times, and preflight.check_gemini_available() reads it with zero API calls (its docstring states the intent — 'Checks Gemini availability BEFORE spending money on Claude drafts'). Claude had none of it. Usage limits were detected at call time and the knowledge was thrown away, so the next run started blind.

The claude CLI exposes no usage or quota subcommand, and Claude Code's /usage numbers belong to the harness, not to anything a pipeline can read. So the Claude side cannot poll — it learns from a failure and remembers it, exactly the way Gemini already works.

What landed:

- **assemblyzero/core/capacity.py** — one read-only view over both providers. Gemini's status derives from the rotation state that already tracks it; Claude's from a new state file. Zero API calls.
- **Claude records what it already detects.** On a usage-limit failure the reset time is parsed and persisted, and the raw message is stored verbatim so an unrecognised format can be diagnosed from evidence rather than memory. A successful call clears the record, which makes the gate self-healing when a window ends early.
- **Narrower detection than is_non_retryable_error.** Billing and auth failures are deliberately NOT recorded as 'exhausted until' — no amount of waiting fixes those, and blocking on them would be worse than the bug.
- **A recorded exhaustion always expires.** If no reset time could be parsed the record lapses after an hour, because a block that never lifts would wedge the pipeline harder than the quota did.
- **orchestrate.py gates at run start**, before stage 1 spends anything, and names the wait: 'claude: exhausted until 1:32 AM (41 min)'. Exit 2, nothing spent. --ignore-capacity overrides.

**Proven end to end, not just in tests.** With a simulated exhaustion recorded, a real orchestrate.py invocation refused to start and printed the reset time; after clearing, both providers read available again. Evidence in data/scratch-2026-07-28-schema-proof/ (gitignored).

This also closes a diagnosis trap: during the 2026-07-28 campaign, quota exhaustion was twice assumed from circumstantial evidence and was wrong both times, costing hours. Capacity is now a lookup, not a guess.

Tests: 24 cases covering every parse shape (unix stamp, ISO, relative, clock-time, unparseable, empty), the window transitions, self-expiry, corrupt/missing state, capacity-vs-billing discrimination, and the summary's platform-portable formatting (%-I is glibc-only and %#I is Windows-only — the #1841 lesson applied). Full unit suite 5770 passed. Ruff: one pre-existing F541 in an untouched line.

Closes #1883