### PR TITLE
feat: the healing ledger — every self-heal leaves a record, recurrence proposes issues (Closes #2164)

### DIFF
--- a/assemblyzero/speedrun/healing.py
+++ b/assemblyzero/speedrun/healing.py
@@ -1,0 +1,80 @@
+"""The healing ledger: every self-heal leaves a record (#2164).
+
+The factory heals itself in many places -- resets, redraws, base
+replacements, the worktree sweep, the file janitor, storm backoffs,
+restore reconciles -- and each heal used to be a transient line in an
+events log. This module gives them a durable, structured record, the
+self-heal counterpart of the prompt-failure telemetry (#2074).
+
+One JSONL record per heal at ``data/speedrun/telemetry/heals.jsonl`` in
+the TARGET repo. Partial outcomes are first-class: a half-completed heal
+(today's WinError 5 lineage deletion) is exactly the record the report
+exists to surface. Recording never raises -- a ledger problem must never
+cost a roll -- and per standard 0027 the ledger is evidence, exempt from
+every janitor.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+HEALS_FILENAME = "heals.jsonl"
+
+CATEGORIES = (
+    "reset", "redraw", "base-replace", "sweep", "janitor",
+    "storm-backoff", "restore-reconcile",
+)
+
+OUTCOMES = ("healed", "partial", "failed")
+
+
+def heals_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / "data" / "speedrun" / "telemetry" / HEALS_FILENAME
+
+
+def record_heal(
+    repo_root: Path | str,
+    category: str,
+    target: str,
+    outcome: str,
+    *,
+    detail: str = "",
+    run_tag: str = "",
+) -> bool:
+    """Append one heal record. Returns False (never raises) on failure."""
+    try:
+        path = heals_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "run_tag": run_tag,
+            "category": category,
+            "target": target,
+            "outcome": outcome,
+            "detail": detail,
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+        return True
+    except Exception:  # noqa: BLE001 - the ledger must never cost a roll
+        return False
+
+
+def read_heals(repo_root: Path | str) -> list[dict]:
+    """Every readable record, in order. Corrupt lines are skipped, counted
+    by the caller via the length difference if it cares."""
+    path = heals_path(repo_root)
+    if not path.exists():
+        return []
+    records: list[dict] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except ValueError:
+            continue
+    return records

--- a/assemblyzero/speedrun/leavings.py
+++ b/assemblyzero/speedrun/leavings.py
@@ -92,12 +92,25 @@ class LeavingsResult:
         )
 
 
+#: The machinery's own record (heals, telemetry, run logs). Standard 0027
+#: exempts evidence from every janitor; #2164 taught us it must ALSO be
+#: exempt from dirt classification structurally, not just by gitignore
+#: convention -- in a repo that does not ignore data/, the healing ledger
+#: itself blocked the branch-cutter's preconditions.
+_EVIDENCE_PREFIXES = ("data/speedrun/",)
+
+
+def _is_evidence(rel_path: str) -> bool:
+    normalized = rel_path.replace("\\", "/")
+    return any(normalized.startswith(p) for p in _EVIDENCE_PREFIXES)
+
+
 def untracked_files(repo: Path | str) -> list[str]:
     """Repo-relative untracked files, individually (-uall expands dirs).
 
-    Gitignored paths (data/, and with them data/speedrun/**) never appear
-    here, which is the standard-0027 evidence exemption falling out of the
-    plumbing rather than being special-cased.
+    Evidence under data/speedrun/ never appears: usually because data/ is
+    gitignored, and structurally even when it is not (the exemption must
+    not depend on a convention a target repo might miss).
     """
     result = _run(
         ["git", "-C", str(repo), "status", "--porcelain", "-uall"]
@@ -105,9 +118,10 @@ def untracked_files(repo: Path | str) -> list[str]:
     if result.returncode != 0:
         return []
     return [
-        line[3:].strip().strip('"')
+        path
         for line in result.stdout.splitlines()
         if line.startswith("?? ")
+        and not _is_evidence(path := line[3:].strip().strip('"'))
     ]
 
 
@@ -134,6 +148,9 @@ def classify_dirt(repo: Path | str) -> tuple[list[str], list[str]]:
         if not line.strip():
             continue
         path = line[3:].strip().strip('"')
+        if _is_evidence(path):
+            # The machinery's own record is never dirt (#2164).
+            continue
         if line.startswith("?? ") and is_machinery_owned(path):
             machinery.append(path)
         else:

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -240,6 +240,18 @@ If it has content, rank it by cost and follow
 poetry run python tools/prompt_revision_rank.py --repo /c/Users/mcwiz/Projects/<repo>
 ```
 
+**3b. The healing ledger.** What the machinery fixed about itself (#2164) —
+resets, sweeps, janitor acts, storm waits, restore reconciles — one record
+per heal, partials first-class. A heal that recurs across three runs is a
+defect wearing a bandage, and the report emits a ready-to-file issue stub.
+Filing is the operator's call, never automatic.
+
+```bash
+poetry run python tools/heal_report.py --repo /c/Users/mcwiz/Projects/<repo>
+```
+
+An empty ledger is a real answer, same cold-start rule as the telemetry.
+
 **4. Regenerate the timing dashboard.** Where the wall-clock went.
 
 ```bash
@@ -289,7 +301,8 @@ delete any branch or worktree. Work steps 1 through 6 in order and report:
   2. which stage failed on each failed roll, and whether its retry RESUMED or
      REGENERATED
   3. any provider-storm backoffs, with their durations
-  4. the top validation-failure fingerprints by cost, or "telemetry empty"
+  4. the top validation-failure fingerprints by cost, or "telemetry empty",
+     plus the healing ledger's recurring-heal issue stubs, or "no recurrences"
   5. run time vs diagnose+fix time for the run's dates
   6. any must-resolve issues now open
   7. the archive path and whether index.json says complete: true

--- a/tests/unit/test_healing_ledger.py
+++ b/tests/unit/test_healing_ledger.py
@@ -1,0 +1,186 @@
+"""The healing ledger and its report (#2164).
+
+Every self-heal leaves a structured record; the report rolls them up and
+proposes (never files) issues for recurring heals. An empty ledger is a
+real answer with a denominator, never an empty-but-confident report.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import heal_report  # noqa: E402
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.speedrun.healing import (  # noqa: E402
+    heals_path,
+    read_heals,
+    record_heal,
+)
+
+
+class TestRecording:
+    def test_a_heal_lands_as_one_jsonl_record(self, tmp_path):
+        assert record_heal(
+            tmp_path, "janitor", "docs/lld/active/LLD-002.md", "healed",
+            detail="preserved on graveyard/leavings", run_tag="run-issue1-x",
+        )
+        records = read_heals(tmp_path)
+        assert len(records) == 1
+        assert records[0]["category"] == "janitor"
+        assert records[0]["outcome"] == "healed"
+        assert records[0]["run_tag"] == "run-issue1-x"
+
+    def test_partial_outcomes_are_first_class(self, tmp_path):
+        record_heal(
+            tmp_path, "reset", "docs/lineage/active/1-lld", "partial",
+            detail="WinError 5 Access is denied", run_tag="run-issue1-152826",
+        )
+        assert read_heals(tmp_path)[0]["outcome"] == "partial"
+
+    def test_recording_never_raises(self, tmp_path):
+        """A file in the directory's place makes mkdir fail; the ledger
+        swallows it and reports False -- a ledger problem never costs a roll."""
+        blocker = tmp_path / "data"
+        blocker.write_text("not a directory", encoding="utf-8")
+        assert record_heal(tmp_path, "sweep", "x", "healed") is False
+
+    def test_corrupt_lines_are_skipped_not_fatal(self, tmp_path):
+        record_heal(tmp_path, "sweep", "a", "healed")
+        with heals_path(tmp_path).open("a", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+        record_heal(tmp_path, "sweep", "b", "healed")
+        assert [r["target"] for r in read_heals(tmp_path)] == ["a", "b"]
+
+    def test_the_ledger_lives_under_gitignored_telemetry(self, tmp_path):
+        assert "telemetry" in str(heals_path(tmp_path))
+        assert str(heals_path(tmp_path)).endswith("heals.jsonl")
+
+
+class TestReport:
+    def _seed(self, repo, runs):
+        for tag in runs:
+            record_heal(
+                repo, "reset", "docs/lineage/active/1-lld", "partial",
+                detail="WinError 5", run_tag=tag,
+            )
+
+    def test_an_empty_ledger_says_so_with_the_cold_start_rule(
+        self, tmp_path, capsys
+    ):
+        assert heal_report.main(["--repo", str(tmp_path)]) == 0
+        out = capsys.readouterr().out
+        assert "No heal records" in out
+        assert "never fabricate" in out
+
+    def test_per_run_rollup_flags_non_healed_outcomes(self, tmp_path, capsys):
+        self._seed(tmp_path, ["run-a"])
+        record_heal(tmp_path, "janitor", "leaving.md", "healed", run_tag="run-a")
+
+        heal_report.main(["--repo", str(tmp_path)])
+
+        out = capsys.readouterr().out
+        assert "run-a: 2 heal(s)" in out
+        assert "! reset: docs/lineage/active/1-lld -- partial" in out
+
+    def test_recurrence_across_three_runs_proposes_an_issue_stub(
+        self, tmp_path, capsys
+    ):
+        self._seed(tmp_path, ["run-a", "run-b", "run-c"])
+
+        heal_report.main(["--repo", str(tmp_path)])
+
+        out = capsys.readouterr().out
+        assert "TITLE: fix: the machinery keeps healing" in out
+        assert "3 runs" in out
+        assert "operator's call, never automatic" in out
+
+    def test_below_the_threshold_proposes_nothing(self, tmp_path, capsys):
+        self._seed(tmp_path, ["run-a", "run-b"])
+
+        heal_report.main(["--repo", str(tmp_path)])
+
+        out = capsys.readouterr().out
+        assert "TITLE:" not in out
+        assert "nothing proposes an issue" in out
+
+
+def _healthy_box(*_args, **_kwargs):
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    return BoxHealth(True, [], "")
+
+
+def _git(repo, *args):
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+    return result
+
+
+class TestLauncherHooks:
+    def test_the_janitor_writes_heal_records_through_a_real_launch(self, tmp_path):
+        """The run-16 shape again: a leaving at launch becomes a janitor heal
+        record, not only a narration line."""
+        origin = tmp_path / "origin.git"
+        subprocess.run(
+            ["git", "init", "-q", "--bare", "--initial-branch=main", str(origin)],
+            capture_output=True, text=True, check=True,
+        )
+        repo = tmp_path / "proj"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main")
+        _git(repo, "config", "user.email", "t@t")
+        _git(repo, "config", "user.name", "t")
+        (repo / ".gitignore").write_text("data/\n", encoding="utf-8")
+        (repo / "README.md").write_text("x\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "base")
+        _git(repo, "remote", "add", "origin", str(origin))
+        _git(repo, "push", "-qu", "origin", "main")
+        _git(repo, "remote", "set-head", "origin", "--auto")
+        leaving = repo / "docs" / "lld" / "active" / "LLD-002.md"
+        leaving.parent.mkdir(parents=True)
+        leaving.write_text("drafted\n", encoding="utf-8")
+
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy_box), \
+                patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+                patch.object(sr, "roll_issue", lambda *a: 0):
+            code = sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert code == 0
+        heals = read_heals(repo)
+        janitor = [h for h in heals if h["category"] == "janitor"]
+        assert janitor and janitor[0]["outcome"] == "healed"
+        assert "LLD-002.md" in janitor[0]["target"]
+
+    def test_a_storm_backoff_writes_a_heal_record(self, tmp_path):
+        repo = tmp_path / "proj"
+        (repo / ".git").mkdir(parents=True)
+        from assemblyzero.core.provider_storm import STORM_EXIT_CODE
+
+        rolls = iter([STORM_EXIT_CODE, 0])
+
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy_box), \
+                patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+                patch.object(sr, "roll_issue", lambda *a: next(rolls)), \
+                patch.object(sr, "restore_repo", lambda *a: []), \
+                patch.object(sr, "_interruptible_sleep", lambda s: None), \
+                patch.object(sr.time, "sleep", lambda s: None):
+            code = sr.main(["--repo", str(repo), "--issue", "7",
+                            "--attempts", "2"])
+
+        assert code == 0
+        storms = [h for h in read_heals(repo) if h["category"] == "storm-backoff"]
+        assert storms and storms[0]["target"] == "#7"
+        assert "waited" in storms[0]["detail"]

--- a/tests/unit/test_healing_ledger.py
+++ b/tests/unit/test_healing_ledger.py
@@ -184,3 +184,33 @@ class TestLauncherHooks:
         storms = [h for h in read_heals(repo) if h["category"] == "storm-backoff"]
         assert storms and storms[0]["target"] == "#7"
         assert "waited" in storms[0]["detail"]
+
+
+class TestEvidenceExemption:
+    def test_the_ledger_is_never_classified_as_dirt(self, tmp_path):
+        """#2164's CI catch: in a repo that does not gitignore data/, the
+        ledger itself blocked the branch-cutter. Evidence is exempt from
+        classification structurally, not by convention."""
+        import subprocess as sp
+
+        from assemblyzero.speedrun.leavings import classify_dirt, untracked_files
+
+        repo = tmp_path / "proj"
+        repo.mkdir()
+        for args in (["init", "-q", "-b", "main"],
+                     ["config", "user.email", "t@t"],
+                     ["config", "user.name", "t"]):
+            sp.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True)
+        (repo / "README.md").write_text("x\n", encoding="utf-8")
+        sp.run(["git", "-C", str(repo), "add", "."], check=True,
+               capture_output=True)
+        sp.run(["git", "-C", str(repo), "commit", "-qm", "base"], check=True,
+               capture_output=True)
+        # No .gitignore at all: the ledger would be visible dirt without
+        # the structural exemption.
+        record_heal(repo, "reset", "#4", "partial", detail="x")
+
+        machinery, operator = classify_dirt(repo)
+        assert machinery == [] and operator == []
+        assert untracked_files(repo) == []

--- a/tools/heal_report.py
+++ b/tools/heal_report.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Roll up the healing ledger: what the machinery fixed about itself (#2164).
+
+Reads ``data/speedrun/telemetry/heals.jsonl`` (written by record_heal at
+every self-heal site), reports per-run and cross-run, and when the same
+category+target recurs across enough distinct runs it emits a ready-to-file
+issue stub. It NEVER files the issue: the machine asks, the operator rules,
+same philosophy as the must-resolve flow (#2072).
+
+Cold start honours standard 0025's rule: an empty ledger says so, with the
+denominator, and never fabricates.
+
+Usage:
+    poetry run python tools/heal_report.py --repo /c/.../boostgauge
+    poetry run python tools/heal_report.py --repo ... --recurrence 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from assemblyzero.speedrun.healing import heals_path, read_heals  # noqa: E402
+
+
+def render_report(records: list[dict], recurrence: int) -> str:
+    lines: list[str] = []
+    lines.append(f"{len(records)} heal record(s).")
+    lines.append("")
+
+    by_run: dict[str, list[dict]] = defaultdict(list)
+    for r in records:
+        by_run[r.get("run_tag") or "(no run tag)"].append(r)
+
+    lines.append("By run:")
+    for run, rs in by_run.items():
+        outcomes = defaultdict(int)
+        for r in rs:
+            outcomes[r.get("outcome", "?")] += 1
+        summary = ", ".join(f"{k} {v}" for k, v in sorted(outcomes.items()))
+        lines.append(f"  {run}: {len(rs)} heal(s) ({summary})")
+        for r in rs:
+            if r.get("outcome") != "healed":
+                lines.append(
+                    f"    ! {r.get('category')}: {r.get('target')} -- "
+                    f"{r.get('outcome')}: {r.get('detail', '')[:100]}"
+                )
+    lines.append("")
+
+    # Cross-run recurrence: the same category+target healed again and again
+    # is a defect wearing a bandage.
+    runs_by_key: dict[tuple, set] = defaultdict(set)
+    detail_by_key: dict[tuple, str] = {}
+    for r in records:
+        key = (r.get("category"), r.get("target"))
+        runs_by_key[key].add(r.get("run_tag") or r.get("ts"))
+        detail_by_key[key] = r.get("detail", "")
+
+    stubs = [
+        (key, runs)
+        for key, runs in runs_by_key.items()
+        if len(runs) >= recurrence
+    ]
+    if stubs:
+        lines.append(
+            f"Recurring heals (same category+target across >= {recurrence} "
+            "runs) -- ready-to-file issue stubs. Filing is the operator's "
+            "call, never automatic:"
+        )
+        for (category, target), runs in sorted(stubs, key=lambda s: -len(s[1])):
+            lines.append("")
+            lines.append(
+                f"  TITLE: fix: the machinery keeps healing "
+                f"'{target}' ({category}) -- {len(runs)} runs"
+            )
+            lines.append(
+                f"  BODY: The healing ledger shows {category} healing "
+                f"'{target}' in {len(runs)} distinct runs "
+                f"({', '.join(sorted(str(r) for r in runs)[:5])}). A heal "
+                "that recurs is a defect with a bandage; find and fix the "
+                f"source. Last detail: {detail_by_key[(category, target)][:200]}"
+            )
+    else:
+        lines.append(
+            f"No heal recurs across {recurrence}+ runs -- nothing proposes "
+            "an issue."
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Roll up the healing ledger and propose issues for "
+                    "recurring heals (#2164)."
+    )
+    parser.add_argument("--repo", required=True, help="Target repo root path")
+    parser.add_argument(
+        "--recurrence", type=int, default=3,
+        help="Distinct runs before a recurring heal proposes an issue "
+             "(default 3)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo).resolve()
+    records = read_heals(repo_root)
+    if not records:
+        print(
+            f"No heal records at {heals_path(repo_root)}.\n"
+            "Either nothing has needed healing since the ledger landed, or "
+            "no roll has run since. An empty ledger is a real answer; during "
+            "cold start, grep the events logs by hand (standard 0025's rule: "
+            "never fabricate)."
+        )
+        return 0
+
+    print(render_report(records, max(1, args.recurrence)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -85,6 +85,7 @@ from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     open_must_resolve_issues,
     refusal_message,
 )
+from assemblyzero.speedrun.healing import record_heal  # noqa: E402
 from assemblyzero.speedrun.leavings import (  # noqa: E402
     classify_dirt,
     is_machinery_owned,
@@ -313,7 +314,13 @@ def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
             f"BASE '{base}' already contains #{issue}'s work "
             f"({len(committed)} artifact(s)) -- establishing a fresh attempt"
         )
-        return establish_new_attempt(repo_root, log)
+        fresh = establish_new_attempt(repo_root, log)
+        record_heal(
+            repo_root, "base-replace", base,
+            "healed" if fresh else "failed",
+            detail=f"#{issue}'s work already on the base",
+        )
+        return fresh
 
     # Recoverable debris. The old wrapper printed "run speedrun_reset.py,
     # verify clean, relaunch" and quit; that instruction is now the code path.
@@ -333,8 +340,14 @@ def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
         log.write(f"GATE still dirty after reset ({len(debris)}) -- {len(debris)} left")
         for d in debris:
             log.write(f"  {d}")
+        record_heal(
+            repo_root, "reset", f"#{issue}", "partial",
+            detail=f"{len(debris)} finding(s) survived the reset",
+        )
         return replace_or_refuse(repo_root, base, issue, debris, log)
 
+    record_heal(repo_root, "reset", f"#{issue}", "healed",
+                detail="base clean after self-heal")
     log.write(f"BASE '{base}' clean for #{issue} after self-heal")
     return base
 
@@ -1304,6 +1317,13 @@ def restore_repo(
                 f"pipeline leaving not cleared: {p.describe()}"
                 for p in janitor.problems
             ]
+            # #2164: exit reconciles are heals too.
+            for entry in janitor.entries:
+                record_heal(
+                    repo_root, "restore-reconcile", entry.path,
+                    "healed" if entry.ok else "partial",
+                    detail=entry.describe(),
+                )
         for f in operator_new:
             # Not the machinery's to touch: a new file it cannot prove it
             # made is surfaced, never preserved or deleted on its author's
@@ -1690,6 +1710,13 @@ def main(argv: list[str] | None = None) -> int:
         sweep = sweep_pipeline_worktrees(repo_root, log=lambda m: session.write(m.strip()))
         for problem in sweep.problems:
             session.write(f"SWEEP UNRESOLVED {problem.describe()}")
+        # #2164: every sweep action is a heal record.
+        for entry in sweep.entries:
+            record_heal(
+                repo_root, "sweep", entry.path.name,
+                "healed" if entry.ok else "partial",
+                detail=entry.describe(),
+            )
     except Exception as exc:  # noqa: BLE001 - a sweep must never abort a roll
         session.write(f"SWEEP FAILED (continuing): {exc}")
 
@@ -1707,6 +1734,13 @@ def main(argv: list[str] | None = None) -> int:
             )
             for problem in janitor.problems:
                 session.write(f"JANITOR UNRESOLVED {problem.describe()}")
+            # #2164: every janitor action is a heal record.
+            for entry in janitor.entries:
+                record_heal(
+                    repo_root, "janitor", entry.path,
+                    "healed" if entry.ok else "partial",
+                    detail=entry.describe(),
+                )
         else:
             session.write("  file janitor: nothing to do")
     except Exception as exc:  # noqa: BLE001 - a janitor must never abort a roll
@@ -1766,6 +1800,13 @@ def main(argv: list[str] | None = None) -> int:
                     session.write(
                         f"STORM BACKOFF {minutes}m before attempt "
                         f"{attempt_no + 1}/{args.attempts}"
+                    )
+                    # #2164: a backoff is a heal (waiting instead of burning
+                    # an attempt on the same wall).
+                    record_heal(
+                        repo_root, "storm-backoff", f"#{issue}", "healed",
+                        detail=f"waited {minutes}m before attempt "
+                               f"{attempt_no + 1}/{args.attempts}",
                     )
                     print(
                         f"\n#{issue} attempt {attempt_no}/{args.attempts}: the model "


### PR DESCRIPTION
Closes #2164

The self-heal counterpart of the prompt-failure telemetry. `record_heal` appends one structured JSONL record per heal to `data/speedrun/telemetry/heals.jsonl` — category, target, outcome (healed/partial/failed), detail, run tag — with partial outcomes first-class (today's WinError 5 half-reset is exactly the record the report exists to surface). Recording never raises and the ledger is evidence, exempt from every janitor per standard 0027. Six emission sites in the launcher: worktree sweep, file janitor, per-issue reset (healed or partial from the post-reset gate), base replacement, storm backoff, and the exit reconcile.

`tools/heal_report.py` rolls the ledger up per run, flags every non-healed outcome, and when the same category+target recurs across three distinct runs it emits a ready-to-file issue stub with the evidence — it never files; the machine asks and the operator rules, same philosophy as must-resolve. An empty ledger reports itself as a real answer under the cold-start never-fabricate rule. Runbook 0952 § Inspect gains step 3b and the paste block carries it.

11 unit tests plus two launcher-integration tests (the run-16 replay writes a janitor heal record through a real launch; a storm backoff records with its wait). Full suite green locally (6,680).