### PR TITLE
fix(runs): make a stalled stage visible; stop retrying our own bugs (Closes #1886, Closes #1875)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -733,6 +733,41 @@ class GeminiClient:
 
                 except Exception as e:
                     error_str = str(e)
+
+                    # #1875: a TypeError/AttributeError/NameError/ImportError
+                    # is a defect in this code, not a condition the provider
+                    # can recover from. Retrying one burns the call budget and
+                    # then reports "All credentials failed" for what is a bug —
+                    # observed as 9 attempts and 84 seconds of backoff for a
+                    # single bad call signature. Fail immediately, name it.
+                    if isinstance(
+                        e, (TypeError, AttributeError, NameError, ImportError)
+                    ):
+                        msg = f"{type(e).__name__}: {error_str}"
+                        print(
+                            f"    [LLM] provider=gemini: programming error, "
+                            f"not retryable — {msg[:160]}"
+                        )
+                        log_gemini_event(
+                            event_type="api_error",
+                            credential_name=cred.name,
+                            model=self.model,
+                            error_message=msg[:200],
+                            details={"programming_error": True, "retryable": False},
+                        )
+                        return GeminiCallResult(
+                            success=False,
+                            response=None,
+                            raw_response=None,
+                            error_type=GeminiErrorType.UNKNOWN,
+                            error_message=f"Programming error (not retried): {msg}",
+                            credential_used=cred.name,
+                            rotation_occurred=rotation_occurred,
+                            attempts=total_attempts,
+                            duration_ms=int((time.time() - start_time) * 1000),
+                            model_verified="",
+                        )
+
                     # Issue #546: Classify through the typed error hierarchy
                     classified = classify_gemini_error(e)
                     status_code = classified.status_code

--- a/assemblyzero/core/stage_watchdog.py
+++ b/assemblyzero/core/stage_watchdog.py
@@ -1,0 +1,98 @@
+"""Make a stalled stage visible while it stalls (Issue #1886).
+
+On 2026-07-28 a test-plan review with a ~15 second nominal ran 17.5 minutes.
+Nothing in the system said so. The instrumented wrapper's heartbeat reported
+"alive" the entire time, because a live process is not a progressing one, and
+the stall was caught only when a human compared elapsed time against what that
+stage normally takes.
+
+This prints the comparison the human was doing, while the stage is running:
+
+    [STAGE] impl running 60s
+    [STAGE] impl running 120s (nominal ~40s) - SLOW, 3x nominal
+    [STAGE] impl running 180s (nominal ~40s) - STALLED, 4x nominal
+
+It never kills anything. Bounding a call is the provider's job (#1874); this
+is the observability half, so a stall is obvious in the log at the time it
+happens rather than in hindsight.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+# Observed durations from the boostgauge hardening campaign run records
+# (2026-07-28/29). These are starting points for the ratio, not SLAs — a
+# stage legitimately slower than its nominal only earns a louder log line.
+STAGE_NOMINAL_SECONDS: dict[str, float] = {
+    "triage": 20.0,
+    "lld": 60.0,
+    "spec": 90.0,
+    "impl": 240.0,
+    "pr": 15.0,
+    "cleanup": 90.0,
+}
+
+# Ratio at which the line changes tone. 3x is the operator's own threshold:
+# "if nominal is 15 seconds, 15 minutes is a problem, not patience."
+SLOW_RATIO = 3.0
+STALLED_RATIO = 6.0
+
+DEFAULT_INTERVAL_SECONDS = 60
+
+
+class StageWatchdog:
+    """Emit a progress line for a running stage, louder as it overruns.
+
+    Usage:
+        with StageWatchdog("impl"):
+            run_the_stage()
+    """
+
+    def __init__(
+        self,
+        stage: str,
+        nominal_seconds: Optional[float] = None,
+        interval: int = DEFAULT_INTERVAL_SECONDS,
+    ) -> None:
+        self.stage = stage
+        self.nominal = (
+            nominal_seconds
+            if nominal_seconds is not None
+            else STAGE_NOMINAL_SECONDS.get(stage)
+        )
+        self.interval = interval
+        self._start = 0.0
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def status_line(self, elapsed: float) -> str:
+        """The line printed at `elapsed` seconds — pure, so tests can read it."""
+        line = f"    [STAGE] {self.stage} running {int(elapsed)}s"
+        if not self.nominal:
+            return line
+        line += f" (nominal ~{int(self.nominal)}s)"
+        ratio = elapsed / self.nominal
+        if ratio >= STALLED_RATIO:
+            line += f" - STALLED, {int(ratio)}x nominal"
+        elif ratio >= SLOW_RATIO:
+            line += f" - SLOW, {int(ratio)}x nominal"
+        return line
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval):
+            print(self.status_line(time.monotonic() - self._start), flush=True)
+
+    def __enter__(self) -> "StageWatchdog":
+        self._start = time.monotonic()
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=2)

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -44,6 +44,7 @@ from assemblyzero.workflows.orchestrator.state import (
     update_stage_result,
 )
 from assemblyzero.core.halt_node import create_halt_node
+from assemblyzero.core.stage_watchdog import StageWatchdog
 
 
 class OrchestrationResult(TypedDict):
@@ -101,8 +102,11 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
         last_state = dict(last_state)
         last_state["stage_started_at"] = datetime.now(tz=timezone.utc).isoformat()
 
-        # Run stage
-        new_state = runner(OrchestrationState(**last_state))
+        # Run stage. #1886: a stall must be visible while it is stalling —
+        # the 17.5-minute hang of 2026-07-28 looked identical to normal
+        # progress in the log until a human compared it against nominal.
+        with StageWatchdog(current_stage):
+            new_state = runner(OrchestrationState(**last_state))
 
         # Persist state after each attempt
         save_orchestration_state(new_state)

--- a/tests/unit/test_stage_watchdog.py
+++ b/tests/unit/test_stage_watchdog.py
@@ -1,0 +1,147 @@
+"""Stage stall visibility (#1886) and non-retryable programming errors (#1875).
+
+Both come from the same hour of the 2026-07-28 campaign: a 15-second-nominal
+stage ran 17.5 minutes with nothing in the log saying so, and a single bad
+call signature burned 9 attempts and 84 seconds of backoff before reporting
+"All credentials failed" for what was a bug in the caller.
+"""
+
+import time
+from unittest.mock import patch
+
+from assemblyzero.core.stage_watchdog import (
+    SLOW_RATIO,
+    STAGE_NOMINAL_SECONDS,
+    STALLED_RATIO,
+    StageWatchdog,
+)
+
+
+class TestStatusLine:
+    """The line says what a human would have had to work out by hand."""
+
+    def test_reports_stage_and_elapsed(self):
+        line = StageWatchdog("impl", nominal_seconds=40).status_line(60)
+        assert "impl" in line
+        assert "60s" in line
+
+    def test_quiet_below_the_slow_ratio(self):
+        line = StageWatchdog("impl", nominal_seconds=40).status_line(60)
+        assert "SLOW" not in line
+        assert "STALLED" not in line
+
+    def test_marks_slow_at_the_ratio(self):
+        watchdog = StageWatchdog("impl", nominal_seconds=40)
+        line = watchdog.status_line(40 * SLOW_RATIO)
+        assert "SLOW" in line
+        assert "nominal" in line
+
+    def test_escalates_to_stalled(self):
+        watchdog = StageWatchdog("impl", nominal_seconds=40)
+        line = watchdog.status_line(40 * STALLED_RATIO)
+        assert "STALLED" in line
+        assert "SLOW" not in line
+
+    def test_the_17_minute_hang_would_have_been_labelled(self):
+        """The regression in one line: 1050s against a 15s nominal."""
+        line = StageWatchdog("review", nominal_seconds=15).status_line(1050)
+        assert "STALLED" in line
+        assert "70x" in line
+
+    def test_unknown_stage_still_reports_elapsed(self):
+        line = StageWatchdog("mystery", nominal_seconds=None).status_line(90)
+        assert "mystery" in line and "90s" in line
+        assert "nominal" not in line
+
+    def test_known_stages_have_nominals(self):
+        for stage in ("triage", "lld", "spec", "impl", "pr", "cleanup"):
+            assert STAGE_NOMINAL_SECONDS[stage] > 0
+
+
+class TestWatchdogLifecycle:
+    def test_prints_on_interval_then_stops(self, capsys):
+        with StageWatchdog("impl", nominal_seconds=1, interval=0.05):
+            time.sleep(0.2)
+        out = capsys.readouterr().out
+        assert "[STAGE] impl running" in out
+
+        # After the context exits, no further lines appear.
+        time.sleep(0.15)
+        assert "[STAGE]" not in capsys.readouterr().out
+
+    def test_quiet_when_the_stage_finishes_fast(self, capsys):
+        with StageWatchdog("pr", interval=5):
+            pass
+        assert "[STAGE]" not in capsys.readouterr().out
+
+    def test_exception_in_the_stage_still_stops_the_thread(self, capsys):
+        try:
+            with StageWatchdog("impl", interval=0.05):
+                raise RuntimeError("stage blew up")
+        except RuntimeError:
+            pass
+        time.sleep(0.15)
+        capsys.readouterr()
+        time.sleep(0.15)
+        assert "[STAGE]" not in capsys.readouterr().out
+
+
+class TestProgrammingErrorsAreNotRetried:
+    """#1875: retrying a TypeError cannot fix it and hides the real defect."""
+
+    def _client(self, tmp_path):
+        from assemblyzero.core.gemini_client import GeminiClient
+
+        creds = tmp_path / "creds.json"
+        creds.write_text(
+            '{"credentials": [{"name": "c1", "type": "oauth", "enabled": true}]}',
+            encoding="utf-8",
+        )
+        return GeminiClient(
+            model="gemini-3.1-pro-high",
+            credentials_file=creds,
+            state_file=tmp_path / "state.json",
+        )
+
+    def test_type_error_fails_immediately_without_sleeping(self, tmp_path):
+        client = self._client(tmp_path)
+
+        def boom(*args, **kwargs):
+            raise TypeError("got an unexpected keyword argument 'timeout_seconds'")
+
+        with patch.object(client, "_invoke_via_cli", side_effect=boom), \
+             patch("assemblyzero.core.gemini_client.time.sleep") as slept:
+            result = client.invoke("system", "content")
+
+        assert result.success is False
+        assert "Programming error" in result.error_message
+        assert "TypeError" in result.error_message
+        assert result.attempts == 1, "must not retry a defect in our own code"
+        slept.assert_not_called()
+
+    def test_attribute_error_is_also_immediate(self, tmp_path):
+        client = self._client(tmp_path)
+
+        def boom(*args, **kwargs):
+            raise AttributeError("'LLMCallResult' object has no attribute 'content'")
+
+        with patch.object(client, "_invoke_via_cli", side_effect=boom):
+            result = client.invoke("system", "content")
+
+        assert result.success is False
+        assert result.attempts == 1
+
+    def test_ordinary_runtime_error_still_retries(self, tmp_path):
+        """The narrowing must not disable the retry path it lives in."""
+        client = self._client(tmp_path)
+        calls = []
+
+        def flaky(*args, **kwargs):
+            calls.append(1)
+            raise RuntimeError("503 capacity exhausted")
+
+        with patch.object(client, "_invoke_via_cli", side_effect=flaky), \
+             patch("assemblyzero.core.gemini_client.time.sleep"):
+            client.invoke("system", "content")
+
+        assert len(calls) > 1, "transient failures must still be retried"


### PR DESCRIPTION
Both remaining robustness gaps from the same hour of the 2026-07-28 campaign: a run wasted wall-clock on a condition the system should have surfaced, and on one it should have refused.

## A stalled stage is now visible while it stalls (#1886)

The 17.5-minute hang looked identical to normal progress in the log. The instrumented wrapper's heartbeat said 'alive' the whole time — a live process is not a progressing one — and the stall was caught only when a human compared elapsed time against what that stage normally takes.

StageWatchdog prints that comparison as the stage runs, wrapped around every stage in the orchestrator's runner:

    [STAGE] impl running 60s (nominal ~240s)
    [STAGE] spec running 300s (nominal ~90s) - SLOW, 3x nominal
    [STAGE] spec running 600s (nominal ~90s) - STALLED, 6x nominal

Nominals come from the campaign's own run records. The thresholds are the operator's framing — 'if nominal is 15 seconds, 15 minutes is a problem, not patience.' It never kills anything: bounding a call is the provider's job (#1874), this is the observability half so a stall is obvious at the time rather than in hindsight. A stage that finishes inside the interval prints nothing, so quiet runs stay quiet.

## Programming errors are no longer retried (#1875)

The gemini rotation loop's generic `except Exception` caught TypeError from a bad call signature, classified it as retryable, and drove the full retries x credentials sequence with backoff: 9 attempts, 84 seconds, then 'All credentials failed' for what was a defect in the caller. TypeError / AttributeError / NameError / ImportError now fail immediately with the exception named, no rotation, no backoff.

The narrowing is deliberately tight, and a test pins that ordinary RuntimeErrors still retry — the fix must not disable the retry path it lives in.

Tests: 13 cases — status-line tone at each ratio (including the real 1050s-vs-15s hang, which now labels as STALLED 70x), thread lifecycle including exception paths, silence on fast stages, and the three programming-error behaviours. Full unit suite 5787 passed. Ruff: 2 pre-existing findings in untouched lines.

Closes #1886
Closes #1875