### PR TITLE
fix(testing): isolate iterations from test-run droppings, name stagnant regressions (Closes #2048)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -597,6 +597,60 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
 COVERAGE_IMPROVEMENT_THRESHOLD = 1.0
 
+
+def _snapshot_untracked(repo_root) -> set[str] | None:
+    """Untracked paths right now, or None when git cannot say (#2048)."""
+    # -uall: without it git collapses an untracked directory to "dir/" and the
+    # files inside never appear -- exactly where generated baselines land
+    # (tests/visual/baselines/ is born whole during the run).
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "-uall"],
+            cwd=str(repo_root), capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+        )
+    except OSError:
+        # Nonexistent cwd, git missing -- could not measure, so measure nothing.
+        return None
+    if result.returncode != 0:
+        return None
+    return {
+        line[3:].strip().strip('"')
+        for line in result.stdout.splitlines()
+        if line.startswith("??")
+    }
+
+
+def _remove_test_run_droppings(repo_root, before: set[str] | None) -> None:
+    """Delete untracked files a pytest run just created (#2048).
+
+    Scope is exact: only paths untracked NOW that were not untracked BEFORE the
+    run started. Implementation files are written by N4 before pytest ever
+    runs, so they are in the before-set; anything newer was created by the test
+    execution itself -- generated baselines, caches, stray outputs -- and
+    carrying it into the next iteration makes iterations judge each other. The
+    poisoning case: a generated visual test saved its baseline in iteration 1
+    and every later iteration failed against it, unwinnable by revision.
+
+    None for `before` means the snapshot failed; delete nothing rather than
+    guess ("could not measure" is not "nothing was there" -- #2028's rule).
+    """
+    if before is None:
+        return
+    after = _snapshot_untracked(repo_root)
+    if after is None:
+        return
+    from pathlib import Path as _Path
+
+    for rel in sorted(after - before):
+        target = _Path(repo_root) / rel
+        try:
+            if target.is_file():
+                target.unlink()
+                print(f"    [N5] removed test-run dropping: {rel}")
+        except OSError as exc:
+            print(f"    [N5] could not remove test-run dropping {rel}: {exc}")
+
 # "cannot import name 'render' from 'boostgauge.gauge'" — the shape pytest
 # prints when a phase removed something an earlier phase published.
 _MISSING_NAME_RE = re.compile(
@@ -1176,7 +1230,17 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     # --------------------------------------------------------------------------
     if not state.get("full_suite_validated", False):
         print("    [N5] Running full test suite regression check...")
+        # #2048: iterations must be independent. boostgauge #2's generated
+        # visual test wrote its baseline PNG on first run; the revise loop then
+        # changed the renderer, and every later iteration failed RMS-diff
+        # against the stale baseline forever -- "2 regressions" became "same 4
+        # failing, stagnant" without the model having any way to win. Files a
+        # test RUN creates are droppings, not implementation: N4 writes its
+        # files before pytest starts, so anything new afterwards was made by
+        # the run itself and is removed before the next iteration judges.
+        droppings_before = _snapshot_untracked(repo_root)
         full_result = run_pytest([], repo_root=repo_root)
+        _remove_test_run_droppings(repo_root, droppings_before)
         full_parsed = full_result["parsed"]
         full_failed = full_parsed.get("failed", 0)
         full_errors = full_parsed.get("errors", 0)
@@ -1190,9 +1254,14 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             # Check for stagnation: same regressions across 2 iterations → halt
             previous_regressions = state.get("full_suite_regressions", [])
             if previous_regressions and sorted(regression_names) == sorted(previous_regressions):
+                # #2048: name them. "same 4 test(s)" sent the diagnosis to a
+                # manual worktree + full-suite re-run; the names were in hand.
+                named = ", ".join(regression_names[:4])
+                if len(regression_names) > 4:
+                    named += f" (and {len(regression_names) - 4} more)"
                 stagnant_msg = (
                     f"Full suite regression stagnant: same {len(regression_names)} test(s) "
-                    f"failing across iterations. Halting."
+                    f"failing across iterations: {named}. Halting."
                 )
                 print(f"    [STAGNANT] {stagnant_msg}")
                 return {

--- a/tests/unit/test_iteration_isolation.py
+++ b/tests/unit/test_iteration_isolation.py
@@ -1,0 +1,116 @@
+"""Test runs must not poison the next iteration, and stagnant halts name names (#2048).
+
+boostgauge #2, 2026-07-31, run-issue2-201843: the generated visual test wrote
+its baseline PNG on first execution ("or not baseline_path.exists()"). The
+revise loop then changed the renderer, and every later iteration failed
+RMS-diff (0.047 vs 1/255) against the stale baseline -- an unwinnable loop.
+"2 regression(s) detected" became "same 4 test(s) failing, stagnant", and the
+halt named none of them; diagnosis took a manual worktree from the checkpoint
+branch and a hand-run full suite.
+
+Files a test RUN creates are droppings, not implementation: N4 writes its
+files before pytest starts, so anything untracked that appears during the run
+was made by the run.
+"""
+
+import subprocess
+
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _remove_test_run_droppings,
+    _snapshot_untracked,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def worktree(tmp_path):
+    r = tmp_path / "boostgauge-2"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "src").mkdir()
+    (r / "src" / "gauge.py").write_text("# committed\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "base")
+    # N4's output: written BEFORE pytest runs, untracked, must survive.
+    (r / "src" / "telltale.py").write_text("# impl\n", encoding="utf-8")
+    return r
+
+
+class TestDroppingsAreRemoved:
+    def test_a_file_the_run_created_is_deleted(self, worktree):
+        """The live poisoning: a baseline PNG born during the test run."""
+        before = _snapshot_untracked(worktree)
+        baselines = worktree / "tests" / "visual" / "baselines"
+        baselines.mkdir(parents=True)
+        (baselines / "test_stingray_telltales.png").write_bytes(b"PNG")
+
+        _remove_test_run_droppings(worktree, before)
+
+        assert not (baselines / "test_stingray_telltales.png").exists()
+
+    def test_implementation_files_survive(self, worktree):
+        """N4's output predates the run and is in the before-set."""
+        before = _snapshot_untracked(worktree)
+        (worktree / "junk.tmp").write_text("x", encoding="utf-8")
+
+        _remove_test_run_droppings(worktree, before)
+
+        assert (worktree / "src" / "telltale.py").exists()
+        assert not (worktree / "junk.tmp").exists()
+
+    def test_committed_files_are_never_touched(self, worktree):
+        before = _snapshot_untracked(worktree)
+        (worktree / "born-in-run.txt").write_text("x", encoding="utf-8")
+
+        _remove_test_run_droppings(worktree, before)
+
+        assert (worktree / "src" / "gauge.py").exists()
+
+    def test_a_failed_snapshot_deletes_nothing(self, worktree):
+        """'Could not measure' is not 'nothing was there' (#2028's rule) --
+        None must never authorise deleting whatever is untracked now."""
+        (worktree / "precious.txt").write_text("x", encoding="utf-8")
+
+        _remove_test_run_droppings(worktree, None)
+
+        assert (worktree / "precious.txt").exists()
+
+    def test_a_quiet_run_removes_nothing(self, worktree):
+        before = _snapshot_untracked(worktree)
+        _remove_test_run_droppings(worktree, before)
+        assert (worktree / "src" / "telltale.py").exists()
+
+
+class TestSnapshot:
+    def test_untracked_files_are_seen(self, worktree):
+        snap = _snapshot_untracked(worktree)
+        assert any("telltale.py" in p for p in snap)
+
+    def test_a_non_repo_returns_none(self, tmp_path):
+        bare = tmp_path / "not-a-repo"
+        bare.mkdir()
+        assert _snapshot_untracked(bare) is None
+
+
+class TestTheStagnantHaltNamesTheTests:
+    def test_the_message_carries_the_names(self):
+        """'same 4 test(s)' sent diagnosis to a manual worktree; the names
+        were in regression_names the whole time."""
+        import inspect
+
+        from assemblyzero.workflows.testing.nodes import verify_phases
+
+        source = inspect.getsource(verify_phases.verify_green_phase)
+        segment = source[source.index("Full suite regression stagnant"):]
+        assert "{named}" in segment.split("Halting.")[0], (
+            "the stagnant halt must name the failing tests, not just count them"
+        )


### PR DESCRIPTION
boostgauge #2, run-issue2-201843: the generated visual test wrote its baseline PNG on first execution (`or not baseline_path.exists()`). The revise loop then changed the renderer, and every later iteration failed RMS-diff (0.047 vs 1/255) against the stale baseline — an unwinnable loop. `2 regression(s) detected` became `same 4 test(s) failing across iterations. Halting.` with none named; diagnosis took a manual worktree from the checkpoint branch and a hand-run suite.

The two real failures: `test_unsupported_skin_rejection` (a genuine behavior regression the revise loop should fight on fair terms) and `test_visual_baseline_telltales` (pure poisoning it could never win).

## Fix

**Files a test RUN creates are droppings, not implementation.** N4 writes its files before pytest starts, so anything untracked that appears during the run was made by the run. Untracked is snapshotted before the full-suite check and what is new afterwards is removed before the next iteration judges.

- `-uall` is load-bearing: without it git collapses a new directory to `dir/` and the files inside never appear — exactly where baselines land. Found by the decisive test failing against the first draft.
- A failed snapshot removes nothing — "could not measure" is not "nothing was there" (#2028's rule) — and survives a nonexistent cwd rather than crashing the node.
- The stagnant halt now **names** the failing tests.

## Verification

6258 unit tests pass. New tests cover: run-created file deleted, N4 output survives, committed files untouched, None-snapshot deletes nothing, halt message carries names. Ruff: only the 3 pre-existing warnings in `verify_phases.py`, unchanged from main.

Closes #2048