### PR TITLE
fix: box-health canary retries once before blocking — cold starts are not sick machines (Closes #2141)

### DIFF
--- a/assemblyzero/speedrun/box_health.py
+++ b/assemblyzero/speedrun/box_health.py
@@ -29,6 +29,13 @@ run must not tighten the threshold onto a machine that cannot meet it again, and
 one slow run must not loosen it forever. The median over a small window tracks
 the machine.
 
+**A slow first run earns a retry, not a refusal (#2141).** The canary times a
+whole fresh interpreter launch, so the first run after days away pays cold
+disk caches and AV rescans -- a one-time startup toll indistinguishable from
+load in a single sample, and unlearnable by a nominal fed only passing (warm)
+runs. Cold is paid once; load is not: a second run fast means healthy, a
+second run slow means degraded. Only warm samples feed the nominal.
+
 **psutil is read directly here.** An earlier phrasing of this work said to
 dogfood the boostgauge collector; that is not buildable today -- the collector
 exists only on integration branches, is absent from boostgauge main, and is not
@@ -202,10 +209,13 @@ def _format_message(failures: list[Metric]) -> str:
         if metric.value is None:
             lines.append(f"  {metric.name}: {metric.detail}")
         elif metric.nominal is not None:
-            lines.append(
+            line = (
                 f"  {metric.name}: {metric.value:.1f}{metric.unit} measured, "
                 f"against a normal of {metric.nominal:.1f}{metric.unit}"
             )
+            if metric.detail:
+                line += f" ({metric.detail})"
+            lines.append(line)
         else:
             lines.append(f"  {metric.name}: {metric.value:.1f}{metric.unit} — {metric.detail}")
     lines += [
@@ -263,13 +273,33 @@ def check_box_health(
         return BoxHealth(False, metrics, _format_message([metrics[-1]]))
 
     if nominal is not None and seconds > multiplier * nominal:
-        metrics.append(
-            Metric(
-                "quick self-check", seconds, nominal=nominal, unit="s", ok=False,
-                detail=f"more than {multiplier} times its normal time",
+        # #2141: cold is paid once; load is not. The canary times a whole
+        # fresh interpreter launch, so the first run after days away pays
+        # disk-cache misses and AV rescans that look exactly like a sick
+        # machine -- and since only passing samples feed the nominal, the
+        # median is warm-only and a cold start can NEVER pass it. One retry
+        # discriminates: a cold box is fast the second time, a degraded one
+        # (the 2026-07-29 incident) is slow both times. Measured live
+        # 2026-08-09: idle machine, 5.8s against a 0.9s nominal, refused.
+        first = seconds
+        seconds, problem = canary(az_root, ceiling=ceiling)
+        if seconds is None:
+            metrics.append(Metric("quick self-check", None, ok=False, detail=problem))
+            return BoxHealth(False, metrics, _format_message([metrics[-1]]))
+        if seconds > multiplier * nominal:
+            metrics.append(
+                Metric(
+                    "quick self-check", seconds, nominal=nominal, unit="s", ok=False,
+                    detail=(
+                        f"slow twice in a row ({first:.1f}s, then {seconds:.1f}s "
+                        "on a retry that rules out a cold start)"
+                    ),
+                )
             )
-        )
-        return BoxHealth(False, metrics, _format_message([metrics[-1]]))
+            return BoxHealth(False, metrics, _format_message([metrics[-1]]))
+        # The retry passed: the slowness was startup cost, not load. Fall
+        # through with the WARM measurement -- the nominal must keep tracking
+        # warm behavior, which is what the comparison above assumes.
 
     # Passing: record the sample so the nominal tracks the machine. A missing
     # baseline is created here and never blocks.

--- a/tests/unit/test_box_health.py
+++ b/tests/unit/test_box_health.py
@@ -89,6 +89,83 @@ def test_canary_exactly_at_the_multiplier_still_passes(tmp_path):
     assert health.ok, "the threshold is 'more than 3x', not '3x or more'"
 
 
+# --- "a slow first run earns a retry, not a refusal" (#2141) --------------
+
+
+def _canary_sequence(*results):
+    """A canary whose consecutive calls replay `results`, counting calls."""
+    calls = {"n": 0}
+
+    def canary(_az_root, **_kw):
+        result = results[min(calls["n"], len(results) - 1)]
+        calls["n"] += 1
+        return result
+
+    canary.calls = calls
+    return canary
+
+
+def test_a_cold_first_run_passes_when_the_retry_is_fast(tmp_path):
+    """The live 2026-08-09 false positive: idle machine, warm-only nominal,
+    first launch in days pays cold caches and AV rescans once. The retry is
+    warm and must clear the box."""
+    for _ in range(3):
+        record_sample(tmp_path, 2.0)
+
+    health = check_box_health(
+        tmp_path, tmp_path,
+        canary=_canary_sequence((6.5, ""), (2.1, "")),
+        resources=_resources(),
+    )
+
+    assert health.ok, "a cold start is not a sick machine"
+    assert read_samples(tmp_path)[-1] == 2.1, (
+        "the WARM measurement feeds the nominal; recording the cold 6.5 "
+        "would loosen the threshold the retry just defended"
+    )
+
+
+def test_slow_twice_blocks_and_names_both_measurements(tmp_path):
+    for _ in range(3):
+        record_sample(tmp_path, 2.0)
+
+    health = check_box_health(
+        tmp_path, tmp_path,
+        canary=_canary_sequence((6.5, ""), (7.0, "")),
+        resources=_resources(),
+    )
+
+    assert not health.ok
+    assert health.failures[0].value == 7.0
+    assert "6.5" in health.message and "7.0" in health.message
+    assert "cold start" in health.message
+
+
+def test_a_passing_first_run_spends_exactly_one_canary(tmp_path):
+    record_sample(tmp_path, 2.0)
+    canary = _canary_sequence((2.2, ""))
+
+    health = check_box_health(
+        tmp_path, tmp_path, canary=canary, resources=_resources()
+    )
+
+    assert health.ok
+    assert canary.calls["n"] == 1, "the retry is for suspects, not for everyone"
+
+
+def test_a_retry_that_cannot_be_timed_blocks(tmp_path):
+    record_sample(tmp_path, 2.0)
+
+    health = check_box_health(
+        tmp_path, tmp_path,
+        canary=_canary_sequence((6.5, ""), (None, "the quick self-check died")),
+        resources=_resources(),
+    )
+
+    assert not health.ok
+    assert "the quick self-check died" in health.message
+
+
 # --- "canary that never completes aborts at the ceiling" -----------------
 
 


### PR DESCRIPTION
Closes #2141

## What

When the quick self-check's first run exceeds `multiplier x nominal`, `check_box_health` now runs it a second time before blocking:

- **Retry fast** → healthy; the first run was startup cost. Proceed, recording the WARM sample (the nominal keeps tracking warm behavior, which is what the threshold comparison assumes).
- **Retry also slow** → block, with both measurements in the message and a note that the retry rules out a cold start.
- **Retry untimeable** → block, as before.

A passing first run spends exactly one canary, unchanged. Module docstring records the design decision; `_format_message` now appends a metric's detail when a nominal is also present so the two-measurement story reaches the operator.

## Why

Live false positive 2026-08-09: first roll in eight days, machine verifiably idle (CPU 3%, disk quiet, memory 64%), refused with `5.8s measured, against a normal of 0.9s`. The canary times a whole fresh interpreter launch, so the first run after days away pays cold disk caches and AV rescans — a one-time toll indistinguishable from load in a single sample. Structurally, only passing samples feed the rolling median, so the nominal is warm-only and a cold start could NEVER pass it: the gate fired precisely when the operator returned to work. Cold is paid once; load is not — the retry discriminates, and the 2026-07-29 degradation this gate exists for (pytest failing to complete) is slow on both runs and still blocks.

## Tests

Four added to `tests/unit/test_box_health.py` (injected stateful canary stubs, same idiom): cold-then-fast passes and records the warm sample; slow-twice blocks naming both measurements; a passing first run spends exactly one canary invocation; an untimeable retry blocks with its problem. Existing 22 unchanged and passing; full unit suite green.
