### PR TITLE
feat(speedrun): a roll returns what it borrowed, says how it died, and refuses stale code (Closes #2005, Closes #2006, Closes #2007)

### DIFF
--- a/tests/unit/test_speedrun_roll.py
+++ b/tests/unit/test_speedrun_roll.py
@@ -227,7 +227,15 @@ class TestNoHumanInputBeyondRepoAndIssue:
             seen[issue] = (repo_root, log_dir)
             return 0
 
-        with patch.object(sr, "roll_issue", fake_roll):
+        # #2005/#2007: main() now gates on the AssemblyZero tree and
+        # restores the repo in a finally. Neither is what these tests
+        # measure, and both reach the real filesystem, so both are stubbed.
+        stubs = {
+            "check_assemblyzero_tree": lambda p: [],
+            "restore_repo": lambda *a: [],
+            "roll_issue": fake_roll,
+        }
+        with patch.multiple(sr, **stubs):
             code = sr.main(["--repo", str(repo), "--issue", "4", "--issue", "2"])
 
         assert code == 0
@@ -240,7 +248,15 @@ class TestNoHumanInputBeyondRepoAndIssue:
             rolled.append(issue)
             return 91 if issue == 4 else 0
 
-        with patch.object(sr, "roll_issue", fake_roll):
+        # #2005/#2007: main() now gates on the AssemblyZero tree and
+        # restores the repo in a finally. Neither is what these tests
+        # measure, and both reach the real filesystem, so both are stubbed.
+        stubs = {
+            "check_assemblyzero_tree": lambda p: [],
+            "restore_repo": lambda *a: [],
+            "roll_issue": fake_roll,
+        }
+        with patch.multiple(sr, **stubs):
             code = sr.main(["--repo", str(repo), "--issue", "4", "--issue", "2"])
 
         assert code == 91
@@ -253,7 +269,15 @@ class TestNoHumanInputBeyondRepoAndIssue:
             captured["extra"] = extra
             return 0
 
-        with patch.object(sr, "roll_issue", fake_roll):
+        # #2005/#2007: main() now gates on the AssemblyZero tree and
+        # restores the repo in a finally. Neither is what these tests
+        # measure, and both reach the real filesystem, so both are stubbed.
+        stubs = {
+            "check_assemblyzero_tree": lambda p: [],
+            "restore_repo": lambda *a: [],
+            "roll_issue": fake_roll,
+        }
+        with patch.multiple(sr, **stubs):
             sr.main(["--repo", str(repo), "--issue", "4", "--max-iterations", "5"])
 
         assert captured["extra"] == ["--max-iterations", "5"]

--- a/tests/unit/test_speedrun_roll_lifecycle.py
+++ b/tests/unit/test_speedrun_roll_lifecycle.py
@@ -1,0 +1,240 @@
+"""A roll returns what it borrowed, says how it died, and refuses stale code.
+
+Three defects observed on live rolls of boostgauge on 2026-07-31:
+
+- #2005 the repo was handed back on the attempt branch with pipeline worktrees
+  still registered;
+- #2006 a roll died seven minutes in leaving only START/BASE/LAUNCH, because the
+  signal traps the bash wrapper had were never reimplemented in the Python
+  rewrite -- so "killed by a supervisor" and "died silently" looked identical;
+- #2007 a tool run from a shared checkout parked on another lane's branch
+  executed pipeline code two commits behind main and failed with a TypeError
+  that was already fixed and merged.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+def _make_repo(tmp_path, name="boostgauge", default="main"):
+    upstream = tmp_path / f"{name}-up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", default)
+    r = tmp_path / name
+    r.mkdir()
+    _git(r, "init", "-b", default)
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", default)
+    _git(r, "remote", "set-head", "origin", default)
+    return r
+
+
+@pytest.fixture
+def log(tmp_path):
+    return sr.EventLog(tmp_path / "events.log")
+
+
+class TestRestoreHandsTheRepoBack:
+    @pytest.fixture
+    def repo(self, tmp_path):
+        r = _make_repo(tmp_path)
+        _git(r, "checkout", "-b", "hardening-run-12")
+        _git(r, "push", "-u", "origin", "hardening-run-12")
+        _git(r, "worktree", "add", str(tmp_path / "boostgauge-7"), "-b", "issue-7")
+        return r
+
+    def test_ends_on_the_default_branch(self, repo, log):
+        assert sr.restore_repo(repo, [7], log) == []
+        assert sr.attempt.current_branch(repo) == "main"
+
+    def test_pipeline_worktrees_are_gone(self, repo, log):
+        sr.restore_repo(repo, [7], log)
+        worktrees = subprocess.run(
+            ["git", "worktree", "list"], cwd=str(repo),
+            capture_output=True, text=True,
+        ).stdout.strip().splitlines()
+        assert len(worktrees) == 1, worktrees
+
+    def test_the_attempt_branch_survives(self, repo, log):
+        """Restoring the checkout must not destroy the run's integration branch."""
+        sr.restore_repo(repo, [7], log)
+        assert sr.attempt.local_branch_exists(repo, "hardening-run-12")
+
+    def test_default_branch_is_read_not_assumed(self, tmp_path, log):
+        r = _make_repo(tmp_path, name="trunkrepo", default="trunk")
+        _git(r, "checkout", "-b", "attempt-1")
+
+        assert sr.restore_repo(r, [], log) == []
+        assert sr.attempt.current_branch(r) == "trunk"
+
+    def test_it_reports_rather_than_claims_when_it_cannot_finish(
+        self, tmp_path, log
+    ):
+        r = tmp_path / "norigin"
+        r.mkdir()
+        _git(r, "init", "-b", "main")
+        (r / "f.txt").write_text("x", encoding="utf-8")
+        _git(r, "add", "-A")
+        _git(r, "commit", "-m", "init")
+
+        failures = sr.restore_repo(r, [], log)
+        assert failures and "origin/HEAD" in failures[0]
+
+
+class TestRestoreRunsOnEveryExit:
+    @pytest.fixture
+    def repo(self, tmp_path):
+        r = _make_repo(tmp_path)
+        _git(r, "checkout", "-b", "hardening-run-12")
+        _git(r, "push", "-u", "origin", "hardening-run-12")
+        return r
+
+    def _main(self, repo, roll_result):
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+             patch.object(sr, "roll_issue", roll_result):
+            return sr.main(["--repo", str(repo), "--issue", "7"])
+
+    def test_restores_after_a_successful_roll(self, repo):
+        self._main(repo, lambda *a: 0)
+        assert sr.attempt.current_branch(repo) == "main"
+
+    def test_restores_after_a_failed_roll(self, repo):
+        code = self._main(repo, lambda *a: 91)
+        assert code == 91
+        assert sr.attempt.current_branch(repo) == "main"
+
+    def test_restores_when_the_roll_raises(self, repo):
+        def boom(*a):
+            raise RuntimeError("pipeline exploded")
+
+        with pytest.raises(RuntimeError):
+            self._main(repo, boom)
+        assert sr.attempt.current_branch(repo) == "main"
+
+    def test_restores_on_the_signal_exit_path(self, repo):
+        """SignalExit is a SystemExit, so `finally` still fires -- that is the
+        whole reason the handler raises instead of calling os._exit."""
+        def killed(*a):
+            raise sr.SignalExit(90)
+
+        with pytest.raises(SystemExit):
+            self._main(repo, killed)
+        assert sr.attempt.current_branch(repo) == "main"
+
+
+class TestSignalHandlersAreRealNotDocumented:
+    def test_handlers_are_installed_for_the_catchable_signals(self, log):
+        import signal
+
+        originals = {}
+        for attr in ("SIGTERM", "SIGINT"):
+            sig = getattr(signal, attr)
+            originals[sig] = signal.getsignal(sig)
+        try:
+            sr.install_signal_handlers(log)
+            for sig in originals:
+                assert signal.getsignal(sig) not in (
+                    signal.SIG_DFL, signal.SIG_IGN, originals[sig]
+                ), f"{sig} handler not installed"
+        finally:
+            for sig, handler in originals.items():
+                signal.signal(sig, handler)
+
+    def test_the_handler_logs_the_signal_then_exits(self, log):
+        import signal
+
+        original = signal.getsignal(signal.SIGTERM)
+        try:
+            sr.install_signal_handlers(log)
+            handler = signal.getsignal(signal.SIGTERM)
+            with pytest.raises(SystemExit):
+                handler(signal.SIGTERM, None)
+        finally:
+            signal.signal(signal.SIGTERM, original)
+
+        assert "SIGNAL: SIGTERM received" in log.path.read_text(encoding="utf-8")
+
+
+class TestAssemblyZeroTreeGate:
+    @pytest.fixture
+    def az(self, tmp_path):
+        return _make_repo(tmp_path, name="AssemblyZero")
+
+    def test_a_level_tree_passes(self, az):
+        assert sr.check_assemblyzero_tree(az) == []
+
+    def test_a_tree_behind_main_is_refused(self, az):
+        """The live failure: right branch name, stale code."""
+        (az / "tools").mkdir()
+        (az / "tools" / "x.py").write_text("new", encoding="utf-8")
+        _git(az, "add", "-A")
+        _git(az, "commit", "-m", "advance main")
+        _git(az, "push")
+        _git(az, "reset", "--soft", "HEAD~1")
+        _git(az, "checkout", "--", ".")
+        _git(az, "stash", "-u")
+
+        problems = sr.check_assemblyzero_tree(az)
+        assert any("behind origin/main" in p for p in problems), problems
+
+    def test_a_detached_tree_at_origin_main_passes(self, az):
+        """A pinned worktree is a legitimate way to run a roll; a branch-name
+        check would have rejected it."""
+        sha = subprocess.run(
+            ["git", "rev-parse", "origin/main"], cwd=str(az),
+            capture_output=True, text=True,
+        ).stdout.strip()
+        _git(az, "checkout", sha)
+
+        assert sr.check_assemblyzero_tree(az) == []
+
+    def test_tracked_modifications_to_pipeline_code_are_refused(self, az):
+        (az / "tools").mkdir()
+        (az / "tools" / "t.py").write_text("v1", encoding="utf-8")
+        _git(az, "add", "-A")
+        _git(az, "commit", "-m", "add tool")
+        _git(az, "push")
+        (az / "tools" / "t.py").write_text("locally edited", encoding="utf-8")
+
+        problems = sr.check_assemblyzero_tree(az)
+        assert any("tracked modification" in p for p in problems), problems
+
+    def test_untracked_files_are_ignored(self, az):
+        """Other lanes leave one-off scripts in tools/; they do not change the
+        code being executed."""
+        (az / "tools").mkdir()
+        (az / "tools" / "land_something.py").write_text("x", encoding="utf-8")
+
+        assert sr.check_assemblyzero_tree(az) == []
+
+    def test_a_stale_tree_blocks_the_roll_before_anything_is_spent(self, tmp_path):
+        repo = _make_repo(tmp_path)
+        rolled = []
+
+        with patch.object(
+            sr, "check_assemblyzero_tree", lambda p: ["2 commit(s) behind origin/main"]
+        ), patch.object(sr, "roll_issue", lambda *a: rolled.append(a) or 0):
+            code = sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert code == 91
+        assert rolled == [], "a stale tree must block before any roll starts"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -47,6 +47,14 @@ import speedrun_reset as reset
 HEARTBEAT_SECONDS = 15
 DEFAULT_PREFIX = "hardening-run"
 
+# Directories whose contents ARE the pipeline. A tracked modification here means
+# the roll would execute code that is not what main says it is (#2007).
+_CODE_DIRS = ("tools", "assemblyzero")
+
+
+class SignalExit(SystemExit):
+    """Raised from a signal handler so the restore in `finally` still runs."""
+
 
 def _stamp() -> str:
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -299,6 +307,139 @@ def _child_env() -> dict[str, str]:
     return env
 
 
+def install_signal_handlers(log: EventLog) -> None:
+    """Log TERM/INT/BREAK/HUP to the events file, then exit via the normal path.
+
+    #2006: the bash wrapper trapped these and logged them; the Python rewrite
+    kept the docstring claiming "trapped signals" and shipped none. A roll of
+    boostgauge #7 then died seven minutes in leaving only START/BASE/LAUNCH, so
+    "killed by a supervisor" and "died silently" were indistinguishable -- and
+    those have different remedies.
+
+    The log line is the point, not the graceful exit. SIGKILL cannot be caught,
+    but once TERM and INT are recorded, a death with NO signal line becomes
+    evidence FOR SIGKILL rather than an absence of information.
+    """
+    import signal
+
+    def _handler(signum: int, _frame: object) -> None:
+        try:
+            name = signal.Signals(signum).name
+        except ValueError:  # pragma: no cover - platform-specific numbers
+            name = str(signum)
+        log.write(f"SIGNAL: {name} received")
+        raise SignalExit(90)
+
+    for attr in ("SIGTERM", "SIGINT", "SIGBREAK", "SIGHUP"):
+        sig = getattr(signal, attr, None)
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _handler)
+        except (OSError, ValueError):  # pragma: no cover - not settable here
+            continue
+
+
+def check_assemblyzero_tree(az_root: Path) -> list[str]:
+    """Reasons the AssemblyZero tree running this roll is not trustworthy (#2007).
+
+    The checkout is shared across concurrent lanes and can be parked on another
+    lane's branch at an older commit, in which case the roll executes stale
+    pipeline code with no indication. That happened: `Projects/AssemblyZero` sat
+    on `1428-canonical-claude-backup` two commits behind main, and a reset run
+    from it failed with a TypeError that was already fixed and merged.
+
+    The assertion is about the COMMIT, not the branch. "Is it named main" is
+    wrong in both directions -- on main but behind is exactly the failure above,
+    and a detached worktree pinned at origin/main is a perfectly good way to run
+    a roll. Untracked files are ignored: other lanes routinely leave one-off
+    scripts in tools/, and those do not change the code being executed.
+    """
+    problems: list[str] = []
+    if not (az_root / ".git").exists():
+        return [f"{az_root} is not an AssemblyZero checkout"]
+
+    _run(["git", "fetch", "origin"], cwd=az_root)
+
+    behind = _run(
+        ["git", "rev-list", "--count", "HEAD..origin/main"], cwd=az_root
+    )
+    if behind.returncode != 0 or not behind.stdout.strip().isdigit():
+        problems.append("cannot compare this tree against origin/main")
+    elif int(behind.stdout.strip()) > 0:
+        head = _run(["git", "log", "--oneline", "-1"], cwd=az_root).stdout.strip()
+        problems.append(
+            f"{int(behind.stdout.strip())} commit(s) behind origin/main "
+            f"(HEAD: {head}) -- this roll would run stale pipeline code"
+        )
+
+    dirty = _run(
+        ["git", "status", "--porcelain", "--", *_CODE_DIRS], cwd=az_root
+    )
+    modified = [
+        line for line in dirty.stdout.splitlines() if not line.startswith("??")
+    ]
+    if modified:
+        problems.append(
+            f"{len(modified)} tracked modification(s) under "
+            f"{'/, '.join(_CODE_DIRS)}/ -- the pipeline is not what main says"
+        )
+    return problems
+
+
+def restore_repo(repo_root: Path, issues: list[int], log: EventLog) -> list[str]:
+    """Hand the repo back the way it was borrowed (#2005). Returns failures.
+
+    A roll leaves the target checked out on the attempt branch with pipeline
+    worktrees registered. Being handed that back is a defect: a run should
+    return the repo to the state it took.
+
+    Called from a `finally`, so it runs on success, on failure, and on any
+    exception -- including the SignalExit raised by the handlers above. It
+    cannot run under SIGKILL; that gap is covered only by the next invocation's
+    self-heal, and is stated rather than papered over.
+    """
+    log.write("RESTORE returning the repo to its default branch")
+
+    for issue in issues:
+        reset.remove_worktree(repo_root, issue)
+
+    base = attempt.default_branch(repo_root)
+    if not base:
+        return ["cannot resolve origin/HEAD; leaving the checkout as it is"]
+
+    checkout = _run(["git", "checkout", base], cwd=repo_root)
+    if checkout.returncode != 0:
+        return [f"could not check out {base}: {(checkout.stderr or '').strip()}"]
+
+    failures: list[str] = []
+    current = attempt.current_branch(repo_root)
+    if current != base:
+        failures.append(f"expected to end on '{base}', ended on '{current}'")
+
+    worktrees = [
+        line for line in _run(
+            ["git", "worktree", "list", "--porcelain"], cwd=repo_root
+        ).stdout.splitlines() if line.startswith("worktree ")
+    ]
+    if len(worktrees) != 1:
+        failures.append(
+            f"{len(worktrees) - 1} pipeline worktree(s) still registered"
+        )
+
+    tracked = [
+        line for line in _run(
+            ["git", "status", "--porcelain"], cwd=repo_root
+        ).stdout.splitlines() if not line.startswith("??")
+    ]
+    if tracked:
+        failures.append(f"{len(tracked)} tracked modification(s) left behind")
+
+    if not failures:
+        log.write(f"RESTORE verified: on '{base}', no pipeline worktrees, clean")
+    return failures
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -337,15 +478,44 @@ def main(argv: list[str] | None = None) -> int:
         else repo_root / "data" / "speedrun" / "runs"
     )
 
-    for issue in args.issue:
-        code = roll_issue(repo_root, issue, log_dir, az_root, extra)
-        if code != 0:
-            print(f"\nSTOPPED at #{issue} (exit {code}); later issues not rolled.")
-            return code
-        time.sleep(1)
+    session = EventLog(log_dir / "session-events.log")
+    install_signal_handlers(session)
 
-    print(f"\nAll {len(args.issue)} issue(s) rolled.")
-    return 0
+    # #2007: refuse before spending anything if the tree running this roll is
+    # not the code main says it is.
+    stale = check_assemblyzero_tree(az_root)
+    if stale:
+        print(f"BLOCKED: the AssemblyZero tree at {az_root} is not trustworthy:")
+        for s in stale:
+            print(f"  - {s}")
+        print(
+            "\n  Bring it level with origin/main (or point --assemblyzero-root "
+            "at a tree that is)\n  before rolling. A roll that runs stale "
+            "pipeline code fails in ways that look\n  like target-repo problems."
+        )
+        return 91
+
+    code = 0
+    try:
+        for issue in args.issue:
+            code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+            if code != 0:
+                print(
+                    f"\nSTOPPED at #{issue} (exit {code}); later issues not rolled."
+                )
+                return code
+            time.sleep(1)
+
+        print(f"\nAll {len(args.issue)} issue(s) rolled.")
+        return 0
+    finally:
+        # #2005: hand the repo back the way it was borrowed -- on success, on
+        # failure, and on the SignalExit raised by the handlers.
+        failures = restore_repo(repo_root, args.issue, session)
+        if failures:
+            print("\nRESTORE INCOMPLETE:")
+            for f in failures:
+                print(f"  - {f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2005
Closes #2006
Closes #2007

Three defects observed on live boostgauge rolls tonight. Shared scope: the integrity of a run's lifecycle.

## #2005 — the repo was handed back on a branch, with worktrees

`restore_repo` removes the pipeline worktrees, checks out the default branch (read from `origin/HEAD`, never assumed), and **asserts** the postconditions: on the default branch, exactly one worktree, no tracked modifications. It runs from a `finally`, so success, failure, and exceptions all restore. The attempt branch survives — restoring the checkout must not destroy the run's integration branch.

**Not covered, stated rather than papered over:** a SIGKILLed process cannot run its own cleanup. That interval is covered only by the next invocation's self-heal.

## #2006 — a killed run couldn't say how it died

The bash wrapper trapped TERM/INT/HUP and logged them. The Python rewrite kept the docstring claiming *"trapped signals"* and shipped none. Tonight's #7 roll died seven minutes in leaving only `START`/`BASE`/`LAUNCH` — so "killed by a supervisor" and "died silently" were indistinguishable, and those have different remedies.

Handlers now log the signal and raise `SignalExit` (a `SystemExit` subclass) so the `finally` still restores. **The log line is the point:** once TERM and INT are recorded, a death with *no* signal line becomes evidence *for* SIGKILL rather than an absence of information.

## #2007 — a roll could execute stale pipeline code

`speedrun_roll` runs from whatever AssemblyZero checkout it lives in, and that checkout is shared across lanes. Tonight it sat on another lane's branch two commits behind main, and a reset run from it failed with a `TypeError` that was already fixed and merged.

The assertion is about the **commit, not the branch**. "Is it named main" is wrong in both directions — on main but *behind* is exactly the failure above, and a detached worktree pinned at `origin/main` is a perfectly good way to run a roll. Untracked files are ignored (other lanes leave one-off scripts in `tools/`; they don't change the code being executed); tracked modifications under `tools/` or `assemblyzero/` do, and are refused.

Validated live while writing it: the gate passes `Projects/AssemblyZero`, and correctly **refused this very worktree** while `speedrun_roll.py` was still uncommitted in it.

## Verification

- **17 new tests.** Restore pinned on all four exit paths including `SignalExit`; attempt branch survives; default branch read not assumed; reports rather than claims when it cannot finish. Signal handlers asserted to be installed *and* to write the line — the previous version's docstring made exactly that claim without the code. Tree gate pinned both directions: behind-main refused, detached-at-origin/main accepted, tracked pipeline edits refused, untracked ignored, stale tree blocks before any roll starts.
- Three existing tests that drove `main()` directly now stub the two new steps.
- **Full suite 6561 passed**, 0 failures. `ruff` clean.