### PR TITLE
feat(speedrun): re-establish the attempt branch so a roll starts from zero (Closes #1986)

### DIFF
--- a/tests/unit/test_speedrun_new_attempt.py
+++ b/tests/unit/test_speedrun_new_attempt.py
@@ -1,0 +1,222 @@
+"""A new attempt branch is established and VERIFIED, not assumed (#1986).
+
+The ritual this tool replaces was performed by hand on 2026-07-30 and got
+wrong: `git checkout -b hardening-run-12 origin/main` sets the upstream to
+`origin/main` and never creates `origin/hardening-run-12`. `gh pr create --base
+hardening-run-12` would have failed on the run's first PR, after the LLD and
+spec stages had already burned. Locally everything looked healthy -- `git
+status` reports a normal tracking branch.
+
+So the postcondition tests below are the point of the file. Every case builds a
+real repo with a real bare origin, because the entire defect class lives in the
+difference between local refs and remote refs, and a fixture that stubs the
+remote could not express it (standard 0024).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_new_attempt as sna  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo on attempt branch `hardening-run-11`, with that branch on origin."""
+    upstream = tmp_path / "upstream.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "README.md")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+    _git(r, "remote", "set-head", "origin", "main")
+
+    _git(r, "checkout", "-b", "hardening-run-11")
+    (r / "src.py").write_text("merged phase work", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "arc work")
+    _git(r, "push", "-u", "origin", "hardening-run-11")
+    return r
+
+
+def _apply(repo, name="hardening-run-12"):
+    return sna.main(["--repo", str(repo), "--name", name, "--apply"])
+
+
+class TestTheHandRunDefect:
+    """The specific breakage that motivated the tool."""
+
+    def test_new_branch_exists_on_origin(self, repo):
+        assert _apply(repo) == 0
+        assert sna.remote_branch_exists(repo, "hardening-run-12")
+
+    def test_upstream_is_its_own_counterpart_not_the_default_branch(self, repo):
+        """`checkout -b X origin/main` leaves upstream=origin/main, which looks
+        healthy in `git status` and breaks `gh pr create --base X`."""
+        assert _apply(repo) == 0
+        assert sna.upstream_of(repo, "hardening-run-12") == "origin/hardening-run-12"
+
+    def test_the_hand_written_form_would_fail_verification(self, repo):
+        """Reproduce the bad ritual, then confirm this tool's checks catch it."""
+        _git(repo, "checkout", "-b", "hardening-run-99", "origin/main")
+
+        failures = sna.verify_postconditions(repo, "hardening-run-99", "main")
+
+        assert any("origin has no branch" in f for f in failures), failures
+        assert any("upstream" in f for f in failures), failures
+
+
+class TestOutcome:
+    def test_repo_ends_on_the_new_branch(self, repo):
+        assert _apply(repo) == 0
+        assert sna.current_branch(repo) == "hardening-run-12"
+
+    def test_new_branch_is_level_with_the_default(self, repo):
+        assert _apply(repo) == 0
+        assert sna.commits_ahead(repo, "hardening-run-12", "origin/main") == 0
+
+    def test_previous_attempt_is_graveyarded_not_deleted(self, repo):
+        assert _apply(repo) == 0
+        assert sna.local_branch_exists(repo, "graveyard/hardening-run-11")
+        assert not sna.local_branch_exists(repo, "hardening-run-11")
+
+    def test_the_old_attempts_work_is_still_reachable(self, repo):
+        """The graveyard is a lab notebook, not a bin."""
+        assert _apply(repo) == 0
+        show = subprocess.run(
+            ["git", "show", "graveyard/hardening-run-11:src.py"],
+            cwd=str(repo), capture_output=True, text=True,
+        )
+        assert show.returncode == 0
+        assert "merged phase work" in show.stdout
+
+    def test_old_attempt_remains_on_origin_under_its_original_name(self, repo):
+        """Matching the existing convention: graveyarding is a LOCAL rename."""
+        assert _apply(repo) == 0
+        assert sna.remote_branch_exists(repo, "hardening-run-11")
+
+    def test_the_arc_work_is_gone_from_the_new_base(self, repo):
+        assert _apply(repo) == 0
+        assert not (repo / "src.py").exists()
+
+
+class TestPreconditions:
+    def test_dirty_tree_is_refused(self, repo, capsys):
+        (repo / "uncommitted.txt").write_text("wip", encoding="utf-8")
+
+        assert _apply(repo) == 1
+        out = capsys.readouterr().out
+        assert "uncommitted change" in out
+        assert sna.current_branch(repo) == "hardening-run-11", "must not mutate"
+
+    def test_extra_worktree_is_refused(self, repo, tmp_path, capsys):
+        _git(repo, "worktree", "add", str(tmp_path / "wt"), "-b", "issue-4")
+
+        assert _apply(repo) == 1
+        assert "worktree" in capsys.readouterr().out
+
+    def test_existing_local_name_is_refused(self, repo, capsys):
+        _git(repo, "branch", "hardening-run-12")
+
+        assert _apply(repo) == 1
+        assert "already exists" in capsys.readouterr().out
+
+    def test_existing_remote_name_is_refused(self, repo, capsys):
+        _git(repo, "push", "origin", "hardening-run-11:hardening-run-12")
+
+        assert _apply(repo) == 1
+        assert "origin already has a branch" in capsys.readouterr().out
+
+    def test_missing_origin_head_is_refused_with_the_remedy(self, repo, capsys):
+        _git(repo, "symbolic-ref", "-d", "refs/remotes/origin/HEAD")
+
+        assert _apply(repo) == 1
+        assert "git remote set-head" in capsys.readouterr().out
+
+
+class TestDryRunIsDefault:
+    def test_without_apply_nothing_changes(self, repo):
+        assert sna.main(["--repo", str(repo), "--name", "hardening-run-12"]) == 0
+
+        assert sna.current_branch(repo) == "hardening-run-11"
+        assert not sna.local_branch_exists(repo, "hardening-run-12")
+        assert not sna.remote_branch_exists(repo, "hardening-run-12")
+
+    def test_dry_run_prints_the_exact_commands(self, repo, capsys):
+        sna.main(["--repo", str(repo), "--name", "hardening-run-12"])
+        out = capsys.readouterr().out
+
+        assert "DRY RUN" in out
+        assert "git branch -m hardening-run-11 graveyard/hardening-run-11" in out
+        assert "git checkout -b hardening-run-12 origin/main" in out
+        assert "git push -u origin hardening-run-12" in out
+
+    def test_no_banned_command_appears_in_the_plan(self, repo):
+        """--apply rather than --execute is only correct if this stays true
+        (standard 0017). The old branch is renamed, never deleted; the new one
+        is pushed as a fresh ref, never forced."""
+        flat = " ".join(
+            " ".join(c) for c in sna.plan_steps("old", "new", "main")
+        )
+        for banned in ("--force", "-D ", "reset --hard", "clean -fd", "-f "):
+            assert banned not in flat, f"{banned!r} in plan: {flat}"
+
+
+class TestDefaultBranchIsReadNotAssumed:
+    """Hardcoding main is the behaviour the attempt-branch model removes."""
+
+    def test_default_branch_comes_from_origin_head(self, tmp_path):
+        upstream = tmp_path / "up.git"
+        upstream.mkdir()
+        _git(upstream, "init", "--bare", "-b", "trunk")
+
+        r = tmp_path / "repo"
+        r.mkdir()
+        _git(r, "init", "-b", "trunk")
+        (r / "f.txt").write_text("x", encoding="utf-8")
+        _git(r, "add", "-A")
+        _git(r, "commit", "-m", "init")
+        _git(r, "remote", "add", "origin", str(upstream))
+        _git(r, "push", "-u", "origin", "trunk")
+        _git(r, "remote", "set-head", "origin", "trunk")
+
+        assert sna.default_branch(r) == "trunk"
+
+    def test_new_attempt_is_cut_from_the_real_default(self, tmp_path):
+        upstream = tmp_path / "up.git"
+        upstream.mkdir()
+        _git(upstream, "init", "--bare", "-b", "trunk")
+
+        r = tmp_path / "repo"
+        r.mkdir()
+        _git(r, "init", "-b", "trunk")
+        (r / "f.txt").write_text("x", encoding="utf-8")
+        _git(r, "add", "-A")
+        _git(r, "commit", "-m", "init")
+        _git(r, "remote", "add", "origin", str(upstream))
+        _git(r, "push", "-u", "origin", "trunk")
+        _git(r, "remote", "set-head", "origin", "trunk")
+        _git(r, "checkout", "-b", "attempt-1")
+        _git(r, "push", "-u", "origin", "attempt-1")
+
+        assert sna.main(["--repo", str(r), "--name", "attempt-2", "--apply"]) == 0
+        assert sna.commits_ahead(r, "attempt-2", "origin/trunk") == 0

--- a/tools/speedrun_new_attempt.py
+++ b/tools/speedrun_new_attempt.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Re-establish a speedrun attempt branch so the next roll starts from zero (#1986).
+
+`speedrun_reset.py` cleans per-ISSUE debris and deliberately never touches the
+attempt branch (#1762 -- a reset must not cut the branch out from under the run
+standing on it). Nothing else did either, so after an arc completed the
+integration branch permanently carried every merged phase and the repo stayed
+parked on it. A roll was idempotent only if a human remembered to graveyard the
+branch and cut a fresh one.
+
+That ritual was performed by hand on 2026-07-30 and got wrong:
+`git checkout -b hardening-run-12 origin/main` sets the upstream to
+`origin/main` and never creates `origin/hardening-run-12`. Every earlier attempt
+branch existed on origin; that one did not, so `gh pr create --base
+hardening-run-12` would have failed on the run's FIRST PR -- after the LLD and
+spec stages had already burned. Nothing local showed a symptom.
+
+Every failure mode here is silent until mid-run, so this tool asserts its own
+postconditions (step 6) instead of assuming them.
+
+Dry-run by default; `--apply` mutates. No banned commands appear here -- the old
+branch is renamed, never deleted, and the new branch is pushed as a fresh ref,
+never force-pushed -- so `--apply` is the correct flag per standard 0017.
+
+Usage:
+    poetry run python tools/speedrun_new_attempt.py --repo /c/.../boostgauge \
+        --name hardening-run-13 [--issue 4 --issue 2] [--apply]
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+GRAVEYARD_PREFIX = "graveyard/"
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=str(cwd) if cwd else None,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+def current_branch(repo_root: Path) -> str:
+    """Checked-out branch, or "" on detached HEAD / git failure."""
+    result = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo_root)
+    if result.returncode != 0:
+        return ""
+    name = result.stdout.strip()
+    return "" if name == "HEAD" else name
+
+
+def default_branch(repo_root: Path) -> str:
+    """origin's default branch (e.g. "main"), or "" if it cannot be resolved.
+
+    Read from `origin/HEAD` rather than assumed: hardcoding main is the
+    behaviour the attempt-branch model exists to remove.
+    """
+    result = _run(
+        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return ""
+    ref = result.stdout.strip()
+    return ref.split("/", 1)[1] if "/" in ref else ""
+
+
+def remote_branch_exists(repo_root: Path, name: str) -> bool:
+    result = _run(
+        ["git", "ls-remote", "--heads", "origin", f"refs/heads/{name}"],
+        cwd=repo_root,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def local_branch_exists(repo_root: Path, name: str) -> bool:
+    result = _run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{name}"],
+        cwd=repo_root,
+    )
+    return result.returncode == 0
+
+
+def upstream_of(repo_root: Path, name: str) -> str:
+    result = _run(
+        ["git", "rev-parse", "--abbrev-ref", f"{name}@{{upstream}}"],
+        cwd=repo_root,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def commits_ahead(repo_root: Path, ref: str, base: str) -> int | None:
+    result = _run(
+        ["git", "rev-list", "--count", f"{base}..{ref}"], cwd=repo_root
+    )
+    if result.returncode != 0 or not result.stdout.strip().isdigit():
+        return None
+    return int(result.stdout.strip())
+
+
+# =============================================================================
+# Preconditions
+# =============================================================================
+
+
+def check_preconditions(repo_root: Path, new_name: str) -> list[str]:
+    """Reasons this repo is not ready for a new attempt. Empty == ready.
+
+    A new attempt starts from a settled repo. Renaming the branch out from
+    under uncommitted work, or leaving a worktree pinned to the old attempt,
+    reproduces exactly the debris the clean gate exists to refuse.
+    """
+    problems: list[str] = []
+
+    if not (repo_root / ".git").exists():
+        return [f"{repo_root} is not a git repository root"]
+
+    status = _run(["git", "status", "--porcelain"], cwd=repo_root)
+    if status.returncode != 0:
+        problems.append(f"git status failed: {status.stderr.strip()}")
+    elif status.stdout.strip():
+        dirty = len(status.stdout.strip().splitlines())
+        problems.append(
+            f"working tree has {dirty} uncommitted change(s) -- commit, stash, "
+            f"or resolve them first (a rename must not strand work)"
+        )
+
+    worktrees = _run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
+    extra = [
+        line.split(" ", 1)[1]
+        for line in worktrees.stdout.splitlines()
+        if line.startswith("worktree ")
+    ][1:]
+    if extra:
+        problems.append(
+            f"{len(extra)} extra worktree(s) still registered: "
+            f"{', '.join(Path(p).name for p in extra)}"
+        )
+
+    if not current_branch(repo_root):
+        problems.append("detached HEAD -- check out the attempt branch first")
+
+    if not default_branch(repo_root):
+        problems.append(
+            "cannot resolve origin/HEAD -- run "
+            "`git remote set-head origin --auto` so the default branch is known"
+        )
+
+    if local_branch_exists(repo_root, new_name):
+        problems.append(f"local branch '{new_name}' already exists")
+    if remote_branch_exists(repo_root, new_name):
+        problems.append(f"origin already has a branch named '{new_name}'")
+
+    return problems
+
+
+# =============================================================================
+# Postconditions -- the point of the tool
+# =============================================================================
+
+
+def verify_postconditions(
+    repo_root: Path, new_name: str, base: str
+) -> list[str]:
+    """Assert the new attempt is actually usable. Empty == verified.
+
+    Each check corresponds to a failure that is invisible locally and only
+    surfaces mid-run:
+
+    - branch missing on origin -> `gh pr create --base <name>` fails on the
+      first PR (the 2026-07-30 hand-run defect);
+    - upstream pointing at the DEFAULT branch rather than its own counterpart
+      -> exactly the shape that hid that defect, since `git status` reports a
+      perfectly healthy tracking branch;
+    - not level with the default branch -> the base carries work and the roll
+      would rebuild what already exists.
+    """
+    problems: list[str] = []
+
+    if current_branch(repo_root) != new_name:
+        problems.append(f"repo is not checked out on '{new_name}'")
+
+    if not remote_branch_exists(repo_root, new_name):
+        problems.append(
+            f"origin has no branch '{new_name}' -- PRs targeting it would fail"
+        )
+
+    upstream = upstream_of(repo_root, new_name)
+    if upstream != f"origin/{new_name}":
+        problems.append(
+            f"upstream of '{new_name}' is '{upstream or 'unset'}', expected "
+            f"'origin/{new_name}' (tracking the default branch is what made "
+            f"the 2026-07-30 breakage invisible)"
+        )
+
+    ahead = commits_ahead(repo_root, new_name, f"origin/{base}")
+    if ahead is None:
+        problems.append(f"cannot compare '{new_name}' against origin/{base}")
+    elif ahead != 0:
+        problems.append(
+            f"'{new_name}' is {ahead} commit(s) ahead of origin/{base} -- a "
+            f"fresh attempt must start level with the default branch"
+        )
+
+    return problems
+
+
+# =============================================================================
+# The operation
+# =============================================================================
+
+
+def plan_steps(old_name: str, new_name: str, base: str) -> list[list[str]]:
+    """The exact git commands, in order. Printed on dry runs, executed on --apply."""
+    return [
+        ["git", "fetch", "origin"],
+        ["git", "branch", "-m", old_name, f"{GRAVEYARD_PREFIX}{old_name}"],
+        ["git", "checkout", "-b", new_name, f"origin/{base}"],
+        ["git", "push", "-u", "origin", new_name],
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Graveyard the current speedrun attempt branch and establish a "
+            "fresh one from origin's default (#1986)."
+        )
+    )
+    parser.add_argument("--repo", required=True, help="Target repo root path")
+    parser.add_argument(
+        "--name", required=True,
+        help="Name for the new attempt branch (e.g. hardening-run-13)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually perform the change. Without it, print the plan and exit.",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo).resolve()
+    new_name = args.name
+
+    problems = check_preconditions(repo_root, new_name)
+    if problems:
+        print(f"BLOCKED: {repo_root.name} is not ready for a new attempt:")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+
+    old_name = current_branch(repo_root)
+    base = default_branch(repo_root)
+
+    print(f"Repo:            {repo_root}")
+    print(f"Current attempt: {old_name}")
+    print(f"Graveyard as:    {GRAVEYARD_PREFIX}{old_name}")
+    print(f"New attempt:     {new_name} (from origin/{base})")
+    print()
+
+    steps = plan_steps(old_name, new_name, base)
+    if not args.apply:
+        print("DRY RUN -- would execute:")
+        for cmd in steps:
+            print(f"  {' '.join(cmd)}")
+        print("\nRe-run with --apply to perform it.")
+        return 0
+
+    for cmd in steps:
+        print(f"  $ {' '.join(cmd)}")
+        result = _run(cmd, cwd=repo_root)
+        if result.returncode != 0:
+            print(f"FAILED: {' '.join(cmd)}")
+            print((result.stderr or result.stdout).strip())
+            print(
+                "\nThe repo may be part-way through the change. "
+                f"Current branch: {current_branch(repo_root) or 'unknown'}"
+            )
+            return 2
+
+    failures = verify_postconditions(repo_root, new_name, base)
+    if failures:
+        print(f"\nUNVERIFIED: '{new_name}' was created but is not usable:")
+        for f in failures:
+            print(f"  - {f}")
+        return 2
+
+    print(f"\nVERIFIED: {repo_root.name} is on '{new_name}'.")
+    print(f"  exists on origin, tracks origin/{new_name}, level with origin/{base}.")
+    print(f"  previous attempt preserved as '{GRAVEYARD_PREFIX}{old_name}'.")
+    print(
+        f"\nPass --base-branch {new_name} to BOTH speedrun_clean_check.py and "
+        f"orchestrate.py\n  so the gate and the roll judge the same tree "
+        f"(#1963/#1968)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1986

## The gap

`speedrun_reset.py` cleans per-**issue** debris and deliberately never touches the attempt branch (#1762 — a reset must not cut the branch out from under the run standing on it). Nothing else did either.

So after an arc completed: the integration branch permanently carried every merged phase, and the repo stayed parked on it. `speedrun_reset --all-issues` reopens the issues and removes the work branches, but the **merged commits remain** — a re-roll starts from finished code.

A roll was idempotent only if a human remembered to graveyard the branch and cut a fresh one. That ritual had no tool, no test, and no documentation.

## Why this is not theoretical

I performed it by hand on 2026-07-30 and got it wrong:

```
git checkout -b hardening-run-12 origin/main
```

That sets the upstream to `origin/main` and **never creates `origin/hardening-run-12`**. Every earlier attempt branch (`-1`, `-8`, `-9`, `-10`, `-11`) exists on origin; that one did not. `gh pr create --base hardening-run-12` requires the base to exist on the remote, so the run's **first PR would have failed** — after the LLD and spec stages had already burned.

Nothing local showed a symptom. `git status` reports a perfectly healthy tracking branch. The clean gate passed. The defect was only visible by comparing against the remote, which nothing did.

If the step that makes runs idempotent can be got wrong by someone who has just spent a day working on exactly this, it does not belong in a human's head.

## What this adds

`tools/speedrun_new_attempt.py` — performs the ritual and, more importantly, **verifies it**.

**Preconditions** (refuse rather than half-do): dirty tree, leftover worktrees, detached HEAD, unresolvable `origin/HEAD`, or a name already taken locally or on origin.

**Postconditions** — the three failures that are invisible locally and only surface mid-run:

| Check | The failure it catches |
|---|---|
| branch exists on origin | `gh pr create --base <name>` fails on the first PR — the 2026-07-30 defect |
| upstream is `origin/<name>`, not the default branch | the exact shape that *hid* that defect, since `git status` looks healthy |
| level with the default branch | base carries work; the roll rebuilds what already exists |

The old attempt is renamed to `graveyard/<name>`, matching the existing lab-notebook convention exactly — the local branch keeps tracking its original remote, as `graveyard/hardening-run-1 -> origin/hardening-run-1` does today; the remote keeps its original name; merged history stays reachable. Destroying an attempt's commits to make a checkout look clean is the wrong trade.

The default branch is read from `origin/HEAD`, never assumed to be `main` — hardcoding it is the behaviour the attempt-branch model exists to remove.

Dry-run by default. No banned command appears in the plan (rename, not delete; fresh push, not force), so `--apply` is correct per standard 0017 — and a test asserts that stays true, so the flag choice cannot silently drift.

## Verification

- **19 tests**, each building a real repo against a real **bare origin** — the entire defect class lives in the difference between local and remote refs, and a stubbed remote could not express it (standard 0024). Three reproduce the hand-run defect directly, including one that performs the bad ritual and confirms the postcondition checks catch it.
- Dry-run against live boostgauge: correct plan emitted, nothing mutated, and `hardening-run-12` now reports **zero** postcondition failures (it was pushed to origin and its upstream corrected before this PR).
- **Full suite 6479 passed**, 17 skipped, 5 xfailed, **0 failures**. `ruff` clean.

## Still open on the run lifecycle

The launcher passes `--base-branch` to neither the gate nor `orchestrate.py`, so both fall back to the checkout — benign only while the checkout happens to be the intended base. It is also still an untracked scratch script in boostgauge's `data/`. That is #1919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)