### PR TITLE
fix(requirements): set the halt message where returns persist, keep the rejected draft (Closes #2046)

### DIFF
--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -68,30 +68,13 @@ from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
 from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 from assemblyzero.core.halt_node import create_halt_node
 
+# #2042: lives beside the node whose final-iteration return carries it into
+# the halt; re-exported here for the router's logging and existing importers.
+from assemblyzero.workflows.requirements.nodes.validate_test_plan import (  # noqa: E402
+    describe_validation_failure,
+)
 
-def describe_validation_failure(result: dict | None, limit: int = 3) -> str:
-    """The errors a revision loop could not clear, as one readable line (#2042).
 
-    The halt used to carry nothing, so `Error: unknown` was all a stopped run
-    said. Everything needed is already on the validation result; it just never
-    left the node that produced it.
-
-    Errors only, and capped: a halt message that dumps forty warnings is read
-    as noise and is no more use than the empty one it replaces.
-    """
-    if not result:
-        return "no validation detail was recorded"
-    violations = [
-        v for v in result.get("violations", []) if v.get("severity") == "error"
-    ]
-    if not violations:
-        return "validation reported failure with no error-level violations"
-    shown = "; ".join(
-        v.get("message", "(no message)") for v in violations[:limit]
-    )
-    if len(violations) > limit:
-        shown += f" (and {len(violations) - limit} more)"
-    return shown
 
 
 # =============================================================================
@@ -276,10 +259,9 @@ def route_after_validate_test_plan(
                 f"test plan errors - halting"
             )
             print(f"    [ROUTING] Unfixed: {summary}")
-            state["error_message"] = (
-                f"test plan validation failed after {max_iterations} "
-                f"revision(s): {summary}"
-            )
+            # The node has already put this summary in error_message on its
+            # final-iteration return; a router's state writes are discarded at
+            # the graph boundary (#2018's channel rule), so nothing is set here.
             return "HALT"
         print("    [ROUTING] Test plan validation failed - returning to drafter")
         return "N1_generate_draft"

--- a/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
@@ -10,6 +10,7 @@ Routes:
 - MAX_ATTEMPTS → END (prevent infinite loops)
 """
 
+from pathlib import Path
 from typing import Any
 
 from assemblyzero.core.validation.test_plan_validator import (
@@ -17,6 +18,29 @@ from assemblyzero.core.validation.test_plan_validator import (
     validate_test_plan,
 )
 from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
+
+
+def describe_validation_failure(result: dict | None, limit: int = 3) -> str:
+    """The errors a revision loop could not clear, as one readable line (#2042).
+
+    Lives beside the node that produces the result, because the consumer that
+    matters is this node's own final-iteration return -- a router cannot carry
+    it (see the halt comment in validate_test_plan_node). graph.py re-exports
+    this for its logging.
+    """
+    if not result:
+        return "no validation detail was recorded"
+    violations = [
+        v for v in result.get("violations", []) if v.get("severity") == "error"
+    ]
+    if not violations:
+        return "validation reported failure with no error-level violations"
+    shown = "; ".join(
+        v.get("message", "(no message)") for v in violations[:limit]
+    )
+    if len(violations) > limit:
+        shown += f" (and {len(violations) - limit} more)"
+    return shown
 
 
 def validate_test_plan_node(state: RequirementsWorkflowState) -> dict[str, Any]:
@@ -97,14 +121,48 @@ def validate_test_plan_node(state: RequirementsWorkflowState) -> dict[str, Any]:
     feedback = _build_validation_feedback(result)
     print(f"    Feedback:\n{feedback}")
 
-    return {
+    # #2042 follow-up: the failing DRAFT must outlive the run. Both LLD-stage
+    # halts of boostgauge #2 judged content that no longer existed afterwards
+    # -- the worktree is removed on restore, so the document the validator
+    # rejected was unrecoverable and the drafter's regression (a table that
+    # parsed as 8 scenarios in one iteration and 0 in the next) could not be
+    # inspected at all. Best-effort: never fail validation over archiving.
+    new_iteration = state.get("iteration_count", 0) + 1
+    audit_dir = state.get("audit_dir", "")
+    if audit_dir:
+        try:
+            keep = Path(audit_dir) / f"failed-draft-iter{new_iteration}.md"
+            keep.parent.mkdir(parents=True, exist_ok=True)
+            keep.write_text(
+                lld_content + "\n\n<!-- validation feedback -->\n" + feedback,
+                encoding="utf-8",
+            )
+            print(f"    [KEEP] failing draft preserved: {keep}")
+        except OSError as exc:
+            print(f"    [KEEP] could not preserve failing draft: {exc}")
+
+    updates = {
         "test_plan_validation_result": result,
         "test_plan_validation_attempts": new_attempts,
         "user_feedback": feedback,
-        "iteration_count": state.get("iteration_count", 0) + 1,
+        "iteration_count": new_iteration,
         "lld_status": "BLOCKED",
         "error_message": "",
     }
+
+    # #2042: the halt message is set HERE, not in the router. A conditional
+    # edge's return value is a node name; mutating state inside one is
+    # discarded at the graph boundary (the same channel rule that ate
+    # impl_pr_url in #2018), which is why the first version of this fix
+    # printed the summary and still halted with `Error: unknown`. This node's
+    # RETURN is a real state update, and the router halts on error_message
+    # first, so the message and the halt arrive together.
+    if new_iteration >= state.get("max_iterations", 3):
+        updates["error_message"] = (
+            f"test plan validation failed after {new_iteration} revision(s): "
+            f"{describe_validation_failure(result)}"
+        )
+    return updates
 
 
 def _build_validation_feedback(result: dict) -> str:

--- a/tests/unit/test_halt_names_the_failure.py
+++ b/tests/unit/test_halt_names_the_failure.py
@@ -77,34 +77,61 @@ class TestDegradedInputs:
         assert "no message" in summary
 
 
-class TestTheRouterCarriesIt:
-    def test_the_halt_sets_a_non_empty_error_message(self):
-        """The whole point: the summary has to reach the halt payload, not just
-        stdout, or the exit path still reports 'unknown'."""
+class TestTheNodeCarriesIt:
+    """The message must ride the NODE's return. The first version of this fix
+    mutated state inside the conditional-edge router; a router returns a node
+    name and its state writes are discarded at the graph boundary (#2018's
+    channel rule) -- so the summary printed and the run still halted with
+    `Error: unknown`. The unit test passed because it called the router as a
+    plain function, where the mutation is visible: it tested the function,
+    not the graph."""
+
+    def _node_state(self, iteration, tmp_path, draft="## 3. Requirements\n"):
+        return {
+            "current_draft": draft,
+            "iteration_count": iteration,
+            "max_iterations": 3,
+            "test_plan_validation_attempts": 0,
+            "audit_dir": str(tmp_path),
+        }
+
+    def test_the_final_failed_iteration_returns_the_message(self, tmp_path):
+        from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
+            validate_test_plan_node,
+        )
+
+        updates = validate_test_plan_node(self._node_state(2, tmp_path))
+        assert updates.get("error_message"), "final iteration must name the failure"
+        assert "revision(s)" in updates["error_message"]
+
+    def test_an_earlier_iteration_loops_without_an_error(self, tmp_path):
+        from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
+            validate_test_plan_node,
+        )
+
+        updates = validate_test_plan_node(self._node_state(0, tmp_path))
+        assert updates.get("error_message") == ""
+        assert updates.get("lld_status") == "BLOCKED"
+
+    def test_the_failing_draft_is_preserved(self, tmp_path):
+        """Both LLD halts of boostgauge #2 judged content that was destroyed
+        with the worktree; the drafter regression they rejected could not be
+        inspected at all."""
+        from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
+            validate_test_plan_node,
+        )
+
+        validate_test_plan_node(self._node_state(0, tmp_path))
+        kept = list(tmp_path.glob("failed-draft-iter*.md"))
+        assert kept, "the rejected draft must outlive the run"
+        body = kept[0].read_text(encoding="utf-8")
+        assert "## 3. Requirements" in body
+        assert "validation feedback" in body
+
+    def test_the_router_halts_on_the_node_set_error(self):
+        """End of the chain: error_message present -> HALT, first check."""
         from assemblyzero.workflows.requirements.graph import (
             route_after_validate_test_plan,
         )
 
-        state = {
-            "test_plan_validation_result": _result("Section 10.1 produced no rows"),
-            "iteration_count": 3,
-            "max_iterations": 3,
-        }
-        assert route_after_validate_test_plan(state) == "HALT"
-        assert state.get("error_message"), "the halt must name the failure"
-        assert "Section 10.1" in state["error_message"]
-
-    def test_a_loop_back_does_not_set_an_error(self):
-        """Iterations that will retry are not failures and must not look like
-        them."""
-        from assemblyzero.workflows.requirements.graph import (
-            route_after_validate_test_plan,
-        )
-
-        state = {
-            "test_plan_validation_result": _result("fixable"),
-            "iteration_count": 1,
-            "max_iterations": 3,
-        }
-        assert route_after_validate_test_plan(state) == "N1_generate_draft"
-        assert not state.get("error_message")
+        assert route_after_validate_test_plan({"error_message": "named failure"}) == "HALT"


### PR DESCRIPTION
The #2042 repair printed its summary and the run still halted `Error: unknown`:

```
[ROUTING] Unfixed: Requirement REQ-1 has no test coverage; ... (and 5 more)
Error:     unknown
```

It set `state["error_message"]` inside a conditional-edge router. A router returns a node name; its state mutations are discarded at the graph boundary — the same channel rule that ate `impl_pr_url` in #2018. The unit test passed because it called the router as a plain function, where the mutation is visible: **it tested the function, not the graph.**

## Fix

- The **node** sets `error_message` on its final failed iteration — a node return is a real state update, and the router already halts on `error_message` first, so message and halt arrive together.
- The router's dead mutation is removed; `describe_validation_failure` moves beside the node with a re-export in `graph.py`.
- Every rejected draft is preserved to the audit dir with its feedback appended. Both LLD halts of boostgauge #2 judged content destroyed with the worktree on restore — a drafter regression whose table parsed as 8 scenarios in one iteration and 0 in the next could not be inspected afterwards at all.

## Verification

Disabling the node's final-iteration branch fails `test_the_final_failed_iteration_returns_the_message`. Tests exercise the node return and router dispatch, not router mutation. 6250 unit tests pass; ruff clean on all three changed files.

Closes #2046