### PR TITLE
feat(requirements): conflict gate before generation + reviewer escalation (Closes #1899, Closes #1900)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -39,6 +39,12 @@ def classify_error(error_message: str) -> str:
     msg_lower = error_message.lower()
 
     # Domain-specific classifications first (no HTTP equivalent)
+    # #1899/#1900: a contradiction in the ISSUE's own requirements. Nothing
+    # transient about it — no retry, revise cycle, or regenerated spec can
+    # satisfy two criteria that specify different outcomes for the same
+    # situation. The fix is an operator ruling on the issue text.
+    if "requirements conflict" in msg_lower:
+        return "requirements_conflict"
     if any(p in msg_lower for p in ("stagnation", "same issues", "same blocking", "two consecutive")):
         return "stagnation"
     if any(p in msg_lower for p in ("budget", "cost budget exceeded")):

--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -175,5 +175,13 @@ def _build_recommendation(error_type: str, error_message: str, workflow: str) ->
             "Non-transient: Authentication failed. "
             "Check your Gemini credentials in ~/.assemblyzero/gemini-credentials.json."
         )
+    elif error_type == "requirements_conflict":
+        return (
+            "Non-transient: the ISSUE's requirements contradict each other — "
+            "no spec can satisfy both readings, so re-rolling burns tokens on "
+            "an unwinnable draft (#1899/#1900). Read the named conflict in the "
+            "error message, rule on the correct reading, edit the issue's "
+            "acceptance criteria to say it, then re-run."
+        )
     else:
         return f"Workflow {workflow} halted: {error_message[:200]}"

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -100,6 +100,19 @@ For each assertion in the spec's test code, name the requirement or behaviour \
 section it traces to. If you cannot, that assertion is the finding — quote it \
 and say which behaviour it contradicts or invents.
 
+REQUIREMENTS CONFLICT ESCALATION (Issue #1900). When the violation you found \
+traces to a CONTRADICTION OR AMBIGUITY IN THE SOURCE REQUIREMENTS themselves \
+— two criteria in the LLD or the issue specifying different outcomes for the \
+same situation, so ANY spec must violate one of them — do not report it as a \
+spec-authoring error. An ambiguous requirement has no correct spec; revise \
+cycles just oscillate between the readings (a real run burned all three \
+cycles exactly this way: drafter picks reading A, you reject citing B, \
+drafter picks B, you reject citing A). Instead: verdict BLOCKED, and begin \
+your rationale with the exact marker 'REQUIREMENTS CONFLICT:' followed by \
+the two conflicting sentences QUOTED VERBATIM and the concrete situation \
+where they diverge. This is the one case #1892 reserves BLOCKED for — no \
+regenerated spec can fix it; the ISSUE needs an operator ruling.
+
 SEVERITY MUST MATCH RECOVERABILITY (Issue #1892). Report a traceability \
 violation as REVISE whenever a regenerated spec could fix it — a wrong \
 assertion, a reference implementation that disagrees with the spec's own \

--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -51,6 +51,7 @@ from assemblyzero.telemetry import emit
 
 from assemblyzero.workflows.requirements.nodes import (
     analyze_codebase,
+    analyze_requirements,
     finalize,
     generate_draft,
     human_gate_draft,
@@ -74,6 +75,7 @@ from assemblyzero.core.halt_node import create_halt_node
 
 N0_LOAD_INPUT = "N0_load_input"
 N0B_ANALYZE_CODEBASE = "N0b_analyze_codebase"  # Issue #401
+N0C_ANALYZE_REQUIREMENTS = "N0c_analyze_requirements"  # Issue #1899
 N1_GENERATE_DRAFT = "N1_generate_draft"
 N1_5_VALIDATE_MECHANICAL = "N1_5_validate_mechanical"  # Issue #277
 N1B_VALIDATE_TEST_PLAN = "N1b_validate_test_plan"  # Issue #166
@@ -88,6 +90,20 @@ HALT = "HALT"
 # =============================================================================
 # Routing Functions
 # =============================================================================
+
+
+def route_after_analyze_requirements(
+    state: RequirementsWorkflowState,
+) -> Literal["N1_generate_draft", "HALT"]:
+    """Route after the requirements-ambiguity gate (Issue #1899).
+
+    A REQUIREMENTS CONFLICT halts before any generation spends tokens —
+    no spec can satisfy contradictory criteria, so the ISSUE needs an
+    operator ruling, not a roll. Anything else proceeds to drafting.
+    """
+    if state.get("error_message"):
+        return "HALT"
+    return "N1_generate_draft"
 
 
 def route_after_load_input(
@@ -461,6 +477,7 @@ def create_requirements_graph() -> StateGraph:
     # Add nodes
     graph.add_node(N0_LOAD_INPUT, load_input)
     graph.add_node(N0B_ANALYZE_CODEBASE, analyze_codebase)  # Issue #401
+    graph.add_node(N0C_ANALYZE_REQUIREMENTS, analyze_requirements)  # Issue #1899
     graph.add_node(N1_GENERATE_DRAFT, generate_draft)
     graph.add_node(N1_5_VALIDATE_MECHANICAL, validate_lld_mechanical)  # Issue #277
     graph.add_node(N1B_VALIDATE_TEST_PLAN, validate_test_plan_node)  # Issue #166
@@ -490,8 +507,17 @@ def create_requirements_graph() -> StateGraph:
         },
     )
 
-    # N0b -> N1 (always proceeds to draft generation)
-    graph.add_edge(N0B_ANALYZE_CODEBASE, N1_GENERATE_DRAFT)
+    # N0b -> N0c (Issue #1899: requirements-ambiguity gate before any
+    # generation spends tokens) -> N1 or HALT
+    graph.add_edge(N0B_ANALYZE_CODEBASE, N0C_ANALYZE_REQUIREMENTS)
+    graph.add_conditional_edges(
+        N0C_ANALYZE_REQUIREMENTS,
+        route_after_analyze_requirements,
+        {
+            "N1_generate_draft": N1_GENERATE_DRAFT,
+            "HALT": HALT,
+        },
+    )
 
     # N1 -> Ponder (LLD) or N2 or N3 or HALT (based on workflow type, gates, error)
     # Issue #565: LLD workflows go through Ponder auto-fix first

--- a/assemblyzero/workflows/requirements/nodes/__init__.py
+++ b/assemblyzero/workflows/requirements/nodes/__init__.py
@@ -22,6 +22,9 @@ Nodes:
 from assemblyzero.workflows.requirements.nodes.analyze_codebase import (
     analyze_codebase,
 )
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+    analyze_requirements,
+)
 from assemblyzero.workflows.requirements.nodes.finalize import finalize
 from assemblyzero.workflows.requirements.nodes.generate_draft import generate_draft
 from assemblyzero.workflows.requirements.nodes.human_gate import (
@@ -40,6 +43,7 @@ from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
 
 __all__ = [
     "analyze_codebase",
+    "analyze_requirements",
     "load_input",
     "generate_draft",
     "validate_lld_mechanical",

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -1,0 +1,183 @@
+"""N0c: Requirements-ambiguity analysis before any generation spends tokens.
+
+Issue #1899 (operator-commissioned after boostgauge#125): issue #41 carried
+two different floors for a decaying peak — 'highest value still in the
+window' vs 'drifts toward the most recent value' — and the contradiction
+surfaced only after two campaign rolls burned three implementation
+iterations each and a third burned all its spec-revision cycles
+oscillating between the readings. The ambiguity was in the issue text the
+whole time; every test case sat where both readings agree, so it survived
+human review too.
+
+This node reads the issue's behavior text, acceptance criteria, and test
+plan as ONE document and checks internal consistency BEFORE the drafter
+runs:
+
+- Do any two criteria specify different outcomes for the same situation?
+- Does every behavioral term have exactly one definition?
+- Do the planned tests discriminate between plausible readings?
+
+On conflict it halts with a message beginning ``REQUIREMENTS CONFLICT:``
+naming the conflicting sentences verbatim and the situation where they
+diverge — the same marker the spec reviewer uses for conflicts that
+emerge mid-pipeline (#1900), so both classify as ``requirements_conflict``
+(non-transient: no retry fixes an ambiguous requirement, the ISSUE needs
+an operator ruling).
+
+Fail-open by design: this gate is protective, not load-bearing. If the
+analysis call itself fails (provider storm, parse noise), the workflow
+proceeds to drafting with a printed warning rather than dying in a
+pre-flight check.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+REQUIREMENTS_CONFLICT_MARKER = "REQUIREMENTS CONFLICT:"
+
+ANALYSIS_SYSTEM_PROMPT = """\
+You are a requirements analyst performing a pre-flight consistency check \
+on a GitHub issue before an autonomous pipeline builds from it.
+
+Read the issue's behavior description, acceptance criteria, and test plan \
+as ONE document. You are looking ONLY for internal contradictions and \
+ambiguities that make the requirements unimplementable-as-written:
+
+1. CONFLICTING CRITERIA: two statements that specify different outcomes \
+for the same situation. Quote both VERBATIM and describe the concrete \
+situation where they diverge (example: 'floor = highest value still in \
+the window' vs 'floor drifts toward the most recent value' — these \
+differ exactly when the window maximum is not the latest sample).
+2. UNDEFINED OR MULTIPLY-DEFINED TERMS: a behavioral term used with two \
+meanings, or two terms used interchangeably for what may be different \
+things ('current value' vs 'most recent value' vs 'values in the window').
+3. NON-DISCRIMINATING TESTS: planned test cases that sit only where all \
+plausible readings agree, so they cannot reveal which reading is meant.
+
+Do NOT flag: missing implementation detail, scope you consider too large, \
+style, feasibility, or anything a competent drafter can decide one \
+reasonable way. Flag ONLY genuine either-reading-is-defensible conflicts \
+where building the wrong reading wastes the whole run.
+
+Respond with JSON only."""
+
+ANALYSIS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_consistent": {"type": "boolean"},
+        "conflicts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "criterion_a": {"type": "string"},
+                    "criterion_b": {"type": "string"},
+                    "diverging_situation": {"type": "string"},
+                },
+                "required": [
+                    "criterion_a",
+                    "criterion_b",
+                    "diverging_situation",
+                ],
+            },
+        },
+    },
+    "required": ["is_consistent", "conflicts"],
+}
+
+
+def _format_conflict_message(conflicts: list[dict]) -> str:
+    """Build the halt message: marker + each conflict named verbatim."""
+    lines = [
+        f"{REQUIREMENTS_CONFLICT_MARKER} the issue's requirements are "
+        f"internally inconsistent — no spec can satisfy both readings. "
+        f"An operator ruling on the issue text is required before any roll."
+    ]
+    for i, c in enumerate(conflicts, 1):
+        lines.append(
+            f"\nConflict {i}:\n"
+            f"  A: {c.get('criterion_a', '?')}\n"
+            f"  B: {c.get('criterion_b', '?')}\n"
+            f"  Diverge when: {c.get('diverging_situation', '?')}"
+        )
+    return "\n".join(lines)
+
+
+def _parse_analysis(raw: str) -> dict | None:
+    """Parse the analysis JSON, tolerating fenced or prefixed output."""
+    if not raw:
+        return None
+    text = raw.strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            text = text[first_newline + 1 :]
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    try:
+        parsed = json.loads(text.strip())
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict) or "is_consistent" not in parsed:
+        return None
+    return parsed
+
+
+def analyze_requirements(state: dict) -> dict[str, Any]:
+    """N0c node body. Returns {} to proceed, or error_message to halt."""
+    if state.get("config_mock_mode"):
+        return {}
+
+    issue_title = state.get("issue_title", "")
+    issue_body = state.get("issue_body", "")
+    if not issue_body.strip():
+        # Nothing to analyze — some entry paths carry file input instead.
+        return {}
+
+    print("  [N0c] Requirements-ambiguity analysis (#1899)...")
+
+    from assemblyzero.core.llm_provider import GeminiProvider, get_provider
+
+    drafter_spec = state.get("config_drafter", "gemini:3.1-pro")
+    try:
+        provider = get_provider(drafter_spec)
+    except ValueError as e:
+        print(f"  [N0c] WARNING: analysis skipped (invalid provider: {e})")
+        return {}
+
+    schema_kwargs: dict[str, Any] = {}
+    if isinstance(provider, GeminiProvider):
+        schema_kwargs["response_schema"] = ANALYSIS_SCHEMA
+    else:
+        schema_kwargs["json_schema"] = ANALYSIS_SCHEMA
+
+    content = f"# Issue: {issue_title}\n\n{issue_body}"
+    result = provider.invoke(
+        system_prompt=ANALYSIS_SYSTEM_PROMPT,
+        content=content,
+        **schema_kwargs,
+    )
+
+    # Fail-open: a dead analysis call must not kill the roll (#1899).
+    if not result.success or not result.response:
+        print(
+            f"  [N0c] WARNING: analysis unavailable "
+            f"({result.error_message or 'empty response'}); proceeding."
+        )
+        return {}
+
+    parsed = _parse_analysis(result.response)
+    if parsed is None:
+        print("  [N0c] WARNING: analysis response unparseable; proceeding.")
+        return {}
+
+    conflicts = parsed.get("conflicts") or []
+    if parsed.get("is_consistent", True) or not conflicts:
+        print("  [N0c] Requirements internally consistent.")
+        return {}
+
+    message = _format_conflict_message(conflicts)
+    print(f"  [N0c] {message}")
+    return {"error_message": message}

--- a/tests/unit/test_requirements_conflict.py
+++ b/tests/unit/test_requirements_conflict.py
@@ -1,0 +1,167 @@
+"""Requirements conflicts halt with the conflict named, at both ends (#1899/#1900).
+
+boostgauge#125 is the reference incident: issue #41 specified two different
+floors for a decaying peak, and the contradiction cost two rolls three impl
+iterations each plus a third roll's entire revise budget before a human
+diagnosed it from transcripts. The remedy is layered:
+
+- N0c (pre-flight, #1899): an analysis gate at the front of the
+  requirements workflow reads the issue as one document and halts BEFORE
+  generation when two criteria specify different outcomes for the same
+  situation. Fail-open: an unavailable analysis never kills the roll.
+- Reviewer escalation (mid-pipeline backstop, #1900): the spec reviewer
+  BLOCKS with a 'REQUIREMENTS CONFLICT:' rationale when its objection
+  traces to the source requirements, instead of burning revise cycles.
+- Shared classification: the marker maps to error_type
+  requirements_conflict — non-transient, with a recovery recommendation
+  that says exactly what the operator must rule on.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from assemblyzero.core.halt_node import classify_error
+from assemblyzero.core.recovery_plan import (
+    TRANSIENT_ERROR_TYPES,
+    generate_recovery_plan,
+)
+from assemblyzero.workflows.requirements.graph import (
+    route_after_analyze_requirements,
+)
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+    REQUIREMENTS_CONFLICT_MARKER,
+    _format_conflict_message,
+    _parse_analysis,
+    analyze_requirements,
+)
+
+MODULE = "assemblyzero.core.llm_provider"
+
+CONFLICT_JSON = (
+    '{"is_consistent": false, "conflicts": [{'
+    '"criterion_a": "the floor is the highest value still in the window", '
+    '"criterion_b": "the needle drifts toward the most recent value", '
+    '"diverging_situation": "whenever the window maximum is not the latest sample"'
+    "}]}"
+)
+CONSISTENT_JSON = '{"is_consistent": true, "conflicts": []}'
+
+
+def _state(**overrides):
+    state = {
+        "issue_title": "feat: telltale needles",
+        "issue_body": "## Behavior\nPeaks decay.\n## Criteria\n- floor rules",
+        "config_mock_mode": False,
+        "config_drafter": "gemini:3.1-pro",
+    }
+    state.update(overrides)
+    return state
+
+
+def _provider_returning(response, success=True, error=None):
+    provider = MagicMock()
+    provider.invoke.return_value = MagicMock(
+        success=success, response=response, error_message=error
+    )
+    return provider
+
+
+class TestN0cGate:
+    def test_conflict_halts_with_both_sentences_named(self):
+        provider = _provider_returning(CONFLICT_JSON)
+        with patch(f"{MODULE}.get_provider", return_value=provider):
+            result = analyze_requirements(_state())
+        msg = result.get("error_message", "")
+        assert msg.startswith(REQUIREMENTS_CONFLICT_MARKER)
+        assert "highest value still in the window" in msg
+        assert "most recent value" in msg
+        assert "window maximum is not the latest sample" in msg
+
+    def test_consistent_requirements_proceed(self):
+        provider = _provider_returning(CONSISTENT_JSON)
+        with patch(f"{MODULE}.get_provider", return_value=provider):
+            result = analyze_requirements(_state())
+        assert result == {}
+
+    def test_failed_analysis_call_fails_open(self):
+        provider = _provider_returning(None, success=False, error="503 storm")
+        with patch(f"{MODULE}.get_provider", return_value=provider):
+            result = analyze_requirements(_state())
+        assert result == {}
+
+    def test_unparseable_response_fails_open(self):
+        provider = _provider_returning("I think it looks fine!")
+        with patch(f"{MODULE}.get_provider", return_value=provider):
+            result = analyze_requirements(_state())
+        assert result == {}
+
+    def test_mock_mode_skips_entirely(self):
+        with patch(f"{MODULE}.get_provider") as gp:
+            result = analyze_requirements(_state(config_mock_mode=True))
+        assert result == {}
+        gp.assert_not_called()
+
+    def test_empty_issue_body_skips(self):
+        with patch(f"{MODULE}.get_provider") as gp:
+            result = analyze_requirements(_state(issue_body="   "))
+        assert result == {}
+        gp.assert_not_called()
+
+    def test_fenced_json_is_tolerated(self):
+        parsed = _parse_analysis(f"```json\n{CONSISTENT_JSON}\n```")
+        assert parsed == {"is_consistent": True, "conflicts": []}
+
+    def test_route_halts_on_error_message(self):
+        assert (
+            route_after_analyze_requirements({"error_message": "REQUIREMENTS CONFLICT: x"})
+            == "HALT"
+        )
+        assert (
+            route_after_analyze_requirements({"error_message": ""})
+            == "N1_generate_draft"
+        )
+
+
+class TestSharedClassification:
+    def test_marker_classifies_requirements_conflict(self):
+        msg = _format_conflict_message(
+            [
+                {
+                    "criterion_a": "a",
+                    "criterion_b": "b",
+                    "diverging_situation": "s",
+                }
+            ]
+        )
+        assert classify_error(msg) == "requirements_conflict"
+
+    def test_reviewer_blocked_rationale_classifies_the_same(self):
+        """#1900: the spec reviewer's BLOCKED rationale uses the same
+        marker, so a mid-pipeline conflict gets the same typed halt."""
+        rationale = (
+            "REQUIREMENTS CONFLICT: 'floor = highest value in window' vs "
+            "'floor = most recent value' — diverge when window max is stale."
+        )
+        assert classify_error(rationale) == "requirements_conflict"
+
+    def test_requirements_conflict_is_not_transient(self):
+        assert "requirements_conflict" not in TRANSIENT_ERROR_TYPES
+
+    def test_recovery_plan_tells_the_operator_what_to_do(self):
+        plan = generate_recovery_plan(
+            issue_number=41,
+            workflow="requirements",
+            stage="N0c_analyze_requirements",
+            error_type="requirements_conflict",
+            error_message="REQUIREMENTS CONFLICT: a vs b",
+            state={},
+        )
+        assert plan.is_transient is False
+        assert "acceptance criteria" in plan.recommendation
+        assert "re-run" in plan.recommendation
+
+    def test_capacity_still_wins_its_own_classification(self):
+        """The new first-position branch must not shadow capacity."""
+        assert (
+            classify_error("Capacity exhausted after 3 retries (503/529)")
+            == "capacity_exhausted"
+        )


### PR DESCRIPTION
Operator-commissioned pair from boostgauge#125: issue #41's two contradictory decay floors cost two rolls three impl iterations each, then a third roll's entire revise budget (drafter picks reading A, reviewer rejects citing B, drafter picks B, reviewer rejects citing A — every objection genuinely new, so two-strike never fired), before a human read three transcripts and found the ambiguity had been in the issue text all along.

**#1899 — pre-flight gate (N0c):** new node in the requirements workflow between codebase analysis and drafting. Reads the issue's behavior text, acceptance criteria, and test plan as one document; halts BEFORE generation when two criteria specify different outcomes for the same situation, a behavioral term carries two meanings, or the planned tests only sit where all readings agree. The halt names the conflicting sentences verbatim plus the diverging situation. **Fail-open:** provider storm or unparseable output proceeds with a warning — a protective gate must never kill a roll on its own weather. Mock mode and file-input paths skip it.

**#1900 — reviewer backstop:** the spec reviewer now escalates conflicts that only emerge once a spec makes requirements concrete: verdict BLOCKED with rationale beginning `REQUIREMENTS CONFLICT:` and both sentences quoted — the exact case #1892 reserves BLOCKED for.

**Shared typed halt:** the marker classifies as `requirements_conflict` (checked ahead of other domain patterns, capacity unshadowed), excluded from TRANSIENT_ERROR_TYPES, recovery recommendation names the operator action. The boostgauge#125 diagnosis now comes from the run record, not from transcript archaeology.

**Tests:** 15 new (conflict halts with both sentences named; consistent/failed/unparseable/mock/file-input paths; fenced-JSON tolerance; routing; both ends classify to the same error type; non-transience; recovery recommendation; capacity unshadowed). Requirements + graph + spec-review suites green: 421 passed.

Closes #1899, Closes #1900