### PR TITLE
feat(dependabot): serve never-audited PRs before the alphabetical sweep (Closes #2155)

### DIFF
--- a/tests/unit/test_dependabot_review.py
+++ b/tests/unit/test_dependabot_review.py
@@ -1204,3 +1204,179 @@ def test_baseline_checkout_stays_detached_like_the_pr_head(tmp_path, capsys):
         f"got {checkouts[0]}"
     )
     assert "dependabot-audit-4242" in checkouts[0]
+
+
+# ---- #2155: zero-review pre-pass (starved-tail fix) ----
+#
+# Repos process in sorted-name order, so a --limit budget is spent by the
+# alphabetically-early repos and the SAME tail is skipped every day. Two
+# repos' PRs had never received a single automated review.
+
+def _pr(number, created_at="", title="t"):
+    return dependabot_review.PRInfo(
+        number=number, title=title, author_login="app/dependabot",
+        body="", head_ref=f"db/{number}", head_oid=f"sha{number}",
+        created_at=created_at,
+    )
+
+
+def _reviews_payload(*bodies):
+    import json as _json
+    return _mk_completed(0, stdout=_json.dumps(
+        [{"user": dependabot_review.GITHUB_USER, "body": b} for b in bodies]
+    ))
+
+
+def test_has_automated_review_true_when_this_tool_reviewed_at_any_sha():
+    """Any prior review counts — APPROVED or COMMENTED, at any SHA."""
+    body = dependabot_review.REVIEW_BODY_PREFIX + " — gate: npm test passed"
+    with patch.object(dependabot_review, "run",
+                      return_value=_reviews_payload(body)):
+        assert dependabot_review.has_automated_review(_pr(7), "o/r") is True
+
+
+def test_has_automated_review_false_when_only_foreign_reviews_exist():
+    """A human review is not an audit by this tool; the PR is still starved."""
+    with patch.object(dependabot_review, "run",
+                      return_value=_reviews_payload("LGTM, merging")):
+        assert dependabot_review.has_automated_review(_pr(7), "o/r") is False
+
+
+def test_has_automated_review_assumes_reviewed_when_the_api_fails():
+    """Fail-safe direction matters: an outage must not flood the pre-pass.
+
+    Returning False on error would make every PR in the fleet look
+    never-audited during a GitHub blip and reorder the whole harvest off
+    bad data. A missed prioritisation only costs a day of latency.
+    """
+    with patch.object(dependabot_review, "run",
+                      return_value=_mk_completed(1, stderr="503")):
+        assert dependabot_review.has_automated_review(_pr(7), "o/r") is True
+
+    with patch.object(dependabot_review, "run",
+                      return_value=_mk_completed(0, stdout="not json")):
+        assert dependabot_review.has_automated_review(_pr(7), "o/r") is True
+
+
+def test_queue_orders_oldest_first_across_repos_not_by_repo_name():
+    """The whole point: an alphabetically-late repo can outrank an early one.
+
+    PR numbers are per-repo counters, so `zzz#2` really can be older than
+    `aaa#900`. Ordering by name or number is what starved the tail.
+    """
+    listings = {
+        "o/aaa": [_pr(900, "2026-08-01T00:00:00Z")],
+        "o/zzz": [_pr(2, "2026-01-01T00:00:00Z")],
+    }
+    with patch.object(dependabot_review, "list_dependabot_prs",
+                      side_effect=lambda r: listings[r]), \
+         patch.object(dependabot_review, "has_automated_review",
+                      return_value=False):
+        q = dependabot_review.build_zero_review_queue(["o/aaa", "o/zzz"])
+
+    assert [(r, p.number) for r, p in q] == [("o/zzz", 2), ("o/aaa", 900)]
+
+
+def test_queue_excludes_already_audited_prs():
+    listings = {"o/a": [_pr(1, "2026-01-01T00:00:00Z"),
+                        _pr(2, "2026-02-01T00:00:00Z")]}
+    audited = {1}
+    with patch.object(dependabot_review, "list_dependabot_prs",
+                      side_effect=lambda r: listings[r]), \
+         patch.object(dependabot_review, "has_automated_review",
+                      side_effect=lambda pr, repo: pr.number in audited):
+        q = dependabot_review.build_zero_review_queue(["o/a"])
+
+    assert [p.number for _, p in q] == [2]
+
+
+def test_queue_is_capped_and_unknown_age_sorts_last():
+    """The cap bounds the pre-pass; a PR with no creation time cannot jump it."""
+    prs = [_pr(1, "")] + [_pr(n, f"2026-0{n}-01T00:00:00Z") for n in range(2, 8)]
+    with patch.object(dependabot_review, "list_dependabot_prs",
+                      side_effect=lambda r: prs), \
+         patch.object(dependabot_review, "has_automated_review",
+                      return_value=False):
+        q = dependabot_review.build_zero_review_queue(["o/a"], max_prs=3)
+
+    assert len(q) == 3
+    assert [p.number for _, p in q] == [2, 3, 4]
+    assert 1 not in [p.number for _, p in q]
+
+
+def test_queue_disabled_returns_empty_and_makes_no_calls():
+    with patch.object(dependabot_review, "list_dependabot_prs") as lister:
+        assert dependabot_review.build_zero_review_queue(["o/a"], max_prs=0) == []
+    lister.assert_not_called()
+
+
+def test_queue_survives_a_repo_whose_listing_fails():
+    """One unreachable repo must not sink the pre-pass for the rest."""
+    def lister(repo):
+        if repo == "o/broken":
+            raise dependabot_review.PRListError("boom")
+        return [_pr(5, "2026-03-01T00:00:00Z")]
+
+    with patch.object(dependabot_review, "list_dependabot_prs",
+                      side_effect=lister), \
+         patch.object(dependabot_review, "has_automated_review",
+                      return_value=False):
+        q = dependabot_review.build_zero_review_queue(["o/broken", "o/ok"])
+
+    assert [(r, p.number) for r, p in q] == [("o/ok", 5)]
+
+
+# ---- #2155: the filter that keeps one run from auditing a PR twice ----
+
+def _run_process_repo(tmp_path, prs, **kwargs):
+    """Drive process_repo with its preconditions satisfied, recording calls."""
+    processed: list[int] = []
+
+    def fake_process_pr(pr, repo, target_repo):
+        processed.append(pr.number)
+        return "merged"
+
+    with patch.object(dependabot_review, "resolve_target_repo_dir",
+                      return_value=tmp_path), \
+         patch.object(dependabot_review, "check_for_orphan_worktrees",
+                      return_value=[]), \
+         patch.object(dependabot_review, "list_dependabot_prs",
+                      return_value=prs), \
+         patch.object(dependabot_review, "already_deferred_at_head",
+                      return_value=False), \
+         patch.object(dependabot_review, "process_pr",
+                      side_effect=fake_process_pr):
+        sub = dependabot_review.process_repo("o/r", tmp_path, **kwargs)
+    return processed, sub
+
+
+def test_only_prs_restricts_the_prepass_to_its_selection(tmp_path):
+    prs = [_pr(1), _pr(2), _pr(3)]
+    processed, _ = _run_process_repo(tmp_path, prs, only_prs={2})
+    assert processed == [2]
+
+
+def test_skip_prs_stops_the_sweep_reauditing_what_the_prepass_did(tmp_path):
+    """Without this the pre-pass PR is audited twice in one run.
+
+    That would post a duplicate review and spend a second budget slot —
+    turning a fix for starvation into extra consumption of the same budget.
+    """
+    prs = [_pr(1), _pr(2), _pr(3)]
+    processed, _ = _run_process_repo(tmp_path, prs, skip_prs={2})
+    assert processed == [1, 3]
+
+
+def test_no_filters_preserves_existing_behaviour_exactly(tmp_path):
+    prs = [_pr(3), _pr(1), _pr(2)]
+    processed, _ = _run_process_repo(tmp_path, prs)
+    assert processed == [1, 2, 3]  # still oldest-number-first within a repo
+
+
+def test_prepass_then_sweep_audits_each_pr_exactly_once(tmp_path):
+    """End-to-end invariant: the two passes partition the repo's PRs."""
+    prs = [_pr(1), _pr(2), _pr(3)]
+    pre, _ = _run_process_repo(tmp_path, prs, only_prs={3})
+    sweep, _ = _run_process_repo(tmp_path, prs, skip_prs={3})
+    assert sorted(pre + sweep) == [1, 2, 3]
+    assert set(pre).isdisjoint(sweep)

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -281,6 +281,18 @@ REVIEW_BODY_PREFIX = "Automated review via tools/dependabot_review.py"
 # 0, disabling the skip entirely for a run (audits everything; strictly
 # more verification, never less).
 SKIP_AFTER_DEFERRALS = 3
+# #2155: how many never-audited PRs the pre-pass may take before the normal
+# alphabetical sweep runs. Repos process in sorted-name order, so under a
+# --limit budget the alphabetically-early repos spend it and the tail is
+# skipped "(queue untouched)" EVERY day -- deterministically the same tail,
+# so a PR there can go unaudited forever rather than merely late. Two repos'
+# PRs had never received a single automated review.
+#
+# 5 is a floor on tail progress, not a redistribution: it guarantees the
+# starved end of the fleet gets some budget every run while leaving the
+# majority to the normal sweep. It does NOT raise the total (--limit is
+# unchanged, #1339 stands) and it does not reorder anything else.
+ZERO_REVIEW_PREPASS_MAX = 5
 
 
 @dataclass
@@ -293,6 +305,11 @@ class PRInfo:
     # #1838: current head SHA (headRefOid). "" when the listing did not
     # provide one; every consumer must treat "" as "unknown, re-audit".
     head_oid: str = ""
+    # #2155: ISO-8601 creation time, used to order the zero-review pre-pass
+    # oldest-first ACROSS repos. PR numbers are per-repo and say nothing
+    # about relative age between them, so they cannot order a fleet queue.
+    # "" sorts last -- an unknown age must not jump the queue.
+    created_at: str = ""
 
 
 class PRBudget:
@@ -452,7 +469,7 @@ def list_dependabot_prs(repo: str) -> list[PRInfo]:
         "gh", "pr", "list", "--repo", repo,
         "--author", "app/dependabot",
         "--state", "open",
-        "--json", "number,title,author,body,headRefName,headRefOid",
+        "--json", "number,title,author,body,headRefName,headRefOid,createdAt",
     ])
     if result.returncode != 0:
         raise PRListError(
@@ -467,6 +484,7 @@ def list_dependabot_prs(repo: str) -> list[PRInfo]:
             body=r["body"] or "",
             head_ref=r["headRefName"],
             head_oid=r.get("headRefOid") or "",
+            created_at=r.get("createdAt") or "",
         )
         for r in raw
     ]
@@ -1093,6 +1111,79 @@ def already_deferred_at_head(pr: PRInfo, repo: str,
         and rv.get("commit_id") == pr.head_oid
     )
     return attempts >= max_attempts
+
+
+def has_automated_review(pr: PRInfo, repo: str) -> bool:
+    """#2155: True iff this tool has EVER reviewed this PR, at any SHA.
+
+    Distinct from already_deferred_at_head, which asks "did we defer this
+    exact head N times". This asks "has this PR ever been looked at at all",
+    which is what identifies the starved tail: a PR the alphabetical sweep
+    has never reached carries zero reviews from this tool at any SHA.
+
+    Counts APPROVED and COMMENTED alike -- both are audits that happened.
+
+    Conservative on ANY failure: returns True, i.e. "assume already
+    reviewed, do not prioritise". The inverse default would be dangerous in
+    exactly the case that matters: a transient GitHub outage would make
+    every PR in the fleet look never-audited at once and flood the pre-pass
+    with the whole queue. A missed prioritisation costs one day of latency
+    and the normal sweep still reaches the PR; the opposite error re-orders
+    the entire harvest off bad data.
+    """
+    result = run(
+        ["gh", "api", f"repos/{repo}/pulls/{pr.number}/reviews?per_page=100",
+         "--jq", "[.[] | {user: .user.login, body: .body}]"],
+        quiet_on_failure=True,
+    )
+    if result.returncode != 0:
+        return True
+    try:
+        reviews = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return True
+    return any(
+        rv.get("user") == GITHUB_USER
+        and (rv.get("body") or "").startswith(REVIEW_BODY_PREFIX)
+        for rv in reviews
+    )
+
+
+def build_zero_review_queue(
+    repos: list[str],
+    max_prs: int = ZERO_REVIEW_PREPASS_MAX,
+) -> list[tuple[str, PRInfo]]:
+    """#2155: up to `max_prs` never-audited PRs, oldest-first across repos.
+
+    Ordering is by PR creation time, not by repo name and not by PR number.
+    PR numbers are per-repo counters, so comparing them across repos is
+    meaningless -- repo-a#3 may be far older than repo-z#900. Creation time
+    is the only fleet-wide ordering that means what it says.
+
+    A PR with no known creation time sorts last: an unknown age must not
+    jump a queue whose whole purpose is to serve the oldest starved work.
+    Ties break on (repo, number) so the selection is deterministic run to
+    run, which matters because a nondeterministic pre-pass would make the
+    harvest unreproducible.
+
+    A repo whose PR listing fails is skipped rather than fatal -- the same
+    posture process_repo takes. The normal sweep will report the failure.
+    Returns [] when max_prs <= 0, which disables the pre-pass entirely.
+    """
+    if max_prs <= 0:
+        return []
+    candidates: list[tuple[str, PRInfo]] = []
+    for repo in repos:
+        try:
+            prs = list_dependabot_prs(repo)
+        except PRListError:
+            continue
+        for pr in prs:
+            if not has_automated_review(pr, repo):
+                candidates.append((repo, pr))
+    candidates.sort(key=lambda rp: (rp[1].created_at or "￿",
+                                    rp[0], rp[1].number))
+    return candidates[:max_prs]
 
 
 # #1400: file patterns that mean "this PR could affect the Python test
@@ -1739,6 +1830,8 @@ def process_repo(
     ignore_orphans: bool = False,
     budget: PRBudget | None = None,
     skip_after: int = SKIP_AFTER_DEFERRALS,
+    only_prs: set[int] | None = None,
+    skip_prs: set[int] | None = None,
 ) -> dict[str, list[str]]:
     """Process all dependabot PRs in one repo, sequentially.
 
@@ -1827,6 +1920,16 @@ def process_repo(
     if dry_run:
         return sub
     for pr in sorted(prs, key=lambda p: p.number):
+        # #2155: the zero-review pre-pass runs this same function with
+        # `only_prs` set, so its PRs go through every gate below exactly as
+        # the normal sweep would -- no second processing path to drift.
+        # The sweep then passes `skip_prs` for whatever the pre-pass already
+        # handled, so a PR is never audited twice in one run (which would
+        # post a duplicate review and spend a second budget slot).
+        if only_prs is not None and pr.number not in only_prs:
+            continue
+        if skip_prs and pr.number in skip_prs:
+            continue
         # #1838: a PR already deferred at this exact head SHA cannot
         # produce a different result -- skip before spending a budget
         # slot, building a worktree, or posting a duplicate review.
@@ -2063,6 +2166,33 @@ def main() -> None:
         "skipped_unchanged": [],
     }
 
+    # #2155: zero-review pre-pass. Repos process in sorted-name order, so a
+    # --limit budget is spent by the alphabetically-early repos and the same
+    # tail is skipped "(queue untouched)" every single day. Deterministic
+    # ordering makes that starvation permanent rather than merely unlucky:
+    # two repos' PRs had never received one automated review.
+    #
+    # Only meaningful when a budget can actually run out, so it is gated on
+    # `budget`. Uncapped runs reach everything anyway and would just pay the
+    # extra review lookups for nothing.
+    prepass: list[tuple[str, PRInfo]] = []
+    if budget and repos:
+        print(f"\nZero-review pre-pass: scanning {len(repos)} repo(s) for "
+              f"PRs this tool has never audited (#2155)...")
+        prepass = build_zero_review_queue(repos)
+        if prepass:
+            print(f"  {len(prepass)} never-audited PR(s), oldest first "
+                  f"(max {ZERO_REVIEW_PREPASS_MAX}):")
+            for repo, pr in prepass:
+                print(f"    {repo}#{pr.number}  created {pr.created_at or '?'}"
+                      f"  {pr.title[:60]}")
+        else:
+            print("  none — every open PR has been audited at least once.")
+
+    # Numbers the pre-pass handled, per repo, so the normal sweep does not
+    # audit them a second time in the same run.
+    done_by_repo: dict[str, set[int]] = {}
+
     # Wrap the worker dispatch + summary print in try/finally so the
     # Summary block ALWAYS prints, even when a stray SIGINT trips the
     # KeyboardInterrupt handler in __main__ before we'd otherwise
@@ -2074,6 +2204,27 @@ def main() -> None:
     # scheduled-task subprocess tree. Not worth chasing further --
     # belt-and-suspenders: print summary in finally.)
     try:
+        # #2155: serve the starved tail first, through the ordinary
+        # process_repo path so every gate (orphan canary, deferral skip,
+        # budget, author/exit-code gates) applies unchanged. Grouped by repo
+        # so each repo's worktree preconditions are established once.
+        if prepass and not args.dry_run:
+            by_repo: dict[str, set[int]] = {}
+            for repo, pr in prepass:
+                by_repo.setdefault(repo, set()).add(pr.number)
+            for repo, numbers in by_repo.items():
+                if budget is not None and budget.exhausted:
+                    break
+                print(f"\n{'=' * 60}\nPRE-PASS REPO: {repo}\n{'=' * 60}")
+                sub = process_repo(
+                    repo, main_repo, args.dry_run, args.ignore_orphans,
+                    budget=budget, skip_after=skip_after, only_prs=numbers,
+                )
+                for k in ("merged", "deferred", "errored", "limit_skipped",
+                          "skipped_unchanged"):
+                    results[k].extend(sub[k])
+                done_by_repo.setdefault(repo, set()).update(numbers)
+
         # Issue #1093: parallelize across repos in --fleet mode. Single-
         # repo mode (or --workers=1) keeps the sequential path. Within a
         # repo, processing is always sequential.
@@ -2127,6 +2278,7 @@ def main() -> None:
                 sub = process_repo(
                     repo, main_repo, args.dry_run, args.ignore_orphans,
                     budget=budget, skip_after=skip_after,
+                    skip_prs=done_by_repo.get(repo),
                 )
                 for k in ("merged", "deferred", "errored", "limit_skipped",
                           "skipped_unchanged"):


### PR DESCRIPTION
Repos process in sorted-name order. Under a `--limit` budget the alphabetically-early repos spend it, and the tail is skipped with `Harvest limit reached — skipping … (queue untouched)`.

Because that ordering is deterministic, it is the **same tail every day**. A PR there is not merely late — it can go unaudited indefinitely. Two repos' PRs had never received a single automated review.

## The change

Before the normal sweep, build a fleet-wide list of open dependabot PRs this tool has **never** reviewed at any SHA, take up to `ZERO_REVIEW_PREPASS_MAX` (5) oldest-first across repos, and process those first.

**Ordering is by PR creation time, not repo name and not PR number.** PR numbers are per-repo counters, so comparing them between repos is meaningless — one repo's `#2` can be far older than another's `#900`. Creation time is the only fleet-wide ordering that means what it says. A PR with unknown creation time sorts *last*: an unknown age must not jump a queue whose entire purpose is serving the oldest starved work.

## Why it reuses `process_repo` instead of adding a second path

The pre-pass calls `process_repo` with a new `only_prs` filter. That keeps the orphan canary, the deferral skip (#1838/#1947), the budget, and the author and exit-code gates applying unchanged — and, more importantly, means there is no duplicate copy of the gate logic that can drift from the sweep's.

The sweep then receives `skip_prs` for whatever the pre-pass handled. Without that, a pre-pass PR would be audited **twice in one run** — a duplicate review and a second budget slot — turning a starvation fix into extra consumption of the same budget. There is a test pinning the partition invariant.

## What this does not do

**It does not raise the harvest total.** `--limit` is untouched, #1339 stands, and the pre-pass draws from the same budget. It is a floor on tail progress, not more consumption.

It does not touch `SKIP_AFTER_DEFERRALS` or the unchanged-head skip, and it does not reorder anything beyond taking those ≤5 first. #2119 and #1964 are untouched.

It is gated on a budget existing: an uncapped run reaches everything anyway, so prioritising would buy nothing while paying one extra review lookup per PR.

## Fail-safe direction

`has_automated_review` returns **True** ("assume already reviewed, do not prioritise") on any API failure. The inverse would be dangerous in exactly the case that matters: a GitHub blip would make every PR in the fleet look never-audited at once and reorder the whole harvest off bad data. A missed prioritisation costs one day of latency and the normal sweep still reaches the PR.

## Verified live

A `--fleet --limit 15 --dry-run` run selected 5 never-audited PRs, oldest first, spanning five different repos — **every one of them alphabetically after the repos the sweep reaches first**, which is precisely the starved tail this targets. The normal sweep then proceeded in name order as before.

Repo names are omitted here deliberately: this is a public repo and some of those repos are private. The selection is visible in the run log locally.

## Tests

13 new, covering: ordering across repos (an alphabetically-late repo outranking an early one), the cap, unknown-age placement, the fail-safe direction on both HTTP error and malformed JSON, a repo whose listing fails not sinking the pre-pass, `only_prs`/`skip_prs` behaviour, unchanged behaviour when neither filter is passed, and the prepass/sweep partition invariant.

Full unit suite: **6705 passed**, 17 skipped, 5 xfailed, zero failures. `ruff` clean.

Closes #2155
