### PR TITLE
feat: the graph atlas and live NODE position narration (Closes #2157, Closes #2158)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/atlas.py
+++ b/assemblyzero/workflows/implementation_spec/atlas.py
@@ -1,0 +1,131 @@
+"""The graph atlas for the implementation-spec workflow (#2157).
+
+Same contract as the requirements atlas: position narration, tutorial and
+quiz modes read from here, and the drift guard in
+``tests/unit/test_graph_atlas.py`` pins this file to the actual compiled
+``StateGraph`` so it cannot rot when the graph is rewired.
+
+``ordinal`` is the position on the forward path; ``HALT`` has none.
+"""
+
+from __future__ import annotations
+
+TOTAL_STEPS = 7
+
+ATLAS: dict[str, dict] = {
+    "N0_load_lld": {
+        "title": "load LLD",
+        "ordinal": 1,
+        "goal": "Load the approved LLD this spec will be built from.",
+        "teach": (
+            "The spec stage never re-litigates the LLD: it consumes the "
+            "approved document as ground truth. A missing or unreadable LLD "
+            "halts here, before anything is spent."
+        ),
+        "successors": {
+            "N1_analyze_codebase": "the LLD loaded",
+            "HALT": "the LLD could not be loaded",
+        },
+    },
+    "N1_analyze_codebase": {
+        "title": "analyze codebase",
+        "ordinal": 2,
+        "goal": "Read the target repo so the spec references real code.",
+        "teach": (
+            "Same grounding rule as the LLD stage: the generator is handed "
+            "the actual tree, so file paths and interfaces in the spec are "
+            "facts rather than guesses."
+        ),
+        "successors": {
+            "N2_generate_spec": "analysis complete",
+            "HALT": "analysis failed",
+        },
+    },
+    "N2_generate_spec": {
+        "title": "generate spec",
+        "ordinal": 3,
+        "goal": "The drafter model writes the implementation spec.",
+        "teach": (
+            "Failed validations and revision verdicts loop back here for a "
+            "fresh generation. A drafter failure halts outright: an "
+            "unconditional forward edge here once let an error ride through "
+            "a vacuous validation pass and severed the error chain."
+        ),
+        "successors": {
+            "N3_validate_completeness": "a draft was generated",
+            "HALT": "the drafter itself failed",
+        },
+    },
+    "N3_validate_completeness": {
+        "title": "completeness validation",
+        "ordinal": 4,
+        "goal": "Check the spec covers everything the LLD requires.",
+        "teach": (
+            "The mechanical gate of this stage: an incomplete spec loops "
+            "back for regeneration up to the iteration cap. Only a complete "
+            "spec earns a review."
+        ),
+        "successors": {
+            "N4_human_gate": "passed, with the human gate on",
+            "N5_review_spec": "passed, with the human gate off",
+            "N2_generate_spec": "incomplete; regenerate",
+            "HALT": "still incomplete at the iteration cap",
+        },
+    },
+    "N4_human_gate": {
+        "title": "human gate",
+        "ordinal": 5,
+        "goal": "An optional human checkpoint before review.",
+        "teach": (
+            "Autonomous rolls run with this gate off. When it is on, a "
+            "human forwards the spec, sends it back for revision, or takes "
+            "it over manually."
+        ),
+        "successors": {
+            "N5_review_spec": "the human approved",
+            "N2_generate_spec": "the human asked for a revision",
+            "HALT": "an error at the gate",
+            "END": "the human took over manually",
+        },
+    },
+    "N5_review_spec": {
+        "title": "adversarial review",
+        "ordinal": 6,
+        "goal": "A second model judges the spec against the LLD.",
+        "teach": (
+            "Approval finalizes; a revise verdict loops back to the "
+            "generator while iterations remain. The same blocking verdict "
+            "twice in a row is stagnation and halts the run instead of "
+            "circling forever."
+        ),
+        "successors": {
+            "N6_finalize_spec": "approved",
+            "N2_generate_spec": "revise; regenerate",
+            "HALT": "error, blocked, stagnation, or the cap",
+        },
+    },
+    "N6_finalize_spec": {
+        "title": "finalize",
+        "ordinal": 7,
+        "goal": "Save the approved spec where implementation will read it.",
+        "teach": (
+            "The saved spec is the hand-off artifact: the implementation "
+            "stage builds from this file, not from this run's transcript."
+        ),
+        "successors": {
+            "END": "always",
+        },
+    },
+    "HALT": {
+        "title": "halt",
+        "ordinal": None,
+        "goal": "Record why the run stopped, then end it cleanly.",
+        "teach": (
+            "HALT is the run stating its reason for stopping in a form the "
+            "launcher and telemetry can read; it is an exit, never a step."
+        ),
+        "successors": {
+            "END": "always",
+        },
+    },
+}

--- a/assemblyzero/workflows/implementation_spec/graph.py
+++ b/assemblyzero/workflows/implementation_spec/graph.py
@@ -313,15 +313,25 @@ def create_implementation_spec_graph() -> CompiledStateGraph:
     # Create graph with state schema
     graph = StateGraph(ImplementationSpecState)
 
+    # #2158: every node narrates its graph position on entry, sourced from
+    # the atlas (#2157) so the lines can never drift from the real graph.
+    from assemblyzero.workflows.implementation_spec.atlas import (
+        ATLAS, TOTAL_STEPS,
+    )
+    from assemblyzero.workflows.narration import narrated
+
+    def _add(name, fn):
+        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS))
+
     # Add nodes
-    graph.add_node(N0_LOAD_LLD, load_lld)
-    graph.add_node(N1_ANALYZE_CODEBASE, analyze_codebase)
-    graph.add_node(N2_GENERATE_SPEC, generate_spec)
-    graph.add_node(N3_VALIDATE_COMPLETENESS, validate_completeness)
-    graph.add_node(N4_HUMAN_GATE, human_gate)
-    graph.add_node(N5_REVIEW_SPEC, review_spec)
-    graph.add_node(N6_FINALIZE_SPEC, finalize_spec)
-    graph.add_node(HALT, create_halt_node("implementation_spec"))  # Issue #486
+    _add(N0_LOAD_LLD, load_lld)
+    _add(N1_ANALYZE_CODEBASE, analyze_codebase)
+    _add(N2_GENERATE_SPEC, generate_spec)
+    _add(N3_VALIDATE_COMPLETENESS, validate_completeness)
+    _add(N4_HUMAN_GATE, human_gate)
+    _add(N5_REVIEW_SPEC, review_spec)
+    _add(N6_FINALIZE_SPEC, finalize_spec)
+    _add(HALT, create_halt_node("implementation_spec"))  # Issue #486
 
     # START -> N0
     graph.add_edge(START, N0_LOAD_LLD)

--- a/assemblyzero/workflows/narration.py
+++ b/assemblyzero/workflows/narration.py
@@ -1,0 +1,53 @@
+"""Graph-position narration: NODE and NEXT lines at every transition (#2158).
+
+The graph itself reports where the run is -- each node is wrapped at
+graph-build time, so the position is authoritative rather than inferred
+from log grepping. Lines land on the workflow's stdout, which the roll
+redirects to the per-roll log and the follower streams to the operator's
+console (standard 0026).
+
+Narration must never cost a run: every failure path here degrades to
+silence, and a node missing from the atlas warns once, by name, and the
+roll continues.
+"""
+
+from __future__ import annotations
+
+_warned: set[str] = set()
+
+
+def _line_for(node_id: str, atlas: dict, total: int) -> list[str]:
+    entry = atlas.get(node_id)
+    if entry is None:
+        if node_id not in _warned:
+            _warned.add(node_id)
+            return [f"NODE {node_id} (no atlas entry -- see #2157)"]
+        return []
+
+    ordinal = entry.get("ordinal")
+    position = f"[{ordinal}/{total}] " if ordinal else ""
+    lines = [f"NODE {position}{entry['title']} -- {entry['goal']}"]
+
+    successors = entry.get("successors") or {}
+    parts = []
+    for successor, condition in successors.items():
+        name = atlas.get(successor, {}).get("title", successor)
+        parts.append(f"{name} ({condition})")
+    if parts:
+        lines.append(f"NEXT {' | '.join(parts)}")
+    return lines
+
+
+def narrated(node_id: str, fn, atlas: dict, total: int):
+    """Wrap a graph node so entering it narrates its position."""
+
+    def _wrapped(state, *args, **kwargs):
+        try:
+            for line in _line_for(node_id, atlas, total):
+                print(line, flush=True)
+        except Exception:  # noqa: BLE001 - narration never costs a run
+            pass
+        return fn(state, *args, **kwargs)
+
+    _wrapped.__name__ = getattr(fn, "__name__", node_id)
+    return _wrapped

--- a/assemblyzero/workflows/requirements/atlas.py
+++ b/assemblyzero/workflows/requirements/atlas.py
@@ -1,0 +1,219 @@
+"""The graph atlas for the requirements workflow (#2157).
+
+Machine-readable answers to the operator's three questions about a live
+run: where are we in the graph, what is this node FOR, and what comes
+next. Position narration (#2158), tutorial mode (#2160), and quiz mode
+(#2161) all read from here, and NOTHING else may hardcode the graph.
+
+The drift guard in ``tests/unit/test_graph_atlas.py`` compares this atlas
+against the actual compiled ``StateGraph``: every node here exists there,
+every node there exists here, and every successor here is a real edge.
+Rewire the graph without touching this file and the suite fails naming
+the gap.
+
+``ordinal`` is the position on the LLD workflow's FORWARD path (loops and
+halts do not consume ordinals; the issue workflow skips some nodes, which
+is documented rather than modeled). ``HALT`` has no ordinal: it is where
+runs end, never a step on the way.
+"""
+
+from __future__ import annotations
+
+TOTAL_STEPS = 11
+
+ATLAS: dict[str, dict] = {
+    "N0_load_input": {
+        "title": "load input",
+        "ordinal": 1,
+        "goal": "Load the issue (or brief) the document will be built from.",
+        "teach": (
+            "Everything downstream builds from this text, which is why an "
+            "ambiguous issue is caught two nodes later rather than at the "
+            "end. LLD runs go on to read the codebase; issue-drafting runs "
+            "skip straight to the drafter."
+        ),
+        "successors": {
+            "N0b_analyze_codebase": "LLD run",
+            "N1_generate_draft": "issue-drafting run",
+            "HALT": "the input could not be loaded",
+        },
+    },
+    "N0b_analyze_codebase": {
+        "title": "analyze codebase",
+        "ordinal": 2,
+        "goal": "Read the target repo so the draft cites real files, not guesses.",
+        "teach": (
+            "The drafter is only as grounded as the context it is handed. "
+            "This node walks the actual code so the LLD names modules that "
+            "exist and follows conventions already in the tree."
+        ),
+        "successors": {
+            "N0c_analyze_requirements": "always",
+        },
+    },
+    "N0c_analyze_requirements": {
+        "title": "requirements consistency gate",
+        "ordinal": 3,
+        "goal": (
+            "Check the issue's requirements agree with each other before any "
+            "tokens are spent drafting."
+        ),
+        "teach": (
+            "No spec can satisfy two contradictory sentences, so a conflict "
+            "halts the run and files a question for the operator instead of "
+            "drafting the wrong reading. A halt here is the system working: "
+            "the cheapest possible failure, before generation."
+        ),
+        "successors": {
+            "N1_generate_draft": "the requirements are consistent",
+            "HALT": "a requirements conflict needs an operator ruling",
+        },
+    },
+    "N1_generate_draft": {
+        "title": "generate draft",
+        "ordinal": 4,
+        "goal": "The drafter model writes the document.",
+        "teach": (
+            "Draw quality varies enormously between attempts on identical "
+            "input, which is why failed validations loop back here for a "
+            "fresh draft rather than patching a bad one. LLD runs go to the "
+            "auto-fix pass next; issue-drafting runs go to review."
+        ),
+        "successors": {
+            "N_ponder_stibbons": "LLD run",
+            "N2_human_gate_draft": "issue-drafting run with the draft gate on",
+            "N3_review": "issue-drafting run with the draft gate off",
+            "HALT": "the drafter itself failed",
+        },
+    },
+    "N_ponder_stibbons": {
+        "title": "auto-fix pass",
+        "ordinal": 5,
+        "goal": "Repair mechanical slips in the draft before validation sees them.",
+        "teach": (
+            "Cheap deterministic fixes (formatting, known slip patterns) "
+            "applied before validation, so the validator judges the best "
+            "version of the draft and loop-backs are spent on real defects."
+        ),
+        "successors": {
+            "N1_5_validate_mechanical": "always",
+        },
+    },
+    "N1_5_validate_mechanical": {
+        "title": "mechanical validation",
+        "ordinal": 6,
+        "goal": (
+            "Check the document's structure: required sections present, "
+            "paths real, tables well-formed."
+        ),
+        "teach": (
+            "This is the gate that catches a drafter dropping mandatory "
+            "sections (the campaign's most common mechanical failure). It "
+            "blocks and redrafts up to the iteration cap; a document that "
+            "cannot pass structure is never shown to a reviewer."
+        ),
+        "successors": {
+            "N1b_validate_test_plan": "the structure passed",
+            "N1_generate_draft": "the structure failed; redraft",
+            "HALT": "still failing at the iteration cap",
+        },
+    },
+    "N1b_validate_test_plan": {
+        "title": "test-plan validation",
+        "ordinal": 7,
+        "goal": (
+            "Check the draft's test plan actually discriminates: coverage, "
+            "no vague assertions, nothing delegated to a human."
+        ),
+        "teach": (
+            "A plan whose tests would pass either way proves nothing. This "
+            "gate reads the plan the way a skeptic would, and sends the "
+            "draft back if the tests could not tell a correct build from a "
+            "wrong one."
+        ),
+        "successors": {
+            "N2_human_gate_draft": "passed, with the draft gate on",
+            "N3_review": "passed, with the draft gate off",
+            "N1_generate_draft": "the plan failed; redraft",
+            "HALT": "an error, or still failing at the cap",
+        },
+    },
+    "N2_human_gate_draft": {
+        "title": "human gate: draft",
+        "ordinal": 8,
+        "goal": "An optional human checkpoint on the draft before review.",
+        "teach": (
+            "Autonomous rolls run with this gate off. When it is on, a "
+            "human reads the draft and sends it forward, back for revision, "
+            "or takes it over manually."
+        ),
+        "successors": {
+            "N3_review": "the human sent it to review",
+            "N1_generate_draft": "the human asked for a revision",
+            "END": "the human took over manually",
+        },
+    },
+    "N3_review": {
+        "title": "adversarial review",
+        "ordinal": 9,
+        "goal": (
+            "A second model judges the draft against the issue with an "
+            "adversarial brief."
+        ),
+        "teach": (
+            "The reviewer never sees the drafter's reasoning, so agreement "
+            "means two independent readings converged. Open questions can "
+            "loop the draft back for revision; the same blocking verdict "
+            "twice in a row is stagnation and halts the run rather than "
+            "circling."
+        ),
+        "successors": {
+            "N4_human_gate_verdict": "the verdict gate is on, or a question needs a human",
+            "N5_finalize": "approved with the verdict gate off",
+            "N1_generate_draft": "blocked or unanswered questions; revise",
+            "N3_review": "follow-up review round",
+            "HALT": "error, stagnation, or the iteration cap",
+        },
+    },
+    "N4_human_gate_verdict": {
+        "title": "human gate: verdict",
+        "ordinal": 10,
+        "goal": "An optional human checkpoint on the review verdict.",
+        "teach": (
+            "The escalation point: when the reviewer marks a question as "
+            "needing a human, the run stops here even in otherwise "
+            "ungated mode."
+        ),
+        "successors": {
+            "N5_finalize": "the human approved",
+            "N1_generate_draft": "the human asked for a revision",
+            "END": "the human took over manually",
+        },
+    },
+    "N5_finalize": {
+        "title": "finalize",
+        "ordinal": 11,
+        "goal": "Save the approved document where the next stage will read it.",
+        "teach": (
+            "An approved LLD lands in the target repo's docs tree; a "
+            "drafted issue is filed on GitHub. The artifact, not this run's "
+            "transcript, is what the next stage consumes."
+        ),
+        "successors": {
+            "END": "always",
+        },
+    },
+    "HALT": {
+        "title": "halt",
+        "ordinal": None,
+        "goal": "Record why the run stopped, then end it cleanly.",
+        "teach": (
+            "HALT is not a crash: it is the run stating its reason for "
+            "stopping (conflict, cap, stagnation, error) in a form the "
+            "launcher and the telemetry can read."
+        ),
+        "successors": {
+            "END": "always",
+        },
+    },
+}

--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -495,19 +495,27 @@ def create_requirements_graph() -> StateGraph:
     # Create graph with state schema
     graph = StateGraph(RequirementsWorkflowState)
 
+    # #2158: every node narrates its graph position on entry, sourced from
+    # the atlas (#2157) so the lines can never drift from the real graph.
+    from assemblyzero.workflows.narration import narrated
+    from assemblyzero.workflows.requirements.atlas import ATLAS, TOTAL_STEPS
+
+    def _add(name, fn):
+        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS))
+
     # Add nodes
-    graph.add_node(N0_LOAD_INPUT, load_input)
-    graph.add_node(N0B_ANALYZE_CODEBASE, analyze_codebase)  # Issue #401
-    graph.add_node(N0C_ANALYZE_REQUIREMENTS, analyze_requirements)  # Issue #1899
-    graph.add_node(N1_GENERATE_DRAFT, generate_draft)
-    graph.add_node(N1_5_VALIDATE_MECHANICAL, validate_lld_mechanical)  # Issue #277
-    graph.add_node(N1B_VALIDATE_TEST_PLAN, validate_test_plan_node)  # Issue #166
-    graph.add_node(N_PONDER, ponder_stibbons_node)  # Issue #307
-    graph.add_node(N2_HUMAN_GATE_DRAFT, human_gate_draft)
-    graph.add_node(N3_REVIEW, review)
-    graph.add_node(N4_HUMAN_GATE_VERDICT, human_gate_verdict)
-    graph.add_node(N5_FINALIZE, finalize)
-    graph.add_node(HALT, create_halt_node("requirements"))  # Issue #486
+    _add(N0_LOAD_INPUT, load_input)
+    _add(N0B_ANALYZE_CODEBASE, analyze_codebase)  # Issue #401
+    _add(N0C_ANALYZE_REQUIREMENTS, analyze_requirements)  # Issue #1899
+    _add(N1_GENERATE_DRAFT, generate_draft)
+    _add(N1_5_VALIDATE_MECHANICAL, validate_lld_mechanical)  # Issue #277
+    _add(N1B_VALIDATE_TEST_PLAN, validate_test_plan_node)  # Issue #166
+    _add(N_PONDER, ponder_stibbons_node)  # Issue #307
+    _add(N2_HUMAN_GATE_DRAFT, human_gate_draft)
+    _add(N3_REVIEW, review)
+    _add(N4_HUMAN_GATE_VERDICT, human_gate_verdict)
+    _add(N5_FINALIZE, finalize)
+    _add(HALT, create_halt_node("requirements"))  # Issue #486
 
     # Add edges
     # START -> N0

--- a/tests/unit/test_graph_atlas.py
+++ b/tests/unit/test_graph_atlas.py
@@ -1,0 +1,114 @@
+"""The graph atlas cannot drift from the compiled graph (#2157).
+
+The atlas is the single source every narration, tutorial, and quiz feature
+reads. Its only failure mode is silent rot when someone rewires a graph,
+so these tests build the REAL compiled StateGraph and compare: every graph
+node is in the atlas, every atlas node is in the graph, and every successor
+the atlas claims is an actual edge (and vice versa). A gap fails naming
+the missing entry.
+"""
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.atlas import (
+    ATLAS as SPEC_ATLAS,
+    TOTAL_STEPS as SPEC_TOTAL,
+)
+from assemblyzero.workflows.implementation_spec.graph import (
+    create_implementation_spec_graph,
+)
+from assemblyzero.workflows.requirements.atlas import (
+    ATLAS as REQ_ATLAS,
+    TOTAL_STEPS as REQ_TOTAL,
+)
+from assemblyzero.workflows.requirements.graph import create_requirements_graph
+
+_BOUNDARY = {"__start__", "__end__"}
+
+
+def _graph_shape(builder):
+    """(nodes, edges) of the compiled graph, with __end__ rendered as END.
+
+    Accepts either an uncompiled StateGraph (requirements) or an
+    already-compiled one (implementation_spec returns CompiledStateGraph).
+    """
+    compiled = builder.compile() if hasattr(builder, "compile") else builder
+    drawable = compiled.get_graph()
+    nodes = {n for n in drawable.nodes if n not in _BOUNDARY}
+    edges: set[tuple[str, str]] = set()
+    for edge in drawable.edges:
+        if edge.source in _BOUNDARY:
+            continue
+        target = "END" if edge.target == "__end__" else edge.target
+        edges.add((edge.source, target))
+    return nodes, edges
+
+
+CASES = [
+    ("requirements", create_requirements_graph, REQ_ATLAS, REQ_TOTAL),
+    ("implementation_spec", create_implementation_spec_graph, SPEC_ATLAS,
+     SPEC_TOTAL),
+]
+
+
+@pytest.mark.parametrize("name,factory,atlas,total", CASES,
+                         ids=[c[0] for c in CASES])
+class TestAtlasMatchesGraph:
+    def test_every_graph_node_is_in_the_atlas(self, name, factory, atlas, total):
+        nodes, _ = _graph_shape(factory())
+        missing = nodes - set(atlas)
+        assert not missing, f"{name}: graph nodes absent from atlas: {missing}"
+
+    def test_every_atlas_node_is_in_the_graph(self, name, factory, atlas, total):
+        nodes, _ = _graph_shape(factory())
+        stale = set(atlas) - nodes
+        assert not stale, f"{name}: atlas entries no longer in the graph: {stale}"
+
+    def test_every_atlas_successor_is_a_real_edge(self, name, factory, atlas, total):
+        _, edges = _graph_shape(factory())
+        for node, entry in atlas.items():
+            for successor in entry["successors"]:
+                assert (node, successor) in edges, (
+                    f"{name}: atlas claims {node} -> {successor}, "
+                    "which is not an edge in the compiled graph"
+                )
+
+    def test_every_real_edge_is_an_atlas_successor(self, name, factory, atlas, total):
+        _, edges = _graph_shape(factory())
+        for source, target in edges:
+            assert target in atlas[source]["successors"], (
+                f"{name}: the graph has {source} -> {target}, "
+                "which the atlas does not name"
+            )
+
+
+@pytest.mark.parametrize("name,factory,atlas,total", CASES,
+                         ids=[c[0] for c in CASES])
+class TestAtlasQuality:
+    def test_goals_and_teach_text_are_present_and_plain(self, name, factory,
+                                                        atlas, total):
+        """Plain-English rule: the operator must never need a code dive to
+        understand a narration line built from these strings."""
+        for node, entry in atlas.items():
+            assert entry["title"].strip(), f"{name}:{node} has no title"
+            assert len(entry["goal"].strip()) > 15, f"{name}:{node} goal too thin"
+            assert len(entry["teach"].strip()) > 40, f"{name}:{node} teach too thin"
+
+    def test_every_successor_names_its_condition(self, name, factory, atlas, total):
+        for node, entry in atlas.items():
+            for successor, condition in entry["successors"].items():
+                assert condition.strip(), (
+                    f"{name}:{node} -> {successor} has no condition text"
+                )
+
+    def test_ordinals_walk_the_forward_path(self, name, factory, atlas, total):
+        ordinals = sorted(
+            e["ordinal"] for e in atlas.values() if e["ordinal"] is not None
+        )
+        assert ordinals == list(range(1, total + 1)), (
+            f"{name}: ordinals must be exactly 1..{total}, got {ordinals}"
+        )
+        assert atlas["HALT"]["ordinal"] is None, (
+            f"{name}: HALT is an exit, never a step"
+        )

--- a/tests/unit/test_narration.py
+++ b/tests/unit/test_narration.py
@@ -1,0 +1,63 @@
+"""Graph-position narration (#2158): NODE and NEXT lines, atlas-sourced.
+
+The wrapper narrates on node entry and must never cost a run: printing
+failures degrade to silence, and an unknown node warns once by name.
+"""
+from __future__ import annotations
+
+from assemblyzero.workflows import narration
+from assemblyzero.workflows.narration import narrated
+
+ATLAS = {
+    "A_first": {
+        "title": "first step",
+        "ordinal": 1,
+        "goal": "Do the first thing.",
+        "teach": "x" * 50,
+        "successors": {"B_second": "always"},
+    },
+    "B_second": {
+        "title": "second step",
+        "ordinal": 2,
+        "goal": "Do the second thing.",
+        "teach": "x" * 50,
+        "successors": {"END": "always"},
+    },
+}
+
+
+def test_node_and_next_lines_render_from_the_atlas(capsys):
+    fn = narrated("A_first", lambda state: {"ok": True}, ATLAS, 2)
+
+    result = fn({"anything": 1})
+
+    out = capsys.readouterr().out
+    assert result == {"ok": True}
+    assert "NODE [1/2] first step -- Do the first thing." in out
+    assert "NEXT second step (always)" in out
+
+
+def test_successor_titles_come_from_the_atlas_end_stays_literal(capsys):
+    fn = narrated("B_second", lambda state: state, ATLAS, 2)
+    fn({})
+    assert "NEXT END (always)" in capsys.readouterr().out
+
+
+def test_an_unknown_node_warns_once_then_stays_silent(capsys):
+    narration._warned.discard("Z_mystery")
+    fn = narrated("Z_mystery", lambda state: state, ATLAS, 2)
+
+    fn({})
+    fn({})
+
+    out = capsys.readouterr().out
+    assert out.count("no atlas entry") == 1
+
+
+def test_a_broken_atlas_entry_never_costs_the_node(capsys):
+    """Narration failure degrades to silence; the node still runs."""
+    broken = {"A_first": {"title": "t", "ordinal": 1}}  # no goal: KeyError
+
+    fn = narrated("A_first", lambda state: "ran", broken, 1)
+
+    assert fn({}) == "ran"

--- a/tests/unit/test_speedrun_roll_follow.py
+++ b/tests/unit/test_speedrun_roll_follow.py
@@ -242,6 +242,59 @@ class TestFollowLoop:
         assert code == 0
         assert "All 1 issue(s) rolled." in capsys.readouterr().out
 
+    def test_the_roll_log_streams_alongside_the_narration(self, tmp_path, capsys):
+        """#2158: the NODE lines land in the per-roll stdout log; the
+        follower merges it so the operator sees the graph position live.
+        Content present at attach is history and stays out."""
+        runs = self._runs(tmp_path)
+        (runs / "detached-launcher.log").write_bytes(b"")
+        roll = runs / "run-issue1-101010.log"
+        roll.write_bytes(b"old history\n")
+
+        def _flip():
+            with roll.open("ab") as fh:
+                fh.write(b"NODE [3/11] requirements consistency gate\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _flip])
+        with patch.object(sr, "_task_status", lambda: next(statuses)()), \
+                patch.object(sr, "_task_last_result", lambda: 0), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            sr.follow_roll(runs)
+
+        out = capsys.readouterr().out
+        assert "NODE [3/11]" in out
+        assert "old history" not in out
+
+    def test_a_new_attempts_log_takes_over_and_the_old_tail_drains(
+        self, tmp_path, capsys
+    ):
+        runs = self._runs(tmp_path)
+        (runs / "detached-launcher.log").write_bytes(b"")
+        first = runs / "run-issue1-101010.log"
+        first.write_bytes(b"")
+
+        def _second_attempt():
+            with first.open("ab") as fh:
+                fh.write(b"attempt 1 tail\n")
+            second = runs / "run-issue1-202020.log"
+            second.write_bytes(b"attempt 2 begins\n")
+            # Same-tick writes tie on mtime granularity; the new attempt
+            # must win the newest-file race deterministically.
+            newer = first.stat().st_mtime + 10
+            os.utime(second, (newer, newer))
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _second_attempt])
+        with patch.object(sr, "_task_status", lambda: next(statuses)()), \
+                patch.object(sr, "_task_last_result", lambda: 0), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            sr.follow_roll(runs)
+
+        out = capsys.readouterr().out
+        assert "attempt 1 tail" in out
+        assert "attempt 2 begins" in out
+
     def test_reattach_to_nothing_says_so_immediately(self, tmp_path, capsys):
         runs = self._runs(tmp_path)
         with patch.object(sr, "_task_status", lambda: "Ready"), \

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -817,6 +817,22 @@ def _task_last_result() -> int | None:
     return code if 0 <= code < 256 else 1
 
 
+def _roll_log_candidates(log_dir: Path) -> list[Path]:
+    return [
+        p for p in log_dir.glob("run-*.log")
+        if not p.name.endswith("-events.log")
+        and not p.name.endswith("-heartbeat.log")
+    ]
+
+
+def _newest_roll_log(log_dir: Path) -> Path | None:
+    """The active attempt's stdout log, where the NODE lines land (#2158)."""
+    candidates = _roll_log_candidates(log_dir)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
 def _newest_heartbeat(log_dir: Path) -> str:
     """`<file>: <last line>` for the freshest heartbeat, or "" without one."""
     beats = sorted(
@@ -857,6 +873,36 @@ def follow_roll(
     if narration.exists():
         pos = max(0, narration.stat().st_size - context_bytes)
 
+    # #2158: the per-roll stdout (stage tables, NODE position lines) streams
+    # too. History present at attach is skipped; a fresh attempt's log starts
+    # from byte zero; when the attempt changes, the old log's tail drains
+    # before the new one takes over.
+    roll_positions = {
+        p.name: p.stat().st_size for p in _roll_log_candidates(log_dir)
+    }
+    current_roll: str | None = None
+
+    def _drain_roll_log() -> bool:
+        nonlocal current_roll
+        newest = _newest_roll_log(log_dir)
+        if newest is None:
+            return False
+        printed = False
+        if current_roll and current_roll != newest.name:
+            old = log_dir / current_roll
+            old_pos, tail = _drain(old, roll_positions.get(current_roll, 0))
+            roll_positions[current_roll] = old_pos
+            if tail:
+                print(tail, end="", flush=True)
+                printed = True
+        current_roll = newest.name
+        new_pos, chunk = _drain(newest, roll_positions.get(newest.name, 0))
+        roll_positions[newest.name] = new_pos
+        if chunk:
+            print(chunk, end="", flush=True)
+            printed = True
+        return printed
+
     seen_running = False
     unknown_streak = 0
     start_deadline = time.time() + _START_GRACE_SECONDS
@@ -866,6 +912,8 @@ def follow_roll(
             pos, chunk = _drain(narration, pos)
             if chunk:
                 print(chunk, end="", flush=True)
+                last_line_at = time.time()
+            if _drain_roll_log():
                 last_line_at = time.time()
 
             status = _task_status()
@@ -890,6 +938,9 @@ def follow_roll(
                 pos, chunk = _drain(narration, pos)
                 if chunk:
                     print(chunk, end="", flush=True)
+                # #2158: the roll's final stdout lines land between the last
+                # drain and the status flip, same race as the narration's.
+                _drain_roll_log()
                 if seen_running or wait_for_start:
                     code = _task_last_result() or 0
                     # #2165: the word, not just the number. The full verdict


### PR DESCRIPTION
Closes #2157, Closes #2158

**The atlas** (#2157): `atlas.py` in the requirements and implementation-spec workflows — per-node title, plain-English goal, teach text, successor conditions, forward-path ordinals. `test_graph_atlas.py` compiles the REAL StateGraphs and asserts node and edge bijection in both directions, so rewiring a graph without the atlas fails the suite naming the gap. Quality tests pin plain-English goals/teach text and ordinal integrity.

**Position narration** (#2158): every node is wrapped at graph-build time with an atlas-sourced narrator emitting `NODE [n/total] title -- goal` and `NEXT successor (condition) | ...` on entry. Narration never costs a run: failures degrade to silence, unknown nodes warn once by name. The follower now merges the active attempt's stdout log into the operator's console (attach-time history skipped; a new attempt's log takes over after the old tail drains), so the seventeen silent minutes of today's roll become a live view of the graph moving.

Tutorial (#2160) and quiz (#2161) modes build on this same atlas next.

Tests: 14 drift/quality pins, 4 narration wrapper tests, 2 follower merge tests. Full suite green locally (6,645).