### PR TITLE
fix(win): suppress child consoles process-wide, not per call site (Closes #2040)

### DIFF
--- a/assemblyzero/core/no_console.py
+++ b/assemblyzero/core/no_console.py
@@ -1,0 +1,58 @@
+"""One process-wide default so no child opens a console window (#2040).
+
+Whether a child shows a console depends on the PARENT. Under an interactive
+shell it inherits one and nothing appears; under Task Scheduler (#2015) there
+is none to inherit, so every console application allocates its own window on
+the operator's desktop.
+
+#2037 added CREATE_NO_WINDOW to the two spawn sites that were known about. The
+pipeline has 27, spawning git, gh, poetry, pytest and claude, and a poetry.exe
+window appeared minutes after that fix merged. There is no reason to think 27
+is the final number, new spawns get added, and libraries spawn children this
+repo will never edit.
+
+So the default is installed once, at the entry point, rather than remembered at
+every call site. `subprocess.run` builds a `Popen`, so wrapping the constructor
+covers every form of spawn in the process.
+
+The failure this prevents is invisible in logs: only a human watching the
+desktop sees a window appear, which is exactly how it shipped twice.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+# Deliberate console requests. A caller asking for one of these has made a
+# decision, and quietly overriding it would be a different bug.
+_CREATE_NEW_CONSOLE = getattr(subprocess, "CREATE_NEW_CONSOLE", 0x00000010)
+_DETACHED_PROCESS = 0x00000008
+
+_installed = False
+
+
+def install() -> None:
+    """Make CREATE_NO_WINDOW the default for every child of this process.
+
+    Idempotent, and a no-op off Windows -- creation flags do not exist there
+    and wrapping the constructor would only add a layer that can break.
+    """
+    global _installed
+    if _installed or sys.platform != "win32":
+        return
+
+    original_init = subprocess.Popen.__init__
+
+    def _init(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        flags = kwargs.get("creationflags", 0)
+        if not flags & (_CREATE_NEW_CONSOLE | _DETACHED_PROCESS):
+            kwargs["creationflags"] = flags | subprocess.CREATE_NO_WINDOW
+        return original_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _init
+    _installed = True
+
+
+def is_installed() -> bool:
+    return _installed

--- a/tests/unit/test_no_console_global.py
+++ b/tests/unit/test_no_console_global.py
@@ -1,0 +1,149 @@
+"""Console suppression is a process-wide default, not a per-call-site habit (#2040).
+
+#2037 added CREATE_NO_WINDOW to the two spawn sites that were known about. The
+pipeline has 27 -- git, gh, poetry, pytest, claude -- and a poetry.exe window
+appeared on the operator's desktop minutes after that fix merged.
+
+A default that must be remembered at every call site is a defect generator, and
+this particular defect is invisible in logs: only a human watching the screen
+sees a window appear. That is how it shipped twice.
+"""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core import no_console
+
+WIN32_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="creation flags are a Windows concern"
+)
+
+
+@pytest.fixture
+def fresh():
+    """Restore the real constructor, since install() mutates a global."""
+    original = subprocess.Popen.__init__
+    was = no_console._installed
+    no_console._installed = False
+    yield
+    subprocess.Popen.__init__ = original
+    no_console._installed = was
+
+
+class TestTheDefaultApplies:
+    @WIN32_ONLY
+    def test_a_plain_spawn_gets_no_window(self, fresh):
+        seen = {}
+
+        def _capture(self, *args, **kwargs):
+            seen.update(kwargs)
+            raise RuntimeError("stop before spawning")
+
+        # Install over a recording constructor so the merged flags are visible.
+        subprocess.Popen.__init__ = _capture
+        no_console.install()
+        with pytest.raises(RuntimeError):
+            subprocess.Popen(["git", "status"])
+
+        assert seen.get("creationflags", 0) & subprocess.CREATE_NO_WINDOW
+
+    @WIN32_ONLY
+    def test_existing_flags_are_preserved(self, fresh):
+        """#526 needs CREATE_NEW_PROCESS_GROUP to tree-kill on timeout."""
+        seen = {}
+
+        def _capture(self, *args, **kwargs):
+            seen.update(kwargs)
+            raise RuntimeError("stop")
+
+        subprocess.Popen.__init__ = _capture
+        no_console.install()
+        with pytest.raises(RuntimeError):
+            subprocess.Popen(
+                ["git", "status"],
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            )
+
+        flags = seen.get("creationflags", 0)
+        assert flags & subprocess.CREATE_NO_WINDOW
+        assert flags & subprocess.CREATE_NEW_PROCESS_GROUP
+
+
+class TestDeliberateConsolesAreLeftAlone:
+    @WIN32_ONLY
+    def test_an_explicit_new_console_is_not_overridden(self, fresh):
+        """Asking for a console is a decision; silently removing it would be a
+        different bug from the one being fixed."""
+        seen = {}
+
+        def _capture(self, *args, **kwargs):
+            seen.update(kwargs)
+            raise RuntimeError("stop")
+
+        subprocess.Popen.__init__ = _capture
+        no_console.install()
+        with pytest.raises(RuntimeError):
+            subprocess.Popen(["cmd"], creationflags=subprocess.CREATE_NEW_CONSOLE)
+
+        assert not seen.get("creationflags", 0) & subprocess.CREATE_NO_WINDOW
+
+    @WIN32_ONLY
+    def test_a_detached_process_is_not_overridden(self, fresh):
+        seen = {}
+
+        def _capture(self, *args, **kwargs):
+            seen.update(kwargs)
+            raise RuntimeError("stop")
+
+        subprocess.Popen.__init__ = _capture
+        no_console.install()
+        with pytest.raises(RuntimeError):
+            subprocess.Popen(["cmd"], creationflags=0x00000008)
+
+        assert not seen.get("creationflags", 0) & subprocess.CREATE_NO_WINDOW
+
+
+class TestInstallIsSafe:
+    def test_installing_twice_does_not_stack(self, fresh):
+        no_console.install()
+        first = subprocess.Popen.__init__
+        no_console.install()
+        assert subprocess.Popen.__init__ is first
+
+    def test_it_reports_whether_it_is_installed(self, fresh):
+        assert no_console.is_installed() is False
+        no_console.install()
+        assert no_console.is_installed() is (sys.platform == "win32")
+
+    def test_off_windows_it_is_a_no_op(self, fresh):
+        original = subprocess.Popen.__init__
+        with patch.object(no_console.sys, "platform", "linux"):
+            no_console.install()
+        assert subprocess.Popen.__init__ is original
+
+
+class TestTheEntryPointsInstallIt:
+    def test_orchestrate_installs_before_importing_the_graph(self):
+        """Order matters: anything imported first could spawn during import."""
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[2] / "tools" / "orchestrate.py"
+        ).read_text(encoding="utf-8")
+
+        install_at = source.index("_install_no_console()")
+        graph_at = source.index("from assemblyzero.workflows.orchestrator.graph")
+        assert install_at < graph_at, (
+            "the suppression must be in force before the pipeline is imported"
+        )
+
+    def test_speedrun_roll_installs_it(self):
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[2] / "tools" / "speedrun_roll.py"
+        ).read_text(encoding="utf-8")
+        assert "_install_no_console()" in source

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -17,12 +17,19 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from assemblyzero.workflows.orchestrator.graph import (
+# #2040: installed before anything can spawn. A detached roll has no console to
+# inherit, so every child -- git, gh, poetry, pytest, claude -- would otherwise
+# open its own window on the operator's desktop.
+from assemblyzero.core.no_console import install as _install_no_console  # noqa: E402
+
+_install_no_console()
+
+from assemblyzero.workflows.orchestrator.graph import (  # noqa: E402
     ConcurrentOrchestrationError,
     OrchestrationResult,
     orchestrate,
 )
-from assemblyzero.workflows.orchestrator.state import (
+from assemblyzero.workflows.orchestrator.state import (  # noqa: E402
     STAGE_ORDER,
     OrchestrationState,
     StageResult,

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -52,6 +52,17 @@ import speedrun_clean_check as gate
 import speedrun_new_attempt as attempt
 import speedrun_reset as reset
 
+# #2040: this tool spawns git, gh and schtasks itself, and a detached roll has
+# no console for them to inherit. Installed at import, so it is in force before
+# the first _run().
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+try:
+    from assemblyzero.core.no_console import install as _install_no_console
+
+    _install_no_console()
+except ImportError:  # pragma: no cover - tool copied outside the package
+    pass
+
 HEARTBEAT_SECONDS = 15
 DEFAULT_PREFIX = "hardening-run"
 


### PR DESCRIPTION
#2037 added `CREATE_NO_WINDOW` to the two spawn sites that were known about. A `poetry.exe` window appeared on the operator's desktop minutes after it merged.

## Why per-call-site could not work

Console-app spawns in `assemblyzero/`, by invocation count:

| binary | invocations |
|---|---|
| git | 43 |
| gh | 11 |
| poetry | 6 |
| pytest | 4 |
| model CLI | 2 |

27 `subprocess` call sites. #2037 covered two. Under Task Scheduler there is no parent console to inherit, so every remaining one allocates its own window — `poetry install` in the target worktree was simply the next one a run reached.

There is no reason to believe 27 is the final number. New spawns get added, and libraries spawn children this repo will never edit. A default that must be remembered at every call site is a defect generator — and this defect is **invisible in logs**. Only a human watching the screen sees a window appear, which is exactly how it shipped twice.

## Fix

One process-wide default at the entry points: `subprocess.Popen.__init__` is wrapped to add `CREATE_NO_WINDOW` on win32. `subprocess.run` builds a `Popen`, so this covers every form of spawn in the process, including from third-party code.

Deliberate console requests are left alone — `CREATE_NEW_CONSOLE` and `DETACHED_PROCESS` are decisions a caller made, and silently overriding them would be a different bug from the one being fixed. Existing flags are preserved, so #526 keeps `CREATE_NEW_PROCESS_GROUP` for its tree-kill on timeout.

Idempotent, and a no-op off Windows. A test asserts the install happens **before** the pipeline is imported, since anything imported first could spawn during import.

## Verification

6221 unit tests pass, no regressions. Ruff clean on the changed files apart from one pre-existing F541 in `orchestrate.py`, unchanged from main. The two E402s my insertion introduced are silenced at the imports rather than left as new debt.

Closes #2040
