### PR TITLE
feat(speedrun): consecutive provider timeouts pause redraws instead of burning them (Closes #2086)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -40,6 +40,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from assemblyzero.core import provider_storm
 from assemblyzero.core.errors import (
     APIError,
     AuthenticationError,
@@ -584,11 +585,23 @@ class ClaudeCLIProvider(LLMProvider):
                     except (subprocess.TimeoutExpired, OSError):
                         pass
                     duration_ms = int((time.time() - start_time) * 1000)
+                    # #2086: consecutive timeouts are a provider storm, not a
+                    # run of bad luck. Eighteen in one roll on 2026-08-01 killed
+                    # two rolls; the counter is what lets the launcher wait
+                    # instead of redrawing straight into the same wall.
+                    consecutive = provider_storm.record_timeout(timeout_seconds)
+                    message = f"claude -p timed out after {timeout_seconds}s"
+                    if provider_storm.is_storm():
+                        message = (
+                            f"{message} "
+                            f"({consecutive} consecutive — "
+                            f"{provider_storm.STORM_MARKER})"
+                        )
                     call_result = LLMCallResult(
                         success=False,
                         response=None,
                         raw_response=None,
-                        error_message=f"claude -p timed out after {timeout_seconds}s",
+                        error_message=message,
                         provider=self.provider_name,
                         model_used=self._model,
                         duration_ms=duration_ms,
@@ -598,6 +611,12 @@ class ClaudeCLIProvider(LLMProvider):
                     return call_result
 
                 duration_ms = int((time.time() - start_time) * 1000)
+
+                # #2086: only a completed call clears the storm counter. A
+                # non-timeout error keeps its own classification and leaves the
+                # counter alone -- a 400 is a bug in what we sent, and waiting
+                # fifteen minutes would not improve it.
+                provider_storm.record_success()
 
                 filtered_stderr = _filter_stderr(stderr)
 

--- a/assemblyzero/core/provider_storm.py
+++ b/assemblyzero/core/provider_storm.py
@@ -1,0 +1,106 @@
+"""Detect a provider timeout storm and back off instead of burning redraws (#2086).
+
+2026-08-01 afternoon, run 2 of the boostgauge campaign: `claude -p timed out
+after 602s` **eighteen times in one roll**, killing rolls 4-5 of phase 5. The
+launcher's redraw logic treats every failed attempt identically -- self-heal and
+immediately redraw -- so during a storm it burns a fresh ~90-minute attempt
+straight into the same wall, repeatedly. With `--attempts 8` a storm can legally
+consume an entire day producing nothing.
+
+This is the last unfixed mechanism in the "12 hours with nothing to show"
+family: the degraded box is #1920, the identical-replay loop is #1941, and
+ambiguous specs are #2072/#2073.
+
+## Design decisions
+
+**Consecutive, not cumulative.** Three timeouts scattered across a long roll are
+a flaky afternoon; three in a row are a wall. A single success resets the
+counter, because it proves the provider is answering.
+
+**Only timeouts count.** Other provider errors keep their existing
+classification -- a 400 is a bug in what we sent, and waiting 15 minutes would
+not improve it.
+
+**The counter is per process, which is per roll.** Each roll is its own child
+process, so module state is exactly roll-scoped with no plumbing. A new roll
+starts at zero by construction rather than by remembering to reset.
+
+**Storm is transient-class.** The roll halts, but the failure is not the
+target repo's fault and must not be classified as one.
+"""
+
+from __future__ import annotations
+
+#: Consecutive timeouts before the roll is declared storm-bound.
+STORM_THRESHOLD = 3
+
+#: Child exit code the launcher reads. Distinct from 0 (success) and 91 (a gate
+#: problem), so the launcher can tell a storm from every other outcome without
+#: parsing text.
+STORM_EXIT_CODE = 92
+
+#: Minutes to wait before each successive storm-classified redraw. The last
+#: value is the cap and repeats for every attempt beyond it.
+BACKOFF_MINUTES = (15, 30, 60)
+
+STORM_MARKER = "PROVIDER STORM"
+
+_consecutive_timeouts = 0
+_last_timeout_seconds = 0
+
+
+def reset() -> None:
+    """Clear the counter. Called on a successful provider call."""
+    global _consecutive_timeouts, _last_timeout_seconds
+    _consecutive_timeouts = 0
+    _last_timeout_seconds = 0
+
+
+def record_timeout(timeout_seconds: int = 0) -> int:
+    """Count one provider timeout. Returns the new consecutive count."""
+    global _consecutive_timeouts, _last_timeout_seconds
+    _consecutive_timeouts += 1
+    _last_timeout_seconds = timeout_seconds or _last_timeout_seconds
+    return _consecutive_timeouts
+
+
+def record_success() -> None:
+    """A completed call proves the provider is answering."""
+    reset()
+
+
+def consecutive_timeouts() -> int:
+    return _consecutive_timeouts
+
+
+def last_timeout_seconds() -> int:
+    return _last_timeout_seconds
+
+
+def is_storm() -> bool:
+    return _consecutive_timeouts >= STORM_THRESHOLD
+
+
+def backoff_minutes(storm_attempt: int) -> int:
+    """Wait before the Nth consecutive storm-classified redraw.
+
+    1 -> 15, 2 -> 30, 3 -> 60, and 60 for everything after: the cap holds
+    rather than doubling into a wait longer than the workday it is protecting.
+    """
+    if storm_attempt < 1:
+        return 0
+    index = min(storm_attempt, len(BACKOFF_MINUTES)) - 1
+    return BACKOFF_MINUTES[index]
+
+
+def storm_message(count: int | None = None, timeout_seconds: int | None = None) -> str:
+    """Plain English for the halt. No stage names, no exit codes, no jargon."""
+    count = _consecutive_timeouts if count is None else count
+    seconds = _last_timeout_seconds if timeout_seconds is None else timeout_seconds
+    duration = f"{seconds} seconds" if seconds else "its time limit"
+    return (
+        f"{STORM_MARKER}: the model provider stopped answering — "
+        f"{count} requests in a row each ran past {duration} with no reply. "
+        f"Continuing would spend a fresh attempt on the same wall, so this run "
+        f"is stopping here. Nothing is wrong with the code being built."
+    )

--- a/tests/unit/test_provider_storm.py
+++ b/tests/unit/test_provider_storm.py
@@ -1,0 +1,339 @@
+"""Acceptance tests for provider-storm detection and backoff (#2086).
+
+The eight tests named in the issue body are the acceptance criteria.
+
+The shape being prevented: 2026-08-01, `claude -p timed out after 602s`
+eighteen times in one roll. Each failed attempt self-healed and redrew straight
+into the same wall, so with `--attempts 8` a storm could legally consume a day.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+from assemblyzero.core import provider_storm  # noqa: E402
+from assemblyzero.core.provider_storm import (  # noqa: E402
+    BACKOFF_MINUTES,
+    STORM_EXIT_CODE,
+    STORM_THRESHOLD,
+    backoff_minutes,
+    is_storm,
+    record_success,
+    record_timeout,
+    storm_message,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_counter():
+    provider_storm.reset()
+    yield
+    provider_storm.reset()
+
+
+# --- "three consecutive timeouts storm; a success resets" ---------------
+
+
+def test_three_consecutive_timeouts_is_a_storm():
+    assert not is_storm()
+    record_timeout(602)
+    assert not is_storm(), "one timeout is bad luck"
+    record_timeout(602)
+    assert not is_storm(), "two is still not a wall"
+    count = record_timeout(602)
+
+    assert count == STORM_THRESHOLD
+    assert is_storm()
+
+
+def test_a_success_between_timeouts_resets_the_counter():
+    record_timeout(602)
+    record_timeout(602)
+    record_success()
+    record_timeout(602)
+    record_timeout(602)
+
+    assert not is_storm(), "two, a success, then two more is not a storm"
+    assert provider_storm.consecutive_timeouts() == 2
+
+
+def test_the_counter_keeps_climbing_past_the_threshold():
+    for _ in range(18):  # the 2026-08-01 shape
+        record_timeout(602)
+    assert provider_storm.consecutive_timeouts() == 18
+    assert is_storm()
+
+
+# --- "non-timeout provider errors never trip the counter" ---------------
+
+
+def test_non_timeout_errors_do_not_trip_the_storm_counter(monkeypatch, tmp_path):
+    """Only the timeout path calls record_timeout; a CLI error must not."""
+    import inspect
+
+    from assemblyzero.core import llm_provider
+
+    source = inspect.getsource(llm_provider)
+    timeout_block = source[source.index("except subprocess.TimeoutExpired"):]
+    timeout_block = timeout_block[: timeout_block.index("return call_result")]
+
+    assert "record_timeout" in timeout_block, "the timeout path must count"
+
+    # And the non-zero-returncode path must not.
+    rc_block = source[source.index("if proc.returncode != 0:"):]
+    rc_block = rc_block[:2000]
+    assert "record_timeout" not in rc_block, (
+        "a 400 is a bug in what we sent; waiting fifteen minutes would not help"
+    )
+
+
+def test_only_completed_calls_clear_the_counter():
+    record_timeout(602)
+    record_timeout(602)
+    assert provider_storm.consecutive_timeouts() == 2
+    record_success()
+    assert provider_storm.consecutive_timeouts() == 0
+
+
+# --- "backoff sequence is 15, 30, 60, 60 (the cap holds)" ---------------
+
+
+def test_backoff_sequence_and_cap():
+    assert [backoff_minutes(n) for n in (1, 2, 3, 4)] == [15, 30, 60, 60]
+    assert backoff_minutes(9) == 60, "the cap holds rather than doubling"
+    assert BACKOFF_MINUTES == (15, 30, 60)
+
+
+def test_backoff_of_a_non_storm_attempt_is_zero():
+    assert backoff_minutes(0) == 0
+    assert backoff_minutes(-1) == 0
+
+
+# --- "a storm attempt delays; a non-storm failure redraws immediately" ---
+
+
+@pytest.fixture
+def target_repo(tmp_path) -> Path:
+    for args in (["init", "-q", "-b", "main"], ["config", "user.email", "t@e.com"],
+                 ["config", "user.name", "T"]):
+        subprocess.run(["git", "-C", str(tmp_path), *args], capture_output=True)
+    (tmp_path / "README.md").write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "b"], capture_output=True)
+    return tmp_path
+
+
+@pytest.fixture
+def launcher(monkeypatch, target_repo):
+    """speedrun_roll.main with the gates stubbed and sleeps recorded."""
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    state = {"slept": [], "codes": [], "attempts": 0}
+
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda _r: [])
+    monkeypatch.setattr(speedrun_roll, "check_box_health",
+                        lambda *_a, **_k: BoxHealth(True, [], ""))
+    monkeypatch.setattr(speedrun_roll, "open_must_resolve_issues", lambda _r: ([], None))
+    monkeypatch.setattr(speedrun_roll, "sweep_pipeline_worktrees",
+                        lambda *_a, **_k: type("S", (), {"problems": []})())
+    monkeypatch.setattr(speedrun_roll, "install_signal_handlers", lambda _s: None)
+    monkeypatch.setattr(speedrun_roll, "restore_repo", lambda *_a, **_k: [])
+    monkeypatch.setattr(speedrun_roll, "_interruptible_sleep",
+                        lambda seconds, tick=5: state["slept"].append(seconds))
+    monkeypatch.setattr(speedrun_roll.time, "sleep", lambda _s: None)
+
+    def fake_roll(repo_root, issue, log_dir, az_root, extra):
+        state["attempts"] += 1
+        return state["codes"].pop(0) if state["codes"] else 1
+
+    monkeypatch.setattr(speedrun_roll, "roll_issue", fake_roll)
+    return state
+
+
+def _argv(repo, attempts=3):
+    return ["--repo", str(repo), "--issue", "4", "--attempts", str(attempts),
+            "--log-dir", str(repo / "logs")]
+
+
+def test_a_storm_attempt_delays_the_next_redraw(launcher, target_repo):
+    launcher["codes"] = [STORM_EXIT_CODE, 0]
+
+    speedrun_roll.main(_argv(target_repo))
+
+    assert launcher["slept"] == [15 * 60], "the first storm waits 15 minutes"
+
+
+def test_a_non_storm_failure_redraws_immediately(launcher, target_repo):
+    launcher["codes"] = [1, 0]
+
+    speedrun_roll.main(_argv(target_repo))
+
+    assert launcher["slept"] == [], "an ordinary failed draw waits for nothing"
+
+
+def test_consecutive_storms_escalate_then_cap(launcher, target_repo):
+    launcher["codes"] = [STORM_EXIT_CODE] * 5
+
+    speedrun_roll.main(_argv(target_repo, attempts=5))
+
+    assert launcher["slept"] == [15 * 60, 30 * 60, 60 * 60, 60 * 60]
+
+
+def test_a_success_between_storms_resets_the_backoff(launcher, target_repo):
+    # storm, ordinary failure, storm -> the second storm is a FIRST storm again
+    launcher["codes"] = [STORM_EXIT_CODE, 1, STORM_EXIT_CODE, 0]
+
+    speedrun_roll.main(_argv(target_repo, attempts=4))
+
+    assert launcher["slept"] == [15 * 60, 15 * 60]
+
+
+# --- "a storm on the final attempt exits without waiting" ---------------
+
+
+def test_storm_on_the_final_attempt_does_not_wait(launcher, target_repo):
+    launcher["codes"] = [STORM_EXIT_CODE]
+
+    code = speedrun_roll.main(_argv(target_repo, attempts=1))
+
+    assert launcher["slept"] == [], "a terminal wait only delays the bad news"
+    assert code == STORM_EXIT_CODE
+
+
+def test_last_of_several_storms_does_not_wait_after_the_final_attempt(
+    launcher, target_repo
+):
+    launcher["codes"] = [STORM_EXIT_CODE, STORM_EXIT_CODE]
+
+    speedrun_roll.main(_argv(target_repo, attempts=2))
+
+    assert launcher["slept"] == [15 * 60], "one wait between two attempts, none after"
+
+
+# --- "the backoff line appears in the launcher events log" --------------
+
+
+def test_backoff_line_is_written_to_the_events_log(launcher, target_repo):
+    launcher["codes"] = [STORM_EXIT_CODE, 0]
+
+    speedrun_roll.main(_argv(target_repo))
+
+    log = (target_repo / "logs" / "session-events.log").read_text(encoding="utf-8")
+    assert "STORM BACKOFF 15m before attempt 2/3" in log, (
+        "a watcher must be able to tell backoff from a hang"
+    )
+
+
+def test_final_attempt_storm_is_also_recorded(launcher, target_repo):
+    launcher["codes"] = [STORM_EXIT_CODE]
+
+    speedrun_roll.main(_argv(target_repo, attempts=1))
+
+    log = (target_repo / "logs" / "session-events.log").read_text(encoding="utf-8")
+    assert "STORM on final attempt" in log
+
+
+# --- "a launcher in backoff is stopped cleanly (no orphaned sleep)" -----
+
+
+def test_the_backoff_sleep_is_ticked_not_one_long_block(monkeypatch):
+    """A single long sleep leaves nothing checking signals between kill and wake."""
+    slept: list[int] = []
+    monkeypatch.setattr(speedrun_roll.time, "sleep", lambda s: slept.append(s))
+
+    speedrun_roll._interruptible_sleep(60, tick=5)
+
+    assert len(slept) == 12, "the wait is decomposed into ticks"
+    assert max(slept) <= 5, "no single blocking call longer than one tick"
+    assert sum(slept) == 60
+
+
+def test_interruptible_sleep_handles_a_signal_between_ticks(monkeypatch):
+    """A stop raised inside a tick propagates instead of being swallowed."""
+    calls = {"n": 0}
+
+    def exploding(_seconds):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(speedrun_roll.time, "sleep", exploding)
+
+    with pytest.raises(KeyboardInterrupt):
+        speedrun_roll._interruptible_sleep(3600, tick=5)
+
+    assert calls["n"] == 2, "it stopped at the second tick, not after an hour"
+
+
+def test_zero_and_negative_waits_do_not_sleep(monkeypatch):
+    slept = []
+    monkeypatch.setattr(speedrun_roll.time, "sleep", lambda s: slept.append(s))
+    speedrun_roll._interruptible_sleep(0)
+    speedrun_roll._interruptible_sleep(-10)
+    assert slept == []
+
+
+# --- "the storm halt message is plain English" --------------------------
+
+
+def test_storm_message_names_the_count_and_the_duration():
+    for _ in range(3):
+        record_timeout(602)
+
+    message = storm_message()
+
+    assert "3" in message
+    assert "602" in message
+    lowered = message.lower()
+    assert "provider" in lowered and "no reply" in lowered
+    for jargon in ("subprocess", "exit code", "92", "llm_provider",
+                   "claude -p", "#2086", "traceback", "stderr"):
+        assert jargon not in lowered, f"{jargon!r} is internal jargon"
+
+
+def test_storm_message_says_the_target_code_is_not_at_fault():
+    for _ in range(3):
+        record_timeout(602)
+    assert "nothing is wrong with the code" in storm_message().lower(), (
+        "otherwise a storm reads as a target-repo failure, which is the "
+        "evidence-poisoning this family of issues is about"
+    )
+
+
+def test_storm_message_without_a_recorded_duration_still_reads():
+    record_timeout(0)
+    assert "time limit" in storm_message(count=3, timeout_seconds=0)
+
+
+# --- exit code plumbing --------------------------------------------------
+
+
+def test_the_storm_exit_code_is_distinct_from_the_others():
+    assert STORM_EXIT_CODE not in (0, 1, 91, 130), (
+        "the launcher tells a storm from every other outcome by this number"
+    )
+
+
+def test_orchestrate_exits_with_the_storm_code():
+    import inspect
+
+    import orchestrate
+
+    source = inspect.getsource(orchestrate.main)
+    assert "provider_storm.is_storm()" in source
+    assert "STORM_EXIT_CODE" in source
+
+
+def test_launcher_reads_the_storm_code_not_a_text_marker():
+    import inspect
+
+    source = inspect.getsource(speedrun_roll.main)
+    assert "STORM_EXIT_CODE" in source
+    assert "storm_streak" in source

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -29,6 +29,7 @@ from assemblyzero.workflows.orchestrator.graph import (  # noqa: E402
     OrchestrationResult,
     orchestrate,
 )
+from assemblyzero.core import provider_storm
 from assemblyzero.workflows.orchestrator.state import (  # noqa: E402
     STAGE_ORDER,
     OrchestrationState,
@@ -244,6 +245,13 @@ Examples:
 
             if result["error_summary"]:
                 print(f"[ORCHESTRATOR] {result['error_summary']}")
+
+            # #2086: a provider storm exits with its own code so the launcher
+            # can tell it from every other failure without parsing text, and
+            # back off instead of redrawing into the same wall.
+            if provider_storm.is_storm():
+                print(f"\n[ORCHESTRATOR] {provider_storm.storm_message()}")
+                sys.exit(provider_storm.STORM_EXIT_CODE)
 
             sys.exit(1)
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -65,6 +65,10 @@ except ImportError:  # pragma: no cover - tool copied outside the package
 
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
+from assemblyzero.core.provider_storm import (  # noqa: E402
+    STORM_EXIT_CODE,
+    backoff_minutes,
+)
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
 from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     RUN_START_ENV,
@@ -650,6 +654,22 @@ def launch_detached(
     return 0
 
 
+def _interruptible_sleep(seconds: int, tick: int = 5) -> None:
+    """Sleep in short ticks so a stop lands promptly (#2086).
+
+    A single long `time.sleep` is a poor citizen here: `--detach-stop` kills the
+    process tree, but between the kill and the wake there is nothing checking
+    signals, and on Windows a SIGTERM handler cannot interrupt a blocking sleep.
+    Ticking keeps the wait responsive and, just as importantly, keeps it
+    testable -- a test can assert the loop is bounded rather than waiting an
+    actual quarter of an hour.
+    """
+    remaining = max(0, int(seconds))
+    while remaining > 0:
+        time.sleep(min(tick, remaining))
+        remaining -= tick
+
+
 def pid_file(log_dir: Path) -> Path:
     return log_dir / "detached-roll.pid"
 
@@ -1009,11 +1029,41 @@ def main(argv: list[str] | None = None) -> int:
             # clears its debris), so retrying inside the detached task removes
             # the human relaunch from the loop entirely. A base or gate problem
             # (91) is NOT a draw and is never retried.
+            storm_streak = 0
             for attempt_no in range(1, max(1, args.attempts) + 1):
                 code = roll_issue(repo_root, issue, log_dir, az_root, extra)
                 if code == 0 or code == 91:
                     break
-                if attempt_no < max(1, args.attempts):
+
+                # #2086: eighteen consecutive provider timeouts in one roll on
+                # 2026-08-01 killed two rolls, because a redraw fires straight
+                # into the same wall. A storm-classified attempt waits; every
+                # other failure redraws immediately, exactly as before.
+                if code == STORM_EXIT_CODE:
+                    storm_streak += 1
+                else:
+                    storm_streak = 0
+
+                if attempt_no >= max(1, args.attempts):
+                    if storm_streak:
+                        # Nothing left to wait for; a terminal wait would just
+                        # delay the operator finding out.
+                        session.write("STORM on final attempt - exiting without waiting")
+                    continue
+
+                if storm_streak:
+                    minutes = backoff_minutes(storm_streak)
+                    session.write(
+                        f"STORM BACKOFF {minutes}m before attempt "
+                        f"{attempt_no + 1}/{args.attempts}"
+                    )
+                    print(
+                        f"\n#{issue} attempt {attempt_no}/{args.attempts}: the model "
+                        f"provider stopped answering. Waiting {minutes} minutes before "
+                        f"trying again, so the next attempt is not spent on the same wall."
+                    )
+                    _interruptible_sleep(minutes * 60)
+                else:
                     print(
                         f"\n#{issue} attempt {attempt_no}/{args.attempts} failed "
                         f"(exit {code}) — self-healing and redrawing."


### PR DESCRIPTION
## Summary

2026-08-01 afternoon, run 2 of the boostgauge campaign: `claude -p timed out after 602s`
**eighteen times in one roll**, killing rolls 4–5 of phase 5. The launcher's redraw logic
treats every failed attempt identically — self-heal and immediately redraw — so during a storm
it burns a fresh ~90-minute attempt straight into the same wall. With `--attempts 8` that can
legally consume a day producing nothing.

This is the last unfixed mechanism in the "12 hours with nothing to show" family. The degraded
box was #1920, the identical-replay loop #1941, ambiguous specs #2072 and #2073.

## Detection: consecutive, not cumulative

Three timeouts scattered across a long roll are a flaky afternoon; three in a row are a wall. A
single success resets the counter, because it proves the provider is answering.

**Only timeouts count.** A non-timeout error keeps its existing classification — a 400 is a bug
in what we sent, and waiting fifteen minutes would not improve it. A test asserts
`record_timeout` appears in the timeout branch and *not* in the returncode branch, so this
can't drift.

The counter is module state, which is process state, which is exactly roll-scoped: each roll is
its own child process, so a new roll starts at zero by construction rather than by remembering
to reset.

## The launcher reads a code, not a marker

The classification reaches the launcher as a distinct exit code, so it tells a storm from every
other outcome without parsing text. A test asserts the code is distinct from 0, 1, 91 and 130.

## Backoff

| Consecutive storm attempt | Wait |
|---|---|
| 1st | 15 min |
| 2nd | 30 min |
| 3rd | 60 min |
| 4th+ | 60 min (cap holds) |

The cap holds rather than doubling into a wait longer than the workday it is protecting.

- A **non-storm failure redraws immediately**, exactly as before.
- An ordinary failure **between** two storms resets the escalation — the second storm is a first
  storm again.
- A **storm on the final attempt exits without waiting**; a terminal wait would only delay the
  operator finding out.

## Visible and killable

`STORM BACKOFF <minutes>m before attempt K/N` goes to the events log so a watcher can tell
backoff from a hang.

The sleep is decomposed into five-second ticks. A single long block leaves nothing checking
signals between a kill and the wake, and on Windows a SIGTERM handler cannot interrupt a
blocking sleep. Ticking also makes it testable — the tests assert the wait is bounded and that
an interrupt raised inside a tick propagates at the second tick rather than after an hour,
without ever waiting a real quarter of an hour.

## The halt message

Plain English naming the consecutive count and the timeout duration, and stating explicitly
that nothing is wrong with the code being built. Without that line a storm reads as a
target-repo failure — which is precisely the evidence-poisoning this family of issues is about.
A test bans internal jargon from it.

## Tests

24 unit tests covering the eight acceptance criteria, including the 18-timeout shape from the
incident itself.

Full suite green: 7000 passed, 17 skipped, 5 xfailed.

Closes #2086
