### PR TITLE
fix(impl): give file generation a floor that reflects the response, not the prompt (Closes #2026)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
@@ -14,6 +14,13 @@ from assemblyzero.core.llm_provider import get_provider
 # Issue #373: Increased from 300s — large test file prompts need more time
 CLI_TIMEOUT = 600  # 10 minutes base (used by compute_dynamic_timeout)
 
+# #2026: what a file generation gets at minimum, and at most. The floor is what
+# matters: generation time tracks the RESPONSE, and a compact prompt can ask for
+# a very large file. The costs are asymmetric — an over-long timeout waits out
+# one slow call, while an under-long one kills the stage and stalls the arc.
+FILE_TIMEOUT_FLOOR = CLI_TIMEOUT
+FILE_TIMEOUT_CAP = 1200
+
 
 class ProgressReporter:
     """Print elapsed time periodically during long operations.
@@ -76,16 +83,26 @@ def compute_dynamic_timeout(prompt: str) -> int:
     Issue #373: Larger prompts need more time for Claude to generate
     correspondingly large responses. Scale linearly with a floor and cap.
 
+    #2026: that premise only ever held one way round. Generation time tracks the
+    RESPONSE, and prompt size does not predict it — a compact spec can ask for a
+    very large file. boostgauge #1 died on `skins/stingray.py`, a big renderer
+    described in about 1.5 KB: it computed 301s, the old floor, and every one of
+    15 attempts hit the same deterministic wall for 11m28s before the stage gave
+    up and stalled the arc at phase 3 of 6.
+
+    So the floor now carries the weight and the scaling is left as a bonus for
+    genuinely large prompts. A too-long timeout costs waiting on one slow call;
+    a too-short one costs the stage.
+
     Args:
         prompt: The prompt string.
 
     Returns:
-        Timeout in seconds (300-600 range).
+        Timeout in seconds (FILE_TIMEOUT_FLOOR–FILE_TIMEOUT_CAP range).
     """
-    base = 300
     # Add 1 second per 1000 characters of prompt
-    scaled = base + len(prompt) // 1000
-    return min(scaled, CLI_TIMEOUT)
+    scaled = FILE_TIMEOUT_FLOOR + len(prompt) // 1000
+    return min(scaled, FILE_TIMEOUT_CAP)
 
 
 def build_system_prompt(file_path: str) -> str:

--- a/tests/unit/test_implement_code_context.py
+++ b/tests/unit/test_implement_code_context.py
@@ -11,6 +11,10 @@ from assemblyzero.workflows.testing.nodes.implement_code import (
     compute_dynamic_timeout,
     CLI_TIMEOUT,
 )
+from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+    FILE_TIMEOUT_CAP,
+    FILE_TIMEOUT_FLOOR,
+)
 
 
 # =============================================================================
@@ -162,32 +166,54 @@ class Config(TypedDict):
 
 
 class TestComputeDynamicTimeout:
-    """Tests for dynamic timeout calculation."""
+    """Tests for dynamic timeout calculation.
 
-    def test_small_prompt_gets_base_timeout(self):
-        """Short prompts should get close to the base 300s timeout."""
-        timeout = compute_dynamic_timeout("short prompt")
-        assert timeout == 300
+    #2026: these previously asserted a 300s base -- the value that killed
+    boostgauge #1. `skins/stingray.py`, a large renderer described in about
+    1.5 KB, computed 301s and hit the same deterministic wall 15 times across
+    11m28s before the stage gave up and stalled the arc at phase 3 of 6.
+
+    The old `test_small_prompt_gets_base_timeout` pinned exactly that behaviour
+    and passed the whole time, because it asserted the formula rather than what
+    the formula is for.
+    """
+
+    def test_a_short_prompt_still_gets_a_generous_timeout(self):
+        """The decisive case: prompt size does not predict response size, so a
+        compact request for a large file must not receive the smallest budget."""
+        timeout = compute_dynamic_timeout("Implement the Stingray skin.")
+        assert timeout >= FILE_TIMEOUT_FLOOR, (
+            "a short prompt can ask for a very large file; the floor is what "
+            "keeps that from killing the stage"
+        )
+
+    def test_the_prompt_size_that_killed_the_arc_now_gets_room(self):
+        """~1.5 KB, which computed 301s before."""
+        timeout = compute_dynamic_timeout("x" * 1500)
+        assert timeout > 301
+        assert timeout >= FILE_TIMEOUT_FLOOR
 
     def test_large_prompt_gets_higher_timeout(self):
-        """Large prompts should scale up the timeout."""
-        # 88KB prompt (like the one that failed)
         large_prompt = "x" * 88000
         timeout = compute_dynamic_timeout(large_prompt)
-        assert timeout > 300
-        assert timeout == min(300 + 88, CLI_TIMEOUT)
+        assert timeout > FILE_TIMEOUT_FLOOR
+        assert timeout == min(FILE_TIMEOUT_FLOOR + 88, FILE_TIMEOUT_CAP)
 
-    def test_timeout_capped_at_cli_timeout(self):
-        """Timeout should never exceed CLI_TIMEOUT."""
-        huge_prompt = "x" * 1_000_000
+    def test_timeout_is_capped(self):
+        huge_prompt = "x" * 10_000_000
         timeout = compute_dynamic_timeout(huge_prompt)
-        assert timeout == CLI_TIMEOUT
+        assert timeout == FILE_TIMEOUT_CAP
 
     def test_medium_prompt_scales_linearly(self):
-        """50KB prompt should get ~350s timeout."""
         medium_prompt = "x" * 50000
         timeout = compute_dynamic_timeout(medium_prompt)
-        assert timeout == 350
+        assert timeout == FILE_TIMEOUT_FLOOR + 50
+
+    def test_the_floor_never_drops_back(self):
+        """Guard against a later edit quietly lowering the floor toward the
+        value that produced 15 timeouts in a single stage."""
+        assert FILE_TIMEOUT_FLOOR >= CLI_TIMEOUT
+        assert FILE_TIMEOUT_CAP > FILE_TIMEOUT_FLOOR
 
 
 # =============================================================================


### PR DESCRIPTION
A short prompt asking for a large file got the minimum timeout, and no retry could help: the value is deterministic in the prompt, so every attempt hit the same wall.

## Measured, boostgauge #1, 2026-07-31

```
FATAL: Failed to implement src/boostgauge/skins/stingray.py:
API error after 2 attempts: claude -p timed out after 301s
impl  failed  688.5s   Attempts: 3 | Duration: 11m 28s
```

**15 timeouts** in one stage, all ~301s, across 3 orchestrator attempts. The arc stalled at phase 3 of 6.

## Cause

```python
base = 300
scaled = base + len(prompt) // 1000
return min(scaled, CLI_TIMEOUT)   # 600
```

301s means `len(prompt) // 1000 == 1` — a prompt of roughly 1.5 KB. The file that timed out was requested by one of the **shortest** prompts in the run and received the **shortest** timeout. `stingray.py` is a skin renderer: a large file, compactly specified.

#373's premise was that larger prompts need more time because they produce correspondingly large responses. Generation time does track the response — but prompt size does not predict it. So the floor was applied to exactly the cases most likely to need the ceiling.

## Fix

The floor now carries the weight: `FILE_TIMEOUT_FLOOR = 600` (the old cap) with `FILE_TIMEOUT_CAP = 1200`. The prompt scaling is kept as a bonus for genuinely large prompts.

The costs are asymmetric. An over-long timeout waits out one slow call; an under-long one kills the stage and stalls the arc — 11m28s and 15 long model calls spent re-deriving one unchanging fact.

## The test that encoded the defect

```python
def test_small_prompt_gets_base_timeout(self):
    timeout = compute_dynamic_timeout("short prompt")
    assert timeout == 300
```

That asserted the exact behaviour that killed the run, and passed the entire time — it tested the formula rather than what the formula is for. Replaced with the decisive case (a short prompt must still get a generous budget), the specific 1.5 KB size that failed, and a guard against the floor being quietly lowered again.

## Verification

6158 unit tests pass, no regressions. Ruff clean on the changed source; the one warning in the test file is a pre-existing unused `pytest` import, unchanged from main.

Related: #1941 (retry resumes identical artifacts) is why each attempt regenerated every file rather than resuming past the one that failed.

Closes #2026
