### PR TITLE
docs: adopt a checkable requirements form (Closes #2218)

### DIFF
--- a/docs/adrs/0226-checkable-requirements-ears-tables-split.md
+++ b/docs/adrs/0226-checkable-requirements-ears-tables-split.md
@@ -1,0 +1,216 @@
+# ADR 0226: Requirements are authored in a checkable form
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Categories:** Process, Data, Reliability
+**Related:** #2218 (this ADR); #1899 (the requirements-consistency gate); standard 0028 (ask structured, get structured, or reject); boostgauge #7 (the first converted requirement); boostgauge #235, #240, #249, #252, #273, #274, #275 (the seven conflicts); boostgauge #270 (a pass criterion carries values, not pointers)
+
+---
+
+## 1. Context
+
+The requirements-consistency gate reads an issue before any drafting begins. It halts the run when two acceptance criteria contradict each other, and files an issue naming the pair. The gate works as designed.
+
+On boostgauge issue #7 it fired seven times across five separate operator rulings. Every firing landed on the same paragraph. The rulings were boostgauge #235, #240, #249 and #252, followed by #273, #274 and #275 from a single run on 2026-08-11.
+
+Each ruling amended one sentence of English prose, and each amendment carried a condition. The neighboring sentences making adjacent claims never received that condition. Prose offers no mechanism to propagate a qualifier across a paragraph, so every repair produced the next contradiction.
+
+The requirement underneath is a function of two independent conditions. The first is whether the app was launched with `--reset-config`. The second is whether the user moved or resized the window. Four combinations exist. The paragraph described three of them in overlapping sentences and left the fourth ambiguous.
+
+The gate's output carries a second signal. One defect produced three issues, because a pairwise comparison over prose can only report pairs. A complete enumeration reports one gap instead.
+
+### The same defect, one stage later
+
+boostgauge ruling #270 established that a test pass criterion must carry the value it asserts, rather than cite the document holding that value. The specification stage reads the LLD and not the design docs. An LLD that pointed at a color instead of quoting it left the test writer nothing to assert, and the only test then available was one that verified nothing. Seven specification halts on boostgauge #1 came from that gap.
+
+This ADR applies the same requirement one level higher. The LLD stage reads the issue. An issue that states combinatorial behavior as overlapping prose leaves the drafter to guess which reading was intended.
+
+## 2. Decision
+
+**We will author requirements in a form whose completeness a program can verify.** Three rules bind every issue the orchestrator rolls.
+
+1. Each requirement is one sentence in an EARS pattern, carrying its own trigger or state condition.
+2. Where behavior depends on two or three independent conditions, the requirement is a decision table enumerating every combination, and each row becomes one acceptance criterion.
+3. A requirement whose behavior depends on more than three conditions is split into several requirements rather than tabulated.
+
+## 3. The three rules in detail
+
+### 3.1 EARS sentence patterns
+
+Every requirement takes one of five forms (Mavin et al., 2009):
+
+| Pattern | Form |
+|---|---|
+| Ubiquitous | The `<system>` shall `<response>` |
+| Event-driven | WHEN `<trigger>` the `<system>` shall `<response>` |
+| State-driven | WHILE `<state>` the `<system>` shall `<response>` |
+| Unwanted behavior | IF `<condition>` THEN the `<system>` shall `<response>` |
+| Optional feature | WHERE `<feature is present>` the `<system>` shall `<response>` |
+
+The benefit is that a conditional requirement cannot be written as though it were universal. Both halves of the boostgauge #7 collision were conditional statements written in the ubiquitous form. "On exit only hand-made changes are written" is state-driven and never said so. "It rewrites the file to defaults regardless" is event-driven and never said so. Each one read as a universal law, so the two appeared to contradict.
+
+A parser can reject a sentence matching none of the five patterns. That check is cheap and runs at authoring time.
+
+### 3.2 Lightweight Parnas tables
+
+David Parnas and the Naval Research Laboratory rebuilt the requirements document for the A-7E aircraft's flight software in the late 1970s, under the Software Cost Reduction project. Its central technique was the tabular expression. Where a function depends on several conditions, the document states it as a grid, and the grid is the definition rather than a summary of one.
+
+Two properties make a grid checkable:
+
+- **Completeness.** The row conditions must cover every case.
+- **Disjointness.** No two rows may apply at once.
+
+Both are decidable by a program. With binary conditions the check reduces to counting, since `n` conditions require `2^n` rows and no combination may repeat.
+
+**What we take:** the grid, the completeness obligation, and the disjointness obligation.
+
+**What we leave:** the formal type system and the mathematical semantics of Parnas tabular expressions. Our rows are plain English with plain yes and no answers. Section 4 explains why.
+
+The worked example is boostgauge #7, converted on 2026-08-11:
+
+| Launched with `--reset-config`? | Did the user move or resize the window? | Config file after quit |
+|---|---|---|
+| no | no | unchanged, byte-for-byte |
+| no | yes | prior contents, with the new position and size |
+| yes | no | defaults |
+| yes | yes | defaults, with the new position and size |
+
+Every one of the seven historical conflicts was a question about which row a sentence described. None of them can be stated against the table.
+
+Two disciplines keep a table readable. The column headers must be plain questions with plain answers, because a header written as a predicate expression removes the benefit. Each row must also appear as its own acceptance criterion, so the four combinations become four independently testable claims.
+
+### 3.3 The split rule
+
+Two conditions produce four rows and read well. Three produce eight and remain workable. Five produce thirty-two, and a table of thirty-two rows is not read by anyone.
+
+Parnas answered this with hierarchical decomposition into several smaller tables. We answer it with a limit at three conditions, because the count is also a design signal. A requirement whose behavior turns on five independent conditions is doing several jobs, and the table exposes that before any code is drafted.
+
+The split is an authoring act and not a scheduling one. Each resulting requirement carries its own conditions and its own table, and each names the requirement it was split from.
+
+## 4. Alternatives Considered
+
+### Option A: EARS sentences, lightweight tables, and a split rule (SELECTED)
+
+**Description:** As stated in section 2.
+
+**Pros:**
+- Completeness becomes countable rather than argued.
+- The notation is readable by the operator, by the drafting LLM, and by a checker. No translation step sits between them.
+- Contradictions of the enumerated kind cannot be written.
+- Each row arrives as an acceptance criterion, which feeds the existing traceability check directly.
+
+**Cons:**
+- Authoring cost rises for simple requirements.
+- A table can be complete and still wrong. Completeness is not correctness.
+- Existing issues are written in prose and need conversion.
+
+### Option B: Formal specification, such as TLA+, Alloy or Z (Rejected, not triggered)
+
+**Description:** State requirements in a formal notation and prove consistency with a model checker.
+
+**Pros:**
+- Machine-checked consistency is a stronger guarantee than counting rows.
+- Decides contradictions that no table can express.
+
+**Cons:**
+- The operator must read these documents and rule on them. A notation he does not read removes his ability to rule, and that is the one step in this process nobody else can perform.
+- The drafters and reviewers in this pipeline are LLMs reading English. A formal notation adds a translation step, and translation is where ambiguity returns.
+- The defect rate does not justify the weight. One paragraph in one issue produced all seven conflicts.
+
+This option is not rejected permanently. It is not triggered.
+
+### Option C: Keep prose and strengthen the gate (Rejected)
+
+**Description:** Leave issues in prose and improve the consistency gate's detection.
+
+**Pros:**
+- No authoring change, and no conversion of existing issues.
+- The gate already detects these contradictions honestly.
+
+**Cons:**
+- Detection is the expensive half. Each catch costs a halted run, an operator ruling and a redraw. Prevention at authoring costs nothing.
+- Pairwise detection over prose reports pairs, which is why one defect produced three issues.
+- Five rounds of this already ran on boostgauge #7. The paragraph produced a new contradiction after every repair.
+
+### Option D: The full Software Cost Reduction method with tool support (Rejected, not triggered)
+
+**Description:** Adopt the published method, including the formal tabular semantics and a consistency checker built for them.
+
+**Pros:**
+- Proven on avionics software far more complex than anything in this fleet.
+- Supplies completeness and disjointness proofs mechanically.
+
+**Cons:**
+- The readability we want is available from the plain grid alone.
+- The tooling would have to be built or adapted, which is a larger piece of work than the defect it prevents.
+
+## 5. Rationale
+
+The deciding factor is who has to read the document.
+
+Three parties read a requirement in this pipeline. The operator rules on it. The drafting LLM derives an LLD from it. A checker verifies its form. A decision table is the one notation all three handle without translation. Formal specification serves the checker well and excludes the operator. Prose serves the operator and the LLM, and gives the checker nothing to verify.
+
+Parnas made this same argument, and it deserves stating plainly because it inverts the usual expectation. His claim for tabular expressions was not only that they were more precise than prose. It was that they were more precise *and easier to read*, which is why engineers under time pressure would keep them current. Formal notations generally buy rigor at the cost of readability. Tables do not.
+
+The second factor is cost asymmetry. Detection is expensive here and prevention is free. Each contradiction the gate catches costs a halted run, a redraw and a ruling from the operator. Writing the requirement as a table costs a few minutes once.
+
+We accept that a complete table can still be wrong. Completeness is a property of form and not of content, and no check proposed here verifies that a row states the correct behavior. Review does that.
+
+## 6. Security Risk Analysis
+
+| Risk | Impact | Likelihood | Severity | Mitigation |
+|---|---|---|---|---|
+| A table that is complete but wrong reads as authoritative, and its form discourages the challenge that loose prose invites | Med | Med | 4 | Review adjudicates row contents. The completeness checker reports completeness only, and states that limit in its output |
+| A passing completeness check is read as a correctness result | Med | Med | 4 | The checker names what it verified and what it did not, following standard 0028's refuse-loudly posture |
+| Splitting a requirement scatters a security-relevant constraint so that no single document states it whole | Med | Low | 2 | Each child requirement names the requirement it was split from, so the full set is recoverable |
+
+**Residual Risk:** Content errors inside a well-formed table remain undetected by every mechanical check in this ADR. That risk is unchanged from prose and is not made worse by this decision.
+
+## 7. Consequences
+
+### Positive
+
+- Conditional statements can no longer be written as universals, so the contradiction class that produced all seven conflicts cannot be expressed.
+- Completeness is countable, so a gap is reported once rather than as a set of pairs.
+- Each row arrives as an independently testable acceptance criterion, which the specification stage can assert against directly.
+- The condition count surfaces an oversized requirement before any code is drafted.
+
+### Negative
+
+- Authoring a simple requirement costs more than writing one sentence. The EARS patterns apply everywhere, while a table applies only above one condition, which bounds the cost.
+- Existing issues are prose. Converting all of them at once is a large piece of work with no immediate return.
+- A table invites the belief that a requirement is settled. Correctness still requires review.
+
+### Neutral
+
+- The requirements-consistency gate is unchanged. It continues to work on prose issues that have not been converted.
+- The LLD, specification and implementation stages are unchanged.
+
+## 8. Implementation
+
+- **Related Issues:** #2218 (this ADR)
+- **Status:** In Progress
+
+Conversion happens when an issue next rolls, and not as a sweep. An issue that is not rolling costs nothing by staying in prose, and a sweep would convert issues whose requirements may change before anything reads them.
+
+The mechanical checker is separate work and is not built. It verifies three things. Each requirement must match an EARS pattern. A table of `n` binary conditions must carry `2^n` rows, with no combination repeated. Each row must appear as an acceptance criterion. The checker reports what it verified and what it did not, per standard 0028.
+
+boostgauge #7 is the first converted requirement and was rolling as of 2026-08-11. Its result is the first evidence about whether this form prevents what it was adopted to prevent.
+
+## 9. References
+
+Bibliographic details below are recorded from recall. Confirm them against the primary sources before citing them in published work.
+
+- Mavin, A., Wilkinson, P., Harwood, A., and Novak, M. "Easy Approach to Requirements Syntax (EARS)." IEEE International Requirements Engineering Conference, 2009.
+- Heninger, K. L. "Specifying Software Requirements for Complex Systems: New Techniques and Their Application." IEEE Transactions on Software Engineering, 1980. This is the A-7E requirements document work.
+- Parnas, D. L., and Madey, J. "Functional Documents for Computer Systems." Science of Computer Programming, 1995.
+- Standard 0028, ask structured, get structured, or reject.
+- boostgauge #7, the first requirement converted to this form.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-08-11 | Claude Opus 5 | Initial draft |


### PR DESCRIPTION
Adopts a requirements-authoring form whose completeness a program can verify, replacing free prose for combinatorial behavior.

Closes #2218

## Why

The requirements-consistency gate (#1899) fired seven times on one paragraph of boostgauge issue #7, across five separate operator rulings: boostgauge #235, #240, #249, #252, then #273, #274 and #275 from a single run. Every ruling amended one sentence and carried a condition into it. The neighboring sentences making adjacent claims never received that condition, because prose cannot propagate a qualifier across a paragraph, so each repair produced the next contradiction.

The requirement underneath depends on two independent conditions and has four combinations. The paragraph stated three of them in overlapping sentences and left the fourth ambiguous.

## What the ADR decides

1. Each requirement is one sentence in an EARS pattern, carrying its own trigger or state condition.
2. Where behavior depends on two or three independent conditions, the requirement is a decision table enumerating every combination, with one acceptance criterion per row.
3. A requirement depending on more than three conditions is split rather than tabulated.

Sections 3.2 and 4 record what this takes from Parnas tabular expressions (the grid, completeness, disjointness) and what it deliberately leaves (the formal semantics). Options B and D, formal specification and the full Software Cost Reduction method, are recorded as rejected but not triggered, with the conditions that would trigger them.

## Evidence

boostgauge #7 was converted to this form on 2026-08-11 and rolled the same day. All seven historical conflicts become unstatable against its table, because each was a question about which row a sentence described.

## Verification

- Canonical prose checker run against the file in the technical register: all notes cleared. Seven hits remain on the production-process gate, for "the operator" and for the model name in the Revision History table. Both fall under that rule's stated exception for artifacts whose subject is the process itself, and both match established convention in this directory: four of twenty-seven existing ADRs use "the operator", and every Revision History names the authoring model.
- Zero em-dashes, per the technical register.
- No lineage directory exists for this issue, so there was nothing for `archive_worktree_lineage.py` to archive. The ADR was written by hand rather than generated by a workflow.

## Follow-up

The mechanical completeness checker described in section 8 is not built and is tracked separately in #2219.
