### PR TITLE
fix: the VERIFIED block never claims a graveyard that did not happen (Closes #2163)

### DIFF
--- a/tests/unit/test_speedrun_new_attempt.py
+++ b/tests/unit/test_speedrun_new_attempt.py
@@ -265,3 +265,46 @@ class TestDefaultBranchIsReadNotAssumed:
 
         assert sna.main(["--repo", str(r), "--name", "attempt-2", "--apply"]) == 0
         assert sna.commits_ahead(r, "attempt-2", "origin/trunk") == 0
+
+
+class TestDefaultBranchDisplay:
+    """#2163: standing on the default branch, there is no previous attempt,
+    and the display must not fabricate one. Live 2026-08-09: the VERIFIED
+    block claimed "previous attempt preserved as 'graveyard/main'" while no
+    rename ran and no such branch existed."""
+
+    def test_no_graveyard_is_claimed_from_the_default_branch(self, repo, capsys):
+        _git(repo, "checkout", "main")
+
+        assert _apply(repo) == 0
+
+        out = capsys.readouterr().out
+        assert "Graveyard as:" not in out
+        assert "preserved as" not in out
+        assert "nothing to graveyard" in out
+        assert sna.local_branch_exists(repo, "main")
+        assert not sna.local_branch_exists(repo, "graveyard/main")
+
+    def test_a_real_attempt_still_claims_its_verified_graveyard(self, repo, capsys):
+        assert _apply(repo) == 0
+        out = capsys.readouterr().out
+        assert "preserved as 'graveyard/hardening-run-11'" in out
+
+    def test_a_missing_graveyard_ref_fails_verification(self, repo, monkeypatch, capsys):
+        """The claim requires the ref: sabotage the plan to skip the rename
+        and the run must end UNVERIFIED, never assert the preservation."""
+        def _no_rename(old_name, new_name, base):
+            return [
+                ["git", "fetch", "origin"],
+                ["git", "checkout", base],
+                ["git", "branch", new_name, f"origin/{base}"],
+                ["git", "push", "-u", "origin", new_name],
+            ]
+
+        monkeypatch.setattr(sna, "plan_steps", _no_rename)
+
+        assert _apply(repo) == 2
+
+        out = capsys.readouterr().out
+        assert "does not exist" in out
+        assert "preserved as" not in out

--- a/tools/speedrun_new_attempt.py
+++ b/tools/speedrun_new_attempt.py
@@ -306,10 +306,23 @@ def main(argv: list[str] | None = None) -> int:
     old_name = current_branch(repo_root)
     base = default_branch(repo_root)
 
+    # #2163: standing on the DEFAULT branch means there is no previous
+    # attempt. plan_steps already refuses to graveyard it; the display must
+    # not claim otherwise -- a VERIFIED block asserting an action that never
+    # happened teaches the operator to distrust verification prose.
+    graveyarding = bool(old_name) and old_name != base
+
     print(f"Repo:            {repo_root}")
-    print(f"Current attempt: {old_name or '(detached HEAD -- nothing to graveyard)'}")
-    if old_name:
+    if graveyarding:
+        print(f"Current attempt: {old_name}")
         print(f"Graveyard as:    {GRAVEYARD_PREFIX}{old_name}")
+    elif old_name:
+        print(
+            f"Current attempt: (none -- checkout is on '{old_name}', the "
+            "default branch; nothing to graveyard)"
+        )
+    else:
+        print("Current attempt: (detached HEAD -- nothing to graveyard)")
     print(f"New attempt:     {new_name} (from origin/{base})")
     print()
 
@@ -334,6 +347,15 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     failures = verify_postconditions(repo_root, new_name, base)
+    # #2163: a preservation may only be claimed after the ref is verified to
+    # exist -- and only when a rename actually ran.
+    if graveyarding and not local_branch_exists(
+        repo_root, f"{GRAVEYARD_PREFIX}{old_name}"
+    ):
+        failures.append(
+            f"expected preserved branch '{GRAVEYARD_PREFIX}{old_name}' "
+            "does not exist"
+        )
     if failures:
         print(f"\nUNVERIFIED: '{new_name}' was created but is not usable:")
         for f in failures:
@@ -343,7 +365,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"\nVERIFIED: {repo_root.name} is on '{new_name}'.")
     print(f"  exists on origin, tracks origin/{new_name}, level with origin/{base}.")
     print(f"  checkout on '{current_branch(repo_root)}' -- an attempt is a ref, not a place to stand.")
-    print(f"  previous attempt preserved as '{GRAVEYARD_PREFIX}{old_name}'.")
+    if graveyarding:
+        print(f"  previous attempt preserved as '{GRAVEYARD_PREFIX}{old_name}'.")
     print(
         f"\nPass --base-branch {new_name} to BOTH speedrun_clean_check.py and "
         f"orchestrate.py\n  so the gate and the roll judge the same tree "


### PR DESCRIPTION
Closes #2163

Standing on the default branch means there is no previous attempt: the plan display now says so plainly and omits the Graveyard line, and the VERIFIED block claims a preservation only after checking the graveyard ref actually exists (a sabotage test skips the rename and the run must end UNVERIFIED naming the missing ref). The genuine attempt-branch flow is unchanged and its claim is now verified rather than assumed. Live incident 2026-08-09: the block asserted 'previous attempt preserved as graveyard/main' while no rename ran and no such branch existed. Three new tests; full suite green locally (6,609).