### PR TITLE
fix(completeness): widget handles on self and import-less stdlib receivers are exempt (Closes #1952)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1019,9 +1019,20 @@ def detect_unknown_method_calls(
         for a in self_assign_re.finditer(block_content):
             spec_defined.add(a.group(1))
 
+    # #1952: stdlib module names are exempt receivers even without a
+    # visible import — spec snippets legitimately omit import headers
+    # (`copy.deepcopy(config)` flagged with no `import copy` in any fence).
+    import sys as _sys
+
+    exempt_receivers |= set(_sys.stdlib_module_names)
+
     # One propagation pass: `draw = ImageDraw.Draw(...)` makes `draw` an
     # exempt receiver too. Single level, matching how spec snippets read.
-    assign_re = re.compile(r"^\s*(\w+)\s*=\s*(\w+)\.", re.MULTILINE)
+    # #1952: same for self-attributes — `self.root = tk.Tk()` then
+    # `self.root.attributes(...)`: the call regex sees receiver `root`,
+    # so the ATTRIBUTE name joins the exempt receivers when its value
+    # came from one (the whole tkinter widget surface arrives this way).
+    assign_re = re.compile(r"^\s*(?:self\.)?(\w+)\s*=\s*(\w+)[.(]", re.MULTILINE)
     for block_content in blocks:
         for a in assign_re.finditer(block_content):
             if a.group(2) in exempt_receivers:

--- a/tests/unit/test_attr_and_stdlib_receivers.py
+++ b/tests/unit/test_attr_and_stdlib_receivers.py
@@ -1,0 +1,71 @@
+"""Self-attribute widget handles and import-less stdlib receivers (#1952).
+
+Finale kills (runs 035215 and 035542): `self.root = tk.Tk()` then
+`self.root.attributes('-alpha', ...)` — the call regex sees receiver
+`root`, which nothing exempted, so the whole tkinter widget surface
+flagged; and `copy.deepcopy(config)` flagged in snippets that
+legitimately omit import headers.
+"""
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+TARGET_SYMBOLS = ["GaugeWindow", "render"]
+
+FINALE_SPEC_SHAPE = """# Spec
+
+```python
+import tkinter as tk
+
+
+class AlwaysOnTop:
+    def __init__(self):
+        self.root = tk.Tk()
+        self.canvas = tk.Canvas(self.root)
+
+    def apply(self, config):
+        updated = copy.deepcopy(config)
+        self.root.attributes("-alpha", updated["idle_alpha"])
+        self.root.after(0, self.toggle_topmost)
+        self.canvas.bind("<ButtonPress-1>", self.on_press)
+        self.canvas.create_image(0, 0, anchor="nw")
+        return updated
+
+    def toggle_topmost(self):
+        pass
+
+    def on_press(self, event):
+        pass
+```
+"""
+
+
+class TestSelfAttributeReceivers:
+    def test_the_finale_shape_passes(self):
+        result = check_api_symbols_exist(FINALE_SPEC_SHAPE, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_widget_methods_via_self_attrs_not_flagged(self):
+        flagged = detect_unknown_method_calls(
+            FINALE_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        for name in ("attributes", "after", "bind", "create_image"):
+            assert name not in flagged, f"{name} flagged: {flagged.get(name)}"
+
+
+class TestStdlibModuleReceivers:
+    def test_importless_stdlib_receiver_not_flagged(self):
+        flagged = detect_unknown_method_calls(
+            FINALE_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "deepcopy" not in flagged
+
+    def test_target_object_hallucination_still_flagged(self):
+        spec = (
+            "# S\n\n```python\ndef f(win):\n"
+            "    win.model_dump()\n```\n"
+        )
+        flagged = detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
+        assert "model_dump" in flagged


### PR DESCRIPTION
Finale kills: `self.root = tk.Tk()` → `self.root.attributes('-alpha', ...)` — the call regex captures receiver `root`, which nothing exempted, so the whole tkinter widget surface flagged; roll 3 failed byte-identically twice (a legitimate kill under the amended two-strike doctrine — roll 2's kill was premature, corrected on the issue). Plus `copy.deepcopy(config)` flagged in snippets that legitimately omit import headers.

**Two additions:** the assignment-propagation regex also matches `self.<attr> =` and dotless constructor calls (`= Tk()`), so attributes assigned from exempt receivers become exempt receivers; and `sys.stdlib_module_names` joins the exempt set unconditionally. Target-object hallucinations (`win.model_dump()`) still flag — pinned.

Third patch tonight on this check (#1948 → #1950 → this), each family broader than the last; the commit records the exit criterion: a fourth family triggers the #1901-style redesign (probe the target venv instead of pattern-modeling Python).

**Tests:** 5 new (the distilled finale shape passes whole; widget methods and stdlib receiver pinned individually; hallucination survival). All four symbol-checker suites green: 83 passed.

Closes #1952