### PR TITLE
fix(cerberus): skip Dependabot PRs in auto-reviewer — Cerberus is the agent fence (Closes #1251)

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -40,8 +40,16 @@ permissions:
 jobs:
   auto-review:
     runs-on: ubuntu-latest
-    # Only run on PRs, not on the PR created by the App itself (prevent loops)
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_call'
+    # Only run on PRs, not on the PR created by the App itself (prevent loops).
+    #
+    # Cerberus is the AGENT fence, not the Dependabot enabler (#1251).
+    # On an agent PR the author is the repo owner, so GitHub's no-self-approval
+    # rule leaves no eligible reviewer and one has to be manufactured -- that is
+    # what this workflow is for. On a Dependabot PR the author is Dependabot, so
+    # the owner already IS an eligible third-party reviewer and there is nothing
+    # at that gate to guard. Dependabot gets its own lane: tools/dependabot_review.py
+    # runs the suite and approves as the owner.
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_call') && github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Generate App token
         id: app-token


### PR DESCRIPTION
Cerberus is the agent fence, not the Dependabot enabler.

On an agent PR the author is the repo owner, so GitHub's no-self-approval rule leaves no
eligible reviewer and Cerberus has to manufacture one. On a Dependabot PR the author is
Dependabot: the owner already is an eligible third-party reviewer, so there is nothing at
that gate to guard.

Because the job ran anyway, it reached for an App token from secrets that do not exist in
the Dependabot secrets store — runs triggered by `dependabot[bot]` resolve secrets from
that store, not the Actions store — exited in seconds with `Input required and not
supplied: app-id`, and left a failed required check behind. Nine Dependabot PRs sit blocked
in this repo today: #2096, #2097, #2099, #2100, #2101, #2102, #2103, #2111, #2112.

The decision dates to 2026-05-12 and the exact one-line procedure to #1251. Neither landed.

## The change

`.github/workflows/auto-reviewer.yml`, the `auto-review` job condition:

```yaml
if: (github.event_name == 'pull_request' || github.event_name == 'workflow_call') && github.event.pull_request.user.login != 'dependabot[bot]'
```

The purpose is written into the file beside the condition. Standard 0025's principle applies
here too: a countermeasure has to be something the reader consumes structurally, and the
original ruling asked for the purpose to live where the machinery lives.

## Blast radius

This is a reusable workflow consumed via `@main` across the fleet. Agent PRs are unaffected —
their author is never `dependabot[bot]`, so the condition is unchanged for them. It does not
touch pr-sentinel, branch protection, or any other workflow.

## Rollback

Revert this PR. Single commit, single file, one condition.

## Verification after merge

The next Dependabot PR should show no `auto-review` check at all, rather than a failed one.
The nine already-open PRs keep their existing failed check until their head SHA changes,
since a job that never runs cannot retract a conclusion recorded days ago — they need a
Dependabot rebase, or to be handled by `tools/dependabot_review.py`.

Landed via the Contents API per ADR-0216: the fine-grained PAT has no `workflow` scope by
design, so `git push` is refused on this path.

Closes #1251
