### PR TITLE
feat(speedrun): refuse to launch onto a degraded dev box (Closes #1920)

### DIFF
--- a/assemblyzero/speedrun/box_health.py
+++ b/assemblyzero/speedrun/box_health.py
@@ -1,0 +1,278 @@
+"""Detect a degraded dev box before a roll spends anything (#1920).
+
+2026-07-29, roughly 14:30-15:15 Central: the box degraded. pytest died
+mid-suite, then stopped completing at all; local verification of a PR was
+impossible and CI had to be declared the authoritative gate. By 20:30 it was
+healthy again (bounds suite 22/22 in 0.93s). Cause unknown.
+
+A roll launched onto a sick box wastes hours AND poisons the evidence, because
+every failure then looks like a target-repo problem.
+
+## Design decisions
+
+**The canary runs a real test suite in a real subprocess.** What actually broke
+on 2026-07-29 was pytest failing to complete, so an in-process arithmetic
+workload would have sailed through the exact episode this exists to catch. The
+canary spends a subprocess spawn deliberately.
+
+**Unknown is not healthy.** A metric that cannot be read aborts the roll. An
+unreadable box is precisely the case this gate exists for, and treating a failed
+read as a pass would make the gate silently absent exactly when the machine is
+sickest.
+
+**A missing baseline never blocks.** The first healthy run records a nominal and
+proceeds. A gate that refuses to run until someone hand-seeds a number would be
+removed within a week.
+
+**Nominal is a rolling median, not the last value or the best value.** One lucky
+run must not tighten the threshold onto a machine that cannot meet it again, and
+one slow run must not loosen it forever. The median over a small window tracks
+the machine.
+
+**psutil is read directly here.** An earlier phrasing of this work said to
+dogfood the boostgauge collector; that is not buildable today -- the collector
+exists only on integration branches, is absent from boostgauge main, and is not
+installed in this environment. Swapping to it is follow-up work for after
+boostgauge ships as an installable package.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: A hung canary must abort rather than hang the launcher, whatever the nominal.
+CANARY_CEILING_SECONDS = 120
+
+#: "This is a fault, not patience" -- the same multiplier used by the other
+#: watchdogs in this pipeline.
+CANARY_MULTIPLIER = 3
+
+MEMORY_ABORT_PERCENT = 90.0
+ROLLING_WINDOW = 5
+HEALTH_FILENAME = "box-health.json"
+
+DEFAULT_CANARY = (
+    "tests/canary/test_box_canary.py",
+)
+
+
+@dataclass
+class Metric:
+    name: str            # plain English, shown to the operator
+    value: float | None
+    nominal: float | None = None
+    unit: str = ""
+    ok: bool = True
+    detail: str = ""
+
+
+@dataclass
+class BoxHealth:
+    ok: bool
+    metrics: list[Metric] = field(default_factory=list)
+    message: str = ""
+
+    @property
+    def failures(self) -> list[Metric]:
+        return [m for m in self.metrics if not m.ok]
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def health_file(log_dir: Path | str) -> Path:
+    return Path(log_dir) / HEALTH_FILENAME
+
+
+def read_samples(log_dir: Path | str) -> list[float]:
+    path = health_file(log_dir)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    samples = data.get("canary_seconds") or []
+    return [float(s) for s in samples if isinstance(s, (int, float))]
+
+
+def nominal_from(samples: list[float]) -> float | None:
+    return statistics.median(samples) if samples else None
+
+
+def record_sample(log_dir: Path | str, seconds: float) -> float:
+    """Append a passing canary time and return the refreshed nominal."""
+    samples = (read_samples(log_dir) + [float(seconds)])[-ROLLING_WINDOW:]
+    path = health_file(log_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"canary_seconds": samples, "nominal_seconds": nominal_from(samples)},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return nominal_from(samples)
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+
+def run_canary(
+    az_root: Path | str,
+    *,
+    targets: tuple[str, ...] = DEFAULT_CANARY,
+    ceiling: int = CANARY_CEILING_SECONDS,
+) -> tuple[float | None, str]:
+    """Time a micro test suite. Returns (seconds, problem).
+
+    `seconds` is None when the canary could not be timed at all; `problem` then
+    says why in plain English. A canary that exceeds the ceiling is reported as
+    a timeout rather than being waited on.
+    """
+    cmd = [sys.executable, "-m", "pytest", *targets, "-q", "--no-header", "-p", "no:randomly"]
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd, cwd=str(az_root), capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=ceiling,
+        )
+    except subprocess.TimeoutExpired:
+        return None, (
+            f"the quick self-check did not finish within {ceiling} seconds"
+        )
+    except OSError as exc:
+        return None, f"the quick self-check could not be started ({exc})"
+
+    elapsed = time.monotonic() - started
+    if result.returncode != 0:
+        return None, (
+            "the quick self-check did not pass, so this machine cannot be "
+            "trusted to judge a real run"
+        )
+    return elapsed, ""
+
+
+def snapshot_resources() -> tuple[dict[str, float], list[str]]:
+    """(metrics, unreadable metric names). Never raises."""
+    metrics: dict[str, float] = {}
+    unreadable: list[str] = []
+
+    try:
+        import psutil
+    except ImportError:
+        return {}, ["memory in use", "running programs", "console windows"]
+
+    try:
+        metrics["memory in use"] = float(psutil.virtual_memory().percent)
+    except Exception:  # noqa: BLE001 - any read failure is "unreadable"
+        unreadable.append("memory in use")
+
+    try:
+        names = [p.info.get("name") or "" for p in psutil.process_iter(["name"])]
+    except Exception:  # noqa: BLE001
+        unreadable.extend(["running programs", "console windows"])
+        return metrics, unreadable
+
+    metrics["running programs"] = float(len(names))
+    console = {"conhost.exe", "openconsole.exe"}
+    metrics["console windows"] = float(
+        sum(1 for n in names if n.lower() in console)
+    )
+    return metrics, unreadable
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def _format_message(failures: list[Metric]) -> str:
+    lines = ["BLOCKED: this machine is not healthy enough to run right now.", ""]
+    for metric in failures:
+        if metric.value is None:
+            lines.append(f"  {metric.name}: {metric.detail}")
+        elif metric.nominal is not None:
+            lines.append(
+                f"  {metric.name}: {metric.value:.1f}{metric.unit} measured, "
+                f"against a normal of {metric.nominal:.1f}{metric.unit}"
+            )
+        else:
+            lines.append(f"  {metric.name}: {metric.value:.1f}{metric.unit} — {metric.detail}")
+    lines += [
+        "",
+        "  A run started on a machine in this state wastes hours and, worse, makes",
+        "  every failure look like a problem with the code being built. Wait for the",
+        "  machine to recover, or find out what is loading it, then start again.",
+    ]
+    return "\n".join(lines)
+
+
+def check_box_health(
+    az_root: Path | str,
+    log_dir: Path | str,
+    *,
+    canary=run_canary,
+    resources=snapshot_resources,
+    memory_limit: float = MEMORY_ABORT_PERCENT,
+    multiplier: int = CANARY_MULTIPLIER,
+    ceiling: int = CANARY_CEILING_SECONDS,
+) -> BoxHealth:
+    """Judge the machine before anything is spent. Never raises."""
+    metrics: list[Metric] = []
+
+    # Resources first: they are cheap, so a box already out of memory is refused
+    # without first spending a canary run on it.
+    values, unreadable = resources()
+    for name in unreadable:
+        metrics.append(
+            Metric(name, None, ok=False, detail="could not be read on this machine")
+        )
+
+    memory = values.get("memory in use")
+    if memory is not None:
+        metrics.append(
+            Metric(
+                "memory in use", memory, nominal=memory_limit, unit="%",
+                ok=memory <= memory_limit,
+                detail=f"above the {memory_limit:.0f}% ceiling",
+            )
+        )
+    for name in ("running programs", "console windows"):
+        if name in values:
+            metrics.append(Metric(name, values[name]))
+
+    if any(not m.ok for m in metrics):
+        return BoxHealth(False, metrics, _format_message([m for m in metrics if not m.ok]))
+
+    seconds, problem = canary(az_root, ceiling=ceiling)
+    samples = read_samples(log_dir)
+    nominal = nominal_from(samples)
+
+    if seconds is None:
+        metrics.append(Metric("quick self-check", None, ok=False, detail=problem))
+        return BoxHealth(False, metrics, _format_message([metrics[-1]]))
+
+    if nominal is not None and seconds > multiplier * nominal:
+        metrics.append(
+            Metric(
+                "quick self-check", seconds, nominal=nominal, unit="s", ok=False,
+                detail=f"more than {multiplier} times its normal time",
+            )
+        )
+        return BoxHealth(False, metrics, _format_message([metrics[-1]]))
+
+    # Passing: record the sample so the nominal tracks the machine. A missing
+    # baseline is created here and never blocks.
+    refreshed = record_sample(log_dir, seconds)
+    metrics.append(Metric("quick self-check", seconds, nominal=refreshed, unit="s"))
+    return BoxHealth(True, metrics, "")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1656,6 +1656,41 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc"},
+    {file = "psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988"},
+    {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
+    {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -3027,4 +3062,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "79244d47b89891751ad76ca808976f666a003d2afddabbff5462d2616e19b7f0"
+content-hash = "ee8e0cb501bcc0e80a6b10bc66ab476089e48314e22a6ee5fec9900957121d2c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "google-auth (>=2.48.0,<3.0.0)",
     "pycparser (>=3.0,<4.0)",
     "boto3 (>=1.35.0,<2.0.0)",
-    "pywinpty (>=3.0.3,<4.0.0) ; sys_platform == \"win32\""
+    "pywinpty (>=3.0.3,<4.0.0) ; sys_platform == \"win32\"",
+    "psutil (>=7.0.0,<8.0.0)"
 ]
 
 [tool.pytest.ini_options]

--- a/tests/canary/test_box_canary.py
+++ b/tests/canary/test_box_canary.py
@@ -1,0 +1,27 @@
+"""The micro suite the launch health check times (#1920).
+
+It is deliberately trivial and deliberately owned by the health check rather
+than borrowed from the real suite. Two properties matter:
+
+- **It must never fail for a code reason.** A canary that goes red when someone
+  breaks an unrelated feature would block every roll on the fleet, so it asserts
+  nothing about this project.
+- **It must stay tiny and stable.** Its runtime IS the measurement. Adding work
+  here silently moves the nominal for every machine.
+
+What it actually measures is that this box can still spawn a process, import
+pytest, collect, and finish. That is exactly what stopped working on
+2026-07-29, when pytest died mid-suite and then stopped completing at all.
+"""
+
+
+def test_canary_arithmetic():
+    assert sum(range(100)) == 4950
+
+
+def test_canary_strings():
+    assert "speedrun".upper() == "SPEEDRUN"
+
+
+def test_canary_collections():
+    assert sorted({3, 1, 2}) == [1, 2, 3]

--- a/tests/unit/test_box_health.py
+++ b/tests/unit/test_box_health.py
@@ -1,0 +1,349 @@
+"""Acceptance tests for the degraded-box launch gate (#1920).
+
+The seven tests named in the issue body are the acceptance criteria.
+
+The canary and the resource reader are both injected, so no test depends on the
+health of the machine running it -- which would make this suite the very thing
+it is meant to detect.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+from assemblyzero.speedrun.box_health import (  # noqa: E402
+    CANARY_CEILING_SECONDS,
+    ROLLING_WINDOW,
+    check_box_health,
+    health_file,
+    nominal_from,
+    read_samples,
+    record_sample,
+    run_canary,
+)
+
+HEALTHY_RESOURCES = (
+    {"memory in use": 60.0, "running programs": 320.0, "console windows": 4.0},
+    [],
+)
+
+
+def _canary(seconds=None, problem=""):
+    def canary(_az_root, **_kw):
+        return seconds, problem
+    return canary
+
+
+def _resources(values=None, unreadable=None):
+    def reader():
+        return (values if values is not None else HEALTHY_RESOURCES[0]), (unreadable or [])
+    return reader
+
+
+# --- "healthy box: preflight passes and the roll proceeds" ---------------
+
+
+def test_healthy_box_passes(tmp_path):
+    record_sample(tmp_path, 1.0)
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=_canary(1.1), resources=_resources()
+    )
+
+    assert health.ok
+    assert health.failures == []
+    assert health.message == ""
+
+
+# --- "canary >3x nominal: exit 91, names measured and nominal" -----------
+
+
+def test_canary_over_three_times_nominal_fails_and_names_both(tmp_path):
+    for _ in range(3):
+        record_sample(tmp_path, 2.0)
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=_canary(6.5), resources=_resources()
+    )
+
+    assert not health.ok
+    failure = health.failures[0]
+    assert failure.value == 6.5
+    assert failure.nominal == 2.0
+    assert "6.5" in health.message and "2.0" in health.message
+
+
+def test_canary_exactly_at_the_multiplier_still_passes(tmp_path):
+    record_sample(tmp_path, 2.0)
+    health = check_box_health(
+        tmp_path, tmp_path, canary=_canary(6.0), resources=_resources()
+    )
+    assert health.ok, "the threshold is 'more than 3x', not '3x or more'"
+
+
+# --- "canary that never completes aborts at the ceiling" -----------------
+
+
+def test_canary_timeout_aborts_and_does_not_hang(tmp_path):
+    def hanging(_az_root, ceiling=CANARY_CEILING_SECONDS, **_kw):
+        # This is what run_canary returns on subprocess.TimeoutExpired.
+        return None, f"the quick self-check did not finish within {ceiling} seconds"
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=hanging, resources=_resources()
+    )
+
+    assert not health.ok
+    assert "did not finish within" in health.message
+    assert str(CANARY_CEILING_SECONDS) in health.message
+
+
+def test_run_canary_passes_a_timeout_to_the_subprocess(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    seconds, problem = run_canary(tmp_path, ceiling=7)
+
+    assert captured["timeout"] == 7, "without a timeout a hung canary hangs the launcher"
+    assert seconds is None and "7 seconds" in problem
+
+
+def test_run_canary_reports_a_failing_suite_as_untrustworthy(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, "", "boom"),
+    )
+    seconds, problem = run_canary(tmp_path)
+    assert seconds is None and "did not pass" in problem
+
+
+# --- "memory above the threshold: exit 91, names memory and percentage" --
+
+
+def test_memory_over_threshold_fails_and_names_the_percentage(tmp_path):
+    health = check_box_health(
+        tmp_path, tmp_path,
+        canary=_canary(1.0),
+        resources=_resources({"memory in use": 94.3, "running programs": 300.0}),
+    )
+
+    assert not health.ok
+    assert "memory in use" in health.message
+    assert "94.3" in health.message
+
+
+def test_memory_is_checked_before_the_canary_is_spent(tmp_path):
+    spent = {"canary": False}
+
+    def canary(_az_root, **_kw):
+        spent["canary"] = True
+        return 1.0, ""
+
+    check_box_health(
+        tmp_path, tmp_path, canary=canary,
+        resources=_resources({"memory in use": 99.0}),
+    )
+
+    assert not spent["canary"], "a box already out of memory must not pay for a canary"
+
+
+# --- "no stored nominal: the run records one and proceeds" ---------------
+
+
+def test_missing_baseline_records_one_and_does_not_block(tmp_path):
+    assert read_samples(tmp_path) == []
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=_canary(4.2), resources=_resources()
+    )
+
+    assert health.ok, "a missing baseline must never block a roll"
+    assert read_samples(tmp_path) == [4.2]
+    assert health_file(tmp_path).is_file()
+
+
+def test_nominal_is_a_rolling_median_not_the_last_value(tmp_path):
+    for seconds in (1.0, 1.0, 1.0, 1.0, 9.0):
+        record_sample(tmp_path, seconds)
+
+    assert nominal_from(read_samples(tmp_path)) == 1.0, (
+        "one slow run must not loosen the threshold forever"
+    )
+
+
+def test_rolling_window_is_bounded(tmp_path):
+    for i in range(ROLLING_WINDOW + 5):
+        record_sample(tmp_path, float(i))
+    assert len(read_samples(tmp_path)) == ROLLING_WINDOW
+
+
+def test_a_corrupt_health_file_is_treated_as_no_baseline(tmp_path):
+    health_file(tmp_path).write_text("{not json", encoding="utf-8")
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=_canary(3.0), resources=_resources()
+    )
+
+    assert health.ok
+    assert read_samples(tmp_path) == [3.0]
+
+
+def test_recorded_file_is_readable_json(tmp_path):
+    record_sample(tmp_path, 2.5)
+    data = json.loads(health_file(tmp_path).read_text(encoding="utf-8"))
+    assert data["canary_seconds"] == [2.5]
+    assert data["nominal_seconds"] == 2.5
+
+
+# --- "a metric that cannot be read: exit 91, names it" -------------------
+
+
+def test_unreadable_metric_aborts_and_names_it(tmp_path):
+    health = check_box_health(
+        tmp_path, tmp_path,
+        canary=_canary(1.0),
+        resources=_resources({"running programs": 300.0}, ["memory in use"]),
+    )
+
+    assert not health.ok, "unknown is not healthy"
+    assert "memory in use" in health.message
+    assert "could not be read" in health.message
+
+
+def test_missing_psutil_is_unreadable_not_healthy(monkeypatch, tmp_path):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_psutil(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("no psutil")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_psutil)
+
+    from assemblyzero.speedrun.box_health import snapshot_resources
+
+    values, unreadable = snapshot_resources()
+    assert values == {}
+    assert "memory in use" in unreadable
+
+
+# --- "the abort message contains no internal identifiers" ----------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"canary": _canary(9.0), "resources": _resources()},
+        {"canary": _canary(1.0), "resources": _resources({"memory in use": 99.0})},
+        {"canary": _canary(None, "the quick self-check did not finish within 120 seconds"),
+         "resources": _resources()},
+        {"canary": _canary(1.0),
+         "resources": _resources({"running programs": 1.0}, ["memory in use"])},
+    ],
+)
+def test_abort_messages_are_plain_english(tmp_path, kwargs):
+    record_sample(tmp_path, 1.0)
+    health = check_box_health(tmp_path, tmp_path, **kwargs)
+
+    assert not health.ok
+    lowered = health.message.lower()
+    for jargon in ("psutil", "canary", "nominal", "preflight", "conpty",
+                   "#1920", "#2007", "exit 91", "metric", "threshold",
+                   "virtual_memory", "subprocess"):
+        assert jargon not in lowered, f"{jargon!r} is internal jargon"
+
+    assert "machine" in lowered
+
+
+# --- launcher wiring ------------------------------------------------------
+
+
+@pytest.fixture
+def target_repo(tmp_path) -> Path:
+    for args in (["init", "-q", "-b", "main"], ["config", "user.email", "t@e.com"],
+                 ["config", "user.name", "T"]):
+        subprocess.run(["git", "-C", str(tmp_path), *args], capture_output=True)
+    (tmp_path / "README.md").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "b"], capture_output=True)
+    return tmp_path
+
+
+def test_launcher_refuses_on_a_degraded_box(monkeypatch, target_repo, capsys):
+    from assemblyzero.speedrun.box_health import BoxHealth, Metric
+
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda _r: [])
+    rolled = []
+    monkeypatch.setattr(
+        speedrun_roll, "roll_issue", lambda *a: rolled.append(a) or 0
+    )
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a, **_k: BoxHealth(
+            False, [Metric("memory in use", 99.0, ok=False)],
+            "BLOCKED: this machine is not healthy enough to run right now.",
+        ),
+    )
+
+    code = speedrun_roll.main(
+        ["--repo", str(target_repo), "--issue", "4",
+         "--log-dir", str(target_repo / "logs")]
+    )
+
+    assert code == 91
+    assert rolled == [], "nothing may be spent on a degraded box"
+    assert "not healthy" in capsys.readouterr().out
+
+
+def test_launcher_health_check_runs_before_the_detach_handoff(monkeypatch, target_repo):
+    from assemblyzero.speedrun.box_health import BoxHealth, Metric
+
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda _r: [])
+    detached = []
+    monkeypatch.setattr(
+        speedrun_roll, "launch_detached", lambda *a: detached.append(a) or 0
+    )
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a, **_k: BoxHealth(False, [Metric("memory in use", 99.0, ok=False)], "BLOCKED"),
+    )
+
+    code = speedrun_roll.main(
+        ["--repo", str(target_repo), "--issue", "4", "--detach",
+         "--log-dir", str(target_repo / "logs")]
+    )
+
+    assert code == 91
+    assert detached == [], "otherwise the refusal lands in a task nobody watches"
+
+
+# --- the canary suite itself ---------------------------------------------
+
+
+def test_the_canary_suite_exists_and_passes():
+    """If this file goes missing every roll on the fleet blocks."""
+    root = Path(__file__).resolve().parents[2]
+    canary_path = root / "tests" / "canary" / "test_box_canary.py"
+    assert canary_path.is_file(), "the health check times this file by path"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(canary_path), "-q", "--no-header"],
+        cwd=str(root), capture_output=True, text=True,
+        encoding="utf-8", errors="replace", timeout=CANARY_CEILING_SECONDS,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_no_console_windows.py
+++ b/tests/unit/test_no_console_windows.py
@@ -20,6 +20,14 @@ from unittest.mock import patch
 
 import pytest
 
+
+def _healthy_box(*_args, **_kwargs):
+    """#1920: these tests exercise argv and the task definition, not machine
+    health. Stubbed like the sibling staleness gate above it."""
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
 TOOLS = Path(__file__).resolve().parents[2] / "tools"
 if str(TOOLS) not in sys.path:
     sys.path.insert(0, str(TOOLS))
@@ -106,7 +114,7 @@ class TestTheRollItselfIsWindowless:
         with patch.object(sr, "_run", _run), \
                 patch.object(sr.sys, "platform", "win32"), \
                 patch.object(sr.sys, "executable", str(py)), \
-                patch.object(sr, "check_assemblyzero_tree", lambda p: []):
+                patch.object(sr, "check_assemblyzero_tree", lambda p: []),                 patch.object(sr, "check_box_health", _healthy_box):
             code = sr.main(["--repo", str(repo), "--issue", "7", "--detach"])
 
         assert code == 0

--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -24,6 +24,14 @@ TOOLS = Path(__file__).resolve().parents[2] / "tools"
 if str(TOOLS) not in sys.path:
     sys.path.insert(0, str(TOOLS))
 
+
+def _healthy_box(*_args, **_kwargs):
+    """#1920: these tests exercise argv and the task definition, not machine
+    health. Stubbed like the sibling staleness gate above it."""
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
 import speedrun_roll as sr  # noqa: E402
 
 
@@ -110,6 +118,7 @@ class TestRelaunchArgv:
         )
         rolled = []
         with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy_box), \
                 patch.object(sr, "roll_issue",
                              lambda *a: rolled.append(a) or 0), \
                 patch.object(sr, "restore_repo", lambda *a: []):

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -65,6 +65,7 @@ except ImportError:  # pragma: no cover - tool copied outside the package
 
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
+from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
 from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     RUN_START_ENV,
     RUN_TAG_ENV,
@@ -950,6 +951,14 @@ def main(argv: list[str] | None = None) -> int:
             "at a tree that is)\n  before rolling. A roll that runs stale "
             "pipeline code fails in ways that look\n  like target-repo problems."
         )
+        return 91
+
+    # #1920: refuse before spending anything if this machine is degraded. On
+    # 2026-07-29 pytest stopped completing for ~45 minutes; a roll launched into
+    # that wastes hours AND makes every failure look like a target-repo problem.
+    health = check_box_health(az_root, log_dir)
+    if not health.ok:
+        print(health.message)
         return 91
 
     # #2073: refuse while the target repo has unanswered questions about what


### PR DESCRIPTION
## Summary

2026-07-29, roughly 14:30–15:15 Central: the dev box degraded. pytest died mid-suite, then
stopped completing at all. Local verification of a PR was impossible and CI had to be
declared the authoritative gate. By 20:30 the box was healthy again. Cause unknown.

A roll launched onto a sick box wastes hours **and poisons the evidence**, because every
failure then looks like a target-repo problem.

Two measurements now run before anything is spent.

## The canary is a real subprocess running a real pytest suite

What actually broke that afternoon was pytest failing to complete. An in-process arithmetic
workload would have sailed straight through the exact episode this gate exists to catch, so
the subprocess spawn is deliberate — it measures that this box can still spawn a process,
import pytest, collect, and finish.

The suite is a dedicated three-assertion file (`tests/canary/test_box_canary.py`) **owned by
this gate**, not borrowed from the real tests. A canary that goes red when someone breaks an
unrelated feature would block every roll on the fleet. It asserts nothing about this project;
its runtime *is* the measurement.

Measured on this machine: 0.9s.

## Thresholds

- Aborts above **3× nominal** — the same "this is a fault, not patience" multiplier the other
  watchdogs use.
- Hard **120s ceiling** regardless of nominal, passed to `subprocess` as a timeout. A test
  asserts the timeout is actually passed, because without it the launcher hangs exactly when
  the machine is sickest.
- Memory above **90%** aborts.
- Memory is checked **before** the canary is spent, so a box already out of memory is refused
  without first paying for a test run.

## Unknown is not healthy

A metric that cannot be read aborts the roll, including psutil being absent. Treating a
failed read as a pass would make the gate silently absent precisely when it matters most.

## Calibration

A missing baseline never blocks — the first healthy run records one and proceeds. A gate that
refused to run until someone hand-seeded a number would be removed within a week.

Nominal is a **rolling median over five samples**, not the last value and not the best. One
lucky run must not tighten the threshold onto a machine that cannot meet it again; one slow
run must not loosen it forever. A corrupt health file is treated as no baseline.

## psutil was undeclared

It was being imported while present in the venv but absent from the lock, so CI could have
lacked it. Now a declared dependency.

## The abort message

Plain English naming the metric, its measured value, and the normal it violated. No stage
names, no library names, no exit codes. Four different failure paths are each asserted
jargon-free.

## Tests

22 unit tests covering the seven acceptance criteria. The canary and the resource reader are
both injected, so no test depends on the health of the machine running it — which would make
this suite the very thing it is meant to detect. One test guards that the canary file itself
exists and passes, since every roll on the fleet blocks if it goes missing.

Two existing launcher tests now stub this gate alongside the staleness gate they already
stubbed; they exercise argv and the task definition, not machine health.

Full suite green: 6878 passed, 17 skipped, 5 xfailed.

## Note on scope

The original phrasing said to dogfood boostgauge's collector. That is not buildable today —
it exists only on integration branches, is absent from boostgauge main, and is not installed
here. psutil is read directly instead; swapping is follow-up work for after boostgauge ships
as an installable package.

Sibling launch gates: #2007 (stale tree) and #2073 (open questions). All three run before any
spend.

Closes #1920
