### PR TITLE
feat(speedrun): archive a completed run into one restorable record (Closes #2076)

### DIFF
--- a/assemblyzero/speedrun/__init__.py
+++ b/assemblyzero/speedrun/__init__.py
@@ -1,0 +1,1 @@
+"""Speedrun campaign support: archiving, placement, and run bookkeeping."""

--- a/assemblyzero/speedrun/archive.py
+++ b/assemblyzero/speedrun/archive.py
@@ -1,0 +1,595 @@
+"""Archive a completed speedrun as one compact, restorable record (#2076).
+
+An arc is never merged to main, so the product of a run exists only on
+integration branches, in `graveyard/*` attempt branches, in the events /
+heartbeat / stdout triplets under the log dir, and in lineage and reset
+artifacts. Nothing is lost, but nothing is compact either -- the record of a
+run is smeared across branches, logs, lineage dirs and PR history.
+
+This module gathers all of it into `data/speedrun/archives/<run>/`.
+
+## Design decisions
+
+**Run membership is read, not guessed.** The launcher writes
+`BASE '<branch>' verified clean for #<issue>` and `LAUNCH base=<branch>` into
+every roll's events log. That is a recorded fact tying a roll to a run, so
+rolls are selected by parsing it rather than by pattern-matching tag names.
+Tag naming across the existing arcs is inconsistent enough (`run-issue4-111608`,
+`run11b-issue4-234552`, `run11-roll10-issue-4`) that any name-based rule would
+silently mis-bin rolls.
+
+**Unknown is not zero.** Every component that cannot be read is named in
+`index.json`, flips `complete` to false, and makes the command exit nonzero. A
+partial archive must never be reportable as a complete one, because a false
+"archived" is what would later authorize a deletion.
+
+**Orphans are a first-class component, not a defensive branch.** Verified
+2026-08-02: `boostgauge-2` and `boostgauge-2-lld` exist as directories on disk,
+are absent from `git worktree list`, and their branches were deleted by a
+reset. An archiver that enumerates a run by walking worktrees or branches sees
+neither and reports success over content it never read.
+
+**This module never deletes anything.** It writes archives. Deletion is gated
+on a verified restore and is out of scope by issue.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import tarfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+ARCHIVES_REL = Path("data/speedrun/archives")
+DEFAULT_LOG_REL = Path("data/speedrun/runs")
+RESET_ARTIFACTS_REL = Path("data/speedrun/reset-artifacts")
+LINEAGE_REL = Path("docs/lineage")
+WORKTREES_REL = Path("data/worktrees")
+
+EVENTS_SUFFIX = "-events.log"
+INDEX_NAME = "index.json"
+INDEX_VERSION = 1
+
+# `git bundle` packs objects, and pack thread count changes delta selection and
+# therefore the output bytes. Pinned to one thread so archiving the same run
+# twice produces the same bundle, which is what makes manifests comparable.
+# Do not remove: the "identical manifest" test is the regression alarm for it.
+_DETERMINISTIC_PACK = ["-c", "pack.threads=1"]
+
+_RE_START = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) START issue=#(?P<issue>\d+)"
+)
+_RE_BASE = re.compile(r"BASE '(?P<base>[^']+)'")
+_RE_LAUNCH = re.compile(r"LAUNCH base=(?P<base>\S+)")
+_RE_EXIT = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) EXIT rc=(?P<rc>-?\d+)"
+)
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Component:
+    """One archived component and whether it could be read in full."""
+
+    name: str
+    ok: bool
+    detail: str = ""
+
+    def as_dict(self) -> dict:
+        return {"name": self.name, "ok": self.ok, "detail": self.detail}
+
+
+@dataclass
+class Roll:
+    """One roll of one issue, reconstructed from its events log."""
+
+    tag: str
+    issue: int | None = None
+    base: str | None = None
+    start: str | None = None
+    end: str | None = None
+    outcome: str = "unknown"
+    duration_s: float | None = None
+    files: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "tag": self.tag,
+            "issue": self.issue,
+            "base": self.base,
+            "start": self.start,
+            "end": self.end,
+            "outcome": self.outcome,
+            "duration_s": self.duration_s,
+            "files": sorted(self.files),
+        }
+
+
+@dataclass
+class ArchiveResult:
+    path: Path
+    complete: bool
+    components: list[Component]
+    index: dict
+
+    @property
+    def missing(self) -> list[str]:
+        return [c.name for c in self.components if not c.ok]
+
+
+# ---------------------------------------------------------------------------
+# git helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, args: list[str], *, config: list[str] | None = None):
+    return subprocess.run(
+        ["git", *(config or []), "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _ref_exists(repo: Path, ref: str) -> bool:
+    return _git(repo, ["rev-parse", "--verify", "--quiet", ref]).returncode == 0
+
+
+def _rev(repo: Path, ref: str) -> str | None:
+    result = _git(repo, ["rev-parse", ref])
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def local_branches(repo: Path) -> list[str]:
+    result = _git(repo, ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def graveyard_branches_for(repo: Path, run: str) -> list[str]:
+    """Graveyard branches belonging to `run`, by documented prefix rule.
+
+    Attempt branches are parked as `graveyard/<run>`, `graveyard/<run>-<suffix>`
+    or `graveyard/<run><separator><suffix>`. The rule is recorded in
+    `index.json` so a human can audit what was and was not swept in; anything
+    outside it must be passed explicitly via `extra_branches`.
+    """
+    prefix = f"graveyard/{run}"
+    matched = []
+    for branch in local_branches(repo):
+        if branch == prefix or branch.startswith(prefix + "-"):
+            matched.append(branch)
+    return sorted(matched)
+
+
+# ---------------------------------------------------------------------------
+# Roll discovery
+# ---------------------------------------------------------------------------
+
+
+def parse_events_log(path: Path) -> Roll:
+    """Reconstruct one roll from its events log.
+
+    Raises OSError if the log cannot be read -- callers turn that into an
+    incomplete component rather than swallowing it.
+    """
+    tag = path.name[: -len(EVENTS_SUFFIX)]
+    roll = Roll(tag=tag)
+    text = path.read_text(encoding="utf-8", errors="replace")
+
+    for line in text.splitlines():
+        start = _RE_START.match(line)
+        if start and roll.start is None:
+            roll.start = start.group("ts")
+            roll.issue = int(start.group("issue"))
+            continue
+        base = _RE_BASE.search(line) or _RE_LAUNCH.search(line)
+        if base and roll.base is None:
+            roll.base = base.group("base")
+            continue
+        exited = _RE_EXIT.match(line)
+        if exited:
+            roll.end = exited.group("ts")
+            rc = int(exited.group("rc"))
+            roll.outcome = "success" if rc == 0 else f"failed rc={rc}"
+
+    if roll.end is None:
+        # No EXIT line: the roll was killed, or is still running. Either way the
+        # outcome is genuinely unknown and must not be rendered as a failure.
+        roll.outcome = "incomplete"
+
+    if roll.start and roll.end:
+        started = datetime.strptime(roll.start, _TS_FMT)
+        ended = datetime.strptime(roll.end, _TS_FMT)
+        roll.duration_s = (ended - started).total_seconds()
+
+    return roll
+
+
+def discover_rolls(log_dir: Path, run: str) -> tuple[list[Roll], list[Component]]:
+    """Every roll whose events log names `run` as its base branch."""
+    rolls: list[Roll] = []
+    problems: list[Component] = []
+
+    if not log_dir.is_dir():
+        return rolls, [Component(f"logs ({log_dir})", False, "log directory not found")]
+
+    for events in sorted(log_dir.glob(f"*{EVENTS_SUFFIX}")):
+        try:
+            roll = parse_events_log(events)
+        except OSError as exc:
+            problems.append(
+                Component(f"logs/{events.name}", False, f"unreadable: {exc}")
+            )
+            continue
+        if roll.base != run:
+            continue
+        for sibling in (
+            events,
+            log_dir / f"{roll.tag}.log",
+            log_dir / f"{roll.tag}-heartbeat.log",
+        ):
+            if sibling.exists():
+                roll.files.append(sibling.name)
+        rolls.append(roll)
+
+    return rolls, problems
+
+
+# ---------------------------------------------------------------------------
+# Orphan worktrees
+# ---------------------------------------------------------------------------
+
+
+def registered_worktrees(repo: Path) -> set[Path]:
+    result = _git(repo, ["worktree", "list", "--porcelain"])
+    paths: set[Path] = set()
+    if result.returncode != 0:
+        return paths
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            paths.add(Path(line[len("worktree ") :].strip()).resolve())
+    return paths
+
+
+def find_orphan_worktrees(repo: Path) -> list[Path]:
+    """Directories that look like pipeline worktrees but git does not register.
+
+    Both layouts are scanned: the pre-#2077 siblings at `<parent>/<repo>-<n>`
+    and the post-#2077 home at `<repo>/data/worktrees/<name>`. An orphan is a
+    directory containing a `.git` entry that is absent from `git worktree list`.
+    """
+    repo = repo.resolve()
+    registered = registered_worktrees(repo)
+    candidates: list[Path] = []
+
+    sibling_prefix = repo.name + "-"
+    parent = repo.parent
+    if parent.is_dir():
+        for entry in sorted(parent.iterdir()):
+            if entry.is_dir() and entry.name.startswith(sibling_prefix):
+                candidates.append(entry)
+
+    managed = repo / WORKTREES_REL
+    if managed.is_dir():
+        for entry in sorted(managed.iterdir()):
+            if entry.is_dir() and entry.name != "orphaned":
+                candidates.append(entry)
+
+    orphans = []
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in registered:
+            continue
+        if not (resolved / ".git").exists():
+            continue
+        orphans.append(resolved)
+    return orphans
+
+
+# ---------------------------------------------------------------------------
+# Archiving
+# ---------------------------------------------------------------------------
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _copy_tree(src: Path, dest: Path) -> None:
+    shutil.copytree(src, dest, dirs_exist_ok=True)
+
+
+def _build_manifest(root: Path) -> dict[str, str]:
+    """sha256 for every archived file, keyed by POSIX path relative to root.
+
+    `index.json` itself is excluded -- it carries the manifest, so it cannot
+    also be inside it.
+    """
+    manifest: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel == INDEX_NAME:
+            continue
+        manifest[rel] = _sha256(path)
+    return dict(sorted(manifest.items()))
+
+
+def archive_run(
+    repo: Path,
+    run: str,
+    *,
+    out_dir: Path | None = None,
+    log_dir: Path | None = None,
+    extra_branches: list[str] | None = None,
+) -> ArchiveResult:
+    """Capture `run` as a restorable record. Writes only; never deletes."""
+    repo = Path(repo).resolve()
+    log_dir = Path(log_dir) if log_dir else repo / DEFAULT_LOG_REL
+    dest = Path(out_dir) if out_dir else repo / ARCHIVES_REL / run
+
+    if dest.exists():
+        # Re-archiving must be idempotent, and a stale file left from an earlier
+        # partial run would otherwise be hashed into the new manifest.
+        shutil.rmtree(dest)
+    (dest / "logs").mkdir(parents=True, exist_ok=True)
+    (dest / "artifacts").mkdir(parents=True, exist_ok=True)
+    (dest / "orphans").mkdir(parents=True, exist_ok=True)
+
+    components: list[Component] = []
+
+    # --- branches + bundle ------------------------------------------------
+    integration_sha = _rev(repo, run) if _ref_exists(repo, run) else None
+    graveyard = graveyard_branches_for(repo, run)
+    for extra in extra_branches or []:
+        if extra not in graveyard and extra != run:
+            graveyard.append(extra)
+    graveyard = sorted(set(graveyard))
+
+    refs = ([run] if integration_sha else []) + graveyard
+    bundle_rel = f"{run}.bundle"
+    bundle_path = dest / bundle_rel
+
+    if integration_sha is None:
+        components.append(
+            Component(
+                f"branch {run}", False, "integration branch not found in this repo"
+            )
+        )
+
+    if not refs:
+        components.append(
+            Component(bundle_rel, False, "no refs to bundle: nothing to capture")
+        )
+    else:
+        result = _git(
+            repo,
+            ["bundle", "create", str(bundle_path), *refs],
+            config=_DETERMINISTIC_PACK,
+        )
+        if result.returncode != 0 or not bundle_path.exists():
+            components.append(
+                Component(bundle_rel, False, f"git bundle failed: {result.stderr.strip()}")
+            )
+        else:
+            verify = _git(repo, ["bundle", "verify", str(bundle_path)])
+            if verify.returncode != 0:
+                components.append(
+                    Component(
+                        bundle_rel, False, f"bundle verify failed: {verify.stderr.strip()}"
+                    )
+                )
+            else:
+                components.append(Component(bundle_rel, True))
+
+    # --- logs -------------------------------------------------------------
+    rolls, log_problems = discover_rolls(log_dir, run)
+    components.extend(log_problems)
+    for roll in rolls:
+        for name in roll.files:
+            src = log_dir / name
+            try:
+                shutil.copy2(src, dest / "logs" / name)
+            except OSError as exc:
+                components.append(
+                    Component(f"logs/{name}", False, f"unreadable: {exc}")
+                )
+    if rolls:
+        components.append(Component("logs", True, f"{len(rolls)} roll(s)"))
+
+    # --- artifacts --------------------------------------------------------
+    lineage = repo / LINEAGE_REL
+    issues = {str(r.issue) for r in rolls if r.issue is not None}
+    if lineage.is_dir():
+        for entry in sorted(lineage.rglob("*")):
+            if not entry.is_dir():
+                continue
+            head = entry.name.split("-")[0]
+            if head not in issues:
+                continue
+            try:
+                _copy_tree(entry, dest / "artifacts" / "lineage" / entry.name)
+            except OSError as exc:
+                components.append(
+                    Component(
+                        f"artifacts/lineage/{entry.name}", False, f"unreadable: {exc}"
+                    )
+                )
+
+    reset_artifacts = repo / RESET_ARTIFACTS_REL
+    if reset_artifacts.is_dir():
+        try:
+            _copy_tree(reset_artifacts, dest / "artifacts" / "reset-artifacts")
+        except OSError as exc:
+            components.append(
+                Component("artifacts/reset-artifacts", False, f"unreadable: {exc}")
+            )
+
+    # --- orphans ----------------------------------------------------------
+    orphan_records = []
+    for orphan in find_orphan_worktrees(repo):
+        tar_name = f"{orphan.name}.tar.gz"
+        try:
+            with tarfile.open(dest / "orphans" / tar_name, "w:gz") as tar:
+                tar.add(orphan, arcname=orphan.name)
+        except OSError as exc:
+            components.append(
+                Component(f"orphans/{tar_name}", False, f"unreadable: {exc}")
+            )
+            continue
+        orphan_records.append(
+            {"name": orphan.name, "source": str(orphan), "archive": f"orphans/{tar_name}"}
+        )
+        components.append(Component(f"orphans/{tar_name}", True))
+
+    # --- index ------------------------------------------------------------
+    manifest = _build_manifest(dest)
+    complete = all(c.ok for c in components)
+
+    index = {
+        "index_version": INDEX_VERSION,
+        "run": run,
+        "repo": str(repo),
+        "created_ts_local": datetime.now().strftime(_TS_FMT),
+        "complete": complete,
+        "incomplete_components": [c.as_dict() for c in components if not c.ok],
+        "components": [c.as_dict() for c in components],
+        "branches": {
+            "integration": {"name": run, "sha": integration_sha},
+            "graveyard": [{"name": b, "sha": _rev(repo, b)} for b in graveyard],
+            "graveyard_match_rule": f"refs/heads/graveyard/{run} and graveyard/{run}-*",
+        },
+        "bundle": bundle_rel if bundle_path.exists() else None,
+        "rolls": [r.as_dict() for r in rolls],
+        "orphans": orphan_records,
+        "manifest": manifest,
+    }
+
+    (dest / INDEX_NAME).write_text(
+        json.dumps(index, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+
+    return ArchiveResult(path=dest, complete=complete, components=components, index=index)
+
+
+# ---------------------------------------------------------------------------
+# Restore
+# ---------------------------------------------------------------------------
+
+
+class RestoreRefused(RuntimeError):
+    """Raised when an incomplete archive is restored without an explicit force."""
+
+
+def _materialize_branches(repo_dest: Path, index: dict) -> None:
+    """Recreate the run's branches by name in a restored clone.
+
+    Cloning a bundle lands its refs as remote-tracking `origin/*` only, so
+    without this the restored repo has the objects but no branch called
+    `hardening-run-15` -- which is the name a human restoring an arc is looking
+    for. Branches are created from the SHAs recorded in `index.json`, so a
+    restore that cannot reproduce a recorded tip fails loudly instead of
+    quietly producing a repo missing an arc.
+    """
+    branches = index.get("branches", {})
+    wanted: list[tuple[str, str]] = []
+    integration = branches.get("integration") or {}
+    if integration.get("name") and integration.get("sha"):
+        wanted.append((integration["name"], integration["sha"]))
+    for entry in branches.get("graveyard", []):
+        if entry.get("name") and entry.get("sha"):
+            wanted.append((entry["name"], entry["sha"]))
+
+    for name, sha in wanted:
+        existing = subprocess.run(
+            ["git", "-C", str(repo_dest), "rev-parse", "--verify", "--quiet", name],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        if existing.returncode == 0:
+            if existing.stdout.strip() != sha:
+                raise RuntimeError(
+                    f"restored branch {name} is at {existing.stdout.strip()}, "
+                    f"archive recorded {sha}"
+                )
+            continue
+        created = subprocess.run(
+            ["git", "-C", str(repo_dest), "branch", name, sha],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        if created.returncode != 0:
+            raise RuntimeError(
+                f"could not restore branch {name} at {sha}: {created.stderr.strip()}"
+            )
+
+
+def restore_archive(archive_dir: Path, dest: Path, *, force: bool = False) -> dict:
+    """Unbundle into a fresh clone and lay logs and artifacts beside it."""
+    archive_dir = Path(archive_dir).resolve()
+    dest = Path(dest)
+
+    index_path = archive_dir / INDEX_NAME
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+
+    if not index.get("complete", False) and not force:
+        missing = ", ".join(
+            c["name"] for c in index.get("incomplete_components", [])
+        ) or "unspecified components"
+        raise RestoreRefused(
+            f"archive is marked incomplete (missing: {missing}); "
+            f"pass force to restore it anyway"
+        )
+
+    dest.mkdir(parents=True, exist_ok=True)
+    repo_dest = dest / "repo"
+
+    bundle = index.get("bundle")
+    if bundle:
+        bundle_path = archive_dir / bundle
+        result = subprocess.run(
+            ["git", "clone", str(bundle_path), str(repo_dest)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"git clone from bundle failed: {result.stderr.strip()}")
+        _materialize_branches(repo_dest, index)
+
+    for name in ("logs", "artifacts", "orphans"):
+        src = archive_dir / name
+        if src.is_dir():
+            _copy_tree(src, dest / name)
+
+    shutil.copy2(index_path, dest / INDEX_NAME)
+    return index
+
+
+def verify_manifest(archive_dir: Path) -> list[str]:
+    """Files whose on-disk sha256 no longer matches the recorded manifest."""
+    archive_dir = Path(archive_dir)
+    index = json.loads((archive_dir / INDEX_NAME).read_text(encoding="utf-8"))
+    mismatched = []
+    for rel, expected in index.get("manifest", {}).items():
+        path = archive_dir / rel
+        if not path.is_file() or _sha256(path) != expected:
+            mismatched.append(rel)
+    return mismatched

--- a/tests/unit/test_speedrun_archive.py
+++ b/tests/unit/test_speedrun_archive.py
@@ -1,0 +1,303 @@
+"""Acceptance tests for the run archiver (#2076).
+
+The six tests named in the issue body are the acceptance criteria; each is
+marked with the bullet it implements. They run against a synthetic run built
+from a real git repository in a temp dir -- never against live campaign state.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun.archive import (
+    RestoreRefused,
+    archive_run,
+    find_orphan_worktrees,
+    parse_events_log,
+    restore_archive,
+    verify_manifest,
+)
+
+RUN = "hardening-run-test"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
+    return result
+
+
+def _events(log_dir: Path, tag: str, issue: int, base: str, rc: int | None = 0) -> None:
+    """Write a roll's events log in the launcher's exact format."""
+    lines = [
+        f"2026-08-02 01:00:00 START issue=#{issue} repo=C:\\repo pid=1234",
+        f"2026-08-02 01:00:02 BASE '{base}' verified clean for #{issue}",
+        f"2026-08-02 01:00:02 LAUNCH base={base} -> {tag}.log",
+    ]
+    if rc is not None:
+        lines.append(f"2026-08-02 01:07:36 CHILD EXITED rc={rc}")
+        lines.append(f"2026-08-02 01:07:36 EXIT rc={rc}")
+    (log_dir / f"{tag}-events.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (log_dir / f"{tag}.log").write_text(f"stdout for {tag}\n", encoding="utf-8")
+    (log_dir / f"{tag}-heartbeat.log").write_text(
+        "2026-08-02 01:00:15 alive\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def synthetic_run(tmp_path: Path) -> dict:
+    """A repo with an integration branch, a graveyard attempt, and two rolls."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-q", "-b", RUN)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "arc work")
+    integration_sha = _git(repo, "rev-parse", RUN).stdout.strip()
+
+    _git(repo, "checkout", "-q", "-b", f"graveyard/{RUN}-attempt1")
+    (repo / "abandoned.py").write_text("nope = True\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "abandoned attempt")
+    _git(repo, "checkout", "-q", RUN)
+
+    log_dir = repo / "data" / "speedrun" / "runs"
+    log_dir.mkdir(parents=True)
+    _events(log_dir, "run-issue1-010000", 1, RUN, rc=0)
+    _events(log_dir, "run-issue4-020000", 4, RUN, rc=1)
+    # A roll belonging to a different run must not be swept in.
+    _events(log_dir, "run-issue9-030000", 9, "hardening-run-other", rc=0)
+
+    lineage = repo / "docs" / "lineage" / "active" / "1-design"
+    lineage.mkdir(parents=True)
+    (lineage / "draft-01.md").write_text("# draft\n", encoding="utf-8")
+
+    reset_artifacts = repo / "data" / "speedrun" / "reset-artifacts"
+    reset_artifacts.mkdir(parents=True)
+    (reset_artifacts / "old-lld.md").write_text("# stale lld\n", encoding="utf-8")
+
+    return {"repo": repo, "log_dir": log_dir, "integration_sha": integration_sha}
+
+
+# --- "index.json lists every roll, and every manifest sha256 matches" -------
+
+
+def test_index_lists_every_roll_and_manifest_matches_disk(synthetic_run):
+    result = archive_run(
+        synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"]
+    )
+
+    assert result.complete, result.missing
+    tags = {r["tag"] for r in result.index["rolls"]}
+    assert tags == {"run-issue1-010000", "run-issue4-020000"}
+
+    by_tag = {r["tag"]: r for r in result.index["rolls"]}
+    assert by_tag["run-issue1-010000"]["issue"] == 1
+    assert by_tag["run-issue1-010000"]["outcome"] == "success"
+    assert by_tag["run-issue4-020000"]["outcome"] == "failed rc=1"
+    assert by_tag["run-issue1-010000"]["duration_s"] == 456.0
+
+    assert result.index["manifest"], "manifest must not be empty"
+    assert verify_manifest(result.path) == []
+
+    on_disk = json.loads((result.path / "index.json").read_text(encoding="utf-8"))
+    assert on_disk["manifest"] == result.index["manifest"]
+
+
+def test_rolls_from_another_run_are_not_swept_in(synthetic_run):
+    result = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+    assert all(r["base"] == RUN for r in result.index["rolls"])
+    assert not (result.path / "logs" / "run-issue9-030000.log").exists()
+
+
+# --- "bundle verify passes, restore reproduces the tip SHA exactly" ---------
+
+
+def test_bundle_verifies_and_restore_reproduces_tip_sha(synthetic_run, tmp_path):
+    result = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+    bundle = result.path / f"{RUN}.bundle"
+    assert bundle.is_file()
+
+    verify = subprocess.run(
+        ["git", "bundle", "verify", str(bundle)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert verify.returncode == 0, verify.stderr
+
+    dest = tmp_path / "restored"
+    restore_archive(result.path, dest)
+
+    restored_sha = subprocess.run(
+        ["git", "-C", str(dest / "repo"), "rev-parse", RUN],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    ).stdout.strip()
+    assert restored_sha == synthetic_run["integration_sha"]
+
+    assert (dest / "logs" / "run-issue1-010000-events.log").is_file()
+    assert (dest / "artifacts" / "lineage" / "1-design" / "draft-01.md").is_file()
+
+
+def test_graveyard_branch_is_bundled(synthetic_run, tmp_path):
+    result = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+    names = [b["name"] for b in result.index["branches"]["graveyard"]]
+    assert names == [f"graveyard/{RUN}-attempt1"]
+
+    dest = tmp_path / "restored"
+    restore_archive(result.path, dest)
+    branches = subprocess.run(
+        ["git", "-C", str(dest / "repo"), "branch", "-a"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    ).stdout
+    assert f"graveyard/{RUN}-attempt1" in branches
+
+
+# --- "on-disk worktree absent from git worktree list is captured" -----------
+
+
+def test_orphan_worktree_is_captured_and_named(synthetic_run):
+    repo = synthetic_run["repo"]
+    # Models the verified boostgauge-2 case: a directory on disk that git does
+    # not register, whose branch was deleted, so no ref reaches its content.
+    orphan = repo.parent / f"{repo.name}-2"
+    orphan.mkdir()
+    (orphan / ".git").write_text("gitdir: /gone\n", encoding="utf-8")
+    (orphan / "unreachable.py").write_text("only_copy = True\n", encoding="utf-8")
+
+    assert orphan.resolve() in [p for p in find_orphan_worktrees(repo)]
+
+    result = archive_run(repo, RUN, log_dir=synthetic_run["log_dir"])
+
+    names = [o["name"] for o in result.index["orphans"]]
+    assert f"{repo.name}-2" in names
+    assert (result.path / "orphans" / f"{repo.name}-2.tar.gz").is_file()
+
+    import tarfile
+
+    with tarfile.open(result.path / "orphans" / f"{repo.name}-2.tar.gz") as tar:
+        members = tar.getnames()
+    assert any(m.endswith("unreachable.py") for m in members)
+
+
+def test_registered_worktree_is_not_reported_as_orphan(synthetic_run):
+    repo = synthetic_run["repo"]
+    live = repo.parent / f"{repo.name}-live"
+    _git(repo, "worktree", "add", "-q", "-b", "live-branch", str(live), "main")
+    assert live.resolve() not in find_orphan_worktrees(repo)
+
+
+# --- "an unreadable component: complete false, names it, exits nonzero" ----
+
+
+def test_unreadable_component_marks_incomplete_and_names_it(synthetic_run):
+    log_dir = synthetic_run["log_dir"]
+    # A directory where the stdout log should be: it is listed, so it is an
+    # expected component, and copying it raises. Unknown is not zero.
+    broken = log_dir / "run-issue1-010000.log"
+    broken.unlink()
+    broken.mkdir()
+
+    result = archive_run(synthetic_run["repo"], RUN, log_dir=log_dir)
+
+    assert result.complete is False
+    assert "logs/run-issue1-010000.log" in result.missing
+    named = [c["name"] for c in result.index["incomplete_components"]]
+    assert "logs/run-issue1-010000.log" in named
+    assert result.index["complete"] is False
+
+
+def test_cli_exits_nonzero_on_incomplete_archive(synthetic_run, tmp_path):
+    import tools.speedrun_archive as cli
+
+    broken = synthetic_run["log_dir"] / "run-issue1-010000.log"
+    broken.unlink()
+    broken.mkdir()
+
+    code = cli.main([
+        "--repo", str(synthetic_run["repo"]),
+        "--run", RUN,
+        "--log-dir", str(synthetic_run["log_dir"]),
+        "--out", str(tmp_path / "arch"),
+    ])
+    assert code == 1
+
+
+def test_missing_integration_branch_is_incomplete(synthetic_run):
+    result = archive_run(
+        synthetic_run["repo"], "no-such-run", log_dir=synthetic_run["log_dir"]
+    )
+    assert result.complete is False
+    assert any("no-such-run" in name for name in result.missing)
+
+
+# --- "archiving the same run twice produces an identical manifest" ---------
+
+
+def test_archiving_twice_produces_identical_manifest(synthetic_run):
+    first = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+    first_manifest = dict(first.index["manifest"])
+
+    second = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+
+    assert second.index["manifest"] == first_manifest
+    assert f"{RUN}.bundle" in first_manifest
+
+
+# --- "restore of an incomplete archive refuses unless forced" --------------
+
+
+def test_restore_refuses_incomplete_archive_and_names_component(
+    synthetic_run, tmp_path
+):
+    broken = synthetic_run["log_dir"] / "run-issue1-010000.log"
+    broken.unlink()
+    broken.mkdir()
+
+    result = archive_run(synthetic_run["repo"], RUN, log_dir=synthetic_run["log_dir"])
+    assert result.complete is False
+
+    with pytest.raises(RestoreRefused) as excinfo:
+        restore_archive(result.path, tmp_path / "restored")
+    assert "run-issue1-010000.log" in str(excinfo.value)
+
+    index = restore_archive(result.path, tmp_path / "forced", force=True)
+    assert index["complete"] is False
+    assert (tmp_path / "forced" / "repo").is_dir()
+
+
+# --- events-log parsing ----------------------------------------------------
+
+
+def test_killed_roll_with_no_exit_line_is_incomplete_not_failed(tmp_path):
+    _events(tmp_path, "run-issue2-040000", 2, RUN, rc=None)
+    roll = parse_events_log(tmp_path / "run-issue2-040000-events.log")
+    assert roll.outcome == "incomplete"
+    assert roll.end is None
+    assert roll.duration_s is None
+    assert roll.issue == 2
+    assert roll.base == RUN
+
+
+def test_archiver_never_deletes_source_content(synthetic_run):
+    repo = synthetic_run["repo"]
+    before = sorted(p.relative_to(repo).as_posix() for p in repo.rglob("*"))
+    archive_run(repo, RUN, log_dir=synthetic_run["log_dir"])
+    after = sorted(p.relative_to(repo).as_posix() for p in repo.rglob("*"))
+    # The archive itself is new; nothing that existed before may be gone.
+    assert set(before) - set(after) == set()

--- a/tools/speedrun_archive.py
+++ b/tools/speedrun_archive.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Archive a completed speedrun into one restorable record (#2076).
+
+An arc is deliberately never merged to main, so a run's product lives only on
+integration and `graveyard/*` branches, in the log triplets, and in lineage and
+reset artifacts. This captures all of it under
+`<repo>/data/speedrun/archives/<run>/` -- already gitignored, per-repo, and it
+adds nothing to `~/Projects` (see #2077).
+
+    # archive a run
+    poetry run python tools/speedrun_archive.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --run hardening-run-15
+
+    # what would be captured, without writing
+    poetry run python tools/speedrun_archive.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --run hardening-run-15 --dry-run
+
+    # restore
+    poetry run python tools/speedrun_archive.py \\
+        --restore /c/.../archives/hardening-run-15 /c/.../restored
+
+Exit codes: 0 complete archive; 1 archive written but incomplete (a named
+component could not be read); 2 usage or restore error.
+
+This tool only ever writes. It deletes nothing, on any path -- deletion is
+gated on a verified restore and belongs to #2077 and later work.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.speedrun.archive import (  # noqa: E402
+    RestoreRefused,
+    archive_run,
+    discover_rolls,
+    find_orphan_worktrees,
+    graveyard_branches_for,
+    restore_archive,
+    verify_manifest,
+)
+
+
+def _log(msg: str) -> None:
+    """Print and flush -- a zero-byte log makes a slow run look like a dead one."""
+    print(msg, flush=True)
+
+
+def cmd_archive(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    log_dir = Path(args.log_dir) if args.log_dir else None
+
+    if args.dry_run:
+        rolls, problems = discover_rolls(
+            log_dir or repo / "data/speedrun/runs", args.run
+        )
+        _log(f"run           {args.run}")
+        _log(f"repo          {repo}")
+        _log(f"rolls         {len(rolls)}")
+        for roll in rolls:
+            _log(f"  {roll.tag}  issue #{roll.issue}  {roll.outcome}")
+        graves = graveyard_branches_for(repo, args.run)
+        _log(f"graveyard     {len(graves)}")
+        for branch in graves:
+            _log(f"  {branch}")
+        orphans = find_orphan_worktrees(repo)
+        _log(f"orphans       {len(orphans)}")
+        for orphan in orphans:
+            _log(f"  {orphan}")
+        for problem in problems:
+            _log(f"  PROBLEM {problem.name}: {problem.detail}")
+        _log("\nDry run. Nothing written.")
+        return 0
+
+    result = archive_run(
+        repo,
+        args.run,
+        out_dir=Path(args.out) if args.out else None,
+        log_dir=log_dir,
+        extra_branches=args.branch,
+    )
+
+    _log(f"archived  {result.path}")
+    _log(f"rolls     {len(result.index['rolls'])}")
+    _log(f"branches  {1 if result.index['branches']['integration']['sha'] else 0}"
+         f" integration + {len(result.index['branches']['graveyard'])} graveyard")
+    _log(f"orphans   {len(result.index['orphans'])}")
+    _log(f"files     {len(result.index['manifest'])}")
+
+    if result.complete:
+        _log("complete  yes")
+        return 0
+
+    _log("complete  NO -- this archive does not authorize deleting anything")
+    for name in result.missing:
+        detail = next(
+            (c.detail for c in result.components if c.name == name and not c.ok), ""
+        )
+        _log(f"  missing: {name} -- {detail}")
+    return 1
+
+
+def cmd_restore(args: argparse.Namespace) -> int:
+    archive_dir, dest = Path(args.restore[0]), Path(args.restore[1])
+    try:
+        index = restore_archive(archive_dir, dest, force=args.force)
+    except RestoreRefused as exc:
+        _log(f"REFUSED: {exc}")
+        return 2
+    except (OSError, RuntimeError) as exc:
+        _log(f"ERROR: {exc}")
+        return 2
+
+    _log(f"restored  {dest}")
+    _log(f"run       {index['run']}")
+    if not index.get("complete", False):
+        _log("WARNING: restored from an archive marked incomplete")
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    mismatched = verify_manifest(Path(args.verify))
+    if not mismatched:
+        _log("manifest OK -- every recorded file matches its sha256")
+        return 0
+    _log(f"MANIFEST MISMATCH on {len(mismatched)} file(s):")
+    for rel in mismatched:
+        _log(f"  {rel}")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Archive a completed speedrun into one restorable record."
+    )
+    parser.add_argument("--repo", help="target repository root")
+    parser.add_argument("--run", help="run name, i.e. its integration branch")
+    parser.add_argument("--out", help="archive destination (default: <repo>/data/speedrun/archives/<run>)")
+    parser.add_argument("--log-dir", help="where the events/heartbeat/stdout triplets live")
+    parser.add_argument(
+        "--branch",
+        action="append",
+        help="extra branch to bundle, repeatable; for attempts outside the graveyard/<run>* rule",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="report what would be captured")
+    parser.add_argument("--restore", nargs=2, metavar=("ARCHIVE", "DEST"))
+    parser.add_argument("--force", action="store_true", help="restore an incomplete archive anyway")
+    parser.add_argument("--verify", metavar="ARCHIVE", help="re-hash an archive against its manifest")
+    args = parser.parse_args(argv)
+
+    if args.restore:
+        return cmd_restore(args)
+    if args.verify:
+        return cmd_verify(args)
+    if not args.repo or not args.run:
+        parser.error("--repo and --run are required unless --restore or --verify is used")
+    return cmd_archive(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

One command that captures a completed run as a single restorable record under
`<repo>/data/speedrun/archives/<run>/` — already gitignored, per-repo, and it adds
nothing to `~/Projects`.

An arc is deliberately never merged to main, so a run's product exists only on
integration and `graveyard/*` branches, in the events/heartbeat/stdout triplets, and
in lineage and reset artifacts. Nothing was lost; nothing was compact either.

## What it captures

| Component | What |
|---|---|
| `<run>.bundle` | the integration branch plus every graveyard attempt belonging to the run |
| `logs/` | the triplet for every roll in the run |
| `artifacts/` | lineage dirs and the run's reset-artifacts entries |
| `orphans/` | tarballs of worktree directories git no longer registers |
| `index.json` | per-roll issue, start, end, outcome, duration; branch tips; sha256 manifest; `complete` |

## Three decisions worth reviewing

**Run membership is read, not guessed.** The launcher already writes
`BASE '<branch>' verified clean for #<issue>` into every roll's events log. Rolls are
selected by parsing that recorded fact. Tag naming across existing arcs is inconsistent
enough — `run-issue4-111608`, `run11b-issue4-234552`, `run11-roll10-issue-4` — that a
name-based rule would silently mis-bin rolls.

**Unknown is not zero.** Any component that cannot be read is named in `index.json`,
flips `complete` to false, and exits nonzero. A partial archive is never reportable as a
complete one, because a false "archived" is what would later authorize a deletion.

**Bundle packing is pinned to one thread** so the same run archives to the same bytes
twice. The identical-manifest test is the regression alarm for it; the comment says so.

## Verified against live state

A dry run against `hardening-run-15` attributes 8 rolls and finds exactly
`boostgauge-2` and `boostgauge-2-lld` — both on disk, both absent from
`git worktree list`, both with their branches deleted, so no ref reaches their content.
An archiver enumerating a run by walking worktrees or branches sees neither. The dry run
writes nothing.

## Tests

13 unit tests covering the six acceptance criteria in the issue: index lists every roll
and the manifest matches disk; `git bundle verify` passes and restore reproduces the
integration tip SHA exactly; an unregistered on-disk worktree is captured and named;
an unreadable component yields `complete: false` and a nonzero exit; archiving twice
produces an identical manifest; restoring an incomplete archive refuses unless forced
and says which component is missing.

Restore also materializes the arc branches by name from the recorded SHAs — cloning a
bundle otherwise lands them as `origin/*` only. That gap was caught by the acceptance
test, not by inspection.

Full unit suite green: 6316 passed, 17 skipped, 5 xfailed.

## Scope

This tool only writes. It deletes nothing on any path. Deletion is gated on a verified
restore and belongs to sibling issue #2077 and later work.

Closes #2076
