### PR TITLE
feat(speedrun): N0c files a must-resolve issue instead of only logging (Closes #2072)

### DIFF
--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -1,0 +1,336 @@
+"""File a `must-resolve` issue when N0c finds a requirements conflict (#2072).
+
+N0c detects that an issue's text is internally inconsistent and says so: "an
+operator ruling on the issue text is required". Before this module, that finding
+went to a run log and nowhere else. N0c is LLM-judged, so a lenient redraw can
+pass the same text minutes later and the roll proceeds over an unresolved
+ambiguity. Measured live: boostgauge #4, run `run-issue4-111608`
+(2026-08-01 11:16 Central) flagged a sampling conflict; the redraw at 11:16:41
+passed and rolled. The only reason the operator ever saw it is that an agent
+happened to be reading the log.
+
+## Design decisions
+
+**The halt outcome is never changed by this module.** The roll was already
+halting when it is called. A filing failure -- no network, no auth, no `gh` --
+is loud in the run log and returns a failure result; it never raises, and it
+never converts a `REQUIREMENTS CONFLICT` halt into a different result.
+
+**Dedupe reads a marker, not prose.** The fingerprint is embedded in the issue
+body as an HTML comment alongside the source issue number. Re-deriving a
+normalization from body text a human has since edited would break the moment
+someone rewords the issue -- which is exactly what an operator does when ruling
+on it.
+
+**The fingerprint is order-independent.** The analysis does not guarantee stable
+A/B ordering between runs, so the same conflict arriving with its two criteria
+swapped must hash the same or a redraw storm files twenty copies of one
+ambiguity.
+
+**The run identifier travels from the launcher through the child environment.**
+Only the launcher knows the tag its events / heartbeat / stdout triplet is named
+after, and that tag is what a human needs in order to go read the logs. The
+workflow's own run id identifies a run within the lineage, which is a different
+thing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+MUST_RESOLVE_LABEL = "must-resolve"
+RUN_TAG_ENV = "SPEEDRUN_RUN_TAG"
+RUN_START_ENV = "SPEEDRUN_RUN_START"
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+_WHITESPACE = re.compile(r"\s+")
+
+#: Machine-readable dedupe marker. Both halves matter: the same conflict text on
+#: a different source issue is a different ambiguity, and a different conflict on
+#: the same source issue is too.
+_MARKER = "<!-- must-resolve source_issue={issue} fingerprint={fp} -->"
+_MARKER_RE = re.compile(
+    r"<!--\s*must-resolve\s+source_issue=(?P<issue>\d+)\s+fingerprint=(?P<fp>[0-9a-f]+)\s*-->"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting
+# ---------------------------------------------------------------------------
+
+
+def normalize_criterion(text: str) -> str:
+    """Collapse whitespace and case-fold. Punctuation is deliberately kept.
+
+    `2s` and `5s` differ by one character and nothing else; stripping
+    punctuation or digits would collapse genuinely different conflicts onto one
+    fingerprint, which is a far worse failure than an occasional near-duplicate.
+    """
+    return _WHITESPACE.sub(" ", (text or "").strip()).casefold()
+
+
+def conflict_fingerprint(criterion_a: str, criterion_b: str) -> str:
+    """Short, order-independent hash of a conflict's two criteria."""
+    parts = sorted([normalize_criterion(criterion_a), normalize_criterion(criterion_b)])
+    joined = "\x1f".join(parts)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# gh plumbing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilingResult:
+    ok: bool
+    action: str  # filed | commented | skipped | failed
+    issue_number: int | None = None
+    fingerprint: str | None = None
+    detail: str = ""
+
+
+def _default_runner(args: list[str]) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
+    except OSError as exc:
+        # `gh` not installed. Modelled as a failed call rather than an
+        # exception so every caller path stays identical.
+        return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+
+def repo_slug(repo_root: Path | str, runner=_default_runner) -> str | None:
+    """`owner/name` from the target repo's origin remote."""
+    result = runner(["git", "-C", str(repo_root), "remote", "get-url", "origin"])
+    if result.returncode != 0:
+        return None
+    url = (result.stdout or "").strip()
+    for prefix in ("https://github.com/", "git@github.com:"):
+        if url.startswith(prefix):
+            path = url[len(prefix) :]
+            break
+    else:
+        return None
+    return path[:-4] if path.endswith(".git") else path
+
+
+def run_context(env: dict[str, str] | None = None) -> tuple[str, str]:
+    """(run identifier, run start) as handed down by the launcher.
+
+    Absence is expected -- a workflow invoked directly, outside a roll, has no
+    launcher and therefore no log triplet to point at. It is reported as
+    "unknown" rather than guessed, because a wrong log name sends a human to
+    read the wrong file.
+    """
+    env = env if env is not None else os.environ
+    return (
+        env.get(RUN_TAG_ENV, "").strip() or "unknown",
+        env.get(RUN_START_ENV, "").strip() or "unknown",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Body / title construction
+# ---------------------------------------------------------------------------
+
+
+def _first_line_summary(conflict: dict, limit: int = 60) -> str:
+    text = normalize_criterion(conflict.get("criterion_a", "")) or "requirements conflict"
+    text = text.splitlines()[0] if text else "requirements conflict"
+    return text[:limit].rstrip()
+
+
+def build_title(source_issue: int, conflict: dict) -> str:
+    return (
+        f"must-resolve: #{source_issue} requirements conflict "
+        f"— {_first_line_summary(conflict)}"
+    )
+
+
+def build_body(
+    source_issue: int,
+    conflict: dict,
+    *,
+    run_id: str,
+    run_start: str,
+    conflict_ts: str,
+    fingerprint: str,
+) -> str:
+    return "\n".join([
+        "Found by N0c (requirements-consistency gate, #1899) during a live roll. "
+        "The gate's own verdict: an operator ruling on the issue text is required "
+        "before any roll.",
+        "",
+        f"**Run:** {run_id} | **Start:** {run_start} | **Conflict reported:** {conflict_ts}",
+        "",
+        f"**Source issue:** #{source_issue}",
+        "",
+        "**Conflict (verbatim):**",
+        f"- A: {conflict.get('criterion_a', '?')}",
+        f"- B: {conflict.get('criterion_b', '?')}",
+        f"- Diverge when: {conflict.get('diverging_situation', '?')}",
+        "",
+        "**Ruling needed:** edit the source issue's text so only one reading "
+        "survives, then close this issue. The roll will refuse to launch while "
+        "it is open.",
+        "",
+        _MARKER.format(issue=source_issue, fp=fingerprint),
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Filing
+# ---------------------------------------------------------------------------
+
+
+def _find_existing(
+    slug: str, source_issue: int, fingerprint: str, runner
+) -> int | None:
+    """An open must-resolve issue for the same source issue AND fingerprint."""
+    result = runner([
+        "gh", "issue", "list", "--repo", slug,
+        "--label", MUST_RESOLVE_LABEL, "--state", "open",
+        "--limit", "100", "--json", "number,body",
+    ])
+    if result.returncode != 0:
+        return None
+    try:
+        rows = json.loads(result.stdout or "[]")
+    except ValueError:
+        return None
+    for row in rows:
+        for match in _MARKER_RE.finditer(row.get("body") or ""):
+            if (
+                int(match.group("issue")) == source_issue
+                and match.group("fp") == fingerprint
+            ):
+                return int(row.get("number"))
+    return None
+
+
+def _ensure_label(slug: str, runner) -> None:
+    runner([
+        "gh", "label", "create", MUST_RESOLVE_LABEL, "--repo", slug,
+        "--description", "Blocks rolls until an operator rules on the issue text",
+        "--color", "B60205",
+    ])
+
+
+def file_must_resolve(
+    repo_root: Path | str,
+    source_issue: int,
+    conflict: dict,
+    *,
+    run_id: str | None = None,
+    run_start: str | None = None,
+    conflict_ts: str | None = None,
+    runner=_default_runner,
+    log=print,
+) -> FilingResult:
+    """File (or comment on) the must-resolve issue for one conflict.
+
+    Never raises. The roll is already halting; a filing problem is reported and
+    the halt outcome is unchanged.
+    """
+    if not source_issue:
+        # Brief and idea entry paths carry file input, not an issue number.
+        # There is nothing to file against.
+        return FilingResult(True, "skipped", detail="entry path has no issue number")
+
+    env_run_id, env_run_start = run_context()
+    run_id = run_id or env_run_id
+    run_start = run_start or env_run_start
+    conflict_ts = conflict_ts or datetime.now().strftime(_TS_FMT)
+
+    fingerprint = conflict_fingerprint(
+        conflict.get("criterion_a", ""), conflict.get("criterion_b", "")
+    )
+
+    slug = repo_slug(repo_root, runner=runner)
+    if not slug:
+        log(f"  [N0c] could not file must-resolve: no GitHub remote for {repo_root}")
+        return FilingResult(
+            False, "failed", fingerprint=fingerprint, detail="no origin remote"
+        )
+
+    existing = _find_existing(slug, source_issue, fingerprint, runner)
+    if existing is not None:
+        comment = runner([
+            "gh", "issue", "comment", str(existing), "--repo", slug,
+            "--body",
+            f"Detected again — run `{run_id}` at {conflict_ts}. "
+            f"Still unresolved; the source issue text has not been ruled on.",
+        ])
+        if comment.returncode != 0:
+            log(f"  [N0c] could not comment on #{existing}: {comment.stderr.strip()}")
+            return FilingResult(
+                False, "failed", issue_number=existing, fingerprint=fingerprint,
+                detail=comment.stderr.strip(),
+            )
+        log(f"  [N0c] recurrence recorded on existing must-resolve #{existing}")
+        return FilingResult(True, "commented", existing, fingerprint)
+
+    title = build_title(source_issue, conflict)
+    body = build_body(
+        source_issue, conflict, run_id=run_id, run_start=run_start,
+        conflict_ts=conflict_ts, fingerprint=fingerprint,
+    )
+    create_args = [
+        "gh", "issue", "create", "--repo", slug,
+        "--title", title, "--body", body, "--label", MUST_RESOLVE_LABEL,
+    ]
+
+    created = runner(create_args)
+    if created.returncode != 0:
+        # Most likely the target repo has never had the label. Create it and
+        # retry exactly once -- a second failure is a real problem, not a
+        # missing label, and looping would delay a halt that already happened.
+        _ensure_label(slug, runner)
+        created = runner(create_args)
+
+    if created.returncode != 0:
+        log(f"  [N0c] could not file must-resolve issue: {created.stderr.strip()}")
+        return FilingResult(
+            False, "failed", fingerprint=fingerprint, detail=created.stderr.strip()
+        )
+
+    number = _issue_number_from_url((created.stdout or "").strip())
+    log(f"  [N0c] filed must-resolve issue #{number or '?'} in {slug}")
+    return FilingResult(True, "filed", number, fingerprint)
+
+
+def _issue_number_from_url(url: str) -> int | None:
+    tail = url.rstrip("/").rsplit("/", 1)[-1]
+    return int(tail) if tail.isdigit() else None
+
+
+def file_all_conflicts(
+    repo_root: Path | str,
+    source_issue: int,
+    conflicts: list[dict],
+    *,
+    runner=_default_runner,
+    log=print,
+) -> list[FilingResult]:
+    """One issue per distinct conflict. Never raises."""
+    results = []
+    for conflict in conflicts or []:
+        try:
+            results.append(
+                file_must_resolve(
+                    repo_root, source_issue, conflict, runner=runner, log=log
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - filing must never kill a halt
+            log(f"  [N0c] must-resolve filing raised, continuing: {exc}")
+            results.append(FilingResult(False, "failed", detail=str(exc)))
+    return results

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -180,4 +180,21 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
 
     message = _format_conflict_message(conflicts)
     print(f"  [N0c] {message}")
+
+    # #2072: the finding used to go to a run log and nowhere else, and N0c is
+    # LLM-judged, so a lenient redraw could pass the same text minutes later and
+    # roll over an unresolved ambiguity. File it where a human will see it.
+    # Never changes the halt outcome: the roll was already halting, and a filing
+    # failure is loud in the log but returns the same error_message.
+    try:
+        from assemblyzero.speedrun.must_resolve import file_all_conflicts
+
+        file_all_conflicts(
+            state.get("target_repo") or ".",
+            int(state.get("issue_number") or 0),
+            conflicts,
+        )
+    except Exception as exc:  # noqa: BLE001 - filing must never mask the halt
+        print(f"  [N0c] WARNING: must-resolve filing failed ({exc}); halting anyway.")
+
     return {"error_message": message}

--- a/tests/unit/test_must_resolve_filing.py
+++ b/tests/unit/test_must_resolve_filing.py
@@ -1,0 +1,426 @@
+"""Acceptance tests for N0c auto-filing must-resolve issues (#2072).
+
+The ten tests named in the issue body are the acceptance criteria. `gh` is
+never actually invoked: a fake runner records the argv it is handed, so these
+assert the exact commands rather than mocking away the thing under test.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+from assemblyzero.speedrun.must_resolve import (
+    MUST_RESOLVE_LABEL,
+    RUN_START_ENV,
+    RUN_TAG_ENV,
+    build_body,
+    conflict_fingerprint,
+    file_all_conflicts,
+    file_must_resolve,
+    normalize_criterion,
+    run_context,
+)
+
+CONFLICT = {
+    "criterion_a": "| Handle count | GetProcessHandleCount aggregated | Every 5s |",
+    "criterion_b": "The collector runs in a background thread with configurable poll interval (default 2s).",
+    "diverging_situation": "Sampling all metrics on each 2s tick polls handle count every 2s.",
+}
+OTHER_CONFLICT = {
+    "criterion_a": "The dashboard refreshes once per minute.",
+    "criterion_b": "The dashboard is real-time with sub-second updates.",
+    "diverging_situation": "A viewer watching a spike sees it a minute late.",
+}
+
+
+class FakeGh:
+    """Records argv and replays scripted responses."""
+
+    def __init__(self, *, existing=None, fail_create_until=0, remote="https://github.com/martymcenroe/boostgauge.git"):
+        self.calls: list[list[str]] = []
+        self.existing = existing or []
+        self.fail_create_until = fail_create_until
+        self.create_attempts = 0
+        self.remote = remote
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+        joined = " ".join(args)
+
+        if args[0] == "git" and "remote" in args:
+            if self.remote is None:
+                return subprocess.CompletedProcess(args, 1, "", "no remote")
+            return subprocess.CompletedProcess(args, 0, self.remote, "")
+
+        if "issue list" in joined:
+            return subprocess.CompletedProcess(args, 0, json.dumps(self.existing), "")
+
+        if "issue create" in joined:
+            self.create_attempts += 1
+            if self.create_attempts <= self.fail_create_until:
+                return subprocess.CompletedProcess(
+                    args, 1, "", "could not add label: 'must-resolve' not found"
+                )
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/martymcenroe/boostgauge/issues/224\n", ""
+            )
+
+        if "issue comment" in joined:
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        if "label create" in joined:
+            return subprocess.CompletedProcess(args, 0, "", "")
+
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    def argv_for(self, fragment):
+        return [c for c in self.calls if fragment in " ".join(c)]
+
+
+def _body_of(call):
+    return call[call.index("--body") + 1]
+
+
+# --- "a conflict verdict files an issue carrying the must-resolve label" ---
+
+
+def test_conflict_files_issue_with_must_resolve_label(tmp_path):
+    gh = FakeGh()
+    result = file_must_resolve(tmp_path, 4, CONFLICT, run_id="run-issue4-111608",
+                               run_start="2026-08-01 11:16:08", runner=gh, log=lambda _m: None)
+
+    assert result.ok and result.action == "filed"
+    assert result.issue_number == 224
+
+    create = gh.argv_for("issue create")[0]
+    assert "--label" in create
+    assert create[create.index("--label") + 1] == MUST_RESOLVE_LABEL
+    assert "--repo" in create
+    assert create[create.index("--repo") + 1] == "martymcenroe/boostgauge"
+
+
+# --- "the body contains run id, source issue, verbatim A and B, fingerprint" ---
+
+
+def test_filed_body_carries_every_required_field(tmp_path):
+    gh = FakeGh()
+    file_must_resolve(tmp_path, 4, CONFLICT, run_id="run-issue4-111608",
+                      run_start="2026-08-01 11:16:08",
+                      conflict_ts="2026-08-01 11:16:38", runner=gh, log=lambda _m: None)
+
+    body = _body_of(gh.argv_for("issue create")[0])
+
+    assert "run-issue4-111608" in body
+    assert "2026-08-01 11:16:08" in body
+    assert "2026-08-01 11:16:38" in body
+    assert "#4" in body
+    assert CONFLICT["criterion_a"] in body, "criterion A must appear verbatim"
+    assert CONFLICT["criterion_b"] in body, "criterion B must appear verbatim"
+    assert CONFLICT["diverging_situation"] in body
+    assert conflict_fingerprint(CONFLICT["criterion_a"], CONFLICT["criterion_b"]) in body
+
+    title = gh.argv_for("issue create")[0]
+    assert title[title.index("--title") + 1].startswith("must-resolve: #4 requirements conflict")
+
+
+def test_timestamps_are_local_not_utc(tmp_path):
+    gh = FakeGh()
+    file_must_resolve(tmp_path, 4, CONFLICT, run_id="r", run_start="2026-08-01 11:16:08",
+                      conflict_ts="2026-08-01 11:16:38", runner=gh, log=lambda _m: None)
+    body = _body_of(gh.argv_for("issue create")[0])
+    assert "Z" not in body.split("**Run:**")[1].split("\n")[0]
+    assert "UTC" not in body
+
+
+# --- "a repo without the label gets it created, retried once, succeeds" ---
+
+
+def test_missing_label_is_created_and_filing_retried_once(tmp_path):
+    gh = FakeGh(fail_create_until=1)
+
+    result = file_must_resolve(tmp_path, 4, CONFLICT, runner=gh, log=lambda _m: None)
+
+    assert result.ok and result.action == "filed"
+    assert gh.create_attempts == 2, "exactly one retry"
+    assert gh.argv_for("label create"), "the label must be created before the retry"
+
+    order = [" ".join(c) for c in gh.calls]
+    first_create = next(i for i, c in enumerate(order) if "issue create" in c)
+    label = next(i for i, c in enumerate(order) if "label create" in c)
+    second_create = next(
+        i for i, c in enumerate(order) if "issue create" in c and i > first_create
+    )
+    assert first_create < label < second_create
+
+
+def test_persistent_create_failure_does_not_retry_forever(tmp_path):
+    gh = FakeGh(fail_create_until=99)
+    result = file_must_resolve(tmp_path, 4, CONFLICT, runner=gh, log=lambda _m: None)
+    assert not result.ok and result.action == "failed"
+    assert gh.create_attempts == 2
+
+
+# --- "the same conflict again comments and files nothing new" -------------
+
+
+def _existing_issue(number, source_issue, conflict):
+    fp = conflict_fingerprint(conflict["criterion_a"], conflict["criterion_b"])
+    return {
+        "number": number,
+        "body": build_body(source_issue, conflict, run_id="prev", run_start="x",
+                           conflict_ts="y", fingerprint=fp),
+    }
+
+
+def test_recurrence_comments_instead_of_filing_a_duplicate(tmp_path):
+    gh = FakeGh(existing=[_existing_issue(224, 4, CONFLICT)])
+
+    result = file_must_resolve(tmp_path, 4, CONFLICT, run_id="run-issue4-999999",
+                               conflict_ts="2026-08-01 12:00:00",
+                               runner=gh, log=lambda _m: None)
+
+    assert result.ok and result.action == "commented"
+    assert result.issue_number == 224
+    assert gh.argv_for("issue create") == [], "a redraw storm must not file duplicates"
+
+    comment = _body_of(gh.argv_for("issue comment")[0])
+    assert "run-issue4-999999" in comment
+    assert "2026-08-01 12:00:00" in comment
+
+
+def test_same_fingerprint_different_source_issue_files_separately(tmp_path):
+    gh = FakeGh(existing=[_existing_issue(224, 4, CONFLICT)])
+
+    result = file_must_resolve(tmp_path, 99, CONFLICT, runner=gh, log=lambda _m: None)
+
+    assert result.action == "filed", "a different source issue is a different ambiguity"
+    assert gh.argv_for("issue create")
+
+
+def test_different_conflict_same_source_issue_files_separately(tmp_path):
+    gh = FakeGh(existing=[_existing_issue(224, 4, CONFLICT)])
+
+    result = file_must_resolve(tmp_path, 4, OTHER_CONFLICT, runner=gh, log=lambda _m: None)
+
+    assert result.action == "filed"
+    assert gh.argv_for("issue create")
+
+
+# --- "the fingerprint is unchanged by whitespace, casing, or ordering" ----
+
+
+def test_fingerprint_is_stable_across_whitespace_casing_and_order():
+    base = conflict_fingerprint(CONFLICT["criterion_a"], CONFLICT["criterion_b"])
+
+    spaced = conflict_fingerprint(
+        "  " + CONFLICT["criterion_a"].replace(" ", "   ") + "\n",
+        CONFLICT["criterion_b"] + "   ",
+    )
+    cased = conflict_fingerprint(
+        CONFLICT["criterion_a"].upper(), CONFLICT["criterion_b"].lower()
+    )
+    swapped = conflict_fingerprint(CONFLICT["criterion_b"], CONFLICT["criterion_a"])
+
+    assert spaced == base
+    assert cased == base
+    assert swapped == base, "the analysis does not guarantee stable A/B ordering"
+
+
+def test_genuinely_different_conflicts_have_different_fingerprints():
+    a = conflict_fingerprint(CONFLICT["criterion_a"], CONFLICT["criterion_b"])
+    b = conflict_fingerprint(OTHER_CONFLICT["criterion_a"], OTHER_CONFLICT["criterion_b"])
+    assert a != b
+
+
+def test_fingerprint_distinguishes_a_single_digit():
+    # `2s` vs `5s` is the whole conflict. Normalization must not collapse it.
+    a = conflict_fingerprint("poll every 2s", "poll every 9s")
+    b = conflict_fingerprint("poll every 2s", "poll every 5s")
+    assert a != b
+
+
+def test_normalize_keeps_punctuation_and_digits():
+    assert normalize_criterion("  Every   5s.  ") == "every 5s."
+
+
+# --- "a missing or failing gh returns failure without raising" ------------
+
+
+def test_missing_gh_returns_failure_and_does_not_raise(tmp_path):
+    def exploding_runner(args):
+        if args[0] == "git":
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/martymcenroe/boostgauge.git", ""
+            )
+        raise OSError("gh not found")
+
+    def guarded(args):
+        try:
+            return exploding_runner(args)
+        except OSError as exc:
+            return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+    result = file_must_resolve(tmp_path, 4, CONFLICT, runner=guarded, log=lambda _m: None)
+    assert not result.ok and result.action == "failed"
+
+
+def test_no_github_remote_is_a_failure_not_an_exception(tmp_path):
+    gh = FakeGh(remote=None)
+    result = file_must_resolve(tmp_path, 4, CONFLICT, runner=gh, log=lambda _m: None)
+    assert not result.ok and result.action == "failed"
+    assert "remote" in result.detail
+
+
+def test_filing_failure_leaves_the_halt_message_intact(monkeypatch, tmp_path):
+    """The roll was already halting; a filing problem must not change that."""
+    # The package re-exports the function under the module's own name, so the
+    # module object has to be reached explicitly.
+    import assemblyzero.core.llm_provider as llm
+    import assemblyzero.speedrun.must_resolve as mr
+    from assemblyzero.workflows.requirements.nodes import (
+        analyze_requirements as node_mod,
+    )
+
+    if not hasattr(node_mod, "_parse_analysis"):  # imported the function, not the module
+        import importlib
+
+        node_mod = importlib.import_module(
+            "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+        )
+
+    monkeypatch.setattr(
+        node_mod, "_parse_analysis",
+        lambda _raw: {"is_consistent": False, "conflicts": [CONFLICT]},
+    )
+
+    class _Result:
+        success = True
+        response = "{}"
+        error_message = ""
+
+    class _Provider:
+        def invoke(self, **_kw):
+            return _Result()
+
+    monkeypatch.setattr(llm, "get_provider", lambda _spec: _Provider())
+    monkeypatch.setattr(llm, "GeminiProvider", type("NotGemini", (), {}))
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("github is down")
+
+    monkeypatch.setattr(mr, "file_all_conflicts", boom)
+
+    out = node_mod.analyze_requirements({
+        "issue_title": "t", "issue_body": "body", "issue_number": 4,
+        "target_repo": str(tmp_path),
+    })
+
+    assert out["error_message"].startswith(node_mod.REQUIREMENTS_CONFLICT_MARKER)
+    assert "Conflict 1:" in out["error_message"]
+
+
+def test_conflict_halt_still_files_when_github_is_healthy(monkeypatch, tmp_path):
+    import importlib
+
+    import assemblyzero.core.llm_provider as llm
+    import assemblyzero.speedrun.must_resolve as mr
+
+    node_mod = importlib.import_module(
+        "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+    )
+
+    monkeypatch.setattr(
+        node_mod, "_parse_analysis",
+        lambda _raw: {"is_consistent": False, "conflicts": [CONFLICT]},
+    )
+
+    class _Result:
+        success = True
+        response = "{}"
+        error_message = ""
+
+    class _Provider:
+        def invoke(self, **_kw):
+            return _Result()
+
+    monkeypatch.setattr(llm, "get_provider", lambda _spec: _Provider())
+    monkeypatch.setattr(llm, "GeminiProvider", type("NotGemini", (), {}))
+
+    seen = {}
+
+    def record(repo, issue, conflicts, **_kw):
+        seen["issue"] = issue
+        seen["conflicts"] = conflicts
+        return []
+
+    monkeypatch.setattr(mr, "file_all_conflicts", record)
+
+    node_mod.analyze_requirements({
+        "issue_title": "t", "issue_body": "body", "issue_number": 4,
+        "target_repo": str(tmp_path),
+    })
+
+    assert seen["issue"] == 4
+    assert seen["conflicts"] == [CONFLICT]
+
+
+# --- "an entry path with no issue number files nothing" ------------------
+
+
+def test_entry_path_without_issue_number_files_nothing(tmp_path):
+    gh = FakeGh()
+    result = file_must_resolve(tmp_path, 0, CONFLICT, runner=gh, log=lambda _m: None)
+
+    assert result.ok and result.action == "skipped"
+    assert gh.calls == [], "brief and idea paths have nothing to file against"
+
+
+# --- "the launcher's run tag reaches the filing through the child env" ---
+
+
+def test_run_tag_travels_through_the_child_environment():
+    env = {RUN_TAG_ENV: "run-issue4-111608", RUN_START_ENV: "2026-08-01 11:16:08"}
+    assert run_context(env) == ("run-issue4-111608", "2026-08-01 11:16:08")
+
+
+def test_absent_run_tag_is_reported_as_unknown_not_guessed():
+    # A workflow invoked outside a roll has no launcher and no log triplet. A
+    # guessed name would send a human to read the wrong file.
+    assert run_context({}) == ("unknown", "unknown")
+
+
+def test_child_env_carries_the_run_tag(monkeypatch):
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+    import speedrun_roll
+
+    env = speedrun_roll._child_env("run-issue4-111608", "2026-08-01 11:16:08")
+    assert env[RUN_TAG_ENV] == "run-issue4-111608"
+    assert env[RUN_START_ENV] == "2026-08-01 11:16:08"
+    assert env["CLAUDECODE"] == ""
+
+    bare = speedrun_roll._child_env()
+    assert RUN_TAG_ENV not in bare
+
+
+# --- multiple conflicts ---------------------------------------------------
+
+
+def test_each_distinct_conflict_gets_its_own_issue(tmp_path):
+    gh = FakeGh()
+    results = file_all_conflicts(
+        tmp_path, 4, [CONFLICT, OTHER_CONFLICT], runner=gh, log=lambda _m: None
+    )
+    assert [r.action for r in results] == ["filed", "filed"]
+    assert len(gh.argv_for("issue create")) == 2
+
+
+def test_file_all_conflicts_never_raises(tmp_path):
+    def boom(_args):
+        raise ValueError("unexpected")
+
+    results = file_all_conflicts(tmp_path, 4, [CONFLICT], runner=boom, log=lambda _m: None)
+    assert len(results) == 1 and not results[0].ok

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -65,6 +65,10 @@ except ImportError:  # pragma: no cover - tool copied outside the package
 
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
+from assemblyzero.speedrun.must_resolve import (  # noqa: E402
+    RUN_START_ENV,
+    RUN_TAG_ENV,
+)
 from assemblyzero.speedrun.worktrees import (  # noqa: E402
     sweep_pipeline_worktrees,
 )
@@ -391,6 +395,7 @@ def roll_issue(
     repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str]
 ) -> int:
     tag = f"run-issue{issue}-{datetime.now().strftime('%H%M%S')}"
+    run_start = _stamp()
     log = EventLog(log_dir / f"{tag}-events.log")
     heartbeat_path = log_dir / f"{tag}-heartbeat.log"
     out_path = log_dir / f"{tag}.log"
@@ -419,7 +424,7 @@ def roll_issue(
         with out_path.open("w", encoding="utf-8", errors="replace") as fh:
             proc = subprocess.run(
                 cmd, cwd=str(az_root), stdout=fh, stderr=subprocess.STDOUT,
-                env=_child_env(),
+                env=_child_env(tag, run_start),
                 # #2037: no console for the pipeline either. Under Task
                 # Scheduler the parent has none to inherit, so without this the
                 # child allocates its own.
@@ -433,10 +438,18 @@ def roll_issue(
     return proc.returncode
 
 
-def _child_env() -> dict[str, str]:
+def _child_env(tag: str = "", start: str = "") -> dict[str, str]:
     env = dict(os.environ)
     env["CLAUDECODE"] = ""         # nested Claude sessions fail without this
     env["PYTHONUNBUFFERED"] = "1"  # Python buffers stdout when not on a TTY
+    # #2072: only the launcher knows the tag its events/heartbeat/stdout triplet
+    # is named after, and that name is what a human needs to go read the logs.
+    # The workflow's own run id identifies a run within the lineage, which is a
+    # different thing, so this has to be handed down rather than guessed.
+    if tag:
+        env[RUN_TAG_ENV] = tag
+    if start:
+        env[RUN_START_ENV] = start
     return env
 
 


### PR DESCRIPTION
## Summary

N0c detects that an issue's text is internally inconsistent and its own message says "an
operator ruling on the issue text is required" — then the finding went to a run log and
nowhere else. N0c is LLM-judged, so a lenient redraw passes the same text minutes later and
the roll proceeds over an unresolved ambiguity.

Measured live: boostgauge #4, run `run-issue4-111608` flagged a sampling conflict at
11:16:38 Central; the redraw at 11:16:41 passed and rolled. The only reason the operator
ever saw it is that an agent happened to be reading the log.

On conflict, the workflow now files an issue in the **target** repo, labelled
`must-resolve`, before halting.

## The halt outcome is never changed

The roll was already halting when the filer runs. A filing failure — no network, no auth,
no `gh` — is loud in the run log and returns a failure result. It never raises, and never
converts a `REQUIREMENTS CONFLICT` halt into a different result. A test breaks the filer
outright and asserts the halt message survives intact.

## Dedupe reads a marker, not prose

The fingerprint and source issue number are embedded in the body as an HTML comment.
Re-deriving a normalization from body text would break the moment someone rewords the
issue — which is exactly what an operator does when ruling on it.

Both halves are matched. The same conflict text on a different source issue is a different
ambiguity; a different conflict on the same source issue is too. Both cases file separately,
and both have tests.

## Two normalization decisions worth reviewing

**Order-independent.** The analysis does not guarantee stable A/B ordering between runs, so
the criteria are sorted before hashing. Without this a redraw storm files twenty copies of
one ambiguity.

**Punctuation and digits are kept.** `2s` versus `5s` *is* the conflict. Stripping
punctuation would collapse genuinely different conflicts onto one fingerprint — a much worse
failure than an occasional near-duplicate. There is a test asserting a single differing
digit yields a different fingerprint.

## Other behaviour

- A missing `must-resolve` label is created and the filing retried **exactly once**. A second
  failure is a real problem, not a missing label, and looping would delay a halt that already
  happened.
- The run tag travels from the launcher through the child environment — only the launcher
  knows the name of its events/heartbeat/stdout triplet, and that is what a human needs to go
  read the logs. Absent, it reports `unknown` rather than guessing; a wrong log name sends a
  human to the wrong file.
- Entry paths with no issue number (brief, idea) file nothing.

## Tests

22 unit tests covering the ten acceptance criteria in the issue. `gh` is never actually
invoked — a fake runner records the argv it is handed, so the tests assert the exact commands
rather than mocking away the thing under test.

Full unit suite green: 6354 passed, 17 skipped, 5 xfailed.

## Reference

Companion: #2073, the preflight gate that reads what this files.

Closes #2072
