### PR TITLE
feat(core): standard 0028 — ask structured, get structured, or reject (Closes #2202, Closes #2203)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1379,7 +1379,13 @@ class MockProvider(LLMProvider):
             "# Mock Issue Title\n\n## Summary\n\nThis is a mock draft for testing.\n\n## Requirements\n\n- Mock requirement 1\n- Mock requirement 2\n\n## Acceptance Criteria\n\n- [ ] Mock criteria met",
         ],
         "review": [
-            "## Final Verdict\n\n[X] **APPROVED** - Ready for implementation\n[ ] **REVISE** - Requires changes\n[ ] **DISCUSS** - Needs clarification\n\n### Strengths\n- Well-structured\n- Clear requirements\n\n### Recommendations\n- None required for approval",
+            # Standard 0028: mock providers honor the structured contract
+            # like every other provider — a schema-valid verdict, never
+            # markdown for the retired scrapers. The shape satisfies both
+            # FEEDBACK_SCHEMA and REVIEW_SPEC_SCHEMA required keys.
+            '{"verdict": "APPROVED", "rationale": "Ready for implementation.'
+            ' Well-structured, clear requirements.", "feedback_items": [],'
+            ' "open_questions": [], "resolved_issues": []}',
         ],
     }
 

--- a/assemblyzero/core/verdict_schema.py
+++ b/assemblyzero/core/verdict_schema.py
@@ -214,6 +214,28 @@ def parse_structured_verdict(response_text: str) -> dict | None:
     return None
 
 
+class StructuredContractError(RuntimeError):
+    """A structured ask returned output that does not honor its schema.
+
+    Standard 0028 (operator ruling 2026-08-10): ask structured, get
+    structured, or reject. Raised by the strict parsers in place of the
+    retired regex fallbacks. Carries what a halt banner needs (#2197
+    legibility): the parser's name, the reason, and a bounded excerpt.
+    The caller surfaces it as an error; the stage retry machinery is the
+    bounded re-ask.
+    """
+
+    def __init__(self, parser: str, reason: str, raw: str = ""):
+        excerpt = (raw or "").strip().replace("\n", " ")[:160]
+        self.parser = parser
+        self.reason = reason
+        self.excerpt = excerpt
+        detail = f" | response begins: {excerpt!r}" if excerpt else " | response empty"
+        super().__init__(
+            f"structured contract violated in {parser}: {reason}{detail}"
+        )
+
+
 def _loads_lenient(raw: str) -> dict:
     """json.loads that tolerates a fenced or prose-wrapped JSON object.
 
@@ -259,9 +281,10 @@ def _validate_enum(value: str, allowed: list[str] | set[str]) -> bool:
 def parse_structured_feedback(raw: str) -> FeedbackResult:
     """Parse structured JSON feedback response into FeedbackResult.
 
-    Issue #775: Primary structured parse with regex fallback.
-    Clamps verdict to _FEEDBACK_VERDICTS; remaps out-of-enum to UNKNOWN.
-    Emits counter metric on fallback (REQ-3, T150).
+    Standard 0028: strict. The response either parses and validates against
+    FEEDBACK_SCHEMA or this raises StructuredContractError — there is no
+    degraded parse. The caller surfaces the rejection; the stage retry
+    machinery re-asks.
     """
     try:
         data = _loads_lenient(raw)
@@ -278,21 +301,14 @@ def parse_structured_feedback(raw: str) -> FeedbackResult:
             source="structured",
         )
     except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
-        logger.warning("Structured feedback parse failed (%s); falling back to regex", e)
-        logger.debug("verdict_schema.regex_fallback parser=feedback")
-        result = _regex_fallback_feedback(raw)
-        # Clamp verdict to FEEDBACK_SCHEMA enum
-        if result["verdict"] not in _FEEDBACK_VERDICTS:
-            result["verdict"] = "UNKNOWN"
-        return result
+        raise StructuredContractError("feedback", str(e), raw) from e
 
 
 def parse_structured_review_spec(raw: str) -> ReviewSpecResult:
     """Parse structured JSON review-spec response into ReviewSpecResult.
 
-    Issue #775: Primary structured parse with regex fallback.
-    Clamps verdict to _REVIEW_SPEC_VERDICTS; remaps out-of-enum to UNKNOWN.
-    Emits counter metric on fallback (REQ-3, T150).
+    Standard 0028: strict. Parses and validates against REVIEW_SPEC_SCHEMA
+    or raises StructuredContractError — no degraded parse.
     """
     try:
         data = _loads_lenient(raw)
@@ -307,225 +323,90 @@ def parse_structured_review_spec(raw: str) -> ReviewSpecResult:
             source="structured",
         )
     except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
-        logger.warning("Structured review-spec parse failed (%s); falling back to regex", e)
-        logger.debug("verdict_schema.regex_fallback parser=review_spec")
-        result = _regex_fallback_verdict(raw)
-        verdict = result["verdict"]
-        # Clamp verdict to REVIEW_SPEC_SCHEMA enum
-        if verdict not in _REVIEW_SPEC_VERDICTS:
-            verdict = "UNKNOWN"
-        # Attempt to extract feedback_items via regex for richer fallback
-        feedback_items = []
-        feedback_section = _extract_section_from_markdown(raw, "Feedback")
-        if not feedback_section:
-            feedback_section = _extract_section_from_markdown(raw, "Required Changes")
-        if not feedback_section:
-            feedback_section = _extract_section_from_markdown(raw, "Blocking Issues")
-        if feedback_section:
-            feedback_items = re.findall(r"^(?:[-*]|\d+\.)\s+(.+)$", feedback_section, re.MULTILINE)
-        return ReviewSpecResult(
-            verdict=verdict,
-            rationale=result["rationale"],
-            feedback_items=feedback_items,
-            source="regex_fallback",
-        )
+        raise StructuredContractError("review_spec", str(e), raw) from e
 
 
-def parse_structured_draft_questions(raw: str) -> DraftQuestionsResult:
-    """Parse structured JSON open-questions response into DraftQuestionsResult.
+def _iter_section_lines(text: str, *titles: str):
+    """Yield the stripped body lines of the first heading matching a title.
 
-    Issue #775: Primary structured parse with regex fallback.
-    Emits counter metric on fallback (REQ-3, T150).
+    A deterministic walk of OUR OWN markdown format — headings the templates
+    define — implemented with string operations. Not a parser of model
+    output and not a fallback (standard 0028 §3). Heading match is
+    case-insensitive and tolerates parenthetical suffixes like
+    "## Open Questions (3 remaining)".
     """
-    try:
-        data = _loads_lenient(raw)
-        if not _validate_required_keys(data, ["open_questions"]):
-            raise ValueError("Missing required key: open_questions")
-        return DraftQuestionsResult(
-            open_questions=data["open_questions"],
-            source="structured",
-        )
-    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
-        logger.warning("Structured draft-questions parse failed (%s); falling back to regex", e)
-        logger.debug("verdict_schema.regex_fallback parser=draft_questions")
-        return _regex_fallback_draft_questions(raw)
+    wanted = tuple(t.casefold() for t in titles)
+    in_section = False
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip().rstrip(":").casefold()
+            in_section = heading.startswith(wanted)
+            continue
+        if in_section:
+            yield stripped
 
 
-def parse_structured_finalize_questions(raw: str) -> FinalizeQuestionsResult:
-    """Parse structured JSON question-detection response into FinalizeQuestionsResult.
+def scan_open_questions_section(text: str) -> DraftQuestionsResult:
+    """Deterministic checkbox scan of a document's ``## Open Questions``.
 
-    Issue #775: Primary structured parse with regex fallback.
-    Emits counter metric on fallback (REQ-3, T150).
+    Replaces parse_structured_draft_questions (standard 0028): the inputs
+    here were never model JSON — they are the pipeline's own markdown
+    documents (the drafter's document response; the rendered verdict), so
+    "structured parse with fallback" was a fiction and the section scan was
+    always the real mechanism. Now it is the named mechanism.
     """
-    try:
-        data = _loads_lenient(raw)
-        if not _validate_required_keys(data, ["has_open_questions", "question_count", "questions"]):
-            raise ValueError("Missing required keys")
+    open_questions: list[dict] = []
+    for line in _iter_section_lines(text, "open questions"):
+        if line.startswith("- [ ]"):
+            question = line[len("- [ ]"):].strip()
+            if question:
+                open_questions.append({"text": question, "resolved": False})
+        elif line[: len("- [x]")].casefold() == "- [x]":
+            question = line[len("- [x]"):].strip()
+            if question:
+                open_questions.append({"text": question, "resolved": True})
+    return DraftQuestionsResult(open_questions=open_questions, source="document_scan")
+
+
+def scan_residual_questions(text: str) -> FinalizeQuestionsResult:
+    """Deterministic residual question/TODO scan of generated content.
+
+    Replaces parse_structured_finalize_questions (standard 0028): the input
+    is already-generated document content, not a model response — finalize
+    validates its own artifact, a scan, not a parse. Lines ending with '?'
+    must be > 5 chars to filter bare punctuation and headings like "Why?";
+    any line carrying a TODO marker counts.
+    """
+    if not text:
         return FinalizeQuestionsResult(
-            has_open_questions=data["has_open_questions"],
-            question_count=data["question_count"],
-            questions=data["questions"],
-            source="structured",
+            has_open_questions=False, question_count=0, questions=[],
+            source="document_scan",
         )
-    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
-        logger.warning("Structured finalize-questions parse failed (%s); falling back to regex", e)
-        logger.debug("verdict_schema.regex_fallback parser=finalize_questions")
-        return _regex_fallback_finalize_questions(raw)
-
-
-def _regex_fallback_verdict(raw: str) -> VerdictResult:
-    """Last-resort regex extraction for verdict checkbox patterns.
-
-    Issue #775: Logs WARNING when invoked. Never raises.
-    Returns verdict='UNKNOWN' if all patterns fail.
-    Note: Does NOT call emit_counter — callers are responsible for metrics.
-    """
-    logger.warning("Using regex fallback for verdict extraction")
-    if not raw or not isinstance(raw, str):
-        return VerdictResult(verdict="UNKNOWN", rationale="", source="regex_fallback")
-    for pattern, verdict in [
-        (r"\[X\]\s*\**APPROVED\**", "APPROVED"),
-        (r"\[X\]\s*\**REVISE\**", "REVISE"),
-        (r"\[X\]\s*\**DISCUSS\**", "DISCUSS"),
-        (r"\[X\]\s*\**BLOCKED\**", "BLOCKED"),
-    ]:
-        if re.search(pattern, raw, re.IGNORECASE):
-            # Try to extract rationale from next paragraph
-            rationale = ""
-            rationale_match = re.search(
-                r"(?:Rationale|Reason|Summary)[:\s]*(.+?)(?:\n\n|\n##|\Z)",
-                raw,
-                re.DOTALL | re.IGNORECASE,
-            )
-            if rationale_match:
-                rationale = rationale_match.group(1).strip()
-            return VerdictResult(verdict=verdict, rationale=rationale, source="regex_fallback")
-
-    # Secondary fallback: keyword patterns (e.g., "Verdict: APPROVED")
-    for keyword in ["APPROVED", "REVISE", "BLOCKED", "DISCUSS"]:
-        if re.search(rf"\b{keyword}\b", raw, re.IGNORECASE):
-            return VerdictResult(verdict=keyword, rationale="", source="regex_fallback")
-
-    logger.error("Regex fallback could not extract verdict from response")
-    return VerdictResult(verdict="UNKNOWN", rationale="", source="regex_fallback")
-
-
-def _regex_fallback_feedback(raw: str) -> FeedbackResult:
-    """Last-resort regex extraction for feedback section patterns.
-
-    Issue #775: Logs WARNING when invoked.
-    Note: verdict is NOT clamped here — caller (parse_structured_feedback)
-    is responsible for clamping to the appropriate enum.
-    Does NOT call emit_counter — caller handles metrics.
-    """
-    logger.warning("Using regex fallback for feedback extraction")
-    if not raw:
-        return FeedbackResult(verdict="UNKNOWN", rationale="", feedback_items=[], open_questions=[], resolved_issues=[], source="regex_fallback")
-    verdict_result = _regex_fallback_verdict(raw)
-
-    # Extract feedback items from bullet lists under Feedback/Required Changes
-    feedback_items = []
-    feedback_section = _extract_section_from_markdown(raw, "Feedback")
-    if not feedback_section:
-        feedback_section = _extract_section_from_markdown(raw, "Required Changes")
-    if feedback_section:
-        feedback_items = re.findall(r"^[-*]\s+(.+)$", feedback_section, re.MULTILINE)
-
-    # Extract open questions
-    open_questions = []
-    oq_section = _extract_section_from_markdown(raw, "Open Questions")
-    if oq_section:
-        unchecked = re.findall(r"^- \[ \] (.+)$", oq_section, re.MULTILINE)
-        checked = re.findall(r"^- \[X\] (.+)$", oq_section, re.MULTILINE | re.IGNORECASE)
-        for q in unchecked:
-            open_questions.append({"text": q.strip(), "resolved": False})
-        for q in checked:
-            open_questions.append({"text": q.strip(), "resolved": True})
-
-    # Extract resolved issues
-    resolved_issues = []
-    ri_section = _extract_section_from_markdown(raw, "Resolved Issues")
-    if not ri_section:
-        ri_section = _extract_section_from_markdown(raw, "Open Questions Resolved")
-    if ri_section:
-        resolved_issues = re.findall(r"^[-*]\s+(.+)$", ri_section, re.MULTILINE)
-
-    return FeedbackResult(
-        verdict=verdict_result["verdict"],
-        rationale=verdict_result["rationale"],
-        feedback_items=feedback_items,
-        open_questions=open_questions,
-        resolved_issues=resolved_issues,
-        source="regex_fallback",
-    )
-
-
-def _regex_fallback_draft_questions(raw: str) -> DraftQuestionsResult:
-    """Last-resort regex extraction for open questions from draft content.
-
-    Issue #775: Logs WARNING when invoked.
-    Does NOT call emit_counter — caller handles metrics.
-    """
-    logger.warning("Using regex fallback for draft questions extraction")
-    if not raw:
-        return DraftQuestionsResult(open_questions=[], source="regex_fallback")
-    open_questions = []
-    oq_match = re.search(r"## Open Questions.*?(?=\n## |\Z)", raw, re.DOTALL)
-    if oq_match:
-        section = oq_match.group(0)
-        unchecked = re.findall(r"^- \[ \] (.+)$", section, re.MULTILINE)
-        checked = re.findall(r"^- \[X\] (.+)$", section, re.MULTILINE | re.IGNORECASE)
-        for q in unchecked:
-            open_questions.append({"text": q.strip(), "resolved": False})
-        for q in checked:
-            open_questions.append({"text": q.strip(), "resolved": True})
-    return DraftQuestionsResult(open_questions=open_questions, source="regex_fallback")
-
-
-def _regex_fallback_finalize_questions(raw: str) -> FinalizeQuestionsResult:
-    """Last-resort regex extraction for question/TODO detection.
-
-    Issue #775: Logs WARNING when invoked.
-    Does NOT call emit_counter — caller handles metrics.
-
-    Note: Lines ending with '?' must be > 5 chars to filter out bare
-    punctuation or headings like "Why?" that are section titles, not
-    unresolved questions. The threshold catches "TODO?" but skips "?".
-    """
-    logger.warning("Using regex fallback for finalize questions detection")
-    if not raw:
-        return FinalizeQuestionsResult(has_open_questions=False, question_count=0, questions=[], source="regex_fallback")
-    questions = []
-    # Detect lines ending with ? (min 6 chars to filter noise)
-    for line in raw.splitlines():
+    questions: list[str] = []
+    for line in text.splitlines():
         stripped = line.strip()
         if stripped.endswith("?") and len(stripped) > 5:
             questions.append(stripped)
-    # Detect TODO markers
-    todo_matches = re.findall(r"^.*\bTODO\b.*$", raw, re.MULTILINE | re.IGNORECASE)
-    for match in todo_matches:
-        questions.append(match.strip())
+    for line in text.splitlines():
+        stripped = line.strip()
+        words = {w.strip(":,.;!?()[]").casefold() for w in stripped.split()}
+        if "todo" in words:
+            questions.append(stripped)
     return FinalizeQuestionsResult(
         has_open_questions=len(questions) > 0,
         question_count=len(questions),
         questions=questions,
-        source="regex_fallback",
+        source="document_scan",
     )
 
 
-def _extract_section_from_markdown(content: str, section_name: str) -> str:
-    """Extract content from a named markdown section.
-
-    Issue #775: Shared helper for regex fallback section extraction.
-    Returns text between a ## heading matching section_name and the next ## heading or EOF.
-    The pattern uses .* after the escaped name to handle parenthetical suffixes
-    like "## Open Questions (3 remaining)".
-    """
-    if not content:
-        return ""
-    pattern = rf"##\s+{re.escape(section_name)}.*?\n(.*?)(?=\n## |\Z)"
-    match = re.search(pattern, content, re.DOTALL | re.IGNORECASE)
-    return match.group(1).strip() if match else ""
+# The _regex_fallback_* scrapers and their _extract_section_from_markdown
+# helper were retired by standard 0028 (operator ruling 2026-08-10): a
+# structured ask that returns unstructured output is rejected and re-asked,
+# never scraped. The #2199 incident is the case study — the fallback masked
+# a rendering defect for eight days and converted twelve approvals into
+# dead rolls.
 
 
 def same_blocking_issues(

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -31,6 +31,7 @@ from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
     REVIEW_SPEC_SCHEMA,
     ReviewSpecResult,
+    StructuredContractError,
     parse_structured_verdict,
     parse_structured_review_spec,
 )
@@ -173,7 +174,13 @@ def _invoke_reviewer_with_spec_schema(
     raw = getattr(result, "response", None) or ""
     if not raw.strip():
         return None, "LLM call returned an empty response"
-    return parse_structured_review_spec(raw), ""
+    # Standard 0028: a schema-violating response is rejected through the
+    # same (None, error) path as an infrastructure failure — the caller
+    # surfaces it and the stage retry re-asks. No regex fallback exists.
+    try:
+        return parse_structured_review_spec(raw), ""
+    except StructuredContractError as e:
+        return None, str(e)
 
 
 # =============================================================================
@@ -593,9 +600,13 @@ IMPORTANT:
 def parse_review_verdict(response: str) -> tuple[str, str]:
     """Extract verdict and feedback from reviewer response.
 
-    Issue #775: Uses structured JSON as primary path, regex as fallback.
-    Kept for backward compatibility — external callers may invoke this directly.
-    The primary call path in review_spec() now uses _invoke_reviewer_with_spec_schema().
+    Kept for backward compatibility — external callers may invoke this
+    directly. The primary call path in review_spec() uses
+    _invoke_reviewer_with_spec_schema(). Standard 0028: the parse is
+    strict — a schema-violating response raises StructuredContractError
+    for the caller to surface; nothing is scraped. (The old UNKNOWN
+    downgrade is gone: a structured verdict is enum-valid by construction,
+    and DISCUSS is not in REVIEW_SPEC_SCHEMA's enum.)
 
     Args:
         response: Raw reviewer response text.
@@ -609,8 +620,6 @@ def parse_review_verdict(response: str) -> tuple[str, str]:
         return "BLOCKED", ""
     result = parse_structured_review_spec(response)
     verdict = result["verdict"]
-    if verdict in ("UNKNOWN", "DISCUSS"):
-        verdict = "BLOCKED"
     feedback = result["rationale"]
     if not feedback and result["feedback_items"]:
         feedback = "\n".join(f"- {item}" for item in result["feedback_items"])

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -31,7 +31,7 @@ from ..git_operations import (
 )
 from assemblyzero.core.verdict_schema import (
     FinalizeQuestionsResult,
-    parse_structured_finalize_questions,
+    scan_residual_questions,
 )
 
 # Constants
@@ -259,19 +259,14 @@ def _mirror_to_worktree(
 
 
 def _detect_open_questions(content: str) -> FinalizeQuestionsResult:
-    """Detect unresolved questions/TODOs in content, trying structured JSON first.
+    """Detect unresolved questions/TODOs in content.
 
-    Issue #775: This is a local parse — no LLM call. Tries json.loads() first
-    (for content that is already structured JSON from a prior step), falls
-    back to regex line scanning via parse_structured_finalize_questions.
-
-    Deviation from LLD: The LLD Section 2.4 defines this function with a
-    `provider: LLMProvider` parameter for an LLM call. This implementation
-    intentionally uses local parsing only because finalize.py validates
-    already-generated content for residual questions/TODOs — a deterministic
-    scan, not a semantic analysis task.
+    Standard 0028: finalize validates its own already-generated artifact —
+    a deterministic document scan, not a parse of model output, and never
+    a "fallback." (The LLD Section 2.4 defined this with an LLM call; the
+    local-scan deviation predates this change and stands.)
     """
-    return parse_structured_finalize_questions(content)
+    return scan_residual_questions(content)
 
 
 def validate_lld_final(content: str, open_questions_resolved: bool = False) -> list[str]:

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -50,9 +50,8 @@ from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
     parse_files_changed_table,
 )
 from assemblyzero.core.verdict_schema import (
-    DRAFT_QUESTIONS_SCHEMA,
     DraftQuestionsResult,
-    parse_structured_draft_questions,
+    scan_open_questions_section,
 )
 
 
@@ -61,17 +60,17 @@ def _extract_open_questions(
     response: str,
     system_prompt: str,
 ) -> DraftQuestionsResult:
-    """Extract open questions from reviewer response using DRAFT_QUESTIONS_SCHEMA.
+    """Extract open questions from the drafter's document response.
 
-    Issue #775: First attempts structured JSON parse of the existing response.
-    If that fails (response is markdown), the parse helper's regex fallback
-    extracts the ## Open Questions section automatically.
-
-    The provider and system_prompt params are accepted for future use
-    (re-extraction via LLM call) but are not used in v1 — we parse the
-    existing response directly.
+    Standard 0028: the drafter's response is a markdown DOCUMENT (its prompt
+    demands "emit ONLY the revised markdown"), so this was never a
+    structured-JSON contract — the old "structured parse with regex
+    fallback" failed the JSON step on every draft by construction and the
+    section scrape was the actual mechanism. Now the deterministic section
+    scan is the named mechanism. The provider and system_prompt params are
+    retained for signature compatibility; they are not used.
     """
-    return parse_structured_draft_questions(response)
+    return scan_open_questions_section(response)
 
 
 def generate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
@@ -266,16 +265,14 @@ Use the template structure provided. Include all sections. Be specific about:
 
     cost_before = get_cumulative_cost()
 
-    # Issue #775: Pass DRAFT_QUESTIONS_SCHEMA to provider for structured output (REQ-2)
-    from assemblyzero.core.llm_provider import GeminiProvider
-
-    schema_kwargs = {}
-    if isinstance(drafter, GeminiProvider):
-        schema_kwargs["response_schema"] = DRAFT_QUESTIONS_SCHEMA
-    else:
-        schema_kwargs["json_schema"] = DRAFT_QUESTIONS_SCHEMA
-
-    result = drafter.invoke(system_prompt=system_prompt, content=prompt, **schema_kwargs)
+    # Standard 0028: one ask, one contract. The drafter's contract is a
+    # markdown document ("emit ONLY the revised markdown") enforced by
+    # mechanical validation downstream — the old code ALSO sent
+    # DRAFT_QUESTIONS_SCHEMA as the response schema, demanding JSON from
+    # the same call. Two contradictory contracts on one ask is how drafts
+    # come back malformed; the schema is gone and the open questions are
+    # scanned from the document it was actually asked to produce.
+    result = drafter.invoke(system_prompt=system_prompt, content=prompt)
     node_cost_usd = get_cumulative_cost() - cost_before
 
     if not result.success:

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -20,9 +20,10 @@ from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
     FEEDBACK_SCHEMA,
     FeedbackResult,
+    StructuredContractError,
     parse_structured_verdict,
     parse_structured_feedback,
-    parse_structured_draft_questions,
+    scan_open_questions_section,
 )
 from assemblyzero.workflows.requirements.audit import (
     load_review_prompt,
@@ -192,11 +193,18 @@ Follow the Review Instructions exactly. Be specific about what needs to change f
     # Issue #775: Use structured schema-passing helper (REQ-2).
     # _invoke_reviewer_with_feedback_schema passes FEEDBACK_SCHEMA to the
     # provider via response_schema (Gemini) or json_schema (Claude CLI),
-    # then parses the response through parse_structured_feedback which
-    # falls back to regex if JSON parse fails.
-    feedback_result = _invoke_reviewer_with_feedback_schema(
-        reviewer, review_content, system_prompt
-    )
+    # then parses the response through parse_structured_feedback.
+    # Standard 0028: a response that violates the contract is rejected —
+    # the error return below hands it to the stage retry machinery, which
+    # is the bounded re-ask. No degraded parse exists.
+    try:
+        feedback_result = _invoke_reviewer_with_feedback_schema(
+            reviewer, review_content, system_prompt
+        )
+    except StructuredContractError as e:
+        msg = f"Reviewer response rejected: {e}"
+        print(f"    ERROR: {msg}")
+        return {"error_message": msg}
 
     node_cost_usd = get_cumulative_cost() - cost_before
 
@@ -212,20 +220,9 @@ Follow the Review Instructions exactly. Be specific about what needs to change f
     # (e.g., logging, state snapshots). Raw text no longer primary; structured result is authoritative.
     response = ""
     verdict_status = feedback_result["verdict"]
-    if verdict_status == "UNKNOWN":
-        # #1766: an unparseable reviewer response is an LLM-format error,
-        # not a review outcome. Silently mapping UNKNOWN -> REVISE produced
-        # contradictory logs ('could not extract verdict' followed by
-        # 'Parsed structured verdict: REVISE' -> BLOCKED with an empty
-        # rationale) and burned two-strike halts on garbage. Fail loudly;
-        # the stage retry machinery re-runs the review.
-        msg = (
-            "Reviewer response unparseable — no verdict found (structured "
-            "parse and regex fallback both failed). Treating as LLM "
-            "format error."
-        )
-        print(f"    ERROR: {msg}")
-        return {"error_message": msg}
+    # #1766's UNKNOWN check is gone: under standard 0028 the parse either
+    # yields a schema-valid verdict or raises StructuredContractError above
+    # — UNKNOWN can no longer reach this point.
     # Backward compat: derive `structured` dict for any remaining callers
     structured = {"verdict": verdict_status, "rationale": feedback_result["rationale"]}
 
@@ -759,12 +756,9 @@ def _check_open_questions_status(
     if _verdict_has_resolved_questions(verdict_content):
         return "RESOLVED"
 
-    # Issue #775: Use structured parse when verdict_content is available.
-    # We parse the full verdict_content (not questions_section) because
-    # parse_structured_draft_questions handles both JSON (from structured
-    # output) and markdown (via regex fallback that finds the ## Open
-    # Questions section internally).
-    dq_result = parse_structured_draft_questions(verdict_content)
+    # Standard 0028: verdict_content is the pipeline's own rendered text, so
+    # this is a document scan, not a parse of model output.
+    dq_result = scan_open_questions_section(verdict_content)
     unchecked = [q["text"] for q in dq_result["open_questions"] if not q["resolved"]]
     checked = [q["text"] for q in dq_result["open_questions"] if q["resolved"]]
 

--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -21,9 +21,7 @@ from typing import Any
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
-    VerdictResult,
     parse_structured_verdict,
-    _regex_fallback_verdict,
 )
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
 from assemblyzero.workflows.testing.audit import (
@@ -349,25 +347,10 @@ def _run_mechanical_gates(state: TestingWorkflowState) -> list[str]:
     return errors
 
 
-def _parse_verdict(raw: str) -> VerdictResult:
-    """Parse verdict from test-plan reviewer response.
-
-    Issue #775: Primary path: structured JSON via parse_structured_verdict.
-    Fallback: _regex_fallback_verdict with WARNING log.
-    Previously: regex-only after structured parse failure.
-
-    Returns VerdictResult TypedDict with 'verdict', 'rationale', 'source' keys.
-    """
-    structured = parse_structured_verdict(raw)
-    if structured:
-        return VerdictResult(
-            verdict=structured.get("verdict", "REVISE"),
-            rationale=structured.get("rationale", ""),
-            source="structured",
-        )
-
-    # Issue #775: Delegate to centralized regex fallback (logs WARNING internally)
-    return _regex_fallback_verdict(raw)
+# _parse_verdict (structured-then-regex-fallback) was retired by standard
+# 0028: the reviewer is asked with VERDICT_SCHEMA, so its response either
+# parses as a schema-valid verdict or the review is rejected and the stage
+# retry re-asks — never scraped.
 
 
 def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
@@ -599,27 +582,25 @@ def review_test_plan(state: TestingWorkflowState) -> dict[str, Any]:
         file_num = next_file_number(audit_dir)
         save_audit_file(audit_dir, file_num, "verdict.md", verdict_content)
 
-    # Issue #775: Parse verdict — structured JSON first, regex fallback via _parse_verdict
+    # Standard 0028: the reviewer was asked with VERDICT_SCHEMA — its
+    # response either parses as a schema-valid verdict or this review is
+    # rejected loudly and the stage retry machinery re-asks. The regex
+    # fallback (which silently downgraded garbage to BLOCKED) is retired.
     structured = parse_structured_verdict(verdict_content)
-    verdict_method = "regex"
-    if structured:
-        test_plan_status = structured["verdict"]
-        # Map REVISE -> BLOCKED for workflow purposes
-        if test_plan_status == "REVISE":
-            test_plan_status = "BLOCKED"
-        verdict_method = "structured"
-        print(f"    Verdict: {test_plan_status} (structured JSON)")
-    else:
-        verdict_result = _parse_verdict(verdict_content)
-        raw_verdict = verdict_result["verdict"]
-        if raw_verdict == "UNKNOWN":
-            raw_verdict = "REVISE"
-        # Map REVISE -> BLOCKED for workflow purposes
-        if raw_verdict == "REVISE":
-            test_plan_status = "BLOCKED"
-        else:
-            test_plan_status = raw_verdict
-        print(f"    Verdict: {test_plan_status} (regex fallback)")
+    if not structured:
+        excerpt = verdict_content.strip().replace("\n", " ")[:160]
+        msg = (
+            "Test-plan reviewer response rejected: no schema-valid verdict "
+            f"found | response begins: {excerpt!r}"
+        )
+        print(f"    ERROR: {msg}")
+        return {"error_message": msg}
+    verdict_method = "structured"
+    test_plan_status = structured["verdict"]
+    # Map REVISE -> BLOCKED for workflow purposes
+    if test_plan_status == "REVISE":
+        test_plan_status = "BLOCKED"
+    print(f"    Verdict: {test_plan_status} (structured JSON)")
 
     # Log review result
     log_workflow_execution(

--- a/docs/standards/0028-structured-or-reject.md
+++ b/docs/standards/0028-structured-or-reject.md
@@ -1,0 +1,77 @@
+# 0028 — Ask structured, get structured, or reject
+
+**Status:** Active
+**Issue:** #2202 (the ruling), #2203 (the implementation that landed it)
+
+**A structured ask is a contract, and a contract violated is rejected — never
+guessed around.** This is the operator's ruling, made 2026-08-10, and it is
+absolute: regex is not a safety fallback. A parser that cannot read its input
+raises; a system that quietly degrades to pattern-scraping and hands back a
+guess is worse than one that stops, because the guess is trusted.
+
+## 1. The contract
+
+When the pipeline asks a model for schema-constrained output (the providers
+send `response_schema` / `json_schema` on every such ask), the response
+either parses as JSON and validates against that schema — required keys,
+enum membership — or the ask is **rejected**:
+
+- The parser raises `StructuredContractError` (never returns a degraded
+  value), carrying the parser's name, the reason, and a bounded excerpt of
+  the response — a halt banner must be legible (#2197).
+- The node surfaces the rejection as its error; the **stage retry machinery
+  is the bounded re-ask**. No bespoke retry loops, no scraping.
+- After the stage's attempts are spent, the run halts loudly, naming the
+  contract that was violated.
+
+Rejection is cheap by construction: schema-enforced asks rarely violate, and
+one re-ask costs seconds against the hours a masked defect costs.
+
+## 2. Recovering JSON is not scraping
+
+Models wrap JSON in ```json fences or a sentence of prose (#1843). Stripping
+delimiters to reach a JSON object that must still pass `json.loads`, key
+validation, and enum validation is **JSON recovery** — the contract is still
+enforced by the schema, and nothing can be hallucinated into existence.
+Extracting *meaning* from non-JSON text with patterns is **scraping**, and it
+is banned from every structured contract.
+
+## 3. Scanning our own documents is not parsing model output
+
+Deterministic checks of the pipeline's OWN artifacts — the `## Open
+Questions` checkbox section a template defines, a residual-TODO scan of a
+finalized document — are document-structure scans (`scan_open_questions_
+section`, `scan_residual_questions`), implemented with string operations,
+named as scans, and never framed as fallbacks. They cannot mask a contract
+failure because there is no contract: the document is what it is.
+
+One ask, one contract: a call whose prompt demands a markdown document must
+not simultaneously carry a JSON response schema (the drafter carried both
+for months; the schema fought the prose and the questions "parse" failed on
+every draft by construction).
+
+## 4. A parse failure is never a value
+
+No function returns an empty result, an `UNKNOWN`, or a silent downgrade
+because it could not read its input. It raises, and the caller decides —
+loudly. The pre-0028 codepaths that mapped garbage to `UNKNOWN → REVISE →
+BLOCKED` turned format errors into review outcomes.
+
+## Origin
+
+2026-08-09/10, the boostgauge campaign. The reviewer's structured verdict
+parsed perfectly — and the node then regex-parsed a re-rendering of it that
+had dropped the very field being sought, ruled the inevitable empty result
+"UNANSWERED", and discarded twelve APPROVED LLDs across eight days (#2199).
+The regex fallback did not provide resilience; it provided silence. The
+operator's ruling, paraphrased: regex fallbacks are at the heart of failed
+systems — if we ask for structured and don't get structured, we reject.
+
+## Reference
+
+- `assemblyzero/core/verdict_schema.py` — `StructuredContractError`, the
+  strict parsers, the document scanners.
+- #2199 — the incident and its counted blast radius.
+- #2200 — the lossy-revision amplifier (separate, still governed by this
+  standard's §3 once revisions edit rather than regenerate).
+- Standard 0027 — the same refuse-loudly posture, applied to janitors.

--- a/tests/unit/test_extract_and_discard.py
+++ b/tests/unit/test_extract_and_discard.py
@@ -116,13 +116,16 @@ class TestApprovedVerdictExtraction:
     @patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
     @patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
     @patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
-    def test_approved_regex_fallback_stores_bare_approved(self, mock_root, mock_prompt, mock_log):
-        """Regex fallback (no structured JSON) → bare 'APPROVED' string."""
+    def test_markdown_verdict_rejected_not_scraped(self, mock_root, mock_prompt, mock_log):
+        """Standard 0028: the old regex fallback scraped APPROVED from this
+        markdown; now a response with no schema-valid verdict is rejected
+        with an error the stage retry acts on — nothing is stored."""
         mock_root.return_value = Path("/tmp/test-repo")
         mock_prompt.return_value = "review prompt"
 
         mock_result = MagicMock()
         mock_result.success = True
+        mock_result.content = ""
         mock_result.response = "## Verdict\n[x] **APPROVED** - Test plan is ready.\n\nLong explanation here..." + ("x" * 500)
         mock_result.input_tokens = 100
         mock_result.output_tokens = 50
@@ -137,8 +140,8 @@ class TestApprovedVerdictExtraction:
             state = _make_state()
             result = review_test_plan(state)
 
-        assert result["test_plan_status"] == "APPROVED"
-        assert result["test_plan_verdict"] == "APPROVED"
+        assert "rejected" in result.get("error_message", "")
+        assert "test_plan_status" not in result
 
 
 class TestFastPathCompliance:

--- a/tests/unit/test_finalize_structured_output.py
+++ b/tests/unit/test_finalize_structured_output.py
@@ -1,12 +1,12 @@
-"""Tests for finalize question detection structured output.
+"""Tests for finalize residual-question detection.
 
-Issue #775: Verify _detect_open_questions and validate_lld_final use
-structured JSON parse with regex fallback.
+Standard 0028 reframed this surface: finalize validates its OWN generated
+artifact, so `_detect_open_questions` is a deterministic document scan
+(`scan_residual_questions`) — never a structured parse of model output and
+never a "fallback." JSON content is just text to the scan; the pre-0028
+structured branch (which read JSON verdict-shaped content) is retired with
+its parser.
 """
-
-import json
-from unittest.mock import patch
-import pytest
 
 from assemblyzero.workflows.requirements.nodes.finalize import (
     _detect_open_questions,
@@ -14,266 +14,82 @@ from assemblyzero.workflows.requirements.nodes.finalize import (
 )
 
 
-class TestDetectOpenQuestionsStructured:
-    """T060: Structured JSON content detection."""
-
-    def test_structured_json_with_questions(self):
-        content = json.dumps({
-            "has_open_questions": True,
-            "question_count": 1,
-            "questions": ["What timeout value?"],
-        })
-        result = _detect_open_questions(content)
-        assert result["source"] == "structured"
-        assert result["has_open_questions"] is True
-        assert result["question_count"] == 1
-        assert "What timeout value?" in result["questions"]
-
-    def test_structured_json_no_questions(self):
-        content = json.dumps({
-            "has_open_questions": False,
-            "question_count": 0,
-            "questions": [],
-        })
-        result = _detect_open_questions(content)
-        assert result["source"] == "structured"
-        assert result["has_open_questions"] is False
-        assert result["question_count"] == 0
-        assert result["questions"] == []
-
-    def test_structured_json_multiple_questions(self):
-        content = json.dumps({
-            "has_open_questions": True,
-            "question_count": 2,
-            "questions": ["What timeout value?", "TODO: fix this"],
-        })
-        result = _detect_open_questions(content)
-        assert result["source"] == "structured"
-        assert result["question_count"] == 2
-        assert len(result["questions"]) == 2
-
-
-class TestDetectOpenQuestionsRegexFallback:
-    """T070: Regex fallback for plain text content."""
-
+class TestDetectOpenQuestionsScan:
     def test_markdown_content_with_question(self):
         content = "## Requirements\n\nWhat timeout value?\nThe system shall process requests.\n"
         result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
         assert result["has_open_questions"] is True
         assert "What timeout value?" in result["questions"]
 
     def test_markdown_content_with_todo(self):
-        content = "## Design\n\nTODO: determine rate limit\nImplement retry logic.\n"
+        content = "## Design\n\nTODO: decide on retry policy\nDone otherwise.\n"
         result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
         assert result["has_open_questions"] is True
         assert any("TODO" in q for q in result["questions"])
 
     def test_markdown_content_with_both(self):
-        content = "## Requirements\n\nThe system should TODO: determine rate limit\nWhat timeout value?\n"
+        content = "Is this the right approach?\nTODO: verify\n"
         result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
         assert result["has_open_questions"] is True
+        assert result["question_count"] == len(result["questions"])
         assert result["question_count"] >= 2
 
     def test_clean_content_no_issues(self):
-        content = "## Requirements\n\nThe system shall process requests within 200ms.\nAll responses are JSON.\n"
+        content = "## Design\n\nEverything is decided.\nShip it.\n"
         result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
         assert result["has_open_questions"] is False
         assert result["question_count"] == 0
 
     def test_empty_content(self):
         result = _detect_open_questions("")
-        assert result["source"] == "regex_fallback"
         assert result["has_open_questions"] is False
-        assert result["question_count"] == 0
+        assert result["questions"] == []
 
     def test_short_question_mark_not_detected(self):
-        # Lines ending with ? but very short (noise filtering)
-        content = "Why?\n"
-        result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
-        # "Why?" is only 4 chars, below the 5-char threshold
+        result = _detect_open_questions("Why?\nAll settled.\n")
         assert result["has_open_questions"] is False
 
     def test_longer_question_detected(self):
-        content = "Why is this?\n"
-        result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
+        result = _detect_open_questions("Should we use asyncio here?\n")
         assert result["has_open_questions"] is True
 
     def test_todo_case_insensitive(self):
-        content = "todo: fix the rate limiting logic\n"
-        result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
+        result = _detect_open_questions("todo: lowercase marker\n")
         assert result["has_open_questions"] is True
 
-    def test_invalid_json_falls_back_to_regex(self):
-        content = '{"has_open_questions": true, "invalid json'
+    def test_source_is_document_scan(self):
+        result = _detect_open_questions("Anything at all.\n")
+        assert result["source"] == "document_scan"
+
+    def test_json_content_is_just_text_to_the_scan(self):
+        """The retired structured branch read verdict-shaped JSON; the scan
+        treats JSON as text — no line ends with '?' so nothing is found."""
+        content = '{"has_open_questions": true, "question_count": 1, "questions": ["What timeout value?"]}'
         result = _detect_open_questions(content)
-        assert result["source"] == "regex_fallback"
+        assert result["has_open_questions"] is False
 
 
-class TestValidateLldFinalStructured:
-    """Integration with validate_lld_final using structured detection."""
-
-    def test_questions_detected_when_not_resolved(self):
-        content = "## Section\n\nWhat is the correct timeout value?\n"
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any("unresolved questions" in i for i in issues)
-
-    def test_no_questions_when_resolved(self):
-        content = "## Section\n\nWhat is the correct timeout value?\n"
-        issues = validate_lld_final(content, open_questions_resolved=True)
-        assert not any("unresolved questions" in i for i in issues)
-
-    def test_todos_detected_even_when_questions_resolved(self):
-        content = "## Section\n\nTODO: finalize this section\n"
-        issues = validate_lld_final(content, open_questions_resolved=True)
-        assert any("TODO" in i for i in issues)
-
-    def test_todos_detected_when_not_resolved(self):
-        content = "## Section\n\nTODO: finalize this section\n"
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any("TODO" in i for i in issues)
-
-    def test_clean_content_no_issues(self):
-        content = "## Section\n\nThe system shall process requests within 200ms.\n"
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert not any("unresolved questions" in i for i in issues)
-        assert not any("TODO" in i for i in issues)
-
-    def test_both_question_and_todo(self):
-        content = "## Section\n\nWhat timeout value?\nTODO: fix this\n"
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any("unresolved questions" in i for i in issues)
-        assert any("TODO" in i for i in issues)
-
-    def test_returns_list(self):
-        content = "## Section\n\nThe system processes requests.\n"
-        issues = validate_lld_final(content)
-        assert isinstance(issues, list)
-
-
-class TestOpenQuestionsCheckboxIgnoresCodeBlocks:
-    """The unchecked-checkbox regex must not match inside fenced code blocks.
-
-    Closes #1470. A draft that documents the Open Questions section format
-    by showing the `- [ ]` syntax in a code block was falsely flagging
-    "Unresolved open questions remain" even when all real checkboxes were
-    checked or resolved.
-    """
-
-    def test_unchecked_inside_fenced_block_does_not_trigger(self):
+class TestValidateLldFinalStillUsesScan:
+    def test_clean_lld_passes(self):
         content = (
-            "# LLD\n\n"
-            "## Open Questions\n\n"
-            "All questions resolved. The format for tracking is:\n\n"
-            "```markdown\n"
-            "- [ ] Example unchecked question\n"
-            "- [x] Example resolved question\n"
-            "```\n\n"
-            "## Next Section\n"
+            "# LLD-001\n\n## Summary\nDone.\n\n"
+            "## Open Questions\n- [x] Decided already\n"
         )
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert not any(
-            "Unresolved open questions remain" in i for i in issues
-        ), f"got: {issues}"
+        errors = validate_lld_final(content)
+        assert errors == []
 
-    def test_real_unchecked_outside_block_still_triggers(self):
+    def test_unchecked_question_flagged(self):
         content = (
-            "# LLD\n\n"
-            "## Open Questions\n\n"
-            "- [ ] What is the timeout?\n\n"
-            "## Next Section\n"
+            "# LLD-001\n\n## Summary\nDone.\n\n"
+            "## Open Questions\n- [ ] Still undecided thing\n"
         )
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any(
-            "Unresolved open questions remain" in i for i in issues
-        ), f"got: {issues}"
+        errors = validate_lld_final(content)
+        assert errors, "an unchecked open question must flag"
 
-    def test_unchecked_in_block_with_real_unchecked_outside_still_triggers(self):
-        """Mixed case: code-block example AND a real unchecked item — the
-        real one must still trigger the error."""
+    def test_resolved_by_reviewer_skips_check(self):
         content = (
-            "# LLD\n\n"
-            "## Open Questions\n\n"
-            "Format example:\n\n"
-            "```markdown\n"
-            "- [ ] example only\n"
-            "```\n\n"
-            "Real questions:\n\n"
-            "- [ ] Actual question that needs answering\n\n"
-            "## Next Section\n"
+            "# LLD-001\n\n## Summary\nDone.\n\n"
+            "## Open Questions\n- [ ] Still undecided thing\n"
         )
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any(
-            "Unresolved open questions remain" in i for i in issues
-        ), f"got: {issues}"
-
-    def test_unchecked_inside_indented_block_does_not_trigger(self):
-        """CommonMark 4-space-indented code blocks: example checkbox syntax
-        in an indented block does NOT trip the regex. Closes #1476."""
-        content = (
-            "# LLD\n\n"
-            "## Open Questions\n\n"
-            "All resolved. The format for tracking is:\n\n"
-            "    - [ ] Example unchecked question (indented = code block)\n"
-            "    - [x] Example resolved question\n\n"
-            "## Next Section\n"
-        )
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert not any(
-            "Unresolved open questions remain" in i for i in issues
-        ), f"got: {issues}"
-
-    def test_unchecked_in_indented_block_with_real_unchecked_outside_still_triggers(self):
-        """Mixed: indented-block example AND a real unchecked item. Closes #1476."""
-        content = (
-            "# LLD\n\n"
-            "## Open Questions\n\n"
-            "Format example:\n\n"
-            "    - [ ] example only (indented = code block)\n\n"
-            "Real questions:\n\n"
-            "- [ ] Actual question that needs answering\n\n"
-            "## Next Section\n"
-        )
-        issues = validate_lld_final(content, open_questions_resolved=False)
-        assert any(
-            "Unresolved open questions remain" in i for i in issues
-        ), f"got: {issues}"
-
-
-class TestDetectOpenQuestionsReturnType:
-    """Verify FinalizeQuestionsResult TypedDict structure."""
-
-    def test_has_required_keys(self):
-        result = _detect_open_questions("some content with a question?")
-        assert "has_open_questions" in result
-        assert "question_count" in result
-        assert "questions" in result
-        assert "source" in result
-
-    def test_source_is_string(self):
-        result = _detect_open_questions("content")
-        assert isinstance(result["source"], str)
-        assert result["source"] in ("structured", "regex_fallback")
-
-    def test_has_open_questions_is_bool(self):
-        result = _detect_open_questions("content")
-        assert isinstance(result["has_open_questions"], bool)
-
-    def test_question_count_is_int(self):
-        result = _detect_open_questions("content")
-        assert isinstance(result["question_count"], int)
-
-    def test_questions_is_list(self):
-        result = _detect_open_questions("content")
-        assert isinstance(result["questions"], list)
-
-    def test_question_count_matches_questions_length(self):
-        content = "## Section\n\nWhat timeout value?\nTODO: fix this\n"
-        result = _detect_open_questions(content)
-        assert result["question_count"] == len(result["questions"])
+        errors = validate_lld_final(content, open_questions_resolved=True)
+        assert errors == []

--- a/tests/unit/test_generate_draft_structured_output.py
+++ b/tests/unit/test_generate_draft_structured_output.py
@@ -1,327 +1,78 @@
 """Tests for draft open-questions extraction in generate_draft node.
 
-Issue #775: Replace regex LLM output parsing with structured JSON schema.
-Tests for _extract_open_questions helper and related behavior.
+Standard 0028 reframed this surface: the drafter's response is a markdown
+DOCUMENT ("emit ONLY the revised markdown"), so open-questions extraction is
+a deterministic scan of the document's ``## Open Questions`` section —
+`scan_open_questions_section` — not a structured-JSON parse with a regex
+fallback. The pre-0028 code also sent DRAFT_QUESTIONS_SCHEMA as the response
+schema on the SAME call whose prompt demanded prose — two contradictory
+contracts on one ask; the schema is gone and these tests pin the scan.
 """
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
-
-from assemblyzero.core.verdict_schema import (
-    DRAFT_QUESTIONS_SCHEMA,
-    DraftQuestionsResult,
-    parse_structured_draft_questions,
+from assemblyzero.workflows.requirements.nodes.generate_draft import (
+    _extract_open_questions,
 )
-from assemblyzero.workflows.requirements.nodes.generate_draft import _extract_open_questions
 
 
-def _make_mock_provider(response_content: str):
-    """Create a mock provider that returns the given content."""
-    provider = MagicMock()
-    result = MagicMock()
-    result.content = response_content
-    provider.invoke.return_value = result
-    return provider
+DRAFT_WITH_QUESTIONS = """# LLD-042: Widget Design
+
+## 1. Summary
+A widget.
+
+## Open Questions
+- [ ] What is the timeout?
+- [x] Rate limit decided
+- [ ] Another unresolved?
+
+## 11. Rollback
+Revert the PR.
+"""
+
+DRAFT_WITHOUT_SECTION = """# LLD-042: Widget Design
+
+## 1. Summary
+A widget with no questions section at all.
+"""
 
 
-class TestExtractOpenQuestionsStructuredPath:
-    """Tests for _extract_open_questions with valid JSON input."""
+class TestExtractOpenQuestionsDocumentScan:
+    def test_scans_unchecked_and_checked(self):
+        result = _extract_open_questions(MagicMock(), DRAFT_WITH_QUESTIONS, "")
+        by_text = {q["text"]: q["resolved"] for q in result["open_questions"]}
+        assert by_text["What is the timeout?"] is False
+        assert by_text["Rate limit decided"] is True
+        assert by_text["Another unresolved?"] is False
 
-    def test_valid_json_returns_structured_source(self):
-        response = json.dumps({
-            "open_questions": [
-                {"text": "What is the timeout?", "resolved": False},
-            ]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "structured"
+    def test_source_is_document_scan(self):
+        result = _extract_open_questions(MagicMock(), DRAFT_WITH_QUESTIONS, "")
+        assert result["source"] == "document_scan"
 
-    def test_valid_json_single_question(self):
-        response = json.dumps({
-            "open_questions": [
-                {"text": "What is the timeout?", "resolved": False},
-            ]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert len(result["open_questions"]) == 1
-        assert result["open_questions"][0]["text"] == "What is the timeout?"
-        assert result["open_questions"][0]["resolved"] is False
-
-    def test_valid_json_multiple_questions(self):
-        response = json.dumps({
-            "open_questions": [
-                {"text": "What is the timeout?", "resolved": False},
-                {"text": "Rate limit decided", "resolved": True},
-            ]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "structured"
-        assert len(result["open_questions"]) == 2
-
-    def test_valid_json_resolved_question(self):
-        response = json.dumps({
-            "open_questions": [
-                {"text": "Rate limit decided", "resolved": True},
-            ]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["open_questions"][0]["resolved"] is True
-
-    def test_valid_json_empty_questions_list(self):
-        response = json.dumps({"open_questions": []})
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "structured"
+    def test_no_section_yields_empty(self):
+        result = _extract_open_questions(MagicMock(), DRAFT_WITHOUT_SECTION, "")
         assert result["open_questions"] == []
 
-    def test_valid_json_mixed_resolved_states(self):
-        response = json.dumps({
-            "open_questions": [
-                {"text": "Unresolved question?", "resolved": False},
-                {"text": "Resolved question", "resolved": True},
-                {"text": "Another unresolved?", "resolved": False},
-            ]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "structured"
-        assert len(result["open_questions"]) == 3
-        unresolved = [q for q in result["open_questions"] if not q["resolved"]]
-        resolved = [q for q in result["open_questions"] if q["resolved"]]
-        assert len(unresolved) == 2
-        assert len(resolved) == 1
+    def test_empty_response_yields_empty(self):
+        result = _extract_open_questions(MagicMock(), "", "")
+        assert result["open_questions"] == []
 
-    def test_returns_draft_questions_result_type(self):
-        response = json.dumps({
-            "open_questions": [{"text": "Question?", "resolved": False}]
-        })
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert "open_questions" in result
-        assert "source" in result
-
-    def test_provider_not_called_when_json_parseable(self):
-        """_extract_open_questions parses existing response directly, no LLM call needed."""
-        provider = _make_mock_provider("")
-        response = json.dumps({"open_questions": []})
-        _extract_open_questions(provider, response, "system prompt")
-        # Provider.invoke should NOT be called since response is already parseable
+    def test_scan_never_calls_the_provider(self):
+        """Extraction is a local document scan — no LLM call, ever."""
+        provider = MagicMock()
+        _extract_open_questions(provider, DRAFT_WITH_QUESTIONS, "system prompt")
         provider.invoke.assert_not_called()
 
-
-class TestExtractOpenQuestionsMarkdownFallback:
-    """Tests for _extract_open_questions with markdown (regex fallback) input."""
-
-    def test_markdown_fallback_returns_regex_fallback_source(self):
-        response = "## Open Questions\n- [ ] What is the timeout?\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-
-    def test_markdown_unchecked_question_extracted(self):
-        response = "## Open Questions\n- [ ] What is the timeout?\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert len(result["open_questions"]) == 1
-        assert result["open_questions"][0]["text"] == "What is the timeout?"
-        assert result["open_questions"][0]["resolved"] is False
-
-    def test_markdown_checked_question_extracted(self):
-        response = "## Open Questions\n- [X] Rate limit decided\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert len(result["open_questions"]) == 1
-        assert result["open_questions"][0]["text"] == "Rate limit decided"
-        assert result["open_questions"][0]["resolved"] is True
-
-    def test_markdown_mixed_questions(self):
-        response = "## Open Questions\n- [ ] What is the timeout?\n- [X] Rate limit decided\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-        assert len(result["open_questions"]) == 2
-
-    def test_markdown_no_open_questions_section(self):
-        response = "## Requirements\n\nThe system shall process requests.\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-        assert result["open_questions"] == []
-
-    def test_markdown_questions_stop_at_next_section(self):
-        response = (
-            "## Open Questions\n"
-            "- [ ] What is the timeout?\n"
-            "## Next Section\n"
-            "- [ ] Not a question\n"
-        )
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-        # Should only extract from Open Questions section
-        assert len(result["open_questions"]) == 1
-        assert result["open_questions"][0]["text"] == "What is the timeout?"
-
-    def test_markdown_case_insensitive_checked_box(self):
-        response = "## Open Questions\n- [x] resolved question\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-
-
-class TestExtractOpenQuestionsEdgeCases:
-    """Edge cases for _extract_open_questions."""
-
-    def test_empty_response_returns_regex_fallback(self):
-        result = _extract_open_questions(MagicMock(), "", "")
-        assert result["source"] == "regex_fallback"
-        assert result["open_questions"] == []
-
-    def test_none_like_empty_string(self):
-        result = _extract_open_questions(MagicMock(), "", "system")
+    def test_result_shape(self):
+        result = _extract_open_questions(MagicMock(), DRAFT_WITH_QUESTIONS, "")
         assert "open_questions" in result
         assert "source" in result
 
-    def test_invalid_json_falls_back_to_regex(self):
-        response = '{"open_questions": [{"text": "missing bracket"'
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-
-    def test_json_missing_open_questions_key_falls_back(self):
-        response = json.dumps({"verdict": "APPROVED", "rationale": "OK"})
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-
-    def test_plain_text_returns_regex_fallback(self):
-        response = "This is just plain text with no structure."
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-        assert result["open_questions"] == []
-
-    def test_provider_param_accepted(self):
-        """_extract_open_questions accepts provider param without error."""
-        provider = _make_mock_provider("")
-        response = json.dumps({"open_questions": []})
-        # Should not raise
-        result = _extract_open_questions(provider, response, "system prompt")
-        assert result is not None
-
-    def test_system_prompt_param_accepted(self):
-        """_extract_open_questions accepts system_prompt param without error."""
-        response = json.dumps({"open_questions": []})
-        result = _extract_open_questions(MagicMock(), response, "system prompt text")
-        assert result is not None
-
-
-class TestExtractOpenQuestionsDebugLogging:
-    """T150: logger.debug called on fallback invocation."""
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug(self, mock_logger):
-        response = "## Open Questions\n- [ ] What is the timeout?\n"
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=draft_questions")
-
-    def test_structured_success_returns_structured_source(self):
-        response = json.dumps({"open_questions": []})
-        result = _extract_open_questions(MagicMock(), response, "")
-        assert result["source"] == "structured"
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_empty_input_logs_debug(self, mock_logger):
-        result = _extract_open_questions(MagicMock(), "", "")
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=draft_questions")
-
-
-class TestParseStructuredDraftQuestionsDirect:
-    """Direct tests for parse_structured_draft_questions function."""
-
-    def test_valid_json_returns_structured(self):
-        raw = json.dumps({
-            "open_questions": [{"text": "What timeout?", "resolved": False}]
-        })
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
+    def test_scan_stops_at_next_section(self):
+        doc = (
+            "## Open Questions\n- [ ] Real?\n"
+            "## Definition of Done\n- [ ] Not a question\n"
+        )
+        result = _extract_open_questions(MagicMock(), doc, "")
         assert len(result["open_questions"]) == 1
-
-    def test_empty_list_valid(self):
-        raw = json.dumps({"open_questions": []})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
-        assert result["open_questions"] == []
-
-    def test_missing_key_falls_back(self):
-        raw = json.dumps({"verdict": "APPROVED"})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_malformed_json_falls_back(self):
-        raw = "{not valid json"
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_empty_string_falls_back(self):
-        result = parse_structured_draft_questions("")
-        assert result["source"] == "regex_fallback"
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug_with_draft_questions_tag(self, mock_logger):
-        result = parse_structured_draft_questions("not json")
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=draft_questions")
-
-    def test_structured_returns_structured_source(self):
-        raw = json.dumps({"open_questions": []})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
-
-    def test_question_text_and_resolved_preserved(self):
-        raw = json.dumps({
-            "open_questions": [
-                {"text": "Q1?", "resolved": False},
-                {"text": "Q2?", "resolved": True},
-            ]
-        })
-        result = parse_structured_draft_questions(raw)
-        assert result["open_questions"][0]["text"] == "Q1?"
-        assert result["open_questions"][0]["resolved"] is False
-        assert result["open_questions"][1]["text"] == "Q2?"
-        assert result["open_questions"][1]["resolved"] is True
-
-
-class TestDraftQuestionsSchema:
-    """Tests for DRAFT_QUESTIONS_SCHEMA structure."""
-
-    def test_schema_has_open_questions_required(self):
-        assert "open_questions" in DRAFT_QUESTIONS_SCHEMA.get("required", [])
-
-    def test_schema_open_questions_is_array(self):
-        props = DRAFT_QUESTIONS_SCHEMA["properties"]
-        assert props["open_questions"]["type"] == "array"
-
-    def test_schema_item_has_text_and_resolved(self):
-        items = DRAFT_QUESTIONS_SCHEMA["properties"]["open_questions"]["items"]
-        assert "text" in items["properties"]
-        assert "resolved" in items["properties"]
-
-    def test_schema_item_required_fields(self):
-        items = DRAFT_QUESTIONS_SCHEMA["properties"]["open_questions"]["items"]
-        assert "text" in items["required"]
-        assert "resolved" in items["required"]
-
-
-class TestNoInlineSchemasInGenerateDraftNode:
-    """T180: No inline schema dict literals in generate_draft.py."""
-
-    def test_no_inline_schema_literals(self):
-        """generate_draft.py should not define DRAFT_QUESTIONS_SCHEMA inline."""
-        import pathlib
-        node_path = pathlib.Path("assemblyzero/workflows/requirements/nodes/generate_draft.py")
-        if node_path.exists():
-            content = node_path.read_text()
-            # The schema should be imported, not defined inline
-            assert "DRAFT_QUESTIONS_SCHEMA" not in content.split("from assemblyzero")[0] or \
-                   "DRAFT_QUESTIONS_SCHEMA = {" not in content
-
-    def test_imports_draft_questions_schema_from_verdict_schema(self):
-        """generate_draft.py imports DRAFT_QUESTIONS_SCHEMA from verdict_schema module."""
-        import pathlib
-        node_path = pathlib.Path("assemblyzero/workflows/requirements/nodes/generate_draft.py")
-        if node_path.exists():
-            content = node_path.read_text()
-            assert "DRAFT_QUESTIONS_SCHEMA" in content
-            assert "verdict_schema" in content
+        assert result["open_questions"][0]["text"] == "Real?"

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -31,6 +31,7 @@ Test IDs map to LLD Section 10.0/10.1:
 - T100: CLI runs full workflow
 """
 
+import json
 import os
 import pytest
 import textwrap
@@ -1997,10 +1998,13 @@ class TestReviewSpec:
     def test_approved_verdict(self, mock_provider, base_state):
         """APPROVED verdict returned."""
         reviewer = Mock()
+        _approved = json.dumps(
+            {"verdict": "APPROVED", "rationale": "Ready", "feedback_items": []}
+        )
         reviewer.invoke.return_value = Mock(
             success=True,
-            response="## Verdict\n[X] **APPROVED** - Ready\n",
-            content="## Verdict\n[X] **APPROVED** - Ready\n",
+            response=_approved,
+            content=_approved,
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -2020,10 +2024,11 @@ class TestReviewSpec:
     def test_revise_verdict(self, mock_provider, base_state):
         """REVISE verdict returned with feedback."""
         reviewer = Mock()
-        _response = (
-            "## Blocking Issues\n1. Missing excerpts.\n\n"
-            "## Verdict\n[X] **REVISE** - Fix issues\n"
-        )
+        _response = json.dumps({
+            "verdict": "REVISE",
+            "rationale": "Fix issues",
+            "feedback_items": ["Missing excerpts."],
+        })
         reviewer.invoke.return_value = Mock(
             success=True,
             response=_response,
@@ -2051,10 +2056,13 @@ class TestReviewSpec:
         Loop safety lives in the routing functions, which require
         review_iteration < max_iterations before any regeneration."""
         reviewer = Mock()
+        _approved = json.dumps(
+            {"verdict": "APPROVED", "rationale": "Ready", "feedback_items": []}
+        )
         reviewer.invoke.return_value = Mock(
             success=True,
-            response="## Verdict\n[X] **APPROVED** - Ready\n",
-            content="## Verdict\n[X] **APPROVED** - Ready\n",
+            response=_approved,
+            content=_approved,
             error_message=None,
             input_tokens=0,
             output_tokens=0,
@@ -2100,56 +2108,82 @@ class TestReviewSpec:
 
 
 class TestParseReviewVerdict:
-    """Tests for parse_review_verdict helper."""
+    """Tests for parse_review_verdict helper.
 
-    def test_approved_checkbox(self):
-        """[X] APPROVED → APPROVED."""
+    Standard 0028: strict — JSON verdicts parse; markdown checkboxes and
+    keyword prose are contract violations that raise, never scrapes.
+    """
+
+    def test_approved_json(self):
+        import json
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        verdict, _ = parse_review_verdict("[X] **APPROVED** - Ready\n")
+        raw = json.dumps({"verdict": "APPROVED", "rationale": "Ready", "feedback_items": []})
+        verdict, _ = parse_review_verdict(raw)
         assert verdict == "APPROVED"
 
-    def test_revise_checkbox(self):
-        """[X] REVISE → REVISE."""
+    def test_revise_json_carries_feedback(self):
+        import json
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        verdict, feedback = parse_review_verdict(
-            "## Blocking Issues\n1. Fix X.\n\n## Verdict\n[X] **REVISE**\n"
-        )
+        raw = json.dumps({
+            "verdict": "REVISE", "rationale": "Fix X.",
+            "feedback_items": ["Fix X in section 2"],
+        })
+        verdict, feedback = parse_review_verdict(raw)
         assert verdict == "REVISE"
         assert feedback != ""
 
-    def test_blocked_checkbox(self):
-        """[X] BLOCKED → BLOCKED."""
+    def test_blocked_json(self):
+        import json
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        verdict, _ = parse_review_verdict("[X] **BLOCKED** - Issues\n")
+        raw = json.dumps({"verdict": "BLOCKED", "rationale": "Issues", "feedback_items": []})
+        verdict, _ = parse_review_verdict(raw)
         assert verdict == "BLOCKED"
 
-    def test_keyword_fallback(self):
-        """VERDICT: APPROVED keyword → APPROVED."""
+    def test_markdown_checkbox_rejects(self):
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        verdict, _ = parse_review_verdict("Verdict: APPROVED\n\nGreat work!")
-        assert verdict == "APPROVED"
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("[X] **APPROVED** - Ready\n")
+
+    def test_keyword_prose_rejects(self):
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
+
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("Verdict: APPROVED\n\nGreat work!")
 
     def test_empty_response_blocked(self):
-        """Empty → BLOCKED."""
+        """Empty → BLOCKED (an empty response is an infrastructure signal;
+        the conservative pre-0028 behavior stands)."""
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
         assert parse_review_verdict("")[0] == "BLOCKED"
 
-    def test_discuss_maps_to_blocked(self):
-        """DISCUSS → BLOCKED."""
+    def test_discuss_json_rejects_not_in_enum(self):
+        """DISCUSS is not in REVIEW_SPEC_SCHEMA's enum — a contract
+        violation, not a silent mapping to BLOCKED."""
+        import json
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        assert parse_review_verdict("[X] **DISCUSS** - Need discussion")[0] == "BLOCKED"
+        raw = json.dumps({"verdict": "DISCUSS", "rationale": "talk", "feedback_items": []})
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict(raw)
 
-    def test_no_verdict_defaults_blocked(self):
-        """No verdict marker → BLOCKED."""
+    def test_prose_without_verdict_rejects(self):
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import parse_review_verdict
 
-        assert parse_review_verdict("Some text without verdict.")[0] == "BLOCKED"
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("Some text without verdict.")
 
 
 # =============================================================================

--- a/tests/unit/test_json_verdict_review_test_plan.py
+++ b/tests/unit/test_json_verdict_review_test_plan.py
@@ -1,7 +1,9 @@
 """Tests for Issue #494: JSON verdict migration in review_test_plan.
 
 Validates that review_test_plan uses structured JSON verdict parsing
-(parse_structured_verdict) first, falling back to regex _parse_verdict.
+(parse_structured_verdict). Standard 0028 retired the regex fallback:
+a response with no schema-valid verdict is rejected loudly (see
+test_review_test_plan_structured_output.py for the rejection pins).
 """
 
 import json
@@ -14,7 +16,6 @@ from assemblyzero.core.verdict_schema import (
     VERDICT_SCHEMA,
     parse_structured_verdict,
 )
-from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
 
 
 class TestStructuredVerdictParsing:
@@ -79,24 +80,9 @@ class TestStructuredVerdictParsing:
         assert parse_structured_verdict(None) is None
 
 
-class TestRegexFallback:
-    """Test _parse_verdict regex fallback still works."""
-
-    def test_approved_checkbox(self):
-        verdict = "## Verdict\n[X] **APPROVED** — all good"
-        assert _parse_verdict(verdict)["verdict"] == "APPROVED"
-
-    def test_blocked_checkbox(self):
-        verdict = "## Verdict\n[X] **BLOCKED** — needs work"
-        assert _parse_verdict(verdict)["verdict"] == "BLOCKED"
-
-    def test_verdict_keyword(self):
-        verdict = "After review, Verdict: APPROVED"
-        assert _parse_verdict(verdict)["verdict"] == "APPROVED"
-
-    def test_default_unknown(self):
-        verdict = "Unclear response with no verdict markers"
-        assert _parse_verdict(verdict)["verdict"] == "UNKNOWN"
+# TestRegexFallback removed: _parse_verdict and its regex fallback were
+# retired by standard 0028. A response that is not schema-valid JSON is a
+# rejected review, not a scraped one.
 
 
 class TestVerdictSchemaShape:

--- a/tests/unit/test_open_questions_loop.py
+++ b/tests/unit/test_open_questions_loop.py
@@ -355,10 +355,13 @@ class TestStateHasOpenQuestionsStatus:
         with patch("assemblyzero.workflows.requirements.nodes.review.get_provider") as mock_get:
             import json as _json
             mock_provider = Mock()
+            _verdict_json = _json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []})
             mock_provider.invoke.return_value = Mock(
                 success=True,
-                content=_json.dumps({"verdict": "APPROVED", "rationale": "", "feedback_items": [], "open_questions": []}),
-                response="[x] APPROVED",
+                content=_verdict_json,
+                # Standard 0028: review reads .response, which must honor the
+                # schema — the old "[x] APPROVED" markdown would be rejected.
+                response=_verdict_json,
                 error_message=None,
                 input_tokens=0,
                 output_tokens=0,

--- a/tests/unit/test_requirements_nodes.py
+++ b/tests/unit/test_requirements_nodes.py
@@ -1895,10 +1895,10 @@ class TestReviewNodeCoverage:
 
         result = review(state)
 
-        # #1766: empty/failed reviewer content is an LLM-format error, not a
-        # synthesized review outcome (was: UNKNOWN -> REVISE -> BLOCKED with
-        # an empty rationale). The stage retry machinery re-runs the review.
-        assert "unparseable" in result.get("error_message", "")
+        # #1766 → standard 0028: empty/failed reviewer content is a rejected
+        # structured contract, not a synthesized review outcome. The stage
+        # retry machinery re-runs the review.
+        assert "rejected" in result.get("error_message", "")
         assert "lld_status" not in result
 
     @patch("assemblyzero.workflows.requirements.nodes.review.get_provider")
@@ -2037,9 +2037,9 @@ class TestReviewNodeCoverage:
 
         result = review(state)
 
-        # #1766: no extractable verdict -> honest LLM-format error, no
-        # synthesized BLOCKED.
-        assert "unparseable" in result.get("error_message", "")
+        # #1766 → standard 0028: no schema-valid verdict -> honest rejection,
+        # no synthesized BLOCKED.
+        assert "rejected" in result.get("error_message", "")
         assert "lld_status" not in result
 
 

--- a/tests/unit/test_review_spec_structured_output.py
+++ b/tests/unit/test_review_spec_structured_output.py
@@ -157,8 +157,9 @@ class TestInvokeReviewerWithSpecSchema:
         assert call_kwargs["response_schema"] == REVIEW_SPEC_SCHEMA
         assert "json_schema" not in call_kwargs
 
-    def test_falls_back_to_regex_on_malformed_json(self):
-        """Fallback path triggered when provider returns non-JSON markdown."""
+    def test_markdown_response_rejects_via_error_path(self):
+        """Standard 0028: a non-JSON response is rejected through the same
+        (None, error) path as an infrastructure failure — never scraped."""
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             _invoke_reviewer_with_spec_schema,
         )
@@ -166,10 +167,11 @@ class TestInvokeReviewerWithSpecSchema:
         raw = "[X] **APPROVED**\n\nRationale: Looks good"
         provider = _make_mock_provider(raw)
 
-        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
-        assert result["verdict"] == "APPROVED"
-        assert result["source"] == "regex_fallback"
+        assert result is None
+        assert "review_spec" in err
+        assert "contract" in err
 
     def test_revise_verdict_propagated(self):
         """REVISE verdict from structured result is returned correctly."""
@@ -280,29 +282,29 @@ class TestParseReviewVerdict:
 
         assert verdict == "BLOCKED"
 
-    def test_unknown_verdict_remapped_to_blocked(self):
-        """UNKNOWN verdict from failed parse is remapped to BLOCKED."""
+    def test_plain_text_rejects_not_remapped(self):
+        """Standard 0028: a failed parse raises — it is never remapped to a
+        synthesized BLOCKED verdict."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             parse_review_verdict,
         )
 
-        raw = "This is just plain text with no verdict"
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("This is just plain text with no verdict")
 
-        verdict, feedback = parse_review_verdict(raw)
-
-        assert verdict == "BLOCKED"
-
-    def test_fallback_markdown_returns_verdict(self):
-        """Legacy markdown checkbox returns correct verdict via fallback."""
+    def test_markdown_checkbox_rejects(self):
+        """Standard 0028: legacy markdown checkboxes are contract
+        violations, not scrapes."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             parse_review_verdict,
         )
 
-        raw = "[X] **REVISE**\n\nRationale: Needs more detail"
-
-        verdict, feedback = parse_review_verdict(raw)
-
-        assert verdict == "REVISE"
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("[X] **REVISE**\n\nRationale: Needs more detail")
 
     def test_feedback_from_items_when_no_rationale(self):
         """feedback_items used as feedback when rationale is empty."""
@@ -394,8 +396,9 @@ class TestReviewSpecResultPropagation:
 
         assert result["source"] == "structured"
 
-    def test_source_is_regex_fallback_on_markdown(self):
-        """source field is 'regex_fallback' when JSON parse fails."""
+    def test_markdown_yields_no_result_at_all(self):
+        """Standard 0028: a markdown verdict is rejected (None, error) — the
+        regex_fallback source no longer exists."""
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             _invoke_reviewer_with_spec_schema,
         )
@@ -403,9 +406,10 @@ class TestReviewSpecResultPropagation:
         raw = "[X] **REVISE**\n\nRationale: missing tests"
         provider = _make_mock_provider(raw)
 
-        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
-        assert result["source"] == "regex_fallback"
+        assert result is None
+        assert err != ""
 
     def test_empty_feedback_items_when_approved(self):
         """feedback_items is empty list for APPROVED verdict."""
@@ -426,11 +430,9 @@ class TestReviewSpecResultPropagation:
 
 
 class TestFallbackBehavior:
-    """Tests for regex fallback path in review_spec node."""
+    """Standard 0028: there is no fallback — violations reject."""
 
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug_metric(self, mock_logger):
-        """T150: logger.debug called when fallback fires in review_spec parse."""
+    def test_contract_violation_names_the_parser(self):
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             _invoke_reviewer_with_spec_schema,
         )
@@ -438,10 +440,10 @@ class TestFallbackBehavior:
         raw = "[X] **REVISE**\n\n## Required Changes\n- Fix error handling"
         provider = _make_mock_provider(raw)
 
-        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=review_spec")
+        assert result is None
+        assert "review_spec" in err
 
     def test_no_fallback_on_structured_success(self):
         """Structured parse succeeds — source is 'structured'."""
@@ -474,8 +476,10 @@ class TestFallbackBehavior:
         assert result is None
         assert err != ""
 
-    def test_feedback_items_extracted_via_fallback(self):
-        """Feedback items extracted from markdown via regex fallback."""
+    def test_markdown_feedback_sections_are_not_scraped(self):
+        """The old fallback scraped Required Changes / Feedback bullets out
+        of markdown; those responses are rejections now — feedback arrives
+        through the schema or not at all."""
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             _invoke_reviewer_with_spec_schema,
         )
@@ -483,35 +487,16 @@ class TestFallbackBehavior:
         raw = (
             "[X] **REVISE**\n\n"
             "## Required Changes\n"
-            "- Fix error handling\n"
-            "- Add missing tests\n"
-        )
-        provider = _make_mock_provider(raw)
-
-        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
-
-        assert result["source"] == "regex_fallback"
-        assert "Fix error handling" in result["feedback_items"]
-        assert "Add missing tests" in result["feedback_items"]
-
-    def test_feedback_section_also_extracted(self):
-        """Feedback items extracted from ## Feedback section via regex fallback."""
-        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
-            _invoke_reviewer_with_spec_schema,
-        )
-
-        raw = (
-            "[X] **REVISE**\n\n"
+            "- Fix error handling\n\n"
             "## Feedback\n"
             "- Update section 6\n"
-            "- Add concrete examples\n"
         )
         provider = _make_mock_provider(raw)
 
-        result, _err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
+        result, err = _invoke_reviewer_with_spec_schema(provider, "prompt", "system")
 
-        assert result["source"] == "regex_fallback"
-        assert "Update section 6" in result["feedback_items"]
+        assert result is None
+        assert err != ""
 
 
 class TestNoInlineSchemasInReviewSpecNode:
@@ -622,38 +607,45 @@ class TestParseStructuredReviewSpecDirect:
         assert result["verdict"] == "BLOCKED"
         assert result["source"] == "structured"
 
-    def test_missing_feedback_items_falls_back(self):
-        """Missing feedback_items triggers fallback."""
+    def test_missing_feedback_items_rejects(self):
+        """Standard 0028: missing required keys is a contract violation."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
+
         raw = json.dumps({
             "verdict": "REVISE",
             "rationale": "needs work",
         })
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec(raw)
 
-    def test_invalid_verdict_enum_falls_back(self):
-        """Invalid verdict (e.g. DISCUSS) triggers fallback for review_spec."""
+    def test_invalid_verdict_enum_rejects(self):
+        """DISCUSS is outside REVIEW_SPEC_SCHEMA's enum — a violation."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
+
         raw = json.dumps({
             "verdict": "DISCUSS",
             "rationale": "Let's talk",
             "feedback_items": [],
         })
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec(raw)
 
-    def test_malformed_json_falls_back(self):
-        """Malformed JSON triggers fallback."""
-        raw = "not valid json {"
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
+    def test_malformed_json_rejects(self):
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
 
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug_with_review_spec_tag(self, mock_logger):
-        """logger.debug called with parser=review_spec on fallback."""
-        raw = "[X] **APPROVED**"
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=review_spec")
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec("not valid json {")
+
+    def test_rejection_carries_parser_name(self):
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
+
+        with pytest.raises(StructuredContractError) as exc_info:
+            parse_structured_review_spec("[X] **APPROVED**")
+        assert exc_info.value.parser == "review_spec"
 
     def test_structured_success_returns_structured_source(self):
         """Structured parse succeeds — source is 'structured'."""

--- a/tests/unit/test_review_structured_output.py
+++ b/tests/unit/test_review_structured_output.py
@@ -121,8 +121,11 @@ class TestInvokeReviewerWithFeedbackSchema:
         assert call_kwargs["response_schema"] == FEEDBACK_SCHEMA
         assert "json_schema" not in call_kwargs
 
-    def test_falls_back_to_regex_on_malformed_json(self):
-        """Fallback path triggered when provider returns non-JSON markdown."""
+    def test_markdown_response_rejects(self):
+        """Standard 0028: non-JSON markdown is a contract violation — it
+        raises for the node to surface, never a regex scrape."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.requirements.nodes.review import (
             _invoke_reviewer_with_feedback_schema,
         )
@@ -130,10 +133,8 @@ class TestInvokeReviewerWithFeedbackSchema:
         raw = "[X] **APPROVED**\n\n## Feedback\n- looks good"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
-
-        assert result["verdict"] == "APPROVED"
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
 
     def test_revise_verdict_propagated(self):
         """REVISE verdict from structured result is returned correctly."""
@@ -313,8 +314,11 @@ class TestFeedbackResultPropagation:
 
         assert result["source"] == "structured"
 
-    def test_source_is_regex_fallback_on_markdown(self):
-        """source field is 'regex_fallback' when JSON parse fails."""
+    def test_markdown_never_yields_a_source(self):
+        """Standard 0028: there is no regex_fallback source anymore — a
+        markdown verdict raises instead of producing a degraded result."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.requirements.nodes.review import (
             _invoke_reviewer_with_feedback_schema,
         )
@@ -322,17 +326,18 @@ class TestFeedbackResultPropagation:
         raw = "[X] **REVISE**\n\nRationale: missing tests"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
-
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
 
 
 class TestFallbackBehavior:
-    """Tests for regex fallback path in review node."""
+    """Standard 0028: there is no fallback — violations reject."""
 
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug_metric(self, mock_logger):
-        """T150: logger.debug called when fallback fires in feedback parse."""
+    def test_contract_violation_raises_not_logs(self):
+        """The pre-0028 fallback logged a debug metric and guessed; now the
+        violation raises with the parser named."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.requirements.nodes.review import (
             _invoke_reviewer_with_feedback_schema,
         )
@@ -340,10 +345,9 @@ class TestFallbackBehavior:
         raw = "[X] **REVISE**\n\n## Feedback\n- Fix error handling"
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
-
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=feedback")
+        with pytest.raises(StructuredContractError) as exc_info:
+            _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
+        assert exc_info.value.parser == "feedback"
 
     def test_no_fallback_on_structured_success(self):
         """Structured parse succeeds — source is 'structured'."""
@@ -363,56 +367,41 @@ class TestFallbackBehavior:
 
         assert result["source"] == "structured"
 
-    def test_empty_response_returns_unknown_verdict(self):
-        """Empty provider response returns UNKNOWN verdict via fallback."""
+    def test_empty_response_rejects(self):
+        """An empty provider response is a contract violation, not an
+        UNKNOWN verdict to be remapped downstream."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.requirements.nodes.review import (
             _invoke_reviewer_with_feedback_schema,
         )
 
         provider = _make_mock_provider("")
 
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
+        with pytest.raises(StructuredContractError) as exc_info:
+            _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
+        assert "response empty" in str(exc_info.value)
 
-        assert result["source"] == "regex_fallback"
-        assert result["verdict"] in {"UNKNOWN", "REVISE"}  # fallback may remap UNKNOWN
-
-    def test_feedback_items_extracted_via_fallback(self):
-        """Feedback items extracted from markdown via regex fallback."""
-        from assemblyzero.workflows.requirements.nodes.review import (
-            _invoke_reviewer_with_feedback_schema,
-        )
-
-        raw = "[X] **REVISE**\n\n## Feedback\n- Fix error handling\n- Add missing tests\n"
-        provider = _make_mock_provider(raw)
-
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
-
-        assert result["source"] == "regex_fallback"
-        assert "Fix error handling" in result["feedback_items"]
-        assert "Add missing tests" in result["feedback_items"]
-
-    def test_open_questions_extracted_via_fallback(self):
-        """Open questions extracted from markdown via regex fallback."""
+    def test_markdown_feedback_sections_are_not_scraped(self):
+        """The old fallback scraped feedback bullets and question checkboxes
+        out of markdown; both are rejections now — the reviewer's data
+        arrives through the schema or not at all."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.requirements.nodes.review import (
             _invoke_reviewer_with_feedback_schema,
         )
 
         raw = (
             "[X] **REVISE**\n\n"
+            "## Feedback\n- Fix error handling\n\n"
             "## Open Questions\n"
             "- [ ] What timeout value?\n"
-            "- [X] Rate limit decided\n"
         )
         provider = _make_mock_provider(raw)
 
-        result = _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
-
-        assert result["source"] == "regex_fallback"
-        texts = [q["text"] for q in result["open_questions"]]
-        assert "What timeout value?" in texts
-        resolved = {q["text"]: q["resolved"] for q in result["open_questions"]}
-        assert resolved["What timeout value?"] is False
-        assert resolved["Rate limit decided"] is True
+        with pytest.raises(StructuredContractError):
+            _invoke_reviewer_with_feedback_schema(provider, "prompt", "system")
 
 
 class TestExtractActionableFeedback:

--- a/tests/unit/test_review_test_plan_structured_output.py
+++ b/tests/unit/test_review_test_plan_structured_output.py
@@ -1,124 +1,124 @@
-"""Tests for test-plan review node structured output and fallback parsing.
+"""Test-plan review under standard 0028: structured verdict or loud rejection.
 
-Issue #775: Verify _parse_verdict returns VerdictResult with correct source field.
+The pre-0028 file pinned _parse_verdict's structured-then-regex behavior;
+_parse_verdict is retired. A reviewer response that yields no schema-valid
+verdict is now rejected with error_message — the stage retry machinery is
+the re-ask — instead of being silently downgraded (UNKNOWN → REVISE →
+BLOCKED) by a regex scrape.
 """
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
-from assemblyzero.core.verdict_schema import VerdictResult
-from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
-
-
-class TestParseVerdictStructuredPath:
-    """T130: Structured JSON path returns VerdictResult(source='structured')."""
-
-    def test_approved_structured(self):
-        raw = json.dumps({"verdict": "APPROVED", "rationale": "All tests pass"})
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-        assert result["rationale"] == "All tests pass"
-        assert result["source"] == "structured"
-
-    def test_revise_structured(self):
-        raw = json.dumps({"verdict": "REVISE", "rationale": "Missing edge case"})
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "REVISE"
-        assert result["source"] == "structured"
-
-    def test_discuss_structured(self):
-        raw = json.dumps({"verdict": "DISCUSS", "rationale": "Needs clarification"})
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "DISCUSS"
-        assert result["source"] == "structured"
-
-    def test_structured_returns_typed_dict_keys(self):
-        raw = json.dumps({"verdict": "APPROVED", "rationale": "LGTM"})
-        result = _parse_verdict(raw)
-        assert "verdict" in result
-        assert "rationale" in result
-        assert "source" in result
-
-    def test_structured_missing_rationale_defaults_empty(self):
-        raw = json.dumps({"verdict": "APPROVED"})
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-        assert result["rationale"] == ""
-        assert result["source"] == "structured"
-
-    def test_structured_with_extra_fields(self):
-        raw = json.dumps({
-            "verdict": "REVISE",
-            "rationale": "Needs work",
-            "feedback_items": ["Fix test T042"],
-        })
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "REVISE"
-        assert result["source"] == "structured"
+def _state_forcing_llm_path() -> dict:
+    """<100% coverage so the fast-path is skipped and the LLM review runs."""
+    return {
+        "test_scenarios": [
+            {"name": "test_a", "type": "unit", "requirement_ref": "REQ-1"},
+            {"name": "test_b", "type": "unit", "requirement_ref": "REQ-1"},
+        ],
+        "requirements": ["REQ-1: A", "REQ-2: B"],
+        "lld_content": (
+            "This is a detailed low-level design document with sufficient "
+            "words to pass the mechanical gate minimum threshold. " * 5
+        ),
+        "issue_number": 42,
+        "repo_root": "/tmp/test-repo",
+        "audit_dir": "/tmp/nonexistent",
+        "mock_mode": False,
+        "node_costs": {},
+        "node_tokens": {},
+        "file_counter": 0,
+        "config_reviewer": "gemini:3.1-pro-preview",
+    }
 
 
-class TestParseVerdictFallbackPath:
-    """T140: Fallback path returns VerdictResult(source='regex_fallback'), emits WARNING."""
+def _llm_result(content: str) -> MagicMock:
+    result = MagicMock()
+    result.success = True
+    result.error_message = None
+    result.content = content
+    result.response = ""
+    result.input_tokens = 100
+    result.output_tokens = 50
+    return result
 
-    def test_markdown_checkbox_approved_triggers_fallback(self):
-        raw = "[X] **APPROVED**\n\nRationale: Looks good"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-        assert result["source"] == "regex_fallback"
 
-    def test_markdown_checkbox_revise_triggers_fallback(self):
-        raw = "[X] **REVISE**\n\nRationale: Needs changes"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "REVISE"
-        assert result["source"] == "regex_fallback"
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+@patch("assemblyzero.utils.retry.with_retry")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_provider")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost")
+def test_schema_valid_verdict_proceeds(
+    mock_cost, mock_provider, mock_with_retry, mock_root, mock_prompt, mock_log,
+):
+    from assemblyzero.workflows.testing.nodes.review_test_plan import review_test_plan
+    from assemblyzero.core.llm_provider import GeminiProvider
 
-    def test_markdown_checkbox_discuss_triggers_fallback(self):
-        raw = "[X] **DISCUSS**\n\nRationale: Open questions remain"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "DISCUSS"
-        assert result["source"] == "regex_fallback"
+    mock_root.return_value = Path("/tmp/test-repo")
+    mock_prompt.return_value = "review prompt"
+    mock_cost.return_value = 0.0
+    mock_provider.return_value = MagicMock(spec=GeminiProvider)
+    mock_with_retry.return_value = _llm_result(
+        json.dumps({"verdict": "APPROVED", "rationale": "Coverage acceptable."})
+    )
 
-    def test_unparseable_returns_unknown(self):
-        raw = "This is just plain text with no verdict"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "UNKNOWN"
-        assert result["source"] == "regex_fallback"
+    result = review_test_plan(_state_forcing_llm_path())
+    assert result["test_plan_status"] == "APPROVED"
+    assert not result.get("error_message")
 
-    def test_empty_string_returns_unknown(self):
-        result = _parse_verdict("")
-        assert result["verdict"] == "UNKNOWN"
-        assert result["source"] == "regex_fallback"
 
-    def test_fallback_logs_warning(self, caplog):
-        import logging
-        raw = "[X] **APPROVED**\n\nRationale: LGTM"
-        with caplog.at_level(logging.WARNING):
-            result = _parse_verdict(raw)
-        assert result["source"] == "regex_fallback"
-        assert any("fallback" in record.message.lower() for record in caplog.records)
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+@patch("assemblyzero.utils.retry.with_retry")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_provider")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost")
+def test_markdown_verdict_is_rejected_loudly(
+    mock_cost, mock_provider, mock_with_retry, mock_root, mock_prompt, mock_log,
+):
+    """The old regex fallback would have scraped APPROVED out of this
+    markdown; under standard 0028 the review is rejected with an error the
+    stage retry machinery acts on."""
+    from assemblyzero.workflows.testing.nodes.review_test_plan import review_test_plan
+    from assemblyzero.core.llm_provider import GeminiProvider
 
-    def test_invalid_json_triggers_fallback(self):
-        raw = '{"verdict": "APPROVED"'  # malformed JSON
-        result = _parse_verdict(raw)
-        assert result["source"] == "regex_fallback"
+    mock_root.return_value = Path("/tmp/test-repo")
+    mock_prompt.return_value = "review prompt"
+    mock_cost.return_value = 0.0
+    mock_provider.return_value = MagicMock(spec=GeminiProvider)
+    mock_with_retry.return_value = _llm_result(
+        "## Verdict\n[X] **APPROVED** — all good"
+    )
 
-    def test_fallback_returns_typed_dict_keys(self):
-        raw = "[X] **REVISE**"
-        result = _parse_verdict(raw)
-        assert "verdict" in result
-        assert "rationale" in result
-        assert "source" in result
+    result = review_test_plan(_state_forcing_llm_path())
+    assert result.get("error_message"), "unparseable verdict must reject, not proceed"
+    assert "rejected" in result["error_message"]
+    assert "test_plan_status" not in result
 
-    def test_case_insensitive_checkbox_match(self):
-        raw = "[X] **approved**"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-        assert result["source"] == "regex_fallback"
 
-    def test_blocked_verdict_via_fallback(self):
-        raw = "[X] **BLOCKED**\n\nRationale: Blocked by dependency"
-        result = _parse_verdict(raw)
-        assert result["verdict"] == "BLOCKED"
-        assert result["source"] == "regex_fallback"
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.log_workflow_execution")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.load_review_prompt")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_repo_root")
+@patch("assemblyzero.utils.retry.with_retry")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_provider")
+@patch("assemblyzero.workflows.testing.nodes.review_test_plan.get_cumulative_cost")
+def test_rejection_message_carries_excerpt(
+    mock_cost, mock_provider, mock_with_retry, mock_root, mock_prompt, mock_log,
+):
+    from assemblyzero.workflows.testing.nodes.review_test_plan import review_test_plan
+    from assemblyzero.core.llm_provider import GeminiProvider
+
+    mock_root.return_value = Path("/tmp/test-repo")
+    mock_prompt.return_value = "review prompt"
+    mock_cost.return_value = 0.0
+    mock_provider.return_value = MagicMock(spec=GeminiProvider)
+    mock_with_retry.return_value = _llm_result("Plain prose, no verdict anywhere.")
+
+    result = review_test_plan(_state_forcing_llm_path())
+    assert "Plain prose" in result.get("error_message", ""), (
+        "the halt banner must be legible (#2197): excerpt included"
+    )

--- a/tests/unit/test_structured_output_contract.py
+++ b/tests/unit/test_structured_output_contract.py
@@ -97,6 +97,10 @@ class TestParsersUseLenientRecovery:
         assert result["source"] == "structured"
         assert result["verdict"] == "APPROVED"
 
-    def test_markdown_review_spec_still_falls_back(self):
-        result = parse_structured_review_spec("## Verdict\n[x] **APPROVED**\n")
-        assert result["source"] == "regex_fallback"
+    def test_markdown_review_spec_rejects(self):
+        """Standard 0028: markdown is a contract violation, not a fallback."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
+
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec("## Verdict\n[x] **APPROVED**\n")

--- a/tests/unit/test_structured_verdicts.py
+++ b/tests/unit/test_structured_verdicts.py
@@ -134,14 +134,14 @@ class TestFallbackToRegex:
         assert _parse_verdict_status("VERDICT: APPROVED") == "APPROVED"
         assert _parse_verdict_status("VERDICT: BLOCKED") == "BLOCKED"
 
-    def test_review_spec_fallback(self):
-        """review_spec.py's parse_review_verdict should still work for non-JSON."""
+    def test_review_spec_rejects_non_json(self):
+        """Standard 0028: parse_review_verdict rejects non-JSON — the old
+        checkbox scrape is retired."""
+        import pytest
+        from assemblyzero.core.verdict_schema import StructuredContractError
         from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
             parse_review_verdict,
         )
 
-        verdict, feedback = parse_review_verdict("[X] **APPROVED** - Spec ready")
-        assert verdict == "APPROVED"
-
-        verdict, feedback = parse_review_verdict("[X] **REVISE** - Fix issues")
-        assert verdict == "REVISE"
+        with pytest.raises(StructuredContractError):
+            parse_review_verdict("[X] **APPROVED** - Spec ready")

--- a/tests/unit/test_testing_workflow.py
+++ b/tests/unit/test_testing_workflow.py
@@ -5,6 +5,7 @@ Issue #102: TDD Initialization
 Issue #93: N8 Documentation Node
 """
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -2008,41 +2009,39 @@ class TestReviewTestPlanModule:
         assert "test_example" in context
         assert "90%" in context
 
-    def test_parse_verdict_approved_explicit(self):
-        """_parse_verdict detects explicit APPROVED."""
-        from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
+    def test_structured_verdict_parses(self):
+        """Standard 0028: _parse_verdict is retired; the node consumes
+        parse_structured_verdict directly — JSON or rejection."""
+        import json
+        from assemblyzero.core.verdict_schema import parse_structured_verdict
 
-        verdict = "[x] **APPROVED** - Test plan is ready"
-        result = _parse_verdict(verdict)
+        raw = json.dumps({"verdict": "APPROVED", "rationale": "Test plan is ready"})
+        result = parse_structured_verdict(raw)
 
+        assert result is not None
         assert result["verdict"] == "APPROVED"
 
-    def test_parse_verdict_blocked_explicit(self):
-        """_parse_verdict detects explicit BLOCKED."""
-        from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
+    def test_structured_blocked_verdict_parses(self):
+        import json
+        from assemblyzero.core.verdict_schema import parse_structured_verdict
 
-        verdict = "[x] **BLOCKED** - Test plan needs revision"
-        result = _parse_verdict(verdict)
+        raw = json.dumps({"verdict": "BLOCKED", "rationale": "Needs revision"})
+        result = parse_structured_verdict(raw)
 
+        assert result is not None
         assert result["verdict"] == "BLOCKED"
 
-    def test_parse_verdict_approved_implicit(self):
-        """_parse_verdict detects implicit APPROVED."""
-        from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
+    def test_markdown_verdict_yields_none_for_rejection(self):
+        """A checkbox/prose response is no longer scraped: the parse yields
+        None and the node rejects with error_message (standard 0028)."""
+        from assemblyzero.core.verdict_schema import parse_structured_verdict
 
-        verdict = "The test plan is APPROVED for implementation."
-        result = _parse_verdict(verdict)
+        assert parse_structured_verdict("[x] **APPROVED** - Test plan is ready") is None
 
-        assert result["verdict"] == "APPROVED"
+    def test_unclear_response_yields_none_for_rejection(self):
+        from assemblyzero.core.verdict_schema import parse_structured_verdict
 
-    def test_parse_verdict_unknown_default(self):
-        """_parse_verdict returns UNKNOWN for unclear verdict (#775)."""
-        from assemblyzero.workflows.testing.nodes.review_test_plan import _parse_verdict
-
-        verdict = "Some unclear response"
-        result = _parse_verdict(verdict)
-
-        assert result["verdict"] == "UNKNOWN"
+        assert parse_structured_verdict("Some unclear response") is None
 
     def test_extract_feedback_required_changes_section(self):
         """_extract_feedback extracts from Required Changes section."""
@@ -4512,7 +4511,7 @@ class TestReviewTestPlanCoverageGaps:
         )
 
         fake = self._fake_reviewer(
-            "## Verdict\n[x] **APPROVED** - Test plan is ready\n"
+            json.dumps({"verdict": "APPROVED", "rationale": "Test plan is ready"})
         )
         audit_dir = tmp_path / "audit"
         audit_dir.mkdir()
@@ -4560,10 +4559,14 @@ class TestReviewTestPlanCoverageGaps:
         )
 
         fake = self._fake_reviewer(
-            "## Verdict\n[x] **BLOCKED** - Test plan needs revision\n\n"
-            "## Required Changes\n"
-            "1. Add more test coverage\n"
-            "2. Fix assertion issues\n"
+            json.dumps({
+                "verdict": "BLOCKED",
+                "rationale": "Test plan needs revision",
+                "blocking_issues": [
+                    {"section": "Coverage", "issue": "Add more test coverage", "severity": "BLOCKING"},
+                    {"section": "Assertions", "issue": "Fix assertion issues", "severity": "BLOCKING"},
+                ],
+            })
         )
         audit_dir = tmp_path / "audit"
         audit_dir.mkdir()

--- a/tests/unit/test_verdict_schema.py
+++ b/tests/unit/test_verdict_schema.py
@@ -1,12 +1,14 @@
 """Unit tests for assemblyzero/core/verdict_schema.py.
 
-Issue #775: Structured output for LLM reviewer responses.
-Tests schemas, parse helpers, regex fallbacks, and counter metrics.
+Issue #775 introduced the schemas and parse helpers; standard 0028
+(operator ruling 2026-08-10) made the parsers strict — a structured ask
+either parses and validates or raises StructuredContractError, and the
+regex fallback scrapers are retired. Document scans of the pipeline's own
+markdown (scan_open_questions_section, scan_residual_questions) replace
+the two "parsers" whose inputs were never model JSON.
 """
 
 import json
-import logging
-from unittest.mock import patch
 
 import pytest
 
@@ -20,19 +22,15 @@ from assemblyzero.core.verdict_schema import (
     FeedbackResult,
     FinalizeQuestionsResult,
     ReviewSpecResult,
+    StructuredContractError,
     VerdictResult,
-    _extract_section_from_markdown,
-    _regex_fallback_draft_questions,
-    _regex_fallback_feedback,
-    _regex_fallback_finalize_questions,
-    _regex_fallback_verdict,
     _validate_enum,
     _validate_required_keys,
-    parse_structured_draft_questions,
     parse_structured_feedback,
-    parse_structured_finalize_questions,
     parse_structured_review_spec,
     parse_structured_verdict,
+    scan_open_questions_section,
+    scan_residual_questions,
 )
 
 
@@ -113,7 +111,7 @@ class TestValidateEnum:
 
 
 # ---------------------------------------------------------------------------
-# parse_structured_verdict
+# parse_structured_verdict (lenient by design: returns None, caller rejects)
 # ---------------------------------------------------------------------------
 
 class TestParseStructuredVerdict:
@@ -133,14 +131,18 @@ class TestParseStructuredVerdict:
     def test_empty_string_returns_none(self):
         assert parse_structured_verdict("") is None
 
+    def test_fenced_json_recovered(self):
+        raw = "```json\n" + json.dumps({"verdict": "REVISE", "rationale": "x"}) + "\n```"
+        result = parse_structured_verdict(raw)
+        assert result is not None
+        assert result["verdict"] == "REVISE"
+
 
 # ---------------------------------------------------------------------------
-# parse_structured_feedback — T010 / test_010
+# parse_structured_feedback — strict (standard 0028)
 # ---------------------------------------------------------------------------
 
 class TestParseStructuredFeedback:
-    """T010 / test_010: Happy path and fallback for feedback parsing."""
-
     def test_valid_json_structured_source(self):
         raw = json.dumps({
             "verdict": "REVISE",
@@ -167,604 +169,264 @@ class TestParseStructuredFeedback:
         assert result["source"] == "structured"
         assert "resolved_issues" in result
 
-    def test_missing_verdict_falls_back(self):
-        raw = json.dumps({"rationale": "ok", "feedback_items": [], "open_questions": []})
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "regex_fallback"
+    def test_fenced_json_is_recovered_as_structured(self):
+        """JSON recovery (fences) is not scraping — standard 0028 §2."""
+        payload = json.dumps({
+            "verdict": "APPROVED",
+            "rationale": "LGTM",
+            "feedback_items": [],
+            "open_questions": [],
+        })
+        result = parse_structured_feedback(f"```json\n{payload}\n```")
+        assert result["source"] == "structured"
+        assert result["verdict"] == "APPROVED"
 
-    def test_invalid_verdict_enum_falls_back(self):
+    def test_prose_wrapped_json_is_recovered_as_structured(self):
+        payload = json.dumps({
+            "verdict": "DISCUSS",
+            "rationale": "needs a decision",
+            "feedback_items": [],
+            "open_questions": [],
+        })
+        result = parse_structured_feedback(f"Here is my verdict: {payload}")
+        assert result["source"] == "structured"
+        assert result["verdict"] == "DISCUSS"
+
+    def test_missing_verdict_rejects(self):
+        raw = json.dumps({"rationale": "ok", "feedback_items": [], "open_questions": []})
+        with pytest.raises(StructuredContractError):
+            parse_structured_feedback(raw)
+
+    def test_invalid_verdict_enum_rejects(self):
         raw = json.dumps({
             "verdict": "NOTAVERDICT",
             "rationale": "x",
             "feedback_items": [],
             "open_questions": [],
         })
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            parse_structured_feedback(raw)
 
-    def test_malformed_json_falls_back(self):
+    def test_markdown_checkbox_response_rejects(self):
+        """The old regex fallback read this; now it is a contract violation."""
         raw = "[X] **REVISE**\n\n## Feedback\n- Fix something\n"
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "regex_fallback"
-        assert result["verdict"] == "REVISE"
+        with pytest.raises(StructuredContractError):
+            parse_structured_feedback(raw)
 
-    def test_empty_string_returns_unknown(self):
-        result = parse_structured_feedback("")
-        assert result["verdict"] == "UNKNOWN"
-        assert result["source"] == "regex_fallback"
+    def test_empty_string_rejects(self):
+        with pytest.raises(StructuredContractError):
+            parse_structured_feedback("")
 
-    def test_blocked_verdict_remapped_to_unknown(self):
-        # BLOCKED is valid in REVIEW_SPEC but not FEEDBACK schema
-        raw = "[X] **BLOCKED**\n"
-        result = parse_structured_feedback(raw)
-        assert result["verdict"] == "UNKNOWN"
-        assert result["source"] == "regex_fallback"
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug(self, mock_logger):
-        raw = "[X] **APPROVED**\n\n## Feedback\n- looks good"
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "regex_fallback"
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=feedback")
-
-    def test_structured_parse_returns_structured_source(self):
-        raw = json.dumps({
-            "verdict": "APPROVED",
-            "rationale": "LGTM",
-            "feedback_items": [],
-            "open_questions": [],
-        })
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "structured"
-
-    def test_missing_open_questions_falls_back(self):
+    def test_missing_open_questions_rejects(self):
         raw = json.dumps({
             "verdict": "APPROVED",
             "rationale": "ok",
             "feedback_items": [],
         })
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_logs_warning_on_fallback(self, caplog):
-        raw = "not json at all"
-        with caplog.at_level(logging.WARNING, logger="assemblyzero.core.verdict_schema"):
+        with pytest.raises(StructuredContractError):
             parse_structured_feedback(raw)
-        assert any("fallback" in r.message.lower() or "parse" in r.message.lower()
-                   for r in caplog.records)
+
+    def test_rejection_names_parser_and_carries_excerpt(self):
+        with pytest.raises(StructuredContractError) as exc_info:
+            parse_structured_feedback("Approved, ship it, great work all around")
+        err = exc_info.value
+        assert err.parser == "feedback"
+        assert "feedback" in str(err)
+        assert "Approved, ship it" in str(err)
 
 
 # ---------------------------------------------------------------------------
-# parse_structured_review_spec — T030 / T040 / test_040 / test_050
+# parse_structured_review_spec — strict (standard 0028)
 # ---------------------------------------------------------------------------
 
 class TestParseStructuredReviewSpec:
-    """T030 / test_040: Happy path and fallback for spec review."""
-
     def test_valid_json_structured_source(self):
         raw = json.dumps({
-            "verdict": "REVISE",
-            "rationale": "Missing diffs",
-            "feedback_items": ["Add diff for section 6"],
-        })
-        result = parse_structured_review_spec(raw)
-        assert result["verdict"] == "REVISE"
-        assert result["rationale"] == "Missing diffs"
-        assert result["feedback_items"] == ["Add diff for section 6"]
-        assert result["source"] == "structured"
-
-    def test_blocked_verdict_valid(self):
-        raw = json.dumps({
-            "verdict": "BLOCKED",
-            "rationale": "Cannot proceed",
+            "verdict": "APPROVED",
+            "rationale": "Spec is complete",
             "feedback_items": [],
         })
         result = parse_structured_review_spec(raw)
-        assert result["verdict"] == "BLOCKED"
+        assert result["verdict"] == "APPROVED"
         assert result["source"] == "structured"
 
-    def test_missing_feedback_items_falls_back(self):
-        # test_050: missing required key
-        raw = json.dumps({"verdict": "REVISE", "rationale": "ok"})
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_invalid_verdict_enum_falls_back(self):
+    def test_blocked_verdict_valid_in_review_spec(self):
         raw = json.dumps({
-            "verdict": "DISCUSS",  # not valid in REVIEW_SPEC_SCHEMA
+            "verdict": "BLOCKED",
+            "rationale": "Cannot implement",
+            "feedback_items": ["Missing API"],
+        })
+        result = parse_structured_review_spec(raw)
+        assert result["verdict"] == "BLOCKED"
+
+    def test_fenced_json_is_recovered_as_structured(self):
+        payload = json.dumps({
+            "verdict": "REVISE",
+            "rationale": "fix the tests",
+            "feedback_items": ["T010 is vague"],
+        })
+        result = parse_structured_review_spec(f"```json\n{payload}\n```")
+        assert result["source"] == "structured"
+
+    def test_markdown_response_rejects(self):
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec("[X] **APPROVED**\nNice spec.")
+
+    def test_missing_keys_rejects(self):
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec(json.dumps({"verdict": "APPROVED"}))
+
+    def test_invalid_enum_rejects(self):
+        raw = json.dumps({
+            "verdict": "DISCUSS",  # not in REVIEW_SPEC enum
             "rationale": "x",
             "feedback_items": [],
         })
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
+        with pytest.raises(StructuredContractError):
+            parse_structured_review_spec(raw)
 
-    def test_malformed_json_falls_back(self):
-        raw = "[X] **APPROVED**\n"
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug(self, mock_logger):
-        parse_structured_review_spec("bad json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=review_spec")
-
-    def test_structured_returns_structured_source(self):
-        raw = json.dumps({
-            "verdict": "APPROVED",
-            "rationale": "ok",
-            "feedback_items": [],
-        })
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "structured"
+    def test_rejection_names_parser(self):
+        with pytest.raises(StructuredContractError) as exc_info:
+            parse_structured_review_spec("")
+        assert exc_info.value.parser == "review_spec"
 
 
 # ---------------------------------------------------------------------------
-# parse_structured_draft_questions — T050 / test_060
+# scan_open_questions_section — document scan, not a parser (0028 §3)
 # ---------------------------------------------------------------------------
 
-class TestParseStructuredDraftQuestions:
-    """T050 / test_060: Happy path and fallback for draft questions."""
+class TestScanOpenQuestionsSection:
+    DOC = (
+        "# LLD-042\n\n"
+        "## Summary\nDesign.\n\n"
+        "## Open Questions\n"
+        "- [ ] Should the collector support IPv6?\n"
+        "- [x] Is 2s polling acceptable?\n"
+        "- [X] Uppercase checkbox too?\n\n"
+        "## 11. Rollback\nRevert.\n"
+    )
 
-    def test_valid_json_structured_source(self):
-        raw = json.dumps({
-            "open_questions": [
-                {"text": "What is the timeout?", "resolved": False},
-                {"text": "Rate limit decided", "resolved": True},
-            ]
-        })
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
-        assert len(result["open_questions"]) == 2
-        assert result["open_questions"][0]["text"] == "What is the timeout?"
-        assert result["open_questions"][0]["resolved"] is False
-
-    def test_empty_questions_list(self):
-        raw = json.dumps({"open_questions": []})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
-        assert result["open_questions"] == []
-
-    def test_missing_open_questions_key_falls_back(self):
-        raw = json.dumps({"something_else": []})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_malformed_json_falls_back(self):
-        raw = "## Open Questions\n- [ ] What is the timeout?\n- [X] Rate limit decided\n"
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-        assert len(result["open_questions"]) == 2
-
-    def test_empty_string_returns_regex_fallback(self):
-        result = parse_structured_draft_questions("")
-        assert result["source"] == "regex_fallback"
-        assert result["open_questions"] == []
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug(self, mock_logger):
-        parse_structured_draft_questions("not json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=draft_questions")
-
-    def test_structured_returns_structured_source(self):
-        raw = json.dumps({"open_questions": []})
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "structured"
-
-
-# ---------------------------------------------------------------------------
-# parse_structured_finalize_questions — T060 / test_070
-# ---------------------------------------------------------------------------
-
-class TestParseStructuredFinalizeQuestions:
-    """T060 / test_070: Happy path and fallback for finalize questions."""
-
-    def test_valid_json_with_questions(self):
-        raw = json.dumps({
-            "has_open_questions": True,
-            "question_count": 1,
-            "questions": ["What timeout value?"],
-        })
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "structured"
-        assert result["has_open_questions"] is True
-        assert result["question_count"] == 1
-        assert "What timeout value?" in result["questions"]
-
-    def test_valid_json_no_questions(self):
-        raw = json.dumps({
-            "has_open_questions": False,
-            "question_count": 0,
-            "questions": [],
-        })
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "structured"
-        assert result["has_open_questions"] is False
-        assert result["question_count"] == 0
-
-    def test_missing_required_key_falls_back(self):
-        raw = json.dumps({"has_open_questions": True})
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "regex_fallback"
-
-    def test_malformed_json_falls_back(self):
-        raw = "## Section\nWhat is the timeout?\n"
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "regex_fallback"
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_fallback_logs_debug(self, mock_logger):
-        parse_structured_finalize_questions("bad json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=finalize_questions")
-
-    def test_structured_returns_structured_source(self):
-        raw = json.dumps({
-            "has_open_questions": False,
-            "question_count": 0,
-            "questions": [],
-        })
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "structured"
-
-
-# ---------------------------------------------------------------------------
-# _regex_fallback_verdict
-# ---------------------------------------------------------------------------
-
-class TestRegexFallbackVerdict:
-    def test_approved_checkbox(self):
-        raw = "[X] **APPROVED**\n\nRationale: Looks good"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-        assert result["source"] == "regex_fallback"
-
-    def test_revise_checkbox(self):
-        raw = "[X] **REVISE**\n"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "REVISE"
-
-    def test_discuss_checkbox(self):
-        raw = "[X] **DISCUSS**\n"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "DISCUSS"
-
-    def test_blocked_checkbox(self):
-        raw = "[X] **BLOCKED**\n"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "BLOCKED"
-
-    def test_case_insensitive(self):
-        raw = "[x] **approved**"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "APPROVED"
-
-    def test_no_match_returns_unknown(self):
-        raw = "This is just plain text"
-        result = _regex_fallback_verdict(raw)
-        assert result["verdict"] == "UNKNOWN"
-        assert result["rationale"] == ""
-
-    def test_extracts_rationale(self):
-        raw = "[X] **APPROVED**\n\nRationale: This is the reason\n\n## Section"
-        result = _regex_fallback_verdict(raw)
-        assert "reason" in result["rationale"].lower() or "rationale" in result["rationale"].lower() or result["rationale"] != ""
-
-    def test_never_raises(self):
-        # Should not raise on any input
-        _regex_fallback_verdict(None)  # type: ignore
-        _regex_fallback_verdict(123)   # type: ignore
-
-    def test_regex_helper_does_not_log_fallback_metric(self):
-        with patch("assemblyzero.core.verdict_schema.logger") as mock_logger:
-            _regex_fallback_verdict("[X] **APPROVED**")
-            # _regex_fallback_verdict logs warnings but NOT the debug metric line
-            for c in mock_logger.debug.call_args_list:
-                assert "regex_fallback" not in str(c)
-
-    def test_logs_warning(self, caplog):
-        with caplog.at_level(logging.WARNING, logger="assemblyzero.core.verdict_schema"):
-            _regex_fallback_verdict("[X] **APPROVED**")
-        assert any("regex fallback" in r.message.lower() or "fallback" in r.message.lower()
-                   for r in caplog.records)
-
-
-# ---------------------------------------------------------------------------
-# _regex_fallback_feedback
-# ---------------------------------------------------------------------------
-
-class TestRegexFallbackFeedback:
-    def test_extracts_verdict_and_feedback_items(self):
-        raw = "[X] **REVISE**\n\n## Feedback\n- Fix error handling\n- Add missing tests\n"
-        result = _regex_fallback_feedback(raw)
-        assert result["verdict"] == "REVISE"
-        assert "Fix error handling" in result["feedback_items"]
-        assert "Add missing tests" in result["feedback_items"]
-        assert result["source"] == "regex_fallback"
-
-    def test_extracts_open_questions(self):
-        raw = "[X] **REVISE**\n\n## Open Questions\n- [ ] What timeout value?\n- [X] Should we retry?\n"
-        result = _regex_fallback_feedback(raw)
-        assert any(q["text"] == "What timeout value?" and not q["resolved"]
-                   for q in result["open_questions"])
-        assert any(q["text"] == "Should we retry?" and q["resolved"]
-                   for q in result["open_questions"])
-
-    def test_empty_input_returns_unknown(self):
-        result = _regex_fallback_feedback("")
-        assert result["verdict"] == "UNKNOWN"
-        assert result["feedback_items"] == []
-        assert result["open_questions"] == []
-
-    def test_regex_helper_does_not_log_fallback_metric(self):
-        with patch("assemblyzero.core.verdict_schema.logger") as mock_logger:
-            _regex_fallback_feedback("[X] **APPROVED**")
-            # _regex_fallback_feedback logs warnings but NOT the debug metric line
-            for c in mock_logger.debug.call_args_list:
-                assert "regex_fallback" not in str(c)
-
-    def test_extracts_resolved_issues(self):
-        raw = "[X] **APPROVED**\n\n## Resolved Issues\n- Fixed missing type annotation\n"
-        result = _regex_fallback_feedback(raw)
-        assert "Fixed missing type annotation" in result["resolved_issues"]
-
-    def test_required_changes_section_fallback(self):
-        raw = "[X] **REVISE**\n\n## Required Changes\n- Update the spec\n"
-        result = _regex_fallback_feedback(raw)
-        assert "Update the spec" in result["feedback_items"]
-
-
-# ---------------------------------------------------------------------------
-# _regex_fallback_draft_questions
-# ---------------------------------------------------------------------------
-
-class TestRegexFallbackDraftQuestions:
     def test_extracts_unchecked_and_checked(self):
-        raw = "## Open Questions\n- [ ] What is the timeout?\n- [X] Rate limit decided\n"
-        result = _regex_fallback_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-        unchecked = [q for q in result["open_questions"] if not q["resolved"]]
-        checked = [q for q in result["open_questions"] if q["resolved"]]
-        assert len(unchecked) == 1
-        assert unchecked[0]["text"] == "What is the timeout?"
-        assert len(checked) == 1
-        assert checked[0]["text"] == "Rate limit decided"
+        result = scan_open_questions_section(self.DOC)
+        texts = {q["text"]: q["resolved"] for q in result["open_questions"]}
+        assert texts["Should the collector support IPv6?"] is False
+        assert texts["Is 2s polling acceptable?"] is True
+        assert texts["Uppercase checkbox too?"] is True
+
+    def test_source_is_document_scan(self):
+        assert scan_open_questions_section(self.DOC)["source"] == "document_scan"
 
     def test_no_section_returns_empty(self):
-        raw = "Some content without open questions section."
-        result = _regex_fallback_draft_questions(raw)
+        result = scan_open_questions_section("# Doc\n\n## Summary\nText.\n")
         assert result["open_questions"] == []
-        assert result["source"] == "regex_fallback"
 
-    def test_regex_helper_does_not_log_fallback_metric(self):
-        with patch("assemblyzero.core.verdict_schema.logger") as mock_logger:
-            _regex_fallback_draft_questions("## Open Questions\n- [ ] Q1\n")
-            # _regex_fallback_draft_questions logs warnings but NOT the debug metric line
-            for c in mock_logger.debug.call_args_list:
-                assert "regex_fallback" not in str(c)
+    def test_empty_text_returns_empty(self):
+        assert scan_open_questions_section("")["open_questions"] == []
+
+    def test_heading_with_parenthetical_suffix(self):
+        doc = "## Open Questions (2 remaining)\n- [ ] One?\n"
+        result = scan_open_questions_section(doc)
+        assert len(result["open_questions"]) == 1
+
+    def test_scan_stops_at_next_heading(self):
+        doc = (
+            "## Open Questions\n- [ ] Real question?\n"
+            "## Notes\n- [ ] Not a question, different section\n"
+        )
+        result = scan_open_questions_section(doc)
+        assert len(result["open_questions"]) == 1
+
+    def test_json_input_has_no_section(self):
+        """The scanner reads documents; JSON is not a document with sections."""
+        raw = json.dumps({"open_questions": [{"text": "Q?", "resolved": False}]})
+        assert scan_open_questions_section(raw)["open_questions"] == []
 
 
 # ---------------------------------------------------------------------------
-# _regex_fallback_finalize_questions
+# scan_residual_questions — document scan, not a parser (0028 §3)
 # ---------------------------------------------------------------------------
 
-class TestRegexFallbackFinalizeQuestions:
+class TestScanResidualQuestions:
     def test_detects_question_lines(self):
-        raw = "## Requirements\n\nWhat timeout value?\nThe system shall process requests.\n"
-        result = _regex_fallback_finalize_questions(raw)
-        assert result["source"] == "regex_fallback"
+        text = "All good.\nBut what about the frobnicator?\nDone."
+        result = scan_residual_questions(text)
         assert result["has_open_questions"] is True
-        assert "What timeout value?" in result["questions"]
+        assert "But what about the frobnicator?" in result["questions"]
+
+    def test_short_question_mark_filtered(self):
+        result = scan_residual_questions("Why?\nAll good.")
+        assert result["has_open_questions"] is False
 
     def test_detects_todo_markers(self):
-        raw = "## Design\n\nTODO: determine rate limit\nImplement retry logic.\n"
-        result = _regex_fallback_finalize_questions(raw)
+        result = scan_residual_questions("Line one.\nTODO: wire up the collector\n")
         assert result["has_open_questions"] is True
         assert any("TODO" in q for q in result["questions"])
 
-    def test_no_questions_or_todos(self):
-        raw = "## Section\n\nThe system shall process requests within 200ms.\n"
-        result = _regex_fallback_finalize_questions(raw)
+    def test_clean_text_has_none(self):
+        result = scan_residual_questions("Everything is finished.\nShip it.")
         assert result["has_open_questions"] is False
         assert result["question_count"] == 0
-        assert result["questions"] == []
 
-    def test_short_question_mark_filtered(self):
-        # Single "?" or very short lines should not be counted
-        raw = "?\n"
-        result = _regex_fallback_finalize_questions(raw)
+    def test_empty_text(self):
+        result = scan_residual_questions("")
         assert result["has_open_questions"] is False
+        assert result["source"] == "document_scan"
 
-    def test_regex_helper_does_not_log_fallback_metric(self):
-        with patch("assemblyzero.core.verdict_schema.logger") as mock_logger:
-            _regex_fallback_finalize_questions("What timeout?")
-            # _regex_fallback_finalize_questions logs warnings but NOT the debug metric line
-            for c in mock_logger.debug.call_args_list:
-                assert "regex_fallback" not in str(c)
-
-    def test_question_count_matches_questions_list(self):
-        raw = "What is the timeout?\nWhat is the retry count?\nTODO: fix this\n"
-        result = _regex_fallback_finalize_questions(raw)
+    def test_question_count_matches_list(self):
+        text = "Is this right?\nWhat about that other thing?\nTODO: check"
+        result = scan_residual_questions(text)
         assert result["question_count"] == len(result["questions"])
 
 
 # ---------------------------------------------------------------------------
-# _extract_section_from_markdown
+# StructuredContractError
 # ---------------------------------------------------------------------------
 
-class TestExtractSectionFromMarkdown:
-    def test_extracts_named_section(self):
-        content = "## Intro\n\nIntro text.\n\n## Feedback\n\nFeedback text.\n\n## Next\n\nNext text."
-        result = _extract_section_from_markdown(content, "Feedback")
-        assert "Feedback text" in result
+class TestStructuredContractError:
+    def test_carries_parser_reason_excerpt(self):
+        err = StructuredContractError("feedback", "Missing required keys", "raw body here")
+        assert err.parser == "feedback"
+        assert err.reason == "Missing required keys"
+        assert "raw body here" in str(err)
 
-    def test_returns_empty_string_when_not_found(self):
-        content = "## Intro\n\nIntro text.\n"
-        result = _extract_section_from_markdown(content, "Missing Section")
-        assert result == ""
+    def test_empty_raw_says_so(self):
+        err = StructuredContractError("feedback", "no JSON object found", "")
+        assert "response empty" in str(err)
 
-    def test_handles_section_with_suffix(self):
-        content = "## Open Questions (3 remaining)\n\n- [ ] Q1\n\n## Next\n"
-        result = _extract_section_from_markdown(content, "Open Questions")
-        assert "Q1" in result
-
-    def test_case_insensitive(self):
-        content = "## FEEDBACK\n\nSome feedback.\n"
-        result = _extract_section_from_markdown(content, "Feedback")
-        assert "feedback" in result.lower()
-
-    def test_last_section_no_trailing_header(self):
-        content = "## Feedback\n\nEnd content."
-        result = _extract_section_from_markdown(content, "Feedback")
-        assert "End content" in result
+    def test_excerpt_is_bounded(self):
+        err = StructuredContractError("feedback", "reason", "x" * 500)
+        assert len(err.excerpt) == 160
 
 
 # ---------------------------------------------------------------------------
-# TypedDict structure tests
+# TypedDict structures
 # ---------------------------------------------------------------------------
 
 class TestTypedDictStructures:
     def test_verdict_result_fields(self):
         result = VerdictResult(verdict="APPROVED", rationale="ok", source="structured")
         assert result["verdict"] == "APPROVED"
-        assert result["rationale"] == "ok"
-        assert result["source"] == "structured"
 
     def test_feedback_result_fields(self):
         result = FeedbackResult(
-            verdict="REVISE",
-            rationale="needs work",
-            feedback_items=["item1"],
-            open_questions=[],
-            resolved_issues=[],
-            source="structured",
+            verdict="REVISE", rationale="r", feedback_items=[],
+            open_questions=[], resolved_issues=[], source="structured",
         )
-        assert result["verdict"] == "REVISE"
-        assert result["feedback_items"] == ["item1"]
+        assert result["source"] == "structured"
 
     def test_review_spec_result_fields(self):
         result = ReviewSpecResult(
-            verdict="BLOCKED",
-            rationale="cannot proceed",
-            feedback_items=[],
-            source="regex_fallback",
+            verdict="BLOCKED", rationale="r", feedback_items=["x"], source="structured",
         )
-        assert result["verdict"] == "BLOCKED"
-        assert result["source"] == "regex_fallback"
+        assert result["feedback_items"] == ["x"]
 
     def test_draft_questions_result_fields(self):
-        result = DraftQuestionsResult(
-            open_questions=[{"text": "Q?", "resolved": False}],
-            source="structured",
-        )
-        assert len(result["open_questions"]) == 1
+        result = DraftQuestionsResult(open_questions=[], source="document_scan")
+        assert result["open_questions"] == []
 
     def test_finalize_questions_result_fields(self):
         result = FinalizeQuestionsResult(
-            has_open_questions=False,
-            question_count=0,
-            questions=[],
-            source="structured",
+            has_open_questions=False, question_count=0, questions=[],
+            source="document_scan",
         )
-        assert result["has_open_questions"] is False
-
-
-# ---------------------------------------------------------------------------
-# Counter metric emission — T150 / test_150
-# ---------------------------------------------------------------------------
-
-class TestFallbackDebugLogging:
-    """T150: logger.debug called on every fallback invocation."""
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_feedback_fallback_logs_debug(self, mock_logger):
-        parse_structured_feedback("not json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=feedback")
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_review_spec_fallback_logs_debug(self, mock_logger):
-        parse_structured_review_spec("not json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=review_spec")
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_draft_questions_fallback_logs_debug(self, mock_logger):
-        parse_structured_draft_questions("not json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=draft_questions")
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_finalize_questions_fallback_logs_debug(self, mock_logger):
-        parse_structured_finalize_questions("not json")
-        mock_logger.debug.assert_any_call("verdict_schema.regex_fallback parser=finalize_questions")
-
-    @patch("assemblyzero.core.verdict_schema.logger")
-    def test_no_fallback_metric_from_regex_helpers(self, mock_logger):
-        # _regex_fallback_feedback does NOT log the debug metric line itself
-        _regex_fallback_feedback("[X] **APPROVE**")
-        for c in mock_logger.debug.call_args_list:
-            assert "regex_fallback" not in str(c)
-
-    def test_structured_success_returns_structured_source(self):
-        raw = json.dumps({
-            "verdict": "APPROVED",
-            "rationale": "ok",
-            "feedback_items": [],
-            "open_questions": [],
-        })
-        result = parse_structured_feedback(raw)
-        assert result["source"] == "structured"
-
-
-# ---------------------------------------------------------------------------
-# Edge cases and integration scenarios
-# ---------------------------------------------------------------------------
-
-class TestEdgeCases:
-    def test_parse_structured_feedback_none_input(self):
-        result = parse_structured_feedback(None)  # type: ignore
-        assert result["source"] == "regex_fallback"
-        assert result["verdict"] == "UNKNOWN"
-
-    def test_parse_structured_review_spec_none_input(self):
-        result = parse_structured_review_spec(None)  # type: ignore
-        assert result["source"] == "regex_fallback"
-
-    def test_parse_structured_draft_questions_none_input(self):
-        result = parse_structured_draft_questions(None)  # type: ignore
-        assert result["source"] == "regex_fallback"
-
-    def test_parse_structured_finalize_questions_none_input(self):
-        result = parse_structured_finalize_questions(None)  # type: ignore
-        assert result["source"] == "regex_fallback"
-
-    def test_feedback_with_no_resolved_issues_key(self):
-        # resolved_issues is optional in schema; missing => defaults to []
-        raw = json.dumps({
-            "verdict": "APPROVED",
-            "rationale": "ok",
-            "feedback_items": [],
-            "open_questions": [],
-        })
-        result = parse_structured_feedback(raw)
-        assert result["resolved_issues"] == []
-        assert result["source"] == "structured"
-
-    def test_review_spec_fallback_extracts_feedback_items(self):
-        raw = "[X] **REVISE**\n\n## Feedback\n- Fix section 6\n- Add diffs\n"
-        result = parse_structured_review_spec(raw)
-        assert result["source"] == "regex_fallback"
-        assert "Fix section 6" in result["feedback_items"]
-
-    def test_finalize_questions_both_question_and_todo(self):
-        raw = "What is the timeout?\nTODO: fix this\n"
-        result = parse_structured_finalize_questions(raw)
-        assert result["source"] == "regex_fallback"
-        assert result["has_open_questions"] is True
-        assert result["question_count"] >= 2
-
-    def test_draft_questions_stops_at_next_section(self):
-        raw = "## Open Questions\n- [ ] Q1\n- [ ] Q2\n\n## Other Section\n- [ ] Not a question\n"
-        result = parse_structured_draft_questions(raw)
-        assert result["source"] == "regex_fallback"
-        # Should only find questions from the Open Questions section
-        texts = [q["text"] for q in result["open_questions"]]
-        assert "Q1" in texts
-        assert "Q2" in texts
-        assert "Not a question" not in texts
+        assert result["question_count"] == 0


### PR DESCRIPTION
## Summary

Lands standard 0028 — **ask structured, get structured, or reject** (operator ruling, 2026-08-10) — and its implementation: every regex fallback is stripped from the structured-output contract. A schema-violating model response now raises `StructuredContractError` (parser name, reason, bounded excerpt — #2197 legibility), the node surfaces it as its error, and the existing stage-retry machinery is the bounded re-ask. Nothing is scraped, nothing is silently downgraded.

The #2199 incident is the case study written into the standard: the regex fallback provided silence, not resilience — twelve approved LLDs discarded over eight days because an inevitable empty scrape was trusted as an answer.

## What changed where

**Strict model contracts** (all already schema-enforced at the provider, so violations are rare and rejection is cheap):
- `parse_structured_feedback` / `parse_structured_review_spec` raise instead of scraping; the four `_regex_fallback_*` scrapers and `_extract_section_from_markdown` are deleted.
- requirements `review` node: rejection → `error_message` → stage retry (the #1766 UNKNOWN block is retired — UNKNOWN can no longer exist).
- implementation-spec `review_spec`: rejection joins the existing `(None, error)` infrastructure-failure path; the legacy `parse_review_verdict` is strict and its UNKNOWN/DISCUSS silent downgrade is gone.
- testing `review_test_plan`: `_parse_verdict` (structured-then-scrape) deleted; no schema-valid verdict → loud `error_message` with excerpt, never a synthesized BLOCKED.
- **MockProvider's canned review response was markdown** — mock-mode reviews would have been rejected forever; it now returns a schema-valid JSON verdict. Mocks honor the contract like every other provider.

**Document scans, no longer cosplaying as parsers** (standard 0028 §3):
- `scan_open_questions_section` and `scan_residual_questions` — string-operation scans of the pipeline's own markdown, replacing `parse_structured_draft_questions` / `parse_structured_finalize_questions`, whose inputs were never model JSON (the "structured parse" failed by construction on every call and the regex branch was the actual mechanism).
- The drafter invocation no longer carries `DRAFT_QUESTIONS_SCHEMA` while its prompt demands "emit ONLY the revised markdown" — two contradictory contracts on one ask, a plausible contributor to the truncated revisions tracked in #2200.

**JSON recovery stays** (standard 0028 §2): stripping ```json fences or prose around a JSON object that must still pass `json.loads` + key + enum validation is recovery, not scraping — pinned by tests.

- `docs/standards/0028-structured-or-reject.md` — the standard itself.

## Tests

Ten test files reworked: every fallback-pinned case converted to a rejection pin (raises with the parser named) or a scan-semantics pin; node-level harnesses now feed schema-valid JSON where they fed markdown. Full suite locally: **7116 passed, 17 skipped, zero failures** (count is lower than pre-change because retired fallback tests were consolidated). Lint: zero new findings versus main on every touched file.

Closes #2202
Closes #2203
