### PR TITLE
fix(completeness): third-party imports validate in the target repo's environment (Closes #1901)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -18,7 +18,9 @@ This node populates:
 - error_message: "" on success, error text on failure
 """
 
+import json
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -793,6 +795,13 @@ def check_import_targets_exist(
 
     unresolvable: list[str] = []
     checked: set[str] = set()
+    # #1901: dotted imports that are neither stdlib nor first-party are
+    # third-party (PIL.Image, psutil.*, google.genai). Walking the repo
+    # tree for those flagged Pillow as "nonexistent" and cost a revision
+    # cycle per affected spec. They validate against the TARGET repo's
+    # own environment instead — grouped by top-level for one batched probe.
+    first_party_tops = _first_party_tops(repo_root)
+    third_party: dict[str, list[str]] = {}
 
     for block_match in code_block_pattern.finditer(spec):
         block_content = block_match.group(1)
@@ -817,7 +826,27 @@ def check_import_targets_exist(
             if _import_resolves(module_path, repo_root, new_file_paths):
                 continue
 
-            unresolvable.append(module_path)
+            if top_level in first_party_tops:
+                unresolvable.append(module_path)
+            else:
+                third_party.setdefault(top_level, []).append(module_path)
+
+    env_note = ""
+    if third_party:
+        probe = _probe_target_env(repo_root, sorted(third_party))
+        if probe is None:
+            # Cannot validate ≠ missing. The target env is the only honest
+            # authority for third-party imports (#1904: wrong-environment
+            # answers are worse than none); without it, give the benefit
+            # of the doubt and say so.
+            env_note = (
+                f" Target environment unavailable — {len(third_party)} "
+                f"third-party top-level import(s) not validated."
+            )
+        else:
+            for top, modules in sorted(third_party.items()):
+                if not probe.get(top, False):
+                    unresolvable.extend(modules)
 
     if unresolvable:
         mod_list = ", ".join(f"`{m}`" for m in unresolvable[:5])
@@ -826,16 +855,18 @@ def check_import_targets_exist(
             check_name="import_targets_exist",
             passed=False,
             details=(
-                f"Imports in spec reference nonexistent modules: "
-                f"{mod_list}{suffix}. Verify these modules exist or "
-                f"are being created by this spec."
+                f"Imports in spec reference modules that neither exist, nor "
+                f"are created by this spec, nor import in the target repo's "
+                f"environment: {mod_list}{suffix}. For first-party modules, "
+                f"verify the path; for third-party, add the dependency to "
+                f"the target repo or fix the import."
             ),
         )
 
     return CompletenessCheck(
         check_name="import_targets_exist",
         passed=True,
-        details=f"All {len(checked)} import targets validated.",
+        details=f"All {len(checked)} import targets validated.{env_note}",
     )
 
 
@@ -1149,6 +1180,89 @@ def _import_resolves(
 
 
 # Common stdlib top-level module names (subset for fast rejection)
+def _first_party_tops(repo_root: Path) -> set[str]:
+    """Top-level package names that belong to the target repo itself (#1901).
+
+    A dotted import whose top level is one of these gets the strict
+    exists-or-created-by-this-spec rule (#842); anything else is
+    third-party and validates against the target environment instead.
+    Covers flat layout (pkg at repo root) and src layout.
+    """
+    tops: set[str] = set()
+    for base in (repo_root, repo_root / "src"):
+        try:
+            if not base.is_dir():
+                continue
+            for child in base.iterdir():
+                if child.is_dir() and (child / "__init__.py").is_file():
+                    tops.add(child.name)
+        except OSError:
+            continue
+    return tops
+
+
+def _target_env_python(repo_root: Path) -> str | None:
+    """Absolute python path of the TARGET repo's poetry venv, or None.
+
+    Asks poetry for the env path explicitly instead of `poetry run python`
+    — poetry silently falls through to PATH when no venv exists (#1904),
+    which would answer the probe from the WRONG environment.
+    """
+    try:
+        proc = subprocess.run(
+            ["poetry", "env", "info", "--path"],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    env_path = Path(proc.stdout.strip())
+    for candidate in (env_path / "Scripts" / "python.exe", env_path / "bin" / "python"):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _probe_target_env(repo_root: Path, tops: list[str]) -> dict[str, bool] | None:
+    """One batched find_spec probe inside the target repo's venv (#1901).
+
+    Returns {top_level: importable} — or None when the environment cannot
+    answer (no venv, timeout, bad output). Callers MUST treat None as
+    "cannot validate", never as "missing": a wrong-environment verdict is
+    worse than no verdict (#1904).
+    """
+    if not tops:
+        return {}
+    python = _target_env_python(repo_root)
+    if python is None:
+        return None
+    script = (
+        "import importlib.util, json, sys; "
+        "print(json.dumps({n: importlib.util.find_spec(n) is not None "
+        "for n in sys.argv[1:]}))"
+    )
+    try:
+        proc = subprocess.run(
+            [python, "-c", script, *tops],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return None
+        result = json.loads(proc.stdout.strip().splitlines()[-1])
+        if not isinstance(result, dict):
+            return None
+        return {str(k): bool(v) for k, v in result.items()}
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return None
+
+
 _KNOWN_STDLIB_TOPS: frozenset[str] = frozenset({
     "abc", "argparse", "ast", "asyncio", "base64", "builtins", "collections",
     "contextlib", "copy", "csv", "dataclasses", "datetime", "decimal",

--- a/tests/unit/test_import_checker_env.py
+++ b/tests/unit/test_import_checker_env.py
@@ -1,0 +1,135 @@
+"""Third-party imports validate against the TARGET repo's environment (#1901).
+
+Hardening run 11 phase 3: the completeness checker flagged PIL.Image /
+PIL.ImageChops as "nonexistent modules" because it resolved every dotted
+non-stdlib import by walking the target repo's file tree — which sees
+first-party modules but never installed site-packages. Pillow was a
+declared, importable dependency of boostgauge; the spec burned a revision
+cycle appeasing a checker that modeled the environment wrongly.
+
+The split now: first-party tops keep the strict exists-or-created rule
+(#842's real scenario); everything else probes the target repo's own venv
+in one batched find_spec call. An unanswerable environment means "cannot
+validate", never "missing" (#1904: wrong-environment answers are worse
+than none).
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    _first_party_tops,
+    check_import_targets_exist,
+)
+
+MODULE = "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+
+
+def _make_repo(tmp_path, package="myproj", src_layout=False):
+    base = tmp_path / "src" if src_layout else tmp_path
+    pkg = base / package
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "core.py").write_text("x = 1", encoding="utf-8")
+    return tmp_path
+
+
+def _spec_with_imports(*imports):
+    lines = "\n".join(imports)
+    return f"# Spec\n\n```python\n{lines}\n```\n"
+
+
+class TestFirstPartyTops:
+    def test_flat_and_src_layouts_detected(self, tmp_path):
+        _make_repo(tmp_path, package="flatpkg")
+        _make_repo(tmp_path, package="srcpkg", src_layout=True)
+        tops = _first_party_tops(tmp_path)
+        assert "flatpkg" in tops
+        assert "srcpkg" in tops
+
+    def test_plain_dirs_without_init_excluded(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        assert "docs" not in _first_party_tops(tmp_path)
+
+
+class TestFirstPartyRuleUnchanged:
+    def test_hallucinated_first_party_module_still_fails(self, tmp_path):
+        """#842's actual scenario survives the split — no env probe runs.
+
+        Depth matters: `_import_resolves` deliberately forgives `pkg.name`
+        when `pkg/__init__.py` exists (name may be an attribute), so the
+        strict rule bites on a missing INTERMEDIATE package — the shape
+        #842 actually described (assemblyzero.core.metrics).
+        """
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from myproj.sub.metrics import Collector")
+        with patch(f"{MODULE}._probe_target_env") as probe:
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is False
+        assert "myproj.sub.metrics" in result["details"]
+        probe.assert_not_called()
+
+    def test_existing_first_party_module_passes(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from myproj.core import x")
+        result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is True
+
+    def test_created_by_spec_passes(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from myproj.telltale import Needle")
+        files = [{"path": "myproj/telltale.py", "change_type": "Add"}]
+        result = check_import_targets_exist(spec, files, str(repo))
+        assert result["passed"] is True
+
+
+class TestThirdPartyProbe:
+    def test_the_pillow_incident_passes_when_env_importable(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports(
+            "from PIL.Image import open", "import PIL.ImageChops"
+        )
+        with patch(f"{MODULE}._probe_target_env", return_value={"PIL": True}):
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is True
+
+    def test_genuinely_missing_third_party_fails(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from requests.sessions import Session")
+        with patch(
+            f"{MODULE}._probe_target_env", return_value={"requests": False}
+        ):
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is False
+        assert "requests.sessions" in result["details"]
+        assert "target repo" in result["details"]
+
+    def test_probe_batches_by_top_level(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports(
+            "import PIL.Image", "import PIL.ImageChops", "import psutil.tests"
+        )
+        with patch(
+            f"{MODULE}._probe_target_env",
+            return_value={"PIL": True, "psutil": True},
+        ) as probe:
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is True
+        assert probe.call_count == 1
+        assert sorted(probe.call_args.args[1]) == ["PIL", "psutil"]
+
+    def test_unavailable_env_gives_benefit_of_the_doubt(self, tmp_path):
+        """None means cannot-validate: pass, and say so in the details."""
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from PIL.Image import open")
+        with patch(f"{MODULE}._probe_target_env", return_value=None):
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is True
+        assert "not validated" in result["details"]
+
+    def test_stdlib_never_reaches_the_probe(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        spec = _spec_with_imports("from pathlib import Path", "import os.path")
+        with patch(f"{MODULE}._probe_target_env") as probe:
+            result = check_import_targets_exist(spec, [], str(repo))
+        assert result["passed"] is True
+        probe.assert_not_called()


### PR DESCRIPTION
The completeness import checker walked the target repo's file tree for every dotted non-stdlib import — first-party modules resolve that way, installed site-packages never do. Phase 3 paid a revision cycle for 'nonexistent modules: PIL.Image, PIL.ImageChops' against a repo that declares and imports Pillow fine; every remaining boostgauge arc phase (psutil, pystray, PIL everywhere) would have paid the same tax, and a checker that models the environment wrongly eventually rejects something the drafter cannot phrase around.

**Split by top-level package:**
- **First-party tops** (package dirs at repo root or src/): the strict #842 exists-or-created-by-this-spec rule, unchanged, no env probe.
- **Everything else** (PIL, psutil, google, …): one batched `find_spec` probe inside the **target repo's own venv**, located via `poetry env info --path` explicitly — never `poetry run python`, which silently falls through to PATH without a venv (#1904) and would answer from the wrong environment.
- **Unanswerable env** (no venv, timeout): cannot-validate ≠ missing — pass with a note in the check details.

Genuine catches get a clearer message too: first-party → verify the path; third-party → add the dependency to the target repo or fix the import.

**Tests:** 11 new — the Pillow incident itself, genuine missing third-party fails, batching by top-level, benefit-of-the-doubt on unavailable env, stdlib never probed, and the #842 first-party rule pinned unchanged (including the depth subtlety where `pkg.name` is forgiven as attribute-import when `pkg/__init__.py` exists). Suites green: 278 passed (new + completeness gate + spec workflow).

Closes #1901