### PR TITLE
fix(testing): do not halt the iteration that fixed the failing tests (Closes #2023)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -966,8 +966,37 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": f"Green phase failed after {max_iterations} iterations: coverage {coverage_achieved:.1f}% < target {coverage_target}%",
             }
 
+        # #2023: coverage is not the only way an iteration makes progress, and
+        # this branch is reached with EVERY test passing -- so the iteration
+        # that fixes the last failing test lands right here. boostgauge #41 was
+        # halted on exactly that iteration: 14/15 -> 15/15 passing with coverage
+        # flat at 94.0% against a 95% target, three of five iterations unspent.
+        #
+        # The tests-failing branch above has three guards and can tell progress
+        # from a loop. This one had a single guard, on the one metric that had
+        # not moved. previous_passed and previous_green_failures are written on
+        # every return from this node and were simply never read here.
+        previous_passed = state.get("previous_passed", -1)
+        previous_green_failures = state.get("previous_green_failures", [])
+        tests_improved = (
+            (previous_passed >= 0 and passed_count > previous_passed)
+            or (bool(previous_green_failures) and not current_green_failures)
+        )
+        coverage_stagnant = (
+            previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0
+        )
+
+        if coverage_stagnant and tests_improved:
+            # Progress the guard could not see. Spending another iteration here
+            # is the point of the iteration budget it exists to protect.
+            print(
+                f"    [N5] Coverage flat at {coverage_achieved:.1f}%, but tests "
+                f"improved ({previous_passed} -> {passed_count} passing) — "
+                f"continuing rather than halting."
+            )
+
         # Stagnation check: if coverage didn't improve by at least 1%, halt
-        if previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0:
+        if coverage_stagnant and not tests_improved:
             stagnant_msg = (
                 f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
                 f"(< 1% improvement). Halting to prevent token waste."

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -1,0 +1,134 @@
+"""The coverage guard must not halt the iteration that fixed the tests (#2023).
+
+boostgauge #41, 2026-07-31:
+
+    iteration 1  14 passed, 1 failed  coverage 94.0%
+    iteration 2  15 passed, 0 failed  coverage 94.0%
+    [STAGNANT] Coverage stagnant: 94.0% -> 94.0% (< 1% improvement). Halting.
+
+Iteration 2 fixed the failing test and the run was halted for making no
+progress, three of five iterations unspent, one point from target.
+
+This branch is reached only when EVERY test passes, so the iteration that fixes
+the last failing test always lands here -- and it had a single guard, on the one
+metric that had not moved. The decisive fixture below therefore varies the test
+counts while holding coverage flat; a fixture with both flat would pass against
+the broken code too.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+
+
+def _state(**overrides):
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 41,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(returncode, passed=0, failed=0, errors=0, coverage=0):
+    return {
+        "returncode": returncode,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {
+            "passed": passed, "failed": failed,
+            "errors": errors, "coverage": coverage,
+        },
+    }
+
+
+class TestProgressTheGuardCouldNotSee:
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_iteration_that_went_green_is_not_stagnant(self, mock_pytest):
+        """The live case, exactly: 14/15 -> 15/15, coverage flat under target."""
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=14, previous_coverage=94.0,
+                   previous_green_failures=["test_decay"])
+        )
+
+        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+        assert "stagnant" not in result.get("error_message", "").lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_more_passing_tests_alone_is_progress(self, mock_pytest):
+        """No recorded prior failures, but the passing count rose."""
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=12, previous_coverage=94.0)
+        )
+        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_it_says_why_it_kept_going(self, mock_pytest, capsys):
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        verify_green_phase(
+            _state(previous_passed=14, previous_coverage=94.0,
+                   previous_green_failures=["test_decay"])
+        )
+        assert "tests improved" in capsys.readouterr().out
+
+
+class TestGenuineStagnationStillHalts:
+    """The guard's purpose is intact: no progress of any kind still stops."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_flat_coverage_and_flat_tests_still_halts(self, mock_pytest):
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=15, previous_coverage=94.0)
+        )
+
+        assert result["next_node"] == "end"
+        assert "stagnant" in result.get("error_message", "").lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_fewer_passing_tests_is_not_progress(self, mock_pytest):
+        """Regression must never buy another iteration."""
+        mock_pytest.return_value = _pytest(1, passed=13, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=15, previous_coverage=94.0)
+        )
+
+        assert result["next_node"] == "end"
+        assert "stagnant" in result.get("error_message", "").lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_max_iterations_still_wins_over_test_progress(self, mock_pytest):
+        """The iteration budget is the outer bound; improving tests must not
+        let a run spend past it."""
+        mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=14, previous_coverage=94.0, iteration_count=4,
+                   max_iterations=5, previous_green_failures=["test_decay"])
+        )
+
+        assert result["next_node"] == "end"
+        assert "Max iterations" in result.get("error_message", "") or \
+               "after 5 iterations" in result.get("error_message", "")
+
+
+class TestReachingTargetIsUnaffected:
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_hitting_the_target_still_finishes(self, mock_pytest):
+        mock_pytest.return_value = _pytest(0, passed=15, failed=0, coverage=96)
+        result = verify_green_phase(
+            _state(previous_passed=14, previous_coverage=94.0)
+        )
+        assert result["next_node"] != "N4_implement_code"
+        assert "stagnant" not in result.get("error_message", "").lower()


### PR DESCRIPTION
The impl stage killed a healthy run at the exact moment the implementation became fully green, with three of five iterations unspent.

## Measured, boostgauge #41, 2026-07-31

```
[N5] Iteration 1/5 | Tests: 14/15 passed | Coverage: 94.0% | Target: 95%
[N5] Results: 15 passed, 0 failed | Coverage: 94.0% | Exit: 1 (coverage below fail-under; all tests passed)
[STAGNANT] Coverage stagnant: 94.0% -> 94.0% (< 1% improvement). Halting to prevent token waste.
```

| iteration | tests | coverage |
|---|---|---|
| 1 | 14 passed, **1 failed** | 94.0% |
| 2 | **15 passed, 0 failed** | 94.0% |

Iteration 2 fixed the failing test. That is unambiguous progress, and the run was halted for making none -- one point from a target it was still moving toward.

## Cause

`verify_phases.py:970` guarded this branch on the coverage delta alone:

```python
if previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0:
```

This is the all-tests-pass path -- reached when every test passes but coverage is under target -- so **the iteration that fixes the last failing test always lands here**. Its only guard was the one metric that had not moved.

The tests-failing branch above it has three guards (test count, test identity, coverage) and can tell progress from a loop. `previous_passed` and `previous_green_failures` are written on every return from this node and were simply never read in this branch.

## Why halting was the wrong call

The guard exists to prevent token waste. Stopping after 2 of 5 iterations, on the iteration that produced real progress, wastes the very budget it protects.

## Fix

The coverage guard stands down when test outcomes improved -- fewer failing tests, or more passing ones -- and prints why instead of continuing silently. Preserved: genuine stagnation still halts, a regression in passing tests is never counted as progress, `max_iterations` remains the outer bound, and reaching target is unaffected.

## The tests

The decisive fixtures vary test counts while holding coverage flat. A fixture with both flat would pass against the broken guard and prove nothing.

**Verified against the defect:** reverting to the coverage-only condition fails `test_the_iteration_that_went_green_is_not_stagnant` and `test_more_passing_tests_alone_is_progress`.

## Verification

6156 unit tests pass, no regressions. Ruff clean on the new test file; the three pre-existing warnings in `verify_phases.py` are unchanged from main and untouched here.

Closes #2023
