### PR TITLE
fix(testing): run tests in the target repo's environment (Closes #1904)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -712,6 +712,40 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                     f"{(push_result.stderr or '').strip()[:200]}"
                 )
 
+            # #1904: provision the worktree's environment. Without this,
+            # `poetry run` silently falls through to PATH for missing
+            # commands and every test executes in AssemblyZero's venv —
+            # phase 3 of the boostgauge campaign passed on AZ's Pillow,
+            # phase 4 died on the target's psutil. A failed install is a
+            # failed stage, not a warning: tests in the wrong environment
+            # are worse than no tests.
+            if (worktree_path / "pyproject.toml").is_file():
+                print("    [ENV] poetry install (target worktree)...")
+                install_result = run_command(
+                    ["poetry", "install"],
+                    cwd=str(worktree_path),
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if install_result.returncode != 0:
+                    detail = (
+                        (install_result.stderr or "").strip()
+                        or (install_result.stdout or "").strip()
+                        or "no output"
+                    )
+                    return _make_stage_result(
+                        status="failed",
+                        error_message=(
+                            f"Worktree environment provisioning failed "
+                            f"(poetry install exit {install_result.returncode}): "
+                            f"{detail[:400]}"
+                        ),
+                        duration_seconds=time.monotonic() - start_time,
+                        attempts=1,
+                    )
+                print("    [ENV] worktree environment ready")
+
         # Run implementation workflow
         from assemblyzero.workflows.testing.graph import build_testing_workflow as create_impl_graph
 

--- a/assemblyzero/workflows/testing/nodes/e2e_validation.py
+++ b/assemblyzero/workflows/testing/nodes/e2e_validation.py
@@ -131,8 +131,10 @@ def run_e2e_tests(
         # Run all tests if no specific E2E files
         e2e_files = test_files
 
+    # #1904: through the target repo's env, matching verify_phases — bare
+    # pytest ran in AssemblyZero's venv.
     cmd = [
-        "pytest",
+        "poetry", "run", "pytest",
         "-v",
         "-m", "e2e or integration",  # Run only e2e/integration marked tests
         "--tb=short",

--- a/assemblyzero/workflows/testing/runners/pytest_runner.py
+++ b/assemblyzero/workflows/testing/runners/pytest_runner.py
@@ -32,7 +32,12 @@ class PytestRunner(BaseTestRunner):
 
         Uses --json-report if available, falls back to stdout parsing.
         """
-        command = ["pytest", "--tb=short", "-q"]
+        # #1904: bare "pytest" resolved from the ORCHESTRATOR's PATH — AZ's
+        # venv, not the target repo's. Phase 3 of the boostgauge campaign
+        # passed only because AZ happens to carry Pillow; phase 4 died on
+        # psutil, which only the target declares. poetry run + cwd at the
+        # (provisioned — see stages.py) worktree resolves the real env.
+        command = ["poetry", "run", "pytest", "--tb=short", "-q"]
 
         if extra_args:
             command.extend(extra_args)

--- a/tests/unit/test_target_env_tests.py
+++ b/tests/unit/test_target_env_tests.py
@@ -1,0 +1,66 @@
+"""Tests execute in the TARGET repo's environment (#1904).
+
+Every test result of the boostgauge campaign before this fix ran in
+AssemblyZero's venv: bare ``pytest`` resolved from the orchestrator's PATH,
+and unprovisioned worktrees let ``poetry run`` fall through to PATH anyway.
+Phase 3 passed on AZ's Pillow; phase 4 died on the target's psutil.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.framework_detector import TestFramework
+from assemblyzero.workflows.testing.runner_registry import get_framework_config
+from assemblyzero.workflows.testing.runners.pytest_runner import PytestRunner
+
+
+def _runner(tmp_path):
+    return PytestRunner(
+        config=dict(get_framework_config(TestFramework.PYTEST)),
+        project_root=str(tmp_path),
+    )
+
+
+class TestPytestRunsInTargetEnv:
+    def test_command_goes_through_poetry_run(self, tmp_path):
+        runner = _runner(tmp_path)
+        with patch.object(
+            runner, "_run_subprocess", return_value=("1 passed", 0)
+        ) as sub:
+            runner.run_tests(test_paths=["tests/unit/test_x.py"])
+
+        command = sub.call_args[0][0]
+        assert command[:3] == ["poetry", "run", "pytest"], (
+            "bare pytest resolves from the orchestrator's PATH — AZ's venv, "
+            "not the target's"
+        )
+
+    def test_extra_args_and_paths_still_ride_along(self, tmp_path):
+        runner = _runner(tmp_path)
+        with patch.object(
+            runner, "_run_subprocess", return_value=("1 passed", 0)
+        ) as sub:
+            runner.run_tests(
+                test_paths=["tests/unit/test_x.py"],
+                extra_args=["--cov=pkg"],
+            )
+
+        command = sub.call_args[0][0]
+        assert "--cov=pkg" in command
+        assert "tests/unit/test_x.py" in command
+
+
+class TestE2EAlsoUsesPoetryRun:
+    def test_source_has_no_bare_pytest_command(self):
+        """Pin at the source level: the e2e node builds its command through
+        poetry run, matching verify_phases."""
+        import importlib
+        from pathlib import Path
+
+        # `import ...e2e_validation as mod` binds the package attribute of
+        # the same name (the function) — importlib returns the real module.
+        mod = importlib.import_module(
+            "assemblyzero.workflows.testing.nodes.e2e_validation"
+        )
+        source = Path(mod.__file__).read_text(encoding="utf-8")
+        assert '"poetry", "run", "pytest"' in source
+        assert '\n    cmd = [\n        "pytest",' not in source


### PR DESCRIPTION
Every test result of the campaign before this ran in AssemblyZero's venv. Two halves, both required:

- **Bare pytest resolved from the orchestrator's PATH** (pytest_runner, e2e_validation) while verify_phases already used poetry run — one workflow, mixed environments. Phase 3 passed 8/8 only because AZ's venv happens to carry Pillow; phase 4 died at collection on psutil, which only the target declares. Both sites now go through poetry run pytest with cwd at the worktree.
- **Worktrees were never provisioned**, and poetry run silently falls through to PATH for missing commands — observed directly (fresh empty venv, pytest still executed from AZ's env). The impl stage now runs poetry install at worktree creation when pyproject.toml exists, with output captured; a failed install is a failed stage with the reason in the record, not a warning — tests in the wrong environment are worse than no tests.

Tests: runner-command construction pinned through poetry run (with args/paths riding along), and a source-level pin that the e2e node matches. 5796 passed on the full suite. Ruff: 3 pre-existing unused imports in untouched lines.

Sibling of #1901 (completeness checker resolving third-party imports in the wrong environment — still open; same disease, different organ).

Closes #1904