### PR TITLE
feat(speedrun): retire the redraw loop; guard resumes against stale drafts (Closes #2206)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -39,7 +39,7 @@ than transcribed:
 |---|---|
 | `--repo` | target repo root (required) |
 | `--issue` | issue to roll — **repeatable**, rolled in order |
-| `--attempts` | redraw a failed issue up to N times before stopping. Base/gate problems never retry. |
+| `--attempts` | retired by operator ruling #2206 — only `1` is accepted, and a higher value refuses at preflight before anything is spent. A failure halts so its cause can be found; the relaunch resumes from the failed stage (#2193) rather than re-paying for the stages that passed. |
 | `--detach` | run via Windows Task Scheduler so the roll outlives this session — then **stay attached, streaming the roll's output into this console** until it finishes (#2138) |
 | `--no-follow` | with `--detach`: hand off and return immediately instead of streaming (for scripted callers) |
 | `--follow` | re-attach to a roll already running and stream its output here. Takes no `--issue` |
@@ -126,15 +126,17 @@ stage is normal, a stopped heartbeat is not:
 2026-08-01 05:23:33 alive
 ```
 
-**A backoff is not a hang.** When the model provider stops answering, the
-launcher waits rather than burning a fresh attempt on the same wall, and says so:
+**A dead provider ends the issue immediately (#2206).** When the model provider
+stops answering, the roll says so and stops — with no redraw to protect, there
+is nothing to wait for:
 
 ```
-STORM BACKOFF 15m before attempt 2/3
+STORM ended #4 -- the provider stopped answering; nothing was redrawn (#2206). Relaunch when it recovers.
 ```
 
-Waits are 15, then 30, then 60 minutes, capped at 60. A storm on the final
-attempt exits immediately rather than waiting for nothing.
+The former behaviour — waiting 15, then 30, then 60 minutes before redrawing —
+went with the redraw loop. Relaunch once the provider recovers; the stages that
+already passed resume rather than re-run.
 
 **The one rule from the watchdog doctrine:** a stage running past three times its
 nominal is a fault, not patience. Waiting longer has never once helped.

--- a/tests/unit/test_healing_ledger.py
+++ b/tests/unit/test_healing_ledger.py
@@ -163,27 +163,16 @@ class TestLauncherHooks:
         assert janitor and janitor[0]["outcome"] == "healed"
         assert "LLD-002.md" in janitor[0]["target"]
 
-    def test_a_storm_backoff_writes_a_heal_record(self, tmp_path):
-        repo = tmp_path / "proj"
-        (repo / ".git").mkdir(parents=True)
-        from assemblyzero.core.provider_storm import STORM_EXIT_CODE
+    def test_a_storm_is_recorded_without_a_backoff_heal(self):
+        """#2206 retired the redraw loop, and the storm BACKOFF heal with it:
+        a heal records something the machinery fixed about itself, and with
+        no redraw to protect there is no wait to record. The storm is still
+        announced in the events log -- pinned in test_provider_storm.py."""
+        import inspect
 
-        rolls = iter([STORM_EXIT_CODE, 0])
-
-        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
-                patch.object(sr, "check_box_health", _healthy_box), \
-                patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
-                patch.object(sr, "roll_issue", lambda *a: next(rolls)), \
-                patch.object(sr, "restore_repo", lambda *a: []), \
-                patch.object(sr, "_interruptible_sleep", lambda s: None), \
-                patch.object(sr.time, "sleep", lambda s: None):
-            code = sr.main(["--repo", str(repo), "--issue", "7",
-                            "--attempts", "2"])
-
-        assert code == 0
-        storms = [h for h in read_heals(repo) if h["category"] == "storm-backoff"]
-        assert storms and storms[0]["target"] == "#7"
-        assert "waited" in storms[0]["detail"]
+        source = inspect.getsource(sr.main)
+        assert "storm-backoff" not in source
+        assert "STORM ended" in source
 
 
 class TestEvidenceExemption:

--- a/tests/unit/test_must_resolve_preflight.py
+++ b/tests/unit/test_must_resolve_preflight.py
@@ -187,13 +187,14 @@ def test_gate_runs_once_per_invocation_not_per_redraw(
 
     monkeypatch.setattr(speedrun_roll, "roll_issue", failing_roll)
 
-    speedrun_roll.main(_argv(target_repo, 4, 9, 12) + ["--attempts", "3"])
+    speedrun_roll.main(_argv(target_repo, 4, 9, 12) + ["--attempts", "1"])
 
-    # The launcher stops the batch at the first issue that exhausts its
-    # attempts, so #4 redraws three times and #9/#12 never start. Three rolls of
-    # ONE issue is exactly the redraw storm this assertion needs.
-    assert launcher["rolls"] == [4, 4, 4], "redraws must actually have happened"
-    assert calls["n"] == 1, "the wall is checked once, not once per redraw"
+    # #2206 retired redraws, so the batch halts at the first failure: #4
+    # rolls once and #9/#12 never start. The invariant this test protects --
+    # the wall is queried once per invocation, never once per roll -- holds
+    # more simply than it did when redraws could multiply the queries.
+    assert launcher["rolls"] == [4], "one roll per issue, then the batch halts"
+    assert calls["n"] == 1, "the wall is checked once per invocation"
 
 
 # --- "a batch is refused as a whole, not partially rolled" ---------------

--- a/tests/unit/test_no_retries.py
+++ b/tests/unit/test_no_retries.py
@@ -1,0 +1,267 @@
+"""Automatic retries are deauthorized; drafts go stale (#2206).
+
+Two halves of one operator ruling, both earned on 2026-08-10/11:
+
+1. The redraw loop is retired. A failed roll halts so its cause can be found;
+   the relaunch resumes from the failed stage (#2193) rather than re-paying
+   for the passed ones. The day that forced it: six spec halts on one issue,
+   every one systematic, every redraw a re-run of a known result.
+
+2. A resumed draft must still be derived from current law. The live case —
+   an LLD drafted at 01:27Z, invalidated by design-doc rulings merged at
+   05:13Z and 06:18Z, while the issue's own text last changed at 01:10Z,
+   BEFORE the draft — proves an issue-only staleness check is insufficient.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+ARC = "hardening-run-17"
+DRAFTED = "2026-08-11T01:27:12Z"
+BEFORE_DRAFT = "2026-08-11T01:10:43Z"   # the real issue-edit time that night
+AFTER_DRAFT = "2026-08-11T06:18:28Z"    # the real doc-ruling merge time
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    root = tmp_path / "target"
+    root.mkdir()
+    for args in (["init", "-q", "-b", "main"],
+                 ["config", "user.email", "t@example.com"],
+                 ["config", "user.name", "Test"]):
+        subprocess.run(["git", "-C", str(root), *args], capture_output=True)
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "."], capture_output=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "base"], capture_output=True)
+    return root
+
+
+@pytest.fixture
+def log(tmp_path) -> "speedrun_roll.EventLog":
+    return speedrun_roll.EventLog(tmp_path / "session-events.log")
+
+
+def fake_runner(issue_ts: str, doc_ts: str, *, issue_rc: int = 0, doc_rc: int = 0):
+    """Stub _run: answers the issue-time probe and the doc-history probe."""
+    def _run(cmd, cwd=None):
+        if cmd and cmd[0] == "gh":
+            return subprocess.CompletedProcess(cmd, issue_rc, issue_ts, "")
+        if cmd and cmd[0] == "git" and "log" in cmd:
+            return subprocess.CompletedProcess(cmd, doc_rc, doc_ts, "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Half 1 — the redraw loop is retired
+# ---------------------------------------------------------------------------
+
+
+def test_attempts_above_one_refuses_before_spending(monkeypatch, repo, capsys):
+    """The refusal lands before any gate, so nothing is spent."""
+    spent: list[str] = []
+    monkeypatch.setattr(
+        speedrun_roll, "check_assemblyzero_tree",
+        lambda *_a: spent.append("tree-gate") or [],
+    )
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a: spent.append("health-gate"),
+    )
+    monkeypatch.setattr(speedrun_roll, "roll_issue", lambda *a: spent.append("roll") or 0)
+
+    code = speedrun_roll.main([
+        "--repo", str(repo), "--issue", "1", "--attempts", "3",
+    ])
+
+    assert code == 91
+    assert spent == [], f"a refused launch must spend nothing, ran: {spent}"
+    out = capsys.readouterr().out
+    assert "#2206" in out
+    assert "--attempts 1" in out
+
+
+def test_attempts_one_is_accepted(monkeypatch, repo):
+    """The sanctioned value passes the gate."""
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda *_a: [])
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a: type("H", (), {"ok": True, "message": ""})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "check_prereqs", lambda *_a: None)
+    monkeypatch.setattr(
+        speedrun_roll, "sweep_pipeline_worktrees",
+        lambda *_a, **_k: type("S", (), {"problems": [], "entries": []})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "classify_dirt", lambda *_a: ([], []))
+    monkeypatch.setattr(speedrun_roll, "untracked_files", lambda *_a: [])
+    monkeypatch.setattr(speedrun_roll, "restore_repo", lambda *a: [])
+    monkeypatch.setattr(speedrun_roll, "print_verdict", lambda *a, **k: None)
+    monkeypatch.setattr(speedrun_roll, "resume_plan", lambda *a: None)
+    rolls: list[int] = []
+    monkeypatch.setattr(
+        speedrun_roll, "roll_issue", lambda *a: rolls.append(a[1]) or 0,
+    )
+
+    code = speedrun_roll.main([
+        "--repo", str(repo), "--issue", "1", "--attempts", "1",
+    ])
+
+    assert code == 0
+    assert rolls == [1]
+
+
+def test_a_failure_rolls_the_issue_exactly_once(monkeypatch, repo):
+    """The heart of the ruling: failure does not redraw."""
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda *_a: [])
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a: type("H", (), {"ok": True, "message": ""})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "check_prereqs", lambda *_a: None)
+    monkeypatch.setattr(
+        speedrun_roll, "sweep_pipeline_worktrees",
+        lambda *_a, **_k: type("S", (), {"problems": [], "entries": []})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "classify_dirt", lambda *_a: ([], []))
+    monkeypatch.setattr(speedrun_roll, "untracked_files", lambda *_a: [])
+    monkeypatch.setattr(speedrun_roll, "restore_repo", lambda *a: [])
+    monkeypatch.setattr(speedrun_roll, "print_verdict", lambda *a, **k: None)
+    monkeypatch.setattr(speedrun_roll, "resume_plan", lambda *a: None)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        speedrun_roll, "roll_issue", lambda *a: calls.append(a[1]) or 1,
+    )
+
+    code = speedrun_roll.main([
+        "--repo", str(repo), "--issue", "1", "--issue", "7", "--attempts", "1",
+    ])
+
+    assert code == 1
+    assert calls == [1], "the failed issue must roll once and stop the batch"
+
+
+def test_a_storm_does_not_wait_or_redraw(monkeypatch, repo):
+    """With one roll per issue there is nothing to back off for."""
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda *_a: [])
+    monkeypatch.setattr(
+        speedrun_roll, "check_box_health",
+        lambda *_a: type("H", (), {"ok": True, "message": ""})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "check_prereqs", lambda *_a: None)
+    monkeypatch.setattr(
+        speedrun_roll, "sweep_pipeline_worktrees",
+        lambda *_a, **_k: type("S", (), {"problems": [], "entries": []})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "classify_dirt", lambda *_a: ([], []))
+    monkeypatch.setattr(speedrun_roll, "untracked_files", lambda *_a: [])
+    monkeypatch.setattr(speedrun_roll, "restore_repo", lambda *a: [])
+    monkeypatch.setattr(speedrun_roll, "print_verdict", lambda *a, **k: None)
+    monkeypatch.setattr(speedrun_roll, "resume_plan", lambda *a: None)
+
+    def _no_sleep(*_a, **_k):  # pragma: no cover - the assertion IS the test
+        raise AssertionError("a storm must not wait when nothing will be redrawn")
+
+    monkeypatch.setattr(speedrun_roll, "_interruptible_sleep", _no_sleep)
+    calls: list[int] = []
+    monkeypatch.setattr(
+        speedrun_roll, "roll_issue",
+        lambda *a: calls.append(a[1]) or speedrun_roll.STORM_EXIT_CODE,
+    )
+
+    speedrun_roll.main(["--repo", str(repo), "--issue", "1", "--attempts", "1"])
+
+    assert calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# Half 2 — a draft goes stale when binding inputs move
+# ---------------------------------------------------------------------------
+
+
+def test_doc_ruling_after_the_draft_is_stale(monkeypatch, repo, log):
+    """The live case: docs moved after the draft, issue text did not."""
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, AFTER_DRAFT),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+
+
+def test_issue_edit_after_the_draft_is_stale(monkeypatch, repo, log):
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner(AFTER_DRAFT, BEFORE_DRAFT),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+
+
+def test_current_draft_is_not_stale(monkeypatch, repo, log):
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is False
+
+
+def test_repo_with_no_doc_history_is_not_stale(monkeypatch, repo, log):
+    """An empty probe result means no binding doc has ever changed."""
+    monkeypatch.setattr(speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, ""))
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is False
+
+
+def test_unknowable_answers_are_stale(monkeypatch, repo, log):
+    """Every probe failure draws fresh, which is always safe."""
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT, issue_rc=1),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT, doc_rc=1),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+
+    monkeypatch.setattr(
+        speedrun_roll, "_run", fake_runner("not-a-time", BEFORE_DRAFT),
+    )
+    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+
+
+def test_missing_draft_time_is_stale(repo, log):
+    assert speedrun_roll.draft_is_stale(repo, 1, "", ARC, log) is True
+
+
+def test_resume_plan_refuses_a_stale_draft(monkeypatch, repo, log, tmp_path):
+    """End to end: every other guard passes, staleness alone draws fresh."""
+    az_root = tmp_path / "az"
+    state_dir = az_root / ".assemblyzero" / "orchestrator" / "state"
+    state_dir.mkdir(parents=True)
+    lld = repo / "docs" / "lld" / "active" / "LLD-001.md"
+    lld.parent.mkdir(parents=True)
+    lld.write_text("# LLD\n", encoding="utf-8")
+    (state_dir / "1.json").write_text(json.dumps({
+        "issue_number": 1,
+        "target_repo": str(repo),
+        "base_branch": ARC,
+        "started_at": DRAFTED,
+        "lld_path": str(lld),
+        "stage_results": {
+            "lld": {"status": "passed"},
+            "spec": {"status": "failed", "error_message": "cap reached"},
+        },
+    }), encoding="utf-8")
+    monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+    monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+
+    monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: False)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) == "spec"
+
+    monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: True)
+    assert speedrun_roll.resume_plan(az_root, repo, 1, log) is None

--- a/tests/unit/test_provider_storm.py
+++ b/tests/unit/test_provider_storm.py
@@ -157,87 +157,51 @@ def launcher(monkeypatch, target_repo):
     return state
 
 
-def _argv(repo, attempts=3):
+def _argv(repo, attempts=1):
     return ["--repo", str(repo), "--issue", "4", "--attempts", str(attempts),
             "--log-dir", str(repo / "logs")]
 
 
-def test_a_storm_attempt_delays_the_next_redraw(launcher, target_repo):
+def test_a_storm_ends_the_issue_without_waiting(launcher, target_repo):
+    """#2206: with one roll per issue there is nothing to back off FOR. The
+    wait existed to keep the next redraw off the same wall; with no next
+    redraw, waiting only delays the operator learning the provider is down."""
     launcher["codes"] = [STORM_EXIT_CODE, 0]
 
-    speedrun_roll.main(_argv(target_repo))
+    code = speedrun_roll.main(_argv(target_repo))
 
-    assert launcher["slept"] == [15 * 60], "the first storm waits 15 minutes"
-
-
-def test_a_non_storm_failure_redraws_immediately(launcher, target_repo):
-    launcher["codes"] = [1, 0]
-
-    speedrun_roll.main(_argv(target_repo))
-
-    assert launcher["slept"] == [], "an ordinary failed draw waits for nothing"
-
-
-def test_consecutive_storms_escalate_then_cap(launcher, target_repo):
-    launcher["codes"] = [STORM_EXIT_CODE] * 5
-
-    speedrun_roll.main(_argv(target_repo, attempts=5))
-
-    assert launcher["slept"] == [15 * 60, 30 * 60, 60 * 60, 60 * 60]
-
-
-def test_a_success_between_storms_resets_the_backoff(launcher, target_repo):
-    # storm, ordinary failure, storm -> the second storm is a FIRST storm again
-    launcher["codes"] = [STORM_EXIT_CODE, 1, STORM_EXIT_CODE, 0]
-
-    speedrun_roll.main(_argv(target_repo, attempts=4))
-
-    assert launcher["slept"] == [15 * 60, 15 * 60]
-
-
-# --- "a storm on the final attempt exits without waiting" ---------------
-
-
-def test_storm_on_the_final_attempt_does_not_wait(launcher, target_repo):
-    launcher["codes"] = [STORM_EXIT_CODE]
-
-    code = speedrun_roll.main(_argv(target_repo, attempts=1))
-
-    assert launcher["slept"] == [], "a terminal wait only delays the bad news"
+    assert launcher["slept"] == [], "no redraw to protect, so no wait"
     assert code == STORM_EXIT_CODE
 
 
-def test_last_of_several_storms_does_not_wait_after_the_final_attempt(
-    launcher, target_repo
-):
-    launcher["codes"] = [STORM_EXIT_CODE, STORM_EXIT_CODE]
+def test_a_non_storm_failure_also_ends_the_issue(launcher, target_repo):
+    launcher["codes"] = [1, 0]
 
-    speedrun_roll.main(_argv(target_repo, attempts=2))
+    code = speedrun_roll.main(_argv(target_repo))
 
-    assert launcher["slept"] == [15 * 60], "one wait between two attempts, none after"
-
-
-# --- "the backoff line appears in the launcher events log" --------------
+    assert launcher["slept"] == []
+    assert code == 1
 
 
-def test_backoff_line_is_written_to_the_events_log(launcher, target_repo):
-    launcher["codes"] = [STORM_EXIT_CODE, 0]
+def test_the_storm_is_named_in_the_events_log(launcher, target_repo):
+    """A watcher must still be able to tell a dead provider from a dead run."""
+    launcher["codes"] = [STORM_EXIT_CODE]
 
     speedrun_roll.main(_argv(target_repo))
 
     log = (target_repo / "logs" / "session-events.log").read_text(encoding="utf-8")
-    assert "STORM BACKOFF 15m before attempt 2/3" in log, (
-        "a watcher must be able to tell backoff from a hang"
-    )
+    assert "STORM ended #4" in log
+    assert "#2206" in log
 
 
-def test_final_attempt_storm_is_also_recorded(launcher, target_repo):
-    launcher["codes"] = [STORM_EXIT_CODE]
+# --- backoff_minutes remains, as the storm classifier's pure helper ----
 
-    speedrun_roll.main(_argv(target_repo, attempts=1))
 
-    log = (target_repo / "logs" / "session-events.log").read_text(encoding="utf-8")
-    assert "STORM on final attempt" in log
+def test_backoff_helper_survives_for_future_use():
+    """The redraw loop is gone but the escalation curve is still the right
+    answer if a bounded wait is ever reintroduced deliberately."""
+    assert backoff_minutes(1) == 15
+    assert backoff_minutes(4) == 60
 
 
 # --- "a launcher in backoff is stopped cleanly (no orphaned sleep)" -----
@@ -336,4 +300,7 @@ def test_launcher_reads_the_storm_code_not_a_text_marker():
 
     source = inspect.getsource(speedrun_roll.main)
     assert "STORM_EXIT_CODE" in source
-    assert "storm_streak" in source
+    # `storm_streak` went with the redraw loop (#2206) — with one roll per
+    # issue there is no streak to count. Classification by exit code rather
+    # than by scraping prose is what this test actually protects.
+    assert "code == STORM_EXIT_CODE" in source

--- a/tests/unit/test_resume_after_failure.py
+++ b/tests/unit/test_resume_after_failure.py
@@ -93,6 +93,8 @@ def resumable(monkeypatch, az_root, repo):
     """Everything a spec-resume needs: matching state, arc, open PR, artifact."""
     monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
     monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    # #2206 staleness has its own suite; here the draft is current.
+    monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: False)
     lld = repo / "docs" / "lld" / "active" / "LLD-001.md"
     lld.parent.mkdir(parents=True)
     lld.write_text("# LLD\n", encoding="utf-8")
@@ -179,6 +181,7 @@ def test_spec_failure_resumes_from_spec(az_root, repo, log, resumable):
 def test_impl_failure_resumes_from_impl(az_root, repo, log, monkeypatch):
     monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
     monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+    monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: False)
     lld = repo / "docs" / "lld" / "active" / "LLD-001.md"
     spec = repo / "docs" / "lld" / "active" / "SPEC-001.md"
     lld.parent.mkdir(parents=True)

--- a/tests/unit/test_solo_runbook.py
+++ b/tests/unit/test_solo_runbook.py
@@ -161,7 +161,11 @@ def test_the_three_launch_gates_named_in_the_runbook_are_real():
     assert "open_must_resolve_issues" in source
 
 
-def test_the_storm_backoff_line_the_runbook_quotes_is_the_real_format():
+def test_the_storm_line_the_runbook_quotes_is_the_real_format():
+    """#2206 replaced the backoff line with an end-the-issue line. The
+    invariant is unchanged: whatever the runbook quotes as a sample must be
+    what the launcher actually emits, or an operator reading the runbook is
+    watching for a string that never appears."""
     import importlib
     import inspect as _inspect
 
@@ -169,9 +173,14 @@ def test_the_storm_backoff_line_the_runbook_quotes_is_the_real_format():
     speedrun_roll = importlib.import_module("speedrun_roll")
 
     source = _inspect.getsource(speedrun_roll.main)
-    assert "STORM BACKOFF" in source
-    assert "STORM BACKOFF 15m before attempt 2/3" in _text(), (
+    assert "STORM ended" in source
+    assert "nothing was redrawn (#2206)" in source
+    text = _text()
+    assert "STORM ended #4 -- the provider stopped answering" in text, (
         "the runbook quotes a sample line; it must match the emitted format"
+    )
+    assert "STORM BACKOFF" not in text, (
+        "the retired backoff line must not survive in the runbook"
     )
 
 

--- a/tests/unit/test_speedrun_roll_attempts.py
+++ b/tests/unit/test_speedrun_roll_attempts.py
@@ -1,9 +1,14 @@
-"""A failed draw redraws inside the detached task (#2068).
+"""The redraw budget is retired (#2206, superseding #2068).
 
-Generation quality varies wildly between draws -- the same issue produced
-39/41-passing and 4/75-passing initial iterations on consecutive rolls. A bad
-draw is self-healing (ensure_base clears its debris), so the retry belongs
-inside the detached task, not with a human relaunching every twenty minutes.
+#2068 added an in-task redraw loop on the premise that generation quality
+varies wildly between draws, so a bad draw was worth re-rolling without a
+human in the loop. The campaign disproved the premise: on 2026-08-10/11 every
+failure was systematic — a parse misroute, stale binding docs, an unwritable
+photo comparison, an under-specified palette — and each redraw re-paid for
+passed stages to reproduce a known result. The operator retired it.
+
+What replaces it: one roll per issue, then a halt with the reason, and a
+relaunch that resumes from the failed stage (#2193) once the cause is fixed.
 """
 
 import argparse
@@ -18,7 +23,7 @@ if str(TOOLS) not in sys.path:
 import speedrun_roll as sr  # noqa: E402
 
 
-def _main(repo, attempts, codes):
+def _main(repo, codes, attempts=1):
     """Run main() with roll_issue scripted to return `codes` in order."""
     calls = []
 
@@ -37,35 +42,35 @@ def _main(repo, attempts, codes):
     return code, calls
 
 
-class TestRedraw:
-    def test_a_failed_draw_is_redrawn(self, tmp_path):
+class TestTheBudgetIsRetired:
+    def test_a_failed_draw_is_not_redrawn(self, tmp_path):
+        """The inversion of the #2068 test this file used to carry."""
         repo = tmp_path / "r"
         (repo / ".git").mkdir(parents=True)
-        code, calls = _main(repo, 3, [1, 1, 0, 0])
+        code, calls = _main(repo, [1, 0, 0])
 
-        assert code == 0
-        assert calls == [2, 2, 2, 5], "three draws of #2, then #5 once"
+        assert code == 1
+        assert calls == [2], "one roll of #2, then the batch halts"
 
-    def test_success_does_not_burn_the_budget(self, tmp_path):
+    def test_success_rolls_every_issue_once(self, tmp_path):
         repo = tmp_path / "r"
         (repo / ".git").mkdir(parents=True)
-        code, calls = _main(repo, 5, [0, 0])
+        code, calls = _main(repo, [0, 0])
         assert code == 0
         assert calls == [2, 5]
 
-    def test_exhausted_attempts_stop_the_arc(self, tmp_path):
+    def test_a_failure_stops_the_arc(self, tmp_path):
         repo = tmp_path / "r"
         (repo / ".git").mkdir(parents=True)
-        code, calls = _main(repo, 2, [1, 1])
+        code, calls = _main(repo, [1, 1])
         assert code == 1
-        assert calls == [2, 2], "later issues must not roll after exhaustion"
+        assert calls == [2], "later issues must not roll after a failure"
 
-    def test_a_base_problem_is_never_redrawn(self, tmp_path):
-        """91 is a gate/base fault, not a draw; retrying it re-spends against
-        the same wall."""
+    def test_a_base_problem_still_stops_at_one(self, tmp_path):
+        """91 is a gate/base fault, not a draw — it was never redrawn."""
         repo = tmp_path / "r"
         (repo / ".git").mkdir(parents=True)
-        code, calls = _main(repo, 5, [91])
+        code, calls = _main(repo, [91])
         assert code == 91
         assert calls == [2]
 
@@ -83,14 +88,26 @@ class TestRedraw:
         assert code == 1
         assert calls == [1]
 
+    def test_a_budget_above_one_refuses(self, tmp_path):
+        """Asking for the retired behaviour is refused, not silently clamped:
+        an operator who typed --attempts 3 believes three draws will happen,
+        and a clamp would leave that belief intact."""
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        code, calls = _main(repo, [0, 0], attempts=3)
+        assert code == 91
+        assert calls == [], "a refused launch spends nothing"
 
-class TestTheBudgetRidesTheRelaunch:
+
+class TestTheFlagRidesTheRelaunch:
     def test_detached_argv_carries_attempts(self, tmp_path):
+        """The detached child re-parses argv, so the flag must still ride —
+        at the only value that now passes preflight."""
         args = argparse.Namespace(
             issue=[2, 5], log_dir=None, assemblyzero_root=None,
-            detach=True, detached_stdout=None, attempts=6,
+            detach=True, detached_stdout=None, attempts=1,
         )
         argv = sr.detached_argv(args, [], tmp_path / "r", tmp_path / "a",
                                 tmp_path / "l")
         assert "--attempts" in argv
-        assert argv[argv.index("--attempts") + 1] == "6"
+        assert argv[argv.index("--attempts") + 1] == "1"

--- a/tests/unit/test_speedrun_roll_verdict.py
+++ b/tests/unit/test_speedrun_roll_verdict.py
@@ -63,7 +63,9 @@ def _main(repo, issues, rolls, *, questions=None, gh_error=None, extra_argv=()):
         counts[issue] += 1
         return result
 
-    argv = ["--repo", str(repo), "--attempts", "3", *extra_argv]
+    # #2206 retired the redraw budget: one roll per issue, and any value
+    # above 1 refuses at preflight.
+    argv = ["--repo", str(repo), "--attempts", "1", *extra_argv]
     for i in issues:
         argv += ["--issue", str(i)]
 
@@ -120,9 +122,12 @@ class TestConflictClassification:
         assert counts[4] == 1 and counts[7] == 1
         assert code == CONFLICT_EXIT_CODE, "the batch result names the block"
 
-    def test_a_generic_failure_still_redraws_and_stops(self, repo):
+    def test_a_generic_failure_halts_without_redrawing(self, repo):
+        """#2206 inverted this: a generic failure used to spend the redraw
+        budget; it now halts on the first, so the cause gets diagnosed
+        instead of reproduced."""
         code, counts = _main(repo, [1, 4], {1: [1, 1, 1], 4: [0]})
-        assert counts[1] == 3, "generic failures keep the redraw budget"
+        assert counts[1] == 1, "the redraw budget is retired"
         assert counts.get(4, 0) == 0, "exhaustion still stops the batch"
         assert code == 1
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -79,8 +79,9 @@ from assemblyzero.core.exit_codes import (  # noqa: E402
 )
 from assemblyzero.workflows.orchestrator.state import STAGE_ORDER  # noqa: E402
 from assemblyzero.core.provider_storm import (  # noqa: E402
+    # backoff_minutes went with the redraw loop (#2206) -- it survives in
+    # provider_storm for a future deliberate wait, but nothing here waits.
     STORM_EXIT_CODE,
-    backoff_minutes,
 )
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
 from assemblyzero.speedrun.must_resolve import (  # noqa: E402
@@ -479,6 +480,101 @@ def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
     return False
 
 
+# Binding-input paths: a commit touching either invalidates a draft derived
+# from them. Design docs and ADRs are what the drafter and the reviewer read
+# as law; issue text is checked separately against the GitHub API.
+BINDING_DOC_PATHS = ("docs/design", "docs/adrs")
+
+
+def _iso_to_epoch(value: str) -> float | None:
+    """Parse an ISO-8601 timestamp (with Z or offset) to epoch seconds."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def draft_is_stale(
+    repo_root: Path, issue: int, drafted_at: str, base: str, log: EventLog
+) -> bool:
+    """True when a binding input moved after the draft was made (#2206).
+
+    A resumed spec is built on a persisted LLD. If the law that LLD was
+    derived from has since changed, resuming spends the stage on a draft that
+    is already wrong -- and worse, produces a failure that reads as evidence
+    against whatever the ruling just fixed.
+
+    Two inputs can invalidate a draft, and BOTH are checked because the live
+    case proved one is not enough. On 2026-08-11 an LLD drafted at 01:27Z was
+    invalidated by design-doc rulings merged at 05:13Z and 06:18Z while the
+    issue's own text had last changed at 01:10Z -- BEFORE the draft. An
+    issue-only staleness check would have called that draft current and
+    resumed onto it.
+
+    Unknowable answers are stale: if the draft time cannot be read or a probe
+    fails, this returns True and the caller draws fresh, which is always safe.
+    """
+    drafted = _iso_to_epoch(drafted_at)
+    if drafted is None:
+        log.write(
+            f"RESUME abandoned for #{issue}: draft time unreadable "
+            f"({drafted_at!r})"
+        )
+        return True
+
+    # 1. Issue text.
+    result = _run(
+        ["gh", "issue", "view", str(issue), "--json", "updatedAt",
+         "--jq", ".updatedAt"],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        log.write(
+            f"RESUME abandoned for #{issue}: cannot read the issue's last-edit "
+            "time to check staleness"
+        )
+        return True
+    edited = _iso_to_epoch(result.stdout.strip())
+    if edited is None:
+        log.write(f"RESUME abandoned for #{issue}: unparseable issue timestamp")
+        return True
+    if edited > drafted:
+        log.write(
+            f"RESUME abandoned for #{issue}: the issue was edited after the "
+            "draft was made -- drawing fresh against the current text"
+        )
+        return True
+
+    # 2. Binding docs on the base branch -- the input that fired live.
+    docs = _run(
+        ["git", "log", "-1", "--format=%cI", f"origin/{base}", "--",
+         *BINDING_DOC_PATHS],
+        cwd=repo_root,
+    )
+    if docs.returncode != 0:
+        log.write(
+            f"RESUME abandoned for #{issue}: cannot read binding-doc history "
+            f"on '{base}' to check staleness"
+        )
+        return True
+    latest_doc = docs.stdout.strip()
+    if latest_doc:
+        doc_ts = _iso_to_epoch(latest_doc)
+        if doc_ts is None:
+            log.write(f"RESUME abandoned for #{issue}: unparseable doc timestamp")
+            return True
+        if doc_ts > drafted:
+            log.write(
+                f"RESUME abandoned for #{issue}: a binding doc "
+                f"({'/'.join(BINDING_DOC_PATHS)}) changed on '{base}' after "
+                "the draft was made -- drawing fresh against the current law"
+            )
+            return True
+    return False
+
+
 def resume_plan(
     az_root: Path, repo_root: Path, issue: int, log: EventLog
 ) -> str | None:
@@ -533,6 +629,12 @@ def resume_plan(
         return None
 
     if not _open_lld_pr_exists(repo_root, issue):
+        return None
+
+    # #2206: the draft must still be derived from current law. `started_at` is
+    # when the run that produced it began, so anything binding that moved
+    # since is a change the draft cannot know about.
+    if draft_is_stale(repo_root, issue, data.get("started_at", ""), base, log):
         return None
 
     needed = [data.get("lld_path", "")]
@@ -1892,8 +1994,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--attempts", type=int, default=1,
         help=(
-            "Redraw a failed issue up to N times before stopping (#2068). "
-            "Base/gate problems (exit 91) are never retried."
+            "Retired by operator ruling #2206: only 1 is accepted. A failure "
+            "halts for diagnosis; the relaunch resumes from the failed stage "
+            "(#2193) instead of redrawing. Values above 1 refuse at preflight, "
+            "before anything is spent."
         ),
     )
     parser.add_argument(
@@ -1989,6 +2093,23 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.issue:
         print("ERROR: --issue is required (repeatable) unless stopping a roll")
+        return 91
+
+    # #2206: automatic retries are deauthorized. Refuse here -- before the
+    # detach hand-off and before any gate spends anything -- so the refusal
+    # lands in the console the operator is standing in.
+    if getattr(args, "attempts", 1) > 1:
+        print(
+            f"BLOCKED: --attempts {args.attempts} is retired (operator ruling "
+            "#2206). Automatic retries are deauthorized:\n"
+            "\n  A failed roll halts so its cause can be found. The relaunch "
+            "after the fix resumes\n  from the failed stage (#2193), so the "
+            "stages that already passed are never re-paid.\n"
+            "\n  The campaign's failures proved systematic, not stochastic: a "
+            "redraw into an unfixed\n  cause spends tokens to reproduce a "
+            "result already known.\n"
+            "\n  Relaunch with --attempts 1."
+        )
         return 91
 
     # #2007: refuse before spending anything if the tree running this roll is
@@ -2114,7 +2235,6 @@ def main(argv: list[str] | None = None) -> int:
             # clears its debris), so retrying inside the detached task removes
             # the human relaunch from the loop entirely. A base or gate problem
             # (91) is NOT a draw and is never retried.
-            storm_streak = 0
             # #2193: a relaunch that finds a non-conflict failure with the lld
             # already passed resumes from the failed stage instead of paying
             # for the passed stages again. Planning failures never block a
@@ -2133,77 +2253,47 @@ def main(argv: list[str] | None = None) -> int:
                     f"\n#{issue}: resuming from '{resume_from}' -- the passed "
                     "stages are reused, not redrawn (--fresh for a full redraw)."
                 )
-            for attempt_no in range(1, max(1, args.attempts) + 1):
-                # The sixth argument travels ONLY when a resume fires: test
-                # stubs replace roll_issue with both bare *args lambdas and
-                # fixed five-arg defs, so the non-resume path must keep the
-                # exact pre-#2193 call shape (same convention as the
-                # positional restore_repo call below).
-                if resume_from:
-                    code = roll_issue(
-                        repo_root, issue, log_dir, az_root, extra, resume_from,
-                    )
-                else:
-                    code = roll_issue(repo_root, issue, log_dir, az_root, extra)
-                # Only the first attempt resumes: a resumed attempt that fails
-                # has proven the preserved state is not enough, so every
-                # redraw after it is fresh.
-                resume_from = None
-                if code == 0 or code == 91:
-                    break
+            # #2206: one roll per issue. The redraw loop is retired by
+            # operator ruling -- a failure halts for diagnosis, and the
+            # relaunch after the fix resumes from the failed stage (#2193)
+            # rather than re-paying for the passed ones. The campaign's
+            # failures proved overwhelmingly systematic, and a redraw into an
+            # unfixed cause spends tokens to reproduce a known result.
+            #
+            # The sixth argument travels ONLY when a resume fires: test stubs
+            # replace roll_issue with both bare *args lambdas and fixed
+            # five-arg defs, so the non-resume path must keep the exact
+            # pre-#2193 call shape (same convention as the positional
+            # restore_repo call below).
+            if resume_from:
+                code = roll_issue(
+                    repo_root, issue, log_dir, az_root, extra, resume_from,
+                )
+            else:
+                code = roll_issue(repo_root, issue, log_dir, az_root, extra)
 
-                # #2166: a requirements conflict means the ISSUE needs an
-                # operator ruling. No redraw can help; the auto-filer (#2072)
-                # has already raised the questions. Stop this issue, keep the
-                # batch moving.
-                if code == CONFLICT_EXIT_CODE:
-                    session.write(
-                        f"BLOCKED #{issue} on an operator ruling -- "
-                        "no redraw can help; continuing the batch"
-                    )
-                    break
-
-                # #2086: eighteen consecutive provider timeouts in one roll on
-                # 2026-08-01 killed two rolls, because a redraw fires straight
-                # into the same wall. A storm-classified attempt waits; every
-                # other failure redraws immediately, exactly as before.
-                if code == STORM_EXIT_CODE:
-                    storm_streak += 1
-                else:
-                    storm_streak = 0
-
-                if attempt_no >= max(1, args.attempts):
-                    if storm_streak:
-                        # Nothing left to wait for; a terminal wait would just
-                        # delay the operator finding out.
-                        session.write("STORM on final attempt - exiting without waiting")
-                    continue
-
-                if storm_streak:
-                    minutes = backoff_minutes(storm_streak)
-                    session.write(
-                        f"STORM BACKOFF {minutes}m before attempt "
-                        f"{attempt_no + 1}/{args.attempts}"
-                    )
-                    # #2164: a backoff is a heal (waiting instead of burning
-                    # an attempt on the same wall).
-                    record_heal(
-                        repo_root, "storm-backoff", f"#{issue}", "healed",
-                        detail=f"waited {minutes}m before attempt "
-                               f"{attempt_no + 1}/{args.attempts}",
-                    )
-                    print(
-                        f"\n#{issue} attempt {attempt_no}/{args.attempts}: the model "
-                        f"provider stopped answering. Waiting {minutes} minutes before "
-                        f"trying again, so the next attempt is not spent on the same wall."
-                    )
-                    _interruptible_sleep(minutes * 60)
-                else:
-                    print(
-                        f"\n#{issue} attempt {attempt_no}/{args.attempts} failed "
-                        f"(exit {code}) — self-healing and redrawing."
-                    )
-                    time.sleep(2)
+            # #2166: a requirements conflict means the ISSUE needs an operator
+            # ruling. The auto-filer (#2072) has already raised the questions.
+            # Stop this issue, keep the batch moving.
+            if code == CONFLICT_EXIT_CODE:
+                session.write(
+                    f"BLOCKED #{issue} on an operator ruling -- "
+                    "no redraw can help; continuing the batch"
+                )
+            # #2086 storms no longer back off and retry -- with one roll per
+            # issue there is nothing to wait for, and the operator finds out
+            # immediately instead of after an hour of sleeping.
+            elif code == STORM_EXIT_CODE:
+                session.write(
+                    f"STORM ended #{issue} -- the provider stopped answering; "
+                    "nothing was redrawn (#2206). Relaunch when it recovers."
+                )
+            elif code not in (0, 91):
+                session.write(
+                    f"HALT #{issue} exited {code} -- no redraw (#2206). "
+                    "Diagnose, fix the cause, then relaunch; the passed "
+                    "stages resume rather than re-run."
+                )
             if code == CONFLICT_EXIT_CODE:
                 blocked.append(issue)
                 continue


### PR DESCRIPTION
## Summary

Implements the operator's ruling of 2026-08-10: **automatic retries are deauthorized.** One roll per issue; a failure halts with its reason so the cause can be found; the relaunch resumes from the failed stage (#2193) rather than re-paying for the stages that passed. Ships with the staleness guard that keeps that resume honest.

## Half 1 — the redraw loop is retired

- `--attempts` above 1 **refuses at preflight**, before the tree gate, the health gate, or the detach hand-off — so nothing is spent and the refusal lands in the console the operator is standing in. It refuses rather than silently clamping: an operator who typed `--attempts 3` believes three draws will happen, and a clamp would leave that belief intact.
- The per-issue loop collapses to a single roll. A conflict still blocks the issue and continues the batch (#2166); every other non-zero exit halts it with a line naming the code and pointing at resume.
- **Storms no longer wait.** The 15/30/60-minute backoff existed to keep the *next redraw* off the same wall; with no next redraw it only delayed the operator learning the provider was down. A storm now ends the issue immediately and says so. `backoff_minutes` survives in `provider_storm` for a future deliberate wait.

## Half 2 — a resumed draft must still be derived from current law

`draft_is_stale()` rejects a resume when a binding input moved after the draft was made. Two inputs are checked, because **the live case proved one is not enough**:

On 2026-08-11 the first resume in the campaign's history fired onto an LLD drafted at 01:27Z. Design-doc rulings merged at 05:13Z and 06:18Z had invalidated it — but the issue's own text had last changed at **01:10Z, before the draft**. An issue-only staleness check (the guard originally proposed in #2206) would have called that draft current and resumed onto it. The run was stopped by hand four minutes in.

So the guard checks the issue's `updatedAt` **and** the last commit touching `docs/design/**` or `docs/adrs/**` on the base branch. Unknowable answers are stale: a failed probe, an unparseable timestamp, or a missing draft time all draw fresh, which is always safe.

Why it deserves a guard rather than operator vigilance: a stale resume does not merely waste a stage. It produces failures that read as evidence against whatever the ruling just fixed — discrediting a correct change at the exact moment confidence in it matters.

## Changes

- `tools/speedrun_roll.py` — preflight refusal; single-roll batch loop; storm/halt log lines; `draft_is_stale()` + `_iso_to_epoch()` + `BINDING_DOC_PATHS`; the staleness check wired into `resume_plan`.
- `docs/runbooks/0952-speedrun-operator-solo.md` — the `--attempts` row and the storm section rewritten to describe what the launcher now does.
- `tests/unit/test_no_retries.py` — 11 new tests across both halves, including the exact timestamps from the live case.
- Five existing suites converted from pinning the redraw budget to pinning its retirement, each keeping the invariant it was really protecting (the runbook quotes what the code emits; the must-resolve wall is queried once per invocation; a storm is classified by exit code, not by scraped prose).

Full suite: 7124 passed, 17 skipped, zero failures. Lint clean on every touched file.

Closes #2206
