### PR TITLE
feat(dependabot): baseline-aware gating -- exonerate a bump when the base already fails the same tests (Closes #1992)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -320,6 +320,10 @@ class TestProcessPrDeferralStaleBranchPriority:
     def _stub_pipeline(self, monkeypatch, exit_code, package_count, is_stale):
         """Stub the pieces of process_pr we need to exercise the deferral branch."""
         monkeypatch.setattr(dependabot_review, "verify_author", lambda pr: True)
+        # #1992: base reads green -> failures are NOT exonerable, so
+        # these deferral-path expectations hold unchanged.
+        monkeypatch.setattr(dependabot_review, "run_baseline_gate",
+                            lambda pr, wt, py, js: (0, ""))
         monkeypatch.setattr(
             dependabot_review,
             "create_audit_worktree",
@@ -333,6 +337,8 @@ class TestProcessPrDeferralStaleBranchPriority:
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda worktree: None)
         monkeypatch.setattr(dependabot_review, "install_deps", lambda worktree: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda worktree: exit_code)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda worktree: (exit_code, ""))
         monkeypatch.setattr(dependabot_review, "count_packages", lambda body: package_count)
         monkeypatch.setattr(dependabot_review, "is_pr_branch_stale", lambda pr, repo: is_stale)
 
@@ -511,6 +517,8 @@ class TestExitCodeFiveIsPass:
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
         monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: exit_code)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: (exit_code, ""))
         # Green-path stubs (only used when the gate doesn't defer).
         monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "approve_pr",
@@ -621,6 +629,8 @@ class TestWaitForMergeableTimeoutDeferred:
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
         monkeypatch.setattr(dependabot_review, "install_deps", lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 0)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: (0, ""))
         monkeypatch.setattr(dependabot_review, "inject_no_issue", lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "approve_pr",
                             lambda pr, repo, gate_desc: True)
@@ -844,8 +854,8 @@ class TestPipelineSkippedForNonPythonPR:
         tests_called = []
         monkeypatch.setattr(dependabot_review, "install_deps",
                             lambda wt: install_called.append(wt) or True)
-        monkeypatch.setattr(dependabot_review, "run_tests",
-                            lambda wt: tests_called.append(wt) or 0)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: tests_called.append(wt) or (0, ""))
 
         result = dependabot_review._process_pr_inside_worktree(
             self._pr(), "owner/repo", Path("/tmp/wt"),
@@ -872,8 +882,8 @@ class TestPipelineSkippedForNonPythonPR:
         monkeypatch.setattr(dependabot_review, "evict_poetry_venv", lambda wt: None)
         monkeypatch.setattr(dependabot_review, "install_deps",
                             lambda wt: install_called.append(wt) or True)
-        monkeypatch.setattr(dependabot_review, "run_tests",
-                            lambda wt: tests_called.append(wt) or 0)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: tests_called.append(wt) or (0, ""))
 
         result = dependabot_review._process_pr_inside_worktree(
             self._pr(), "owner/repo", Path("/tmp/wt"),
@@ -1501,6 +1511,10 @@ class TestProcessPrJsFlow:
     def _stub_green_path(self, monkeypatch):
         monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
                             lambda worktree, pr_number, repo: True)
+        # #1992: base green -> a failing PR is a real regression, not
+        # exonerable. Tests that want exoneration stub this themselves.
+        monkeypatch.setattr(dependabot_review, "run_baseline_gate",
+                            lambda pr, wt, py, js: (0, ""))
         monkeypatch.setattr(dependabot_review, "inject_no_issue",
                             lambda pr, repo: True)
         monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
@@ -1527,11 +1541,11 @@ class TestProcessPrJsFlow:
         installs, tests, js = [], [], []
         monkeypatch.setattr(dependabot_review, "install_deps",
                             lambda wt: installs.append(wt) or True)
-        monkeypatch.setattr(dependabot_review, "run_tests",
-                            lambda wt: tests.append(wt) or 0)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: tests.append(wt) or (0, ""))
         monkeypatch.setattr(
             dependabot_review, "run_js_gate",
-            lambda wt, dirs: js.append(dirs) or
+            lambda wt, dirs, sink=None: js.append(dirs) or
             (True, "npm test passed (exit 0) in 'dashboard'"))
 
         result = dependabot_review._process_pr_inside_worktree(
@@ -1548,7 +1562,7 @@ class TestProcessPrJsFlow:
                             lambda pr, repo: ["package.json"])
         monkeypatch.setattr(
             dependabot_review, "run_js_gate",
-            lambda wt, dirs: (False, "no runnable npm test script in '.' -- "
+            lambda wt, dirs, sink=None: (False, "no runnable npm test script in '.' -- "
                               "not auto-merging unverified (#1839)"))
         reviews: list[str] = []
         monkeypatch.setattr(
@@ -1582,10 +1596,12 @@ class TestProcessPrJsFlow:
         monkeypatch.setattr(dependabot_review, "install_deps",
                             lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 0)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: (0, ""))
         js: list = []
         monkeypatch.setattr(
             dependabot_review, "run_js_gate",
-            lambda wt, dirs: js.append(dirs) or
+            lambda wt, dirs, sink=None: js.append(dirs) or
             (True, "npm test passed (exit 0) in 'web'"))
 
         result = dependabot_review._process_pr_inside_worktree(
@@ -1606,9 +1622,11 @@ class TestProcessPrJsFlow:
         monkeypatch.setattr(dependabot_review, "install_deps",
                             lambda wt: True)
         monkeypatch.setattr(dependabot_review, "run_tests", lambda wt: 1)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda wt: (1, "FAILED t.py::a"))
         js: list = []
         monkeypatch.setattr(dependabot_review, "run_js_gate",
-                            lambda wt, dirs: js.append(dirs) or (True, "x"))
+                            lambda wt, dirs, sink=None: js.append(dirs) or (True, "x"))
         monkeypatch.setattr(dependabot_review, "review_comment_on_pr",
                             lambda pr, repo, body: True)
         monkeypatch.setattr(dependabot_review, "is_pr_branch_stale",
@@ -1773,3 +1791,166 @@ class TestTeeSurvivesUndecodableTerminal:
         assert tee.write("plain ascii line") == len("plain ascii line")
         logfile.close()
         assert stream.written == ["plain ascii line"]
+
+
+VITEST_FAIL = (
+    "\x1b[31m × \x1b[39msrc/api.test.ts > auth > rejects bad token 12ms\n"
+    " × src/api.test.ts > auth > returns 400 on malformed body\n"
+    " Test Files  1 failed | 110 passed (111)\n"
+)
+PYTEST_FAIL = (
+    "FAILED tests/test_a.py::TestX::test_one - AssertionError\n"
+    "FAILED tests/test_b.py::test_two - ValueError\n"
+    "2 failed, 300 passed in 5.2s\n"
+)
+
+
+class TestExtractFailures:
+    """#1992: identifiers must be stable enough to compare across runs."""
+
+    def test_pytest_ids(self):
+        got = dependabot_review.extract_failures(PYTEST_FAIL)
+        assert "tests/test_a.py::TestX::test_one" in got
+        assert "tests/test_b.py::test_two" in got
+
+    def test_vitest_ids_with_ansi_and_timings_stripped(self):
+        got = dependabot_review.extract_failures(VITEST_FAIL)
+        assert any("rejects bad token" in g for g in got)
+        assert all("\x1b" not in g for g in got), "ANSI must be stripped"
+        assert all(not g.endswith("12ms") for g in got), "timing must be cut"
+
+    def test_same_suite_twice_yields_equal_sets(self):
+        """The whole comparison rests on this: identical output must give
+        identical identifiers, or exoneration is meaningless."""
+        assert (dependabot_review.extract_failures(VITEST_FAIL)
+                == dependabot_review.extract_failures(VITEST_FAIL))
+
+    def test_clean_output_yields_nothing(self):
+        assert dependabot_review.extract_failures(
+            "300 passed in 5.2s\n") == set()
+
+    def test_empty_and_none_safe(self):
+        assert dependabot_review.extract_failures("") == set()
+        assert dependabot_review.extract_failures(None) == set()
+
+
+class TestIsExoneratedByBaseline:
+    """#1992: the ONLY path where a red gate still merges. It must never
+    fire on uncertainty."""
+
+    def test_identical_failures_exonerate(self):
+        f = {"a::t1", "b::t2"}
+        assert dependabot_review.is_exonerated_by_baseline(f, set(f)) is True
+
+    def test_subset_exonerates(self):
+        """Base is broken in 3 ways, PR fails 2 of them -- introduced
+        nothing new."""
+        assert dependabot_review.is_exonerated_by_baseline(
+            {"a::t1"}, {"a::t1", "b::t2", "c::t3"}) is True
+
+    def test_one_new_failure_blocks(self):
+        assert dependabot_review.is_exonerated_by_baseline(
+            {"a::t1", "NEW::regression"}, {"a::t1"}) is False
+
+    def test_green_baseline_blocks(self):
+        """Base passes, PR fails -> the bump did it."""
+        assert dependabot_review.is_exonerated_by_baseline(
+            {"a::t1"}, set()) is False
+
+    def test_unparseable_pr_output_blocks(self):
+        """Empty PR set means 'could not parse', NOT 'nothing failed'.
+        Exonerating here would merge on ignorance."""
+        assert dependabot_review.is_exonerated_by_baseline(
+            set(), {"a::t1"}) is False
+
+    def test_both_unparseable_blocks(self):
+        assert dependabot_review.is_exonerated_by_baseline(
+            set(), set()) is False
+
+
+class TestBaselineGateFlow:
+    """#1992: end-to-end behaviour inside _process_pr_inside_worktree."""
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=77, title="bump x", author_login="app/dependabot",
+            body="", head_ref="dependabot/pip/x-2")
+
+    def _wire(self, monkeypatch, baseline):
+        monkeypatch.setattr(dependabot_review, "checkout_pr_into_worktree",
+                            lambda w, n, r: True)
+        monkeypatch.setattr(dependabot_review, "_pr_changed_files",
+                            lambda pr, repo: ["poetry.lock"])
+        monkeypatch.setattr(dependabot_review, "evict_poetry_venv",
+                            lambda w: None)
+        monkeypatch.setattr(dependabot_review, "install_deps", lambda w: True)
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda w: (1, PYTEST_FAIL))
+        monkeypatch.setattr(dependabot_review, "run_baseline_gate",
+                            lambda pr, w, py, js: baseline)
+        monkeypatch.setattr(dependabot_review, "inject_no_issue",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "wait_for_mergeable",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review, "squash_merge",
+                            lambda pr, repo: True)
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+        approvals: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "approve_pr",
+            lambda pr, repo, gate_desc: approvals.append(gate_desc) or True)
+        reviews: list[str] = []
+        monkeypatch.setattr(
+            dependabot_review, "review_comment_on_pr",
+            lambda pr, repo, body: reviews.append(body) or True)
+        monkeypatch.setattr(dependabot_review, "is_pr_branch_stale",
+                            lambda pr, repo: False)
+        return approvals, reviews
+
+    def test_red_pr_on_red_base_merges_and_says_so(self, monkeypatch):
+        approvals, _ = self._wire(monkeypatch, (1, PYTEST_FAIL))
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "o/r", Path("/tmp/wt"))
+        assert result == "merged"
+        body = approvals[0]
+        assert "exonerated" in body.lower()
+        assert "already fail" in body.lower(), (
+            "the audit trail must never imply a green suite")
+
+    def test_red_pr_on_green_base_still_defers(self, monkeypatch):
+        approvals, reviews = self._wire(monkeypatch, (0, ""))
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "o/r", Path("/tmp/wt"))
+        assert result == "deferred"
+        assert approvals == [], "a real regression must never be approved"
+        assert reviews and "baseline check" in reviews[0]
+
+    def test_new_failure_against_red_base_defers(self, monkeypatch):
+        """Base is red, but the PR adds a failure the base does not have."""
+        approvals, _ = self._wire(
+            monkeypatch, (1, "FAILED tests/test_a.py::TestX::test_one\n"))
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "o/r", Path("/tmp/wt"))
+        assert result == "deferred"
+        assert approvals == []
+
+    def test_unparseable_baseline_defers(self, monkeypatch):
+        approvals, _ = self._wire(monkeypatch, (1, "something unparseable"))
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "o/r", Path("/tmp/wt"))
+        assert result == "deferred"
+        assert approvals == []
+
+    def test_passing_pr_never_runs_baseline(self, monkeypatch):
+        """Cost control: the baseline must only run on the failure path."""
+        called: list = []
+        self._wire(monkeypatch, (1, PYTEST_FAIL))
+        monkeypatch.setattr(dependabot_review, "run_tests_detailed",
+                            lambda w: (0, ""))
+        monkeypatch.setattr(
+            dependabot_review, "run_baseline_gate",
+            lambda pr, w, py, js: called.append(1) or (0, ""))
+        result = dependabot_review._process_pr_inside_worktree(
+            self._pr(), "o/r", Path("/tmp/wt"))
+        assert result == "merged"
+        assert called == [], "baseline must not run when the gate passes"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -622,12 +622,72 @@ def run_tests(worktree: Path) -> int:
     # run. Without it, any target repo whose .gitignore lacks __pycache__/
     # ends up with untracked .pyc files that dirty the audit worktree, making
     # `git worktree remove` (no --force) refuse and leak the worktree.
+    return run_tests_detailed(worktree)[0]
+
+
+def run_tests_detailed(worktree: Path) -> tuple[int, str]:
+    """#1992: as run_tests, but also returns captured output so the caller
+    can compare WHICH tests failed against a baseline run of the base."""
     pytest_env = _clean_subprocess_env()
     pytest_env["PYTHONDONTWRITEBYTECODE"] = "1"
     result = run(["poetry", "run", "pytest", "-q", "--tb=short"],
                  cwd=str(worktree), timeout=PYTEST_TIMEOUT_S, env=pytest_env)
     print(f"  pytest exit code: {result.returncode}")
-    return result.returncode
+    return result.returncode, (result.stdout or "") + (result.stderr or "")
+
+
+# #1992: strip ANSI before matching -- vitest and jest colour their failure
+# lines, so escape codes sit between the marker and the test name and
+# defeat a naive pattern.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# Failure-identifier patterns for the frameworks this fleet uses. Each must
+# capture something stable enough to compare across two runs of one suite.
+_FAILURE_PATTERNS = (
+    re.compile(r"^FAILED\s+(\S+)", re.M),                        # pytest
+    re.compile(r"^\s*●\s+(.+?)\s*$", re.M),                      # jest
+    re.compile(r"^\s*[×✕]\s+(.+?)(?:\s+\d+\s*ms)?\s*$", re.M),   # vitest
+    re.compile(r"^\s*FAIL\s+(\S+)", re.M),                       # file-level
+)
+
+
+def extract_failures(output: str) -> set[str]:
+    """#1992: the set of failing-test identifiers in a gate's output.
+
+    Used ONLY to decide whether a failing PR fails in exactly the ways its
+    base already fails. An empty result means "could not determine", which
+    callers MUST treat as non-exonerable -- never as "nothing failed".
+    """
+    text = _ANSI_RE.sub("", output or "")
+    found: set[str] = set()
+    for pattern in _FAILURE_PATTERNS:
+        for m in pattern.finditer(text):
+            ident = m.group(1).strip()
+            # Drop trailing duration noise so one test compares equal
+            # between runs.
+            ident = re.sub(r"\s*\(?\d+(\.\d+)?\s*m?s\)?$", "", ident).strip()
+            if ident and not ident.startswith("-"):
+                found.add(ident)
+    return found
+
+
+def is_exonerated_by_baseline(pr_failures: set[str],
+                              baseline_failures: set[str]) -> bool:
+    """#1992: True iff every test failing WITH the bump was already failing
+    WITHOUT it.
+
+    Deliberately conservative -- this is the one place a red gate can still
+    merge, so it must never fire on uncertainty:
+
+    * either side unparseable (empty) -> False. An empty PR-failure set
+      means the parser did not understand the output, NOT that nothing
+      failed; treating it as exoneration would merge on ignorance.
+    * a single failure absent from the baseline -> False. That is exactly
+      the regression the gate exists to catch.
+    """
+    if not pr_failures or not baseline_failures:
+        return False
+    return pr_failures <= baseline_failures
 
 
 def _npm_cmd() -> str:
@@ -683,7 +743,8 @@ def _remove_node_modules(pkg_dir: Path) -> None:
               file=sys.stderr)
 
 
-def run_js_gate(worktree: Path, js_dirs: list[str]) -> tuple[bool, str]:
+def run_js_gate(worktree: Path, js_dirs: list[str],
+                output_sink: list[str] | None = None) -> tuple[bool, str]:
     """#1839: install + test gate for npm ecosystems, one pass per
     touched manifest directory.
 
@@ -728,6 +789,11 @@ def run_js_gate(worktree: Path, js_dirs: list[str]) -> tuple[bool, str]:
                          timeout=NPM_TEST_TIMEOUT_S,
                          env=_clean_subprocess_env())
             print(f"  npm test exit code ('{d}'): {result.returncode}")
+            if output_sink is not None:
+                # #1992: hand the raw output back so the caller can compare
+                # which tests failed against a baseline run of the base.
+                output_sink.append((result.stdout or "")
+                                   + (result.stderr or ""))
             if result.returncode != 0:
                 return False, (f"npm test FAILED "
                                f"(exit {result.returncode}) in '{d}'")
@@ -1238,6 +1304,48 @@ def check_for_orphan_worktrees(target_repo: Path) -> list[str]:
 # Per-PR processing
 # ---------------------------------------------------------------------------
 
+def run_baseline_gate(pr: PRInfo, worktree: Path, touches_py: bool,
+                      js_dirs: list[str]) -> tuple[int, str]:
+    """#1992: re-run the gate with the PR's changes REMOVED.
+
+    The audit worktree was created as `dependabot-audit-<N>` pointing at
+    the base, then `gh pr checkout --detach` moved HEAD onto the PR. So
+    checking that branch back out restores the base content in the very
+    same worktree -- same machine, same env, same suite, only the bump
+    removed. That is what makes the comparison meaningful.
+
+    Returns (exit_code, combined_output). Returns (0, "") when the base
+    could not be established, which the caller reads as "not exonerable"
+    -- an unknown baseline must never license a merge.
+    """
+    branch = f"dependabot-audit-{pr.number}"
+    print(f"  BASELINE: re-running the gate on the base ({branch}) to see "
+          f"whether these failures predate the bump (#1992)")
+    if run(["git", "checkout", branch], cwd=str(worktree)).returncode != 0:
+        print("  BASELINE: could not restore the base commit -- not "
+              "exonerable", file=sys.stderr)
+        return 0, ""
+
+    output = ""
+    code = 0
+    if touches_py:
+        evict_poetry_venv(worktree)
+        if not install_deps(worktree):
+            print("  BASELINE: poetry install failed on the base -- not "
+                  "exonerable", file=sys.stderr)
+            return 0, ""
+        code, output = run_tests_detailed(worktree)
+        if code == PYTEST_EXIT_NO_TESTS_COLLECTED:
+            code = 0
+    if code == 0 and js_dirs:
+        sink: list[str] = []
+        ok, _ = run_js_gate(worktree, js_dirs, sink)
+        output += "\n" + "\n".join(sink)
+        if not ok:
+            code = 1
+    return code, output
+
+
 def _process_pr_inside_worktree(
     pr: PRInfo, repo: str, worktree: Path,
 ) -> str:
@@ -1261,6 +1369,7 @@ def _process_pr_inside_worktree(
     gate_descs: list[str] = []
     exit_code = 0
     defer_reason = ""
+    gate_output = ""
 
     # #1400: only run the Python gate (poetry install + pytest) when the
     # PR actually touches a Python file or manifest. A Dockerfile-only
@@ -1284,7 +1393,7 @@ def _process_pr_inside_worktree(
             )
             return "deferred"
 
-        exit_code = run_tests(worktree)
+        exit_code, gate_output = run_tests_detailed(worktree)
 
         # #1397: exit 5 = "no tests collected" is a normal pytest result for
         # test-less repos (decorative-deps honeypots, scaffold stubs), not a
@@ -1305,11 +1414,44 @@ def _process_pr_inside_worktree(
     # #1839: npm gate for every touched manifest directory, after the
     # Python gate -- a grouped PR touching both ecosystems must pass both.
     if exit_code == 0 and js_dirs:
-        js_ok, js_desc = run_js_gate(worktree, js_dirs)
+        js_sink: list[str] = []
+        js_ok, js_desc = run_js_gate(worktree, js_dirs, js_sink)
         gate_descs.append(js_desc)
         if not js_ok:
             exit_code = 1
             defer_reason = js_desc
+            gate_output = "\n".join(js_sink)
+
+    # #1992: baseline-aware gating. A red gate might mean the bump broke
+    # something -- or it might mean this repo's default branch was ALREADY
+    # broken, in which case the bump is being blamed for a failure that
+    # predates it. Re-run the same gate against the base and compare.
+    # Only ever runs on the failure path, so a passing PR costs nothing.
+    if exit_code != 0:
+        pr_failures = extract_failures(gate_output)
+        base_code, base_output = run_baseline_gate(
+            pr, worktree, touches_py, js_dirs)
+        base_failures = extract_failures(base_output)
+        if base_code != 0 and is_exonerated_by_baseline(
+                pr_failures, base_failures):
+            shared = ", ".join(sorted(pr_failures)[:3])
+            print(f"  EXONERATED: every failure here already fails on the "
+                  f"base without this bump ({len(pr_failures)} failing, "
+                  f"base has {len(base_failures)}) -- #1992")
+            gate_descs.append(
+                f"gate RED but exonerated against a RED baseline (#1992): "
+                f"the {len(pr_failures)} failing test(s) already fail on the "
+                f"base commit without this bump [{shared}]. This repository's "
+                f"suite is broken independently of this dependency")
+            exit_code = 0
+            defer_reason = ""
+        else:
+            why = ("base is green -- this bump introduced the failure"
+                   if base_code == 0 else
+                   "failures differ from the base run" if base_failures
+                   else "baseline could not be established")
+            print(f"  NOT exonerated ({why}) -- deferring")
+            defer_reason = f"{defer_reason} [baseline check: {why}]"
 
     if not touches_py and not js_dirs:
         # #1400: PR touches neither ecosystem -- docker / workflow / docs


### PR DESCRIPTION
Closes #1992

## Problem

The gate could not distinguish **"this bump broke the tests"** from **"this repo's tests were already broken."** Both are a non-zero exit; both defer. So a repository with a red default branch can never receive a dependency update — including security patches, which are the majority of the fleet's queue.

Measured tonight: a clean checkout of one repo's `origin/main`, no dependabot changes whatsoever, installed and tested:

```
Test Files  1 failed | 110 passed (111)
     Tests  35 failed | 2192 passed | 5 skipped
```

All 8 of that repo's open PRs were deferring on a failure that predates every one of them. Fleet-wide, a full re-audit sweep produced `merged=0 deferred=32 errored=6`.

## Change

On the **failure path only**, re-run the same gate against the PR's base and compare failing-test identifiers.

The audit worktree was created as `dependabot-audit-<N>` pointing at the base, and `gh pr checkout --detach` then moved HEAD onto the PR — so checking that branch back out restores the base *in the same worktree*, same machine, same environment, with only the bump removed. That is what makes the comparison meaningful rather than a guess.

| Comparison | Outcome |
|---|---|
| PR failures ⊆ base failures | **Exonerated** — bump introduced nothing new, treat as pass |
| Any failure absent from base | **Defer** — genuine regression |
| Base green, PR red | **Defer** — the bump did it |

## This is not a bypass

- **A passing PR is untouched** — the baseline only runs when the gate has already failed, so the common path costs nothing.
- **Exoneration requires a parsed, non-empty failure set from *both* runs.** An empty set means "could not parse the output", never "nothing failed" — exonerating on that would be merging on ignorance. Unparseable either side ⇒ defer.
- **One new failure defers the PR.** Every regression the gate caught before, it still catches.
- **The audit trail stays honest**: the approval body states the merge was exonerated against a red baseline and names the shared failures, so it never implies a green suite.

## Tests

140 passed, `ruff` clean. New coverage:

- **Identifier extraction** across pytest, vitest and jest, including ANSI stripping and timing-suffix removal — plus the property the whole comparison rests on: identical output must yield identical identifiers.
- **The exoneration predicate**: identical sets exonerate, subsets exonerate, one new failure blocks, green baseline blocks, and *both* unparseable-input cases block.
- **End-to-end flow**: red-on-red merges and says so in the approval body; red-on-green defers with no approval posted; a new failure against a red base defers; an unparseable baseline defers; and a passing PR never invokes the baseline at all.

Existing deferral-path tests were given a green-baseline stub so their original intent is preserved unchanged.
