### PR TITLE
fix(dependabot): pin the audit venv interpreter so the install gate can pass (Closes #2126)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -1087,3 +1087,87 @@ class TestBaselineGateSurvivesAMissingWorktree:
     def test_a_red_gate_is_never_exonerated_by_an_unknown_baseline(self):
         """(0, "") must not read as a green baseline that clears the bump."""
         assert not dependabot_review.is_exonerated_by_baseline({"test_a"}, set())
+
+
+# ---- #2126: audit venv interpreter pinning ----
+#
+# The audit venv is destroyed and rebuilt per PR, so a locked binary dependency
+# with no wheel for the default interpreter turns every audit into a source
+# build. On this machine that made `poetry install` fail for EVERY PR, including
+# an unchanged baseline, and the tool reported it as a per-PR deferral.
+
+def _pyproject_at(tmp_path, with_dev: bool = False):
+    wt = tmp_path / "wt"
+    wt.mkdir(parents=True, exist_ok=True)
+    body = '[project]\nname = "x"\nversion = "0"\n'
+    if with_dev:
+        body += '\n[dependency-groups]\ndev = ["pytest"]\n'
+    (wt / "pyproject.toml").write_text(body)
+    return wt
+
+
+def test_audit_python_pins_the_interpreter_before_install(tmp_path):
+    """`poetry env use <python>` must run BEFORE `poetry install`.
+
+    Ordering is the whole point: poetry creates the venv on first use, so
+    pinning after install would pin a venv that was already built with the
+    wrong interpreter.
+    """
+    wt = _pyproject_at(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _mk_completed(0)
+
+    with patch.object(dependabot_review, "run", side_effect=fake_run), \
+         patch.object(dependabot_review, "AUDIT_PYTHON", r"C:\Python313\python.exe"):
+        assert dependabot_review.install_deps(wt) is True
+
+    env_use = [c for c in calls if c[:3] == ["poetry", "env", "use"]]
+    install = [c for c in calls if c[:2] == ["poetry", "install"]]
+    assert env_use, f"expected a `poetry env use` call, got {calls}"
+    assert env_use[0][3] == r"C:\Python313\python.exe"
+    assert install, f"expected a `poetry install` call, got {calls}"
+    assert calls.index(env_use[0]) < calls.index(install[0]), \
+        "interpreter must be pinned before the venv is created"
+
+
+def test_no_audit_python_leaves_interpreter_selection_alone(tmp_path):
+    """Unset must preserve the previous behaviour exactly -- no `env use`."""
+    wt = _pyproject_at(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _mk_completed(0)
+
+    with patch.object(dependabot_review, "run", side_effect=fake_run), \
+         patch.object(dependabot_review, "AUDIT_PYTHON", None):
+        assert dependabot_review.install_deps(wt) is True
+
+    assert not [c for c in calls if c[:3] == ["poetry", "env", "use"]]
+
+
+def test_unusable_audit_python_fails_install_rather_than_installing_elsewhere(tmp_path):
+    """A bad interpreter must fail, not silently fall through to the default.
+
+    Falling through would rebuild the venv with the very interpreter the pin
+    exists to avoid, and the audit would fail again with an unrelated-looking
+    build error.
+    """
+    wt = _pyproject_at(tmp_path)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["poetry", "env", "use"]:
+            return _mk_completed(1, stderr="no such python")
+        return _mk_completed(0)
+
+    with patch.object(dependabot_review, "run", side_effect=fake_run), \
+         patch.object(dependabot_review, "AUDIT_PYTHON", "/nope/python"):
+        assert dependabot_review.install_deps(wt) is False
+
+    assert not [c for c in calls if c[:2] == ["poetry", "install"]], \
+        "install must not run when the interpreter pin failed"

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -536,6 +536,24 @@ def checkout_pr_into_worktree(worktree: Path, pr_number: int, repo: str) -> bool
     return result.returncode == 0
 
 
+# #2126: the audit venv is destroyed and rebuilt from scratch for every PR
+# (evict_poetry_venv, below), so every locked binary dependency must have a
+# wheel for whichever interpreter poetry resolves. On this machine poetry
+# resolves Python 3.14, the lock pins numpy 2.2.6 (which publishes no cp314
+# wheel), pip falls back to a source build, and the build fails for want of a
+# C compiler -- for EVERY PR, including a no-change baseline checkout of main.
+#
+# CI never hits this because it restores a cached .venv keyed on poetry.lock
+# with a `venv-${{ runner.os }}-` restore-key fallback, so it installs only the
+# delta and never rebuilds numpy. That makes CI green and the local gate red
+# for the same commit, which is what made this look like a per-PR problem for
+# five days.
+#
+# When set, the audit venv is pinned to this interpreter before install.
+# Unset means "whatever poetry picks", i.e. the previous behaviour.
+AUDIT_PYTHON: str | None = os.environ.get("DEPENDABOT_AUDIT_PYTHON") or None
+
+
 def evict_poetry_venv(worktree: Path) -> None:
     """Fix 5 / #944 — evict poetry-cached venv to release Windows file locks."""
     if not (worktree / "pyproject.toml").exists():
@@ -604,6 +622,15 @@ def install_deps(worktree: Path) -> bool:
     pyproject = worktree / "pyproject.toml"
     if not pyproject.exists():
         return True  # Not a poetry project
+    # #2126: pin the interpreter before poetry creates the venv, so a locked
+    # binary dependency without a wheel for the default interpreter cannot
+    # turn every audit into a source build. Failure here is reported as an
+    # install failure, which it is -- there is no venv to install into.
+    if AUDIT_PYTHON:
+        env_result = run(["poetry", "env", "use", AUDIT_PYTHON],
+                         cwd=str(worktree), env=_clean_subprocess_env())
+        if env_result.returncode != 0:
+            return False
     cmd = ["poetry", "install", "--no-root"]
     if _has_dev_group(pyproject):
         cmd.extend(["--with", "dev"])
@@ -1941,7 +1968,22 @@ def main() -> None:
             "(manual drains previously left no record). Pass this to skip."
         ),
     )
+    parser.add_argument(
+        "--audit-python", default=None, metavar="PATH",
+        help=(
+            "#2126: interpreter to build the audit venv with. The venv is "
+            "rebuilt from scratch per PR, so a locked binary dependency with "
+            "no wheel for the default interpreter makes every audit a source "
+            "build -- and fail, for every PR, including an unchanged baseline. "
+            "Overrides DEPENDABOT_AUDIT_PYTHON. Unset means whatever poetry "
+            "picks."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.audit_python:
+        global AUDIT_PYTHON
+        AUDIT_PYTHON = args.audit_python
 
     # #1876: UTF-8 the streams BEFORE _Tee wraps them, so both the
     # terminal and the run log can carry subprocess output verbatim.


### PR DESCRIPTION
The audit venv is destroyed and rebuilt for every PR, so every locked binary dependency must have a wheel for whichever interpreter poetry resolves. On this machine poetry resolves Python 3.14, the lock pins numpy 2.2.6 which publishes no cp314 wheel, pip falls back to a source build, and the build fails because no C compiler is installed.

This failed for **every** Poetry PR, not just bumped ones. Control test: checking out unmodified `main` into a fresh worktree and running the identical command reproduces the identical failure.

CI stayed green the whole time because it restores a cached `.venv` keyed on `poetry.lock` with a runner-os restore-key fallback, so it installs only the delta and never rebuilds numpy. A green CI beside a red local gate on the same commit is what made this look like a per-PR problem for five days.

## The change

Adds `--audit-python` and `DEPENDABOT_AUDIT_PYTHON`. Unset preserves previous behaviour exactly.

Measured, not asserted — pointing it at the already-installed Python 3.13.9:

```
install exit code: 0
numpy 2.2.6 on 3.13.9
pytest 9.0.3
```

A live harvest run with the pin produced **zero** install failures across eight PRs, where every prior run failed all of them.

## Tests

Three, covering the parts that would silently rot:

- the pin runs **before** the venv is created — pinning afterwards would pin a venv already built with the wrong interpreter
- unset issues no `poetry env use` at all, so other repos and machines are unaffected
- an unusable interpreter fails the install rather than falling through to the default it exists to avoid

Full unit suite: `6553 passed, 17 skipped, 5 xfailed`, zero failures.

## Scope

This does not address the separate finding that the gate blames dependency bumps for failures caused by a stale PR base, or the stderr truncation that hid this for five days — those are tracked in #2127 and their own issue.

Closes #2126