### PR TITLE
feat: tutorial narration mode — the live roll annotated from the atlas (Closes #2160)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -47,7 +47,7 @@ than transcribed:
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
-| `--narration` | starting view level, `terse` or `verbose` (#2159). Press `v` in the console to toggle live; the log on disk is always complete |
+| `--narration` | starting view level: `terse`, `verbose`, or `tutorial` (#2159/#2160 — tutorial annotates each node and gate with what it is for). Press `v` in the console to toggle live; the log on disk is always complete |
 
 **Use `--detach`.** A roll started from a session is a descendant of that
 session's shell, and a harness kill of the shell takes the whole tree with it.

--- a/docs/tutorial/0001-follow-orientation.md
+++ b/docs/tutorial/0001-follow-orientation.md
@@ -1,0 +1,22 @@
+# Watching a roll, for the first time
+
+You are watching AssemblyZero build software from a GitHub issue with no
+human in the loop. What is scrolling past is called a roll: one issue,
+drawn through a pipeline of stages, end to end.
+
+Three things to know while you watch:
+
+1. **The pipeline is a graph.** Each `NODE [n/total]` line is the run
+   entering one node of it: loading the issue, reading the codebase,
+   checking the requirements agree with each other, drafting, validating,
+   adversarial review by a second model, finalizing. The `NEXT` line
+   tells you where it can go from here and why.
+2. **A refusal is the system working.** Gates refuse to spend money on a
+   sick machine, an ambiguous issue, or a dirty repo. When something is
+   BLOCKED, read the reason: it usually ends with a question filed for a
+   human to rule on, because the machine never rewrites meaning on its
+   own.
+3. **Everything you see is durable.** The console is just a view; the
+   full record lands in `data/speedrun/runs/` and survives whether or not
+   anyone watched. Press `v` to switch between terse and verbose at any
+   time. Ctrl+C stops watching, never the roll.

--- a/tests/unit/test_tutorial_mode.py
+++ b/tests/unit/test_tutorial_mode.py
@@ -1,0 +1,95 @@
+"""Tutorial narration mode (#2160): the live roll, annotated for newcomers.
+
+Same emit-once architecture as its siblings: the view annotates, the roll
+never knows, the log on disk stays complete.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.workflows.requirements.atlas import (  # noqa: E402
+    ATLAS as REQ_ATLAS,
+    TOTAL_STEPS as REQ_TOTAL,
+)
+
+
+def _node_line(node_id: str) -> str:
+    entry = REQ_ATLAS[node_id]
+    return (
+        f"NODE [{entry['ordinal']}/{REQ_TOTAL}] {entry['title']} -- "
+        f"{entry['goal']}\n"
+    )
+
+
+class TestAnnotation:
+    def test_a_node_line_gets_its_teach_text_indented(self):
+        view = sr._NarrationView("tutorial")
+        out = view.feed("n", _node_line("N0c_analyze_requirements"))
+        assert "NODE [3/11]" in out
+        assert "  | " in out
+        assert "cheapest possible failure" in out, "teach text comes from the atlas"
+
+    def test_totals_disambiguate_titles_both_graphs_share(self):
+        from assemblyzero.workflows.implementation_spec.atlas import (
+            ATLAS as SPEC_ATLAS, TOTAL_STEPS as SPEC_TOTAL,
+        )
+        view = sr._NarrationView("tutorial")
+        req = view.feed("a", _node_line("N0b_analyze_codebase"))
+        spec_entry = SPEC_ATLAS["N1_analyze_codebase"]
+        spec = view.feed("b", (
+            f"NODE [{spec_entry['ordinal']}/{SPEC_TOTAL}] "
+            f"{spec_entry['title']} -- {spec_entry['goal']}\n"
+        ))
+        assert REQ_ATLAS["N0b_analyze_codebase"]["teach"].split()[0] in req
+        assert spec_entry["teach"].split()[-1].rstrip(".") in spec
+
+    def test_an_unknown_title_renders_the_line_alone(self):
+        view = sr._NarrationView("tutorial")
+        out = view.feed("n", "NODE [9/99] mystery step -- does things\n")
+        assert "mystery step" in out
+        assert "  | " not in out
+
+    def test_refusals_and_storms_teach_too(self):
+        view = sr._NarrationView("tutorial")
+        storm = view.feed("n", "STORM BACKOFF 15m before attempt 2/3\n")
+        blocked = view.feed("n", "BLOCKED: this machine is not healthy enough\n")
+        assert "provider stopped answering" in storm
+        assert "system working" in blocked
+
+    def test_detail_lines_stay_filtered_tutorial_implies_terse(self):
+        view = sr._NarrationView("tutorial")
+        assert view.feed("n", "incidental model chatter\n") == ""
+
+    def test_toggle_leaves_tutorial_for_terse(self):
+        view = sr._NarrationView("tutorial")
+        assert view.toggle() == "terse"
+
+
+class TestOrientation:
+    def test_the_orientation_file_prints_once_on_attach(self, tmp_path, capsys):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        (runs / "detached-launcher.log").write_bytes(b"")
+
+        with patch.object(sr, "_task_status", lambda: "Ready"), \
+                patch.object(sr, "_poll_view_keys", lambda v: None), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            sr.follow_roll(runs, wait_for_start=False, level="tutorial")
+
+        out = capsys.readouterr().out
+        assert "Watching a roll, for the first time" in out
+
+    def test_the_orientation_names_the_real_file(self):
+        path = (
+            Path(sr.__file__).resolve().parents[1]
+            / "docs" / "tutorial" / "0001-follow-orientation.md"
+        )
+        assert path.is_file(), "the curriculum file must exist where the code looks"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -861,12 +861,87 @@ def _is_terse_line(line: str) -> bool:
     return any(marker in line for marker in _TERSE_MARKERS)
 
 
+# #2160: teach text for events the atlas cannot know (gate refusals,
+# storms). One entry per marker; the first matching marker teaches.
+_EVENT_TEACH = {
+    "STORM BACKOFF": (
+        "The model provider stopped answering several times in a row. "
+        "Retrying immediately would burn an attempt on the same wall, so "
+        "the launcher waits and says for how long."
+    ),
+    "ROLL BLOCKED": (
+        "The run found the issue's own wording ambiguous and filed a "
+        "question for the human to rule on. No redraw can help until the "
+        "ruling; the machine never rewrites meaning on its own."
+    ),
+    "BLOCKED:": (
+        "A gate refused to spend anything. Refusals are the system "
+        "working: the reason names what to fix, and nothing was lost."
+    ),
+}
+
+
+def _teach_map() -> dict:
+    """(total_steps, title) -> teach text, from every atlas (#2160).
+
+    Keyed by total because the NODE line carries [n/total], and totals
+    differ per workflow -- which disambiguates titles both graphs share.
+    Import failure degrades to an empty map; teaching never costs a view.
+    """
+    table: dict = {}
+    try:
+        from assemblyzero.workflows.implementation_spec.atlas import (
+            ATLAS as SPEC_ATLAS, TOTAL_STEPS as SPEC_TOTAL,
+        )
+        from assemblyzero.workflows.requirements.atlas import (
+            ATLAS as REQ_ATLAS, TOTAL_STEPS as REQ_TOTAL,
+        )
+        for total, atlas in ((REQ_TOTAL, REQ_ATLAS), (SPEC_TOTAL, SPEC_ATLAS)):
+            for entry in atlas.values():
+                table[(total, entry["title"])] = entry["teach"]
+                table[(None, entry["title"])] = entry["teach"]
+    except Exception:  # noqa: BLE001 - teaching never costs the view
+        pass
+    return table
+
+
+_NODE_LINE = re.compile(r"NODE (?:\[(\d+)/(\d+)\] )?(.+?) -- ")
+
+
 class _NarrationView:
-    """Line-buffered level filter for the follower's streams (#2159)."""
+    """Line-buffered level filter for the follower's streams (#2159, #2160)."""
 
     def __init__(self, level: str) -> None:
         self.level = level
         self._partial: dict[str, str] = {}
+        self._teach = _teach_map() if level == "tutorial" else {}
+
+    def _annotate(self, line: str) -> list[str]:
+        """Tutorial mode: the atlas teach text under a NODE line, an event
+        teach under its first marker; everything else passes bare."""
+        out = [line]
+        teach = None
+        match = _NODE_LINE.search(line)
+        if match:
+            total = int(match.group(2)) if match.group(2) else None
+            teach = self._teach.get((total, match.group(3)))
+        else:
+            for marker, text in _EVENT_TEACH.items():
+                if marker in line:
+                    teach = text
+                    break
+        if teach:
+            width = 66
+            words, cur = [], ""
+            for word in teach.split():
+                if len(cur) + len(word) + 1 > width:
+                    words.append(cur)
+                    cur = word
+                else:
+                    cur = f"{cur} {word}".strip()
+            words.append(cur)
+            out += [f"  | {w}" for w in words]
+        return out
 
     def feed(self, stream: str, chunk: str) -> str:
         if not chunk:
@@ -877,10 +952,14 @@ class _NarrationView:
         lines = buf.split("\n")
         self._partial[stream] = lines.pop()
         kept = [line for line in lines if _is_terse_line(line)]
+        if self.level == "tutorial":
+            kept = [a for line in kept for a in self._annotate(line)]
         return "".join(line + "\n" for line in kept)
 
     def toggle(self) -> str:
-        self.level = "terse" if self.level == "verbose" else "verbose"
+        # Tutorial drops to terse first (annotations off), then verbose,
+        # then back to terse -- tutorial is an attach-time choice.
+        self.level = "terse" if self.level in ("verbose", "tutorial") else "verbose"
         # Stale partials must not replay across a mode switch.
         self._partial.clear()
         return self.level
@@ -928,6 +1007,17 @@ def follow_roll(
         f"running. Narration level: {level} (press v to toggle).\n",
         flush=True,
     )
+    if level == "tutorial":
+        # #2160: orientation comes from an editable markdown file, once per
+        # attach. A missing file is one line, never a failure.
+        orientation = (
+            Path(__file__).resolve().parents[1]
+            / "docs" / "tutorial" / "0001-follow-orientation.md"
+        )
+        try:
+            print(orientation.read_text(encoding="utf-8"), flush=True)
+        except OSError:
+            print(f"(orientation file missing: {orientation})\n", flush=True)
 
     pos = 0
     if narration.exists():
@@ -1470,11 +1560,14 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
-        "--narration", choices=("terse", "verbose"), default="verbose",
+        "--narration", choices=("terse", "verbose", "tutorial"),
+        default="verbose",
         help=(
-            "Starting view level while following (#2159): terse shows the "
-            "lines you act on, verbose shows everything. Press v in the "
-            "console to toggle live; the log on disk is always complete."
+            "Starting view level while following (#2159/#2160): terse shows "
+            "the lines you act on, verbose shows everything, tutorial is "
+            "terse annotated with what each node and gate is for. Press v "
+            "in the console to toggle live; the log on disk is always "
+            "complete."
         ),
     )
     # Set by --detach on the relaunch; not something anyone types.


### PR DESCRIPTION
Closes #2160

A third view level: `--narration tutorial` is terse annotated for newcomers. Each NODE transition renders the atlas's teach text indented beneath it — the (total, title) pair from the position line disambiguates node titles both graphs share — and gate refusals and storm backoffs carry their own teach entries, since a refusal is the most teachable moment. An orientation page (`docs/tutorial/0001-follow-orientation.md`, editable curriculum, no code) prints once per attach. Toggling with `v` drops tutorial to terse (tutorial is an attach-time choice); teaching failures degrade to silence and never cost the view; the log on disk stays complete. 8 new tests including title disambiguation across graphs and the real-orientation-file existence pin. Full suite green locally (6,669).