### PR TITLE
fix(testing): group revision feedback by root cause, widen the window (Closes #2058)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -42,7 +42,10 @@ from assemblyzero.workflows.testing.state import TestingWorkflowState
 PYTEST_TIMEOUT_SECONDS = 300
 
 # Issue #498: Max chars for failure summary fed back to N4
-MAX_FAILURE_SUMMARY_CHARS = 2000
+# #2058: was 2000 -- roughly the first 16 lines of a 100-failure suite. With
+# root-cause grouping in _build_failure_summary, 12000 comfortably holds every
+# DISTINCT cause of even a large generated test plan.
+MAX_FAILURE_SUMMARY_CHARS = 12000
 
 # Issue #562: Critical skip keywords (aligned with tools/test-gate.py)
 _CRITICAL_SKIP_KEYWORDS = ["security", "auth", "payment", "critical"]
@@ -129,7 +132,34 @@ def _build_failure_summary(output: str) -> str:
     if not summary_lines:
         return ""
 
-    result = "\n".join(summary_lines)
+    # #2058: group by root cause before spending the budget. Three consecutive
+    # runs of boostgauge #2 rewrote all 7 files and landed on an identical pass
+    # count -- N4 was revising against the first ~16 of 100+ failure lines the
+    # 2000-char cap let through, blind to the rest. 41 tests failing on one
+    # TypeError are ONE fact; grouping says so in one line and leaves budget
+    # for every other distinct cause.
+    grouped: dict[str, list[str]] = {}
+    ungrouped: list[str] = []
+    for line in summary_lines:
+        m = re.match(r"FAILED\s+(\S+?)(?:\s+-\s+(.*))?$", line)
+        if m and m.group(2):
+            grouped.setdefault(m.group(2).strip(), []).append(m.group(1))
+        else:
+            ungrouped.append(line)
+
+    if grouped:
+        blocks: list[str] = []
+        for reason, tests in sorted(
+            grouped.items(), key=lambda kv: len(kv[1]), reverse=True
+        ):
+            shown = ", ".join(tests[:3])
+            more = f" (and {len(tests) - 3} more)" if len(tests) > 3 else ""
+            blocks.append(f"{len(tests)} test(s): {reason}\n    e.g. {shown}{more}")
+        blocks.extend(ungrouped)
+        result = "\n".join(blocks)
+    else:
+        result = "\n".join(summary_lines)
+
     if len(result) > MAX_FAILURE_SUMMARY_CHARS:
         result = result[:MAX_FAILURE_SUMMARY_CHARS] + "\n... (truncated)"
     return result

--- a/tests/unit/test_failure_feedback.py
+++ b/tests/unit/test_failure_feedback.py
@@ -72,9 +72,10 @@ tests/test_foo.py::test_b PASSED
         result = _build_failure_summary(output)
         assert result == ""
 
-    def test_truncates_long_output(self):
-        """Truncates output exceeding MAX_FAILURE_SUMMARY_CHARS."""
-        # Build output with many FAILED lines
+    def test_identical_causes_compress_instead_of_truncating(self):
+        """#2058: 200 tests failing on ONE cause are one fact. The old cap fed
+        N4 the first ~16 lines and cut the rest -- now the group compresses and
+        nothing is lost."""
         lines = ["=========================== short test summary info ============================"]
         for i in range(200):
             lines.append(f"FAILED tests/test_x.py::test_{i:04d} - AssertionError: value mismatch")
@@ -82,7 +83,25 @@ tests/test_foo.py::test_b PASSED
         output = "\n".join(lines)
 
         result = _build_failure_summary(output)
-        assert len(result) <= 2100  # 2000 + truncation message
+        assert "200 test(s):" in result
+        assert "truncated" not in result
+
+    def test_truly_oversized_distinct_causes_still_truncate(self):
+        """The cap survives as the last resort for pathological suites."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            MAX_FAILURE_SUMMARY_CHARS,
+        )
+
+        lines = ["=========================== short test summary info ============================"]
+        for i in range(400):
+            lines.append(
+                f"FAILED tests/test_x.py::test_{i:04d} - AssertionError: "
+                f"unique cause {i} " + "x" * 80
+            )
+        lines.append("=" * 50 + " 400 failed " + "=" * 50)
+        result = _build_failure_summary("\n".join(lines))
+
+        assert len(result) <= MAX_FAILURE_SUMMARY_CHARS + 100
         assert "truncated" in result
 
     def test_empty_input(self):

--- a/tests/unit/test_failure_summary_grouping.py
+++ b/tests/unit/test_failure_summary_grouping.py
@@ -1,0 +1,69 @@
+"""N4's failure feedback must carry every distinct cause, not the first 16 lines (#2058).
+
+Three consecutive runs of boostgauge #2 rewrote all 7 files and landed on an
+identical pass count. The revision was blind: with 100+ failures at ~120 chars
+per summary line, the 2000-char cap fed N4 the first ~16 lines and cut the
+rest. 41 tests failing on one TypeError are ONE fact -- grouping says so in one
+line and leaves budget for every other distinct cause.
+"""
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _build_failure_summary,
+)
+
+
+def _output(lines):
+    return (
+        "===== short test summary info =====\n"
+        + "\n".join(lines)
+        + "\n==================================\n"
+    )
+
+
+class TestGrouping:
+    def test_one_cause_many_tests_is_one_line(self):
+        """The live shape: 41 tests, one TypeError."""
+        lines = [
+            f"FAILED tests/unit/test_m.py::test_{i} - TypeError: Telltale.__init__() "
+            f"got an unexpected keyword argument 'window_seconds'"
+            for i in range(41)
+        ]
+        summary = _build_failure_summary(_output(lines))
+
+        assert "41 test(s):" in summary
+        assert summary.count("window_seconds") == 1
+        assert "and 38 more" in summary
+
+    def test_every_distinct_cause_survives_a_large_suite(self):
+        """The defect: causes past the old cap were invisible to the revision."""
+        lines = []
+        for c in range(20):
+            for i in range(5):
+                lines.append(
+                    f"FAILED tests/unit/test_x.py::test_c{c}_{i} - "
+                    f"AssertionError: distinct cause number {c} was violated"
+                )
+        summary = _build_failure_summary(_output(lines))
+
+        for c in range(20):
+            assert f"distinct cause number {c}" in summary, (
+                f"cause {c} fell off the feedback; the revision is blind to it"
+            )
+
+    def test_biggest_group_leads(self):
+        lines = [
+            "FAILED tests/a.py::t1 - RareError: once",
+            "FAILED tests/a.py::t2 - CommonError: lots",
+            "FAILED tests/a.py::t3 - CommonError: lots",
+        ]
+        summary = _build_failure_summary(_output(lines))
+        assert summary.index("CommonError") < summary.index("RareError")
+
+    def test_lines_without_a_reason_are_kept_verbatim(self):
+        lines = ["FAILED tests/a.py::t1", "ERROR tests/b.py"]
+        summary = _build_failure_summary(_output(lines))
+        assert "tests/a.py::t1" in summary
+        assert "ERROR tests/b.py" in summary
+
+    def test_no_failures_is_still_empty(self):
+        assert _build_failure_summary("all good\n") == ""


### PR DESCRIPTION
Three consecutive runs of boostgauge #2 rewrote all 7 files and landed on an **identical** pass count (33/74, 106/208, 27/68 — each twice). The revision was blind: pytest short-summary lines run ~120 chars, so `MAX_FAILURE_SUMMARY_CHARS = 2000` fed N4 the first ~16 lines of 100+ failures and silently cut the rest. It fixed what it could see and re-rolled the dice on everything else.

## Fix

41 tests failing on one TypeError are **one fact**. Failures group by root-cause message — biggest group first, exemplar test names, `(and N more)` — so every *distinct* cause reaches the revision. Cap raised to 12000, which holds every distinct cause of even a large generated plan; truncation survives as the last resort.

The old test asserting truncation on 200 *identical* causes now asserts compression instead — that fixture is exactly the case the grouping exists for. A new test pins that 20 distinct causes all survive, which is the defect stated as an assertion.

## Verification

362 targeted tests pass (22 in the two feedback files, incl. 5 new grouping + updated truncation contract). Ruff: only the 3 pre-existing warnings.

Note: the branch commit references #2059 (mis-guessed issue number); the squash commit takes this title/body, so `Closes #2058` is what lands on main.

Closes #2058