### PR TITLE
fix(testing): freeze tests on a repeated failing set; rewrite only the impl (Closes #2064)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -549,9 +549,46 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
     # Replace files_to_modify with regular_specs for the main loop
     files_to_modify = regular_specs
 
+    # #2064: symmetry-break for a repeated failing set. Tests and impl are both
+    # regenerated from the same spec, so when they disagree, a deterministic
+    # drafter reproduces the exact same failures every iteration -- six
+    # boostgauge #2 runs repeated their counts to the digit. When N5 saw the
+    # same set twice it froze the tests: they are the contract now (the passing
+    # ones prove they run), and only the implementation may change.
+    freeze_tests = bool(state.get("freeze_tests"))
+    revision_error_context = (
+        (test_failure_summary or e2e_failure_summary or green_phase_output)
+        if iteration_count > 0 else ""
+    )
+    if freeze_tests and revision_error_context:
+        revision_error_context = (
+            "THE TESTS ARE A FROZEN CONTRACT. They will not be rewritten. "
+            "Change the implementation so the tests pass exactly as written; "
+            "read the failing assertions for the expected behavior.\n\n"
+            + revision_error_context
+        )
+    if freeze_tests:
+        print(
+            "    [N4] tests are FROZEN this iteration (repeated failing set): "
+            "rewriting implementation only, against the tests as written"
+        )
+
     for i, file_spec in enumerate(files_to_modify):
         filepath = file_spec["path"]
         change_type = file_spec.get("change_type", "Add")
+
+        if freeze_tests and filepath.replace("\\", "/").startswith("tests/"):
+            target_path = repo_root / filepath
+            if target_path.is_file():
+                completed_files.append(
+                    (filepath, target_path.read_text(encoding="utf-8"))
+                )
+                written_paths.append(str(target_path))
+                print(
+                    f"\n    [{i+1}/{len(files_to_modify)}] {filepath} — frozen "
+                    f"(contract; not rewritten)"
+                )
+                continue
 
         existing_content = ""
         target_path = repo_root / filepath
@@ -665,8 +702,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             repo_root=repo_root,
             test_content=test_content,
             # Issue #498: Use structured failure summary (targeted) over raw output (noisy)
-            previous_error=(test_failure_summary or e2e_failure_summary or green_phase_output)
-            if iteration_count > 0 else "",
+            previous_error=revision_error_context,
             path_enforcement_section=path_enforcement_section,
             context_content=state.get("context_content", ""),
             repo_structure=repo_structure,
@@ -680,8 +716,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             completed_files=[],  # <-- PRUNED
             repo_root=repo_root,
             test_content=test_content,
-            previous_error=(test_failure_summary or e2e_failure_summary or green_phase_output)
-            if iteration_count > 0 else "",
+            previous_error=revision_error_context,
             path_enforcement_section=path_enforcement_section,
             context_content=state.get("context_content", ""),
             repo_structure=repo_structure,

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -1153,16 +1153,31 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
         # Issue #501: Identity-based stagnation — same tests failing across iterations.
         # Catches cases where pass count fluctuates but the SAME tests keep failing.
+        #
+        # #2064: a repeated failing set is a FIXED POINT, not just fatigue. Both
+        # tests and impl are regenerated from the same spec that causes their
+        # disagreement, so a deterministic drafter reproduces the exact failure
+        # set — six boostgauge #2 runs repeated their counts to the digit. The
+        # first repeat now breaks the symmetry instead of halting: the tests
+        # become a frozen contract (the passing ones prove they can run) and N4
+        # rewrites ONLY the implementation to satisfy them. Halt on the third
+        # identical set, when the symmetry-break has had its chance.
         previous_green_failures = state.get("previous_green_failures", [])
         identity_stagnant = (
             bool(current_green_failures)
             and bool(previous_green_failures)
             and current_green_failures == sorted(previous_green_failures)
         )
+        identity_strikes = state.get("identity_plateau_strikes", 0)
         if identity_stagnant:
+            identity_strikes += 1
+        else:
+            identity_strikes = 0
+        if identity_stagnant and identity_strikes >= 2:
             stagnant_msg = (
                 f"Test identity stagnant: same {len(current_green_failures)} test(s) failing "
-                f"across iterations. Halting to prevent token waste."
+                f"across {identity_strikes + 1} iterations (tests were frozen for the "
+                f"retry). Halting to prevent token waste."
             )
             print(f"    [STAGNANT] {stagnant_msg}")
             return {
@@ -1178,6 +1193,12 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "next_node": "end",
                 "error_message": stagnant_msg,
             }
+        if identity_stagnant:
+            print(
+                f"    [N5] same {len(current_green_failures)} test(s) failing again — "
+                f"freezing tests as the contract; next revision rewrites only the "
+                f"implementation (strike {identity_strikes})"
+            )
 
         # Stagnation check: one shared decision, see coverage_has_stagnated.
         # Skip when passed_count == 0: coverage is vacuously 100% with no passing
@@ -1255,6 +1276,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "next_node": "N4_implement_code",
             "error_message": "",
             "count_plateau_strikes": plateau_strikes,
+            "identity_plateau_strikes": identity_strikes,
+            "freeze_tests": identity_stagnant,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)
@@ -1355,6 +1378,8 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "error_message": "",
             # All tests pass here; a count plateau is a failing-branch concept.
             "count_plateau_strikes": 0,
+            "identity_plateau_strikes": 0,
+            "freeze_tests": False,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
                     current_green_failures, updates)

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -177,6 +177,10 @@ class TestingWorkflowState(TypedDict, total=False):
     best_iteration: dict | None
     # #2062: consecutive identical nonzero pass counts (three-strike plateau).
     count_plateau_strikes: int
+    # #2064: consecutive identical failing SETS, and the symmetry-break flag --
+    # when True, N4 must not rewrite test files; they are the frozen contract.
+    identity_plateau_strikes: int
+    freeze_tests: bool
     test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
     e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
     full_suite_validated: bool  # Issue #842: True after full test suite passes regression check

--- a/tests/unit/test_failure_feedback.py
+++ b/tests/unit/test_failure_feedback.py
@@ -229,6 +229,9 @@ FAILED tests/test_foo.py::test_baz - TypeError
         state = _make_state(
             previous_passed=1,
             previous_coverage=-1.0,
+            # #2064: the first repeat now freezes tests and retries; the halt
+            # comes on the THIRD identical set. Seed two prior strikes.
+            identity_plateau_strikes=2,
             previous_green_failures=[
                 "tests/test_foo.py::test_bar",
                 "tests/test_foo.py::test_baz",

--- a/tests/unit/test_freeze_tests_symmetry_break.py
+++ b/tests/unit/test_freeze_tests_symmetry_break.py
@@ -1,0 +1,142 @@
+"""A repeated failing set freezes the tests and rewrites only the impl (#2064).
+
+Six boostgauge #2 runs repeated their pass counts to the digit (33/74, 106/208,
+27/68, 44/94, 37/82...). Tests and implementation are both regenerated from the
+same spec, so when they disagree, a deterministic drafter reproduces the exact
+failure set every iteration -- a fixed point no amount of re-rolling escapes.
+
+The break: on the first repeat the tests become a frozen contract (the passing
+ones prove they can run) and N4 rewrites only the implementation to satisfy
+them. The identity guard halts on the THIRD identical set, after the break has
+had its chance -- it used to halt on the first repeat, before anything new
+could happen.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.verify_phases import verify_green_phase
+
+
+def _state(**overrides):
+    base = {
+        "test_files": ["/tmp/t.py"],
+        "repo_root": "/tmp/repo",
+        "audit_dir": "",
+        "file_counter": 0,
+        "issue_number": 2,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(passed, failed, failing_names):
+    lines = "\n".join(
+        f"FAILED tests/unit/test_m.py::{n} - AssertionError: x" for n in failing_names
+    )
+    return {
+        "returncode": 1,
+        "stdout": f"===== short test summary info =====\n{lines}\n=====\n"
+                  f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": failed, "errors": 0, "coverage": 40},
+    }
+
+
+def _run(state, passed, failed, names):
+    from assemblyzero.workflows.testing.nodes import verify_phases
+
+    with patch.object(verify_phases, "run_pytest",
+                      return_value=_pytest(passed, failed, names)):
+        return verify_green_phase(state)
+
+
+FAILS = ["t_a", "t_b"]
+PREV = [f"tests/unit/test_m.py::{n}" for n in FAILS]
+
+
+class TestTheFirstRepeatBreaksSymmetryInsteadOfHalting:
+    def test_it_loops_back_with_tests_frozen(self):
+        out = _run(
+            _state(previous_passed=5, previous_green_failures=PREV,
+                   count_plateau_strikes=0),
+            5, 2, FAILS,
+        )
+        assert out["next_node"] == "N4_implement_code", out.get("error_message")
+        assert out["freeze_tests"] is True
+        assert out["identity_plateau_strikes"] == 1
+
+    def test_the_third_identical_set_halts(self):
+        """count_plateau_strikes seeded 0 so the count guard (strike 1 of 2)
+        defers and the IDENTITY path is what halts here."""
+        out = _run(
+            _state(previous_passed=5, previous_green_failures=PREV,
+                   identity_plateau_strikes=2, count_plateau_strikes=0),
+            5, 2, FAILS,
+        )
+        assert out["next_node"] == "end"
+        assert "frozen" in out["error_message"]
+
+    def test_a_changed_failing_set_resets_the_strikes_and_unfreezes(self):
+        out = _run(
+            _state(previous_passed=4, previous_green_failures=PREV,
+                   identity_plateau_strikes=1, freeze_tests=True),
+            5, 2, ["t_c", "t_d"],
+        )
+        assert out["next_node"] == "N4_implement_code"
+        assert out["identity_plateau_strikes"] == 0
+        assert out["freeze_tests"] is False
+
+
+class TestN4HonorsTheFreeze:
+    def test_frozen_test_files_are_not_rewritten(self, tmp_path):
+        from assemblyzero.workflows.testing.nodes.implementation import orchestrator
+
+        repo = tmp_path / "wt"
+        (repo / "tests").mkdir(parents=True)
+        test_file = repo / "tests" / "test_m.py"
+        test_file.write_text("# the contract\n", encoding="utf-8")
+
+        calls = []
+        state = {
+            "files_to_modify": [
+                {"path": "tests/test_m.py", "change_type": "Modify",
+                 "description": "d"},
+            ],
+            "repo_root": str(repo),
+            "audit_dir": "",
+            "issue_number": 2,
+            "iteration_count": 1,
+            "freeze_tests": True,
+            "test_failure_summary": "2 test(s): AssertionError",
+            "lld_content": "x", "spec_path": "", "mock_mode": False,
+        }
+        with patch.object(orchestrator, "call_claude_for_file",
+                          side_effect=lambda *a, **k: calls.append(1) or ("code", "")), \
+             patch.object(orchestrator, "get_repo_structure", return_value=""), \
+             patch.object(orchestrator, "extract_paths_from_lld",
+                          return_value=None):
+            try:
+                orchestrator.implement_code(state)
+            except Exception:
+                pass  # downstream needs more state; the freeze check runs first
+
+        assert test_file.read_text(encoding="utf-8") == "# the contract\n"
+        assert calls == [], "no model call may target a frozen test file"
+
+    def test_the_prompt_names_the_contract(self):
+        """The instruction must reach the impl rewrite, or the model keeps
+        assuming the tests will move to meet it."""
+        import inspect
+
+        from assemblyzero.workflows.testing.nodes.implementation import orchestrator
+
+        source = inspect.getsource(orchestrator.implement_code)
+        assert "FROZEN CONTRACT" in source
+        assert "revision_error_context" in source


### PR DESCRIPTION
Six boostgauge #2 runs repeated their pass counts **to the digit** (33/74, 106/208, 27/68, 44/94, 37/82 — each twice). Tests and implementation are both regenerated from the same spec, so when they disagree, a deterministic drafter reproduces the exact failure set every iteration — a fixed point that re-rolling only re-samples. The identity guard (#501) halted on the **first** repeat, before anything different could be tried.

## Fix

- First repeat → **symmetry break**: tests become a frozen contract (the passing ones prove they can run); N4 rewrites only the implementation, with the failing assertions as the spec and an explicit `FROZEN CONTRACT` instruction in the prompt.
- Identity guard halts on the **third** identical set, after the break has had its chance.
- Strike counter + freeze flag are declared channels (#2018) written explicitly on both loop-backs; the all-pass branch resets them.
- Two prior tests encoding halt-on-first-repeat now seed prior strikes — they pinned the exact contract this replaces.

## Verification

331 guard-family tests pass (5 new: loop-back-with-freeze, third-set halt via the identity path, reset-on-changed-set, N4 refuses to rewrite a frozen test file, prompt carries the contract). Ruff: only pre-existing warnings.

Closes #2064