### PR TITLE
fix(gemini): bound the PTY read (Closes #1910, Closes #1915)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -373,6 +373,68 @@ def _spawn_pty_bounded(argv, cwd, dimensions, timeout_seconds=SPAWN_TIMEOUT_SECO
     )
 
 
+def _read_pty_bounded(proc, timeout_seconds: float):
+    """Drain a PTY child under a bound the child cannot defeat (#1910).
+
+    pywinpty's read() blocks until data arrives, so a deadline checked
+    between reads never fires against a silent child — observed live as 12
+    minutes inside read() while agy produced nothing. The drain runs in a
+    worker thread; on expiry the process TREE dies, which forces the
+    blocked read to EOF so the thread exits too.
+
+    Returns:
+        (True, text, exit_status) on completion;
+        (False, error_message, None) on timeout.
+    """
+    import threading
+
+    chunks: list[str] = []
+    done = threading.Event()
+    holder: dict = {}
+
+    def _drain() -> None:
+        try:
+            while True:
+                try:
+                    data = proc.read(4096)
+                except EOFError:
+                    break
+                except Exception:  # noqa: BLE001 — killed mid-read
+                    break
+                if data:
+                    chunks.append(data)
+                elif not proc.isalive():
+                    break
+                else:
+                    time.sleep(0.05)
+            try:
+                holder["exit_status"] = proc.exitstatus
+            except Exception:  # noqa: BLE001
+                holder["exit_status"] = None
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=_drain, daemon=True)
+    thread.start()
+    if not done.wait(timeout=timeout_seconds):
+        try:
+            proc.terminate(force=True)
+        except Exception:  # noqa: BLE001
+            pass
+        # #1874: terminate() ends the console host, not the grandchildren.
+        try:
+            kill_process_tree(proc.pid)
+        except Exception:  # noqa: BLE001
+            pass
+        done.wait(timeout=10)  # the blocked read returns once the tree dies
+        return (
+            False,
+            f"agy CLI timeout ({timeout_seconds:.0f}s, silent child killed)",
+            None,
+        )
+    return True, "".join(chunks), holder.get("exit_status")
+
+
 def _is_spawn_failure(error_text: str) -> bool:
     """True when an error string carries a Windows process-creation code.
 
@@ -519,37 +581,17 @@ class GeminiClient:
                     )
                 except TimeoutError as e:
                     return False, "", str(e)
-                deadline = time.time() + timeout_seconds
-                timed_out = True
-                while time.time() < deadline:
-                    try:
-                        data = proc.read(4096)
-                    except EOFError:
-                        timed_out = False
-                        break
-                    if data:
-                        chunks.append(data)
-                    elif not proc.isalive():
-                        timed_out = False
-                        break
-                    else:
-                        time.sleep(0.05)
-                if timed_out:
-                    try:
-                        proc.terminate(force=True)
-                    except Exception:
-                        pass
-                    # #1874: terminate() ends the console host, not the
-                    # grandchildren agy spawned under it.
-                    try:
-                        kill_process_tree(proc.pid)
-                    except Exception:
-                        pass
-                    return False, "", f"agy CLI timeout ({timeout_seconds:.0f}s)"
-                try:
-                    exit_status = proc.exitstatus
-                except Exception:
-                    exit_status = None
+                # #1910: the old between-reads deadline was no bound at all —
+                # pywinpty's read() blocks, so a silent child parked the loop
+                # inside read() for 12+ minutes with the deadline never
+                # consulted. The drain runs in a worker thread the child
+                # cannot hold hostage.
+                ok, payload, exit_status = _read_pty_bounded(
+                    proc, timeout_seconds
+                )
+                if not ok:
+                    return False, "", payload
+                chunks.append(payload)
         except Exception as e:  # pywinpty raises assorted OS/runtime errors
             return False, "", f"agy CLI invocation failed: {e}"
 

--- a/tests/unit/test_gemini_call_bounds.py
+++ b/tests/unit/test_gemini_call_bounds.py
@@ -236,21 +236,39 @@ class TestReadIsBounded:
 
     def test_silent_child_is_killed_at_the_bound(self):
         import threading
+        import time
 
-        release = threading.Event()
+        killed = threading.Event()
         proc = MagicMock()
         proc.pid = 777
-        proc.read.side_effect = lambda n: release.wait(10) or ""
+
+        def _read_until_killed(n):
+            # Block like a real silent child; the tree-kill below forces the
+            # blocked read to EOF, exactly as on a live PTY.
+            killed.wait(30)
+            raise EOFError
+
+        proc.read.side_effect = _read_until_killed
         proc.isalive.return_value = True
 
-        with patch.object(gc, "kill_process_tree") as killer:
+        threads_before = threading.active_count()
+        with patch.object(
+            gc, "kill_process_tree", side_effect=lambda pid: killed.set()
+        ) as killer:
             ok, payload, status = gc._read_pty_bounded(proc, timeout_seconds=0.3)
 
-        release.set()
         assert ok is False
         assert "timeout" in payload.lower()
         assert status is None
         killer.assert_called_once_with(777)
+
+        # #1915: an unkillable mock (no EOF, isalive always True) leaked the
+        # drain thread spinning hot, which took down the CI runner. The
+        # drain must actually exit once the kill lands.
+        deadline = time.time() + 5
+        while threading.active_count() > threads_before and time.time() < deadline:
+            time.sleep(0.01)
+        assert threading.active_count() <= threads_before
 
     def test_completing_child_returns_its_output(self):
         proc = MagicMock()

--- a/tests/unit/test_gemini_call_bounds.py
+++ b/tests/unit/test_gemini_call_bounds.py
@@ -229,3 +229,54 @@ class TestSpawnIsBounded:
         assert gc._is_spawn_failure(
             "agy spawn timed out (30s) — machine-pressure hang; treated like a spawn failure"
         ) is True
+
+
+class TestReadIsBounded:
+    """#1910: the drain must not depend on the child ever producing output."""
+
+    def test_silent_child_is_killed_at_the_bound(self):
+        import threading
+
+        release = threading.Event()
+        proc = MagicMock()
+        proc.pid = 777
+        proc.read.side_effect = lambda n: release.wait(10) or ""
+        proc.isalive.return_value = True
+
+        with patch.object(gc, "kill_process_tree") as killer:
+            ok, payload, status = gc._read_pty_bounded(proc, timeout_seconds=0.3)
+
+        release.set()
+        assert ok is False
+        assert "timeout" in payload.lower()
+        assert status is None
+        killer.assert_called_once_with(777)
+
+    def test_completing_child_returns_its_output(self):
+        proc = MagicMock()
+        proc.pid = 778
+        proc.read.side_effect = ["hello ", "world", EOFError()]
+        proc.exitstatus = 0
+
+        ok, payload, status = gc._read_pty_bounded(proc, timeout_seconds=5)
+
+        assert ok is True
+        assert payload == "hello world"
+        assert status == 0
+
+    def test_dead_child_with_no_output_completes(self):
+        proc = MagicMock()
+        proc.pid = 779
+        proc.read.return_value = ""
+        proc.isalive.return_value = False
+        proc.exitstatus = 3221225794
+
+        ok, payload, status = gc._read_pty_bounded(proc, timeout_seconds=5)
+
+        assert ok is True
+        assert payload == ""
+        assert status == 3221225794
+
+    def test_timeout_message_is_a_recognized_timeout(self):
+        """The failure routes like other timeouts, not like a verdict."""
+        assert "timeout" in "agy CLI timeout (300s, silent child killed)"


### PR DESCRIPTION
Third and final escape from the call bounds, each one layer deeper: #1874 bounded the budget and the stdin drain, #1906 bounded spawn, and this bounds the read. A silent agy (alive 12 minutes, zero output, while Gemini was serving 503s elsewhere in the same run) parked the drain loop inside pywinpty's blocking read() — the between-reads deadline was never consulted, so every bound upstream was moot.

The drain now runs in a worker thread joined against the remaining budget. On expiry the process tree dies, which forces the blocked read to EOF so the thread exits too, and the caller gets a standard timeout failure that routes into retry/rotation. After this no phase of the agy interaction — spawn, read, drain, budget — trusts the child for anything.

Tests: silent-child kill at the bound (tree-kill asserted), completing child returns output and exit status, dead-silent child completes rather than hangs — 22/22 on the bounds suite this morning on this exact diff. Local full-suite verification was NOT possible for this PR: the dev machine degraded mid-afternoon (pytest itself stopped completing — the same pressure window that produced the silent-agy hang this fixes), so CI is the authoritative gate here, as designed.

Closes #1910

---

CI update (2026-07-29 evening): the first CI run on this PR died at the runner level — the new silent-child test had wired a mock that no kill could end (read never hit EOF, isalive stayed True), leaking the drain thread into a hot spin (~97k calls/sec measured, MagicMock recording every call) that exhausted the runner ~30 minutes in with zero pytest output. Commit 6143281 rewires the mock to block until the patched tree-kill fires and then raise EOFError — the real-world effect of a tree-kill on a PTY read — and adds a bounded thread-count assertion so an unkillable mock fails fast instead of taking down the runner. 22/22 on the bounds suite against the fixed head, sub-second.

Closes #1915
