### PR TITLE
fix(dependabot): an unusable worktree is an unestablishable baseline, not a crash (Closes #1997)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -135,6 +135,11 @@ def test_deferred_test_fail_path_calls_cleanup_worktree(tmp_path):
     returning 'deferred'. #1116."""
     main_repo = tmp_path / "repo"
     main_repo.mkdir()
+    # #1997: the real create_audit_worktree CREATES this directory, and #1992's
+    # baseline gate chdirs into it. Returning the path without creating it
+    # asserted against a state that cannot occur, and made CI red on Linux
+    # where a nonexistent cwd raises before git ever runs.
+    (tmp_path / "repo-dependabot-43").mkdir()
     pr = dependabot_review.PRInfo(
         number=43, title="bump foo", author_login="dependabot[bot]",
         body="", head_ref="dependabot/pip/foo",
@@ -1038,3 +1043,47 @@ class TestProcessRepoWithBudget:
         assert set(sub) == {
             "merged", "deferred", "errored", "limit_skipped", "skipped_unchanged",
         }
+
+
+# ---- #1997: an unusable worktree is an unestablishable baseline ----
+
+
+class TestBaselineGateSurvivesAMissingWorktree:
+    """#1992's baseline gate chdirs into the audit worktree. On Linux a
+    nonexistent cwd raises OSError before git runs, and nothing caught it, so
+    one vanished directory killed an entire fleet sweep. The function already
+    documents the safe answer for a baseline it cannot establish -- (0, "")
+    reads as 'not exonerable' -- and that is where this must land."""
+
+    def _pr(self):
+        return dependabot_review.PRInfo(
+            number=43, title="bump foo", author_login="dependabot[bot]",
+            body="", head_ref="dependabot/pip/foo",
+        )
+
+    def test_missing_worktree_returns_not_exonerable(self, tmp_path):
+        code, output = dependabot_review.run_baseline_gate(
+            self._pr(), tmp_path / "does-not-exist", touches_py=True, js_dirs=[]
+        )
+
+        assert (code, output) == (0, "")
+
+    def test_missing_worktree_does_not_raise(self, tmp_path):
+        """The regression itself: this used to raise FileNotFoundError."""
+        try:
+            dependabot_review.run_baseline_gate(
+                self._pr(), tmp_path / "gone", touches_py=True, js_dirs=[]
+            )
+        except OSError as err:  # pragma: no cover - the failure being pinned
+            raise AssertionError(f"baseline gate raised instead of deferring: {err}")
+
+    def test_it_says_why_on_stderr(self, tmp_path, capsys):
+        dependabot_review.run_baseline_gate(
+            self._pr(), tmp_path / "gone", touches_py=True, js_dirs=[]
+        )
+
+        assert "not exonerable" in capsys.readouterr().err
+
+    def test_a_red_gate_is_never_exonerated_by_an_unknown_baseline(self):
+        """(0, "") must not read as a green baseline that clears the bump."""
+        assert not dependabot_review.is_exonerated_by_baseline({"test_a"}, set())

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -1321,7 +1321,18 @@ def run_baseline_gate(pr: PRInfo, worktree: Path, touches_py: bool,
     branch = f"dependabot-audit-{pr.number}"
     print(f"  BASELINE: re-running the gate on the base ({branch}) to see "
           f"whether these failures predate the bump (#1992)")
-    if run(["git", "checkout", branch], cwd=str(worktree)).returncode != 0:
+    # #1997: a missing worktree makes subprocess raise OSError on the cwd
+    # BEFORE git runs, which killed the whole sweep. That is exactly an
+    # unestablishable baseline, and this function already has the safe answer
+    # for one -- (0, "") reads as "not exonerable" -- so route there rather
+    # than raising.
+    try:
+        checkout = run(["git", "checkout", branch], cwd=str(worktree))
+    except OSError as err:
+        print(f"  BASELINE: worktree unusable ({err}) -- not exonerable",
+              file=sys.stderr)
+        return 0, ""
+    if checkout.returncode != 0:
         print("  BASELINE: could not restore the base commit -- not "
               "exonerable", file=sys.stderr)
         return 0, ""


### PR DESCRIPTION
Closes #1997

**`main` has been red since `d4c011d1`** (#1992 / PR #1995). Every PR opened against it fails through no fault of its own — including #1996, which is how I found this.

```
tests/unit/test_dependabot_review.py::test_deferred_test_fail_path_calls_cleanup_worktree FAILED
FileNotFoundError: [Errno 2] No such file or directory:
  '/tmp/pytest-of-runner/pytest-0/test_deferred_test_fail_path_c0/repo-dependabot-43'
```

## Two defects, one symptom

**Production.** `run_baseline_gate` runs `git checkout` with `cwd=worktree`. If that directory is absent, `subprocess` raises `OSError` on the cwd *before git runs*, and nothing catches it — so one vanished audit worktree takes down an entire fleet sweep.

The function already documents the correct answer for this: `(0, "")` means *"could not restore the base commit"*, which the caller reads as **not exonerable**, because *"an unknown baseline must never license a merge."* A missing worktree is exactly an unestablishable baseline. It now routes there instead of raising.

**Test.** The fixture mocked `create_audit_worktree` to return a path it never created, while the real function creates it — asserting against a state that cannot occur. It only surfaced once #1992 added a path that actually chdirs into it. Windows tolerates a nonexistent cwd differently, which is why this was green locally and red in CI; that platform split is how it landed.

Fixing only the test would leave a fleet sweep able to die on a missing directory. Fixing only production would leave a fixture that lies about reality. Both are here.

## Verification

- **4 regression tests**: a missing worktree returns exactly `(0, "")`, does not raise, says why on stderr, and — the one that matters — an unknown baseline **never** exonerates a red gate, so the safe return cannot be mistaken for a green baseline that clears the bump.
- **Full suite 6530 passed**, 17 skipped, 5 xfailed, **0 failures**. `ruff` clean.