### PR TITLE
feat(speedrun): --attempts redraws a failed issue inside the detached task (Closes #2068)

### DIFF
--- a/tests/unit/test_speedrun_roll_attempts.py
+++ b/tests/unit/test_speedrun_roll_attempts.py
@@ -1,0 +1,96 @@
+"""A failed draw redraws inside the detached task (#2068).
+
+Generation quality varies wildly between draws -- the same issue produced
+39/41-passing and 4/75-passing initial iterations on consecutive rolls. A bad
+draw is self-healing (ensure_base clears its debris), so the retry belongs
+inside the detached task, not with a human relaunching every twenty minutes.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+def _main(repo, attempts, codes):
+    """Run main() with roll_issue scripted to return `codes` in order."""
+    calls = []
+
+    def _roll(repo_root, issue, log_dir, az_root, extra):
+        calls.append(issue)
+        return codes[len(calls) - 1]
+
+    with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+            patch.object(sr, "roll_issue", _roll), \
+            patch.object(sr, "restore_repo", lambda *a: []), \
+            patch.object(sr.time, "sleep", lambda s: None):
+        code = sr.main(
+            ["--repo", str(repo), "--issue", "2", "--issue", "5",
+             "--attempts", str(attempts)]
+        )
+    return code, calls
+
+
+class TestRedraw:
+    def test_a_failed_draw_is_redrawn(self, tmp_path):
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        code, calls = _main(repo, 3, [1, 1, 0, 0])
+
+        assert code == 0
+        assert calls == [2, 2, 2, 5], "three draws of #2, then #5 once"
+
+    def test_success_does_not_burn_the_budget(self, tmp_path):
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        code, calls = _main(repo, 5, [0, 0])
+        assert code == 0
+        assert calls == [2, 5]
+
+    def test_exhausted_attempts_stop_the_arc(self, tmp_path):
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        code, calls = _main(repo, 2, [1, 1])
+        assert code == 1
+        assert calls == [2, 2], "later issues must not roll after exhaustion"
+
+    def test_a_base_problem_is_never_redrawn(self, tmp_path):
+        """91 is a gate/base fault, not a draw; retrying it re-spends against
+        the same wall."""
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        code, calls = _main(repo, 5, [91])
+        assert code == 91
+        assert calls == [2]
+
+    def test_default_is_a_single_attempt(self, tmp_path):
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+
+        calls = []
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "roll_issue",
+                             lambda *a: calls.append(1) or 1), \
+                patch.object(sr, "restore_repo", lambda *a: []), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.main(["--repo", str(repo), "--issue", "2"])
+        assert code == 1
+        assert calls == [1]
+
+
+class TestTheBudgetRidesTheRelaunch:
+    def test_detached_argv_carries_attempts(self, tmp_path):
+        args = argparse.Namespace(
+            issue=[2, 5], log_dir=None, assemblyzero_root=None,
+            detach=True, detached_stdout=None, attempts=6,
+        )
+        argv = sr.detached_argv(args, [], tmp_path / "r", tmp_path / "a",
+                                tmp_path / "l")
+        assert "--attempts" in argv
+        assert argv[argv.index("--attempts") + 1] == "6"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -539,6 +539,10 @@ def detached_argv(
         "--log-dir", str(log_dir),
         "--assemblyzero-root", str(az_root),
         "--detached-stdout", str(log_dir / "detached-launcher.log"),
+        # #2068: the redraw budget must ride the relaunch or the detached run
+        # silently falls back to a single attempt. getattr: callers that build
+        # a bare Namespace (tests, embedders) predate the flag.
+        "--attempts", str(max(1, getattr(args, "attempts", 1))),
     ]
     return argv + extra
 
@@ -870,6 +874,13 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--attempts", type=int, default=1,
+        help=(
+            "Redraw a failed issue up to N times before stopping (#2068). "
+            "Base/gate problems (exit 91) are never retried."
+        ),
+    )
+    parser.add_argument(
         "--detach-stop", action="store_true",
         help="Stop a detached roll and every process it spawned (#2016)",
     )
@@ -936,7 +947,22 @@ def main(argv: list[str] | None = None) -> int:
     code = 0
     try:
         for issue in args.issue:
-            code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+            # #2068: generation quality varies wildly between draws -- the same
+            # issue produced 39/41-passing and 4/75-passing initial iterations
+            # on consecutive rolls. A failed draw is self-healing (ensure_base
+            # clears its debris), so retrying inside the detached task removes
+            # the human relaunch from the loop entirely. A base or gate problem
+            # (91) is NOT a draw and is never retried.
+            for attempt_no in range(1, max(1, args.attempts) + 1):
+                code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+                if code == 0 or code == 91:
+                    break
+                if attempt_no < max(1, args.attempts):
+                    print(
+                        f"\n#{issue} attempt {attempt_no}/{args.attempts} failed "
+                        f"(exit {code}) — self-healing and redrawing."
+                    )
+                    time.sleep(2)
             if code != 0:
                 print(
                     f"\nSTOPPED at #{issue} (exit {code}); later issues not rolled."


### PR DESCRIPTION
Same issue, consecutive rolls tonight: 39/41-passing and 4/75-passing initial iterations. Draw variance is the residual bottleneck, and every bad draw ended the detached task and waited for a relaunch — unattended operation impossible.

A failed draw is self-healing (the next `ensure_base` clears its debris), so the retry belongs **inside** the task:

- `--attempts N`: redraw a failed issue up to N times before stopping the arc.
- Exit 91 (base/gate problem) is never redrawn — a wall, not a draw.
- The budget rides the detached relaunch argv (`getattr`-guarded for bare-Namespace callers) or the scheduled run would silently fall back to one attempt — a test pins it.

93 roll-family tests pass (6 new). Ruff clean.

Closes #2068