### PR TITLE
fix(new_repo): merge .claude/settings.json instead of overwriting it (Closes #2113)

### DIFF
--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -1744,3 +1744,143 @@ class TestScaffoldValidationGate:
         (tmp_path / ".claude" / "project.json").write_text("{ not json", encoding="utf-8")
         blocking, _ = validate_scaffold(tmp_path)
         assert any("project.json" in m for m in blocking), blocking
+
+
+# ---- #2113: create_settings_json must merge, never overwrite ----
+#
+# The scaffolder is re-run over existing repos as a normal catch-up when a
+# template change needs to reach repos created before it. The previous
+# implementation wrote a fixed dict unconditionally, silently destroying
+# whatever that repo had added since.
+
+import new_repo as _nr  # noqa: E402
+
+
+def _settings_dir(tmp_path):
+    d = tmp_path / "myrepo" / ".claude"
+    d.mkdir(parents=True)
+    return tmp_path / "myrepo"
+
+
+def _read(project):
+    return json.loads(
+        (project / ".claude" / "settings.json").read_text(encoding="utf-8")
+    )
+
+
+def _guard_entry(settings):
+    return next(
+        e for e in settings["hooks"]["PreToolUse"]
+        if e.get("matcher") == _nr._GUARD_MATCHER
+    )
+
+
+def test_creates_settings_when_absent(tmp_path):
+    project = _settings_dir(tmp_path)
+    assert _nr.create_settings_json(project) == "created"
+    assert _guard_entry(_read(project))["hooks"][0]["type"] == "command"
+
+
+def test_preserves_unrelated_top_level_keys(tmp_path):
+    """A repo's own permissions must survive a scaffolder re-run.
+
+    This is the actual reported harm: permission rules vanishing, discovered
+    later as a repo prompting for something it never prompted for.
+    """
+    project = _settings_dir(tmp_path)
+    (project / ".claude" / "settings.json").write_text(json.dumps({
+        "permissions": {"allow": ["Bash(gh:*)"], "deny": ["Read(.env)"]},
+        "model": "opus",
+    }), encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "merged"
+    after = _read(project)
+    assert after["permissions"] == {"allow": ["Bash(gh:*)"], "deny": ["Read(.env)"]}
+    assert after["model"] == "opus"
+    assert _guard_entry(after)["hooks"][0]["command"].endswith("secret-file-guard.sh")
+
+
+def test_preserves_other_hook_events(tmp_path):
+    """The old code wrote PostToolUse: [] — erasing post-hooks outright."""
+    project = _settings_dir(tmp_path)
+    post = [{"matcher": "Bash", "hooks": [{"type": "command", "command": "echo hi"}]}]
+    (project / ".claude" / "settings.json").write_text(
+        json.dumps({"hooks": {"PostToolUse": post}}), encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "merged"
+    assert _read(project)["hooks"]["PostToolUse"] == post
+
+
+def test_preserves_other_matchers_in_pretooluse(tmp_path):
+    project = _settings_dir(tmp_path)
+    other = {"matcher": "Bash", "hooks": [{"type": "command", "command": "guard.sh"}]}
+    (project / ".claude" / "settings.json").write_text(
+        json.dumps({"hooks": {"PreToolUse": [other]}}), encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "merged"
+    pre = _read(project)["hooks"]["PreToolUse"]
+    assert other in pre
+    assert any(e.get("matcher") == _nr._GUARD_MATCHER for e in pre)
+
+
+def test_preserves_sibling_hooks_on_our_own_matcher(tmp_path):
+    """A repo may add its own hook to the same matcher; it must survive."""
+    project = _settings_dir(tmp_path)
+    sibling = {"type": "command", "command": "bash /repo/.claude/hooks/mine.sh"}
+    (project / ".claude" / "settings.json").write_text(json.dumps({
+        "hooks": {"PreToolUse": [
+            {"matcher": _nr._GUARD_MATCHER, "hooks": [sibling]}
+        ]}
+    }), encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "merged"
+    entry_hooks = _guard_entry(_read(project))["hooks"]
+    assert sibling in entry_hooks
+    assert any(h["command"].endswith("secret-file-guard.sh") for h in entry_hooks)
+
+
+def test_rerun_is_a_no_op_and_does_not_touch_the_file(tmp_path):
+    """A catch-up sweep over compliant repos must produce no diff, no churn."""
+    project = _settings_dir(tmp_path)
+    assert _nr.create_settings_json(project) == "created"
+
+    path = project / ".claude" / "settings.json"
+    before_bytes = path.read_bytes()
+    before_mtime = path.stat().st_mtime_ns
+
+    assert _nr.create_settings_json(project) == "unchanged"
+    assert path.read_bytes() == before_bytes
+    assert path.stat().st_mtime_ns == before_mtime
+
+
+def test_unparseable_file_is_backed_up_never_discarded(tmp_path):
+    """The one remaining destructive path must preserve the original."""
+    project = _settings_dir(tmp_path)
+    path = project / ".claude" / "settings.json"
+    garbage = "{ this is not json"
+    path.write_text(garbage, encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "replaced-unparseable"
+    backup = project / ".claude" / "settings.json.bak"
+    assert backup.exists()
+    assert backup.read_text(encoding="utf-8") == garbage
+    assert _guard_entry(_read(project))["hooks"][0]["type"] == "command"
+
+
+def test_json_array_at_top_level_is_treated_as_unparseable(tmp_path):
+    """Valid JSON that is not an object cannot be merged into; back it up."""
+    project = _settings_dir(tmp_path)
+    path = project / ".claude" / "settings.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    assert _nr.create_settings_json(project) == "replaced-unparseable"
+    assert (project / ".claude" / "settings.json.bak").read_text(
+        encoding="utf-8") == "[1, 2, 3]"
+
+
+def test_merge_helper_does_not_mutate_its_input():
+    """Purity matters: the caller compares merged against existing."""
+    existing = {"hooks": {"PreToolUse": []}}
+    snapshot = json.dumps(existing, sort_keys=True)
+    _nr._merge_settings(existing, {"type": "command", "command": "x"})
+    assert json.dumps(existing, sort_keys=True) == snapshot

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -23,6 +23,7 @@ See: docs/standards/0009-canonical-project-structure.md
 
 import argparse
 import base64
+import copy
 import json
 import logging
 import os
@@ -1812,41 +1813,125 @@ def create_dependabot_config(project_path: Path) -> list[str]:
     return [eco for eco, _label in ecosystems]
 
 
-def create_settings_json(project_path: Path) -> None:
+# #2113: the PreToolUse matcher this scaffolder owns. Merging keys on this
+# exact string so a repo's own entries under other matchers survive untouched.
+_GUARD_MATCHER = "Read|Write|Edit|Grep|NotebookEdit"
+
+
+def _merge_settings(existing: dict, canonical_hook: dict) -> dict:
+    """Return `existing` with the canonical guard hook ensured, nothing lost.
+
+    #2113: the previous implementation built a fixed dict and wrote it
+    unconditionally, so re-running the scaffolder over an existing repo -- a
+    normal catch-up when a template change needs to reach repos created before
+    it -- silently destroyed whatever that repo had added since: permission
+    rules, extra hooks, tool-specific config. `settings.json` is not a file
+    anyone opens routinely, so the loss surfaced much later as a repo
+    prompting for something it never prompted for.
+
+    Merge rules, deliberately the narrowest that still guarantees the guard:
+      * every top-level key is preserved; only `hooks` is touched
+      * every hook EVENT other than PreToolUse is preserved -- note the old
+        code wrote `"PostToolUse": []`, erasing post-hooks outright
+      * within PreToolUse, only the entry whose matcher we own is touched
+      * within that entry the guard command is appended only when absent, so a
+        repo may carry its own additional hooks on the same matcher
+
+    Pure: mutates neither argument, so the merge decision is testable without
+    a filesystem.
     """
-    Create .claude/settings.json with per-repo hooks.
+    merged = copy.deepcopy(existing)
+    hooks = merged.setdefault("hooks", {})
+    pre = hooks.setdefault("PreToolUse", [])
+
+    entry = next(
+        (e for e in pre
+         if isinstance(e, dict) and e.get("matcher") == _GUARD_MATCHER),
+        None,
+    )
+    if entry is None:
+        pre.append({"matcher": _GUARD_MATCHER, "hooks": [canonical_hook]})
+        return merged
+
+    entry_hooks = entry.setdefault("hooks", [])
+    if not any(
+        isinstance(h, dict) and h.get("command") == canonical_hook["command"]
+        for h in entry_hooks
+    ):
+        entry_hooks.append(canonical_hook)
+    return merged
+
+
+def create_settings_json(project_path: Path) -> str:
+    """
+    Ensure .claude/settings.json carries the per-repo secret-file guard.
 
     Only deploys secret-file-guard.sh per-repo. Security hooks (secret-guard.sh,
     bash-gate.sh) are registered globally in ~/.claude/settings.json and do not
     need per-repo copies. See AssemblyZero #872.
 
+    #2113: reads and merges rather than overwriting. Returns what it did, so
+    callers and tests assert on the outcome instead of inferring it from the
+    file's contents.
+
+    A file that does not parse as JSON is the one destructive path left. The
+    original is copied to `<name>.bak` beside itself before canonical settings
+    are written, and the outcome names that case; nothing is discarded quietly.
+
     Args:
         project_path: Path to the project root
+
+    Returns:
+        "created" | "unchanged" | "merged" | "replaced-unparseable"
     """
     projects_root_unix = config.projects_root_unix()
     project_name = project_path.name
 
-    settings = {
+    canonical_hook = {
+        "type": "command",
+        "command": f"bash {projects_root_unix}/{project_name}/.claude/hooks/secret-file-guard.sh",
+        "timeout": 5,
+        "description": "Secret File Guard (blocks file tools on .env, credentials)"
+    }
+    canonical = {
         "hooks": {
             "PreToolUse": [
-                {
-                    "matcher": "Read|Write|Edit|Grep|NotebookEdit",
-                    "hooks": [
-                        {
-                            "type": "command",
-                            "command": f"bash {projects_root_unix}/{project_name}/.claude/hooks/secret-file-guard.sh",
-                            "timeout": 5,
-                            "description": "Secret File Guard (blocks file tools on .env, credentials)"
-                        }
-                    ]
-                }
+                {"matcher": _GUARD_MATCHER, "hooks": [canonical_hook]}
             ],
             "PostToolUse": []
         }
     }
 
     settings_path = project_path / ".claude" / "settings.json"
-    settings_path.write_text(json.dumps(settings, indent=2) + "\n", encoding='utf-8')
+
+    if not settings_path.exists():
+        settings_path.write_text(
+            json.dumps(canonical, indent=2) + "\n", encoding='utf-8')
+        return "created"
+
+    raw = settings_path.read_text(encoding='utf-8')
+    try:
+        existing = json.loads(raw)
+        if not isinstance(existing, dict):
+            raise ValueError("settings.json is not a JSON object")
+    except (json.JSONDecodeError, ValueError):
+        backup = settings_path.with_suffix(settings_path.suffix + ".bak")
+        backup.write_text(raw, encoding='utf-8')
+        settings_path.write_text(
+            json.dumps(canonical, indent=2) + "\n", encoding='utf-8')
+        print(f"  WARNING: {settings_path} did not parse as JSON; original "
+              f"preserved at {backup.name} and canonical settings written")
+        return "replaced-unparseable"
+
+    merged = _merge_settings(existing, canonical_hook)
+    if merged == existing:
+        # #2113: a no-op run leaves the file untouched, so a catch-up sweep
+        # over already-compliant repos produces no diff and no mtime churn.
+        return "unchanged"
+
+    settings_path.write_text(
+        json.dumps(merged, indent=2) + "\n", encoding='utf-8')
+    return "merged"
 
 
 def deploy_canonical_hooks(project_path: Path) -> None:


### PR DESCRIPTION
`create_settings_json` built a fixed dict and wrote it unconditionally, with no read of the existing file.

On a genuinely new repo that is harmless. It stops being harmless the moment the scaffolder is re-run over an existing repo — a normal catch-up when a template change needs to reach repos created before it — because everything that repo added since is destroyed: permission rules, extra hooks, tool-specific configuration.

The failure was quiet. `settings.json` is not a file anyone opens routinely, so the loss surfaced much later as a repo prompting for something it never prompted for.

## The merge

Deliberately the narrowest one that still guarantees the guard:

- every top-level key preserved — only `hooks` is touched
- every hook **event** other than `PreToolUse` preserved. The old code wrote `"PostToolUse": []`, erasing post-hooks outright.
- within `PreToolUse`, only the entry under our own matcher is touched
- within that entry, the guard command is appended only when absent, so a repo may keep its own hooks on the same matcher

`create_settings_json` now returns what it did — `created` / `unchanged` / `merged` / `replaced-unparseable` — so callers and tests assert the outcome instead of inferring it from file contents.

**A no-op run leaves the file untouched**, byte-identical and same mtime, so a catch-up sweep over already-compliant repos produces no diff and no churn.

## The one destructive path left

A file that does not parse as JSON cannot be merged into. The original is copied to `<name>.bak` beside itself, a warning names the case, and canonical settings are written. Valid JSON that is not an object takes the same path, since there is nothing to merge into. Nothing is discarded quietly.

## Proven non-vacuous, not assumed

The new tests were run against the **old** implementation, restored from `origin/main`:

```
FAILED test_preserves_unrelated_top_level_keys
FAILED test_preserves_other_hook_events
FAILED test_preserves_other_matchers_in_pretooluse
FAILED test_preserves_sibling_hooks_on_our_own_matcher
FAILED test_rerun_is_a_no_op_and_does_not_touch_the_file
FAILED test_unparseable_file_is_backed_up_never_discarded
FAILED test_json_array_at_top_level_is_treated_as_unparseable
7 failed, 5 passed
```

All 7 pass with the fix. A preservation test that cannot fail is worthless, so this is measured rather than claimed.

## Verification

- `tests/unit/test_new_repo.py`: **120 passed**
- Full unit suite: **6663 passed**, 17 skipped, 5 xfailed, zero failures
- `ruff`: clean

## Not addressed here

The issue also records that the scaffolder cannot emit resource-scoped permission rules at creation time, because the resource does not exist yet. That is correctly out of scope — it needs a separate re-runnable tool once resources exist, and this PR does not attempt to push it into `new_repo.py`.

Closes #2113
