### PR TITLE
fix(audit): prune LLD status-cache slices for repos that no longer exist (Closes #1971)

### DIFF
--- a/assemblyzero/workflows/requirements/audit.py
+++ b/assemblyzero/workflows/requirements/audit.py
@@ -700,6 +700,51 @@ def _read_status_file(target_repo: Path) -> dict:
     return data
 
 
+def _prune_dead_repo_slices(raw: dict, *, keep: str) -> list[str]:
+    """Drop slices whose repo path no longer exists. Returns what was pruned.
+
+    #1160 scoped entries per repo and fixed the collision, but nothing ever
+    removed a slice, so a deleted, renamed or moved repo left its approvals on
+    disk permanently and the file grew without bound. A path that is gone cannot
+    be the target of a future run, so its approvals can never be consulted
+    again -- pruning them loses nothing.
+
+    Two deliberate choices:
+
+    **A missing path is not always a dead repo.** An unmounted drive or a
+    temporarily-renamed checkout is pruned too, and its approvals are lost,
+    costing one re-review. That is the affordable direction -- the opposite
+    error is a cache that grows forever -- but it is a chosen tradeoff, not an
+    accident.
+
+    **``legacy_unscoped`` is never pruned.** It has no path to test, and it is
+    deliberately retained history rather than live cache state.
+
+    The slice being written is never pruned either: it is the repo the caller is
+    running against, and a target that somehow fails an existence check mid-run
+    should not have this run's own result discarded underneath it.
+    """
+    repos = raw.get("repos")
+    if not isinstance(repos, dict):
+        return []
+
+    pruned = []
+    for repo_key in list(repos):
+        if repo_key == keep:
+            continue
+        if not Path(repo_key).exists():
+            del repos[repo_key]
+            pruned.append(repo_key)
+
+    for repo_key in pruned:
+        # Logged, not silent: an operator who notices a re-review they did not
+        # expect needs to be able to find out why without reading this source.
+        logger.info(
+            "LLD status cache: pruned slice for %s (path no longer exists)", repo_key
+        )
+    return pruned
+
+
 def load_lld_tracking(target_repo: Path) -> LLDStatusCache:
     """Load THIS target repo's slice of the shared LLD status cache.
 
@@ -738,6 +783,7 @@ def save_lld_tracking(tracking: LLDStatusCache, target_repo: Path) -> None:
     raw.setdefault("repos", {})[_repo_key(target_repo)] = {
         "issues": tracking.get("issues", {}),
     }
+    _prune_dead_repo_slices(raw, keep=_repo_key(target_repo))
     raw["version"] = LLD_STATUS_CACHE_VERSION
     raw["last_updated"] = datetime.now(timezone.utc).isoformat()
 

--- a/tests/unit/test_lld_cache_pruning.py
+++ b/tests/unit/test_lld_cache_pruning.py
@@ -1,0 +1,182 @@
+"""Acceptance tests for pruning dead LLD status-cache slices (#1971).
+
+The four tests named in the issue body are the acceptance criteria.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.requirements.audit import (
+    LLD_STATUS_CACHE_VERSION,
+    _prune_dead_repo_slices,
+    _repo_key,
+    lld_status_path,
+    load_lld_tracking,
+    save_lld_tracking,
+)
+
+
+def _write_cache(target_repo: Path, repos: dict, legacy: dict | None = None) -> Path:
+    path = lld_status_path(target_repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": LLD_STATUS_CACHE_VERSION,
+        "last_updated": "2026-01-01T00:00:00+00:00",
+        "repos": repos,
+    }
+    if legacy is not None:
+        payload["legacy_unscoped"] = legacy
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _slice(issue: str = "7") -> dict:
+    return {"issues": {issue: {"status": "approved", "lld_path": f"docs/lld/LLD-{issue}.md"}}}
+
+
+# --- "dead slice gone, live slice byte-identical" -----------------------
+
+
+def test_a_dead_slice_is_pruned_and_a_live_one_survives_intact(tmp_path):
+    live = tmp_path / "live-repo"
+    live.mkdir()
+    dead = tmp_path / "deleted-repo"  # never created
+
+    target = tmp_path / "target"
+    target.mkdir()
+
+    live_slice = _slice("11")
+    _write_cache(target, {
+        _repo_key(live): live_slice,
+        _repo_key(dead): _slice("99"),
+    })
+
+    save_lld_tracking({"version": 1, "last_updated": "x", "issues": {}}, target)
+
+    data = json.loads(lld_status_path(target).read_text(encoding="utf-8"))
+
+    assert _repo_key(dead) not in data["repos"], "a path that is gone cannot be a future target"
+    assert data["repos"][_repo_key(live)] == live_slice, "the live slice must be untouched"
+
+
+def test_the_live_slices_approvals_still_load_after_a_prune(tmp_path):
+    live = tmp_path / "live-repo"
+    live.mkdir()
+    dead = tmp_path / "gone"
+
+    _write_cache(live, {
+        _repo_key(live): _slice("11"),
+        _repo_key(dead): _slice("99"),
+    })
+
+    save_lld_tracking(load_lld_tracking(live), live)
+
+    assert "11" in load_lld_tracking(live)["issues"]
+
+
+# --- "legacy_unscoped survives a write untouched" -----------------------
+
+
+def test_legacy_unscoped_is_never_pruned(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    legacy = {"5": {"status": "approved"}}
+
+    _write_cache(target, {_repo_key(tmp_path / "gone"): _slice()}, legacy=legacy)
+
+    save_lld_tracking({"version": 1, "last_updated": "x", "issues": {}}, target)
+
+    data = json.loads(lld_status_path(target).read_text(encoding="utf-8"))
+    assert data["legacy_unscoped"] == legacy, (
+        "it has no path to test and is retained history, not live cache state"
+    )
+
+
+def test_prune_helper_ignores_legacy_unscoped_entirely():
+    raw = {"repos": {}, "legacy_unscoped": {"5": {"status": "approved"}}}
+    pruned = _prune_dead_repo_slices(raw, keep="whatever")
+    assert pruned == []
+    assert raw["legacy_unscoped"] == {"5": {"status": "approved"}}
+
+
+# --- "a cache with only live slices is unchanged" -----------------------
+
+
+def test_all_live_slices_are_left_alone(tmp_path):
+    a, b = tmp_path / "repo-a", tmp_path / "repo-b"
+    a.mkdir()
+    b.mkdir()
+
+    raw = {"repos": {_repo_key(a): _slice("1"), _repo_key(b): _slice("2")}}
+    before = json.dumps(raw, sort_keys=True)
+
+    pruned = _prune_dead_repo_slices(raw, keep=_repo_key(a))
+
+    assert pruned == []
+    assert json.dumps(raw, sort_keys=True) == before, "no gratuitous rewrites"
+
+
+def test_the_slice_being_written_is_never_pruned(tmp_path):
+    """Even if the target somehow fails an existence check mid-run, this run's
+    own result must not be discarded underneath it."""
+    missing_target = tmp_path / "vanished"
+    raw = {"repos": {_repo_key(missing_target): _slice()}}
+
+    pruned = _prune_dead_repo_slices(raw, keep=_repo_key(missing_target))
+
+    assert pruned == []
+    assert _repo_key(missing_target) in raw["repos"]
+
+
+# --- "pruning is logged with the pruned repo path" ----------------------
+
+
+def test_pruning_names_the_path_it_removed(tmp_path, caplog):
+    dead = tmp_path / "deleted-repo"
+    raw = {"repos": {_repo_key(dead): _slice()}}
+
+    with caplog.at_level(logging.INFO):
+        pruned = _prune_dead_repo_slices(raw, keep="other")
+
+    assert pruned == [_repo_key(dead)]
+    assert any(
+        _repo_key(dead) in record.getMessage() for record in caplog.records
+    ), "an operator seeing an unexpected re-review must be able to find out why"
+
+
+def test_the_log_says_why_not_just_what(tmp_path, caplog):
+    dead = tmp_path / "deleted-repo"
+    raw = {"repos": {_repo_key(dead): _slice()}}
+
+    with caplog.at_level(logging.INFO):
+        _prune_dead_repo_slices(raw, keep="other")
+
+    combined = " ".join(r.getMessage() for r in caplog.records)
+    assert "no longer exists" in combined
+
+
+# --- robustness -----------------------------------------------------------
+
+
+def test_a_malformed_repos_key_does_not_raise():
+    assert _prune_dead_repo_slices({"repos": "not a dict"}, keep="x") == []
+    assert _prune_dead_repo_slices({}, keep="x") == []
+
+
+def test_growth_is_actually_bounded(tmp_path):
+    """The point of the issue: repeated writes must not accumulate dead slices."""
+    target = tmp_path / "target"
+    target.mkdir()
+
+    repos = {_repo_key(tmp_path / f"gone-{i}"): _slice(str(i)) for i in range(40)}
+    repos[_repo_key(target)] = _slice("1")
+    _write_cache(target, repos)
+
+    save_lld_tracking(load_lld_tracking(target), target)
+
+    data = json.loads(lld_status_path(target).read_text(encoding="utf-8"))
+    assert list(data["repos"]) == [_repo_key(target)], "40 dead slices should be gone"

--- a/tests/unit/test_lld_cache_pruning.py
+++ b/tests/unit/test_lld_cache_pruning.py
@@ -8,7 +8,6 @@ import json
 import logging
 from pathlib import Path
 
-import pytest
 
 from assemblyzero.workflows.requirements.audit import (
     LLD_STATUS_CACHE_VERSION,


### PR DESCRIPTION
## Summary

#1160 nested cache entries under a repo key and fixed the collision, but nothing ever removed a
slice. A repo that is deleted, renamed or moved left its approvals on disk permanently and the
file grew without bound — the live file is at 42 slices.

On write, slices whose repo path no longer exists are dropped. A path that is gone cannot be the
target of a future run, so its approvals can never be consulted again; pruning them loses
nothing.

## Three deliberate choices, all in the docstring

**A missing path is not always a dead repo.** An unmounted drive or a temporarily-renamed
checkout gets pruned too and its approvals lost, costing one re-review. That is the affordable
direction — the opposite error is a cache that grows forever — but it is a chosen tradeoff, not
an accident.

**`legacy_unscoped` is never pruned.** It has no path to test, and it is deliberately retained
history rather than live cache state.

**The slice being written is never pruned either.** It is the repo the caller is running
against, and a target that somehow fails an existence check mid-run should not have this run's
own result discarded underneath it. There is a test for that case specifically.

## Logged, not silent

Pruning logs the path and the reason, so an operator who notices an unexpected re-review can
find out why without reading the source.

## Tests

10 tests covering the four acceptance criteria in the issue, including one that writes 40 dead
slices and asserts they are all gone afterwards — growth being bounded is the whole point — and
one asserting an all-live cache is left byte-identical, so there are no gratuitous rewrites.

Full suite green: 7025 passed, 17 skipped, 5 xfailed.

Closes #1971
