### PR TITLE
feat: deterministic requirements completeness checker for ADR 0226 (Closes #2219)

### DIFF
--- a/assemblyzero/workflows/requirements/form_check.py
+++ b/assemblyzero/workflows/requirements/form_check.py
@@ -1,0 +1,694 @@
+"""Deterministic completeness checker for the ADR 0226 requirement form (#2219).
+
+ADR 0226 adopts an authoring form whose completeness a program can verify. This
+is that program. It makes no model calls, reads nothing but the issue text, and
+returns the same answer every time it is run against the same input.
+
+It verifies three things:
+
+1. **EARS conformance.** Bullets under a ``## Requirements`` heading must match
+   one of the five patterns. Acceptance criteria are never EARS-validated: a
+   row criterion is a table row's projection into the test list, not a
+   requirement sentence, and its terse form is mandated by ADR 0226 section
+   3.2.
+2. **Table completeness and disjointness.** A decision table of ``n`` binary
+   conditions carries ``2^n`` rows and repeats no combination.
+3. **Row-to-criterion coverage.** Every row appears as its own acceptance
+   criterion.
+
+What it cannot do
+-----------------
+
+Report completeness as correctness. A table can enumerate every combination
+and state the wrong outcome in every row, and nothing here can tell. The
+report names what was verified and what was not, per standard 0028, and never
+lets a reader mistake the weaker of the two join modes for the stronger.
+
+The two join modes
+------------------
+
+With row IDs (the convention for every issue converted after boostgauge #7)
+the join is exact: the ID sets on both sides must be a bijection, and each
+criterion's outcome text must match the outcome cell of the row it names.
+
+Without row IDs the checker runs two hard checks instead — a table of ``N``
+rows requires exactly ``N`` criteria opening with the table's subject word,
+and each row's outcome must match a distinct criterion in that group. What
+this mode cannot verify, whether a criterion describes its own row's
+combination of condition values, is delegated to the semantic
+requirements-consistency gate. That delegation is real rather than hopeful: a
+criterion naming the wrong combination contradicts its own table, which is
+the conflict class the gate already fires on.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# EARS (ADR 0226 section 3.1)
+# ---------------------------------------------------------------------------
+
+#: The five patterns, in match order. The keyword-led forms are tried before
+#: the ubiquitous form so a conditional cannot be scored as a universal law --
+#: which is the whole point of the rule (both halves of the boostgauge #7
+#: collision were conditionals written as universals).
+EARS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("event-driven", re.compile(r"^WHEN\b.*\bshall\s+\S")),
+    ("state-driven", re.compile(r"^WHILE\b.*\bshall\s+\S")),
+    ("unwanted behavior", re.compile(r"^IF\b.*\bTHEN\b.*\bshall\s+\S")),
+    ("optional feature", re.compile(r"^WHERE\b.*\bshall\s+\S")),
+    ("ubiquitous", re.compile(r"^The\b.*\bshall\s+\S")),
+)
+
+EARS_FORMS = (
+    "The <system> shall <response> | "
+    "WHEN <trigger> the <system> shall <response> | "
+    "WHILE <state> ... | IF <condition> THEN ... | WHERE <feature> ..."
+)
+
+REQUIREMENTS_HEADING = "Requirements"
+CRITERIA_HEADING = "Acceptance Criteria"
+
+_BINARY_VALUES = frozenset({"yes", "no"})
+_ROW_ID = re.compile(r"^[A-Z][A-Za-z]*[0-9]+$")
+_LIST_ITEM = re.compile(r"^(\s*)[-*+]\s+(?:\[[ xX]\]\s*)?(.*)$")
+_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+_LEADING_ID = re.compile(r"^([A-Z][A-Za-z]*[0-9]+)[.):]?\s+")
+
+
+def _norm(text: str) -> str:
+    """Compare text the way a reader does: no code ticks, no case, one space."""
+    stripped = text.replace("`", "").replace("*", "")
+    return re.sub(r"\s+", " ", stripped).strip().casefold()
+
+
+def _first_word(text: str) -> str:
+    match = re.search(r"[A-Za-z][A-Za-z0-9_-]*", text.replace("`", ""))
+    return match.group(0) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Violation:
+    """One thing the form requires that this document does not do."""
+
+    kind: str
+    where: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"[{self.kind}] {self.where}: {self.detail}"
+
+
+@dataclass
+class TableReport:
+    """What was checked about one decision table, and how strongly."""
+
+    subject: str
+    line_no: int
+    condition_count: int
+    row_count: int
+    expected_rows: int
+    join_mode: str
+    row_ids: list[str] = field(default_factory=list)
+    matched_rows: int = 0
+    group_size: int = 0
+
+    @property
+    def exact_join(self) -> bool:
+        return self.join_mode == "exact"
+
+    @property
+    def join_description(self) -> str:
+        if self.exact_join:
+            return "row join: exact (IDs)"
+        return (
+            "row join: count and outcome; combination correctness delegated "
+            "to the semantic gate"
+        )
+
+
+@dataclass
+class FormReport:
+    """The whole verdict for one issue body."""
+
+    requirements_examined: int = 0
+    requirements_found: int = 0
+    ears_ran: bool = False
+    nested_bullets_skipped: int = 0
+    criteria_examined: int = 0
+    criteria_section_found: bool = False
+    tables: list[TableReport] = field(default_factory=list)
+    non_decision_tables: int = 0
+    violations: list[Violation] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+
+# ---------------------------------------------------------------------------
+# Document structure
+# ---------------------------------------------------------------------------
+
+
+def section_lines(body: str, heading: str) -> list[str] | None:
+    """Lines under an exact ``## <heading>``, up to the next heading.
+
+    Returns None when the section is absent, which is a different fact from
+    the section being empty and must not be flattened into one.
+    """
+    lines = body.splitlines()
+    start = None
+    level = 0
+    for i, line in enumerate(lines):
+        match = _HEADING.match(line)
+        if not match:
+            continue
+        if start is None:
+            if match.group(2).strip() == heading:
+                start = i + 1
+                level = len(match.group(1))
+            continue
+        if len(match.group(1)) <= level:
+            return lines[start:i]
+    if start is None:
+        return None
+    return lines[start:]
+
+
+def list_items(lines: list[str]) -> tuple[list[str], int]:
+    """Top-level list items, and the count of nested ones left unchecked.
+
+    Nested bullets are elaboration on the item above them, not separate
+    requirements. They are counted rather than silently dropped.
+    """
+    items: list[str] = []
+    nested = 0
+    for line in lines:
+        match = _LIST_ITEM.match(line)
+        if not match:
+            continue
+        text = match.group(2).strip()
+        if not text:
+            continue
+        if match.group(1):
+            nested += 1
+        else:
+            items.append(text)
+    return items, nested
+
+
+@dataclass
+class RawTable:
+    line_no: int
+    header: list[str]
+    rows: list[list[str]]
+
+
+def _split_row(line: str) -> list[str]:
+    cells = line.strip().split("|")
+    if cells and not cells[0].strip():
+        cells = cells[1:]
+    if cells and not cells[-1].strip():
+        cells = cells[:-1]
+    return [c.strip() for c in cells]
+
+
+def parse_tables(body: str) -> list[RawTable]:
+    """Every markdown pipe table in the document, in order."""
+    tables: list[RawTable] = []
+    lines = body.splitlines()
+    i = 0
+    while i < len(lines):
+        if not lines[i].strip().startswith("|"):
+            i += 1
+            continue
+        if i + 1 >= len(lines) or not re.fullmatch(
+            r"\|?[\s:|-]+\|?", lines[i + 1].strip()
+        ):
+            i += 1
+            continue
+        header = _split_row(lines[i])
+        rows: list[list[str]] = []
+        j = i + 2
+        while j < len(lines) and lines[j].strip().startswith("|"):
+            rows.append(_split_row(lines[j]))
+            j += 1
+        tables.append(RawTable(line_no=i + 1, header=header, rows=rows))
+        i = j
+    return tables
+
+
+def _has_id_column(table: RawTable) -> bool:
+    if len(table.header) < 3 or not table.rows:
+        return False
+    return all(
+        row and _ROW_ID.fullmatch(row[0].replace("`", "").strip())
+        for row in table.rows
+    )
+
+
+def is_decision_table(table: RawTable) -> bool:
+    """A table whose non-outcome columns hold only plain yes and no answers.
+
+    ADR 0226 section 3.2 defines the grid this way. Anything else in an issue
+    body -- a risk grid, a flag reference -- is a table but not a decision
+    table, and is reported as unchecked rather than checked wrongly.
+    """
+    if not table.rows or len(table.header) < 2:
+        return False
+    first = 1 if _has_id_column(table) else 0
+    condition_columns = range(first, len(table.header) - 1)
+    if not condition_columns:
+        return False
+    for row in table.rows:
+        if len(row) != len(table.header):
+            return False
+        for col in condition_columns:
+            if _norm(row[col]) not in _BINARY_VALUES:
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Matching
+# ---------------------------------------------------------------------------
+
+
+def _max_matching(candidates: list[list[int]], right_size: int) -> list[int | None]:
+    """Maximum bipartite matching (Kuhn's algorithm).
+
+    Greedy assignment is wrong here: 'unchanged' is a substring of 'unchanged;
+    the CLI value is not written', so matching in row order can consume the
+    only criterion a later row could have used and report a false gap.
+    """
+    assigned: list[int | None] = [None] * right_size
+    result: list[int | None] = [None] * len(candidates)
+
+    def augment(left: int, seen: set[int]) -> bool:
+        for right in candidates[left]:
+            if right in seen:
+                continue
+            seen.add(right)
+            holder = assigned[right]
+            if holder is None or augment(holder, seen):
+                assigned[right] = left
+                result[left] = right
+                return True
+        return False
+
+    for left in range(len(candidates)):
+        augment(left, set())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def check_ears(body: str, report: FormReport) -> None:
+    """Validate the marked requirements section. Absence is a vacuous pass."""
+    lines = section_lines(body, REQUIREMENTS_HEADING)
+    if lines is None:
+        report.ears_ran = False
+        return
+
+    report.ears_ran = True
+    items, nested = list_items(lines)
+    report.nested_bullets_skipped = nested
+    report.requirements_found = len(items)
+    report.requirements_examined = len(items)
+
+    for index, item in enumerate(items, 1):
+        sentence = re.sub(r"\s+", " ", item.replace("`", "")).strip()
+        if any(pattern.match(sentence) for _, pattern in EARS_PATTERNS):
+            continue
+        report.violations.append(
+            Violation(
+                kind="ears",
+                where=f"Requirements bullet {index}",
+                detail=(
+                    f"matches no EARS pattern: {sentence!r}. "
+                    f"Expected one of: {EARS_FORMS}"
+                ),
+            )
+        )
+
+
+def _check_table_shape(
+    table: RawTable, subject: str, has_ids: bool, report: FormReport
+) -> tuple[int, list[tuple[str, ...]]]:
+    """Completeness and disjointness. Returns (condition count, combinations)."""
+    first = 1 if has_ids else 0
+    condition_columns = list(range(first, len(table.header) - 1))
+    n = len(condition_columns)
+    expected = 2**n
+    where = f"table '{subject}' (line {table.line_no})"
+
+    if len(table.rows) != expected:
+        report.violations.append(
+            Violation(
+                kind="table-rows",
+                where=where,
+                detail=(
+                    f"{n} binary conditions require 2^{n} = {expected} rows; "
+                    f"it carries {len(table.rows)}"
+                ),
+            )
+        )
+
+    combinations = [
+        tuple(_norm(row[col]) for col in condition_columns) for row in table.rows
+    ]
+    seen: dict[tuple[str, ...], int] = {}
+    for position, combo in enumerate(combinations, 1):
+        if combo in seen:
+            report.violations.append(
+                Violation(
+                    kind="table-duplicate",
+                    where=where,
+                    detail=(
+                        f"rows {seen[combo]} and {position} repeat the same "
+                        f"combination of condition values: {', '.join(combo)}"
+                    ),
+                )
+            )
+        else:
+            seen[combo] = position
+    return n, combinations
+
+
+def _check_rows_exact(
+    table: RawTable,
+    subject: str,
+    criteria: list[str],
+    report: FormReport,
+    table_report: TableReport,
+) -> None:
+    """ID mode: bijection on IDs, then outcome text per named row."""
+    where = f"table '{subject}' (line {table.line_no})"
+    row_ids = [row[0].replace("`", "").strip() for row in table.rows]
+    outcomes = {
+        rid: row[-1] for rid, row in zip(row_ids, table.rows, strict=False)
+    }
+    table_report.row_ids = row_ids
+
+    criteria_by_id: dict[str, list[str]] = {}
+    for text in criteria:
+        match = _LEADING_ID.match(text)
+        if match:
+            criteria_by_id.setdefault(match.group(1), []).append(text)
+
+    for rid in row_ids:
+        matches = criteria_by_id.get(rid, [])
+        if not matches:
+            report.violations.append(
+                Violation(
+                    kind="row-criterion",
+                    where=where,
+                    detail=f"row {rid} has no acceptance criterion opening with {rid}",
+                )
+            )
+            continue
+        if len(matches) > 1:
+            report.violations.append(
+                Violation(
+                    kind="row-criterion",
+                    where=where,
+                    detail=f"{len(matches)} acceptance criteria open with {rid}; expected exactly one",
+                )
+            )
+            continue
+        outcome = _norm(outcomes[rid])
+        if outcome and outcome not in _norm(matches[0]):
+            report.violations.append(
+                Violation(
+                    kind="row-criterion",
+                    where=where,
+                    detail=(
+                        f"criterion {rid} does not carry its row's outcome. "
+                        f"Row says {outcomes[rid]!r}; criterion reads {matches[0]!r}"
+                    ),
+                )
+            )
+        else:
+            table_report.matched_rows += 1
+
+    # A criterion carrying an ID with this table's letter prefix but no matching
+    # row is this table's problem -- most likely a row deleted from the grid and
+    # left behind in the list. IDs belonging to another table are not.
+    prefixes = {re.sub(r"[0-9]+$", "", rid) for rid in row_ids}
+    owned = {
+        rid: texts
+        for rid, texts in criteria_by_id.items()
+        if re.sub(r"[0-9]+$", "", rid) in prefixes
+    }
+    table_report.group_size = sum(len(texts) for texts in owned.values())
+    for orphan in sorted(set(owned) - set(row_ids)):
+        report.violations.append(
+            Violation(
+                kind="row-criterion",
+                where=where,
+                detail=f"criterion {orphan} names a row this table does not contain",
+            )
+        )
+
+
+def _check_rows_by_count_and_outcome(
+    table: RawTable,
+    subject: str,
+    criteria: list[str],
+    report: FormReport,
+    table_report: TableReport,
+) -> None:
+    """No-ID mode: exact criterion count in the subject group, plus outcomes."""
+    where = f"table '{subject}' (line {table.line_no})"
+    if not subject:
+        report.violations.append(
+            Violation(
+                kind="row-criterion",
+                where=where,
+                detail=(
+                    "no subject word could be read from the outcome column "
+                    "header, so its rows cannot be joined to criteria"
+                ),
+            )
+        )
+        return
+
+    prefix = _norm(subject)
+    group = [c for c in criteria if _norm(c).startswith(prefix)]
+    table_report.group_size = len(group)
+
+    if len(group) != len(table.rows):
+        report.violations.append(
+            Violation(
+                kind="row-criterion",
+                where=where,
+                detail=(
+                    f"{len(table.rows)} rows require exactly {len(table.rows)} "
+                    f"acceptance criteria opening with '{subject}'; found {len(group)}"
+                ),
+            )
+        )
+
+    normalized_group = [_norm(c) for c in group]
+    candidates = [
+        [
+            j
+            for j, criterion in enumerate(normalized_group)
+            if _norm(row[-1]) and _norm(row[-1]) in criterion
+        ]
+        for row in table.rows
+    ]
+    matching = _max_matching(candidates, len(group))
+    table_report.matched_rows = sum(1 for m in matching if m is not None)
+
+    for index, assigned in enumerate(matching):
+        if assigned is None:
+            report.violations.append(
+                Violation(
+                    kind="row-criterion",
+                    where=where,
+                    detail=(
+                        f"row {index + 1} states {table.rows[index][-1]!r}, and no "
+                        f"unclaimed criterion in the '{subject}' group carries that outcome"
+                    ),
+                )
+            )
+
+
+def check_tables(body: str, report: FormReport) -> None:
+    """Completeness, disjointness and row coverage for every decision table."""
+    criteria_lines = section_lines(body, CRITERIA_HEADING)
+    report.criteria_section_found = criteria_lines is not None
+    criteria: list[str] = []
+    if criteria_lines is not None:
+        criteria, _ = list_items(criteria_lines)
+    report.criteria_examined = len(criteria)
+
+    all_tables = parse_tables(body)
+    decision_tables = [t for t in all_tables if is_decision_table(t)]
+    report.non_decision_tables = len(all_tables) - len(decision_tables)
+
+    seen_ids: dict[str, str] = {}
+
+    for table in decision_tables:
+        has_ids = _has_id_column(table)
+        subject = _first_word(table.header[-1])
+        n, _ = _check_table_shape(table, subject, has_ids, report)
+
+        table_report = TableReport(
+            subject=subject or "(unnamed)",
+            line_no=table.line_no,
+            condition_count=n,
+            row_count=len(table.rows),
+            expected_rows=2**n,
+            join_mode="exact" if has_ids else "count-and-outcome",
+        )
+
+        if not report.criteria_section_found:
+            report.violations.append(
+                Violation(
+                    kind="row-criterion",
+                    where=f"table '{table_report.subject}' (line {table.line_no})",
+                    detail=(
+                        f"no '## {CRITERIA_HEADING}' section, so none of its "
+                        f"{len(table.rows)} rows has a criterion"
+                    ),
+                )
+            )
+        elif has_ids:
+            _check_rows_exact(table, subject, criteria, report, table_report)
+        else:
+            _check_rows_by_count_and_outcome(
+                table, subject, criteria, report, table_report
+            )
+
+        for rid in table_report.row_ids:
+            if rid in seen_ids:
+                owner = seen_ids[rid]
+                clash = (
+                    "twice in this table"
+                    if owner == table_report.subject
+                    else f"already by table '{owner}'"
+                )
+                report.violations.append(
+                    Violation(
+                        kind="table-duplicate",
+                        where=f"table '{table_report.subject}' (line {table.line_no})",
+                        detail=(
+                            f"row ID {rid} is used {clash}; IDs are unique "
+                            f"across the issue"
+                        ),
+                    )
+                )
+            else:
+                seen_ids[rid] = table_report.subject
+
+        report.tables.append(table_report)
+
+
+def check_form(body: str) -> FormReport:
+    """Run every form check over one issue body."""
+    report = FormReport()
+    check_ears(body, report)
+    check_tables(body, report)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_report(report: FormReport, label: str) -> str:
+    """Render the operator-facing report. Every zero carries its denominator."""
+    rule = "=" * 70
+    out = [rule, f"Requirements form check -- {label}", rule, "", "EARS"]
+
+    if not report.ears_ran:
+        out += [
+            "  0 requirement sentences examined out of 0; EARS check did not run.",
+            f"  This issue has no '## {REQUIREMENTS_HEADING}' section. That is an",
+            "  honest vacuous result, not a pass: nothing was checked.",
+        ]
+    else:
+        failures = sum(1 for v in report.violations if v.kind == "ears")
+        out.append(
+            f"  {report.requirements_examined - failures} of "
+            f"{report.requirements_examined} requirement sentences match an "
+            f"EARS pattern."
+        )
+        if report.nested_bullets_skipped:
+            out.append(
+                f"  {report.nested_bullets_skipped} nested bullet(s) were read as "
+                f"elaboration and not EARS-checked."
+            )
+
+    out.append("")
+    if not report.tables:
+        out.append("Decision tables: 0 found, so 0 checked.")
+    else:
+        out.append(f"Decision tables: {len(report.tables)}")
+        for table in report.tables:
+            out += [
+                f"  {table.subject} (line {table.line_no}) -- "
+                f"{table.condition_count} binary condition(s), "
+                f"{table.row_count} of {table.expected_rows} required rows",
+                f"    {table.join_description}",
+                f"    {table.matched_rows} of {table.row_count} rows joined to a "
+                f"criterion; {table.group_size} criteria in its group",
+            ]
+
+    out.append("")
+    if report.criteria_section_found:
+        out.append(f"Acceptance criteria examined: {report.criteria_examined}")
+    else:
+        out.append(f"Acceptance criteria: no '## {CRITERIA_HEADING}' section found.")
+
+    out += ["", "Not verified"]
+    out += [
+        "  - Whether any requirement, row or criterion states the CORRECT",
+        "    behavior. Completeness is a property of form. A table can",
+        "    enumerate every combination and be wrong in every row.",
+    ]
+    if any(not t.exact_join for t in report.tables):
+        weak = ", ".join(t.subject for t in report.tables if not t.exact_join)
+        out += [
+            f"  - For {weak}: that each criterion describes its own row's",
+            "    combination of condition values. Those tables carry no row IDs,",
+            "    so the join rests on count and outcome text. Combination",
+            "    correctness is delegated to the semantic consistency gate.",
+        ]
+    if report.non_decision_tables:
+        out.append(
+            f"  - {report.non_decision_tables} markdown table(s) whose non-outcome "
+            f"columns are not plain yes/no, so they are not decision tables."
+        )
+    if not report.ears_ran:
+        out += [
+            "  - Every sentence in this issue. With no requirements section,",
+            "    nothing was read as a requirement sentence, so the EARS rule",
+            "    was not applied to anything.",
+        ]
+
+    out += [""]
+    if report.ok:
+        out.append("RESULT: PASS -- 0 violations of the ADR 0226 form.")
+    else:
+        out.append(f"RESULT: FAIL -- {len(report.violations)} violation(s).")
+        out.append("")
+        for violation in report.violations:
+            out.append(f"  {violation}")
+
+    out += ["", rule]
+    return "\n".join(out) + "\n"

--- a/docs/adrs/0226-checkable-requirements-ears-tables-split.md
+++ b/docs/adrs/0226-checkable-requirements-ears-tables-split.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-11
 **Categories:** Process, Data, Reliability
-**Related:** #2218 (this ADR); #1899 (the requirements-consistency gate); standard 0028 (ask structured, get structured, or reject); boostgauge #7 (the first converted requirement); boostgauge #235, #240, #249, #252, #273, #274, #275 (the seven conflicts); boostgauge #270 (a pass criterion carries values, not pointers)
+**Related:** #2218 (this ADR); #2219 (the checker, and the rulings that scoped EARS and defined the row ID convention); #1899 (the requirements-consistency gate); #2221 (the standalone caller for that gate); standard 0028 (ask structured, get structured, or reject); boostgauge #7 (the first converted requirement); boostgauge #235, #240, #249, #252, #273, #274, #275 (the seven conflicts); boostgauge #270 (a pass criterion carries values, not pointers)
 
 ---
 
@@ -51,6 +51,8 @@ The benefit is that a conditional requirement cannot be written as though it wer
 
 A parser can reject a sentence matching none of the five patterns. That check is cheap and runs at authoring time.
 
+**EARS binds the sentences of the marked requirements section, and nothing else.** The requirements of an issue are the bullets under a `## Requirements` heading, and each of those bullets must match one of the five patterns. Prose elsewhere in the issue, including the summary, a narrative paragraph, and a table's preamble, is not read as a requirement sentence and is not EARS-checked. An issue with no such section is reported as zero requirement sentences examined out of zero, which is an honest vacuous result rather than a pass. Section 3.2 states the one exemption that matters, for acceptance criteria (#2219).
+
 ### 3.2 Lightweight Parnas tables
 
 David Parnas and the Naval Research Laboratory rebuilt the requirements document for the A-7E aircraft's flight software in the late 1970s, under the Software Cost Reduction project. Its central technique was the tabular expression. Where a function depends on several conditions, the document states it as a grid, and the grid is the definition rather than a summary of one.
@@ -78,6 +80,23 @@ The worked example is boostgauge #7, converted on 2026-08-11:
 Every one of the seven historical conflicts was a question about which row a sentence described. None of them can be stated against the table.
 
 Two disciplines keep a table readable. The column headers must be plain questions with plain answers, because a header written as a predicate expression removes the benefit. Each row must also appear as its own acceptance criterion, so the four combinations become four independently testable claims.
+
+**A row criterion takes the row form, and is exempt from EARS.** A row criterion is a table row's projection into the test list, not a requirement sentence, and it is written in the terse form the projection produces: the conditions in column order, then the outcome. "Position, reset, moved: `position` holds the new position" is correct and complete as written. Requiring EARS of it would demand a shall-sentence per row, which restates the grid in prose and reintroduces the ambiguity the grid removed. No acceptance criterion is EARS-checked (#2219).
+
+**Each row carries an ID, and its criterion opens with that ID.** The table gains a leading ID column holding the subject word's first letter, capitalised, plus the row number counting from one: `P1` through `P4` for a position table, `S1` through `S8` for a size table. Where two subjects share an initial, use enough letters to distinguish them. IDs are unique across the issue. The worked example above, under the convention:
+
+| ID | Launched with `--reset-config`? | Did the user move or resize the window? | Config file after quit |
+|---|---|---|---|
+| C1 | no | no | unchanged, byte-for-byte |
+| C2 | no | yes | prior contents, with the new position and size |
+| C3 | yes | no | defaults |
+| C4 | yes | yes | defaults, with the new position and size |
+
+The criterion for `C3` then reads `- [ ] C3. Reset, not moved: the config file holds defaults`.
+
+The ID is what makes the join between grid and test list exact rather than inferred. With IDs a checker verifies a bijection between the two ID sets and confirms that each criterion carries its own row's outcome, so a criterion labelled `C3` stating row two's outcome fails mechanically. Without them the strongest available check is a count of criteria per table plus a match on outcome text, which cannot tell whether a criterion describes its own row's combination. That residue is left to the semantic consistency gate, where a criterion contradicting its own table surfaces as the conflict class the gate already reports. The human-readable condition phrase after the ID is decoration for the reader; the ID is the join.
+
+The convention binds every issue converted after boostgauge #7, which was converted before it existed (#2219).
 
 ### 3.3 The split rule
 
@@ -193,7 +212,9 @@ We accept that a complete table can still be wrong. Completeness is a property o
 
 Conversion happens when an issue next rolls, and not as a sweep. An issue that is not rolling costs nothing by staying in prose, and a sweep would convert issues whose requirements may change before anything reads them.
 
-The mechanical checker is separate work and is not built. It verifies three things. Each requirement must match an EARS pattern. A table of `n` binary conditions must carry `2^n` rows, with no combination repeated. Each row must appear as an acceptance criterion. The checker reports what it verified and what it did not, per standard 0028.
+The mechanical checker is built (#2219): `tools/check_requirements_form.py --repo <path> --issue N`, or `--file <draft>` while authoring. It is fully deterministic and makes no model calls, so it is free and instant and runs before anything else. It verifies three things. Each bullet under `## Requirements` must match an EARS pattern. A table of `n` binary conditions must carry `2^n` rows, with no combination repeated. Each row must appear as an acceptance criterion. The checker reports what it verified and what it did not, per standard 0028, and names its row-join mode per table so the count-and-outcome mode can never be mistaken for the exact one.
+
+The full pre-roll sequence is this form check, then the semantic requirements-consistency gate via `tools/check_requirements.py` (#2221, one model call), then the roll.
 
 boostgauge #7 is the first converted requirement and was rolling as of 2026-08-11. Its result is the first evidence about whether this form prevents what it was adopted to prevent.
 
@@ -214,3 +235,4 @@ Bibliographic details below are recorded from recall. Confirm them against the p
 | Date | Author | Change |
 |---|---|---|
 | 2026-08-11 | Claude Opus 5 | Initial draft |
+| 2026-08-11 | Claude Fable 5 | Building the checker (#2219) surfaced a contradiction between rule 1 and this ADR's own worked example: boostgauge #7's row criteria are mandated by section 3.2 and match no EARS pattern, so an EARS check over acceptance criteria would fail the fixture the ADR cites as its first success. Operator rulings on #2219 scoped EARS to the bullets of a marked `## Requirements` section, exempted row criteria explicitly, and adopted a row ID convention that makes the grid-to-criteria join exact. Sections 3.1, 3.2 and 8 carry those rulings. |

--- a/tests/fixtures/requirements/boostgauge-7-body.md
+++ b/tests/fixtures/requirements/boostgauge-7-body.md
@@ -1,0 +1,123 @@
+## Summary
+
+BoostGauge needs a configuration system for thresholds, polling intervals, visual preferences, and window behavior.
+
+## Config file
+
+Location: `~/.boostgauge/config.json` (or `%APPDATA%/boostgauge/config.json` on Windows)
+
+```json
+{
+  "polling_interval_seconds": 2,
+  "theme": "dark",
+  "size": 300,
+  "opacity": 0.9,
+  "always_on_top": true,
+  "position": {"x": 100, "y": 100},
+  "thresholds": {
+    "conpty": {"yellow": 30, "red": 60},
+    "memory_percent": {"yellow": 60, "red": 80},
+    "process_count": {"yellow": 300, "red": 500},
+    "handle_count": {"yellow": 30000, "red": 50000}
+  },
+  "telltale_windows": {
+    "short": 60,
+    "medium": 600,
+    "long": 3600
+  },
+  "show_driver_label": true,
+  "show_digital_readout": true,
+  "show_session_count": true
+}
+```
+
+## CLI arguments
+
+```
+boostgauge [OPTIONS]
+
+Options:
+  --theme THEME          Visual theme (dark, light, neon, classic)
+  --size PIXELS          Gauge diameter in pixels (default: 300)
+  --poll SECONDS         Polling interval (default: 2)
+  --opacity FLOAT        Window opacity 0.0-1.0 (default: 0.9)
+  --no-topmost           Don't keep window on top
+  --config PATH          Path to config file
+  --reset-config         Reset config to defaults
+```
+
+## Config persistence
+
+**Writes.** The app writes to the config file at exactly three moments and at no other time:
+
+1. **First-run auto-create.** Launch finds no config file and creates one with defaults.
+2. **Launch reset.** `--reset-config` rewrites the file to defaults before the app reads it. The flag has no further effect; the rest of the session proceeds as any other.
+3. **Exit write.** The app writes the keys the user changed by hand during the session, and only those keys: `position` if the window was moved, `size` if it was resized. Every other key keeps whatever the file already holds, including edits made directly to the file while the app ran. Position and size are the only keys with a hand-change mechanism, so they are the only keys the exit write can ever touch. A session with no hand-made changes skips the exit write entirely.
+
+**Reads are not restricted.** Launch reads the file after step 2, and the app re-reads it during the session so that threshold edits take effect without a restart. Reading never modifies the file.
+
+**Direct edits to the file while the app runs are the user's writes, not the app's.** The three moments above are the app's complete write behavior. After launch, the app's only write is the exit write, and the exit write never overwrites a key the user did not change by hand during the session. The launch writes (auto-create, reset) happen before the app reads the file and before any session activity exists. The file's content after quit is therefore the composition of the app's writes and the user's.
+
+**Launch order** is: reset if flagged, then read the file (auto-create if missing), then apply CLI overrides in memory. CLI value overrides (`--theme`, `--size`, `--poll`, `--opacity`, `--no-topmost`) govern the running session; the app never writes them to the file. The window opens at the file's position, since no position flag exists, and at the CLI size when `--size` is given, otherwise the file's size. After a `--reset-config` launch the file holds defaults when it is read, so the window opens at the default position, and at the default size unless `--size` overrides it for the session.
+
+**Persistence of `position` and `size` is independent**, each governed by its own table. Every row follows from the write rules above, and each row is an acceptance criterion below. Both tables hold one further condition fixed: no direct edit to the file during the session. The composition criterion in the acceptance list governs a session with one.
+
+Position, which has no CLI flag and only ever changes by hand:
+
+| `--reset-config`? | Window moved by hand? | `position` in the file after quit (no direct edits) |
+|---|---|---|
+| no | no | unchanged |
+| no | yes | the new position |
+| yes | no | default |
+| yes | yes | the new position |
+
+Size, which has a CLI flag:
+
+| `--reset-config`? | `--size` given? | Window resized by hand? | `size` in the file after quit (no direct edits) |
+|---|---|---|---|
+| no | no | no | unchanged |
+| no | no | yes | the new size |
+| no | yes | no | unchanged; the CLI value is not written |
+| no | yes | yes | the new size |
+| yes | no | no | default |
+| yes | no | yes | the new size |
+| yes | yes | no | default; the CLI value is not written |
+| yes | yes | yes | the new size |
+
+`--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments above apply to the selected file.
+
+## Acceptance Criteria
+
+- [ ] First run with no config file creates one with defaults
+- [ ] Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file
+- [ ] With no CLI overrides, the window opens at the file's position and size
+- [ ] Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size
+- [ ] Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file
+- [ ] The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size
+- [ ] With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins
+- [ ] A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit
+- [ ] Position, no reset, not moved, no direct edits: `position` unchanged
+- [ ] Position, no reset, moved, no direct edits: `position` holds the new position
+- [ ] Position, reset, not moved, no direct edits: `position` holds the default
+- [ ] Position, reset, moved, no direct edits: `position` holds the new position
+- [ ] Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged
+- [ ] Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written
+- [ ] Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] Size, reset, no `--size`, not resized, no direct edits: `size` holds the default
+- [ ] Size, reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written
+- [ ] Size, reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] Invalid config values produce clear error messages
+
+## Revision History
+
+- **2026-08-09 — ruling on #235 (filed by run-issue7-181229's requirements-consistency gate):** The original text held both "CLI args override config" and "Position/size saved on exit" with no rule for a session that exits under an untouched CLI override. Operator ruling: CLI overrides are session-scoped and never persisted. On exit the app writes only hand-made changes (drag/resize) to the config file; a CLI-injected value the user never touched leaves the config file unchanged. Acceptance criteria 2 and 3 rewritten to carry the ruling.
+- **2026-08-10 — ruling on #240 (filed by run-issue7-233727's requirements-consistency gate):** The #235 ruling's blanket sentence ("an override is never written back to the config file") contradicted `--reset-config`, whose entire purpose is to write defaults into the config file. Operator ruling: the session-only rule governs value overrides; `--reset-config` is the one deliberate exception and rewrites the config file to defaults. `--config` selects the file and writes nothing by itself.
+- **2026-08-10 — ruling on #249 (filed by run-issue7-031357's requirements-consistency gate):** "Position always persists on exit" read as an unconditional write, contradicting "persists only changes the user made by hand" for a session in which the window was never moved. Operator ruling: persistence is change-driven — exit writes only hand-made changes, and an untouched session leaves the config file byte-identical, preserving any direct edits made to the file while the app ran. The "always persists" sentence rephrased to its intent: position only ever changes by hand, so a moved window always keeps its new position.
+- **2026-08-10 — ruling on #252 (filed by run-issue7-094316's requirements-consistency gate):** The #249 sentence's byte-identical guarantee, written without its exception, contradicted the #240 carve-out when the app is launched with `--reset-config` and exited untouched. Operator ruling: the reset wins — `--reset-config` is a config-file command and rewrites the file regardless of hand-made changes; the byte-identical guarantee is scoped to sessions launched without a config-file command. Both sentences now carry the exception inline.
+- **2026-08-11 — ruling on #273/#274/#275 (filed by run-issue7-083155's requirements-consistency gate):** Three conflicts from one run, each pitting a persistence sentence against `--reset-config`'s "rewrites the file regardless." Operator ruling: **the reset happens at launch.** `--reset-config` rewrites the file to defaults before the app reads it; the session then behaves normally and exit writes hand-made changes as usual, so a window moved during a reset session keeps its new position, and that session's own window opens at the defaults. The prose paragraph that produced seven conflicts across five rulings was replaced by an ordered rule and a decision table.
+- **2026-08-11 — repair after #277/#278/#279 (filed by run-issue7-140703's requirements-consistency gate):** All three conflicts were in text introduced by the #273/#274/#275 rewrite itself, and none required a new behavioral decision. (1) "Nothing else touches it" accidentally forbade the mid-session reads that hot threshold reload requires; the constraint is now scoped to writes, with reads explicitly unrestricted (#277). (2) The single table bundled position and size into one "moved or resized" condition, so a session launched with `--size` whose window was only moved appeared to write the CLI size to the file; position and size are independent variables with different rules, because size has a CLI flag and position does not, and each now has its own table (#278). The four-condition count that forced the split is AssemblyZero ADR 0226's split rule applied. (3) "Opens at the default position and size" overstated the reset launch by one noun; with `--reset-config --size N` the session runs at the CLI size while the file holds the default (#279). Two latent gaps no run had yet reported were closed in the same pass: the exit write is defined as a per-key patch, so direct file edits survive an exit that writes position or size; and the byte-identical guarantee is stated with its no-reset scope inline, so the #252 collision shape cannot recur. First-run auto-create was also added to the enumerated write moments, which the previous "exactly three things" sentence omitted.
+- **2026-08-11 — repair after #280/#281 (filed by run-issue7-152239's requirements-consistency gate):** Both conflicts paired a table row's final-state claim against #249's standing rule that direct file edits survive. The rows were written as if the app were the file's only writer; the user can edit the file while the app runs, so the file's final content is a composition of the app's writes and the user's, and a row claiming "holds the default" is false when a direct edit lands after the launch reset. No behavior changed and no new ruling was needed: the app's writes were already fully specified, and #249 already governed direct edits. The repair is scope. Every table row now names its held-fixed condition ("no direct edits"), a composition criterion states what a direct edit leaves behind, and the byte-identical guarantee carries the same scope. The underlying rule, from the same body of work ADR 0226 draws on: state post-conditions only over variables the system controls. The config file is shared with the user, so the app's requirement is its write behavior; file content follows by composition.
+- **2026-08-11 — repair after #282/#283 (filed by the standalone pre-check, AssemblyZero #2221, on its first run against this issue):** The first conflicts caught without spending a roll: the pre-check invokes the same gate a roll runs, offline, and it found two overclaimed guarantees in the prose around the tables. (1) "The app never overwrites a key the user did not change by hand" was written as a blanket claim about the app; the launch reset exists to overwrite untouched keys. The claim is now scoped to the exit write, which is what it was always about (#282). (2) The byte-identical guarantee did not exclude a first run, where auto-create writes a file from nothing; it now requires that the session found an existing config file at launch (#283). No behavior changed and no ruling was needed. Both defects are the universal-dressed-as-conditional disease recurring in the prose that remains around the tables.
+

--- a/tests/fixtures/requirements/ids-exact-mode.md
+++ b/tests/fixtures/requirements/ids-exact-mode.md
@@ -1,0 +1,30 @@
+# feat: cache eviction policy
+
+Synthetic fixture for the exact row-join mode (#2219). Every decision table
+carries a leading ID column, and every row criterion opens with its ID, so the
+checker can verify a bijection rather than a count.
+
+## Requirements
+
+- The cache shall evict entries in least-recently-used order.
+- WHEN the cache exceeds its size limit the cache shall evict until it fits.
+- WHILE a write to an entry is in flight the cache shall not evict that entry.
+- IF an entry is pinned THEN the cache shall skip it during eviction.
+- WHERE metrics are enabled the cache shall count every eviction.
+
+Eviction depends on two independent conditions.
+
+| ID | Entry pinned? | Cache over limit? | Entry after the sweep |
+|---|---|---|---|
+| E1 | no | no | retained |
+| E2 | no | yes | evicted |
+| E3 | yes | no | retained |
+| E4 | yes | yes | retained, and the skip is counted |
+
+## Acceptance Criteria
+
+- [ ] Cache size is read from the configured limit at startup
+- [ ] E1. Not pinned, not over limit: the entry is retained
+- [ ] E2. Not pinned, over limit: the entry is evicted
+- [ ] E3. Pinned, not over limit: the entry is retained
+- [ ] E4. Pinned, over limit: the entry is retained, and the skip is counted

--- a/tests/unit/test_check_requirements_form.py
+++ b/tests/unit/test_check_requirements_form.py
@@ -1,0 +1,555 @@
+"""Unit tests for the ADR 0226 requirements form checker (#2219).
+
+Two fixtures anchor the suite. `boostgauge-7-body.md` is the live artifact --
+the first requirement converted to the new form, frozen here as it stood when
+it passed the semantic gate -- and it exercises the no-ID join mode.
+`ids-exact-mode.md` is synthetic and exercises the exact mode.
+
+Every positive claim has a negative beside it. A checker whose passing result
+has never been made to fail is not a check, and this one's whole value is that
+a clean report can be trusted.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.workflows.requirements import form_check as fc  # noqa: E402
+
+FIXTURES = ROOT / "tests" / "fixtures" / "requirements"
+BOOSTGAUGE_7 = FIXTURES / "boostgauge-7-body.md"
+IDS_EXACT = FIXTURES / "ids-exact-mode.md"
+
+
+@pytest.fixture(scope="module")
+def boostgauge_body() -> str:
+    return BOOSTGAUGE_7.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ids_body() -> str:
+    return IDS_EXACT.read_text(encoding="utf-8")
+
+
+def kinds(report: fc.FormReport) -> list[str]:
+    return [v.kind for v in report.violations]
+
+
+def details(report: fc.FormReport) -> str:
+    return " || ".join(v.detail for v in report.violations)
+
+
+# ---------------------------------------------------------------------------
+# The live fixture (ruling 2: boostgauge #7 is the no-ID artifact)
+# ---------------------------------------------------------------------------
+
+
+class TestBoostgaugeSeven:
+    def test_it_passes(self, boostgauge_body):
+        report = fc.check_form(boostgauge_body)
+        assert report.ok, details(report)
+
+    def test_two_decision_tables_with_twelve_rows_between_them(self, boostgauge_body):
+        report = fc.check_form(boostgauge_body)
+
+        assert len(report.tables) == 2
+        assert [t.row_count for t in report.tables] == [4, 8]
+        assert sum(t.row_count for t in report.tables) == 12
+
+    def test_every_row_joined_to_a_criterion(self, boostgauge_body):
+        report = fc.check_form(boostgauge_body)
+
+        for table in report.tables:
+            assert table.matched_rows == table.row_count
+            assert table.group_size == table.row_count
+
+    def test_it_runs_in_the_weaker_mode_and_says_so(self, boostgauge_body):
+        """The no-silent-caps rule: a reader must not mistake the modes."""
+        report = fc.check_form(boostgauge_body)
+        rendered = fc.render_report(report, "boostgauge #7")
+
+        assert all(not t.exact_join for t in report.tables)
+        assert "row join: count and outcome" in rendered
+        assert "delegated to the semantic gate" in rendered
+        assert "row join: exact" not in rendered
+
+    def test_ears_did_not_run_and_the_zero_carries_its_denominator(
+        self, boostgauge_body
+    ):
+        report = fc.check_form(boostgauge_body)
+        rendered = fc.render_report(report, "boostgauge #7")
+
+        assert report.ears_ran is False
+        assert report.requirements_examined == 0
+        assert (
+            "0 requirement sentences examined out of 0; EARS check did not run."
+            in rendered
+        )
+
+    def test_its_row_criteria_are_not_ears_validated(self, boostgauge_body):
+        """Row criteria take the row form and are exempt (ADR 0226 3.2).
+
+        Every one of this issue's twenty-one criteria would fail EARS. If the
+        checker ever reads acceptance criteria as requirement sentences, the
+        live positive fixture turns into a wall of violations.
+        """
+        report = fc.check_form(boostgauge_body)
+
+        assert report.criteria_examined == 21
+        assert "ears" not in kinds(report)
+
+
+# ---------------------------------------------------------------------------
+# Exact mode
+# ---------------------------------------------------------------------------
+
+
+class TestExactMode:
+    def test_it_passes(self, ids_body):
+        report = fc.check_form(ids_body)
+        assert report.ok, details(report)
+
+    def test_join_is_exact_and_named(self, ids_body):
+        report = fc.check_form(ids_body)
+        rendered = fc.render_report(report, "cache")
+
+        assert report.tables[0].exact_join
+        assert "row join: exact (IDs)" in rendered
+        assert "delegated to the semantic gate" not in rendered
+
+    def test_all_five_ears_patterns_are_accepted(self, ids_body):
+        report = fc.check_form(ids_body)
+
+        assert report.ears_ran
+        assert report.requirements_examined == 5
+        assert "ears" not in kinds(report)
+
+    def test_dropped_row_fails(self, ids_body):
+        """A row deleted from the grid: incomplete, and its criterion orphaned."""
+        broken = ids_body.replace("| E3 | yes | no | retained |\n", "")
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "table-rows" in kinds(report)
+        assert "row-criterion" in kinds(report)
+        assert "E3" in details(report)
+
+    def test_dropped_criterion_fails(self, ids_body):
+        broken = ids_body.replace(
+            "- [ ] E3. Pinned, not over limit: the entry is retained\n", ""
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "row-criterion" in kinds(report)
+        assert "E3 has no acceptance criterion" in details(report)
+
+    def test_duplicated_id_fails(self, ids_body):
+        broken = ids_body.replace("| E3 | yes | no |", "| E2 | yes | no |")
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "table-duplicate" in kinds(report)
+        assert "row ID E2 is used twice in this table" in details(report)
+
+    def test_wrong_outcome_criterion_fails(self, ids_body):
+        """The criterion names row E2 but carries row E1's outcome."""
+        broken = ids_body.replace(
+            "- [ ] E2. Not pinned, over limit: the entry is evicted",
+            "- [ ] E2. Not pinned, over limit: the entry is retained",
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "row-criterion" in kinds(report)
+        assert "does not carry its row's outcome" in details(report)
+
+    def test_criterion_naming_a_row_that_does_not_exist_fails(self, ids_body):
+        broken = ids_body.replace(
+            "- [ ] E4. Pinned, over limit:",
+            "- [ ] E9. Pinned, over limit:",
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "E9 names a row this table does not contain" in details(report)
+
+    def test_ids_must_be_unique_across_the_issue(self, ids_body):
+        second_table = (
+            "\n| ID | Flushed? | Dirty? | Buffer after the sweep |\n"
+            "|---|---|---|---|\n"
+            "| E1 | no | no | kept |\n"
+            "| E2 | no | yes | kept |\n"
+            "| E3 | yes | no | dropped |\n"
+            "| E4 | yes | yes | dropped |\n"
+        )
+        broken = ids_body.replace("\n## Acceptance Criteria", second_table + "\n## Acceptance Criteria")
+
+        report = fc.check_form(broken)
+
+        assert "table-duplicate" in kinds(report)
+        assert "already by table" in details(report)
+
+
+# ---------------------------------------------------------------------------
+# EARS (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+
+def _with_requirements(*bullets: str) -> str:
+    body = "## Requirements\n\n"
+    body += "".join(f"- {b}\n" for b in bullets)
+    return body
+
+
+class TestEars:
+    @pytest.mark.parametrize(
+        "sentence",
+        [
+            "The system shall write the file on exit.",
+            "WHEN the user quits the system shall write the file.",
+            "WHILE a write is in flight the system shall reject a second write.",
+            "IF the file is unreadable THEN the system shall report the error.",
+            "WHERE metrics are enabled the system shall count each write.",
+        ],
+    )
+    def test_each_pattern_is_accepted(self, sentence):
+        report = fc.check_form(_with_requirements(sentence))
+
+        assert report.ok, details(report)
+        assert report.requirements_examined == 1
+
+    @pytest.mark.parametrize(
+        "sentence",
+        [
+            "Config is saved when the app exits.",
+            "The system writes the file on exit.",
+            "When the user quits the system shall write the file.",
+            "Save the position.",
+        ],
+    )
+    def test_a_sentence_matching_no_pattern_is_reported(self, sentence):
+        report = fc.check_form(_with_requirements(sentence))
+
+        assert not report.ok
+        assert kinds(report) == ["ears"]
+        assert "matches no EARS pattern" in details(report)
+
+    def test_the_violation_names_the_offending_sentence_and_its_position(self):
+        report = fc.check_form(
+            _with_requirements(
+                "The system shall start.",
+                "Config is saved on exit.",
+            )
+        )
+
+        assert len(report.violations) == 1
+        assert report.violations[0].where == "Requirements bullet 2"
+        assert "Config is saved on exit." in report.violations[0].detail
+
+    def test_nested_bullets_are_counted_not_checked(self):
+        body = (
+            "## Requirements\n\n"
+            "- The system shall write the file on exit.\n"
+            "  - only the keys the user changed\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert report.ok
+        assert report.requirements_examined == 1
+        assert report.nested_bullets_skipped == 1
+        assert "1 nested bullet(s)" in fc.render_report(report, "x")
+
+    def test_the_section_heading_must_be_exact(self):
+        """'## Requirements (draft)' is not the marked section."""
+        body = "## Requirements (draft)\n\n- Config is saved on exit.\n"
+
+        report = fc.check_form(body)
+
+        assert report.ears_ran is False
+        assert report.ok
+
+    def test_the_section_ends_at_the_next_heading(self):
+        body = (
+            "## Requirements\n\n"
+            "- The system shall start.\n\n"
+            "## Notes\n\n"
+            "- this bullet is not a requirement\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert report.requirements_examined == 1
+        assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# Table completeness and disjointness (acceptance criteria 2 and 3)
+# ---------------------------------------------------------------------------
+
+
+def _table(rows: str, header: str = "| A? | B? | Result |") -> str:
+    return (
+        f"{header}\n|---|---|---|\n{rows}\n"
+        "\n## Acceptance Criteria\n\n"
+        "- [ ] Result, a, b: kept\n"
+    )
+
+
+class TestTableShape:
+    def test_missing_row_is_reported(self):
+        body = _table(
+            "| no | no | kept |\n| no | yes | kept |\n| yes | no | kept |"
+        )
+
+        report = fc.check_form(body)
+
+        assert "table-rows" in kinds(report)
+        assert "2 binary conditions require 2^2 = 4 rows; it carries 3" in details(
+            report
+        )
+
+    def test_extra_row_is_reported(self):
+        body = _table(
+            "| no | no | kept |\n| no | yes | kept |\n"
+            "| yes | no | kept |\n| yes | yes | kept |\n| yes | yes | dropped |"
+        )
+
+        report = fc.check_form(body)
+
+        assert "table-rows" in kinds(report)
+        assert "it carries 5" in details(report)
+
+    def test_repeated_combination_is_reported(self):
+        body = _table(
+            "| no | no | kept |\n| no | no | dropped |\n"
+            "| yes | no | kept |\n| yes | yes | kept |"
+        )
+
+        report = fc.check_form(body)
+
+        assert "table-duplicate" in kinds(report)
+        assert "rows 1 and 2 repeat the same combination" in details(report)
+
+    def test_three_conditions_require_eight_rows(self, boostgauge_body):
+        report = fc.check_form(boostgauge_body)
+        size = [t for t in report.tables if t.subject == "size"][0]
+
+        assert size.condition_count == 3
+        assert size.expected_rows == 8
+
+    def test_a_table_that_is_not_binary_is_not_a_decision_table(self):
+        body = (
+            "| Risk | Impact | Mitigation |\n|---|---|---|\n"
+            "| a | Med | review |\n| b | Low | none |\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert report.tables == []
+        assert report.non_decision_tables == 1
+        assert "not decision tables" in fc.render_report(report, "x")
+
+
+# ---------------------------------------------------------------------------
+# Row-to-criterion coverage in no-ID mode (acceptance criterion 4)
+# ---------------------------------------------------------------------------
+
+
+class TestNoIdJoin:
+    BODY = (
+        "| Reset? | Moved? | `position` after quit |\n|---|---|---|\n"
+        "| no | no | unchanged |\n"
+        "| no | yes | the new position |\n"
+        "| yes | no | default |\n"
+        "| yes | yes | the new position |\n"
+        "\n## Acceptance Criteria\n\n"
+        "- [ ] Position, no reset, not moved: `position` unchanged\n"
+        "- [ ] Position, no reset, moved: `position` holds the new position\n"
+        "- [ ] Position, reset, not moved: `position` holds the default\n"
+        "- [ ] Position, reset, moved: `position` holds the new position\n"
+    )
+
+    def test_the_group_passes(self):
+        report = fc.check_form(self.BODY)
+        assert report.ok, details(report)
+
+    def test_a_missing_criterion_fails_on_count_and_on_outcome(self):
+        broken = self.BODY.replace(
+            "- [ ] Position, reset, not moved: `position` holds the default\n", ""
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "4 rows require exactly 4 acceptance criteria" in details(report)
+        assert "no unclaimed criterion" in details(report)
+
+    def test_a_criterion_with_the_wrong_outcome_fails(self):
+        broken = self.BODY.replace(
+            "Position, reset, not moved: `position` holds the default",
+            "Position, reset, not moved: `position` holds the previous value",
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "row 3 states 'default'" in details(report)
+
+    def test_duplicate_outcomes_need_distinct_criteria(self):
+        """Two rows sharing an outcome cannot both claim one criterion."""
+        broken = self.BODY.replace(
+            "- [ ] Position, reset, moved: `position` holds the new position",
+            "- [ ] Position, reset, moved: `position` holds whatever it held",
+        )
+
+        report = fc.check_form(broken)
+
+        assert not report.ok
+        assert "the new position" in details(report)
+
+    def test_nested_outcomes_are_matched_by_maximum_matching(self):
+        """'unchanged' is a substring of 'unchanged; the CLI value is not written'.
+
+        Greedy assignment in row order consumes the longer criterion for the
+        shorter row and then reports a false gap. This is the boostgauge #7
+        size table's exact shape, reduced.
+        """
+        body = (
+            "| A? | `size` after quit |\n|---|---|\n"
+            "| no | unchanged |\n"
+            "| yes | unchanged; the CLI value is not written |\n"
+            "\n## Acceptance Criteria\n\n"
+            "- [ ] Size, no flag: `size` unchanged\n"
+            "- [ ] Size, flag: `size` unchanged; the CLI value is not written\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert report.ok, details(report)
+
+    def test_no_criteria_section_is_reported_not_ignored(self):
+        body = (
+            "| A? | B? | Result |\n|---|---|---|\n"
+            "| no | no | kept |\n| no | yes | kept |\n"
+            "| yes | no | kept |\n| yes | yes | kept |\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert not report.ok
+        assert "no '## Acceptance Criteria' section" in details(report)
+        assert report.criteria_section_found is False
+
+
+# ---------------------------------------------------------------------------
+# Output honesty (acceptance criterion 5)
+# ---------------------------------------------------------------------------
+
+
+class TestReportHonesty:
+    def test_a_clean_report_still_names_what_it_did_not_verify(self, ids_body):
+        rendered = fc.render_report(fc.check_form(ids_body), "cache")
+
+        assert "RESULT: PASS" in rendered
+        assert "Not verified" in rendered
+        assert "states the CORRECT" in rendered
+
+    def test_it_never_claims_correctness(self, boostgauge_body):
+        rendered = fc.render_report(fc.check_form(boostgauge_body), "boostgauge #7")
+
+        assert "enumerate every combination and be wrong in every row" in rendered
+
+    def test_counts_carry_denominators(self, ids_body):
+        rendered = fc.render_report(fc.check_form(ids_body), "cache")
+
+        assert "5 of 5 requirement sentences" in rendered
+        assert "4 of 4 required rows" in rendered
+        assert "4 of 4 rows joined to a criterion" in rendered
+
+    def test_an_empty_document_reports_zeroes_with_denominators(self):
+        report = fc.check_form("# just a title\n")
+        rendered = fc.render_report(report, "empty")
+
+        assert report.ok
+        assert "0 requirement sentences examined out of 0" in rendered
+        assert "Decision tables: 0 found, so 0 checked." in rendered
+
+    def test_failures_are_listed_with_their_location(self):
+        report = fc.check_form(_with_requirements("Config is saved on exit."))
+        rendered = fc.render_report(report, "x")
+
+        assert "RESULT: FAIL -- 1 violation(s)." in rendered
+        assert "[ears] Requirements bullet 1" in rendered
+
+    def test_the_checker_is_deterministic(self, boostgauge_body):
+        first = fc.render_report(fc.check_form(boostgauge_body), "b")
+        second = fc.render_report(fc.check_form(boostgauge_body), "b")
+
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def _cli(self):
+        import check_requirements_form
+
+        return check_requirements_form
+
+    def test_passing_file_exits_zero(self, capsys):
+        code = self._cli().main(["--file", str(BOOSTGAUGE_7)])
+
+        assert code == 0
+        assert "RESULT: PASS" in capsys.readouterr().out
+
+    def test_violations_exit_one(self, tmp_path, capsys):
+        bad = tmp_path / "bad.md"
+        bad.write_text(_with_requirements("Config is saved on exit."), encoding="utf-8")
+
+        code = self._cli().main(["--file", str(bad)])
+
+        assert code == 1
+        assert "RESULT: FAIL" in capsys.readouterr().out
+
+    def test_missing_file_exits_two(self, tmp_path, capsys):
+        code = self._cli().main(["--file", str(tmp_path / "nope.md")])
+
+        assert code == 2
+        assert "has been verified" in capsys.readouterr().err
+
+    def test_empty_body_exits_two(self, tmp_path, capsys):
+        blank = tmp_path / "blank.md"
+        blank.write_text("   \n", encoding="utf-8")
+
+        code = self._cli().main(["--file", str(blank)])
+
+        assert code == 2
+        assert "nothing to check" in capsys.readouterr().err
+
+    def test_issue_path_reads_through_gh(self, tmp_path, monkeypatch, capsys):
+        cli = self._cli()
+        monkeypatch.setattr(
+            cli,
+            "fetch_issue",
+            lambda repo, issue: ("t", BOOSTGAUGE_7.read_text(encoding="utf-8")),
+        )
+
+        code = cli.main(["--repo", str(tmp_path), "--issue", "7"])
+
+        assert code == 0
+        assert "RESULT: PASS" in capsys.readouterr().out

--- a/tools/check_requirements_form.py
+++ b/tools/check_requirements_form.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Check an issue against the ADR 0226 requirement form. Free and instant.
+
+Issue #2219. Fully deterministic: no model calls, no network beyond reading
+the issue, and the same answer every time for the same input.
+
+    poetry run python tools/check_requirements_form.py \\
+        --repo /c/Users/mcwiz/Projects/boostgauge --issue 7
+
+    poetry run python tools/check_requirements_form.py --file draft.md
+
+It verifies EARS conformance of the bullets under a ``## Requirements``
+heading, that a decision table of n binary conditions carries 2^n rows with no
+combination repeated, and that every table row appears as its own acceptance
+criterion. Acceptance criteria are never EARS-validated -- a row criterion is
+a row's projection into the test list, and its terse form is mandated by
+ADR 0226 section 3.2.
+
+It cannot report correctness. A table can enumerate every combination and
+state the wrong outcome in every row. The report names what it verified and
+what it did not, and never lets the weaker row-join mode read as the stronger.
+
+This is the first of the two pre-roll checks. It is free, so it runs first;
+tools/check_requirements.py then spends one model call on the semantic gate
+(#2221), and only then is it worth rolling.
+
+Exit codes:
+    0  the form holds
+    1  at least one violation, each named with its location
+    2  the check could not run, so nothing was verified
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.workflows.requirements.form_check import (  # noqa: E402
+    check_form,
+    render_report,
+)
+from assemblyzero.workflows.requirements.precheck import (  # noqa: E402
+    PrecheckError,
+    fetch_issue,
+)
+
+EXIT_PASS = 0
+EXIT_VIOLATIONS = 1
+EXIT_ERROR = 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify an issue against the checkable requirement form of "
+            "ADR 0226. Deterministic; no model calls."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--issue", type=int, help="issue number to read via gh")
+    source.add_argument("--file", help="a local draft body to check instead")
+    parser.add_argument(
+        "--repo",
+        default=".",
+        help="target repository checkout, for --issue (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.file:
+            path = Path(args.file)
+            if not path.is_file():
+                raise PrecheckError(f"--file is not a file: {path}")
+            body = path.read_text(encoding="utf-8")
+            label = path.name
+        else:
+            repo = Path(args.repo).resolve()
+            _, body = fetch_issue(repo, args.issue)
+            label = f"{repo.name} #{args.issue}"
+        if not body.strip():
+            raise PrecheckError("the body is empty; there is nothing to check")
+    except PrecheckError as exc:
+        print(f"ERROR -- the form check could not run: {exc}", file=sys.stderr)
+        print("Nothing about this issue's form has been verified.", file=sys.stderr)
+        return EXIT_ERROR
+
+    report = check_form(body)
+    print(render_report(report, label), end="", flush=True)
+    return EXIT_PASS if report.ok else EXIT_VIOLATIONS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this adds

`tools/check_requirements_form.py` verifies an issue against the checkable
requirement form of ADR 0226 (#2218). Fully deterministic: no model calls, and
identical input produces byte-identical output.

```
poetry run python tools/check_requirements_form.py \
    --repo /c/Users/mcwiz/Projects/boostgauge --issue 7

poetry run python tools/check_requirements_form.py --file draft.md
```

`--file` exists because authoring time is the point of the check, and a draft
is usually a buffer before it is an issue body.

## The rulings, as built

**EARS binds the marked requirements section and nothing else.** Bullets under
an exact `## Requirements` heading must match one of the five patterns.
Acceptance criteria are never EARS-validated. With no such section the report
reads `0 requirement sentences examined out of 0; EARS check did not run`, and
says in as many words that this is an honest vacuous result rather than a
pass. Nested bullets are counted as elaboration and reported, not silently
dropped.

**Row-to-criterion coverage runs in one of two modes, and the report always
names which.** With row IDs the join is exact: a bijection between the ID set
in the table and the ID set in the criteria, plus each criterion's outcome
text checked against the outcome cell of the row it names, so a criterion
labelled `E2` carrying row one's outcome fails mechanically. Without IDs the
checker requires exactly N criteria opening with the table's subject word and
matches each row's outcome to a distinct one. That mode's blind spot,
combination correctness, is printed as delegated to the semantic gate, never
omitted.

The no-ID outcome match uses maximum bipartite matching rather than greedy
assignment, and that is load-bearing rather than fussy. `unchanged` is a
substring of `unchanged; the CLI value is not written`, both of which are real
outcomes in boostgauge #7's size table. Matching in row order consumes the
longer criterion for the shorter row and then reports a gap that is not there.
`test_nested_outcomes_are_matched_by_maximum_matching` pins that case.

**The ADR carries the conventions.** A convention that lives only in checker
source is not a convention. Section 3.1 gains the scoping sentence, section
3.2 gains the row-criterion exemption and the row ID convention with a worked
example, section 8 records that the checker is built and names the full
pre-roll sequence, and the revision history cites this issue and the
contradiction that prompted it.

## Fixtures and negatives

`tests/fixtures/requirements/boostgauge-7-body.md` holds boostgauge #7 exactly
as it stood when it passed the semantic gate, and drives the no-ID mode. It
was read, never edited: the freeze holds until its pending roll concludes.
`ids-exact-mode.md` is synthetic and drives the exact mode with all five EARS
patterns.

Both pass. Every passing claim has a negative beside it: a dropped table row,
a dropped criterion, a duplicated ID, an ID reused across two tables, a
criterion naming a row that does not exist, a criterion carrying the wrong
outcome, a table short of `2^n` rows, a table with an extra row, a repeated
combination of condition values, four non-EARS sentence shapes, and a missing
acceptance-criteria section.

The fixture also pins the exemption itself. All twenty-one of boostgauge #7's
criteria would fail EARS, so if the checker ever starts reading acceptance
criteria as requirement sentences, the live positive fixture turns into a wall
of violations and `test_its_row_criteria_are_not_ears_validated` fails.

## Honesty of the output

Per standard 0028 and the enforcement rule that a zero needs a denominator,
every count is rendered against its denominator (`5 of 5 requirement
sentences`, `4 of 4 required rows`, `8 of 8 rows joined to a criterion`), and
a clean report still prints what it did not verify. Markdown tables whose
non-outcome columns are not plain yes/no are not decision tables, and the
count of those skipped is reported rather than passed over.

The checker cannot report correctness and says so on every run: a table can
enumerate every combination and state the wrong outcome in every row.

## Verification

- 50 new unit tests. Full unit suite: **6765 passed, 17 skipped, 5 xfailed**,
  no failures.
- `ruff check` clean on all three new Python files.
- Both fixtures were run through the CLI end to end and exit 0.
- The ADR was authored with zero em dashes; the additions were checked and
  carry zero.

Sibling: #2221, the semantic consistency gate's standalone caller. The full
pre-roll sequence is now this form check, free and instant, then that gate at
one model call, then the roll.

Closes #2219
