### PR TITLE
feat(speedrun): move pipeline worktrees inside data/ and sweep stranded ones (Closes #2077)

### DIFF
--- a/assemblyzero/speedrun/worktrees.py
+++ b/assemblyzero/speedrun/worktrees.py
@@ -1,0 +1,273 @@
+"""Pipeline worktree placement and stranded-worktree sweep (#2077).
+
+Operator directive 2026-08-01: pipeline worktrees stop appearing as siblings in
+`~/Projects`. Two parts, and they are independent.
+
+**Placement.** A roll's worktrees move from `Projects/<repo>-<issue>` to
+`<repo>/data/worktrees/<name>`. `data/` is already gitignored in every campaign
+repo, so a roll adds nothing to `~/Projects` and nothing to `git status`.
+
+**Sweep.** At launcher start, every pipeline worktree is swept -- not only the
+issue about to be rolled. The old behaviour self-healed one issue and left the
+rest, which is how ten accumulated in a single day.
+
+| State | Action |
+|---|---|
+| clean, registered | plain `git worktree remove` |
+| dirty, registered | commit to `graveyard/<branch>-<timestamp>`, push, then plain remove |
+| on disk, not registered | move under `data/worktrees/orphaned/`, never delete |
+
+**Nothing here deletes content, on any path.** Dirty work is committed to a
+branch before its worktree goes; an unregistered directory is relocated, never
+removed. That is what lets this ship without waiting on a proven archive.
+
+**Never `--force`, anywhere.** A worktree that resists a plain remove is a fact
+to surface, not to overpower -- it is reported by name and the roll continues.
+`test_sweep_source_contains_no_force` asserts this against this file's source.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+WORKTREES_REL = Path("data/worktrees")
+ORPHANED_DIRNAME = "orphaned"
+
+# `<issue>` or `<issue>-lld`. Deliberately strict: the sweep walks directories
+# that sit beside a real repo, and a loose glob would pull in anything sharing
+# the repo's name prefix. Only names this pattern produces are ever touched.
+_PIPELINE_NAME = re.compile(r"^\d+(-lld)?$")
+
+_TS_FMT = "%Y%m%d-%H%M%S"
+
+
+def _now_tag() -> str:
+    return datetime.now().strftime(_TS_FMT)
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        args, capture_output=True, text=True, encoding="utf-8", errors="replace"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Placement
+# ---------------------------------------------------------------------------
+
+
+def worktrees_root(repo: Path | str) -> Path:
+    return Path(repo) / WORKTREES_REL
+
+
+def orphaned_root(repo: Path | str) -> Path:
+    return worktrees_root(repo) / ORPHANED_DIRNAME
+
+
+def pipeline_worktree_path(repo: Path | str, issue: int, *, lld: bool = False) -> Path:
+    """Where a roll's worktree lives: `<repo>/data/worktrees/<issue>[-lld]`."""
+    name = f"{issue}-lld" if lld else f"{issue}"
+    return worktrees_root(repo) / name
+
+
+def legacy_worktree_path(repo: Path | str, issue: int, *, lld: bool = False) -> Path:
+    """The pre-#2077 sibling location, still swept so old debris is found."""
+    repo = Path(repo)
+    suffix = f"{issue}-lld" if lld else f"{issue}"
+    return repo.parent / f"{repo.name}-{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Discovery and classification
+# ---------------------------------------------------------------------------
+
+
+def registered_worktrees(repo: Path) -> set[Path]:
+    result = _run(["git", "-C", str(repo), "worktree", "list", "--porcelain"])
+    paths: set[Path] = set()
+    if result.returncode != 0:
+        return paths
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            paths.add(Path(line[len("worktree ") :].strip()).resolve())
+    return paths
+
+
+def discover_pipeline_worktrees(repo: Path | str) -> list[Path]:
+    """Every pipeline worktree directory, in both the old and new locations.
+
+    Scans siblings named `<repo>-<issue>[-lld]` and entries under
+    `<repo>/data/worktrees/`. The `orphaned/` holding area is never a candidate
+    -- relocating an already-relocated directory would loop.
+    """
+    repo = Path(repo).resolve()
+    found: list[Path] = []
+
+    parent = repo.parent
+    if parent.is_dir():
+        prefix = repo.name + "-"
+        for entry in sorted(parent.iterdir()):
+            if not entry.is_dir() or not entry.name.startswith(prefix):
+                continue
+            if _PIPELINE_NAME.match(entry.name[len(prefix) :]):
+                found.append(entry)
+
+    managed = worktrees_root(repo)
+    if managed.is_dir():
+        for entry in sorted(managed.iterdir()):
+            if entry.is_dir() and _PIPELINE_NAME.match(entry.name):
+                found.append(entry)
+
+    return found
+
+
+def is_dirty(path: Path) -> bool:
+    """True when the worktree holds uncommitted or untracked content."""
+    result = _run(["git", "-C", str(path), "status", "--porcelain"])
+    if result.returncode != 0:
+        # Cannot read its state. Treated as dirty so the preserve path runs
+        # rather than the remove path -- unknown is never "safe to discard".
+        return True
+    return bool(result.stdout.strip())
+
+
+def current_branch(path: Path) -> str | None:
+    result = _run(["git", "-C", str(path), "branch", "--show-current"])
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SweepEntry:
+    path: Path
+    state: str  # clean | dirty | orphan
+    action: str  # removed | preserved-and-removed | relocated | reported
+    ok: bool = True
+    branch: str | None = None
+    detail: str = ""
+
+    def describe(self) -> str:
+        bits = f"{self.path.name}: {self.state} -> {self.action}"
+        if self.branch:
+            bits += f" ({self.branch})"
+        if self.detail:
+            bits += f" -- {self.detail}"
+        return bits
+
+
+@dataclass
+class SweepResult:
+    entries: list[SweepEntry] = field(default_factory=list)
+
+    @property
+    def problems(self) -> list[SweepEntry]:
+        return [e for e in self.entries if not e.ok]
+
+    def summary(self) -> str:
+        if not self.entries:
+            return "worktree sweep: nothing to do"
+        return f"worktree sweep: {len(self.entries)} handled, {len(self.problems)} reported"
+
+
+def _preserve_dirty(repo: Path, path: Path, log) -> SweepEntry:
+    """Commit a dirty worktree's content to a graveyard branch, then remove it."""
+    branch = current_branch(path) or "detached"
+    grave = f"graveyard/{branch}-{_now_tag()}"
+
+    created = _run(["git", "-C", str(path), "checkout", "-b", grave])
+    if created.returncode != 0:
+        return SweepEntry(
+            path, "dirty", "reported", ok=False,
+            detail=f"could not create {grave}: {created.stderr.strip()}",
+        )
+
+    _run(["git", "-C", str(path), "add", "-A"])
+    committed = _run([
+        "git", "-C", str(path), "commit",
+        "-m", f"chore(graveyard): preserve stranded worktree {path.name}",
+    ])
+    if committed.returncode != 0 and "nothing to commit" not in committed.stdout.lower():
+        return SweepEntry(
+            path, "dirty", "reported", ok=False, branch=grave,
+            detail=f"commit failed: {committed.stderr.strip() or committed.stdout.strip()}",
+        )
+
+    pushed = _run(["git", "-C", str(path), "push", "-u", "origin", grave])
+    if pushed.returncode != 0:
+        # The local branch already holds the content, so the work is safe. A
+        # push failure is reported and the sweep proceeds; refusing here would
+        # strand the worktree again for a reason unrelated to its content.
+        log(f"    push of {grave} failed (content is safe on the local branch)")
+
+    removed = _run(["git", "-C", str(repo), "worktree", "remove", str(path)])
+    if removed.returncode != 0:
+        return SweepEntry(
+            path, "dirty", "reported", ok=False, branch=grave,
+            detail=f"preserved on {grave} but not removed: {removed.stderr.strip()}",
+        )
+    return SweepEntry(path, "dirty", "preserved-and-removed", branch=grave)
+
+
+def _relocate_orphan(repo: Path, path: Path) -> SweepEntry:
+    """Move an unregistered directory into the holding area. Never deletes."""
+    dest_root = orphaned_root(repo)
+    dest_root.mkdir(parents=True, exist_ok=True)
+    dest = dest_root / f"{path.name}-{_now_tag()}"
+    try:
+        shutil.move(str(path), str(dest))
+    except OSError as exc:
+        return SweepEntry(
+            path, "orphan", "reported", ok=False, detail=f"could not relocate: {exc}"
+        )
+    return SweepEntry(dest, "orphan", "relocated", detail=f"from {path}")
+
+
+def sweep_pipeline_worktrees(repo: Path | str, *, log=None) -> SweepResult:
+    """Sweep every pipeline worktree, not only the issue being rolled.
+
+    Returns a result describing what happened to each. Never raises for a
+    single bad worktree: one that cannot be handled is reported by name and the
+    caller continues, because a stuck directory must not cost a roll.
+    """
+    repo = Path(repo).resolve()
+    log = log or (lambda _msg: None)
+    result = SweepResult()
+
+    registered = registered_worktrees(repo)
+
+    for path in discover_pipeline_worktrees(repo):
+        resolved = path.resolve()
+        try:
+            if resolved not in registered:
+                entry = _relocate_orphan(repo, resolved)
+            elif is_dirty(resolved):
+                entry = _preserve_dirty(repo, resolved, log)
+            else:
+                removed = _run(["git", "-C", str(repo), "worktree", "remove", str(resolved)])
+                if removed.returncode == 0:
+                    entry = SweepEntry(resolved, "clean", "removed")
+                else:
+                    entry = SweepEntry(
+                        resolved, "clean", "reported", ok=False,
+                        detail=f"git declined to remove it: {removed.stderr.strip()}",
+                    )
+        except OSError as exc:  # pragma: no cover - defensive
+            entry = SweepEntry(path, "unknown", "reported", ok=False, detail=str(exc))
+
+        result.entries.append(entry)
+        log(f"  {entry.describe()}")
+
+    _run(["git", "-C", str(repo), "worktree", "prune"])
+    log(f"  {result.summary()}")
+    return result

--- a/assemblyzero/workflows/orchestrator/artifacts.py
+++ b/assemblyzero/workflows/orchestrator/artifacts.py
@@ -23,14 +23,20 @@ def _base_dir(target_repo: str | None) -> Path:
 def worktree_path_for(issue_number: int, target_repo: str | None = None) -> Path:
     """Return the worktree path for an issue.
 
-    A sibling of the target repo named ``{repo_name}-{issue_number}`` (mirrors
-    ``run_implement_from_lld.py``). Falls back to ``../AssemblyZero-{N}`` when
-    no target is given (backward compatibility).
+    ``{target_repo}/data/worktrees/{issue_number}`` (#2077). These used to be
+    siblings of the target repo, which put one directory per roll into
+    ``~/Projects`` -- ten accumulated in a single day. ``data/`` is already
+    gitignored in every campaign repo, so a roll now adds nothing to
+    ``~/Projects`` and nothing to ``git status``.
+
+    Falls back to ``data/worktrees/{N}`` relative to cwd when no target is
+    given (AssemblyZero self-build).
     """
+    from assemblyzero.speedrun.worktrees import pipeline_worktree_path
+
     if target_repo:
-        repo = Path(target_repo)
-        return repo.parent / f"{repo.name}-{issue_number}"
-    return Path(f"../AssemblyZero-{issue_number}")
+        return pipeline_worktree_path(target_repo, issue_number)
+    return Path("data/worktrees") / str(issue_number)
 
 
 def detect_existing_artifacts(

--- a/assemblyzero/workflows/requirements/git_operations.py
+++ b/assemblyzero/workflows/requirements/git_operations.py
@@ -49,17 +49,21 @@ def lld_worktree_path_for(target_repo: Path | str, issue_number: int) -> Path:
 
     Mirrors `orchestrator/artifacts.worktree_path_for` (impl stage) but with
     a `-lld` suffix so the LLD worktree is distinct from any later impl
-    worktree for the same issue. Closes #1459.
+    worktree for the same issue. See #1459.
+
+    Lives under the target repo's gitignored `data/` since #2077; it used to be
+    a sibling, which put a second directory per roll into `~/Projects`.
 
     Args:
         target_repo: Path to the target repository.
         issue_number: GitHub issue number.
 
     Returns:
-        Sibling path: {target_parent}/{target_name}-{issue_number}-lld
+        {target_repo}/data/worktrees/{issue_number}-lld
     """
-    repo = Path(target_repo)
-    return repo.parent / f"{repo.name}-{issue_number}-lld"
+    from assemblyzero.speedrun.worktrees import pipeline_worktree_path
+
+    return pipeline_worktree_path(target_repo, issue_number, lld=True)
 
 
 def setup_lld_worktree(target_repo: Path | str, issue_number: int) -> tuple[Path, str]:

--- a/tests/unit/test_issue_162.py
+++ b/tests/unit/test_issue_162.py
@@ -254,13 +254,18 @@ def test_080(tmp_path):
 # --------------------------------
 
 def test_lld_worktree_path_for_appends_lld_suffix():
-    """Worktree path is `{parent}/{name}-{N}-lld`, distinct from impl's
-    `{parent}/{name}-{N}` so LLD and impl worktrees don't collide."""
+    """Worktree path is `{repo}/data/worktrees/{N}-lld`, distinct from impl's
+    `{repo}/data/worktrees/{N}` so LLD and impl worktrees don't collide.
+
+    Moved inside the repo's gitignored data/ by #2077; it used to be a sibling,
+    which put a directory per roll into ~/Projects.
+    """
     from assemblyzero.workflows.requirements.git_operations import lld_worktree_path_for
 
     path = lld_worktree_path_for("/c/Users/x/Projects/Chiron", 4)
-    assert path.name == "Chiron-4-lld"
-    assert path.parent.name == "Projects"
+    assert path.name == "4-lld"
+    assert path.parent.name == "worktrees"
+    assert path == Path("/c/Users/x/Projects/Chiron/data/worktrees/4-lld")
 
 
 def test_commit_and_pr_returns_empty_for_empty_created_files():

--- a/tests/unit/test_orchestrator_artifacts.py
+++ b/tests/unit/test_orchestrator_artifacts.py
@@ -103,8 +103,9 @@ class TestGetArtifactPath:
         assert path == Path("docs/lineage/305/impl-spec.md")
 
     def test_impl_path(self):
+        # #2077: inside the repo's gitignored data/, not a sibling.
         path = get_artifact_path(305, "impl")
-        assert path == Path("../AssemblyZero-305")
+        assert path == Path("data/worktrees/305")
 
     def test_pr_raises(self):
         with pytest.raises(ValueError, match="PR artifact is a URL"):

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -136,8 +136,9 @@ def test_impl_carves_worktree_from_target(mock_run, mock_create_graph):
     argv = add_calls[0].args[0]
     assert argv[:3] == ["git", "-C", EXTERNAL], f"worktree not carved from target: {argv}"
 
-    expected_wt = str(Path(EXTERNAL).parent / "Chiron-5")
-    assert expected_wt in argv, f"worktree path is not a sibling of target: {argv}"
+    # #2077: under the target repo's gitignored data/, not beside it.
+    expected_wt = str(Path(EXTERNAL) / "data" / "worktrees" / "5")
+    assert expected_wt in argv, f"worktree path is not under target data/: {argv}"
     assert "issue-5" in argv  # branch
 
     # Closes #1504. The testing sub-workflow writes files relative to
@@ -162,22 +163,22 @@ def test_create_initial_state_defaults_to_assemblyzero():
     assert "AssemblyZero" in state["assemblyzero_root"]
 
 
-def test_worktree_path_for_default_is_assemblyzero_sibling():
-    # Backward-compatible fallback when no target is supplied.
-    assert worktree_path_for(5, None) == Path("../AssemblyZero-5")
+def test_worktree_path_for_default_is_under_data_worktrees():
+    # Fallback when no target is supplied (#2077: no longer a sibling).
+    assert worktree_path_for(5, None) == Path("data/worktrees/5")
 
 
 # --- artifact path resolution ----------------------------------------------
 
 
-def test_worktree_path_for_external_is_target_sibling():
-    assert worktree_path_for(5, EXTERNAL) == Path(EXTERNAL).parent / "Chiron-5"
+def test_worktree_path_for_external_is_under_target_data():
+    assert worktree_path_for(5, EXTERNAL) == Path(EXTERNAL) / "data" / "worktrees" / "5"
 
 
 def test_get_artifact_path_resolves_under_target():
     assert get_artifact_path(5, "triage", EXTERNAL) == Path(EXTERNAL) / "docs/lineage/5/issue-brief.md"
     assert get_artifact_path(5, "spec", EXTERNAL) == Path(EXTERNAL) / "docs/lineage/5/impl-spec.md"
-    assert get_artifact_path(5, "impl", EXTERNAL) == Path(EXTERNAL).parent / "Chiron-5"
+    assert get_artifact_path(5, "impl", EXTERNAL) == Path(EXTERNAL) / "data" / "worktrees" / "5"
 
 
 def test_detect_existing_artifacts_scoped_to_target(tmp_path):

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -311,8 +311,9 @@ class TestWorktreeRemovalRetry:
 
         target = tmp_path / "boostgauge"
         target.mkdir()
-        (tmp_path / "boostgauge-7-lld").mkdir()
-        (tmp_path / "boostgauge-7").mkdir()
+        # #2077: worktrees live under the repo's gitignored data/, not beside it.
+        (target / "data" / "worktrees" / "7-lld").mkdir(parents=True)
+        (target / "data" / "worktrees" / "7").mkdir(parents=True)
 
         # Each worktree: first attempt locked, second succeeds
         mock_remove.side_effect = [
@@ -340,7 +341,7 @@ class TestWorktreeRemovalRetry:
 
         target = tmp_path / "boostgauge"
         target.mkdir()
-        (tmp_path / "boostgauge-7").mkdir()
+        (target / "data" / "worktrees" / "7").mkdir(parents=True)  # #2077
 
         mock_remove.side_effect = OSError("exit 128: file in use")
 

--- a/tests/unit/test_spec_rides_lld_pr.py
+++ b/tests/unit/test_spec_rides_lld_pr.py
@@ -28,8 +28,9 @@ def test_ride_spec_commits_to_lld_worktree(tmp_path):
     drafts.mkdir(parents=True)
     spec = drafts / "spec-0042-implementation-readiness.md"
     spec.write_text("# spec")
-    worktree = tmp_path / "target-42-lld"  # == lld_worktree_path_for(target, 42)
-    worktree.mkdir()
+    # == lld_worktree_path_for(target, 42); under the repo's data/ since #2077.
+    worktree = target / "data" / "worktrees" / "42-lld"
+    worktree.mkdir(parents=True)
 
     calls = []
 

--- a/tests/unit/test_speedrun_worktrees.py
+++ b/tests/unit/test_speedrun_worktrees.py
@@ -1,0 +1,332 @@
+"""Acceptance tests for pipeline worktree placement and the sweep (#2077).
+
+The seven tests named in the issue body are the acceptance criteria.
+
+Every test builds its own throwaway repo under tmp_path. The sweep is never
+pointed at a real campaign repo here -- the live stranded worktrees are cleaned
+by its first real run, with the operator watching, not by a test.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun import worktrees as wt
+from assemblyzero.speedrun.worktrees import (
+    discover_pipeline_worktrees,
+    orphaned_root,
+    pipeline_worktree_path,
+    sweep_pipeline_worktrees,
+)
+from assemblyzero.workflows.orchestrator.artifacts import worktree_path_for
+from assemblyzero.workflows.requirements.git_operations import lld_worktree_path_for
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+    return result
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    return root
+
+
+# --- "after a complete roll, ~/Projects contains no new entries" -----------
+
+
+def test_placement_is_inside_the_repo_not_a_sibling(repo):
+    impl = worktree_path_for(7, str(repo))
+    lld = lld_worktree_path_for(repo, 7)
+
+    assert impl == repo / "data" / "worktrees" / "7"
+    assert lld == repo / "data" / "worktrees" / "7-lld"
+
+    # The property that matters: nothing lands beside the repo.
+    for path in (impl, lld):
+        assert repo in path.parents
+        assert path.parent.parent == repo / "data"
+        assert not str(path).startswith(str(repo.parent / (repo.name + "-")))
+
+
+def test_placement_leaves_projects_dir_untouched_after_a_roll(repo, tmp_path):
+    before = sorted(p.name for p in tmp_path.iterdir())
+
+    for issue, lld in ((7, False), (7, True), (12, False)):
+        path = pipeline_worktree_path(repo, issue, lld=lld)
+        branch = f"{issue}-lld" if lld else f"issue-{issue}"
+        _git(repo, "worktree", "add", "-q", str(path), "-b", branch)
+
+    after = sorted(p.name for p in tmp_path.iterdir())
+    assert after == before, "a roll must add nothing beside the repo"
+
+
+def test_data_worktrees_is_not_visible_to_git_status(repo):
+    (repo / ".gitignore").write_text("data/\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-qm", "ignore data")
+
+    path = pipeline_worktree_path(repo, 7)
+    _git(repo, "worktree", "add", "-q", str(path), "-b", "issue-7")
+
+    status = _git(repo, "status", "--porcelain").stdout
+    assert "worktrees" not in status
+
+
+# --- "a killed roll's clean worktrees are gone after the next start" -------
+
+
+def test_clean_worktrees_are_removed(repo):
+    for issue in (7, 12):
+        _git(repo, "worktree", "add", "-q",
+             str(pipeline_worktree_path(repo, issue)), "-b", f"issue-{issue}")
+
+    result = sweep_pipeline_worktrees(repo)
+
+    assert {e.action for e in result.entries} == {"removed"}
+    assert not pipeline_worktree_path(repo, 7).exists()
+    assert not pipeline_worktree_path(repo, 12).exists()
+    assert result.problems == []
+
+
+def test_sweep_handles_issues_other_than_the_one_being_rolled(repo):
+    # The old behaviour self-healed only the current issue, which is how ten
+    # stranded directories accumulated in one day.
+    for issue in (1, 4, 41):
+        _git(repo, "worktree", "add", "-q",
+             str(pipeline_worktree_path(repo, issue)), "-b", f"issue-{issue}")
+
+    result = sweep_pipeline_worktrees(repo)
+
+    swept = {e.path.name for e in result.entries}
+    assert swept == {"1", "4", "41"}
+
+
+def test_legacy_sibling_worktrees_are_swept_too(repo):
+    legacy = repo.parent / f"{repo.name}-9"
+    _git(repo, "worktree", "add", "-q", str(legacy), "-b", "issue-9")
+
+    assert legacy.resolve() in [p.resolve() for p in discover_pipeline_worktrees(repo)]
+    sweep_pipeline_worktrees(repo)
+    assert not legacy.exists()
+
+
+def test_unrelated_sibling_directories_are_never_touched(repo):
+    decoy = repo.parent / f"{repo.name}-notes"
+    decoy.mkdir()
+    (decoy / "keep.txt").write_text("mine\n", encoding="utf-8")
+
+    sweep_pipeline_worktrees(repo)
+
+    assert decoy.is_dir() and (decoy / "keep.txt").is_file()
+
+
+# --- "a dirty worktree is committed to graveyard/* before removal" --------
+
+
+def test_dirty_worktree_is_preserved_on_a_graveyard_branch(repo):
+    path = pipeline_worktree_path(repo, 5)
+    _git(repo, "worktree", "add", "-q", str(path), "-b", "issue-5")
+    (path / "wip.py").write_text("half_done = True\n", encoding="utf-8")
+    (path / "README.md").write_text("edited\n", encoding="utf-8")
+
+    result = sweep_pipeline_worktrees(repo)
+
+    entry = result.entries[0]
+    assert entry.state == "dirty"
+    assert entry.action == "preserved-and-removed"
+    assert entry.branch.startswith("graveyard/issue-5-")
+    assert not path.exists()
+
+    branches = _git(repo, "branch", "--list", "--format=%(refname:short)").stdout.split()
+    assert entry.branch in branches
+
+    # The branch's tree must match what was in the worktree.
+    listing = _git(repo, "ls-tree", "-r", "--name-only", entry.branch).stdout.split()
+    assert "wip.py" in listing
+    blob = _git(repo, "show", f"{entry.branch}:wip.py").stdout
+    assert blob.strip() == "half_done = True"
+    edited = _git(repo, "show", f"{entry.branch}:README.md").stdout
+    assert edited.strip() == "edited"
+
+
+def test_dirty_worktree_content_survives_a_failed_push(repo):
+    # No origin is configured, so the push inside the sweep fails. The content
+    # is already on the local branch, so the sweep must proceed rather than
+    # strand the worktree for a reason unrelated to its content.
+    path = pipeline_worktree_path(repo, 6)
+    _git(repo, "worktree", "add", "-q", str(path), "-b", "issue-6")
+    (path / "wip.py").write_text("value = 42\n", encoding="utf-8")
+
+    result = sweep_pipeline_worktrees(repo)
+
+    entry = result.entries[0]
+    assert entry.ok and entry.action == "preserved-and-removed"
+    assert _git(repo, "show", f"{entry.branch}:wip.py").stdout.strip() == "value = 42"
+
+
+# --- "an unregistered on-disk directory is relocated, never deleted" ------
+
+
+def test_orphan_is_relocated_and_named_in_the_log(repo):
+    # Models the verified boostgauge-2 case: on disk, absent from git worktree
+    # list, branch deleted, so no ref reaches its content.
+    orphan = repo.parent / f"{repo.name}-2"
+    orphan.mkdir()
+    (orphan / ".git").write_text("gitdir: /gone\n", encoding="utf-8")
+    (orphan / "unreachable.py").write_text("only_copy = True\n", encoding="utf-8")
+
+    lines: list[str] = []
+    result = sweep_pipeline_worktrees(repo, log=lines.append)
+
+    entry = next(e for e in result.entries if e.state == "orphan")
+    assert entry.action == "relocated"
+    assert not orphan.exists(), "the source directory was moved, not copied"
+
+    relocated = list(orphaned_root(repo).iterdir())
+    assert len(relocated) == 1
+    assert relocated[0].name.startswith(f"{repo.name}-2-")
+    assert (relocated[0] / "unreachable.py").read_text().strip() == "only_copy = True"
+
+    assert any(f"{repo.name}-2" in line for line in lines)
+
+
+def test_orphan_relocation_never_deletes_content(repo):
+    orphan = pipeline_worktree_path(repo, 3)
+    orphan.mkdir(parents=True)
+    (orphan / ".git").write_text("gitdir: /gone\n", encoding="utf-8")
+    (orphan / "a.py").write_text("a\n", encoding="utf-8")
+    (orphan / "nested").mkdir()
+    (orphan / "nested" / "b.py").write_text("b\n", encoding="utf-8")
+
+    sweep_pipeline_worktrees(repo)
+
+    moved = list(orphaned_root(repo).iterdir())[0]
+    assert (moved / "a.py").read_text() == "a\n"
+    assert (moved / "nested" / "b.py").read_text() == "b\n"
+
+
+def test_already_orphaned_holding_area_is_not_re_swept(repo):
+    holding = orphaned_root(repo) / "7-20260802-010101"
+    holding.mkdir(parents=True)
+    (holding / "kept.py").write_text("kept\n", encoding="utf-8")
+
+    result = sweep_pipeline_worktrees(repo)
+
+    assert result.entries == []
+    assert (holding / "kept.py").is_file()
+
+
+# --- "no code path passes --force; asserted against the source" -----------
+
+
+def _string_literals_excluding_docstrings(source: str) -> list[str]:
+    """Every string constant the module can actually pass to a subprocess.
+
+    Docstrings are excluded deliberately: this module's docstring states the
+    no-force prohibition in prose, and a scan that cannot tell a rule from its
+    violation would force the rule to be deleted to satisfy the test.
+    """
+    tree = ast.parse(source)
+    docstring_nodes = set()
+    for node in ast.walk(tree):
+        if isinstance(
+            node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            body = getattr(node, "body", None)
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                docstring_nodes.add(id(body[0].value))
+
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstring_nodes
+    ]
+
+
+def test_sweep_source_contains_no_force():
+    literals = _string_literals_excluding_docstrings(inspect.getsource(wt))
+    banned = {"--force", "-f", "--force-with-lease", "-D"}
+    offending = [lit for lit in literals if lit in banned]
+    assert offending == [], (
+        f"{offending} reachable in the sweep. A worktree that resists a plain "
+        f"remove is a fact to surface, not to overpower."
+    )
+
+
+def test_the_no_force_scan_would_actually_catch_a_violation():
+    """The guard above is worthless if it cannot fail. This proves it can."""
+    literals = _string_literals_excluding_docstrings(
+        'def f():\n    """Never --force."""\n    return run(["git", "worktree", '
+        '"remove", "--force", p])\n'
+    )
+    assert "--force" in literals
+
+
+# --- "a worktree that cannot be removed is reported, roll continues" ------
+
+
+def test_unremovable_worktree_is_reported_by_name_and_does_not_raise(repo, monkeypatch):
+    path = pipeline_worktree_path(repo, 8)
+    _git(repo, "worktree", "add", "-q", str(path), "-b", "issue-8")
+
+    real_run = wt._run
+
+    def fake_run(args):
+        if "worktree" in args and "remove" in args:
+            return subprocess.CompletedProcess(args, 1, "", "fatal: cannot remove")
+        return real_run(args)
+
+    monkeypatch.setattr(wt, "_run", fake_run)
+
+    result = sweep_pipeline_worktrees(repo)
+
+    assert len(result.problems) == 1
+    problem = result.problems[0]
+    assert problem.path.name == "8"
+    assert "cannot remove" in problem.detail
+    assert path.exists(), "a worktree it could not remove must be left alone"
+
+
+def test_one_bad_worktree_does_not_stop_the_others(repo, monkeypatch):
+    for issue in (10, 11):
+        _git(repo, "worktree", "add", "-q",
+             str(pipeline_worktree_path(repo, issue)), "-b", f"issue-{issue}")
+
+    real_run = wt._run
+
+    def fake_run(args):
+        if "remove" in args and str(pipeline_worktree_path(repo, 10)) in args:
+            return subprocess.CompletedProcess(args, 1, "", "fatal: locked")
+        return real_run(args)
+
+    monkeypatch.setattr(wt, "_run", fake_run)
+
+    result = sweep_pipeline_worktrees(repo)
+
+    assert len(result.entries) == 2
+    assert len(result.problems) == 1
+    assert not pipeline_worktree_path(repo, 11).exists()

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -122,9 +122,16 @@ def remove_worktree(repo_root: Path, issue: int) -> bool:
     parent = repo_root.parent
     removed_any = False
     for suffix in (f"{issue}", f"{issue}-lld"):
-        worktree_path = parent / f"{repo_root.name}-{suffix}"
-        if _remove_worktree_at(repo_root, worktree_path):
-            removed_any = True
+        candidates = [
+            # Current home (#2077): inside the repo's gitignored data/.
+            repo_root / "data" / "worktrees" / suffix,
+            # Pre-#2077 sibling. Still checked so a reset run against debris
+            # left by an older pipeline still finds and clears it.
+            parent / f"{repo_root.name}-{suffix}",
+        ]
+        for worktree_path in candidates:
+            if _remove_worktree_at(repo_root, worktree_path):
+                removed_any = True
     return removed_any
 
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -63,6 +63,12 @@ try:
 except ImportError:  # pragma: no cover - tool copied outside the package
     pass
 
+# Imported after the sys.path insert above -- the package root is not on the
+# path when this tool is run as a script from tools/ (#2077).
+from assemblyzero.speedrun.worktrees import (  # noqa: E402
+    sweep_pipeline_worktrees,
+)
+
 HEARTBEAT_SECONDS = 15
 DEFAULT_PREFIX = "hardening-run"
 
@@ -943,6 +949,19 @@ def main(argv: list[str] | None = None) -> int:
     # process does the rolling, detached or not.
     log_dir.mkdir(parents=True, exist_ok=True)
     pid_file(log_dir).write_text(str(os.getpid()), encoding="utf-8")
+
+    # #2077: sweep EVERY pipeline worktree, not just the issue about to roll.
+    # Healing only the current issue is how ten stranded directories piled up
+    # in one day. Nothing here deletes content -- dirty work is committed to a
+    # graveyard branch first and unregistered directories are relocated -- so a
+    # sweep problem is reported and never costs the roll.
+    session.write("SWEEP pipeline worktrees")
+    try:
+        sweep = sweep_pipeline_worktrees(repo_root, log=lambda m: session.write(m.strip()))
+        for problem in sweep.problems:
+            session.write(f"SWEEP UNRESOLVED {problem.describe()}")
+    except Exception as exc:  # noqa: BLE001 - a sweep must never abort a roll
+        session.write(f"SWEEP FAILED (continuing): {exc}")
 
     code = 0
     try:


### PR DESCRIPTION
## Summary

Two independent parts: where pipeline worktrees live, and what happens to the ones a
killed roll leaves behind.

**Placement.** Worktrees move from `Projects/<repo>-<issue>` to
`<repo>/data/worktrees/<name>`. `data/` is already gitignored in every campaign repo, so
a roll adds nothing to `~/Projects` and nothing to `git status`. Both seams change —
`worktree_path_for` (impl) and `lld_worktree_path_for` (LLD).

**Sweep.** At launcher start, *every* pipeline worktree is swept, not only the issue
about to roll. Self-healing one issue and leaving the rest is how ten stranded
directories accumulated in one day.

| State | Action |
|---|---|
| clean, registered | plain `git worktree remove` |
| dirty, registered | commit to `graveyard/<branch>-<timestamp>`, push, then plain remove |
| on disk, not registered | relocate under `data/worktrees/orphaned/`, never delete |

## Nothing here deletes content

Dirty work is committed to a branch before its worktree goes; an unregistered directory
is moved, never removed. That is what lets this ship without waiting on a proven archive.
A push failure leaves the content on the local branch and the sweep continues rather than
re-stranding a worktree for a reason unrelated to its content — there is a test for that.

## Never `--force`, and the guard is real

A worktree that resists a plain remove is reported by name and the roll continues.

The no-force guard is asserted against the module's own source. It parses with `ast` and
skips docstrings, because a naive substring scan fired on the docstring *stating* the
prohibition — a scan that cannot tell a rule from its violation would force the rule to be
deleted to satisfy the test. A second test feeds the scanner a known violation to prove it
can still fail.

## Discovery is deliberately strict

Only directories named `<issue>` or `<issue>-lld` are ever touched, so a sibling like
`<repo>-notes` is never swept — there is a test for that too. Legacy sibling locations are
still scanned so existing debris is found, and `speedrun_reset` checks both locations for
the same reason.

## Tests

16 unit tests covering the seven acceptance criteria in the issue: nothing lands beside
the repo after a roll; a killed roll's clean worktrees are gone after the next start; a
dirty worktree's content is on a `graveyard/*` branch whose tree matches what was in the
worktree; an unregistered directory is relocated, still exists, and is named in the log;
the sweep handles issues other than the one rolling; no code path passes `--force`; and a
worktree that cannot be removed is reported without aborting the roll.

Nine existing tests pinned the old sibling convention and were updated to the new one —
each is a placement assertion this issue deliberately changes, not a behaviour regression.

Full unit suite green: 6332 passed, 17 skipped, 5 xfailed.

## The live stranded worktrees are untouched

The ten directories at `~/Projects/boostgauge-*` were not swept by this work. Every test
builds a throwaway repo under `tmp_path`. Their first real sweep happens when the operator
is awake and watching.

Reference: sibling issue #2076 writes archives under `data/speedrun/archives/`; both stay
inside the repo's gitignored `data/`.

Closes #2077
