### PR TITLE
feat(speedrun): carry binding-doc rulings onto the arc at preflight (Closes #2205)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -67,14 +67,30 @@ and nothing to type. Ctrl+C stops watching only — the roll keeps running.
 
 ### What can refuse to launch, and what you do about it
 
-All three gates run **before anything is spent** — no branch is created, no
-tokens are used. All three exit **91**.
+All of these gates run **before anything is spent** — no branch is created, no
+tokens are used. All exit **91**.
 
 | Refusal | What it means | What you do |
 |---|---|---|
 | The AssemblyZero tree is not trustworthy | this checkout is behind or dirty, so the roll would execute pipeline code that `main` does not describe | bring it level with `origin/main`, or point `--assemblyzero-root` at a tree that is |
 | This machine is not healthy enough | a quick self-check ran far slower than normal, or memory is above 90% | wait for the machine to recover, or find what is loading it. Do not override it — a roll on a sick box wastes hours *and* makes every failure look like a target-repo problem |
 | The repository has unanswered questions | one or more issues are open asking you to rule on ambiguous issue text | read each, decide which reading is right, edit the issue so only one survives, close the question |
+| The arc's binding docs conflict with the default branch | design docs or ADRs were ruled on both branches and the two edits collide (#2205) | merge them by hand, then roll. Nothing was changed — the launcher refuses rather than resolving a ruling on your behalf |
+
+**Binding docs sync themselves (#2205).** The roll reads design docs and ADRs
+from the attempt branch, not from `main` — issue text arrives live from
+GitHub, docs do not. Before anything is drawn, the launcher carries any
+binding-doc commits from the default branch onto the arc and says so:
+
+```
+SYNC 2 binding-doc commit(s) on 'main' not yet on 'hardening-run-17' -- carrying them onto the arc before the roll reads them
+SYNC verified: 'hardening-run-17' now carries the binding docs from 'main'
+```
+
+An arc already current is silent and costs nothing. This exists because an
+arc once carried a two-day-old aesthetic doc while five rulings sat on
+`main`: the spec stage failed twice on an objection the operator had already
+answered, and the answer was invisible to the pipeline.
 
 **The first-ever run on a machine records the health baseline and proceeds.** A
 missing baseline never blocks. Nominal is a rolling median over five runs, so it

--- a/tests/unit/test_arc_doc_sync.py
+++ b/tests/unit/test_arc_doc_sync.py
@@ -1,0 +1,191 @@
+"""Binding-doc rulings reach the arc before the roll reads them (#2205).
+
+The roll's worktree stands on the attempt branch, so the design docs and
+ADRs the drafter and reviewer treat as law are the ARC's copies. Issue text
+arrives live from GitHub; docs do not.
+
+Earned 2026-08-10: an arc carried a two-day-old aesthetic doc while five
+rulings sat on the default branch. Issue #1's spec stage failed twice on an
+objection the operator had already answered — the answer existed and was
+invisible. Doc rulings had been reaching arcs only when a pipeline PR
+happened to smuggle a snapshot along with it.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+ARC = "hardening-run-9"
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def origin(tmp_path) -> Path:
+    """A bare remote with main and an arc branch cut from it."""
+    bare = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--quiet", "--bare", "--initial-branch=main", str(bare)],
+        capture_output=True,
+    )
+    return bare
+
+
+@pytest.fixture
+def repo(tmp_path, origin) -> Path:
+    root = tmp_path / "work"
+    subprocess.run(
+        ["git", "clone", "--quiet", str(origin), str(root)], capture_output=True
+    )
+    git(root, "config", "user.email", "t@example.com")
+    git(root, "config", "user.name", "Test")
+    (root / "docs" / "design").mkdir(parents=True)
+    (root / "docs" / "design" / "0002-aesthetic.md").write_text(
+        "needle: red\n", encoding="utf-8"
+    )
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    git(root, "add", ".")
+    git(root, "commit", "-qm", "base")
+    git(root, "push", "-q", "origin", "main")
+    git(root, "branch", ARC)
+    git(root, "push", "-q", "origin", ARC)
+    git(root, "fetch", "-q", "origin")
+    return root
+
+
+@pytest.fixture
+def log(tmp_path) -> "speedrun_roll.EventLog":
+    return speedrun_roll.EventLog(tmp_path / "session-events.log")
+
+
+def rule_on_main(repo: Path, text: str, msg: str = "docs: a ruling") -> None:
+    """Land a binding-doc ruling on main, as a merged doc PR would."""
+    git(repo, "checkout", "-q", "main")
+    (repo / "docs" / "design" / "0002-aesthetic.md").write_text(text, encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", msg)
+    git(repo, "push", "-q", "origin", "main")
+    git(repo, "fetch", "-q", "origin")
+
+
+def arc_doc(repo: Path) -> str:
+    return git(
+        repo, "show", f"origin/{ARC}:docs/design/0002-aesthetic.md"
+    ).stdout
+
+
+# ---------------------------------------------------------------------------
+# The case that was live on 2026-08-10
+# ---------------------------------------------------------------------------
+
+
+def test_a_ruling_on_main_reaches_the_arc(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    rule_on_main(repo, "needle: candy-apple #F73923\n", "docs: the palette ruling")
+
+    assert "F73923" not in arc_doc(repo), "precondition: the arc is behind"
+
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    assert problems == []
+    assert "F73923" in arc_doc(repo), "the ruling must now be on the arc"
+
+
+def test_the_sync_is_announced_with_what_it_carried(repo, log, monkeypatch):
+    """Standard 0026: the console says what the machinery did, by name — a
+    silent mutation of a shared branch is exactly what an operator must not
+    discover later from a diff."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    rule_on_main(repo, "needle: candy-apple #F73923\n", "docs: the palette ruling")
+
+    speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    written = log.path.read_text(encoding="utf-8")
+    assert "SYNC 1 binding-doc commit(s)" in written
+    assert "the palette ruling" in written, "name the ruling being carried"
+    assert "SYNC verified" in written
+
+
+def test_an_arc_already_current_is_silent(repo, log, monkeypatch):
+    """No drift, no worktree, no push — the common case must cost nothing."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+
+    assert speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log) == []
+
+
+def test_non_doc_commits_do_not_trigger_a_sync(repo, log, monkeypatch):
+    """Code on main is the arc's business to merge, not this gate's."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    git(repo, "checkout", "-q", "main")
+    (repo / "README.md").write_text("changed\n", encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", "chore: readme")
+    git(repo, "push", "-q", "origin", "main")
+    git(repo, "fetch", "-q", "origin")
+
+    assert speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log) == []
+
+
+def test_rolling_on_the_default_branch_needs_no_sync(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    assert speedrun_roll.sync_binding_docs_to_arc(repo, "main", log) == []
+
+
+# ---------------------------------------------------------------------------
+# Refusal beats guessing
+# ---------------------------------------------------------------------------
+
+
+def test_a_conflict_refuses_and_changes_nothing(repo, log, monkeypatch):
+    """Both sides edited the same doc lines: the launcher must refuse rather
+    than resolve a ruling on the operator's behalf."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+
+    # The arc edits the doc...
+    git(repo, "checkout", "-q", ARC)
+    (repo / "docs" / "design" / "0002-aesthetic.md").write_text(
+        "needle: arc-side edit\n", encoding="utf-8"
+    )
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", "docs: arc-side edit")
+    git(repo, "push", "-q", "origin", ARC)
+    # ...and main edits the same lines.
+    rule_on_main(repo, "needle: main-side ruling\n")
+
+    before = arc_doc(repo)
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    assert problems, "a conflict must be reported, not silently merged"
+    assert "conflict" in problems[0].lower()
+    assert "0002-aesthetic.md" in problems[0]
+    assert arc_doc(repo) == before, "nothing on the arc may change"
+
+
+def test_an_unresolvable_default_branch_is_reported(repo, log, monkeypatch):
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "")
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+    assert problems and "default branch" in problems[0]
+
+
+def test_no_worktree_is_left_behind(repo, log, monkeypatch):
+    """The sync borrows a worktree under data/speedrun/ and returns it —
+    stranded worktrees are the failure this campaign already paid for."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    rule_on_main(repo, "needle: candy-apple #F73923\n")
+
+    speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    listing = git(repo, "worktree", "list").stdout
+    assert ".arc-sync" not in listing
+    assert not (repo / "data" / "speedrun" / ".arc-sync").exists()

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -496,6 +496,105 @@ def _iso_to_epoch(value: str) -> float | None:
         return None
 
 
+def sync_binding_docs_to_arc(
+    repo_root: Path, base: str, log: EventLog
+) -> list[str]:
+    """Carry the default branch's binding-doc rulings onto the arc (#2205).
+
+    The roll's worktree stands on the attempt branch, so the design docs and
+    ADRs the drafter and reviewer read as law are the ARC's copies. Issue
+    text arrives live from GitHub; docs do not. An arc cut before a ruling
+    never sees it, and nothing in the machinery noticed.
+
+    The cost was not theoretical. On 2026-08-10 an arc carried a two-day-old
+    aesthetic doc while five rulings sat on the default branch; issue #1's
+    spec stage failed twice on an objection the operator had already
+    answered, invisibly. Worse, doc rulings had been reaching arcs only when
+    a pipeline PR happened to smuggle a snapshot -- nondeterministic and
+    version-skewed.
+
+    Preserve-then-proceed, never force: an ordinary merge, a conflict refuses
+    loudly rather than guessing, nothing discarded. Returns a list of
+    problems; empty means the arc now carries current law.
+    """
+    default = attempt.default_branch(repo_root)
+    if not default:
+        return ["cannot resolve the default branch to sync binding docs from"]
+    if base == default:
+        return []
+
+    _run(["git", "fetch", "--quiet", "origin"], cwd=repo_root)
+    pending = _run(
+        ["git", "log", "--oneline", f"origin/{base}..origin/{default}", "--",
+         *BINDING_DOC_PATHS],
+        cwd=repo_root,
+    )
+    if pending.returncode != 0:
+        return [
+            f"cannot compare binding docs between '{base}' and '{default}': "
+            f"{(pending.stderr or '').strip()}"
+        ]
+    commits = [ln for ln in pending.stdout.splitlines() if ln.strip()]
+    if not commits:
+        return []
+
+    log.write(
+        f"SYNC {len(commits)} binding-doc commit(s) on '{default}' not yet on "
+        f"'{base}' -- carrying them onto the arc before the roll reads them"
+    )
+    for line in commits[:5]:
+        log.write(f"  {line}")
+
+    # A worktree under data/speedrun/** -- evidence space, structurally exempt
+    # from dirt classification (standard 0027), and never a ~/Projects sibling
+    # (the stranded-worktree failure this campaign already paid for).
+    sync_tree = repo_root / "data" / "speedrun" / ".arc-sync"
+    problems: list[str] = []
+    try:
+        if sync_tree.exists():
+            _run(["git", "worktree", "remove", str(sync_tree)], cwd=repo_root)
+        add = _run(
+            ["git", "worktree", "add", str(sync_tree), base], cwd=repo_root
+        )
+        if add.returncode != 0:
+            return [
+                f"could not check out '{base}' to sync binding docs: "
+                f"{(add.stderr or '').strip()}"
+            ]
+        merge = _run(
+            ["git", "merge", f"origin/{default}", "-m",
+             f"Merge {default} into {base} - carry binding-doc rulings onto "
+             f"the arc before rolling (#2205)"],
+            cwd=sync_tree,
+        )
+        if merge.returncode != 0:
+            conflicted = _run(
+                ["git", "diff", "--name-only", "--diff-filter=U"], cwd=sync_tree
+            ).stdout.split()
+            _run(["git", "merge", "--abort"], cwd=sync_tree)
+            problems.append(
+                f"binding docs on '{default}' conflict with '{base}' in "
+                f"{', '.join(conflicted) or 'unknown file(s)'} -- resolve by "
+                "hand, then roll. Nothing was changed."
+            )
+        else:
+            push = _run(["git", "push", "origin", base], cwd=sync_tree)
+            if push.returncode != 0:
+                problems.append(
+                    f"synced '{base}' locally but could not push it: "
+                    f"{(push.stderr or '').strip()}"
+                )
+            else:
+                log.write(
+                    f"SYNC verified: '{base}' now carries the binding docs "
+                    f"from '{default}'"
+                )
+    finally:
+        _run(["git", "worktree", "remove", "--", str(sync_tree)], cwd=repo_root)
+        _run(["git", "worktree", "prune"], cwd=repo_root)
+    return problems
+
+
 def draft_is_stale(
     repo_root: Path, issue: int, drafted_at: str, base: str, log: EventLog
 ) -> bool:
@@ -2218,6 +2317,29 @@ def main(argv: list[str] | None = None) -> int:
             session.write("  file janitor: nothing to do")
     except Exception as exc:  # noqa: BLE001 - a janitor must never abort a roll
         session.write(f"JANITOR FAILED (continuing): {exc}")
+
+    # #2205: the arc is what the drafter and reviewer read as law. Carry the
+    # default branch's binding-doc rulings onto it BEFORE anything is drawn,
+    # and before resume planning, whose staleness check reads the same
+    # history. A conflict refuses the launch rather than rolling against
+    # docs nobody reconciled.
+    arc_base = resolve_attempt_branch(repo_root)
+    if arc_base:
+        try:
+            doc_problems = sync_binding_docs_to_arc(repo_root, arc_base, session)
+        except Exception as exc:  # noqa: BLE001
+            doc_problems = [f"binding-doc sync failed: {exc}"]
+        if doc_problems:
+            print("BLOCKED: the arc's binding docs could not be brought current:")
+            for p in doc_problems:
+                print(f"  - {p}")
+                session.write(f"SYNC BLOCKED: {p}")
+            print(
+                "\n  The roll reads design docs and ADRs from the attempt "
+                "branch, so rolling now\n  would build against rulings the "
+                "operator has already made. Nothing was spent."
+            )
+            return 91
 
     # #2145: the untracked set the roll borrows. Everything beyond this at
     # exit is the roll's own emission, and restore_repo reconciles it.


### PR DESCRIPTION
## Summary

Binding-doc rulings now reach the arc automatically, before the roll reads them. The launcher carries any `docs/design/**` or `docs/adrs/**` commits from the default branch onto the attempt branch during preflight, announces what it carried, and refuses the launch if the two sides conflict.

## Why

The roll's worktree stands on the attempt branch, so the design docs and ADRs the drafter and reviewer treat as law are the **arc's** copies. Issue text arrives live from GitHub; docs do not. An arc cut before a ruling never sees it, and nothing in the machinery noticed.

The cost was not theoretical. On 2026-08-10 `hardening-run-17` carried a two-day-old aesthetic doc while five rulings sat on `main`. Issue #1's spec stage failed twice on an objection the operator had already answered — the answer existed and was invisible to the pipeline. Worse, the investigation found doc rulings had been reaching arcs only when a pipeline PR happened to smuggle a snapshot along with it: nondeterministic, invisible, and version-skewed. Four hand-merges were needed across 2026-08-10/11 to keep the arc honest, and forgetting one wastes a whole run and produces a misleading verdict.

## Behaviour

- **Arc already current** → silent, no worktree, no push. The common case costs nothing.
- **Docs behind** → merge, push, and two log lines naming the count and the rulings carried (standard 0026: the console says what the machinery did — a silent mutation of a shared branch is exactly what an operator must not discover later from a diff).
- **Conflict** → `git merge --abort`, nothing changed, launch refuses with exit 91 naming the conflicted files. Resolving a ruling on the operator's behalf is not the launcher's business.
- **Non-doc commits on main** → ignored. Merging code into the arc is the arc's business, not this gate's.
- Never forces. The temporary worktree lives under `data/speedrun/**` — evidence space, structurally exempt from dirt classification (standard 0027) and never a `~/Projects` sibling, which is the stranded-worktree failure this campaign already paid for. It is removed in a `finally`.

Runs before resume planning, whose staleness check (#2206) reads the same doc history — so the sync and the guard agree rather than racing.

## Changes

- `tools/speedrun_roll.py` — `sync_binding_docs_to_arc()`, wired into preflight after the janitor and before the batch loop.
- `docs/runbooks/0952-speedrun-operator-solo.md` — the new refusal row, and a section showing the log lines an operator will see.
- `tests/unit/test_arc_doc_sync.py` — 8 tests against real git repos with a bare remote: the live 2026-08-10 case (a ruling on main reaching the arc), the announcement naming the ruling carried, silence when current, non-doc commits ignored, rolling on the default branch, conflict refusing without changing the arc, an unresolvable default branch, and no worktree left behind.

Full suite: 7144 passed, 17 skipped, zero failures. Lint clean.

Closes #2205
