### PR TITLE
fix(speedrun): never discard a mid-arc base over debris (Closes #2028)

### DIFF
--- a/tests/unit/test_speedrun_roll_no_silent_discard.py
+++ b/tests/unit/test_speedrun_roll_no_silent_discard.py
@@ -1,0 +1,171 @@
+"""A mid-arc base is not thrown away over debris (#2028).
+
+Twice on 2026-07-31 a single local branch the reset could not delete -- one
+branch, for one issue -- was met by cutting a fresh attempt from the default
+branch, walking away from a base holding four finished phases. The log recorded
+it as routine progress and named neither what was being abandoned nor how much
+was on it. Both times the arc survived by accident: once because a human was
+watching, once because creating the replacement happened to fail.
+
+The costs are not comparable. Refusing costs one stopped run and a message.
+Replacing discards every phase accumulated so far, silently, and the next roll
+builds against a base that has never seen them.
+
+Replacement stays right where nothing is lost: a base level with the default
+branch, or one already carrying this issue's work.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+class _Log:
+    def __init__(self):
+        self.lines = []
+
+    def write(self, message):
+        self.lines.append(message)
+
+    def text(self):
+        return "\n".join(self.lines)
+
+
+@pytest.fixture
+def log():
+    return _Log()
+
+
+class TestAMidArcBaseIsKept:
+    def test_it_refuses_rather_than_discarding_accumulated_work(self, log):
+        established = []
+        with patch.object(sr, "commits_carried", lambda r, b: 8), \
+                patch.object(sr, "establish_new_attempt",
+                             lambda r, lg: established.append(b"x") or "new"):
+            result = sr.replace_or_refuse(
+                Path("."), "hardening-run-14", 2, ["local branch: issue-2"], log
+            )
+
+        assert result is None, "a base carrying work must not be replaced"
+        assert established == [], "no fresh attempt may be cut"
+
+    def test_it_says_what_it_is_protecting(self, log):
+        """The old message named neither the cost nor the cause."""
+        with patch.object(sr, "commits_carried", lambda r, b: 8):
+            sr.replace_or_refuse(
+                Path("."), "hardening-run-14", 2, ["local branch: issue-2"], log
+            )
+
+        text = log.text()
+        assert "8 commit(s)" in text
+        assert "hardening-run-14" in text
+
+    def test_it_names_every_unresolved_finding(self, log):
+        """Whoever reads this has to know what to clear."""
+        with patch.object(sr, "commits_carried", lambda r, b: 4):
+            sr.replace_or_refuse(
+                Path("."), "hardening-run-14", 2,
+                ["local branch: issue-2", "worktree: C:\\x\\boostgauge-2"], log
+            )
+
+        text = log.text()
+        assert "local branch: issue-2" in text
+        assert "worktree: C:\\x\\boostgauge-2" in text
+
+    def test_it_says_how_to_clear_an_undeletable_branch(self, log):
+        """A branch with commits reachable from nowhere else refuses a safe
+        delete, and -D is banned. Renaming under graveyard/ is the way out, and
+        an operator should not have to rediscover that."""
+        with patch.object(sr, "commits_carried", lambda r, b: 4):
+            sr.replace_or_refuse(Path("."), "hardening-run-14", 2, ["x"], log)
+
+        assert "graveyard/" in log.text()
+
+
+class TestReplacementStillHappensWhenNothingIsLost:
+    def test_a_base_level_with_the_default_branch_is_replaced(self, log):
+        """A fresh attempt carrying nothing: replacing costs nothing."""
+        with patch.object(sr, "commits_carried", lambda r, b: 0), \
+                patch.object(sr, "establish_new_attempt", lambda r, lg: "hardening-run-15"):
+            result = sr.replace_or_refuse(Path("."), "hardening-run-14", 2, ["x"], log)
+
+        assert result == "hardening-run-15"
+
+    def test_a_failed_replacement_still_reports_none(self, log):
+        with patch.object(sr, "commits_carried", lambda r, b: 0), \
+                patch.object(sr, "establish_new_attempt", lambda r, lg: None):
+            assert sr.replace_or_refuse(Path("."), "b", 2, ["x"], log) is None
+
+
+class TestCountingWhatTheBaseCarries:
+    def _git(self, cwd, *args):
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+            cwd=str(cwd), check=True, capture_output=True, text=True,
+        )
+
+    @pytest.fixture
+    def repo(self, tmp_path):
+        upstream = tmp_path / "up.git"
+        upstream.mkdir()
+        self._git(upstream, "init", "--bare", "-b", "main")
+        r = tmp_path / "repo"
+        r.mkdir()
+        self._git(r, "init", "-b", "main")
+        (r / "a.txt").write_text("x", encoding="utf-8")
+        self._git(r, "add", "-A")
+        self._git(r, "commit", "-m", "init")
+        self._git(r, "remote", "add", "origin", str(upstream))
+        self._git(r, "push", "-u", "origin", "main")
+        return r
+
+    def test_a_level_base_carries_nothing(self, repo):
+        self._git(repo, "checkout", "-b", "hardening-run-1")
+        self._git(repo, "push", "-u", "origin", "hardening-run-1")
+        self._git(repo, "checkout", "main")
+
+        assert sr.commits_carried(repo, "hardening-run-1") == 0
+
+    def test_an_accumulating_base_carries_its_phases(self, repo):
+        self._git(repo, "checkout", "-b", "hardening-run-1")
+        for i in range(3):
+            (repo / f"phase{i}.py").write_text("x", encoding="utf-8")
+            self._git(repo, "add", "-A")
+            self._git(repo, "commit", "-m", f"phase {i}")
+        self._git(repo, "push", "-u", "origin", "hardening-run-1")
+        self._git(repo, "checkout", "main")
+
+        assert sr.commits_carried(repo, "hardening-run-1") == 3
+
+    def test_an_unmeasurable_base_is_unknown_not_zero(self, repo):
+        """"Could not measure" and "nothing here" lead to opposite decisions.
+        Folding the first into the second fails destructively -- it authorises
+        discarding an arc exactly when the tooling cannot see what is on it,
+        which is how the first draft of this fix behaved."""
+        assert sr.commits_carried(repo, "no-such-branch") is None
+
+
+class TestUnknownFailsSafe:
+    def test_an_unmeasurable_base_is_never_replaced(self, log):
+        established = []
+        with patch.object(sr, "commits_carried", lambda r, b: None), \
+                patch.object(sr, "establish_new_attempt",
+                             lambda r, lg: established.append(1) or "new"):
+            result = sr.replace_or_refuse(Path("."), "b", 2, ["x"], log)
+
+        assert result is None
+        assert established == []
+
+    def test_it_admits_it_could_not_measure(self, log):
+        with patch.object(sr, "commits_carried", lambda r, b: None):
+            sr.replace_or_refuse(Path("."), "b", 2, ["x"], log)
+        assert "unknown amount" in log.text()

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -287,13 +287,82 @@ def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
     findings = gate.check_repo(repo_root, [issue], base)
     debris = [f for f in findings if not f.startswith("ERROR:")]
     if debris:
-        log.write(f"GATE still dirty after reset ({len(debris)}) -- fresh attempt")
+        log.write(f"GATE still dirty after reset ({len(debris)}) -- {len(debris)} left")
         for d in debris:
             log.write(f"  {d}")
-        return establish_new_attempt(repo_root, log)
+        return replace_or_refuse(repo_root, base, issue, debris, log)
 
     log.write(f"BASE '{base}' clean for #{issue} after self-heal")
     return base
+
+
+def commits_carried(repo_root: Path, base: str) -> int | None:
+    """Commits the base holds beyond the default branch, or None if unknowable.
+
+    None is deliberate and is NOT folded into 0. "I could not measure this" and
+    "there is nothing here" lead to opposite decisions, and treating the first
+    as the second fails in the destructive direction -- it would authorise
+    discarding an arc precisely when the tooling cannot see what is on it.
+    """
+    default = attempt.default_branch(repo_root)
+    candidates = [default] if default else []
+    candidates += ["origin/main", "origin/master"]
+
+    for ref in candidates:
+        if not ref:
+            continue
+        if _run(
+            ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+            cwd=repo_root,
+        ).returncode != 0:
+            continue
+        result = _run(
+            ["git", "rev-list", "--count", f"{ref}..origin/{base}"], cwd=repo_root
+        )
+        out = result.stdout.strip()
+        if result.returncode == 0 and out.isdigit():
+            return int(out)
+    return None
+
+
+def replace_or_refuse(
+    repo_root: Path, base: str, issue: int, debris: list[str], log: EventLog
+) -> str | None:
+    """Cut a fresh attempt only when nothing is lost by it (#2028).
+
+    Replacing the base is right for one that is level with the default branch,
+    or already carries this issue's work: nothing accumulated is discarded.
+
+    Mid-arc it is not. On 2026-07-31 a single local branch the reset could not
+    delete -- one branch, for #2 -- was met by walking away from a base holding
+    four finished phases of #7, #41, #1 and #4, and the log called it routine
+    progress. It happened twice; both times the arc survived by accident rather
+    than design.
+
+    The costs are not comparable. Refusing costs one stopped run and a message
+    naming what to clear. Replacing silently discards every phase accumulated
+    so far, and the next roll builds against a base that has never seen them.
+    """
+    carried = commits_carried(repo_root, base)
+    if carried == 0:
+        return establish_new_attempt(repo_root, log)
+
+    amount = (
+        "an unknown amount of" if carried is None else f"{carried} commit(s) of"
+    )
+    log.write(
+        f"ABORT refusing to replace '{base}': it carries {amount} "
+        f"accumulated work beyond the default branch, and {len(debris)} finding(s) "
+        f"for #{issue} could not be cleared."
+    )
+    for d in debris:
+        log.write(f"  unresolved: {d}")
+    log.write(
+        "  Clear the finding(s) above and roll again. A branch carrying commits "
+        "reachable from nowhere else refuses a safe delete, which is correct -- "
+        "rename it under graveyard/ to keep the commits and free the name."
+    )
+    return None
 
 
 # =============================================================================


### PR DESCRIPTION
Twice on 2026-07-31 a single local branch the reset could not delete was met by cutting a fresh attempt from the default branch, walking away from a base holding four finished phases.

```
GATE still dirty after reset (1) -- fresh attempt
  local branch: issue-2
BASE establishing new attempt 'hardening-run-15'
```

`hardening-run-14` held #7, #41, #1 and #4 — eight commits, nine source files, all landed by the pipeline itself. The log recorded the replacement as routine progress and named neither what was being abandoned nor how much was on it.

Both times the arc survived by accident: once because a human was watching, once because creating the replacement happened to fail.

## Why the escape hatch was too broad

`ensure_base` treated "cannot fully clean THIS issue" as grounds to replace the base. That is right for a fresh attempt, or one already containing this issue's work. Mid-arc it is not: the debris was one branch for #2, while the base held finished work for four other issues.

Refusing costs one stopped run and a message. Replacing discards the arc, silently.

## Fix

Replacement is kept where nothing is lost — a base level with the default branch, or already carrying this issue's work. Otherwise the roll aborts, names every unresolved finding, and says how to clear a branch that refuses a safe delete: rename it under `graveyard/`, which preserves the commits and frees the name. `-D` is banned and should not be what an operator reaches for at that moment.

## A bug in the first draft of this fix

`commits_carried` originally returned `0` when it could not measure — and `0` means "nothing to lose", which **permits** the discard. Fail-open on the destructive path.

Its own test caught it against a repo with no `origin/HEAD`. It now returns `None` for unmeasurable, resolves the default branch through fallbacks, and treats unknown as refuse. "Could not measure" and "nothing here" lead to opposite decisions and must not be folded together.

## Verification

6212 unit tests pass, no regressions. Ruff clean on both changed files.

Closes #2028