### PR TITLE
fix(speedrun): three defects blocking a clean idempotent roll (Closes #1937, Closes #1959, Closes #1960)

### DIFF
--- a/assemblyzero/utils/git.py
+++ b/assemblyzero/utils/git.py
@@ -21,6 +21,11 @@ from pathlib import Path
 # {N}-implementation (implement tool), issue-{N} (orchestrator impl stage).
 _WORK_BRANCH_RE = re.compile(r"^(?:\d+-lld|\d+-implementation|issue-\d+)$")
 
+# git's `branch --list` decoration: `* ` (current) or `+ ` (checked out in
+# another worktree). Matched only as marker-then-whitespace so a branch named
+# `+foo` is not mangled. See parse_branch_names (#1937).
+_BRANCH_DECORATION_RE = re.compile(r"^[*+]\s+")
+
 
 class GitBranchError(RuntimeError):
     """Raised when a repo's checked-out branch cannot serve as a base."""
@@ -54,6 +59,39 @@ def current_branch(repo: Path | str) -> str:
             "branch (e.g. main or speedrun-attempt-N) before running."
         )
     return branch
+
+
+def parse_branch_names(stdout: str) -> list[str]:
+    """Bare branch names from any ``git branch`` listing, decorated or not.
+
+    ``git branch`` decorates its output: ``* `` for the current branch and
+    ``+ `` for a branch checked out in another worktree. Callers should pass
+    ``--format=%(refname:short)``, which suppresses both — this parser is the
+    backstop for listings that arrive decorated anyway.
+
+    It strips the markers only in the exact form git emits them (marker then
+    whitespace), so a branch legitimately named ``+foo`` survives intact.
+    ``lstrip("*+ ")`` would eat that leading ``+``; the pre-#1937 code used
+    ``lstrip("* ")``, which stripped the star but left the plus, so a
+    worktree-held branch parsed as ``+ issue-4``. That mattered because the
+    sites reading these listings include safety comparisons — #1762's "never
+    delete the branch the run stands on" — where a name that fails to match
+    opens the guard instead of closing it.
+
+    Args:
+        stdout: Raw stdout from a ``git branch`` listing.
+
+    Returns:
+        Non-empty branch names in the order git listed them. Git's detached-HEAD
+        pseudo-entry (``* (HEAD detached at abc1234)``) is not a branch and is
+        omitted.
+    """
+    names: list[str] = []
+    for line in stdout.splitlines():
+        name = _BRANCH_DECORATION_RE.sub("", line.strip()).strip()
+        if name and not name.startswith("(HEAD "):
+            names.append(name)
+    return names
 
 
 def is_generated_work_branch(branch: str) -> bool:

--- a/assemblyzero/workflows/janitor/probes/worktrees.py
+++ b/assemblyzero/workflows/janitor/probes/worktrees.py
@@ -5,6 +5,7 @@ Issue #94: Lu-Tze: The Janitor
 
 from __future__ import annotations
 
+from assemblyzero.utils.git import parse_branch_names
 from assemblyzero.utils.shell import run_command
 from datetime import datetime, timedelta, timezone
 
@@ -169,8 +170,13 @@ def is_branch_merged(
     repo_root: str, branch: str, target: str = "main"
 ) -> bool:
     """Check if branch has been merged into target branch."""
+    # `--format` emits bare refnames (#1937). This function's `branch in
+    # merged_branches` is an EXACT-name comparison, so the old
+    # `lstrip("* ")` — which strips `*` and spaces but not the `+` git puts
+    # on a worktree-checked-out branch — made any such branch read as
+    # unmerged. That is a silent wrong answer, not a cosmetic one.
     result = run_command(
-        ["git", "branch", "--merged", target],
+        ["git", "branch", "--merged", target, "--format=%(refname:short)"],
         cwd=repo_root,
         capture_output=True,
         text=True,
@@ -178,5 +184,4 @@ def is_branch_merged(
     if result.returncode != 0:
         return False
 
-    merged_branches = [b.strip().lstrip("* ") for b in result.stdout.splitlines()]
-    return branch in merged_branches
+    return branch in parse_branch_names(result.stdout)

--- a/assemblyzero/workflows/janitor/probes/worktrees.py
+++ b/assemblyzero/workflows/janitor/probes/worktrees.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from assemblyzero.utils.git import parse_branch_names
 from assemblyzero.utils.shell import run_command
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from assemblyzero.workflows.janitor.state import Finding, ProbeResult
 

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -10,7 +10,7 @@ Each stage function:
 
 from __future__ import annotations
 
-from assemblyzero.utils.git import current_branch
+from assemblyzero.utils.git import GitBranchError, current_branch
 from assemblyzero.utils.shell import run_command
 import json
 import os
@@ -698,6 +698,35 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             if target_repo:
                 add_cmd += ["-C", target_repo]
             add_cmd += ["worktree", "add", str(worktree_path), "-b", branch_name]
+            # #1960: name the base explicitly. `worktree add -b X <path>` with
+            # no commit-ish branches from whatever the target repo happens to
+            # be checked out on, so the content a roll starts from was decided
+            # by ambient state — the same trap #1852/#1903 closed for
+            # hand-driven branching. base_branch is already resolved upstream
+            # (graph.py: the flag, else the target's current branch), so the
+            # default behaviour is unchanged; what changes is that passing
+            # --base-branch now controls the roll's CONTENT as well as the PR
+            # target, and the resolved base is printed rather than implied.
+            base_branch = state.get("base_branch", "")
+            if not base_branch:
+                # current_branch raises GitBranchError on detached HEAD by
+                # design (it must not silently fall back to main), and OSError
+                # when the path is not a directory git can run in. Resolving the
+                # base is an improvement here, not a new failure mode, so a repo
+                # it cannot answer for keeps the previous ambient-HEAD behaviour
+                # rather than failing the stage.
+                try:
+                    base_branch = current_branch(target_repo or ".")
+                except (GitBranchError, OSError) as err:
+                    print(f"    [WARN] base branch unresolved: {err}")
+            if base_branch:
+                add_cmd.append(base_branch)
+                print(f"    Worktree base: {base_branch}")
+            else:
+                print(
+                    "    [WARN] could not resolve a base branch; worktree "
+                    "will be carved from the target repo's current HEAD"
+                )
             run_command(
                 add_cmd,
                 check=True,

--- a/tests/unit/test_branch_decoration_parsing.py
+++ b/tests/unit/test_branch_decoration_parsing.py
@@ -1,0 +1,233 @@
+"""Branch listings are read as bare refnames, not parsed decoration (#1937).
+
+`git branch --list` decorates the current branch with `* ` and a branch
+checked out in a WORKTREE with `+ `. Three tools stripped only `'* '`, so a
+worktree-held branch parsed as `+ issue-4`. In the speedrun tools that
+mangled the report text and any exact-name comparison; in the janitor's
+`is_branch_merged` — whose whole body is `branch in merged_branches` — it
+produced a silent wrong ANSWER, reporting a merged branch as unmerged.
+
+Every case here builds a real throwaway repo and a real worktree, so the
+`+` prefix is genuinely present in git's default output rather than
+simulated (standard 0024). Each test asserts the fixed behaviour AND, where
+it is observable, that the pre-fix `lstrip('* ')` would have failed it.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from assemblyzero.utils.git import parse_branch_names
+from assemblyzero.workflows.janitor.probes.worktrees import is_branch_merged
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_clean_check as scc  # noqa: E402
+import speedrun_reset as srr  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+def _make_repo(tmp_path, name="boostrepo"):
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("x", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _raw_branch_lines(repo, *patterns):
+    """git's DEFAULT (decorated) output — proves the `+` is really there."""
+    out = subprocess.run(
+        ["git", "branch", "--list", *patterns],
+        cwd=str(repo), check=True, capture_output=True, text=True,
+    ).stdout
+    return [line for line in out.splitlines() if line.strip()]
+
+
+class TestTheDecorationIsReallyPresent:
+    """Guards the guard: if git stopped emitting `+`, these tests would pass
+    vacuously and the regression they pin would be unprotected."""
+
+    def test_worktree_checked_out_branch_gets_a_plus_prefix(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-7")
+        _git(repo, "worktree", "add", str(tmp_path / "wt"), "issue-7")
+
+        lines = _raw_branch_lines(repo, "issue-7")
+        assert lines == ["+ issue-7"], lines
+        # And the old idiom demonstrably fails to clean it.
+        assert lines[0].strip().lstrip("* ").strip() == "+ issue-7"
+
+
+class TestCleanCheckLocalBranchDebris:
+    def test_worktree_held_branch_reported_by_bare_name(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-7")
+        _git(repo, "worktree", "add", str(tmp_path / "wt"), "issue-7")
+
+        findings = scc.find_local_branch_debris(repo, 7)
+        assert findings == ["local branch: issue-7"], findings
+
+    def test_current_branch_star_prefix_also_clean(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "issue-9")
+
+        findings = scc.find_local_branch_debris(repo, 9)
+        assert findings == ["local branch: issue-9"], findings
+
+    def test_undecorated_branch_unaffected(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "9-lld")
+
+        assert scc.find_local_branch_debris(repo, 9) == ["local branch: 9-lld"]
+
+
+class TestResetLocalBranchSweep:
+    def test_worktree_held_branch_named_correctly_in_output(
+        self, tmp_path, capsys
+    ):
+        """The branch cannot be deleted while a worktree holds it — but the
+        name in the report has to be the real one, and the comparison against
+        the active branch has to be able to match."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "issue-7")
+        _git(repo, "worktree", "add", str(tmp_path / "wt"), "issue-7")
+
+        srr.delete_local_branches(repo, 7)
+        out = capsys.readouterr().out
+        assert "issue-7" in out
+        assert "+ issue-7" not in out
+
+    def test_deletable_branch_still_deleted(self, tmp_path):
+        """The sweep's actual job keeps working."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "branch", "7-lld")
+
+        assert srr.delete_local_branches(repo, 7) == 1
+        assert scc.find_local_branch_debris(repo, 7) == []
+
+    def test_checked_out_branch_is_skipped_by_matching_name(
+        self, tmp_path, capsys
+    ):
+        """#1762's guard depends on `branch == active` matching. With a `* `
+        prefix left on the parsed name it never could."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "issue-8")
+
+        assert srr.delete_local_branches(repo, 8) == 0
+        assert "currently checked out" in capsys.readouterr().out
+
+
+class TestFormatFlagIsPinned:
+    """The speedrun tools are deliberately stdlib-only standalone scripts, so
+    they cannot import the shared parser (running one from a worktree resolves
+    `assemblyzero` to the MAIN checkout — a #1904 wrong-environment trap). Their
+    protection is `--format`, so a future edit must not be able to drop it
+    silently and reintroduce decoration parsing."""
+
+    def _branch_list_calls(self, monkeypatch, module, fn, *args):
+        seen = []
+
+        def fake_run(cmd, cwd=None, check=False):
+            seen.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr(module, "_run", fake_run)
+        fn(*args)
+        return [c for c in seen if c[:3] == ["git", "branch", "--list"]]
+
+    def test_clean_check_passes_format(self, monkeypatch, tmp_path):
+        calls = self._branch_list_calls(
+            monkeypatch, scc, scc.find_local_branch_debris, tmp_path, 7
+        )
+        assert calls, "no branch listing was issued"
+        for cmd in calls:
+            assert "--format=%(refname:short)" in cmd, cmd
+
+    def test_reset_local_sweep_passes_format(self, monkeypatch, tmp_path):
+        calls = self._branch_list_calls(
+            monkeypatch, srr, srr.delete_local_branches, tmp_path, 7
+        )
+        assert calls, "no branch listing was issued"
+        for cmd in calls:
+            assert "--format=%(refname:short)" in cmd, cmd
+
+    def test_reset_remote_sweep_passes_format(self, monkeypatch, tmp_path):
+        calls = self._branch_list_calls(
+            monkeypatch, srr, srr.delete_remote_branches, tmp_path, 7
+        )
+        assert calls, "no branch listing was issued"
+        for cmd in calls:
+            assert "--format=%(refname:short)" in cmd, cmd
+
+
+class TestSharedParser:
+    """`parse_branch_names` is the backstop for package consumers."""
+
+    def test_strips_current_marker(self):
+        assert parse_branch_names("* main\n  other\n") == ["main", "other"]
+
+    def test_strips_worktree_marker(self):
+        assert parse_branch_names("+ issue-4\n  main\n") == ["issue-4", "main"]
+
+    def test_undecorated_passthrough(self):
+        assert parse_branch_names("main\nissue-4\n") == ["main", "issue-4"]
+
+    def test_a_branch_literally_named_plus_foo_survives(self):
+        """`lstrip('*+ ')` — the obvious fix — would have eaten this."""
+        assert parse_branch_names("  +foo\n") == ["+foo"]
+
+    def test_detached_head_pseudo_entry_omitted(self):
+        out = "* (HEAD detached at abc1234)\n  main\n"
+        assert parse_branch_names(out) == ["main"]
+
+    def test_blank_lines_ignored(self):
+        assert parse_branch_names("\n  main\n\n") == ["main"]
+
+
+class TestJanitorMergedCheck:
+    """The silent wrong answer — an exact-name comparison against the list."""
+
+    def _repo_with_merged_branch(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "feature")
+        (repo / "f.txt").write_text("f", encoding="utf-8")
+        _git(repo, "add", "f.txt")
+        _git(repo, "commit", "-m", "feature work")
+        _git(repo, "checkout", "main")
+        _git(repo, "merge", "feature", "--no-edit")
+        return repo
+
+    def test_merged_branch_held_by_a_worktree_reads_as_merged(self, tmp_path):
+        repo = self._repo_with_merged_branch(tmp_path)
+        _git(repo, "worktree", "add", str(tmp_path / "wt"), "feature")
+
+        assert is_branch_merged(str(repo), "feature", "main") is True
+
+    def test_merged_branch_without_a_worktree_reads_as_merged(self, tmp_path):
+        repo = self._repo_with_merged_branch(tmp_path)
+
+        assert is_branch_merged(str(repo), "feature", "main") is True
+
+    def test_unmerged_branch_still_reads_as_unmerged(self, tmp_path):
+        """The fix must not turn the check into a rubber stamp."""
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "solo")
+        (repo / "s.txt").write_text("s", encoding="utf-8")
+        _git(repo, "add", "s.txt")
+        _git(repo, "commit", "-m", "unmerged work")
+        _git(repo, "checkout", "main")
+
+        assert is_branch_merged(str(repo), "solo", "main") is False

--- a/tests/unit/test_branch_decoration_parsing.py
+++ b/tests/unit/test_branch_decoration_parsing.py
@@ -16,7 +16,6 @@ it is observable, that the pre-fix `lstrip('* ')` would have failed it.
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 from assemblyzero.utils.git import parse_branch_names
 from assemblyzero.workflows.janitor.probes.worktrees import is_branch_merged

--- a/tests/unit/test_branch_decoration_parsing.py
+++ b/tests/unit/test_branch_decoration_parsing.py
@@ -16,6 +16,7 @@ it is observable, that the pre-fix `lstrip('* ')` would have failed it.
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 from assemblyzero.utils.git import parse_branch_names
 from assemblyzero.workflows.janitor.probes.worktrees import is_branch_merged

--- a/tests/unit/test_clean_check_committed_artifacts.py
+++ b/tests/unit/test_clean_check_committed_artifacts.py
@@ -1,0 +1,145 @@
+"""The clean gate sees a branch that already contains the work (#1959).
+
+`find_artifact_debris` reads `git status`, so it sees only what a killed roll
+left lying around. It could not see the quieter and more dangerous case: a
+branch already holding this issue's merged LLD, spec, and implementation. A
+roll started there resolves the existing artifacts, finds the tests already
+green, and reports success having built nothing — with the preflight that
+exists to guarantee a run starts from verified zero signing off on it.
+
+That was boostgauge's live state when this was found: `hardening-run-11`
+carried all six arc phases as committed files and the gate returned CLEAN for
+every one of the six issues.
+
+Real repos, real commits, no mocks except the two network-edge finders
+(standard 0024).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_clean_check as scc  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+def _make_repo(tmp_path, name="boostrepo"):
+    repo = tmp_path / name
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("x", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+class TestCommittedArtifactDebris:
+    """#1959: the gate could not see a branch that already held the work.
+
+    Every case commits real files into a real repo — the exact state that
+    produced a CLEAN verdict on boostgauge's `hardening-run-11` while all six
+    arc phases sat merged on it.
+    """
+
+    def _commit_artifacts(self, repo, *rel_paths):
+        for rel in rel_paths:
+            target = repo / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("content", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "land pipeline artifacts")
+
+    def test_committed_lld_is_found(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        self._commit_artifacts(repo, "docs/lld/active/LLD-004.md")
+
+        findings = scc.find_committed_artifact_debris(repo, 4)
+        assert findings == ["committed artifact: docs/lld/active/LLD-004.md"]
+
+    def test_committed_spec_is_found(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        self._commit_artifacts(
+            repo, "docs/lld/drafts/spec-0004-implementation-readiness.md"
+        )
+
+        assert scc.find_committed_artifact_debris(repo, 4) == [
+            "committed artifact: "
+            "docs/lld/drafts/spec-0004-implementation-readiness.md"
+        ]
+
+    def test_other_issues_artifacts_are_not_this_issues_debris(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        self._commit_artifacts(
+            repo, "docs/lld/active/LLD-041.md", "docs/lld/active/LLD-002.md"
+        )
+
+        assert scc.find_committed_artifact_debris(repo, 4) == []
+        assert scc.find_committed_artifact_debris(repo, 41) == [
+            "committed artifact: docs/lld/active/LLD-041.md"
+        ]
+
+    def test_clean_branch_has_no_committed_findings(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        assert scc.find_committed_artifact_debris(repo, 4) == []
+
+    def test_untracked_artifact_is_not_double_reported(self, tmp_path):
+        """An uncommitted artifact belongs to the untracked class only."""
+        repo = _make_repo(tmp_path)
+        (repo / "docs" / "lld" / "active").mkdir(parents=True)
+        (repo / "docs/lld/active/LLD-004.md").write_text("x", encoding="utf-8")
+
+        assert scc.find_committed_artifact_debris(repo, 4) == []
+        assert scc.find_artifact_debris(repo, 4) == [
+            "untracked artifact: docs/lld/active/LLD-004.md"
+        ]
+
+    def test_check_repo_surfaces_the_committed_class(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        self._commit_artifacts(repo, "docs/lld/active/LLD-004.md")
+
+        findings = scc.check_repo(repo, [4])
+        assert any(f.startswith("committed artifact:") for f in findings), findings
+
+    def test_main_exits_nonzero_and_names_the_remedy(self, tmp_path, capsys):
+        """The regression that matters: this state used to print CLEAN."""
+        repo = _make_repo(tmp_path)
+        self._commit_artifacts(repo, "docs/lld/active/LLD-004.md")
+
+        with patch.object(scc, "find_open_pr_debris", return_value=[]), \
+             patch.object(scc, "find_remote_branch_debris", return_value=[]):
+            code = scc.main(["--repo", str(repo), "--issue", "4"])
+
+        out = capsys.readouterr().out
+        assert code == 1, out
+        assert "CLEAN" not in out
+        assert "ALREADY CONTAINS" in out
+        assert "wrong base" in out
+
+    def test_verdict_line_names_the_branch_it_measured(self, tmp_path, capsys):
+        repo = _make_repo(tmp_path)
+        _git(repo, "checkout", "-b", "hardening-run-12")
+
+        with patch.object(scc, "find_open_pr_debris", return_value=[]), \
+             patch.object(scc, "find_remote_branch_debris", return_value=[]):
+            code = scc.main(["--repo", str(repo), "--issue", "4"])
+
+        out = capsys.readouterr().out
+        assert code == 0, out
+        assert "CLEAN" in out
+        assert "hardening-run-12" in out
+
+    def test_describe_base_survives_a_repo_without_origin(self, tmp_path):
+        """Throwaway repos have no origin/HEAD; the gate must not error out."""
+        repo = _make_repo(tmp_path)
+        assert "branch main" in scc.describe_base(repo)

--- a/tests/unit/test_impl_worktree_base.py
+++ b/tests/unit/test_impl_worktree_base.py
@@ -1,0 +1,150 @@
+"""The impl stage's worktree is carved from a NAMED base (#1960).
+
+`git worktree add -b issue-N <path>` with no commit-ish branches from whatever
+the target repo is checked out on, so the content a roll started from was
+decided by ambient state. `--base-branch` did not help: it resolves to the PR
+target (`stages.py`: `gh pr create --base`), so a roll could target `main`
+while its worktree carried a different branch's tree entirely.
+
+That is the same trap #1852/#1903 closed for hand-driven branching — never cut
+a branch from ambient HEAD without checking where HEAD is. The pipeline did it
+on every roll.
+
+These tests assert on the argv handed to git. That is deliberately white-box:
+the base ref is a positional argument whose ABSENCE was the defect, and no
+observable output distinguishes "carved from the right base" from "carved from
+whatever was checked out" until a whole roll has run and silently built nothing.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.utils.git import GitBranchError
+from assemblyzero.workflows.orchestrator import stages
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    # mock-ok: subprocess boundary, and a REAL CompletedProcess (standard 0024).
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class _Recorder:
+    """Captures every run_command argv, succeeding for all of them."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd) if isinstance(cmd, list) else [cmd])
+        return _completed()
+
+    def worktree_add(self) -> list[str] | None:
+        for cmd in self.calls:
+            if "worktree" in cmd and "add" in cmd:
+                return cmd
+        return None
+
+
+@pytest.fixture
+def state(tmp_path):
+    target = tmp_path / "targetrepo"
+    target.mkdir()
+    return {
+        "issue_number": 4,
+        "target_repo": str(target),
+        "assemblyzero_root": str(tmp_path / "az"),
+    }
+
+
+def _run_impl(state, recorder, worktree_missing=True):
+    """Drive run_impl_stage far enough to issue the worktree add."""
+    with patch.object(stages, "run_command", recorder), \
+         patch.object(Path, "is_dir", return_value=not worktree_missing):
+        try:
+            stages.run_impl_stage(state)
+        except Exception:
+            # Downstream stage work (provisioning, workflow invocation) is not
+            # under test; the worktree add has already been recorded.
+            pass
+    return recorder.worktree_add()
+
+
+class TestBaseIsNamedExplicitly:
+    def test_base_branch_from_state_is_passed_as_the_base_ref(self, state):
+        state["base_branch"] = "hardening-run-12"
+        cmd = _run_impl(state, _Recorder())
+
+        assert cmd is not None, "no worktree add was issued"
+        assert cmd[-1] == "hardening-run-12", cmd
+        # And it must come AFTER -b <branch>, i.e. be the base, not the name.
+        assert cmd[cmd.index("-b") + 1] == "issue-4", cmd
+
+    def test_the_new_branch_name_is_still_the_issue_branch(self, state):
+        state["base_branch"] = "main"
+        cmd = _run_impl(state, _Recorder())
+
+        assert "-b" in cmd and cmd[cmd.index("-b") + 1] == "issue-4", cmd
+
+    def test_resolved_base_is_printed(self, state, capsys):
+        state["base_branch"] = "speedrun-attempt-3"
+        _run_impl(state, _Recorder())
+
+        assert "Worktree base: speedrun-attempt-3" in capsys.readouterr().out
+
+    def test_worktree_belongs_to_the_target_repo(self, state):
+        """#1374: `git -C <target>` must still precede the subcommand."""
+        state["base_branch"] = "main"
+        cmd = _run_impl(state, _Recorder())
+
+        assert cmd[:3] == ["git", "-C", state["target_repo"]], cmd
+
+
+class TestFallbackWhenStateCarriesNoBase:
+    def test_falls_back_to_the_target_repos_current_branch(self, state):
+        with patch.object(stages, "current_branch", return_value="main"):
+            cmd = _run_impl(state, _Recorder())
+
+        assert cmd[-1] == "main", cmd
+
+    def test_detached_head_keeps_the_previous_ambient_behaviour(
+        self, state, capsys
+    ):
+        """Resolving the base is an improvement, not a new failure mode: a repo
+        git cannot answer for must not start failing rolls."""
+        with patch.object(
+            stages, "current_branch", side_effect=GitBranchError("detached")
+        ):
+            cmd = _run_impl(state, _Recorder())
+
+        assert cmd is not None
+        assert cmd[-1] == "issue-4", cmd  # -b <name>, no trailing base ref
+        out = capsys.readouterr().out
+        assert "base branch unresolved" in out
+
+    @pytest.mark.parametrize(
+        "error", [FileNotFoundError("no such dir"), NotADirectoryError("nope")]
+    )
+    def test_unrunnable_target_path_does_not_fail_the_stage(self, state, error):
+        """A target_repo git cannot chdir into raises OSError, not
+        GitBranchError. Letting that escape aborted the stage before it issued
+        a single command -- caught by the existing orchestrator suite when the
+        first version of this change only handled GitBranchError."""
+        with patch.object(stages, "current_branch", side_effect=error):
+            cmd = _run_impl(state, _Recorder())
+
+        assert cmd is not None, "the worktree add must still be attempted"
+        assert cmd[-1] == "issue-4", cmd
+
+
+class TestExistingWorktreeUntouched:
+    def test_no_add_when_the_worktree_already_exists(self, state):
+        state["base_branch"] = "main"
+        recorder = _Recorder()
+        cmd = _run_impl(state, recorder, worktree_missing=False)
+
+        assert cmd is None, f"worktree add issued for an existing worktree: {cmd}"

--- a/tests/unit/test_speedrun_reset.py
+++ b/tests/unit/test_speedrun_reset.py
@@ -53,7 +53,10 @@ class TestBranchSweepIsAttemptBranchAware:
         def fake_run(cmd, cwd=None, check=False):
             calls.append(cmd)
             if cmd[:3] == ["git", "branch", "--list"]:
-                return _completed(stdout="  1234-lld\n* 1234-attempt\n")
+                # Bare refnames: the sweep now passes
+                # --format=%(refname:short), so git emits no `* ` / `+ `
+                # decoration to parse (#1937).
+                return _completed(stdout="1234-lld\n1234-attempt\n")
             if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
                 return _completed(stdout="1234-attempt\n")
             return _completed()
@@ -93,7 +96,10 @@ class TestBranchSweepIsAttemptBranchAware:
         with patch("speedrun_reset._run", return_value=_completed(stdout="")) as run:
             delete_local_branches(tmp_path, 1234)
         listing = run.call_args_list[0].args[0]
-        assert listing == ["git", "branch", "--list", "1234-*", "issue-1234"]
+        assert listing == [
+            "git", "branch", "--list", "--format=%(refname:short)",
+            "1234-*", "issue-1234",
+        ]
 
     def test_unmerged_branch_is_left_alone_without_suggesting_force_delete(
         self, tmp_path, capsys

--- a/tools/speedrun_clean_check.py
+++ b/tools/speedrun_clean_check.py
@@ -142,6 +142,20 @@ def find_open_pr_debris(repo_root: Path, issue: int) -> list[str]:
     return findings
 
 
+def _artifact_needles(issue: int) -> tuple[str, ...]:
+    """Filename fragments identifying one issue's pipeline artifacts.
+
+    Shared by the untracked and committed scans so the two cannot drift apart
+    on what counts as this issue's artifact (#1959).
+    """
+    return (
+        f"lld-{issue:03d}",
+        f"lld-{issue}",
+        f"spec-{issue:04d}",
+        f"spec-{issue}",
+    )
+
+
 def find_artifact_debris(repo_root: Path, issue: int) -> list[str]:
     """Untracked pipeline artifacts under docs/lld for this issue.
 
@@ -153,12 +167,7 @@ def find_artifact_debris(repo_root: Path, issue: int) -> list[str]:
     result = _run(["git", "status", "--porcelain", "-uall"], cwd=repo_root)
     if result.returncode != 0:
         return [f"ERROR: git status failed: {result.stderr.strip()}"]
-    needles = (
-        f"lld-{issue:03d}",
-        f"lld-{issue}",
-        f"spec-{issue:04d}",
-        f"spec-{issue}",
-    )
+    needles = _artifact_needles(issue)
     findings: list[str] = []
     for line in result.stdout.splitlines():
         if not line.startswith("??"):
@@ -170,6 +179,58 @@ def find_artifact_debris(repo_root: Path, issue: int) -> list[str]:
     return findings
 
 
+def find_committed_artifact_debris(repo_root: Path, issue: int) -> list[str]:
+    """Pipeline artifacts for this issue already COMMITTED on the current branch.
+
+    The untracked scan above reads `git status`, so it sees only what a killed
+    roll left lying around. It cannot see the quieter case: a branch that
+    already CONTAINS this issue's finished work. A roll started there finds the
+    LLD present and the implementation's tests already green, so it runs fast,
+    exits successfully, and produces nothing — while the preflight that exists
+    to guarantee a run starts from verified zero signs off on it (#1959).
+
+    That is the state boostgauge's `hardening-run-11` was in when this was
+    found: six phases of committed LLDs, specs, and implementations, and a
+    CLEAN verdict for every one of the six issues.
+    """
+    result = _run(["git", "ls-files", "--", "docs/lld"], cwd=repo_root)
+    if result.returncode != 0:
+        return [f"ERROR: git ls-files failed: {result.stderr.strip()}"]
+    needles = _artifact_needles(issue)
+    findings: list[str] = []
+    for line in result.stdout.splitlines():
+        path = line.strip()
+        if not path:
+            continue
+        lower = path.lower().replace("\\", "/")
+        if any(n in lower for n in needles):
+            findings.append(f"committed artifact: {path}")
+    return findings
+
+
+def describe_base(repo_root: Path) -> str:
+    """Current branch and its divergence from origin's default, for context.
+
+    A CLEAN verdict is only meaningful relative to the branch it was measured
+    on, so the verdict line carries that branch (#1959).
+    """
+    branch = _run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_root
+    )
+    if branch.returncode != 0:
+        return "unknown branch"
+    name = branch.stdout.strip() or "unknown branch"
+    count = _run(
+        ["git", "rev-list", "--count", f"origin/HEAD..{name}"], cwd=repo_root
+    )
+    if count.returncode != 0 or not count.stdout.strip().isdigit():
+        return f"branch {name}"
+    ahead = int(count.stdout.strip())
+    if ahead == 0:
+        return f"branch {name}, level with origin's default"
+    return f"branch {name}, {ahead} commit(s) ahead of origin's default"
+
+
 def check_repo(repo_root: Path, issues: list[int]) -> list[str]:
     """All findings for the given issues. Empty list == verified clean."""
     findings: list[str] = []
@@ -179,6 +240,7 @@ def check_repo(repo_root: Path, issues: list[int]) -> list[str]:
         findings.extend(find_remote_branch_debris(repo_root, issue))
         findings.extend(find_open_pr_debris(repo_root, issue))
         findings.extend(find_artifact_debris(repo_root, issue))
+        findings.extend(find_committed_artifact_debris(repo_root, issue))
     return findings
 
 
@@ -203,19 +265,36 @@ def main(argv: list[str] | None = None) -> int:
     debris = [f for f in findings if not f.startswith("ERROR:")]
 
     issue_list = ", ".join(f"#{i}" for i in args.issue)
+    base = describe_base(repo_root)
     if errors:
         for e in errors:
             print(e)
         return 2
     if debris:
         print(
-            f"DEBRIS: {repo_root.name} is NOT clean for {issue_list} — "
-            f"{len(debris)} finding(s):"
+            f"DEBRIS: {repo_root.name} is NOT clean for {issue_list} on "
+            f"{base} -- {len(debris)} finding(s):"
         )
         for d in debris:
             print(f"  {d}")
+        # The two artifact classes need opposite remedies, so name them
+        # separately rather than leaving the operator to infer (#1959).
+        if any(d.startswith("committed artifact:") for d in debris):
+            print(
+                "\n  The committed artifacts above mean this branch ALREADY "
+                "CONTAINS the issue's work,\n  so it is the wrong base for a "
+                "roll. A run started here would resolve the existing\n  "
+                "artifacts, find the tests already green, and report success "
+                "having built nothing.\n  Roll from a base that predates the "
+                "work (or reset the issue) rather than deleting\n  these "
+                "files: unlike untracked debris, they are somebody's merged "
+                "commit."
+            )
         return 1
-    print(f"CLEAN: {repo_root.name} carries zero speedrun debris for {issue_list}.")
+    print(
+        f"CLEAN: {repo_root.name} carries zero speedrun debris for "
+        f"{issue_list} on {base}."
+    )
     return 0
 
 

--- a/tools/speedrun_clean_check.py
+++ b/tools/speedrun_clean_check.py
@@ -75,16 +75,24 @@ def find_worktree_debris(repo_root: Path, issue: int) -> list[str]:
 
 def find_local_branch_debris(repo_root: Path, issue: int) -> list[str]:
     """Local branches issue-{N} and {N}-* (graveyard/* exempt by pattern)."""
+    # `--format` emits the bare refname. Plain `git branch --list` decorates the
+    # current branch with `* ` and a worktree-checked-out branch with `+ `, and
+    # the previous `lstrip('* ')` left that `+` in place (#1937) — mangling the
+    # report text and, worse, any exact-name comparison downstream. Not parsing
+    # decoration at all is the fix; widening the strip set only moves the bug.
     result = _run(
-        ["git", "branch", "--list", f"issue-{issue}", f"{issue}-*"],
+        [
+            "git", "branch", "--list", "--format=%(refname:short)",
+            f"issue-{issue}", f"{issue}-*",
+        ],
         cwd=repo_root,
     )
     if result.returncode != 0:
         return [f"ERROR: git branch --list failed: {result.stderr.strip()}"]
     return [
-        f"local branch: {line.strip().lstrip('* ').strip()}"
-        for line in result.stdout.splitlines()
-        if line.strip()
+        f"local branch: {name}"
+        for name in (line.strip() for line in result.stdout.splitlines())
+        if name
     ]
 
 

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -200,16 +200,23 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
     reset can never delete the very branch the attempt is standing on
     (#1762).
     """
+    # `--format` emits the bare refname — see #1937. Plain output decorates a
+    # worktree-checked-out branch with `+ `, which the old `lstrip('* ')` left
+    # intact, so the name compared against `active` below (and printed in the
+    # skip message) was `+ issue-4` rather than `issue-4`.
     result = _run(
-        ["git", "branch", "--list", f"{issue}-*", f"issue-{issue}"],
+        [
+            "git", "branch", "--list", "--format=%(refname:short)",
+            f"{issue}-*", f"issue-{issue}",
+        ],
         cwd=repo_root,
     )
     if result.returncode != 0:
         return 0
     branches = [
-        line.strip().lstrip("* ").strip()
-        for line in result.stdout.splitlines()
-        if line.strip()
+        name
+        for name in (line.strip() for line in result.stdout.splitlines())
+        if name
     ]
     active = current_branch(repo_root)
     deleted = 0
@@ -248,12 +255,17 @@ def delete_remote_branches(repo_root: Path, issue: int) -> int:
     exclusion the local sweep honours (#1762).
     """
     candidates = [f"issue-{issue}"]
-    result = _run(["git", "branch", "--list", f"{issue}-*"], cwd=repo_root)
+    result = _run(
+        ["git", "branch", "--list", "--format=%(refname:short)", f"{issue}-*"],
+        cwd=repo_root,
+    )
     if result.returncode == 0:
+        # Bare refnames only (#1937): a `+ `-decorated name here would be
+        # pushed to origin as a nonexistent ref and silently skipped.
         candidates.extend(
-            line.strip().lstrip("* ").strip()
-            for line in result.stdout.splitlines()
-            if line.strip()
+            name
+            for name in (line.strip() for line in result.stdout.splitlines())
+            if name
         )
     # Whatever the local sweep already deleted still needs removing on origin,
     # so ask origin what it actually has rather than trusting local state.


### PR DESCRIPTION
Closes #1937
Closes #1959
Closes #1960

Three defects in the machinery that is supposed to guarantee a speedrun roll starts from verified zero and leaves the repo clean. Shared scope, so they land together; one commit each.

## #1937 — branch listings were parsed, not read

`git branch --list` decorates the current branch with `* ` and a branch checked out in another worktree with `+ `. Four sites stripped only `'* '`, leaving the `+`.

| Site | Consequence |
|---|---|
| `speedrun_reset.delete_local_branches` | The mangled name was compared against the active branch, so #1762's "never delete the branch the run stands on" guard could not match |
| `speedrun_reset.delete_remote_branches` | A decorated candidate would be pushed to origin as a nonexistent ref and silently skipped |
| `speedrun_clean_check.find_local_branch_debris` | Wrong name in the report |
| `janitor probes.worktrees.is_branch_merged` | Whole body is `branch in merged_branches` — an exact-name comparison — so a merged branch held by a worktree read as **unmerged**. A silent wrong answer, not a cosmetic one |

All four now pass `--format=%(refname:short)`, which suppresses decoration entirely. Widening to `lstrip("*+ ")` — the obvious fix — would only move the bug: it eats the leading character of a branch legitimately named `+foo`.

`parse_branch_names` in `assemblyzero/utils/git.py` is the backstop for package consumers, matching only git's exact marker-then-whitespace form. The two speedrun tools deliberately stay stdlib-only standalone and are **not** wired to it — running a `tools/` script from a worktree resolves `assemblyzero` to the MAIN checkout, so importing shared code there would build in a #1904 wrong-environment trap. I verified that resolution before deciding. Their protection is `--format`, pinned by tests asserting each call site passes it.

## #1959 — the gate reported CLEAN on a branch that already held the work

`find_artifact_debris` filters `git status` on `??` lines, so it saw only what a killed roll left lying around. Its own docstring named the failure it exists to prevent — *"left in place they make the next run resolve existing artifacts and skip stages (#1849)"* — and that reasoning applies identically to committed artifacts, which were invisible.

boostgauge's `hardening-run-11` carried all six arc phases as committed LLDs, specs, and implementations. The gate returned CLEAN for every one of the six issues. A roll launched on that verdict would resolve the existing artifacts, find the tests already green, and exit successfully having built nothing — with #1918's preflight signing off. A gate that says CLEAN when the answer is "everything is already built" is worse than no gate.

Adds `find_committed_artifact_debris` (`git ls-files`, not `git status`) as a sixth debris class, with `_artifact_needles` shared by both scans so they cannot drift on what counts as this issue's artifact. The two classes need **opposite** remedies, so the output names them separately: untracked debris gets deleted; committed artifacts mean the branch is the wrong base and must not be deleted, being somebody's merged commit. The verdict line now carries the branch measured and its divergence, since CLEAN is only meaningful relative to that branch.

Verified against the live repo:

```
DEBRIS: boostgauge is NOT clean for #4 on branch hardening-run-11,
13 commit(s) ahead of origin's default -- 2 finding(s):
  committed artifact: docs/lld/active/LLD-004.md
  committed artifact: docs/lld/drafts/spec-0004-implementation-readiness.md
```

Output is deliberately ASCII — it lands in the wrapper's events log, and non-ASCII punctuation mojibakes on this platform's cp1252 stdout (I hit that in testing).

## #1960 — the worktree was carved from ambient HEAD

`git worktree add -b issue-N <path>` with no commit-ish branches from whatever the target repo is checked out on. `--base-branch` resolves to the PR target, so a roll could target `main` while its worktree carried a different branch's tree — and no flag set the content base. Same trap #1852/#1903 closed for hand-driven branching; the pipeline did it every roll.

The base is now named explicitly from `state["base_branch"]` and printed. Default behaviour is unchanged; what changes is that `--base-branch` governs content as well as PR target, and the base is stated rather than implied. Resolution is best-effort: `GitBranchError` (detached HEAD) and `OSError` (unrunnable path) both fall back to the prior behaviour with a warning — naming the base is an improvement, not a licence to add a new way for a roll to die.

**The first version of this caught only `GitBranchError`, and the existing orchestrator suite caught the gap**: an `OSError` from a nonexistent `target_repo` escaped and aborted the stage before it issued a single command, failing 6 tests. That path now has its own parametrized test.

## Verification

- **Full suite: 6432 passed**, 17 skipped, 5 xfailed, **0 failures**.
- **35 new tests** across three suites, one per concern:
  - `test_branch_decoration_parsing.py` builds real repos and real worktrees so the `+` prefix is genuinely present rather than simulated, and one test *guards the guard* — asserting git still emits `+` and that the old idiom demonstrably fails to clean it, so these tests cannot pass vacuously.
  - `test_clean_check_committed_artifacts.py` commits real files, including the regression that matters: this exact state now exits non-zero instead of printing CLEAN.
  - `test_impl_worktree_base.py` pins the base ref, the OSError path, #1374's `git -C`, and that an existing worktree is untouched.
- Two existing fakes in `test_speedrun_reset.py` were emitting decorated stdout that `--format` no longer produces; updated to bare refnames, purpose preserved.
- `ruff check` clean on every changed file; repo-wide count 262 → 261.

Note for the recorded take: these are the durable fixes. boostgauge is still checked out on `hardening-run-11`, so the take must move to a base that predates the arc regardless — the gate will now refuse rather than wave it through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)