### PR TITLE
fix(speedrun_reset): finish the wipe on origin, not just locally (Closes #1885)

### DIFF
--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -23,6 +23,7 @@ from speedrun_reset import (
     close_open_prs,
     current_branch,
     delete_local_branches,
+    delete_remote_branches,
     relocate_lld_artifacts,
     remove_worktree,
     worktree_is_dirty,
@@ -325,3 +326,80 @@ class TestCurrentBranch:
     def test_returns_empty_string_when_undetermined(self, tmp_path):
         with patch("speedrun_reset._run", return_value=_completed(returncode=128)):
             assert current_branch(tmp_path) == ""
+
+
+class TestRemoteBranchSweep:
+    """#1885: the wipe must finish on origin, not just locally."""
+
+    def _ls_remote(self, *names):
+        return "\n".join(
+            f"{'a' * 40}\trefs/heads/{name}" for name in names
+        ) + "\n"
+
+    def test_deletes_pipeline_branches_present_on_origin(self, tmp_path):
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="  7-lld\n")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return _completed(stdout=self._ls_remote("issue-7", "7-lld", "main"))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _completed(stdout="hardening-run-12\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            deleted = delete_remote_branches(tmp_path, 7)
+
+        assert deleted == 2
+        pushed = [c[4] for c in calls if c[:4] == ["git", "push", "origin", "--delete"]]
+        assert sorted(pushed) == ["7-lld", "issue-7"]
+        assert "main" not in pushed
+
+    def test_absent_ref_is_not_an_error(self, tmp_path):
+        """A partially-cleaned repo is the common case; a single combined
+        push --delete aborts entirely when one ref is already gone."""
+
+        def fake_run(cmd, cwd=None, check=False):
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return _completed(stdout=self._ls_remote("issue-7"))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _completed(stdout="hardening-run-12\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            assert delete_remote_branches(tmp_path, 7) == 1
+
+    def test_never_deletes_the_checked_out_attempt_branch(self, tmp_path):
+        calls = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            calls.append(cmd)
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return _completed(stdout=self._ls_remote("issue-7", "hardening-run-12"))
+            if cmd[:2] == ["git", "rev-parse"]:
+                return _completed(stdout="hardening-run-12\n")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            delete_remote_branches(tmp_path, 7)
+
+        pushed = [c[4] for c in calls if c[:4] == ["git", "push", "origin", "--delete"]]
+        assert "hardening-run-12" not in pushed
+
+    def test_unreachable_remote_is_a_warning_not_a_crash(self, tmp_path, capsys):
+        def fake_run(cmd, cwd=None, check=False):
+            if cmd[:3] == ["git", "branch", "--list"]:
+                return _completed(stdout="")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return _completed(returncode=128, stderr="could not read from remote")
+            return _completed()
+
+        with patch("speedrun_reset._run", side_effect=fake_run):
+            assert delete_remote_branches(tmp_path, 7) == 0
+        assert "skipping remote sweep" in capsys.readouterr().out

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -6,7 +6,8 @@ Performs the cleanup needed between attempts:
   1. Closes any open PR for the issue (without merging).
   2. Removes the worktrees at `{repo}-{issue}` and `{repo}-{issue}-lld`
      if they exist (#1848).
-  3. Deletes the local feature branch (safe-delete).
+  3. Deletes the local feature branch (safe-delete) and the same branches
+     on origin (#1885) — the attempt branch is never a candidate.
   4. Deletes `docs/lineage/active/{issue}-*/` directories.
   5. Relocates untracked LLD/spec artifacts out of the target repo's
      docs/lld tree into `data/speedrun/reset-artifacts/` (#1849) — left
@@ -234,6 +235,59 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
     return deleted
 
 
+def delete_remote_branches(repo_root: Path, issue: int) -> int:
+    """Delete the pipeline's pushed branches on origin. Returns count deleted.
+
+    The local sweep alone left `issue-{N}` and `{N}-lld` on origin after every
+    roll of the 2026-07-28 campaign, so the wipe was one forgotten command away
+    from leaving debris that collides with the next roll's push (#1885).
+
+    Deletes each ref independently: a single `git push --delete a b` aborts the
+    whole push when either ref is already gone, which is the common case on a
+    partially-cleaned repo. The attempt branch is never a candidate — the same
+    exclusion the local sweep honours (#1762).
+    """
+    candidates = [f"issue-{issue}"]
+    result = _run(["git", "branch", "--list", f"{issue}-*"], cwd=repo_root)
+    if result.returncode == 0:
+        candidates.extend(
+            line.strip().lstrip("* ").strip()
+            for line in result.stdout.splitlines()
+            if line.strip()
+        )
+    # Whatever the local sweep already deleted still needs removing on origin,
+    # so ask origin what it actually has rather than trusting local state.
+    ls_remote = _run(["git", "ls-remote", "--heads", "origin"], cwd=repo_root)
+    if ls_remote.returncode != 0:
+        print("  WARNING: could not list remote branches; skipping remote sweep")
+        return 0
+    remote_names = {
+        line.split("refs/heads/", 1)[1].strip()
+        for line in ls_remote.stdout.splitlines()
+        if "refs/heads/" in line
+    }
+    for suffix in (f"{issue}-lld",):
+        candidates.append(suffix)
+
+    active = current_branch(repo_root)
+    deleted = 0
+    for branch in dict.fromkeys(candidates):  # de-dupe, keep order
+        if not branch or branch == active or branch not in remote_names:
+            continue
+        r = _run(
+            ["git", "push", "origin", "--delete", branch], cwd=repo_root
+        )
+        if r.returncode == 0:
+            print(f"  Deleted remote branch: {branch}")
+            deleted += 1
+        else:
+            print(
+                f"  WARNING: could not delete remote branch {branch}: "
+                f"{(r.stderr or '').strip()[:120]}"
+            )
+    return deleted
+
+
 def delete_lineage_dirs(repo_root: Path, issue: int) -> int:
     """Delete docs/lineage/active/{issue}-* directories. Returns count deleted."""
     lineage_active = repo_root / "docs" / "lineage" / "active"
@@ -351,6 +405,7 @@ def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
     close_open_prs(repo, issue)
     remove_worktree(repo_root, issue)
     delete_local_branches(repo_root, issue)
+    delete_remote_branches(repo_root, issue)
     delete_lineage_dirs(repo_root, issue)
     relocate_lld_artifacts(repo_root, issue)
     reopen_issue(repo, issue)


### PR DESCRIPTION
Every roll of the hardening campaign ended with the same manual follow-up: `git push origin --delete issue-N N-lld`. The tool swept local branches, both worktrees, lineage, artifacts, the PR, and the issue — and left the pushed pipeline branches on origin, so the wipe was one forgotten command from leaving debris that collides with the next roll's push.

The sweep now finishes on origin. Three details earned from the campaign:

- **Each ref is deleted independently.** A single combined `push --delete a b` aborts the entire push when either ref is already gone — the common case on a partially-cleaned repo, and exactly what happened mid-campaign.
- **Origin is asked what it actually has** (`ls-remote`) rather than inferring from local state, since the local branches are deleted moments earlier in the same run.
- **The attempt branch is never a candidate**, matching the local sweep's existing exclusion (#1762). An unreachable remote is a warning, not a crash.

Tests: 4 new cases (deletes both pipeline branches while leaving main alone, tolerates an already-absent ref, never deletes the checked-out attempt branch, survives an unreachable remote). 23/23 module tests, full unit suite 5774 passed, ruff clean.

Closes #1885