### PR TITLE
fix(testing): hill-climb the iterate loop — never revise from worse than the best (Closes #2050)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -598,6 +598,89 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
 COVERAGE_IMPROVEMENT_THRESHOLD = 1.0
 
 
+def _hill_climb(
+    state, repo_root, passed_count, coverage_achieved, current_green_failures,
+    updates,
+) -> None:
+    """Never revise from a state worse than the best one seen (#2050).
+
+    boostgauge #2 oscillated 36% -> 99% (39/41 passing) -> 36% (7/15) and
+    halted holding the WORST state it had produced: iteration 2 was one
+    revision from done and iteration 3 threw it away. The loop was a random
+    walk over drafter variance with no memory of its best result.
+
+    After each measurement: a new best snapshots the implementation and test
+    files; a worse iteration restores the best files to the worktree before N4
+    revises again and carries the BEST metrics as previous_*, so the stagnation
+    guards compare against the best rather than the latest roll of the dice.
+    A worse iteration then costs one revision instead of the run.
+
+    Mutates `updates` in place. Best-effort: snapshot or restore trouble is
+    reported and never fails the node.
+    """
+    import shutil
+
+    impl_files = state.get("implementation_files", []) or []
+    test_files = state.get("test_files", []) or []
+    tracked = [f for f in (*impl_files, *test_files) if f]
+    if not tracked:
+        return
+
+    best = state.get("best_iteration") or None
+    score = (passed_count, coverage_achieved)
+    best_score = (
+        (best.get("passed", -1), best.get("coverage", -1.0)) if best else None
+    )
+
+    if best_score is None or score > best_score:
+        snap_root = Path(state.get("audit_dir") or Path(repo_root) / ".az-best-iteration")
+        snap_dir = snap_root / "best-iteration"
+        manifest: dict[str, str] = {}
+        try:
+            if snap_dir.exists():
+                shutil.rmtree(snap_dir)
+            snap_dir.mkdir(parents=True, exist_ok=True)
+            for idx, file_str in enumerate(tracked):
+                src = Path(file_str)
+                if src.is_file():
+                    dst = snap_dir / f"{idx:02d}-{src.name}"
+                    shutil.copy2(src, dst)
+                    manifest[str(src)] = str(dst)
+        except OSError as exc:
+            print(f"    [N5] best-iteration snapshot failed (non-fatal): {exc}")
+            return
+        updates["best_iteration"] = {
+            "passed": passed_count,
+            "coverage": coverage_achieved,
+            "green_failures": list(current_green_failures or []),
+            "files": manifest,
+        }
+        print(
+            f"    [N5] best iteration so far: {passed_count} passing at "
+            f"{coverage_achieved:.1f}% — snapshotted {len(manifest)} file(s)"
+        )
+        return
+
+    if score < best_score:
+        restored = 0
+        for src_str, snap_str in (best.get("files") or {}).items():
+            try:
+                if Path(snap_str).is_file():
+                    shutil.copy2(snap_str, src_str)
+                    restored += 1
+            except OSError as exc:
+                print(f"    [N5] could not restore {src_str} (non-fatal): {exc}")
+        updates["previous_passed"] = best.get("passed", passed_count)
+        updates["previous_coverage"] = best.get("coverage", coverage_achieved)
+        updates["previous_green_failures"] = best.get("green_failures", [])
+        print(
+            f"    [N5] iteration regressed ({passed_count} passing at "
+            f"{coverage_achieved:.1f}% vs best {best.get('passed')} at "
+            f"{best.get('coverage'):.1f}%) — restored {restored} file(s) from "
+            f"the best iteration; revising from there instead"
+        )
+
+
 def _snapshot_untracked(repo_root) -> set[str] | None:
     """Untracked paths right now, or None when git cannot say (#2048)."""
     # -uall: without it git collapses an untracked directory to "dir/" and the
@@ -1112,7 +1195,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         )
 
         # Loop back to implementation with failure feedback
-        return {
+        updates = {
             "green_phase_output": output,
             "coverage_achieved": coverage_achieved,
             "previous_coverage": coverage_achieved,
@@ -1125,6 +1208,9 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "next_node": "N4_implement_code",
             "error_message": "",
         }
+        _hill_climb(state, repo_root, passed_count, coverage_achieved,
+                    current_green_failures, updates)
+        return updates
 
     # Check coverage
     if coverage_achieved < coverage_target:
@@ -1207,7 +1293,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         )
 
         # Loop back to implementation for more coverage
-        return {
+        updates = {
             "green_phase_output": output,
             "coverage_achieved": coverage_achieved,
             "previous_coverage": coverage_achieved,
@@ -1220,6 +1306,9 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "next_node": "N4_implement_code",
             "error_message": "",
         }
+        _hill_climb(state, repo_root, passed_count, coverage_achieved,
+                    current_green_failures, updates)
+        return updates
 
     # Success: all tests pass and coverage meets target
     print(f"    [N5] Green phase PASSED: {passed_count} tests, {coverage_achieved:.1f}% coverage")

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -171,6 +171,10 @@ class TestingWorkflowState(TypedDict, total=False):
     previous_e2e_passed: int  # Previous E2E pass count for stagnation detection
     previous_e2e_failures: list[str]  # Issue #504: Previous E2E failed test names for identity comparison
     previous_green_failures: list[str]  # Issue #501: Previous green phase failed test names for identity comparison
+    # #2050: the best (passed, coverage) iteration's metrics and file
+    # snapshots. MUST stay declared -- an undeclared key is discarded at the
+    # node boundary (#2018) and the hill-climb would silently never engage.
+    best_iteration: dict | None
     test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
     e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
     full_suite_validated: bool  # Issue #842: True after full test suite passes regression check

--- a/tests/unit/test_hill_climb.py
+++ b/tests/unit/test_hill_climb.py
@@ -1,0 +1,152 @@
+"""The iterate loop must never revise from a state worse than its best (#2050).
+
+boostgauge #2, run-issue2-205420, impl stage 1534.7s:
+
+    Iteration 1: 7/15 passing,  36.0%
+    Iteration 2: 39/41 passing, 99.0%   (one revision from done)
+    Iteration 3: 7/15 passing,  36.0%   (reverted, and the run halted here)
+
+The loop was a random walk over drafter variance with no memory of its best
+result, and the halt left the WORST state it had produced on disk.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import _hill_climb
+
+
+@pytest.fixture
+def tree(tmp_path):
+    repo = tmp_path / "worktree"
+    (repo / "src").mkdir(parents=True)
+    (repo / "tests").mkdir()
+    impl = repo / "src" / "renderer.py"
+    test = repo / "tests" / "test_renderer.py"
+    impl.write_text("GOOD_IMPL = 2\n", encoding="utf-8")
+    test.write_text("# 41 tests\n", encoding="utf-8")
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    return repo, impl, test, audit
+
+
+def _state(repo, impl, test, audit, best=None):
+    return {
+        "implementation_files": [str(impl)],
+        "test_files": [str(test)],
+        "audit_dir": str(audit),
+        "best_iteration": best,
+    }
+
+
+class TestABetterIterationIsSnapshotted:
+    def test_first_measurement_becomes_the_best(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 39, 99.0, ["t_a"], updates)
+
+        best = updates["best_iteration"]
+        assert best["passed"] == 39 and best["coverage"] == 99.0
+        assert len(best["files"]) == 2
+        for snap in best["files"].values():
+            assert Path(snap).is_file()
+
+    def test_an_improvement_replaces_the_best(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 7, 36.0, [], updates)
+        prior = updates["best_iteration"]
+
+        updates2 = {}
+        _hill_climb(
+            _state(repo, impl, test, audit, best=prior), repo, 39, 99.0, [], updates2
+        )
+        assert updates2["best_iteration"]["passed"] == 39
+
+
+class TestAWorseIterationIsRolledBack:
+    def test_the_live_oscillation_restores_the_best_files(self, tree):
+        """Iteration 3 reverts to 7/15 -- the best files must come back."""
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 39, 99.0, ["t_a"], updates)
+        best = updates["best_iteration"]
+
+        # The bad revision destroys the good implementation.
+        impl.write_text("BROKEN = 1\n", encoding="utf-8")
+
+        updates3 = {}
+        _hill_climb(
+            _state(repo, impl, test, audit, best=best), repo, 7, 36.0, [], updates3
+        )
+
+        assert impl.read_text(encoding="utf-8") == "GOOD_IMPL = 2\n"
+
+    def test_the_guards_compare_against_the_best_not_the_dice(self, tree):
+        """previous_* must carry the best metrics, or the next stagnation
+        decision judges progress against the bad roll."""
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 39, 99.0, ["t_a"], updates)
+        best = updates["best_iteration"]
+
+        updates3 = {"previous_passed": 7, "previous_coverage": 36.0}
+        _hill_climb(
+            _state(repo, impl, test, audit, best=best), repo, 7, 36.0, [], updates3
+        )
+
+        assert updates3["previous_passed"] == 39
+        assert updates3["previous_coverage"] == 99.0
+        assert updates3["previous_green_failures"] == ["t_a"]
+
+    def test_an_equal_iteration_neither_snapshots_nor_restores(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 39, 99.0, [], updates)
+        best = updates["best_iteration"]
+        impl.write_text("DIFFERENT_BUT_EQUAL = 3\n", encoding="utf-8")
+
+        updates2 = {}
+        _hill_climb(
+            _state(repo, impl, test, audit, best=best), repo, 39, 99.0, [], updates2
+        )
+
+        assert "best_iteration" not in updates2
+        assert impl.read_text(encoding="utf-8") == "DIFFERENT_BUT_EQUAL = 3\n"
+
+
+class TestDegradedInputs:
+    def test_no_tracked_files_is_a_no_op(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(
+            {"implementation_files": [], "test_files": [], "audit_dir": str(audit)},
+            repo, 10, 50.0, [], updates,
+        )
+        assert updates == {}
+
+    def test_a_missing_snapshot_file_restores_what_it_can(self, tree):
+        repo, impl, test, audit = tree
+        updates = {}
+        _hill_climb(_state(repo, impl, test, audit), repo, 39, 99.0, [], updates)
+        best = updates["best_iteration"]
+        # One snapshot vanishes (disk cleanup, whatever).
+        next(iter(best["files"].values())) and Path(
+            next(iter(best["files"].values()))
+        ).unlink()
+        impl.write_text("BROKEN = 1\n", encoding="utf-8")
+
+        updates3 = {}
+        _hill_climb(
+            _state(repo, impl, test, audit, best=best), repo, 7, 36.0, [], updates3
+        )
+        # No crash; metrics still carried.
+        assert updates3["previous_passed"] == 39
+
+    def test_the_state_field_is_declared(self):
+        """#2018's channel rule: an undeclared key never crosses the node
+        boundary and the hill-climb would silently never engage."""
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        assert "best_iteration" in TestingWorkflowState.__annotations__


### PR DESCRIPTION
boostgauge #2, run-issue2-205420, impl stage 1534.7s:

```
Iteration 1: 7/15 passing,  36.0%
Iteration 2: 39/41 passing, 99.0%   ← one revision from done
Iteration 3: 7/15 passing,  36.0%   ← reverted; the run halted here
```

The loop was a random walk over drafter variance with no memory of its best result, and the halt left the **worst** state it had produced on disk.

## Fix

After each green-phase measurement:

- a new best (more passing tests, or equal and higher coverage) **snapshots** the implementation and test files to the audit dir;
- a worse iteration **restores** the best files to the worktree before N4 revises again, and carries the best metrics as `previous_*`, so the stagnation guards compare against the best rather than the latest roll of the dice.

Oscillation becomes convergence: a worse iteration costs one revision instead of the run. An equal iteration neither snapshots nor restores. Snapshot/restore are best-effort and never fail the node. `best_iteration` is a **declared** state field (#2018's channel rule; undeclared and the hill-climb silently never engages — a test pins it).

## Verification

6266 unit tests pass. Tests cover the live oscillation (best files restored over the broken revision), metric carry, equal-score no-op, missing-snapshot degradation, and the declared field. Ruff: only the 3 pre-existing `verify_phases.py` warnings.

Closes #2050