### PR TITLE
feat(speedrun): resume from the failed stage after a non-conflict failure (Closes #2193)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -47,6 +47,7 @@ than transcribed:
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
+| `--fresh` | redraw every stage from scratch (#2193). Without it, a launch that finds a prior non-conflict failure with the LLD already passed resumes from the failed stage — the passed stages are reused, not paid for again. A conflict-blocked issue always redraws fresh: the ruling edited the issue text, and the preserved draft embeds the pre-ruling wording |
 | `--narration` | starting view level: `terse`, `verbose`, `tutorial`, or `quiz` (#2159/#2160/#2161 — tutorial annotates each node and gate; quiz pauses the DISPLAY at transitions for multiple choice generated from the graph, roll unaffected). Press `v` in the console to toggle live; the log on disk is always complete |
 
 **Use `--detach`.** A roll started from a session is a descendant of that

--- a/tests/unit/test_resume_after_failure.py
+++ b/tests/unit/test_resume_after_failure.py
@@ -1,0 +1,320 @@
+"""Acceptance tests for resume-after-failure (#2193).
+
+A relaunch that finds a prior non-conflict failure with the lld already
+passed resumes from the failed stage; every guard failure falls back to the
+fresh redraw, which is always safe. The launcher is the unit under test --
+orchestrate.py's --resume-from machinery is exercised by its own suite.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+ARC = "hardening-run-17"
+CONFLICT = "REQUIREMENTS CONFLICT: the issue's requirements are inconsistent"
+
+
+@pytest.fixture
+def az_root(tmp_path) -> Path:
+    root = tmp_path / "az"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    """A real git repo: _restore_artifact runs actual git against it."""
+    root = tmp_path / "target"
+    root.mkdir()
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["config", "user.email", "t@example.com"],
+        ["config", "user.name", "Test"],
+    ):
+        subprocess.run(["git", "-C", str(root), *args], capture_output=True)
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "base"], capture_output=True)
+    return root
+
+
+@pytest.fixture
+def log(tmp_path) -> "speedrun_roll.EventLog":
+    return speedrun_roll.EventLog(tmp_path / "session-events.log")
+
+
+def write_state(
+    az_root: Path,
+    issue: int,
+    *,
+    target_repo: Path,
+    base_branch: str = ARC,
+    lld_status: str = "passed",
+    failed_stage: str | None = "spec",
+    failed_status: str = "failed",
+    error_message: str = "Spec workflow completed but no artifact produced",
+    lld_path: str = "",
+    spec_path: str = "",
+) -> Path:
+    state_dir = az_root / ".assemblyzero" / "orchestrator" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    stage_results: dict = {"triage": {"status": "skipped"}}
+    stage_results["lld"] = {"status": lld_status}
+    if failed_stage:
+        stage_results[failed_stage] = {
+            "status": failed_status,
+            "error_message": error_message,
+        }
+    data = {
+        "issue_number": issue,
+        "current_stage": failed_stage or "lld",
+        "target_repo": str(target_repo),
+        "base_branch": base_branch,
+        "lld_path": lld_path,
+        "spec_path": spec_path,
+        "stage_results": stage_results,
+    }
+    path = state_dir / f"{issue}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def resumable(monkeypatch, az_root, repo):
+    """Everything a spec-resume needs: matching state, arc, open PR, artifact."""
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    lld = repo / "docs" / "lld" / "active" / "LLD-001.md"
+    lld.parent.mkdir(parents=True)
+    lld.write_text("# LLD\n", encoding="utf-8")
+    write_state(az_root, 1, target_repo=repo, lld_path=str(lld))
+    return lld
+
+
+# ---------------------------------------------------------------------------
+# resume_plan guards -- each unmet condition falls back to fresh (None)
+# ---------------------------------------------------------------------------
+
+
+def test_no_state_file_means_fresh(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_other_repos_state_never_matches(az_root, repo, tmp_path, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    other = tmp_path / "other-campaign-repo"
+    other.mkdir()
+    write_state(az_root, 1, target_repo=other)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_rotated_arc_means_fresh(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: "hardening-run-18")
+    write_state(az_root, 1, target_repo=repo, base_branch=ARC)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_failed_lld_means_fresh(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    write_state(
+        az_root, 1, target_repo=repo,
+        lld_status="failed", failed_stage="lld",
+        error_message="MECHANICAL VALIDATION FAILED",
+    )
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_requirements_conflict_means_fresh(az_root, repo, log, monkeypatch):
+    """The documented case: a ruling edited the issue, the draft is stale."""
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    write_state(
+        az_root, 1, target_repo=repo,
+        failed_status="blocked", error_message=CONFLICT,
+    )
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_pr_stage_failure_is_not_resumable(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    write_state(az_root, 1, target_repo=repo, failed_stage="pr")
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_closed_lld_pr_means_fresh(az_root, repo, log, monkeypatch, resumable):
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: False)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+def test_unrestorable_artifact_means_fresh(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    write_state(
+        az_root, 1, target_repo=repo,
+        lld_path=str(repo / "docs" / "lld" / "active" / "LLD-001.md"),
+    )
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None
+
+
+# ---------------------------------------------------------------------------
+# resume_plan happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_spec_failure_resumes_from_spec(az_root, repo, log, resumable):
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) == "spec"
+
+
+def test_impl_failure_resumes_from_impl(az_root, repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    lld = repo / "docs" / "lld" / "active" / "LLD-001.md"
+    spec = repo / "docs" / "lld" / "active" / "SPEC-001.md"
+    lld.parent.mkdir(parents=True)
+    lld.write_text("# LLD\n", encoding="utf-8")
+    spec.write_text("# SPEC\n", encoding="utf-8")
+    write_state(
+        az_root, 1, target_repo=repo,
+        failed_stage="impl", lld_path=str(lld), spec_path=str(spec),
+        error_message="impl worktree build failed",
+    )
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) == "impl"
+
+
+# ---------------------------------------------------------------------------
+# _restore_artifact -- the janitor-cleared file comes back from the branch
+# ---------------------------------------------------------------------------
+
+
+def test_restore_artifact_from_lld_branch(repo):
+    rel = Path("docs") / "lld" / "active" / "LLD-005.md"
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "5-lld"], capture_output=True)
+    target = repo / rel
+    target.parent.mkdir(parents=True)
+    target.write_text("# LLD five\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "lld"], capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "main"], capture_output=True)
+    assert not target.exists()
+
+    assert speedrun_roll._restore_artifact(repo, 5, str(target)) is True
+    assert target.read_text(encoding="utf-8") == "# LLD five\n"
+
+
+def test_restore_artifact_outside_repo_refuses(repo, tmp_path):
+    outside = tmp_path / "elsewhere" / "LLD-005.md"
+    assert speedrun_roll._restore_artifact(repo, 5, str(outside)) is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_base_for_resume -- verify, never reset
+# ---------------------------------------------------------------------------
+
+
+def test_resume_base_requires_attempt_branch(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: "")
+    assert speedrun_roll.ensure_base_for_resume(repo, 1, log) is None
+
+
+def test_resume_base_requires_structural_soundness(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(
+        speedrun_roll, "base_is_structurally_sound",
+        lambda *_a: ["'hardening-run-17' does not exist on origin"],
+    )
+    assert speedrun_roll.ensure_base_for_resume(repo, 1, log) is None
+
+
+def test_resume_base_accepts_sound_base_without_reset(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "base_is_structurally_sound", lambda *_a: [])
+
+    def _no_reset(*_a, **_k):  # pragma: no cover - the assertion IS the test
+        raise AssertionError("reset must never run on the resume path")
+
+    monkeypatch.setattr(speedrun_roll.reset, "reset_one_issue", _no_reset)
+    assert speedrun_roll.ensure_base_for_resume(repo, 1, log) == ARC
+
+
+# ---------------------------------------------------------------------------
+# roll_issue -- the flag reaches the child, the reset stays away
+# ---------------------------------------------------------------------------
+
+
+def _capture_child(monkeypatch):
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **_kw):
+        captured.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(speedrun_roll.subprocess, "run", fake_run)
+    return captured
+
+
+def test_roll_issue_resume_passes_flag_and_skips_reset(repo, tmp_path, monkeypatch):
+    captured = _capture_child(monkeypatch)
+    monkeypatch.setattr(
+        speedrun_roll, "ensure_base_for_resume", lambda *_a: ARC
+    )
+
+    def _no_fresh_base(*_a, **_k):  # pragma: no cover - the assertion IS the test
+        raise AssertionError("ensure_base must not run when resuming")
+
+    monkeypatch.setattr(speedrun_roll, "ensure_base", _no_fresh_base)
+
+    code = speedrun_roll.roll_issue(
+        repo, 1, tmp_path, tmp_path, [], resume_from="spec"
+    )
+    assert code == 0
+    assert captured, "the orchestrator child was never launched"
+    child = captured[0]
+    assert "--resume-from" in child
+    assert child[child.index("--resume-from") + 1] == "spec"
+
+
+def test_roll_issue_falls_back_to_fresh_when_resume_base_fails(
+    repo, tmp_path, monkeypatch
+):
+    captured = _capture_child(monkeypatch)
+    monkeypatch.setattr(speedrun_roll, "ensure_base_for_resume", lambda *_a: None)
+    monkeypatch.setattr(speedrun_roll, "ensure_base", lambda *_a: ARC)
+
+    code = speedrun_roll.roll_issue(
+        repo, 1, tmp_path, tmp_path, [], resume_from="spec"
+    )
+    assert code == 0
+    assert captured
+    assert "--resume-from" not in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_detached_argv_forwards_fresh(tmp_path):
+    args = argparse.Namespace(
+        issue=[1, 7], attempts=3, override_prereqs=False, fresh=True
+    )
+    argv = speedrun_roll.detached_argv(args, [], tmp_path, tmp_path, tmp_path)
+    assert "--fresh" in argv
+
+
+def test_detached_argv_omits_fresh_by_default(tmp_path):
+    args = argparse.Namespace(
+        issue=[1], attempts=1, override_prereqs=False, fresh=False
+    )
+    argv = speedrun_roll.detached_argv(args, [], tmp_path, tmp_path, tmp_path)
+    assert "--fresh" not in argv

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -73,7 +73,11 @@ except ImportError:  # pragma: no cover - tool copied outside the package
 
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
-from assemblyzero.core.exit_codes import CONFLICT_EXIT_CODE  # noqa: E402
+from assemblyzero.core.exit_codes import (  # noqa: E402
+    CONFLICT_EXIT_CODE,
+    is_requirements_conflict,
+)
+from assemblyzero.workflows.orchestrator.state import STAGE_ORDER  # noqa: E402
 from assemblyzero.core.provider_storm import (  # noqa: E402
     STORM_EXIT_CODE,
     backoff_minutes,
@@ -422,12 +426,167 @@ def replace_or_refuse(
 
 
 # =============================================================================
+# Resume -- reuse passed stages after a non-conflict failure (#2193)
+# =============================================================================
+
+# Stages a relaunch may resume from. lld failing means nothing expensive
+# passed (a redraw IS the restart), and pr/cleanup resumes are deferred --
+# their preserved state (impl worktree, opened PRs) has more unverified
+# surface than the savings justify today.
+RESUMABLE_STAGES = ("spec", "impl")
+
+
+def _orchestrator_state_path(az_root: Path, issue: int) -> Path:
+    """Where orchestrate.py persists per-issue state (resume.py STATE_DIR,
+    which is relative to the child's cwd -- always az_root, see roll_issue)."""
+    return az_root / ".assemblyzero" / "orchestrator" / "state" / f"{issue}.json"
+
+
+def _open_lld_pr_exists(repo_root: Path, issue: int) -> bool:
+    """The lld PR still being open proves the reset has not destroyed the
+    draft a resume would reuse -- reset_one_issue closes it first thing, so
+    closed means the artifacts are already gone and only a redraw is left."""
+    result = _run([
+        "gh", "pr", "list", "--head", f"{issue}-lld",
+        "--state", "open", "--json", "number",
+    ], cwd=repo_root)
+    if result.returncode != 0:
+        return False
+    try:
+        return bool(json.loads(result.stdout or "[]"))
+    except json.JSONDecodeError:
+        return False
+
+
+def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
+    """Materialize a passed stage's file from the issue's lld branch when the
+    working tree no longer has it -- the exit janitor clears pipeline-authored
+    untracked files (standard 0027), but the draft itself is committed on the
+    branch and can be shown back into place."""
+    path = Path(artifact)
+    if path.is_file():
+        return True
+    try:
+        rel = path.relative_to(repo_root)
+    except ValueError:
+        return False
+    for ref in (f"{issue}-lld", f"origin/{issue}-lld"):
+        show = _run(["git", "show", f"{ref}:{rel.as_posix()}"], cwd=repo_root)
+        if show.returncode == 0 and show.stdout:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(show.stdout, encoding="utf-8")
+            return True
+    return False
+
+
+def resume_plan(
+    az_root: Path, repo_root: Path, issue: int, log: EventLog
+) -> str | None:
+    """The stage to resume #issue from, or None for a fresh draw.
+
+    Resume is offered only when every one of these holds -- anything less
+    falls back to the fresh redraw, which is always safe:
+
+      - orchestrate persisted state for this issue, for THIS repo and THIS
+        attempt branch (state files are keyed by issue number alone, so a
+        same-numbered issue in another campaign repo must not match);
+      - the lld stage passed and a later resumable stage failed;
+      - the failure was NOT a requirements conflict. A conflict means an
+        operator ruling edited the issue text, and the persisted draft embeds
+        the pre-ruling text -- resuming spec would re-review the stale LLD
+        and re-block on the very conflict the operator just retired
+        (boostgauge #253 is the documented case);
+      - the lld PR is still open and the passed artifacts exist on disk or
+        are restorable from the lld branch.
+    """
+    state_path = _orchestrator_state_path(az_root, issue)
+    if not state_path.is_file():
+        return None
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    try:
+        if Path(data.get("target_repo", "")).resolve() != repo_root.resolve():
+            return None
+    except OSError:
+        return None
+
+    base = resolve_attempt_branch(repo_root)
+    if not base or data.get("base_branch") != base:
+        return None
+
+    results = data.get("stage_results", {}) or {}
+    if results.get("lld", {}).get("status") not in ("passed", "skipped"):
+        return None
+
+    failed = next(
+        (s for s in STAGE_ORDER
+         if results.get(s, {}).get("status") in ("failed", "blocked")),
+        None,
+    )
+    if failed not in RESUMABLE_STAGES:
+        return None
+
+    if is_requirements_conflict(results.get(failed, {}).get("error_message", "")):
+        return None
+
+    if not _open_lld_pr_exists(repo_root, issue):
+        return None
+
+    needed = [data.get("lld_path", "")]
+    if failed == "impl":
+        needed.append(data.get("spec_path", ""))
+    for artifact in needed:
+        if not artifact or not _restore_artifact(repo_root, issue, artifact):
+            log.write(
+                f"RESUME abandoned for #{issue}: artifact missing and not "
+                f"restorable: {artifact or '<unset>'}"
+            )
+            return None
+
+    log.write(
+        f"RESUME planned for #{issue}: from '{failed}' (state {state_path.name})"
+    )
+    return failed
+
+
+def ensure_base_for_resume(
+    repo_root: Path, issue: int, log: EventLog
+) -> str | None:
+    """The resume counterpart of ensure_base: verify, never reset.
+
+    The debris ensure_base would clear IS the work a resume reuses -- the lld
+    branch, its open PR, the lineage. Only the structural checks run here; any
+    problem abandons the resume rather than healing, and the caller falls back
+    to the fresh path where the ordinary janitor applies.
+    """
+    base = resolve_attempt_branch(repo_root)
+    if not base:
+        log.write("RESUME abandoned: no attempt branch exists")
+        return None
+    problems = base_is_structurally_sound(repo_root, base)
+    if problems:
+        log.write(
+            f"RESUME abandoned: base '{base}' unusable: {'; '.join(problems)}"
+        )
+        return None
+    log.write(
+        f"BASE '{base}' accepted for resume of #{issue} "
+        "(this issue's work preserved)"
+    )
+    return base
+
+
+# =============================================================================
 # The roll
 # =============================================================================
 
 
 def roll_issue(
-    repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str]
+    repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str],
+    resume_from: str | None = None,
 ) -> int:
     tag = f"run-issue{issue}-{datetime.now().strftime('%H%M%S')}"
     run_start = _stamp()
@@ -438,7 +597,14 @@ def roll_issue(
     log.write(f"START issue=#{issue} repo={repo_root} pid={os.getpid()}")
 
     with Heartbeat(heartbeat_path):
-        base = ensure_base(repo_root, issue, log)
+        base: str | None = None
+        if resume_from:
+            base = ensure_base_for_resume(repo_root, issue, log)
+            if base is None:
+                log.write(f"RESUME fell back to a fresh draw for #{issue}")
+                resume_from = None
+        if base is None:
+            base = ensure_base(repo_root, issue, log)
         if base is None:
             log.write("ABORT could not establish a usable base")
             return 91
@@ -451,6 +617,12 @@ def roll_issue(
             "--base-branch", base,
             *extra,
         ]
+        if resume_from:
+            cmd += ["--resume-from", resume_from]
+            log.write(
+                f"RESUME #{issue} from '{resume_from}' -- passed stages "
+                "reused, not redrawn"
+            )
         log.write(f"LAUNCH base={base} -> {out_path.name}")
 
         # Direct redirect: the child's stdout goes straight to the file with no
@@ -602,6 +774,10 @@ def detached_argv(
     # the detached run re-refuses on the very gate the operator waived.
     if getattr(args, "override_prereqs", False):
         argv.append("--override-prereqs")
+    # #2193: same for a demanded full redraw -- the detached run must not
+    # resume the very state the operator asked to discard.
+    if getattr(args, "fresh", False):
+        argv.append("--fresh")
     return argv + extra
 
 
@@ -866,7 +1042,7 @@ _TERSE_MARKERS = (
     "NODE ", "NEXT ", "BASE", "LAUNCH", "EXIT", "START ", "CHILD EXITED",
     "STOPPED", "BLOCKED", "STORM", "ROLL ", "RESTORE", "SWEEP", "JANITOR",
     " attempt ", "OVERRIDE", "Previous run's questions", "must-resolve",
-    "VERIFIED", "UNVERIFIED", "Pipeline failed", "WARNING", "Resume",
+    "VERIFIED", "UNVERIFIED", "Pipeline failed", "WARNING", "Resume", "RESUME",
 )
 
 
@@ -1733,6 +1909,15 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--fresh", action="store_true",
+        help=(
+            "Redraw every stage from scratch, ignoring any resumable state "
+            "(#2193). Without it, a launch that finds a prior non-conflict "
+            "failure with the lld already passed resumes from the failed "
+            "stage instead of paying for the passed stages again."
+        ),
+    )
+    parser.add_argument(
         "--no-follow", action="store_true",
         help=(
             "With --detach: hand the roll off and return immediately instead "
@@ -1930,8 +2115,40 @@ def main(argv: list[str] | None = None) -> int:
             # the human relaunch from the loop entirely. A base or gate problem
             # (91) is NOT a draw and is never retried.
             storm_streak = 0
+            # #2193: a relaunch that finds a non-conflict failure with the lld
+            # already passed resumes from the failed stage instead of paying
+            # for the passed stages again. Planning failures never block a
+            # roll -- resume is an optimization, fresh is always correct.
+            resume_from: str | None = None
+            if not getattr(args, "fresh", False):
+                try:
+                    resume_from = resume_plan(az_root, repo_root, issue, session)
+                except Exception as exc:  # noqa: BLE001
+                    session.write(
+                        f"RESUME planning failed for #{issue} "
+                        f"(continuing fresh): {exc}"
+                    )
+            if resume_from:
+                print(
+                    f"\n#{issue}: resuming from '{resume_from}' -- the passed "
+                    "stages are reused, not redrawn (--fresh for a full redraw)."
+                )
             for attempt_no in range(1, max(1, args.attempts) + 1):
-                code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+                # The sixth argument travels ONLY when a resume fires: test
+                # stubs replace roll_issue with both bare *args lambdas and
+                # fixed five-arg defs, so the non-resume path must keep the
+                # exact pre-#2193 call shape (same convention as the
+                # positional restore_repo call below).
+                if resume_from:
+                    code = roll_issue(
+                        repo_root, issue, log_dir, az_root, extra, resume_from,
+                    )
+                else:
+                    code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+                # Only the first attempt resumes: a resumed attempt that fails
+                # has proven the preserved state is not enough, so every
+                # redraw after it is fresh.
+                resume_from = None
                 if code == 0 or code == 91:
                     break
 


### PR DESCRIPTION
## Summary

A relaunch that finds a prior **non-conflict** failure with the LLD already passed now resumes from the failed stage instead of redrawing the whole pipeline. The passed stages' cost — 6+ minutes of model time for an LLD, more for a spec — is paid once, not once per relaunch. `--fresh` forces the old full-redraw behavior; the flag rides the detached relaunch like `--override-prereqs` does.

The orchestrator side already existed in full (`--resume-from`, persisted per-issue state under `.assemblyzero/orchestrator/state/`). The launcher was the whole gap: its self-heal reset destroys exactly what a resume needs (closes the lld PR, deletes the branches, relocates the LLD) before every roll. This PR teaches the launcher to recognize a resumable failure, preserve that state, and pass the flag through.

## The design question in the issue, answered by evidence

The issue asked whether resume-after-a-RULING is safe, proposing re-validation as the guard. The live evidence (boostgauge #253, run-issue1-092650) settled it the other way: a requirements conflict means an operator ruling **edited the issue text**, and the persisted LLD embeds the pre-ruling wording — resuming spec re-reviews the stale draft and re-blocks on the very conflict the operator just retired. So conflict-blocked issues ALWAYS redraw fresh (the LLD drafter reads the live issue, so the redraw sees the ruled text), and resume applies only to non-conflict failures, where the draft is still valid. That is the cheap-validation fallback from the issue taken to its conclusion: for ruling-changed text the fallback is certain, so the resume attempt is never worth its cost.

## How resume qualifies (every guard falls back to fresh, which is always safe)

- Persisted state exists for this issue, for THIS repo and THIS attempt branch (state files are keyed by issue number alone).
- lld passed; the first failed stage is `spec` or `impl` (pr/cleanup deferred — follow-up: #2194).
- The failure is not a requirements conflict (`is_requirements_conflict` on the recorded error).
- The lld PR is still open — the reset closes it first thing, so open proves the artifacts survived.
- The passed artifacts exist on disk, or are restored from the lld branch (`git show`) — the exit janitor clears pipeline-authored untracked files (standard 0027), but the draft is committed on the branch.

On the resume path the base is verified (structural checks) but never reset — the debris the reset would clear IS the work being reused. Only the first attempt resumes; a resumed attempt that fails proves the preserved state insufficient, and every redraw after it is fresh.

## Changes

- `tools/speedrun_roll.py` — `resume_plan`, `ensure_base_for_resume`, `_open_lld_pr_exists`, `_restore_artifact`; `roll_issue` takes an optional resume stage; the batch loop plans a resume per issue (planning failures never block a roll); `--fresh` CLI flag + detached-argv forwarding; RESUME lines in the terse narration set.
- `docs/runbooks/0952-speedrun-operator-solo.md` — `--fresh` documented in the flag table (the flag-coverage test enforces this).
- `tests/unit/test_resume_after_failure.py` — 19 tests: every guard's fresh-fallback, both happy paths, artifact restore from the lld branch (real git), the no-reset invariant, roll_issue argv, CLI forwarding.

Full suite: 7214 passed, 17 skipped locally.

Closes #2193
