### PR TITLE
fix(win): no console windows from a detached roll (Closes #2037)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -524,9 +524,18 @@ class ClaudeCLIProvider(LLMProvider):
             # only kills the root process; grandchild processes keep the
             # pipes open, blocking for 200-400s after the timeout fires.
             # See issue #526.
+            # #2037: CREATE_NO_WINDOW or this opens a console window per model
+            # call. Whether that shows depends on the PARENT: under the agent's
+            # shell the child inherited an existing console and nothing
+            # appeared, but a roll running under Task Scheduler (#2015) has no
+            # console, so every call allocated its own -- continuously, for the
+            # length of an unattended run. Composes with CREATE_NEW_PROCESS_GROUP,
+            # which #526 needs to tree-kill on timeout.
             creation_flags = 0
             if sys.platform == "win32":
-                creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP
+                creation_flags = (
+                    subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+                )
 
             # Issue #787: When using temp dir, wrap in TemporaryDirectory
             # context manager so cleanup is guaranteed.

--- a/tests/unit/test_no_console_windows.py
+++ b/tests/unit/test_no_console_windows.py
@@ -1,0 +1,127 @@
+"""A detached roll must not put windows on the operator's desktop (#2037).
+
+Reported live during boostgauge phases 5-6, 2026-07-31: console windows popping
+up continuously during an unattended run.
+
+Whether a child shows a console depends on the PARENT. Under the agent's Bash
+shell the child inherited an existing console and nothing appeared; under Task
+Scheduler (#2015) the parent has no console, so every `claude -p` call allocated
+its own. The flags were unchanged -- the environment moved out from under them,
+which is why this shipped without anyone seeing it.
+
+Only a human watching the desktop can catch a regression here, so these assert
+the flags directly.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+WIN32_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="console windows are a Windows concern"
+)
+
+
+class TestModelCallsAreWindowless:
+    @WIN32_ONLY
+    def test_the_provider_asks_for_no_window(self):
+        """One window per model call, and a roll makes one call per file per
+        iteration."""
+        import inspect
+
+        from assemblyzero.core import llm_provider
+
+        source = inspect.getsource(llm_provider)
+        assert "CREATE_NO_WINDOW" in source, (
+            "the model subprocess must suppress its console; without a console "
+            "to inherit it allocates one"
+        )
+
+    @WIN32_ONLY
+    def test_process_group_is_kept(self):
+        """#526 needs CREATE_NEW_PROCESS_GROUP to tree-kill on timeout. The two
+        flags compose; suppressing the window must not cost that."""
+        import inspect
+
+        from assemblyzero.core import llm_provider
+
+        source = inspect.getsource(llm_provider)
+        assert "CREATE_NEW_PROCESS_GROUP" in source
+
+    def test_the_two_flags_compose(self):
+        """Guard against someone 'simplifying' to one of them later."""
+        if sys.platform != "win32":
+            pytest.skip("Windows creation flags")
+        combined = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+        assert combined & subprocess.CREATE_NO_WINDOW
+        assert combined & subprocess.CREATE_NEW_PROCESS_GROUP
+
+
+class TestTheRollItselfIsWindowless:
+    def test_pythonw_is_preferred_when_present(self, tmp_path):
+        """A scheduled task running python.exe shows a console for the whole
+        roll, not just a flash."""
+        py = tmp_path / "python.exe"
+        py.write_text("", encoding="utf-8")
+        (tmp_path / "pythonw.exe").write_text("", encoding="utf-8")
+
+        assert sr.windowless_interpreter(str(py)) == str(tmp_path / "pythonw.exe")
+
+    def test_it_falls_back_when_there_is_no_pythonw(self, tmp_path):
+        """A visible console beats a task that cannot start."""
+        py = tmp_path / "python.exe"
+        py.write_text("", encoding="utf-8")
+
+        assert sr.windowless_interpreter(str(py)) == str(py)
+
+    def test_a_non_python_interpreter_is_left_alone(self, tmp_path):
+        other = tmp_path / "pypy.exe"
+        other.write_text("", encoding="utf-8")
+        assert sr.windowless_interpreter(str(other)) == str(other)
+
+    def test_the_scheduled_command_uses_the_windowless_interpreter(self, tmp_path):
+        """End to end through launch_detached: the XML must name pythonw."""
+        py = tmp_path / "python.exe"
+        py.write_text("", encoding="utf-8")
+        (tmp_path / "pythonw.exe").write_text("", encoding="utf-8")
+
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+
+        calls = []
+
+        def _run(cmd, cwd=None):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch.object(sr, "_run", _run), \
+                patch.object(sr.sys, "platform", "win32"), \
+                patch.object(sr.sys, "executable", str(py)), \
+                patch.object(sr, "check_assemblyzero_tree", lambda p: []):
+            code = sr.main(["--repo", str(repo), "--issue", "7", "--detach"])
+
+        assert code == 0
+        xml = (repo / "data" / "speedrun" / "runs" / "detached-task.xml").read_text(
+            encoding="utf-16"
+        )
+        assert "pythonw.exe" in xml
+        assert "<Command>" in xml
+
+
+class TestThePipelineSubprocess:
+    def test_orchestrate_is_spawned_without_a_console(self):
+        """The roll's own child gets the same treatment; under Task Scheduler
+        it has no console to inherit either."""
+        import inspect
+
+        source = inspect.getsource(sr.roll_issue)
+        assert "CREATE_NO_WINDOW" in source

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -334,6 +334,12 @@ def roll_issue(
             proc = subprocess.run(
                 cmd, cwd=str(az_root), stdout=fh, stderr=subprocess.STDOUT,
                 env=_child_env(),
+                # #2037: no console for the pipeline either. Under Task
+                # Scheduler the parent has none to inherit, so without this the
+                # child allocates its own.
+                creationflags=(
+                    subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+                ),
             )
         log.write(f"CHILD EXITED rc={proc.returncode}")
 
@@ -409,6 +415,25 @@ def _quote(arg: str) -> str:
     return f'"{arg}"' if " " in arg else arg
 
 
+def windowless_interpreter(executable: str) -> str:
+    """pythonw.exe beside this interpreter, if there is one (#2037).
+
+    A scheduled task running python.exe puts a console on the operator's
+    desktop for the whole roll. pythonw has none, and is safe here only because
+    --detached-stdout rebinds stdout and stderr to the launcher log before
+    anything prints -- under pythonw they would otherwise be absent.
+
+    Falls back to the interpreter as given when no pythonw is present, since a
+    visible console is much better than a task that cannot start.
+    """
+    path = Path(executable)
+    if path.name.lower() == "python.exe":
+        candidate = path.with_name("pythonw.exe")
+        if candidate.is_file():
+            return str(candidate)
+    return executable
+
+
 def current_user() -> str:
     domain = os.environ.get("USERDOMAIN", "")
     name = os.environ.get("USERNAME", "")
@@ -479,7 +504,7 @@ def launch_detached(
     )
     issues = ", ".join(f"#{i}" for i in args.issue)
     xml = build_task_xml(
-        command=sys.executable,
+        command=windowless_interpreter(sys.executable),
         arguments=arguments,
         working_dir=str(az_root),
         description=f"Detached speedrun roll of {issues} in {repo_root.name}",


### PR DESCRIPTION
Every `claude -p` call in a detached roll opened a console window on the operator's desktop — continuously, for the length of an unattended run. Reported live during boostgauge phases 5-6, with no other agent session active.

## Cause

```python
creation_flags = subprocess.CREATE_NEW_PROCESS_GROUP    # no CREATE_NO_WINDOW
```

The flags never changed. The environment moved out from under them:

| parent | result |
|---|---|
| agent Bash shell (has a console) | child inherits it, nothing appears |
| Task Scheduler service (no console) | child allocates its **own** console window |

So this was latent for as long as rolls ran as children of the agent shell, and became visible the moment #2015 moved them under Task Scheduler to survive harness kills. **That was my change, so this is my regression.** A roll makes one model call per file per iteration, which is why they arrive continuously rather than once.

## Fix

- `CREATE_NO_WINDOW` alongside `CREATE_NEW_PROCESS_GROUP` on the model subprocess. The two compose, and a test pins both — #526 needs the process group to tree-kill on timeout, and suppressing a window must not quietly cost that.
- The roll's own `orchestrate.py` subprocess gets the same treatment; under Task Scheduler it has no console to inherit either.
- The scheduled task runs `pythonw.exe` when one sits beside the interpreter, so the roll process itself has no console. This is safe **only** because `--detached-stdout` (added in #2015) already rebinds stdout and stderr to the launcher log before anything prints — under `pythonw` they would otherwise be absent. Falls back to `python.exe` when there is no `pythonw`, since a visible console beats a task that cannot start.

## Why the tests assert flags directly

Nothing in a log records that a window appeared. Only a human watching the desktop catches this, which is precisely how it shipped. The tests assert the creation flags and the scheduled command, including an end-to-end check that the generated task XML names `pythonw.exe`.

## Verification

6201 unit tests pass, no regressions. Ruff clean on both changed files; the 16 warnings in `llm_provider.py` are pre-existing and unchanged from main.

Closes #2037
