### PR TITLE
fix(spec-review): traceability severity matches recoverability (Closes #1892)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -83,8 +83,8 @@ You ARE reviewing:
 - Internal consistency of the tests: does every assertion in the spec's test \
 code follow from behaviour the spec itself specifies?
 
-ASSERTION TRACEABILITY (Issue #1866) — check this explicitly and BLOCK on any \
-violation. Three real specs shipped an unwinnable test this way:
+ASSERTION TRACEABILITY (Issue #1866) — check this explicitly on every review. \
+Three real specs shipped an unwinnable test this way:
 
 1. An assertion that contradicts the spec's own behaviour text. One spec said \
 peaks never decay below the latest value, then asserted a decayed peak BELOW \
@@ -98,7 +98,17 @@ flavour does not change with sys.platform, so on Windows it can never pass.
 
 For each assertion in the spec's test code, name the requirement or behaviour \
 section it traces to. If you cannot, that assertion is the finding — quote it \
-and say which behaviour it contradicts or invents."""
+and say which behaviour it contradicts or invents.
+
+SEVERITY MUST MATCH RECOVERABILITY (Issue #1892). Report a traceability \
+violation as REVISE whenever a regenerated spec could fix it — a wrong \
+assertion, a reference implementation that disagrees with the spec's own \
+requirements, a test whose inputs cannot distinguish correct from incorrect \
+behaviour. That is the overwhelmingly common case, and REVISE returns your \
+feedback to the drafter so the spec gets fixed. Reserve BLOCKED for a \
+contradiction in the LLD itself that no spec could satisfy, because BLOCKED \
+stops the run outright and needs a human. State the finding just as forcefully \
+either way; only the verdict changes."""
 
 
 # =============================================================================

--- a/tests/unit/test_spec_review_quality.py
+++ b/tests/unit/test_spec_review_quality.py
@@ -31,8 +31,15 @@ class TestReviewerChecksAssertionTraceability:
         # cannot hold on the platform the tests run on
         assert "sys.platform" in text
 
-    def test_prompt_requires_blocking_not_merely_noting(self):
-        assert "BLOCK" in REVIEWER_SYSTEM_PROMPT
+    def test_prompt_ties_severity_to_recoverability(self):
+        """#1892: a fixable violation must come back as REVISE so the revise
+        loop can heal it; BLOCKED halts the run and needs a human."""
+        assert "SEVERITY MUST MATCH RECOVERABILITY" in REVIEWER_SYSTEM_PROMPT
+        assert "REVISE whenever a regenerated spec could fix it" in REVIEWER_SYSTEM_PROMPT
+        assert "Reserve BLOCKED" in REVIEWER_SYSTEM_PROMPT
+
+    def test_prompt_still_demands_the_finding_be_stated(self):
+        assert "that assertion is the finding" in REVIEWER_SYSTEM_PROMPT
 
     def test_prompt_keeps_its_original_review_dimensions(self):
         for dimension in ("Completeness", "Concreteness", "Specificity", "Feasibility"):


### PR DESCRIPTION
The #1866 traceability gate works. Its first live catch (boostgauge#41, 2026-07-29) is a genuine spec self-contradiction found BEFORE implementation:

> REQ-5 and Section 1 specify that peak decay must be clamped so the peak does not decay below active sample values. Scenario 080 specifies querying at t=8.0 expecting 50.0. However, the reference implementation in Section 6.1 does not clamp and returns 20.0 at t=8.0. Furthermore, test_t080 queries at t=5.0 where the decayed peak (100-50=50) coincidentally equals sample 1's value (50), masking the bug.

Both claims check out arithmetically, and the second is the better catch — a test that would pass whether or not the bug exists. Same defect family that killed two earlier phase-2 rolls, now caught pre-implementation instead of after three wasted impl iterations.

**The severity was wrong, not the finding.** My #1866 wording said 'BLOCK on any violation', and BLOCKED routes straight to HALT — the run stops dead, which on a recorded take is a dead take. But this defect is fixable by regeneration, which is exactly what REVISE is for: the revise loop already returns the reviewer's feedback to the drafter, with two-strike stagnation detection as the backstop.

The prompt now ties severity to recoverability: REVISE whenever a regenerated spec could fix the violation (a wrong assertion, a reference implementation disagreeing with the spec's own requirements, a test whose inputs cannot distinguish correct from incorrect behaviour), BLOCKED reserved for a contradiction in the LLD itself that no spec could satisfy. The finding is stated just as forcefully either way; only the routing changes, so the pipeline heals what it can instead of halting on its own work.

Tests updated to pin the severity rule alongside the existing traceability requirements. Full unit suite 5793 passed.

Follow-up to #1866; the finding was only visible because #1889 made BLOCKED verdicts report their reason.

Closes #1892