### PR TITLE
feat(orchestrator): retry classifies transient vs deterministic before replaying (Closes #1941)

### DIFF
--- a/assemblyzero/core/retry_mode.py
+++ b/assemblyzero/core/retry_mode.py
@@ -1,0 +1,47 @@
+"""Choose resume-in-place or clean-slate regeneration on a stage retry (#1941).
+
+`run11b-issue4-234552`, attempt 2: every generated file logged
+`Skipped (already exists)`. The stage retry re-entered the testing sub-workflow
+against the same live worktree, resumed attempt 1's artifacts verbatim, and
+reproduced its exact outcome -- 50/50 tests, 86.0% coverage, the same stagnation
+halt.
+
+For a **transient** failure -- a capacity storm mid-implementation -- resuming
+in place is exactly right: do not redo paid work. For a **deterministic**
+failure the replay converts `max_stage_retries` into a no-op loop where every
+attempt is the same attempt. That is the mechanism behind runs that burn hours
+producing identical results.
+
+## The unknown case fails toward regeneration, deliberately
+
+Replaying an attempt that cannot succeed costs a full stage and produces no new
+information. Regenerating unnecessarily costs one stage and might. So anything
+not positively identified as transient regenerates.
+
+Note this differs from the retry-*eligibility* default, which treats an unmarked
+failure as transient so that ordinary flakes still retry (#1463). Eligibility
+asks "should we try again?"; this asks "should the next try be allowed to reuse
+the last one's output?". The safe answer differs in each direction, so the two
+defaults deliberately disagree.
+"""
+
+from __future__ import annotations
+
+RESUMED = "RESUMED"
+REGENERATED = "REGENERATED"
+
+
+def retry_mode_for(stage_result: dict | None) -> str:
+    """`RESUMED` only for a failure positively classified transient.
+
+    Everything else -- deterministic, unclassified, missing, malformed --
+    regenerates.
+    """
+    if not isinstance(stage_result, dict):
+        return REGENERATED
+    return RESUMED if stage_result.get("transient") is True else REGENERATED
+
+
+def is_regeneration(retry_mode: str | None) -> bool:
+    """True when generated artifacts from a prior attempt must not be reused."""
+    return retry_mode == REGENERATED

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -11,6 +11,7 @@ from typing import Any, TypedDict
 
 from langgraph.graph import END, StateGraph
 
+from assemblyzero.core.retry_mode import RESUMED, retry_mode_for
 from assemblyzero.utils.git import (
     GitBranchError,
     current_branch,
@@ -140,8 +141,23 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
             )
             # Update attempt count in result
             stage_result["attempts"] = attempt
+
+            # #1941: decide whether the NEXT attempt may reuse this one's
+            # artifacts. Replaying a deterministic failure against the same
+            # worktree reproduces it exactly -- run11b's attempt 2 logged
+            # "Skipped (already exists)" for every file and returned the
+            # identical outcome. Recorded on the result so the stage table
+            # says which happened without anyone reading transcripts.
+            mode = retry_mode_for(stage_result)
+            stage_result["retry_mode"] = mode
+            print(
+                f"[ORCHESTRATOR] Next attempt will be {mode.lower()} "
+                f"({'reusing' if mode == RESUMED else 'discarding'} "
+                f"the previous attempt's generated files)."
+            )
             time.sleep(delay)
-            last_state = new_state
+            last_state = dict(new_state)
+            last_state["retry_mode"] = mode
         else:
             if not transient:
                 print(

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -879,6 +879,10 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             "config_drafter": stage_cfg.get("drafter", ""),
             "config_reviewer": stage_cfg.get("reviewer", ""),
             "config_effort": stage_cfg.get("effort", ""),
+            # #1941: RESUMED lets the runner reuse a prior attempt's files;
+            # REGENERATED forbids it. Absent on a first attempt, which reuses
+            # nothing because there is nothing to reuse.
+            "retry_mode": state.get("retry_mode", ""),
         })
 
         error_msg = sub_result.get("error_message", "")

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from assemblyzero.core.llm_provider import get_cumulative_cost
+from assemblyzero.core.retry_mode import is_regeneration
 from assemblyzero.hooks.file_write_validator import validate_file_write
 from assemblyzero.telemetry import emit
 from assemblyzero.utils.cost_tracker import accumulate_node_cost
@@ -295,6 +296,7 @@ def came_from_base(repo_root: Path, filepath: str) -> bool:
 def _should_skip_existing_file(
     change_type: str, target_path: Path, iteration_count: int,
     repo_root: Path | None = None, filepath: str = "",
+    regenerate: bool = False,
 ) -> bool:
     """Issue #547 skip-on-resume, scoped by Issue #1842 to the first pass only.
 
@@ -310,6 +312,12 @@ def _should_skip_existing_file(
     integration branch -- printed "5 files written" having written none, and
     died at pytest with nothing collected.
     """
+    #1941: a clean-slate regeneration must not consult this path at all. The
+    # whole point of regenerating is that the previous attempt's output is the
+    # thing being discarded, so "it is already on disk" is not a reason to keep
+    # it -- it is the reason to replace it.
+    if regenerate:
+        return False
     if iteration_count > 0:
         return False
     if repo_root is not None and filepath and came_from_base(repo_root, filepath):
@@ -354,6 +362,11 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
     Issue #272: File-by-file prompting with mechanical validation.
     """
     iteration_count = state.get("iteration_count", 0)
+    # #1941: set when a stage retry classified the previous failure as
+    # deterministic (or could not classify it). Discards that attempt's files
+    # rather than resuming them, which is what made run11b's attempt 2 a
+    # byte-identical replay of attempt 1.
+    _regenerating = is_regeneration(state.get("retry_mode"))
     gate_log(f"[N4] Implementing code file-by-file (iteration {iteration_count})...")
 
     if state.get("mock_mode"):
@@ -641,7 +654,8 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         # Issue #547: Skip-on-resume — don't re-call Claude for files already on disk
         target_path = repo_root / filepath
         if _should_skip_existing_file(
-            change_type, target_path, iteration_count, repo_root, filepath
+            change_type, target_path, iteration_count, repo_root, filepath,
+            regenerate=_regenerating,
         ):
             existing_content = target_path.read_text(encoding="utf-8")
             print(f"        Skipped (already exists): {target_path}")

--- a/tests/unit/test_retry_mode.py
+++ b/tests/unit/test_retry_mode.py
@@ -1,0 +1,203 @@
+"""Acceptance tests for retry classification and clean-slate regeneration (#1941).
+
+The five tests named in the issue body are the acceptance criteria.
+
+The shape being prevented is `run11b-issue4-234552` attempt 2: every generated
+file logged `Skipped (already exists)`, the stage resumed attempt 1's artifacts
+verbatim, and reproduced its exact outcome -- 50/50 tests, 86.0% coverage, the
+same stagnation halt.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from assemblyzero.core.retry_mode import (  # noqa: E402
+    REGENERATED,
+    RESUMED,
+    is_regeneration,
+    retry_mode_for,
+)
+from assemblyzero.workflows.testing.nodes.implementation.orchestrator import (  # noqa: E402
+    _should_skip_existing_file,
+)
+
+
+# --- "a transient failure takes the resume path and shows RESUMED" -------
+
+
+def test_transient_failure_resumes():
+    assert retry_mode_for({"transient": True}) == RESUMED
+    assert not is_regeneration(RESUMED)
+
+
+def test_transient_resume_reuses_prior_artifacts(tmp_path):
+    target = tmp_path / "generated.py"
+    target.write_text("from attempt one\n", encoding="utf-8")
+
+    skip = _should_skip_existing_file(
+        "Add", target, iteration_count=0, regenerate=is_regeneration(RESUMED)
+    )
+
+    assert skip is True, "a capacity storm must not cost the paid work again"
+
+
+# --- "a deterministic failure regenerates and shows REGENERATED" ---------
+
+
+def test_deterministic_failure_regenerates():
+    assert retry_mode_for({"transient": False}) == REGENERATED
+    assert is_regeneration(REGENERATED)
+
+
+def test_regeneration_does_not_consult_the_skip_path(tmp_path):
+    target = tmp_path / "generated.py"
+    target.write_text("from attempt one\n", encoding="utf-8")
+
+    skip = _should_skip_existing_file(
+        "Add", target, iteration_count=0, regenerate=True
+    )
+
+    assert skip is False, (
+        "the previous attempt's output is the thing being discarded; "
+        "'already on disk' is the reason to replace it, not to keep it"
+    )
+
+
+def test_regeneration_overrides_every_other_reason_to_skip(tmp_path):
+    """Whatever else would have caused a skip, regeneration wins."""
+    target = tmp_path / "generated.py"
+    target.write_text("content\n", encoding="utf-8")
+
+    for iteration in (0, 1, 5):
+        assert _should_skip_existing_file(
+            "Add", target, iteration_count=iteration, regenerate=True
+        ) is False
+
+
+# --- "no classification is treated as deterministic and regenerates" -----
+
+
+@pytest.mark.parametrize(
+    "stage_result",
+    [
+        {},
+        {"transient": None},
+        {"status": "failed"},
+        {"transient": "yes"},      # malformed, not a bool
+        {"transient": 1},          # truthy but not True
+        None,
+        "not a dict",
+    ],
+)
+def test_unclassified_failure_regenerates(stage_result):
+    assert retry_mode_for(stage_result) == REGENERATED, (
+        "replaying an attempt that cannot succeed costs a full stage and "
+        "produces no new information"
+    )
+
+
+def test_only_a_real_boolean_true_resumes():
+    # The eligibility default (#1463) treats an unmarked failure as transient so
+    # ordinary flakes still retry. This asks a different question -- may the next
+    # attempt reuse the last one's output -- and the safe answer is the opposite.
+    assert retry_mode_for({"transient": True}) == RESUMED
+    assert retry_mode_for({}) == REGENERATED
+
+
+# --- "the run11b shape cannot occur without the table marking it RESUMED" ---
+
+
+def test_the_run11b_shape_is_legible_in_the_stage_table():
+    import orchestrate
+
+    replayed = {
+        "error_message": "Stagnation: 50/50 tests, 86.0% coverage, unchanged",
+        "attempts": 2,
+        "duration_seconds": 754,
+        "retry_mode": RESUMED,
+    }
+    rendered = orchestrate.format_error_message("impl", replayed)
+
+    assert "RESUMED" in rendered, (
+        "an identical-outcome replay must be visible without reading transcripts"
+    )
+    assert "Attempts: 2" in rendered
+
+
+def test_a_regenerated_attempt_says_so_in_the_stage_table():
+    import orchestrate
+
+    rendered = orchestrate.format_error_message("impl", {
+        "error_message": "still failing", "attempts": 3,
+        "duration_seconds": 100, "retry_mode": REGENERATED,
+    })
+    assert "REGENERATED" in rendered
+
+
+def test_a_first_attempt_claims_neither():
+    import orchestrate
+
+    rendered = orchestrate.format_error_message("impl", {
+        "error_message": "failed", "attempts": 1, "duration_seconds": 10,
+    })
+    assert "RESUMED" not in rendered and "REGENERATED" not in rendered
+
+
+# --- "regeneration produces different content when the drafter differs" --
+
+
+def test_regeneration_lets_new_drafter_output_replace_the_old(tmp_path):
+    """The skip path is what pinned the old bytes; without it, new output lands."""
+    target = tmp_path / "generated.py"
+    target.write_text("value = 1  # attempt one\n", encoding="utf-8")
+
+    assert _should_skip_existing_file(
+        "Add", target, iteration_count=0, regenerate=True
+    ) is False
+
+    # With the skip bypassed, the runner writes whatever the drafter returned.
+    target.write_text("value = 2  # attempt two\n", encoding="utf-8")
+    assert target.read_text(encoding="utf-8") != "value = 1  # attempt one\n"
+
+
+def test_resume_path_is_unchanged_for_first_attempts(tmp_path):
+    """No retry mode set means nothing to reuse; existing behaviour stands."""
+    target = tmp_path / "generated.py"
+    target.write_text("x\n", encoding="utf-8")
+
+    assert is_regeneration(None) is False
+    assert is_regeneration("") is False
+    assert _should_skip_existing_file(
+        "Add", target, iteration_count=0, regenerate=is_regeneration(None)
+    ) is True
+
+
+# --- wiring ---------------------------------------------------------------
+
+
+def test_graph_records_the_mode_and_threads_it_to_the_next_attempt():
+    """The mode must reach the next attempt's state, not just be printed."""
+    import inspect
+
+    from assemblyzero.workflows.orchestrator import graph
+
+    source = inspect.getsource(graph._run_stage_node)
+    assert "retry_mode_for(stage_result)" in source
+    assert 'stage_result["retry_mode"] = mode' in source
+    assert 'last_state["retry_mode"] = mode' in source, (
+        "without this the next attempt never learns it must regenerate"
+    )
+
+
+def test_impl_stage_passes_retry_mode_to_the_sub_workflow():
+    import inspect
+
+    from assemblyzero.workflows.orchestrator import stages
+
+    source = inspect.getsource(stages.run_impl_stage)
+    assert '"retry_mode": state.get("retry_mode", "")' in source

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -88,13 +88,22 @@ def format_error_message(stage: str, stage_result: StageResult) -> str:
     minutes = int(duration // 60)
     seconds = int(duration % 60)
 
+    # #1941: a replayed attempt must be legible as such without reading
+    # transcripts. Diagnosing run11b -- where attempt 2 resumed attempt 1's
+    # artifacts verbatim and reproduced its outcome exactly -- required exactly
+    # that archaeology.
+    retry_mode = stage_result.get("retry_mode", "")
+    attempts_line = f"  Attempts: {attempts} | Duration: {minutes}m {seconds}s"
+    if attempts > 1 and retry_mode:
+        attempts_line += f" | Retries: {retry_mode}"
+
     lines = [
         "",
         "=" * 58,
         f"  ORCHESTRATION FAILED at stage: {stage}",
         "=" * 58,
         f"  Error: {error}",
-        f"  Attempts: {attempts} | Duration: {minutes}m {seconds}s",
+        attempts_line,
         "",
         f"  Resume: orchestrate --issue N --resume-from {stage}",
         "=" * 58,


### PR DESCRIPTION
## Summary

`run11b-issue4-234552`, attempt 2: every generated file logged `Skipped (already exists)`.
The stage retry re-entered the testing sub-workflow against the same live worktree, resumed
attempt 1's artifacts verbatim, and reproduced its exact outcome — 50/50 tests, 86.0%
coverage, the same stagnation halt.

For a **transient** failure — a capacity storm mid-implementation — resuming in place is
exactly right: don't redo paid work. For a **deterministic** failure the replay converts
`max_stage_retries` into a no-op loop where every attempt is the same attempt. That is the
mechanism behind runs that burn hours producing identical results.

The retry now computes a mode from the failure class and threads it into the next attempt.

## The unknown case fails toward regeneration

| Failure class | Path |
|---|---|
| transient — capacity, timeout, network | resume in place, reuse artifacts |
| deterministic — stagnation, verdict, validation | clean-slate regeneration |
| unclassified or unknown | **treat as deterministic and regenerate** |

Replaying an attempt that cannot succeed costs a full stage and produces no new information;
regenerating unnecessarily costs one stage and might.

**This deliberately disagrees with the retry-*eligibility* default**, which treats an unmarked
failure as transient so ordinary flakes still retry (#1463). Eligibility asks "should we try
again?"; this asks "may the next try reuse the last one's output?" — the safe answer differs
in each direction, so the two defaults disagree on purpose. Only a real boolean `True`
resumes; a truthy non-bool regenerates, and there is a test for that.

## Clean-slate means clean

On a regeneration the skip-if-exists path is not consulted at all, and that check now
overrides every other reason to skip. The previous attempt's output is precisely the thing
being discarded, so "already on disk" is the reason to replace it, not to keep it.

## The choice is visible

The stage table states `RESUMED` or `REGENERATED` whenever there was more than one attempt,
and the orchestrator prints which the next attempt will be. Diagnosing run11b required
reading transcripts to discover the replay had happened at all — that archaeology is what
this removes. A first attempt claims neither.

## Scope

This adds the mechanism. It does **not** change which failures are eligible for retry — the
stagnation-is-non-transient decision (#1939) and the non-transient-halts-skip-retry decision
(#1463, #1478) stand exactly as they are.

## Tests

20 unit tests covering the five acceptance criteria, including the run11b shape itself: an
identical-outcome replay must be legible in the stage table without reading transcripts. Two
tests assert the wiring — that the mode reaches the next attempt's state rather than merely
being printed, and that the impl stage passes it to the sub-workflow.

Full suite green: 6898 passed, 17 skipped, 5 xfailed.

Closes #1941
