### PR TITLE
feat(speedrun): roll issues end to end with zero human decisions (Closes #1919)

### DIFF
--- a/tests/unit/test_speedrun_new_attempt.py
+++ b/tests/unit/test_speedrun_new_attempt.py
@@ -146,6 +146,27 @@ class TestPreconditions:
         assert _apply(repo) == 1
         assert "origin already has a branch" in capsys.readouterr().out
 
+    def test_detached_head_is_handled_not_refused(self, repo):
+        """Nothing to graveyard is not a reason to stop. Refusing here told a
+        human to check out a branch first -- an instruction the tool can carry
+        out itself, which makes it a ritual rather than a safeguard (#1919)."""
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo),
+            capture_output=True, text=True,
+        ).stdout.strip()
+        _git(repo, "checkout", sha)
+
+        assert _apply(repo) == 0
+        assert sna.current_branch(repo) == "hardening-run-12"
+        assert sna.remote_branch_exists(repo, "hardening-run-12")
+        # The old attempt keeps its own name; it was never checked out.
+        assert sna.local_branch_exists(repo, "hardening-run-11")
+
+    def test_plan_omits_the_rename_when_there_is_no_branch(self):
+        flat = [" ".join(c) for c in sna.plan_steps("", "attempt-2", "main")]
+        assert not any("branch -m" in c for c in flat), flat
+        assert any("checkout -b attempt-2 origin/main" in c for c in flat), flat
+
     def test_missing_origin_head_is_refused_with_the_remedy(self, repo, capsys):
         _git(repo, "symbolic-ref", "-d", "refs/remotes/origin/HEAD")
 

--- a/tests/unit/test_speedrun_roll.py
+++ b/tests/unit/test_speedrun_roll.py
@@ -1,0 +1,262 @@
+"""A roll makes its own decisions (#1919).
+
+The wrapper this replaces required a human to know which branch to roll on and
+pass it to two tools consistently, to notice when a finished arc had left the
+base carrying the work, to name and cut the next attempt branch by hand, and to
+read an ABORT saying "run speedrun_reset.py, verify clean, relaunch" and then
+do it.
+
+Each of those is a decision the repo can answer for itself, so each is tested
+here as a decision the tool makes -- not as a message it prints.
+
+Real repos against a real bare origin throughout; the only stubs are at the
+network boundary (`gh`) and around the pipeline child itself (standard 0024).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Repo on attempt branch `hardening-run-11`, that branch pushed to origin."""
+    upstream = tmp_path / "upstream.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+    _git(r, "remote", "set-head", "origin", "main")
+
+    _git(r, "checkout", "-b", "hardening-run-11")
+    _git(r, "push", "-u", "origin", "hardening-run-11")
+    return r
+
+
+@pytest.fixture
+def log(tmp_path):
+    return sr.EventLog(tmp_path / "events.log")
+
+
+def _commit_lld(repo, issue=4):
+    d = repo / "docs" / "lld" / "active"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"LLD-{issue:03d}.md").write_text("x", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", f"land LLD #{issue}")
+    _git(repo, "push")
+
+
+def _no_network():
+    """gh-backed debris classes return nothing; they are not what is under test."""
+    return patch.multiple(
+        sr.gate,
+        find_open_pr_debris=lambda *a, **k: [],
+        find_remote_branch_debris=lambda *a, **k: [],
+    )
+
+
+class TestNamingIsDerivedNotChosen:
+    def test_prefix_comes_from_the_current_attempt(self, repo):
+        assert sr.attempt_prefix(repo) == "hardening-run"
+
+    def test_prefix_falls_back_when_not_on_an_attempt(self, repo):
+        _git(repo, "checkout", "main")
+        assert sr.attempt_prefix(repo) == sr.DEFAULT_PREFIX
+
+    def test_next_name_increments_past_the_highest(self, repo):
+        assert sr.next_attempt_name(repo, "hardening-run") == "hardening-run-12"
+
+    def test_graveyarded_attempts_still_count(self, repo):
+        """A name freed by graveyarding must not be handed out again -- the old
+        remote ref still holds it."""
+        _git(repo, "branch", "-m", "hardening-run-11", "graveyard/hardening-run-11")
+        assert sr.next_attempt_name(repo, "hardening-run") == "hardening-run-12"
+
+    def test_remote_only_attempts_still_count(self, repo):
+        """A push would collide even with no local branch of that name."""
+        _git(repo, "push", "origin", "hardening-run-11:hardening-run-40")
+        _git(repo, "fetch", "origin")
+        assert sr.next_attempt_name(repo, "hardening-run") == "hardening-run-41"
+
+    def test_first_attempt_when_none_exist(self, repo):
+        assert sr.next_attempt_name(repo, "brand-new") == "brand-new-1"
+
+
+class TestStructuralSoundness:
+    def test_a_pushed_tracking_branch_is_sound(self, repo):
+        assert sr.base_is_structurally_sound(repo, "hardening-run-11") == []
+
+    def test_missing_on_origin_is_caught(self, repo):
+        """The 2026-07-30 defect: `checkout -b X origin/main` never pushes X."""
+        _git(repo, "checkout", "-b", "hardening-run-12", "origin/main")
+        problems = sr.base_is_structurally_sound(repo, "hardening-run-12")
+        assert any("does not exist on origin" in p for p in problems), problems
+        assert any("upstream" in p for p in problems), problems
+
+    def test_a_mid_arc_base_ahead_of_default_is_still_sound(self, repo):
+        """An integration branch carrying earlier phases is the POINT; only a
+        fresh attempt must be level with the default branch."""
+        _commit_lld(repo, 2)
+        assert sr.base_is_structurally_sound(repo, "hardening-run-11") == []
+
+
+class TestEnsureBaseDecides:
+    def test_sound_and_clean_base_is_reused(self, repo, log):
+        with _no_network():
+            assert sr.ensure_base(repo, 4, log) == "hardening-run-11"
+
+    def test_unsound_base_triggers_a_fresh_attempt(self, repo, log):
+        _git(repo, "checkout", "-b", "hardening-run-12", "origin/main")
+
+        with _no_network():
+            base = sr.ensure_base(repo, 4, log)
+
+        assert base == "hardening-run-13"
+        assert sr.base_is_structurally_sound(repo, base) == []
+
+    def test_base_holding_this_issues_work_triggers_a_fresh_attempt(
+        self, repo, log
+    ):
+        """No amount of debris cleanup fixes a base that already merged the
+        issue -- it needs a base that predates it."""
+        _commit_lld(repo, 4)
+
+        with _no_network():
+            base = sr.ensure_base(repo, 4, log)
+
+        assert base == "hardening-run-12"
+        assert sr.gate.find_committed_artifact_debris(repo, 4, base) == []
+
+    def test_another_issues_work_does_not_trigger_a_fresh_attempt(
+        self, repo, log
+    ):
+        """Phases accumulate on one integration branch; only THIS issue matters."""
+        _commit_lld(repo, 2)
+
+        with _no_network():
+            assert sr.ensure_base(repo, 4, log) == "hardening-run-11"
+
+    def test_recoverable_debris_is_self_healed_not_reported(self, repo, log):
+        """The old wrapper printed 'run speedrun_reset.py, verify clean,
+        relaunch' and quit. That instruction is now a code path."""
+        _git(repo, "branch", "issue-4")
+        healed = {}
+
+        def fake_reset(repo_root, slug, issue):
+            healed["called"] = issue
+            _git(repo_root, "branch", "-d", "issue-4")
+
+        with _no_network(), \
+             patch.object(sr.reset, "reset_one_issue", fake_reset), \
+             patch.object(sr.reset, "_gh_repo", lambda p: "o/r"):
+            base = sr.ensure_base(repo, 4, log)
+
+        assert healed["called"] == 4
+        assert base == "hardening-run-11"
+
+    def test_debris_that_survives_reset_escalates_to_a_fresh_attempt(
+        self, repo, log
+    ):
+        _git(repo, "branch", "issue-4")
+
+        with _no_network(), \
+             patch.object(sr.reset, "reset_one_issue", lambda *a: None), \
+             patch.object(sr.reset, "_gh_repo", lambda p: "o/r"):
+            base = sr.ensure_base(repo, 4, log)
+
+        assert base == "hardening-run-12"
+
+    def test_detached_head_triggers_a_fresh_attempt(self, repo, log):
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(repo),
+            capture_output=True, text=True,
+        ).stdout.strip()
+        _git(repo, "checkout", sha)
+
+        with _no_network():
+            assert sr.ensure_base(repo, 4, log) == "hardening-run-12"
+
+
+class TestInstrumentationSurvives:
+    def test_events_and_heartbeat_are_written(self, tmp_path):
+        log = sr.EventLog(tmp_path / "e.log")
+        log.write("START something")
+        with sr.Heartbeat(tmp_path / "hb.log", interval=1):
+            pass
+
+        assert "START something" in (tmp_path / "e.log").read_text(encoding="utf-8")
+        assert (tmp_path / "hb.log").read_text(encoding="utf-8").strip().endswith("alive")
+
+    def test_child_env_carries_the_two_load_bearing_vars(self):
+        env = sr._child_env()
+        assert env["CLAUDECODE"] == ""
+        assert env["PYTHONUNBUFFERED"] == "1"
+
+
+class TestNoHumanInputBeyondRepoAndIssue:
+    def test_roll_needs_only_repo_and_issue(self, repo, tmp_path):
+        """No base, no attempt name, no apply flag -- the tool resolves all of
+        it. Anything else here would be a ritual with a different name."""
+        seen = {}
+
+        def fake_roll(repo_root, issue, log_dir, az_root, extra):
+            seen[issue] = (repo_root, log_dir)
+            return 0
+
+        with patch.object(sr, "roll_issue", fake_roll):
+            code = sr.main(["--repo", str(repo), "--issue", "4", "--issue", "2"])
+
+        assert code == 0
+        assert sorted(seen) == [2, 4]
+
+    def test_a_failing_issue_stops_the_sequence(self, repo):
+        rolled = []
+
+        def fake_roll(repo_root, issue, log_dir, az_root, extra):
+            rolled.append(issue)
+            return 91 if issue == 4 else 0
+
+        with patch.object(sr, "roll_issue", fake_roll):
+            code = sr.main(["--repo", str(repo), "--issue", "4", "--issue", "2"])
+
+        assert code == 91
+        assert rolled == [4], "later issues must not roll on a broken base"
+
+    def test_extra_args_pass_through_to_the_pipeline(self, repo):
+        captured = {}
+
+        def fake_roll(repo_root, issue, log_dir, az_root, extra):
+            captured["extra"] = extra
+            return 0
+
+        with patch.object(sr, "roll_issue", fake_roll):
+            sr.main(["--repo", str(repo), "--issue", "4", "--max-iterations", "5"])
+
+        assert captured["extra"] == ["--max-iterations", "5"]
+
+    def test_non_repo_path_is_refused(self, tmp_path):
+        assert sr.main(["--repo", str(tmp_path), "--issue", "4"]) == 91

--- a/tools/speedrun_new_attempt.py
+++ b/tools/speedrun_new_attempt.py
@@ -141,8 +141,11 @@ def check_preconditions(repo_root: Path, new_name: str) -> list[str]:
             f"{', '.join(Path(p).name for p in extra)}"
         )
 
-    if not current_branch(repo_root):
-        problems.append("detached HEAD -- check out the attempt branch first")
+    # A detached HEAD is NOT a blocker. There is simply no branch to graveyard,
+    # so the rename step is skipped and the fresh attempt is cut from the
+    # default branch as usual. Refusing here (as this tool first did) told a
+    # human to "check out the attempt branch first" -- an instruction the tool
+    # can carry out itself, which makes it a ritual rather than a safeguard.
 
     if not default_branch(repo_root):
         problems.append(
@@ -215,13 +218,19 @@ def verify_postconditions(
 
 
 def plan_steps(old_name: str, new_name: str, base: str) -> list[list[str]]:
-    """The exact git commands, in order. Printed on dry runs, executed on --apply."""
-    return [
-        ["git", "fetch", "origin"],
-        ["git", "branch", "-m", old_name, f"{GRAVEYARD_PREFIX}{old_name}"],
-        ["git", "checkout", "-b", new_name, f"origin/{base}"],
-        ["git", "push", "-u", "origin", new_name],
-    ]
+    """The exact git commands, in order. Printed on dry runs, executed on --apply.
+
+    ``old_name`` is empty on a detached HEAD: there is no branch to graveyard,
+    so that step is simply absent rather than being a reason to stop.
+    """
+    steps: list[list[str]] = [["git", "fetch", "origin"]]
+    if old_name:
+        steps.append(
+            ["git", "branch", "-m", old_name, f"{GRAVEYARD_PREFIX}{old_name}"]
+        )
+    steps.append(["git", "checkout", "-b", new_name, f"origin/{base}"])
+    steps.append(["git", "push", "-u", "origin", new_name])
+    return steps
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -256,8 +265,9 @@ def main(argv: list[str] | None = None) -> int:
     base = default_branch(repo_root)
 
     print(f"Repo:            {repo_root}")
-    print(f"Current attempt: {old_name}")
-    print(f"Graveyard as:    {GRAVEYARD_PREFIX}{old_name}")
+    print(f"Current attempt: {old_name or '(detached HEAD -- nothing to graveyard)'}")
+    if old_name:
+        print(f"Graveyard as:    {GRAVEYARD_PREFIX}{old_name}")
     print(f"New attempt:     {new_name} (from origin/{base})")
     print()
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Roll one or more speedrun issues end to end, with zero human decisions (#1919).
+
+This replaces the untracked `run_instrumented.sh` scratch script AND the ritual
+that surrounded it. The old flow required a human to:
+
+  - know which branch to roll on, and pass it to two tools consistently;
+  - notice when a finished arc had left the base carrying the work;
+  - pick a name for the next attempt branch and cut it by hand (done wrong on
+    2026-07-30: the branch was never pushed, so the run's first PR would have
+    failed);
+  - read an ABORT message saying "run speedrun_reset.py, verify clean,
+    relaunch" and then do exactly that.
+
+Every one of those is now resolved by this tool. It takes a repo and issue
+numbers. Nothing else is a decision.
+
+Preserved verbatim from the wrapper, because each was earned:
+  - events log     -- start/stop, trapped signals, child exit code
+  - heartbeat      -- a line every 15s; the last one is the time of death under
+                      SIGKILL, and the only trustworthy run status (the harness
+                      fired three phantom "killed" notifications in one night,
+                      all disproven by a live heartbeat)
+  - direct redirect -- the child's stdout goes straight to a file with no pipe
+                      in the path, which is what stopped the kills
+
+Exit codes: 0 all issues rolled; 91 a base or gate problem this tool could not
+heal; otherwise the failing child's return code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import speedrun_clean_check as gate
+import speedrun_new_attempt as attempt
+import speedrun_reset as reset
+
+HEARTBEAT_SECONDS = 15
+DEFAULT_PREFIX = "hardening-run"
+
+
+def _stamp() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=str(cwd) if cwd else None,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+class EventLog:
+    """Append-only run record. The file, not the harness, is the truth."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, message: str) -> None:
+        line = f"{_stamp()} {message}"
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        print(line, flush=True)
+
+
+class Heartbeat:
+    """A line every 15s until stopped. Last line == time of death under SIGKILL."""
+
+    def __init__(self, path: Path, interval: int = HEARTBEAT_SECONDS) -> None:
+        self.path = path
+        self.interval = interval
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> Heartbeat:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._thread = threading.Thread(target=self._beat, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval + 5)
+
+    def _beat(self) -> None:
+        while not self._stop.is_set():
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(f"{_stamp()} alive\n")
+            self._stop.wait(self.interval)
+
+
+# =============================================================================
+# Base resolution -- the ritual this tool exists to delete
+# =============================================================================
+
+
+def attempt_prefix(repo_root: Path) -> str:
+    """Naming family for attempt branches, taken from the current one.
+
+    `hardening-run-12` -> `hardening-run`. A branch that does not look like an
+    attempt (e.g. `main`) falls back to the campaign default, so a repo sitting
+    on its default branch still gets a sensibly named first attempt.
+    """
+    current = attempt.current_branch(repo_root)
+    match = re.match(r"^(.*)-\d+$", current or "")
+    return match.group(1) if match else DEFAULT_PREFIX
+
+
+def next_attempt_name(repo_root: Path, prefix: str) -> str:
+    """The next free `{prefix}-{N}`, counting local, graveyard, and remote refs.
+
+    Every namespace is consulted because a name only has to collide in ONE of
+    them to break: `git branch` fails on a local clash, `git push` on a remote
+    one, and the graveyard holds every previous attempt by construction.
+    """
+    seen: set[int] = set()
+    esc = re.escape(prefix)
+    pattern = re.compile(rf"^(?:{esc}|graveyard/{esc})-(\d+)$")
+
+    local = _run(["git", "branch", "--list", "--format=%(refname:short)"], cwd=repo_root)
+    remote = _run(["git", "ls-remote", "--heads", "origin"], cwd=repo_root)
+
+    names = [line.strip() for line in local.stdout.splitlines()]
+    names += [
+        line.split("refs/heads/", 1)[1].strip()
+        for line in remote.stdout.splitlines()
+        if "refs/heads/" in line
+    ]
+    for name in names:
+        match = pattern.match(name)
+        if match:
+            seen.add(int(match.group(1)))
+
+    return f"{prefix}-{(max(seen) + 1) if seen else 1}"
+
+
+def establish_new_attempt(repo_root: Path, log: EventLog) -> str | None:
+    """Cut and verify a fresh attempt branch. Returns its name, or None."""
+    prefix = attempt_prefix(repo_root)
+    name = next_attempt_name(repo_root, prefix)
+    log.write(f"BASE establishing new attempt '{name}'")
+
+    code = attempt.main(["--repo", str(repo_root), "--name", name, "--apply"])
+    if code != 0:
+        log.write(f"BASE FAILED to establish '{name}' (exit {code})")
+        return None
+    log.write(f"BASE established and verified: {name}")
+    return name
+
+
+def base_is_structurally_sound(repo_root: Path, base: str) -> list[str]:
+    """What must hold for ANY base, fresh or mid-arc. Empty == sound.
+
+    Deliberately NOT "level with the default branch": mid-arc a base carries
+    the earlier phases, which is the whole point of an integration branch. Only
+    a FRESH attempt must be level, and speedrun_new_attempt enforces that.
+
+    What must always hold is that the base exists on origin and tracks its own
+    counterpart -- `gh pr create --base` needs the remote ref, and an upstream
+    pointing at the default branch is the exact shape that hid the 2026-07-30
+    breakage from `git status`.
+    """
+    problems: list[str] = []
+    if not attempt.remote_branch_exists(repo_root, base):
+        problems.append(
+            f"'{base}' does not exist on origin -- PRs targeting it would fail"
+        )
+    upstream = attempt.upstream_of(repo_root, base)
+    if upstream != f"origin/{base}":
+        problems.append(
+            f"upstream of '{base}' is '{upstream or 'unset'}', expected "
+            f"'origin/{base}'"
+        )
+    return problems
+
+
+def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
+    """A base this issue can actually be rolled on. Heals what it can.
+
+    Order matters: structure first (a base that cannot receive PRs is useless
+    however clean it looks), then this issue's debris, then this issue's
+    already-merged work.
+    """
+    base = attempt.current_branch(repo_root)
+    if not base:
+        log.write("BASE detached HEAD -- establishing a fresh attempt")
+        return establish_new_attempt(repo_root, log)
+
+    problems = base_is_structurally_sound(repo_root, base)
+    if problems:
+        log.write(f"BASE '{base}' unusable: {'; '.join(problems)}")
+        return establish_new_attempt(repo_root, log)
+
+    findings = gate.check_repo(repo_root, [issue], base)
+    debris = [f for f in findings if not f.startswith("ERROR:")]
+    errors = [f for f in findings if f.startswith("ERROR:")]
+    if errors:
+        for e in errors:
+            log.write(f"GATE {e}")
+        return None
+    if not debris:
+        log.write(f"BASE '{base}' verified clean for #{issue}")
+        return base
+
+    committed = [d for d in debris if d.startswith("committed artifact:")]
+    if committed:
+        # The base already contains this issue's merged work. No amount of
+        # debris cleanup fixes that -- it needs a base that predates it.
+        log.write(
+            f"BASE '{base}' already contains #{issue}'s work "
+            f"({len(committed)} artifact(s)) -- establishing a fresh attempt"
+        )
+        return establish_new_attempt(repo_root, log)
+
+    # Recoverable debris. The old wrapper printed "run speedrun_reset.py,
+    # verify clean, relaunch" and quit; that instruction is now the code path.
+    log.write(f"GATE {len(debris)} finding(s) for #{issue} -- self-healing")
+    for d in debris:
+        log.write(f"  {d}")
+    try:
+        repo_slug = reset._gh_repo(repo_root)
+    except RuntimeError as err:
+        log.write(f"RESET could not determine owner/repo: {err}")
+        return None
+    reset.reset_one_issue(repo_root, repo_slug, issue)
+
+    findings = gate.check_repo(repo_root, [issue], base)
+    debris = [f for f in findings if not f.startswith("ERROR:")]
+    if debris:
+        log.write(f"GATE still dirty after reset ({len(debris)}) -- fresh attempt")
+        for d in debris:
+            log.write(f"  {d}")
+        return establish_new_attempt(repo_root, log)
+
+    log.write(f"BASE '{base}' clean for #{issue} after self-heal")
+    return base
+
+
+# =============================================================================
+# The roll
+# =============================================================================
+
+
+def roll_issue(
+    repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str]
+) -> int:
+    tag = f"run-issue{issue}-{datetime.now().strftime('%H%M%S')}"
+    log = EventLog(log_dir / f"{tag}-events.log")
+    heartbeat_path = log_dir / f"{tag}-heartbeat.log"
+    out_path = log_dir / f"{tag}.log"
+
+    log.write(f"START issue=#{issue} repo={repo_root} pid={os.getpid()}")
+
+    with Heartbeat(heartbeat_path):
+        base = ensure_base(repo_root, issue, log)
+        if base is None:
+            log.write("ABORT could not establish a usable base")
+            return 91
+
+        cmd = [
+            sys.executable, "tools/orchestrate.py",
+            "--issue", str(issue),
+            "--repo", str(repo_root),
+            "--no-gate-pr",
+            "--base-branch", base,
+            *extra,
+        ]
+        log.write(f"LAUNCH base={base} -> {out_path.name}")
+
+        # Direct redirect: the child's stdout goes straight to the file with no
+        # pipe in the path. Restoring a pipe here reintroduces the teardown that
+        # killed campaign runs.
+        with out_path.open("w", encoding="utf-8", errors="replace") as fh:
+            proc = subprocess.run(
+                cmd, cwd=str(az_root), stdout=fh, stderr=subprocess.STDOUT,
+                env=_child_env(),
+            )
+        log.write(f"CHILD EXITED rc={proc.returncode}")
+
+    log.write(f"EXIT rc={proc.returncode}")
+    return proc.returncode
+
+
+def _child_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["CLAUDECODE"] = ""         # nested Claude sessions fail without this
+    env["PYTHONUNBUFFERED"] = "1"  # Python buffers stdout when not on a TTY
+    return env
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Roll speedrun issues end to end: resolve and heal the base, gate "
+            "it, run the pipeline, all with no human decisions (#1919)."
+        )
+    )
+    parser.add_argument("--repo", required=True, help="Target repo root path")
+    parser.add_argument(
+        "--issue", type=int, action="append", required=True,
+        help="Issue to roll (repeatable; rolled in order)",
+    )
+    parser.add_argument(
+        "--log-dir", default=None,
+        help="Where events/heartbeat/output land. Default: <repo>/data/speedrun/runs",
+    )
+    parser.add_argument(
+        "--assemblyzero-root", default=None,
+        help="AssemblyZero checkout that owns orchestrate.py. Default: this tool's repo",
+    )
+    args, extra = parser.parse_known_args(argv)
+
+    repo_root = Path(args.repo).resolve()
+    if not (repo_root / ".git").exists():
+        print(f"ERROR: {repo_root} is not a git repository root")
+        return 91
+
+    az_root = (
+        Path(args.assemblyzero_root).resolve()
+        if args.assemblyzero_root
+        else Path(__file__).resolve().parents[1]
+    )
+    log_dir = (
+        Path(args.log_dir).resolve()
+        if args.log_dir
+        else repo_root / "data" / "speedrun" / "runs"
+    )
+
+    for issue in args.issue:
+        code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+        if code != 0:
+            print(f"\nSTOPPED at #{issue} (exit {code}); later issues not rolled.")
+            return code
+        time.sleep(1)
+
+    print(f"\nAll {len(args.issue)} issue(s) rolled.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1919

Promotes the untracked `run_instrumented.sh` scratch script into `tools/` **and deletes the ritual around it**.

## The rituals removed

The old flow required a human to:

| Ritual | Now |
|---|---|
| know which branch to roll on, and pass it to two tools consistently | resolved from the repo |
| notice a finished arc left the base carrying the work | detected and replaced |
| pick a name for the next attempt and cut it by hand | derived and cut |
| read `ABORT: run speedrun_reset.py, verify clean, relaunch` and go do it | that instruction **is** the code path |

`tools/speedrun_roll.py` takes a repo and issue numbers. Nothing else is a decision.

## How the base is resolved

Order matters, and each step answers a different question:

1. **Structure.** A base missing on origin, or whose upstream points at the default branch, cannot receive PRs however clean it looks — replaced. This is the 2026-07-30 defect: `git checkout -b hardening-run-12 origin/main` never pushes the branch, `git status` looks perfectly healthy, and the run's first PR fails after the LLD and spec stages have burned.
2. **This issue's debris.** Recoverable leftovers are reset in-process rather than reported.
3. **This issue's merged work.** No cleanup fixes a base that already contains the issue — a fresh attempt is cut from the default branch.
4. **Another issue's work is left alone.** Phases accumulating on one integration branch is what it is *for*.

Attempt names are derived, never chosen: the next free `{prefix}-{N}` counted across local, graveyard, **and remote** refs, because a name only has to collide in one namespace to break the run.

## A ritual found inside the tool I shipped yesterday

`speedrun_new_attempt.py` refused on a detached HEAD with *"check out the attempt branch first"* — an instruction the tool can carry out itself. There is no branch to graveyard, so that step is now simply absent rather than fatal. The roll tests caught it.

## Preserved verbatim

Each was earned, so none was rewritten in spirit: the events log; the 15s heartbeat whose last line is the time of death under SIGKILL (three phantom harness "killed" notifications in one night, all disproven by a live heartbeat); the direct file redirect that keeps a pipe out of the child's stdout path; and `CLAUDECODE=""` / `PYTHONUNBUFFERED=1` travelling with the child.

## Verification

- **22 new tests**, asserting the **decisions** rather than the messages: reuse a sound base, replace an unsound one, escalate past a base holding this issue's work, ignore another issue's work, self-heal recoverable debris, escalate when the heal does not take, handle a detached HEAD.
- One test pins that a roll needs nothing beyond `--repo` and `--issue`, so any newly-required argument fails as the ritual it would be.
- Real repos against a real **bare origin** throughout; the only stubs are the `gh` network boundary and the pipeline child (standard 0024).
- **Full suite 6503 passed**, 17 skipped, 5 xfailed, **0 failures**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)