### PR TITLE
fix(orchestrator): provisioning failures report themselves instead of crashing (Closes #1993, Closes #1994)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -671,6 +671,50 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
     return update_stage_result(state, stage, result)
 
 
+_MISSING_ROOT_PACKAGE = "the current project could not be installed"
+
+
+def _provision_worktree_env(worktree_path: Path) -> subprocess.CompletedProcess:
+    """Install the target worktree's dependencies, tolerating a not-yet-built package.
+
+    #1904 provisions the worktree so tests run in the TARGET's environment
+    rather than AssemblyZero's -- phase 3 of the boostgauge campaign passed on
+    AssemblyZero's Pillow and phase 4 died on the target's psutil. That finding
+    is about DEPENDENCIES; installing the project's own package is incidental.
+
+    #1994: provisioning runs BEFORE the implementation stage writes any code, so
+    on a base that predates the work -- exactly what an idempotent roll requires
+    (#1959, #1968, #1986) -- the project package does not exist yet and poetry
+    refuses with "No file/folder found for package <name>". The first roll of
+    any arc therefore failed to provision.
+
+    So: try the full install, and retry with --no-root ONLY when the failure was
+    the absent root package. Where the package does exist it is still installed,
+    because that is what makes `import <pkg>` resolve the way the target repo
+    expects; dropping it unconditionally would trade a loud failure for a subtle
+    one.
+    """
+    result = run_command(
+        ["poetry", "install"],
+        cwd=str(worktree_path), check=False, capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return result
+
+    combined = f"{result.stdout or ''}\n{result.stderr or ''}".lower()
+    if _MISSING_ROOT_PACKAGE not in combined:
+        return result
+
+    print(
+        "    [ENV] project package not present yet (base predates the code); "
+        "retrying with --no-root"
+    )
+    return run_command(
+        ["poetry", "install", "--no-root"],
+        cwd=str(worktree_path), check=False, capture_output=True, text=True,
+    )
+
+
 def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute implementation workflow (TDD).
 
@@ -758,28 +802,33 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # are worse than no tests.
             if (worktree_path / "pyproject.toml").is_file():
                 print("    [ENV] poetry install (target worktree)...")
-                install_result = run_command(
-                    ["poetry", "install"],
-                    cwd=str(worktree_path),
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
+                install_result = _provision_worktree_env(worktree_path)
                 if install_result.returncode != 0:
                     detail = (
                         (install_result.stderr or "").strip()
                         or (install_result.stdout or "").strip()
                         or "no output"
                     )
-                    return _make_stage_result(
-                        status="failed",
-                        error_message=(
-                            f"Worktree environment provisioning failed "
-                            f"(poetry install exit {install_result.returncode}): "
-                            f"{detail[:400]}"
+                    # #1993: every OTHER exit from this function returns
+                    # update_stage_result(...). This one returned a bare stage
+                    # result, so `state` -- and with it `issue_number` -- was
+                    # gone by the time graph.py persisted it, and the run died
+                    # with `KeyError: 'issue_number'` from save_orchestration_state.
+                    # The path that exists to REPORT a provisioning failure was
+                    # destroying the report and hiding its own cause.
+                    return update_stage_result(
+                        state,
+                        stage,
+                        _make_stage_result(
+                            status="failed",
+                            error_message=(
+                                f"Worktree environment provisioning failed "
+                                f"(poetry install exit "
+                                f"{install_result.returncode}): {detail[:400]}"
+                            ),
+                            duration_seconds=time.monotonic() - start_time,
+                            attempts=1,
                         ),
-                        duration_seconds=time.monotonic() - start_time,
-                        attempts=1,
                     )
                 print("    [ENV] worktree environment ready")
 

--- a/tests/unit/test_impl_stage_provisioning.py
+++ b/tests/unit/test_impl_stage_provisioning.py
@@ -1,0 +1,199 @@
+"""Provisioning failures report themselves instead of crashing (#1993, #1994).
+
+Both defects surfaced on one live roll (boostgauge #19, 2026-07-31) and each
+hid the other:
+
+- #1994: `poetry install` runs BEFORE the implementation writes any code, so on
+  a base that predates the work -- exactly what an idempotent roll requires --
+  the project package does not exist and poetry refuses. The first roll of any
+  arc could not provision.
+- #1993: the path that reports that failure returned a BARE stage result rather
+  than `update_stage_result(state, ...)`, so `issue_number` was gone by the time
+  graph.py persisted the state and the run died with `KeyError: 'issue_number'`
+  inside save_orchestration_state -- 60 lines of traceback with no mention of
+  poetry. Diagnosing the real cause required reproducing the install by hand.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.orchestrator import stages
+
+MISSING_ROOT = (
+    "Installing the current project: boostgauge (0.1.0)\n"
+    "Error: The current project could not be installed: "
+    "No file/folder found for package boostgauge\n"
+)
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    # mock-ok: subprocess boundary, and a REAL CompletedProcess (standard 0024).
+    return subprocess.CompletedProcess(
+        args=["poetry", "install"], returncode=returncode,
+        stdout=stdout, stderr=stderr,
+    )
+
+
+class TestNoRootFallback:
+    def test_successful_install_is_not_retried(self, tmp_path):
+        calls = []
+
+        def fake(cmd, **kw):
+            calls.append(cmd)
+            return _completed()
+
+        with patch.object(stages, "run_command", fake):
+            result = stages._provision_worktree_env(tmp_path)
+
+        assert result.returncode == 0
+        assert calls == [["poetry", "install"]], calls
+
+    def test_absent_root_package_retries_with_no_root(self, tmp_path):
+        calls = []
+
+        def fake(cmd, **kw):
+            calls.append(cmd)
+            if "--no-root" in cmd:
+                return _completed()
+            return _completed(returncode=1, stderr=MISSING_ROOT)
+
+        with patch.object(stages, "run_command", fake):
+            result = stages._provision_worktree_env(tmp_path)
+
+        assert result.returncode == 0
+        assert calls[-1] == ["poetry", "install", "--no-root"], calls
+
+    def test_the_message_is_matched_on_stdout_too(self, tmp_path):
+        """Poetry writes this to stdout in some versions, stderr in others."""
+        calls = []
+
+        def fake(cmd, **kw):
+            calls.append(cmd)
+            if "--no-root" in cmd:
+                return _completed()
+            return _completed(returncode=1, stdout=MISSING_ROOT)
+
+        with patch.object(stages, "run_command", fake):
+            stages._provision_worktree_env(tmp_path)
+
+        assert ["poetry", "install", "--no-root"] in calls
+
+    def test_an_unrelated_failure_is_not_retried(self, tmp_path):
+        """--no-root must not become a blanket retry that masks real breakage."""
+        calls = []
+
+        def fake(cmd, **kw):
+            calls.append(cmd)
+            return _completed(returncode=1, stderr="Could not parse pyproject.toml")
+
+        with patch.object(stages, "run_command", fake):
+            result = stages._provision_worktree_env(tmp_path)
+
+        assert result.returncode == 1
+        assert calls == [["poetry", "install"]], calls
+
+    def test_a_failing_no_root_retry_still_reports_failure(self, tmp_path):
+        def fake(cmd, **kw):
+            if "--no-root" in cmd:
+                return _completed(returncode=2, stderr="lock file is stale")
+            return _completed(returncode=1, stderr=MISSING_ROOT)
+
+        with patch.object(stages, "run_command", fake):
+            result = stages._provision_worktree_env(tmp_path)
+
+        assert result.returncode == 2
+        assert "lock file is stale" in result.stderr
+
+
+class TestFailureKeepsTheState:
+    """#1993: the report must survive the failure it is reporting."""
+
+    @pytest.fixture
+    def state(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "pyproject.toml").write_text("[tool.poetry]", encoding="utf-8")
+        return {
+            "issue_number": 19,
+            "target_repo": str(target),
+            "assemblyzero_root": str(tmp_path / "az"),
+            "base_branch": "hardening-run-12",
+        }
+
+    def _run_with_failing_install(self, state, tmp_path):
+        # The worktree must NOT pre-exist: run_impl_stage skips creation AND
+        # provisioning when it is already a directory, which would let these
+        # tests pass on a path that never runs. The fake `git worktree add`
+        # materialises it, as the real one would.
+        worktree = tmp_path / "target-19"
+
+        def fake(cmd, **kw):
+            if "worktree" in cmd and "add" in cmd:
+                worktree.mkdir(parents=True, exist_ok=True)
+                (worktree / "pyproject.toml").write_text(
+                    "[tool.poetry]", encoding="utf-8"
+                )
+            return _completed()
+
+        def failing_env(_path):
+            return _completed(returncode=1, stderr="boom: dependency resolution failed")
+
+        with patch.object(stages, "run_command", fake), \
+             patch.object(stages, "_provision_worktree_env", failing_env), \
+             patch.object(stages, "worktree_path_for", lambda *a, **k: worktree):
+            return stages.run_impl_stage(dict(state))
+
+    def test_the_provisioning_path_actually_ran(self, state, tmp_path):
+        """Guards the guard: if the worktree pre-exists, run_impl_stage skips
+        provisioning entirely and the assertions below prove nothing."""
+        result = self._run_with_failing_install(state, tmp_path)
+
+        blob = str(result.get("stage_results", {}).get("impl", {}))
+        assert "provisioning failed" in blob, (
+            "provisioning was skipped; these tests would be vacuous"
+        )
+
+    def test_issue_number_survives_a_provisioning_failure(self, state, tmp_path):
+        """save_orchestration_state does state['issue_number']; losing it turned
+        a reportable failure into KeyError."""
+        result = self._run_with_failing_install(state, tmp_path)
+
+        assert "issue_number" in result, result
+        assert result["issue_number"] == 19
+
+    def test_the_failure_is_recorded_as_a_stage_result(self, state, tmp_path):
+        result = self._run_with_failing_install(state, tmp_path)
+
+        impl = result.get("stage_results", {}).get("impl", {})
+        assert impl.get("status") == "failed", result
+
+    def test_the_real_cause_reaches_the_operator(self, state, tmp_path):
+        """The whole point: the poetry output must not be thrown away."""
+        result = self._run_with_failing_install(state, tmp_path)
+
+        blob = str(result.get("stage_results", {}).get("impl", {}))
+        assert "provisioning failed" in blob
+        assert "dependency resolution failed" in blob
+
+
+class TestEveryExitKeepsTheState:
+    """The defect was one exit out of twelve with the wrong shape, so assert on
+    the shape rather than on any single path."""
+
+    def test_no_bare_stage_result_returns_remain(self):
+        source = Path(stages.__file__).read_text(encoding="utf-8")
+        impl = source[source.index("def run_impl_stage("):]
+        impl = impl[: impl.index("\ndef ")]
+
+        bare = [
+            line.strip()
+            for line in impl.splitlines()
+            if line.strip().startswith("return _make_stage_result(")
+        ]
+        assert bare == [], (
+            "every return in run_impl_stage must be wrapped in "
+            f"update_stage_result(state, ...); found bare: {bare}"
+        )


### PR DESCRIPTION
Closes #1993
Closes #1994

Both surfaced on one live roll (boostgauge #19, 2026-07-31) while smoke-testing `speedrun_roll.py` before a recorded run. **Each hid the other.**

## #1994 — the first roll of any arc could not provision

`poetry install` runs *before* the implementation stage writes any code. On a base that predates the work — exactly what an idempotent roll requires (#1959, #1968, #1986) — the project package does not exist yet:

```
Error: The current project could not be installed:
No file/folder found for package boostgauge
```

boostgauge's `main` carries `pyproject.toml` and the `docs/lld` scaffolding but no `src/boostgauge/`; the arc's source lives only on the branch that built it. A collision between two correct requirements, not a mistake in either.

#1904's finding was about **dependencies** (phase 3 passing on AssemblyZero's Pillow, phase 4 dying on the target's psutil). Installing the root package is incidental. So the install now retries with `--no-root` **when, and only when**, the failure was the absent root package. Where the package exists it is still installed — that is what makes `import <pkg>` resolve as the target repo expects, and dropping it unconditionally would trade a loud failure for a subtle one. Unrelated failures are not retried.

## #1993 — the failure report destroyed itself

The provisioning-failure path returned a bare `_make_stage_result(...)`; all **eleven** other exits from `run_impl_stage` return `update_stage_result(state, ...)`. So `state` — and `issue_number` with it — was gone by the time `graph.py` persisted it:

```
KeyError: 'issue_number'   (resume.py:33, save_orchestration_state)
```

Sixty lines of traceback with no mention of poetry. The `error_message` naming the exit code and install output was discarded, and the issue's resume state went with it. **The path that exists to report a failure was hiding its own cause** — diagnosing it required reproducing the install by hand.

## Verification

- **10 tests.** The `--no-root` fallback is pinned in both directions: retries on the absent-package message (stdout *or* stderr, since poetry varies), does **not** retry an unrelated failure, and still reports failure when the retry itself fails. State-shape tests assert `issue_number` survives, the stage records `status=failed`, and the poetry output reaches the operator.
- **Two of those tests initially passed for the wrong reason** — the fixture pre-created the worktree, which makes `run_impl_stage` skip creation *and* provisioning entirely. The fake `git worktree add` now materialises it as the real one would, and a guard test asserts the provisioning path actually ran so the others cannot go vacuous again.
- A final test parses `run_impl_stage` and fails on any remaining bare return, because the defect was one exit out of twelve having the wrong shape.
- **Full suite 6520 passed**, 17 skipped, 5 xfailed, **0 failures**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)