### PR TITLE
fix(gemini): bound the PTY spawn itself (Closes #1906)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -310,12 +310,79 @@ def _append_json_schema_directive(system_instruction: str, schema: dict) -> str:
     )
 
 
+# #1906: spawn nominal is sub-second; a spawn still pending after this long
+# is the hang-shaped sibling of the #1872 instant spawn failures.
+SPAWN_TIMEOUT_SECONDS = 30.0
+
+
+def _spawn_pty_bounded(argv, cwd, dimensions, timeout_seconds=SPAWN_TIMEOUT_SECONDS):
+    """PtyProcess.spawn with a wall-clock bound (#1906).
+
+    The #1874 budget bounds the PTY READ loop, whose deadline is set after
+    spawn returns — so a spawn that hangs under machine pressure sits before
+    any deadline exists and escapes the budget entirely (observed live:
+    13:45:22 entry, killed by hand at 13:58). Spawn runs in a worker thread;
+    on expiry the caller gets the standard failure path and the abandoned
+    thread terminates its own late-arriving process so nothing leaks.
+
+    Returns:
+        The spawned PtyProcess.
+
+    Raises:
+        TimeoutError: spawn did not complete within the bound.
+        Exception: whatever spawn itself raised, re-raised in the caller.
+    """
+    import threading
+
+    from winpty import PtyProcess
+
+    holder: dict = {}
+    lock = threading.Lock()
+
+    def _target() -> None:
+        try:
+            proc = PtyProcess.spawn(argv, cwd=cwd, dimensions=dimensions)
+        except Exception as exc:  # noqa: BLE001 — re-raised by the caller
+            with lock:
+                holder["error"] = exc
+            return
+        with lock:
+            if holder.get("abandoned"):
+                # The caller gave up; a process arriving now would be an
+                # orphan burning quota with nobody reading its output.
+                try:
+                    proc.terminate(force=True)
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+            holder["proc"] = proc
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout_seconds)
+
+    with lock:
+        if "proc" in holder:
+            return holder["proc"]
+        if "error" in holder:
+            raise holder["error"]
+        holder["abandoned"] = True
+    raise TimeoutError(
+        f"agy spawn timed out ({timeout_seconds:.0f}s) — machine-pressure "
+        f"hang; treated like a spawn failure"
+    )
+
+
 def _is_spawn_failure(error_text: str) -> bool:
     """True when an error string carries a Windows process-creation code.
 
     Issue #1872: these mean the child never started. That is transient
     machine pressure and deserves a backoff, not a credential write-off.
+    Issue #1906: a hung spawn (timed out) is the same condition in slow
+    motion and takes the same retry path.
     """
+    if "spawn timed out" in error_text:
+        return True
     return any(str(code) in error_text for code in SPAWN_FAILURE_EXIT_CODES)
 
 
@@ -433,7 +500,7 @@ class GeminiClient:
             return self._invoke_via_stdin(full_prompt, timeout_seconds)
 
         try:
-            from winpty import PtyProcess
+            import winpty  # noqa: F401 — availability probe only
         except ImportError as e:
             return False, "", f"pywinpty unavailable for agy invocation: {e}"
 
@@ -444,7 +511,14 @@ class GeminiClient:
         exit_status = None
         try:
             with tempfile.TemporaryDirectory() as tmp_cwd:
-                proc = PtyProcess.spawn(argv, cwd=tmp_cwd, dimensions=(60, 1000))
+                # #1906: spawn itself must be bounded — the read deadline
+                # below does not exist yet while spawn hangs.
+                try:
+                    proc = _spawn_pty_bounded(
+                        argv, cwd=tmp_cwd, dimensions=(60, 1000)
+                    )
+                except TimeoutError as e:
+                    return False, "", str(e)
                 deadline = time.time() + timeout_seconds
                 timed_out = True
                 while time.time() < deadline:

--- a/tests/unit/test_gemini_call_bounds.py
+++ b/tests/unit/test_gemini_call_bounds.py
@@ -136,3 +136,96 @@ class TestStdinTransportTimeout:
         assert "3221225794" in err
         # and that message is what #1872's detector keys on
         assert gc._is_spawn_failure(err) is True
+
+
+class TestSpawnIsBounded:
+    """#1906: a hung spawn escaped the #1874 budget — the read deadline does
+    not exist while spawn hangs. Observed live: 13:45:22 entry, hand-killed
+    at 13:58."""
+
+    def test_hung_spawn_raises_timeout(self):
+        import threading
+
+        release = threading.Event()
+
+        class HangingPty:
+            @staticmethod
+            def spawn(argv, cwd=None, dimensions=None):
+                release.wait(5)  # far past the test's bound
+                raise AssertionError("spawn should have been abandoned")
+
+        import sys
+
+        with patch.dict(sys.modules, {"winpty": MagicMock(PtyProcess=HangingPty)}):
+            try:
+                gc._spawn_pty_bounded(["agy"], cwd=".", dimensions=(60, 100),
+                                      timeout_seconds=0.2)
+            except TimeoutError as e:
+                assert "spawn timed out" in str(e)
+            else:  # pragma: no cover
+                raise AssertionError("expected TimeoutError")
+        release.set()
+
+    def test_fast_spawn_returns_the_process(self):
+        import sys
+
+        proc = MagicMock()
+
+        class FastPty:
+            @staticmethod
+            def spawn(argv, cwd=None, dimensions=None):
+                return proc
+
+        with patch.dict(sys.modules, {"winpty": MagicMock(PtyProcess=FastPty)}):
+            got = gc._spawn_pty_bounded(["agy"], cwd=".", dimensions=(60, 100),
+                                        timeout_seconds=5)
+        assert got is proc
+
+    def test_spawn_error_is_reraised(self):
+        import sys
+
+        class BrokenPty:
+            @staticmethod
+            def spawn(argv, cwd=None, dimensions=None):
+                raise OSError("conpty allocation failed")
+
+        with patch.dict(sys.modules, {"winpty": MagicMock(PtyProcess=BrokenPty)}):
+            try:
+                gc._spawn_pty_bounded(["agy"], cwd=".", dimensions=(60, 100),
+                                      timeout_seconds=5)
+            except OSError as e:
+                assert "conpty" in str(e)
+            else:  # pragma: no cover
+                raise AssertionError("expected OSError")
+
+    def test_late_spawn_is_terminated_not_leaked(self):
+        import sys
+        import threading
+
+        gate = threading.Event()
+        proc = MagicMock()
+
+        class SlowPty:
+            @staticmethod
+            def spawn(argv, cwd=None, dimensions=None):
+                gate.wait(5)
+                return proc
+
+        with patch.dict(sys.modules, {"winpty": MagicMock(PtyProcess=SlowPty)}):
+            try:
+                gc._spawn_pty_bounded(["agy"], cwd=".", dimensions=(60, 100),
+                                      timeout_seconds=0.2)
+            except TimeoutError:
+                pass
+            gate.set()  # let the abandoned thread finish spawning
+            import time as _time
+
+            deadline = _time.time() + 3
+            while _time.time() < deadline and not proc.terminate.called:
+                _time.sleep(0.05)
+        proc.terminate.assert_called_once_with(force=True)
+
+    def test_spawn_timeout_message_takes_the_retry_path(self):
+        assert gc._is_spawn_failure(
+            "agy spawn timed out (30s) — machine-pressure hang; treated like a spawn failure"
+        ) is True


### PR DESCRIPTION
Phase 4's relaunch hung 13 minutes inside PtyProcess.spawn — the #1874 budget bounds the READ loop, whose deadline is set after spawn returns, so a spawn that hangs under machine pressure (the hang-shaped sibling of #1872's instant spawn failures) sits before any deadline exists and escapes the budget entirely. Caught by the #1886 stage watchdog at 3x nominal and killed by hand.

Fix: spawn runs in a worker thread bounded at 30s (nominal is sub-second). On expiry the caller gets the standard failure tuple whose message routes into the #1872 retryable-transient path — backoff and retry, not credential write-off. A late-completing spawn in the abandoned thread terminates its own process under a lock, so nothing leaks an orphan agy burning quota with nobody reading it.

Tests: hung spawn raises within the bound; fast spawn returns the process; spawn exceptions re-raise; a late spawn is terminated rather than leaked (polled to termination); the timeout message is recognised by the retry classifier. 5801 on the full suite; ruff finding is the known pre-existing unused import.

Sibling issues from the same diagnosis: #1907 (retry stacking multiplies budgets to ~50 min worst case) stays open for a call-site audit.

Closes #1906