### PR TITLE
fix(completeness): the symbol checker knows whose method it is judging (Closes #1948)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -974,17 +974,56 @@ def detect_unknown_method_calls(
     """
     # Extract method/function call names from code fences only
     code_block_re = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
-    # Match  <ident>.<method>(  —  the opening paren marks a call, not an annotation
-    method_call_re = re.compile(r"\b\w+\.(\w+)\s*\(")
+    # Match  <receiver>.<method>(  —  the opening paren marks a call, not an
+    # annotation. #1948: capture the receiver too — WHOSE method it is decides
+    # whether the target repo's symbol table has any authority over it.
+    method_call_re = re.compile(r"\b(\w+)\.(\w+)\s*\(")
+    import_re = re.compile(
+        r"^\s*(?:from\s+([\w.]+)\s+import\s+([\w ,]+)|import\s+([\w.]+)(?:\s+as\s+(\w+))?)",
+        re.MULTILINE,
+    )
+    def_re = re.compile(r"^\s*(?:def|class)\s+(\w+)", re.MULTILINE)
+
+    blocks = [m.group(1) for m in code_block_re.finditer(text)]
+
+    # #1948: three universes the target repo's symbol table has no authority
+    # over — the phase-5 kill was this check rejecting Pillow's documented
+    # API (ImageDraw.Draw, alpha_composite), pathlib, and a method the spec
+    # itself defined. Same wrong-universe disease #1901 fixed for imports.
+    exempt_receivers: set[str] = set()
+    spec_defined: set[str] = set()
+    for block_content in blocks:
+        for imp in import_re.finditer(block_content):
+            if imp.group(1):  # from X import a, b — names land in scope
+                exempt_receivers.add(imp.group(1).split(".")[0])
+                for name in imp.group(2).split(","):
+                    name = name.strip().split(" as ")
+                    exempt_receivers.add(name[-1].strip())
+            elif imp.group(3):  # import X [as y]
+                exempt_receivers.add(
+                    imp.group(4) or imp.group(3).split(".")[0]
+                )
+        for d in def_re.finditer(block_content):
+            spec_defined.add(d.group(1))
+
+    # One propagation pass: `draw = ImageDraw.Draw(...)` makes `draw` an
+    # exempt receiver too. Single level, matching how spec snippets read.
+    assign_re = re.compile(r"^\s*(\w+)\s*=\s*(\w+)\.", re.MULTILINE)
+    for block_content in blocks:
+        for a in assign_re.finditer(block_content):
+            if a.group(2) in exempt_receivers:
+                exempt_receivers.add(a.group(1))
 
     flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
 
-    for block_match in code_block_re.finditer(text):
-        block_content = block_match.group(1)
+    for block_content in blocks:
         for call_match in method_call_re.finditer(block_content):
-            method_name = call_match.group(1)
+            receiver = call_match.group(1)
+            method_name = call_match.group(2)
 
-            if method_name in symbol_set:
+            if receiver in exempt_receivers:
+                continue
+            if method_name in symbol_set or method_name in spec_defined:
                 continue
             if method_name in _API_SYMBOL_ALLOWLIST:
                 continue

--- a/tests/unit/test_receiver_aware_symbols.py
+++ b/tests/unit/test_receiver_aware_symbols.py
@@ -1,0 +1,103 @@
+"""The symbol checker knows whose method it is judging (#1948).
+
+Phase-5 kill (run11b-issue2-032618): api_symbols_exist rejected Pillow's
+documented API (ImageDraw.Draw, alpha_composite, ellipse), pathlib.Path,
+and a method the spec itself defined — the target repo's 20 gathered
+symbols have no authority over any of those universes. Twice-identical
+BLOCKs made the revise loop unwinnable; the roll was killed as a
+determined outcome. Same wrong-universe disease #1901 fixed for imports.
+"""
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+TARGET_SYMBOLS = ["TelltaleState", "update", "decay_floor", "to_dict"]
+
+# Distilled from the killed roll's actual spec content.
+PHASE5_SPEC_SHAPE = """# Spec
+
+```python
+from PIL import Image, ImageDraw
+from pathlib import Path
+import queue as q
+
+
+class TelltaleTrayHelper:
+    def get_context_menu_actions(self):
+        return ["Reset"]
+
+
+def render(telltale_layer, base_img, x_pos):
+    er_draw = ImageDraw.Draw(telltale_layer)
+    er_draw.ellipse([x_pos, 0, x_pos + 4, 4])
+    out = Path("out.png")
+    q.Queue()
+    helper = TelltaleTrayHelper()
+    actions = helper.get_context_menu_actions()
+    return Image.alpha_composite(base_img, telltale_layer)
+```
+"""
+
+HALLUCINATED_SPEC = """# Spec
+
+```python
+def apply(state):
+    state.model_dump()
+    return question.model_validate(state)
+```
+"""
+
+
+class TestExemptUniverses:
+    def test_the_phase5_shape_passes(self):
+        result = check_api_symbols_exist(PHASE5_SPEC_SHAPE, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_imported_module_receivers_exempt(self):
+        flagged = detect_unknown_method_calls(
+            PHASE5_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        for name in ("Draw", "alpha_composite", "Path", "Queue"):
+            assert name not in flagged
+
+    def test_import_alias_receiver_exempt(self):
+        flagged = detect_unknown_method_calls(
+            PHASE5_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "Queue" not in flagged  # `import queue as q` → q.Queue()
+
+    def test_spec_defined_method_exempt(self):
+        flagged = detect_unknown_method_calls(
+            PHASE5_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "get_context_menu_actions" not in flagged
+
+    def test_assignment_propagation_one_level(self):
+        """`er_draw = ImageDraw.Draw(...)` makes er_draw exempt, so
+        `er_draw.ellipse(` is Pillow's business, not the target repo's."""
+        flagged = detect_unknown_method_calls(
+            PHASE5_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "ellipse" not in flagged
+
+
+class TestTruePositivesSurvive:
+    def test_hallucinated_target_api_still_flagged(self):
+        """#1527's founding case: pydantic methods on a plain dataclass."""
+        flagged = detect_unknown_method_calls(
+            HALLUCINATED_SPEC, set(TARGET_SYMBOLS)
+        )
+        assert "model_dump" in flagged
+        assert "model_validate" in flagged
+
+    def test_check_blocks_on_true_positive(self):
+        result = check_api_symbols_exist(HALLUCINATED_SPEC, TARGET_SYMBOLS)
+        assert result["passed"] is False
+        assert "model_dump" in result["details"]
+
+    def test_known_target_methods_pass(self):
+        spec = "# S\n\n```python\ndef f(state):\n    state.update(1)\n    return state.to_dict()\n```\n"
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is True


### PR DESCRIPTION
Live kill at 3:31 AM: the phase-5 telltale spec BLOCKED twice byte-identically on `api_symbols_exist` for calling **Pillow's documented API** (`ImageDraw.Draw`, `alpha_composite`, `ellipse`), **pathlib.Path**, and **a method the spec itself defines** — the target repo's gathered symbols were treated as the only legal universe, making a renderer spec unwritable and the revise loop unwinnable. The #1901 prophecy ('a checker that models the environment wrongly will eventually reject something the drafter cannot phrase around') fulfilled by the sibling check within hours of the fix landing.

**Fix in the shared core** `detect_unknown_method_calls` (heals the #1812 hallucination telemetry too): the regex now captures the **receiver**, and three universes are exempt — (1) names the spec imports: module roots, from-names, and aliases; (2) symbols the spec itself defines (`def`/`class` in fences); (3) one assignment-propagation level, so `er_draw = ImageDraw.Draw(...)` makes `er_draw.ellipse(` Pillow's business. Calls on target-repo objects keep their gate: the #1527 founding case (pydantic methods hallucinated onto a plain dataclass) still flags, pinned by test.

**Tests:** 8 new — a distilled replica of the killed roll's spec shape passes whole; each exempt universe pinned individually; both true-positive cases still block. Suites green: 93 (all completeness checks) + 61 (telemetry/hallucination consumers).

Closes #1948