### PR TITLE
fix(dependabot): flush the run log per line so a live run is observable (Closes #1961)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -844,6 +844,104 @@ class TestRunLog:
         tee.flush()
 
 
+# ---- #1961: the log must be readable WHILE the run is in progress ----
+
+class TestRunLogVisibleDuringRun:
+    """A 0-byte log makes a slow harvest indistinguishable from a hung one.
+
+    The 2026-07-30 06:00 harvest sat at 0 bytes for 78 minutes while doing
+    real work, then completed normally with exit 0. The unreadable log is
+    what produced a false "permanent deadlock" diagnosis. These tests
+    deliberately never call flush() -- an explicit flush is exactly the
+    crutch that hid the bug.
+    """
+
+    def test_line_reaches_disk_without_an_explicit_flush(self, tmp_path):
+        import sys as _sys
+        orig_out, orig_err = _sys.stdout, _sys.stderr
+        try:
+            log_path = dependabot_review.setup_run_log(tmp_path / "runs")
+            assert log_path is not None
+            print("progress: PR #1 gate passed")
+            # NO flush() here on purpose -- that is the whole point.
+            content = log_path.read_text(encoding="utf-8")
+        finally:
+            _sys.stdout, _sys.stderr = orig_out, orig_err
+        assert "progress: PR #1 gate passed" in content, (
+            "run log was not readable mid-run; a slow run is again "
+            "indistinguishable from a hung one (#1961)"
+        )
+
+    def test_stderr_also_reaches_disk_without_an_explicit_flush(self, tmp_path):
+        import sys as _sys
+        orig_out, orig_err = _sys.stdout, _sys.stderr
+        try:
+            log_path = dependabot_review.setup_run_log(tmp_path / "runs")
+            assert log_path is not None
+            print("WARNING: rebase requested", file=_sys.stderr)
+            content = log_path.read_text(encoding="utf-8")
+        finally:
+            _sys.stdout, _sys.stderr = orig_out, orig_err
+        assert "WARNING: rebase requested" in content
+
+    def test_flushes_the_wrapped_stream_too_not_just_the_logfile(self):
+        """The redirected wrapper log was the second stale sink.
+
+        Line-buffering the log file alone would not have fixed it; the
+        flush has to reach the stream _Tee wraps.
+        """
+        import io
+
+        class _CountingStream(io.StringIO):
+            flushes = 0
+
+            def flush(self):
+                type(self).flushes += 1
+                super().flush()
+
+        stream = _CountingStream()
+        tee = dependabot_review._Tee(stream, io.StringIO())
+        tee.write("a complete line\n")
+        assert _CountingStream.flushes >= 1, (
+            "wrapped stream was never flushed; a redirected stdout stays "
+            "block-buffered and the wrapper log stays stale (#1961)"
+        )
+
+    def test_partial_line_does_not_flush(self):
+        """Flush is gated on a newline so partial writes cost nothing."""
+        import io
+
+        class _CountingStream(io.StringIO):
+            flushes = 0
+
+            def flush(self):
+                type(self).flushes += 1
+                super().flush()
+
+        stream = _CountingStream()
+        tee = dependabot_review._Tee(stream, io.StringIO())
+        tee.write("no terminator yet")
+        assert _CountingStream.flushes == 0
+
+    def test_write_still_returns_chars_written(self):
+        import io
+        tee = dependabot_review._Tee(io.StringIO(), io.StringIO())
+        assert tee.write("five\n") == len("five\n")
+
+    def test_tee_survives_unflushable_stream(self):
+        """Flush now runs on the write path -- it must not break output."""
+        import io
+
+        class _UnflushableStream(io.StringIO):
+            def flush(self):
+                raise OSError("stream cannot be flushed")
+
+        log = io.StringIO()
+        tee = dependabot_review._Tee(_UnflushableStream(), log)
+        tee.write("drain continues\n")  # must not raise
+        assert "drain continues" in log.getvalue()
+
+
 # ---- #1339: --limit N calibrated harvest ----
 
 class TestPRBudget:

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -112,7 +112,7 @@ class _Tee:
         except (OSError, ValueError):
             pass  # log file gone/closed — terminal keeps working
         try:
-            return self._stream.write(text)
+            written = self._stream.write(text)
         except UnicodeEncodeError:
             # #1876: the terminal's encoding cannot represent this text
             # (cp1252 console + vitest/jest box-drawing or check marks).
@@ -121,16 +121,43 @@ class _Tee:
             # the faithful text. Belt-and-suspenders behind
             # _force_utf8_streams(), which normally prevents this.
             enc = getattr(self._stream, "encoding", None) or "ascii"
-            return self._stream.write(
+            written = self._stream.write(
                 text.encode(enc, "replace").decode(enc, "replace")
             )
+        # #1961: flush once a line is complete, so the log is readable
+        # WHILE the run is in progress. Both sinks were block-buffered:
+        # the 2026-07-30 06:00 harvest sat at 0 bytes for 78 minutes
+        # while doing real work, and the redirected wrapper log likewise
+        # never grew. With no observable progress a slow run and a dead
+        # run are indistinguishable from outside, and that ambiguity
+        # produced a false "permanent deadlock" diagnosis for a run that
+        # in fact completed normally with exit 0.
+        #
+        # Flushing HERE rather than only line-buffering the log file is
+        # what covers the second sink: self.flush() also flushes the
+        # wrapped stream, which is block-buffered whenever stdout is
+        # redirected to a file (every scheduled run).
+        #
+        # Gated on a newline so partial-line writes (print emits text and
+        # its terminator separately) don't each pay a syscall; a drain's
+        # output is line-oriented, so per-line cost is negligible.
+        if "\n" in text:
+            self.flush()
+        return written
 
     def flush(self) -> None:
         try:
             self._logfile.flush()
         except (OSError, ValueError):
             pass
-        self._stream.flush()
+        try:
+            self._stream.flush()
+        except (OSError, ValueError):
+            # #1961: flush now runs on the write path, so a stream that
+            # fails to flush would break output that previously worked.
+            # Same contract as the log file above: logging never breaks
+            # the drain.
+            pass
 
     def __getattr__(self, name):
         return getattr(self._stream, name)
@@ -169,12 +196,17 @@ def setup_run_log(log_dir: Path = RUN_LOG_DIR):
 
     Returns the log path, or None when the log could not be created (the
     run proceeds terminal-only — a warning says so).
+
+    #1961: the handle is line-buffered so the file is readable during the
+    run even if the `_Tee.write` flush is ever lost to a later edit. The
+    flush in `_Tee.write` is the load-bearing half (it reaches the
+    redirected stdout too); this is the cheap second layer.
     """
     try:
         log_dir.mkdir(parents=True, exist_ok=True)
         stamp = datetime.datetime.now().strftime("%Y-%m-%d_%H%M%S")
         log_path = log_dir / f"{stamp}.log"
-        logfile = open(log_path, "a", encoding="utf-8")  # noqa: SIM115 — lives for the process
+        logfile = open(log_path, "a", encoding="utf-8", buffering=1)  # noqa: SIM115 — lives for the process
     except OSError as e:
         print(f"WARNING: run log unavailable ({e}); continuing terminal-only",
               file=sys.stderr)


### PR DESCRIPTION
## Problem

`setup_run_log()` creates the log file immediately, but both output sinks were block-buffered and nothing flushed. The 2026-07-30 06:00 harvest sat at **0 bytes for 78 minutes** while doing real work, and the redirected wrapper log likewise never grew past its install output.

With no observable progress, a slow run and a dead run are indistinguishable from outside. That ambiguity produced a false "permanent `subprocess.run` pipe deadlock" diagnosis for a run that in fact completed normally at 07:25:32 with exit 0 (`merged=1 deferred=10 errored=4 skipped_unchanged=3`). Even the process table misled — sampling CPU during one of the run's 10-second sleep intervals showed a 0.00s delta with no live child, which reads exactly like a deadlock.

## Fix

`_Tee.write` flushes once a line is complete.

Flushing **here** rather than only line-buffering the log handle is what covers the second sink: `self.flush()` also flushes the wrapped stream, which is block-buffered whenever stdout is redirected to a file — every scheduled run. The flush is gated on a newline so partial-line writes (`print` emits text and its terminator separately) don't each pay a syscall; a drain's output is line-oriented, so per-line cost is negligible.

`_Tee.flush()` now guards the stream flush the same way it already guarded the log file. Flush runs on the write path now, so an unflushable stream would otherwise break output that previously worked — and the class contract is that logging never breaks the drain.

The log handle is additionally opened line-buffered. That is redundant with the flush above, kept deliberately as a cheap second layer if the flush is ever lost to a later edit.

## Verification

- 6 new tests in `TestRunLogVisibleDuringRun`. They deliberately never call `flush()` — an explicit flush is exactly the crutch that hid the bug (the pre-existing `test_creates_timestamped_log_and_tees_stdout` calls it).
- **Regression guard proven, not assumed:** with the fix neutralised, 3 of the 6 fail (mid-run visibility on stdout, on stderr, and the wrapped-stream flush). The other 3 pin invariants that hold either way — the newline gate, the return value, and survival of an unflushable stream.
- Full suite: 6394 passed, 17 skipped, 5 xfailed. Both `tests/unit/test_dependabot_review.py` (49) and `tests/tools/test_dependabot_review.py` (117) green.
- `ruff` clean on both touched files.

## Scope

This ships the issue's Finding 1 only — the one thing the issue designated with an explicit **Fix:**. Its other findings are distinct concerns and are filed separately:

- **#1964** — mergeable-state polling dominates wall clock. Framed in the issue as "worth considering", and in direct tension with #1399's deliberate decision to poll `blocked` to the full budget (which fixed two documented silent-failure cases). Needs its own reasoning; also, sibling contention explains only a fraction of the observed cost.
- **#1965** — ungrouped npm PRs contending on one `package-lock.json`. Remedy is `dependabot.yml` config in target repos, not tool code.
- **#1966** — `run()` defaults to `timeout=None`. The issue explicitly labels this latent hardening, not an active bug; it did not cause the incident.

Closes #1961
