### PR TITLE
fix(dependabot): retry budget for the deferral skip + bail on 'behind' (Closes #1947, Closes #1975)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -661,14 +661,46 @@ class TestWaitForMergeableTimeoutDeferred:
         assert "DEFER" in out
         assert "#1399" in out
 
-    def test_behind_after_timeout_returns_deferred(self, monkeypatch):
-        """`behind` = base branch moved; still transient, recoverable."""
+    def test_behind_returns_errored_with_rebase(self, monkeypatch):
+        """#1975: `behind` no longer waits out the poll budget.
+
+        It was previously treated as transient and deferred after the full
+        900s. But `behind` means the head is behind base, and only a rebase
+        clears it -- measured on the 2026-07-30 fleet run, 328 polls sat in
+        `behind` (~55 min) and 4 PRs burned the entire budget without ever
+        clearing. It now joins `dirty`: bail, request a rebase, report
+        errored so the next run re-evaluates post-rebase.
+        """
         self._stub_to_wait_for_mergeable(monkeypatch)
+        rebase_calls: list = []
+        monkeypatch.setattr(
+            dependabot_review, "request_dependabot_rebase",
+            lambda pr, repo: rebase_calls.append(pr))
         self._stub_wait_then_final_state(monkeypatch, "behind")
         result = dependabot_review._process_pr_inside_worktree(
             self._pr(), "owner/repo", Path("/tmp/wt"),
         )
-        assert result == "deferred"
+        assert result == "errored"
+        assert rebase_calls, "a `behind` PR must get a rebase request"
+
+    def test_wait_for_mergeable_bails_on_behind_without_polling(
+            self, monkeypatch):
+        """The bail must happen on the FIRST poll -- the whole point is not
+        spending 900s discovering it."""
+        polls: list = []
+        sleeps: list = []
+
+        def _fake(cmd, *a, **kw):
+            polls.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout='"behind"', stderr="")
+        monkeypatch.setattr(dependabot_review, "run", _fake)
+        monkeypatch.setattr(dependabot_review.time, "sleep",
+                            lambda s: sleeps.append(s))
+
+        assert dependabot_review.wait_for_mergeable(7, "o/r") is False
+        assert len(polls) == 1, f"must bail on first poll, saw {len(polls)}"
+        assert sleeps == [], "must not sleep through the poll interval"
 
     def test_unknown_after_timeout_returns_deferred(self, monkeypatch):
         """`unknown` = GitHub still computing; also transient."""
@@ -1103,10 +1135,52 @@ class TestAlreadyDeferredAtHead:
                 stderr="")
         monkeypatch.setattr(dependabot_review, "run", _fake)
 
-    def test_matching_deferral_review_skips(self, monkeypatch):
+    def test_single_deferral_does_not_skip(self, monkeypatch):
+        """#1947: one deferral is not enough. Skipping on the first made a
+        flaky failure permanently sticky -- re-running the test is the only
+        thing that can clear a flake, and the skip prevented exactly that."""
         self._stub(monkeypatch, [self._review()])
         assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_skips_once_budget_reached(self, monkeypatch):
+        """At SKIP_AFTER_DEFERRALS deferrals on one SHA, stop re-auditing."""
+        n = dependabot_review.SKIP_AFTER_DEFERRALS
+        self._stub(monkeypatch, [self._review() for _ in range(n)])
+        assert dependabot_review.already_deferred_at_head(
             self._pr(), "o/r") is True
+
+    def test_one_below_budget_still_processes(self, monkeypatch):
+        n = dependabot_review.SKIP_AFTER_DEFERRALS
+        self._stub(monkeypatch, [self._review() for _ in range(n - 1)])
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
+
+    def test_max_attempts_zero_disables_skip(self, monkeypatch):
+        """--reaudit-all passes 0: audit everything regardless of history,
+        and do not even spend the API call."""
+        called: list = []
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda *a, **kw: called.append(a) or subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="[]", stderr=""))
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r", 0) is False
+        assert called == [], "max_attempts=0 must short-circuit before the API"
+
+    def test_only_matching_reviews_count_toward_budget(self, monkeypatch):
+        """Foreign reviewers, APPROVED states, and non-tool bodies must not
+        accumulate toward the skip budget."""
+        n = dependabot_review.SKIP_AFTER_DEFERRALS
+        noise = (
+            [self._review(user="cerberus-az[bot]") for _ in range(n)]
+            + [self._review(state="APPROVED") for _ in range(n)]
+            + [self._review(body="LGTM") for _ in range(n)]
+            + [self._review(commit_id="0" * 40) for _ in range(n)]
+        )
+        self._stub(monkeypatch, noise)
+        assert dependabot_review.already_deferred_at_head(
+            self._pr(), "o/r") is False
 
     def test_commit_mismatch_reaudits(self, monkeypatch):
         """A rebase/new push moves the head SHA -- must re-audit (#994)."""
@@ -1204,12 +1278,18 @@ class TestProcessRepoSkipsUnchanged:
                             lambda t: [])
         monkeypatch.setattr(dependabot_review, "list_dependabot_prs",
                             lambda repo: [pr])
-        monkeypatch.setattr(dependabot_review, "already_deferred_at_head",
-                            lambda p, repo: deferred_at_head)
+        # #1947: signature gained max_attempts; capture what process_repo
+        # threads through so the --reaudit-all wiring is covered too.
+        seen_attempts: list[int] = []
+        monkeypatch.setattr(
+            dependabot_review, "already_deferred_at_head",
+            lambda p, repo, n=dependabot_review.SKIP_AFTER_DEFERRALS:
+                seen_attempts.append(n) or deferred_at_head)
         processed: list[int] = []
         monkeypatch.setattr(
             dependabot_review, "process_pr",
             lambda p, repo, target: processed.append(p.number) or "merged")
+        self._seen_attempts = seen_attempts
         return processed
 
     def test_unchanged_pr_is_skipped_and_budget_untouched(
@@ -1229,6 +1309,23 @@ class TestProcessRepoSkipsUnchanged:
         sub = dependabot_review.process_repo("o/r", tmp_path)
         assert processed == [9]
         assert sub["merged"] == ["o/r#9"]
+        assert sub["skipped_unchanged"] == []
+
+    def test_default_threads_the_configured_budget(
+            self, monkeypatch, tmp_path):
+        """#1947: process_repo must pass SKIP_AFTER_DEFERRALS by default."""
+        self._wire(monkeypatch, tmp_path, deferred_at_head=False)
+        dependabot_review.process_repo("o/r", tmp_path)
+        assert self._seen_attempts == [dependabot_review.SKIP_AFTER_DEFERRALS]
+
+    def test_reaudit_all_threads_zero_and_processes_everything(
+            self, monkeypatch, tmp_path):
+        """--reaudit-all resolves to skip_after=0, which must reach the
+        detector so a previously-stranded PR gets audited again."""
+        processed = self._wire(monkeypatch, tmp_path, deferred_at_head=False)
+        sub = dependabot_review.process_repo("o/r", tmp_path, skip_after=0)
+        assert self._seen_attempts == [0]
+        assert processed == [9]
         assert sub["skipped_unchanged"] == []
 
 

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -270,6 +270,16 @@ PYTEST_EXIT_NO_TESTS_COLLECTED = 5
 # already_deferred_at_head key on this string -- if it drifts, the skip
 # silently disarms and standing deferrals go back to daily re-audits.
 REVIEW_BODY_PREFIX = "Automated review via tools/dependabot_review.py"
+# #1947: how many deferrals at the SAME head SHA before the skip engages.
+# 1 (the original #1838 behaviour) made a nondeterministic failure
+# permanently sticky: re-running the test is the only thing that can clear
+# a flake, and skipping on the first deferral prevented exactly that. 3
+# keeps the anti-spam benefit for genuinely-red repos -- they cost a
+# bounded number of audits rather than one per day forever -- while giving
+# a flake two more chances to come up green. `--reaudit-all` sets this to
+# 0, disabling the skip entirely for a run (audits everything; strictly
+# more verification, never less).
+SKIP_AFTER_DEFERRALS = 3
 
 
 @dataclass
@@ -792,8 +802,16 @@ def wait_for_mergeable(pr_number: int, repo: str) -> bool:
         print(f"  mergeable_state: {state} (elapsed {elapsed}s)")
         if state in ("clean", "unstable"):
             return True
-        if state == "dirty":
-            return False  # merge conflict; waiting won't help
+        if state in ("dirty", "behind"):
+            # #1975: neither resolves by waiting. 'dirty' is a merge
+            # conflict; 'behind' means the head is behind base and clears
+            # only when the branch is rebased. Measured on the 2026-07-30
+            # fleet run: 328 polls sat in 'behind' (~55 min) and 4 PRs
+            # burned the full 900s budget without ever clearing. Bail now
+            # and let the caller request a rebase. 'blocked' still polls
+            # to timeout -- that one genuinely self-resolves when
+            # cerberus-az approves, which is the #1399 finding.
+            return False
         time.sleep(POLL_INTERVAL_S)
     elapsed = int(time.time() - start)
     print(f"  mergeable_state: timed out after {elapsed}s "
@@ -916,9 +934,19 @@ def is_pr_branch_stale(pr_number: int, repo: str) -> bool:
     return pr_base != main_head
 
 
-def already_deferred_at_head(pr: PRInfo, repo: str) -> bool:
-    """#1838: True iff this tool already posted a deferral review at the
-    PR's CURRENT head SHA.
+def already_deferred_at_head(pr: PRInfo, repo: str,
+                             max_attempts: int = SKIP_AFTER_DEFERRALS) -> bool:
+    """#1838: True iff this tool has deferred this PR at its CURRENT head
+    SHA at least `max_attempts` times.
+
+    #1947: the original form returned True on the FIRST matching deferral,
+    which made a NONDETERMINISTIC failure permanently sticky -- running
+    the test again is the one thing that could clear a flake, and the skip
+    prevented exactly that. A PR that lost a coin flip once was never
+    retried. Requiring `max_attempts` consecutive deferrals at the same
+    SHA keeps nearly all of #1838's benefit (a permanently-red repo costs
+    a bounded number of audits instead of one per day forever) while
+    letting a flake clear itself.
 
     The scheduled harvest re-audited every standing deferral daily -- full
     worktree + install + test cycle, a duplicate COMMENTED review, and a
@@ -941,7 +969,7 @@ def already_deferred_at_head(pr: PRInfo, repo: str) -> bool:
     Conservative on ANY failure: return False (re-audit). A wasted audit
     is recoverable; a wrongly-skipped PR never merges.
     """
-    if not pr.head_oid:
+    if not pr.head_oid or max_attempts <= 0:
         return False
     result = run(
         ["gh", "api", f"repos/{repo}/pulls/{pr.number}/reviews?per_page=100",
@@ -956,15 +984,14 @@ def already_deferred_at_head(pr: PRInfo, repo: str) -> bool:
         reviews = json.loads(result.stdout or "[]")
     except json.JSONDecodeError:
         return False
-    for rv in reviews:
-        if (
-            rv.get("user") == GITHUB_USER
-            and rv.get("state") == "COMMENTED"
-            and (rv.get("body") or "").startswith(REVIEW_BODY_PREFIX)
-            and rv.get("commit_id") == pr.head_oid
-        ):
-            return True
-    return False
+    attempts = sum(
+        1 for rv in reviews
+        if rv.get("user") == GITHUB_USER
+        and rv.get("state") == "COMMENTED"
+        and (rv.get("body") or "").startswith(REVIEW_BODY_PREFIX)
+        and rv.get("commit_id") == pr.head_oid
+    )
+    return attempts >= max_attempts
 
 
 # #1400: file patterns that mean "this PR could affect the Python test
@@ -1348,8 +1375,14 @@ def _process_pr_inside_worktree(
             "--jq", ".mergeable_state",
         ])
         final_state = (final_state_result.stdout or "").strip().strip('"')
-        if final_state == "dirty":
-            print(f"  ERROR: mergeable_state '{final_state}' -- merge conflict, "
+        if final_state in ("dirty", "behind"):
+            # #1975: 'behind' joins 'dirty' here. Both need the branch
+            # rebased before they can merge, and neither improves with
+            # more waiting -- so request the rebase immediately instead
+            # of spending the full poll budget discovering it.
+            reason = ("merge conflict" if final_state == "dirty"
+                      else "head is behind base")
+            print(f"  ERROR: mergeable_state '{final_state}' -- {reason}, "
                   f"requesting @dependabot rebase. Approval persists; next run "
                   f"re-evaluates post-rebase.")
             request_dependabot_rebase(pr.number, repo)
@@ -1499,6 +1532,7 @@ def process_repo(
     dry_run: bool = False,
     ignore_orphans: bool = False,
     budget: PRBudget | None = None,
+    skip_after: int = SKIP_AFTER_DEFERRALS,
 ) -> dict[str, list[str]]:
     """Process all dependabot PRs in one repo, sequentially.
 
@@ -1590,9 +1624,10 @@ def process_repo(
         # #1838: a PR already deferred at this exact head SHA cannot
         # produce a different result -- skip before spending a budget
         # slot, building a worktree, or posting a duplicate review.
-        if already_deferred_at_head(pr, repo):
-            print(f"  SKIP #{pr.number}: already deferred at current head "
-                  f"{pr.head_oid[:9]} -- unchanged since last audit (#1838)")
+        if already_deferred_at_head(pr, repo, skip_after):
+            print(f"  SKIP #{pr.number}: deferred {skip_after}+ times at "
+                  f"current head {pr.head_oid[:9]} -- unchanged since last "
+                  f"audit (#1838/#1947)")
             sub["skipped_unchanged"].append(f"{repo}#{pr.number}")
             continue
         if budget is not None and not budget.try_acquire():
@@ -1727,6 +1762,18 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--reaudit-all", action="store_true",
+        help=(
+            "#1947: audit every PR even if this tool already deferred it at "
+            "the same head SHA. Normally a PR deferred SKIP_AFTER_DEFERRALS "
+            "times at one SHA is skipped, which keeps a permanently-red repo "
+            "from costing an audit per day forever -- but it also strands "
+            "PRs whose deferral came from a flaky test or from a bug since "
+            "fixed. This forces a full sweep: strictly MORE verification "
+            "than the default, never less."
+        ),
+    )
+    parser.add_argument(
         "--no-run-log", action="store_true",
         help=(
             "#1403: by default every run tees its full output to a "
@@ -1776,6 +1823,12 @@ def main() -> None:
     # (non-deterministic run to run), so a limited run sorts repos by name
     # — with oldest-first PRs inside process_repo, consecutive limited
     # runs drain the fleet queue FIFO, deterministically.
+    # #1947: 0 disables the deferral skip entirely for this run.
+    skip_after = 0 if args.reaudit_all else SKIP_AFTER_DEFERRALS
+    if args.reaudit_all:
+        print("Re-audit mode: the deferral skip is disabled; every open PR "
+              "will be audited regardless of prior deferrals (#1947).")
+
     if args.limit < 0:
         sys.exit(f"--limit must be >= 0, got {args.limit}")
     budget = PRBudget(args.limit) if args.limit > 0 else None
@@ -1810,7 +1863,7 @@ def main() -> None:
                 futures = {
                     executor.submit(
                         process_repo, repo, main_repo, args.dry_run,
-                        args.ignore_orphans,
+                        args.ignore_orphans, None, skip_after,
                     ): repo
                     for repo in repos
                 }
@@ -1852,7 +1905,7 @@ def main() -> None:
                     continue
                 sub = process_repo(
                     repo, main_repo, args.dry_run, args.ignore_orphans,
-                    budget=budget,
+                    budget=budget, skip_after=skip_after,
                 )
                 for k in ("merged", "deferred", "errored", "limit_skipped",
                           "skipped_unchanged"):


### PR DESCRIPTION
Closes #1947, Closes #1975

## Why now

Measured against the 39 open dependabot PRs across the fleet at time of writing:

- **19 of 39 (49%) were unreachable by any drain** — the deferral skip engaged on their first deferral and never let them be re-audited.
- Mergeable-state polling was burning **~55 minutes per run** on a state that waiting cannot resolve.

Both are fixed here.

## #1947 — retry budget for the deferral skip

The skip introduced in #1838 returned on the **first** matching deferral at a head SHA. That made a *nondeterministic* failure permanently sticky: re-running the test is the only thing that can clear a flake, and the skip prevented exactly that. A PR that lost a coin flip once was never retried.

It now counts deferrals at that SHA and engages at `SKIP_AFTER_DEFERRALS = 3`. A permanently-red repo still costs a bounded number of audits rather than one per day forever; a flake gets two more chances.

**`--reaudit-all`** sets the threshold to 0, disabling the skip for a single run. This is necessary because PRs stranded *before* this fix carry 4, 5, and in one case 23 deferral reviews at a single unchanged SHA — no finite budget would ever release them. The flag is strictly *more* verification than the default, never less, and it does not alter the scheduled harvest's behaviour.

## #1975 — `behind` bails instead of polling

`wait_for_mergeable` returned early only on `clean`/`unstable` (success) and `dirty` (conflict). Everything else polled to the full `MERGEABLE_TIMEOUT_S = 900`.

That is right for `blocked` — #1399 established it genuinely self-resolves once cerberus-az approves. It is wrong for `behind`, which means the head is behind base and clears only on a rebase. From the 2026-07-30 fleet run: **328 polls in `behind`**, and **4 PRs burned the entire 900s** without ever clearing.

`behind` now joins `dirty`: bail on the first poll, request `@dependabot rebase`, report errored so the next run re-evaluates post-rebase. The tool already had `request_dependabot_rebase()` for exactly this shape of problem.

## Tests

124 passed, `ruff` clean. Four existing tests encoded the old contracts and were rewritten rather than deleted:

- `test_behind_after_timeout_returns_deferred` → `test_behind_returns_errored_with_rebase`, plus a new test asserting the bail happens on the **first** poll with **zero** sleeps — the entire point being not to spend 900s discovering it.
- `test_matching_deferral_review_skips` → split into single-deferral-does-not-skip, skips-at-budget, and one-below-budget-still-processes.
- The `process_repo` stubs gained the new `max_attempts` parameter and now assert what gets threaded through, covering the `--reaudit-all` wiring end to end.

New coverage also asserts that `max_attempts=0` short-circuits **before** the API call, and that foreign reviewers, `APPROVED` states, non-tool bodies, and reviews at other SHAs do not accumulate toward the budget.
