### PR TITLE
fix: apply LLD revisions as edit scripts, never as a redraw (Closes #2200)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -49,10 +49,33 @@ from assemblyzero.workflows.requirements.feedback_window import (
 from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
     parse_files_changed_table,
 )
+from assemblyzero.workflows.requirements.nodes.lld_revision import (
+    EDIT_SCRIPT_SYSTEM_PROMPT,
+    apply_edit_blocks,
+    build_lld_edit_prompt,
+    parse_edit_blocks,
+    removed_required_sections,
+    unchanged_ratio,
+)
 from assemblyzero.core.verdict_schema import (
     DraftQuestionsResult,
     scan_open_questions_section,
 )
+
+
+def _edit_script_halt(reason: str) -> str:
+    """Halt message for a revision that could not be applied as edits (#2200).
+
+    Legible on its own in a halt banner (#2197): it names the contract, what
+    broke it, and the fact that nothing was lost.
+    """
+    return (
+        f"[EDIT-SCRIPT] LLD revision rejected: {reason}. The prior draft is "
+        f"unchanged and remains the working copy. A revision is applied as "
+        f"SEARCH/REPLACE edit blocks and is never redrawn wholesale (#2200), "
+        f"so there is no full-regeneration fallback to take. Relaunch to "
+        f"resume from this stage."
+    )
 
 
 def _extract_open_questions(
@@ -272,7 +295,37 @@ Use the template structure provided. Include all sections. Be specific about:
     # the same call. Two contradictory contracts on one ask is how drafts
     # come back malformed; the schema is gone and the open questions are
     # scanned from the document it was actually asked to produce.
-    result = drafter.invoke(system_prompt=system_prompt, content=prompt)
+    # #2200: an LLD revision is applied as edit blocks, never redrawn. The
+    # model names its edits and the harness applies them, so content it does
+    # not name cannot change. Two measured regenerations lost required
+    # sections from drafts that had already passed validation; the prompt had
+    # asked for preservation both times.
+    use_edit_script = (
+        workflow_type == "lld"
+        and is_revision
+        and not drafter_spec.startswith("mock:")
+    )
+
+    if use_edit_script:
+        edit_context = build_revision_context(state)
+        # #1443's cross-run context rides in the classic system prompt, which
+        # the edit path does not use. Carry the prior attempt's verdict across
+        # explicitly so a resumed stage revises with everything it had before.
+        # The prior draft itself needs no carrying: it IS the patch target.
+        if previous_verdict_text:
+            edit_context += (
+                "## REVIEWER FEEDBACK ON A PRIOR ATTEMPT AT THIS STAGE\n\n"
+                f"{previous_verdict_text}\n\n"
+            )
+        edit_prompt = build_lld_edit_prompt(
+            existing_draft=state.get("current_draft", ""),
+            revision_context=edit_context,
+        )
+        result = drafter.invoke(
+            system_prompt=EDIT_SCRIPT_SYSTEM_PROMPT, content=edit_prompt
+        )
+    else:
+        result = drafter.invoke(system_prompt=system_prompt, content=prompt)
     node_cost_usd = get_cumulative_cost() - cost_before
 
     if not result.success:
@@ -290,9 +343,55 @@ Use the template structure provided. Include all sections. Be specific about:
     response = result.response or ""
     draft_content = response
 
+    if use_edit_script:
+        # #2200: apply the named edits, or halt. There is no fall back to a
+        # full redraw -- wholesale regeneration is the defect being removed,
+        # so a revision that cannot be expressed as edits stops and names the
+        # contract it broke (standard 0028). The prior draft is untouched on
+        # disk and stays in state, and a relaunch resumes this stage (#2193).
+        prior_draft = state.get("current_draft", "")
+        blocks = parse_edit_blocks(response)
+        if not blocks:
+            return {
+                "error_message": _edit_script_halt(
+                    "the drafter returned no well-formed SEARCH/REPLACE blocks"
+                )
+            }
+
+        patched, failures = apply_edit_blocks(prior_draft, blocks)
+        if failures:
+            return {"error_message": _edit_script_halt("; ".join(failures))}
+        if patched == prior_draft:
+            return {
+                "error_message": _edit_script_halt(
+                    f"{len(blocks)} edit block(s) applied but changed nothing"
+                )
+            }
+
+        # The guard runs BEFORE the draft is saved, so a lossy revision never
+        # becomes the working copy and is never discovered downstream by
+        # mechanical validation.
+        removed = removed_required_sections(prior_draft, patched, template)
+        if removed:
+            return {
+                "error_message": _edit_script_halt(
+                    f"the edits would remove template-required section(s) "
+                    f"{', '.join(removed)}, which the prior draft carried"
+                )
+            }
+
+        ratio = unchanged_ratio(prior_draft, patched)
+        print(
+            f"    [EDIT-SCRIPT] Applied {len(blocks)} edit(s); "
+            f"{ratio:.0%} of prior draft preserved byte-identical (#2200)"
+        )
+        draft_content = patched
+
     # Issue #775: Use structured parse for open questions extraction (REQ-1, REQ-2).
     # parse_structured_draft_questions tries JSON first, falls back to regex.
-    dq_result = _extract_open_questions(drafter, response, system_prompt)
+    # #2200: scans the document, so on the edit path it must see the patched
+    # draft rather than the edit blocks that produced it.
+    dq_result = _extract_open_questions(drafter, draft_content, system_prompt)
     open_questions = dq_result["open_questions"]
 
     # Save to audit trail
@@ -337,6 +436,95 @@ Use the template structure provided. Include all sections. Be specific about:
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
     }
+
+
+def build_revision_context(state: RequirementsWorkflowState) -> str:
+    """Assemble the feedback a revision must act on.
+
+    Extracted from ``_build_prompt`` by #2200 so the classic revision prompt
+    and the edit-script prompt are fed from one place. Behavior is unchanged;
+    the assembly order (mechanical errors first, then repository structure,
+    the Tiphys interface refresh, the bounded verdict window, and finally
+    human feedback) is preserved exactly as the issues that added each piece
+    established it.
+
+    Args:
+        state: Current workflow state.
+
+    Returns:
+        Markdown feedback block, empty when there is nothing to say.
+    """
+    current_draft = state.get("current_draft", "")
+    verdict_history = state.get("verdict_history", [])
+    user_feedback = state.get("user_feedback", "")
+    validation_errors = state.get("validation_errors", [])
+
+    revision_context = ""
+
+    # Issue #294: Include mechanical validation errors FIRST (highest priority)
+    # Issue #339: Include repo structure so drafter knows what directories exist
+    if validation_errors:
+        revision_context += "## MECHANICAL VALIDATION ERRORS (MUST FIX FIRST)\n\n"
+        revision_context += "The following errors were found by automated validation. "
+        revision_context += "These MUST be fixed before the LLD can proceed:\n\n"
+        for error in validation_errors:
+            revision_context += f"- **ERROR:** {error}\n"
+        revision_context += "\n"
+
+        # Issue #339: Show actual repo structure so drafter can use real paths
+        # Issue #490: Use cached repo_structure from state, fallback to inline call
+        target_repo = state.get("target_repo", "")
+        if target_repo:
+            repo_structure = state.get("repo_structure") or get_repo_structure(target_repo)
+            revision_context += "## ACTUAL REPOSITORY STRUCTURE\n\n"
+            revision_context += "**Use ONLY these existing directories** (or explicitly Add new ones):\n\n"
+            revision_context += f"```\n{repo_structure}\n```\n\n"
+            revision_context += "**To add files in a NEW directory:**\n"
+            revision_context += "1. First add the directory itself with Change Type: `Add (Directory)`\n"
+            revision_context += "2. Then add files inside it with Change Type: `Add`\n\n"
+        else:
+            revision_context += "**CRITICAL:** Check that all file paths in Section 2.1 are correct:\n"
+            revision_context += "- 'Modify' files MUST exist in the repository\n"
+            revision_context += "- 'Add' files must have existing parent directories\n"
+            revision_context += "- Use actual file names from the codebase, not generic names\n\n"
+
+    # Tiphys (#1688): revision feedback loop — the draft's own Files
+    # Changed table declares the change's actual blast radius; refresh
+    # signatures for exactly those files (plus one-hop imports). Any
+    # draft-one selection miss becomes a one-iteration transient. Falls
+    # back to the N0b-computed map when the table yields nothing.
+    refreshed_map: dict = {}
+    revision_target_repo = state.get("target_repo", "")
+    if revision_target_repo and current_draft:
+        try:
+            entries, _parse_errors = parse_files_changed_table(current_draft)
+            draft_paths = [
+                e.get("path", "") for e in entries
+                if e.get("path", "").endswith(".py")
+            ]
+            if draft_paths:
+                refreshed_map = build_interface_map_for_paths(
+                    draft_paths, Path(revision_target_repo)
+                )
+        except Exception:  # noqa: BLE001 — Tiphys must never block revision
+            logger.warning("Tiphys revision refresh failed", exc_info=True)
+    interface_section = format_interface_map_section(
+        refreshed_map or state.get("interface_map") or {}
+    )
+    if interface_section:
+        revision_context += interface_section + "\n\n"
+
+    # Issue #497: Bounded feedback window replaces cumulative verdict history
+    if verdict_history:
+        window = build_feedback_block(verdict_history)
+        feedback_section = render_feedback_markdown(window)
+        if feedback_section:
+            revision_context += feedback_section + "\n\n"
+
+    if user_feedback:
+        revision_context += f"## Additional Human Feedback\n\n{user_feedback}\n\n"
+
+    return revision_context
 
 
 def _build_prompt(
@@ -405,71 +593,10 @@ def _build_prompt(
     # is_revision computed above, before input assembly (Issue #294 origin;
     # moved for Tiphys injection placement).
     if is_revision:
-        # Revision mode
-        revision_context = ""
-
-        # Issue #294: Include mechanical validation errors FIRST (highest priority)
-        # Issue #339: Include repo structure so drafter knows what directories exist
-        if validation_errors:
-            revision_context += "## MECHANICAL VALIDATION ERRORS (MUST FIX FIRST)\n\n"
-            revision_context += "The following errors were found by automated validation. "
-            revision_context += "These MUST be fixed before the LLD can proceed:\n\n"
-            for error in validation_errors:
-                revision_context += f"- **ERROR:** {error}\n"
-            revision_context += "\n"
-
-            # Issue #339: Show actual repo structure so drafter can use real paths
-            # Issue #490: Use cached repo_structure from state, fallback to inline call
-            target_repo = state.get("target_repo", "")
-            if target_repo:
-                repo_structure = state.get("repo_structure") or get_repo_structure(target_repo)
-                revision_context += "## ACTUAL REPOSITORY STRUCTURE\n\n"
-                revision_context += "**Use ONLY these existing directories** (or explicitly Add new ones):\n\n"
-                revision_context += f"```\n{repo_structure}\n```\n\n"
-                revision_context += "**To add files in a NEW directory:**\n"
-                revision_context += "1. First add the directory itself with Change Type: `Add (Directory)`\n"
-                revision_context += "2. Then add files inside it with Change Type: `Add`\n\n"
-            else:
-                revision_context += "**CRITICAL:** Check that all file paths in Section 2.1 are correct:\n"
-                revision_context += "- 'Modify' files MUST exist in the repository\n"
-                revision_context += "- 'Add' files must have existing parent directories\n"
-                revision_context += "- Use actual file names from the codebase, not generic names\n\n"
-
-        # Tiphys (#1688): revision feedback loop — the draft's own Files
-        # Changed table declares the change's actual blast radius; refresh
-        # signatures for exactly those files (plus one-hop imports). Any
-        # draft-one selection miss becomes a one-iteration transient. Falls
-        # back to the N0b-computed map when the table yields nothing.
-        refreshed_map: dict = {}
-        revision_target_repo = state.get("target_repo", "")
-        if revision_target_repo and current_draft:
-            try:
-                entries, _parse_errors = parse_files_changed_table(current_draft)
-                draft_paths = [
-                    e.get("path", "") for e in entries
-                    if e.get("path", "").endswith(".py")
-                ]
-                if draft_paths:
-                    refreshed_map = build_interface_map_for_paths(
-                        draft_paths, Path(revision_target_repo)
-                    )
-            except Exception:  # noqa: BLE001 — Tiphys must never block revision
-                logger.warning("Tiphys revision refresh failed", exc_info=True)
-        interface_section = format_interface_map_section(
-            refreshed_map or state.get("interface_map") or {}
-        )
-        if interface_section:
-            revision_context += interface_section + "\n\n"
-
-        # Issue #497: Bounded feedback window replaces cumulative verdict history
-        if verdict_history:
-            window = build_feedback_block(verdict_history)
-            feedback_section = render_feedback_markdown(window)
-            if feedback_section:
-                revision_context += feedback_section + "\n\n"
-
-        if user_feedback:
-            revision_context += f"## Additional Human Feedback\n\n{user_feedback}\n\n"
+        # Revision mode. #2200 extracted the context assembly so the
+        # edit-script path feeds the drafter exactly the same feedback this
+        # prompt does; two assemblies would drift.
+        revision_context = build_revision_context(state)
 
         # Issue #489: Try section-level revision for focused changes
         targeted = ""

--- a/assemblyzero/workflows/requirements/nodes/lld_revision.py
+++ b/assemblyzero/workflows/requirements/nodes/lld_revision.py
@@ -1,0 +1,123 @@
+"""Edit-script revision for LLD drafts, ported from the spec stage (#2200).
+
+The measured failure, twice, in boostgauge:
+
+- ``run-issue1-122404``: draft 2 passed mechanical and test-plan validation
+  and the reviewer APPROVED it at 321 lines. The forced revision came back at
+  163 lines with sections 2.1, 11 and 12 gone.
+- ``run-issue7-182028``: draft 003 carried all twelve numbered sections
+  through both validators at 422 lines. Draft 005, responding to a REVISE
+  verdict, came back at 268 lines with sections 3, 10, 11 and 12 replaced by
+  the literal heading ``## [UNCHANGED] 3. Requirements``. The model emitted
+  the revision prompt's own preservation marker in place of the content it
+  was being told to preserve.
+
+Draft 003 happened to keep its structure and 005 did not, which is the point:
+under the old path preservation was luck. The prompt already said "PRESERVE
+sections that weren't flagged" and "Keep ALL template sections intact". Asking
+the generator to police its own drift is the defect, not the fix.
+
+The mechanism here is the one the implementation-spec stage adopted in #1528
+and has run cleanly since: **the revision model is never asked to redraw the
+document.** It names its edits, the harness applies them, and everything
+outside the named spans survives byte-identical because no generation ever
+touches it. The primitives are imported from the spec stage rather than
+copied, so there is one parser and one applier in the fleet; a copy would
+drift, and a drifted patcher is worse than none.
+
+There is deliberately no fall back to full regeneration. The spec stage keeps
+one because in #1528 the alternative was the pre-existing behavior; here
+wholesale regeneration IS the defect being removed, so a revision that cannot
+be expressed as edits halts loudly and names the contract it violated, per
+standard 0028. The prior draft is retained untouched, on disk and in state,
+and a relaunch resumes from this stage (#2193).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Imported, never copied: one parser and one applier for the whole fleet.
+# These three are document-agnostic -- they operate on text and edit blocks
+# and know nothing about specs -- so the spec stage's module is their home
+# and this stage is a second caller (the same discipline as #2221).
+from assemblyzero.workflows.implementation_spec.nodes.edit_script import (  # noqa: F401
+    EDIT_SCRIPT_SYSTEM_PROMPT,
+    apply_edit_blocks,
+    parse_edit_blocks,
+    unchanged_ratio,
+)
+
+#: A numbered section heading: ``## 3. Requirements``, ``### 2.1 Files
+#: Changed``, ``### 2.1.1 Path Validation``. The number must follow the hashes
+#: immediately, which is what makes ``## [UNCHANGED] 3. Requirements`` read as
+#: the absence of section 3 rather than its presence. That is the exact shape
+#: draft 005 shipped, and mechanical validation agreed: it flagged 11 and 12 as
+#: Critical because ``"## 11"`` no longer appeared in the document.
+_SECTION_HEADING = re.compile(r"^#{2,4}[ \t]+(\d+(?:\.\d+)*)\.?[ \t]", re.MULTILINE)
+
+
+def section_numbers(text: str) -> set[str]:
+    """The numbered sections a document actually has as headings."""
+    return {match.group(1) for match in _SECTION_HEADING.finditer(text or "")}
+
+
+def _numeric_key(section: str) -> list[int]:
+    return [int(part) for part in section.split(".")]
+
+
+def removed_required_sections(
+    prior_draft: str, revised_draft: str, template: str
+) -> list[str]:
+    """Template-required sections this revision would drop, in order.
+
+    A section counts as removed when the template requires it, the prior
+    draft had it, and the revision does not. A section the prior draft never
+    carried cannot be removed by this revision, and one the template does not
+    require is the author's to delete on a reviewer's instruction, so neither
+    is reported here. Only numbered sections are protected; the template's
+    unnumbered appendix is a log rather than a requirement-bearing section.
+    """
+    required = section_numbers(template)
+    before = section_numbers(prior_draft)
+    after = section_numbers(revised_draft)
+    return sorted((required & before) - after, key=_numeric_key)
+
+
+def build_lld_edit_prompt(existing_draft: str, revision_context: str) -> str:
+    """Build the revision prompt that asks for edit blocks, not a document.
+
+    Deliberately carries no "preserve what you did not change" instruction.
+    Under this contract untouched content is never emitted at all, so there is
+    nothing for such an instruction to protect, and adding one would restore
+    the very please-behave posture that produced the two measured losses.
+    """
+    sections: list[str] = [
+        "You are revising a Low-Level Design document. Do NOT rewrite it. "
+        "Output ONLY edit blocks in EXACTLY this format:\n\n"
+        "<<<<<<< SEARCH\n"
+        "(exact lines copied verbatim from the CURRENT LLD below)\n"
+        "=======\n"
+        "(replacement lines)\n"
+        ">>>>>>> REPLACE\n\n"
+        "Rules:\n"
+        "1. Each SEARCH text must be copied EXACTLY from the current LLD "
+        "(character-for-character, including whitespace) and must occur "
+        "exactly ONCE in the document. Keep SEARCH as small as practical "
+        "(typically 1-15 lines).\n"
+        "2. To INSERT new content, SEARCH for the nearest existing anchor "
+        "line(s) and REPLACE with those same anchor lines plus the new "
+        "content.\n"
+        "3. Emit one edit block per fix, and fix EVERY item listed below.\n"
+        "4. No preamble, no explanation, no markdown fences around the "
+        "blocks -- edit blocks only."
+    ]
+
+    if revision_context.strip():
+        sections.append(revision_context.strip())
+
+    sections.append(
+        "## CURRENT LLD (the document you are patching)\n\n" + existing_draft
+    )
+
+    return "\n\n".join(sections)

--- a/tests/fixtures/lld_revision/boostgauge-7-003-draft.md
+++ b/tests/fixtures/lld_revision/boostgauge-7-003-draft.md
@@ -1,0 +1,426 @@
+# Issue #7 - Feature: configuration file and CLI arguments
+
+## 1. Context & Goal
+* **Issue:** #7
+* **Objective:** Implement a configuration system for BoostGauge with a persistent config file and session-scoped CLI overrides.
+* **Status:** Draft
+* **Related Issues:** None
+
+### Open Questions
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Implements `ConfigManager` for file read/write, validation, and CLI override merging. |
+| `src/boostgauge/app.py` | Add | Hook up `argparse` for CLI options, instantiate `ConfigManager`, and handle exit writes. Main entry point. |
+| `tests/unit/test_config.py` | Add | Unit tests for configuration logic and file persistence rules. |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+### 2.2 Dependencies
+
+```toml
+
+# pyproject.toml additions
+
+# No new dependencies required (using standard library argparse, json, pathlib).
+```
+
+### 2.3 Data Structures
+
+```python
+class AppState(TypedDict):
+    position_changed: bool
+    size_changed: bool
+    current_position: dict[str, int]
+    current_size: int
+
+class ConfigData(TypedDict):
+    polling_interval_seconds: float
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: dict[str, int]
+    thresholds: dict[str, dict[str, int]]
+    telltale_windows: dict[str, int]
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+```
+
+### 2.4 Function Signatures
+
+```python
+
+# src/boostgauge/config.py
+
+def get_default_config_path() -> Path:
+    """Resolve ~/.boostgauge/config.json or %APPDATA%/boostgauge/config.json."""
+    ...
+
+class ConfigManager:
+    def __init__(self, config_path: Path | None = None):
+        """Initialize with path. Does not read or write yet."""
+        ...
+
+    def reset_to_defaults(self) -> None:
+        """Write default configuration to the config file."""
+        ...
+
+    def load_and_merge(self, cli_args: dict) -> ConfigData:
+        """
+        Read the config file (creating it with defaults if missing).
+        Merge with CLI args for the running session.
+        Keep track of which keys come from file vs CLI.
+        """
+        ...
+
+    def get_live_thresholds(self) -> dict:
+        """Read thresholds from the config file without modifying it, for hot reload."""
+        ...
+
+    def exit_write(self, app_state: AppState) -> None:
+        """
+        Patch the config file on exit ONLY with hand-made changes (position, size).
+        Leaves other keys (and direct file edits) untouched.
+        """
+        ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. App launch
+2. Parse CLI arguments via argparse
+3. Determine config_path (from --config or default)
+4. Initialize ConfigManager(config_path)
+5. IF --reset-config is set THEN
+   - ConfigManager.reset_to_defaults()
+6. session_config = ConfigManager.load_and_merge(cli_args)
+   - IF file missing, create with defaults
+   - Read file
+   - Override session_config values with CLI args
+7. Run application loop
+   - Periodically call ConfigManager.get_live_thresholds() to apply file edits
+   - Track if user manually moves or resizes the window
+8. On application exit
+   - Call ConfigManager.exit_write(app_state)
+   - IF position or size manually changed:
+       - Read current file contents (preserving direct user edits)
+       - Patch position/size keys
+       - Write back to file
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/config.py`
+* **Pattern:** Configuration Manager with session overlay
+* **Key Decisions:** We separate the "session configuration" (which the app runs on) from the "file configuration". Exit writing reads the current state of the file from disk, applies *only* the specific patches requested by the UI state (moved, resized), and writes it back. This guarantees that background direct edits to the file survive the exit write.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Config File Parsing | `json`, `tomllib` | `json` | Required by the specification (config.json). |
+| Exit Write Strategy | Overwrite whole file, JSON patch | JSON patch | Ensures direct file edits during the session are not clobbered by exit writes unless specifically overridden by hand-made UI changes. |
+| CLI Argument parsing | `argparse`, `click` | `argparse` | Standard library, no extra dependencies needed for simple flags. |
+
+**Architectural Constraints:**
+- Must not write CLI values to the config file under any circumstances.
+- Must not instantiate `tkinter.Tk()` in tests per `docs/design/0001-test-strategy.md`.
+
+## 3. Requirements
+
+1. First run with no config file creates one with defaults.
+2. Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file.
+3. With no CLI overrides, the window opens at the file's position and size.
+4. Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size.
+5. Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file.
+6. The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size.
+7. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins.
+8. A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit.
+9. Position, no reset, not moved, no direct edits: `position` unchanged.
+10. Position, no reset, moved, no direct edits: `position` holds the new position.
+11. Position, reset, not moved, no direct edits: `position` holds the default.
+12. Position, reset, moved, no direct edits: `position` holds the new position.
+13. Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged.
+14. Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size.
+15. Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written.
+16. Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size.
+17. Size, reset, no `--size`, not resized, no direct edits: `size` holds the default.
+18. Size, reset, no `--size`, resized, no direct edits: `size` holds the new size.
+19. Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written.
+20. Size, reset, `--size` given, resized, no direct edits: `size` holds the new size.
+21. Invalid config values produce clear error messages.
+22. `--config PATH` selects which config file is in play for the session and writes nothing by itself.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Keep config state purely in-memory and dump | Easy to implement | Clobbers direct file edits on exit | **Rejected** |
+| JSON patching on exit | Safely merges hand-made changes with direct file edits | Slightly more complex file IO logic | **Selected** |
+
+**Rationale:** JSON patching is the only way to satisfy the requirement that a direct file edit made while the app ran survives an exit that also writes a new position or size.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | File system (`config.json`) |
+| Format | JSON |
+| Size | < 1 KB |
+| Refresh | On launch, periodically (for thresholds), and on exit |
+| Copyright/License | N/A |
+
+### 5.2 Data Pipeline
+
+```
+Local File System ──JSON Parse──► ConfigManager ──Merge CLI args──► Session Config
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Mock filesystem | `pytest` `tmp_path` | Used to isolate file read/write logic |
+| Valid JSON config | Hardcoded string | Standard defaults |
+| Invalid JSON config | Hardcoded string | For error handling tests |
+
+### 5.4 Deployment Pipeline
+
+No external data pipeline. Configuration is strictly local to the user's machine.
+
+## 6. Diagram
+
+### 6.1 Mermaid Quality Gate
+
+**Auto-Inspection Results:**
+```
+- Touching elements: [x] None / [ ] Found: ___
+- Hidden lines: [x] None / [ ] Found: ___
+- Label readability: [x] Pass / [ ] Issue: ___
+- Flow clarity: [x] Clear / [ ] Issue: ___
+```
+
+### 6.2 Diagram
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant ConfigManager
+    participant FileSystem
+
+    App->>ConfigManager: Init with CLI args
+    alt --reset-config flag
+        ConfigManager->>FileSystem: Write defaults
+    end
+    ConfigManager->>FileSystem: Read config.json
+    FileSystem-->>ConfigManager: JSON Data
+    ConfigManager-->>App: Session Config (File + CLI)
+
+    loop Every Tick
+        App->>ConfigManager: get_live_thresholds()
+        ConfigManager->>FileSystem: Read config.json
+        FileSystem-->>ConfigManager: JSON Data
+        ConfigManager-->>App: Thresholds
+    end
+
+    App->>ConfigManager: exit_write(app_state)
+    alt position or size hand-changed
+        ConfigManager->>FileSystem: Read config.json
+        ConfigManager->>FileSystem: Write config.json (patched)
+    end
+```
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Malicious JSON execution | Standard `json` parser prevents arbitrary code execution | Addressed |
+| Directory traversal via `--config` | Ensure the process only has user-level permissions | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Data loss on failure | Exit write patches file atomically if possible (write to temp, rename) | Addressed |
+| Corrupt config file | Fall back to defaults in memory, surface clear error, do not overwrite unless reset requested | Addressed |
+
+**Fail Mode:** Fail Open - If config file is completely unreadable, emit a clear error and exit, or run with defaults depending on context. For invalid keys, emit a clear error message.
+
+**Recovery Strategy:** The user can repair the file directly or use `--reset-config` to restore defaults.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Config read latency | < 10ms | Minimal JSON payload, native Python `json` library |
+| API Calls | 0 | Local file system only |
+
+**Bottlenecks:** Hot-reloading thresholds requires reading the file periodically. This is extremely fast (< 1ms) and won't bottleneck the main loop.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| Cloud compute | N/A | Local app | $0 |
+
+**Cost Controls:**
+- [x] Budget alerts configured at N/A
+- [x] Rate limiting prevents runaway costs
+- [x] Fallback to cheaper alternatives when appropriate
+
+**Worst-Case Scenario:** High disk I/O if the polling interval is set unusually low (e.g., 1ms) and we poll the config file on every tick. The threshold reload could be bound to the main metric polling interval (`--poll`) to restrict I/O.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | Purely local configuration data |
+| Third-Party Licenses | No | |
+| Terms of Service | No | |
+| Data Retention | No | |
+| Export Controls | No | |
+
+**Data Classification:** Public
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. Per `docs/design/0001-test-strategy.md`, no `tkinter.Tk()` instantiation is allowed in tests, and assertions must check for literal values, not ambiguous terms.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | First run auto-create | Creates file with defaults if none exists | RED |
+| T020 | Launch order with CLI args | Returns session config matching CLI, file unaffected | RED |
+| T030 | No CLI overrides | Session config position/size matches file | RED |
+| T040 | Reset config logic | Rewrites file to defaults, session size is N | RED |
+| T050 | Hot threshold reload | Reading live thresholds reflects direct file edits | RED |
+| T060 | Exit write patch isolation | Hand-changed keys written, direct edits preserved | RED |
+| T070 | Hand-made value wins | Hand-changed key overwrites direct edit to same key | RED |
+| T080 | Byte-identical exit | No changes skips write, file remains byte-identical | RED |
+| T090 | Pos: no reset, not moved, no direct | Position unchanged | RED |
+| T091 | Pos: no reset, moved, no direct | Position is new | RED |
+| T092 | Pos: reset, not moved, no direct | Position is default | RED |
+| T093 | Pos: reset, moved, no direct | Position is new | RED |
+| T100 | Size: no reset, no `--size`, not resized | Size unchanged | RED |
+| T101 | Size: no reset, no `--size`, resized | Size is new | RED |
+| T102 | Size: no reset, `--size` given, not resized | Size unchanged | RED |
+| T103 | Size: no reset, `--size` given, resized | Size is new | RED |
+| T104 | Size: reset, no `--size`, not resized | Size is default | RED |
+| T105 | Size: reset, no `--size`, resized | Size is new | RED |
+| T106 | Size: reset, `--size` given, not resized | Size is default | RED |
+| T107 | Size: reset, `--size` given, resized | Size is new | RED |
+| T110 | Invalid config values | Parses error correctly, surfaces clear message | RED |
+| T120 | Config path selection | Uses specified path, writes nothing by itself | RED |
+
+**Coverage Target:** ≥100% for all new code in `config.py`
+
+**TDD Checklist:**
+- [x] All tests written before implementation
+- [x] Tests currently RED (failing)
+- [x] Test IDs match scenario IDs in 10.1
+- [x] Test file created at: `tests/unit/test_config.py`
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | First run auto-create (REQ-1) | Auto | No file present on launch | File created with defaults | `path.exists()` is True, `theme` is `"dark"`, `size` is `300` |
+| 020 | Launch order with CLI args (REQ-2) | Auto | `--theme light`, existing config has `dark` | Session uses `light`, file retains `dark` | Session theme is `"light"`, file theme is `"dark"` |
+| 030 | No CLI overrides (REQ-3) | Auto | Existing config with size 400 | Session size is 400 | Session size is `400` |
+| 040 | Reset config logic (REQ-4) | Auto | `--reset-config --size 500` | File reset to size 300, session uses 500 | File size is `300`, session size is `500` |
+| 050 | Hot threshold reload (REQ-5) | Auto | Direct edit threshold to 90 | `get_live_thresholds()` returns 90, file unmodified | Live threshold is `90`, `stat().st_mtime` is unchanged |
+| 060 | Exit write patch isolation (REQ-6) | Auto | Direct edit theme to `neon`, hand-move position | File has `neon` theme and new position | Theme is `"neon"`, position is `{"x": 200, "y": 200}` |
+| 070 | Hand-made value wins (REQ-7) | Auto | Direct edit size to 600, hand-resize to 700 | File size is 700 | File size is `700` |
+| 080 | Byte-identical exit (REQ-8) | Auto | No hand-made changes | No write performed | `stat().st_mtime` is unchanged, contents are `b"{...}"` |
+| 090 | Pos: no reset, not moved, no direct (REQ-9) | Auto | Untouched file `{"x": 150, "y": 150}` | Position unchanged | Position is `{"x": 150, "y": 150}` |
+| 091 | Pos: no reset, moved, no direct (REQ-10) | Auto | Moved window to 250, 250 | Position is new | Position is `{"x": 250, "y": 250}` |
+| 092 | Pos: reset, not moved, no direct (REQ-11) | Auto | `--reset-config` | Position is default | Position is `{"x": 100, "y": 100}` |
+| 093 | Pos: reset, moved, no direct (REQ-12) | Auto | `--reset-config`, moved window to 250, 250 | Position is new | Position is `{"x": 250, "y": 250}` |
+| 100 | Size: no reset, no `--size`, not resized (REQ-13) | Auto | Untouched file size 400 | Size unchanged | Size is `400` |
+| 101 | Size: no reset, no `--size`, resized (REQ-14) | Auto | Resized window to 600 | Size is new | Size is `600` |
+| 102 | Size: no reset, `--size` given, not resized (REQ-15) | Auto | `--size 500`, file size 400 | Size unchanged | Size is `400` |
+| 103 | Size: no reset, `--size` given, resized (REQ-16) | Auto | `--size 500`, resized to 600 | Size is new | Size is `600` |
+| 104 | Size: reset, no `--size`, not resized (REQ-17) | Auto | `--reset-config` | Size is default | Size is `300` |
+| 105 | Size: reset, no `--size`, resized (REQ-18) | Auto | `--reset-config`, resized to 600 | Size is new | Size is `600` |
+| 106 | Size: reset, `--size` given, not resized (REQ-19) | Auto | `--reset-config --size 500` | Size is default | Size is `300` |
+| 107 | Size: reset, `--size` given, resized (REQ-20) | Auto | `--reset-config --size 500`, resized 600 | Size is new | Size is `600` |
+| 110 | Invalid config values (REQ-21) | Auto | Malformed JSON in config | Raises clear error | Exception message is `"Invalid config format"` |
+| 120 | Config path selection (REQ-22) | Auto | `--config /tmp/custom.json` | Uses specified path | `Path("/tmp/custom.json").exists()` is True |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run all automated tests
+poetry run pytest tests/unit/test_config.py -v
+
+# Run only fast/mocked tests (exclude live)
+poetry run pytest tests/unit/test_config.py -v -m "not live"
+
+# Run live integration tests
+poetry run pytest tests/unit/test_config.py -v -m live
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated.
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| File system race condition during exit write | Medium | Low | Use `json` load and save block atomically or handle `FileNotFoundError` gracefully. Handled in `exit_write`. |
+| Concurrency with direct file edits | Medium | Low | Ensure `exit_write` re-reads the file immediately before writing to apply patches over the freshest state. |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+- [ ] Test Report (0113) completed if applicable
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| Pending | (auto) | PENDING | - |
+
+**Final Status:** PENDING

--- a/tests/fixtures/lld_revision/boostgauge-7-005-draft.md
+++ b/tests/fixtures/lld_revision/boostgauge-7-005-draft.md
@@ -1,0 +1,268 @@
+# Issue #7 - Feature: configuration file and CLI arguments
+
+## 1. Context & Goal
+* **Issue:** #7
+* **Objective:** Implement a configuration system for BoostGauge with a persistent config file strictly scoped to the project worktree (`data/config.json`), and session-scoped CLI overrides.
+* **Status:** Draft
+* **Related Issues:** None
+
+### Open Questions
+
+## 2. Proposed Changes
+
+*This section is the **source of truth** for implementation. Describe exactly what will be built.*
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Implements `ConfigManager` for file read/write, validation, CLI override merging, and logging. |
+| `src/boostgauge/app.py` | Add | Hook up `argparse` for CLI options, instantiate `ConfigManager`, enforce polling interval for config reloads, and handle exit writes. Main entry point. |
+| `tests/unit/test_config.py` | Add | Unit tests for configuration logic and file persistence rules. |
+
+### [UNCHANGED] 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+### [UNCHANGED] 2.2 Dependencies
+
+### [UNCHANGED] 2.3 Data Structures
+
+### 2.4 Function Signatures
+
+```python
+
+# src/boostgauge/config.py
+
+def get_default_config_path() -> Path:
+    """Resolve data/config.json within the project worktree."""
+    ...
+
+class ConfigManager:
+    def __init__(self, config_path: Path | None = None):
+        """Initialize with path. Does not read or write yet."""
+        ...
+
+    def reset_to_defaults(self) -> None:
+        """Write default configuration to the config file. Logs the action."""
+        ...
+
+    def load_and_merge(self, cli_args: dict) -> ConfigData:
+        """
+        Read the config file (creating it with defaults if missing, and logging it).
+        Merge with CLI args for the running session.
+        Keep track of which keys come from file vs CLI.
+        Logs configuration loading and any fallback scenarios.
+        """
+        ...
+
+    def get_live_thresholds(self) -> dict:
+        """Read thresholds from the config file without modifying it, for hot reload."""
+        ...
+
+    def exit_write(self, app_state: AppState) -> None:
+        """
+        Patch the config file on exit ONLY with hand-made changes (position, size).
+        Leaves other keys (and direct file edits) untouched.
+        Logs the exit-write patching process.
+        """
+        ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. App launch
+2. Parse CLI arguments via argparse
+3. Determine config_path (from --config or default `data/config.json`)
+4. Initialize ConfigManager(config_path)
+5. Initialize logger for configuration events
+6. IF --reset-config is set THEN
+   - ConfigManager.reset_to_defaults()
+   - Log reset action
+7. session_config = ConfigManager.load_and_merge(cli_args)
+   - IF file missing, create with defaults and log creation
+   - Read file
+   - Override session_config values with CLI args
+   - Log configuration load success or fallback to defaults on error
+8. Run application loop
+   - IF current tick matches the main metric polling interval (--poll):
+       - Call ConfigManager.get_live_thresholds() to apply file edits
+   - Track if user manually moves or resizes the window
+9. On application exit
+   - Call ConfigManager.exit_write(app_state)
+   - IF position or size manually changed:
+       - Read current file contents (preserving direct user edits)
+       - Patch position/size keys
+       - Write back to file atomically
+       - Log exit-write patching
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/config.py`
+* **Pattern:** Configuration Manager with session overlay
+* **Key Decisions:** We separate the "session configuration" (which the app runs on) from the "file configuration". Exit writing reads the current state of the file from disk, applies *only* the specific patches requested by the UI state (moved, resized), and writes it back. This guarantees that background direct edits to the file survive the exit write. Configuration operations (load, create, reset, exit-write, fallback) will output structured logs for observability. The hot-reload for thresholds is bound to the main metric polling interval (`--poll`) to explicitly control I/O frequency and prevent excessive reads on every tick. All file operations are strictly scoped to the `data/config.json` path within the project worktree to prevent scope violations.
+
+### [UNCHANGED] 2.7 Architecture Decisions
+
+## [UNCHANGED] 3. Requirements
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Keep config state purely in-memory and dump | Easy to implement | Clobbers direct file edits on exit | **Rejected** |
+| JSON patching on exit | Safely merges hand-made changes with direct file edits | Slightly more complex file IO logic | **Selected** |
+| Read config file on every UI tick | Simplifies hot-reload logic | Causes excessive, uncontrolled I/O | **Rejected** |
+| Poll config file at `--poll` interval | Controls disk I/O, aligns with existing data collection | Very slight delay in threshold updates | **Selected** |
+
+**Rationale:** JSON patching is the only way to satisfy the requirement that a direct file edit made while the app ran survives an exit that also writes a new position or size. Binding the hot-reload to the `--poll` interval ensures we enforce I/O control and avoid the worst-case scenario of unbounded disk reads.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | File system (`data/config.json`) |
+| Format | JSON |
+| Size | < 1 KB |
+| Refresh | On launch, periodically (bound to `--poll` interval), and on exit |
+| Copyright/License | N/A |
+
+### [UNCHANGED] 5.2 Data Pipeline
+
+### [UNCHANGED] 5.3 Test Fixtures
+
+### 5.4 Deployment Pipeline
+
+No external data pipeline. Configuration is strictly local to the user's project worktree.
+
+## 6. Diagram
+
+### 6.1 Mermaid Quality Gate
+
+**Auto-Inspection Results:**
+```
+- Touching elements: [x] None / [ ] Found: ___
+- Hidden lines: [x] None / [ ] Found: ___
+- Label readability: [x] Pass / [ ] Issue: ___
+- Flow clarity: [x] Clear / [ ] Issue: ___
+```
+
+### 6.2 Diagram
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant ConfigManager
+    participant FileSystem
+
+    App->>ConfigManager: Init with CLI args
+    alt --reset-config flag
+        ConfigManager->>FileSystem: Write defaults
+        ConfigManager-->>App: Log reset
+    end
+    ConfigManager->>FileSystem: Read data/config.json
+    FileSystem-->>ConfigManager: JSON Data
+    ConfigManager-->>App: Session Config (File + CLI) & Log load
+
+    loop Every --poll Interval
+        App->>ConfigManager: get_live_thresholds()
+        ConfigManager->>FileSystem: Read data/config.json
+        FileSystem-->>ConfigManager: JSON Data
+        ConfigManager-->>App: Thresholds
+    end
+
+    App->>ConfigManager: exit_write(app_state)
+    alt position or size hand-changed
+        ConfigManager->>FileSystem: Read data/config.json
+        ConfigManager->>FileSystem: Write data/config.json (patched)
+        ConfigManager-->>App: Log exit-write
+    end
+```
+
+## 7. Security & Safety Considerations
+
+### [UNCHANGED] 7.1 Security
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Data loss on failure | Exit write patches file atomically if possible (write to temp, rename) | Addressed |
+| Corrupt config file | Fall back to defaults in memory, surface clear error via logs and stderr, do not overwrite unless reset requested | Addressed |
+| Worktree violation | Hardcode/resolve all paths strictly relative to the project worktree (`data/config.json`) | Addressed |
+
+**Fail Mode:** Fail Open - If config file is completely unreadable, emit a clear error, log the fallback scenario, and run with defaults depending on context. For invalid keys, emit a clear error message and log it.
+
+**Recovery Strategy:** The user can repair the file directly or use `--reset-config` to restore defaults.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Config read latency | < 10ms | Minimal JSON payload, native Python `json` library |
+| API Calls | 0 | Local file system only |
+
+**Bottlenecks:** Hot-reloading thresholds requires reading the file periodically. This is mitigated by explicitly binding the reload to the main metric polling interval (`--poll`), ensuring it won't bottleneck the main loop or cause excessive I/O.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| Cloud compute | N/A | Local app | $0 |
+
+**Cost Controls:**
+- [x] Budget alerts configured at N/A
+- [x] Rate limiting prevents runaway costs
+- [x] Fallback to cheaper alternatives when appropriate
+
+**Worst-Case Scenario:** High disk I/O if the polling interval is set unusually low (e.g., 1ms). To mitigate this, the config reload is strictly bound to the main metric polling interval (`--poll`) instead of every application tick, providing an explicit, user-controlled upper bound on disk I/O.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | Purely local configuration data |
+| Third-Party Licenses | No | |
+| Terms of Service | No | |
+| Data Retention | No | |
+| Export Controls | No | |
+
+**Data Classification:** Public
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## [UNCHANGED] 10. Verification & Testing
+
+### [UNCHANGED] 10.0 Test Plan (TDD - Complete Before Implementation)
+
+### [UNCHANGED] 10.1 Test Scenarios
+
+### [UNCHANGED] 10.2 Test Commands
+
+### [UNCHANGED] 10.3 Manual Tests (Only If Unavoidable)
+
+## [UNCHANGED] 11. Risks & Mitigations
+
+## [UNCHANGED] 12. Definition of Done
+
+### [UNCHANGED] Code
+
+### [UNCHANGED] Tests
+
+### [UNCHANGED] Documentation
+
+### [UNCHANGED] Review
+
+### [UNCHANGED] 12.1 Traceability (Mechanical - Auto-Checked)
+
+## [UNCHANGED] Appendix: Review Log
+
+### [UNCHANGED] Review Summary

--- a/tests/unit/test_lld_edit_script_revision.py
+++ b/tests/unit/test_lld_edit_script_revision.py
@@ -1,0 +1,520 @@
+"""Tests for edit-script LLD revision and its section guard (#2200).
+
+The regression these hold shut is measured, not hypothetical. Fixtures
+`boostgauge-7-003-draft.md` and `boostgauge-7-005-draft.md` are the real
+drafts from `run-issue7-182028`: 003 carried all twelve numbered sections
+through mechanical and test-plan validation at 425 lines, and 005, revising it
+in response to a REVISE verdict, came back at 267 lines with sections 3, 10,
+11 and 12 replaced by the literal heading `## [UNCHANGED] 3. Requirements`.
+
+The binding property is structural, not statistical: on a revision the model
+is never asked to redraw the document, so content it does not name in a SEARCH
+block cannot change. These tests assert that no path through the node can
+regenerate an LLD, that the guard refuses a lossy patch before anything is
+saved, and that removing the guard is what lets 005 through.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from importlib import import_module
+
+from assemblyzero.core.llm_provider import LLMCallResult
+from assemblyzero.workflows.requirements.nodes.lld_revision import (
+    build_lld_edit_prompt,
+    removed_required_sections,
+    section_numbers,
+)
+
+# The nodes package re-exports the generate_draft FUNCTION under the same name
+# as its module, so a plain `from ... import generate_draft` binds the function.
+gd = import_module("assemblyzero.workflows.requirements.nodes.generate_draft")
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures" / "lld_revision"
+TEMPLATE_PATH = ROOT / "docs" / "templates" / "0102-feature-lld-template.md"
+
+
+@pytest.fixture(scope="module")
+def draft_003() -> str:
+    return (FIXTURES / "boostgauge-7-003-draft.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def draft_005() -> str:
+    return (FIXTURES / "boostgauge-7-005-draft.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def template() -> str:
+    return TEMPLATE_PATH.read_text(encoding="utf-8")
+
+
+def _result(response: str) -> LLMCallResult:
+    return LLMCallResult(
+        success=True,
+        response=response,
+        raw_response=response,
+        error_message=None,
+        provider="fake",
+        model_used="fake-model",
+        duration_ms=1,
+        attempts=1,
+    )
+
+
+def _edit_block(search: str, replace: str) -> str:
+    return f"<<<<<<< SEARCH\n{search}\n=======\n{replace}\n>>>>>>> REPLACE"
+
+
+class _Recorder:
+    """A drafter that records every call and replays canned responses."""
+
+    def __init__(self, *responses: str) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs) -> LLMCallResult:
+        self.calls.append(kwargs)
+        if not self._responses:
+            raise AssertionError(
+                "drafter invoked more times than the test supplied responses; "
+                "a revision must make exactly one call and never fall back"
+            )
+        return _result(self._responses.pop(0))
+
+
+@pytest.fixture
+def lld_state(tmp_path, draft_003):
+    """A revision state: an existing draft plus a reviewer verdict."""
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    return {
+        "workflow_type": "lld",
+        "assemblyzero_root": str(ROOT),
+        "target_repo": str(tmp_path / "repo"),
+        "audit_dir": str(audit),
+        "config_mock_mode": False,
+        "config_drafter": "fake:model",
+        "issue_number": 7,
+        "issue_title": "config persistence",
+        "issue_body": "the issue body",
+        "current_draft": draft_003,
+        "verdict_history": ["REVISE: section 5 needs the fixture path spelled out"],
+        "draft_count": 2,
+        "iteration_count": 2,
+    }
+
+
+def _run(monkeypatch, state, drafter):
+    monkeypatch.setattr(gd, "get_provider", lambda spec, *a, **k: drafter)
+    return gd.generate_draft(state)
+
+
+# ---------------------------------------------------------------------------
+# The regression fixture (acceptance 5)
+# ---------------------------------------------------------------------------
+
+
+class TestBoostgaugeRegression:
+    def test_003_carries_all_twelve_sections(self, draft_003):
+        top_level = {s for s in section_numbers(draft_003) if "." not in s}
+        assert top_level == {str(n) for n in range(1, 13)}
+
+    def test_005_lost_four_of_them(self, draft_005):
+        top_level = {s for s in section_numbers(draft_005) if "." not in s}
+        assert top_level == {"1", "2", "4", "5", "6", "7", "8", "9"}
+
+    def test_the_unchanged_marker_is_not_a_section(self, draft_005):
+        """005's sections were not deleted; their bodies became a marker.
+
+        `## [UNCHANGED] 3. Requirements` is what shipped. Mechanical
+        validation agreed it was absent -- it flagged 11 and 12 as Critical
+        because `"## 11"` no longer appeared -- so the guard must read it the
+        same way.
+        """
+        assert "## [UNCHANGED] 3. Requirements" in draft_005
+        assert "3" not in section_numbers(draft_005)
+
+    def test_the_guard_names_every_lost_section(self, draft_003, draft_005, template):
+        removed = removed_required_sections(draft_003, draft_005, template)
+
+        # The four the operator counted, and nothing else, at the top level.
+        assert [s for s in removed if "." not in s] == ["3", "10", "11", "12"]
+        # Subsections went with them: 003 carried 35 template sections and
+        # 005 kept 19, so the guard names all 16 it would have to lose.
+        assert len(removed) == 16
+        assert removed[0] == "2.1.1"
+
+    def test_a_revision_of_003_cannot_produce_005(
+        self, monkeypatch, lld_state, draft_005, tmp_path
+    ):
+        """The whole point, end to end.
+
+        The drafter here behaves exactly as the one that produced 005: it
+        returns a complete replacement document. Under the edit-script
+        contract that response carries no edit blocks, so it is not a
+        revision at all and nothing is saved.
+        """
+        drafter = _Recorder(draft_005)
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert "current_draft" not in out
+        assert out["error_message"].startswith("[EDIT-SCRIPT]")
+        assert "no well-formed SEARCH/REPLACE blocks" in out["error_message"]
+        assert list((tmp_path / "audit").iterdir()) == []
+
+    def test_edits_that_would_strip_a_section_are_refused_before_saving(
+        self, monkeypatch, lld_state, draft_003, tmp_path
+    ):
+        """Even named as edits, removing section 11 does not get saved."""
+        section_11 = "## 11. Risks & Mitigations"
+        assert section_11 in draft_003
+        drafter = _Recorder(
+            _edit_block(section_11, "## [UNCHANGED] 11. Risks & Mitigations")
+        )
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert "current_draft" not in out
+        assert "template-required section(s) 11" in out["error_message"]
+        assert list((tmp_path / "audit").iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Preservation (acceptance 1)
+# ---------------------------------------------------------------------------
+
+
+class TestPreservation:
+    def test_everything_outside_the_named_span_is_byte_identical(
+        self, monkeypatch, lld_state, draft_003
+    ):
+        search = "## 4. Alternatives Considered"
+        replace = "## 4. Alternatives Considered\n\nAdded by the revision."
+        drafter = _Recorder(_edit_block(search, replace))
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        revised = out["current_draft"]
+        assert revised == draft_003.replace(search, replace, 1)
+        # Line-for-line: only the named span differs.
+        before = draft_003.splitlines()
+        after = revised.splitlines()
+        assert before[: before.index(search)] == after[: after.index(search)]
+
+    def test_the_revision_is_the_prior_draft_plus_the_edits(
+        self, monkeypatch, lld_state, draft_003
+    ):
+        drafter = _Recorder(
+            _edit_block("## 9. Legal & Compliance", "## 9. Legal & Compliance\n\nNone.")
+        )
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert section_numbers(out["current_draft"]) == section_numbers(draft_003)
+        assert len(out["current_draft"]) > len(draft_003)
+
+    def test_multiple_edits_all_apply(self, monkeypatch, lld_state):
+        drafter = _Recorder(
+            _edit_block("## 5. Data & Fixtures", "## 5. Data & Fixtures\n\nOne.")
+            + "\n"
+            + _edit_block("## 6. Diagram", "## 6. Diagram\n\nTwo.")
+        )
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert "One." in out["current_draft"]
+        assert "Two." in out["current_draft"]
+
+
+# ---------------------------------------------------------------------------
+# No redraw, ever (the design constraint)
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRedraws:
+    def test_the_revision_asks_for_edit_blocks_not_a_document(
+        self, monkeypatch, lld_state
+    ):
+        drafter = _Recorder(_edit_block("## 6. Diagram", "## 6. Diagram\n\nx"))
+
+        _run(monkeypatch, lld_state, drafter)
+
+        content = drafter.calls[0]["content"]
+        assert "<<<<<<< SEARCH" in content
+        assert "Do NOT rewrite it" in content
+        assert "precision patch engine" in drafter.calls[0]["system_prompt"]
+
+    def test_a_failed_revision_makes_exactly_one_model_call(
+        self, monkeypatch, lld_state, draft_005
+    ):
+        """_Recorder raises if invoked twice, which a fallback would do."""
+        drafter = _Recorder(draft_005)
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert len(drafter.calls) == 1
+        assert out["error_message"]
+
+    def test_the_revision_prompt_carries_no_preservation_pleading(self):
+        """Asking the generator to police its own drift is the defect.
+
+        The old prompt said "PRESERVE sections that weren't flagged" and
+        "Keep ALL template sections intact", and 005 shipped anyway.
+        """
+        prompt = build_lld_edit_prompt("# doc\n\n## 1. A\n", "## FEEDBACK\n\nfix it")
+
+        lowered = prompt.lower()
+        assert "preserve" not in lowered
+        assert "byte-identical" not in lowered
+        assert "intact" not in lowered
+
+    def test_unmatched_search_halts_rather_than_redrawing(
+        self, monkeypatch, lld_state
+    ):
+        drafter = _Recorder(_edit_block("text that is not in the draft", "x"))
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert "current_draft" not in out
+        assert "SEARCH text not found" in out["error_message"]
+        assert len(drafter.calls) == 1
+
+    def test_ambiguous_search_halts(self, monkeypatch, lld_state, draft_003):
+        repeated = "| Risk | Impact |"
+        state = dict(lld_state)
+        state["current_draft"] = f"## 1. A\n\n{repeated}\n\n{repeated}\n"
+        drafter = _Recorder(_edit_block(repeated, "changed"))
+
+        out = _run(monkeypatch, state, drafter)
+
+        assert "SEARCH text ambiguous" in out["error_message"]
+
+    def test_a_no_op_edit_halts(self, monkeypatch, lld_state):
+        heading = "## 6. Diagram"
+        drafter = _Recorder(_edit_block(heading, heading))
+
+        out = _run(monkeypatch, lld_state, drafter)
+
+        assert "changed nothing" in out["error_message"]
+
+    def test_the_halt_message_says_the_prior_draft_survived(
+        self, monkeypatch, lld_state, draft_005
+    ):
+        out = _run(monkeypatch, lld_state, _Recorder(draft_005))
+
+        assert "prior draft is unchanged" in out["error_message"]
+        assert "no full-regeneration fallback" in out["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# The guard is what stops it (acceptance 4)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardMutation:
+    def test_removing_the_guard_lets_the_lossy_revision_through(
+        self, monkeypatch, lld_state, draft_003
+    ):
+        """Mutation: neuter the guard and the section loss is saved.
+
+        Without this, a passing suite cannot distinguish "the guard fires"
+        from "nothing ever reached the guard".
+        """
+        section_11 = "## 11. Risks & Mitigations"
+        blocks = _edit_block(section_11, "## [UNCHANGED] 11. Risks & Mitigations")
+
+        guarded = _run(monkeypatch, dict(lld_state), _Recorder(blocks))
+        assert "current_draft" not in guarded
+
+        monkeypatch.setattr(gd, "removed_required_sections", lambda *a, **k: [])
+        unguarded = _run(monkeypatch, dict(lld_state), _Recorder(blocks))
+
+        assert "current_draft" in unguarded
+        assert "11" not in section_numbers(unguarded["current_draft"])
+
+    def test_the_guard_ignores_sections_the_prior_draft_never_had(self, template):
+        prior = "## 1. Context & Goal\n\nx\n"
+        revised = "## 1. Context & Goal\n\ny\n"
+
+        assert removed_required_sections(prior, revised, template) == []
+
+    def test_the_guard_ignores_sections_the_template_does_not_require(
+        self, template
+    ):
+        prior = "## 1. Context & Goal\n\nx\n\n## 99. Scratch\n\nnotes\n"
+        revised = "## 1. Context & Goal\n\nx\n"
+
+        assert removed_required_sections(prior, revised, template) == []
+
+    def test_the_guard_runs_before_the_draft_is_saved(
+        self, monkeypatch, lld_state, tmp_path
+    ):
+        saved = MagicMock()
+        monkeypatch.setattr(gd, "save_audit_file", saved)
+        drafter = _Recorder(
+            _edit_block("## 12. Definition of Done", "## [UNCHANGED] 12. DoD")
+        )
+
+        _run(monkeypatch, lld_state, drafter)
+
+        saved.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The preservation log line (acceptance 3)
+# ---------------------------------------------------------------------------
+
+
+class TestPreservationLogLine:
+    def test_it_matches_the_spec_stage_line(self, monkeypatch, lld_state, capsys):
+        drafter = _Recorder(_edit_block("## 6. Diagram", "## 6. Diagram\n\nx"))
+
+        _run(monkeypatch, lld_state, drafter)
+
+        out = capsys.readouterr().out
+        assert "[EDIT-SCRIPT] Applied 1 edit(s);" in out
+        assert "of prior draft preserved byte-identical" in out
+
+    def test_a_large_rewrite_would_show_a_low_percentage(
+        self, monkeypatch, lld_state, capsys
+    ):
+        """The line is the narration's tell that a rewrite happened.
+
+        A single edit block may legally replace most of a section's body. The
+        percentage is what makes that visible the moment it happens, instead
+        of after a validator notices the document shrank.
+        """
+        body = "\n".join(f"line {n}" for n in range(100))
+        state = dict(lld_state)
+        state["current_draft"] = f"## 1. Context & Goal\n\n{body}\n"
+        drafter = _Recorder(_edit_block(body, "gutted"))
+
+        _run(monkeypatch, state, drafter)
+
+        out = capsys.readouterr().out
+        assert "[EDIT-SCRIPT] Applied 1 edit(s);" in out
+        percent = int(out.split("edit(s); ")[1].split("%")[0])
+        assert percent < 10
+
+
+# ---------------------------------------------------------------------------
+# Scope: what the port must not disturb
+# ---------------------------------------------------------------------------
+
+
+class TestScope:
+    def test_an_initial_lld_draft_still_generates_a_document(
+        self, monkeypatch, lld_state
+    ):
+        state = dict(lld_state)
+        state["current_draft"] = ""
+        state["verdict_history"] = []
+        document = "# LLD-007\n\n## 1. Context & Goal\n\nfresh\n"
+        drafter = _Recorder(document)
+
+        out = _run(monkeypatch, state, drafter)
+
+        assert out["current_draft"] == document
+        assert "<<<<<<< SEARCH" not in drafter.calls[0]["content"]
+
+    def test_mock_mode_keeps_the_classic_path(self, monkeypatch, lld_state):
+        state = dict(lld_state)
+        state["config_mock_mode"] = True
+        document = "# LLD-007\n\n## 1. Context & Goal\n\nmocked\n"
+        drafter = _Recorder(document)
+
+        out = _run(monkeypatch, state, drafter)
+
+        assert out["current_draft"] == document
+
+    def test_the_issue_workflow_is_untouched(self, monkeypatch, lld_state):
+        state = dict(lld_state)
+        state["workflow_type"] = "issue"
+        state["brief_content"] = "a brief"
+        document = "# feat: a thing\n\n## Summary\n\nprose\n"
+        drafter = _Recorder(document)
+
+        out = _run(monkeypatch, state, drafter)
+
+        assert out["current_draft"] == document
+        assert "<<<<<<< SEARCH" not in drafter.calls[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Section parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSectionNumbers:
+    @pytest.mark.parametrize(
+        "heading,expected",
+        [
+            ("## 1. Context & Goal", {"1"}),
+            ("### 2.1 Files Changed", {"2.1"}),
+            ("### 2.1.1 Path Validation", {"2.1.1"}),
+            ("## 12. Definition of Done", {"12"}),
+            ("## [UNCHANGED] 3. Requirements", set()),
+            ("## Appendix: Review Log", set()),
+            ("Some prose mentioning ## 4. not at line start", set()),
+        ],
+    )
+    def test_headings(self, heading, expected):
+        assert section_numbers(heading + "\n") == expected
+
+    def test_ordering_is_numeric_not_lexical(self, template):
+        prior = "\n".join(
+            f"## {n}. S{n}" for n in (2, 3, 9, 10, 11, 12)
+        )
+        removed = removed_required_sections(prior, "## 2. S2", template)
+
+        assert removed == ["3", "9", "10", "11", "12"]
+
+
+# ---------------------------------------------------------------------------
+# The extracted context builder
+# ---------------------------------------------------------------------------
+
+
+class TestRevisionContext:
+    def test_both_paths_are_fed_the_same_feedback(self, lld_state, template):
+        context = gd.build_revision_context(lld_state)
+        classic = gd._build_prompt(lld_state, template, "lld")
+        edit = build_lld_edit_prompt(lld_state["current_draft"], context)
+
+        assert "section 5 needs the fixture path spelled out" in context
+        assert context.strip() in edit
+        assert "section 5 needs the fixture path spelled out" in classic
+
+    def test_a_prior_run_verdict_still_reaches_the_edit_path(
+        self, monkeypatch, lld_state
+    ):
+        """#1443 context rides in the system prompt the edit path replaces.
+
+        On a resumed stage the prior attempt's verdict must not vanish just
+        because the revision is now expressed as edits.
+        """
+        state = dict(lld_state)
+        state["previous_verdict_text"] = "prior run said: section 7 is thin"
+        drafter = _Recorder(_edit_block("## 6. Diagram", "## 6. Diagram\n\nx"))
+
+        _run(monkeypatch, state, drafter)
+
+        assert "prior run said: section 7 is thin" in drafter.calls[0]["content"]
+
+    def test_mechanical_errors_come_first(self, lld_state):
+        state = dict(lld_state)
+        state["validation_errors"] = ["Critical: Section 11 missing from LLD"]
+
+        context = gd.build_revision_context(state)
+
+        assert context.startswith("## MECHANICAL VALIDATION ERRORS")
+        assert "Section 11 missing" in context
+
+    def test_no_feedback_yields_an_empty_context(self, tmp_path):
+        assert gd.build_revision_context({"current_draft": "# doc\n"}) == ""


### PR DESCRIPTION
## The change

An LLD revision is no longer a redraw. The model names its edits as
SEARCH/REPLACE blocks, the harness applies them to the prior draft, and
content it does not name cannot change because no generation ever touches it.
This is the implementation-spec stage's #1528 mechanism, ported.

`parse_edit_blocks`, `apply_edit_blocks`, `unchanged_ratio` and the patch-engine
system prompt are **imported** from `implementation_spec/nodes/edit_script.py`,
not copied. One parser and one applier in the fleet; a copy would drift, and a
drifted patcher is worse than none.

## Why a prompt fix was not an option

The prompt already asked. The path that produced draft 005 carried
`PRESERVE sections that weren't flagged` and `Keep ALL template sections
intact`, and 005 shipped with four sections gone anyway. Worse, it did not
delete them: it replaced their bodies with `## [UNCHANGED] 3. Requirements`,
emitting the prompt's own preservation marker in place of the content the
marker was invented to protect. Mechanical validation agreed the sections were
absent, flagged 11 and 12 as Critical, and the stage died at its cap.

So the new prompt carries no preservation instruction at all, and a test
asserts it stays that way (`test_the_revision_prompt_carries_no_preservation_pleading`
fails if the words `preserve`, `byte-identical` or `intact` reappear). Under
this contract untouched content is never emitted, so there is nothing for such
an instruction to protect.

## No fall back to regeneration

The spec stage keeps a full-revision fallback because in #1528 the alternative
was the pre-existing behavior. Here wholesale regeneration **is** the defect, so
there is no fallback to take. A revision that cannot be expressed as edits
halts and names the contract it broke, per standard 0028. The prior draft is
untouched on disk and stays in state, and a relaunch resumes from this stage
(#2193).

`test_a_failed_revision_makes_exactly_one_model_call` holds this shut: the test
drafter raises if invoked twice, which is exactly what a fallback would do.

## The section guard

A patch that would drop a template-required section the prior draft carried is
refused **before the draft is saved**, so a loss never becomes the working copy
and is never discovered downstream by validation. Sections the prior draft
never had cannot be removed by this revision, and sections the template does
not require are the author's to delete on a reviewer's instruction, so neither
is reported. That keeps the guard from firing on legitimate edits.

## Acceptance, each with the test that holds it

| Acceptance | Test |
|---|---|
| Untouched spans byte-identical | `test_everything_outside_the_named_span_is_byte_identical` |
| A revision can never remove a required section, before saving | `test_edits_that_would_strip_a_section_are_refused_before_saving`, `test_the_guard_runs_before_the_draft_is_saved` |
| Same preservation line as the spec stage | `test_it_matches_the_spec_stage_line` |
| Mutation proves the guard fires | `test_removing_the_guard_lets_the_lossy_revision_through` |
| Regression fixture 003 cannot become 005 | `test_a_revision_of_003_cannot_produce_005` |

The mutation test is the load-bearing one. It runs the same lossy patch twice,
once with the guard and once with it neutered, and asserts the first is refused
and the second saves a draft missing section 11. Without it a passing suite
could not distinguish "the guard fires" from "nothing ever reached the guard".

The regression test uses the real drafts as its fixtures, and its drafter
behaves exactly like the one that produced 005: it returns a complete
replacement document. Under the edit-script contract that response carries no
edit blocks, so it is not a revision at all, nothing is saved, and the audit
directory is asserted empty.

Against the fixtures the guard names all 16 template sections 005 would drop.
At the top level that is exactly sections 3, 10, 11 and 12, the four counted in
the issue.

## The refactor, proven rather than assumed

Revision-context assembly moved out of `_build_prompt` into
`build_revision_context` so the classic prompt and the edit prompt are fed from
one place; two assemblies would drift. The extraction was verified by loading
`origin/main`'s module alongside the working-tree one and comparing
`_build_prompt` output byte-for-byte across seven shapes: initial draft,
revision on a verdict, on validation errors, on human feedback, on all three,
the iteration-3 skeleton path, and the issue workflow. All seven identical.

One gap closed while porting: #1443's cross-run verdict context rides in the
classic system prompt, which the edit path replaces, so a resumed stage would
have silently lost it. It is now carried into the edit prompt explicitly, with
a test.

## Scope

LLD revisions only. Initial drafts still generate a document, mock mode keeps
the classic path, and the issue workflow is untouched, each with a test.

## Verification

- 37 new unit tests. Full unit suite: **6802 passed, 17 skipped, 5 xfailed**,
  no failures.
- `ruff check` clean on the new module and tests. The modified node gains one
  E402, joining nine of the same kind already in its import block; the file's
  pre-existing count is otherwise unchanged.

Sibling: #2221 certified this issue's text before the run that produced the
fixture, which is how the frontier reached this stage.

Closes #2200
