### PR TITLE
fix(testing): the armed symmetry-break outranks the remaining guards (Closes #2066)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -1194,11 +1194,34 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": stagnant_msg,
             }
         if identity_stagnant:
+            # #2066: the armed break LOOPS BACK HERE, before any further guard.
+            # The first version printed this and fell through -- the coverage
+            # guard then saw the same flat numbers and halted the run before
+            # the frozen iteration ever executed. A break that never runs is
+            # the old halt with extra words. If the frozen attempt also fails
+            # to move anything, the NEXT pass halts through the normal guards,
+            # which is the break having had its chance.
             print(
                 f"    [N5] same {len(current_green_failures)} test(s) failing again — "
                 f"freezing tests as the contract; next revision rewrites only the "
                 f"implementation (strike {identity_strikes})"
             )
+            return {
+                "green_phase_output": output,
+                "coverage_achieved": coverage_achieved,
+                "previous_coverage": coverage_achieved,
+                "previous_passed": passed_count,
+                "previous_green_failures": current_green_failures,
+                "test_failure_summary": failure_summary,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "iteration_count": iteration_count + 1,
+                "next_node": "N4_implement_code",
+                "error_message": "",
+                "count_plateau_strikes": plateau_strikes,
+                "identity_plateau_strikes": identity_strikes,
+                "freeze_tests": True,
+            }
 
         # Stagnation check: one shared decision, see coverage_has_stagnated.
         # Skip when passed_count == 0: coverage is vacuously 100% with no passing

--- a/tests/unit/test_freeze_tests_symmetry_break.py
+++ b/tests/unit/test_freeze_tests_symmetry_break.py
@@ -140,3 +140,18 @@ class TestN4HonorsTheFreeze:
         source = inspect.getsource(orchestrator.implement_code)
         assert "FROZEN CONTRACT" in source
         assert "revision_error_context" in source
+
+
+class TestTheArmedBreakOutranksOtherGuards:
+    def test_flat_coverage_does_not_steal_the_frozen_iteration(self):
+        """The live failure of the first version: identity armed the freeze,
+        fell through, and the coverage guard halted on the same flat numbers
+        before the frozen iteration ever executed (run-issue2-015725:
+        40/74 twice, 'Coverage stagnant: 45.0% -> 45.0%')."""
+        out = _run(
+            _state(previous_passed=5, previous_coverage=45.0,
+                   previous_green_failures=PREV, count_plateau_strikes=0),
+            5, 2, FAILS,
+        )
+        assert out["next_node"] == "N4_implement_code", out.get("error_message")
+        assert out["freeze_tests"] is True


### PR DESCRIPTION
run-issue2-015725: 40/74 twice; the identity guard armed the freeze (strike 1), printed so, then **fell through** — the coverage guard saw the same flat `45.0% -> 45.0%` and halted before the frozen iteration ever executed. A break that never runs is the old halt with extra words.

An armed break now loops back immediately, before any further guard, carrying `freeze_tests` and both strike counters. If the frozen attempt also moves nothing, the next pass halts through the normal guards — the break having had its chance.

332 guard-family tests pass (new: flat coverage does not steal the frozen iteration — the live failure as an assertion). Ruff: pre-existing only.

Closes #2066