### PR TITLE
docs(runbook): operator-solo speedrun — launch, watch cheaply, stop, inspect (Closes #2087)

### DIFF
--- a/docs/babysit-protocol.md
+++ b/docs/babysit-protocol.md
@@ -1,5 +1,14 @@
 # Babysit Protocol (The Perdita Protocol)
 
+> **Solo operation is the default; this document is the exception (#2087).**
+> For an ordinary campaign run — launch, walk away, evaluate afterwards from
+> artifacts — follow `docs/runbooks/0952-speedrun-operator-solo.md`. Watching a
+> run costs tokens for the whole of its duration to learn what the logs already
+> record.
+>
+> Use this protocol only when you intend to **intervene mid-run**: debugging a
+> new failure mode live, or validating a change to the pipeline itself.
+
 When the user says "babysit": run a workflow in the background, monitor its execution mechanically, and intervene only when the **Perdita Protocol** guardrails are triggered.
 
 ## The Perdita Shift (Mechanical Monitoring)

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -1,0 +1,285 @@
+# 0952 — Operator-solo speedrun: launch, watch cheaply, stop, inspect
+
+- **Date:** 2026-08-02
+- **Issue:** #2087
+- **Status:** Active. This is the default way to run the campaign. `docs/babysit-protocol.md` is the exception, for live-intervention debugging.
+
+The campaign's original goal was that the operator runs one command, records the
+output, and no agent watches anything. The instrumentation for that now exists —
+events/heartbeat/stdout triplets, launcher narration, preflight and storm
+classifications, failure telemetry, the timing dashboard, the run archiver — but
+the operator-facing procedure did not. This is it.
+
+**Watching costs tokens. Reading artifacts afterwards is nearly free.** An agent
+tailing a log for ninety minutes spends a fortune to learn what the log already
+records. Launch, walk away, and hand an agent § Inspect when it is done.
+
+Every command below was executed once while writing this file. The one exception
+is named in § Launch, with its reason.
+
+---
+
+## § Launch
+
+**Operator.** From the AssemblyZero checkout:
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/speedrun_roll.py \
+    --repo /c/Users/mcwiz/Projects/boostgauge \
+    --issue 1 --issue 4 --issue 7 \
+    --attempts 3 \
+    --detach
+```
+
+Flags, verified against `poetry run python tools/speedrun_roll.py --help` rather
+than transcribed:
+
+| Flag | Meaning |
+|---|---|
+| `--repo` | target repo root (required) |
+| `--issue` | issue to roll — **repeatable**, rolled in order |
+| `--attempts` | redraw a failed issue up to N times before stopping. Base/gate problems never retry. |
+| `--detach` | run via Windows Task Scheduler so the roll outlives this session, then return immediately |
+| `--log-dir` | where the triplets land. Default `<repo>/data/speedrun/runs` |
+| `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
+| `--detach-stop` | stop a detached roll and everything it spawned |
+
+**Use `--detach`.** A roll started from a session is a descendant of that
+session's shell, and a harness kill of the shell takes the whole tree with it.
+A scheduled task is parented by the Task Scheduler service instead, so nothing
+done to the launching session can reach it.
+
+> **The launch command is the one command in this runbook not executed during
+> authoring.** Running it would start a real pipeline roll, and the shakedown of
+> the new gates is deliberately the operator's own session. Its flags are
+> verified against `--help` above, which is what the issue's acceptance asks for.
+
+### What can refuse to launch, and what you do about it
+
+All three gates run **before anything is spent** — no branch is created, no
+tokens are used. All three exit **91**.
+
+| Refusal | What it means | What you do |
+|---|---|---|
+| The AssemblyZero tree is not trustworthy | this checkout is behind or dirty, so the roll would execute pipeline code that `main` does not describe | bring it level with `origin/main`, or point `--assemblyzero-root` at a tree that is |
+| This machine is not healthy enough | a quick self-check ran far slower than normal, or memory is above 90% | wait for the machine to recover, or find what is loading it. Do not override it — a roll on a sick box wastes hours *and* makes every failure look like a target-repo problem |
+| The repository has unanswered questions | one or more issues are open asking you to rule on ambiguous issue text | read each, decide which reading is right, edit the issue so only one survives, close the question |
+
+**The first-ever run on a machine records the health baseline and proceeds.** A
+missing baseline never blocks. Nominal is a rolling median over five runs, so it
+tracks the machine rather than one lucky run.
+
+---
+
+## § Watch — optional, and free
+
+**Operator.** One file. Do not tail anything else:
+
+```bash
+tail -f /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/detached-launcher.log
+```
+
+Healthy output looks like this — a `BASE` line, then a `LAUNCH` line per roll:
+
+```
+2026-08-01 16:34:55 BASE 'hardening-run-16' clean for #2 after self-heal
+2026-08-01 16:34:55 LAUNCH base=hardening-run-16 -> run-issue2-163450.log
+```
+
+**Liveness lives in the heartbeat, not the launcher log.** A roll writes a beat
+every 15 seconds; the last beat is the time of death under an uncatchable kill.
+A quiet launcher log during a long stage is normal. A heartbeat that stopped is
+not:
+
+```bash
+tail -3 /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/run-issue1-051632-heartbeat.log
+```
+
+```
+2026-08-01 05:23:03 alive
+2026-08-01 05:23:18 alive
+2026-08-01 05:23:33 alive
+```
+
+**A backoff is not a hang.** When the model provider stops answering, the
+launcher waits rather than burning a fresh attempt on the same wall, and says so:
+
+```
+STORM BACKOFF 15m before attempt 2/3
+```
+
+Waits are 15, then 30, then 60 minutes, capped at 60. A storm on the final
+attempt exits immediately rather than waiting for nothing.
+
+**The one rule from the watchdog doctrine:** a stage running past three times its
+nominal is a fault, not patience. Waiting longer has never once helped.
+
+---
+
+## § Done, or dead?
+
+Three independent signals. Use more than one.
+
+```bash
+# 1. Did the launcher finish? Look for a terminal line per issue.
+tail -20 /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/detached-launcher.log
+
+# 2. Is anything still beating? A fresh timestamp means alive.
+ls -t /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/*-heartbeat.log | head -1 | xargs tail -2
+
+# 3. What does Windows think? Ready == not running.
+MSYS_NO_PATHCONV=1 schtasks /Query /TN AZ-SpeedrunRoll
+```
+
+```
+TaskName                                 Next Run Time          Status
+======================================== ====================== ===============
+AZ-SpeedrunRoll                          N/A                    Ready
+```
+
+`Running` means it is still going. `Ready` means it is not.
+
+> **`MSYS_NO_PATHCONV=1` is load-bearing here.** Without it Git Bash rewrites
+> `/Query` into `C:/Program Files/Git/Query` and schtasks rejects it. This bit
+> the author of this runbook while writing this very line.
+
+---
+
+## § Stop
+
+**Operator.**
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/speedrun_roll.py \
+    --repo /c/Users/mcwiz/Projects/boostgauge --detach-stop
+```
+
+With nothing running it says so and exits 0:
+
+```
+No recorded pid at C:\Users\mcwiz\Projects\boostgauge\data\speedrun\runs\detached-roll.pid.
+```
+
+**What it does:** kills the detached launcher and every process it spawned.
+
+**What it does not do:** it does not revert the target repo, delete a worktree,
+close a PR, or roll back a branch. Whatever the roll had already written is still
+there. That is deliberate — a stop should not also destroy the evidence of why
+you stopped it. Clean-up happens on the next launcher start, which sweeps every
+pipeline worktree: clean ones are removed, dirty ones have their content
+committed to a `graveyard/*` branch first, and directories git no longer tracks
+are relocated rather than deleted.
+
+---
+
+## § Inspect — the post-run evaluation
+
+**Agent.** Executed by *reading artifacts*, not by having watched. Work top to
+bottom; each step names its own file or tool.
+
+**1. The roll-by-roll record.** Read the launcher narration end to end. It is the
+only file that shows the sequence of attempts, self-heals, redraws and backoffs.
+
+```bash
+cat /c/Users/mcwiz/Projects/<repo>/data/speedrun/runs/detached-launcher.log
+```
+
+**2. Per-roll outcome.** Each roll has a triplet — `<tag>-events.log` (START /
+BASE / LAUNCH / EXIT), `<tag>.log` (orchestrator stdout, including the stage
+table), `<tag>-heartbeat.log`. The events log's `EXIT rc=` is authoritative for
+success; the stage table in the stdout log says which stage failed and whether a
+retry was `RESUMED` or `REGENERATED`.
+
+```bash
+ls /c/Users/mcwiz/Projects/<repo>/data/speedrun/runs/*-events.log | tail -5
+```
+
+**3. Validation-failure telemetry.** One record per drafter validation failure,
+fingerprinted.
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/prompt_failure_report.py --repo /c/Users/mcwiz/Projects/<repo>
+```
+
+An empty file is a real answer, not a broken tool:
+
+```
+No telemetry file at C:\Users\mcwiz\Projects\boostgauge\data\speedrun\telemetry\prompt-failures.jsonl
+```
+
+If it has content, rank it by cost and follow
+`docs/standards/0025-prompt-revision-from-telemetry.md`:
+
+```bash
+poetry run python tools/prompt_revision_rank.py --repo /c/Users/mcwiz/Projects/<repo>
+```
+
+**4. Regenerate the timing dashboard.** Where the wall-clock went.
+
+```bash
+poetry run python tools/campaign_timing_dashboard.py --repo /c/Users/mcwiz/Projects/<repo>
+```
+
+Writes `data/speedrun/analysis/runs.csv` and `campaign-timing.png` under the
+target repo. Read the CSV; the PNG is for the operator.
+
+**5. Questions the run raised.** If any rolls halted on ambiguous issue text,
+they filed issues. These block the next launch until ruled on.
+
+```bash
+gh issue list --repo martymcenroe/<repo> --label must-resolve --state open
+```
+
+Empty output means none are open.
+
+**6. Archive the run.** Last, because it is the only step that is unrecoverable
+if skipped — arcs are never merged to main, so a run's product lives only on
+branches and in logs.
+
+```bash
+poetry run python tools/speedrun_archive.py \
+    --repo /c/Users/mcwiz/Projects/<repo> --run <integration-branch> --dry-run
+poetry run python tools/speedrun_archive.py \
+    --repo /c/Users/mcwiz/Projects/<repo> --run <integration-branch>
+```
+
+**Verify `"complete": true` in the archive's `index.json`.** The command exits
+nonzero and names the missing component when it is not. A partial archive never
+authorizes deleting anything.
+
+### The paste block
+
+Give this to any agent, verbatim. Evaluation should be one paste, not a
+conversation.
+
+```
+Evaluate speedrun run <RUN-NAME> in <REPO-PATH> per AssemblyZero
+docs/runbooks/0952-speedrun-operator-solo.md § Inspect.
+
+Read artifacts only — do not launch, re-run, or resume anything, and do not
+delete any branch or worktree. Work steps 1 through 6 in order and report:
+
+  1. rolls attempted, and the outcome of each
+  2. which stage failed on each failed roll, and whether its retry RESUMED or
+     REGENERATED
+  3. any provider-storm backoffs, with their durations
+  4. the top validation-failure fingerprints by cost, or "telemetry empty"
+  5. run time vs diagnose+fix time for the run's dates
+  6. any must-resolve issues now open
+  7. the archive path and whether index.json says complete: true
+
+Finish with the single highest-value change to make before the next run, and
+the evidence for it.
+```
+
+---
+
+## Related
+
+- `docs/babysit-protocol.md` — the agent-watching model this replaces. Use it
+  only when you intend to intervene mid-run.
+- `docs/standards/0025-prompt-revision-from-telemetry.md` — what to do with the
+  telemetry once step 3 has ranked it.

--- a/tests/unit/test_solo_runbook.py
+++ b/tests/unit/test_solo_runbook.py
@@ -1,0 +1,193 @@
+"""Acceptance tests for the operator-solo runbook (#2087).
+
+A runbook rots silently: a flag is renamed, a tool moves, and the document keeps
+claiming otherwise until an operator follows it at 2am and it does not work.
+These assert the claims against the code they describe.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNBOOK = ROOT / "docs/runbooks/0952-speedrun-operator-solo.md"
+BABYSIT = ROOT / "docs/babysit-protocol.md"
+
+
+def _text() -> str:
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+# --- "the runbook exists and follows the section conventions" -----------
+
+
+def test_runbook_exists_with_the_required_sections():
+    assert RUNBOOK.is_file()
+    text = _text()
+    for heading in ("## § Launch", "## § Watch", "## § Done", "## § Stop", "## § Inspect"):
+        assert heading in text, f"missing {heading}"
+
+
+def test_runbook_has_a_dated_header_with_its_issue():
+    text = _text()
+    assert "**Issue:** #2087" in text
+    assert re.search(r"\*\*Date:\*\* \d{4}-\d{2}-\d{2}", text)
+
+
+# --- "contains the paste-block evaluation prompt" -----------------------
+
+
+def test_runbook_contains_the_paste_block():
+    text = _text()
+    assert "### The paste block" in text
+    assert "per AssemblyZero" in text
+    assert "0952-speedrun-operator-solo.md § Inspect" in text, (
+        "the prompt must name the runbook it comes from, or a pasted prompt "
+        "is unmoored from its procedure"
+    )
+
+
+def test_the_paste_block_forbids_the_agent_launching_anything():
+    block = _text()[_text().index("### The paste block"):]
+    # Collapse whitespace: the prompt is hard-wrapped, so a phrase can straddle
+    # a newline and a naive substring check would miss it.
+    flat = " ".join(block.lower().split())
+
+    assert "do not launch" in flat
+    assert "do not delete any branch or worktree" in flat
+
+
+# --- "the launch section's flags match --help exactly" ------------------
+
+
+def _help_flags() -> set[str]:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools/speedrun_roll.py"), "--help"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(ROOT), timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    return set(re.findall(r"--[a-z][a-z-]+", result.stdout))
+
+
+def test_every_flag_the_runbook_names_exists_in_help():
+    documented = set(re.findall(r"`(--[a-z][a-z-]+)`", _text()))
+    # Flags named in the runbook's own prose about other tools are filtered by
+    # taking only those in the launch table, which uses backticks exclusively.
+    real = _help_flags()
+    launcher_flags = {f for f in documented if f in real or f.startswith("--detach")}
+
+    assert launcher_flags, "the runbook must document the launcher's flags"
+    for flag in launcher_flags:
+        assert flag in real, f"{flag} is documented but not in --help"
+
+
+def test_the_runbook_documents_every_launcher_flag():
+    real = _help_flags() - {"--help"}
+    text = _text()
+    for flag in real:
+        assert f"`{flag}`" in text, f"{flag} exists but the runbook never mentions it"
+
+
+# --- "the inspect checklist names tools and paths that exist" -----------
+
+
+def test_every_tool_the_runbook_invokes_exists():
+    text = _text()
+    invoked = set(re.findall(r"tools/([a-z_]+\.py)", text))
+    assert invoked, "the inspect section must name concrete tools"
+    for tool in invoked:
+        assert (ROOT / "tools" / tool).is_file(), f"tools/{tool} does not exist"
+
+
+def test_every_referenced_document_exists():
+    text = _text()
+    for rel in set(re.findall(r"`(docs/[a-z0-9/._-]+\.md)`", text)):
+        assert (ROOT / rel).is_file(), f"{rel} does not exist"
+
+
+def test_the_inspect_section_covers_all_six_steps():
+    text = _text()
+    section = text[text.index("## § Inspect"):]
+    for step in ("**1.", "**2.", "**3.", "**4.", "**5.", "**6."):
+        assert step in section, f"inspect step {step} missing"
+
+    lowered = section.lower()
+    assert "detached-launcher.log" in lowered
+    assert "prompt_failure_report.py" in lowered
+    assert "campaign_timing_dashboard.py" in lowered
+    assert "must-resolve" in lowered
+    assert "speedrun_archive.py" in lowered
+    assert "complete" in lowered and "index.json" in lowered
+
+
+def test_the_archive_step_requires_verifying_completeness():
+    section = _text()[_text().index("## § Inspect"):]
+    assert '"complete": true' in section, (
+        "a partial archive must never be reported as done"
+    )
+
+
+# --- "babysit-protocol.md gains the pointer" ----------------------------
+
+
+def test_babysit_protocol_points_at_the_solo_runbook_first():
+    text = BABYSIT.read_text(encoding="utf-8")
+    head = text[:1200]
+
+    assert "0952-speedrun-operator-solo.md" in head, (
+        "the pointer must be at the top, where someone opening the file sees it"
+    )
+    assert "default" in head.lower()
+    assert "exception" in head.lower()
+
+
+# --- the gates the runbook promises are actually wired ------------------
+
+
+def test_the_three_launch_gates_named_in_the_runbook_are_real():
+    """Each refusal row must correspond to something in the launcher."""
+    import importlib
+
+    sys.path.insert(0, str(ROOT / "tools"))
+    speedrun_roll = importlib.import_module("speedrun_roll")
+    import inspect as _inspect
+
+    source = _inspect.getsource(speedrun_roll.main)
+    assert "check_assemblyzero_tree" in source
+    assert "check_box_health" in source
+    assert "open_must_resolve_issues" in source
+
+
+def test_the_storm_backoff_line_the_runbook_quotes_is_the_real_format():
+    import importlib
+    import inspect as _inspect
+
+    sys.path.insert(0, str(ROOT / "tools"))
+    speedrun_roll = importlib.import_module("speedrun_roll")
+
+    source = _inspect.getsource(speedrun_roll.main)
+    assert "STORM BACKOFF" in source
+    assert "STORM BACKOFF 15m before attempt 2/3" in _text(), (
+        "the runbook quotes a sample line; it must match the emitted format"
+    )
+
+
+def test_the_task_name_the_runbook_queries_is_the_real_one():
+    import importlib
+
+    sys.path.insert(0, str(ROOT / "tools"))
+    speedrun_roll = importlib.import_module("speedrun_roll")
+
+    assert speedrun_roll.TASK_NAME in _text(), (
+        "the status command must query the task the launcher actually creates"
+    )
+
+
+def test_the_runbook_carries_the_msys_guard_on_the_schtasks_command():
+    """Without it Git Bash rewrites /Query into a path and schtasks refuses."""
+    text = _text()
+    index = text.index("schtasks /Query")
+    assert "MSYS_NO_PATHCONV=1" in text[max(0, index - 120):index]


### PR DESCRIPTION
## Summary

The campaign's original goal was that the operator runs one command, records the output, and
no agent watches anything. The instrumentation for that now exists — the events/heartbeat/stdout
triplets, launcher narration, preflight and storm classifications, failure telemetry, the timing
dashboard, the run archiver — but the operator-facing procedure did not. The only written
protocol was `docs/babysit-protocol.md`, the agent-watches model this replaces.

Watching costs tokens for a run's whole duration to learn what the logs already record. Reading
artifacts afterwards is nearly free.

New runbook: `docs/runbooks/0952-speedrun-operator-solo.md`.

## Written last, deliberately

It documents the launch gates and inspect tools that #2085, #2075 and #2086 shipped today, so it
describes what actually landed rather than what was planned.

## Every command was executed while writing it

Including `--help`, the launcher-log and heartbeat tails, the scheduled-task query,
`--detach-stop`, the telemetry report, the timing dashboard, the must-resolve query, and the
archive dry run. The samples in the runbook are real output, not illustrations.

**One exception, stated in the runbook rather than left implicit:** the launch command itself
was not run, because it would start a real pipeline roll and the shakedown of the new gates is
deliberately the operator's own session. Its flags are verified against `--help`, which is what
the acceptance asks for.

## Authoring surfaced a real trap

Git Bash rewrites `schtasks /Query` into `C:/Program Files/Git/Query` and schtasks refuses it.
The status command carries `MSYS_NO_PATHCONV=1`, and the runbook says why — it bit the author
while writing that line. There is a test asserting the guard stays.

## Structure

- **§ Launch** — the invocation, a flag table verified against `--help`, and a table of what each
  of the three preflight gates can refuse for and what the operator does about it. All three
  refuse before anything is spent.
- **§ Watch** — one file to glance at, what healthy cadence looks like, that liveness lives in
  the heartbeat rather than the launcher log, and that a storm backoff is not a hang.
- **§ Done, or dead?** — three independent signals, because one is not enough.
- **§ Stop** — and, more usefully, what it does *not* clean up, and why that is deliberate.
- **§ Inspect** — an ordered six-step checklist executed by *reading*, each step naming its own
  file or tool, ending with a verbatim paste block so evaluation is one paste rather than a
  conversation. The paste block forbids launching, re-running, resuming, and deleting branches
  or worktrees.

`docs/babysit-protocol.md` gains a pointer at the top: solo is the default, babysit is for live
intervention.

## Tests

15 tests, because a runbook rots silently — a flag gets renamed, a tool moves, and the document
keeps claiming otherwise until an operator follows it at 2am and it does not work. They assert:

- every documented flag exists in `--help`, **and** every real flag is documented (both
  directions, so a new flag cannot land undocumented)
- every tool and document the runbook names exists on disk
- the scheduled task name it queries is the one the launcher actually creates
- the storm backoff line it quotes matches the emitted format
- the three gates it describes are really wired into `main`
- the MSYS guard is present on the schtasks command
- the paste block forbids launching and branch deletion

Full suite green: 7015 passed, 17 skipped, 5 xfailed.

Closes #2087
