### PR TITLE
fix(impl): a mid-arc phase extends earlier phases instead of skipping them (Closes #2032)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -3,6 +3,7 @@
 Contains implement_code() (the N4 node entry point) and supporting functions.
 """
 
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -272,8 +273,28 @@ def validate_files_to_modify(
     return errors
 
 
+def came_from_base(repo_root: Path, filepath: str) -> bool:
+    """Is this path TRACKED, i.e. inherited from the base branch? (#2032)
+
+    The discriminator the skip-on-resume guard was missing. A pipeline worktree
+    is cut from the integration branch, so a file present when a run starts is
+    tracked and belongs to an earlier phase. A file a previous attempt of THIS
+    run wrote is untracked, because nothing commits mid-stage.
+
+    Same observation -- "the file is already there" -- with opposite correct
+    responses: resume past our own half-written output, never past another
+    phase's finished work.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", filepath],
+        cwd=str(repo_root), capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
 def _should_skip_existing_file(
-    change_type: str, target_path: Path, iteration_count: int
+    change_type: str, target_path: Path, iteration_count: int,
+    repo_root: Path | None = None, filepath: str = "",
 ) -> bool:
     """Issue #547 skip-on-resume, scoped by Issue #1842 to the first pass only.
 
@@ -283,14 +304,48 @@ def _should_skip_existing_file(
     so no retry ever called the model — N5 re-ran byte-identical files until
     the stagnation detector halted the run (hardening runs 8/10/11, boostgauge
     campaign 2026-07-28).
+
+    #2032: a file that came from the BASE is never a resume. boostgauge #2
+    skipped all five planned files -- #41 and #1 had landed them on the
+    integration branch -- printed "5 files written" having written none, and
+    died at pytest with nothing collected.
     """
     if iteration_count > 0:
+        return False
+    if repo_root is not None and filepath and came_from_base(repo_root, filepath):
         return False
     return (
         change_type.lower() == "add"
         and target_path.exists()
         and target_path.stat().st_size > 0
     )
+
+
+def resolve_change_type(
+    change_type: str, repo_root: Path, filepath: str, target_path: Path
+) -> str:
+    """An Add whose file the base already ships is really a Modify (#2032/#2033).
+
+    The spec plans every file as Add because it is drafted against an empty tree
+    rather than the base the worktree is cut from. Followed literally on a
+    mid-arc phase that OVERWRITES an earlier phase: #2 would have replaced the
+    telltale module #41 built instead of extending it.
+
+    Coercing here makes the destructive case impossible while the plan is still
+    wrong, and routes the file through the Modify prompt, which carries the
+    current contents and asks for a change rather than a replacement.
+    """
+    if (
+        change_type.lower() == "add"
+        and target_path.exists()
+        and came_from_base(repo_root, filepath)
+    ):
+        print(
+            f"        Base already ships {filepath}; implementing as Modify so "
+            f"the earlier phase's work is extended rather than replaced."
+        )
+        return "Modify"
+    return change_type
 
 
 def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
@@ -548,12 +603,22 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
 
         # Issue #547: Skip-on-resume — don't re-call Claude for files already on disk
         target_path = repo_root / filepath
-        if _should_skip_existing_file(change_type, target_path, iteration_count):
+        if _should_skip_existing_file(
+            change_type, target_path, iteration_count, repo_root, filepath
+        ):
             existing_content = target_path.read_text(encoding="utf-8")
             print(f"        Skipped (already exists): {target_path}")
             completed_files.append((filepath, existing_content))
             written_paths.append(str(target_path))
             continue
+
+        # #2032: the base already ships this file, so extend it rather than
+        # overwriting an earlier phase. Must run AFTER the resume check, whose
+        # subject is our own output, and BEFORE the validation below, which
+        # reads change_type.
+        change_type = resolve_change_type(
+            change_type, repo_root, filepath, target_path
+        )
 
         # Validate change type
         if change_type.lower() == "modify" and not target_path.exists():

--- a/tests/unit/test_implementation_base_collision.py
+++ b/tests/unit/test_implementation_base_collision.py
@@ -1,0 +1,131 @@
+"""A mid-arc phase must extend what earlier phases built (#2032).
+
+boostgauge #2, 2026-07-31:
+
+    [1/5] src/boostgauge/telltale.py (Add)... Skipped (already exists)
+    [2/5] src/boostgauge/skins/stingray.py (Add)... Skipped (already exists)
+    ... all five ...
+    Implementation complete: 5 files written        <- wrote zero
+    [N5] Results: 0 passed, 0 failed | Exit: 2 (test execution interrupted)
+
+`hardening-run-14` already carried those files from #41 and #1, and the worktree
+is cut from that base, so every planned path existed before the node started.
+The #547 skip-on-resume guard could not tell "our own half-written output" from
+"an earlier phase's finished work" and skipped all of them.
+
+Not skipping alone would be worse: the plan says Add, so the node would have
+OVERWRITTEN the telltale module #41 built. Hence both halves -- do not skip a
+base file, and treat it as a Modify so it is extended.
+"""
+
+import subprocess
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation.orchestrator import (
+    _should_skip_existing_file,
+    came_from_base,
+    resolve_change_type,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def worktree(tmp_path):
+    """A repo standing in for a pipeline worktree cut from an integration
+    branch: one file committed (an earlier phase), one written but uncommitted
+    (a previous attempt of this run)."""
+    repo = tmp_path / "boostgauge-2"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "src").mkdir()
+    (repo / "src" / "telltale.py").write_text("# from phase 41\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "phase 41 landed telltale")
+
+    # Written by a previous attempt of the current stage: never committed.
+    (repo / "src" / "windows.py").write_text("# half done\n", encoding="utf-8")
+    return repo
+
+
+class TestTellingBaseWorkFromOurOwn:
+    def test_a_committed_file_came_from_the_base(self, worktree):
+        assert came_from_base(worktree, "src/telltale.py") is True
+
+    def test_an_uncommitted_file_is_this_run_s_output(self, worktree):
+        assert came_from_base(worktree, "src/windows.py") is False
+
+    def test_a_missing_file_is_not_from_the_base(self, worktree):
+        assert came_from_base(worktree, "src/nope.py") is False
+
+
+class TestSkipOnResume:
+    def test_a_base_file_is_never_skipped(self, worktree):
+        """The live defect: skipping here implements nothing at all."""
+        assert _should_skip_existing_file(
+            "Add", worktree / "src" / "telltale.py", 0, worktree, "src/telltale.py"
+        ) is False
+
+    def test_our_own_output_is_still_skipped(self, worktree):
+        """#547's actual purpose survives: don't re-call the model for a file
+        this run already wrote."""
+        assert _should_skip_existing_file(
+            "Add", worktree / "src" / "windows.py", 0, worktree, "src/windows.py"
+        ) is True
+
+    def test_retry_iterations_still_rewrite(self, worktree):
+        """#1842: iteration > 0 exists to rewrite with failure feedback."""
+        assert _should_skip_existing_file(
+            "Add", worktree / "src" / "windows.py", 1, worktree, "src/windows.py"
+        ) is False
+
+
+class TestAddOnABaseFileBecomesModify:
+    def test_a_base_file_planned_as_add_is_coerced(self, worktree):
+        """Following the plan literally would replace #41's module."""
+        assert resolve_change_type(
+            "Add", worktree, "src/telltale.py", worktree / "src" / "telltale.py"
+        ) == "Modify"
+
+    def test_a_genuinely_new_file_stays_an_add(self, worktree):
+        assert resolve_change_type(
+            "Add", worktree, "src/new.py", worktree / "src" / "new.py"
+        ) == "Add"
+
+    def test_our_own_uncommitted_output_stays_an_add(self, worktree):
+        """Untracked means this run wrote it; it is not an earlier phase's."""
+        assert resolve_change_type(
+            "Add", worktree, "src/windows.py", worktree / "src" / "windows.py"
+        ) == "Add"
+
+    def test_an_explicit_modify_is_left_alone(self, worktree):
+        assert resolve_change_type(
+            "Modify", worktree, "src/telltale.py", worktree / "src" / "telltale.py"
+        ) == "Modify"
+
+    def test_the_coercion_is_announced(self, worktree, capsys):
+        resolve_change_type(
+            "Add", worktree, "src/telltale.py", worktree / "src" / "telltale.py"
+        )
+        out = capsys.readouterr().out
+        assert "Modify" in out and "src/telltale.py" in out
+
+
+class TestEarlierPhaseWorkIsNotDestroyed:
+    def test_the_base_file_is_untouched_by_these_decisions(self, worktree):
+        """The whole point: #41's content must still be there afterwards, since
+        a Modify prompt carries it as context instead of replacing it."""
+        before = (worktree / "src" / "telltale.py").read_text(encoding="utf-8")
+        _should_skip_existing_file(
+            "Add", worktree / "src" / "telltale.py", 0, worktree, "src/telltale.py"
+        )
+        resolve_change_type(
+            "Add", worktree, "src/telltale.py", worktree / "src" / "telltale.py"
+        )
+        assert (worktree / "src" / "telltale.py").read_text(encoding="utf-8") == before


### PR DESCRIPTION
A mid-arc phase implemented nothing, reported that it had, and died two nodes later at pytest.

## Measured, boostgauge #2, 2026-07-31

```
[1/5] src/boostgauge/telltale.py (Add)...       Skipped (already exists)
[2/5] src/boostgauge/skins/stingray.py (Add)... Skipped (already exists)
[3/5] src/boostgauge/gauge.py (Add)...          Skipped (already exists)
[4/5] tests/unit/test_telltale.py (Add)...      Skipped (already exists)
[5/5] tests/visual/test_gauge.py (Add)...       Skipped (already exists)
Implementation complete: 5 files written
[N5] Results: 0 passed, 0 failed | Coverage: 0.0% | Exit: 2 (test execution interrupted)
```

Zero files written. `hardening-run-14` already carried all five from #41 and #1, and a pipeline worktree is cut from that base, so every planned path existed before the node started.

## Why the guard could not tell

#547's skip-on-resume exists so a retry does not re-call the model for a file this run already wrote. It tests `target_path.exists()`, which is true in two very different situations:

| the file is already there because | correct response |
|---|---|
| a previous attempt of THIS run wrote it | skip — that is the resume |
| an earlier PHASE landed it on the base | do not skip — nothing has been implemented |

The discriminator is tracking. A worktree file present at the start of a run is **committed**; a file this run wrote is **untracked**, because nothing commits mid-stage. `came_from_base()` asks git that question directly.

## Not skipping alone would have been worse

The plan says `Add`. Had the node simply proceeded, it would have **overwritten the telltale module #41 built** — silently destroying an earlier phase instead of merely failing to extend it.

So an `Add` whose file came from the base is coerced to `Modify`, which routes it through the prompt that carries the file's current contents and asks for a change rather than a replacement. A test asserts the base file's content is untouched by both decisions.

Preserved: #547's real purpose (our own untracked output is still skipped) and #1842's rewrite-on-retry (`iteration_count > 0` still returns False).

## Why this blocked the campaign

The arc exists to accumulate — each phase lands on the integration branch and the next is cut from it — so the chance a phase touches an earlier phase's file rises with every phase. #7, #41, #1 and #4 all landed first; #2 was simply the first whose subject matter overlapped one of them.

A pipeline that can only `Add` cannot build a second layer on anything. It works right up until the arc starts working.

The root cause of the all-`Add` plan — the spec is drafted against an empty tree rather than the base — is #2033. Coercing at the point of use makes the destructive case impossible while that stands.

## Verification

6180 unit tests pass, no regressions. Ruff clean on both changed files (the one pre-existing warning in `orchestrator.py` is unrelated and unchanged from main).

Closes #2032
