### PR TITLE
fix(requirements): path validator accepts files the base ships (Closes #2056)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -338,7 +338,8 @@ def validate_repo_root(repo_root: Path | None) -> tuple[bool, str | None]:
 
 def validate_file_paths_with_repo_check(
     files: list[dict],
-    repo_root: Path | None
+    repo_root: Path | None,
+    base_branch: str = "",
 ) -> tuple[list[ValidationError], bool]:
     """Validate file paths against repo, with explicit repo validation.
     
@@ -366,7 +367,7 @@ def validate_file_paths_with_repo_check(
         return (errors, False)
     
     # repo_root is valid, proceed with file path validation
-    path_errors = validate_file_paths(files, repo_root)
+    path_errors = validate_file_paths(files, repo_root, base_branch)
     errors.extend(path_errors)
     
     return (errors, True)
@@ -753,9 +754,33 @@ def find_similar_files(filename: str, repo_root: Path, max_results: int = 3) -> 
     return suggestions
 
 
+def _exists_on_base(repo_root: Path, base_branch: str, path: str) -> bool:
+    """Does the integration branch ship this path? (#2056)
+
+    Resolved against origin/<base> -- the local attempt ref is never
+    fast-forwarded (#2021), so a bare name would read a stale tree. Empty
+    base or any git trouble reads as "no", which restores the old behavior.
+    """
+    if not base_branch:
+        return False
+    import subprocess as _sp
+
+    ref = base_branch if base_branch.startswith("origin/") else f"origin/{base_branch}"
+    normalised = path.replace("\\", "/")
+    try:
+        probe = _sp.run(
+            ["git", "cat-file", "-e", f"{ref}:{normalised}"],
+            cwd=str(repo_root), capture_output=True, text=True,
+        )
+    except OSError:
+        return False
+    return probe.returncode == 0
+
+
 def validate_file_paths(
     files: list[dict],
     repo_root: Path,
+    base_branch: str = "",
 ) -> list[ValidationError]:
     """Check that Modify/Delete files exist, Add files have valid parents.
 
@@ -810,6 +835,16 @@ def validate_file_paths(
         full_path = repo_root / path
 
         if change_type in ("Modify", "Delete"):
+            # #2056: fourth organ of the two-trees disease. The checkout sits
+            # on the default branch and mid-arc carries none of the arc, so a
+            # CORRECT plan -- Modify a file an earlier phase landed on the
+            # integration branch -- was rejected here, while a wrong Add for
+            # the same file sailed through. boostgauge #2's LLD stage burned
+            # its iterations against this and halted.
+            if not full_path.exists() and _exists_on_base(
+                repo_root, base_branch, path
+            ):
+                continue
             if not full_path.exists():
                 # Issue #300: Find similar files to suggest
                 filename = Path(path).name
@@ -1337,7 +1372,9 @@ def validate_lld_mechanical(state: Dict[str, Any]) -> Dict[str, Any]:
 
     # Step 4: Issue #322 - Validate file paths with explicit repo_root check
     # This replaces the old silent skip behavior
-    path_errors, path_validation_ran = validate_file_paths_with_repo_check(files, repo_root)
+    path_errors, path_validation_ran = validate_file_paths_with_repo_check(
+        files, repo_root, state.get("base_branch", "")
+    )
     all_errors.extend(path_errors)
 
     # If repo_root validation failed, we have a blocking error - return early

--- a/tests/unit/test_validate_paths_against_base.py
+++ b/tests/unit/test_validate_paths_against_base.py
@@ -1,0 +1,94 @@
+"""The LLD path validator must accept files the base ships (#2056).
+
+boostgauge #2, run-issue2-221951, lld failed 84.4s:
+
+    MECHANICAL VALIDATION FAILED:
+      1. File marked Modify but does not exist: src/boostgauge/skins/stingray.py
+      2. File marked Modify but does not exist: src/boostgauge/gauge.py
+
+Both files exist -- #1 landed them on origin/hardening-run-14. The validator
+checks the CHECKOUT, which sits on the default branch and mid-arc carries none
+of the arc. So the CORRECT plan (Modify what an earlier phase built) was
+rejected, while a wrong Add for the same file sailed through -- the validator
+was steering the drafter toward the overwrite bug #2032 exists to prevent.
+
+Fourth organ of the two-trees disease: #2021 clean-check, #2033 spec planning,
+#2052 symbol universe, now LLD path validation.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    validate_file_paths,
+)
+
+
+def _git(cwd, *args):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    upstream = tmp_path / "up.git"
+    upstream.mkdir()
+    _git(upstream, "init", "--bare", "-b", "main")
+
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    (r / "README.md").write_text("x", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "init")
+    _git(r, "remote", "add", "origin", str(upstream))
+    _git(r, "push", "-u", "origin", "main")
+
+    _git(r, "checkout", "-b", "hardening-run-14")
+    (r / "src").mkdir()
+    (r / "src" / "gauge.py").write_text("def render(): pass\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "phase 3")
+    _git(r, "push", "-u", "origin", "hardening-run-14")
+    _git(r, "checkout", "main")
+    return r
+
+
+def _entry(path, change_type="Modify"):
+    return {"path": path, "change_type": change_type, "is_directory": False}
+
+
+class TestBaseFilesAreLegitimateModifyTargets:
+    def test_the_live_rejection_no_longer_fires(self, repo):
+        """gauge.py exists only on the base; the checkout lacks it."""
+        assert not (repo / "src" / "gauge.py").exists()
+        errors = validate_file_paths(
+            [_entry("src/gauge.py")], repo, base_branch="hardening-run-14"
+        )
+        assert errors == []
+
+    def test_a_genuinely_missing_file_is_still_rejected(self, repo):
+        errors = validate_file_paths(
+            [_entry("src/nope.py")], repo, base_branch="hardening-run-14"
+        )
+        assert len(errors) == 1
+        assert "does not exist" in errors[0].message
+
+    def test_no_base_branch_keeps_the_old_behavior(self, repo):
+        """A fresh feature on main: base-unaware, unchanged."""
+        errors = validate_file_paths([_entry("src/gauge.py")], repo)
+        assert len(errors) == 1
+
+    def test_a_checkout_file_needs_no_base(self, repo):
+        (repo / "local.py").write_text("x\n", encoding="utf-8")
+        assert validate_file_paths([_entry("local.py")], repo) == []
+
+    def test_delete_on_a_base_file_is_also_accepted(self, repo):
+        errors = validate_file_paths(
+            [_entry("src/gauge.py", "Delete")], repo, base_branch="hardening-run-14"
+        )
+        assert errors == []


### PR DESCRIPTION
boostgauge #2, run-issue2-221951, lld failed 84.4s: `File marked Modify but does not exist: src/boostgauge/skins/stingray.py` — it exists, #1 landed it on `origin/hardening-run-14`. The validator checks the checkout, which mid-arc carries none of the arc, so the **correct** plan was rejected while a wrong `Add` for the same file sailed through.

Fourth organ of the two-trees disease (see #2021, #2033, #2052 context). Modify/Delete paths now also check `origin/<base>` via `git cat-file`; empty base or git trouble reads as no, restoring old behavior. `base_branch` was already in requirements state.

485 targeted tests pass incl. 5 new (decisive fixture: file only on the base, checkout lacks it). Ruff clean.

Closes #2057