### PR TITLE
feat: the file janitor — preserve pipeline leavings, then clear them (Closes #2144, Closes #2145, Closes #2146)

### DIFF
--- a/assemblyzero/speedrun/leavings.py
+++ b/assemblyzero/speedrun/leavings.py
@@ -1,0 +1,254 @@
+"""Pipeline file leavings: classify, preserve, clear (#2144, #2145, #2146).
+
+Standard 0027: the machinery cleans up after itself; it never hands its mess
+to the operator. The worktree sweep (#2077) is the reference janitor for
+worktrees; this module is its sibling for FILES the pipeline emits into the
+target repo's main checkout -- the run-16 LLD droppings that sat untracked
+for eight days and then blocked two launches (2026-08-09).
+
+## The authorship line
+
+The janitor only ever touches untracked files under `EMISSION_ALLOWLIST`,
+the pipeline's known write sites in a target repo. Everything else is
+presumed to be the operator's work: reported by name, never preserved on the
+operator's behalf, never deleted. Refusal is reserved for content the
+machinery cannot prove it authored.
+
+## Preserve, then clear -- structurally
+
+A leaving is removed from the working tree only after it is reachable from a
+pushed graveyard ref. Commit or push failure leaves the file exactly where it
+was, reported. The preserving commit is built through a TEMPORARY index
+(`GIT_INDEX_FILE`), so the checkout's HEAD, real index, and working tree are
+never touched by the preservation itself.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+#: Where the pipeline writes files into a target repo's main checkout.
+#: Grounded in the actual write sites: `workflows/requirements/audit.py`
+#: saves approved LLDs to docs/lld/active/; draft specs land in
+#: docs/lld/drafts/. Extend deliberately, never wildcard -- the allowlist IS
+#: the proof of authorship.
+EMISSION_ALLOWLIST = (
+    "docs/lld/active/",
+    "docs/lld/drafts/",
+)
+
+GRAVEYARD_LEAVINGS_PREFIX = "graveyard/leavings"
+
+_TS_FMT = "%Y%m%d-%H%M%S"
+
+
+def _run(
+    cmd: list[str], cwd: Path | None = None, env: dict | None = None
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=str(cwd) if cwd else None, env=env,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+
+
+def _now_tag() -> str:
+    return datetime.now().strftime(_TS_FMT)
+
+
+@dataclass
+class LeavingsEntry:
+    path: str          # repo-relative, forward slashes
+    action: str        # preserved-and-cleared | reported
+    ok: bool = True
+    detail: str = ""
+
+    def describe(self) -> str:
+        bits = f"{self.path}: {self.action}"
+        if self.detail:
+            bits += f" -- {self.detail}"
+        return bits
+
+
+@dataclass
+class LeavingsResult:
+    entries: list[LeavingsEntry] = field(default_factory=list)
+    branch: str | None = None
+
+    @property
+    def problems(self) -> list[LeavingsEntry]:
+        return [e for e in self.entries if not e.ok]
+
+    def summary(self) -> str:
+        if not self.entries:
+            return "file janitor: nothing to do"
+        kept = f" (preserved on {self.branch})" if self.branch else ""
+        return (
+            f"file janitor: {len(self.entries)} handled, "
+            f"{len(self.problems)} reported{kept}"
+        )
+
+
+def untracked_files(repo: Path | str) -> list[str]:
+    """Repo-relative untracked files, individually (-uall expands dirs).
+
+    Gitignored paths (data/, and with them data/speedrun/**) never appear
+    here, which is the standard-0027 evidence exemption falling out of the
+    plumbing rather than being special-cased.
+    """
+    result = _run(
+        ["git", "-C", str(repo), "status", "--porcelain", "-uall"]
+    )
+    if result.returncode != 0:
+        return []
+    return [
+        line[3:].strip().strip('"')
+        for line in result.stdout.splitlines()
+        if line.startswith("?? ")
+    ]
+
+
+def is_machinery_owned(rel_path: str) -> bool:
+    normalized = rel_path.replace("\\", "/")
+    return any(normalized.startswith(prefix) for prefix in EMISSION_ALLOWLIST)
+
+
+def classify_dirt(repo: Path | str) -> tuple[list[str], list[str]]:
+    """(machinery-owned untracked, operator-owned dirt) as porcelain lines.
+
+    Machinery-owned: untracked AND under the emission allowlist -- ours to
+    preserve and clear. Operator-owned: every other dirty entry (tracked
+    modifications of any kind, untracked outside the allowlist) -- named,
+    never touched.
+    """
+    result = _run(["git", "-C", str(repo), "status", "--porcelain", "-uall"])
+    if result.returncode != 0:
+        return [], [f"git status failed: {result.stderr.strip()}"]
+
+    machinery: list[str] = []
+    operator: list[str] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip().strip('"')
+        if line.startswith("?? ") and is_machinery_owned(path):
+            machinery.append(path)
+        else:
+            operator.append(line.strip())
+    return machinery, operator
+
+
+def preserve_and_clear(
+    repo: Path | str, files: list[str], *, log=None
+) -> LeavingsResult:
+    """Commit `files` to a pushed graveyard branch, then remove them.
+
+    All-or-nothing on the preservation: if the commit or the push fails, every
+    file stays in place and the failure is reported -- nothing is ever removed
+    unpreserved. Removal never uses git (the files are untracked); it is a
+    plain unlink plus pruning of directories the removals emptied, bounded to
+    the allowlist so an operator's directory is never rmdir'd.
+    """
+    repo = Path(repo).resolve()
+    log = log or (lambda _msg: None)
+    result = LeavingsResult()
+    if not files:
+        return result
+
+    branch = f"{GRAVEYARD_LEAVINGS_PREFIX}-{_now_tag()}"
+    index = repo / ".git" / f"leavings-index-{os.getpid()}"
+    env = dict(os.environ)
+    env["GIT_INDEX_FILE"] = str(index)
+
+    def _fail_all(stage: str, detail: str) -> LeavingsResult:
+        for f in files:
+            result.entries.append(
+                LeavingsEntry(f, "reported", ok=False,
+                              detail=f"{stage} failed: {detail}")
+            )
+        log(f"  file janitor: {stage} failed -- nothing cleared ({detail})")
+        index.unlink(missing_ok=True)
+        return result
+
+    try:
+        read = _run(["git", "-C", str(repo), "read-tree", "HEAD"], env=env)
+        if read.returncode != 0:
+            return _fail_all("read-tree", read.stderr.strip())
+
+        added = _run(
+            ["git", "-C", str(repo), "add", "--", *files], env=env
+        )
+        if added.returncode != 0:
+            return _fail_all("add", added.stderr.strip())
+
+        tree = _run(["git", "-C", str(repo), "write-tree"], env=env)
+        if tree.returncode != 0:
+            return _fail_all("write-tree", tree.stderr.strip())
+
+        commit = _run(
+            [
+                "git", "-C", str(repo), "commit-tree", tree.stdout.strip(),
+                "-p", "HEAD",
+                "-m", "chore(graveyard): preserve pipeline file leavings "
+                      "before clearing (standard 0027)",
+            ],
+            env=env,
+        )
+        if commit.returncode != 0:
+            return _fail_all("commit-tree", commit.stderr.strip())
+
+        branched = _run(
+            ["git", "-C", str(repo), "branch", branch, commit.stdout.strip()]
+        )
+        if branched.returncode != 0:
+            return _fail_all("branch", branched.stderr.strip())
+
+        pushed = _run(
+            ["git", "-C", str(repo), "push", "-u", "origin", branch]
+        )
+        if pushed.returncode != 0:
+            # Spec (#2144): unpushed is unpreserved. The local branch is left
+            # for a human to inspect, the files are left in place.
+            return _fail_all("push", pushed.stderr.strip())
+    finally:
+        index.unlink(missing_ok=True)
+
+    result.branch = branch
+    for f in files:
+        target = repo / f
+        try:
+            target.unlink()
+        except OSError as exc:
+            result.entries.append(
+                LeavingsEntry(f, "reported", ok=False,
+                              detail=f"preserved on {branch} but not removed: {exc}")
+            )
+            continue
+        _prune_empty_dirs(repo, target.parent)
+        result.entries.append(LeavingsEntry(f, "preserved-and-cleared"))
+
+    for entry in result.entries:
+        log(f"  {entry.describe()}")
+    log(f"  {result.summary()}")
+    return result
+
+
+def _prune_empty_dirs(repo: Path, start: Path) -> None:
+    """Remove now-empty directories, but only inside the allowlist."""
+    current = start
+    while current != repo:
+        rel = str(current.relative_to(repo)).replace("\\", "/") + "/"
+        inside = any(
+            rel.startswith(prefix) or prefix.startswith(rel)
+            for prefix in EMISSION_ALLOWLIST
+        )
+        if not inside:
+            return
+        try:
+            current.rmdir()  # fails on non-empty, which is the stop condition
+        except OSError:
+            return
+        current = current.parent

--- a/tests/unit/test_leavings_janitor.py
+++ b/tests/unit/test_leavings_janitor.py
@@ -50,7 +50,10 @@ def repo(tmp_path: Path) -> Path:
     """A repo with a bare origin, gitignored data/, and origin/HEAD set."""
     origin = tmp_path / "origin.git"
     subprocess.run(
-        ["git", "init", "-q", "--bare", str(origin)],
+        # --initial-branch pins the bare repo's HEAD to main on every
+        # machine; without it a runner with no init.defaultBranch creates
+        # HEAD -> master and `remote set-head --auto` cannot resolve.
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(origin)],
         capture_output=True, text=True, check=True,
     )
     root = tmp_path / "proj"

--- a/tests/unit/test_leavings_janitor.py
+++ b/tests/unit/test_leavings_janitor.py
@@ -1,0 +1,314 @@
+"""Acceptance tests for the file janitor and its consumers (#2144, #2145, #2146).
+
+Standard 0027: preserve, then restore. Every test builds a throwaway repo
+with a local bare origin under tmp_path -- preservation is only preservation
+when the ref is pushed, so the tests give the janitor somewhere to push.
+
+The run-16 scenario (untracked LLD droppings blocking a launch eight days
+later) is replayed here as the acceptance case for all three issues.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+
+def _healthy_box(*_args, **_kwargs):
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
+import speedrun_new_attempt as attempt  # noqa: E402
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.speedrun.leavings import (  # noqa: E402
+    classify_dirt,
+    preserve_and_clear,
+    untracked_files,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+    return result
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with a bare origin, gitignored data/, and origin/HEAD set."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", str(origin)],
+        capture_output=True, text=True, check=True,
+    )
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / ".gitignore").write_text("data/\n", encoding="utf-8")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    _git(root, "remote", "add", "origin", str(origin))
+    _git(root, "push", "-qu", "origin", "main")
+    _git(root, "remote", "set-head", "origin", "--auto")
+    return root
+
+
+def _drop_leaving(repo: Path, rel: str = "docs/lld/active/LLD-002.md") -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("drafted by the pipeline\n", encoding="utf-8")
+    return path
+
+
+def _leavings_branches(repo: Path) -> list[str]:
+    out = _git(repo, "branch", "--list", "graveyard/leavings-*",
+               "--format=%(refname:short)").stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+# --- the janitor itself (#2144) -------------------------------------------
+
+
+class TestPreserveAndClear:
+    def test_a_leaving_is_preserved_on_a_pushed_ref_then_cleared(self, repo):
+        _drop_leaving(repo)
+
+        result = preserve_and_clear(repo, ["docs/lld/active/LLD-002.md"])
+
+        assert result.problems == []
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        branches = _leavings_branches(repo)
+        assert len(branches) == 1
+        shown = _git(
+            repo, "show", f"{branches[0]}:docs/lld/active/LLD-002.md"
+        ).stdout
+        assert "drafted by the pipeline" in shown
+        on_origin = _git(repo, "ls-remote", "--heads", "origin",
+                         branches[0]).stdout
+        assert branches[0] in on_origin, "unpushed is unpreserved"
+
+    def test_the_emptied_directory_is_pruned_but_not_beyond(self, repo):
+        _drop_leaving(repo, "docs/lld/drafts/spec-0002.md")
+        (repo / "docs" / "keep.md").write_text("tracked-ish\n", encoding="utf-8")
+
+        preserve_and_clear(repo, ["docs/lld/drafts/spec-0002.md"])
+
+        assert not (repo / "docs" / "lld" / "drafts").exists()
+        assert (repo / "docs").exists(), "docs/ still has content and must stay"
+
+    def test_preservation_failure_leaves_the_file_in_place(self, repo):
+        """No origin to push to == no durable ref == nothing may be removed."""
+        _git(repo, "remote", "remove", "origin")
+        leaving = _drop_leaving(repo)
+
+        result = preserve_and_clear(repo, ["docs/lld/active/LLD-002.md"])
+
+        assert leaving.exists(), "a file is never removed unpreserved"
+        assert result.problems, "the failure must be reported, not swallowed"
+
+    def test_the_main_checkout_is_undisturbed_by_preservation(self, repo):
+        _drop_leaving(repo)
+        head_before = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+        preserve_and_clear(repo, ["docs/lld/active/LLD-002.md"])
+
+        assert _git(repo, "rev-parse", "HEAD").stdout.strip() == head_before
+        assert _git(repo, "branch", "--show-current").stdout.strip() == "main"
+        status = _git(repo, "status", "--porcelain").stdout.strip()
+        assert status == "", f"preservation dirtied the checkout: {status}"
+
+
+class TestClassification:
+    def test_allowlisted_untracked_is_machinery_owned(self, repo):
+        _drop_leaving(repo)
+        machinery, operator = classify_dirt(repo)
+        assert machinery == ["docs/lld/active/LLD-002.md"]
+        assert operator == []
+
+    def test_untracked_outside_the_allowlist_is_operator_owned(self, repo):
+        (repo / "notes.md").write_text("mine\n", encoding="utf-8")
+        machinery, operator = classify_dirt(repo)
+        assert machinery == []
+        assert any("notes.md" in entry for entry in operator)
+
+    def test_a_tracked_modification_is_operator_owned(self, repo):
+        (repo / "README.md").write_text("edited\n", encoding="utf-8")
+        machinery, operator = classify_dirt(repo)
+        assert machinery == []
+        assert any("README.md" in entry for entry in operator)
+
+    def test_gitignored_evidence_is_invisible(self, repo):
+        (repo / "data" / "speedrun").mkdir(parents=True)
+        (repo / "data" / "speedrun" / "run.log").write_text("evidence\n",
+                                                            encoding="utf-8")
+        machinery, operator = classify_dirt(repo)
+        assert machinery == [] and operator == []
+
+
+# --- the launcher's entry janitor and exit reconcile (#2144, #2145) --------
+
+
+def _launch(repo: Path, roll_stub) -> int:
+    with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+            patch.object(sr, "check_box_health", _healthy_box), \
+            patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+            patch.object(sr, "roll_issue", roll_stub):
+        return sr.main(["--repo", str(repo), "--issue", "7"])
+
+
+class TestEntryJanitor:
+    def test_a_predecessors_leavings_are_cleared_before_any_roll(self, repo):
+        """The run-16 replay: droppings on disk at launch, gone (and
+        preserved) before the roll starts, no human involved."""
+        _drop_leaving(repo)
+        seen = {}
+
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            seen["leavings_at_roll_time"] = [
+                f for f in untracked_files(repo_root) if "lld" in f
+            ]
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert seen["leavings_at_roll_time"] == []
+        assert _leavings_branches(repo), "cleared but never preserved"
+
+
+class TestExitReconcile:
+    def test_a_rolls_own_emission_is_preserved_and_cleared_on_exit(self, repo):
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            _drop_leaving(Path(repo_root))
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        assert _leavings_branches(repo)
+
+    def test_reconcile_runs_on_the_failure_path_too(self, repo):
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            _drop_leaving(Path(repo_root))
+            return 91
+
+        code = _launch(repo, _roll)
+
+        assert code == 91
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        assert _leavings_branches(repo)
+
+    def test_a_file_the_machinery_cannot_prove_it_made_is_kept_and_named(
+        self, repo, capsys
+    ):
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            (Path(repo_root) / "mystery.md").write_text("whose?\n",
+                                                        encoding="utf-8")
+            return 0
+
+        _launch(repo, _roll)
+
+        assert (repo / "mystery.md").exists(), "never delete unproven authorship"
+        out = capsys.readouterr().out
+        assert "RESTORE INCOMPLETE" in out and "mystery.md" in out
+
+    def test_evidence_under_data_is_exempt(self, repo, capsys):
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            # data/ is gitignored in the fixture, as in every campaign repo;
+            # the run's own logs land there and must never fail the restore.
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert "RESTORE INCOMPLETE" not in capsys.readouterr().out
+        assert (repo / "data" / "speedrun" / "runs").exists()
+
+
+# --- the branch-cutter's posture (#2146) -----------------------------------
+
+
+class TestNewAttemptPosture:
+    def test_a_tree_dirty_only_with_leavings_does_not_stop_a_launch(self, repo):
+        _drop_leaving(repo)
+
+        code = attempt.main(
+            ["--repo", str(repo), "--name", "hardening-run-99", "--apply"]
+        )
+
+        assert code == 0
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        assert _leavings_branches(repo)
+        assert "hardening-run-99" in _git(
+            repo, "branch", "--list", "hardening-run-99",
+            "--format=%(refname:short)",
+        ).stdout
+
+    def test_operator_owned_dirt_still_refuses_by_name(self, repo, capsys):
+        (repo / "README.md").write_text("edited\n", encoding="utf-8")
+
+        code = attempt.main(
+            ["--repo", str(repo), "--name", "hardening-run-99", "--apply"]
+        )
+
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "README.md" in out
+        assert "not machinery-owned" in out
+
+    def test_untracked_outside_the_allowlist_refuses_by_name(self, repo, capsys):
+        (repo / "notes.md").write_text("mine\n", encoding="utf-8")
+
+        code = attempt.main(
+            ["--repo", str(repo), "--name", "hardening-run-99", "--apply"]
+        )
+
+        assert code == 1
+        assert "notes.md" in capsys.readouterr().out
+
+    def test_a_mixed_tree_preserves_the_machinerys_share_then_refuses(
+        self, repo, capsys
+    ):
+        _drop_leaving(repo)
+        (repo / "README.md").write_text("edited\n", encoding="utf-8")
+
+        code = attempt.main(
+            ["--repo", str(repo), "--name", "hardening-run-99", "--apply"]
+        )
+
+        assert code == 1, "the operator-owned entry still blocks"
+        assert _leavings_branches(repo), (
+            "the machinery's share is preserved-and-cleared even when the "
+            "launch then refuses on the operator's"
+        )
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        out = capsys.readouterr().out
+        assert "README.md" in out and "not machinery-owned" in out
+
+    def test_dry_run_mutates_nothing_and_classifies(self, repo, capsys):
+        leaving = _drop_leaving(repo)
+
+        code = attempt.main(
+            ["--repo", str(repo), "--name", "hardening-run-99"]
+        )
+
+        assert code == 1, "dry run reports; only --apply may clean"
+        assert leaving.exists()
+        assert _leavings_branches(repo) == []
+        assert "pipeline-authored leaving" in capsys.readouterr().out

--- a/tests/unit/test_speedrun_new_attempt.py
+++ b/tests/unit/test_speedrun_new_attempt.py
@@ -141,11 +141,15 @@ class TestOutcome:
 
 class TestPreconditions:
     def test_dirty_tree_is_refused(self, repo, capsys):
+        # #2146: refusal now classifies. An untracked file OUTSIDE the
+        # pipeline-emission allowlist is operator-owned and refuses by name;
+        # machinery-owned leavings are the janitor's (test_leavings_janitor).
         (repo / "uncommitted.txt").write_text("wip", encoding="utf-8")
 
         assert _apply(repo) == 1
         out = capsys.readouterr().out
-        assert "uncommitted change" in out
+        assert "uncommitted.txt" in out
+        assert "not machinery-owned" in out
         assert sna.current_branch(repo) == "hardening-run-11", "must not mutate"
 
     def test_extra_worktree_is_refused(self, repo, tmp_path, capsys):

--- a/tools/speedrun_new_attempt.py
+++ b/tools/speedrun_new_attempt.py
@@ -34,6 +34,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+# The tool runs as a script from tools/, so the package root needs adding
+# before assemblyzero imports resolve (same pattern as speedrun_roll).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from assemblyzero.speedrun.leavings import (  # noqa: E402
+    classify_dirt,
+    preserve_and_clear,
+)
+
 GRAVEYARD_PREFIX = "graveyard/"
 
 
@@ -119,14 +127,22 @@ def check_preconditions(repo_root: Path, new_name: str) -> list[str]:
     if not (repo_root / ".git").exists():
         return [f"{repo_root} is not a git repository root"]
 
-    status = _run(["git", "status", "--porcelain"], cwd=repo_root)
-    if status.returncode != 0:
-        problems.append(f"git status failed: {status.stderr.strip()}")
-    elif status.stdout.strip():
-        dirty = len(status.stdout.strip().splitlines())
+    # #2146 / standard 0027: classify before refusing. Machinery-owned dirt
+    # (untracked, under the pipeline-emission allowlist) is the janitor's to
+    # preserve-and-clear -- main() runs it under --apply before this check,
+    # so anything still here means the janitor failed or was not allowed to
+    # run, and the message says so. Operator-owned dirt refuses BY NAME:
+    # that refusal is the safeguard working.
+    machinery, operator = classify_dirt(repo_root)
+    for path in machinery:
         problems.append(
-            f"working tree has {dirty} uncommitted change(s) -- commit, stash, "
-            f"or resolve them first (a rename must not strand work)"
+            f"{path}: pipeline-authored leaving -- preserved and cleared "
+            "automatically under --apply (a rename must not strand work)"
+        )
+    for entry in operator:
+        problems.append(
+            f"{entry}: not machinery-owned -- commit, stash, or resolve it "
+            "first (a rename must not strand work)"
         )
 
     worktrees = _run(["git", "worktree", "list", "--porcelain"], cwd=repo_root)
@@ -268,6 +284,17 @@ def main(argv: list[str] | None = None) -> int:
 
     repo_root = Path(args.repo).resolve()
     new_name = args.name
+
+    # #2146: the janitor runs before the preconditions, so a tree dirty only
+    # with pipeline leavings does not stop a launch. Mutation, so --apply
+    # only; a dry run classifies and reports instead (via the precondition
+    # message). Nothing is cleared without first being preserved on a pushed
+    # ref -- preserve_and_clear leaves files in place on any failure.
+    if args.apply:
+        machinery, _operator = classify_dirt(repo_root)
+        if machinery:
+            print(f"Janitor: {len(machinery)} pipeline-authored leaving(s):")
+            preserve_and_clear(repo_root, machinery, log=print)
 
     problems = check_preconditions(repo_root, new_name)
     if problems:

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -83,6 +83,12 @@ from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     open_must_resolve_issues,
     refusal_message,
 )
+from assemblyzero.speedrun.leavings import (  # noqa: E402
+    classify_dirt,
+    is_machinery_owned,
+    preserve_and_clear,
+    untracked_files,
+)
 from assemblyzero.speedrun.worktrees import (  # noqa: E402
     sweep_pipeline_worktrees,
 )
@@ -1001,17 +1007,29 @@ def check_assemblyzero_tree(az_root: Path) -> list[str]:
     return problems
 
 
-def restore_repo(repo_root: Path, issues: list[int], log: EventLog) -> list[str]:
+def restore_repo(
+    repo_root: Path,
+    issues: list[int],
+    log: EventLog,
+    baseline_untracked: set[str] | None = None,
+) -> list[str]:
     """Hand the repo back the way it was borrowed (#2005). Returns failures.
 
     A roll leaves the target checked out on the attempt branch with pipeline
     worktrees registered. Being handed that back is a defect: a run should
     return the repo to the state it took.
 
+    #2145 / standard 0027: `baseline_untracked` is the untracked-file set the
+    roll borrowed. Any NEW untracked file the pipeline emitted is preserved
+    to a graveyard ref and cleared; a new file the machinery cannot prove it
+    made is a restore failure by name, never deleted. "RESTORE verified" may
+    only print when the untracked delta is empty. `data/speedrun/**` is
+    gitignored, so the evidence never appears in the delta at all.
+
     Called from a `finally`, so it runs on success, on failure, and on any
     exception -- including the SignalExit raised by the handlers above. It
-    cannot run under SIGKILL; that gap is covered only by the next invocation's
-    self-heal, and is stated rather than papered over.
+    cannot run under SIGKILL; that gap is covered only by the next
+    invocation's entry janitor, and is stated rather than papered over.
     """
     log.write("RESTORE returning the repo to its default branch")
 
@@ -1049,8 +1067,31 @@ def restore_repo(repo_root: Path, issues: list[int], log: EventLog) -> list[str]
     if tracked:
         failures.append(f"{len(tracked)} tracked modification(s) left behind")
 
+    if baseline_untracked is not None:
+        new = sorted(set(untracked_files(repo_root)) - baseline_untracked)
+        machinery_new = [f for f in new if is_machinery_owned(f)]
+        operator_new = [f for f in new if not is_machinery_owned(f)]
+
+        if machinery_new:
+            janitor = preserve_and_clear(
+                repo_root, machinery_new,
+                log=lambda m: log.write(m.strip()),
+            )
+            failures += [
+                f"pipeline leaving not cleared: {p.describe()}"
+                for p in janitor.problems
+            ]
+        for f in operator_new:
+            # Not the machinery's to touch: a new file it cannot prove it
+            # made is surfaced, never preserved or deleted on its author's
+            # behalf.
+            failures.append(f"new untracked file not made by the pipeline: {f}")
+
     if not failures:
-        log.write(f"RESTORE verified: on '{base}', no pipeline worktrees, clean")
+        log.write(
+            f"RESTORE verified: on '{base}', no pipeline worktrees, clean, "
+            "no new untracked files"
+        )
     return failures
 
 
@@ -1221,6 +1262,29 @@ def main(argv: list[str] | None = None) -> int:
     except Exception as exc:  # noqa: BLE001 - a sweep must never abort a roll
         session.write(f"SWEEP FAILED (continuing): {exc}")
 
+    # #2144 / standard 0027: the entry janitor for FILES. A predecessor that
+    # died uncontrolled may have left pipeline-authored untracked files in the
+    # target repo (run-16's LLD droppings blocked two launches). Preserve them
+    # to a pushed graveyard ref, then clear them -- and like the sweep, a
+    # janitor problem is reported and never costs the roll.
+    session.write("JANITOR pipeline file leavings")
+    try:
+        machinery, _operator = classify_dirt(repo_root)
+        if machinery:
+            janitor = preserve_and_clear(
+                repo_root, machinery, log=lambda m: session.write(m.strip())
+            )
+            for problem in janitor.problems:
+                session.write(f"JANITOR UNRESOLVED {problem.describe()}")
+        else:
+            session.write("  file janitor: nothing to do")
+    except Exception as exc:  # noqa: BLE001 - a janitor must never abort a roll
+        session.write(f"JANITOR FAILED (continuing): {exc}")
+
+    # #2145: the untracked set the roll borrows. Everything beyond this at
+    # exit is the roll's own emission, and restore_repo reconciles it.
+    baseline_untracked = set(untracked_files(repo_root))
+
     code = 0
     try:
         for issue in args.issue:
@@ -1285,7 +1349,9 @@ def main(argv: list[str] | None = None) -> int:
         # A finished roll leaves no pid behind to be stopped, or mistaken for a
         # live one once Windows reuses the number.
         pid_file(log_dir).unlink(missing_ok=True)
-        failures = restore_repo(repo_root, args.issue, session)
+        # Positional: pre-#2145 test stubs replace restore_repo with bare
+        # *args lambdas, and the keyword form would break every one of them.
+        failures = restore_repo(repo_root, args.issue, session, baseline_untracked)
         if failures:
             print("\nRESTORE INCOMPLETE:")
             for f in failures:


### PR DESCRIPTION
Closes #2144, Closes #2145, Closes #2146

Implements standard 0027 (per issue 2143): the machinery cleans up after itself, preserve-first, and never hands its mess to the operator.

## What

**New module `assemblyzero/speedrun/leavings.py`** — the file janitor all three issues share. `EMISSION_ALLOWLIST` names the pipeline's write sites in a target repo (`docs/lld/active/`, `docs/lld/drafts/`, grounded in the requirements workflow's actual save paths); `classify_dirt` splits a dirty tree into machinery-owned (untracked, allowlisted) and operator-owned (everything else); `preserve_and_clear` commits leavings to a pushed `graveyard/leavings-<ts>` branch through a temporary index (HEAD, real index, and working tree untouched), then removes them and prunes only allowlist directories the removals emptied. All-or-nothing: commit or push failure leaves every file in place, reported. Unpushed is unpreserved.

**#2144 — entry janitor.** The launcher's start sequence gains a JANITOR step beside the worktree sweep: a predecessor's leavings are preserved and cleared before any roll, narrated per standard 0026, and a janitor problem never aborts the roll.

**#2145 — exit reconcile.** The launcher snapshots the untracked set it borrows; `restore_repo` reconciles the delta on every controlled exit (success, failure, SignalExit): machinery-owned emissions are preserved-and-cleared, a new file the machinery cannot prove it made is a restore failure by name and is never deleted, and "RESTORE verified" now requires an empty untracked delta. `data/speedrun/**` is gitignored, so the evidence never enters the delta.

**#2146 — classify-first preconditions.** `speedrun_new_attempt` runs the janitor before its precondition check under `--apply` (dry runs mutate nothing and report the classification instead). Refusals now name each blocking path and its classification; a tree dirty only with pipeline leavings no longer stops a launch, and operator-owned dirt still refuses, which is the safeguard working.

## Why

Two consecutive launches on 2026-08-09 were blocked by run-16's untracked LLD droppings, eight days old, that a human had to move. The sweep (per issue 2077) was the only janitor and only knew about worktrees. Full narrative in the three issues and standard 0027.

## Tests

`tests/unit/test_leavings_janitor.py` (new, 18 tests, real throwaway repos with bare origins): preserved-on-pushed-ref-then-cleared with content verification; directory pruning bounded to the allowlist; preservation failure leaves files in place; the main checkout undisturbed by preservation; classification for allowlisted/outside/tracked-modified/gitignored; the run-16 replay through the launcher (leavings gone and preserved before the roll starts); exit reconcile on success and failure paths; unproven-authorship files kept and named in RESTORE INCOMPLETE; evidence exemption; and the four new-attempt posture cases including the mixed tree (machinery share preserved, operator entry still refuses) and the dry run.

Adjusted for the new contract: `test_speedrun_new_attempt.py::test_dirty_tree_is_refused` now pins the classified refusal message; the launcher passes the baseline positionally so pre-existing bare-lambda `restore_repo` stubs keep working.

Full unit suite green locally before push. Ruff clean.
