### PR TITLE
fix(requirements): a halted run names the check it could not fix (Closes #2042)

### DIFF
--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -69,6 +69,31 @@ from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 from assemblyzero.core.halt_node import create_halt_node
 
 
+def describe_validation_failure(result: dict | None, limit: int = 3) -> str:
+    """The errors a revision loop could not clear, as one readable line (#2042).
+
+    The halt used to carry nothing, so `Error: unknown` was all a stopped run
+    said. Everything needed is already on the validation result; it just never
+    left the node that produced it.
+
+    Errors only, and capped: a halt message that dumps forty warnings is read
+    as noise and is no more use than the empty one it replaces.
+    """
+    if not result:
+        return "no validation detail was recorded"
+    violations = [
+        v for v in result.get("violations", []) if v.get("severity") == "error"
+    ]
+    if not violations:
+        return "validation reported failure with no error-level violations"
+    shown = "; ".join(
+        v.get("message", "(no message)") for v in violations[:limit]
+    )
+    if len(violations) > limit:
+        shown += f" (and {len(violations) - limit} more)"
+    return shown
+
+
 # =============================================================================
 # Node Name Constants
 # =============================================================================
@@ -240,7 +265,21 @@ def route_after_validate_test_plan(
         iteration_count = state.get("iteration_count", 0)
         max_iterations = state.get("max_iterations", 3)
         if iteration_count >= max_iterations:
-            print(f"    [ROUTING] Max iterations ({max_iterations}) reached with test plan errors - halting")
+            # #2042: say what could not be fixed. This halt reported
+            # `Error: unknown` with an empty message, so a run that stopped here
+            # gave no way to tell WHICH check failed -- characterising one took
+            # two runs and re-executing the checker by hand. The detail is right
+            # there in the result and was simply never carried out.
+            summary = describe_validation_failure(result)
+            print(
+                f"    [ROUTING] Max iterations ({max_iterations}) reached with "
+                f"test plan errors - halting"
+            )
+            print(f"    [ROUTING] Unfixed: {summary}")
+            state["error_message"] = (
+                f"test plan validation failed after {max_iterations} "
+                f"revision(s): {summary}"
+            )
             return "HALT"
         print("    [ROUTING] Test plan validation failed - returning to drafter")
         return "N1_generate_draft"

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -100,7 +100,18 @@ def generate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
     audit_dir = Path(state.get("audit_dir", ""))
 
     draft_count = state.get("draft_count", 0) + 1
-    is_revision = bool(state.get("current_draft") and state.get("verdict_history"))
+    # #2042: the same predicate the prompt builder uses. This one drives only
+    # the log line, and requiring verdict_history made every mechanical-validation
+    # retry announce "Generating initial draft" while it was in fact revising --
+    # so a loop that was working looked like one that had reset each time.
+    is_revision = bool(
+        state.get("current_draft")
+        and (
+            state.get("verdict_history")
+            or state.get("validation_errors")
+            or state.get("user_feedback")
+        )
+    )
 
     if is_revision:
         print(f"\n[N1] Generating revision (draft #{draft_count})...")

--- a/tests/unit/test_halt_names_the_failure.py
+++ b/tests/unit/test_halt_names_the_failure.py
@@ -1,0 +1,110 @@
+"""A halted run must say what it could not fix (#2042).
+
+Two rolls of boostgauge #2 stopped on 2026-07-31 reporting `Error: unknown`
+with an empty halt message. The failing check and its detail had been printed
+earlier in the run and were dropped at the halt, so the exit code and the
+summary between them said only that something stopped.
+
+Characterising those two failures took two runs plus re-executing both checkers
+by hand against preserved artifacts. Everything needed was already on the
+validation result and simply never left the node that produced it.
+"""
+
+
+from assemblyzero.workflows.requirements.graph import describe_validation_failure
+
+
+def _result(*messages, warnings=()):
+    violations = [
+        {"severity": "error", "message": m} for m in messages
+    ] + [{"severity": "warning", "message": w} for w in warnings]
+    return {"passed": False, "violations": violations}
+
+
+class TestTheFailureIsNamed:
+    def test_a_single_error_is_reported_verbatim(self):
+        summary = describe_validation_failure(
+            _result("No requirements found in Section 3")
+        )
+        assert "No requirements found in Section 3" in summary
+
+    def test_several_errors_are_all_named(self):
+        summary = describe_validation_failure(
+            _result("REQ-1 has no test coverage", "REQ-2 has no test coverage")
+        )
+        assert "REQ-1" in summary and "REQ-2" in summary
+
+    def test_the_live_case_produces_something_actionable(self):
+        """The message that was lost: 0 scenarios from section 10."""
+        summary = describe_validation_failure(
+            _result("Section 10.1 produced no test scenarios")
+        )
+        assert "Section 10.1" in summary
+        assert summary != "no validation detail was recorded"
+
+
+class TestItStaysReadable:
+    def test_a_long_list_is_capped_and_says_so(self):
+        """A halt that dumps forty violations is read as noise, which is no
+        more use than the empty message it replaces."""
+        summary = describe_validation_failure(_result(*[f"err {i}" for i in range(10)]))
+
+        assert "and 7 more" in summary
+        assert summary.count(";") == 2
+
+    def test_warnings_are_not_reported_as_the_cause(self):
+        """Only errors block; naming warnings would misdirect the reader."""
+        summary = describe_validation_failure(
+            _result("the real error", warnings=("cosmetic", "style"))
+        )
+        assert "the real error" in summary
+        assert "cosmetic" not in summary
+
+
+class TestDegradedInputs:
+    def test_a_missing_result_still_says_something(self):
+        assert describe_validation_failure(None) == "no validation detail was recorded"
+
+    def test_a_failure_with_no_error_violations_is_admitted(self):
+        """Rather than claiming a cause that is not there."""
+        summary = describe_validation_failure({"passed": False, "violations": []})
+        assert "no error-level violations" in summary
+
+    def test_a_violation_without_a_message_does_not_crash(self):
+        summary = describe_validation_failure(
+            {"passed": False, "violations": [{"severity": "error"}]}
+        )
+        assert "no message" in summary
+
+
+class TestTheRouterCarriesIt:
+    def test_the_halt_sets_a_non_empty_error_message(self):
+        """The whole point: the summary has to reach the halt payload, not just
+        stdout, or the exit path still reports 'unknown'."""
+        from assemblyzero.workflows.requirements.graph import (
+            route_after_validate_test_plan,
+        )
+
+        state = {
+            "test_plan_validation_result": _result("Section 10.1 produced no rows"),
+            "iteration_count": 3,
+            "max_iterations": 3,
+        }
+        assert route_after_validate_test_plan(state) == "HALT"
+        assert state.get("error_message"), "the halt must name the failure"
+        assert "Section 10.1" in state["error_message"]
+
+    def test_a_loop_back_does_not_set_an_error(self):
+        """Iterations that will retry are not failures and must not look like
+        them."""
+        from assemblyzero.workflows.requirements.graph import (
+            route_after_validate_test_plan,
+        )
+
+        state = {
+            "test_plan_validation_result": _result("fixable"),
+            "iteration_count": 1,
+            "max_iterations": 3,
+        }
+        assert route_after_validate_test_plan(state) == "N1_generate_draft"
+        assert not state.get("error_message")


### PR DESCRIPTION
Two rolls of boostgauge #2 stopped reporting `Error: unknown` with an empty halt message.

```
Stage:     N3_review_iter6
Error:     unknown
Transient: No
Workflow requirements halted:
```

The failing check and its detail were printed earlier in the run and dropped at the halt. Characterising those two failures took two runs plus re-executing both checkers by hand against preserved artifacts — everything needed was already on the validation result and simply never left the node that produced it.

## Fix

The router carries the unfixed error-level violations into `error_message`.

Capped at three with a count of the rest: a halt that dumps forty violations is read as noise and is no more use than the empty one it replaces. Warnings are excluded — naming a non-blocking violation as the cause misdirects the reader.

## A second, quieter lie in the same loop

`generate_draft` computed `is_revision` two different ways. The prompt builder accepted `user_feedback` or `validation_errors`; the log line required `verdict_history`. So every mechanical-validation retry announced **"Generating initial draft"** while it was in fact revising — a loop that was working looked like one resetting each time, which is part of why it read as non-convergent. Both now use the same predicate.

## What this does not fix, stated plainly

The loop still failed to converge in three attempts on both documents. I checked the plumbing rather than assuming: the validator builds feedback, `user_feedback` carries it, the drafter consumes it in revision mode, and `current_draft` is populated so the gate opens. That path is intact.

So the non-convergence is generation quality on those specific documents, not a wiring gap, and re-rolling remains the mitigation. What changes here is that the next such failure is diagnosable from the run itself rather than by hand.

## Verification

6231 unit tests pass, no regressions. Ruff back to the 12 pre-existing warnings — the two my change introduced (an E402 from function placement, an unused import) are fixed rather than left as debt.

Closes #2042