### PR TITLE
fix(dependabot): keep the baseline detached so content is the only variable (Closes #2130)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -1171,3 +1171,36 @@ def test_unusable_audit_python_fails_install_rather_than_installing_elsewhere(tm
 
     assert not [c for c in calls if c[:2] == ["poetry", "install"]], \
         "install must not run when the interpreter pin failed"
+
+
+# ---- #2130: the baseline must differ from the PR head ONLY in content ----
+
+def test_baseline_checkout_stays_detached_like_the_pr_head(tmp_path, capsys):
+    """`gh pr checkout --detach` leaves HEAD detached; the baseline must match.
+
+    A plain `git checkout <branch>` restores the base content AND re-attaches
+    HEAD. Six orchestrator tests read the current branch and fail when there
+    is none, so the PR head failed them while the base passed -- on every PR,
+    in every ecosystem, regardless of content. Measured on one commit in one
+    worktree: attached 9 passed, detached 6 failed.
+    """
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _mk_completed(0)
+
+    pr = type("PR", (), {"number": 4242})()
+
+    with patch.object(dependabot_review, "run", side_effect=fake_run):
+        dependabot_review.run_baseline_gate(pr, worktree, touches_py=False, js_dirs=[])
+
+    checkouts = [c for c in calls if c[:2] == ["git", "checkout"]]
+    assert checkouts, f"expected a baseline checkout, got {calls}"
+    assert "--detach" in checkouts[0], (
+        "baseline checkout must stay detached so content is the only variable; "
+        f"got {checkouts[0]}"
+    )
+    assert "dependabot-audit-4242" in checkouts[0]

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -1348,6 +1348,23 @@ def run_baseline_gate(pr: PRInfo, worktree: Path, touches_py: bool,
     same worktree -- same machine, same env, same suite, only the bump
     removed. That is what makes the comparison meaningful.
 
+    #2130: `--detach` is load-bearing here and must match the PR-head side.
+    `gh pr checkout --detach` leaves HEAD detached, so a plain
+    `git checkout <branch>` restores the base content AND re-attaches HEAD,
+    changing two variables at once. Six orchestrator integration tests read
+    the current branch and fail when there isn't one, so the PR head failed
+    them and the base passed them -- on every PR, in every ecosystem,
+    regardless of content. Five unrelated bumps (pathspec, packaging,
+    langgraph-checkpoint-sqlite, mypy, pytest-cov) each drew an identical
+    six-test verdict of "this bump introduced the failure"; an npm-only PR
+    drew it too. Measured on one commit in one worktree: attached, 9 passed;
+    detached, 6 failed.
+
+    Staying detached keeps content the only thing that differs. It does not
+    fix those tests' dependence on being on a branch -- that is a real defect
+    in them, tracked separately -- but it stops the gate from misattributing
+    it to whatever it happens to be auditing.
+
     Returns (exit_code, combined_output). Returns (0, "") when the base
     could not be established, which the caller reads as "not exonerable"
     -- an unknown baseline must never license a merge.
@@ -1361,7 +1378,8 @@ def run_baseline_gate(pr: PRInfo, worktree: Path, touches_py: bool,
     # for one -- (0, "") reads as "not exonerable" -- so route there rather
     # than raising.
     try:
-        checkout = run(["git", "checkout", branch], cwd=str(worktree))
+        checkout = run(["git", "checkout", "--detach", branch],
+                       cwd=str(worktree))
     except OSError as err:
         print(f"  BASELINE: worktree unusable ({err}) -- not exonerable",
               file=sys.stderr)


### PR DESCRIPTION
`run_baseline_gate` documents its own invariant as "same machine, same env, same suite, only the bump removed". It was not holding it.

`gh pr checkout --detach` leaves the PR head **detached**. The baseline used a plain `git checkout <branch>`, which restores the base content **and re-attaches HEAD**. Two variables changed; one was attributed to the other.

Six orchestrator integration tests read the current branch and fail when there is none. So the PR head failed them and the base passed them — on every PR, in every ecosystem, regardless of content.

## How it surfaced

Five unrelated bumps each drew an identical six-test verdict of "this bump introduced the failure": pathspec, packaging, langgraph-checkpoint-sqlite, mypy, pytest-cov. An npm-only PR touching `/dashboard` drew it too, and that is what gave it away — an npm bump cannot affect Python orchestrator tests. Five independent causes producing one identical signature is not five causes.

`#2103` was the cleanest disproof: its entire diff is `pytest-cov 7.0.0 → 7.1.0`, no transitive movement at all.

## Measurement

One commit, one worktree, one venv, changing nothing but HEAD state:

```
main, attached branch : 9 passed
main, detached HEAD   : 6 failed
```

## The change

`--detach` on the baseline checkout, so content is the only difference. `--detach` on the PR-head side stays as-is; it is load-bearing per #1107, which is why the baseline moves to match rather than the other way round.

## What this does not do

It does not fix those six tests depending on being on a branch. That is a genuine defect in them and is filed separately. This PR stops the gate misattributing that defect to whatever it is auditing, and stops it writing a false regression claim onto innocent PRs.

## Tests

A regression test asserts the baseline checkout carries `--detach` and names the audit branch. Tool suite: 57 passed.

Closes #2130