### PR TITLE
fix(testing): give the completeness gate the LLD, and say when it has nothing (Closes #2024)

### DIFF
--- a/assemblyzero/workflows/testing/completeness/report_generator.py
+++ b/assemblyzero/workflows/testing/completeness/report_generator.py
@@ -161,6 +161,17 @@ def prepare_review_materials(
     """
     # Extract requirements from LLD
     lld_requirements = extract_lld_requirements(lld_path)
+    if not lld_requirements:
+        # #2024: with nothing to check against, a verdict from this gate is not
+        # meaningful -- "reviewed and found minor issues" and "reviewed nothing"
+        # came out identical, and the only trace was a logger warning nobody
+        # reads. Say it where the run can see it.
+        print(
+            f"    [N4b] NO REQUIREMENTS extracted from {lld_path} — this review "
+            f"compares the implementation against nothing. A Section 3 "
+            f"'Requirements' heading was expected; the implementation spec has "
+            f"'Current State' there, so check which document was passed."
+        )
 
     # Read code snippets from implementation files
     code_snippets: dict[str, str] = {}

--- a/assemblyzero/workflows/testing/nodes/completeness_gate.py
+++ b/assemblyzero/workflows/testing/nodes/completeness_gate.py
@@ -84,7 +84,12 @@ def completeness_gate(state: TestingWorkflowState) -> dict[str, Any]:
     repo_root_str = state.get("repo_root", "")
     repo_root = Path(repo_root_str) if repo_root_str else get_repo_root()
     issue_number = state.get("issue_number", 0)
-    lld_path_str = state.get("lld_path", "")
+    # #2024: prefer the canonical LLD. `lld_path` is a legacy name that in this
+    # workflow holds the SPEC, whose Section 3 is "Current State" -- so the
+    # requirement extractor found nothing, said so in a log warning, and the
+    # gate reviewed the implementation against ZERO requirements and returned a
+    # verdict anyway. Falls back to lld_path when no LLD was resolved.
+    lld_path_str = state.get("original_lld_path", "") or state.get("lld_path", "")
     implementation_files_strs = state.get("implementation_files", [])
     test_files_strs = state.get("test_files", [])
     audit_dir_str = state.get("audit_dir", "")

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -965,6 +965,12 @@ def load_lld(state: TestingWorkflowState) -> dict[str, Any]:  # pragma: no cover
 
     return {
         "lld_path": str(lld_path_obj),
+        # #2024: the canonical LLD, which is NOT lld_path -- that key holds the
+        # SPEC here (legacy name; see find_spec_path above). The completeness
+        # gate needs Section 3 "Requirements", and only the LLD has it: the
+        # spec's Section 3 is "Current State". #656 already resolves this path
+        # for its own use; it was simply never put in state for anyone else.
+        "original_lld_path": str(original_lld_path) if original_lld_path else "",
         "lld_content": lld_content,
         "test_plan_section": test_plan_section,
         "test_scenarios": test_scenarios,

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -131,7 +131,11 @@ class TestingWorkflowState(TypedDict, total=False):
 
     # Input
     issue_number: int
-    lld_path: str
+    lld_path: str  # legacy name: in this workflow it holds the SPEC (#2024)
+    # #2024: the canonical LLD. Must stay declared -- an undeclared key is
+    # discarded by LangGraph at the node boundary and never reaches the reader
+    # (#2018 lost the implementation PR exactly that way).
+    original_lld_path: str
     repo_root: str
 
     # Worktree isolation (for multi-branch safety)

--- a/tests/unit/test_completeness_gate_reads_the_lld.py
+++ b/tests/unit/test_completeness_gate_reads_the_lld.py
@@ -1,0 +1,135 @@
+"""The completeness gate must be handed the LLD, not the spec (#2024).
+
+Every run of boostgauge #2 and #41 logged:
+
+    Section 3 (Requirements) not found in ...spec-0002-implementation-readiness.md
+    Layer 2: Prepared 0 requirements, 2 code snippets
+    Completeness gate verdict: WARN
+
+The gate compared the implementation against nothing and returned a verdict
+anyway. The two documents both have a section 3 and they are not the same
+section:
+
+    LLD-041.md   ## 3. Requirements                        <- extractable
+    spec-0041... ## 3. Current State (for Modify/Delete files)
+
+`completeness_gate` read `state["lld_path"]`, a legacy key that in this
+workflow holds the SPEC -- `load_lld.py` sets it from `find_spec_path()` and
+even prints "Spec path:" for it. #656 already resolves the real LLD for its own
+use; it was simply never put in state for anyone else to reach.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.completeness.report_generator import (
+    extract_lld_requirements,
+)
+
+LLD = """# LLD
+
+## 2. Proposed Changes
+stuff
+
+## 3. Requirements
+
+1. The telltale holds a peak for the duration of its window.
+2. The peak drops to the highest remaining in-window sample once it ages out.
+
+## 4. Alternatives
+"""
+
+SPEC = """# Implementation Spec
+
+## 2. Files to Implement
+stuff
+
+## 3. Current State (for Modify/Delete files)
+none
+
+## 4. Data Structures
+"""
+
+
+@pytest.fixture
+def docs(tmp_path):
+    lld = tmp_path / "LLD-002.md"
+    lld.write_text(LLD, encoding="utf-8")
+    spec = tmp_path / "spec-0002-implementation-readiness.md"
+    spec.write_text(SPEC, encoding="utf-8")
+    return lld, spec
+
+
+class TestTheTwoDocumentsDiffer:
+    def test_the_lld_yields_requirements(self, docs):
+        lld, _ = docs
+        assert len(extract_lld_requirements(lld)) == 2
+
+    def test_the_spec_yields_none(self, docs):
+        """Not a bug in the extractor -- the spec genuinely has no requirements
+        section. Handing it one is the bug."""
+        _, spec = docs
+        assert extract_lld_requirements(spec) == []
+
+
+class TestTheGatePrefersTheLld:
+    def _state(self, **kw):
+        base = {
+            "repo_root": "",
+            "issue_number": 2,
+            "implementation_files": [],
+            "test_files": [],
+            "audit_dir": "",
+        }
+        base.update(kw)
+        return base
+
+    def test_it_reads_original_lld_path_when_present(self, docs):
+        lld, spec = docs
+        state = self._state(lld_path=str(spec), original_lld_path=str(lld))
+        chosen = state.get("original_lld_path", "") or state.get("lld_path", "")
+
+        assert Path(chosen) == lld
+        assert len(extract_lld_requirements(Path(chosen))) == 2
+
+    def test_it_falls_back_to_lld_path_when_no_lld_resolved(self, docs):
+        """Pre-#656 shape, and repos where no separate LLD exists."""
+        _, spec = docs
+        state = self._state(lld_path=str(spec), original_lld_path="")
+        chosen = state.get("original_lld_path", "") or state.get("lld_path", "")
+
+        assert Path(chosen) == spec
+
+
+class TestAnEmptyExtractionIsVisible:
+    def test_it_says_the_review_compared_against_nothing(self, docs, capsys):
+        from assemblyzero.workflows.testing.completeness.report_generator import (
+            prepare_review_materials,
+        )
+
+        _, spec = docs
+        prepare_review_materials(issue_number=2, lld_path=spec, implementation_files=[])
+        out = capsys.readouterr().out
+
+        assert "NO REQUIREMENTS" in out
+        assert "against nothing" in out
+
+    def test_a_good_lld_says_nothing_alarming(self, docs, capsys):
+        from assemblyzero.workflows.testing.completeness.report_generator import (
+            prepare_review_materials,
+        )
+
+        lld, _ = docs
+        prepare_review_materials(issue_number=2, lld_path=lld, implementation_files=[])
+
+        assert "NO REQUIREMENTS" not in capsys.readouterr().out
+
+
+class TestTheKeyIsDeclared:
+    def test_original_lld_path_is_a_declared_state_field(self):
+        """#2018: LangGraph discards undeclared keys at the node boundary, so
+        an undeclared key here would never reach the gate at all."""
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        assert "original_lld_path" in TestingWorkflowState.__annotations__


### PR DESCRIPTION
The completeness gate has been reviewing implementations against **zero requirements**. Every run of boostgauge #2 and #41 logged:

```
Section 3 (Requirements) not found in ...spec-0002-implementation-readiness.md
Layer 2: Prepared 0 requirements, 2 code snippets
Completeness gate verdict: WARN
```

## Right section number, wrong document

| document | section 3 |
|---|---|
| `LLD-002.md` | `## 3. Requirements` — extractable |
| `spec-0002-implementation-readiness.md` | `## 3. Current State (for Modify/Delete files)` |

The extractor searches for the former and was handed the latter, returned nothing, and the gate produced a verdict anyway.

## Cause

The gate read `state["lld_path"]` — a legacy name that in this workflow holds the **spec**. `load_lld` sets it from `find_spec_path()` and even prints `Spec path:` for it.

#656 anticipated this precisely ("The impl spec's Section 3 is Current State, not Requirements... The original LLD has the canonical Section 3") and already resolves the real LLD for its own use. The path was simply never put in state for anyone else to reach. It is now, and the gate prefers it — falling back to `lld_path` when no separate LLD exists, which is the pre-#656 shape.

`original_lld_path` is a **declared** state field, with a test pinning that. #2018 lost the implementation PR by writing an undeclared key that LangGraph discarded at the node boundary; there is no reason to repeat it here.

## An empty extraction is no longer silent

Previously the only trace was a logger warning, which made "reviewed and found minor issues" indistinguishable from "reviewed nothing" — and the second is not a verdict at all. It now says so where the run can see it, naming the likely cause.

## Verification

6238 unit tests pass, no regressions. Ruff clean on the changed files.

Closes #2024