### PR TITLE
fix(speedrun): run the roll outside the harness process tree, and stop it without orphans (Closes #2015, Closes #2016)

### DIFF
--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -1,0 +1,250 @@
+"""A roll must outlive the session that started it (#2015).
+
+Two boostgauge rolls died on 2026-07-31 with no `session-events.log` at all --
+no trapped signal, no `finally`. Measured the same day: a backgrounded parent
+killed by the harness takes every child with it, and neither DETACHED_PROCESS
+nor CREATE_BREAKAWAY_FROM_JOB escapes. A scheduled task does, because the Task
+Scheduler service parents it instead of the agent's shell.
+
+These pin the parts of that hand-off which are silent when they break: the
+relaunch argv, the task definition's long-run settings, the failure paths, and
+-- load-bearing for every future diagnosis -- that the launcher never writes
+the session log it is used to detect the absence of.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Enough of a repo for main() -- the git-touching checks are patched."""
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+class _Recorder:
+    """Stands in for _run, recording argv and replaying scripted exit codes."""
+
+    def __init__(self, codes=None):
+        self.calls = []
+        self.codes = codes or {}
+
+    def __call__(self, cmd, cwd=None):
+        self.calls.append(cmd)
+        code = self.codes.get(cmd[1] if len(cmd) > 1 else "", 0)
+        return subprocess.CompletedProcess(cmd, code, stdout="", stderr="boom")
+
+    def schtasks(self, verb):
+        return [c for c in self.calls if c[0] == "schtasks" and c[1] == verb]
+
+
+def _detach(repo, recorder, issues=("7",), platform="win32"):
+    argv = ["--repo", str(repo), "--detach"]
+    for i in issues:
+        argv += ["--issue", str(i)]
+    with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+            patch.object(sr, "_run", recorder), \
+            patch.object(sr.sys, "platform", platform):
+        return sr.main(argv)
+
+
+class TestRelaunchArgv:
+    def _args(self, issues=(7, 41)):
+        return argparse.Namespace(
+            issue=list(issues), log_dir=None, assemblyzero_root=None,
+            detach=True, detached_stdout=None,
+        )
+
+    def test_the_detach_request_is_not_passed_on(self, tmp_path):
+        """A relaunch that kept --detach would schedule a task that schedules a
+        task, forever, and never roll anything."""
+        argv = sr.detached_argv(
+            self._args(), [], tmp_path / "repo", tmp_path / "az", tmp_path / "logs"
+        )
+        assert "--detach" not in argv
+
+    def test_every_issue_survives_the_rebuild(self, tmp_path):
+        argv = sr.detached_argv(
+            self._args((7, 41, 1)), [], tmp_path / "r", tmp_path / "az", tmp_path / "l"
+        )
+        assert [argv[i + 1] for i, a in enumerate(argv) if a == "--issue"] == [
+            "7", "41", "1"
+        ]
+
+    def test_paths_are_absolute_because_the_scheduler_picks_the_cwd(self, tmp_path):
+        argv = sr.detached_argv(
+            self._args(), [], tmp_path / "r", tmp_path / "az", tmp_path / "l"
+        )
+        for flag in ("--repo", "--log-dir", "--assemblyzero-root"):
+            value = argv[argv.index(flag) + 1]
+            assert Path(value).is_absolute(), f"{flag} must be absolute, got {value}"
+
+    def test_unrecognised_flags_are_forwarded(self, tmp_path):
+        """parse_known_args passes pipeline flags through; detaching must not
+        silently drop them."""
+        argv = sr.detached_argv(
+            self._args(), ["--no-gate-pr"], tmp_path / "r", tmp_path / "a",
+            tmp_path / "l",
+        )
+        assert "--no-gate-pr" in argv
+
+    def test_the_rebuilt_argv_actually_parses(self, tmp_path, repo):
+        """Guard: the relaunch is only ever executed by the scheduler, so a
+        malformed argv would surface as a task that dies instantly with nobody
+        watching. Feed it back through main() and require it to reach a roll."""
+        argv = sr.detached_argv(
+            self._args((7,)), ["--no-gate-pr"], repo, tmp_path / "az", tmp_path / "l"
+        )
+        rolled = []
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "roll_issue",
+                             lambda *a: rolled.append(a) or 0), \
+                patch.object(sr, "restore_repo", lambda *a: []):
+            code = sr.main(argv)
+
+        assert code == 0
+        assert [c[1] for c in rolled] == [7]
+
+
+class TestTaskDefinition:
+    def _xml(self, **kw):
+        base = dict(
+            command=r"C:\py\python.exe", arguments="-x", working_dir=r"C:\az",
+            description="roll #7", user="DOM\\user",
+        )
+        base.update(kw)
+        return sr.build_task_xml(**base)
+
+    def test_no_trigger_so_it_can_never_fire_on_its_own(self):
+        assert "<Triggers />" in self._xml()
+
+    def test_no_execution_time_limit(self):
+        """The scheduler's default stops a task partway; an arc runs hours."""
+        assert "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>" in self._xml()
+
+    def test_the_scheduler_may_not_hard_terminate_the_roll(self):
+        assert "<AllowHardTerminate>false</AllowHardTerminate>" in self._xml()
+
+    def test_battery_state_neither_blocks_nor_stops_it(self):
+        xml = self._xml()
+        assert "<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>" in xml
+        assert "<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>" in xml
+
+    def test_runs_unelevated_as_the_current_user(self):
+        """Runbook 0903 hard rule: no UAC, and gh credentials come from the
+        user's own profile."""
+        xml = self._xml()
+        assert "<RunLevel>LeastPrivilege</RunLevel>" in xml
+        assert "<LogonType>InteractiveToken</LogonType>" in xml
+
+    def test_a_second_roll_does_not_stomp_a_running_one(self):
+        assert "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>" in self._xml()
+
+    def test_xml_special_characters_are_escaped(self):
+        """A repo path or description with & or < would otherwise produce a
+        definition schtasks rejects."""
+        xml = self._xml(description="roll #7 & #41 <fast>")
+        assert "&amp;" in xml and "&lt;fast&gt;" in xml
+        assert "& #41" not in xml
+
+
+class TestLaunch:
+    def test_it_creates_then_starts_the_task(self, repo):
+        rec = _Recorder()
+        assert _detach(repo, rec) == 0
+        verbs = [c[1] for c in rec.calls if c[0] == "schtasks"]
+        assert verbs == ["/Create", "/Run"]
+
+    def test_the_definition_is_written_as_utf16(self, repo):
+        """schtasks rejects a UTF-8 definition as malformed -- a silent,
+        confusing failure if this regresses."""
+        rec = _Recorder()
+        _detach(repo, rec)
+        xml_path = repo / "data" / "speedrun" / "runs" / "detached-task.xml"
+        assert xml_path.read_bytes()[:2] in (b"\xff\xfe", b"\xfe\xff")
+        assert "<Triggers />" in xml_path.read_text(encoding="utf-16")
+
+    def test_a_failed_create_does_not_start_anything(self, repo):
+        rec = _Recorder(codes={"/Create": 1})
+        assert _detach(repo, rec) == 91
+        assert rec.schtasks("/Run") == []
+
+    def test_a_failed_start_is_reported_not_swallowed(self, repo):
+        rec = _Recorder(codes={"/Run": 1})
+        assert _detach(repo, rec) == 91
+
+    def test_a_failure_says_why_in_the_detach_log(self, repo):
+        rec = _Recorder(codes={"/Create": 1})
+        _detach(repo, rec)
+        log = (repo / "data" / "speedrun" / "runs" / "detach-events.log").read_text(
+            encoding="utf-8"
+        )
+        assert "DETACH create failed" in log and "boom" in log
+
+    def test_non_windows_refuses_loudly_and_rolls_nothing(self, repo, capsys):
+        """Silently rolling inline would hand back exactly the fragile run the
+        operator asked to escape."""
+        rec = _Recorder()
+        code = _detach(repo, rec, platform="linux")
+        assert code == 91
+        assert rec.schtasks("/Create") == []
+        assert "ERROR" in capsys.readouterr().out
+
+    def test_a_stale_tree_blocks_before_the_task_is_created(self, repo):
+        rec = _Recorder()
+        with patch.object(sr, "check_assemblyzero_tree",
+                          lambda p: ["2 commit(s) behind origin/main"]), \
+                patch.object(sr, "_run", rec):
+            code = sr.main(["--repo", str(repo), "--issue", "7", "--detach"])
+
+        assert code == 91
+        assert rec.calls == [], "a stale tree must not reach the scheduler"
+
+
+class TestTheSessionLogStaysDiagnostic:
+    """The absence of session-events.log is how an uncatchable kill is told
+    apart from an orderly exit. A launcher that wrote it would silently retire
+    that evidence for every future death."""
+
+    def test_detaching_does_not_create_the_session_log(self, repo):
+        rec = _Recorder()
+        _detach(repo, rec)
+        runs = repo / "data" / "speedrun" / "runs"
+        assert not (runs / "session-events.log").exists()
+        assert (runs / "detach-events.log").exists()
+
+
+class TestConsolelessNarration:
+    def test_stdout_is_rebound_to_the_file(self, tmp_path):
+        """A scheduled task inherits no console, so prints must land somewhere
+        or the roll narrates into nothing."""
+        target = tmp_path / "nested" / "launcher.log"
+        real = sys.stdout
+        try:
+            sr._redirect_stdio(target)
+            print("hello from a task")
+        finally:
+            sys.stdout.close()
+            sys.stdout = real
+        assert "hello from a task" in target.read_text(encoding="utf-8")
+
+    def test_the_relaunch_asks_for_that_redirect(self, tmp_path):
+        args = argparse.Namespace(
+            issue=[7], log_dir=None, assemblyzero_root=None,
+            detach=True, detached_stdout=None,
+        )
+        argv = sr.detached_argv(args, [], tmp_path / "r", tmp_path / "a", tmp_path / "l")
+        assert "--detached-stdout" in argv

--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -227,6 +227,144 @@ class TestTheSessionLogStaysDiagnostic:
         assert (runs / "detach-events.log").exists()
 
 
+class TestStoppingADetachedRoll:
+    """`schtasks /End` ends the task's own process and leaves the pipeline
+    running, reparented to nothing -- measured 2026-07-31, where the tree kill
+    that followed had to walk four levels /End never reached (#2016)."""
+
+    @pytest.fixture
+    def runs(self, repo):
+        d = repo / "data" / "speedrun" / "runs"
+        d.mkdir(parents=True)
+        return d
+
+    def _stop(self, repo, recorder, platform="win32"):
+        with patch.object(sr, "_run", recorder), \
+                patch.object(sr.sys, "platform", platform):
+            return sr.main(["--repo", str(repo), "--issue", "7", "--detach-stop"])
+
+    def test_it_kills_the_whole_tree_not_just_the_task(self, repo, runs):
+        runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "is_live_python", lambda pid: True):
+            assert self._stop(repo, rec) == 0
+
+        kill = [c for c in rec.calls if c[0] == "taskkill"]
+        assert kill and kill[0] == ["taskkill", "/PID", "4242", "/T", "/F"], kill
+
+    def test_the_task_is_ended_after_the_tree_is_killed(self, repo, runs):
+        runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "is_live_python", lambda pid: True):
+            self._stop(repo, rec)
+
+        order = [c[0] for c in rec.calls if c[0] in ("taskkill", "schtasks")]
+        assert order == ["taskkill", "schtasks"], order
+
+    def test_a_recycled_pid_is_not_killed(self, repo, runs):
+        """Windows reuses pids. A stale file must never authorise tree-killing
+        whatever now holds that number on a machine running other lanes."""
+        runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "is_live_python", lambda pid: False):
+            assert self._stop(repo, rec) == 0
+
+        assert [c for c in rec.calls if c[0] == "taskkill"] == []
+
+    def test_a_stale_pid_file_is_cleared(self, repo, runs):
+        pid = runs / "detached-roll.pid"
+        pid.write_text("4242", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "is_live_python", lambda p: False):
+            self._stop(repo, rec)
+        assert not pid.exists()
+
+    def test_stopping_with_nothing_running_is_not_an_error(self, repo, runs):
+        rec = _Recorder(codes={"/End": 1})
+        assert self._stop(repo, rec) == 0
+
+    def test_stopping_works_from_a_stale_tree(self, repo, runs):
+        """Stopping is about processes, not code -- a staleness gate standing
+        between the operator and a runaway roll would be the wrong tradeoff."""
+        runs.joinpath("detached-roll.pid").write_text("99", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "check_assemblyzero_tree",
+                          lambda p: ["2 commit(s) behind origin/main"]), \
+                patch.object(sr, "is_live_python", lambda p: True), \
+                patch.object(sr, "_run", rec), \
+                patch.object(sr.sys, "platform", "win32"):
+            code = sr.main(["--repo", str(repo), "--issue", "7", "--detach-stop"])
+
+        assert code == 0
+        assert [c for c in rec.calls if c[0] == "taskkill"]
+
+    def test_a_roll_records_its_pid_so_it_can_be_stopped(self, repo):
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "restore_repo", lambda *a: []), \
+                patch.object(sr, "roll_issue", lambda *a: 0):
+            seen = {}
+
+            def _capture(repo_root, issue, log_dir, az_root, extra):
+                seen["pid"] = sr.pid_file(log_dir).read_text(encoding="utf-8")
+                return 0
+
+            with patch.object(sr, "roll_issue", _capture):
+                sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert seen["pid"] == str(__import__("os").getpid())
+
+    def test_a_finished_roll_leaves_no_pid_behind(self, repo):
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "restore_repo", lambda *a: []), \
+                patch.object(sr, "roll_issue", lambda *a: 0):
+            sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert not sr.pid_file(repo / "data" / "speedrun" / "runs").exists()
+
+    def test_non_windows_refuses(self, repo, runs, capsys):
+        rec = _Recorder()
+        assert self._stop(repo, rec, platform="linux") == 91
+        assert "ERROR" in capsys.readouterr().out
+
+
+class TestPidLivenessGuard:
+    def test_a_non_numeric_pid_is_never_trusted(self):
+        assert sr.is_live_python("not-a-pid") is False
+
+    def test_no_matching_task_reads_as_not_live(self):
+        """tasklist prints an INFO line on stdout and still exits 0, so the
+        return code alone would say every pid is alive."""
+        def _run(cmd, cwd=None):
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="INFO: No tasks are running which match the criteria.",
+                stderr="",
+            )
+
+        with patch.object(sr, "_run", _run):
+            assert sr.is_live_python("4242") is False
+
+    def test_a_matching_python_process_reads_as_live(self):
+        def _run(cmd, cwd=None):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='"python.exe","4242","Console","1","90,000 K"',
+                stderr="",
+            )
+
+        with patch.object(sr, "_run", _run):
+            assert sr.is_live_python("4242") is True
+
+    def test_a_reused_pid_running_something_else_reads_as_not_live(self):
+        def _run(cmd, cwd=None):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='"chrome.exe","4242","Console","1","90,000 K"',
+                stderr="",
+            )
+
+        with patch.object(sr, "_run", _run):
+            assert sr.is_live_python("4242") is False
+
+
 class TestConsolelessNarration:
     def test_stdout_is_rebound_to_the_file(self, tmp_path):
         """A scheduled task inherits no console, so prints must land somewhere

--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -239,9 +239,34 @@ class TestStoppingADetachedRoll:
         return d
 
     def _stop(self, repo, recorder, platform="win32"):
+        # Deliberately no --issue: stopping names no issue, and every stop test
+        # passing one is how the missing-argument defect survived a green suite
+        # until a live run hit it.
         with patch.object(sr, "_run", recorder), \
                 patch.object(sr.sys, "platform", platform):
-            return sr.main(["--repo", str(repo), "--issue", "7", "--detach-stop"])
+            return sr.main(["--repo", str(repo), "--detach-stop"])
+
+    def test_stopping_needs_no_issue_number(self, repo, runs):
+        """The live defect: --issue was required at parse time, so the stop
+        path could not be invoked at all without inventing an issue."""
+        runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
+        rec = _Recorder()
+        with patch.object(sr, "is_live_python", lambda pid: True), \
+                patch.object(sr, "_run", rec), \
+                patch.object(sr.sys, "platform", "win32"):
+            code = sr.main(["--repo", str(repo), "--detach-stop"])
+
+        assert code == 0
+        assert [c for c in rec.calls if c[0] == "taskkill"]
+
+    def test_rolling_still_demands_an_issue(self, repo, capsys):
+        """Relaxing --issue for the stop path must not let a roll start with
+        nothing to roll."""
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []):
+            code = sr.main(["--repo", str(repo)])
+
+        assert code == 91
+        assert "--issue is required" in capsys.readouterr().out
 
     def test_it_kills_the_whole_tree_not_just_the_task(self, repo, runs):
         runs.joinpath("detached-roll.pid").write_text("4242", encoding="utf-8")
@@ -293,7 +318,7 @@ class TestStoppingADetachedRoll:
                 patch.object(sr, "is_live_python", lambda p: True), \
                 patch.object(sr, "_run", rec), \
                 patch.object(sr.sys, "platform", "win32"):
-            code = sr.main(["--repo", str(repo), "--issue", "7", "--detach-stop"])
+            code = sr.main(["--repo", str(repo), "--detach-stop"])
 
         assert code == 0
         assert [c for c in rec.calls if c[0] == "taskkill"]

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -24,6 +24,13 @@ Preserved verbatim from the wrapper, because each was earned:
   - direct redirect -- the child's stdout goes straight to a file with no pipe
                       in the path, which is what stopped the kills
 
+`--detach` hands the roll to Windows Task Scheduler instead of running it here
+(#2015). A roll started from an agent session is a descendant of that session's
+shell, and a harness kill of the shell takes the entire tree with it -- measured
+2026-07-31, and neither DETACHED_PROCESS nor CREATE_BREAKAWAY_FROM_JOB escaped
+it. A scheduled task is spawned by the Task Scheduler service, so it is not in
+the tree at all and nothing done to the launching session can reach it.
+
 Exit codes: 0 all issues rolled; 91 a base or gate problem this tool could not
 heal; otherwise the failing child's return code.
 """
@@ -39,6 +46,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
+from xml.sax.saxutils import escape
 
 import speedrun_clean_check as gate
 import speedrun_new_attempt as attempt
@@ -340,6 +348,189 @@ def _child_env() -> dict[str, str]:
     return env
 
 
+# =============================================================================
+# Detached launch -- outliving the session that started the roll (#2015)
+# =============================================================================
+
+TASK_NAME = "AZ-SpeedrunRoll"
+
+# No <Triggers> element: the task can never fire on its own, so there is no
+# far-future trigger date to pick and nothing to clean up on a calendar.
+# It exists solely to be started on demand.
+#
+# ExecutionTimeLimit PT0S means no limit -- the default would stop a long arc
+# partway. AllowHardTerminate false keeps the scheduler from killing the roll,
+# which is the entire point of running here. The battery settings matter on a
+# laptop: the defaults refuse to start, and stop a running task, on battery.
+_TASK_XML = """<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>{description}</Description>
+  </RegistrationInfo>
+  <Triggers />
+  <Principals>
+    <Principal id="Author">
+      <UserId>{user}</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>false</AllowHardTerminate>
+    <StartWhenAvailable>false</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>{command}</Command>
+      <Arguments>{arguments}</Arguments>
+      <WorkingDirectory>{working_dir}</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+
+def _quote(arg: str) -> str:
+    return f'"{arg}"' if " " in arg else arg
+
+
+def current_user() -> str:
+    domain = os.environ.get("USERDOMAIN", "")
+    name = os.environ.get("USERNAME", "")
+    return f"{domain}\\{name}" if domain else name
+
+
+def detached_argv(
+    args: argparse.Namespace,
+    extra: list[str],
+    repo_root: Path,
+    az_root: Path,
+    log_dir: Path,
+) -> list[str]:
+    """The argv the scheduled task runs: this same roll, minus the detach ask.
+
+    Every path is made absolute because the detached process inherits whatever
+    working directory the scheduler gives it, not the one the operator typed in.
+    """
+    argv = ["--repo", str(repo_root)]
+    for issue in args.issue:
+        argv += ["--issue", str(issue)]
+    argv += [
+        "--log-dir", str(log_dir),
+        "--assemblyzero-root", str(az_root),
+        "--detached-stdout", str(log_dir / "detached-launcher.log"),
+    ]
+    return argv + extra
+
+
+def build_task_xml(
+    command: str, arguments: str, working_dir: str, description: str, user: str
+) -> str:
+    return _TASK_XML.format(
+        description=escape(description),
+        user=escape(user),
+        command=escape(command),
+        arguments=escape(arguments),
+        working_dir=escape(working_dir),
+    )
+
+
+def launch_detached(
+    args: argparse.Namespace,
+    extra: list[str],
+    repo_root: Path,
+    az_root: Path,
+    log_dir: Path,
+) -> int:
+    """Hand the roll to Task Scheduler and return immediately (#2015).
+
+    Deliberately logs to `detach-events.log`, NOT the session log: the absence
+    of `session-events.log` is the evidence that distinguishes an uncatchable
+    kill from an orderly exit, and a launcher writing to it would destroy that
+    signal for every future diagnosis.
+    """
+    if sys.platform != "win32":
+        print(
+            "ERROR: --detach is implemented against Windows Task Scheduler and "
+            f"this is {sys.platform}. Run without --detach, or add an equivalent "
+            "for this platform."
+        )
+        return 91
+
+    log = EventLog(log_dir / "detach-events.log")
+    argv = detached_argv(args, extra, repo_root, az_root, log_dir)
+    arguments = " ".join(
+        _quote(a) for a in [str(Path(__file__).resolve()), *argv]
+    )
+    issues = ", ".join(f"#{i}" for i in args.issue)
+    xml = build_task_xml(
+        command=sys.executable,
+        arguments=arguments,
+        working_dir=str(az_root),
+        description=f"Detached speedrun roll of {issues} in {repo_root.name}",
+        user=current_user(),
+    )
+
+    xml_path = log_dir / "detached-task.xml"
+    xml_path.parent.mkdir(parents=True, exist_ok=True)
+    # schtasks requires UTF-16 here; it rejects a UTF-8 definition as malformed.
+    xml_path.write_text(xml, encoding="utf-16")
+
+    created = _run(
+        ["schtasks", "/Create", "/TN", TASK_NAME, "/XML", str(xml_path), "/F"]
+    )
+    if created.returncode != 0:
+        detail = (created.stdout + created.stderr).strip()
+        log.write(f"DETACH create failed: {detail}")
+        return 91
+
+    started = _run(["schtasks", "/Run", "/TN", TASK_NAME])
+    if started.returncode != 0:
+        detail = (started.stdout + started.stderr).strip()
+        log.write(f"DETACH start failed: {detail}")
+        return 91
+
+    log.write(f"DETACH launched '{TASK_NAME}' for {issues} (interpreter {sys.executable})")
+    print(f"Detached: scheduled task '{TASK_NAME}' is rolling {issues}.")
+    print("It is parented by the Task Scheduler service, so ending this session")
+    print("(or killing this shell) cannot reach it.\n")
+    print(f"  launcher narration  {log_dir / 'detached-launcher.log'}")
+    print(f"  run lifecycle       {log_dir / 'session-events.log'}")
+    print(f"  per-issue logs      {log_dir}")
+    print(f"\n  status   schtasks /Query /TN {TASK_NAME}")
+    print(f"  stop     schtasks /End /TN {TASK_NAME}")
+    return 0
+
+
+def _redirect_stdio(path: Path) -> None:
+    """Point stdout and stderr at a file, for a run with no console (#2015).
+
+    A scheduled task inherits no console. Without this every print in this tool
+    -- including EventLog's, which is how a roll narrates itself -- would go
+    nowhere or fail outright. Rebinding before anything else makes the narration
+    durable instead of merely absent.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stream = path.open("a", encoding="utf-8", errors="replace", buffering=1)
+    sys.stdout = stream
+    sys.stderr = stream
+
+
 def install_signal_handlers(log: EventLog) -> None:
     """Log TERM/INT/BREAK/HUP to the events file, then exit via the normal path.
 
@@ -493,7 +684,19 @@ def main(argv: list[str] | None = None) -> int:
         "--assemblyzero-root", default=None,
         help="AssemblyZero checkout that owns orchestrate.py. Default: this tool's repo",
     )
+    parser.add_argument(
+        "--detach", action="store_true",
+        help=(
+            "Run via Windows Task Scheduler so the roll outlives this session, "
+            "then return immediately (#2015)"
+        ),
+    )
+    # Set by --detach on the relaunch; not something anyone types.
+    parser.add_argument("--detached-stdout", default=None, help=argparse.SUPPRESS)
     args, extra = parser.parse_known_args(argv)
+
+    if args.detached_stdout:
+        _redirect_stdio(Path(args.detached_stdout))
 
     repo_root = Path(args.repo).resolve()
     if not (repo_root / ".git").exists():
@@ -511,11 +714,9 @@ def main(argv: list[str] | None = None) -> int:
         else repo_root / "data" / "speedrun" / "runs"
     )
 
-    session = EventLog(log_dir / "session-events.log")
-    install_signal_handlers(session)
-
     # #2007: refuse before spending anything if the tree running this roll is
-    # not the code main says it is.
+    # not the code main says it is. Runs before the detach hand-off too, so a
+    # stale tree is caught here rather than inside a task nobody is watching.
     stale = check_assemblyzero_tree(az_root)
     if stale:
         print(f"BLOCKED: the AssemblyZero tree at {az_root} is not trustworthy:")
@@ -527,6 +728,14 @@ def main(argv: list[str] | None = None) -> int:
             "pipeline code fails in ways that look\n  like target-repo problems."
         )
         return 91
+
+    if args.detach:
+        return launch_detached(args, extra, repo_root, az_root, log_dir)
+
+    # Created only by a process that actually rolls, never by the launcher --
+    # see launch_detached on why that separation is load-bearing.
+    session = EventLog(log_dir / "session-events.log")
+    install_signal_handlers(session)
 
     code = 0
     try:
@@ -549,6 +758,9 @@ def main(argv: list[str] | None = None) -> int:
             print("\nRESTORE INCOMPLETE:")
             for f in failures:
                 print(f"  - {f}")
+                # Also to the events file: a detached run has no one reading
+                # stdout, and this is exactly the state the next roll inherits.
+                session.write(f"RESTORE INCOMPLETE: {f}")
 
 
 if __name__ == "__main__":

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -513,7 +513,78 @@ def launch_detached(
     print(f"  run lifecycle       {log_dir / 'session-events.log'}")
     print(f"  per-issue logs      {log_dir}")
     print(f"\n  status   schtasks /Query /TN {TASK_NAME}")
-    print(f"  stop     schtasks /End /TN {TASK_NAME}")
+    # NOT `schtasks /End`: that ends the task's own process and leaves the
+    # pipeline running, reparented to nothing (#2016).
+    print(f"  stop     {Path(__file__).name} --repo {repo_root} --detach-stop")
+    return 0
+
+
+def pid_file(log_dir: Path) -> Path:
+    return log_dir / "detached-roll.pid"
+
+
+def is_live_python(pid: str) -> bool:
+    """Is this pid a running python process right now?
+
+    Guards the tree kill against pid reuse: a leftover pid file naming a number
+    Windows has since handed to something else must not authorise killing that
+    something else, on a machine that runs concurrent lanes.
+    """
+    if not pid.isdigit():
+        return False
+    result = _run(["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"])
+    out = result.stdout or ""
+    # tasklist reports "INFO: No tasks..." on stdout with exit 0 when nothing
+    # matches, so the pid must be looked for rather than trusting the code.
+    return f'"{pid}"' in out and "python" in out.lower()
+
+
+def stop_detached(log_dir: Path) -> int:
+    """Stop a detached roll and everything it spawned (#2016).
+
+    `schtasks /End` is not enough on its own: it ends the task's own process and
+    leaves the pipeline running, reparented to nothing. Measured 2026-07-31 --
+    ending a roll left two orchestrate processes alive, and the tree kill that
+    followed had to walk four more levels that /End never touched. Those orphans
+    keep calling models and keep writing to the target repo.
+
+    So the pid the roll recorded is killed WITH its tree first, and the task is
+    ended afterwards to return it to Ready.
+    """
+    if sys.platform != "win32":
+        print(f"ERROR: --detach-stop is Windows-only; this is {sys.platform}")
+        return 91
+
+    log = EventLog(log_dir / "detach-events.log")
+    path = pid_file(log_dir)
+    killed = False
+    if path.exists():
+        pid = path.read_text(encoding="utf-8").strip()
+        if not is_live_python(pid):
+            # Windows recycles pids. A stale file plus an unlucky reuse would
+            # tree-kill somebody else's work on a shared machine.
+            log.write(f"DETACH-STOP pid {pid} is not a live python; refusing")
+            print(f"Recorded pid {pid} is not a running python process.")
+            print("Refusing to kill it -- the roll is already gone.")
+            path.unlink(missing_ok=True)
+        else:
+            result = _run(["taskkill", "/PID", pid, "/T", "/F"])
+            if result.returncode == 0:
+                killed = True
+                log.write(f"DETACH-STOP tree-killed pid {pid}")
+                print(f"Stopped the roll and its process tree (pid {pid}).")
+            else:
+                detail = (result.stdout + result.stderr).strip()
+                log.write(f"DETACH-STOP pid {pid} not killed: {detail}")
+                print(f"No live tree for pid {pid} ({detail}).")
+            path.unlink(missing_ok=True)
+    else:
+        print(f"No recorded pid at {path}.")
+
+    ended = _run(["schtasks", "/End", "/TN", TASK_NAME])
+    if ended.returncode != 0 and not killed:
+        log.write("DETACH-STOP nothing was running")
+        print(f"Task '{TASK_NAME}' was not running.")
     return 0
 
 
@@ -691,6 +762,10 @@ def main(argv: list[str] | None = None) -> int:
             "then return immediately (#2015)"
         ),
     )
+    parser.add_argument(
+        "--detach-stop", action="store_true",
+        help="Stop a detached roll and every process it spawned (#2016)",
+    )
     # Set by --detach on the relaunch; not something anyone types.
     parser.add_argument("--detached-stdout", default=None, help=argparse.SUPPRESS)
     args, extra = parser.parse_known_args(argv)
@@ -713,6 +788,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.log_dir
         else repo_root / "data" / "speedrun" / "runs"
     )
+
+    # Stopping is about processes, not code: it must work even from a stale or
+    # dirty tree, so it comes before the staleness gate.
+    if args.detach_stop:
+        return stop_detached(log_dir)
 
     # #2007: refuse before spending anything if the tree running this roll is
     # not the code main says it is. Runs before the detach hand-off too, so a
@@ -737,6 +817,11 @@ def main(argv: list[str] | None = None) -> int:
     session = EventLog(log_dir / "session-events.log")
     install_signal_handlers(session)
 
+    # How --detach-stop finds the tree to kill (#2016). Written by whichever
+    # process does the rolling, detached or not.
+    log_dir.mkdir(parents=True, exist_ok=True)
+    pid_file(log_dir).write_text(str(os.getpid()), encoding="utf-8")
+
     code = 0
     try:
         for issue in args.issue:
@@ -753,6 +838,9 @@ def main(argv: list[str] | None = None) -> int:
     finally:
         # #2005: hand the repo back the way it was borrowed -- on success, on
         # failure, and on the SignalExit raised by the handlers.
+        # A finished roll leaves no pid behind to be stopped, or mistaken for a
+        # live one once Windows reuses the number.
+        pid_file(log_dir).unlink(missing_ok=True)
         failures = restore_repo(repo_root, args.issue, session)
         if failures:
             print("\nRESTORE INCOMPLETE:")

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -744,7 +744,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--repo", required=True, help="Target repo root path")
     parser.add_argument(
-        "--issue", type=int, action="append", required=True,
+        # Not required at parse time: --detach-stop names no issue, it stops
+        # whatever is running. Enforced below for the paths that do roll.
+        "--issue", type=int, action="append", default=None,
         help="Issue to roll (repeatable; rolled in order)",
     )
     parser.add_argument(
@@ -793,6 +795,10 @@ def main(argv: list[str] | None = None) -> int:
     # dirty tree, so it comes before the staleness gate.
     if args.detach_stop:
         return stop_detached(log_dir)
+
+    if not args.issue:
+        print("ERROR: --issue is required (repeatable) unless stopping a roll")
+        return 91
 
     # #2007: refuse before spending anything if the tree running this roll is
     # not the code main says it is. Runs before the detach hand-off too, so a


### PR DESCRIPTION
A roll launched from an agent session dies with that session. This makes it outlive it, and makes stopping it actually stop it.

## The kill is uncatchable, and it was measured

`57ca5bf2` (restore-on-finish, signal handlers) landed 10:20:03 on 2026-07-31. Two rolls ran after it from one process, pid 42392: `run-issue7-102040` finished rc=0, then `run-issue41-105526` started 10:55:26 and stopped at 10:56:11. That process had live SIGTERM/SIGINT/SIGBREAK/SIGHUP handlers and a `finally` calling `restore_repo`, both of which write `session-events.log`, and `EventLog` creates the file on first write. That file does not exist. No signal arrived; the `finally` never ran.

A backgrounded parent was then stopped by the harness with three children spawned three ways:

| child | last beat | survived |
|---|---|---|
| parent | 12:20:22 | killed |
| plain | 12:20:22 | no |
| `DETACHED_PROCESS \| CREATE_NEW_PROCESS_GROUP` | 12:20:22 | no |
| `+ CREATE_BREAKAWAY_FROM_JOB` | 12:20:20 | no |

`CREATE_BREAKAWAY_FROM_JOB` was accepted by `CreateProcess` and the child died anyway, so creation flags are not an available fix. The same child registered as a scheduled task was still beating long after, parented by `svchost.exe`.

## What this does

`--detach` re-invokes the tool through Windows Task Scheduler. Verified on a live roll -- the whole tree hangs off the service:

```
svchost.exe 2708
 |- speedrun_roll 25396 -> 54132
     |- orchestrate 29416 -> 34988
```

The task carries no trigger, so it can only start on demand; no execution time limit, since the default stops an arc partway; no hard terminate; and battery state neither blocks nor stops it. Registration follows runbook 0903: current-user principal, unelevated, so gh credentials come from the operator profile.

`--detach-stop` is the second half. `schtasks /End` reports success and leaves the pipeline running, reparented to nothing -- measured, with a tree kill afterwards walking four levels /End never reached. Those orphans keep calling models and keep writing to the target repo. The stop path tree-kills the recorded pid then ends the task, guarded against pid reuse so a stale file cannot kill another lane work.

## Two things that would have gone silently wrong

The launcher logs to `detach-events.log`, never the session log. The absence of `session-events.log` is precisely what distinguishes an uncatchable kill from an orderly exit, and a launcher writing it would have retired that evidence for every future diagnosis. A test pins it.

`--issue` was required at parse time, so `--detach-stop` could not be invoked at all. The suite missed it because every stop test passed `--issue 7` alongside -- passing for the wrong reason. The live run caught it; two guard tests now pin both halves.

## Verification

153 speedrun unit tests pass (37 new). Ruff clean on both changed files. Launch, run, and stop each verified against a real detached roll of boostgauge #7, with process parentage confirmed at every step.

Closes #2015
Closes #2016
