### PR TITLE
feat(speedrun): deterministic clean-state gate + reset self-verification (Closes #1918)

### DIFF
--- a/tests/unit/test_speedrun_clean_check.py
+++ b/tests/unit/test_speedrun_clean_check.py
@@ -1,0 +1,151 @@
+"""The clean-state gate detects every debris class a killed roll leaves (#1918).
+
+Local classes (worktrees, branches, untracked artifacts) are exercised
+against REAL throwaway git repos — no mocks (standard 0024). The two
+network-edge finders (origin refs, open PRs) substitute _run with real
+subprocess.CompletedProcess instances: an I/O boundary, and still real
+result objects.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_clean_check as scc  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+def _make_repo(tmp_path, name="boostrepo"):
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("x", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _completed(stdout="", returncode=0):
+    # mock-ok: subprocess/network boundary — but the stand-in result is a
+    # REAL CompletedProcess, not a MagicMock (standard 0024 §1.3).
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+class TestLocalDebris:
+    def test_clean_repo_has_zero_local_findings(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        assert scc.find_worktree_debris(repo, 7) == []
+        assert scc.find_local_branch_debris(repo, 7) == []
+        assert scc.find_artifact_debris(repo, 7) == []
+
+    def test_issue_branches_are_found(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-7")
+        _git(repo, "branch", "7-lld")
+        _git(repo, "branch", "unrelated")
+        findings = scc.find_local_branch_debris(repo, 7)
+        assert "local branch: issue-7" in findings
+        assert "local branch: 7-lld" in findings
+        assert len(findings) == 2
+
+    def test_worktrees_are_found(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-7")
+        wt = tmp_path / "boostrepo-7"
+        _git(repo, "worktree", "add", str(wt), "issue-7")
+        findings = scc.find_worktree_debris(repo, 7)
+        assert len(findings) == 1
+        assert "boostrepo-7" in findings[0]
+        # The other issue's check does not fire on it
+        assert scc.find_worktree_debris(repo, 4) == []
+
+    def test_untracked_lld_artifacts_are_found(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        active = repo / "docs" / "lld" / "active"
+        active.mkdir(parents=True)
+        (active / "LLD-007.md").write_text("draft", encoding="utf-8")
+        drafts = repo / "docs" / "lld" / "drafts"
+        drafts.mkdir(parents=True)
+        (drafts / "spec-0007-implementation-readiness.md").write_text(
+            "draft", encoding="utf-8"
+        )
+        findings = scc.find_artifact_debris(repo, 7)
+        assert len(findings) == 2
+        assert any("LLD-007.md" in f for f in findings)
+        # A TRACKED artifact is not debris
+        _git(repo, "add", "docs")
+        _git(repo, "commit", "-m", "land artifacts")
+        assert scc.find_artifact_debris(repo, 7) == []
+
+
+class TestRemoteDebris:
+    def test_origin_refs_found_and_graveyard_exempt(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        ls_remote = (
+            "aaa\trefs/heads/main\n"
+            "bbb\trefs/heads/issue-7\n"
+            "ccc\trefs/heads/7-lld\n"
+            "ddd\trefs/heads/graveyard/run11-issue-7\n"
+            "eee\trefs/heads/hardening-run-11\n"
+        )
+        with patch.object(scc, "_run", return_value=_completed(ls_remote)):
+            findings = scc.find_remote_branch_debris(repo, 7)
+        assert "remote branch: origin/issue-7" in findings
+        assert "remote branch: origin/7-lld" in findings
+        assert len(findings) == 2
+
+    def test_open_prs_matched_by_head_branch(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        pr_json = (
+            '[{"number": 135, "headRefName": "4-lld", "title": "docs: LLD-4"},'
+            ' {"number": 200, "headRefName": "feature-x", "title": "other"}]'
+        )
+
+        def fake_run(cmd, cwd=None):
+            if cmd[0] == "gh":
+                return _completed(pr_json)
+            if cmd[:3] == ["git", "remote", "get-url"]:
+                return _completed("https://github.com/owner/boostrepo.git\n")
+            return _completed("")
+
+        with patch.object(scc, "_run", side_effect=fake_run):
+            findings = scc.find_open_pr_debris(repo, 4)
+        assert len(findings) == 1
+        assert "#135" in findings[0]
+        assert "4-lld" in findings[0]
+
+
+class TestVerdict:
+    def test_check_repo_aggregates_all_classes(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-9")
+        with patch.object(
+            scc, "find_remote_branch_debris", return_value=[]
+        ), patch.object(scc, "find_open_pr_debris", return_value=[]):
+            findings = scc.check_repo(repo, [9])
+        assert findings == ["local branch: issue-9"]
+
+    def test_main_exit_codes(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        with patch.object(
+            scc, "find_remote_branch_debris", return_value=[]
+        ), patch.object(scc, "find_open_pr_debris", return_value=[]):
+            clean = scc.main(["--repo", str(repo), "--issue", "9"])
+            _git(repo, "branch", "issue-9")
+            dirty = scc.main(["--repo", str(repo), "--issue", "9"])
+        assert clean == 0
+        assert dirty == 1
+        assert scc.main(["--repo", str(tmp_path / "nope"), "--issue", "9"]) == 2

--- a/tools/speedrun_clean_check.py
+++ b/tools/speedrun_clean_check.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Deterministic clean-state gate for speedrun rolls (#1918).
+
+Debris is the antithesis of idempotent. A killed roll leaves worktrees,
+branches, remote refs, open PRs, and stray pipeline artifacts;
+`speedrun_reset.py` removes all of those — but only when someone runs it,
+and until now nothing VERIFIED zero. This tool is the verification:
+read-only enumeration of every debris class the 2026-07-29 killed
+phase-4 roll actually produced, exit nonzero listing findings.
+
+Usage:
+    poetry run python tools/speedrun_clean_check.py \
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 4
+
+    # several issues at once
+    ... --issue 4 --issue 2 --issue 5
+
+Exit codes:
+    0 — clean (no debris for the given issues)
+    1 — debris found (every finding printed, one per line)
+    2 — cannot answer (not a git repo, gh failure, ...)
+
+Wired as:
+  - launch preflight in the instrumented run wrapper (a roll must start
+    from verified zero);
+  - self-verification at the end of `speedrun_reset.py` (a reset that
+    cannot prove it finished did not finish).
+
+Read-only by design: this tool never deletes anything. It asks origin
+directly (`git ls-remote`) rather than trusting possibly-stale local
+remote-tracking refs. `graveyard/*` branches are intentionally exempt —
+they are the operator's lab notebook, not debris.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True
+    )
+
+
+def _gh_repo(repo_root: Path) -> str:
+    """owner/repo from the origin URL, or '' if undetermined."""
+    result = _run(["git", "remote", "get-url", "origin"], cwd=repo_root)
+    if result.returncode != 0:
+        return ""
+    url = result.stdout.strip()
+    tail = url.split("github.com")[-1].lstrip(":/")
+    return tail.removesuffix(".git")
+
+
+def find_worktree_debris(repo_root: Path, issue: int) -> list[str]:
+    """Worktrees at {repo}-{issue} and {repo}-{issue}-lld."""
+    findings: list[str] = []
+    result = _run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
+    if result.returncode != 0:
+        return [f"ERROR: git worktree list failed: {result.stderr.strip()}"]
+    suffixes = {f"{repo_root.name}-{issue}", f"{repo_root.name}-{issue}-lld"}
+    for line in result.stdout.splitlines():
+        if not line.startswith("worktree "):
+            continue
+        path = Path(line.split(" ", 1)[1])
+        if path.name in suffixes:
+            findings.append(f"worktree: {path}")
+    return findings
+
+
+def find_local_branch_debris(repo_root: Path, issue: int) -> list[str]:
+    """Local branches issue-{N} and {N}-* (graveyard/* exempt by pattern)."""
+    result = _run(
+        ["git", "branch", "--list", f"issue-{issue}", f"{issue}-*"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return [f"ERROR: git branch --list failed: {result.stderr.strip()}"]
+    return [
+        f"local branch: {line.strip().lstrip('* ').strip()}"
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def find_remote_branch_debris(repo_root: Path, issue: int) -> list[str]:
+    """Refs on origin itself — never trust stale remote-tracking state."""
+    result = _run(["git", "ls-remote", "--heads", "origin"], cwd=repo_root)
+    if result.returncode != 0:
+        return [f"ERROR: git ls-remote failed: {result.stderr.strip()}"]
+    findings: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        name = parts[1].removeprefix("refs/heads/")
+        if name == f"issue-{issue}" or (
+            name.startswith(f"{issue}-") and not name.startswith("graveyard/")
+        ):
+            findings.append(f"remote branch: origin/{name}")
+    return findings
+
+
+def find_open_pr_debris(repo_root: Path, issue: int) -> list[str]:
+    """Open PRs whose head branch belongs to this issue's roll."""
+    gh_repo = _gh_repo(repo_root)
+    if not gh_repo:
+        return ["ERROR: cannot determine owner/repo from origin URL"]
+    result = _run(
+        [
+            "gh", "pr", "list", "--repo", gh_repo, "--state", "open",
+            "--json", "number,headRefName,title",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return [f"ERROR: gh pr list failed: {result.stderr.strip()}"]
+    try:
+        prs = json.loads(result.stdout or "[]")
+    except ValueError:
+        return ["ERROR: gh pr list returned unparseable JSON"]
+    findings: list[str] = []
+    for pr in prs:
+        head = pr.get("headRefName", "")
+        if head == f"issue-{issue}" or head.startswith(f"{issue}-"):
+            findings.append(
+                f"open PR: #{pr.get('number')} ({head}) {pr.get('title', '')!r}"
+            )
+    return findings
+
+
+def find_artifact_debris(repo_root: Path, issue: int) -> list[str]:
+    """Untracked pipeline artifacts under docs/lld for this issue.
+
+    Left in place they make the next run resolve existing artifacts and
+    skip stages (#1849) — the quietest debris class of all.
+    """
+    # -uall: porcelain collapses a fully-untracked directory to one
+    # `?? docs/` line, which would hide every artifact inside it.
+    result = _run(["git", "status", "--porcelain", "-uall"], cwd=repo_root)
+    if result.returncode != 0:
+        return [f"ERROR: git status failed: {result.stderr.strip()}"]
+    needles = (
+        f"lld-{issue:03d}",
+        f"lld-{issue}",
+        f"spec-{issue:04d}",
+        f"spec-{issue}",
+    )
+    findings: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.startswith("??"):
+            continue
+        path = line[2:].strip()
+        lower = path.lower().replace("\\", "/")
+        if lower.startswith("docs/lld/") and any(n in lower for n in needles):
+            findings.append(f"untracked artifact: {path}")
+    return findings
+
+
+def check_repo(repo_root: Path, issues: list[int]) -> list[str]:
+    """All findings for the given issues. Empty list == verified clean."""
+    findings: list[str] = []
+    for issue in issues:
+        findings.extend(find_worktree_debris(repo_root, issue))
+        findings.extend(find_local_branch_debris(repo_root, issue))
+        findings.extend(find_remote_branch_debris(repo_root, issue))
+        findings.extend(find_open_pr_debris(repo_root, issue))
+        findings.extend(find_artifact_debris(repo_root, issue))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a target repo carries zero speedrun debris (#1918)."
+    )
+    parser.add_argument("--repo", required=True, help="Target repo root path")
+    parser.add_argument(
+        "--issue", type=int, action="append", required=True,
+        help="Issue number to check (repeatable)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo).resolve()
+    if not (repo_root / ".git").exists():
+        print(f"ERROR: {repo_root} is not a git repository root")
+        return 2
+
+    findings = check_repo(repo_root, args.issue)
+    errors = [f for f in findings if f.startswith("ERROR:")]
+    debris = [f for f in findings if not f.startswith("ERROR:")]
+
+    issue_list = ", ".join(f"#{i}" for i in args.issue)
+    if errors:
+        for e in errors:
+            print(e)
+        return 2
+    if debris:
+        print(
+            f"DEBRIS: {repo_root.name} is NOT clean for {issue_list} — "
+            f"{len(debris)} finding(s):"
+        )
+        for d in debris:
+            print(f"  {d}")
+        return 1
+    print(f"CLEAN: {repo_root.name} carries zero speedrun debris for {issue_list}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -459,6 +459,7 @@ def main() -> int:
         return 1
 
     if args.issue:
+        reset_issues = [args.issue]
         reset_one_issue(repo_root, repo, args.issue)
     else:
         issues = all_logged_issues(repo_root)
@@ -468,8 +469,30 @@ def main() -> int:
         print(f"Resetting {len(issues)} issue(s) from run-log: {issues}")
         for issue in issues:
             reset_one_issue(repo_root, repo, issue)
+        reset_issues = issues
 
-    print("\nspawn state restored")
+    # #1918: a reset that cannot prove it finished did not finish. The
+    # clean-check enumerates every debris class this tool is supposed to
+    # clear; a nonzero remainder (e.g. a dirty worktree deliberately left
+    # for the operator per #1762) is reported honestly instead of the
+    # unconditional success banner this tool used to print.
+    from speedrun_clean_check import check_repo
+
+    findings = check_repo(repo_root, reset_issues)
+    errors = [f for f in findings if f.startswith("ERROR:")]
+    debris = [f for f in findings if not f.startswith("ERROR:")]
+    if errors:
+        print("\nVERIFY: clean-check could not fully answer:")
+        for e in errors:
+            print(f"  {e}")
+        return 2
+    if debris:
+        print(f"\nVERIFY: reset INCOMPLETE — {len(debris)} finding(s) remain:")
+        for d in debris:
+            print(f"  {d}")
+        return 1
+
+    print("\nspawn state restored — verified clean (speedrun_clean_check)")
     return 0
 
 


### PR DESCRIPTION
**Root cause, settled:** `speedrun_reset.py` already clears every debris class the killed phase-4 roll produced — open PRs, both worktrees, local AND origin branches (#1885), stray LLD/spec artifacts (#1849). The debris existed because reset only runs when a human remembers, kill paths never invoke it, and nothing ever VERIFIED zero. The missing piece was verification, not removal.

**`tools/speedrun_clean_check.py`** — read-only, deterministic, exit-code-gated:
- worktrees `{repo}-{N}` / `{repo}-{N}-lld`; local branches `issue-N` / `N-*`
- refs on **origin itself** via `ls-remote` (never trusts stale remote-tracking state)
- open PRs matched by head branch; untracked `docs/lld` artifacts via `status -uall` (plain porcelain collapses fully-untracked dirs and hides everything inside)
- `graveyard/*` exempt by design. Exit 0 clean / 1 findings / 2 cannot-answer.

**Reset self-verification:** `speedrun_reset.py` now finishes by running the gate over what it reset — remaining debris downgrades the old unconditional success banner to an honest INCOMPLETE listing with nonzero exit; a reset that cannot prove it finished did not finish.

Launch-preflight wiring lands in the instrumented wrapper (boostgauge scratch script tonight; first-class promotion tracked in #1919). This tool will be exercised live immediately: verify-dirty → wipe → verify-zero → relaunch phase 4.

**Tests:** 8 — real throwaway git repos for the local classes (standard 0024: no MagicMock; network-edge stand-ins are real `CompletedProcess` objects), graveyard exemption, tracked-artifact exclusion, aggregation, exit codes.

Closes #1918