### PR TITLE
fix(dependabot): scheduled runs execute a pinned clone synced ff-only to origin/main (Closes #1879)

### DIFF
--- a/tools/run_dependabot_fleet.ps1
+++ b/tools/run_dependabot_fleet.ps1
@@ -36,15 +36,55 @@ $env:PYTHONIOENCODING = 'utf-8'
 $env:PYTHONUTF8 = '1'
 
 $LogFile = 'C:\Users\mcwiz\Projects\dependabot-fleet.log'
-$RepoRoot = 'C:\Users\mcwiz\Projects\AssemblyZero'
+
+# #1879: the scheduled run executes a PINNED clone, never the shared
+# interactive checkout. The interactive AssemblyZero tree cycles branches
+# continuously under concurrent sessions, so "what code runs at 06:00"
+# used to be "whatever branch someone left checked out at 05:59". The
+# pinned clone is synced ff-only to origin/main each run; on ANY sync
+# surprise the run refuses loudly instead of executing wrong code.
+# (No force-sync by design: reset --hard is banned fleet-wide, and a
+# diverged pinned clone means tampering that deserves eyes, not a wipe.)
+$RepoRoot = 'C:\Users\mcwiz\Projects\AssemblyZero-scheduled'
 $Timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+Add-Content -Path $LogFile -Value "$Timestamp | START | dependabot --fleet" -Encoding utf8
+
+# --- #1879 sync gate -------------------------------------------------------
+if (-not (Test-Path (Join-Path $RepoRoot '.git'))) {
+    Add-Content -Path $LogFile -Value "$Timestamp | BOOTSTRAP | pinned clone absent; cloning" -Encoding utf8
+    & gh repo clone martymcenroe/AssemblyZero $RepoRoot 2>&1 | Out-Null
+    if (-not (Test-Path (Join-Path $RepoRoot '.git'))) {
+        Add-Content -Path $LogFile -Value "$Timestamp | ERROR | bootstrap clone failed; aborting" -Encoding utf8
+        exit 1
+    }
+}
+
+& git -C $RepoRoot fetch origin 2>&1 | Out-Null
+$branch = (& git -C $RepoRoot branch --show-current | Out-String).Trim()
+if ($branch -ne 'main') {
+    Add-Content -Path $LogFile -Value "$Timestamp | SYNC-REFUSED | pinned clone on '$branch', not main — investigate before next run" -Encoding utf8
+    exit 1
+}
+& git -C $RepoRoot merge --ff-only origin/main 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Add-Content -Path $LogFile -Value "$Timestamp | SYNC-REFUSED | ff-only to origin/main failed (diverged pinned clone) — investigate" -Encoding utf8
+    exit 1
+}
+
+# Provenance (#1879 option 3): every run log answers "which code ran".
+$sha = (& git -C $RepoRoot rev-parse --short HEAD | Out-String).Trim()
+$dirtyCount = (& git -C $RepoRoot status --porcelain | Measure-Object -Line).Lines
+Add-Content -Path $LogFile -Value "$Timestamp | PROVENANCE | branch=$branch sha=$sha dirty=$dirtyCount root=$RepoRoot" -Encoding utf8
 
 # Set-Location instead of Push-Location so that environment poetry
 # pick-up matches an interactive shell (poetry resolves its venv from
 # the current directory).
 Set-Location -Path $RepoRoot
 
-Add-Content -Path $LogFile -Value "$Timestamp | START | dependabot --fleet" -Encoding utf8
+# Keep the pinned clone's venv current with its lock (no-op when synced;
+# builds the venv on first run after bootstrap).
+& cmd.exe /c "poetry install --no-interaction >> `"$LogFile`" 2>&1"
 
 try {
     # Bypass PowerShell's pipeline and use cmd.exe's native >>


### PR DESCRIPTION
The scheduled 06:00 harvest executed the shared interactive checkout's working tree — i.e. whatever branch a concurrent session left checked out at 05:59 (observed cycling six branches in a day; one near-miss would have silently run the pre-#1839 tool with no indication in the Summary).

**Composes the issue's options 1 + 3:**
- **Pinned clone** `AssemblyZero-scheduled`, bootstrapped with `gh repo clone` on first run; `poetry install --no-interaction` keeps its venv current (no-op when synced). Interactive sessions never touch it; its audit worktrees are `AssemblyZero-scheduled-dependabot-N`, collision-free with interactive runs (path shape per `dependabot_review.py:472`).
- **ff-only sync gate:** `fetch` then `merge --ff-only origin/main`, with loud `SYNC-REFUSED` log lines + nonzero exit on wrong-branch or divergence. Deliberately no force-sync — `reset --hard` is banned fleet-wide, and a diverged pinned clone that nobody should be committing to means tampering that deserves eyes, not an auto-wipe. Refusal skips one harvest visibly; wrong code never runs invisibly.
- **PROVENANCE line** (branch, SHA, dirty count, root) in the fleet log per run — every past run now answers 'which code produced this'.

Residual, noted for honesty: the ps1 wrapper itself still launches from wherever the scheduled task points it (the interactive tree today) — the pinned clone governs the PYTHON tool, which is where all the gate logic lives. Wrapper staleness is a far smaller surface and updates on every merge to main.

Sibling of #1852 (same shared-checkout root cause; its branch-guard amendment landed in the universal CLAUDE.md tonight).

Closes #1879