### PR TITLE
feat(tools): rank drafter failures by cost and close the revision loop (Closes #2075)

### DIFF
--- a/assemblyzero/speedrun/prompt_ranking.py
+++ b/assemblyzero/speedrun/prompt_ranking.py
@@ -1,0 +1,163 @@
+"""Rank drafter failure fingerprints by what they actually cost (#2075).
+
+#2074 counts validation failures. Counting alone ranks a cheap failure that
+happens often above an expensive one that happens rarely, which is the wrong
+order to fix things in. This joins the counts to roll durations so the ranking
+is by cost:
+
+    cost = occurrences x mean wasted roll seconds
+
+## Unknown is not zero
+
+A fingerprint with no duration data is ranked by occurrence count and flagged
+`duration-unknown`. It is never costed at zero -- that would sort the most
+expensive unmeasured failure to the bottom of the list, which is precisely the
+failure this tool exists to surface. Unknown-duration entries sort after
+costed ones at equal standing, but they are never dropped.
+
+## The join
+
+Telemetry records carry `run_id`, the events-log basename (`run-issue2-133746`).
+The timing dashboard's `runs.csv` carries `start_local` and `issue`. The tag
+encodes both -- issue number and HHMMSS -- so the join parses the tag and
+matches the row whose issue and start time agree. No new column is needed on
+either side, and a tag that matches nothing yields unknown duration rather than
+a silent drop.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+TELEMETRY_REL = Path("data/speedrun/telemetry/prompt-failures.jsonl")
+RUNS_CSV_REL = Path("data/speedrun/analysis/runs.csv")
+
+_RE_TAG = re.compile(r"run-?\w*?-?issue(?P<issue>\d+)-(?P<hhmmss>\d{6})")
+
+UNKNOWN_DURATION = "duration-unknown"
+
+
+@dataclass
+class Ranked:
+    fingerprint: str
+    occurrences: int
+    mean_wasted_seconds: float | None
+    cost: float | None
+    flags: tuple[str, ...] = ()
+    models: tuple[str, ...] = ()
+
+    @property
+    def duration_known(self) -> bool:
+        return self.mean_wasted_seconds is not None
+
+
+def load_telemetry(repo_root: Path | str) -> list[dict]:
+    path = Path(repo_root) / TELEMETRY_REL
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    rows = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            rows.append(json.loads(line))
+        except ValueError:
+            continue
+    return rows
+
+
+def load_durations(repo_root: Path | str) -> dict[tuple[int, str], float]:
+    """(issue, HHMMSS) -> run seconds, from the timing dashboard's runs.csv."""
+    path = Path(repo_root) / RUNS_CSV_REL
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    durations: dict[tuple[int, str], float] = {}
+    for row in csv.DictReader(text.splitlines()):
+        try:
+            issue = int(row["issue"])
+            seconds = float(row["run_seconds"])
+            hhmmss = row["start_local"].split(" ")[1].replace(":", "")
+        except (KeyError, ValueError, IndexError):
+            continue
+        durations[(issue, hhmmss)] = seconds
+    return durations
+
+
+def duration_for(run_id: str, durations: dict[tuple[int, str], float]) -> float | None:
+    match = _RE_TAG.search(run_id or "")
+    if not match:
+        return None
+    key = (int(match.group("issue")), match.group("hhmmss"))
+    return durations.get(key)
+
+
+def rank(rows: list[dict], durations: dict[tuple[int, str], float]) -> list[Ranked]:
+    """Fingerprints ordered by cost, then by occurrences, then by name.
+
+    The tie-breaks are what make the output byte-identical for identical input;
+    sorting on cost alone leaves equal-cost entries in dict order.
+    """
+    grouped: dict[str, list[dict]] = {}
+    for row in rows:
+        fingerprint = row.get("fingerprint") or "unknown"
+        grouped.setdefault(fingerprint, []).append(row)
+
+    ranked: list[Ranked] = []
+    for fingerprint, entries in grouped.items():
+        seconds = [
+            d for d in (duration_for(e.get("run_id", ""), durations) for e in entries)
+            if d is not None
+        ]
+        models = tuple(sorted({e.get("drafter_model") or "unknown" for e in entries}))
+        occurrences = len(entries)
+
+        if seconds:
+            mean = sum(seconds) / len(seconds)
+            ranked.append(
+                Ranked(fingerprint, occurrences, mean, occurrences * mean, (), models)
+            )
+        else:
+            ranked.append(
+                Ranked(fingerprint, occurrences, None, None, (UNKNOWN_DURATION,), models)
+            )
+
+    # Costed entries first by cost; unknown-duration entries after, ordered by
+    # occurrences. Never dropped, never costed at zero.
+    return sorted(
+        ranked,
+        key=lambda r: (
+            0 if r.duration_known else 1,
+            -(r.cost if r.cost is not None else 0.0),
+            -r.occurrences,
+            r.fingerprint,
+        ),
+    )
+
+
+def render(ranked: list[Ranked]) -> str:
+    """Deterministic text table. Identical input yields identical bytes."""
+    if not ranked:
+        return "No validation failures recorded — nothing to rank.\n"
+
+    width = max(len(r.fingerprint) for r in ranked)
+    lines = [
+        f"{'fingerprint'.ljust(width)}  {'count':>5}  {'mean_s':>8}  {'cost_s':>10}  flags",
+        f"{'-' * width}  {'-' * 5}  {'-' * 8}  {'-' * 10}  -----",
+    ]
+    for entry in ranked:
+        mean = f"{entry.mean_wasted_seconds:.1f}" if entry.duration_known else "-"
+        cost = f"{entry.cost:.1f}" if entry.duration_known else "-"
+        lines.append(
+            f"{entry.fingerprint.ljust(width)}  {entry.occurrences:>5}  "
+            f"{mean:>8}  {cost:>10}  {','.join(entry.flags)}"
+        )
+    return "\n".join(lines) + "\n"

--- a/docs/standards/0025-prompt-revision-from-telemetry.md
+++ b/docs/standards/0025-prompt-revision-from-telemetry.md
@@ -1,0 +1,119 @@
+# 0025 — Revising drafter prompts from failure telemetry
+
+**Status:** Active
+**Issue:** #2075 (companion to #2074, which produces the telemetry)
+
+Everything else in the factory improves from evidence. The drafter prompts and
+templates have been static for the life of the campaign, while their failure
+modes — malformed section tables, missing sections, missing REQ-N refs,
+fenceless imports, invented kwargs — recur at rates nobody measured. Every
+recurrence costs a full roll, between 3 and 90 minutes.
+
+This is the loop that closes. It never ends; there is no state in which the
+prompts are finished.
+
+## The procedure
+
+### 1. Rank by cost, not by count
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/prompt_revision_rank.py --repo /c/Users/mcwiz/Projects/<target>
+```
+
+Cost is `occurrences × mean wasted roll seconds`. Counting alone ranks a cheap
+frequent failure above an expensive rare one, which is the wrong order to fix
+things in.
+
+**A `duration-unknown` flag is not a zero.** Those fingerprints are ranked by
+occurrence count and listed after the costed ones. Treating unknown as zero
+would sort the most expensive unmeasured failure to the bottom. If the top of
+the list is flagged `duration-unknown`, that is a signal to go get durations —
+run the timing dashboard (#2085) — not a signal to skip the entry.
+
+### 2. Take the top fingerprint and write down its before-rate
+
+Record, in the PR body, both numbers:
+
+- **occurrences** — how many times the failure fired
+- **blast radius** — how many distinct rolls it appeared in, out of how many total
+
+Two numbers, because they answer different questions. A failure firing 16 times
+inside one roll is a retry loop; the same 16 spread across 6 rolls is a
+systematic prompt defect. The countermeasure differs.
+
+### 3. Revise with an explicit countermeasure, not an exhortation
+
+The revision must change something the drafter *reads structurally* — a literal
+template row that keeps parsing, an in-place marker on the section that goes
+missing, a worked example of the construct being fumbled.
+
+**Adding "please remember to…" to a system prompt is not a countermeasure.** If
+the revision cannot be pointed at as a concrete artifact the drafter consumes,
+it is not one.
+
+Prefer copying a construct that demonstrably survives. When one section of a
+template is dropped far less often than its neighbours, whatever that section
+does differently is the countermeasure — and it has already been validated by
+the failure data itself.
+
+### 4. Compare the rate before and after over N rolls
+
+`N` is a real number chosen before the change, not "until it looks better."
+Ten rolls is a reasonable default for a failure with a double-digit
+before-count; fewer for a failure that fires on nearly every roll.
+
+Re-run the ranking tool after those rolls and compare the same fingerprint.
+
+### 5. Keep or revert on that evidence
+
+A revision that does not move its fingerprint's rate is reverted, not kept and
+rationalized. Prompt text accumulates; every line that does nothing makes the
+next revision harder to reason about and eats context budget that the codebase
+sections need.
+
+## What a prompt-change PR must contain
+
+**The before-rate goes in the PR body.** This is the requirement that makes the
+revision history the experiment log — without it, a later reader cannot tell
+whether a prompt line was evidence-driven or somebody's hunch.
+
+A conforming PR body carries:
+
+1. The fingerprint being targeted, verbatim.
+2. Its before-rate: occurrences and blast radius, with the source of those
+   numbers (telemetry, or run logs and lineage during cold start).
+3. The countermeasure, named as a concrete artifact change.
+4. The value of N and when the after-measurement will be taken.
+
+## Cold start
+
+`#2074`'s telemetry only populates from rolls run after it landed on
+2026-08-02. Before those rolls exist the JSONL is empty and the ranking tool
+correctly reports nothing.
+
+**Do not fabricate telemetry records to feed the ranker**, and do not wait for
+data before revising anything. While telemetry is empty or sparse, take the
+before-rate by hand from the run logs and lineage directories:
+
+```bash
+cd /c/Users/mcwiz/Projects/<target>/data/speedrun/runs
+
+# occurrences of each distinct mechanical failure, numbers normalized
+grep -h -A8 'MECHANICAL VALIDATION FAILED' *.log \
+  | grep -E '^\s+[0-9]+\. ' | sed -E 's/^\s+[0-9]+\. //; s/[0-9]+/N/g' \
+  | sort | uniq -c | sort -rn
+
+# blast radius: how many distinct rolls a given failure appeared in
+grep -l '<the failure text>' *.log | wc -l
+```
+
+Hand-derived numbers are quoted the same way in the PR body, with their source
+named as run logs rather than telemetry. They are evidence; they are simply
+evidence gathered by grep instead of by instrumentation.
+
+## Reference
+
+- #2074 — the telemetry and its fingerprint format, which this consumes.
+- #2085 — the timing dashboard producing `runs.csv`, the duration source.
+- `tools/prompt_revision_rank.py` — the ranking tool.

--- a/docs/templates/0102-feature-lld-template.md
+++ b/docs/templates/0102-feature-lld-template.md
@@ -336,11 +336,15 @@ poetry run pytest tests/test_{module}.py -v -m live
 
 ## 11. Risks & Mitigations
 
+**This section is MANDATORY and mechanically checked. If `## 11` is missing, the LLD is BLOCKED.**
+
 | Risk | Impact | Likelihood | Mitigation |
 |------|--------|------------|------------|
 | {Risk description} | High/Med/Low | High/Med/Low | {How addressed} |
 
 ## 12. Definition of Done
+
+**This section is MANDATORY and mechanically checked. If `## 12` is missing, the LLD is BLOCKED.**
 
 ### Code
 - [ ] Implementation complete and linted

--- a/tests/unit/test_prompt_revision_rank.py
+++ b/tests/unit/test_prompt_revision_rank.py
@@ -1,0 +1,299 @@
+"""Acceptance tests for cost-ranked prompt revision (#2075).
+
+The five tests named in the issue body are the acceptance criteria. The rule
+that matters most is that `duration-unknown` is never treated as zero cost —
+that would sort the most expensive unmeasured failure to the bottom, which is
+the exact failure the ranking exists to surface.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from assemblyzero.speedrun.prompt_ranking import (  # noqa: E402
+    RUNS_CSV_REL,
+    TELEMETRY_REL,
+    UNKNOWN_DURATION,
+    duration_for,
+    load_durations,
+    load_telemetry,
+    rank,
+    render,
+)
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "docs/templates/0102-feature-lld-template.md"
+PROCEDURE = (
+    Path(__file__).resolve().parents[2]
+    / "docs/standards/0025-prompt-revision-from-telemetry.md"
+)
+
+
+def _telemetry(repo: Path, records: list[dict]) -> None:
+    path = repo / TELEMETRY_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(r) + "\n" for r in records), encoding="utf-8"
+    )
+
+
+def _runs_csv(repo: Path, rows: list[tuple[str, int, float]]) -> None:
+    path = repo / RUNS_CSV_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["start_local,issue,outcome,run_seconds,fix_seconds_attributed,source"]
+    for start, issue, seconds in rows:
+        lines.append(f"{start},{issue},failed,{seconds:.1f},0.0,events")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="")
+
+
+def _record(fingerprint: str, run_id: str, model: str = "gemini:3.1-pro") -> dict:
+    return {
+        "ts_local": "2026-08-02 10:00:00", "repo": "x", "issue": 2,
+        "stage": "lld", "check": "mechanical", "fingerprint": fingerprint,
+        "draft_number": 1, "drafter_model": model, "run_id": run_id,
+        "detail_raw": fingerprint,
+    }
+
+
+# --- "fixture telemetry + fixture durations produce the expected order" ---
+
+
+def test_ranking_is_by_cost_not_by_count(tmp_path):
+    _runs_csv(tmp_path, [
+        ("2026-08-02 13:37:46", 2, 5400.0),   # expensive roll
+        ("2026-08-02 14:00:00", 2, 60.0),     # cheap roll
+        ("2026-08-02 15:00:00", 2, 60.0),
+        ("2026-08-02 16:00:00", 2, 60.0),
+    ])
+    _telemetry(tmp_path, [
+        # 1 occurrence x 5400s = 5400
+        _record("lld:mechanical:expensive", "run-issue2-133746"),
+        # 3 occurrences x 60s = 180 — more frequent, far cheaper
+        _record("lld:mechanical:cheap", "run-issue2-140000"),
+        _record("lld:mechanical:cheap", "run-issue2-150000"),
+        _record("lld:mechanical:cheap", "run-issue2-160000"),
+    ])
+
+    ranked = rank(load_telemetry(tmp_path), load_durations(tmp_path))
+
+    assert [r.fingerprint for r in ranked] == [
+        "lld:mechanical:expensive", "lld:mechanical:cheap",
+    ], "counting alone would invert this"
+    assert ranked[0].cost == pytest.approx(5400.0)
+    assert ranked[1].cost == pytest.approx(180.0)
+    assert ranked[1].occurrences == 3
+
+
+def test_cost_is_occurrences_times_mean_wasted_seconds(tmp_path):
+    _runs_csv(tmp_path, [
+        ("2026-08-02 10:00:00", 2, 100.0),
+        ("2026-08-02 11:00:00", 2, 300.0),
+    ])
+    _telemetry(tmp_path, [
+        _record("lld:mechanical:a", "run-issue2-100000"),
+        _record("lld:mechanical:a", "run-issue2-110000"),
+    ])
+
+    ranked = rank(load_telemetry(tmp_path), load_durations(tmp_path))
+
+    assert ranked[0].mean_wasted_seconds == pytest.approx(200.0)
+    assert ranked[0].cost == pytest.approx(400.0)
+
+
+def test_the_run_id_tag_joins_to_the_duration_table():
+    durations = {(2, "133746"): 5400.0}
+    assert duration_for("run-issue2-133746", durations) == 5400.0
+    assert duration_for("run11b-issue2-133746", durations) == 5400.0
+    assert duration_for("garbage", durations) is None
+    assert duration_for("run-issue9-999999", durations) is None
+
+
+# --- "absent from the duration table: ranked by count, flagged, never zero" ---
+
+
+def test_missing_duration_is_flagged_and_never_costed_at_zero(tmp_path):
+    _runs_csv(tmp_path, [("2026-08-02 10:00:00", 2, 50.0)])
+    _telemetry(tmp_path, [
+        _record("lld:mechanical:costed", "run-issue2-100000"),
+        # No matching row in runs.csv — duration unknown.
+        _record("lld:mechanical:unmeasured", "run-issue77-235959"),
+        _record("lld:mechanical:unmeasured", "run-issue77-235958"),
+    ])
+
+    ranked = rank(load_telemetry(tmp_path), load_durations(tmp_path))
+    by_fp = {r.fingerprint: r for r in ranked}
+
+    unmeasured = by_fp["lld:mechanical:unmeasured"]
+    assert UNKNOWN_DURATION in unmeasured.flags
+    assert unmeasured.cost is None, "zero would sort it below every costed entry"
+    assert unmeasured.mean_wasted_seconds is None
+    assert unmeasured.occurrences == 2
+    assert len(ranked) == 2, "an unmeasured fingerprint is never dropped"
+
+
+def test_unknown_duration_entries_are_ordered_among_themselves_by_count(tmp_path):
+    _telemetry(tmp_path, [
+        _record("lld:mechanical:rare", "run-issue77-000001"),
+        _record("lld:mechanical:common", "run-issue77-000002"),
+        _record("lld:mechanical:common", "run-issue77-000003"),
+        _record("lld:mechanical:common", "run-issue77-000004"),
+    ])
+
+    ranked = rank(load_telemetry(tmp_path), {})
+
+    assert [r.fingerprint for r in ranked] == [
+        "lld:mechanical:common", "lld:mechanical:rare",
+    ]
+    assert all(UNKNOWN_DURATION in r.flags for r in ranked)
+
+
+def test_a_costed_entry_outranks_an_unknown_one_even_with_fewer_occurrences(tmp_path):
+    _runs_csv(tmp_path, [("2026-08-02 10:00:00", 2, 5000.0)])
+    _telemetry(tmp_path, [
+        _record("lld:mechanical:costed", "run-issue2-100000"),
+        _record("lld:mechanical:unknown1", "run-issue77-000001"),
+        _record("lld:mechanical:unknown1", "run-issue77-000002"),
+    ])
+
+    ranked = rank(load_telemetry(tmp_path), load_durations(tmp_path))
+
+    assert ranked[0].fingerprint == "lld:mechanical:costed"
+    assert ranked[1].flags == (UNKNOWN_DURATION,)
+    # But it is still present and still carries its real count.
+    assert ranked[1].occurrences == 2
+
+
+# --- "identical inputs produce byte-identical output" --------------------
+
+
+def test_output_is_byte_identical_for_identical_input(tmp_path):
+    _runs_csv(tmp_path, [
+        ("2026-08-02 10:00:00", 2, 100.0),
+        ("2026-08-02 11:00:00", 2, 100.0),
+    ])
+    records = [
+        _record("lld:mechanical:b", "run-issue2-100000"),
+        _record("lld:mechanical:a", "run-issue2-110000"),
+    ]
+
+    _telemetry(tmp_path, records)
+    first = render(rank(load_telemetry(tmp_path), load_durations(tmp_path)))
+
+    _telemetry(tmp_path, list(reversed(records)))
+    second = render(rank(load_telemetry(tmp_path), load_durations(tmp_path)))
+
+    assert first == second, "equal-cost entries must tie-break on name, not dict order"
+
+
+# --- "an empty telemetry file produces an empty ranking and exit 0" ------
+
+
+def test_empty_telemetry_ranks_empty_and_exits_zero(tmp_path, capsys):
+    import prompt_revision_rank as cli
+
+    _telemetry(tmp_path, [])
+
+    code = cli.main(["--repo", str(tmp_path)])
+
+    assert code == 0, "no failures recorded is a fact, not an error"
+    assert "No validation failures recorded" in capsys.readouterr().out
+
+
+def test_missing_telemetry_file_is_not_an_error(tmp_path, capsys):
+    import prompt_revision_rank as cli
+
+    assert cli.main(["--repo", str(tmp_path)]) == 0
+    assert load_telemetry(tmp_path) == []
+
+
+def test_render_of_an_empty_ranking():
+    assert "nothing to rank" in render([])
+
+
+def test_cli_warns_when_durations_are_absent(tmp_path, capsys):
+    import prompt_revision_rank as cli
+
+    _telemetry(tmp_path, [_record("lld:mechanical:a", "run-issue2-100000")])
+
+    code = cli.main(["--repo", str(tmp_path)])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "duration-unknown" in out
+    assert "no durations" in out, "silence would read as 'everything is measured'"
+
+
+def test_cli_top_limits_the_listing(tmp_path, capsys):
+    import prompt_revision_rank as cli
+
+    _runs_csv(tmp_path, [("2026-08-02 10:00:00", 2, 100.0)])
+    _telemetry(tmp_path, [
+        _record("lld:mechanical:a", "run-issue2-100000"),
+        _record("lld:mechanical:b", "run-issue2-100000"),
+    ])
+
+    cli.main(["--repo", str(tmp_path), "--top", "1"])
+    body = [
+        line for line in capsys.readouterr().out.splitlines()
+        if line.startswith("lld:")
+    ]
+    assert len(body) == 1
+
+
+# --- "the procedure document exists and requires before/after" -----------
+
+
+def test_procedure_document_exists_and_requires_the_comparison():
+    assert PROCEDURE.is_file()
+    text = PROCEDURE.read_text(encoding="utf-8")
+
+    assert "before" in text.lower() and "after" in text.lower()
+    assert "revert" in text.lower(), "keep-or-revert on evidence is the point"
+    assert "before-rate" in text.lower(), "PR bodies must quote it"
+    assert "do not fabricate" in text.lower(), "the cold-start rule must be written down"
+
+
+def test_procedure_names_the_ranking_tool_that_exists():
+    text = PROCEDURE.read_text(encoding="utf-8")
+    assert "tools/prompt_revision_rank.py" in text
+    assert (Path(__file__).resolve().parents[2] / "tools/prompt_revision_rank.py").is_file()
+
+
+# --- the worked example ---------------------------------------------------
+
+
+def test_the_mandatory_sections_carry_an_in_place_blocked_marker():
+    """The worked example: §11 and §12 went missing 16 times each across 6 rolls.
+
+    §2.1 — the third mandatory section — already carried an in-place BLOCKED
+    warning and was dropped far less often. This copies that construct onto the
+    two sections that lacked it.
+    """
+    from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+        MANDATORY_SECTIONS,
+    )
+
+    template = TEMPLATE.read_text(encoding="utf-8")
+
+    for section in MANDATORY_SECTIONS:
+        assert section in template, f"{section} must exist in the template at all"
+
+    for heading in ("## 11. Risks & Mitigations", "## 12. Definition of Done"):
+        index = template.index(heading)
+        following = template[index : index + 400]
+        assert "MANDATORY" in following and "BLOCKED" in following, (
+            f"{heading} must state its own gate in place — a drafter that stops "
+            f"early never reaches a warning stored further down"
+        )
+
+
+def test_the_marker_names_the_literal_heading_the_validator_checks():
+    """The marker has to name `## 11`, not 'section eleven' — the validator
+    matches the literal string, and so must the instruction."""
+    template = TEMPLATE.read_text(encoding="utf-8")
+    assert "If `## 11` is missing" in template
+    assert "If `## 12` is missing" in template

--- a/tools/prompt_revision_rank.py
+++ b/tools/prompt_revision_rank.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Rank drafter failure fingerprints by what they cost (#2075).
+
+Companion to #2074's telemetry. Counting alone ranks a cheap frequent failure
+above an expensive rare one; this joins the counts to roll durations from the
+timing dashboard's `runs.csv` so the ranking is by cost:
+
+    cost = occurrences x mean wasted roll seconds
+
+    poetry run python tools/prompt_revision_rank.py --repo /c/.../boostgauge
+
+A fingerprint with no duration data is ranked by occurrence count and flagged
+`duration-unknown`. It is never costed at zero -- that would sort the most
+expensive unmeasured failure to the bottom.
+
+Exit 0 always, including on an empty telemetry file: no failures recorded is a
+fact about the pipeline, not an error in this tool.
+
+The procedure this feeds is `docs/standards/0025-prompt-revision-from-telemetry.md`.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.speedrun.prompt_ranking import (  # noqa: E402
+    RUNS_CSV_REL,
+    TELEMETRY_REL,
+    load_durations,
+    load_telemetry,
+    rank,
+    render,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Rank drafter failure fingerprints by occurrences x mean wasted roll seconds."
+    )
+    parser.add_argument("--repo", required=True, help="repository whose telemetry to rank")
+    parser.add_argument("--top", type=int, default=0, help="show only the N most expensive")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo)
+    rows = load_telemetry(repo)
+    durations = load_durations(repo)
+
+    if not rows:
+        print(
+            f"No validation failures recorded at {repo / TELEMETRY_REL}.\n"
+            f"Telemetry populates from rolls run after it landed; an empty file "
+            f"means no roll has hit a validation failure since.",
+            flush=True,
+        )
+        return 0
+
+    if not durations:
+        print(
+            f"note: no durations at {repo / RUNS_CSV_REL} — every fingerprint will "
+            f"be flagged duration-unknown and ranked by count.",
+            flush=True,
+        )
+
+    ranked = rank(rows, durations)
+    if args.top > 0:
+        ranked = ranked[: args.top]
+    print(render(ranked), end="", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Three deliverables: the ranking tool, the written procedure, and one worked example. The loop
never ends, so the definition of done is the machinery plus a first application — not "prompts
are good now".

## 1. Ranking by cost

`tools/prompt_revision_rank.py` joins #2074's telemetry to roll durations from #2085's
`runs.csv`:

```
cost = occurrences × mean wasted roll seconds
```

Counting alone puts a cheap frequent failure above an expensive rare one, which is the wrong
order to fix things in. A test builds exactly that inversion and asserts the ranking corrects it.

**Unknown is not zero.** A fingerprint with no duration data is ranked by occurrence count and
flagged `duration-unknown` — listed after the costed entries, but never dropped and never costed
at zero. Zero would sort the most expensive *unmeasured* failure to the bottom, which is the
exact thing the ranking exists to surface.

The join needs no new column on either side: telemetry carries the events-log basename, which
encodes issue and HHMMSS, and `runs.csv` carries issue and `start_local`. A tag that matches
nothing yields unknown duration rather than a silent drop.

## 2. Procedure — `docs/standards/0025`

Rank by cost → record the before-rate → revise with a structural countermeasure → compare over
an N chosen in advance → keep or revert on that evidence.

Two things it insists on:

- **The before-rate is two numbers**, occurrences *and* blast radius. Sixteen failures inside
  one roll is a retry loop; sixteen across six rolls is a systematic prompt defect. The
  countermeasure differs.
- **"Please remember to…" in a system prompt is not a countermeasure.** If the revision cannot
  be pointed at as a concrete artifact the drafter consumes, it is not one.

Prompt-change PRs must quote the before-rate, which is what makes the revision history the
experiment log rather than a pile of accreted text.

## 3. Cold start, honoured

Telemetry is empty — #2074 landed today and no roll has run since. The tool reports that
correctly and exits 0. **No telemetry records were fabricated.** The worked example takes its
before-rate by hand from run logs, exactly as the issue requires.

## The worked example

Measured across boostgauge's 69 instrumented run logs:

| Failure | Occurrences | Blast radius |
|---|---|---|
| `Critical: Section ## N missing from LLD` | **32** (16 × `## 11`, 16 × `## 12`) | 6 of 69 rolls |
| `Critical: Section N.N missing from LLD` | 10 | — |
| `File marked Modify but does not exist` | 12 | — |
| `Section N.N table malformed or empty` | 2 | — |

The top target is the missing mandatory section, not the table-malformed case the issue cited
from a single log — the full distribution says otherwise.

**The diagnosis.** The template already contained both sections, so absence was not the cause.
What differs is *how the gate is stated*. Section 2.1 — the third mandatory section — carries an
in-place "**the LLD is BLOCKED**" warning on its own heading. Sections 11 and 12 stated their
gate only in prose further down, inside §12.1, which a drafter that stopped early never reaches.
2.1 is dropped 10 times against their 16 each.

**The countermeasure** copies the construct that demonstrably survives: an in-place
MANDATORY/BLOCKED marker on each of the two headings, naming the literal string the validator
matches (`## 11`) rather than prose. A test asserts the marker sits within 400 characters of each
heading, and a second asserts it names the literal string.

**N = 10 rolls**, measured with `prompt_revision_rank.py` once telemetry populates. Keep or
revert on that number.

## Tests

16 unit tests covering the five acceptance criteria plus the worked example.

Full suite green: 6976 passed, 17 skipped, 5 xfailed.

Closes #2075
