### PR TITLE
fix(llm): Gemini failures are final at the provider boundary — no outer retry stacking (Closes #1907)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1300,6 +1300,14 @@ class GeminiProvider(LLMProvider):
                 credential_used=result.credential_used,
                 rotation_occurred=result.rotation_occurred,
                 rate_limited=was_rate_limited,
+                # #1907: a failure GeminiClient.invoke() REPORTS is
+                # post-exhaustion — it already retried per credential,
+                # rotated across all of them, and enforced its own wall
+                # clock (#1874). The dataclass default (retryable=True)
+                # invited with_retry(5) to stack five more full gauntlets
+                # (~50 min worst case) on top. Riding out longer storms
+                # is the stage retry's job (#1909), not another lap here.
+                retryable=result.success,
             )
             log_llm_call(call_result)
             return call_result

--- a/tests/unit/test_gemini_retry_boundary.py
+++ b/tests/unit/test_gemini_retry_boundary.py
@@ -1,0 +1,102 @@
+"""Gemini failures are final at the provider boundary (#1907).
+
+GeminiClient.invoke() retries per credential, rotates across credentials,
+and enforces its own wall-clock budget (#1874). A failure it reports is
+post-exhaustion — but LLMCallResult defaulted retryable=True, so the
+#1071 with_retry(5) wrapper at call sites like review_test_plan stacked
+up to five more full gauntlets (~50 minutes worst case) on a review call
+that had already burned every internal recovery. On a recorded take that
+is indistinguishable from a hang.
+
+The provider now reports retryable=False on any failure its client
+returns, which makes with_retry a pass-through for Gemini — storm-riding
+escalates to the stage retry loop (#1909) instead.
+"""
+
+from unittest.mock import Mock, patch
+
+from assemblyzero.core.llm_provider import GeminiProvider
+from assemblyzero.utils.retry import RetryPolicy, with_retry
+
+
+def _failed_client_result():
+    return Mock(
+        success=False,
+        response=None,
+        raw_response=None,
+        error_message=(
+            "All credentials failed:\n"
+            "  - oauth-primary: Capacity exhausted after 3 retries (503/529)"
+        ),
+        error_type=None,
+        model_verified="gemini-3.1-pro-high",
+        duration_ms=28000,
+        attempts=3,
+        credential_used="oauth-primary",
+        rotation_occurred=True,
+    )
+
+
+class TestGeminiFailureIsFinal:
+    @patch("assemblyzero.core.llm_provider.GeminiProvider._get_client")
+    def test_client_reported_failure_is_not_retryable(self, mock_get_client):
+        mock_client = Mock()
+        mock_client.invoke.return_value = _failed_client_result()
+        mock_get_client.return_value = mock_client
+
+        result = GeminiProvider(model="3.1-pro").invoke(
+            system_prompt="review", content="content"
+        )
+
+        assert result.success is False
+        assert result.retryable is False
+
+    @patch("assemblyzero.core.llm_provider.GeminiProvider._get_client")
+    def test_success_keeps_retryable_semantics(self, mock_get_client):
+        mock_client = Mock()
+        mock_client.invoke.return_value = Mock(
+            success=True,
+            response="ok",
+            raw_response="ok",
+            error_message=None,
+            error_type=None,
+            model_verified="gemini-3.1-pro-high",
+            duration_ms=900,
+            attempts=1,
+            credential_used="oauth-primary",
+            rotation_occurred=False,
+        )
+        mock_get_client.return_value = mock_client
+
+        result = GeminiProvider(model="3.1-pro").invoke(
+            system_prompt="review", content="content"
+        )
+
+        assert result.success is True
+        assert result.retryable is True
+
+    @patch("assemblyzero.core.llm_provider.GeminiProvider._get_client")
+    def test_with_retry_runs_the_exhausted_gauntlet_exactly_once(
+        self, mock_get_client
+    ):
+        """The #1907 regression itself: 1 invocation, not 1 + max_retries."""
+        mock_client = Mock()
+        mock_client.invoke.return_value = _failed_client_result()
+        mock_get_client.return_value = mock_client
+
+        provider = GeminiProvider(model="3.1-pro")
+        calls = {"n": 0}
+
+        def call_provider():
+            calls["n"] += 1
+            return provider.invoke(system_prompt="review", content="content")
+
+        result = with_retry(
+            call_provider,
+            policy=RetryPolicy.default(),
+            sleep_fn=lambda s: None,
+            description="N1 testing reviewer",
+        )
+
+        assert result.success is False
+        assert calls["n"] == 1


### PR DESCRIPTION
One-line root cause: `GeminiProvider.invoke()`'s result mapping never set `retryable`, so a failure that GeminiClient reports **after exhausting per-credential retries, full rotation, and its #1874 wall-clock budget** inherited the dataclass default `retryable=True` — inviting every #1071 `with_retry(5)` call site to re-run the whole exhausted gauntlet five more times (~50 minutes worst case per review call).

**Fix at the provider boundary, covering all call sites at once:** a failure the client returns is post-exhaustion, so the provider now reports `retryable=False`; `with_retry` short-circuits on its existing non-retryable branch and returns immediately. Riding out longer provider storms is the stage retry's job, freshly calibrated with escalating capacity backoff in PR #1926. The exception path still trusts `classify_gemini_error`, and ClaudeCLIProvider keeps outer retries (single-shot CLI, no internal budget — retrying there is correct).

**Layering after this + #1926:** client handles seconds-scale blips (4s/8s/16s per credential), stage handles minutes-scale storms (10s/60s/300s), capacity gate (#1883) handles hours-scale quota.

**Tests:** 3 new (failure→retryable False; success semantics unchanged; the regression itself — with_retry invokes the exhausted provider exactly once, not six times). Full provider + retry suites green: 159 passed.

Closes #1907