### PR TITLE
fix(testing): coverage failures are honest and terminal (Closes #1938, Closes #1939, Closes #1940)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -45,7 +45,10 @@ def classify_error(error_message: str) -> str:
     # situation. The fix is an operator ruling on the issue text.
     if "requirements conflict" in msg_lower:
         return "requirements_conflict"
-    if any(p in msg_lower for p in ("stagnation", "same issues", "same blocking", "two consecutive")):
+    # #1939: 'stagnant' is what the live guards actually print
+    # ("[STAGNANT] Coverage stagnant: 87.0% -> 86.0%") — the old
+    # 'stagnation'-only pattern never matched a real halt message.
+    if any(p in msg_lower for p in ("stagnation", "stagnant", "same issues", "same blocking", "two consecutive")):
         return "stagnation"
     if any(p in msg_lower for p in ("budget", "cost budget exceeded")):
         return "budget"

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -148,6 +148,14 @@ def _classify_halt_transience(sub_result: dict) -> bool | None:
     import json
     plan_path = sub_result.get("recovery_plan_path", "")
     if not plan_path:
+        # #1939: no recovery plan, but some sub-workflow guards halt with a
+        # bare error_message. A stagnation halt is deterministic given the
+        # worktree the retry will resume ("Skipped (already exists)" replayed
+        # attempt 1 verbatim on 2026-07-30) — retrying it burns full stage
+        # attempts to re-measure the number the guard already reported.
+        message = str(sub_result.get("error_message", "")).lower()
+        if any(m in message for m in ("stagnant", "stagnation")):
+            return False
         return None
     try:
         plan = json.loads(Path(plan_path).read_text(encoding="utf-8"))

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -182,6 +182,19 @@ CRITICAL — REQUIREMENT/TEST MAPPING (failure to follow halts the workflow):
 - EVERY requirement in Section 3 MUST be covered by at least one test scenario via the `(REQ-N)` suffix. A mechanical validator counts coverage by regex-matching `(REQ-N)` patterns in Section 10.1 against the numbered list in Section 3. Missing coverage halts the workflow.
 - Multiple scenarios may cover the same requirement (e.g. two error-case scenarios both ending in `(REQ-2)`). That's fine. What's NOT fine: a requirement with zero matching `(REQ-N)` references.
 
+COVERAGE TARGETS MUST BE REACHABLE BY THE PLANNED TESTS (Issue #1940):
+- If the target repo declares a coverage gate (pyproject `fail_under`), use \
+THAT number as the LLD's coverage target. Do NOT invent a stricter one \
+unless the issue itself demands it — a live run died holding generated \
+code to an invented 95% while the repo's own gate said 89%.
+- Every percentage you promise must be arithmetically reachable by the \
+tests you plan. If your design includes defensive branches — queue-full \
+eviction, race-window except blocks, abstract method bodies — the test \
+plan MUST either include a deterministic scenario that exercises each one \
+(prefill the queue to force eviction; inject the exception) or explicitly \
+name the lines as coverage exclusions with a one-line justification. A \
+target with unplanned-for defensive branches is an unwinnable spec.
+
 Use the template structure provided. Include all sections. Be specific about:
 - Files to be created/modified
 - Function signatures

--- a/assemblyzero/workflows/testing/exit_code_router.py
+++ b/assemblyzero/workflows/testing/exit_code_router.py
@@ -71,6 +71,20 @@ def route_by_exit_code(
     return "end"
 
 
+def describe_run_outcome(exit_code: int, failed_count: int | None = None) -> str:
+    """describe_exit_code, but never blames tests for the coverage gate.
+
+    #1938: pytest-cov's fail-under forces exit 1 even when every test
+    passes. A live run printed '50 passed, 0 failed | Exit: 1 (some tests
+    failed)' — the mislabel cost a full log-forensics pass during the
+    kill-diagnosis. When the caller knows the failure count is zero, exit 1
+    means the coverage gate, and the label says so.
+    """
+    if exit_code == EXIT_TESTSFAILED and failed_count == 0:
+        return "coverage below fail-under; all tests passed"
+    return describe_exit_code(exit_code)
+
+
 def describe_exit_code(exit_code: int) -> str:
     """Return a human-readable description of a pytest exit code.
 

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -30,6 +30,7 @@ from assemblyzero.workflows.testing.exit_code_router import (
     EXIT_USAGEERROR,
     EXIT_NOTESTSCOLLECTED,
     describe_exit_code,
+    describe_run_outcome,
     route_by_exit_code,
 )
 from assemblyzero.workflows.testing.framework_detector import CoverageType, TestFramework
@@ -734,7 +735,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     parsed = result["parsed"]
 
     print(f"    [N5] Results: {parsed.get('passed', 0)} passed, {parsed.get('failed', 0)} failed | "
-          f"Coverage: {parsed.get('coverage', 0):.1f}% | Exit: {exit_code} ({describe_exit_code(exit_code)})")
+          f"Coverage: {parsed.get('coverage', 0):.1f}% | Exit: {exit_code} "
+          f"({describe_run_outcome(exit_code, parsed.get('failed'))})")
 
     # Save output to audit trail
     audit_dir_str = state.get("audit_dir", "")

--- a/tests/unit/test_honest_coverage_failures.py
+++ b/tests/unit/test_honest_coverage_failures.py
@@ -1,0 +1,78 @@
+"""Coverage failures are honest and terminal (#1938, #1939, #1940).
+
+Reference incident: run11b-issue4-234552 (2026-07-30). The N5 loop printed
+'50 passed, 0 failed | Exit: 1 (some tests failed)' — the coverage gate
+wearing a test-failure label — then the stagnation guard's correct halt
+was retried as if transient, and the stage retry resumed the identical
+worktree ('Skipped (already exists)') to reproduce the identical 86%.
+Meanwhile the LLD had invented a 95% target against the repo's declared
+fail_under of 89, with no tests planned for the 12 defensive-concurrency
+lines that made the number unreachable.
+"""
+
+from assemblyzero.core.halt_node import classify_error
+from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+from assemblyzero.workflows.requirements.nodes import generate_draft
+from assemblyzero.workflows.testing.exit_code_router import (
+    describe_exit_code,
+    describe_run_outcome,
+)
+
+LIVE_STAGNATION_MESSAGE = (
+    "Coverage stagnant: 87.0% -> 86.0% (< 1% improvement). "
+    "Halting to prevent token waste."
+)
+
+
+class TestHonestExitLabel:
+    def test_exit_1_with_zero_failures_names_the_coverage_gate(self):
+        label = describe_run_outcome(1, failed_count=0)
+        assert "coverage" in label
+        assert "tests failed" not in label
+
+    def test_exit_1_with_real_failures_keeps_the_test_label(self):
+        assert describe_run_outcome(1, failed_count=3) == "some tests failed"
+
+    def test_unknown_failed_count_defers_to_plain_description(self):
+        assert describe_run_outcome(1, failed_count=None) == "some tests failed"
+
+    def test_other_exit_codes_pass_through(self):
+        for code in (0, 2, 3, 4, 5):
+            assert describe_run_outcome(code, failed_count=0) == describe_exit_code(code)
+
+
+class TestStagnationIsTerminal:
+    def test_live_message_classifies_stagnation(self):
+        """The old 'stagnation'-only pattern never matched what the guard
+        actually prints."""
+        assert classify_error(LIVE_STAGNATION_MESSAGE) == "stagnation"
+
+    def test_planless_stagnation_halt_is_non_transient(self):
+        sub_result = {"error_message": LIVE_STAGNATION_MESSAGE}
+        assert _classify_halt_transience(sub_result) is False
+
+    def test_planless_non_stagnation_failure_keeps_default(self):
+        """gh flakes and friends keep their retry budget (the #1463
+        contract): no plan + no stagnation marker -> None -> retry-default."""
+        sub_result = {"error_message": "gh CLI flake: connection reset"}
+        assert _classify_halt_transience(sub_result) is None
+
+    def test_empty_sub_result_keeps_default(self):
+        assert _classify_halt_transience({}) is None
+
+
+class TestDrafterCoverageGuidance:
+    def test_prompt_pins_target_to_repo_gate(self):
+        src = generate_draft.__dict__.get("__doc__") or ""
+        import inspect
+
+        source = inspect.getsource(generate_draft)
+        assert "fail_under" in source
+        assert "Issue #1940" in source
+
+    def test_prompt_demands_reachable_targets(self):
+        import inspect
+
+        source = inspect.getsource(generate_draft)
+        assert "arithmetically reachable" in source
+        assert "defensive branches" in source


### PR DESCRIPTION
Tonight's phase-4 roll was killed on a determined outcome; the forensics produced one causal chain with three fixable links (the fourth, the general retry-resume design, is filed as #1941):

1. **Honest label (#1938):** `50 passed, 0 failed | Exit: 1 (some tests failed)` — pytest-cov's fail-under forces exit 1 with zero failures. New `describe_run_outcome(exit_code, failed_count)` says `coverage below fail-under; all tests passed`; N5 uses it. Unknown counts and real failures keep the old labels.
2. **Stagnation is terminal (#1939):** the guard's halt was correct, but planless (`recovery_plan_path` absent) → `transient` unset → stage retry → same live worktree → `Skipped (already exists)` → identical 86%. Planless halts with stagnation markers now classify `transient=False`; `halt_node` patterns gain `'stagnant'` — the word the guard actually prints ('stagnation' has never matched a live message). gh-flake-style planless failures keep the #1463 retry-default (pinned by test).
3. **Reachable targets (#1940):** the LLD declared ≥95% against the repo's declared `fail_under = 89`, while designing the exact 12 defensive-concurrency lines (collector.py 115, 141-142, 153-161) its test plan never covered. Drafter prompt now pins the target to the repo's declared gate and demands arithmetic reachability: hard branches get a planned deterministic test (prefill the queue; inject the exception) or an explicit justified exclusion.

**Tests:** 10 new incl. the live stagnation message verbatim; suites green: 95 (new + halt + stages + capacity + requirements-conflict) and 109 (exit-router + verify-phases + generate-draft).

Closes #1938, Closes #1939, Closes #1940