### PR TITLE
fix(spec): the API check knows the base tree, not just the plan (Closes #2052)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -17,6 +17,7 @@ This node populates:
 
 import ast
 import re
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -298,7 +299,24 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
     # Runs over the full current_content (before excerpt trimming) so that
     # methods defined deep in a class body are captured.
     gathered_symbols = _extract_symbols_from_files(updated_files)
-    print(f"    Gathered {len(gathered_symbols)} target-repo symbols for API check")
+
+    # #2052: the plan is not the universe. This gathered only files_to_modify,
+    # so a spec CALLING an earlier phase's API without modifying its file was
+    # judged hallucinated -- boostgauge #2 was blocked for using
+    # Telltale.current_peak(), which #41 landed on the base, because
+    # telltale.py was not in #2's plan. Mid-arc, calling earlier phases' APIs
+    # is the entire point of accumulation, so the base tree's symbols join the
+    # universe. No base branch -> unchanged behavior.
+    if base_ref_name:
+        base_symbols = _extract_symbols_from_base(repo_root, base_ref_name)
+        before = len(gathered_symbols)
+        gathered_symbols = sorted(set(gathered_symbols) | base_symbols)
+        print(
+            f"    Gathered {before} planned-file symbol(s) + "
+            f"{len(base_symbols)} from {base_ref_name} for API check"
+        )
+    else:
+        print(f"    Gathered {len(gathered_symbols)} target-repo symbols for API check")
 
     return {
         "current_state_snapshots": current_state_snapshots,
@@ -878,6 +896,55 @@ def _extract_import_dependencies(
         lines.append(f"- **{filename}** imports: {import_list}")
 
     return "\n".join(lines)
+
+
+def _extract_symbols_from_base(repo_root: Path, base_ref_name: str) -> set[str]:
+    """Class/function names from every non-test .py on the base ref (#2052).
+
+    Read through git, never the checkout -- the checkout sits on the default
+    branch and mid-arc carries none of the arc (#2033's two-trees rule).
+    Tests are excluded (their helpers are not an API surface), and the sweep
+    is capped: past the cap the check degrades toward false positives, which
+    the message below makes visible rather than silent.
+    """
+    from assemblyzero.workflows.implementation_spec.base_tree import read_from_base
+
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", base_ref_name],
+        cwd=str(repo_root), capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    if result.returncode != 0:
+        return set()
+
+    paths = [
+        p.strip() for p in result.stdout.splitlines()
+        if p.strip().endswith(".py") and not p.strip().startswith("tests/")
+    ]
+    cap = 200
+    if len(paths) > cap:
+        print(
+            f"    [BASE] symbol sweep capped at {cap} of {len(paths)} .py "
+            f"file(s); calls into uncovered files may be misflagged"
+        )
+        paths = paths[:cap]
+
+    _def_re = re.compile(r"^\s*def\s+(\w+)", re.MULTILINE)
+    _cls_re = re.compile(r"^\s*class\s+(\w+)", re.MULTILINE)
+    symbols: set[str] = set()
+    for rel in paths:
+        content = read_from_base(repo_root, base_ref_name, rel)
+        if not content:
+            continue
+        try:
+            tree = ast.parse(content)
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    symbols.add(node.name)
+        except SyntaxError:
+            symbols.update(_def_re.findall(content))
+            symbols.update(_cls_re.findall(content))
+    return symbols
 
 
 def _extract_symbols_from_files(files: list[FileToModify]) -> list[str]:

--- a/tests/unit/test_base_symbols_in_api_check.py
+++ b/tests/unit/test_base_symbols_in_api_check.py
@@ -1,0 +1,89 @@
+"""The API-hallucination check must know the base tree, not just the plan (#2052).
+
+boostgauge #2, run-issue2-213425:
+
+    Gathered 10 target-repo symbols for API check
+    [FAIL] api_symbols_exist
+      - Spec calls methods not found ...: `current_peak`
+
+`Telltale.current_peak()` exists -- #41 landed it on origin/hardening-run-14.
+But #2's plan does not MODIFY telltale.py, it calls it, and symbols were
+gathered only from files_to_modify. The universe was the plan, so a correct
+call into an earlier phase's API read as hallucination and the revise loop
+could never fix it, because there was nothing to fix.
+
+The decisive fixture puts the API only on the base branch and keeps the
+checkout without it: a symbol readable from the working tree would pass
+against the old code and prove nothing (the #2033 fixture rule).
+"""
+
+import subprocess
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+    _extract_symbols_from_base,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Checkout on main; the attempt branch carries telltale.py, main does not."""
+    upstream = tmp_path / "up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+
+    _git(r, "checkout", "-b", "hardening-run-14")
+    src = r / "src"
+    src.mkdir()
+    (src / "telltale.py").write_text(
+        "class Telltale:\n    def current_peak(self):\n        return 1\n",
+        encoding="utf-8",
+    )
+    tests_dir = r / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_telltale.py").write_text(
+        "def test_helper_not_api():\n    pass\n", encoding="utf-8"
+    )
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "phase 41")
+    _git(r, "push", "-u", "origin", "hardening-run-14")
+    _git(r, "checkout", "main")
+    return r
+
+
+class TestBaseSymbolsAreKnown:
+    def test_an_earlier_phases_method_is_in_the_universe(self, repo):
+        """The live miss: current_peak flagged as hallucinated."""
+        assert not (repo / "src" / "telltale.py").exists(), "fixture: checkout must lack it"
+        symbols = _extract_symbols_from_base(repo, "origin/hardening-run-14")
+        assert "current_peak" in symbols
+        assert "Telltale" in symbols
+
+    def test_test_helpers_are_not_an_api_surface(self, repo):
+        symbols = _extract_symbols_from_base(repo, "origin/hardening-run-14")
+        assert "test_helper_not_api" not in symbols
+
+    def test_a_missing_ref_yields_an_empty_set(self, repo):
+        assert _extract_symbols_from_base(repo, "origin/no-such-branch") == set()
+
+    def test_a_non_repo_yields_an_empty_set(self, tmp_path):
+        bare = tmp_path / "empty"
+        bare.mkdir()
+        assert _extract_symbols_from_base(bare, "origin/x") == set()


### PR DESCRIPTION
boostgauge #2, run-issue2-213425, spec stage failed 288s:

```
Gathered 10 target-repo symbols for API check
[FAIL] api_symbols_exist
  - Spec calls methods not found ...: `current_peak`
```

`Telltale.current_peak()` **exists** — #41 landed it on `origin/hardening-run-14`. But #2's plan does not modify `telltale.py`, it calls it, and symbols were gathered only from `files_to_modify`. The universe was the plan, so a correct call into an earlier phase's API read as hallucination — and the revise loop could never fix it, because there was nothing to fix.

Mid-arc, a phase calling earlier phases' APIs is the entire point of accumulation. This is the third organ of the two-trees disease: #2021 (clean-check read the local ref), #2033 (spec planned against the checkout), now the symbol universe.

## Fix

Every non-test `.py` on the base ref joins the gather — read through git, never the checkout. Capped with a visible message rather than degrading silently; tests excluded (helpers are not an API surface). No base branch → unchanged behavior.

The decisive fixture puts the API **only on the base branch** and asserts the checkout lacks it — a symbol readable from the working tree would pass against the old code and prove nothing.

## Verification

6270 unit tests pass. Ruff: only the 4 pre-existing `analyze_codebase.py` warnings, unchanged from main.

Closes #2052