### PR TITLE
fix(spec): plan against the base the implementation is built on (Closes #2033)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/base_tree.py
+++ b/assemblyzero/workflows/implementation_spec/base_tree.py
@@ -1,0 +1,99 @@
+"""Reading the integration branch a phase will actually be built on (#2033).
+
+The spec is drafted against the CHECKOUT, which since #2012 sits permanently on
+the default branch. The implementation happens in a worktree cut from the
+attempt branch. Mid-arc those are different trees: `main` has none of the arc,
+while the attempt branch carries every phase landed so far.
+
+So a phase that extends an earlier one was planned as if that earlier one did
+not exist. boostgauge #2 listed `telltale.py`, `gauge.py` and `stingray.py` as
+files to Add -- all three were already on the base, landed by #41 and #1 -- and
+the resulting spec described modules to create rather than modules to extend.
+
+Everything here reads git rather than the working tree, because the working
+tree is the wrong tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _git(repo_root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo_root),
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+def base_ref(repo_root: Path, base_branch: str) -> str:
+    """The ref to read the base from, preferring origin (#2021).
+
+    A bare attempt-branch name resolves to the LOCAL branch, which nothing
+    fast-forwards -- every PR the pipeline opens merges on origin. The same trap
+    made the clean-check blind to the pipeline's own merges.
+    """
+    if not base_branch:
+        return ""
+    if base_branch.startswith("origin/"):
+        return base_branch
+    _git(repo_root, "fetch", "origin", "--quiet")
+    remote = f"origin/{base_branch}"
+    if _git(repo_root, "rev-parse", "--verify", "--quiet", f"{remote}^{{commit}}").returncode == 0:
+        return remote
+    return base_branch
+
+
+def exists_on_base(repo_root: Path, base_ref_name: str, file_path: str) -> bool:
+    """Does the base already ship this path?"""
+    if not base_ref_name:
+        return False
+    normalised = file_path.replace("\\", "/")
+    result = _git(repo_root, "cat-file", "-e", f"{base_ref_name}:{normalised}")
+    return result.returncode == 0
+
+
+def read_from_base(repo_root: Path, base_ref_name: str, file_path: str) -> str:
+    """Contents of this path on the base, or "" if it is not there."""
+    if not base_ref_name:
+        return ""
+    normalised = file_path.replace("\\", "/")
+    result = _git(repo_root, "show", f"{base_ref_name}:{normalised}")
+    return result.stdout if result.returncode == 0 else ""
+
+
+def reclassify_against_base(
+    files_to_modify: list[dict], repo_root: Path, base_branch: str
+) -> tuple[list[dict], list[str]]:
+    """Turn every Add whose file the base already ships into a Modify.
+
+    Returns the updated list and a note per reclassified path, so the change is
+    stated in the run log rather than being a silent rewrite of the plan.
+
+    Deliberately one-way. A Modify the base does not have is left alone: the
+    existing guard in analyze_codebase reports it, and inventing an Add here
+    would paper over an LLD that named the wrong file.
+    """
+    if not base_branch:
+        return files_to_modify, []
+
+    ref = base_ref(repo_root, base_branch)
+    if not ref:
+        return files_to_modify, []
+
+    updated: list[dict] = []
+    notes: list[str] = []
+    for spec in files_to_modify:
+        path = spec.get("path", "")
+        if spec.get("change_type") == "Add" and exists_on_base(repo_root, ref, path):
+            changed = dict(spec)
+            changed["change_type"] = "Modify"
+            updated.append(changed)
+            notes.append(
+                f"{path}: planned as Add, but {ref} already ships it — "
+                f"specifying a Modify so the earlier phase is extended"
+            )
+        else:
+            updated.append(spec)
+    return updated, notes

--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -20,6 +20,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.workflows.implementation_spec.base_tree import (
+    base_ref,
+    read_from_base,
+    reclassify_against_base,
+)
 from assemblyzero.workflows.requirements.audit import get_repo_structure
 from assemblyzero.workflows.implementation_spec.state import (
     FileToModify,
@@ -122,6 +127,18 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
     print(f"    Repo root: {repo_root}")
     print(f"    Files to analyze: {len(files_to_modify)}")
 
+    # #2033: plan against the tree the implementation will be built on, not the
+    # checkout. Mid-arc a file the LLD calls "Add" is already on the attempt
+    # branch, put there by an earlier phase, and specifying it as new is what
+    # produced a spec describing modules to create instead of modules to extend.
+    base_branch = state.get("base_branch", "")
+    files_to_modify, base_notes = reclassify_against_base(
+        files_to_modify, repo_root, base_branch
+    )
+    for note in base_notes:
+        print(f"    [BASE] {note}")
+    base_ref_name = base_ref(repo_root, base_branch) if base_branch else ""
+
     # Step 1: Load current content for Modify/Delete files
     current_state_snapshots: dict[str, str] = {}
     updated_files: list[FileToModify] = []
@@ -133,6 +150,29 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
         full_path = repo_root / file_path
 
         if change_type in ("Modify", "Delete"):
+            # #2033: the checkout is on the default branch, so a file an earlier
+            # phase landed on the attempt branch is absent here while being very
+            # much present in the tree the implementation is cut from. Read the
+            # base before concluding the file does not exist.
+            if not full_path.exists() and base_ref_name:
+                base_content = read_from_base(repo_root, base_ref_name, file_path)
+                if base_content:
+                    excerpt = extract_relevant_excerpt(
+                        file_path, base_content, lld_content
+                    )
+                    current_state_snapshots[file_path] = excerpt
+                    updated_files.append(FileToModify(
+                        path=file_path,
+                        change_type=change_type,
+                        description=file_spec["description"],
+                        current_content=base_content,
+                    ))
+                    print(
+                        f"    [BASE] Loaded from {base_ref_name}: {file_path} "
+                        f"({len(excerpt):,} chars excerpt)"
+                    )
+                    continue
+
             # --------------------------------------------------------------------------
             # GUARD: File must exist for Modify/Delete
             # --------------------------------------------------------------------------

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -120,6 +120,12 @@ class ImplementationSpecState(TypedDict, total=False):
     repo_root: str
     assemblyzero_root: str
     audit_dir: str
+    # #2033: the integration branch the implementation worktree is cut from.
+    # repo_root's checkout sits on the default branch (#2012), which mid-arc
+    # carries none of the phases landed so far -- so a spec drafted from the
+    # checkout plans against the wrong tree. Empty when there is no attempt
+    # branch, which restores the previous behaviour exactly.
+    base_branch: str
 
     # Configuration (set by CLI runner)
     config_mock_mode: bool

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -627,6 +627,9 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
             "lld_path": lld_path,
             "repo_root": state.get("target_repo", ""),
             "assemblyzero_root": state.get("assemblyzero_root", ""),
+            # #2033: the tree the implementation will actually be built on. The
+            # checkout is on the default branch and mid-arc has none of the arc.
+            "base_branch": state.get("base_branch", ""),
             "config_drafter": stage_cfg.get("drafter", ""),
             "config_reviewer": stage_cfg.get("reviewer", ""),
             "config_effort": stage_cfg.get("effort", ""),

--- a/tests/unit/test_spec_base_aware.py
+++ b/tests/unit/test_spec_base_aware.py
@@ -1,0 +1,146 @@
+"""The spec must be planned against the base, not the checkout (#2033).
+
+The implementation happens in a worktree cut from the attempt branch. The spec
+is drafted from `repo_root`, whose checkout has sat permanently on the default
+branch since #2012. Mid-arc those are different trees -- `main` carries none of
+the arc, the attempt branch carries every phase landed so far.
+
+boostgauge #2 listed `telltale.py`, `gauge.py` and `stingray.py` as files to
+Add. All three were already on the base, put there by #41 and #1. The spec
+described modules to create; the implementation followed it and deleted
+`render` and `render_stingray`, which #1's own tests import.
+
+The fixtures here put the file ONLY on the base branch and leave the checkout
+without it, because that is the shape that fails. A fixture with the file in the
+working tree passes against the old code and proves nothing.
+"""
+
+import subprocess
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.base_tree import (
+    base_ref,
+    exists_on_base,
+    read_from_base,
+    reclassify_against_base,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Checkout on main; an attempt branch carrying a file main has never seen."""
+    upstream = tmp_path / "up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+
+    # An earlier phase lands telltale.py on the attempt branch.
+    _git(r, "checkout", "-b", "hardening-run-14")
+    src = r / "src"
+    src.mkdir()
+    (src / "telltale.py").write_text(
+        "def render_stingray():\n    return 'phase 41'\n", encoding="utf-8"
+    )
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "phase 41")
+    _git(r, "push", "-u", "origin", "hardening-run-14")
+
+    # The checkout goes back to the default branch, per #2012. src/ is gone.
+    _git(r, "checkout", "main")
+    return r
+
+
+class TestSeeingTheBase:
+    def test_the_checkout_really_lacks_the_file(self, repo):
+        """Pins the fixture. If the file were present in the working tree the
+        tests below would pass against the old behaviour and mean nothing."""
+        assert not (repo / "src" / "telltale.py").exists()
+
+    def test_a_base_file_is_visible(self, repo):
+        ref = base_ref(repo, "hardening-run-14")
+        assert exists_on_base(repo, ref, "src/telltale.py") is True
+
+    def test_its_contents_can_be_read(self, repo):
+        ref = base_ref(repo, "hardening-run-14")
+        assert "render_stingray" in read_from_base(repo, ref, "src/telltale.py")
+
+    def test_a_file_on_no_branch_is_not_found(self, repo):
+        ref = base_ref(repo, "hardening-run-14")
+        assert exists_on_base(repo, ref, "src/nope.py") is False
+        assert read_from_base(repo, ref, "src/nope.py") == ""
+
+    def test_the_base_resolves_to_origin(self, repo):
+        """#2021: the local attempt ref is never fast-forwarded, so reading it
+        would report the tree as it was when the branch was cut."""
+        assert base_ref(repo, "hardening-run-14") == "origin/hardening-run-14"
+
+
+class TestReclassification:
+    def test_an_add_the_base_already_ships_becomes_a_modify(self, repo):
+        """The live defect: planned as new, already present, spec described a
+        module to create."""
+        files = [{"path": "src/telltale.py", "change_type": "Add", "description": "d"}]
+        updated, notes = reclassify_against_base(files, repo, "hardening-run-14")
+
+        assert updated[0]["change_type"] == "Modify"
+        assert any("telltale.py" in n for n in notes)
+
+    def test_a_genuinely_new_file_stays_an_add(self, repo):
+        files = [{"path": "src/brand_new.py", "change_type": "Add", "description": "d"}]
+        updated, notes = reclassify_against_base(files, repo, "hardening-run-14")
+
+        assert updated[0]["change_type"] == "Add"
+        assert notes == []
+
+    def test_an_explicit_modify_is_left_alone(self, repo):
+        files = [{"path": "src/telltale.py", "change_type": "Modify", "description": "d"}]
+        updated, _ = reclassify_against_base(files, repo, "hardening-run-14")
+        assert updated[0]["change_type"] == "Modify"
+
+    def test_a_modify_the_base_lacks_is_not_invented_into_an_add(self, repo):
+        """One-way only. An LLD naming the wrong file must still be reported by
+        the existing guard rather than quietly rewritten into something valid."""
+        files = [{"path": "src/nope.py", "change_type": "Modify", "description": "d"}]
+        updated, _ = reclassify_against_base(files, repo, "hardening-run-14")
+        assert updated[0]["change_type"] == "Modify"
+
+    def test_the_change_is_stated_not_silent(self, repo):
+        files = [{"path": "src/telltale.py", "change_type": "Add", "description": "d"}]
+        _, notes = reclassify_against_base(files, repo, "hardening-run-14")
+        assert notes and "already ships it" in notes[0]
+
+
+class TestRunsWithoutAnAttemptBranch:
+    """A fresh feature on main must behave exactly as before."""
+
+    def test_no_base_branch_changes_nothing(self, repo):
+        files = [{"path": "src/telltale.py", "change_type": "Add", "description": "d"}]
+        updated, notes = reclassify_against_base(files, repo, "")
+
+        assert updated[0]["change_type"] == "Add"
+        assert notes == []
+
+    def test_an_empty_base_ref_reads_as_absent(self, repo):
+        assert exists_on_base(repo, "", "src/telltale.py") is False
+        assert read_from_base(repo, "", "src/telltale.py") == ""
+
+    def test_a_base_that_does_not_exist_is_not_fatal(self, repo):
+        files = [{"path": "src/telltale.py", "change_type": "Add", "description": "d"}]
+        updated, _ = reclassify_against_base(files, repo, "no-such-branch")
+        assert updated[0]["change_type"] == "Add"


### PR DESCRIPTION
The spec is drafted against the wrong tree, so a phase that extends an earlier one is planned as if that earlier one does not exist.

## The two trees

The spec workflow reads `repo_root`, whose checkout has sat permanently on the default branch since #2012. The implementation happens in a worktree cut from the **attempt branch**. Mid-arc these differ completely: `main` carries none of the arc, the attempt branch carries every phase landed so far.

## Measured, boostgauge #2, 2026-07-31

Every file operation in the run was `(Add)` — 30 of them, zero `Modify` — and three of the five planned paths were already on the base, landed by #41 and #1.

With #2032 merged the files were genuinely written rather than skipped, so the run got further and failed differently:

```
ERROR collecting tests/unit/test_gauge.py
  E ImportError: cannot import name render_stingray from boostgauge.skins.stingray
ERROR collecting tests/visual/test_stingray_visual.py
  E ImportError: cannot import name render from boostgauge.gauge
161 tests collected, 2 errors
```

The spec described modules to create. The implementation followed it faithfully and deleted `render` and `render_stingray` — symbols #1 published and #1's own tests import.

## Fix

An `Add` whose file the base already ships is specified as a `Modify`, and current state is read from the base when the checkout does not have the file.

The machinery already existed: `analyze_codebase` loads current content for Modify files and populates the spec's `## 3. Current State` section. It was never given a file to load, because everything arrived classified as `Add` and the tree it consulted was the wrong one. `base_branch` is now threaded from the orchestrator into the spec workflow, and the base is resolved to `origin/<base>` — a bare attempt-branch name resolves to the local ref, which nothing fast-forwards (the same trap as #2021).

Reclassification is **one-way**. A `Modify` the base lacks is left alone, so the existing guard still reports an LLD naming a file that does not exist rather than quietly rewriting it into something that parses.

## Blast radius

Only a phase touching a file an earlier phase landed. With no attempt branch, or a genuinely new file, behaviour is unchanged — three tests pin exactly that, since this touches spec generation for every repo the pipeline serves.

## The fixtures

The decisive ones put the file **only on the base** and leave the checkout without it, because that is the shape that fails. A fixture with the file in the working tree passes against the old code and proves nothing. A separate assertion pins that the checkout really lacks the file, so the suite cannot silently degrade into one that tests nothing.

## Relationship to #2032

#2032 made the destructive case impossible at the point of use — a base file planned as `Add` is implemented as a `Modify` rather than overwritten. This removes the cause: the plan itself is now drawn against the right tree.

## Verification

6193 unit tests pass, no regressions. Ruff clean on both new files; the four warnings in `analyze_codebase.py` are pre-existing and unchanged from main.

Closes #2033
