### PR TITLE
fix(spec): ride the base's declared signatures into the drafter's context (Closes #2054)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -318,6 +318,22 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
     else:
         print(f"    Gathered {len(gathered_symbols)} target-repo symbols for API check")
 
+    # #2054: names alone were not enough. The drafter still invented kwargs for
+    # APIs outside its plan (Telltale(window_seconds=...) against #41's actual
+    # parameter -- 41 of 74 tests failed on one TypeError, twice). Ride the
+    # base's declared signatures into the drafter's context via
+    # project_context, which reaches both the initial and revision prompts.
+    if base_ref_name:
+        surface = _base_api_surface(repo_root, base_ref_name)
+        if surface:
+            project_context = (
+                f"{project_context}\n\n{surface}" if project_context else surface
+            )
+            print(
+                f"    [BASE] API surface of {base_ref_name} added to drafter "
+                f"context ({len(surface):,} chars)"
+            )
+
     return {
         "current_state_snapshots": current_state_snapshots,
         "pattern_references": pattern_references,
@@ -896,6 +912,74 @@ def _extract_import_dependencies(
         lines.append(f"- **{filename}** imports: {import_list}")
 
     return "\n".join(lines)
+
+
+def _list_base_python_files(repo_root: Path, base_ref_name: str) -> list[str]:
+    """Non-test .py paths on the base ref, capped with a visible message."""
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", base_ref_name],
+        cwd=str(repo_root), capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+    )
+    if result.returncode != 0:
+        return []
+    paths = [
+        p.strip() for p in result.stdout.splitlines()
+        if p.strip().endswith(".py") and not p.strip().startswith("tests/")
+    ]
+    cap = 200
+    if len(paths) > cap:
+        print(
+            f"    [BASE] sweep capped at {cap} of {len(paths)} .py file(s); "
+            f"calls into uncovered files may be misflagged"
+        )
+        paths = paths[:cap]
+    return paths
+
+
+def _base_api_surface(
+    repo_root: Path, base_ref_name: str, max_chars: int = 12_000
+) -> str:
+    """Signatures of everything the base publishes, for the drafter (#2054).
+
+    #2052 taught the CHECKER the base's symbol names, so a call to
+    Telltale.current_peak() stopped being flagged as hallucinated. The DRAFTER
+    still could not see the signatures of files outside its plan, so it
+    invented kwargs: boostgauge #2 called Telltale(window_seconds=...) against
+    #41's actual parameter and 41 of 74 tests failed on one TypeError, twice,
+    until the stagnation guard halted the stage.
+
+    A phase that must CALL an earlier phase's API needs to read that API's
+    declaration, exactly as a human would before writing the call.
+    """
+    from assemblyzero.workflows.implementation_spec.base_tree import read_from_base
+
+    sections: list[str] = [
+        "## Existing APIs on the integration branch "
+        "(call these EXACTLY as declared — do not invent parameter names)"
+    ]
+    total = len(sections[0])
+    truncated = False
+    for rel in _list_base_python_files(repo_root, base_ref_name):
+        content = read_from_base(repo_root, base_ref_name, rel)
+        if not content:
+            continue
+        summary = _summarize_python_file(content).strip()
+        if not summary:
+            continue
+        block = f"### {rel}\n{summary}"
+        if total + len(block) > max_chars:
+            truncated = True
+            break
+        sections.append(block)
+        total += len(block)
+    if len(sections) == 1:
+        return ""
+    if truncated:
+        sections.append(
+            "(base API surface truncated — files beyond the budget omitted)"
+        )
+    return "\n\n".join(sections)
 
 
 def _extract_symbols_from_base(repo_root: Path, base_ref_name: str) -> set[str]:

--- a/tests/unit/test_base_api_surface.py
+++ b/tests/unit/test_base_api_surface.py
@@ -1,0 +1,95 @@
+"""The drafter must see the signatures of APIs it will call (#2054).
+
+boostgauge #2, run-issue2-214927: the new telltale_manager called
+Telltale(window_seconds=...). #41's actual parameter is different, so 41 of 74
+tests failed on one TypeError -- twice, identically -- until the stagnation
+guard halted the stage.
+
+#2052 taught the CHECKER the base's symbol names, so the correct call to
+current_peak() stopped being flagged. The DRAFTER still could not see the
+declarations of files outside its plan, so it invented the kwarg. A phase that
+must call an earlier phase's API needs to read that API's declaration, exactly
+as a human would before writing the call.
+
+Fixture rule as in #2033/#2052: the API lives only on the base branch and the
+checkout lacks it, because that is the shape that fails.
+"""
+
+import subprocess
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+    _base_api_surface,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    upstream = tmp_path / "up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+
+    _git(r, "checkout", "-b", "hardening-run-14")
+    src = r / "src"
+    src.mkdir()
+    (src / "telltale.py").write_text(
+        "class Telltale:\n"
+        '    """Peak-hold."""\n'
+        "    def __init__(self, window: float | None = None):\n"
+        "        self.window = window\n"
+        "    def current_peak(self):\n"
+        "        return 1\n",
+        encoding="utf-8",
+    )
+    tests_dir = r / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_x.py").write_text("def test_h(): pass\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "phase 41")
+    _git(r, "push", "-u", "origin", "hardening-run-14")
+    _git(r, "checkout", "main")
+    return r
+
+
+class TestTheDrafterSeesDeclarations:
+    def test_the_signature_that_was_invented_is_now_readable(self, repo):
+        """The live miss: the drafter guessed window_seconds because it never
+        saw `def __init__(self, window: ...)`."""
+        assert not (repo / "src" / "telltale.py").exists()
+        surface = _base_api_surface(repo, "origin/hardening-run-14")
+
+        assert "src/telltale.py" in surface
+        assert "window" in surface
+        assert "current_peak" in surface
+
+    def test_it_tells_the_drafter_not_to_invent(self, repo):
+        surface = _base_api_surface(repo, "origin/hardening-run-14")
+        assert "EXACTLY as declared" in surface
+
+    def test_test_helpers_are_not_included(self, repo):
+        surface = _base_api_surface(repo, "origin/hardening-run-14")
+        assert "test_x.py" not in surface
+
+    def test_no_base_files_yields_empty_not_a_bare_header(self, repo):
+        assert _base_api_surface(repo, "origin/no-such-branch") == ""
+
+    def test_the_budget_truncates_visibly(self, repo):
+        surface = _base_api_surface(repo, "origin/hardening-run-14", max_chars=80)
+        assert surface == "" or "truncated" in surface


### PR DESCRIPTION
boostgauge #2, run-issue2-214927, impl failed 945.5s:

```
TypeError: Telltale.__init__() got an unexpected keyword argument 'window_seconds'
Error: Test count stagnant: 33/74 passed (unchanged from previous iteration).
```

41 of 74 tests failed on that one TypeError — twice, identically. The new `telltale_manager` calls #41's `Telltale` with an invented parameter name.

#2052 taught the **checker** the base's symbol names, so the correct `current_peak()` call stopped being flagged. The **drafter** still could not see the declarations of files outside its plan — `telltale.py` is not in #2's `files_to_modify` — so it guessed the kwarg, and the revise loop kept the guess because nothing in its context contradicted it.

## Fix

`interface_surface.summarize_python_file` existed for exactly this and was never wired — its imports sat unused in `analyze_codebase` (ruff F401 the whole time). Now every non-test `.py` on the base ref is summarized — read through git, never the checkout — and the digest rides `project_context`, which reaches both initial and revision prompts, under a header that says to call these **exactly as declared**.

Budget-capped with a visible truncation note. No base branch → unchanged behavior. Decisive fixture keeps the API only on the base branch and asserts the checkout lacks it.

## Verification

6275 unit tests pass. Ruff clean on the new test; only the 4 pre-existing `analyze_codebase.py` warnings remain.

Closes #2054