### PR TITLE
fix(dependabot): extract pytest collection errors so import-time failures can be compared (Closes #2060)

### DIFF
--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -1954,3 +1954,53 @@ class TestBaselineGateFlow:
             self._pr(), "o/r", Path("/tmp/wt"))
         assert result == "merged"
         assert called == [], "baseline must not run when the gate passes"
+
+
+PYTEST_COLLECT_ERR = (
+    "ERROR tests/unit/test_enrich.py\n"
+    "ERROR tests/unit/test_export.py\n"
+    "!!!!!! Interrupted: 2 errors during collection !!!!!!\n"
+)
+
+
+class TestCollectionErrorExtraction:
+    """#2060: a suite that dies at IMPORT prints `ERROR <path>`, not
+    `FAILED`. Missing it made both sides parse empty, so the comparison was
+    impossible and every such PR deferred."""
+
+    def test_collection_errors_are_extracted(self):
+        got = dependabot_review.extract_failures(PYTEST_COLLECT_ERR)
+        assert "tests/unit/test_enrich.py" in got
+        assert "tests/unit/test_export.py" in got
+
+    def test_identical_collection_failures_exonerate(self):
+        """The case that stranded a whole repo: base and PR both die at
+        import in exactly the same modules."""
+        f = dependabot_review.extract_failures(PYTEST_COLLECT_ERR)
+        assert dependabot_review.is_exonerated_by_baseline(f, f) is True
+
+    def test_a_newly_erroring_module_still_defers(self):
+        """Safety unchanged: an extra broken module is a real regression."""
+        base = dependabot_review.extract_failures(PYTEST_COLLECT_ERR)
+        pr = dependabot_review.extract_failures(
+            PYTEST_COLLECT_ERR + "ERROR tests/unit/test_new.py\n")
+        assert dependabot_review.is_exonerated_by_baseline(pr, base) is False
+
+    def test_does_not_swallow_ordinary_error_prose(self):
+        """`ERROR:` narrative output must not masquerade as a test id.
+
+        An inflated baseline is the DANGEROUS direction: it would let a real
+        regression look like it was already failing on the base.
+        """
+        got = dependabot_review.extract_failures(
+            "ERROR: poetry install failed\n"
+            "ERROR: something else went wrong\n")
+        assert got == set(), f"prose must not parse as failures; got {got}"
+
+    def test_prose_cannot_exonerate_a_real_regression(self):
+        """End-to-end of that danger: prose in the baseline output must not
+        absorb a genuine PR failure."""
+        base = dependabot_review.extract_failures(
+            "ERROR: poetry install failed\n")
+        pr = dependabot_review.extract_failures("FAILED tests/x.py::test_a\n")
+        assert dependabot_review.is_exonerated_by_baseline(pr, base) is False

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -645,6 +645,13 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 # capture something stable enough to compare across two runs of one suite.
 _FAILURE_PATTERNS = (
     re.compile(r"^FAILED\s+(\S+)", re.M),                        # pytest
+    # #2060: pytest COLLECTION errors (exit 2/3) print `ERROR <path>`, not
+    # `FAILED`. Without this, a suite that dies at import parses to an
+    # empty set on BOTH the PR and the baseline run, so the comparison is
+    # impossible and every such PR defers as "baseline could not be
+    # established" -- even when the base is equally broken and the bump
+    # changes nothing. Seen stranding a repo's entire dependabot queue.
+    re.compile(r"^ERROR\s+(\S+)", re.M),                         # pytest collect
     re.compile(r"^\s*●\s+(.+?)\s*$", re.M),                      # jest
     re.compile(r"^\s*[×✕]\s+(.+?)(?:\s+\d+\s*ms)?\s*$", re.M),   # vitest
     re.compile(r"^\s*FAIL\s+(\S+)", re.M),                       # file-level


### PR DESCRIPTION
Closes #2060

## Gap

`extract_failures` (#1992) matched `FAILED` (pytest), `●` (jest), `×` (vitest) and `FAIL` (file-level). It did **not** match pytest **collection errors**, which are emitted as `ERROR <path>` with exit code 2:

```
ERROR tests/unit/test_enrich.py
ERROR tests/unit/test_export.py
!!!!!! Interrupted: 2 errors during collection !!!!!!
```

A suite that dies at *import* therefore parsed to an **empty set on both sides** — the PR run and the baseline run. The exoneration predicate then correctly refused (empty means "could not parse", never "nothing failed") and the PR deferred as `baseline could not be established`.

The safety behaviour was right. The parser was simply blind to an entire failure mode.

## Impact

One repo had its whole dependabot queue stranded this way — every PR deferring while the base was equally broken and the bumps changed nothing. The same message accounted for 4 further deferrals in a fleet run.

## Fix

One pattern added to `_FAILURE_PATTERNS`. Both sides now parse to comparable identifiers (the erroring module paths) and the existing subset comparison decides.

## Safety is unchanged

- A module that errors on the PR but **not** on the base is still a new failure and still defers.
- `ERROR:` narrative prose — `ERROR: poetry install failed` — does **not** match, because the pattern requires whitespace after `ERROR`, not a colon. This matters in one direction specifically: an inflated baseline is the dangerous case, since it could make a genuine regression look like it was already failing on the base.

## Tests

145 passed, `ruff` clean. New coverage asserts collection errors are extracted, identical import failures on both sides exonerate, a newly-erroring module still defers, prose parses to an empty set, and — end to end — prose in the baseline cannot absorb a real PR failure.

sibling: #1992
