### PR TITLE
feat: standalone entry point for the N0c consistency gate (Closes #2221)

### DIFF
--- a/assemblyzero/workflows/requirements/precheck.py
+++ b/assemblyzero/workflows/requirements/precheck.py
@@ -1,0 +1,318 @@
+"""Call the N0c requirements-consistency gate without a roll (#2221).
+
+The gate lives in ``nodes/analyze_requirements.py`` and runs as node 3 of the
+LLD workflow, so the only way to ask it a question used to be a launch. On
+boostgauge #7 that meant five operator rulings each verified by the next roll:
+edit the issue text, launch, wait for the codebase-analysis node, and learn
+three minutes in whether the edit introduced a fresh contradiction. Every
+defect cost a full iteration to discover.
+
+This module gives the same gate a second caller. It **imports**
+``analyze_requirements``; it does not reimplement it. A separate
+implementation would drift, and a clean result from a drifted checker is false
+confidence, which is worse than no pre-check at all.
+
+Fail-open does not carry over
+-----------------------------
+
+In a roll the gate fails open by design: a provider storm must not brick a
+launch, so an analysis that cannot run prints a warning and the workflow
+proceeds to drafting. Standalone, a human explicitly asked for the check, so
+an analysis that cannot run is an error rather than a pass.
+
+The node signals every one of those outcomes the same way — an empty state
+update — so a caller cannot tell "consistent" from "skipped" by return value
+alone. This module therefore requires *positive* evidence of a clean verdict,
+the node's own ``CLEAN_MARKER`` line, and treats its absence as failure. Every
+unknown resolves to a nonzero exit; nothing resolves to a silent pass.
+
+Side effects are the gate's own
+-------------------------------
+
+On conflict the node files must-resolve issues on the target repo and records
+prompt telemetry, exactly as it does in a roll. That is the imported
+behavior and it is not suppressed here: the conflicts are real, and a blocked
+launcher is the correct state for an issue whose text still contradicts
+itself.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+    analyze_requirements,
+)
+
+#: Exit code: the gate ran and found no contradictions.
+EXIT_CLEAN = 0
+#: Exit code: the gate ran and found at least one contradiction.
+EXIT_CONFLICT = 1
+#: Exit code: the check could not run. Nothing was verified.
+EXIT_ERROR = 2
+
+#: The sentence the node prints when the analysis ran and found nothing. The
+#: node returns an empty state update for a clean verdict AND for every
+#: fail-open skip, so this line is the only positive evidence a caller has.
+#: ``tests/unit/test_check_requirements.py`` drives the live node and asserts
+#: this string still appears, so a wording change fails the suite rather than
+#: silently turning every clean result into an error.
+CLEAN_MARKER = "Requirements internally consistent."
+
+#: Matches ``--drafter`` in ``tools/run_requirements_workflow.py``, so the
+#: pre-check asks the same model the roll's gate will ask.
+DEFAULT_DRAFTER = "claude:sonnet"
+
+_GATE_PATH = "assemblyzero/workflows/requirements/nodes/analyze_requirements.py"
+_FILING_FAILED_MARKER = "must-resolve filing failed"
+
+
+class PrecheckError(RuntimeError):
+    """The pre-check could not reach a verdict. Never a degraded result."""
+
+
+@dataclass
+class PrecheckResult:
+    """Outcome of one gate call.
+
+    Attributes:
+        status: ``clean``, ``conflict`` or ``error``.
+        detail: The verbatim conflict message, or the reason no verdict came.
+        node_output: Everything the gate printed, captured.
+    """
+
+    status: str
+    detail: str
+    node_output: str
+
+    @property
+    def exit_code(self) -> int:
+        """Exit code for this outcome. Only ``clean`` is zero."""
+        if self.status == "clean":
+            return EXIT_CLEAN
+        if self.status == "conflict":
+            return EXIT_CONFLICT
+        return EXIT_ERROR
+
+    @property
+    def filing_failed(self) -> bool:
+        """True when the gate reported that must-resolve filing failed."""
+        return _FILING_FAILED_MARKER in self.node_output
+
+
+class _Tee(io.TextIOBase):
+    """Write to a capture buffer and, optionally, a live stream."""
+
+    def __init__(self, capture: io.StringIO, live: TextIO | None) -> None:
+        self._capture = capture
+        self._live = live
+
+    def write(self, text: str) -> int:
+        self._capture.write(text)
+        if self._live is not None:
+            self._live.write(text)
+        return len(text)
+
+    def flush(self) -> None:
+        if self._live is not None:
+            self._live.flush()
+
+
+def fetch_issue(repo: Path, issue_number: int, timeout: int = 60) -> tuple[str, str]:
+    """Read an issue's title and body via ``gh``, from the target repo.
+
+    Args:
+        repo: Target repository checkout; supplies the gh CLI's repo context.
+        issue_number: Issue to read.
+        timeout: Seconds to wait for gh.
+
+    Returns:
+        ``(title, body)``.
+
+    Raises:
+        PrecheckError: gh is missing, failed, timed out, or returned something
+            that is not an issue payload. Per standard 0028 a read that cannot
+            be trusted raises rather than returning a degraded value.
+    """
+    if not repo.is_dir():
+        raise PrecheckError(f"--repo is not a directory: {repo}")
+
+    try:
+        proc = subprocess.run(
+            ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=timeout,
+            cwd=str(repo),
+        )
+    except FileNotFoundError as exc:
+        raise PrecheckError(
+            "gh CLI not found. Install it from https://cli.github.com/"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise PrecheckError(
+            f"gh issue view timed out after {timeout}s reading #{issue_number}"
+        ) from exc
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or "no stderr"
+        raise PrecheckError(
+            f"gh issue view #{issue_number} failed in {repo}: {stderr}"
+        )
+
+    try:
+        payload = json.loads(proc.stdout)
+    except ValueError as exc:
+        excerpt = proc.stdout.strip()[:200]
+        raise PrecheckError(
+            f"gh returned output that is not JSON for #{issue_number}: {excerpt!r}"
+        ) from exc
+
+    if not isinstance(payload, dict) or "body" not in payload:
+        raise PrecheckError(
+            f"gh returned no issue body for #{issue_number}; got keys "
+            f"{sorted(payload) if isinstance(payload, dict) else type(payload).__name__}"
+        )
+
+    return str(payload.get("title") or ""), str(payload.get("body") or "")
+
+
+def _explain_missing_verdict(output: str) -> str:
+    """Name why the gate returned without a verdict, from what it printed."""
+    warnings = [line.strip() for line in output.splitlines() if "WARNING" in line]
+    if warnings:
+        return " / ".join(warnings)
+    return (
+        "the gate returned without reporting a conflict and without printing "
+        f"{CLEAN_MARKER!r}, so no verdict was reached"
+    )
+
+
+def run_gate(
+    repo: Path,
+    issue_number: int,
+    issue_title: str,
+    issue_body: str,
+    *,
+    drafter: str = DEFAULT_DRAFTER,
+    echo_stream: TextIO | None = None,
+) -> PrecheckResult:
+    """Run the imported N0c gate against one issue's text.
+
+    Args:
+        repo: Target repository; the gate files must-resolve issues here.
+        issue_number: Issue under analysis.
+        issue_title: Issue title.
+        issue_body: Issue body. The whole document is the gate's input.
+        drafter: Provider spec for the analysis call.
+        echo_stream: Stream to mirror the gate's output to while it runs.
+
+    Returns:
+        The verdict.
+
+    Raises:
+        PrecheckError: The body is empty, or the gate raised.
+    """
+    if not issue_body.strip():
+        raise PrecheckError(
+            f"issue #{issue_number} has an empty body; there is nothing to analyze"
+        )
+
+    # config_mock_mode is deliberately absent: the node returns early on it,
+    # which standalone would be an unverified pass wearing a clean exit code.
+    state: dict[str, Any] = {
+        "issue_title": issue_title,
+        "issue_body": issue_body,
+        "issue_number": issue_number,
+        "target_repo": str(repo),
+        "config_drafter": drafter,
+    }
+
+    capture = io.StringIO()
+    try:
+        with redirect_stdout(_Tee(capture, echo_stream)):
+            update = analyze_requirements(state)
+    except Exception as exc:  # noqa: BLE001 - reported, never swallowed
+        raise PrecheckError(
+            f"the gate raised {type(exc).__name__}: {exc}"
+        ) from exc
+
+    output = capture.getvalue()
+    conflict = str((update or {}).get("error_message") or "")
+
+    if conflict:
+        return PrecheckResult("conflict", conflict, output)
+    if CLEAN_MARKER in output:
+        return PrecheckResult("clean", "", output)
+    return PrecheckResult("error", _explain_missing_verdict(output), output)
+
+
+def render_report(
+    result: PrecheckResult,
+    repo: Path,
+    issue_number: int,
+    drafter: str,
+) -> str:
+    """Render the operator-facing report for one verdict."""
+    rule = "=" * 70
+    lines = [
+        rule,
+        f"Requirements pre-check -- {repo.name} #{issue_number}",
+        rule,
+        f"Gate:    {_GATE_PATH}",
+        f"Drafter: {drafter}",
+        "",
+    ]
+
+    if result.status == "clean":
+        lines += [
+            "CLEAN -- the gate found no internal contradictions.",
+            "",
+            "Verified: the issue's behavior text, acceptance criteria and test",
+            "  plan were read as one document, and no two statements were found",
+            "  to specify different outcomes for the same situation.",
+            "Not verified: whether any requirement is correct, complete, or",
+            "  implementable. This gate finds contradictions; it does not rule",
+            "  on content. The roll runs it again and remains authoritative.",
+        ]
+    elif result.status == "conflict":
+        lines += [
+            "CONFLICT -- the gate's message follows verbatim:",
+            "",
+            result.detail,
+            "",
+        ]
+        if result.filing_failed:
+            lines.append(
+                "The gate could not file must-resolve issues (see its output "
+                "above); the conflicts stand regardless."
+            )
+        else:
+            lines.append(
+                f"Must-resolve issues were filed on {repo.name}, exactly as a "
+                "roll would file them."
+            )
+        lines.append(
+            "Rule on the text, edit the issue, and run this pre-check again."
+        )
+    else:
+        lines += [
+            "ERROR -- no verdict. Nothing about this issue was verified.",
+            "",
+            f"Reason: {result.detail}",
+            "",
+            "In a roll this is a warning and the workflow proceeds, because the",
+            "  gate fails open by design so a provider storm cannot brick a",
+            "  launch. Standalone it is an error: you asked for the check and it",
+            "  did not run, so a clean exit here would be a lie.",
+        ]
+
+    lines += ["", rule]
+    return "\n".join(lines) + "\n"

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -74,7 +74,7 @@ tokens are used. All exit **91**.
 |---|---|---|
 | The AssemblyZero tree is not trustworthy | this checkout is behind or dirty, so the roll would execute pipeline code that `main` does not describe | bring it level with `origin/main`, or point `--assemblyzero-root` at a tree that is |
 | This machine is not healthy enough | a quick self-check ran far slower than normal, or memory is above 90% | wait for the machine to recover, or find what is loading it. Do not override it — a roll on a sick box wastes hours *and* makes every failure look like a target-repo problem |
-| The repository has unanswered questions | one or more issues are open asking you to rule on ambiguous issue text | read each, decide which reading is right, edit the issue so only one survives, close the question |
+| The repository has unanswered questions | one or more issues are open asking you to rule on ambiguous issue text | work § Rule below — decide, edit, **pre-check**, then close the question |
 | The arc's binding docs conflict with the default branch | design docs or ADRs were ruled on both branches and the two edits collide (#2205) | merge them by hand, then roll. Nothing was changed — the launcher refuses rather than resolving a ruling on your behalf |
 
 **Binding docs sync themselves (#2205).** The roll reads design docs and ADRs
@@ -95,6 +95,65 @@ answered, and the answer was invisible to the pipeline.
 **The first-ever run on a machine records the health baseline and proceeds.** A
 missing baseline never blocks. Nominal is a rolling median over five runs, so it
 tracks the machine rather than one lucky run.
+
+---
+
+## § Rule — answering a must-resolve question
+
+A roll that finds two acceptance criteria specifying different outcomes for the
+same situation halts, files a `must-resolve` issue naming both sentences, and
+blocks every later launch until you answer. Only you can answer it: the gate
+reports that two readings are defensible, and choosing between them is a
+decision about the product.
+
+**The order is: decide, edit, pre-check, close, roll.**
+
+**1. Decide, and edit the issue so only one reading survives.** Read the two
+sentences the question quotes. Amend the issue text — both sentences, not only
+the one the gate named. A qualifier added to one sentence and not its
+neighbours is what produces the next contradiction.
+
+**2. Pre-check before you close anything.**
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/check_requirements.py \
+    --repo /c/Users/mcwiz/Projects/boostgauge --issue 7
+```
+
+This runs the roll's own gate against your edited text — the same function,
+imported, not a second implementation of it. One model call, a few minutes.
+
+| Exit | Meaning | What you do |
+|---|---|---|
+| 0 | the gate found no contradictions | go to step 3 |
+| 1 | it found more, printed verbatim | return to step 1. The pre-check filed them as must-resolve issues, exactly as a roll would |
+| 2 | the check could not run | fix that first. Nothing was verified, and unlike a roll this never passes quietly |
+
+> **This command's flags and its exit-2 path were executed while writing this
+> section; a full clean run against a live issue was not.** That call spends a
+> drafter-class model request and, on a conflict, files must-resolve issues on
+> the target repo — side effects that belong to a real ruling rather than to
+> authoring a runbook. The gate call itself is covered by
+> `tests/unit/test_check_requirements.py`, which drives the live node through
+> every one of its outcomes.
+
+**3. Close the must-resolve issues, and roll.** Close them only on a clean
+pre-check. Closing them on an unverified edit puts the launcher back in
+business against text that still contradicts itself.
+
+**Why the pre-check exists.** boostgauge #7 took five rulings, and each was
+verified by paying for the next launch: edit, roll, wait through the
+codebase-analysis node, and learn three minutes in that the amendment had
+introduced a fresh contradiction. Seven conflicts were discovered that way. On
+the sixth iteration the gate was run by hand against the draft first and caught
+three defects before anything was spent. This step is that pass, made
+repeatable (#2221).
+
+**The pre-check is advisory; the roll's gate is authoritative.** A pre-check
+attestation goes stale the same way a draft does — the issue text and the
+binding docs both keep moving (#2206). The roll runs the gate again on every
+launch, and that run is the one that counts.
 
 ---
 
@@ -287,7 +346,9 @@ they filed issues. These block the next launch until ruled on.
 gh issue list --repo martymcenroe/<repo> --label must-resolve --state open
 ```
 
-Empty output means none are open.
+Empty output means none are open. Anything listed is answered by working
+§ Rule above — decide, edit, pre-check, close — and the pre-check is what keeps
+the answer from costing a launch to verify.
 
 **6. Archive the run.** Last, because it is the only step that is unrecoverable
 if skipped — arcs are never merged to main, so a run's product lives only on

--- a/tests/unit/test_check_requirements.py
+++ b/tests/unit/test_check_requirements.py
@@ -1,0 +1,425 @@
+"""Unit tests for the standalone N0c requirements pre-check (#2221).
+
+The load-bearing property is that standalone the gate never fails open. In a
+roll an analysis that cannot run is a warning and the workflow proceeds; here
+it must be an error, because a human asked for the check and a clean exit
+would assert something nobody verified. Most of this file drives the live node
+through each of its fail-open branches and asserts a nonzero result.
+
+No test may reach the network. The conflict path files must-resolve issues via
+gh in production, so every conflict test patches that out and asserts on the
+recorded call instead.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.core.llm_provider import LLMCallResult  # noqa: E402
+from assemblyzero.workflows.requirements import precheck  # noqa: E402
+
+ISSUE_BODY = "The app shall persist window position on exit."
+ISSUE_TITLE = "feat: config persistence"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    """Stands in for whatever get_provider() returns inside the node."""
+
+    def __init__(self, result: LLMCallResult) -> None:
+        self._result = result
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs) -> LLMCallResult:
+        self.calls.append(kwargs)
+        return self._result
+
+
+def _result(success: bool, response: str | None, error: str | None = None) -> LLMCallResult:
+    return LLMCallResult(
+        success=success,
+        response=response,
+        raw_response=response,
+        error_message=error,
+        provider="fake",
+        model_used="fake-model",
+        duration_ms=1,
+        attempts=1,
+    )
+
+
+@pytest.fixture
+def no_filing(monkeypatch):
+    """Capture must-resolve filings and telemetry instead of performing them."""
+    filings: list[tuple] = []
+
+    def _fake_file_all_conflicts(repo_root, source_issue, conflicts, **kwargs):
+        filings.append((repo_root, source_issue, conflicts))
+        return []
+
+    monkeypatch.setattr(
+        "assemblyzero.speedrun.must_resolve.file_all_conflicts",
+        _fake_file_all_conflicts,
+    )
+    monkeypatch.setattr(
+        "assemblyzero.speedrun.prompt_telemetry.record_failures",
+        lambda *a, **k: None,
+    )
+    return filings
+
+
+def _install_provider(monkeypatch, provider) -> None:
+    """The node imports get_provider at call time, so patch the module."""
+    monkeypatch.setattr(
+        "assemblyzero.core.llm_provider.get_provider",
+        lambda spec, *a, **k: provider,
+    )
+
+
+def _run(tmp_path, *, body: str = ISSUE_BODY, drafter: str = "fake:model"):
+    return precheck.run_gate(tmp_path, 7, ISSUE_TITLE, body, drafter=drafter)
+
+
+CONSISTENT = '{"is_consistent": true, "conflicts": []}'
+
+CONFLICT_A = "the exit write touches only hand-changed keys"
+CONFLICT_B = "--reset-config rewrites the file regardless"
+CONFLICTED = (
+    '{"is_consistent": false, "conflicts": [{"criterion_a": "%s", '
+    '"criterion_b": "%s", "diverging_situation": "a reset session that was '
+    'never touched"}]}' % (CONFLICT_A, CONFLICT_B)
+)
+
+
+# ---------------------------------------------------------------------------
+# The gate is imported, never reimplemented (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+
+class TestSameGate:
+    def test_precheck_calls_the_function_the_graph_registers_as_n0c(self):
+        """Identity, not equivalence: one function object, two callers.
+
+        A copied or re-derived checker could drift from the gate, and a clean
+        result from a drifted checker is false confidence.
+        """
+        from assemblyzero.workflows.requirements import graph
+
+        assert precheck.analyze_requirements is graph.analyze_requirements
+
+    def test_gate_module_is_the_workflow_node_module(self):
+        assert (
+            precheck.analyze_requirements.__module__
+            == "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Clean
+# ---------------------------------------------------------------------------
+
+
+class TestClean:
+    def test_consistent_requirements_exit_zero(self, tmp_path, monkeypatch):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONSISTENT)))
+
+        result = _run(tmp_path)
+
+        assert result.status == "clean"
+        assert result.exit_code == 0
+
+    def test_clean_marker_still_matches_the_live_node(self, tmp_path, monkeypatch):
+        """Drift guard for the one string this tool reads as a pass.
+
+        The node signals a clean verdict only by printing it -- the state
+        update is empty for a clean result and for every fail-open skip
+        alike. If the node's wording changes, this fails here rather than
+        turning every clean pre-check into a spurious error in the field.
+        """
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONSISTENT)))
+
+        result = _run(tmp_path)
+
+        assert precheck.CLEAN_MARKER in result.node_output
+
+    def test_report_names_what_it_did_not_verify(self, tmp_path, monkeypatch):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONSISTENT)))
+        result = _run(tmp_path)
+
+        report = precheck.render_report(result, tmp_path, 7, "fake:model")
+
+        assert "CLEAN" in report
+        assert "Not verified" in report
+
+    def test_fenced_json_is_still_a_clean_verdict(self, tmp_path, monkeypatch):
+        fenced = f"```json\n{CONSISTENT}\n```"
+        _install_provider(monkeypatch, _FakeProvider(_result(True, fenced)))
+
+        assert _run(tmp_path).status == "clean"
+
+
+# ---------------------------------------------------------------------------
+# Conflict (acceptance criterion 2)
+# ---------------------------------------------------------------------------
+
+
+class TestConflict:
+    def test_conflict_exits_nonzero(self, tmp_path, monkeypatch, no_filing):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONFLICTED)))
+
+        result = _run(tmp_path)
+
+        assert result.status == "conflict"
+        assert result.exit_code != 0
+
+    def test_both_sentences_print_verbatim(self, tmp_path, monkeypatch, no_filing):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONFLICTED)))
+
+        result = _run(tmp_path)
+        report = precheck.render_report(result, tmp_path, 7, "fake:model")
+
+        assert CONFLICT_A in report
+        assert CONFLICT_B in report
+        assert "a reset session that was never touched" in report
+
+    def test_conflict_files_must_resolve_issues_against_the_target_repo(
+        self, tmp_path, monkeypatch, no_filing
+    ):
+        """The gate's own side effect, aimed at the repo under analysis.
+
+        Passing no target_repo would make the node fall back to ".", filing
+        the target repo's conflicts against whatever repo the tool ran from.
+        """
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONFLICTED)))
+
+        _run(tmp_path)
+
+        assert len(no_filing) == 1
+        repo_root, source_issue, conflicts = no_filing[0]
+        assert Path(repo_root) == tmp_path
+        assert source_issue == 7
+        assert len(conflicts) == 1
+
+    def test_report_says_filing_failed_when_it_did(self, tmp_path, monkeypatch):
+        def _boom(*a, **k):
+            raise RuntimeError("gh exploded")
+
+        monkeypatch.setattr(
+            "assemblyzero.speedrun.must_resolve.file_all_conflicts", _boom
+        )
+        monkeypatch.setattr(
+            "assemblyzero.speedrun.prompt_telemetry.record_failures",
+            lambda *a, **k: None,
+        )
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONFLICTED)))
+
+        result = _run(tmp_path)
+        report = precheck.render_report(result, tmp_path, 7, "fake:model")
+
+        assert result.status == "conflict"
+        assert result.filing_failed
+        assert "could not file" in report
+
+
+# ---------------------------------------------------------------------------
+# Fail-open does not carry over (acceptance criterion 4)
+# ---------------------------------------------------------------------------
+
+
+class TestNeverASilentPass:
+    def test_provider_failure_is_an_error_not_a_pass(self, tmp_path, monkeypatch):
+        """The roll proceeds here. Standalone this must not read as clean."""
+        _install_provider(
+            monkeypatch, _FakeProvider(_result(False, None, "503 from provider"))
+        )
+
+        result = _run(tmp_path)
+
+        assert result.status == "error"
+        assert result.exit_code == precheck.EXIT_ERROR
+        assert "503 from provider" in result.detail
+
+    def test_empty_response_is_an_error(self, tmp_path, monkeypatch):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, "")))
+
+        assert _run(tmp_path).status == "error"
+
+    def test_unparseable_response_is_an_error(self, tmp_path, monkeypatch):
+        _install_provider(monkeypatch, _FakeProvider(_result(True, "not json at all")))
+
+        result = _run(tmp_path)
+
+        assert result.status == "error"
+        assert "unparseable" in result.detail
+
+    def test_schema_violating_json_is_an_error(self, tmp_path, monkeypatch):
+        """Valid JSON missing the contract's required key is still no verdict."""
+        _install_provider(
+            monkeypatch, _FakeProvider(_result(True, '{"something_else": true}'))
+        )
+
+        assert _run(tmp_path).status == "error"
+
+    def test_invalid_provider_spec_is_an_error(self, tmp_path):
+        """get_provider raises, the node warns and returns {}. Not a pass."""
+        result = _run(tmp_path, drafter="nosuchprovider:model")
+
+        assert result.status == "error"
+        assert result.exit_code == precheck.EXIT_ERROR
+
+    def test_mock_mode_is_never_requested(self, tmp_path, monkeypatch):
+        """config_mock_mode short-circuits the node before any analysis."""
+        seen: list[dict] = []
+
+        def _spy(state):
+            seen.append(dict(state))
+            return {}
+
+        monkeypatch.setattr(precheck, "analyze_requirements", _spy)
+
+        precheck.run_gate(tmp_path, 7, ISSUE_TITLE, ISSUE_BODY)
+
+        assert "config_mock_mode" not in seen[0]
+
+    def test_silent_empty_update_is_an_error(self, tmp_path, monkeypatch):
+        """A node that returns {} while printing nothing verified nothing."""
+        monkeypatch.setattr(precheck, "analyze_requirements", lambda state: {})
+
+        result = precheck.run_gate(tmp_path, 7, ISSUE_TITLE, ISSUE_BODY)
+
+        assert result.status == "error"
+        assert "no verdict" in result.detail
+
+    def test_empty_issue_body_raises(self, tmp_path):
+        with pytest.raises(precheck.PrecheckError, match="empty body"):
+            precheck.run_gate(tmp_path, 7, ISSUE_TITLE, "   \n  ")
+
+    def test_gate_exception_raises_rather_than_returning_clean(
+        self, tmp_path, monkeypatch
+    ):
+        def _boom(state):
+            raise RuntimeError("node exploded")
+
+        monkeypatch.setattr(precheck, "analyze_requirements", _boom)
+
+        with pytest.raises(precheck.PrecheckError, match="node exploded"):
+            precheck.run_gate(tmp_path, 7, ISSUE_TITLE, ISSUE_BODY)
+
+
+# ---------------------------------------------------------------------------
+# Issue fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchIssue:
+    def _fake_run(self, monkeypatch, *, returncode=0, stdout="", stderr=""):
+        import subprocess
+
+        class _Proc:
+            pass
+
+        proc = _Proc()
+        proc.returncode = returncode
+        proc.stdout = stdout
+        proc.stderr = stderr
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: proc)
+
+    def test_returns_title_and_body(self, tmp_path, monkeypatch):
+        self._fake_run(
+            monkeypatch, stdout='{"title": "feat: x", "body": "the body"}'
+        )
+
+        assert precheck.fetch_issue(tmp_path, 7) == ("feat: x", "the body")
+
+    def test_gh_failure_raises(self, tmp_path, monkeypatch):
+        self._fake_run(monkeypatch, returncode=1, stderr="could not resolve to an Issue")
+
+        with pytest.raises(precheck.PrecheckError, match="could not resolve"):
+            precheck.fetch_issue(tmp_path, 7)
+
+    def test_non_json_output_raises(self, tmp_path, monkeypatch):
+        self._fake_run(monkeypatch, stdout="<html>login</html>")
+
+        with pytest.raises(precheck.PrecheckError, match="not JSON"):
+            precheck.fetch_issue(tmp_path, 7)
+
+    def test_payload_without_body_raises(self, tmp_path, monkeypatch):
+        self._fake_run(monkeypatch, stdout='{"title": "feat: x"}')
+
+        with pytest.raises(precheck.PrecheckError, match="no issue body"):
+            precheck.fetch_issue(tmp_path, 7)
+
+    def test_missing_repo_raises(self, tmp_path):
+        with pytest.raises(precheck.PrecheckError, match="not a directory"):
+            precheck.fetch_issue(tmp_path / "nope", 7)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def _cli(self):
+        import check_requirements
+
+        return check_requirements
+
+    def test_clean_run_exits_zero(self, tmp_path, monkeypatch, capsys):
+        cli = self._cli()
+        monkeypatch.setattr(
+            cli, "fetch_issue", lambda repo, issue, **k: (ISSUE_TITLE, ISSUE_BODY)
+        )
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONSISTENT)))
+
+        code = cli.main(["--repo", str(tmp_path), "--issue", "7", "--drafter", "fake:m"])
+
+        assert code == 0
+        assert "CLEAN" in capsys.readouterr().out
+
+    def test_conflict_exits_one(self, tmp_path, monkeypatch, capsys, no_filing):
+        cli = self._cli()
+        monkeypatch.setattr(
+            cli, "fetch_issue", lambda repo, issue, **k: (ISSUE_TITLE, ISSUE_BODY)
+        )
+        _install_provider(monkeypatch, _FakeProvider(_result(True, CONFLICTED)))
+
+        code = cli.main(["--repo", str(tmp_path), "--issue", "7", "--drafter", "fake:m"])
+
+        out = capsys.readouterr().out
+        assert code == 1
+        assert CONFLICT_A in out and CONFLICT_B in out
+
+    def test_analysis_failure_exits_two(self, tmp_path, monkeypatch, capsys):
+        cli = self._cli()
+        monkeypatch.setattr(
+            cli, "fetch_issue", lambda repo, issue, **k: (ISSUE_TITLE, ISSUE_BODY)
+        )
+        _install_provider(monkeypatch, _FakeProvider(_result(False, None, "529")))
+
+        code = cli.main(["--repo", str(tmp_path), "--issue", "7", "--drafter", "fake:m"])
+
+        assert code == 2
+        assert "ERROR" in capsys.readouterr().out
+
+    def test_fetch_failure_exits_two(self, tmp_path, monkeypatch, capsys):
+        cli = self._cli()
+
+        def _boom(repo, issue, **k):
+            raise precheck.PrecheckError("gh issue view #7 failed")
+
+        monkeypatch.setattr(cli, "fetch_issue", _boom)
+
+        code = cli.main(["--repo", str(tmp_path), "--issue", "7"])
+
+        assert code == 2
+        assert "has been verified" in capsys.readouterr().err

--- a/tools/check_requirements.py
+++ b/tools/check_requirements.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run the N0c requirements-consistency gate against an issue, without a roll.
+
+Issue #2221. The gate is node 3 of the LLD workflow, so every ruling on an
+issue's text used to be verified by paying for the next launch. This calls the
+same gate directly -- imported from the workflow, never reimplemented -- so a
+defect in an edit is found while the editor still holds the context.
+
+    poetry run python tools/check_requirements.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 7
+
+The call costs one drafter-class model request (roughly 200 seconds). What it
+saves is the launch around it: the codebase-analysis node, the blocked
+launcher, the filed issues, and the operator round-trip.
+
+Exit codes:
+    0  clean    -- the gate ran and found no contradictions
+    1  conflict -- the gate ran and found at least one; they print verbatim
+    2  error    -- the check could not run, so nothing was verified
+
+There is no fail-open here. In a roll the gate proceeds on a dead provider by
+design; standalone, an analysis that cannot run exits 2 rather than passing.
+
+On conflict the gate files must-resolve issues on the target repo, exactly as
+it does in a roll. That is the imported behavior, not an addition.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.workflows.requirements.precheck import (  # noqa: E402
+    DEFAULT_DRAFTER,
+    EXIT_ERROR,
+    PrecheckError,
+    fetch_issue,
+    render_report,
+    run_gate,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the LLD workflow's requirements-consistency gate against a "
+            "GitHub issue without launching a roll."
+        )
+    )
+    parser.add_argument("--repo", required=True, help="target repository checkout")
+    parser.add_argument("--issue", required=True, type=int, help="issue number")
+    parser.add_argument(
+        "--drafter",
+        default=DEFAULT_DRAFTER,
+        help=f"provider spec for the analysis call (default: {DEFAULT_DRAFTER})",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="mirror the gate's own output while it runs",
+    )
+    args = parser.parse_args(argv)
+
+    # Issue #773: subscription only. Never the paid Anthropic API.
+    from assemblyzero.core.llm_provider import set_api_policy
+
+    set_api_policy(False)
+
+    repo = Path(args.repo).resolve()
+
+    try:
+        title, body = fetch_issue(repo, args.issue)
+        print(
+            f"Reading #{args.issue} through the N0c gate with {args.drafter} "
+            f"-- one model call, expect a few minutes.",
+            flush=True,
+        )
+        result = run_gate(
+            repo,
+            args.issue,
+            title,
+            body,
+            drafter=args.drafter,
+            echo_stream=sys.stdout if args.verbose else None,
+        )
+    except PrecheckError as exc:
+        print(f"\nERROR -- the pre-check could not run: {exc}", file=sys.stderr)
+        print(
+            "Nothing about this issue's requirements has been verified.",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+    print()
+    print(render_report(result, repo, args.issue, args.drafter), end="", flush=True)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this adds

`tools/check_requirements.py --repo <path> --issue N` runs the N0c
requirements-consistency gate against an issue without launching a roll.

```
poetry run python tools/check_requirements.py \
    --repo /c/Users/mcwiz/Projects/boostgauge --issue 7
```

The gate is node 3 of the LLD workflow, so asking it a question used to
require a launch: a branch, the codebase-analysis node, three minutes, and on
a conflict a blocked launcher plus filed must-resolve issues. Five rulings on
boostgauge #7 were each verified by paying for the next iteration.

## Same code, second caller

`assemblyzero/workflows/requirements/precheck.py` **imports**
`analyze_requirements`. It does not copy or re-derive it. A second
implementation would drift from the gate, and a clean result from a drifted
checker is false confidence — worse than no pre-check.

Two tests hold that property rather than asserting it in a comment:
`test_precheck_calls_the_function_the_graph_registers_as_n0c` compares
function identity against the object the graph registers as N0c, and
`test_gate_module_is_the_workflow_node_module` pins its defining module.

## Fail-open does not carry over

In a roll the gate fails open by design so a provider storm cannot brick a
launch. Standalone, a human explicitly asked for the check, so an analysis
that cannot run is an error.

This is the load-bearing part, because the node cannot be read by return value
alone: it signals a clean verdict and every fail-open skip with the same empty
state update. The tool therefore requires *positive* evidence of a clean
analysis — the node's own `Requirements internally consistent.` line — and
treats its absence as failure. Provider error, empty response, unparseable
response, schema-violating JSON, invalid provider spec, and a silent empty
update all exit 2. Every unknown resolves nonzero; nothing resolves to a
silent pass.

`test_clean_marker_still_matches_the_live_node` drives the real node and
asserts that line still appears, so a wording change fails the suite here
instead of turning every clean pre-check into a spurious error in the field.

| Exit | Meaning |
|---|---|
| 0 | the gate ran and found no contradictions |
| 1 | the gate ran and found at least one; A and B print verbatim |
| 2 | the check could not run, so nothing was verified |

## Side effects are the gate's own

On conflict the node files must-resolve issues on the target repo and records
prompt telemetry, exactly as in a roll. That behavior is imported and is not
suppressed: the conflicts are real, and a blocked launcher is the correct
state for an issue whose text still contradicts itself. The tool passes the
real `target_repo` so the filing lands on the repo under analysis rather than
on the `"."` the node falls back to, and it reports honestly when filing
failed rather than claiming issues exist that do not.

## Runbook

Runbook 0952 gains **§ Rule — answering a must-resolve question**: decide,
edit, pre-check, close the must-resolve issues, roll. The launch-refusal table
and § Inspect step 5 both point at it. The pre-check is advisory and the
roll's own gate remains authoritative — an attestation goes stale the same way
a draft does (see #2206).

## Verification

- 28 new unit tests, `tests/unit/test_check_requirements.py`. Full unit suite:
  **6715 passed, 17 skipped, 5 xfailed**, no failures.
- The fail-open guards were mutation-checked: replacing the clean-marker
  condition with an unconditional pass fails exactly the seven tests that
  assert "never a silent pass", and no others.
- `ruff check` clean on all three new files.
- **The in-roll gate is byte-identical.**
  `git diff origin/main -- assemblyzero/workflows/requirements/nodes/analyze_requirements.py`
  returns empty; no file under `nodes/` appears in this diff.
- The runbook's `--help` output and its exit-2 path were executed while
  writing the section. A full clean run against a live issue was not, because
  it spends a model call and files issues on a real repo; the runbook says so
  in place, following the precedent already set for the launch command.

## Relationship to other work

Sibling: #2219, the deterministic form checker mandated by ADR 0226. It is
free and instant and runs first; this tool is the semantic layer above it. The
full pre-roll sequence once both exist is form check, consistency gate, roll.

Closes #2221
