### PR TITLE
fix(completeness): diff-formatted snippets stop blinding the symbol collectors (Closes #1954)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -992,10 +992,21 @@ def detect_unknown_method_calls(
     # instantiated' — the test-strategy rule itself) — prose, not calls.
     docstring_re = re.compile(r'""".*?"""|\'\'\'.*?\'\'\'', re.DOTALL)
 
-    blocks = [
-        docstring_re.sub("", m.group(1))
-        for m in code_block_re.finditer(text)
-    ]
+    # #1954: the spec template REQUIRES before/after diff snippets, whose
+    # +/- prefixes blinded every line-anchored collector (imports, defs,
+    # assignments never matched `^\s*` past a '+') while the \b-anchored
+    # call regex still fired inside them — `+ root = tk.Tk()` invisible,
+    # `root.after(...)` flagged. Normalize: drop +++/--- file headers,
+    # strip a single leading +/- as whitespace.
+    diff_header_re = re.compile(r"(?m)^(?:\+\+\+|---).*$")
+    diff_marker_re = re.compile(r"(?m)^[+-](?![+-])")
+
+    def _normalize(block: str) -> str:
+        block = diff_header_re.sub("", block)
+        block = diff_marker_re.sub(" ", block)
+        return docstring_re.sub("", block)
+
+    blocks = [_normalize(m.group(1)) for m in code_block_re.finditer(text)]
 
     # #1948: three universes the target repo's symbol table has no authority
     # over — the phase-5 kill was this check rejecting Pillow's documented

--- a/tests/unit/test_diff_snippet_symbols.py
+++ b/tests/unit/test_diff_snippet_symbols.py
@@ -1,0 +1,60 @@
+"""Diff-formatted snippets stop blinding the symbol collectors (#1954).
+
+Finale roll 5: the spec template's required before/after diffs carried
+`+ root = tk.Tk()` (invisible to every line-anchored collector past the
+'+') while `root.after(...)` still matched the call regex — asymmetric
+blindness, byte-identical double strike, roll killed.
+"""
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+TARGET_SYMBOLS = ["GaugeWindow", "render"]
+
+DIFF_SPEC_SHAPE = """# Spec
+
+```diff
++import tkinter as tk
++
++def build(poll_ms, tick):
++    root = tk.Tk()
++    root.attributes('-topmost', False)
++    root.after(poll_ms, tick)
+```
+"""
+
+DIFF_WITH_UNKNOWN_RECEIVER = """# Spec
+
+```diff
+-    old_helper.legacy_call()
++    pass
+```
+"""
+
+
+class TestDiffNormalization:
+    def test_the_finale_diff_shape_passes(self):
+        result = check_api_symbols_exist(DIFF_SPEC_SHAPE, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_plus_prefixed_definitions_are_seen(self):
+        flagged = detect_unknown_method_calls(
+            DIFF_SPEC_SHAPE, set(TARGET_SYMBOLS)
+        )
+        assert "attributes" not in flagged
+        assert "after" not in flagged
+
+    def test_minus_lines_also_normalized(self):
+        """Removed-side calls on unknown receivers still get judged (and
+        here 'old_helper' is neither imported nor assigned — flagged)."""
+        flagged = detect_unknown_method_calls(
+            DIFF_WITH_UNKNOWN_RECEIVER, set(TARGET_SYMBOLS)
+        )
+        assert "legacy_call" in flagged
+
+    def test_plain_code_unaffected(self):
+        spec = "# S\n\n```python\ndef f(win):\n    win.model_dump()\n```\n"
+        flagged = detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
+        assert "model_dump" in flagged


### PR DESCRIPTION
Finale roll 5's byte-identical double strike: the spec template itself REQUIRES before/after diff snippets, and their `+`/`-` prefixes blinded every line-anchored collector (imports, defs, assignments) while the `\b`-anchored call regex kept firing inside them — `+ root = tk.Tk()` invisible, `root.after(...)` flagged. Asymmetric blindness, unwinnable revise loop, legitimate kill under the amended two-strike doctrine.

**The patch:** normalize fences before scanning — `+++`/`---` headers dropped, single leading `+`/`-` stripped as whitespace. Minus-side calls on genuinely unknown receivers still get judged, plain code is untouched (both pinned).

**The debt, formally recorded in the issue:** fourth false-positive family in one night (#1948 → #1950 → #1952 → this) hits the exit criterion written into #1952's commit — the check owes the #1901-style redesign (AST-parse the normalized fences with regex fallback, or probe receivers in the target venv) instead of accreting regex exemptions. Day-shift task; the issue carries the design sketch.

**Tests:** 4 new (the finale diff shape passes whole; +-prefixed definitions seen; minus-side unknown receivers still flagged; plain code unaffected). All five symbol-checker suites green: 87 passed.

Closes #1954