### PR TITLE
feat: follower view levels — terse and verbose with live keypress switching (Closes #2159)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -47,6 +47,7 @@ than transcribed:
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
+| `--narration` | starting view level, `terse` or `verbose` (#2159). Press `v` in the console to toggle live; the log on disk is always complete |
 
 **Use `--detach`.** A roll started from a session is a descendant of that
 session's shell, and a harness kill of the shell takes the whole tree with it.

--- a/tests/unit/test_narration_levels.py
+++ b/tests/unit/test_narration_levels.py
@@ -1,0 +1,144 @@
+"""Follower view levels: terse/verbose with live switching (#2159).
+
+The roll emits everything once; verbosity is a property of the VIEW. These
+pin the line-buffered filter, the emit-once invariant (the log on disk is
+identical whichever level watched), the live toggle, and the flag plumb.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+class TestTheFilter:
+    def test_terse_keeps_actionable_lines_and_drops_detail(self):
+        view = sr._NarrationView("terse")
+        out = view.feed("n", (
+            "2026-08-09 15:10 LAUNCH base=run-17 -> x.log\n"
+            "some model chatter about tokens\n"
+            "NODE [3/11] requirements consistency gate -- checking\n"
+            "more incidental detail\n"
+            "ROLL BLOCKED: issue(s) #1 await an operator ruling.\n"
+        ))
+        assert "LAUNCH" in out and "NODE [3/11]" in out and "ROLL BLOCKED" in out
+        assert "chatter" not in out and "incidental" not in out
+
+    def test_verbose_passes_everything_through(self):
+        view = sr._NarrationView("verbose")
+        chunk = "anything at all\npartial tail without newline"
+        assert view.feed("n", chunk) == chunk
+
+    def test_a_line_split_across_drains_is_judged_once_whole(self):
+        """A drain can end mid-line; the filter must reassemble before
+        judging, or NODE lines get dropped when cut at the wrong byte."""
+        view = sr._NarrationView("terse")
+        first = view.feed("n", "NOD")
+        second = view.feed("n", "E [1/2] load input -- reads the issue\n")
+        assert first == ""
+        assert "NODE [1/2]" in second
+
+    def test_streams_buffer_independently(self):
+        view = sr._NarrationView("terse")
+        view.feed("narration", "NOD")
+        out = view.feed("roll", "NODE [2/2] finalize -- saves\n")
+        assert "NODE [2/2]" in out
+        out = view.feed("narration", "E [1/2] load input -- reads\n")
+        assert "NODE [1/2]" in out
+
+    def test_toggle_flips_and_clears_partials(self):
+        view = sr._NarrationView("terse")
+        view.feed("n", "half a li")
+        assert view.toggle() == "verbose"
+        assert view.feed("n", "detail now visible\n") == "detail now visible\n"
+        assert view.toggle() == "terse"
+
+
+class TestTheKeyToggle:
+    def test_v_toggles_and_announces(self, capsys, monkeypatch):
+        keys = iter(["v"])
+
+        class _FakeMsvcrt:
+            @staticmethod
+            def kbhit():
+                return bool(keys.__length_hint__())
+
+            @staticmethod
+            def getwch():
+                return next(keys)
+
+        monkeypatch.setitem(sys.modules, "msvcrt", _FakeMsvcrt)
+        view = sr._NarrationView("verbose")
+
+        sr._poll_view_keys(view)
+
+        assert view.level == "terse"
+        assert "narration level: terse" in capsys.readouterr().out
+
+    def test_other_keys_are_ignored(self, monkeypatch):
+        keys = iter(["x", "q"])
+
+        class _FakeMsvcrt:
+            @staticmethod
+            def kbhit():
+                return bool(keys.__length_hint__())
+
+            @staticmethod
+            def getwch():
+                return next(keys)
+
+        monkeypatch.setitem(sys.modules, "msvcrt", _FakeMsvcrt)
+        view = sr._NarrationView("terse")
+
+        sr._poll_view_keys(view)
+
+        assert view.level == "terse"
+
+
+class TestFollowIntegration:
+    def test_terse_follow_filters_the_stream_and_the_log_stays_complete(
+        self, tmp_path, capsys
+    ):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        narration = runs / "detached-launcher.log"
+        narration.write_bytes(b"")
+
+        def _flip():
+            with narration.open("ab") as fh:
+                fh.write(b"boring detail line\nSTORM BACKOFF 15m\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _flip])
+        with patch.object(sr, "_task_status", lambda: next(statuses)()), \
+                patch.object(sr, "_task_last_result", lambda: 0), \
+                patch.object(sr, "_poll_view_keys", lambda v: None), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            sr.follow_roll(runs, level="terse")
+
+        out = capsys.readouterr().out
+        assert "STORM BACKOFF" in out
+        assert "boring detail line" not in out
+        on_disk = narration.read_bytes().decode()
+        assert "boring detail line" in on_disk, "the view filters; the log never does"
+
+    def test_the_narration_flag_reaches_the_follower(self, tmp_path):
+        seen = {}
+
+        def _follow(log_dir, **kw):
+            seen.update(kw)
+            return 0
+
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        with patch.object(sr, "follow_roll", _follow), \
+                patch.object(sr.sys, "platform", "win32"):
+            sr.main(["--repo", str(repo), "--follow", "--narration", "terse"])
+
+        assert seen.get("level") == "terse"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -846,8 +846,67 @@ def _newest_heartbeat(log_dir: Path) -> str:
     return f"{beats[-1].name}: {lines[-1]}" if lines else ""
 
 
+# #2159: the roll emits everything once; verbosity is a property of the VIEW.
+# Terse keeps the lines an operator acts on; verbose is the full stream. The
+# filter is line-buffered because a drain can end mid-line.
+_TERSE_MARKERS = (
+    "NODE ", "NEXT ", "BASE", "LAUNCH", "EXIT", "START ", "CHILD EXITED",
+    "STOPPED", "BLOCKED", "STORM", "ROLL ", "RESTORE", "SWEEP", "JANITOR",
+    " attempt ", "OVERRIDE", "Previous run's questions", "must-resolve",
+    "VERIFIED", "UNVERIFIED", "Pipeline failed", "WARNING", "Resume",
+)
+
+
+def _is_terse_line(line: str) -> bool:
+    return any(marker in line for marker in _TERSE_MARKERS)
+
+
+class _NarrationView:
+    """Line-buffered level filter for the follower's streams (#2159)."""
+
+    def __init__(self, level: str) -> None:
+        self.level = level
+        self._partial: dict[str, str] = {}
+
+    def feed(self, stream: str, chunk: str) -> str:
+        if not chunk:
+            return ""
+        if self.level == "verbose":
+            return chunk
+        buf = self._partial.get(stream, "") + chunk
+        lines = buf.split("\n")
+        self._partial[stream] = lines.pop()
+        kept = [line for line in lines if _is_terse_line(line)]
+        return "".join(line + "\n" for line in kept)
+
+    def toggle(self) -> str:
+        self.level = "terse" if self.level == "verbose" else "verbose"
+        # Stale partials must not replay across a mode switch.
+        self._partial.clear()
+        return self.level
+
+
+def _poll_view_keys(view: _NarrationView) -> None:
+    """`v` toggles the view level live (#2159). The keypress reaches only the
+    VIEW; nothing here can touch the roll. Windows console only; a harmless
+    no-op everywhere else (following is Windows-gated anyway)."""
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - non-Windows
+        return
+    try:
+        while msvcrt.kbhit():
+            ch = msvcrt.getwch()
+            if ch in ("v", "V"):
+                level = view.toggle()
+                print(f"\n[view] narration level: {level}", flush=True)
+    except Exception:  # noqa: BLE001 - a key poll must never cost the view
+        pass
+
+
 def follow_roll(
-    log_dir: Path, *, context_bytes: int = 0, wait_for_start: bool = True
+    log_dir: Path, *, context_bytes: int = 0, wait_for_start: bool = True,
+    level: str = "verbose",
 ) -> int:
     """Stream the detached roll's narration to THIS console until it finishes.
 
@@ -863,9 +922,10 @@ def follow_roll(
     the grace window.
     """
     narration = log_dir / "detached-launcher.log"
+    view = _NarrationView(level)
     print(
         "Following the roll. Ctrl+C stops WATCHING only -- the roll keeps "
-        "running.\n",
+        f"running. Narration level: {level} (press v to toggle).\n",
         flush=True,
     )
 
@@ -893,14 +953,18 @@ def follow_roll(
             old_pos, tail = _drain(old, roll_positions.get(current_roll, 0))
             roll_positions[current_roll] = old_pos
             if tail:
-                print(tail, end="", flush=True)
                 printed = True
+                out = view.feed("roll", tail)
+                if out:
+                    print(out, end="", flush=True)
         current_roll = newest.name
         new_pos, chunk = _drain(newest, roll_positions.get(newest.name, 0))
         roll_positions[newest.name] = new_pos
         if chunk:
-            print(chunk, end="", flush=True)
             printed = True
+            out = view.feed("roll", chunk)
+            if out:
+                print(out, end="", flush=True)
         return printed
 
     seen_running = False
@@ -909,10 +973,16 @@ def follow_roll(
     last_line_at = time.time()
     try:
         while True:
+            _poll_view_keys(view)
             pos, chunk = _drain(narration, pos)
             if chunk:
-                print(chunk, end="", flush=True)
+                # Liveness tracks RAW arrival: filtered-out detail still
+                # proves the roll is moving, so terse mode does not emit
+                # quiet-notes into an active run.
                 last_line_at = time.time()
+                out = view.feed("narration", chunk)
+                if out:
+                    print(out, end="", flush=True)
             if _drain_roll_log():
                 last_line_at = time.time()
 
@@ -937,7 +1007,9 @@ def follow_roll(
             ):
                 pos, chunk = _drain(narration, pos)
                 if chunk:
-                    print(chunk, end="", flush=True)
+                    out = view.feed("narration", chunk)
+                    if out:
+                        print(out, end="", flush=True)
                 # #2158: the roll's final stdout lines land between the last
                 # drain and the status flip, same race as the narration's.
                 _drain_roll_log()
@@ -1397,6 +1469,14 @@ def main(argv: list[str] | None = None) -> int:
             "narration into this console (#2138). Takes no --issue."
         ),
     )
+    parser.add_argument(
+        "--narration", choices=("terse", "verbose"), default="verbose",
+        help=(
+            "Starting view level while following (#2159): terse shows the "
+            "lines you act on, verbose shows everything. Press v in the "
+            "console to toggle live; the log on disk is always complete."
+        ),
+    )
     # Set by --detach on the relaunch; not something anyone types.
     parser.add_argument("--detached-stdout", default=None, help=argparse.SUPPRESS)
     args, extra = parser.parse_known_args(argv)
@@ -1437,7 +1517,10 @@ def main(argv: list[str] | None = None) -> int:
         if sys.platform != "win32":
             print(f"ERROR: --follow is Windows-only; this is {sys.platform}")
             return 91
-        return follow_roll(log_dir, context_bytes=2048, wait_for_start=False)
+        return follow_roll(
+            log_dir, context_bytes=2048, wait_for_start=False,
+            level=args.narration,
+        )
 
     if not args.issue:
         print("ERROR: --issue is required (repeatable) unless stopping a roll")
@@ -1492,7 +1575,7 @@ def main(argv: list[str] | None = None) -> int:
             return code
         # Standard 0026: the console the operator launched from is the
         # display. The work is detached; the view is not.
-        return follow_roll(log_dir)
+        return follow_roll(log_dir, level=args.narration)
 
     # Created only by a process that actually rolls, never by the launcher --
     # see launch_detached on why that separation is load-bearing.


### PR DESCRIPTION
Closes #2159

The roll emits everything once; verbosity is a property of the view. The follower gains a line-buffered level filter (terse keeps the lines an operator acts on: NODE/NEXT position lines, stage boundaries, refusals, storms, verdicts, restore reports; verbose passes everything), `--narration terse|verbose` sets the starting level for both `--detach` follow and `--follow` re-attach, and pressing `v` in the console toggles live. The keypress reaches only the view — nothing in the follow path can touch the roll — and mid-run switching therefore needs no IPC and carries no risk. Liveness tracks raw arrival, so terse mode never emits quiet-notes into an active run, and the emit-once invariant is pinned: the log on disk is byte-identical whichever level watched. Runbook 0952 documents the flag (its drift test enforced that). 12 new tests; full suite green locally (6,661).