### PR TITLE
fix(sentinel): repair mangled em-dashes and strip BOMs in Worker source (Closes #1973)

### DIFF
--- a/sentinel/src/validate.js
+++ b/sentinel/src/validate.js
@@ -1,4 +1,4 @@
-﻿// PR body validation rules:
+// PR body validation rules:
 // Pass: Closes #N (case-insensitive, also cross-repo owner/repo#N)
 // Pass: No-Issue: <reason> (requires non-empty reason)
 // Fail: empty body, no matching pattern

--- a/sentinel/src/webhook.js
+++ b/sentinel/src/webhook.js
@@ -1,4 +1,4 @@
-﻿// Webhook handler â€” HMAC-SHA256 signature verification + event dispatch.
+// Webhook handler — HMAC-SHA256 signature verification + event dispatch.
 
 import { getInstallationToken } from "./auth.js";
 import { createCheckRun } from "./checks.js";
@@ -88,7 +88,7 @@ export async function handleWebhook(request, env) {
     const installationId = payload.installation.id;
     const checkName = env.CHECK_NAME || "pr-sentinel / issue-reference";
 
-    // Auto-pass dependabot PRs â€” they don't have issue references
+    // Auto-pass dependabot PRs — they don't have issue references
     // but the check run must be created to complete the check suite
     if (pr.user?.login === "dependabot[bot]") {
       const token = await getInstallationToken(
@@ -98,7 +98,7 @@ export async function handleWebhook(request, env) {
       );
       await createCheckRun(token, owner, repo, headSha, checkName, {
         valid: true,
-        reason: "Dependabot PR â€” issue reference not required.",
+        reason: "Dependabot PR — issue reference not required.",
       });
       return new Response(
         JSON.stringify({ conclusion: "success", skipped: "dependabot" }),

--- a/sentinel/tests/validate.test.js
+++ b/sentinel/tests/validate.test.js
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { validatePRBody, extractIssueRefs } from "../src/validate.js";
 
 describe("extractIssueRefs", () => {


### PR DESCRIPTION
## Problem

Commit `303cb2d7` (PR #862, 2026-03-21) rewrote `sentinel/src/webhook.js` through something that mangled its encoding. Its entire diff to that file was encoding damage — no functional change:

- each em-dash (U+2014, UTF-8 `E2 80 94`) was decoded as cp1252 and re-encoded, yielding `C3 A2 E2 82 AC E2 80 9D`
- a UTF-8 BOM was prepended to line 1

The bundler carries it through verbatim, so the corruption is **live and user-visible fleet-wide**. Every dependabot PR in every repo the App is installed on gets a garbled check summary. Confirmed in production on `martymcenroe/sentinel` PR #35 before this fix:

```
name:       pr-sentinel / issue-reference
conclusion: success
title:      Issue reference found
summary:    Dependabot PR <mangled bytes> issue reference not required.
```

## Fix

Restores the three em-dashes in `webhook.js` and strips its BOM.

The issue asked to check whether other files carried the same damage. They did — `src/validate.js` and `tests/validate.test.js` both had BOMs. Those are stripped too. A re-scan of every `.js` under `src/` and `tests/` reports no remaining BOM or mojibake byte sequence.

## Verification

- Byte-level before/after on `webhook.js`: BOM `True → False`, mojibake sequences `3 → 0`, clean em-dashes `0 → 3`.
- Full-tree re-scan: no damaged files remain.
- `npm test` (vitest): **58 passed** across `validate`, `verify-issues`, `webhook`.
- No behavior change — this is purely a byte repair.

## Scope

Source-only. The Worker has no CI deploy (see #1974), so this commit does not by itself change production. Deploying it is a separate step tracked on the issue.

Closes #1973
