### PR TITLE
docs(0951): Advanced settings is a heading, not an expandable control (Closes #1982)

### DIFF
--- a/docs/runbooks/0951-pr-sentinel-ci-deploy.md
+++ b/docs/runbooks/0951-pr-sentinel-ci-deploy.md
@@ -57,11 +57,19 @@ The panel has, top to bottom:
 - **Builds for non-production branches** — checkbox, **checked by default. Uncheck it.** With it on, every push to any non-production branch triggers a build running `npx wrangler versions upload`. AssemblyZero has constant agent branch activity, and because watch paths cannot be scoped until *after* connecting, this would burn account build limits on pushes that never touch `sentinel/`. There is also no upside: preview versions exist to exercise a change before promoting it, and this Worker is a webhook receiver with no UI — its real test is the vitest suite, which already runs in AssemblyZero's CI. Re-enable later only if per-branch preview versions become useful, and only once watch paths are scoped.
 - **Build command** *(marked Optional)* — see table below.
 - **Deploy command** — pre-filled `npx wrangler deploy`.
-- **Advanced settings** — a set of collapsed accordions. **Root directory is in here**, not at top level. Expand the chevron. Also holds Non-production branch deploy command, API Token, Build variables, and Build caching.
+- **Advanced settings** — a **static section heading, not a control.** It does not expand. Beneath it sit five individually-collapsible rows, each with its own `>` chevron on the left:
+
+  1. Non-production branch deploy command
+  2. **Root directory** ← click *this* row's chevron
+  3. API Token
+  4. Build variables
+  5. Build caching
+
+  **Root directory is row 2.** Click the chevron beside the words "Root directory" itself. Do not look for a way to open "Advanced settings" first — there isn't one, and telling the operator to "expand Advanced settings" sends them clicking a heading that does nothing.
 
 | Setting | Value | Where | Why |
 |---|---|---|---|
-| **Root directory** | `sentinel` | Advanced settings (collapsed) | The Wrangler config lives in a subdirectory of a large repo. Documented [monorepo](https://developers.cloudflare.com/workers/ci-cd/builds/advanced-setups/#monorepos) mechanism. Required — without it the build finds no `wrangler.toml`. |
+| **Root directory** | `sentinel` | Own collapsible row, 2nd under the Advanced settings heading | The Wrangler config lives in a subdirectory of a large repo. Documented [monorepo](https://developers.cloudflare.com/workers/ci-cd/builds/advanced-setups/#monorepos) mechanism. Required — without it the build finds no `wrangler.toml`. |
 | **Deploy command** | `npx wrangler deploy` | Main panel | The default. Stated explicitly so it is not silently changed. |
 | **Build command** | `npm test` | Main panel, Optional | Gates the deploy on the vitest suite, answering the "should deploys be test-gated?" question #1974 raised. Optional — if the form misbehaves, leave it blank and add it after connecting. |
 | **API token** | leave blank | Advanced settings | Cloudflare auto-generates and reuses one. Do not create a token. |


### PR DESCRIPTION
## Problem

Third correction to one UI section of runbook `0951-pr-sentinel-ci-deploy.md`. The operator was blocked on the same field each time.

| Round | What the runbook said | Reality | Operator's report |
|---|---|---|---|
| 1 (PR #1979) | Root directory is a build setting on the connect panel | It is under the Advanced settings heading | "root directory entry won't stick" |
| 2 (PR #1981) | It is under Advanced settings — expand the chevron | "Advanced settings" is a static heading with no control | "advanced setting is not something that expands!" |
| 3 (this PR) | Click the chevron on the **Root directory row itself**, 2nd of five collapsible rows under that heading | — | — |

## Why round 2 still failed

Round 1 was fixed by consulting a screenshot instead of docs — the right move, and it corrected the *location*. But it described *how to reach* the field by inference. "Under Advanced settings" is true. "Expand Advanced settings" is not, because that heading is not a control.

So the header's existing writing rule (verify against current docs or a screenshot) was followed in round 2 and still produced a wrong instruction. The rule is insufficient as written — it covers where a setting lives, not how it is operated.

## Change

Enumerates the five collapsible rows under the heading in order, marks Root directory as row 2, and says to click the chevron beside those words. Adds an explicit note not to hunt for a way to open the heading, since that is the specific dead end the operator hit.

## Note on the commit message

The commit message references issue #1980 as its closing target. That issue was already resolved when the commit was written — the correct target is #1982, filed for this round. The commit is on origin and force-push is banned, so it stands as-is; this PR's title and body carry the right reference, and the squash-merge subject will too.

(Writing it the original way put a second closing-keyword match in this body pointing at a resolved issue, which is precisely the parasitic-extraction trap the sentinel catches — and which the now-deployed issue-liveness check would have flagged. Rephrased so the only match is the intended one.)

## Follow-on

#1982 also proposes tightening the rule: for operator-facing UI runbooks, a verified screenshot must establish the **interaction** (which element is clickable, whether a grouping label is a control, what appears after the click), not merely the location. Where a screenshot cannot establish that, say the location is unverified rather than inventing a plausible gesture — a confident wrong gesture costs more than an admitted gap.

That is the third instance in this family after #1818, and it is not Cloudflare-specific, so it may warrant a line in the universal CLAUDE.md.

Closes #1982
