### PR TITLE
fix(testing): three strikes for a nonzero count plateau (Closes #2062)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -1113,11 +1113,28 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
         # Stagnation check: if passed count unchanged from previous iteration, halt.
         # Catches 0/N->0/N loops (e.g., circular imports, total import failures).
+        #
+        # #2062: two strikes for ZERO passing (the #457 import-death loop this
+        # guard was built for), three for a nonzero plateau. Five boostgauge #2
+        # runs halted on the SECOND identical count with three iterations
+        # unspent -- and the first of those seconds was judged while the
+        # revision was starving on a 2000-char feedback window (#2058). With
+        # full-cause feedback now flowing, one identical count is one revision
+        # that did not move the needle, not proof no revision can.
         previous_passed = state.get("previous_passed", -1)
+        plateau_strikes = state.get("count_plateau_strikes", 0)
         if previous_passed >= 0 and passed_count == previous_passed:
+            plateau_strikes += 1
+        else:
+            plateau_strikes = 0
+        strikes_needed = 1 if passed_count == 0 else 2
+        if previous_passed >= 0 and passed_count == previous_passed and (
+            plateau_strikes >= strikes_needed
+        ):
             stagnant_msg = (
                 f"Test count stagnant: {passed_count}/{passed_count + failed_count} passed "
-                f"(unchanged from previous iteration). Halting to prevent token waste."
+                f"(unchanged across {plateau_strikes + 1} iterations). "
+                f"Halting to prevent token waste."
             )
             print(f"    [STAGNANT] {stagnant_msg}")
             return {
@@ -1237,6 +1254,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "iteration_count": iteration_count + 1,
             "next_node": "N4_implement_code",
             "error_message": "",
+            "count_plateau_strikes": plateau_strikes,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)
@@ -1335,6 +1353,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "iteration_count": iteration_count + 1,
             "next_node": "N4_implement_code",
             "error_message": "",
+            # All tests pass here; a count plateau is a failing-branch concept.
+            "count_plateau_strikes": 0,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -175,6 +175,8 @@ class TestingWorkflowState(TypedDict, total=False):
     # snapshots. MUST stay declared -- an undeclared key is discarded at the
     # node boundary (#2018) and the hill-climb would silently never engage.
     best_iteration: dict | None
+    # #2062: consecutive identical nonzero pass counts (three-strike plateau).
+    count_plateau_strikes: int
     test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
     e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
     full_suite_validated: bool  # Issue #842: True after full test suite passes regression check

--- a/tests/unit/test_count_plateau_three_strikes.py
+++ b/tests/unit/test_count_plateau_three_strikes.py
@@ -1,0 +1,85 @@
+"""A nonzero pass-count plateau gets three strikes, import-death still gets two (#2062).
+
+Five boostgauge #2 runs halted on the SECOND identical count with three
+iterations unspent -- and the first of each pair was judged while the revision
+starved on a 2000-char feedback window (#2058). One identical count is one
+revision that did not move the needle, not proof that none can.
+
+The #457 case this guard was built for -- 0/N -> 0/N import-death loops --
+keeps its fast halt: zero passing twice is structural, not variance.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+
+
+def _state(**overrides):
+    base = {
+        "test_files": ["/tmp/t.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 2,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(passed, failed, coverage=50):
+    return {
+        "returncode": 1,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": failed, "errors": 0,
+                   "coverage": coverage},
+    }
+
+
+def _run(state, passed, failed):
+    from assemblyzero.workflows.testing.nodes import verify_phases
+
+    with patch.object(verify_phases, "run_pytest",
+                      return_value=_pytest(passed, failed)):
+        return verify_green_phase(state)
+
+
+class TestNonzeroPlateau:
+    def test_the_first_identical_count_loops_back(self):
+        """The five live halts all died here, three iterations unspent."""
+        out = _run(_state(previous_passed=44), 44, 50)
+        assert out["next_node"] == "N4_implement_code", out.get("error_message")
+        assert out["count_plateau_strikes"] == 1
+
+    def test_the_second_identical_count_halts(self):
+        out = _run(_state(previous_passed=44, count_plateau_strikes=1), 44, 50)
+        assert out["next_node"] == "end"
+        assert "3 iterations" in out["error_message"]
+
+    def test_progress_resets_the_strikes(self):
+        out = _run(_state(previous_passed=44, count_plateau_strikes=1), 45, 49)
+        assert out["next_node"] == "N4_implement_code"
+        assert out["count_plateau_strikes"] == 0
+
+
+class TestImportDeathKeepsItsFastHalt:
+    def test_zero_to_zero_still_halts_at_two(self):
+        out = _run(_state(previous_passed=0), 0, 50)
+        assert out["next_node"] == "end"
+        assert "stagnant" in out.get("error_message", "").lower()
+
+
+class TestTheFieldIsDeclared:
+    def test_count_plateau_strikes_is_a_channel(self):
+        """#2018: undeclared keys are dropped at the node boundary, and the
+        strike counter would silently reset every iteration."""
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        assert "count_plateau_strikes" in TestingWorkflowState.__annotations__

--- a/tests/unit/test_verify_green_stagnation_both_branches.py
+++ b/tests/unit/test_verify_green_stagnation_both_branches.py
@@ -82,7 +82,8 @@ class TestTheTestsFailingBranch:
         mock_pytest.return_value = _pytest(1, passed=20, failed=3, coverage=94)
         result = verify_green_phase(
             _state(previous_passed=20, previous_coverage=94.0,
-                   previous_green_failures=["t_a", "t_b", "t_c"])
+                   previous_green_failures=["t_a", "t_b", "t_c"],
+                   count_plateau_strikes=1)  # #2062: third identical count
         )
         assert result["next_node"] == "end"
         assert "stagnant" in result.get("error_message", "").lower()


### PR DESCRIPTION
Five boostgauge #2 runs halted `Test count stagnant: N/M passed (unchanged from previous iteration)` on the **second** identical count with three iterations unspent — and the first of each pair was judged while the revision starved on the 2000-char feedback window (#2058). One identical count is one revision that did not move the needle, not proof that none can.

## Fix

- Nonzero plateau: **three** identical counts before halting.
- The #457 import-death case (0/N → 0/N) keeps its fast halt — zero passing twice is structural, not variance.
- Strike counter is a **declared channel** (#2018's rule), written explicitly on both loop-backs — an omitted key keeps the stale value and would wrongly preserve strikes after progress. The all-tests-pass branch resets it.
- The #2029-era test asserting halt on the first identical count now seeds the prior strike; it encoded the exact contract this replaces.

## Verification

220 guard-family tests pass (5 new). Ruff: only the 3 pre-existing `verify_phases.py` warnings.

Closes #2062