### PR TITLE
feat(speedrun): fingerprint and count every drafter validation failure (Closes #2074)

### DIFF
--- a/assemblyzero/speedrun/prompt_telemetry.py
+++ b/assemblyzero/speedrun/prompt_telemetry.py
@@ -1,0 +1,232 @@
+"""Fingerprint and count every drafter validation failure (#2074).
+
+Operator observation 2026-08-01: a drafter emitted a malformed Section 2.1
+table (`run-issue2-133746`, lld failed 86.1s, "MECHANICAL VALIDATION FAILED:
+Section 2.1 table malformed"). Nothing counted it. Each failure printed to a run
+log, the retry re-rolled, and the failure mode evaporated -- while the prompts
+that produce the failure rate stayed static.
+
+The raw material already existed: lineage dirs keep every numbered draft,
+rejected test-plan drafts are preserved to the audit dir, and the workflow-audit
+JSONL is already written. What was missing is classification and aggregation.
+
+## The fingerprint is a contract
+
+`<stage>:<check>:<normalized-detail>`, where normalization lowercases, collapses
+every run of non-alphanumeric characters to a single hyphen, and strips leading
+and trailing hyphens. The 2026-08-01 example becomes:
+
+    lld:mechanical:section-2-1-table-malformed
+
+It is specified here rather than left to the implementation because #2075
+consumes it. Changing the normalization silently re-buckets every historical
+record, so the round-trip is guarded by tests rather than by convention.
+
+## No deduplication at write time
+
+Every occurrence is a record. Aggregation is the report's job. Collapsing at
+write time destroys the rate this exists to measure -- and the rate is the whole
+point, because "this failed twice today" and "this failed forty times today" are
+different problems with the same fingerprint.
+
+## Writing telemetry never changes a roll's outcome
+
+A failure to append is logged loudly and swallowed. Telemetry that can break the
+thing it measures is worse than no telemetry.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+TELEMETRY_REL = Path("data/speedrun/telemetry")
+FAILURES_FILENAME = "prompt-failures.jsonl"
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+#: Markers the pipeline prefixes onto validation messages. Stripped before
+#: normalization so the fingerprint names the DEFECT, not the announcement --
+#: otherwise every mechanical failure would share one fingerprint.
+_MARKERS = (
+    "MECHANICAL VALIDATION FAILED:",
+    "REQUIREMENTS CONFLICT:",
+    "TEST PLAN VALIDATION FAILED:",
+    "VALIDATION FAILED:",
+)
+
+
+def normalize_detail(detail: str) -> str:
+    """Lowercase, non-alphanumeric runs to single hyphens, ends stripped."""
+    text = (detail or "").strip()
+    for marker in _MARKERS:
+        if text.upper().startswith(marker):
+            text = text[len(marker):]
+            break
+    return _NON_ALNUM.sub("-", text.lower()).strip("-")
+
+
+def fingerprint(stage: str, check: str, detail: str) -> str:
+    """`<stage>:<check>:<normalized-detail>` -- the contract #2075 reads."""
+    return f"{normalize_detail(stage)}:{normalize_detail(check)}:{normalize_detail(detail)}"
+
+
+@dataclass
+class PromptFailure:
+    ts_local: str
+    repo: str
+    issue: int | None
+    stage: str
+    check: str
+    fingerprint: str
+    draft_number: int | None
+    drafter_model: str
+    run_id: str
+    detail_raw: str
+
+
+def telemetry_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / TELEMETRY_REL / FAILURES_FILENAME
+
+
+def record_failure(
+    repo_root: Path | str,
+    *,
+    stage: str,
+    check: str,
+    detail: str,
+    issue: int | None = None,
+    draft_number: int | None = None,
+    drafter_model: str = "",
+    run_id: str = "",
+    log=print,
+) -> PromptFailure | None:
+    """Append one record. Never raises; returns None if the write failed."""
+    if not (detail or "").strip():
+        return None
+
+    record = PromptFailure(
+        ts_local=datetime.now().strftime(_TS_FMT),
+        repo=str(repo_root),
+        issue=issue,
+        stage=stage,
+        check=check,
+        fingerprint=fingerprint(stage, check, detail),
+        draft_number=draft_number,
+        drafter_model=drafter_model or "",
+        run_id=run_id or "",
+        detail_raw=detail,
+    )
+
+    try:
+        path = telemetry_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(record), ensure_ascii=False) + "\n")
+    except OSError as exc:
+        log(f"  [telemetry] could not record a validation failure: {exc}")
+        return None
+    return record
+
+
+def record_failures(
+    repo_root: Path | str, details: list[str], **kwargs
+) -> list[PromptFailure]:
+    """One record per failure. N failures in one roll produce N records."""
+    written = []
+    for detail in details or []:
+        entry = record_failure(repo_root, detail=detail, **kwargs)
+        if entry is not None:
+            written.append(entry)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Reading and aggregation
+# ---------------------------------------------------------------------------
+
+
+def read_failures(repo_root: Path | str, *, since: str = "") -> list[dict]:
+    """Every recorded failure, oldest first. A malformed line is skipped."""
+    path = telemetry_path(repo_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    rows = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if since and str(row.get("ts_local", "")) < since:
+            continue
+        rows.append(row)
+    return rows
+
+
+def _week_of(ts_local: str) -> str:
+    try:
+        parsed = datetime.strptime(ts_local, _TS_FMT)
+    except (ValueError, TypeError):
+        return "unknown"
+    year, week, _ = parsed.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def aggregate(rows: list[dict], group_by: str = "fingerprint") -> list[tuple[str, int]]:
+    """Counts by one key, sorted by count descending then key ascending.
+
+    The tie-break on key is what makes the report byte-identical for identical
+    input; sorting on count alone leaves equal counts in dict order.
+    """
+    keyed: dict[str, int] = {}
+    for row in rows:
+        if group_by == "model":
+            key = row.get("drafter_model") or "unknown"
+        elif group_by == "week":
+            key = _week_of(row.get("ts_local", ""))
+        else:
+            key = row.get("fingerprint") or "unknown"
+        keyed[key] = keyed.get(key, 0) + 1
+    return sorted(keyed.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def cross_tab(rows: list[dict]) -> list[tuple[str, str, str, int]]:
+    """(fingerprint, model, week, count), deterministically ordered."""
+    keyed: dict[tuple[str, str, str], int] = {}
+    for row in rows:
+        key = (
+            row.get("fingerprint") or "unknown",
+            row.get("drafter_model") or "unknown",
+            _week_of(row.get("ts_local", "")),
+        )
+        keyed[key] = keyed.get(key, 0) + 1
+    return sorted(
+        ((f, m, w, c) for (f, m, w), c in keyed.items()),
+        key=lambda r: (-r[3], r[0], r[1], r[2]),
+    )
+
+
+def render_report(rows: list[dict], group_by: str = "fingerprint") -> str:
+    """Deterministic text report. Identical input yields identical bytes."""
+    if not rows:
+        return "No validation failures recorded.\n"
+
+    lines = [f"{len(rows)} validation failure(s) recorded.", ""]
+    width = max((len(k) for k, _ in aggregate(rows, group_by)), default=10)
+    lines.append(f"By {group_by}:")
+    for key, count in aggregate(rows, group_by):
+        lines.append(f"  {key.ljust(width)}  {count}")
+
+    lines += ["", "By fingerprint x model x week:"]
+    for fp, model, week, count in cross_tab(rows):
+        lines.append(f"  {fp} | {model} | {week} | {count}")
+
+    return "\n".join(lines) + "\n"

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -186,6 +186,25 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
     # roll over an unresolved ambiguity. File it where a human will see it.
     # Never changes the halt outcome: the roll was already halting, and a filing
     # failure is loud in the log but returns the same error_message.
+    # #2074: count it too. The must-resolve issue is the human-facing record;
+    # this is the one a rate is computed from.
+    try:
+        from assemblyzero.speedrun.must_resolve import run_context
+        from assemblyzero.speedrun.prompt_telemetry import record_failures
+
+        run_id, _ = run_context()
+        record_failures(
+            state.get("target_repo") or ".",
+            [str(c.get("criterion_a", "")) for c in conflicts],
+            stage="lld",
+            check="requirements-conflict",
+            issue=int(state.get("issue_number") or 0) or None,
+            drafter_model=state.get("config_drafter", ""),
+            run_id=run_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - telemetry never breaks a halt
+        print(f"  [telemetry] conflict telemetry skipped: {exc}")
+
     try:
         from assemblyzero.speedrun.must_resolve import file_all_conflicts
 

--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -1231,7 +1231,7 @@ def run_ast_sentinel_on_modify_files(
 # =============================================================================
 
 
-def validate_lld_mechanical(state: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_lld_mechanical_inner(state: Dict[str, Any]) -> Dict[str, Any]:
     """Mechanical validation of LLD content.
 
     Issue #277: Validates LLD structure and paths without LLM calls.
@@ -1460,3 +1460,36 @@ def validate_lld_mechanical(state: Dict[str, Any]) -> Dict[str, Any]:
         "lld_status": "PENDING",  # Clear BLOCKED status from previous Gemini verdicts
         "error_message": "",
     }
+
+
+def validate_lld_mechanical(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Mechanical validation, with every failure counted (#2074).
+
+    A wrapper rather than an emission at each of the failure returns: a return
+    added later would silently escape per-site instrumentation, and this node is
+    exactly where new checks get added. Wrapping means a new check is counted
+    the day it ships.
+    """
+    result = _validate_lld_mechanical_inner(state)
+
+    errors = result.get("validation_errors") or []
+    if errors:
+        try:
+            from assemblyzero.speedrun.must_resolve import run_context
+            from assemblyzero.speedrun.prompt_telemetry import record_failures
+
+            run_id, _ = run_context()
+            record_failures(
+                state.get("target_repo") or ".",
+                [str(e) for e in errors],
+                stage="lld",
+                check="mechanical",
+                issue=int(state.get("issue_number") or 0) or None,
+                draft_number=state.get("draft_number"),
+                drafter_model=state.get("config_drafter", ""),
+                run_id=run_id,
+            )
+        except Exception as exc:  # noqa: BLE001 - telemetry never breaks a roll
+            print(f"  [telemetry] validation-failure telemetry skipped: {exc}")
+
+    return result

--- a/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
@@ -117,6 +117,27 @@ def validate_test_plan_node(state: RequirementsWorkflowState) -> dict[str, Any]:
             "error_message": "",
         }
 
+    # #2074: count every violation before the retry re-rolls and the failure
+    # mode evaporates. One record per violation -- the rate is the measurement.
+    try:
+        from assemblyzero.speedrun.must_resolve import run_context
+        from assemblyzero.speedrun.prompt_telemetry import record_failures
+
+        run_id, _ = run_context()
+        record_failures(
+            state.get("target_repo") or ".",
+            [str(v.get("message", v)) for v in result.get("violations", [])
+             if isinstance(v, dict) and v.get("severity") == "error"],
+            stage="lld",
+            check="test-plan",
+            issue=int(state.get("issue_number") or 0) or None,
+            draft_number=state.get("iteration_count", 0) + 1,
+            drafter_model=state.get("config_drafter", ""),
+            run_id=run_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - telemetry never breaks a roll
+        print(f"    [telemetry] test-plan failure telemetry skipped: {exc}")
+
     # Build feedback for drafter
     feedback = _build_validation_feedback(result)
     print(f"    Feedback:\n{feedback}")

--- a/tests/unit/test_prompt_telemetry.py
+++ b/tests/unit/test_prompt_telemetry.py
@@ -1,0 +1,363 @@
+"""Acceptance tests for prompt-failure telemetry (#2074).
+
+The seven tests named in the issue body are the acceptance criteria.
+
+The fingerprint format is a contract #2075 consumes, so its round-trip is
+guarded here rather than left to convention -- changing the normalization
+silently re-buckets every historical record.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from assemblyzero.speedrun.prompt_telemetry import (  # noqa: E402
+    aggregate,
+    cross_tab,
+    fingerprint,
+    normalize_detail,
+    read_failures,
+    record_failure,
+    record_failures,
+    render_report,
+    telemetry_path,
+)
+
+# The message the operator observed on 2026-08-01, verbatim.
+OBSERVED = "MECHANICAL VALIDATION FAILED: Section 2.1 table malformed"
+EXPECTED_FINGERPRINT = "lld:mechanical:section-2-1-table-malformed"
+
+
+# --- "a known mechanical failure emits exactly one record" ---------------
+
+
+def test_the_observed_failure_produces_the_specified_fingerprint(tmp_path):
+    record = record_failure(
+        tmp_path, stage="lld", check="mechanical", detail=OBSERVED,
+        issue=2, draft_number=1, drafter_model="gemini:3.1-pro",
+        run_id="run-issue2-133746",
+    )
+
+    assert record is not None
+    assert record.fingerprint == EXPECTED_FINGERPRINT
+
+    rows = read_failures(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["fingerprint"] == EXPECTED_FINGERPRINT
+
+
+def test_every_specified_field_is_present(tmp_path):
+    record_failure(
+        tmp_path, stage="lld", check="mechanical", detail=OBSERVED,
+        issue=2, draft_number=3, drafter_model="gemini:3.1-pro",
+        run_id="run-issue2-133746",
+    )
+    row = read_failures(tmp_path)[0]
+
+    for field in ("ts_local", "repo", "issue", "stage", "check", "fingerprint",
+                  "draft_number", "drafter_model", "run_id", "detail_raw"):
+        assert field in row, f"{field} is part of the contract"
+
+    assert row["issue"] == 2
+    assert row["draft_number"] == 3
+    assert row["drafter_model"] == "gemini:3.1-pro"
+    assert row["run_id"] == "run-issue2-133746"
+
+
+def test_timestamp_is_local_with_no_utc_marker(tmp_path):
+    record_failure(tmp_path, stage="lld", check="mechanical", detail=OBSERVED)
+    ts = read_failures(tmp_path)[0]["ts_local"]
+    assert "Z" not in ts and "+" not in ts and "UTC" not in ts
+
+
+def test_records_land_at_the_specified_path(tmp_path):
+    record_failure(tmp_path, stage="lld", check="mechanical", detail=OBSERVED)
+    assert telemetry_path(tmp_path) == (
+        tmp_path / "data" / "speedrun" / "telemetry" / "prompt-failures.jsonl"
+    )
+    assert telemetry_path(tmp_path).is_file()
+
+
+# --- "casing, whitespace and punctuation give the identical fingerprint" --
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "MECHANICAL VALIDATION FAILED: Section 2.1 table malformed",
+        "mechanical validation failed: section 2.1 table malformed",
+        "MECHANICAL VALIDATION FAILED:    Section  2.1   table  malformed  ",
+        "MECHANICAL VALIDATION FAILED: Section 2.1 table malformed!!!",
+        "MECHANICAL VALIDATION FAILED:\n  Section 2.1 table malformed",
+        "MECHANICAL VALIDATION FAILED: --Section 2.1, table malformed--",
+    ],
+)
+def test_the_same_failure_normalizes_identically(variant):
+    assert fingerprint("lld", "mechanical", variant) == EXPECTED_FINGERPRINT
+
+
+def test_two_genuinely_different_failures_differ():
+    a = fingerprint("lld", "mechanical", "Section 2.1 table malformed")
+    b = fingerprint("lld", "mechanical", "Section 3.4 heading missing")
+    assert a != b
+
+
+def test_the_same_defect_at_a_different_check_is_a_different_fingerprint():
+    a = fingerprint("lld", "mechanical", "table malformed")
+    b = fingerprint("lld", "test-plan", "table malformed")
+    assert a != b
+
+
+def test_normalization_matches_the_specified_rules():
+    assert normalize_detail("Section 2.1 table malformed") == "section-2-1-table-malformed"
+    assert normalize_detail("---leading and trailing---") == "leading-and-trailing"
+    assert normalize_detail("") == ""
+
+
+def test_the_announcement_marker_is_stripped_not_fingerprinted():
+    # Otherwise every mechanical failure would share one fingerprint and the
+    # whole exercise would measure nothing.
+    with_marker = fingerprint("lld", "mechanical", OBSERVED)
+    without = fingerprint("lld", "mechanical", "Section 2.1 table malformed")
+    assert with_marker == without
+    assert "mechanical-validation-failed" not in with_marker.split(":")[2]
+
+
+# --- "N failures in one roll produce N records -- no write-time dedupe" --
+
+
+def test_no_deduplication_at_write_time(tmp_path):
+    for _ in range(5):
+        record_failure(tmp_path, stage="lld", check="mechanical", detail=OBSERVED)
+
+    rows = read_failures(tmp_path)
+    assert len(rows) == 5, "collapsing at write time destroys the rate"
+    assert len({r["fingerprint"] for r in rows}) == 1
+
+
+def test_record_failures_writes_one_per_detail(tmp_path):
+    written = record_failures(
+        tmp_path, ["first problem", "second problem", "third problem"],
+        stage="lld", check="mechanical",
+    )
+    assert len(written) == 3
+    assert len(read_failures(tmp_path)) == 3
+
+
+def test_empty_details_are_not_recorded(tmp_path):
+    assert record_failure(tmp_path, stage="lld", check="mechanical", detail="") is None
+    assert record_failure(tmp_path, stage="lld", check="mechanical", detail="   ") is None
+    assert read_failures(tmp_path) == []
+
+
+# --- "detail_raw round-trips the original message unmodified" ------------
+
+
+def test_detail_raw_round_trips_unmodified(tmp_path):
+    messy = "MECHANICAL VALIDATION FAILED:\n  - Section 2.1 table malformed (row 3, 'Files Changed')"
+    record_failure(tmp_path, stage="lld", check="mechanical", detail=messy)
+
+    row = read_failures(tmp_path)[0]
+    assert row["detail_raw"] == messy, (
+        "a fingerprint must always be traceable back to what produced it"
+    )
+
+
+def test_unicode_survives_the_round_trip(tmp_path):
+    detail = "Section 2.1 table malformed — em dash and ünïcode"
+    record_failure(tmp_path, stage="lld", check="mechanical", detail=detail)
+    assert read_failures(tmp_path)[0]["detail_raw"] == detail
+
+
+# --- "the report groups by fingerprint, model and week, deterministically" ---
+
+
+def _rows():
+    return [
+        {"fingerprint": "lld:mechanical:a", "drafter_model": "gemini:3.1-pro",
+         "ts_local": "2026-08-01 10:00:00"},
+        {"fingerprint": "lld:mechanical:a", "drafter_model": "gemini:3.1-pro",
+         "ts_local": "2026-08-01 11:00:00"},
+        {"fingerprint": "lld:mechanical:b", "drafter_model": "claude:haiku",
+         "ts_local": "2026-07-20 09:00:00"},
+    ]
+
+
+def test_report_groups_by_each_key():
+    rows = _rows()
+    assert aggregate(rows, "fingerprint") == [
+        ("lld:mechanical:a", 2), ("lld:mechanical:b", 1)
+    ]
+    assert aggregate(rows, "model") == [
+        ("gemini:3.1-pro", 2), ("claude:haiku", 1)
+    ]
+    weeks = dict(aggregate(rows, "week"))
+    assert sum(weeks.values()) == 3 and len(weeks) == 2
+
+
+def test_report_is_byte_identical_for_identical_input():
+    first = render_report(_rows(), "fingerprint")
+    second = render_report(list(reversed(_rows())), "fingerprint")
+    assert first == second, "equal counts must tie-break on key, not dict order"
+
+
+def test_cross_tab_is_fingerprint_by_model_by_week():
+    table = cross_tab(_rows())
+    assert ("lld:mechanical:a", "gemini:3.1-pro", "2026-W31", 2) in table
+    assert len(table) == 2
+
+
+def test_report_handles_an_empty_record_set():
+    assert render_report([], "fingerprint") == "No validation failures recorded.\n"
+
+
+def test_since_filters_older_records(tmp_path):
+    path = telemetry_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"ts_local": "2026-07-01 10:00:00", "fingerprint": "old"}) + "\n"
+        + json.dumps({"ts_local": "2026-08-01 10:00:00", "fingerprint": "new"}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert [r["fingerprint"] for r in read_failures(tmp_path, since="2026-08-01")] == ["new"]
+    assert len(read_failures(tmp_path)) == 2
+
+
+def test_a_malformed_line_does_not_break_the_report(tmp_path):
+    path = telemetry_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"ts_local": "2026-08-01 10:00:00", "fingerprint": "ok"}) + "\n"
+        + "{ this is not json\n",
+        encoding="utf-8",
+    )
+    assert len(read_failures(tmp_path)) == 1
+
+
+# --- "a write failure is loud and does not change the roll's outcome" ----
+
+
+def test_a_write_failure_is_logged_and_swallowed(tmp_path):
+    # A file where the telemetry directory must go: mkdir raises, and the roll
+    # must not care.
+    blocker = tmp_path / "data" / "speedrun"
+    blocker.parent.mkdir(parents=True)
+    blocker.write_text("not a directory\n", encoding="utf-8")
+
+    logged: list[str] = []
+    result = record_failure(
+        tmp_path, stage="lld", check="mechanical", detail=OBSERVED, log=logged.append
+    )
+
+    assert result is None
+    assert logged, "a silent telemetry failure is worse than none"
+    assert "could not record" in logged[0]
+
+
+def test_reading_a_missing_file_is_empty_not_an_error(tmp_path):
+    assert read_failures(tmp_path) == []
+
+
+# --- the report tool ------------------------------------------------------
+
+
+def test_report_tool_runs_and_exits_zero(tmp_path, capsys):
+    import prompt_failure_report
+
+    record_failure(
+        tmp_path, stage="lld", check="mechanical", detail=OBSERVED,
+        drafter_model="gemini:3.1-pro",
+    )
+
+    code = prompt_failure_report.main(["--repo", str(tmp_path)])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert EXPECTED_FINGERPRINT in out
+    assert "gemini:3.1-pro" in out
+
+
+def test_report_tool_on_a_repo_with_no_telemetry_is_not_an_error(tmp_path, capsys):
+    import prompt_failure_report
+
+    assert prompt_failure_report.main(["--repo", str(tmp_path)]) == 0
+    assert "No telemetry file" in capsys.readouterr().out
+
+
+def test_report_tool_accepts_each_grouping(tmp_path):
+    import prompt_failure_report
+
+    record_failure(tmp_path, stage="lld", check="mechanical", detail=OBSERVED)
+    for grouping in ("fingerprint", "model", "week"):
+        assert prompt_failure_report.main(
+            ["--repo", str(tmp_path), "--group-by", grouping]
+        ) == 0
+
+
+# --- wiring ---------------------------------------------------------------
+
+
+def test_mechanical_validation_records_its_failures(tmp_path, monkeypatch):
+    from assemblyzero.workflows.requirements.nodes import validate_mechanical as vm
+
+    monkeypatch.setattr(
+        vm, "_validate_lld_mechanical_inner",
+        lambda _state: {
+            "validation_errors": ["Section 2.1 table malformed"],
+            "lld_status": "BLOCKED",
+            "error_message": "MECHANICAL VALIDATION FAILED:\n  - Section 2.1 table malformed",
+        },
+    )
+
+    result = vm.validate_lld_mechanical({
+        "target_repo": str(tmp_path), "issue_number": 2, "draft_number": 1,
+        "config_drafter": "gemini:3.1-pro",
+    })
+
+    assert result["lld_status"] == "BLOCKED", "the wrapper must not alter the verdict"
+    rows = read_failures(tmp_path)
+    assert len(rows) == 1
+    assert rows[0]["fingerprint"] == EXPECTED_FINGERPRINT
+
+
+def test_mechanical_validation_records_nothing_when_it_passes(tmp_path, monkeypatch):
+    from assemblyzero.workflows.requirements.nodes import validate_mechanical as vm
+
+    monkeypatch.setattr(
+        vm, "_validate_lld_mechanical_inner",
+        lambda _state: {"validation_errors": [], "lld_status": "PENDING", "error_message": ""},
+    )
+
+    vm.validate_lld_mechanical({"target_repo": str(tmp_path), "issue_number": 2})
+    assert read_failures(tmp_path) == []
+
+
+def test_telemetry_failure_does_not_change_the_validation_verdict(tmp_path, monkeypatch):
+    from assemblyzero.speedrun import prompt_telemetry as pt
+    from assemblyzero.workflows.requirements.nodes import validate_mechanical as vm
+
+    monkeypatch.setattr(
+        vm, "_validate_lld_mechanical_inner",
+        lambda _state: {
+            "validation_errors": ["boom"], "lld_status": "BLOCKED",
+            "error_message": "MECHANICAL VALIDATION FAILED:\n  - boom",
+        },
+    )
+
+    def explode(*_a, **_kw):
+        raise RuntimeError("telemetry is broken")
+
+    monkeypatch.setattr(pt, "record_failures", explode)
+
+    result = vm.validate_lld_mechanical({
+        "target_repo": str(tmp_path), "issue_number": 2,
+    })
+
+    assert result["lld_status"] == "BLOCKED"
+    assert result["validation_errors"] == ["boom"]

--- a/tools/prompt_failure_report.py
+++ b/tools/prompt_failure_report.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Count drafter validation failures by fingerprint, model and week (#2074).
+
+Each failure used to print to a run log, the retry re-rolled, and the failure
+mode evaporated -- while the prompts producing the failure rate stayed static.
+This reads the records and turns them into a rate.
+
+    poetry run python tools/prompt_failure_report.py --repo /c/.../boostgauge
+    poetry run python tools/prompt_failure_report.py --repo <path> --since 2026-08-01
+    poetry run python tools/prompt_failure_report.py --repo <path> --group-by model
+
+Output is deterministic: identical input produces byte-identical output, so a
+report can be diffed across days to see what changed rather than re-read.
+
+Exit codes: 0 always, including "nothing recorded" -- an empty telemetry file
+is a fact about the pipeline, not an error in this tool.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.speedrun.prompt_telemetry import (  # noqa: E402
+    read_failures,
+    render_report,
+    telemetry_path,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Count drafter validation failures by fingerprint, model and week."
+    )
+    parser.add_argument("--repo", required=True, help="repository whose telemetry to read")
+    parser.add_argument("--since", default="", help="local date or timestamp lower bound, e.g. 2026-08-01")
+    parser.add_argument(
+        "--group-by", default="fingerprint",
+        choices=("fingerprint", "model", "week"),
+        help="primary grouping for the summary table",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo)
+    rows = read_failures(repo, since=args.since)
+
+    if not rows and not telemetry_path(repo).exists():
+        print(f"No telemetry file at {telemetry_path(repo)}", flush=True)
+        return 0
+
+    print(render_report(rows, args.group_by), end="", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Operator observation 2026-08-01: a drafter emitted a malformed Section 2.1 table
(`run-issue2-133746`, lld failed 86.1s). **Nothing counted it.** Each failure printed to a run
log, the retry re-rolled, and the failure mode evaporated — while the prompts producing the
failure rate stayed static.

One record per validation failure now lands in
`<repo>/data/speedrun/telemetry/prompt-failures.jsonl`, from the mechanical check, the
test-plan check, and the requirements-consistency check.

## The fingerprint is a contract

`<stage>:<check>:<normalized-detail>` — lowercase, non-alphanumeric runs collapsed to a single
hyphen, ends stripped. The observed message becomes:

```
lld:mechanical:section-2-1-table-malformed
```

It is specified in the module rather than left to the implementation because #2075 consumes
it. Changing the normalization silently re-buckets every historical record, so the round-trip
is guarded by tests — including the operator's verbatim message and six normalization variants
of it.

**Announcement markers are stripped before normalization.** Without that, every mechanical
failure would share the fingerprint `lld:mechanical:mechanical-validation-failed` and the whole
exercise would measure nothing. There is a test for it.

## No deduplication at write time

Every occurrence is a record; aggregation is the report's job. "This failed twice today" and
"this failed forty times today" are different problems with the same fingerprint, and
collapsing at write time destroys the difference — which is the rate this exists to measure.

`detail_raw` round-trips the original message unmodified, so a fingerprint is always traceable
back to what produced it.

## The mechanical check is wrapped, not edited per-return

That node has five separate failure returns. A sixth added later would silently escape
per-site instrumentation, and that node is exactly where new checks get added — wrapping means
a new check is counted the day it ships.

## Telemetry never changes a roll's outcome

Every emission is wrapped, and a write failure is logged loudly and swallowed. One test breaks
the recorder outright and asserts the validation verdict and errors are untouched; another
blocks the telemetry directory on disk and asserts the call returns cleanly with a loud log
line. Telemetry that can break the thing it measures is worse than no telemetry.

## The report

`tools/prompt_failure_report.py --repo <path> [--since <date>] [--group-by fingerprint|model|week]`
prints counts by fingerprint × model × week.

Output is deterministic — equal counts tie-break on key rather than dict order — so reports
can be diffed across days to see what changed instead of being re-read. A repo with no
telemetry is a fact about the pipeline, not an error: it exits 0.

## Tests

33 unit tests covering the seven acceptance criteria.

Full suite green: 6931 passed, 17 skipped, 5 xfailed.

## Reference

Companion: #2075 acts on this data and depends on the fingerprint format being stable. That
issue is not started — its ranking tool also needs `runs.csv`, which does not exist yet.

Closes #2074
