### PR TITLE
fix: reset deletions survive the ReadOnly attribute (Closes #2162)

### DIFF
--- a/tests/unit/test_speedrun_reset_readonly.py
+++ b/tests/unit/test_speedrun_reset_readonly.py
@@ -1,0 +1,89 @@
+"""Reset deletions survive the ReadOnly attribute (#2162).
+
+Measured live 2026-08-09 mid-roll: the pipeline's own freshly created
+lineage directory carried the Windows ReadOnly attribute, and the reset's
+plain rmtree died on it with WinError 5, leaving the next attempt to draw
+over a predecessor's lineage. These pin the clear-and-retry handler at both
+deletion sites.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_reset as reset  # noqa: E402
+
+
+def _protect(path: Path) -> None:
+    """Make `path` refuse plain deletion, the way today's incident did."""
+    if sys.platform == "win32":
+        subprocess.run(
+            ["attrib", "+R", str(path)], capture_output=True, check=True
+        )
+    else:
+        # POSIX: a write-protected PARENT refuses deletion of its entries.
+        path.chmod(0o555)
+
+
+def _lineage_tree(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    d = repo / "docs" / "lineage" / "active" / "1-lld"
+    d.mkdir(parents=True)
+    (d / "001-issue.md").write_text("lineage\n", encoding="utf-8")
+    inner = d / "phase"
+    inner.mkdir()
+    (inner / "002-draft.md").write_text("draft\n", encoding="utf-8")
+    return repo
+
+
+class TestClearingRmtree:
+    def test_a_readonly_tree_is_fully_removed(self, tmp_path):
+        repo = _lineage_tree(tmp_path)
+        target = repo / "docs" / "lineage" / "active" / "1-lld"
+        _protect(target)
+        _protect(target / "phase")
+
+        reset._rmtree_clearing_readonly(target)
+
+        assert not target.exists()
+
+    def test_a_plain_tree_is_removed_without_ceremony(self, tmp_path):
+        repo = _lineage_tree(tmp_path)
+        target = repo / "docs" / "lineage" / "active" / "1-lld"
+
+        reset._rmtree_clearing_readonly(target)
+
+        assert not target.exists()
+
+
+class TestLineageDeletion:
+    def test_todays_incident_replayed(self, tmp_path, capsys):
+        """A ReadOnly lineage dir left by a prior attempt deletes cleanly,
+        with no WARNING line."""
+        repo = _lineage_tree(tmp_path)
+        target = repo / "docs" / "lineage" / "active" / "1-lld"
+        _protect(target)
+        _protect(target / "phase")
+
+        count = reset.delete_lineage_dirs(repo, 1)
+
+        out = capsys.readouterr().out
+        assert count == 1
+        assert not target.exists()
+        assert "WARNING" not in out
+        assert "Deleted lineage dir" in out
+
+    def test_only_the_issues_dirs_are_touched(self, tmp_path):
+        repo = _lineage_tree(tmp_path)
+        other = repo / "docs" / "lineage" / "active" / "41-lld"
+        other.mkdir()
+        (other / "keep.md").write_text("other issue\n", encoding="utf-8")
+
+        reset.delete_lineage_dirs(repo, 1)
+
+        assert other.exists(), "issue 41's lineage is not issue 1's to delete"

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -38,10 +38,35 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
+
+
+def _rmtree_clearing_readonly(path: Path) -> None:
+    """rmtree that survives the ReadOnly attribute (#2162).
+
+    The pipeline's own lineage directories carry the Windows ReadOnly
+    attribute (root cause hunted in #2136), and a plain rmtree dies on them
+    with WinError 5 -- measured live 2026-08-09, mid-roll. The handler
+    clears the attribute on the failing entry AND its parent (POSIX refusals
+    come from a write-protected parent), then retries that one deletion.
+    Plain deletion first; the chmod fires only on failure. Same pattern as
+    dependabot_review's worktree cleanup.
+    """
+
+    def _clear_and_retry(func, failing, _exc):
+        for target in (failing, os.path.dirname(failing)):
+            try:
+                os.chmod(target, stat.S_IWRITE | stat.S_IREAD | stat.S_IEXEC)
+            except OSError:
+                pass
+        func(failing)
+
+    shutil.rmtree(path, onexc=_clear_and_retry)
 
 
 def _run(cmd: list[str], cwd: Path | None = None, check: bool = False):
@@ -166,7 +191,7 @@ def _remove_worktree_at(repo_root: Path, worktree_path: Path) -> bool:
     # Clean, but git would not remove it — typically a directory that is no
     # longer registered as a worktree. Nothing uncommitted is at stake.
     try:
-        shutil.rmtree(worktree_path)
+        _rmtree_clearing_readonly(worktree_path)
         print(f"  Removed unregistered worktree directory: {worktree_path}")
         _prune_worktrees(repo_root)
         return True
@@ -317,7 +342,7 @@ def delete_lineage_dirs(repo_root: Path, issue: int) -> int:
         if not d.is_dir():
             continue
         try:
-            shutil.rmtree(d)
+            _rmtree_clearing_readonly(d)
             print(f"  Deleted lineage dir: {d.relative_to(repo_root)}")
             deleted += 1
         except OSError as e:


### PR DESCRIPTION
Closes #2162

Both rmtree sites in speedrun_reset (unregistered worktree dirs, lineage dirs) now clear the ReadOnly attribute on the failing entry and its parent in an error handler and retry that one deletion — plain deletion first, chmod only on failure, the pattern dependabot_review already proved. Live incident 2026-08-09: WinError 5 on a freshly pipeline-created lineage dir left attempt 2 drawing over attempt 1's leavings. New tests replay the incident cross-platform (attrib +R on Windows, write-protected parent on POSIX): a protected tree deletes fully with no WARNING, a plain tree needs no ceremony, and only the target issue's lineage dirs are touched. Full suite green locally.