### PR TITLE
fix(orchestrator): land the implementation, sync the base, stop parking the operator on a branch (Closes #2011, Closes #2012)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -752,6 +752,23 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # --base-branch now controls the roll's CONTENT as well as the PR
             # target, and the resolved base is printed rather than implied.
             base_branch = state.get("base_branch", "")
+            if base_branch and target_repo:
+                # #2011: the pipeline merges on ORIGIN but cuts the worktree from
+                # the LOCAL ref, so each phase was built from a base that had not
+                # received the previous phase's merge. `fetch origin b:b` is
+                # atomic and fast-forward-only, and REFUSES if the branch is
+                # checked out anywhere -- which is the correct failure, and why
+                # the main checkout must stay on the default branch (#2012).
+                sync = run_command(
+                    ["git", "-C", target_repo, "fetch", "origin",
+                     f"{base_branch}:{base_branch}"],
+                    check=False, capture_output=True, text=True,
+                )
+                if sync.returncode == 0:
+                    print(f"    Base synced from origin/{base_branch}")
+                else:
+                    detail = (sync.stderr or "").strip()[:200]
+                    print(f"    [WARN] could not sync {base_branch}: {detail}")
             if not base_branch:
                 # current_branch raises GitBranchError on detached HEAD by
                 # design (it must not silently fall back to main), and OSError
@@ -1000,6 +1017,10 @@ def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
         )
 
         pr_url = pr_result.stdout.strip()
+        # #2011: the impl PR was created and then abandoned -- nothing merged it,
+        # so the attempt branch received the design and never the code. Record it
+        # so the cleanup stage can land it alongside the LLD PR.
+        state["impl_pr_url"] = pr_url
         result = _make_stage_result(
             status="passed",
             artifact_path=pr_url,
@@ -1024,11 +1045,16 @@ def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
     return update_stage_result(state, stage, result)
 
 
-def _merge_lld_pr(pr_url: str, timeout_s: int, notes: list[str]) -> bool:
-    """Closes #1531. Poll the LLD PR until mergeable, then squash-merge it (landing
-    the LLD + spec on target main per ADR 0221). Best-effort; returns True iff the PR
-    is now merged. Bounded by ``timeout_s``; on timeout the PR is left open and
-    deferred to manual ``/cleanup``. No ``--admin``, no force.
+def _merge_pr(pr_url: str, timeout_s: int, notes: list[str], label: str = "LLD") -> bool:
+    """Poll a PR until mergeable, then squash-merge it. Returns True iff merged.
+
+    Closes #1531 for the LLD PR (landing LLD + spec per ADR 0221). #2011 applies
+    the same discipline to the IMPLEMENTATION PR, which nothing merged: the arc
+    could not accumulate, and every previous "pipeline-built" arc had a human
+    merging six impl PRs by hand.
+
+    Bounded by ``timeout_s``; on timeout the PR is left open and reported. No
+    ``--admin``, no force -- a PR that will not merge cleanly is a finding.
     """
     deadline = time.monotonic() + max(0, timeout_s)
     last = ""
@@ -1051,13 +1077,13 @@ def _merge_lld_pr(pr_url: str, timeout_s: int, notes: list[str]) -> bool:
                 )
                 if merge.returncode == 0:
                     return True
-                notes.append(f"LLD PR merge attempt failed: {(merge.stderr or '').strip()[:160]}")
+                notes.append(f"{label} PR merge attempt failed: {(merge.stderr or '').strip()[:160]}")
         else:
-            notes.append(f"LLD PR view failed: {(view.stderr or '').strip()[:160]}")
+            notes.append(f"{label} PR view failed: {(view.stderr or '').strip()[:160]}")
         if time.monotonic() >= deadline:
             notes.append(
-                f"LLD PR not merged within {timeout_s}s (last merge-state="
-                f"{last or '?'}); deferred to manual /cleanup"
+                f"{label} PR not merged within {timeout_s}s (last merge-state="
+                f"{last or '?'})"
             )
             return False
         time.sleep(15)
@@ -1179,9 +1205,20 @@ def run_cleanup_stage(state: OrchestrationState) -> OrchestrationState:
 
     lld_merged = False
     if lld_pr_url:
-        lld_merged = _merge_lld_pr(lld_pr_url, merge_timeout, notes)
+        lld_merged = _merge_pr(lld_pr_url, merge_timeout, notes, label="LLD")
     else:
         notes.append("no LLD PR URL in state — skipping LLD merge")
+
+    # #2011: land the IMPLEMENTATION PR. This is the step that was missing
+    # entirely; without it the attempt branch never receives the code and the
+    # next phase of an arc builds against a base that has never seen this one.
+    # LLD first, matching the order every previous arc landed in.
+    impl_pr_url = state.get("impl_pr_url", "")
+    impl_merged = False
+    if impl_pr_url:
+        impl_merged = _merge_pr(impl_pr_url, merge_timeout, notes, label="impl")
+    else:
+        notes.append("no implementation PR URL in state — nothing to land")
 
     # #1624: only delete the working-tree copies once the content is safely on main.
     if lld_merged and target_repo:
@@ -1193,9 +1230,19 @@ def run_cleanup_stage(state: OrchestrationState) -> OrchestrationState:
     for note in notes:
         print(f"    [cleanup] {note}")
 
+    # #2011: this stage was documented as best-effort and ALWAYS returned passed,
+    # which is the wrong contract for a step the next phase depends on. A cleanup
+    # hiccup still passes; an unlanded implementation does not -- that is the run
+    # not having landed, and reporting it green is how the gap stayed invisible.
+    landed = impl_merged or not impl_pr_url
     result = _make_stage_result(
-        status="passed",
-        artifact_path=lld_pr_url if lld_merged else "",
+        status="passed" if landed else "failed",
+        error_message=(
+            "" if landed else
+            f"implementation PR was not merged into the attempt branch "
+            f"({impl_pr_url}); the arc cannot accumulate without it"
+        ),
+        artifact_path=impl_pr_url if impl_merged else (lld_pr_url if lld_merged else ""),
         duration_seconds=time.monotonic() - start_time,
         attempts=1,
     )

--- a/tests/unit/test_cleanup_stage.py
+++ b/tests/unit/test_cleanup_stage.py
@@ -43,7 +43,7 @@ def test_cleanup_registered_in_order_and_runners():
 
 def test_cleanup_merges_deletes_removes_when_lld_pr_present(tmp_path):
     state = _state(tmp_path, lld_pr_url="https://github.com/o/r/pull/9")
-    with patch.object(stages, "_merge_lld_pr", return_value=True) as m_merge, \
+    with patch.object(stages, "_merge_pr", return_value=True) as m_merge, \
          patch.object(stages, "_delete_landed_working_copies") as m_del, \
          patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
         new_state = stages.run_cleanup_stage(state)
@@ -56,7 +56,7 @@ def test_cleanup_merges_deletes_removes_when_lld_pr_present(tmp_path):
 
 def test_cleanup_no_lld_pr_skips_merge_and_delete(tmp_path):
     state = _state(tmp_path)  # lld_pr_url == "" from create_initial_state
-    with patch.object(stages, "_merge_lld_pr") as m_merge, \
+    with patch.object(stages, "_merge_pr") as m_merge, \
          patch.object(stages, "_delete_landed_working_copies") as m_del, \
          patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
         new_state = stages.run_cleanup_stage(state)
@@ -70,7 +70,7 @@ def test_cleanup_unmerged_lld_skips_delete_but_passes(tmp_path):
     """Gate: if the LLD PR did not merge, the working-tree copies are NOT deleted
     (they would be lost), but the stage still passes and worktrees are still removed."""
     state = _state(tmp_path, lld_pr_url="https://github.com/o/r/pull/9")
-    with patch.object(stages, "_merge_lld_pr", return_value=False), \
+    with patch.object(stages, "_merge_pr", return_value=False), \
          patch.object(stages, "_delete_landed_working_copies") as m_del, \
          patch.object(stages, "_remove_orchestrator_worktrees") as m_rm:
         new_state = stages.run_cleanup_stage(state)
@@ -79,9 +79,9 @@ def test_cleanup_unmerged_lld_skips_delete_but_passes(tmp_path):
     assert new_state["stage_results"]["cleanup"]["status"] == "passed"
 
 
-# ---- _merge_lld_pr ----
+# ---- _merge_pr (was _merge_lld_pr; #2011 applies it to both PRs) ----
 
-def test_merge_lld_pr_merges_when_clean():
+def test_merge_pr_merges_when_clean():
     notes = []
 
     def fake_run(cmd, **kw):
@@ -90,11 +90,11 @@ def test_merge_lld_pr_merges_when_clean():
         return _resp()  # merge succeeds
 
     with patch.object(stages, "run_command", side_effect=fake_run):
-        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 600, notes)
+        ok = stages._merge_pr("https://github.com/o/r/pull/9", 600, notes)
     assert ok is True
 
 
-def test_merge_lld_pr_already_merged_no_merge_call():
+def test_merge_pr_already_merged_no_merge_call():
     calls = []
 
     def fake_run(cmd, **kw):
@@ -102,12 +102,12 @@ def test_merge_lld_pr_already_merged_no_merge_call():
         return _resp(stdout="MERGED\tCLEAN\n")
 
     with patch.object(stages, "run_command", side_effect=fake_run):
-        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 600, [])
+        ok = stages._merge_pr("https://github.com/o/r/pull/9", 600, [])
     assert ok is True
     assert all("merge" not in c for c in calls), "must not attempt merge when already MERGED"
 
 
-def test_merge_lld_pr_timeout_returns_false():
+def test_merge_pr_timeout_returns_false():
     notes = []
 
     def fake_run(cmd, **kw):
@@ -115,7 +115,7 @@ def test_merge_lld_pr_timeout_returns_false():
 
     # timeout_s=0 → exits after the first check without sleeping
     with patch.object(stages, "run_command", side_effect=fake_run):
-        ok = stages._merge_lld_pr("https://github.com/o/r/pull/9", 0, notes)
+        ok = stages._merge_pr("https://github.com/o/r/pull/9", 0, notes)
     assert ok is False
     assert any("not merged within" in n for n in notes)
 
@@ -222,3 +222,58 @@ def test_lld_stage_captures_lld_pr_url(tmp_path):
         "run_lld_stage must capture final_lld_pr_url into orchestration state for the "
         "terminal cleanup stage to merge"
     )
+
+
+# ---- #2011: the implementation PR must actually land ----
+
+
+def test_cleanup_merges_the_impl_pr_too(tmp_path):
+    """Nothing merged the impl PR before this. The attempt branch received the
+    design and never the code, so an arc could not accumulate -- every previous
+    'pipeline-built' arc had a human merging six impl PRs by hand."""
+    merged: list[str] = []
+
+    def fake_merge(url, timeout, notes, label="LLD"):
+        merged.append(label)
+        return True
+
+    state = _state(tmp_path)
+    state["impl_pr_url"] = "https://github.com/o/r/pull/155"
+    with patch.object(stages, "_merge_pr", side_effect=fake_merge), \
+         patch.object(stages, "_delete_landed_working_copies"), \
+         patch.object(stages, "_remove_orchestrator_worktrees"):
+        new_state = stages.run_cleanup_stage(state)
+
+    assert "impl" in merged, f"impl PR was not merged: {merged}"
+    assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+
+def test_an_unlanded_impl_pr_fails_the_stage(tmp_path):
+    """This stage always returned 'passed', which is the wrong contract for a
+    step the next phase depends on. Reporting an unlanded implementation as
+    green is exactly how the gap stayed invisible."""
+    def fake_merge(url, timeout, notes, label="LLD"):
+        return label != "impl"
+
+    state = _state(tmp_path)
+    state["impl_pr_url"] = "https://github.com/o/r/pull/155"
+    with patch.object(stages, "_merge_pr", side_effect=fake_merge), \
+         patch.object(stages, "_delete_landed_working_copies"), \
+         patch.object(stages, "_remove_orchestrator_worktrees"):
+        new_state = stages.run_cleanup_stage(state)
+
+    result = new_state["stage_results"]["cleanup"]
+    assert result["status"] == "failed", result
+    assert "cannot accumulate" in result.get("error_message", "")
+
+
+def test_a_cleanup_hiccup_without_an_impl_pr_still_passes(tmp_path):
+    """Best-effort housekeeping keeps its old contract; only the landing is
+    now load-bearing."""
+    state = _state(tmp_path)
+    with patch.object(stages, "_merge_pr", return_value=False), \
+         patch.object(stages, "_delete_landed_working_copies"), \
+         patch.object(stages, "_remove_orchestrator_worktrees"):
+        new_state = stages.run_cleanup_stage(state)
+
+    assert new_state["stage_results"]["cleanup"]["status"] == "passed"

--- a/tests/unit/test_speedrun_new_attempt.py
+++ b/tests/unit/test_speedrun_new_attempt.py
@@ -86,9 +86,24 @@ class TestTheHandRunDefect:
 
 
 class TestOutcome:
-    def test_repo_ends_on_the_new_branch(self, repo):
+    def test_the_checkout_ends_on_the_default_branch(self, repo):
+        """#2012: an attempt is a REF, and the operator is never parked on one.
+        The repo starts this test standing on hardening-run-11, which is also
+        the branch being graveyarded -- `git branch -m` would drag the checkout
+        to `graveyard/hardening-run-11`, worse than where it began."""
+        assert sna.current_branch(repo) == "hardening-run-11"
+
         assert _apply(repo) == 0
-        assert sna.current_branch(repo) == "hardening-run-12"
+
+        assert sna.current_branch(repo) == "main"
+
+    def test_the_graveyarded_branch_is_not_where_you_land(self, repo):
+        assert _apply(repo) == 0
+        assert not sna.current_branch(repo).startswith("graveyard/")
+
+    def test_the_new_attempt_exists_as_a_local_ref(self, repo):
+        assert _apply(repo) == 0
+        assert sna.local_branch_exists(repo, "hardening-run-12")
 
     def test_new_branch_is_level_with_the_default(self, repo):
         assert _apply(repo) == 0
@@ -114,9 +129,14 @@ class TestOutcome:
         assert _apply(repo) == 0
         assert sna.remote_branch_exists(repo, "hardening-run-11")
 
-    def test_the_arc_work_is_gone_from_the_new_base(self, repo):
+    def test_the_new_base_does_not_carry_the_old_arc_work(self, repo):
+        """Checked against the REF, since the checkout is no longer moved."""
         assert _apply(repo) == 0
-        assert not (repo / "src.py").exists()
+        shown = subprocess.run(
+            ["git", "show", "hardening-run-12:src.py"],
+            cwd=str(repo), capture_output=True, text=True,
+        )
+        assert shown.returncode != 0, "new attempt must not carry the old work"
 
 
 class TestPreconditions:
@@ -157,7 +177,7 @@ class TestPreconditions:
         _git(repo, "checkout", sha)
 
         assert _apply(repo) == 0
-        assert sna.current_branch(repo) == "hardening-run-12"
+        assert sna.local_branch_exists(repo, "hardening-run-12")
         assert sna.remote_branch_exists(repo, "hardening-run-12")
         # The old attempt keeps its own name; it was never checked out.
         assert sna.local_branch_exists(repo, "hardening-run-11")
@@ -165,7 +185,7 @@ class TestPreconditions:
     def test_plan_omits_the_rename_when_there_is_no_branch(self):
         flat = [" ".join(c) for c in sna.plan_steps("", "attempt-2", "main")]
         assert not any("branch -m" in c for c in flat), flat
-        assert any("checkout -b attempt-2 origin/main" in c for c in flat), flat
+        assert any("branch attempt-2 origin/main" in c for c in flat), flat
 
     def test_missing_origin_head_is_refused_with_the_remedy(self, repo, capsys):
         _git(repo, "symbolic-ref", "-d", "refs/remotes/origin/HEAD")
@@ -188,7 +208,7 @@ class TestDryRunIsDefault:
 
         assert "DRY RUN" in out
         assert "git branch -m hardening-run-11 graveyard/hardening-run-11" in out
-        assert "git checkout -b hardening-run-12 origin/main" in out
+        assert "git branch hardening-run-12 origin/main" in out
         assert "git push -u origin hardening-run-12" in out
 
     def test_no_banned_command_appears_in_the_plan(self, repo):

--- a/tests/unit/test_speedrun_roll.py
+++ b/tests/unit/test_speedrun_roll.py
@@ -135,7 +135,7 @@ class TestEnsureBaseDecides:
         with _no_network():
             base = sr.ensure_base(repo, 4, log)
 
-        assert base == "hardening-run-13"
+        assert base == "hardening-run-11", "must use the attempt that is on origin"
         assert sr.base_is_structurally_sound(repo, base) == []
 
     def test_base_holding_this_issues_work_triggers_a_fresh_attempt(
@@ -190,15 +190,18 @@ class TestEnsureBaseDecides:
 
         assert base == "hardening-run-12"
 
-    def test_detached_head_triggers_a_fresh_attempt(self, repo, log):
-        sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=str(repo),
-            capture_output=True, text=True,
-        ).stdout.strip()
-        _git(repo, "checkout", sha)
+    def test_no_attempt_ref_at_all_establishes_one(self, repo, log):
+        """#2012: base discovery no longer reads HEAD, so the trigger is the
+        absence of an attempt REF, not the state of the checkout."""
+        _git(repo, "checkout", "main")
+        _git(repo, "push", "origin", "--delete", "hardening-run-11")
+        _git(repo, "fetch", "origin", "--prune")
 
         with _no_network():
-            assert sr.ensure_base(repo, 4, log) == "hardening-run-12"
+            base = sr.ensure_base(repo, 4, log)
+
+        assert base and base != "hardening-run-11", base
+        assert sr.base_is_structurally_sound(repo, base) == []
 
 
 class TestInstrumentationSurvives:

--- a/tools/speedrun_new_attempt.py
+++ b/tools/speedrun_new_attempt.py
@@ -184,9 +184,14 @@ def verify_postconditions(
     """
     problems: list[str] = []
 
-    if current_branch(repo_root) != new_name:
-        problems.append(f"repo is not checked out on '{new_name}'")
-
+    # #2012: the attempt is a REF, so the assertion is the inverse of what it
+    # used to be -- the checkout must be on the DEFAULT branch, not on the
+    # attempt. Being handed back on a branch is the defect this closes.
+    if base and current_branch(repo_root) != base:
+        problems.append(
+            f"checkout ended on '{current_branch(repo_root) or 'detached'}', "
+            f"expected the default branch '{base}'"
+        )
     if not remote_branch_exists(repo_root, new_name):
         problems.append(
             f"origin has no branch '{new_name}' -- PRs targeting it would fail"
@@ -224,11 +229,21 @@ def plan_steps(old_name: str, new_name: str, base: str) -> list[list[str]]:
     so that step is simply absent rather than being a reason to stop.
     """
     steps: list[list[str]] = [["git", "fetch", "origin"]]
-    if old_name:
+    # #2012: step off the branch BEFORE renaming it. `git branch -m` moves the
+    # checkout along with the branch, so graveyarding the branch you are
+    # standing on lands you on `graveyard/<name>` -- worse than where you
+    # started. Ending on the default branch is the guarantee, so take it first.
+    if old_name != base:
+        steps.append(["git", "checkout", base])
+    if old_name and old_name != base:
         steps.append(
             ["git", "branch", "-m", old_name, f"{GRAVEYARD_PREFIX}{old_name}"]
         )
-    steps.append(["git", "checkout", "-b", new_name, f"origin/{base}"])
+    # #2012: create the ref WITHOUT checking it out. Nothing needs the main
+    # checkout to stand on the attempt branch -- the worktree is cut from an
+    # explicit base and PRs target it by name. Parking the operator on it was a
+    # leftover from the manual ritual this tool replaced.
+    steps.append(["git", "branch", new_name, f"origin/{base}"])
     steps.append(["git", "push", "-u", "origin", new_name])
     return steps
 
@@ -300,6 +315,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"\nVERIFIED: {repo_root.name} is on '{new_name}'.")
     print(f"  exists on origin, tracks origin/{new_name}, level with origin/{base}.")
+    print(f"  checkout on '{current_branch(repo_root)}' -- an attempt is a ref, not a place to stand.")
     print(f"  previous attempt preserved as '{GRAVEYARD_PREFIX}{old_name}'.")
     print(
         f"\nPass --base-branch {new_name} to BOTH speedrun_clean_check.py and "

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -120,6 +120,9 @@ def attempt_prefix(repo_root: Path) -> str:
     attempt (e.g. `main`) falls back to the campaign default, so a repo sitting
     on its default branch still gets a sensibly named first attempt.
     """
+    # #2012: the checkout is normally on the DEFAULT branch now, so HEAD is no
+    # longer a source of the prefix. It is still honoured when the operator has
+    # deliberately checked an attempt out; otherwise the campaign default wins.
     current = attempt.current_branch(repo_root)
     match = re.match(r"^(.*)-\d+$", current or "")
     return match.group(1) if match else DEFAULT_PREFIX
@@ -151,6 +154,36 @@ def next_attempt_name(repo_root: Path, prefix: str) -> str:
             seen.add(int(match.group(1)))
 
     return f"{prefix}-{(max(seen) + 1) if seen else 1}"
+
+
+def resolve_attempt_branch(repo_root: Path) -> str:
+    """The newest attempt branch on origin, or "" if there is none (#2012).
+
+    Base discovery used to read the CHECKOUT, which is why every operation left
+    the operator parked on an attempt branch: the tooling had to stand on it to
+    know its name. Nothing else needs that -- the worktree is cut from an
+    explicit base and PRs target it by name -- so the attempt is resolved from
+    refs and the main checkout stays on the default branch.
+
+    Graveyarded attempts are excluded by prefix: they are the lab notebook of
+    finished runs, not candidates to roll onto.
+    """
+    prefix = attempt_prefix(repo_root)
+    esc = re.escape(prefix)
+    pattern = re.compile(rf"^{esc}-(\d+)$")
+
+    result = _run(["git", "ls-remote", "--heads", "origin"], cwd=repo_root)
+    best: tuple[int, str] | None = None
+    for line in result.stdout.splitlines():
+        if "refs/heads/" not in line:
+            continue
+        name = line.split("refs/heads/", 1)[1].strip()
+        match = pattern.match(name)
+        if match:
+            n = int(match.group(1))
+            if best is None or n > best[0]:
+                best = (n, name)
+    return best[1] if best else ""
 
 
 def establish_new_attempt(repo_root: Path, log: EventLog) -> str | None:
@@ -200,9 +233,9 @@ def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
     however clean it looks), then this issue's debris, then this issue's
     already-merged work.
     """
-    base = attempt.current_branch(repo_root)
+    base = resolve_attempt_branch(repo_root)
     if not base:
-        log.write("BASE detached HEAD -- establishing a fresh attempt")
+        log.write("BASE no attempt branch exists -- establishing one")
         return establish_new_attempt(repo_root, log)
 
     problems = base_is_structurally_sound(repo_root, base)


### PR DESCRIPTION
Closes #2011
Closes #2012

Two defects that together meant **an arc could not accumulate without a human**, plus the one that explains why the repo kept coming back on a branch.

## The implementation PR was never merged

`stages.py` had exactly one merge helper, `_merge_lld_pr`, and no counterpart. `run_pr_stage` created the impl PR and abandoned it; `run_cleanup_stage` merged only the LLD PR. The attempt branch received the design and never the code.

The previous arc looked automated because a human merged all six by hand:

```
#141 mergedBy=martymcenroe   #144 mergedBy=martymcenroe   #150 mergedBy=martymcenroe
```

plus a hand-made `merge main into attempt branch` commit. Live proof at filing time: boostgauge PR #155 sat `CLEAN`/`MERGEABLE`/`APPROVED`, all checks green, **open**, because no code path would ever merge it.

The helper was never LLD-specific except in its name — it's now `_merge_pr` with a label, applied to both, LLD first to match the order every previous arc landed in.

**The cleanup stage's contract changes with it.** It was documented best-effort and *always* returned `passed` — wrong for a step the next phase depends on. Reporting an unlanded implementation as green is exactly how this stayed invisible. A housekeeping hiccup still passes; an unlanded implementation now fails.

## The base was never synced

The pipeline merges on **origin** and cut its worktree from the **local** ref, one commit behind. Even with the impl PR merged, phase N+1 builds from a base that never saw phase N. Now fast-forwarded via `git fetch origin b:b` — atomic, ff-only, and it **refuses if the branch is checked out anywhere**. That refusal is the correct failure mode, and it only works because of the next change.

## Why you kept finding the repo on a branch

Base discovery read the **checkout**, so the tooling had to *stand* on the attempt branch to know its name — and every operation left you there. Nothing else needed it: since #1960 the worktree is cut from an explicit base and PRs target it by name. Resolution now reads **refs** (newest `{prefix}-{N}` on origin, graveyard excluded), and `speedrun_new_attempt` creates the ref without checking it out.

**That change exposed a sharper bug, caught by its own test:** `git branch -m` moves the checkout along with the branch, so graveyarding the branch you're standing on lands you on `graveyard/<name>` — worse than where you began. The tool now steps to the default branch first, and *asserts* it ended there.

Resolving from origin also means an unpushed attempt is invisible rather than chosen-then-rejected, so the 2026-07-30 hand-cut-never-pushed branch cannot recur.

## Verification

- 3 new tests in `test_cleanup_stage`: the impl PR is merged, an unlanded one **fails** the stage, a plain hiccup still passes.
- `test_speedrun_new_attempt` restated around the ref and the default-branch guarantee, including never landing on a graveyard branch.
- `test_speedrun_roll` restated for origin-based resolution.
- **Full suite 6572 passed**, 0 failures. `ruff` clean on every changed file.