### PR TITLE
fix(dashboard): runnable test script + repair the uninstallable lock (Closes #2154)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250214.0",
+        "@cloudflare/workers-types": "^5.20260722.1",
         "@tailwindcss/vite": "^4.3.1",
         "@types/node": "^25.3.0",
         "@types/react": "^19.2.1",
@@ -879,9 +879,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260619.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260619.1.tgz",
-      "integrity": "sha512-bprsNzG0DapQPFwU2AvQlQ6FUO7Y4bKWaPBzLNI7nBSqlHsK0P62xx2NaNT6i/htzAgQspKZm1D32y0RxofrRQ==",
+      "version": "5.20260810.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260810.1.tgz",
+      "integrity": "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1492,9 +1492,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1512,9 +1509,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1532,9 +1526,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1552,9 +1543,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1572,9 +1560,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1592,9 +1577,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1612,9 +1594,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1632,9 +1611,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1652,9 +1628,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1678,9 +1651,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1704,9 +1674,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1730,9 +1697,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1756,9 +1720,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1782,9 +1743,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1808,9 +1766,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1834,9 +1789,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2195,9 +2147,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2215,9 +2164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2235,9 +2181,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2255,9 +2198,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2275,9 +2215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2295,9 +2232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3131,9 +3065,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3151,9 +3082,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3171,9 +3099,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3191,9 +3116,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3903,9 +3825,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3927,9 +3846,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3951,9 +3867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3975,9 +3888,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,8 @@
     "dev:client": "vite",
     "build": "vite build",
     "deploy": "vite build && wrangler deploy",
-    "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.client.json --noEmit"
+    "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.client.json --noEmit",
+    "test": "npm run typecheck"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.996.0",
@@ -21,7 +22,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250214.0",
+    "@cloudflare/workers-types": "^5.20260722.1",
     "@tailwindcss/vite": "^4.3.1",
     "@types/node": "^25.3.0",
     "@types/react": "^19.2.1",


### PR DESCRIPTION
Dependabot PR #2111 (hono in `/dashboard`) deferred on every harvest with `no runnable npm test script in 'dashboard' (#1839)`. Adding a script alone would not have helped — the package could not be installed at all.

## The part that was not in the issue

`npm ci` fails on a clean checkout of `main`:

```
npm error While resolving: wrangler@4.114.0
npm error Found: @cloudflare/workers-types@4.20260619.1
npm error Could not resolve dependency:
npm error peerOptional @cloudflare/workers-types@"^5.20260722.1" from wrangler@4.114.0
```

The lock pins `wrangler@4.114.0` beside `@cloudflare/workers-types@4.20260619.1`, and wrangler 4.114.0 requires workers-types `^5` as a peer. Those two cannot resolve together, so the lock is internally inconsistent.

It read as green locally because the working tree's `node_modules` holds `wrangler@4.68.0` and `workers-types@4.20260303.0` — an older, self-consistent pair, far behind the lock. Nobody had run `npm ci` from clean since wrangler was bumped, so a cached environment masked a broken lock. Same shape as the numpy failure in #2126: an environment that is never rebuilt hides a build that cannot be reproduced.

This is why the fix is in the same PR rather than split out. A `test` script on a package that cannot install is theatre — the harvester's gate would fail at install and never reach it, so #2154's acceptance ("`npm test` exits 0 in `dashboard/`") is unreachable without it.

## The change

- `@cloudflare/workers-types` → `^5.20260722.1`, which is what wrangler already requires. Lock regenerated.
- `"test": "npm run typecheck"` — reusing the check that already existed rather than inventing one.

## Why typecheck is a real check here, not a formality

`tsc --noEmit` runs over both `tsconfig.worker.json` and `tsconfig.client.json`. hono types the worker directly:

```ts
import { Hono } from "hono";
const app = new Hono<{ Bindings: Env }>();
```

so an incompatible hono bump — precisely the class of change #2111 is — fails it.

Vitest was not added. There is no test suite here, and standing up a framework to hold one trivial assertion would produce a check that passes because it asserts nothing. The typecheck covers real source and can genuinely fail. This is the "at minimum `tsc --noEmit`" option, chosen deliberately over a hollow suite.

## Verification, measured

```
npm ci        (from empty node_modules)  -> exit 0
npm test                                 -> exit 0
```

Proven non-vacuous rather than assumed. Injecting one invalid call on the Hono app:

```
src/index.ts(33,5): error TS2339: Property 'thisMethodDoesNotExistOnHono'
  does not exist on type 'Hono<{ Bindings: Env; }, BlankSchema, "/">'.
BROKEN EXIT: 2
```

Removing it returned exit 0 with the file byte-identical (`git diff` empty). No test was mocked, skipped, or weakened to pass.

## Effect

`/dashboard` dependabot PRs can now be audited instead of deferred. #2111 remains open for the 6 AM pipeline to process — nothing here approves or merges it.

Closes #2154
