### PR TITLE
feat: --detach streams the roll narration in the launching console (Closes #2137, Closes #2138)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -40,7 +40,9 @@ than transcribed:
 | `--repo` | target repo root (required) |
 | `--issue` | issue to roll — **repeatable**, rolled in order |
 | `--attempts` | redraw a failed issue up to N times before stopping. Base/gate problems never retry. |
-| `--detach` | run via Windows Task Scheduler so the roll outlives this session, then return immediately |
+| `--detach` | run via Windows Task Scheduler so the roll outlives this session — then **stay attached, streaming the roll's output into this console** until it finishes (#2138) |
+| `--no-follow` | with `--detach`: hand off and return immediately instead of streaming (for scripted callers) |
+| `--follow` | re-attach to a roll already running and stream its output here. Takes no `--issue` |
 | `--log-dir` | where the triplets land. Default `<repo>/data/speedrun/runs` |
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
@@ -49,6 +51,11 @@ than transcribed:
 session's shell, and a harness kill of the shell takes the whole tree with it.
 A scheduled task is parented by the Task Scheduler service instead, so nothing
 done to the launching session can reach it.
+
+**Detaching the work does not detach the view** (standard 0026). The command
+you typed keeps your console: it streams the roll's narration live until the
+final line, then exits with the roll's result. There is nothing else to open
+and nothing to type. Ctrl+C stops watching only — the roll keeps running.
 
 > **The launch command is the one command in this runbook not executed during
 > authoring.** Running it would start a real pipeline roll, and the shakedown of
@@ -72,29 +79,43 @@ tracks the machine rather than one lucky run.
 
 ---
 
-## § Watch — optional, and free
+## § Watch
 
-**Operator.** One file. Do not tail anything else:
-
-```bash
-tail -f /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/detached-launcher.log
-```
-
-Healthy output looks like this — a `BASE` line, then a `LAUNCH` line per roll:
+**You are already watching.** The launch command streams the roll's narration
+into the console you launched from (#2138, standard 0026). Healthy output looks
+like this — a `BASE` line, then a `LAUNCH` line per roll:
 
 ```
 2026-08-01 16:34:55 BASE 'hardening-run-16' clean for #2 after self-heal
 2026-08-01 16:34:55 LAUNCH base=hardening-run-16 -> run-issue2-163450.log
 ```
 
-**Liveness lives in the heartbeat, not the launcher log.** A roll writes a beat
-every 15 seconds; the last beat is the time of death under an uncatchable kill.
-A quiet launcher log during a long stage is normal. A heartbeat that stopped is
-not:
+**A quiet stretch is normal, and the follower says so.** Model stages run long
+between narration lines. After five minutes of silence the follower prints one
+liveness note naming the freshest heartbeat (a roll beats every 15 seconds), so
+"slow stage" and "dead" are distinguishable without touching anything.
+
+**Ctrl+C stops WATCHING only, never the roll.** It prints the re-attach and
+stop commands as it exits. **Closed the console entirely?** Nothing was lost —
+the roll is parented by the scheduler. Re-attach from AssemblyZero:
 
 ```bash
+poetry run python tools/speedrun_roll.py --repo /c/Users/mcwiz/Projects/boostgauge --follow
+```
+
+### Recovery — reading the record by hand
+
+The narration and heartbeats are durable files whether or not anything is
+watching. If no follower is available (remote shell, agent doing § Inspect):
+
+```bash
+tail -f /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/detached-launcher.log
 tail -3 /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs/run-issue1-051632-heartbeat.log
 ```
+
+**Liveness lives in the heartbeat, not the launcher log.** The last beat is the
+time of death under an uncatchable kill; a quiet launcher log during a long
+stage is normal, a stopped heartbeat is not:
 
 ```
 2026-08-01 05:23:03 alive

--- a/docs/standards/0026-operator-console-narration.md
+++ b/docs/standards/0026-operator-console-narration.md
@@ -1,0 +1,92 @@
+# 0026 — Operator-launched programs narrate to the console they were launched from
+
+**Status:** Active
+**Issue:** #2137 (first conforming implementation: #2138, `tools/speedrun_roll.py`)
+
+When the operator runs a command, that command's progress prints live in the
+console it was typed into, from launch to final status. Learning what a program
+is doing must never require a second console, a `cd`, a `tail`, or a status
+command recalled from memory. The console the operator launched from IS the
+display.
+
+This principle has been enforced piecemeal for months without ever being
+written down, which is how runbook 0952 shipped violating it: issue #128 forced
+narration onto the silent requirements workflow, `workflow-lessons-learned-1.md`
+names "Silent long-running operations" an anti-pattern ("Progress indicators
+every 5 seconds max"), and standard 0019 echoes validation failures to the
+console specifically so operators "see what failed without grepping log files".
+Each was the same ruling. This document is that ruling, stated once.
+
+## The clauses
+
+### 1. The launched-from console is the display
+
+Progress prints there, live, unbuffered (`PYTHONUNBUFFERED=1` or
+`flush=True` — Python buffers stdout off-TTY), until a final line states the
+outcome. A program that is silent while working is defective even when it
+works: the operator has twice misdiagnosed healthy long stages as hangs
+because nothing said otherwise.
+
+### 2. Backgrounding never removes the obligation
+
+Detaching work for survivability (Task Scheduler, service parents, `--detach`)
+is a property of the WORK, not of the VIEW. The launching command still streams
+the narration by default until the work finishes. Opting OUT of watching is the
+flag (`--no-follow`); watching is **never opt-in**. A tool that detaches and
+returns silently has moved the display problem onto the operator, which is the
+exact thing this standard prohibits.
+
+### 3. Logs are the record; the console is the view
+
+Everything shown on the console must also be durable in a log file (a viewer
+can die; the record must not), and everything in the log that the operator
+would act on must reach the console. One narration file per run, appended, is
+the reference shape (`detached-launcher.log`).
+
+### 4. Silence is a defect
+
+A long quiet stage emits a periodic liveness note — at most every 5 minutes of
+narration silence, naming the freshest heartbeat and its timestamp — so
+"working on something slow" and "dead" are distinguishable without touching
+anything. This does not license chatter: the note is one line, and it appears
+only when the narration is quiet.
+
+### 5. Detaching the view is safe, and says so
+
+Ctrl+C on a follower **stops the view, never the work**, and prints two
+verbatim commands before exiting: how to re-attach, and how to actually stop
+the work. A viewer must be structurally incapable of harming what it watches —
+read-only file access and status queries only.
+
+### 6. One command
+
+If a runbook needs a menu of consoles, directories, and from-memory commands
+to answer "what is it doing?", the defect is in the program, not the runbook.
+Manual log-reading commands may exist in runbooks as **recovery** paths
+(follower unavailable, remote shell), never as the primary interface.
+
+## Enforcement
+
+- `tests/unit/test_speedrun_roll_follow.py` pins the reference
+  implementation: follow-by-default wiring, the viewer's inability to touch
+  the work, and this document's load-bearing clauses at string level.
+- New operator-facing tools conform at review. "It writes a log the operator
+  can tail" does not satisfy this standard.
+- Runbooks present the one-command flow first; hand log-reading demotes to a
+  recovery section.
+
+## Origin
+
+2026-08-09. The operator refused runbook 0952's original § Watch — a detached
+launch followed by four manual surfaces (tail the narration, tail the newest
+heartbeat, query the scheduler, read the triplets) — as unusable, and was
+right: every prior incarnation of this ruling (#128, 0019, the lessons-learned
+anti-pattern) said the same thing about a different tool. The rule was being
+re-derived per program because no standard carried it.
+
+## Reference
+
+- #128 — the requirements workflow made to narrate (the earliest incarnation).
+- Standard 0019 § console echo — validation failures reach the console.
+- Runbook 0952 — the operator-solo speedrun flow this standard reshaped.
+- `tools/speedrun_roll.py` `follow_roll` — the reference viewer.

--- a/tests/unit/test_no_console_windows.py
+++ b/tests/unit/test_no_console_windows.py
@@ -115,7 +115,12 @@ class TestTheRollItselfIsWindowless:
                 patch.object(sr.sys, "platform", "win32"), \
                 patch.object(sr.sys, "executable", str(py)), \
                 patch.object(sr, "check_assemblyzero_tree", lambda p: []),                 patch.object(sr, "check_box_health", _healthy_box):
-            code = sr.main(["--repo", str(repo), "--issue", "7", "--detach"])
+            # --no-follow: this test pins the task XML, not the view. Without
+            # it the default follower (#2138) polls the stubbed _run for a
+            # task status that can never come.
+            code = sr.main(
+                ["--repo", str(repo), "--issue", "7", "--detach", "--no-follow"]
+            )
 
         assert code == 0
         xml = (repo / "data" / "speedrun" / "runs" / "detached-task.xml").read_text(

--- a/tests/unit/test_speedrun_roll_detach.py
+++ b/tests/unit/test_speedrun_roll_detach.py
@@ -60,7 +60,11 @@ class _Recorder:
 
 
 def _detach(repo, recorder, issues=("7",), platform="win32"):
-    argv = ["--repo", str(repo), "--detach"]
+    # --no-follow: these tests pin the HAND-OFF mechanics. Following after a
+    # successful hand-off is the default now (#2138) and is pinned by
+    # test_speedrun_roll_follow.py; entering the real follow loop here would
+    # hang on the patched recorder's unknowable task status.
+    argv = ["--repo", str(repo), "--detach", "--no-follow"]
     for i in issues:
         argv += ["--issue", str(i)]
     with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \

--- a/tests/unit/test_speedrun_roll_follow.py
+++ b/tests/unit/test_speedrun_roll_follow.py
@@ -250,6 +250,17 @@ class TestFollowLoop:
         assert code == 0
         assert "No roll is running" in capsys.readouterr().out
 
+    def test_an_unqueryable_scheduler_bounds_the_wait(self, tmp_path, capsys):
+        """A stub or broken schtasks answering nothing must never hold the
+        viewer forever -- this exact shape hung CI for its full 30-minute
+        timeout before the bound existed."""
+        runs = self._runs(tmp_path)
+        with patch.object(sr, "_task_status", lambda: ""), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.follow_roll(runs)
+        assert code == 1
+        assert "Cannot query the scheduler" in capsys.readouterr().out
+
     def test_ctrl_c_detaches_the_view_and_never_the_roll(self, tmp_path, capsys):
         """The whole reason following can be the default: stopping the watch
         must be consequence-free for the work."""

--- a/tests/unit/test_speedrun_roll_follow.py
+++ b/tests/unit/test_speedrun_roll_follow.py
@@ -1,0 +1,312 @@
+"""--detach without a view turned the operator into a log spelunker (#2138).
+
+The roll narrates everything into `detached-launcher.log`; runbook 0952 then
+told the operator to open more consoles and tail it by hand, which standard
+0026 now prohibits: the console an operator launches from IS the display.
+
+These pin the contract: following is the default and opting OUT is the flag,
+a failed hand-off never follows, `--follow` is a pure viewer that runs no
+spend gates, Ctrl+C detaches the view and never reaches the roll, and the
+drain/status helpers the loop is built from read incrementally and never fold
+"could not query" into "done". Also pins the documents: the standard's two
+load-bearing clauses, and that runbook 0952 leads with the follower rather
+than a tail command.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+
+def _healthy_box(*_args, **_kwargs):
+    """#1920: these tests exercise wiring, not machine health. Same stub as
+    the sibling detach tests."""
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
+import speedrun_roll as sr  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Enough of a repo for main() -- the git-touching checks are patched."""
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+def _wire(repo, argv_tail, *, launch_code=0):
+    """Run main() with the hand-off and the follower both recorded, not run."""
+    calls = {"launch": 0, "follow": []}
+
+    def _launch(*_a, **_k):
+        calls["launch"] += 1
+        return launch_code
+
+    def _follow(log_dir, **kw):
+        calls["follow"].append((log_dir, kw))
+        return 0
+
+    with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+            patch.object(sr, "check_box_health", _healthy_box), \
+            patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+            patch.object(sr, "launch_detached", _launch), \
+            patch.object(sr, "follow_roll", _follow), \
+            patch.object(sr.sys, "platform", "win32"):
+        code = sr.main(["--repo", str(repo), *argv_tail])
+    return code, calls
+
+
+class TestFollowIsTheDefault:
+    """Standard 0026: watching is never opt-in. Opting OUT is the flag."""
+
+    def test_detach_streams_after_a_successful_handoff(self, repo):
+        code, calls = _wire(repo, ["--issue", "7", "--detach"])
+        assert code == 0
+        assert calls["launch"] == 1
+        assert len(calls["follow"]) == 1
+
+    def test_no_follow_hands_off_and_returns(self, repo):
+        code, calls = _wire(repo, ["--issue", "7", "--detach", "--no-follow"])
+        assert code == 0
+        assert calls["launch"] == 1
+        assert calls["follow"] == []
+
+    def test_a_failed_handoff_never_follows(self, repo):
+        """Streaming after a failed schedule would sit on a roll that does not
+        exist, hiding the 91 the operator needs to see."""
+        code, calls = _wire(repo, ["--issue", "7", "--detach"], launch_code=91)
+        assert code == 91
+        assert calls["follow"] == []
+
+
+class TestReattach:
+    def test_follow_needs_no_issue_and_does_not_wait_for_start(self, repo):
+        code, calls = _wire(repo, ["--follow"])
+        assert code == 0
+        assert calls["launch"] == 0
+        assert len(calls["follow"]) == 1
+        assert calls["follow"][0][1].get("wait_for_start") is False
+
+    def test_follow_runs_no_spend_gates(self, repo):
+        """A viewer must attach even when a gate would refuse a launch --
+        the roll it is watching already passed those gates."""
+
+        def _boom(*_a, **_k):
+            raise AssertionError("a spend gate ran for a pure viewer")
+
+        with patch.object(sr, "check_assemblyzero_tree", _boom), \
+                patch.object(sr, "check_box_health", _boom), \
+                patch.object(sr, "open_must_resolve_issues", _boom), \
+                patch.object(sr, "follow_roll", lambda *a, **k: 0), \
+                patch.object(sr.sys, "platform", "win32"):
+            assert sr.main(["--repo", str(repo), "--follow"]) == 0
+
+    def test_follow_refuses_an_issue(self, repo, capsys):
+        code, calls = _wire(repo, ["--follow", "--issue", "7"])
+        assert code == 91
+        assert calls["follow"] == []
+        assert "no --issue" in capsys.readouterr().out
+
+    def test_non_windows_refuses(self, repo, capsys):
+        with patch.object(sr, "follow_roll", lambda *a, **k: 0), \
+                patch.object(sr.sys, "platform", "linux"):
+            code = sr.main(["--repo", str(repo), "--follow"])
+        assert code == 91
+        assert "ERROR" in capsys.readouterr().out
+
+
+class TestDrain:
+    def test_reads_only_what_was_appended(self, tmp_path):
+        # Bytes, not text: on Windows a text-mode write translates \n to \r\n
+        # and the assertion would be about the translation, not the drain.
+        f = tmp_path / "narration.log"
+        f.write_bytes(b"one\n")
+        pos, chunk = sr._drain(f, 0)
+        assert chunk == "one\n"
+        with f.open("ab") as fh:
+            fh.write(b"two\n")
+        pos, chunk = sr._drain(f, pos)
+        assert chunk == "two\n"
+
+    def test_a_missing_file_is_quiet(self, tmp_path):
+        assert sr._drain(tmp_path / "nope.log", 0) == (0, "")
+
+
+def _scripted_run(stdout, returncode=0):
+    def _run(cmd, cwd=None):
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+    return _run
+
+
+class TestTaskStatus:
+    def test_running_is_read_from_the_csv(self):
+        line = f'"\\{sr.TASK_NAME}","N/A","Running"'
+        with patch.object(sr, "_run", _scripted_run(line)):
+            assert sr._task_status() == "Running"
+
+    def test_ready_is_read_from_the_csv(self):
+        line = f'"\\{sr.TASK_NAME}","N/A","Ready"'
+        with patch.object(sr, "_run", _scripted_run(line)):
+            assert sr._task_status() == "Ready"
+
+    def test_a_failed_query_is_unknown_not_done(self):
+        """Folding "could not ask" into "finished" would detach the view from
+        a live roll on any transient schtasks hiccup."""
+        with patch.object(sr, "_run", _scripted_run("", returncode=1)):
+            assert sr._task_status() == ""
+
+    def test_garbage_output_is_unknown(self):
+        with patch.object(sr, "_run", _scripted_run("INFO: nothing here")):
+            assert sr._task_status() == ""
+
+
+class TestLastResult:
+    def _csv(self, value):
+        return (
+            '"HostName","TaskName","Status","Last Result","Author"\n'
+            f'"BOX","\\{sr.TASK_NAME}","Ready","{value}","user"'
+        )
+
+    def test_the_rolls_exit_code_comes_back(self):
+        with patch.object(sr, "_run", _scripted_run(self._csv("91"))):
+            assert sr._task_last_result() == 91
+
+    def test_success_is_zero(self):
+        with patch.object(sr, "_run", _scripted_run(self._csv("0"))):
+            assert sr._task_last_result() == 0
+
+    def test_a_scheduler_status_is_not_an_exit_code(self):
+        """267009 is SCHED_S_TASK_RUNNING, not a result of the roll."""
+        with patch.object(sr, "_run", _scripted_run(self._csv("267009"))):
+            assert sr._task_last_result() == 1
+
+    def test_a_failed_query_is_none(self):
+        with patch.object(sr, "_run", _scripted_run("", returncode=1)):
+            assert sr._task_last_result() is None
+
+
+class TestFollowLoop:
+    def _runs(self, tmp_path):
+        d = tmp_path / "runs"
+        d.mkdir()
+        return d
+
+    def test_streams_then_returns_the_rolls_result(self, tmp_path, capsys):
+        runs = self._runs(tmp_path)
+        narration = runs / "detached-launcher.log"
+        narration.write_text("BASE clean\nLAUNCH base=x\n", encoding="utf-8")
+
+        statuses = iter(["Running", "Ready"])
+        with patch.object(sr, "_task_status", lambda: next(statuses)), \
+                patch.object(sr, "_task_last_result", lambda: 91), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.follow_roll(runs, context_bytes=narration.stat().st_size)
+
+        out = capsys.readouterr().out
+        assert code == 91
+        assert "LAUNCH base=x" in out
+        assert "The roll is done" in out
+
+    def test_content_written_after_the_last_status_poll_still_prints(
+        self, tmp_path, capsys
+    ):
+        """The roll's final lines land between the last drain and the status
+        flip; the loop must drain again before declaring done."""
+        runs = self._runs(tmp_path)
+        narration = runs / "detached-launcher.log"
+        narration.write_text("", encoding="utf-8")
+
+        def _flip():
+            with narration.open("a", encoding="utf-8") as fh:
+                fh.write("All 1 issue(s) rolled.\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _flip])
+        with patch.object(sr, "_task_status", lambda: next(statuses)()), \
+                patch.object(sr, "_task_last_result", lambda: 0), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.follow_roll(runs)
+
+        assert code == 0
+        assert "All 1 issue(s) rolled." in capsys.readouterr().out
+
+    def test_reattach_to_nothing_says_so_immediately(self, tmp_path, capsys):
+        runs = self._runs(tmp_path)
+        with patch.object(sr, "_task_status", lambda: "Ready"), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.follow_roll(runs, wait_for_start=False)
+        assert code == 0
+        assert "No roll is running" in capsys.readouterr().out
+
+    def test_ctrl_c_detaches_the_view_and_never_the_roll(self, tmp_path, capsys):
+        """The whole reason following can be the default: stopping the watch
+        must be consequence-free for the work."""
+        runs = self._runs(tmp_path)
+        recorder = []
+
+        def _record(cmd, cwd=None):
+            recorder.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        def _interrupt():
+            raise KeyboardInterrupt
+
+        with patch.object(sr, "_task_status", _interrupt), \
+                patch.object(sr, "_run", _record), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.follow_roll(runs)
+
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "still running" in out
+        assert "--follow" in out and "--detach-stop" in out
+        assert [c for c in recorder if c[0] in ("taskkill",)] == []
+        assert [c for c in recorder if c[0] == "schtasks" and "/End" in c] == []
+
+
+class TestHeartbeatNote:
+    def test_the_freshest_heartbeat_and_its_last_line(self, tmp_path):
+        old = tmp_path / "run-a-heartbeat.log"
+        new = tmp_path / "run-b-heartbeat.log"
+        old.write_text("01:00:00 alive\n", encoding="utf-8")
+        new.write_text("01:00:00 alive\n02:00:00 alive\n", encoding="utf-8")
+        os.utime(old, (1_000_000, 1_000_000))
+        os.utime(new, (2_000_000, 2_000_000))
+        assert sr._newest_heartbeat(tmp_path) == "run-b-heartbeat.log: 02:00:00 alive"
+
+    def test_no_heartbeat_yet_is_empty(self, tmp_path):
+        assert sr._newest_heartbeat(tmp_path) == ""
+
+
+class TestTheDocumentsConform:
+    """#2137: the standard's load-bearing clauses, pinned at string level the
+    same way test_sweep_source_contains_no_force pins the sweep."""
+
+    STANDARD = REPO_ROOT / "docs" / "standards" / "0026-operator-console-narration.md"
+    RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "0952-speedrun-operator-solo.md"
+
+    def test_the_standard_exists_with_its_load_bearing_clauses(self):
+        text = self.STANDARD.read_text(encoding="utf-8")
+        assert "never opt-in" in text
+        assert "stops the view, never the work" in text
+
+    def test_the_runbook_leads_with_the_follower_not_a_tail(self):
+        text = self.RUNBOOK.read_text(encoding="utf-8")
+        assert "You are already watching" in text
+        watch = text.index("You are already watching")
+        first_tail = text.index("tail -f")
+        assert watch < first_tail, (
+            "runbook 0952 must present the follower before any tail command"
+        )

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -754,6 +754,10 @@ def stop_detached(log_dir: Path) -> int:
 FOLLOW_POLL_SECONDS = 2
 QUIET_NOTE_SECONDS = 300
 _START_GRACE_SECONDS = 60
+# A viewer that cannot ask the scheduler anything must eventually let go: an
+# unbounded unknown-status loop held CI for its full 30-minute timeout when a
+# test stub answered every query with nothing (#2138).
+_MAX_UNKNOWN_STATUS = 30
 
 
 def _drain(path: Path, pos: int) -> tuple[int, str]:
@@ -842,6 +846,7 @@ def follow_roll(
         pos = max(0, narration.stat().st_size - context_bytes)
 
     seen_running = False
+    unknown_streak = 0
     start_deadline = time.time() + _START_GRACE_SECONDS
     last_line_at = time.time()
     try:
@@ -852,9 +857,20 @@ def follow_roll(
                 last_line_at = time.time()
 
             status = _task_status()
-            if status == "Running":
+            if not status:
+                unknown_streak += 1
+                if unknown_streak >= _MAX_UNKNOWN_STATUS:
+                    print(
+                        f"\nCannot query the scheduler after {unknown_streak} "
+                        "attempts; detaching the view. The roll, if any, is "
+                        "unaffected -- re-attach with --follow.",
+                        flush=True,
+                    )
+                    return 1
+            elif status == "Running":
+                unknown_streak = 0
                 seen_running = True
-            elif status and (
+            elif (
                 seen_running
                 or not wait_for_start
                 or time.time() > start_deadline

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -31,6 +31,12 @@ shell, and a harness kill of the shell takes the entire tree with it -- measured
 it. A scheduled task is spawned by the Task Scheduler service, so it is not in
 the tree at all and nothing done to the launching session can reach it.
 
+Detaching the WORK never detaches the VIEW (standard 0026, #2138): after the
+hand-off the launching command stays attached, streaming the roll's narration
+into the console the operator launched from until the final line. Ctrl+C stops
+the view, never the roll. `--no-follow` restores fire-and-forget; `--follow`
+re-attaches to a roll already running.
+
 Exit codes: 0 all issues rolled; 91 a base or gate problem this tool could not
 heal; otherwise the failing child's return code.
 """
@@ -38,6 +44,7 @@ heal; otherwise the failing child's return code.
 from __future__ import annotations
 
 import argparse
+import csv
 import os
 import re
 import subprocess
@@ -739,6 +746,151 @@ def stop_detached(log_dir: Path) -> int:
     return 0
 
 
+# =============================================================================
+# Following a detached roll -- the console the operator launched from IS the
+# display (standard 0026, #2138)
+# =============================================================================
+
+FOLLOW_POLL_SECONDS = 2
+QUIET_NOTE_SECONDS = 300
+_START_GRACE_SECONDS = 60
+
+
+def _drain(path: Path, pos: int) -> tuple[int, str]:
+    """New content of `path` since byte `pos`. A missing file is quiet."""
+    if not path.exists():
+        return pos, ""
+    with path.open("rb") as fh:
+        fh.seek(pos)
+        data = fh.read()
+    return pos + len(data), data.decode("utf-8", errors="replace")
+
+
+def _task_status() -> str:
+    """The scheduled task's status ('Running', 'Ready', ...), or "" if unknown.
+
+    Unknown is NOT folded into "done": a transient query failure while the
+    roll is mid-arc must keep the view attached, not declare victory.
+    """
+    result = _run(["schtasks", "/Query", "/TN", TASK_NAME, "/FO", "CSV", "/NH"])
+    if result.returncode != 0:
+        return ""
+    for line in (result.stdout or "").splitlines():
+        fields = [f.strip().strip('"') for f in line.split('","')]
+        if len(fields) >= 3 and TASK_NAME in fields[0]:
+            return fields[-1]
+    return ""
+
+
+def _task_last_result() -> int | None:
+    """The task's Last Result as an exit code, when schtasks will say.
+
+    Clamped to the exit-code range: outside it the value is a scheduler status
+    (e.g. SCHED_S_TASK_HAS_NOT_RUN), not the roll's result.
+    """
+    result = _run(["schtasks", "/Query", "/TN", TASK_NAME, "/V", "/FO", "CSV"])
+    if result.returncode != 0:
+        return None
+    rows = list(csv.reader((result.stdout or "").splitlines()))
+    if len(rows) < 2:
+        return None
+    try:
+        code = int(rows[1][rows[0].index("Last Result")].strip())
+    except (ValueError, IndexError):
+        return None
+    return code if 0 <= code < 256 else 1
+
+
+def _newest_heartbeat(log_dir: Path) -> str:
+    """`<file>: <last line>` for the freshest heartbeat, or "" without one."""
+    beats = sorted(
+        log_dir.glob("*-heartbeat.log"), key=lambda p: p.stat().st_mtime
+    )
+    if not beats:
+        return ""
+    lines = beats[-1].read_text(
+        encoding="utf-8", errors="replace"
+    ).strip().splitlines()
+    return f"{beats[-1].name}: {lines[-1]}" if lines else ""
+
+
+def follow_roll(
+    log_dir: Path, *, context_bytes: int = 0, wait_for_start: bool = True
+) -> int:
+    """Stream the detached roll's narration to THIS console until it finishes.
+
+    The roll runs under Task Scheduler; this process is only a viewer. Nothing
+    here can reach the roll: the only schtasks verb used is /Query, and Ctrl+C
+    detaches the view and says so. That is what makes following safe to be the
+    default (standard 0026, #2138).
+
+    `wait_for_start` covers the launch race: right after the hand-off the task
+    may not have reached Running yet, and declaring "done" off that first poll
+    would abandon a roll that is seconds old. Re-attaching passes False so a
+    finished (or never-started) roll is reported immediately instead of after
+    the grace window.
+    """
+    narration = log_dir / "detached-launcher.log"
+    print(
+        "Following the roll. Ctrl+C stops WATCHING only -- the roll keeps "
+        "running.\n",
+        flush=True,
+    )
+
+    pos = 0
+    if narration.exists():
+        pos = max(0, narration.stat().st_size - context_bytes)
+
+    seen_running = False
+    start_deadline = time.time() + _START_GRACE_SECONDS
+    last_line_at = time.time()
+    try:
+        while True:
+            pos, chunk = _drain(narration, pos)
+            if chunk:
+                print(chunk, end="", flush=True)
+                last_line_at = time.time()
+
+            status = _task_status()
+            if status == "Running":
+                seen_running = True
+            elif status and (
+                seen_running
+                or not wait_for_start
+                or time.time() > start_deadline
+            ):
+                pos, chunk = _drain(narration, pos)
+                if chunk:
+                    print(chunk, end="", flush=True)
+                if seen_running or wait_for_start:
+                    code = _task_last_result() or 0
+                    print(
+                        f"\nThe roll is done (task status: {status}, "
+                        f"exit {code}).",
+                        flush=True,
+                    )
+                    return code
+                print(f"\nNo roll is running (task status: {status}).", flush=True)
+                return 0
+
+            if time.time() - last_line_at >= QUIET_NOTE_SECONDS:
+                quiet = int((time.time() - last_line_at) // 60)
+                beat = _newest_heartbeat(log_dir)
+                note = f"... still running; narration quiet {quiet}m"
+                if beat:
+                    note += f" (freshest heartbeat {beat})"
+                print(note, flush=True)
+                last_line_at = time.time()
+
+            time.sleep(FOLLOW_POLL_SECONDS)
+    except KeyboardInterrupt:
+        name = Path(__file__).name
+        print("\n\nStopped WATCHING. The roll is still running under Task Scheduler.")
+        print(f"  re-attach   {name} --repo <repo> --follow")
+        print(f"  stop roll   {name} --repo <repo> --detach-stop")
+        return 0
+
+
 def _redirect_stdio(path: Path) -> None:
     """Point stdout and stderr at a file, for a run with no console (#2015).
 
@@ -926,6 +1078,20 @@ def main(argv: list[str] | None = None) -> int:
         "--detach-stop", action="store_true",
         help="Stop a detached roll and every process it spawned (#2016)",
     )
+    parser.add_argument(
+        "--no-follow", action="store_true",
+        help=(
+            "With --detach: hand the roll off and return immediately instead "
+            "of streaming its narration into this console (#2138)"
+        ),
+    )
+    parser.add_argument(
+        "--follow", action="store_true",
+        help=(
+            "Attach to a roll that is already running and stream its "
+            "narration into this console (#2138). Takes no --issue."
+        ),
+    )
     # Set by --detach on the relaunch; not something anyone types.
     parser.add_argument("--detached-stdout", default=None, help=argparse.SUPPRESS)
     args, extra = parser.parse_known_args(argv)
@@ -953,6 +1119,20 @@ def main(argv: list[str] | None = None) -> int:
     # dirty tree, so it comes before the staleness gate.
     if args.detach_stop:
         return stop_detached(log_dir)
+
+    # #2138 / standard 0026: a viewer, not a launcher. It spends nothing and
+    # runs no gates, so it must work even when a gate would refuse a launch.
+    if args.follow:
+        if args.issue:
+            print(
+                "ERROR: --follow attaches to a roll already running; it takes "
+                "no --issue"
+            )
+            return 91
+        if sys.platform != "win32":
+            print(f"ERROR: --follow is Windows-only; this is {sys.platform}")
+            return 91
+        return follow_roll(log_dir, context_bytes=2048, wait_for_start=False)
 
     if not args.issue:
         print("ERROR: --issue is required (repeatable) unless stopping a roll")
@@ -995,7 +1175,12 @@ def main(argv: list[str] | None = None) -> int:
         return 91
 
     if args.detach:
-        return launch_detached(args, extra, repo_root, az_root, log_dir)
+        code = launch_detached(args, extra, repo_root, az_root, log_dir)
+        if code != 0 or args.no_follow:
+            return code
+        # Standard 0026: the console the operator launched from is the
+        # display. The work is detached; the view is not.
+        return follow_roll(log_dir)
 
     # Created only by a process that actually rolls, never by the launcher --
     # see launch_detached on why that separation is load-bearing.


### PR DESCRIPTION
Closes #2137, Closes #2138

## What

**Standard 0026** (`docs/standards/0026-operator-console-narration.md`): a program the operator launches prints its progress live in the console it was launched from, until a final status line. Backgrounding the work never detaches the view; watching is never opt-in; Ctrl+C on a viewer stops the view, never the work; manual log-reading is a recovery path, not the interface.

**First conforming implementation** (`tools/speedrun_roll.py`): after the Task Scheduler hand-off, `--detach` now stays attached and streams `detached-launcher.log` into the operator's console until the task leaves `Running`, then exits with the roll's result. `--no-follow` restores fire-and-forget for scripted callers. `--follow` re-attaches to a running roll (no `--issue`, runs no spend gates — it is a pure viewer). Five minutes of narration silence produces one liveness note naming the freshest heartbeat. The follower's only schtasks verb is `/Query`; it is structurally incapable of touching the roll.

**Runbook 0952** § Watch rewritten: "You are already watching" leads; the tail commands demote to a recovery subsection; the flags table documents `--no-follow` and `--follow`.

## Why

The operator refused the shipped § Watch — a detached launch followed by four manual surfaces (tail the narration, tail the newest heartbeat, query the scheduler, read triplets) — and was right: the same ruling has been made repeatedly (issue #128 made the requirements workflow narrate, standard 0019 echoes validation failures to the console, workflow-lessons-learned names "Silent long-running operations" an anti-pattern) but was never written as a standard, so tools kept re-deriving it wrong.

## Tests

- `tests/unit/test_speedrun_roll_follow.py` (new, 24 tests): follow-by-default wiring, `--no-follow`, failed hand-off never follows, `--follow` viewer runs no spend gates, incremental drain, task-status parsing (unknown is never folded into done), completion drains final lines and returns the roll's result, KeyboardInterrupt detaches the view with no `taskkill`/`/End`, heartbeat-note helper, and string-level pins on the standard's load-bearing clauses and the runbook's follower-first § Watch.
- `tests/unit/test_speedrun_roll_detach.py`: `_detach` helper opts out via `--no-follow` (those tests pin hand-off mechanics; the default is pinned by the new file).
- Full speedrun_roll suite: 118 passed. Ruff clean.
