### PR TITLE
fix(requirements): the LLD approval cache lives inside the repo it describes (Closes #1970)

### DIFF
--- a/assemblyzero/workflows/requirements/audit.py
+++ b/assemblyzero/workflows/requirements/audit.py
@@ -21,6 +21,7 @@ import json
 import logging
 import re
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, TypedDict
@@ -35,20 +36,32 @@ AUDIT_ACTIVE_DIR = Path("docs/lineage/active")
 AUDIT_DONE_DIR = Path("docs/lineage/done")
 LLD_ACTIVE_DIR = Path("docs/lld/active")
 LLD_DONE_DIR = Path("docs/lld/done")
-# #1151: LLD approval cache lives OUTSIDE any repo tree. Pre-#1151 this
-# was relative and dirtied every worktree the moment a workflow run
-# wrote an approval entry. Operational cache state shouldn't live in
-# tracked repo paths.
+# Where the LLD approval cache lives, RELATIVE TO THE TARGET REPO (#1970).
 #
-# #1160: the file is shared by every target repo, and the old caller pattern
-# `target_repo / LLD_STATUS_FILE` collapses to this absolute path (Python's
-# `/` semantics), so target_repo was silently discarded. Entries were keyed by
-# bare issue number, and the comment here claimed each one "self-identifies via
-# issue_number / target_repo" -- it did not; no entry carried a repo at all.
-# boostgauge #4 and any other repo's #4 shared one entry, and every entry
-# outlived every repo reset. Entries are now nested under a repo key; see
-# _repo_key and _read_status_file.
-LLD_STATUS_FILE = Path.home() / ".claude" / "assemblyzero" / "lld-status.json"
+# History, because the wrong answer here was deliberate and survived review:
+# #1151 saw that a repo-relative cache dirtied every worktree the moment a run
+# wrote an approval, and "fixed" it by moving the file to
+# `~/.claude/assemblyzero/lld-status.json` -- outside every repo. That traded a
+# visible problem for four hidden ones. The file was shared by every target
+# repo, invisible to the operator, outside version control, and untouched by
+# every cleanup tool including speedrun_reset.
+#
+# The damage was real. #1160 found entries keyed by bare issue number, so two
+# repos' issue #4 shared one entry and every entry outlived every repo reset.
+# #1970 found 42 slices in the live file, all pytest temp directories, because
+# test isolation depended on each test file remembering to monkeypatch a
+# constant -- and before repo-scoping those writes had been OVERWRITING real
+# approvals, leaving fixture issue numbers (42, 50, 77, 99, 100, 200, 300) in a
+# production cache.
+#
+# The universal CLAUDE.md already mandated the right answer: the repo's
+# gitignored `data/`. Operator-visible, per-repo, wiped by repo cleanup, and
+# incapable of colliding. `~/.claude/**` is sanctioned for HARNESS state; an
+# application's approval cache was wearing that exception as a costume.
+#
+# Test isolation now falls out of the design instead of being remembered: a
+# test whose target repo is `tmp_path` writes under `tmp_path`.
+LLD_STATUS_RELATIVE = Path("data") / "assemblyzero" / "lld-status.json"
 
 # Schema version of the shared cache file. "1.0" is the pre-#1160 flat layout
 # whose entries cannot be attributed to a repo.
@@ -597,9 +610,46 @@ def _repo_key(target_repo: Path) -> str:
     collide across the fleet, which is the collision this fix exists to end.
     """
     try:
-        return Path(target_repo).resolve().as_posix()
+        return _main_worktree_root(target_repo).resolve().as_posix()
     except OSError:
         return Path(target_repo).as_posix()
+
+
+def lld_status_path(target_repo: Path) -> Path:
+    """Where THIS repo's approval cache lives: inside it, gitignored (#1970).
+
+    Resolved against the MAIN worktree, not the calling one. A repo's worktrees
+    are separate directories, and the pipeline runs stages from `{repo}-{issue}`
+    worktrees; without this, each worktree would keep its own cache and an
+    approval recorded in one would be invisible to the next.
+
+    `data/` is the destination the universal CLAUDE.md names for agent-written
+    state, and is gitignored fleet-wide, so writing here neither dirties the
+    repo nor hides from the operator.
+    """
+    return _main_worktree_root(target_repo) / LLD_STATUS_RELATIVE
+
+
+def _main_worktree_root(path: Path) -> Path:
+    """The repo's MAIN worktree root, or ``path`` when it is not a git tree.
+
+    Both the cache file's location and its repo key must agree on this. They
+    did not at first: the path resolved to the main worktree while the key
+    resolved to the calling tree, so an approval written from `{repo}-{issue}`
+    landed under a key the repo itself never read -- caught by the worktree
+    test below.
+    """
+    root = Path(path)
+    common = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        cwd=str(root), capture_output=True, text=True,
+    )
+    if common.returncode != 0 or not common.stdout.strip():
+        return root
+    git_dir = Path(common.stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = (root / git_dir).resolve()
+    return git_dir.parent
 
 
 def _empty_status_file() -> dict:
@@ -610,7 +660,7 @@ def _empty_status_file() -> dict:
     }
 
 
-def _read_status_file() -> dict:
+def _read_status_file(target_repo: Path) -> dict:
     """The whole shared cache file, migrated forward to the repo-scoped layout.
 
     A pre-#1160 file is flat: ``issues`` keyed by bare issue number, with no
@@ -622,11 +672,12 @@ def _read_status_file() -> dict:
     dropping them is one extra review per issue; the cost of honouring them is
     skipping a review the workflow was told to perform.
     """
-    if not LLD_STATUS_FILE.exists():
+    status_file = lld_status_path(target_repo)
+    if not status_file.exists():
         return _empty_status_file()
 
     try:
-        data = json.loads(LLD_STATUS_FILE.read_text(encoding="utf-8"))
+        data = json.loads(status_file.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return _empty_status_file()
 
@@ -654,14 +705,14 @@ def load_lld_tracking(target_repo: Path) -> LLDStatusCache:
 
     Args:
         target_repo: Target repository root. Now actually honoured — before
-            #1160 it was discarded by `target_repo / LLD_STATUS_FILE`, so every
+            #1160 it was discarded by path-joining against an absolute constant, so every
             repo read every other repo's entries.
 
     Returns:
         LLDStatusCache dict. Empty cache when the file is missing, corrupt, or
         carries nothing for this repo.
     """
-    raw = _read_status_file()
+    raw = _read_status_file(target_repo)
     slice_ = raw.get("repos", {}).get(_repo_key(target_repo), {})
     issues = slice_.get("issues") if isinstance(slice_, dict) else None
     return {
@@ -683,15 +734,16 @@ def save_lld_tracking(tracking: LLDStatusCache, target_repo: Path) -> None:
         tracking: LLDStatusCache dict for this repo.
         target_repo: Target repository root.
     """
-    raw = _read_status_file()
+    raw = _read_status_file(target_repo)
     raw.setdefault("repos", {})[_repo_key(target_repo)] = {
         "issues": tracking.get("issues", {}),
     }
     raw["version"] = LLD_STATUS_CACHE_VERSION
     raw["last_updated"] = datetime.now(timezone.utc).isoformat()
 
-    LLD_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    LLD_STATUS_FILE.write_text(
+    status_file = lld_status_path(target_repo)
+    status_file.parent.mkdir(parents=True, exist_ok=True)
+    status_file.write_text(
         json.dumps(raw, indent=2) + "\n",
         encoding="utf-8",
     )

--- a/tests/unit/test_lld_cache_repo_isolation.py
+++ b/tests/unit/test_lld_cache_repo_isolation.py
@@ -1,205 +1,222 @@
-"""The LLD status cache is scoped per target repo (#1160).
+"""The LLD approval cache lives inside the repo it describes (#1970, #1160).
 
-PR #1156 moved LLD_STATUS_FILE to an absolute path under ~/.claude. The caller
-pattern `target_repo / LLD_STATUS_FILE` then collapsed to that absolute path --
-Python's `/` discards the left operand when the right is absolute -- so
-`target_repo` was silently ignored on every read and write. Entries were keyed
-by bare issue number with no repo recorded anywhere, which meant:
+#1151 moved this cache to `~/.claude/assemblyzero/lld-status.json` to stop it
+dirtying worktrees. That solved a visible problem by creating four hidden ones:
+one file shared by every target repo, outside version control, invisible to the
+operator, and untouched by every cleanup tool including speedrun_reset.
 
-  - boostgauge #4 and any other repo's #4 shared one entry, each overwriting
-    the other's approval state;
-  - the whole file outlived every repo reset, because `speedrun_reset.py` has
-    no reason to know about a cache in the home directory.
+The damage was measurable. #1160 found entries keyed by bare issue number, so
+two repos' issue #4 shared one entry and every entry survived every repo reset.
+#1970 found 42 slices in the live file, all pytest temp directories, because
+isolation depended on each test file remembering to monkeypatch a constant --
+and two files forgot. Before repo-scoping, those test writes had been
+OVERWRITING real approvals: the production cache carried issue numbers 42, 50,
+77, 99, 100, 200, 300.
 
-The constant's own comment asserted that "each entry self-identifies via
-issue_number / target_repo". It did not; no entry carried a repo at all. These
-tests exist so that claim is enforced rather than asserted.
+The cache is now `<target_repo>/data/assemblyzero/lld-status.json`. Note what
+this file no longer needs: an isolation fixture. A test whose target repo is
+`tmp_path` writes under `tmp_path`. Isolation stopped being something to
+remember and became something the design guarantees.
 """
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from assemblyzero.workflows.requirements.audit import (
+    LLD_STATUS_RELATIVE,
+    lld_status_path,
     load_lld_tracking,
     save_lld_tracking,
     update_lld_status,
 )
 
-
-@pytest.fixture(autouse=True)
-def _shared_cache_file(monkeypatch, tmp_path: Path) -> Path:
-    """One shared cache file, as in production -- NOT one per repo.
-
-    Pointing this at a per-test path would hide the very collision under test.
-    """
-    cache = tmp_path / "home" / ".claude" / "assemblyzero" / "lld-status.json"
-    monkeypatch.setattr(
-        "assemblyzero.workflows.requirements.audit.LLD_STATUS_FILE", cache
-    )
-    return cache
-
-
-@pytest.fixture
-def repo_a(tmp_path: Path) -> Path:
-    path = tmp_path / "boostgauge"
-    path.mkdir()
-    return path
-
-
-@pytest.fixture
-def repo_b(tmp_path: Path) -> Path:
-    path = tmp_path / "someotherrepo"
-    path.mkdir()
-    return path
-
-
 APPROVED = {
     "has_gemini_review": True,
     "final_verdict": "APPROVED",
-    "last_review_date": "2026-07-30",
+    "last_review_date": "2026-07-31",
     "review_count": 1,
 }
 UNREVIEWED = {"has_gemini_review": False, "final_verdict": None, "review_count": 0}
 
 
-class TestTwoReposSameIssueNumber:
-    """The founding collision: issue #4 exists in more than one repo."""
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
 
-    def test_one_repos_approval_is_not_visible_to_another(
-        self, repo_a, repo_b
-    ):
+
+@pytest.fixture
+def repo_a(tmp_path):
+    p = tmp_path / "boostgauge"
+    p.mkdir()
+    return p
+
+
+@pytest.fixture
+def repo_b(tmp_path):
+    p = tmp_path / "someotherrepo"
+    p.mkdir()
+    return p
+
+
+class TestTheCacheIsInsideTheRepo:
+    def test_path_resolves_under_the_target_repo(self, repo_a):
+        assert lld_status_path(repo_a) == repo_a / LLD_STATUS_RELATIVE
+
+    def test_it_is_not_in_the_users_home(self, repo_a):
+        assert Path.home() / ".claude" not in lld_status_path(repo_a).parents
+
+    def test_the_constant_is_relative(self):
+        """An absolute constant is exactly how this escaped into ~/.claude."""
+        assert not LLD_STATUS_RELATIVE.is_absolute()
+
+    def test_writing_creates_it_inside_the_repo(self, repo_a):
+        update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
+
+        assert (repo_a / LLD_STATUS_RELATIVE).is_file()
+
+    def test_it_lands_under_data_which_is_gitignored_fleet_wide(self):
+        """The universal CLAUDE.md names data/ as the destination for
+        agent-written state, precisely so it is visible but never committed."""
+        assert LLD_STATUS_RELATIVE.parts[0] == "data"
+
+
+class TestCollisionIsStructurallyImpossible:
+    """Two repos cannot share an entry because they no longer share a file."""
+
+    def test_two_repos_have_separate_files(self, repo_a, repo_b):
+        assert lld_status_path(repo_a) != lld_status_path(repo_b)
+
+    def test_one_repos_approval_is_invisible_to_another(self, repo_a, repo_b):
         update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
 
         assert load_lld_tracking(repo_b)["issues"] == {}
 
-    def test_one_repos_approval_is_visible_to_itself(self, repo_a):
-        update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
-
-        entry = load_lld_tracking(repo_a)["issues"]["4"]
-        assert entry["status"] == "approved"
-
-    def test_writing_one_repo_does_not_clobber_another(self, repo_a, repo_b):
+    def test_same_issue_number_in_both_repos_does_not_clash(self, repo_a, repo_b):
         update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
         update_lld_status(4, "docs/lld/active/LLD-004.md", UNREVIEWED, repo_b)
 
         assert load_lld_tracking(repo_a)["issues"]["4"]["status"] == "approved"
         assert load_lld_tracking(repo_b)["issues"]["4"]["status"] == "draft"
 
-    def test_both_slices_coexist_in_one_file(self, repo_a, repo_b, _shared_cache_file):
+    def test_a_repos_own_approval_round_trips(self, repo_a):
         update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
-        update_lld_status(9, "docs/lld/active/LLD-009.md", APPROVED, repo_b)
 
-        raw = json.loads(_shared_cache_file.read_text(encoding="utf-8"))
-        assert len(raw["repos"]) == 2, raw
-        assert raw["version"] == "2.0"
+        assert load_lld_tracking(repo_a)["issues"]["4"]["status"] == "approved"
 
 
-class TestRepoKeyNormalisation:
-    def test_same_repo_via_a_relative_path_hits_the_same_slice(
-        self, repo_a, monkeypatch
+class TestWorktreesShareTheMainRepoCache:
+    """The pipeline runs stages from `{repo}-{issue}` worktrees. Per-worktree
+    caches would make an approval recorded in one invisible to the next."""
+
+    @pytest.fixture
+    def repo(self, tmp_path):
+        r = tmp_path / "target"
+        r.mkdir()
+        _git(r, "init", "-b", "main")
+        (r / "README.md").write_text("x", encoding="utf-8")
+        _git(r, "add", "-A")
+        _git(r, "commit", "-m", "init")
+        return r
+
+    def test_a_worktree_resolves_to_the_main_repos_cache(self, repo, tmp_path):
+        worktree = tmp_path / "target-7"
+        _git(repo, "worktree", "add", str(worktree), "-b", "issue-7")
+
+        assert lld_status_path(worktree) == lld_status_path(repo)
+
+    def test_an_approval_written_from_a_worktree_is_visible_in_the_repo(
+        self, repo, tmp_path
     ):
-        update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
+        worktree = tmp_path / "target-7"
+        _git(repo, "worktree", "add", str(worktree), "-b", "issue-7")
 
-        monkeypatch.chdir(repo_a.parent)
-        assert load_lld_tracking(Path(repo_a.name))["issues"]["4"]["status"] == (
-            "approved"
-        )
+        update_lld_status(7, "docs/lld/active/LLD-007.md", APPROVED, worktree)
 
-    def test_trailing_separator_hits_the_same_slice(self, repo_a):
-        update_lld_status(4, "docs/lld/active/LLD-004.md", APPROVED, repo_a)
+        assert load_lld_tracking(repo)["issues"]["7"]["status"] == "approved"
 
-        assert load_lld_tracking(Path(str(repo_a) + "/"))["issues"] != {}
+    def test_a_non_git_directory_still_resolves(self, tmp_path):
+        """`git rev-parse` fails outside a repo; the path must still resolve
+        rather than raising, so plain-directory callers keep working."""
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+
+        assert lld_status_path(plain) == plain / LLD_STATUS_RELATIVE
 
 
-class TestLegacyUnscopedMigration:
+class TestLegacyFlatFileMigration:
     """A pre-#1160 flat file records no repo, so its entries cannot be
-    attributed. They are kept on disk and served to nobody."""
+    attributed. Kept on disk, served to nobody."""
 
-    def _write_legacy(self, cache: Path) -> None:
-        cache.parent.mkdir(parents=True, exist_ok=True)
-        cache.write_text(
-            json.dumps(
-                {
-                    "version": "1.0",
-                    "last_updated": "2026-07-29T00:00:00Z",
-                    "issues": {
-                        "4": {
-                            "lld_path": "docs\\lld\\active\\LLD-004.md",
-                            "status": "approved",
-                            "has_gemini_review": True,
-                            "final_verdict": "APPROVED",
-                            "last_review_date": "2026-07-30",
-                            "review_count": 1,
-                        }
-                    },
-                }
-            ),
-            encoding="utf-8",
-        )
+    def _write_legacy(self, repo):
+        path = repo / LLD_STATUS_RELATIVE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "version": "1.0",
+            "last_updated": "2026-07-29T00:00:00Z",
+            "issues": {"4": {
+                "lld_path": "docs/lld/active/LLD-004.md",
+                "status": "approved", "has_gemini_review": True,
+                "final_verdict": "APPROVED", "last_review_date": "2026-07-30",
+                "review_count": 1,
+            }},
+        }), encoding="utf-8")
 
-    def test_legacy_entries_are_not_served_to_any_repo(
-        self, repo_a, repo_b, _shared_cache_file
-    ):
-        self._write_legacy(_shared_cache_file)
+    def test_legacy_entries_are_not_served(self, repo_a):
+        self._write_legacy(repo_a)
 
         assert load_lld_tracking(repo_a)["issues"] == {}
-        assert load_lld_tracking(repo_b)["issues"] == {}
 
-    def test_legacy_entries_are_preserved_on_disk(
-        self, repo_a, _shared_cache_file
-    ):
-        """Not served is not the same as destroyed -- the operator's file keeps
-        its history."""
-        self._write_legacy(_shared_cache_file)
-
-        update_lld_status(9, "docs/lld/active/LLD-009.md", APPROVED, repo_a)
-
-        raw = json.loads(_shared_cache_file.read_text(encoding="utf-8"))
-        assert raw["legacy_unscoped"]["4"]["final_verdict"] == "APPROVED"
-        assert raw["repos"][Path(repo_a).resolve().as_posix()]["issues"]["9"]
-
-    def test_an_unattributable_approval_does_not_skip_review(self, repo_a, _shared_cache_file):
-        """The direction that matters. Honouring a legacy approval would skip a
-        review the workflow was told to perform; dropping it costs one review."""
-        self._write_legacy(_shared_cache_file)
+    def test_an_unattributable_approval_does_not_skip_review(self, repo_a):
+        """The direction that matters: honouring it would skip a review the
+        workflow was told to perform. Dropping it costs one review."""
+        self._write_legacy(repo_a)
 
         assert "4" not in load_lld_tracking(repo_a)["issues"]
 
+    def test_legacy_entries_are_preserved_on_disk(self, repo_a):
+        self._write_legacy(repo_a)
+        update_lld_status(9, "docs/lld/active/LLD-009.md", APPROVED, repo_a)
+
+        raw = json.loads((repo_a / LLD_STATUS_RELATIVE).read_text(encoding="utf-8"))
+        assert raw["legacy_unscoped"]["4"]["final_verdict"] == "APPROVED"
+
 
 class TestFileLevelRobustness:
-    def test_missing_file_yields_empty_slice(self, repo_a):
+    def test_missing_file_yields_empty(self, repo_a):
         assert load_lld_tracking(repo_a)["issues"] == {}
 
-    def test_corrupt_file_yields_empty_slice(self, repo_a, _shared_cache_file):
-        _shared_cache_file.parent.mkdir(parents=True, exist_ok=True)
-        _shared_cache_file.write_text("not json {", encoding="utf-8")
-
-        assert load_lld_tracking(repo_a)["issues"] == {}
-
-    def test_non_dict_file_yields_empty_slice(self, repo_a, _shared_cache_file):
-        _shared_cache_file.parent.mkdir(parents=True, exist_ok=True)
-        _shared_cache_file.write_text("[1, 2, 3]", encoding="utf-8")
+    def test_corrupt_file_yields_empty(self, repo_a):
+        path = repo_a / LLD_STATUS_RELATIVE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json {", encoding="utf-8")
 
         assert load_lld_tracking(repo_a)["issues"] == {}
 
-    def test_save_creates_the_directory(self, repo_a, _shared_cache_file):
-        assert not _shared_cache_file.exists()
+    def test_non_dict_file_yields_empty(self, repo_a):
+        path = repo_a / LLD_STATUS_RELATIVE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+
+        assert load_lld_tracking(repo_a)["issues"] == {}
+
+    def test_save_creates_the_directory(self, repo_a):
+        assert not (repo_a / LLD_STATUS_RELATIVE).exists()
 
         save_lld_tracking({"issues": {}}, repo_a)
 
-        assert _shared_cache_file.exists()
+        assert (repo_a / LLD_STATUS_RELATIVE).is_file()
 
     def test_round_trip_through_save_and_load(self, repo_a):
         tracking = load_lld_tracking(repo_a)
         tracking["issues"]["7"] = {
-            "lld_path": "docs/lld/active/LLD-007.md",
-            "status": "blocked",
-            "has_gemini_review": True,
-            "final_verdict": "REJECTED",
-            "last_review_date": "2026-07-30",
-            "review_count": 2,
+            "lld_path": "docs/lld/active/LLD-007.md", "status": "blocked",
+            "has_gemini_review": True, "final_verdict": "REJECTED",
+            "last_review_date": "2026-07-31", "review_count": 2,
         }
         save_lld_tracking(tracking, repo_a)
 

--- a/tests/unit/test_lld_tracking.py
+++ b/tests/unit/test_lld_tracking.py
@@ -34,26 +34,6 @@ from assemblyzero.workflows.requirements.audit import (
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "lld_tracking"
 
 
-@pytest.fixture(autouse=True)
-def _patch_lld_status_file(monkeypatch, tmp_path: Path) -> None:
-    """Redirect LLD_STATUS_FILE under tmp_path for test isolation.
-
-    PR #1156 made LLD_STATUS_FILE an absolute Path (~/.claude/assemblyzero/...).
-    The function `load_lld_tracking(target_repo)` uses `target_repo / LLD_STATUS_FILE`
-    which collapses to the absolute path (Python Path `/` semantics), so passing
-    `tmp_path` is silently ignored. The function reads from the user's real
-    ~/.claude file instead of the test's tmp_path.
-
-    This autouse fixture monkeypatches the constant to live under tmp_path,
-    restoring per-test isolation. Tests still write to `tmp_path/docs/lld/...`
-    so the original test write locations remain valid. (#1158)
-    """
-    monkeypatch.setattr(
-        "assemblyzero.workflows.requirements.audit.LLD_STATUS_FILE",
-        tmp_path / "docs" / "lld" / "lld-status.json",
-    )
-
-
 @pytest.fixture
 def lld_with_review() -> str:
     """Load sample LLD content that contains a Gemini review section."""
@@ -265,7 +245,7 @@ class TestLoadLLDTracking:
     def test_loads_valid_json(self, tmp_path: Path) -> None:
         """T120: Valid tracking JSON returns parsed dict with expected keys."""
         # Set up lld-status.json in the expected location
-        status_dir = tmp_path / "docs" / "lld"
+        status_dir = tmp_path / "data" / "assemblyzero"
         status_dir.mkdir(parents=True)
         # #1160: entries are nested under the repo they belong to. A flat
         # `issues` map is the pre-#1160 layout and is no longer served to any
@@ -308,7 +288,7 @@ class TestLoadLLDTracking:
 
     def test_corrupt_json(self, tmp_path: Path) -> None:
         """T140: Corrupt JSON returns empty cache (exercises JSONDecodeError branch)."""
-        status_dir = tmp_path / "docs" / "lld"
+        status_dir = tmp_path / "data" / "assemblyzero"
         status_dir.mkdir(parents=True)
         # Write intentionally corrupt JSON (from fixture)
         corrupt_content = (
@@ -323,7 +303,7 @@ class TestLoadLLDTracking:
 
     def test_empty_file(self, tmp_path: Path) -> None:
         """T150: Empty file returns empty cache (exercises empty-input branch)."""
-        status_dir = tmp_path / "docs" / "lld"
+        status_dir = tmp_path / "data" / "assemblyzero"
         status_dir.mkdir(parents=True)
         (status_dir / "lld-status.json").write_text("", encoding="utf-8")
 
@@ -333,7 +313,7 @@ class TestLoadLLDTracking:
 
     def test_multiple_entries(self, tmp_path: Path) -> None:
         """T160: Tracking file with 3 entries returns all entries correctly."""
-        status_dir = tmp_path / "docs" / "lld"
+        status_dir = tmp_path / "data" / "assemblyzero"
         status_dir.mkdir(parents=True)
         tracking_data = {
             "version": "2.0",
@@ -451,7 +431,7 @@ class TestUpdateLLDStatus:
 
     def test_creates_new_file(self, tmp_path: Path) -> None:
         """T190: If the tracking file doesn't exist, it is created with a single entry."""
-        status_file = tmp_path / "docs" / "lld" / "lld-status.json"
+        status_file = tmp_path / "data" / "assemblyzero" / "lld-status.json"
         assert not status_file.exists()  # precondition
 
         update_lld_status(

--- a/tests/unit/test_path_constants_absolute.py
+++ b/tests/unit/test_path_constants_absolute.py
@@ -49,9 +49,11 @@ def test_workflow_audit_file_is_absolute():
 
 
 def test_lld_status_file_is_absolute():
-    from assemblyzero.workflows.requirements.audit import LLD_STATUS_FILE
-    assert LLD_STATUS_FILE.is_absolute(), (
-        f"LLD_STATUS_FILE={LLD_STATUS_FILE} must be absolute "
+    from assemblyzero.workflows.requirements.audit import LLD_STATUS_RELATIVE
+    assert not LLD_STATUS_RELATIVE.is_absolute(), (
+        f"LLD_STATUS_RELATIVE={LLD_STATUS_RELATIVE} must be RELATIVE so it "
+        "resolves inside the target repo (#1970) -- an absolute constant "
+        "is exactly how this cache escaped into ~/.claude "
         "(#1151: LLD approval cache lives outside any repo tree)"
     )
 
@@ -65,7 +67,6 @@ def test_all_relocated_paths_live_under_claude_home():
         AGE_METER_STATE_PATH,
         HISTORY_PATH,
     )
-    from assemblyzero.workflows.requirements.audit import LLD_STATUS_FILE
     from assemblyzero.workflows.testing.audit import WORKFLOW_AUDIT_FILE
 
     claude_home = Path.home() / ".claude"
@@ -73,7 +74,11 @@ def test_all_relocated_paths_live_under_claude_home():
         ("HISTORY_PATH", Path(HISTORY_PATH)),
         ("AGE_METER_STATE_PATH", Path(AGE_METER_STATE_PATH)),
         ("WORKFLOW_AUDIT_FILE", WORKFLOW_AUDIT_FILE),
-        ("LLD_STATUS_FILE", LLD_STATUS_FILE),
+        # LLD_STATUS_RELATIVE is deliberately NOT here: #1970 moved the LLD
+        # approval cache back INTO the target repo. It is application state,
+        # not harness state, and consolidating it under ~/.claude is what made
+        # it shared across every repo, invisible, and untouched by cleanup.
+        # The three paths above remain out-of-repo and are under fleet audit.
     ]:
         try:
             p.relative_to(claude_home)

--- a/tests/unit/test_requirements_audit.py
+++ b/tests/unit/test_requirements_audit.py
@@ -12,24 +12,12 @@ Tests for:
 
 import pytest
 from pathlib import Path
-from unittest.mock import Mock, patch
-import tempfile
-import shutil
 
 
-@pytest.fixture(autouse=True)
-def _patch_lld_status_file(monkeypatch, tmp_path: Path) -> None:
-    """Redirect LLD_STATUS_FILE under tmp_path for test isolation (#1158).
-
-    PR #1156 made the constant absolute (~/.claude/assemblyzero/lld-status.json);
-    `target_repo / LLD_STATUS_FILE` now silently ignores target_repo. Tests that
-    pass `tmp_path` were reading the user's real ~/.claude file instead of the
-    test's tmp_path. This fixture restores per-test isolation.
-    """
-    monkeypatch.setattr(
-        "assemblyzero.workflows.requirements.audit.LLD_STATUS_FILE",
-        tmp_path / "docs" / "lld" / "lld-status.json",
-    )
+# #1970: the LLD cache now lives at <target_repo>/data/assemblyzero/, so a
+# test whose target repo is tmp_path is isolated by construction. The
+# autouse fixture that used to redirect an absolute constant is gone --
+# it was isolation-by-remembering, and two test files forgot.
 
 
 class TestCreateAuditDir:
@@ -467,7 +455,7 @@ class TestUpdateLLDStatus:
         """Test creates lld-status.json if it doesn't exist."""
         from assemblyzero.workflows.requirements.audit import update_lld_status
 
-        status_file = tmp_path / "docs" / "lld" / "lld-status.json"
+        status_file = tmp_path / "data" / "assemblyzero" / "lld-status.json"
         assert not status_file.exists()
 
         update_lld_status(
@@ -584,7 +572,6 @@ class TestAssembleContextEdgeCases:
     def test_handles_oserror_in_directory_files(self, tmp_path):
         """Test handles OSError when reading files in directory."""
         from assemblyzero.workflows.requirements.audit import assemble_context
-        import os
 
         # Create directory with a file that will cause OSError
         ctx_dir = tmp_path / "context"
@@ -629,7 +616,7 @@ class TestLoadLLDTrackingErrors:
         """Test returns empty cache when JSON is invalid."""
         from assemblyzero.workflows.requirements.audit import load_lld_tracking
 
-        status_file = tmp_path / "docs" / "lld" / "lld-status.json"
+        status_file = tmp_path / "data" / "assemblyzero" / "lld-status.json"
         status_file.parent.mkdir(parents=True)
         status_file.write_text("not valid json {")
 
@@ -643,7 +630,7 @@ class TestLoadLLDTrackingErrors:
         from assemblyzero.workflows.requirements.audit import load_lld_tracking
 
         # Create a directory where the status file should be
-        status_file = tmp_path / "docs" / "lld" / "lld-status.json"
+        status_file = tmp_path / "data" / "assemblyzero" / "lld-status.json"
         status_file.parent.mkdir(parents=True)
         status_file.mkdir()  # Directory, not file - will cause OSError
 


### PR DESCRIPTION
Closes #1970

## The real defect was the location, not the fixture

#1151 saw that a repo-relative cache dirtied every worktree and "fixed" it by moving the file to `~/.claude/assemblyzero/lld-status.json` — outside every repo. That traded one visible problem for four hidden ones: a single file shared by every target repo, outside version control, invisible to the operator, and untouched by every cleanup tool including `speedrun_reset`.

The universal CLAUDE.md already mandated the answer — the repo's gitignored `data/` — and scopes the `~/.claude/**` exception to **harness** state. An application's approval cache was wearing that exception as a costume.

**The damage was measurable.** #1160 found entries keyed by bare issue number, so two repos' issue #4 shared one entry and every entry outlived every repo reset. This issue found **42 slices in the live file, every one a pytest temp directory**, because isolation depended on each test file remembering to monkeypatch an absolute constant — and two forgot. Before repo-scoping, those test writes had been *overwriting real approvals*: the production cache carried issue numbers 42, 50, 77, 99, 100, 200, 300.

## What changed

The cache is now `<target_repo>/data/assemblyzero/lld-status.json`, resolved against the **main worktree** so an approval recorded from a `{repo}-{issue}` worktree is visible to the repo and to later stages.

**What this deletes is the point.** The autouse isolation fixtures in `test_lld_tracking.py` and `test_requirements_audit.py` are *gone* — a test whose target repo is `tmp_path` now writes under `tmp_path`. Isolation stopped being something to remember and became something the design guarantees, which is why remembering failed twice.

`test_path_constants_absolute.py` inverted: the constant must now be **relative**, since an absolute constant is precisely how this escaped. The LLD cache is also removed from that file's "must live under `~/.claude`" list — the three paths still on it are out-of-repo and under fleet audit.

## Two bugs in this change, caught by its own tests

- The repo key resolved to the **calling** tree while the path resolved to the **main worktree**, so a write from a worktree landed under a key the repo never read. Both now share `_main_worktree_root`.
- The "not in the user's home" assertion failed because `tmp_path` lives under home on Windows. The real claim is "not under `~/.claude`".

## Verification

- **20 tests**: cache inside the repo and under `data/`, constant is relative, two repos have separate files so collision is **structurally impossible** rather than merely avoided, worktrees share the main repo's cache, non-git directories still resolve, legacy flat entries stay unattributed and unserved.
- **Full suite 6567 passed**, 0 failures.
- Live: `boostgauge -> C:\Users\mcwiz\Projects\boostgauge\data\assemblyzero\lld-status.json`
- `ruff`: removed 5 pre-existing unused imports from the touched test file; the one remaining `F841` there predates this change.