### PR TITLE
feat(new_repo): name npm directories whose dependabot PRs could never be merged (Closes #2182)

### DIFF
--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -1884,3 +1884,52 @@ def test_merge_helper_does_not_mutate_its_input():
     snapshot = json.dumps(existing, sort_keys=True)
     _nr._merge_settings(existing, {"type": "command", "command": "x"})
     assert json.dumps(existing, sort_keys=True) == snapshot
+
+
+# ---- #2182: the scaffolder names npm dirs whose PRs could never merge ----
+
+def test_warns_for_npm_dir_without_runnable_test_script(tmp_path, capsys):
+    """A repo must not be born receiving PRs it cannot pass review on."""
+    web = tmp_path / "web"
+    web.mkdir(parents=True)
+    (web / "package.json").write_text(json.dumps({"name": "web"}), encoding="utf-8")
+    (web / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    warned = _nr.warn_npm_dirs_without_test_script(tmp_path)
+
+    assert warned == ["/web"]
+    out = capsys.readouterr().out
+    assert "/web" in out
+    assert "1839" in out          # names the gate that will refuse the merge
+    assert "no test specified" in out   # tells them the placeholder won't do
+
+
+def test_compliant_repo_produces_no_warning(tmp_path, capsys):
+    web = tmp_path / "web"
+    web.mkdir(parents=True)
+    (web / "package.json").write_text(
+        json.dumps({"name": "web", "scripts": {"test": "vitest run"}}),
+        encoding="utf-8")
+    (web / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    assert _nr.warn_npm_dirs_without_test_script(tmp_path) == []
+    assert capsys.readouterr().out == ""
+
+
+def test_warns_about_a_directory_dependabot_yml_never_declared(tmp_path, capsys):
+    """The case that prompted this: security updates ignore dependabot.yml.
+
+    AssemblyZero declared npm for /sentinel only and never for /dashboard,
+    yet /dashboard received npm PRs and deferred on every harvest. A guard
+    that only checked configured directories would have missed it.
+    """
+    for name, scripts in (("sentinel", {"test": "vitest run"}), ("dashboard", None)):
+        d = tmp_path / name
+        d.mkdir(parents=True)
+        body = {"name": name}
+        if scripts:
+            body["scripts"] = scripts
+        (d / "package.json").write_text(json.dumps(body), encoding="utf-8")
+        (d / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    assert _nr.warn_npm_dirs_without_test_script(tmp_path) == ["/dashboard"]

--- a/tests/unit/test_npm_manifest.py
+++ b/tests/unit/test_npm_manifest.py
@@ -1,0 +1,150 @@
+"""Tests for tools/_npm_manifest.py — the npm test-script guard (#2182).
+
+The guard exists because a repo could be born receiving npm dependabot PRs it
+was structurally incapable of passing review on. The review gate (#1839)
+refuses to merge an npm PR whose directory has no runnable `test` script, and
+nothing on the enabling side checked for one.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS))
+
+import _npm_manifest as npm  # noqa: E402
+
+
+def _pkg(d: Path, scripts=None, lock="package-lock.json"):
+    d.mkdir(parents=True, exist_ok=True)
+    body = {"name": d.name}
+    if scripts is not None:
+        body["scripts"] = scripts
+    (d / "package.json").write_text(json.dumps(body), encoding="utf-8")
+    if lock:
+        (d / lock).write_text("{}", encoding="utf-8")
+    return d
+
+
+# ---- npm_test_script: what counts as runnable ----
+
+def test_real_script_is_runnable(tmp_path):
+    d = _pkg(tmp_path / "a", {"test": "vitest run"})
+    assert npm.npm_test_script(d) == "vitest run"
+
+
+def test_npm_init_placeholder_does_not_count(tmp_path):
+    """The subtle one, and the reason this cannot be a truthiness check.
+
+    Running the placeholder exits 1 with a message that would be misreported
+    as a test failure, when the real condition is "declares no tests".
+    """
+    d = _pkg(tmp_path / "a",
+             {"test": 'echo "Error: no test specified" && exit 1'})
+    assert npm.npm_test_script(d) is None
+
+
+@pytest.mark.parametrize("scripts", [None, {}, {"test": ""}, {"test": "   "},
+                                     {"test": 42}, {"build": "vite build"}])
+def test_absent_empty_or_non_string_is_not_runnable(tmp_path, scripts):
+    d = _pkg(tmp_path / "a", scripts)
+    assert npm.npm_test_script(d) is None
+
+
+def test_unreadable_manifest_is_conservative(tmp_path):
+    """Cannot evaluate means report as missing — prompts a look, never a pass."""
+    d = tmp_path / "a"
+    d.mkdir()
+    (d / "package.json").write_text("{ not json", encoding="utf-8")
+    assert npm.npm_test_script(d) is None
+
+
+def test_missing_manifest_is_not_runnable(tmp_path):
+    d = tmp_path / "a"
+    d.mkdir()
+    assert npm.npm_test_script(d) is None
+
+
+# ---- find_npm_manifests: which directories can receive npm PRs ----
+
+def test_a_lockfile_is_what_makes_a_directory_reachable(tmp_path):
+    _pkg(tmp_path / "withlock", {"test": "x"})
+    _pkg(tmp_path / "nolock", {"test": "x"}, lock=None)
+    found = npm.find_npm_manifests(tmp_path)
+    assert found == [tmp_path / "withlock"]
+
+
+@pytest.mark.parametrize("lock", ["package-lock.json", "npm-shrinkwrap.json",
+                                  "yarn.lock", "pnpm-lock.yaml"])
+def test_every_lockfile_flavour_counts(tmp_path, lock):
+    _pkg(tmp_path / "a", {"test": "x"}, lock=lock)
+    assert npm.find_npm_manifests(tmp_path) == [tmp_path / "a"]
+
+
+def test_node_modules_is_never_descended(tmp_path):
+    """Vendored manifests are not ours; thousands of them would swamp output."""
+    _pkg(tmp_path / "app", {"test": "x"})
+    _pkg(tmp_path / "app" / "node_modules" / "left-pad", None)
+    assert npm.find_npm_manifests(tmp_path) == [tmp_path / "app"]
+
+
+def test_subdirectories_are_covered_not_just_the_root(tmp_path):
+    """The observed failure was a subdirectory the root said nothing about."""
+    _pkg(tmp_path, {"test": "x"})
+    _pkg(tmp_path / "dashboard", None)
+    assert (tmp_path / "dashboard") in npm.find_npm_manifests(tmp_path)
+
+
+# ---- dirs_missing_test_script: the reportable answer ----
+
+def test_reports_dependabot_style_paths(tmp_path):
+    _pkg(tmp_path, None)                        # root, no script
+    _pkg(tmp_path / "dashboard", None)          # subdir, no script
+    _pkg(tmp_path / "sentinel", {"test": "vitest run"})   # compliant
+    assert npm.dirs_missing_test_script(tmp_path) == ["/", "/dashboard"]
+
+
+def test_compliant_repo_reports_nothing(tmp_path):
+    _pkg(tmp_path, {"test": "pytest"})
+    _pkg(tmp_path / "web", {"test": "vitest run"})
+    assert npm.dirs_missing_test_script(tmp_path) == []
+
+
+def test_placeholder_directory_is_reported(tmp_path):
+    _pkg(tmp_path / "web", {"test": 'echo "Error: no test specified" && exit 1'})
+    assert npm.dirs_missing_test_script(tmp_path) == ["/web"]
+
+
+# ---- drift: this must keep agreeing with the review gate ----
+
+def test_agrees_with_the_review_gate_definition(tmp_path):
+    """The two halves must not drift apart on what "runnable" means.
+
+    Skips cleanly if the harvester is no longer in this repo — it is slated to
+    move (see the migration tracked in the private fleet repo), and a
+    hard-failing cross-import would turn that move into a broken build. When
+    it does move, this skip is the signal to re-point the check.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_dr_probe", TOOLS / "dependabot_review.py")
+    if spec is None or not (TOOLS / "dependabot_review.py").exists():
+        pytest.skip("dependabot_review.py not in this repo (migrated)")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    cases = [
+        {"test": "vitest run"},
+        {"test": 'echo "Error: no test specified" && exit 1'},
+        {"test": ""},
+        {},
+        None,
+    ]
+    for i, scripts in enumerate(cases):
+        d = _pkg(tmp_path / f"c{i}", scripts)
+        assert (npm.npm_test_script(d) is None) == (mod._npm_test_script(d) is None), (
+            f"definitions disagree on {scripts!r}"
+        )

--- a/tools/_npm_manifest.py
+++ b/tools/_npm_manifest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""npm manifest inspection shared by the scaffolder and the fleet tooling.
+
+#2182. A repo can receive npm dependabot PRs it is structurally incapable of
+passing review on, and then every one of those PRs defers forever.
+
+The review gate (#1839) refuses to merge an npm PR whose directory has no
+runnable `test` script -- correctly, since merging an unverified dependency
+bump is the thing that gate exists to prevent. Nothing on the enabling side
+checks for one, so the two halves disagree: PRs arrive for a directory whose
+PRs can never be merged.
+
+WHY THIS SCANS THE REPO RATHER THAN dependabot.yml
+--------------------------------------------------
+The obvious design is to check each `directory:` in `.github/dependabot.yml`
+when that file is written. That would not have caught the case that prompted
+this module.
+
+AssemblyZero's dependabot.yml declares npm for `/sentinel` only. There has
+never been a `/dashboard` entry. `/dashboard` nevertheless received npm PRs
+(#2111, "in the npm_and_yarn group across 1 directory") because **GitHub's
+security updates fire on any lockfile in the repo, independent of
+version-update configuration**. That repo's own dependabot.yml header records
+the same asymmetry from the other direction: before it existed the repo "had
+only GitHub's default security updates, and those do not cover everything".
+
+So the set of directories that can receive npm PRs is not the set configured
+in dependabot.yml -- it is every directory holding a package.json with a
+lockfile. That is what these helpers enumerate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# A lockfile is what makes a directory reachable by security updates; a
+# package.json alone (no lock) is not a dependency tree GitHub will bump.
+NPM_LOCKFILES = ("package-lock.json", "npm-shrinkwrap.json", "yarn.lock",
+                 "pnpm-lock.yaml")
+
+# Never descend into these. node_modules in particular contains thousands of
+# vendored package.json files, none of them ours.
+_SKIP_DIRS = {"node_modules", ".git", "dist", "build", ".next", ".wrangler",
+              ".venv", "__pycache__"}
+
+
+def npm_test_script(pkg_dir: Path) -> str | None:
+    """The package.json "test" script in `pkg_dir`, or None when unrunnable.
+
+    Mirrors the semantics of the review gate's own check, deliberately and
+    including its subtlety: `npm init`'s placeholder
+    (`echo "Error: no test specified" && exit 1`) counts as NO script.
+    Running it can only exit 1 with a message that would then be misreported
+    as a test failure, when the real condition is "this package declares no
+    tests".
+
+    Any unreadable or malformed manifest returns None -- a directory we cannot
+    evaluate is reported as lacking a script, which is the conservative
+    direction: it prompts a human look rather than silently passing.
+    """
+    pkg = pkg_dir / "package.json"
+    if not pkg.exists():
+        return None
+    try:
+        with pkg.open("rb") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    script = (data.get("scripts") or {}).get("test")
+    if not isinstance(script, str) or not script.strip():
+        return None
+    if "no test specified" in script:
+        return None
+    return script
+
+
+def find_npm_manifests(root: Path) -> list[Path]:
+    """Every directory under `root` holding a package.json AND a lockfile.
+
+    These are exactly the directories GitHub can open npm PRs against,
+    whether or not dependabot.yml mentions them. Returned sorted for
+    deterministic output.
+    """
+    found: list[Path] = []
+    for pkg in root.rglob("package.json"):
+        if any(part in _SKIP_DIRS for part in pkg.relative_to(root).parts):
+            continue
+        d = pkg.parent
+        if any((d / lf).exists() for lf in NPM_LOCKFILES):
+            found.append(d)
+    return sorted(found)
+
+
+def dirs_missing_test_script(root: Path) -> list[str]:
+    """Repo-relative directories that can receive npm PRs but cannot pass review.
+
+    `"/"` denotes the repo root, matching dependabot.yml's `directory:` form
+    so the output can be read against that file directly.
+    """
+    missing: list[str] = []
+    for d in find_npm_manifests(root):
+        if npm_test_script(d) is None:
+            rel = d.relative_to(root).as_posix()
+            missing.append("/" if rel == "." else f"/{rel}")
+    return missing

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -58,6 +58,14 @@ except ImportError:
     from enable_dependabot import enable_dependabot_for_repo
     from deploy_cerberus_secrets import deploy_to_repo, verify_secrets
 
+# #2182: npm manifest inspection, shared so the enabling side and any later
+# audit agree on what "has a runnable test script" means.
+try:
+    from _npm_manifest import dirs_missing_test_script
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from _npm_manifest import dirs_missing_test_script
+
 # In-process classic PAT for privileged REST calls (ADR-0216).
 # Branch protection PUT and repo settings PATCH used to shell out to
 # `gh api` which reads GH_TOKEN from the env block (snoopable by sibling
@@ -1810,7 +1818,51 @@ def create_dependabot_config(project_path: Path) -> list[str]:
     (github_dir / "dependabot.yml").write_text(
         render_dependabot_yml(ecosystems), encoding="utf-8", newline="",
     )
+    warn_npm_dirs_without_test_script(project_path)
     return [eco for eco, _label in ecosystems]
+
+
+def warn_npm_dirs_without_test_script(project_path: Path) -> list[str]:
+    """#2182: name every npm directory whose PRs could never be merged.
+
+    The review gate (#1839) refuses to merge an npm PR whose directory has no
+    runnable `test` script. Nothing on the enabling side checked for one, so a
+    repo could be born receiving PRs it was structurally incapable of passing
+    review on -- every one of them deferring, forever, for a reason visible
+    only in a harvest log.
+
+    Scans the repo rather than the dependabot.yml just written, because the
+    two sets differ. Security updates fire on any lockfile regardless of
+    version-update config: AssemblyZero declares npm for `/sentinel` only and
+    has never declared `/dashboard`, yet `/dashboard` received npm PRs (#2111)
+    and deferred on every harvest until a test script was added. Checking only
+    what we configured would have missed exactly that case.
+
+    Warns rather than refuses. A repo may legitimately be scaffolded before
+    its test story exists, and blocking creation over a script that can be
+    added in a minute trades a real capability for a hypothetical tidiness.
+    The diagnostic names each directory so the choice is informed, and
+    `dirs_missing_test_script` stays importable so an audit can find the
+    condition later in repos that already exist.
+
+    Returns the directories warned about, so callers and tests can assert.
+    """
+    missing = dirs_missing_test_script(project_path)
+    if not missing:
+        return []
+    print(
+        f"  WARNING: {len(missing)} npm director"
+        f"{'y' if len(missing) == 1 else 'ies'} with a lockfile but no "
+        f"runnable `test` script: {', '.join(missing)}"
+    )
+    print(
+        "    Dependabot can open npm PRs against these (security updates do "
+        "not require a dependabot.yml entry), and the review gate will refuse "
+        "to merge them unverified (#1839) -- so they would defer on every "
+        "harvest. Add a real `test` script to each. `npm init`'s "
+        "\"no test specified\" placeholder does not count."
+    )
+    return missing
 
 
 # #2113: the PreToolUse matcher this scaffolder owns. Merging keys on this


### PR DESCRIPTION
The review gate (#1839) refuses to merge an npm PR whose directory has no runnable `test` script. Nothing on the enabling side checked for one, so a repo could be born receiving PRs it was structurally incapable of passing review on — every one deferring forever, for a reason visible only in a harvest log.

## The issue's premise was wrong, and the fix is better for it

The issue proposed guarding the point where npm is *enabled* — `new_repo.py` and the fleet backfill writing a `directory:` into `dependabot.yml`. **That would not have caught the case that prompted it.**

This repo's `dependabot.yml` declares npm for `/sentinel` only. There has never been a `/dashboard` entry. `/dashboard` received npm PRs anyway — #2111, *"in the npm_and_yarn group across 1 directory"* — because **GitHub's security updates fire on any lockfile, independent of version-update configuration**. The file's own header records the same asymmetry from the other side: before it existed the repo *"had only GitHub's default security updates, and those do not cover everything."*

So the set of directories that can receive npm PRs is **not** the set configured in `dependabot.yml` — it is every directory holding a `package.json` with a lockfile. `_npm_manifest` enumerates that instead.

## The change

**`tools/_npm_manifest.py`** — one definition of "runnable", shared so the enabling side and any later audit cannot disagree:

- `npm_test_script(dir)` — including the subtlety: `npm init`'s `echo "Error: no test specified" && exit 1` is **not** a test script. Running it exits 1 with a message that gets misreported as a test failure, when the real condition is "declares no tests".
- `find_npm_manifests(root)` — package.json + lockfile pairs, `node_modules` never descended.
- `dirs_missing_test_script(root)` — the reportable answer, in `dependabot.yml`'s own `/dir` form so it reads against that file directly.

**`new_repo.py`** warns, naming each directory, citing the gate that will refuse the merge, and stating the placeholder does not count.

## Warning, not refusal — deliberately

A repo may legitimately be scaffolded before its test story exists. Blocking creation over a script that takes a minute to add trades a real capability for tidiness. The issue left this open; this is the call, and `dirs_missing_test_script` stays importable so an audit can find the condition in repos that already exist.

## Validated live, not just in fixtures

Run against this repo: **332 `package.json` files reduce to 2** real manifests — `dashboard: 'npm run typecheck'`, `sentinel: 'vitest run'`, none missing. It reports clean *because* #2154 fixed `/dashboard`; before that it would have been flagged.

## Drift protection that survives the planned migration

A test cross-checks this definition against the review gate's own `_npm_test_script` across five cases. It **skips cleanly** if the harvester is no longer in this repo — that tool is slated to move, and a hard cross-import would turn the move into a broken build. The skip is the signal to re-point the check.

## Deliberately not done

The issue also asked for the same guard in the API-based fleet backfill. **Left out, and worth saying why:** that tool detects root markers over the Contents API without cloning, so it can only ever check the root manifest — while the corrected mechanism above shows the exposure is subdirectories that nothing configured. Adding a root-only check there would be motion against the wrong surface. The durable answer is a fleet audit using `dirs_missing_test_script`, which the shared module now makes possible; filed separately rather than half-built here.

## Verification

- 21 new tests; `test_new_repo.py` + `test_npm_manifest.py`: 144 passed
- Full unit suite: **6687 passed**, 17 skipped, 5 xfailed, zero failures
- `ruff`: clean

Closes #2182
