### PR TITLE
fix(speedrun): read the base as origin has it, not as the local ref remembers (Closes #2021)

### DIFF
--- a/tests/unit/test_speedrun_clean_check_base_ref.py
+++ b/tests/unit/test_speedrun_clean_check_base_ref.py
@@ -1,0 +1,152 @@
+"""The clean check must read the base as origin has it (#2021).
+
+Boostgauge, 2026-07-31: PR #158 merged LLD-007 into `hardening-run-13`, and the
+next roll of #7 reported that base CLEAN and started building on top of it.
+
+`git ls-tree hardening-run-13` resolves the LOCAL branch. Every PR the pipeline
+opens merges on origin, and since #2012 the checkout stays on the default
+branch forever, so nothing fast-forwards the local attempt branch -- it still
+pointed at the commit it was cut from. Before #2012 the checkout stood on the
+attempt branch and got dragged forward incidentally; that accident was the only
+thing keeping the detector honest.
+
+The decisive fixture here commits the artifact ONLY on the remote and leaves
+the local branch behind. A fixture that committed locally would pass against
+the broken implementation too, and prove nothing -- which is exactly how this
+survived #1959's test pass.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_clean_check as scc  # noqa: E402
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo_with_remote(tmp_path):
+    """A repo whose attempt branch has advanced on origin only.
+
+    Mirrors the live shape: `hardening-run-13` exists on both sides, origin
+    carries a merged LLD, and the local ref still points at the branch point.
+    """
+    upstream = tmp_path / "up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    repo = tmp_path / "boostgauge"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "README.md").write_text("x", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "init")
+    _git(repo, "remote", "add", "origin", str(upstream))
+    _git(repo, "push", "-u", "origin", "main")
+
+    _git(repo, "checkout", "-b", "hardening-run-13")
+    _git(repo, "push", "-u", "origin", "hardening-run-13")
+
+    # The pipeline's own merge: lands on origin, never pulled back down.
+    clone = tmp_path / "elsewhere"
+    _git(tmp_path, "clone", str(upstream), str(clone))
+    _git(clone, "checkout", "hardening-run-13")
+    lld = clone / "docs" / "lld" / "active"
+    lld.mkdir(parents=True)
+    (lld / "LLD-007.md").write_text("# LLD 7", encoding="utf-8")
+    _git(clone, "add", "-A")
+    _git(clone, "commit", "-m", "merge LLD-007")
+    _git(clone, "push")
+
+    # Local ref deliberately left at the branch point, as on the real box.
+    _git(repo, "checkout", "main")
+    return repo
+
+
+class TestArtifactsThatExistOnlyOnOrigin:
+    def test_the_local_ref_is_genuinely_behind(self, repo_with_remote):
+        """Pins the fixture itself. If local ever equals origin here, the test
+        below would pass against the broken implementation and mean nothing."""
+        _git(repo_with_remote, "fetch", "origin")
+        local = subprocess.run(
+            ["git", "rev-parse", "hardening-run-13"], cwd=str(repo_with_remote),
+            capture_output=True, text=True,
+        ).stdout.strip()
+        remote = subprocess.run(
+            ["git", "rev-parse", "origin/hardening-run-13"],
+            cwd=str(repo_with_remote), capture_output=True, text=True,
+        ).stdout.strip()
+        assert local != remote, "fixture must leave the local ref behind"
+
+    def test_a_committed_artifact_on_origin_is_found(self, repo_with_remote):
+        """The live miss: reading the local ref saw nothing and a roll of #7
+        started on a base already holding its LLD."""
+        findings = scc.find_committed_artifact_debris(
+            repo_with_remote, 7, "hardening-run-13"
+        )
+        assert any("LLD-007" in f for f in findings), findings
+        assert all(f.startswith("committed artifact:") for f in findings), findings
+
+    def test_an_unrelated_issue_is_still_clean(self, repo_with_remote):
+        """The check must stay specific -- a base carrying #7 is a fine base
+        for #41 as far as this detector is concerned."""
+        assert scc.find_committed_artifact_debris(
+            repo_with_remote, 41, "hardening-run-13"
+        ) == []
+
+
+class TestRefResolution:
+    def test_a_branch_with_a_remote_resolves_to_origin(self, repo_with_remote):
+        assert scc.resolve_base_ref(
+            repo_with_remote, "hardening-run-13"
+        ) == "origin/hardening-run-13"
+
+    def test_a_local_only_branch_falls_back_to_itself(self, tmp_path):
+        """Test fixtures and one-off local bases have no remote counterpart and
+        must keep working rather than erroring."""
+        repo = tmp_path / "solo"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        (repo / "a.txt").write_text("x", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "init")
+
+        assert scc.resolve_base_ref(repo, "main") == "main"
+
+    def test_an_already_qualified_ref_is_left_alone(self, repo_with_remote):
+        assert scc.resolve_base_ref(
+            repo_with_remote, "origin/hardening-run-13"
+        ) == "origin/hardening-run-13"
+
+    def test_an_empty_ref_is_returned_unchanged(self, repo_with_remote):
+        assert scc.resolve_base_ref(repo_with_remote, "") == ""
+
+
+class TestLocalOnlyBasesStillWork:
+    def test_a_locally_committed_artifact_is_still_found(self, tmp_path):
+        """The pre-existing contract: a local-only base must not regress. This
+        is the assertion #1959 shipped, and it passed before AND after the
+        defect -- which is why it could not be the only one."""
+        repo = tmp_path / "local"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        lld = repo / "docs" / "lld" / "active"
+        lld.mkdir(parents=True)
+        (lld / "LLD-007.md").write_text("# LLD 7", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "init")
+
+        findings = scc.find_committed_artifact_debris(repo, 7, "main")
+        assert any("LLD-007" in f for f in findings), findings

--- a/tools/speedrun_clean_check.py
+++ b/tools/speedrun_clean_check.py
@@ -179,6 +179,33 @@ def find_artifact_debris(repo_root: Path, issue: int) -> list[str]:
     return findings
 
 
+def resolve_base_ref(repo_root: Path, base_ref: str) -> str:
+    """The ref that actually reflects the base, preferring origin (#2021).
+
+    A bare branch name resolves to the LOCAL branch, which for an attempt
+    branch is whatever it was when the branch was cut -- the pipeline merges
+    everything on origin and nothing pulls it back down. So `origin/<base>` is
+    used whenever it exists, after a fetch to make it current.
+
+    Falls back to the name as given when there is no remote counterpart: an
+    explicit sha, a detached ref, or a local-only branch in a test fixture are
+    all legitimate and must keep working.
+    """
+    if not base_ref:
+        return base_ref
+    if base_ref.startswith("origin/"):
+        _run(["git", "fetch", "origin", "--quiet"], cwd=repo_root)
+        return base_ref
+
+    _run(["git", "fetch", "origin", "--quiet"], cwd=repo_root)
+    remote = f"origin/{base_ref}"
+    verified = _run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{remote}^{{commit}}"],
+        cwd=repo_root,
+    )
+    return remote if verified.returncode == 0 else base_ref
+
+
 def find_committed_artifact_debris(
     repo_root: Path, issue: int, base_ref: str
 ) -> list[str]:
@@ -200,14 +227,25 @@ def find_committed_artifact_debris(
     be what the repo is checked out on. Measuring the checkout would answer a
     question nobody asked, and would refuse a perfectly clean
     `--base-branch main` roll launched from a dirty checkout (#1963).
+
+    Reads the REMOTE-TRACKING ref, not the bare name (#2021). Every PR the
+    pipeline opens merges on origin, and since #2012 the checkout stays on the
+    default branch forever, so nothing ever fast-forwards the local attempt
+    branch. Resolving `hardening-run-13` to the local ref therefore measured a
+    commit from before the pipeline's own merges: boostgauge's base carried
+    LLD-007 and its spec on origin while this check reported CLEAN and a roll
+    of #7 started on top of it. Before #2012 the checkout stood on the attempt
+    branch and got dragged forward incidentally -- that accident was the only
+    thing that had kept this honest.
     """
+    ref = resolve_base_ref(repo_root, base_ref)
     result = _run(
-        ["git", "ls-tree", "-r", "--name-only", base_ref, "--", "docs/lld"],
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", "docs/lld"],
         cwd=repo_root,
     )
     if result.returncode != 0:
         return [
-            f"ERROR: git ls-tree failed for {base_ref}: {result.stderr.strip()}"
+            f"ERROR: git ls-tree failed for {ref}: {result.stderr.strip()}"
         ]
     needles = _artifact_needles(issue)
     findings: list[str] = []


### PR DESCRIPTION
The committed-artifact detector from #1959 -- the check whose whole purpose is to guarantee a roll starts from verified zero -- reads a ref the pipeline never updates. It reported CLEAN on a base that already carried the issue work, and a roll started there.

## Measured, boostgauge 2026-07-31

PR #158 merged LLD-007 into `hardening-run-13`. The next roll of #7 then logged `BASE hardening-run-13 clean for #7 after self-heal` and began building.

| ref | sha | `git ls-tree -r --name-only <ref> -- docs/lld` |
|---|---|---|
| `hardening-run-13` (local) | `e80008d2` | nothing |
| `origin/hardening-run-13` | `528ad27f` | `docs/lld/active/LLD-007.md`, `docs/lld/drafts/spec-0007-implementation-readiness.md` |

## Cause

A bare branch name resolves to the LOCAL branch. Every PR the pipeline opens merges on origin, and since #2012 the checkout stays on the default branch permanently, so nothing ever fast-forwards the local attempt branch -- it still points at the commit it was cut from.

Before #2012 the checkout stood on the attempt branch and got dragged forward incidentally. That accident was the only thing keeping this check honest, and removing it (correctly) left the detector blind in exactly the case it was written for: artifacts the pipeline merged itself. `hardening-run-11` in #1959 was found carrying six phases of committed work while every issue returned CLEAN, and this is the mechanism.

## Fix

`resolve_base_ref` fetches and resolves the base to `origin/<base>` when a remote counterpart exists, matching `base_is_structurally_sound`, which already requires the base to exist on origin and track `origin/<base>`. An explicit sha, an already-qualified `origin/...` ref, and a local-only branch all still work unchanged.

## The test, and why the old one could not catch this

The decisive fixture commits the artifact **only on the remote** and deliberately leaves the local ref at the branch point, with a separate assertion pinning that the fixture really is behind -- otherwise it would silently degrade into a test that proves nothing.

**Verified against the defect:** reverting to the local ref fails `test_a_committed_artifact_on_origin_is_found` with an empty finding list, which is the live symptom exactly.

The pre-existing local-commit test passes against both the broken and fixed implementation. That is precisely how this survived #1959's own test pass, so it is kept and labelled as insufficient rather than trusted.

## Verification

6149 unit tests pass, no regressions. Ruff clean on both changed files.

Closes #2021
