### PR TITLE
fix(capacity): the budget wall carries what it rode; '≥' targets parse (Closes #1943, Closes #1944)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -766,6 +766,12 @@ class GeminiClient:
         initial_credential = available[0]
         errors: list[str] = []
         budget_exhausted = False
+        # #1944: what the budget wall was riding when it fired. Without
+        # this, 'call budget exhausted' erases the capacity signature —
+        # downstream, the stage retried a 10-minute 503 storm with a flat
+        # 10s delay (no escalation) and the halt classifier false-matched
+        # the COST-budget pattern (non-transient).
+        last_error_type: GeminiErrorType | None = None
 
         for cred in available:
             rotation_occurred = cred.name != initial_credential.name
@@ -789,9 +795,15 @@ class GeminiClient:
                 remaining = self._remaining_budget(start_time)
                 if remaining < MIN_ATTEMPT_SECONDS:
                     budget_exhausted = True
+                    if last_error_type == GeminiErrorType.CAPACITY_EXHAUSTED:
+                        flavor = " riding 503/529 capacity storms"
+                    elif last_error_type is not None:
+                        flavor = f" (last error class: {last_error_type.name.lower()})"
+                    else:
+                        flavor = ""
                     errors.append(
                         f"{cred.name}: call budget of "
-                        f"{MAX_TOTAL_INVOKE_SECONDS:.0f}s exhausted"
+                        f"{MAX_TOTAL_INVOKE_SECONDS:.0f}s exhausted{flavor}"
                     )
                     print(
                         f"    [LLM] provider=gemini model={self.model}: "
@@ -898,6 +910,7 @@ class GeminiClient:
                         and _is_spawn_failure(error_str)
                     ):
                         error_type = GeminiErrorType.CAPACITY_EXHAUSTED
+                    last_error_type = error_type  # #1944: budget wall carries this
 
                     if error_type == GeminiErrorType.CAPACITY_EXHAUSTED:
                         # 529/503: Backoff and retry same credential

--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -50,7 +50,13 @@ def classify_error(error_message: str) -> str:
     # 'stagnation'-only pattern never matched a real halt message.
     if any(p in msg_lower for p in ("stagnation", "stagnant", "same issues", "same blocking", "two consecutive")):
         return "stagnation"
-    if any(p in msg_lower for p in ("budget", "cost budget exceeded")):
+    # #1944: the bare token 'budget' false-matched the CLIENT's wall-clock
+    # wall ('call budget of 600s exhausted') — a pure capacity storm halted
+    # as a non-transient cost problem telling the operator to raise
+    # --budget. Cost halts all carry '[BUDGET]' or 'cost budget'; match
+    # those, and let capacity-flavored budget-wall messages fall through to
+    # the capacity classifier below.
+    if any(p in msg_lower for p in ("[budget]", "cost budget")):
         return "budget"
     if "preflight" in msg_lower:
         if "unavailable" in msg_lower or "exhausted" in msg_lower:

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -530,24 +530,31 @@ def _extract_assertions(content: str) -> list[str]:  # pragma: no cover
     return assertions[:5]  # Limit to 5 assertions
 
 
-def extract_coverage_target(lld_content: str) -> int:  # pragma: no cover
+def extract_coverage_target(lld_content: str) -> int:
     """Extract coverage target from LLD.
 
     Looks for patterns like:
     - Coverage: 90%
     - Target coverage: 85%
     - Code coverage >= 80%
+    - Coverage Target: ≥89%   (#1943: comparators before the number)
+
+    #1943: every live LLD writes its target as '≥N%', which the old
+    digit-first patterns could not parse — extraction silently fell to
+    the default, nullifying the #1940 repo-gate pin at the consumer end
+    (a declared 89 ran as 95).
 
     Args:
         lld_content: Full LLD content.
 
     Returns:
-        Coverage target percentage (default 90).
+        Coverage target percentage (default 95, per ADR 0207).
     """
+    comparator = r"(?:[≥≤>=<≧≦]|>=|<=)?\s*"
     patterns = [
-        r"coverage[:\s]+(\d+)%",
-        r"target coverage[:\s]+(\d+)%",
-        r"code coverage[:\s]*>=?\s*(\d+)%",
+        rf"coverage(?: target)?[:\*\s]+{comparator}(\d+)%",
+        rf"target coverage[:\*\s]+{comparator}(\d+)%",
+        rf"code coverage[:\*\s]*{comparator}(\d+)%",
         r"(\d+)%\s*coverage",
     ]
 

--- a/tests/unit/test_capacity_fidelity.py
+++ b/tests/unit/test_capacity_fidelity.py
@@ -1,0 +1,65 @@
+"""The capacity signature survives the budget wall and the '≥' sign (#1943, #1944).
+
+Reference: run11b-issue4-001307 attempts 2-3 (2026-07-30 ~00:40). Gemini
+served 503s; the #1874 wall correctly halted at 600s — and the surfaced
+error 'call budget of 600s exhausted' erased the storm: the stage retried
+flat (no #1909 escalation) and the halt classifier's bare-'budget' pattern
+would have called it a non-transient COST problem. Separately, the fresh
+LLD's repo-pinned '≥89%' target was unparseable (the comparator broke
+every regex) and silently ran as the hardcoded 95.
+"""
+
+from assemblyzero.core.errors import is_capacity_message
+from assemblyzero.core.halt_node import classify_error
+from assemblyzero.workflows.testing.nodes.load_lld import extract_coverage_target
+
+FLAVORED_WALL = (
+    "All credentials failed:\n"
+    "  - oauth-primary: call budget of 600s exhausted riding 503/529 capacity storms"
+)
+BARE_WALL = (
+    "All credentials failed:\n"
+    "  - oauth-primary: call budget of 600s exhausted"
+)
+COST_HALT = "[BUDGET] $5.20 exceeds $5.00 budget. Halting."
+LEGACY_COST_HALT = "Cost budget exceeded: $5.20 spent of $5.00 budget"
+
+
+class TestBudgetWallCarriesTheStorm:
+    def test_flavored_wall_is_a_capacity_signature(self):
+        assert is_capacity_message(FLAVORED_WALL) is True
+
+    def test_flavored_wall_classifies_capacity_not_budget(self):
+        assert classify_error(FLAVORED_WALL) == "capacity_exhausted"
+
+    def test_cost_halts_still_classify_budget(self):
+        assert classify_error(COST_HALT) == "budget"
+        assert classify_error(LEGACY_COST_HALT) == "budget"
+
+    def test_bare_wall_no_longer_false_matches_cost_budget(self):
+        """A budget-wall message with no flavor (e.g. the wall fired before
+        any attempt ran) must not classify as a COST problem. It is not
+        capacity either — it falls through to the generic bucket, which
+        retries by default rather than telling the operator to raise
+        --budget for provider weather."""
+        assert classify_error(BARE_WALL) != "budget"
+
+
+class TestCoverageTargetParsesComparators:
+    def test_the_live_lld_line_parses(self):
+        lld = (
+            "**Coverage Target:** ≥89% for all new code "
+            "(matching `pyproject.toml` `fail_under = 89`)"
+        )
+        assert extract_coverage_target(lld) == 89
+
+    def test_ascii_ge_parses(self):
+        assert extract_coverage_target("Code coverage >= 80% required") == 80
+
+    def test_plain_forms_still_parse(self):
+        assert extract_coverage_target("Coverage: 90%") == 90
+        assert extract_coverage_target("Target coverage: 85%") == 85
+        assert extract_coverage_target("Achieve 92% coverage overall") == 92
+
+    def test_no_declaration_falls_to_default(self):
+        assert extract_coverage_target("No numbers here.") == 95


### PR DESCRIPTION
Both leaks were caught live on tonight's phase-4 roll (run11b-issue4-001307) and both nullified fixes that had just landed:

**#1944 — the wall erased the storm.** Attempts 2-3 rode Gemini 503s into the #1874 600s wall, whose message — 'call budget of 600s exhausted' — carried no capacity marker. Consequences measured in the log: the #1909 escalating backoff never engaged (the stage retried a 10-minute storm after a flat 10 seconds), and `classify_error`'s bare-'budget' token would have labeled provider weather a non-transient cost halt ('raise --budget'). Now the client records the last error class per attempt; the wall says `call budget of 600s exhausted riding 503/529 capacity storms` (other classes get `last error class: …`); and the cost-budget pattern narrows to `[BUDGET]` / `cost budget` — every real cost halt carries one of these (pinned by test against both live formats), so flavored wall messages fall through to the capacity classifier and re-enter the escalation path.

**#1943 — '≥' unparseable.** Every live LLD writes its target as '≥N%'; the digit-first regexes matched none of them, so extraction silently fell to the hardcoded 95 — the #1940 repo-gate pin (a declared ≥89 matching `fail_under=89`) ran as 95. Patterns now accept comparators and markdown-bold separators; the live LLD line parses to 89 (pinned); the docstring's 'default 90' fiction is corrected to the actual 95; pragma no-cover removed now that the function has tests.

**Tests:** 10 new (flavored wall → capacity; both live cost-halt formats → budget; bare wall no longer cost; the exact live LLD line → 89; ASCII/plain/default forms). Suites green: 73 (all classification neighbors incl. gemini bounds) + 189 (load_lld + gemini).

Closes #1943, Closes #1944