### PR TITLE
fix(requirements): structured open-questions verdict governs — approved LLDs no longer discarded (Closes #2199)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -293,7 +293,12 @@ Follow the Review Instructions exactly. Be specific about what needs to change f
         verdict_path = None
 
     # Issue #248: Check open questions resolution status
-    open_questions_status = _check_open_questions_status(current_draft, audit_content)
+    # #2199: hand over the structured verdict — audit_content is rendered
+    # without the open-questions field, so re-parsing it can never find
+    # the reviewer's answer.
+    open_questions_status = _check_open_questions_status(
+        current_draft, audit_content, feedback_result
+    )
 
     # Issue #257: Update draft with resolutions if APPROVED
     updated_draft = current_draft
@@ -696,7 +701,11 @@ def _extract_section(content: str, section_name: str) -> str:
     return ""
 
 
-def _check_open_questions_status(draft_content: str, verdict_content: str) -> str:
+def _check_open_questions_status(
+    draft_content: str,
+    verdict_content: str,
+    feedback_result: dict | None = None,
+) -> str:
     """Check whether open questions have been resolved.
 
     Issue #248: After Gemini review, check if:
@@ -704,11 +713,20 @@ def _check_open_questions_status(draft_content: str, verdict_content: str) -> st
     2. Questions marked as HUMAN REQUIRED
     3. Questions remain unanswered
 
-    Issue #775: Uses parse_structured_draft_questions for structured parsing.
+    #2199: when the reviewer's verdict parsed structured, its
+    ``open_questions`` field IS the answer — consume it directly. The old
+    path re-parsed ``verdict_content``, which the caller re-renders from the
+    parsed verdict WITHOUT the open-questions field, so the extraction found
+    nothing and every question-bearing draft was ruled UNANSWERED even when
+    the reviewer had APPROVED — twelve approved LLDs were discarded that way
+    in the boostgauge campaign. The markdown/regex path survives only for
+    verdicts that genuinely failed structured parsing.
 
     Args:
         draft_content: The draft that was reviewed.
-        verdict_content: Gemini's verdict.
+        verdict_content: Gemini's verdict (rendered audit text).
+        feedback_result: The structured parse of the reviewer's raw response
+            (FeedbackResult-shaped dict), when the caller has one.
 
     Returns:
         One of:
@@ -725,6 +743,17 @@ def _check_open_questions_status(draft_content: str, verdict_content: str) -> st
     # Check for HUMAN REQUIRED in verdict
     if _verdict_has_human_required(verdict_content):
         return "HUMAN_REQUIRED"
+
+    # #2199: structured verdict first — the parsed object in hand outranks
+    # any re-parse of rendered text. An unresolved item listed by the
+    # reviewer is a real UNANSWERED; none listed means the reviewer stands
+    # behind the draft as reviewed, which is RESOLVED.
+    if feedback_result is not None and feedback_result.get("source") == "structured":
+        unresolved = [
+            q for q in (feedback_result.get("open_questions") or [])
+            if isinstance(q, dict) and not q.get("resolved")
+        ]
+        return "UNANSWERED" if unresolved else "RESOLVED"
 
     # Check if verdict has "Open Questions Resolved" section with answers
     if _verdict_has_resolved_questions(verdict_content):

--- a/tests/unit/test_structured_questions_status.py
+++ b/tests/unit/test_structured_questions_status.py
@@ -1,0 +1,156 @@
+"""The reviewer's structured verdict governs open-questions status (#2199).
+
+The regression these tests pin: ``audit_content`` is rendered from the parsed
+verdict WITHOUT the open-questions field, and ``_check_open_questions_status``
+re-parsed that rendering — so every question-bearing draft was ruled
+UNANSWERED even when the reviewer APPROVED, and the forced revision (lossy,
+tracked separately) turned approvals into dead rolls. Twelve approved LLDs
+were discarded this way in the boostgauge campaign before the chain was
+caught (run-issue1-122404: 321-line APPROVED draft regenerated into a
+163-line invalid one).
+"""
+from __future__ import annotations
+
+from assemblyzero.workflows.requirements.nodes.review import (
+    _check_open_questions_status,
+)
+
+DRAFT_WITH_QUESTIONS = """# LLD-042: Test Document
+
+## 1. Summary
+Some design.
+
+## Open Questions
+- [ ] Should the collector support IPv6?
+- [ ] Is 2s polling acceptable on battery?
+
+## 11. Rollback
+Revert the PR.
+"""
+
+DRAFT_WITHOUT_QUESTIONS = """# LLD-042: Test Document
+
+## 1. Summary
+Some design.
+
+## Open Questions
+- [ ] None
+
+## 11. Rollback
+Revert the PR.
+"""
+
+# What the caller actually passes: audit text re-rendered from the parsed
+# verdict — no JSON, no "## Open Questions Resolved" section. This is the
+# exact shape that made the legacy path rule UNANSWERED unconditionally.
+AUDIT_APPROVED = "Verdict: APPROVED\n\nRationale: Solid, complete design.\n"
+
+
+def structured(open_questions):
+    return {
+        "verdict": "APPROVED",
+        "rationale": "Solid, complete design.",
+        "feedback_items": [],
+        "open_questions": open_questions,
+        "resolved_issues": [],
+        "source": "structured",
+    }
+
+
+# ---------------------------------------------------------------------------
+# The regression: structured verdicts govern
+# ---------------------------------------------------------------------------
+
+
+def test_structured_empty_questions_is_resolved():
+    """The 12-dead-runs case: APPROVED, reviewer lists nothing unresolved."""
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS, AUDIT_APPROVED, structured([])
+    )
+    assert status == "RESOLVED"
+
+
+def test_structured_all_resolved_is_resolved():
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS,
+        AUDIT_APPROVED,
+        structured([
+            {"text": "Should the collector support IPv6?", "resolved": True},
+            {"text": "Is 2s polling acceptable on battery?", "resolved": True},
+        ]),
+    )
+    assert status == "RESOLVED"
+
+
+def test_structured_unresolved_item_is_unanswered():
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS,
+        AUDIT_APPROVED,
+        structured([
+            {"text": "Should the collector support IPv6?", "resolved": True},
+            {"text": "Is 2s polling acceptable on battery?", "resolved": False},
+        ]),
+    )
+    assert status == "UNANSWERED"
+
+
+def test_structured_item_without_resolved_flag_counts_unresolved():
+    """An item the reviewer listed but did not mark resolved is unresolved."""
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS, AUDIT_APPROVED,
+        structured([{"text": "Should the collector support IPv6?"}]),
+    )
+    assert status == "UNANSWERED"
+
+
+def test_structured_non_dict_items_are_ignored():
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS, AUDIT_APPROVED, structured(["just a string"])
+    )
+    assert status == "RESOLVED"
+
+
+# ---------------------------------------------------------------------------
+# Precedence and fallbacks unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_no_questions_in_draft_is_none_regardless_of_verdict():
+    status = _check_open_questions_status(
+        DRAFT_WITHOUT_QUESTIONS, AUDIT_APPROVED, structured([])
+    )
+    assert status == "NONE"
+
+
+def test_human_required_beats_structured_resolution():
+    audit = AUDIT_APPROVED + "\nHUMAN REQUIRED: licensing decision.\n"
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS, audit, structured([])
+    )
+    assert status == "HUMAN_REQUIRED"
+
+
+def test_regex_fallback_source_uses_legacy_path():
+    """A verdict that genuinely failed structured parsing keeps old behavior:
+    a bare audit text answers nothing, so questions stay UNANSWERED."""
+    fallback = dict(structured([]), source="regex_fallback")
+    status = _check_open_questions_status(
+        DRAFT_WITH_QUESTIONS, AUDIT_APPROVED, fallback
+    )
+    assert status == "UNANSWERED"
+
+
+def test_no_feedback_result_uses_legacy_path():
+    """Callers that pass nothing (older call sites, tests) are unchanged."""
+    status = _check_open_questions_status(DRAFT_WITH_QUESTIONS, AUDIT_APPROVED)
+    assert status == "UNANSWERED"
+
+
+def test_legacy_resolved_section_still_wins_without_structured():
+    verdict = (
+        "Verdict: APPROVED\n\n## Open Questions Resolved\n"
+        "- [x] ~~Should the collector support IPv6?~~ **RESOLVED:** No, v1 is local-only.\n"
+        "- [x] ~~Is 2s polling acceptable on battery?~~ **RESOLVED:** Yes, measured.\n"
+    )
+    status = _check_open_questions_status(DRAFT_WITH_QUESTIONS, verdict)
+    assert status == "RESOLVED"


### PR DESCRIPTION
## Summary

Stops the requirements workflow from discarding approved LLDs. The open-questions status check now consumes the reviewer's **already-parsed structured verdict** (its `open_questions` field, with per-question resolved flags) instead of re-parsing a rendered audit text that never contained that data.

## The defect chain this ends

1. The reviewer's raw response parses structured (`parse_structured_feedback`) — verdict APPROVED, `open_questions` in hand.
2. The node re-renders the verdict into `audit_content` ("Verdict: …\n\nRationale: …") — **dropping the open-questions field**.
3. `_check_open_questions_status` then re-parsed that rendering: the JSON parse necessarily fails at char 0 ("no JSON object found"), the regex fallback finds no questions section in text that never had one, and the empty extraction is ruled UNANSWERED.
4. UNANSWERED overrides APPROVED in `route_after_review`, forcing a revision the draft never needed — and the LLD revision path regenerates wholesale and loses required sections (#2200), converting the approval into a mechanical-validation failure and, at the iteration cap, a dead roll.

Counted blast radius in the boostgauge campaign: 14 runs hit the misroute; **12 of them had an APPROVED draft discarded** (issues #1, #2, #4, 2026-08-02 → 2026-08-10). `run-issue1-122404` is the archetype: a 321-line draft passed mechanical + test-plan validation, was APPROVED, and the forced revision produced a 163-line document missing sections 2.1/11/12.

## Behavior after this change

- Structured verdict present → its `open_questions` list governs: any item not marked resolved → UNANSWERED (real); none → RESOLVED. HUMAN REQUIRED retains precedence; a draft with no real questions is NONE, unchanged.
- Verdicts that genuinely failed structured parsing keep the exact legacy markdown/regex path.
- No routing change: `route_after_review` is untouched; it simply now receives a status computed from data instead of from a parse of nothing. (The router's comment-vs-code discrepancy — "loop back to review" vs returning the drafter — is noted in #2199 discussion territory and deliberately not touched here.)

## Changes

- `assemblyzero/workflows/requirements/nodes/review.py` — `_check_open_questions_status` takes the structured `feedback_result` (optional third arg; all existing call shapes and tests unchanged); the call site passes it.
- `tests/unit/test_structured_questions_status.py` — 10 tests: the 12-dead-runs regression case (APPROVED + empty questions → RESOLVED), resolved/unresolved/unflagged items, precedence (NONE, HUMAN_REQUIRED), and both legacy paths pinned unchanged.

Full suite: 7224 passed, 17 skipped locally. The #248 and open-questions-loop suites pass untouched.

Closes #2199
