### PR TITLE
fix(testing): name the imports that stopped collection (Closes #2035)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -597,6 +597,59 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
 COVERAGE_IMPROVEMENT_THRESHOLD = 1.0
 
+# "cannot import name 'render' from 'boostgauge.gauge'" — the shape pytest
+# prints when a phase removed something an earlier phase published.
+_MISSING_NAME_RE = re.compile(
+    r"cannot import name ['\"](?P<name>[\w.]+)['\"] from ['\"](?P<module>[\w.]+)['\"]"
+)
+_MISSING_MODULE_RE = re.compile(
+    r"No module named ['\"](?P<module>[\w.]+)['\"]"
+)
+_COLLECT_ERROR_RE = re.compile(r"ERROR collecting (?P<path>\S+)")
+
+
+def describe_collection_failures(output: str, limit: int = 3) -> str:
+    """Name what failed to import, from pytest's own output (#2035).
+
+    Exit 2 is usually a collection failure, and pytest has already said which
+    import broke. That was discarded, so a phase deleting a symbol an earlier
+    phase published surfaced as "pytest test execution interrupted" with
+    Error: unknown -- and diagnosing one took a manual worktree from a
+    checkpoint commit plus a re-run by hand.
+
+    Deliberately reports the symbol and its module rather than the traceback:
+    "cannot import name render from boostgauge.gauge" is the whole diagnosis,
+    and the phase that published `render` is then obvious.
+    """
+    if not output:
+        return ""
+
+    parts: list[str] = []
+    seen: set[str] = set()
+
+    for match in _MISSING_NAME_RE.finditer(output):
+        item = f"{match.group('module')}.{match.group('name')} no longer exists"
+        if item not in seen:
+            seen.add(item)
+            parts.append(item)
+    for match in _MISSING_MODULE_RE.finditer(output):
+        item = f"module {match.group('module')} not found"
+        if item not in seen:
+            seen.add(item)
+            parts.append(item)
+
+    if not parts:
+        files = [m.group("path") for m in _COLLECT_ERROR_RE.finditer(output)]
+        unique = list(dict.fromkeys(files))
+        if unique:
+            return f"Collection failed in: {', '.join(unique[:limit])}"
+        return ""
+
+    shown = "; ".join(parts[:limit])
+    if len(parts) > limit:
+        shown += f" (and {len(parts) - limit} more)"
+    return f"Imports that no longer resolve: {shown}"
+
 
 def coverage_has_stagnated(
     coverage_achieved: float,
@@ -831,6 +884,17 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         reason = describe_exit_code(exit_code)
         print(f"    [EXIT CODE {exit_code}] {reason} — stopping workflow")
 
+        # #2035: exit 2 is usually a COLLECTION failure, and pytest has already
+        # said exactly which import broke. That detail was discarded, so a phase
+        # that deleted a symbol an earlier phase published surfaced as
+        # "pytest test execution interrupted" with Error: unknown -- diagnosing
+        # one took a manual worktree from a checkpoint commit and a re-run by
+        # hand. Everything below was in the output all along.
+        broken = describe_collection_failures(output)
+        detail = f" {broken}" if broken else ""
+        if broken:
+            print(f"    [EXIT CODE {exit_code}] {broken}")
+
         return {
             "green_phase_output": output,
             "coverage_achieved": 0,
@@ -838,7 +902,10 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "pytest_exit_code": exit_code,
             "iteration_count": iteration_count,
             "next_node": "end",
-            "error_message": f"Green phase stopped: pytest {reason} (exit code {exit_code})",
+            "error_message": (
+                f"Green phase stopped: pytest {reason} "
+                f"(exit code {exit_code}).{detail}"
+            ),
         }
 
     # Analyze results (exit codes 0 and 1)

--- a/tests/unit/test_collection_failure_is_named.py
+++ b/tests/unit/test_collection_failure_is_named.py
@@ -1,0 +1,130 @@
+"""A phase that breaks an earlier phase's imports must say so (#2035).
+
+boostgauge #2, 2026-07-31, after #2032 made the files genuinely written:
+
+    [N5] Results: 0 passed, 0 failed | Coverage: 0.0% | Exit: 2
+    impl failed 140.6s  Green phase stopped: pytest test execution interrupted
+    Error: unknown
+
+The run had rewritten gauge.py and stingray.py without `render` and
+`render_stingray`, which #1 published and #1's own tests import. pytest said
+exactly that and the message was discarded, so the halt named only pytest.
+
+Diagnosing it took a manual worktree from the [CP:post-impl] checkpoint commit
+and a re-run by hand. Everything needed was in the output the whole time.
+"""
+
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    describe_collection_failures,
+)
+
+LIVE_OUTPUT = """
+==================== ERRORS ====================
+____________ ERROR collecting tests/unit/test_gauge.py ____________
+ImportError while importing test module 'tests/unit/test_gauge.py'.
+Traceback:
+tests/unit/test_gauge.py:13: in <module>
+    from boostgauge.gauge import render
+src/boostgauge/gauge.py:9: in <module>
+    from boostgauge.skins.stingray import (
+src/boostgauge/skins/__init__.py:3: in <module>
+    from boostgauge.skins.stingray import render_stingray
+E   ImportError: cannot import name 'render_stingray' from 'boostgauge.skins.stingray'
+____________ ERROR collecting tests/visual/test_stingray_visual.py ____________
+tests/visual/test_stingray_visual.py:13: in <module>
+    from boostgauge.gauge import render
+E   ImportError: cannot import name 'render' from 'boostgauge.gauge'
+!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
+"""
+
+
+class TestTheLiveFailure:
+    def test_it_names_both_vanished_symbols(self):
+        summary = describe_collection_failures(LIVE_OUTPUT)
+        assert "boostgauge.skins.stingray.render_stingray" in summary
+        assert "boostgauge.gauge.render" in summary
+
+    def test_it_says_they_no_longer_exist(self):
+        """The wording has to point at deletion, since that is what happened --
+        an earlier phase published these and this phase removed them."""
+        assert "no longer exists" in describe_collection_failures(LIVE_OUTPUT)
+
+    def test_the_summary_is_not_empty(self):
+        """The whole defect was an empty diagnosis."""
+        assert describe_collection_failures(LIVE_OUTPUT).strip()
+
+
+class TestOtherCollectionShapes:
+    def test_a_missing_module_is_named(self):
+        out = "E   ModuleNotFoundError: No module named 'boostgauge.collector'"
+        assert "boostgauge.collector" in describe_collection_failures(out)
+
+    def test_it_falls_back_to_the_failing_files(self):
+        """A syntax error gives no import line, but the file is still the
+        single most useful thing to report."""
+        out = (
+            "ERROR collecting tests/unit/test_thing.py\n"
+            "E   SyntaxError: invalid syntax\n"
+        )
+        summary = describe_collection_failures(out)
+        assert "tests/unit/test_thing.py" in summary
+
+    def test_duplicates_are_collapsed(self):
+        """The same import fails once per importing module; reporting it three
+        times is noise."""
+        out = LIVE_OUTPUT + LIVE_OUTPUT
+        summary = describe_collection_failures(out)
+        assert summary.count("boostgauge.gauge.render") == 1
+
+    def test_a_long_list_is_capped(self):
+        out = "\n".join(
+            f"E   ImportError: cannot import name 'n{i}' from 'mod{i}'"
+            for i in range(8)
+        )
+        summary = describe_collection_failures(out)
+        assert "and 5 more" in summary
+
+
+class TestQuietWhenThereIsNothingToSay:
+    def test_empty_output_yields_empty(self):
+        assert describe_collection_failures("") == ""
+
+    def test_ordinary_test_failures_are_not_reported_as_import_breakage(self):
+        out = "FAILED tests/unit/test_x.py::test_y - assert 1 == 2\n1 failed"
+        assert describe_collection_failures(out) == ""
+
+
+class TestItReachesTheHalt:
+    def test_the_error_message_carries_the_detail(self):
+        """stdout is not enough -- the halt payload is what the orchestrator
+        reports, and it said 'unknown'."""
+        from unittest.mock import patch
+
+        from assemblyzero.workflows.testing.nodes import verify_phases
+
+        state = {
+            "test_files": ["/tmp/t.py"],
+            "repo_root": "/tmp/repo",
+            "audit_dir": "",
+            "file_counter": 0,
+            "issue_number": 2,
+            "iteration_count": 0,
+            "max_iterations": 5,
+            "coverage_target": 95,
+            "implementation_files": [],
+            "skip_e2e": True,
+        }
+        result_stub = {
+            "returncode": 2,
+            "stdout": LIVE_OUTPUT,
+            "stderr": "",
+            "parsed": {"passed": 0, "failed": 0, "errors": 2, "coverage": 0},
+        }
+        with patch.object(verify_phases, "run_pytest", return_value=result_stub):
+            out = verify_phases.verify_green_phase(state)
+
+        assert out["next_node"] == "end"
+        message = out.get("error_message", "")
+        assert "no longer resolve" in message or "no longer exists" in message
+        assert "boostgauge.gauge.render" in message


### PR DESCRIPTION
A phase that deleted symbols an earlier phase published reported only:

```
Green phase stopped: pytest test execution interrupted (exit code 2)
Error: unknown
```

boostgauge #2 had rewritten `gauge.py` and `stingray.py` without `render` and `render_stingray` — symbols #1 published and #1's own tests import. pytest said exactly that:

```
E ImportError: cannot import name 'render_stingray' from 'boostgauge.skins.stingray'
E ImportError: cannot import name 'render' from 'boostgauge.gauge'
```

and the message was discarded, so the halt named the test runner rather than the breakage. Diagnosing it took a manual worktree from the `[CP:post-impl]` checkpoint commit and a re-run by hand.

## Fix

Exit 2 is usually a **collection** failure, and the collection error is the whole diagnosis. It is now parsed out and carried into `error_message`: which symbol vanished and which module it left, so the phase that published it is immediately obvious.

- Falls back to naming the files that failed to collect when there is no import line (a syntax error, say).
- Silent on ordinary test failures — those are not import breakage and reporting them as such would misdirect.
- Duplicates collapsed, since one broken import fails once per importing module.
- Capped, because a halt that dumps forty lines is as unread as the empty one it replaces.

## Scope, stated plainly

This makes the failure **diagnosable**; it does not **prevent** it. A proactive check that the base's published symbols still resolve after implementation is the stronger guard and is not here — with #2033 now planning against the base and #2032 coercing base files to Modify, the conditions that produced this are much rarer, and the remaining need is to see it instantly when it does happen.

## Verification

6248 unit tests pass, no regressions. The decisive test uses the real pytest output from the live failure. Ruff clean on the new test; the 3 warnings in `verify_phases.py` are pre-existing and unchanged from main.

Closes #2035