### PR TITLE
fix(completeness): callbacks assigned on self and docstring-quoted code are not hallucinations (Closes #1950)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -983,8 +983,19 @@ def detect_unknown_method_calls(
         re.MULTILINE,
     )
     def_re = re.compile(r"^\s*(?:def|class)\s+(\w+)", re.MULTILINE)
+    # #1950: `self._on_quit_cb = on_quit` then `self._on_quit_cb()` —
+    # constructor-assigned callables are spec-defined too. The def-only
+    # collector drove the drafter into rename-oscillation (_on_quit ->
+    # _on_quit_cb) because the checker could never see the definitions.
+    self_assign_re = re.compile(r"^\s*self\.(\w+)\s*=", re.MULTILINE)
+    # #1950: docstrings inside fences quote code ('No tkinter.Tk()
+    # instantiated' — the test-strategy rule itself) — prose, not calls.
+    docstring_re = re.compile(r'""".*?"""|\'\'\'.*?\'\'\'', re.DOTALL)
 
-    blocks = [m.group(1) for m in code_block_re.finditer(text)]
+    blocks = [
+        docstring_re.sub("", m.group(1))
+        for m in code_block_re.finditer(text)
+    ]
 
     # #1948: three universes the target repo's symbol table has no authority
     # over — the phase-5 kill was this check rejecting Pillow's documented
@@ -1005,6 +1016,8 @@ def detect_unknown_method_calls(
                 )
         for d in def_re.finditer(block_content):
             spec_defined.add(d.group(1))
+        for a in self_assign_re.finditer(block_content):
+            spec_defined.add(a.group(1))
 
     # One propagation pass: `draw = ImageDraw.Draw(...)` makes `draw` an
     # exempt receiver too. Single level, matching how spec snippets read.

--- a/tests/unit/test_callback_and_docstring_symbols.py
+++ b/tests/unit/test_callback_and_docstring_symbols.py
@@ -1,0 +1,77 @@
+"""Constructor-assigned callbacks and docstring-quoted code are not
+hallucinations (#1950).
+
+Phase-6 kill (run11b-issue5-034438): the drafter defined GUI callbacks
+idiomatically (`self._on_quit_cb = on_quit`), the def-only collector
+couldn't see them, and the checker drove a rename-oscillation
+(_on_quit → _on_quit_cb) across revise cycles. Separately, `Tk` was
+flagged from a DOCSTRING quoting the test-strategy rule verbatim.
+"""
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+TARGET_SYMBOLS = ["GaugeWindow", "render", "to_dict"]
+
+PHASE6_SPEC_SHAPE = '''# Spec
+
+```python
+class WindowHelper:
+    """Complies with docs/design/0001-test-strategy.md (No tkinter.Tk() instantiated)."""
+
+    def __init__(self, on_quit, on_geometry_change):
+        self._on_quit_cb = on_quit
+        self._on_geometry_change_cb = on_geometry_change
+
+    def handle_close(self):
+        self._on_quit_cb()
+
+    def handle_move(self, x, y, size):
+        self._on_geometry_change_cb(x, y, size)
+```
+'''
+
+
+class TestCallbackAssignments:
+    def test_the_phase6_shape_passes(self):
+        result = check_api_symbols_exist(PHASE6_SPEC_SHAPE, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_assigned_callbacks_not_flagged(self):
+        flagged = detect_unknown_method_calls(
+            PHASE6_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "_on_quit_cb" not in flagged
+        assert "_on_geometry_change_cb" not in flagged
+
+
+class TestDocstringQuotedCode:
+    def test_docstring_tk_not_flagged(self):
+        flagged = detect_unknown_method_calls(
+            PHASE6_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "Tk" not in flagged
+
+    def test_real_code_outside_docstrings_still_flagged(self):
+        spec = (
+            "# S\n\n```python\ndef f(win):\n"
+            '    """No tkinter.Tk() instantiated."""\n'
+            "    win.model_dump()\n```\n"
+        )
+        flagged = detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
+        assert "Tk" not in flagged
+        assert "model_dump" in flagged
+
+    def test_uncalled_undefined_self_attribute_still_flagged(self):
+        """Calling a self method never defined OR assigned stays a finding —
+        the #1527 spirit for private APIs the implementer would have to
+        guess."""
+        spec = (
+            "# S\n\n```python\nclass A:\n"
+            "    def go(self):\n"
+            "        self._mystery_hook()\n```\n"
+        )
+        flagged = detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
+        assert "_mystery_hook" in flagged


### PR DESCRIPTION
Phase-6 finale kill (3:50 AM), two shapes past #1948's receiver-awareness, caught as drafter **rename-oscillation** — iteration 0 flagged `_on_geometry_change`, iteration 1 flagged the renamed `_on_geometry_change_cb`: the drafter's only move against 'method not found' was renaming, because the checker could never see the definitions.

1. **Constructor-assigned callables:** `self._on_quit_cb = on_quit` then `self._on_quit_cb()` — idiomatic GUI wiring the def/class collector cannot see. `self.<name> =` assignments in fences now count as spec-defined.
2. **Docstring-quoted code:** `Tk` flagged from a docstring quoting the test-strategy rule ('No tkinter.Tk() instantiated'). Triple-quoted spans are stripped before scanning.

Truly-undefined private calls (`self._mystery_hook()` with no def and no assignment) still flag — the implementer would have to guess them, #1527's spirit — pinned by test, along with real-code-after-docstring still flagging.

**Tests:** 5 new (distilled phase-6 shape passes whole; each shape pinned; two survival cases). Suites green: 79 (new + receiver-aware + completeness gate).

Closes #1950