### PR TITLE
fix(orchestrator): declare impl_pr_url so the implementation PR reaches cleanup (Closes #2018, Closes #2019)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1213,12 +1213,30 @@ def run_cleanup_stage(state: OrchestrationState) -> OrchestrationState:
     # entirely; without it the attempt branch never receives the code and the
     # next phase of an arc builds against a base that has never seen this one.
     # LLD first, matching the order every previous arc landed in.
+    # #2019: decide against what the run actually produced, not against one
+    # optional key. `pr_url` is the pr stage's own artifact and a declared
+    # field, so when impl_pr_url is missing it still says whether there IS an
+    # implementation PR. Treating "no URL" as "nothing to land" is what let a
+    # dropped key report green while the arc failed to accumulate.
     impl_pr_url = state.get("impl_pr_url", "")
+    pr_stage = state.get("stage_results", {}).get("pr", {})
+    pr_stage_produced = pr_stage.get("status") == "passed" and state.get("pr_url", "")
+    if not impl_pr_url and pr_stage_produced:
+        impl_pr_url = state.get("pr_url", "")
+        notes.append(
+            f"implementation PR URL was missing from state; recovered the pr "
+            f"stage's own artifact ({impl_pr_url})"
+        )
+
     impl_merged = False
     if impl_pr_url:
         impl_merged = _merge_pr(impl_pr_url, merge_timeout, notes, label="impl")
+    elif pr_stage_produced:
+        # Unreachable via the recovery above, but a pr stage that passed and
+        # left nothing landable is a fault, never a quiet pass.
+        notes.append("the pr stage passed but no implementation PR can be found")
     else:
-        notes.append("no implementation PR URL in state — nothing to land")
+        notes.append("the pr stage produced no implementation PR — nothing to land")
 
     # #1624: only delete the working-tree copies once the content is safely on main.
     if lld_merged and target_repo:
@@ -1234,13 +1252,16 @@ def run_cleanup_stage(state: OrchestrationState) -> OrchestrationState:
     # which is the wrong contract for a step the next phase depends on. A cleanup
     # hiccup still passes; an unlanded implementation does not -- that is the run
     # not having landed, and reporting it green is how the gap stayed invisible.
-    landed = impl_merged or not impl_pr_url
+    # #2019: a run whose pr stage produced an implementation PR has landed only
+    # when that PR is merged. Only a run that produced none may pass unlanded.
+    landed = impl_merged or not (impl_pr_url or pr_stage_produced)
     result = _make_stage_result(
         status="passed" if landed else "failed",
         error_message=(
             "" if landed else
             f"implementation PR was not merged into the attempt branch "
-            f"({impl_pr_url}); the arc cannot accumulate without it"
+            f"({impl_pr_url or 'URL missing from state'}); the arc cannot "
+            f"accumulate without it"
         ),
         artifact_path=impl_pr_url if impl_merged else (lld_pr_url if lld_merged else ""),
         duration_seconds=time.monotonic() - start_time,

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -48,6 +48,13 @@ class OrchestrationState(TypedDict, total=False):
     worktree_path: str
     pr_url: str
     lld_pr_url: str  # Issue #1531: the LLD PR, captured so the terminal cleanup stage can merge it
+    # #2018: the implementation PR, written by the pr stage and read by cleanup.
+    # This MUST stay declared. The graph is StateGraph(OrchestrationState), so
+    # LangGraph builds its channels from these annotations and discards any key
+    # it has no channel for. #2011 wrote state["impl_pr_url"] without declaring
+    # it here: the write succeeded, the value never crossed the node boundary,
+    # and boostgauge #7 landed its design with the code left in an open PR.
+    impl_pr_url: str
 
     # Progress tracking
     stage_results: dict[str, StageResult]
@@ -133,6 +140,7 @@ def create_initial_state(
         worktree_path="",
         pr_url="",
         lld_pr_url="",
+        impl_pr_url="",
         stage_results={},
         stage_attempts={stage: 0 for stage in STAGE_ORDER},
         started_at=now,

--- a/tests/unit/test_cleanup_impl_pr_recovery.py
+++ b/tests/unit/test_cleanup_impl_pr_recovery.py
@@ -1,0 +1,96 @@
+"""The cleanup stage must not report success when it cannot land the code (#2019).
+
+Boostgauge #7, 2026-07-31: `rc=0`, "All stages passed", implementation PR #159
+left open. `landed = impl_merged or not impl_pr_url` read a missing URL as
+"there was no PR to land" -- indistinguishable from "there was one and I lost
+it", which is what had happened.
+
+So the one stage positioned to notice the arc failed to accumulate was the
+stage reporting green. These pin the recovery and the fault.
+"""
+from unittest.mock import patch
+
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.config import get_default_config
+from assemblyzero.workflows.orchestrator.state import create_initial_state
+
+IMPL_PR = "https://github.com/o/r/pull/159"
+LLD_PR = "https://github.com/o/r/pull/158"
+
+
+def _state(tmp_path, pr_passed=True, **overrides):
+    state = create_initial_state(
+        7, get_default_config(),
+        target_repo=str(tmp_path / "target"),
+        assemblyzero_root=str(tmp_path / "az"),
+    )
+    if pr_passed:
+        state["stage_results"] = dict(state.get("stage_results", {}))
+        state["stage_results"]["pr"] = {"status": "passed", "artifact_path": IMPL_PR}
+        state["pr_url"] = IMPL_PR
+    state.update(overrides)
+    return state
+
+
+def _run(state, merge_result):
+    with patch.object(stages, "_merge_pr", side_effect=merge_result), \
+            patch.object(stages, "_delete_landed_working_copies"), \
+            patch.object(stages, "_remove_orchestrator_worktrees"):
+        return stages.run_cleanup_stage(state)
+
+
+class TestAMissingUrlIsRecoveredNotExcused:
+    def test_it_lands_the_pr_stage_artifact_when_the_url_is_missing(self, tmp_path):
+        """Exactly the live shape: pr stage passed with a PR, impl_pr_url gone."""
+        merged = []
+
+        def fake(url, timeout, notes, label="LLD"):
+            merged.append((label, url))
+            return True
+
+        new_state = _run(_state(tmp_path, lld_pr_url=LLD_PR), fake)
+
+        assert ("impl", IMPL_PR) in merged, merged
+        assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+    def test_the_recovery_is_stated_not_silent(self, tmp_path, capsys):
+        _run(_state(tmp_path), lambda *a, **k: True)
+        assert "URL was missing from state" in capsys.readouterr().out
+
+    def test_an_unmergeable_recovered_pr_still_fails(self, tmp_path):
+        """Recovery must not become a second way to pass without landing."""
+        new_state = _run(_state(tmp_path), lambda u, t, n, label="LLD": label != "impl")
+
+        result = new_state["stage_results"]["cleanup"]
+        assert result["status"] == "failed", result
+        assert "cannot accumulate" in result.get("error_message", "")
+
+
+class TestARunThatProducedNoPrMayStillPass:
+    def test_no_pr_stage_result_means_nothing_to_land(self, tmp_path):
+        """An LLD-only run has no implementation PR and is not a failure."""
+        new_state = _run(_state(tmp_path, pr_passed=False), lambda *a, **k: False)
+        assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+    def test_a_failed_pr_stage_is_not_treated_as_a_landable_pr(self, tmp_path):
+        state = _state(tmp_path, pr_passed=False)
+        state["stage_results"] = dict(state.get("stage_results", {}))
+        state["stage_results"]["pr"] = {"status": "failed", "artifact_path": ""}
+
+        new_state = _run(state, lambda *a, **k: False)
+        assert new_state["stage_results"]["cleanup"]["status"] == "passed"
+
+
+class TestTheExplicitUrlStillWins:
+    def test_a_present_impl_pr_url_is_used_as_is(self, tmp_path):
+        """The normal path once #2018 is fixed -- recovery must not shadow it."""
+        explicit = "https://github.com/o/r/pull/999"
+        merged = []
+
+        def fake(url, timeout, notes, label="LLD"):
+            merged.append((label, url))
+            return True
+
+        _run(_state(tmp_path, impl_pr_url=explicit), fake)
+        assert ("impl", explicit) in merged, merged
+        assert ("impl", IMPL_PR) not in merged

--- a/tests/unit/test_orchestrator_cross_stage_keys.py
+++ b/tests/unit/test_orchestrator_cross_stage_keys.py
@@ -1,0 +1,92 @@
+"""Values a stage writes for a later stage must survive the node boundary.
+
+Boostgauge #7, 2026-07-31: the pr stage recorded the implementation PR, the
+cleanup stage read back an empty string, PR #159 was never merged, and the run
+exited 0 saying "All stages passed". The attempt branch got the design and not
+the code.
+
+The graph is `StateGraph(OrchestrationState)`, so LangGraph builds its channels
+from that TypedDict's annotations and discards any key it has no channel for.
+#2011 wrote `state["impl_pr_url"]` without declaring it. A TypedDict does not
+validate at runtime, so nothing raised anywhere along the path.
+
+The existing cleanup tests could not catch it: they assign `impl_pr_url` by hand
+and assert the consumer merges it, verifying the reader while assuming the
+writer. These cover the boundary instead -- and the declaration guard covers
+every future key, not just this one.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.state import OrchestrationState
+
+STAGES_PY = Path(stages.__file__)
+
+
+def _keys_assigned_to_state(source: Path) -> set[str]:
+    """Every literal key assigned as `state["..."] = ...` in a module."""
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "state"
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                found.add(target.slice.value)
+    return found
+
+
+class TestEveryCrossStageKeyIsDeclared:
+    def test_impl_pr_url_is_a_declared_field(self):
+        """The specific regression: undeclared, so LangGraph dropped it."""
+        assert "impl_pr_url" in OrchestrationState.__annotations__
+
+    def test_no_stage_writes_an_undeclared_key(self):
+        """The class of bug, not the instance. A key with no channel is thrown
+        away silently, and the run still reports success -- so this must fail a
+        test rather than an arc."""
+        assigned = _keys_assigned_to_state(STAGES_PY)
+        declared = set(OrchestrationState.__annotations__)
+        undeclared = assigned - declared
+
+        assert not undeclared, (
+            f"stages.py writes state keys that OrchestrationState does not "
+            f"declare: {sorted(undeclared)}. LangGraph builds channels from "
+            f"those annotations and discards everything else, so these values "
+            f"never reach the stage meant to read them."
+        )
+
+    def test_the_guard_actually_inspects_something(self):
+        """A guard that parsed nothing would pass forever. Pin that it really
+        does find the cross-stage writes it is meant to police."""
+        assigned = _keys_assigned_to_state(STAGES_PY)
+        assert "impl_pr_url" in assigned, (
+            "the AST scan found no `state[\"impl_pr_url\"] = ...` write, so the "
+            "guard above is not looking at what it claims to"
+        )
+
+
+class TestTheReaderAndWriterAgree:
+    def test_the_pr_stage_writes_the_key_cleanup_reads(self):
+        """Producer and consumer are in different functions hundreds of lines
+        apart; a rename on one side is invisible to the other."""
+        source = STAGES_PY.read_text(encoding="utf-8")
+        assert 'state["impl_pr_url"] = ' in source
+        assert 'state.get("impl_pr_url"' in source
+
+
+@pytest.mark.parametrize("key", ["pr_url", "lld_pr_url", "impl_pr_url", "base_branch"])
+def test_pr_carrying_keys_stay_declared(key):
+    """These four are what an arc accumulates on. Losing any one reproduces a
+    failure this campaign has already paid for twice."""
+    assert key in OrchestrationState.__annotations__


### PR DESCRIPTION
The #2011 repair never took effect at runtime. `run_pr_stage` recorded the implementation PR, `run_cleanup_stage` read back an empty string, and the PR was never landed -- the same failure #2011 was filed to end.

## The live evidence

Roll of boostgauge #7, 2026-07-31:

```
pr        passed       3.0s  https://github.com/martymcenroe/boostgauge/pull/159
cleanup   passed      63.7s  https://github.com/martymcenroe/boostgauge/pull/158
[cleanup] no implementation PR URL in state -> nothing to land
[ORCHESTRATOR] All stages passed.
```

Exit 0. LLD PR #158 merged, implementation PR #159 still open. The attempt branch received the design and not the code, and the next phase launched against it.

Persisted state at `.assemblyzero/orchestrator/state/7.json`:

| key | value |
|---|---|
| `pr_url` | `.../pull/159` |
| `lld_pr_url` | `.../pull/158` |
| `impl_pr_url` | **absent** |

## Cause

`OrchestrationState` declared `pr_url` and `lld_pr_url` but not `impl_pr_url`. The graph is `StateGraph(OrchestrationState)`, so LangGraph builds its channels from those annotations and discards keys it has no channel for. `stages.py` wrote `state["impl_pr_url"]` into an undeclared key: the write succeeded, `update_stage_result` copied it, and it was dropped at the node boundary. Nothing raised -- a TypedDict does not validate at runtime.

The state file proves the drop is above persistence: `save_orchestration_state` writes `json.dumps(dict(state))` unfiltered, and the key is still absent.

## Why the tests missed it, and what is different now

The two tests covering this path assigned `impl_pr_url` by hand and asserted cleanup merged it -- verifying the reader while assuming the writer. They passed whether or not the value ever arrived.

The guard added here is not another instance test. It walks `stages.py` with `ast`, collects every `state["..."] = ...` write, and requires each key to be a declared field, so the next undeclared key fails a test instead of an arc. It also asserts the scan really found the write it polices, so a guard that parsed nothing cannot pass forever.

**Verified against the defect:** removing the declaration fails three tests, including the guard.

## The silence (#2019)

`landed = impl_merged or not impl_pr_url` read a missing URL as "there was no implementation PR" -- indistinguishable from "there was one and I lost track of it", which is what happened. The one stage positioned to notice the arc had not accumulated was the stage reporting green.

Cleanup now decides against what the run produced: if the pr stage passed and recorded a PR, that PR must land or the stage fails, and a missing URL is recovered from the pr stage own artifact and stated in the notes rather than excused. A run that genuinely produced no implementation PR still passes.

## Verification

6141 unit tests pass, no regressions. Ruff clean on all four changed files.

Closes #2018
Closes #2019
