### PR TITLE
feat: verdict in words, conflict never redrawn, prerequisites gate the next launch (Closes #2165, Closes #2166, Closes #2167)

### DIFF
--- a/assemblyzero/core/exit_codes.py
+++ b/assemblyzero/core/exit_codes.py
@@ -1,0 +1,30 @@
+"""Exit codes the roll machinery uses to speak without parsing prose (#2166).
+
+The launcher classifies a child's death by exit code alone. Prose parsing is
+how classifications rot, so each non-generic failure class gets a code:
+
+- 91: a base or gate problem. Never retried (established behavior).
+- 92: a provider storm (``assemblyzero.core.provider_storm.STORM_EXIT_CODE``).
+  Backed off, then retried.
+- 93: a requirements conflict. The ISSUE needs an operator ruling, so no
+  redraw can help; the launcher stops the issue and continues the batch.
+"""
+
+from __future__ import annotations
+
+CONFLICT_EXIT_CODE = 93
+
+#: Must match ``REQUIREMENTS_CONFLICT_MARKER`` in
+#: ``assemblyzero.workflows.requirements.nodes.analyze_requirements`` -- a
+#: test pins the two together so they cannot drift.
+CONFLICT_MARKER = "REQUIREMENTS CONFLICT:"
+
+
+def is_requirements_conflict(error_summary: str | None) -> bool:
+    """True when a failure's error summary carries the conflict marker.
+
+    The marker is a deliberate structured prefix set by the analysis gate
+    (#1899) and the spec reviewer (#1900); detecting it here is reading our
+    own protocol, not scraping free text.
+    """
+    return bool(error_summary) and CONFLICT_MARKER in error_summary

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -46,6 +46,7 @@ than transcribed:
 | `--log-dir` | where the triplets land. Default `<repo>/data/speedrun/runs` |
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
+| `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
 
 **Use `--detach`.** A roll started from a session is a descendant of that
 session's shell, and a harness kill of the shell takes the whole tree with it.

--- a/tests/unit/test_speedrun_roll_verdict.py
+++ b/tests/unit/test_speedrun_roll_verdict.py
@@ -1,0 +1,255 @@
+"""The verdict, the conflict classification, and the prerequisite gate
+(#2165, #2166, #2167).
+
+A roll ended 2026-08-09 with `exit 1` as its last word: the operator had to
+interpret the code, nothing said "resolve #228 and #229", nothing said
+"do not re-roll", and the redraw loop had already burned two draws against
+an issue whose verdict said no draw could help. These pin the repairs: the
+conflict exit code and its never-redraw/continue-the-batch classification,
+the verdict block as the narration's last words, and the prerequisite file
+that makes the next launch refuse while the questions stay open.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+
+def _healthy_box(*_args, **_kwargs):
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.core.exit_codes import (  # noqa: E402
+    CONFLICT_EXIT_CODE,
+    CONFLICT_MARKER,
+    is_requirements_conflict,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+QUESTIONS = [
+    {"number": 228, "title": "must-resolve: #1 needle visibility at 75"},
+    {"number": 229, "title": "must-resolve: #1 arc 60-100 vs mid-arc 50"},
+]
+
+
+def _main(repo, issues, rolls, *, questions=None, gh_error=None, extra_argv=()):
+    """Run main() with scripted per-issue roll results.
+
+    `rolls` maps issue number to a list of exit codes, one per attempt.
+    """
+    counts = {i: 0 for i in rolls}
+
+    def _roll(repo_root, issue, log_dir, az_root, _extra):
+        result = rolls[issue][min(counts[issue], len(rolls[issue]) - 1)]
+        counts[issue] += 1
+        return result
+
+    argv = ["--repo", str(repo), "--attempts", "3", *extra_argv]
+    for i in issues:
+        argv += ["--issue", str(i)]
+
+    # Stateful: the PREFLIGHT query (call 1) sees a repo with no open
+    # questions, as in real life -- the run FILES them, so only the
+    # verdict-time query (call 2+) returns them.
+    calls = {"n": 0}
+
+    def _must_resolve(_repo):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return [], None
+        return (questions or [], gh_error)
+
+    with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+            patch.object(sr, "check_box_health", _healthy_box), \
+            patch.object(sr, "open_must_resolve_issues", _must_resolve), \
+            patch.object(sr, "roll_issue", _roll), \
+            patch.object(sr, "restore_repo", lambda *a: []), \
+            patch.object(sr.time, "sleep", lambda s: None):
+        code = sr.main(argv)
+    return code, counts
+
+
+class TestConflictClassification:
+    def test_the_marker_is_pinned_to_its_source(self):
+        """The exit-code module's copy must never drift from the analysis
+        gate's canonical marker."""
+        from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+            REQUIREMENTS_CONFLICT_MARKER,
+        )
+        assert CONFLICT_MARKER == REQUIREMENTS_CONFLICT_MARKER
+
+    def test_detection_reads_the_protocol_prefix(self):
+        assert is_requirements_conflict(
+            "REQUIREMENTS CONFLICT: no spec can satisfy both readings"
+        )
+        assert not is_requirements_conflict("MECHANICAL VALIDATION FAILED")
+        assert not is_requirements_conflict(None)
+
+    def test_a_conflict_is_never_redrawn(self, repo):
+        _code, counts = _main(repo, [1], {1: [CONFLICT_EXIT_CODE]},
+                              questions=QUESTIONS)
+        assert counts[1] == 1, "no redraw can help an ambiguous issue"
+
+    def test_the_batch_continues_past_a_blocked_issue(self, repo):
+        """Today's shape: with this classification, #4 and #7 would have
+        rolled while #1 waited for its ruling."""
+        code, counts = _main(
+            repo, [1, 4, 7],
+            {1: [CONFLICT_EXIT_CODE], 4: [0], 7: [0]},
+            questions=QUESTIONS,
+        )
+        assert counts[4] == 1 and counts[7] == 1
+        assert code == CONFLICT_EXIT_CODE, "the batch result names the block"
+
+    def test_a_generic_failure_still_redraws_and_stops(self, repo):
+        code, counts = _main(repo, [1, 4], {1: [1, 1, 1], 4: [0]})
+        assert counts[1] == 3, "generic failures keep the redraw budget"
+        assert counts.get(4, 0) == 0, "exhaustion still stops the batch"
+        assert code == 1
+
+
+class TestVerdictBlock:
+    def test_blocked_verdict_names_questions_and_forbids_rerolling(
+        self, repo, capsys
+    ):
+        _main(repo, [1], {1: [CONFLICT_EXIT_CODE]}, questions=QUESTIONS)
+        out = capsys.readouterr().out
+        assert "ROLL BLOCKED" in out
+        assert "#228" in out and "#229" in out
+        assert "resolve #228 and #229" in out
+        assert "Do not re-roll without resolution" in out
+        assert "--override-prereqs" in out
+
+    def test_success_verdict_states_it_in_words(self, repo, capsys):
+        code, _ = _main(repo, [4, 7], {4: [0], 7: [0]})
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "ROLL SUCCEEDED: all 2 issue(s) rolled (#4, #7)." in out
+
+    def test_failed_verdict_names_the_stop_and_the_next_step(self, repo, capsys):
+        _main(repo, [1, 4], {1: [1, 1, 1], 4: [0]})
+        out = capsys.readouterr().out
+        assert "ROLL FAILED at #1" in out
+        assert "Not rolled: #4." in out
+        assert "Inspect" in out
+
+    def test_gh_unreachable_still_renders_a_verdict(self, repo, capsys):
+        _main(repo, [1], {1: [CONFLICT_EXIT_CODE]}, gh_error="boom")
+        out = capsys.readouterr().out
+        assert "ROLL BLOCKED" in out
+        assert "gh was unreachable" in out
+
+
+class TestPrereqFile:
+    def test_a_blocked_run_writes_the_prereq_file(self, repo):
+        _main(repo, [1], {1: [CONFLICT_EXIT_CODE]}, questions=QUESTIONS)
+        data = json.loads(sr.prereqs_path(repo).read_text(encoding="utf-8"))
+        assert [b["number"] for b in data["blocking"]] == [228, 229]
+
+    def test_a_clean_run_writes_no_prereq_file(self, repo):
+        _main(repo, [4], {4: [0]})
+        assert not sr.prereqs_path(repo).exists()
+
+
+def _gh_state(state):
+    def _run(cmd, cwd=None, env=None):
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=state, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return _run
+
+
+class TestPrereqGate:
+    def _seed(self, repo, blocking=None):
+        sr.write_prereqs(
+            repo,
+            QUESTIONS if blocking is None else blocking,
+            "blocked issue(s) #1",
+        )
+
+    def test_no_file_means_no_gate(self, repo):
+        assert sr.check_prereqs(repo, override=False) is None
+
+    def test_open_questions_refuse_and_name_the_override(self, repo, capsys):
+        self._seed(repo)
+        with patch.object(sr, "_run", _gh_state("OPEN")):
+            assert sr.check_prereqs(repo, override=False) == 91
+        out = capsys.readouterr().out
+        assert "#228" in out and "#229" in out
+        assert "Do not re-roll without resolution" in out
+        assert "--override-prereqs" in out
+
+    def test_resolved_questions_clear_the_gate_and_the_file(self, repo, capsys):
+        self._seed(repo)
+        with patch.object(sr, "_run", _gh_state("CLOSED")):
+            assert sr.check_prereqs(repo, override=False) is None
+        assert not sr.prereqs_path(repo).exists()
+        assert "resolved" in capsys.readouterr().out
+
+    def test_offline_refuses_conservatively(self, repo, capsys):
+        """Unlike the live must-resolve gate, this file is certain local
+        knowledge of a block; unverifiable closure must not proceed."""
+        self._seed(repo)
+
+        def _down(cmd, cwd=None, env=None):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no net")
+
+        with patch.object(sr, "_run", _down):
+            assert sr.check_prereqs(repo, override=False) == 91
+        assert "cannot verify" in capsys.readouterr().out
+
+    def test_override_proceeds_once_and_keeps_the_file(self, repo, capsys):
+        self._seed(repo)
+        assert sr.check_prereqs(repo, override=True) is None
+        assert sr.prereqs_path(repo).exists(), "override is not forgetting"
+        assert "OVERRIDE" in capsys.readouterr().out
+
+    def test_an_unreadable_file_refuses_rather_than_guessing(self, repo, capsys):
+        path = sr.prereqs_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert sr.check_prereqs(repo, override=False) == 91
+        assert "could not be read" in capsys.readouterr().out
+
+    def test_the_gate_runs_before_anything_is_spent(self, repo, capsys):
+        self._seed(repo)
+        rolled = []
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy_box), \
+                patch.object(sr, "roll_issue",
+                             lambda *a: rolled.append(a) or 0), \
+                patch.object(sr, "_run", _gh_state("OPEN")):
+            code = sr.main(["--repo", str(repo), "--issue", "7"])
+        assert code == 91
+        assert rolled == []
+
+    def test_the_override_rides_the_detached_relaunch(self, tmp_path):
+        import argparse
+
+        args = argparse.Namespace(
+            issue=[7], log_dir=None, assemblyzero_root=None,
+            detach=True, detached_stdout=None, override_prereqs=True,
+        )
+        argv = sr.detached_argv(args, [], tmp_path / "r", tmp_path / "a",
+                                tmp_path / "l")
+        assert "--override-prereqs" in argv

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -253,6 +253,16 @@ Examples:
                 print(f"\n[ORCHESTRATOR] {provider_storm.storm_message()}")
                 sys.exit(provider_storm.STORM_EXIT_CODE)
 
+            # #2166: a requirements conflict is not a bad draw -- the ISSUE
+            # needs an operator ruling, so the launcher must stop this issue
+            # (never redraw it) and continue the batch. The code carries the
+            # classification; the marker is our own structured prefix.
+            from assemblyzero.core.exit_codes import (
+                CONFLICT_EXIT_CODE, is_requirements_conflict,
+            )
+            if is_requirements_conflict(result["error_summary"]):
+                sys.exit(CONFLICT_EXIT_CODE)
+
             sys.exit(1)
 
     except ConcurrentOrchestrationError as exc:

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
 import re
 import subprocess
@@ -72,6 +73,7 @@ except ImportError:  # pragma: no cover - tool copied outside the package
 
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
+from assemblyzero.core.exit_codes import CONFLICT_EXIT_CODE  # noqa: E402
 from assemblyzero.core.provider_storm import (  # noqa: E402
     STORM_EXIT_CODE,
     backoff_minutes,
@@ -583,6 +585,10 @@ def detached_argv(
         # a bare Namespace (tests, embedders) predate the flag.
         "--attempts", str(max(1, getattr(args, "attempts", 1))),
     ]
+    # #2167: an operator's deliberate override must ride the relaunch too, or
+    # the detached run re-refuses on the very gate the operator waived.
+    if getattr(args, "override_prereqs", False):
+        argv.append("--override-prereqs")
     return argv + extra
 
 
@@ -886,9 +892,13 @@ def follow_roll(
                     print(chunk, end="", flush=True)
                 if seen_running or wait_for_start:
                     code = _task_last_result() or 0
+                    # #2165: the word, not just the number. The full verdict
+                    # block streams above this from the narration; this line
+                    # is the follower's own sign-off.
+                    word = "SUCCEEDED" if code == 0 else "FAILED"
                     print(
-                        f"\nThe roll is done (task status: {status}, "
-                        f"exit {code}).",
+                        f"\nThe roll is done: {word} "
+                        f"(task status: {status}, exit {code}).",
                         flush=True,
                     )
                     return code
@@ -1095,6 +1105,185 @@ def restore_repo(
     return failures
 
 
+# =============================================================================
+# Verdict and prerequisites -- the last words in the narration (#2165, #2167)
+# =============================================================================
+
+PREREQS_FILENAME = "prereqs.json"
+
+
+def prereqs_path(repo_root: Path) -> Path:
+    return Path(repo_root) / "data" / "speedrun" / PREREQS_FILENAME
+
+
+def write_prereqs(repo_root: Path, blocking: list[dict], note: str) -> None:
+    path = prereqs_path(repo_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"created": _stamp(), "note": note, "blocking": blocking},
+            indent=2,
+        ) + "\n",
+        encoding="utf-8",
+    )
+
+
+def check_prereqs(repo_root: Path, override: bool) -> int | None:
+    """The previous run's unresolved questions gate this launch (#2167).
+
+    Returns None to proceed, 91 to refuse. Unlike the general must-resolve
+    query (which proceeds with a warning offline), this file is local,
+    certain knowledge of a known block -- unverifiable closure REFUSES.
+    The override runs anyway ONCE and leaves the file, so the following
+    launch re-checks: override means "run anyway", never "forget".
+    """
+    path = prereqs_path(repo_root)
+    if not path.exists():
+        return None
+
+    if override:
+        print(
+            "OVERRIDE: launching despite the previous run's open questions "
+            f"({path.name} kept; the next launch will re-check)."
+        )
+        return None
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        blocking = data.get("blocking") or []
+    except (OSError, ValueError):
+        blocking = []
+
+    if not blocking:
+        print(
+            "BLOCKED: a previous run recorded unresolved questions but their "
+            f"numbers could not be read from {path}. Check "
+            "must-resolve issues by hand, or pass --override-prereqs to run anyway."
+        )
+        return 91
+
+    still_open: list[dict] = []
+    for item in blocking:
+        number = item.get("number")
+        state = _run(
+            ["gh", "issue", "view", str(number), "--json", "state",
+             "--jq", ".state"],
+            cwd=repo_root,
+        )
+        if state.returncode != 0:
+            print(
+                f"BLOCKED: cannot verify that question #{number} was resolved "
+                "(gh unreachable). This launch refuses rather than re-roll "
+                "into a known wall. Pass --override-prereqs to run anyway."
+            )
+            return 91
+        if state.stdout.strip().upper() != "CLOSED":
+            still_open.append(item)
+
+    if still_open:
+        print("BLOCKED: the previous run's questions are still open:")
+        for item in still_open:
+            print(f"  #{item.get('number')}  {item.get('title', '')}")
+        print(
+            "\n  Resolve them (edit the source issue, close each question), "
+            "then launch again.\n  Do not re-roll without resolution -- the "
+            "same conflicts will refire.\n  Deliberately rolling anyway: "
+            "--override-prereqs."
+        )
+        return 91
+
+    path.unlink(missing_ok=True)
+    numbers = ", ".join(f"#{i.get('number')}" for i in blocking)
+    print(f"Previous run's questions resolved ({numbers}) -- proceeding.")
+    return None
+
+
+def print_verdict(
+    repo_root: Path,
+    *,
+    requested: list[int],
+    rolled: list[int],
+    blocked: list[int],
+    stopped_at: int | None,
+    code: int,
+) -> None:
+    """State the outcome in words, last, with the next step (#2165).
+
+    Never raises: a verdict must not cost a run, and it must render even
+    when gh is unreachable.
+    """
+    try:
+        _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code)
+    except Exception as exc:  # noqa: BLE001 - the verdict is best-effort display
+        print(f"(verdict rendering failed: {exc})")
+
+
+def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code):
+    names = ", ".join(f"#{i}" for i in rolled) or "none"
+    print()
+    if blocked:
+        blocked_names = ", ".join(f"#{i}" for i in blocked)
+        print(f"ROLL BLOCKED: issue(s) {blocked_names} await an operator ruling.")
+        if stopped_at is not None:
+            print(
+                f"  Also FAILED at #{stopped_at} (exit {code}); later "
+                "issues were not rolled."
+            )
+        print(f"  Rolled successfully: {names}.")
+        questions, gh_error = open_must_resolve_issues(repo_root)
+        if gh_error:
+            print(
+                "  Questions were filed during this run, but gh was "
+                "unreachable to list them."
+            )
+            write_prereqs(
+                repo_root, [],
+                f"blocked issue(s) {blocked_names}; question numbers unverified",
+            )
+        else:
+            print("  This run filed the questions blocking it:")
+            for q in questions:
+                print(f"    #{q['number']}  {q['title']}")
+            write_prereqs(
+                repo_root, questions,
+                f"blocked issue(s) {blocked_names}",
+            )
+            shortlist = " and ".join(f"#{q['number']}" for q in questions)
+            print(f"\n  Next step: resolve {shortlist}.")
+        print(
+            "  Do not re-roll without resolution -- the next launch will "
+            "refuse while these stay open (--override-prereqs to run anyway)."
+        )
+    elif stopped_at is not None:
+        print(
+            f"ROLL FAILED at #{stopped_at} (exit {code}) after exhausting "
+            "its attempts."
+        )
+        remaining = [i for i in requested if i not in rolled and i != stopped_at]
+        if remaining:
+            print(f"  Not rolled: {', '.join(f'#{i}' for i in remaining)}.")
+        print(f"  Rolled successfully: {names}.")
+        print(
+            "  Next step: hand an agent runbook 0952 section Inspect for the "
+            "post-mortem before rolling again."
+        )
+    elif rolled == requested and code == 0:
+        print(f"ROLL SUCCEEDED: all {len(rolled)} issue(s) rolled ({names}).")
+        print(
+            "  Next step: archive the run (runbook 0952 section Inspect, "
+            "step 6), then roll the next batch."
+        )
+    else:
+        print(
+            f"ROLL DID NOT COMPLETE (exit {code}) -- interrupted or errored "
+            f"mid-batch. Rolled before the interruption: {names}."
+        )
+        print(
+            "  Next step: hand an agent runbook 0952 section Inspect; the "
+            "events logs say where it died."
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -1134,6 +1323,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--detach-stop", action="store_true",
         help="Stop a detached roll and every process it spawned (#2016)",
+    )
+    parser.add_argument(
+        "--override-prereqs", action="store_true",
+        help=(
+            "Launch even though a previous run's questions are still open "
+            "(#2167). Runs anyway ONCE; the prerequisite file survives and "
+            "the following launch re-checks."
+        ),
     )
     parser.add_argument(
         "--no-follow", action="store_true",
@@ -1218,6 +1415,13 @@ def main(argv: list[str] | None = None) -> int:
         print(health.message)
         return 91
 
+    # #2167: the previous run's own unresolved questions gate this launch,
+    # from a local file, before the live query -- certain knowledge refuses
+    # even offline.
+    prereq_refusal = check_prereqs(repo_root, args.override_prereqs)
+    if prereq_refusal is not None:
+        return prereq_refusal
+
     # #2073: refuse while the target repo has unanswered questions about what
     # its issue text asks for. Checked ONCE per invocation, here rather than per
     # redraw, and before the detach hand-off -- so nothing is spent, no branch
@@ -1286,6 +1490,9 @@ def main(argv: list[str] | None = None) -> int:
     baseline_untracked = set(untracked_files(repo_root))
 
     code = 0
+    rolled: list[int] = []
+    blocked: list[int] = []
+    stopped_at: int | None = None
     try:
         for issue in args.issue:
             # #2068: generation quality varies wildly between draws -- the same
@@ -1298,6 +1505,17 @@ def main(argv: list[str] | None = None) -> int:
             for attempt_no in range(1, max(1, args.attempts) + 1):
                 code = roll_issue(repo_root, issue, log_dir, az_root, extra)
                 if code == 0 or code == 91:
+                    break
+
+                # #2166: a requirements conflict means the ISSUE needs an
+                # operator ruling. No redraw can help; the auto-filer (#2072)
+                # has already raised the questions. Stop this issue, keep the
+                # batch moving.
+                if code == CONFLICT_EXIT_CODE:
+                    session.write(
+                        f"BLOCKED #{issue} on an operator ruling -- "
+                        "no redraw can help; continuing the batch"
+                    )
                     break
 
                 # #2086: eighteen consecutive provider timeouts in one roll on
@@ -1334,14 +1552,20 @@ def main(argv: list[str] | None = None) -> int:
                         f"(exit {code}) — self-healing and redrawing."
                     )
                     time.sleep(2)
+            if code == CONFLICT_EXIT_CODE:
+                blocked.append(issue)
+                continue
             if code != 0:
+                stopped_at = issue
                 print(
                     f"\nSTOPPED at #{issue} (exit {code}); later issues not rolled."
                 )
                 return code
+            rolled.append(issue)
             time.sleep(1)
 
-        print(f"\nAll {len(args.issue)} issue(s) rolled.")
+        if blocked:
+            return CONFLICT_EXIT_CODE
         return 0
     finally:
         # #2005: hand the repo back the way it was borrowed -- on success, on
@@ -1359,6 +1583,17 @@ def main(argv: list[str] | None = None) -> int:
                 # Also to the events file: a detached run has no one reading
                 # stdout, and this is exactly the state the next roll inherits.
                 session.write(f"RESTORE INCOMPLETE: {f}")
+        # #2165/#2167: the verdict is the LAST thing in the narration, after
+        # the restore -- the operator's eye lands at the bottom. It also
+        # persists the blocking questions as the next launch's prerequisite.
+        print_verdict(
+            repo_root,
+            requested=list(args.issue),
+            rolled=rolled,
+            blocked=blocked,
+            stopped_at=stopped_at,
+            code=code,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2165, Closes #2166, Closes #2167

The completion path, rebuilt from today's live roll: the run that ended with a bare `exit 1`, two filed questions nobody was told to resolve, and two redraws burned against an issue whose own verdict said no draw could help.

## What

**#2166 — the conflict speaks in code, and the batch survives it.** New `assemblyzero/core/exit_codes.py`: `CONFLICT_EXIT_CODE = 93` (beside gate 91 and storm 92), with a drift-guard test pinning its marker to `analyze_requirements.REQUIREMENTS_CONFLICT_MARKER`. `orchestrate.py` exits 93 when the error summary carries the marker. The launcher classifies 93 as never-redraw: the issue is marked blocked-on-ruling and the batch CONTINUES — today's shape would have rolled #4 and #7 while #1 waited.

**#2165 — the verdict block.** The narration's last words (printed in the `finally`, after the restore) state the outcome in words: `ROLL BLOCKED` with the filed question numbers and titles, `ROLL FAILED at #N` with what didn't roll and the § Inspect pointer, `ROLL SUCCEEDED` with the archive reminder, or `ROLL DID NOT COMPLETE` for interruptions. The blocked verdict says plainly: resolve these, and do not re-roll without resolution. The follower's sign-off now carries the word too: `The roll is done: FAILED (task status: Ready, exit 93).`

**#2167 — the prerequisite file.** A blocked run writes `data/speedrun/prereqs.json` (created stamp, note, blocking issue numbers/titles). The next launch checks it before anything is spent: all closed deletes the file and proceeds narrating the resolution; any open refuses 91 naming each; gh unreachable refuses conservatively (this file is certain local knowledge of a block, unlike the live must-resolve gate's proceed-with-warning); an unreadable file refuses rather than guesses. `--override-prereqs` runs anyway once, narrates loudly, keeps the file, and rides the detached relaunch argv.

## Tests

`tests/unit/test_speedrun_roll_verdict.py` (new, 19 tests): marker drift guard, conflict detection, never-redraw, batch-continuation, generic failures unchanged, all four verdict shapes including gh-unreachable, prereq write on block and absence on success, and the full gate matrix (no file, open refuses naming the override, closed clears and deletes, offline refuses, override proceeds keeping the file, unreadable refuses, gate runs before any roll, override rides `detached_argv`). Runbook 0952 documents the new flag (its drift-guard test caught the omission). All nine affected suites green locally; full suite before push.
