### PR TITLE
fix(spec-review): a BLOCKED verdict must say why (Closes #1889)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -311,11 +311,18 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         for item in spec_result["feedback_items"]:
             verdict_content += f"- {item}\n"
 
-    if audit_dir and audit_dir.exists():
-        file_num = next_file_number(audit_dir)
-        verdict_path = save_audit_file(
-            audit_dir, file_num, "readiness-verdict.md", verdict_content
-        )
+    # #1889: create the audit dir if it is absent rather than silently
+    # dropping the verdict. A run that blocked and left no record of why is
+    # the failure this whole gate exists to prevent.
+    if audit_dir:
+        try:
+            audit_dir.mkdir(parents=True, exist_ok=True)
+            file_num = next_file_number(audit_dir)
+            verdict_path = save_audit_file(
+                audit_dir, file_num, "readiness-verdict.md", verdict_content
+            )
+        except OSError as exc:
+            print(f"    WARNING: could not persist verdict: {exc}")
 
     # -------------------------------------------------------------------------
     # Report results
@@ -325,8 +332,10 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
     if verdict_path:
         print(f"    Saved: {verdict_path.name}")
 
-    if verdict_status == "REVISE" and feedback:
-        # Show a preview of feedback
+    # #1889: BLOCKED is the more severe outcome and used to print nothing but
+    # a line count, so the reviewer's finding — the whole point of the gate —
+    # was invisible in the run record.
+    if verdict_status in ("REVISE", "BLOCKED") and feedback:
         feedback_preview = feedback[:200].replace("\n", " ")
         if len(feedback) > 200:
             feedback_preview += "..."
@@ -343,10 +352,20 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         0,
     )
 
+    # #1889: a BLOCKED verdict routes to HALT either way, but the halt used
+    # to report nothing because error_message stayed empty — the rationale
+    # and feedback sat unused in state while the operator saw a blank. Carry
+    # the reason so the stage that stopped says why it stopped.
+    blocked_reason = ""
+    if verdict_status == "BLOCKED":
+        blocked_reason = (
+            f"Spec review BLOCKED: {feedback or spec_result['rationale'] or 'no reason given'}"
+        )
+
     return {
         "review_verdict": verdict_status,
         "review_feedback": feedback,
-        "error_message": "",
+        "error_message": blocked_reason,
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
     }

--- a/tests/unit/test_spec_review_quality.py
+++ b/tests/unit/test_spec_review_quality.py
@@ -5,6 +5,8 @@ pass (#1866), and the console called a spec "7/7 checks passed" when most of
 those checks had nothing to check (#1870).
 """
 
+from unittest.mock import MagicMock
+
 from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
     REVIEWER_SYSTEM_PROMPT,
 )
@@ -67,3 +69,74 @@ class TestNotApplicableChecksAreNotPasses:
         })
         out = capsys.readouterr().out
         assert "[FAIL]" in out
+
+
+class TestBlockedVerdictSaysWhy:
+    """#1889: the gate's finding must survive into the run record."""
+
+    def _state(self, tmp_path):
+        return {
+            "spec_draft": "# Spec\n" + ("x" * 200),
+            "lld_content": "# LLD",
+            "audit_dir": str(tmp_path / "audit"),
+            "issue_number": 41,
+            "cost_budget_usd": 0.0,
+        }
+
+    def _spec_result(self, verdict, rationale="", items=None):
+        return {
+            "verdict": verdict,
+            "rationale": rationale,
+            "feedback_items": items or [],
+            "source": "structured",
+        }
+
+    def _run(self, tmp_path, spec_result):
+        from unittest.mock import patch
+
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            review_spec,
+        )
+
+        base = "assemblyzero.workflows.implementation_spec.nodes.review_spec"
+        with patch(f"{base}.get_provider", return_value=MagicMock()), patch(
+            f"{base}._invoke_reviewer_with_spec_schema",
+            return_value=(spec_result, ""),
+        ):
+            return review_spec(self._state(tmp_path))
+
+    def test_blocked_carries_its_reason_into_error_message(self, tmp_path):
+        result = self._run(
+            tmp_path,
+            self._spec_result(
+                "BLOCKED", rationale="Assertion T080 contradicts section 5.2."
+            ),
+        )
+        assert result["review_verdict"] == "BLOCKED"
+        assert "BLOCKED" in result["error_message"]
+        assert "T080" in result["error_message"]
+
+    def test_approved_leaves_error_message_empty(self, tmp_path):
+        result = self._run(tmp_path, self._spec_result("APPROVED", rationale="fine"))
+        assert result["error_message"] == ""
+
+    def test_revise_leaves_error_message_empty(self, tmp_path):
+        """REVISE must keep routing to another revision, not halt."""
+        result = self._run(tmp_path, self._spec_result("REVISE", rationale="tighten"))
+        assert result["error_message"] == ""
+
+    def test_blocked_prints_the_feedback(self, tmp_path, capsys):
+        self._run(
+            tmp_path,
+            self._spec_result("BLOCKED", rationale="Unwinnable assertion in T080."),
+        )
+        assert "Unwinnable assertion" in capsys.readouterr().out
+
+    def test_verdict_persists_even_when_audit_dir_is_absent(self, tmp_path):
+        """The run that exposed this wrote no verdict file at all."""
+        audit = tmp_path / "audit"
+        assert not audit.exists()
+        self._run(tmp_path, self._spec_result("BLOCKED", rationale="because"))
+        written = list(audit.glob("*readiness-verdict.md"))
+        assert written, "a blocked verdict must leave a record"
+        assert "because" in written[0].read_text(encoding="utf-8")


### PR DESCRIPTION
Caught live on the first phase-2 roll under the new gates (2026-07-29). The spec reviewer returned BLOCKED and halted the run correctly — and the reason was recoverable from nowhere: the console printed only a line count, the halt banner was blank, the orchestrator's stage table showed an empty error column, and no verdict file was written.

The reviewer working is worth nothing if its finding is invisible, and this is the gate #1866 just strengthened to catch unwinnable specs. Three fixes, one per gap:

- **Console.** The feedback preview printed only for REVISE. BLOCKED — the more severe outcome — now prints it too.
- **Halt.** review_spec returned error_message='' even on BLOCKED, so HALT had nothing to report while the rationale sat unused in state. A BLOCKED verdict now carries its reason into error_message. Routing is unchanged (BLOCKED routed to HALT before and still does); APPROVED and REVISE keep an empty error_message so the revise loop is untouched — both pinned by tests.
- **Audit trail.** The verdict was written only if the audit dir already existed, which it did not on this run. It is created on demand now, and a failure to persist warns instead of passing silently.

Tests: 5 new cases — BLOCKED carries its reason, APPROVED and REVISE do not, BLOCKED prints its feedback, and a verdict persists even with no pre-existing audit dir. Full unit suite 5792 passed. Ruff: 3 pre-existing findings in untouched lines.

Sibling of #1873 and the #1868/#1869 honest-failure work — same principle one layer up: a stage that stops must say why.

Closes #1889