### PR TITLE
fix(orchestrator): escalate stage-retry delays for capacity storms (Closes #1909)

### DIFF
--- a/assemblyzero/core/errors.py
+++ b/assemblyzero/core/errors.py
@@ -394,3 +394,24 @@ def _extract_retry_after(exc: Exception) -> Optional[float]:
             except (ValueError, TypeError):
                 pass
     return None
+
+
+# ---------------------------------------------------------------------------
+# Capacity-signature detection (#1909)
+# ---------------------------------------------------------------------------
+
+# Substrings that mark a provider-capacity failure in flattened error text.
+# Single source of truth shared by halt classification (halt_node.py) and the
+# orchestrator's capacity-aware stage retry escalation (graph.py).
+CAPACITY_MESSAGE_MARKERS = ("capacity exhausted", "503", "529", "overloaded")
+
+
+def is_capacity_message(message: str) -> bool:
+    """True when flattened error text carries a provider-capacity signature.
+
+    Capacity storms (503/529/overloaded) are the transient class that
+    outlasts a flat retry delay — callers use this to pick the escalating
+    backoff schedule instead of retry_delay_seconds.
+    """
+    lower = message.lower()
+    return any(marker in lower for marker in CAPACITY_MESSAGE_MARKERS)

--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -17,6 +17,7 @@ from assemblyzero.core.errors import (
     CapacityError,
     RateLimitError,
     classify_http_status,
+    is_capacity_message,
 )
 from assemblyzero.core.recovery_plan import generate_recovery_plan
 from assemblyzero.core.state_persistence import STATE_DIR, save_state_snapshot
@@ -60,8 +61,11 @@ def classify_error(error_message: str) -> str:
         if isinstance(classified, AuthenticationError):
             return "auth"
 
-    # Fallback: pattern matching for messages without status codes
-    if any(p in msg_lower for p in ("capacity exhausted", "503", "529", "overloaded")):
+    # Fallback: pattern matching for messages without status codes.
+    # #1909: markers live in errors.CAPACITY_MESSAGE_MARKERS so the halt
+    # classifier and the orchestrator's escalating retry agree on what
+    # "capacity" looks like.
+    if is_capacity_message(error_message):
         return "capacity_exhausted"
     if any(p in msg_lower for p in ("quota exhausted", "429", "all credentials exhausted")):
         return "quota_exhausted"

--- a/assemblyzero/workflows/orchestrator/config.py
+++ b/assemblyzero/workflows/orchestrator/config.py
@@ -26,6 +26,7 @@ class OrchestratorConfig(TypedDict, total=False):
     gates: dict[str, bool]
     max_stage_retries: int
     retry_delay_seconds: int
+    capacity_retry_delays: list[int]
 
 
 VALID_STAGES = ["triage", "lld", "spec", "impl", "pr"]
@@ -86,6 +87,11 @@ def get_default_config() -> OrchestratorConfig:
         },
         max_stage_retries=3,
         retry_delay_seconds=10,
+        # #1909: capacity storms (503/529/overloaded) outlast a flat 10s
+        # delay — the 2026-07-29 phase-4 run burned all three stage attempts
+        # inside ~2 minutes while the Gemini storm ran for several. Attempt
+        # N sleeps capacity_retry_delays[N-1] (last entry repeats).
+        capacity_retry_delays=[10, 60, 300],
     )
 
 
@@ -123,6 +129,19 @@ def validate_config(config: OrchestratorConfig) -> list[str]:
     retry_delay = config.get("retry_delay_seconds", 0)
     if not isinstance(retry_delay, (int, float)) or retry_delay < 0:
         errors.append("retry_delay_seconds must be >= 0")
+
+    capacity_delays = config.get("capacity_retry_delays", [10, 60, 300])
+    if (
+        not isinstance(capacity_delays, list)
+        or not capacity_delays
+        or any(
+            not isinstance(d, (int, float)) or isinstance(d, bool) or d < 0
+            for d in capacity_delays
+        )
+    ):
+        errors.append(
+            "capacity_retry_delays must be a non-empty list of numbers >= 0"
+        )
 
     stages = config.get("stages", {})
     if not isinstance(stages, dict):

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -43,6 +43,7 @@ from assemblyzero.workflows.orchestrator.state import (
     get_next_stage,
     update_stage_result,
 )
+from assemblyzero.core.errors import is_capacity_message
 from assemblyzero.core.halt_node import create_halt_node
 from assemblyzero.core.stage_watchdog import StageWatchdog
 
@@ -122,13 +123,24 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
         # (preserve current behavior for non-halt failures). Closes #1463.
         transient = stage_result.get("transient", True)
         if attempt < max_retries and transient:
+            # #1909: capacity storms outlast a flat delay — the 2026-07-29
+            # phase-4 run burned attempts 1-3 inside ~2 minutes while the
+            # provider's 503 storm ran for several. Escalate delays for
+            # capacity-class failures; everything else keeps retry_delay.
+            if is_capacity_message(stage_result.get("error_message", "")):
+                delays = config.get("capacity_retry_delays", [10, 60, 300])
+                delay = delays[min(attempt - 1, len(delays) - 1)]
+                flavor = " [capacity storm — escalated backoff]"
+            else:
+                delay = retry_delay
+                flavor = ""
             print(
                 f"[ORCHESTRATOR] Stage '{current_stage}' failed (attempt {attempt}/{max_retries}). "
-                f"Retrying in {retry_delay}s..."
+                f"Retrying in {delay}s...{flavor}"
             )
             # Update attempt count in result
             stage_result["attempts"] = attempt
-            time.sleep(retry_delay)
+            time.sleep(delay)
             last_state = new_state
         else:
             if not transient:

--- a/tests/unit/test_capacity_stage_retry.py
+++ b/tests/unit/test_capacity_stage_retry.py
@@ -1,0 +1,158 @@
+"""Capacity storms get escalating stage-retry delays (#1909).
+
+The 2026-07-29 phase-4 run proved classification and stage retry both
+worked — and the run still died, because three attempts with flat 10s
+delays span ~2 minutes while real provider storms (Gemini 503, Anthropic
+529) run for several. Attempt N against a capacity-class failure now
+sleeps capacity_retry_delays[N-1] (last entry repeats); every other
+transient failure keeps retry_delay_seconds.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.core.errors import is_capacity_message
+from assemblyzero.workflows.orchestrator.config import (
+    get_default_config,
+    validate_config,
+)
+from assemblyzero.workflows.orchestrator.state import create_initial_state
+
+
+class TestCapacityMessageDetection:
+    """The shared marker set recognizes real capacity failures, not noise."""
+
+    def test_live_incident_message_is_capacity(self):
+        msg = (
+            "Drafter failed: All credentials failed:\n"
+            "  - oauth-primary: Capacity exhausted after 3 retries (503/529)"
+        )
+        assert is_capacity_message(msg) is True
+
+    def test_anthropic_overloaded_is_capacity(self):
+        assert is_capacity_message("API error: overloaded_error (529)") is True
+
+    def test_bare_503_is_capacity(self):
+        assert is_capacity_message("upstream returned status 503") is True
+
+    def test_ordinary_failure_is_not_capacity(self):
+        assert is_capacity_message("Failed to read LLD: file not found") is False
+
+    def test_auth_failure_is_not_capacity(self):
+        assert is_capacity_message("Invalid API key for oauth-primary") is False
+
+
+class TestCapacityRetryConfig:
+    def test_default_schedule_is_escalating(self):
+        config = get_default_config()
+        assert config["capacity_retry_delays"] == [10, 60, 300]
+
+    def test_default_config_validates(self):
+        assert validate_config(get_default_config()) == []
+
+    def test_non_list_schedule_rejected(self):
+        config = get_default_config()
+        config["capacity_retry_delays"] = 60
+        assert any("capacity_retry_delays" in e for e in validate_config(config))
+
+    def test_empty_schedule_rejected(self):
+        config = get_default_config()
+        config["capacity_retry_delays"] = []
+        assert any("capacity_retry_delays" in e for e in validate_config(config))
+
+    def test_negative_entry_rejected(self):
+        config = get_default_config()
+        config["capacity_retry_delays"] = [10, -5]
+        assert any("capacity_retry_delays" in e for e in validate_config(config))
+
+
+class TestCapacityEscalatedStageRetry:
+    """_run_stage_node sleeps the escalating schedule for capacity failures."""
+
+    def _make_state(self):
+        config = get_default_config()
+        state = create_initial_state(305, config)
+        state["current_stage"] = "triage"
+        return state
+
+    def _failed_runner(self, error_message):
+        def fake_runner(s):
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "failed",
+                    "error_message": error_message,
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                    "transient": True,
+                }
+            }
+            return new_state
+
+        return fake_runner
+
+    def test_capacity_failure_sleeps_escalating_schedule(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        runner = self._failed_runner(
+            "All credentials failed:\n  - oauth-primary: Capacity exhausted "
+            "after 3 retries (503/529)"
+        )
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep") as sleeper:
+            result = graph_mod._run_stage_node(self._make_state())
+
+        assert [c.args[0] for c in sleeper.call_args_list] == [10, 60]
+        assert result["stage_results"]["triage"]["status"] == "failed"
+
+    def test_non_capacity_transient_keeps_flat_delay(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        runner = self._failed_runner("gh CLI flake: connection reset")
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep") as sleeper:
+            graph_mod._run_stage_node(self._make_state())
+
+        assert [c.args[0] for c in sleeper.call_args_list] == [10, 10]
+
+    def test_schedule_last_entry_repeats_when_attempts_exceed_it(self):
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        state = self._make_state()
+        state["config"] = dict(state["config"])
+        state["config"]["max_stage_retries"] = 4
+        state["config"]["capacity_retry_delays"] = [10, 60]
+
+        runner = self._failed_runner("Capacity exhausted (503)")
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep") as sleeper:
+            graph_mod._run_stage_node(state)
+
+        assert [c.args[0] for c in sleeper.call_args_list] == [10, 60, 60]
+
+    def test_non_transient_capacity_lookalike_still_skips_retry(self):
+        """transient=False wins over a capacity-looking message — the
+        escalation only widens delays, it never revives a dead retry."""
+        from assemblyzero.workflows.orchestrator import graph as graph_mod
+
+        def runner(s):
+            new_state = dict(s)
+            new_state["stage_results"] = {
+                "triage": {
+                    "status": "failed",
+                    "error_message": "spec references 503 in acceptance text",
+                    "duration_seconds": 0.0,
+                    "attempts": 1,
+                    "transient": False,
+                }
+            }
+            return new_state
+
+        with patch.dict(graph_mod.STAGE_RUNNERS, {"triage": runner}, clear=False), \
+             patch("assemblyzero.workflows.orchestrator.graph.save_orchestration_state"), \
+             patch("assemblyzero.workflows.orchestrator.graph.time.sleep") as sleeper:
+            graph_mod._run_stage_node(self._make_state())
+
+        assert sleeper.call_args_list == []


### PR DESCRIPTION
The instrumented run log (run11b-issue4-140453) settled what actually failed on 2026-07-29: NOT classification (both recovery plans said `capacity_exhausted`, `is_transient: true`) and NOT the retry loop (log shows attempts 1/3 → 2/3 → 3/3, 10s apart). The run died because three flat-10s attempts span ~2 minutes and the Gemini 503 storm ran longer — while the recovery plan's own recommendation says 'wait 15 minutes'. Issue #1909 was corrected and retitled to match the evidence before this fix.

**Change:** capacity-class transient failures (matched via `errors.CAPACITY_MESSAGE_MARKERS` — `capacity exhausted`/`503`/`529`/`overloaded`, now the single source of truth shared with halt classification) sleep an escalating schedule between stage attempts: default `capacity_retry_delays=[10, 60, 300]`, last entry repeating, validated in config. Non-capacity transients keep flat `retry_delay_seconds`; `transient=False` still skips retry entirely.

Total capacity ride-out envelope goes from ~2 minutes to ~7½ — covering the observed storm, which had cleared 'within a minute of the halt'.

**Tests:** 13 new (marker detection incl. the live incident message; config default + validation rejects; escalating sleep sequence [10, 60]; flat [10, 10] for non-capacity; last-entry repeat; transient=False immunity). Neighboring suites green: 87 passed (capacity + orchestrator stages + errors), 50 passed (halt/recovery).

Closes #1909