### PR TITLE
fix(testing): one stagnation decision for both branches (Closes #2029, Closes #2030)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -595,6 +595,61 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
     }
 
 
+COVERAGE_IMPROVEMENT_THRESHOLD = 1.0
+
+
+def coverage_has_stagnated(
+    coverage_achieved: float,
+    previous_coverage: float,
+    passed_count: int,
+    previous_passed: int,
+    current_green_failures: list[str],
+    previous_green_failures: list[str],
+) -> bool:
+    """Whether this iteration earned another one (#2029, #2030).
+
+    ONE decision, called from both branches of verify_green_phase. They carried
+    near-identical copies of this check, and #2023 repaired only the branch
+    whose symptom had been seen -- so the twin halted a plainly improving run on
+    the very next live arc: 20 -> 22 passing, 3 -> 1 failing, 97.0% -> 98.0%,
+    reported as stagnant. A duplicated guard is how a fix lands on one side
+    only, so there is now nowhere for the two to disagree.
+
+    Two things count that the old condition missed.
+
+    Test outcomes are progress (#2029). The point of another iteration is that
+    the last one moved something, and in the tests-failing branch the two guards
+    immediately above compute exactly this and then it was thrown away.
+
+    An improvement of exactly the threshold MEETS the threshold (#2030). The old
+    `<= previous + 1.0` halted on a 1.0 point gain while printing
+    "< 1% improvement", so the code and its own message described different
+    rules.
+    """
+    if previous_coverage < 0:
+        return False  # first iteration has nothing to compare against
+
+    if coverage_achieved - previous_coverage >= COVERAGE_IMPROVEMENT_THRESHOLD:
+        return False
+
+    tests_improved = (
+        (previous_passed >= 0 and passed_count > previous_passed)
+        or (
+            bool(previous_green_failures)
+            and len(current_green_failures) < len(previous_green_failures)
+        )
+    )
+    if tests_improved:
+        print(
+            f"    [N5] Coverage {previous_coverage:.1f}% -> {coverage_achieved:.1f}%, "
+            f"but tests improved ({previous_passed} -> {passed_count} passing) — "
+            f"continuing rather than halting."
+        )
+        return False
+
+    return True
+
+
 def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     """N5: Verify all tests pass with coverage target.
 
@@ -873,10 +928,13 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": stagnant_msg,
             }
 
-        # Stagnation check: if coverage didn't improve by at least 1%, halt.
+        # Stagnation check: one shared decision, see coverage_has_stagnated.
         # Skip when passed_count == 0: coverage is vacuously 100% with no passing
         # tests, so the metric is meaningless. The test-count check above handles that case.
-        if passed_count > 0 and previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0:
+        if passed_count > 0 and coverage_has_stagnated(
+            coverage_achieved, previous_coverage, passed_count, previous_passed,
+            current_green_failures, previous_green_failures,
+        ):
             stagnant_msg = (
                 f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
                 f"(< 1% improvement). Halting to prevent token waste."
@@ -966,37 +1024,13 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": f"Green phase failed after {max_iterations} iterations: coverage {coverage_achieved:.1f}% < target {coverage_target}%",
             }
 
-        # #2023: coverage is not the only way an iteration makes progress, and
-        # this branch is reached with EVERY test passing -- so the iteration
-        # that fixes the last failing test lands right here. boostgauge #41 was
-        # halted on exactly that iteration: 14/15 -> 15/15 passing with coverage
-        # flat at 94.0% against a 95% target, three of five iterations unspent.
-        #
-        # The tests-failing branch above has three guards and can tell progress
-        # from a loop. This one had a single guard, on the one metric that had
-        # not moved. previous_passed and previous_green_failures are written on
-        # every return from this node and were simply never read here.
+        # Stagnation check: one shared decision, see coverage_has_stagnated.
         previous_passed = state.get("previous_passed", -1)
         previous_green_failures = state.get("previous_green_failures", [])
-        tests_improved = (
-            (previous_passed >= 0 and passed_count > previous_passed)
-            or (bool(previous_green_failures) and not current_green_failures)
-        )
-        coverage_stagnant = (
-            previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0
-        )
-
-        if coverage_stagnant and tests_improved:
-            # Progress the guard could not see. Spending another iteration here
-            # is the point of the iteration budget it exists to protect.
-            print(
-                f"    [N5] Coverage flat at {coverage_achieved:.1f}%, but tests "
-                f"improved ({previous_passed} -> {passed_count} passing) — "
-                f"continuing rather than halting."
-            )
-
-        # Stagnation check: if coverage didn't improve by at least 1%, halt
-        if coverage_stagnant and not tests_improved:
+        if coverage_has_stagnated(
+            coverage_achieved, previous_coverage, passed_count, previous_passed,
+            current_green_failures, previous_green_failures,
+        ):
             stagnant_msg = (
                 f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
                 f"(< 1% improvement). Halting to prevent token waste."

--- a/tests/unit/test_verify_green_stagnation_both_branches.py
+++ b/tests/unit/test_verify_green_stagnation_both_branches.py
@@ -1,0 +1,140 @@
+"""Both branches must judge stagnation the same way (#2029, #2030).
+
+#2023 fixed the coverage guard in the all-tests-pass branch, because that is
+the branch boostgauge #41 died in. `verify_green_phase` carries the same check
+twice, and the untouched copy halted the very next live arc:
+
+    [N5] Results: 20 passed, 3 failed | Coverage: 97.0%
+    [N5] Results: 22 passed, 1 failed | Coverage: 98.0%
+    [STAGNANT] Coverage stagnant: 97.0% -> 98.0% (< 1% improvement). Halting.
+
+Two more passing, two fewer failing, coverage up a point -- stopped for lack of
+progress, at phase 3 of 6.
+
+Every #2023 test enters through the all-tests-pass branch (failed=0) and passes
+regardless of that defect. These enter with tests still failing, which is the
+only way to reach the other copy.
+
+#2030 is separate and fires even with flat tests: 97.0 -> 98.0 is a 1.0 point
+gain, and `<= previous + 1.0` called it insufficient while printing
+"< 1% improvement".
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    coverage_has_stagnated,
+    verify_green_phase,
+)
+
+
+def _state(**overrides):
+    base = {
+        "test_files": ["/tmp/test_example.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 1,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(returncode, passed=0, failed=0, errors=0, coverage=0):
+    return {
+        "returncode": returncode,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {
+            "passed": passed, "failed": failed,
+            "errors": errors, "coverage": coverage,
+        },
+    }
+
+
+class TestTheTestsFailingBranch:
+    """Reached only while tests are still failing -- the copy #2023 missed."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_live_case_is_not_stagnant(self, mock_pytest):
+        """20/3 -> 22/1 with coverage 97.0 -> 98.0, exactly as it happened."""
+        mock_pytest.return_value = _pytest(1, passed=22, failed=1, coverage=98)
+        result = verify_green_phase(
+            _state(previous_passed=20, previous_coverage=97.0,
+                   previous_green_failures=["t_a", "t_b", "t_c"])
+        )
+
+        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+        assert "stagnant" not in result.get("error_message", "").lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_no_progress_at_all_still_halts(self, mock_pytest):
+        """Same pass count, same failing set, flat coverage. The test-count
+        guard reaches this one first, which is correct -- what matters is that
+        a genuinely stuck loop still stops."""
+        mock_pytest.return_value = _pytest(1, passed=20, failed=3, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=20, previous_coverage=94.0,
+                   previous_green_failures=["t_a", "t_b", "t_c"])
+        )
+        assert result["next_node"] == "end"
+        assert "stagnant" in result.get("error_message", "").lower()
+
+
+class TestTheThresholdBoundary:
+    """#2030: reaching the stated bar must satisfy it."""
+
+    def test_exactly_one_point_is_enough(self):
+        assert coverage_has_stagnated(98.0, 97.0, 20, 20, [], []) is False
+
+    def test_just_under_one_point_is_not(self):
+        assert coverage_has_stagnated(97.9, 97.0, 20, 20, [], []) is True
+
+    def test_flat_coverage_with_flat_tests_is_stagnant(self):
+        assert coverage_has_stagnated(97.0, 97.0, 20, 20, [], []) is True
+
+    def test_a_first_iteration_is_never_stagnant(self):
+        """previous_coverage of -1 means nothing to compare against."""
+        assert coverage_has_stagnated(50.0, -1.0, 5, -1, [], []) is False
+
+    def test_a_drop_in_coverage_with_flat_tests_is_stagnant(self):
+        assert coverage_has_stagnated(90.0, 97.0, 20, 20, [], []) is True
+
+    def test_fewer_failures_is_progress_even_without_reaching_zero(self):
+        """3 -> 1 failing counts. The #2023 form only recognised 'none failing
+        now', which the tests-failing branch by definition never sees, so that
+        signal was dead exactly where it was needed."""
+        assert coverage_has_stagnated(
+            94.0, 94.0, 21, 21, ["t_a"], ["t_a", "t_b", "t_c"]
+        ) is False
+
+    def test_the_same_failures_recurring_is_not_progress(self):
+        assert coverage_has_stagnated(
+            94.0, 94.0, 21, 21, ["t_a", "t_b"], ["t_a", "t_b"]
+        ) is True
+
+
+class TestBothBranchesAgree:
+    def test_one_helper_backs_every_stagnation_decision(self):
+        """The duplicated guard is what let #2023 land on one side only. If a
+        raw inline comparison reappears, this catches it."""
+        import inspect
+
+        from assemblyzero.workflows.testing.nodes import verify_phases
+
+        source = inspect.getsource(verify_phases.verify_green_phase)
+        assert source.count("coverage_has_stagnated(") == 2, (
+            "both branches must route their coverage-stagnation decision "
+            "through the shared helper"
+        )
+        assert "previous_coverage + 1.0" not in source, (
+            "an inline threshold comparison has reappeared; the two copies "
+            "drift apart under exactly this kind of repair"
+        )


### PR DESCRIPTION
#2023 repaired the coverage-stagnation guard in one of the two branches that carry it. The other one halted the very next live arc.

## Measured, boostgauge #1, 2026-07-31

```
[N5] Results: 20 passed, 3 failed | Coverage: 97.0%
[N5] Results: 22 passed, 1 failed | Coverage: 98.0%
[STAGNANT] Coverage stagnant: 97.0% -> 98.0% (< 1% improvement). Halting to prevent token waste.
```

Two more tests passing, two fewer failing, coverage up a point — stopped for lack of progress. `impl failed 389.6s`, arc halted at phase 3 of 6.

## #2029 — the copy that was missed

`verify_green_phase` carries the coverage check twice: once in the tests-failing branch, once in the all-tests-pass branch. #2023 fixed only the second, because that is the branch #41 died in.

In the tests-failing branch the two guards immediately above the coverage check are test-count and test-identity. On this run **both concluded there was progress and declined to halt** — `passed_count` moved 20 → 22, the failing set changed from 3 tests to 1. Then the third guard discarded that and halted on a metric which had also improved.

Both branches now route through `coverage_has_stagnated`, so there is nowhere for them to disagree. A test asserts both call sites use the helper and that no inline threshold comparison has reappeared — the duplication is what let the first fix land on one side only.

## #2030 — the boundary, visible in the same line

```python
coverage_achieved <= previous_coverage + 1.0     # 98.0 <= 98.0  → "stagnant"
```

A 1.0 point gain was called insufficient while the message printed `< 1% improvement`. The code and its own message described different rules. Reaching the stated bar now satisfies it.

This is independent of #2029: it fires with flat test counts too, so a run climbing exactly 1.0 point per iteration — steady, real progress — was halted on its first step.

## Also

The failure signal was generalised from "none failing now" to "fewer failing than before". The old form could only fire once tests were fully green, which the tests-failing branch by definition never sees — so it was dead precisely where it was needed.

## Verification

Reverting both the threshold and the test-progress check fails three tests, including `test_the_live_case_is_not_stagnant`, which reproduces the 20/3 → 22/1 failure exactly. Every #2023 test enters through the all-tests-pass branch and passes regardless of this defect, which is why the new ones enter with tests still failing.

6168 unit tests pass, no regressions. Ruff clean.

Closes #2029
Closes #2030
