### PR TITLE
feat(lld-gate): reject test-plan pass criteria that defer their value (Closes #2208)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -76,6 +76,25 @@ MANDATORY_SECTIONS = ["### 2.1", "## 11", "## 12"]
 # Common placeholder prefixes that often indicate hallucinated paths
 PLACEHOLDER_PREFIXES = ["src", "lib", "app"]
 
+# #2208: words a pass criterion uses when it defers a value rather than
+# carrying one. Matched case-insensitively as substrings, so "as specified"
+# also catches "exactly as specified".
+PLACEHOLDER_CRITERION_WORDS = (
+    "correct",
+    "appropriate",
+    "expected value",
+    "proper",
+    "as specified",
+    "per the design doc",
+    "per the aesthetic doc",
+    "per the spec",
+    "per spec",
+    "matching the",
+    "as documented",
+    "as defined in",
+    "defined in the",
+)
+
 # Stopwords to filter from keyword extraction
 STOPWORDS = {
     "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
@@ -574,6 +593,110 @@ def validate_title_issue_number(content: str, issue_number: int) -> list[Validat
 # =============================================================================
 # Validation Functions
 # =============================================================================
+
+
+def validate_test_plan_pass_criteria(lld_content: str) -> list[ValidationError]:
+    """Reject pass criteria that defer a value instead of carrying it (#2208).
+
+    The spec stage is drafted from the LLD, not from the design docs. A pass
+    criterion reading "needles show correct width/color" or "colors per the
+    aesthetic doc" hands the spec writer nothing to assert, so the only test
+    it can produce is one that verifies nothing --
+    ``assert isinstance(img, Image.Image)`` -- which the spec reviewer then
+    rejects for assertion traceability, round after round, to the cap.
+
+    That deadlock cost seven spec-stage halts on one issue across
+    2026-08-10/11, 6-12 minutes each, while the values sat in a design doc
+    the test writer never read. The defect was visible in the LLD's own text
+    at draft time, which is why it belongs here: this fails during the lld
+    stage, before any spec tokens are spent, and names the row to fix.
+
+    A criterion may cite the binding doc -- it must also carry the value.
+    ``needle pixels classify as candy-apple #F73923 (aesthetic doc)`` passes;
+    ``needle color per the aesthetic doc`` does not.
+    """
+    errors: list[ValidationError] = []
+    section = _extract_test_plan_section(lld_content)
+    if not section:
+        return errors
+
+    for row_id, criterion in _iter_pass_criteria(section):
+        lowered = criterion.lower()
+        hits = [w for w in PLACEHOLDER_CRITERION_WORDS if w in lowered]
+        if hits and not _carries_a_literal(criterion):
+            errors.append(
+                ValidationError(
+                    severity=ValidationSeverity.ERROR,
+                    section="10 Test Plan",
+                    message=(
+                        f"Critical: test {row_id}'s pass criterion says "
+                        f"{hits[0]!r} but carries no value -- quote the "
+                        f"literal it asserts (a number, a hex colour, a "
+                        f"backticked symbol), citing the binding doc if you "
+                        f"like: {criterion[:80]!r}"
+                    ),
+                )
+            )
+    return errors
+
+
+def _extract_test_plan_section(lld_content: str) -> str:
+    """The Test Plan section's body, or "" when the LLD has none.
+
+    Matched on heading text rather than number, so renumbering the template
+    cannot silently disable the check.
+    """
+    out: list[str] = []
+    inside = False
+    for line in (lld_content or "").splitlines():
+        if line.startswith("#"):
+            heading = line.lstrip("#").strip().lower()
+            if "test plan" in heading:
+                inside = True
+                continue
+            if inside:
+                # Deeper subsections stay inside; a new top-level section ends it.
+                depth = len(line) - len(line.lstrip("#"))
+                if depth <= 2:
+                    inside = False
+        elif inside:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _iter_pass_criteria(section: str):
+    """Yield (row id, final cell) for each data row of the test table.
+
+    The pass criterion is the last column by template convention. Header and
+    separator rows are skipped; a row with fewer than three cells is not a
+    test row.
+    """
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        if set("".join(cells)) <= set("-: "):        # separator row
+            continue
+        if cells[0].lower() in {"id", "test", "#"}:  # header row
+            continue
+        yield cells[0] or "?", cells[-1]
+
+
+def _carries_a_literal(text: str) -> bool:
+    """True when a criterion carries something a test can assert against.
+
+    Deliberately generous -- a backticked symbol, a quoted string, or any
+    digit counts. This catches criteria with NO value at all; it does not
+    adjudicate whether the value is the right one. A narrower rule would
+    fire on good rows and teach drafters to pad, which is worse than the
+    defect (the fleet's no-false-alarms rule).
+    """
+    if "`" in text or '"' in text or "'" in text:
+        return True
+    return any(ch.isdigit() for ch in text)
 
 
 def validate_mandatory_sections(lld_content: str) -> list[ValidationError]:
@@ -1408,6 +1531,11 @@ def _validate_lld_mechanical_inner(state: Dict[str, Any]) -> Dict[str, Any]:
     # Step 6: Cross-reference DoD with Files Changed
     xref_errors = cross_reference_sections(lld_content, files)
     all_errors.extend(xref_errors)
+
+    # Step 6b (#2208): a pass criterion that defers its value leaves the spec
+    # stage nothing to assert. Caught here, in the lld stage, rather than
+    # after the spec has spent its budget discovering the same thing.
+    all_errors.extend(validate_test_plan_pass_criteria(lld_content))
 
     # Step 7: Trace risk mitigations (warnings only, with Issue #312 smart filtering)
     mitigations = extract_mitigations_from_risks(lld_content)

--- a/tests/unit/test_pass_criteria_carry_values.py
+++ b/tests/unit/test_pass_criteria_carry_values.py
@@ -1,0 +1,163 @@
+"""A pass criterion carries its value or the LLD is rejected (#2208).
+
+The spec stage is drafted from the LLD, not from the design docs. A criterion
+that defers -- "correct width/color", "per the aesthetic doc" -- leaves the
+spec writer nothing to assert, so it writes a test that verifies nothing and
+the spec reviewer rejects it for assertion traceability, every round, to the
+cap. Seven spec halts on martymcenroe/boostgauge#1 across 2026-08-10/11 came
+from exactly that, while the values sat in a design doc the test writer never
+read.
+
+The rows quoted below are verbatim from the LLD that produced the last of
+those halts (`graveyard/leavings-20260811-020312`), so this suite fails if
+the gate would ever let that LLD through again.
+"""
+from __future__ import annotations
+
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    ValidationSeverity,
+    validate_test_plan_pass_criteria,
+)
+
+HEADER = (
+    "## 10. Verification & Testing\n\n"
+    "### 10.0 Test Plan (TDD - Complete Before Implementation)\n\n"
+    "| ID | Scenario | Type | Input | Expected Output | Pass Criteria |\n"
+    "|---|---|---|---|---|---|\n"
+)
+
+
+def lld(*rows: str) -> str:
+    return HEADER + "".join(rows) + "\n## 11. Rollback\nRevert.\n"
+
+
+# ---------------------------------------------------------------------------
+# The real rows from the deadlock
+# ---------------------------------------------------------------------------
+
+
+def test_the_row_that_caused_the_deadlock_is_rejected():
+    """Verbatim from the LLD of run-issue1-014959."""
+    content = lld(
+        "| 050 | Multiple non-coincident telltales (REQ-5) | Auto | `value=50`, "
+        "peaks `[20, 30]` | `PIL.Image` | Needles visible at respective angles "
+        "with correct width/color. |\n"
+    )
+    errors = validate_test_plan_pass_criteria(content)
+    assert len(errors) == 1
+    assert errors[0].severity is ValidationSeverity.ERROR
+    assert "050" in errors[0].message
+    assert "correct" in errors[0].message
+
+
+def test_a_deferring_criterion_is_rejected():
+    content = lld(
+        "| 060 | Telltale colours (REQ-6) | Auto | `value=40` | `PIL.Image` | "
+        "Colours per the aesthetic doc. |\n"
+    )
+    errors = validate_test_plan_pass_criteria(content)
+    assert len(errors) == 1
+    assert "060" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# Rows that must NOT fire -- a noisy gate is worse than the defect
+# ---------------------------------------------------------------------------
+
+
+def test_a_criterion_carrying_a_hex_value_passes():
+    content = lld(
+        "| 070 | Redline distinctness (REQ-7) | Auto | `value=75` | `PIL.Image` | "
+        "Needle tip pixels classify as candy-apple `#F73923`, band pixels as "
+        "brick `#9B3020` (aesthetic doc §palette). |\n"
+    )
+    assert validate_test_plan_pass_criteria(content) == []
+
+
+def test_the_word_correct_with_a_value_passes():
+    """The gate catches missing values, not the word itself."""
+    content = lld(
+        "| 080 | Angle mapping (REQ-8) | Auto | `value=50` | float | "
+        "`calculate_angle(50)` returns the correct value, `90.0`. |\n"
+    )
+    assert validate_test_plan_pass_criteria(content) == []
+
+
+def test_criteria_that_already_carry_values_pass():
+    content = lld(
+        "| 010 | Purity (REQ-1) | Auto | import | none | `sys.modules` contains "
+        "no `tkinter` references. |\n"
+        "| 030 | Determinism (REQ-3) | Auto | `value=50` x2 | `PIL.Image` | "
+        "Image 1 bytes strictly equal Image 2 bytes. |\n"
+    )
+    assert validate_test_plan_pass_criteria(content) == []
+
+
+def test_the_header_and_separator_are_not_criteria():
+    assert validate_test_plan_pass_criteria(lld()) == []
+
+
+def test_an_lld_without_a_test_plan_is_not_flagged():
+    """Missing sections are a different check's job (#579)."""
+    assert validate_test_plan_pass_criteria("## 1. Context\nText.\n") == []
+
+
+def test_prose_outside_the_test_plan_is_ignored():
+    """"Correct" in ordinary narrative is not a pass criterion."""
+    content = (
+        "## 2. Proposed Changes\n\nThe renderer must produce the correct "
+        "output for every value.\n\n" + lld(
+            "| 010 | Purity | Auto | import | none | `sys.modules` clean. |\n"
+        )
+    )
+    assert validate_test_plan_pass_criteria(content) == []
+
+
+def test_a_table_outside_the_test_plan_is_ignored():
+    content = (
+        "## 2.1 Files Changed\n\n"
+        "| File | Change | Why |\n|---|---|---|\n"
+        "| `src/x.py` | Add | correct behaviour |\n\n"
+        "## 10. Test Plan\n\n"
+        "| ID | Scenario | Type | Input | Expected | Pass Criteria |\n"
+        "|---|---|---|---|---|---|\n"
+        "| 010 | Purity | Auto | import | none | `sys.modules` clean. |\n"
+    )
+    assert validate_test_plan_pass_criteria(content) == []
+
+
+def test_subsections_of_the_test_plan_stay_inside_it():
+    content = (
+        "## 10. Verification & Testing\n\n"
+        "### 10.0 Test Plan\n\n"
+        "| ID | Scenario | Type | Input | Expected | Pass Criteria |\n"
+        "|---|---|---|---|---|---|\n"
+        "| 010 | Purity | Auto | import | none | `sys.modules` clean. |\n\n"
+        "### 10.1 Render tier\n\n"
+        "| ID | Scenario | Type | Input | Expected | Pass Criteria |\n"
+        "|---|---|---|---|---|---|\n"
+        "| 020 | Colours | Auto | `value=0` | image | Colours as specified. |\n"
+    )
+    errors = validate_test_plan_pass_criteria(content)
+    assert len(errors) == 1, "a deeper subsection is still the test plan"
+    assert "020" in errors[0].message
+
+
+def test_every_bad_row_is_named_individually():
+    content = lld(
+        "| 010 | A | Auto | x | y | Renders correct output. |\n"
+        "| 020 | B | Auto | x | y | Colours per the design doc. |\n"
+        "| 030 | C | Auto | x | y | Byte-identical to `baseline.png`. |\n"
+    )
+    errors = validate_test_plan_pass_criteria(content)
+    assert len(errors) == 2
+    assert {"010", "020"} == {e.message.split("test ")[1].split("'")[0].strip()
+                              for e in errors}
+
+
+def test_the_message_quotes_the_offending_text():
+    """The operator must be able to fix the row without opening the file."""
+    content = lld("| 010 | A | Auto | x | y | Renders correct output. |\n")
+    (error,) = validate_test_plan_pass_criteria(content)
+    assert "Renders correct output" in error.message
+    assert "quote the" in error.message


### PR DESCRIPTION
## Summary

The LLD's mechanical validation now rejects a test-plan pass criterion that defers its value instead of carrying it — "correct width/color", "colours per the aesthetic doc" — when the row carries no literal at all.

## Why it belongs in the lld stage

The spec stage is drafted from the LLD, not from the design docs. Handed a pointer, the spec writer can only produce a test that verifies nothing (`assert isinstance(img, Image.Image)`), which the spec reviewer then rejects for assertion traceability, every round, to the iteration cap.

That deadlock cost **seven spec-stage halts** on martymcenroe/boostgauge#1 across 2026-08-10/11 at 6–12 minutes each, while the values sat in a design doc the test writer never read. Every one of those failures was visible in the LLD's own text at draft time.

Caught here, the same defect fails during the lld stage before a single spec token is spent, and the message names the row and quotes the offending text so it can be fixed without opening the file.

## Verified against the real artifact

Run against the actual LLD from the last halt (`run-issue1-014959`, preserved at `graveyard/leavings-20260811-020312`), the gate produces exactly one rejection:

```
Critical: test 050's pass criterion says 'correct' but carries no value -- quote the
literal it asserts (a number, a hex colour, a backticked symbol), citing the binding
doc if you like: 'Needles visible at respective angles with correct width/color.'
```

That is the row that fed the anemic assertion the reviewer rejected three rounds running.

## Deliberately generous

A criterion passes if it carries **any** literal — a backticked symbol, a quoted string, or any digit. The check catches criteria with no value at all; it does not adjudicate whether the value is the right one. A narrower rule would fire on good rows and teach drafters to pad, which is worse than the defect it prevents (the fleet's no-false-alarms rule). "Renders the correct value, `90.0`" passes; "renders correct output" does not.

Scope is the Test Plan section only, located by heading text rather than number so renumbering cannot silently disable it. Prose elsewhere in the LLD and tables in other sections are untouched.

## Changes

- `assemblyzero/workflows/requirements/nodes/validate_mechanical.py` — `validate_test_plan_pass_criteria()` plus three helpers and the `PLACEHOLDER_CRITERION_WORDS` list; wired in as step 6b of `validate_lld_mechanical`.
- `tests/unit/test_pass_criteria_carry_values.py` — 12 tests, including the two verbatim rows from the deadlock and six that must NOT fire (values present, prose outside the test plan, other sections' tables, headers and separators).

Full suite: 7136 passed, 17 skipped, zero failures. Lint clean on both files (the one finding in `validate_mechanical.py` is a pre-existing unused import, identical on main).

Closes #2208
