### PR TITLE
fix: the Open Questions empty state no longer kills approved drafts (Closes #2232)

### DIFF
--- a/assemblyzero/core/verdict_schema.py
+++ b/assemblyzero/core/verdict_schema.py
@@ -347,6 +347,44 @@ def _iter_section_lines(text: str, *titles: str):
             yield stripped
 
 
+#: What a drafter writes in the Open Questions section to mean "there are
+#: none". The template scaffolds that section as an unchecked checkbox, so a
+#: drafter with nothing to ask fills the scaffold rather than deleting it
+#: (#2232: four drafts out of four in one run wrote "- [ ] None").
+_NONE_PLACEHOLDERS = frozenset({"none", "n/a", "na", "none at this time", "nothing"})
+
+
+def is_none_placeholder(text: str) -> bool:
+    """True when an Open Questions entry means "there are none".
+
+    One predicate, imported by every caller, because the alternative is what
+    #2232 measured: ``review.py`` filtered "- [ ] None" and read the draft as
+    having no questions, ``finalize.py`` read the same line as an unresolved
+    question and blocked, and an APPROVED draft died between them. Two
+    detectors over one document must not disagree, so there is one detector.
+
+    Matching ignores case, surrounding whitespace, trailing punctuation and
+    markdown emphasis, and it accepts a placeholder carrying an aside, since
+    "None - scope is well-defined" is how drafters actually write it.
+
+    What it must NOT swallow is a real sentence that merely begins with the
+    word: "None of the thresholds are specified" is a question. The rule that
+    separates them is the character after the token -- a dash, colon, comma or
+    bracket introduces an aside, whereas a space followed by more sentence
+    does not.
+    """
+    cleaned = (text or "").strip().strip("*_`").strip()
+    cleaned = cleaned.rstrip(".!?,;:").strip().casefold()
+    if cleaned in _NONE_PLACEHOLDERS:
+        return True
+    for separator in ("—", "–", " - ", ":", ";", ",", "("):
+        if separator in cleaned:
+            head = cleaned.split(separator, 1)[0].strip().rstrip(".!?,;:").strip()
+            if head in _NONE_PLACEHOLDERS:
+                return True
+    return False
+
+
 def scan_open_questions_section(text: str) -> DraftQuestionsResult:
     """Deterministic checkbox scan of a document's ``## Open Questions``.
 

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -269,6 +269,31 @@ def _detect_open_questions(content: str) -> FinalizeQuestionsResult:
     return scan_residual_questions(content)
 
 
+#: Review-node statuses that mean "nothing is outstanding", so finalize's
+#: unchecked-box scan has nothing left to protect.
+_SETTLED_STATUSES = frozenset({"RESOLVED", "NONE"})
+
+
+def open_questions_settled(status: str) -> bool:
+    """Whether the review node's status means no question is outstanding.
+
+    #259 built this escape hatch for the reviewer-answered case and wired it
+    to RESOLVED alone. But the review node reports NONE when its own detector
+    finds no real questions, and that detector already filters
+    none-placeholders -- so the template's "- [ ] None" scaffold produces
+    NONE. The semantically-correct verdict "this draft asks nothing"
+    therefore failed to suppress a form-based block, and in
+    run-issue7-234943 an APPROVED draft died on the difference between
+    "- [ ] None" and "None." (#2232).
+
+    An absent or empty status is NOT settled: a path that never reviewed is
+    never waved through. A draft carrying a real unchecked question cannot
+    reach NONE either -- the review detector returns UNANSWERED or
+    HUMAN_REQUIRED for those -- so widening this does not weaken the gate.
+    """
+    return status in _SETTLED_STATUSES
+
+
 def validate_lld_final(content: str, open_questions_resolved: bool = False) -> list[str]:
     """Final structural checks before LLD finalization.
 
@@ -377,10 +402,8 @@ def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
     if not current_draft:
         return state
 
-    # Issue #259: Check if reviewer already resolved open questions
-    # If so, skip the open questions check (but still check for TODOs)
     open_questions_status = state.get("open_questions_status", "")
-    open_questions_resolved = open_questions_status == "RESOLVED"
+    open_questions_resolved = open_questions_settled(open_questions_status)
 
     # Issue #273: Clean up TODO placeholders in table cells before validation
     current_draft = cleanup_todo_placeholders(current_draft)

--- a/assemblyzero/workflows/requirements/nodes/ponder_rules.py
+++ b/assemblyzero/workflows/requirements/nodes/ponder_rules.py
@@ -13,6 +13,8 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from assemblyzero.core.verdict_schema import is_none_placeholder
+
 
 @dataclass
 class AutoFix:
@@ -269,10 +271,66 @@ def fix_directory_ordering(
     ]
 
 
+_OPEN_QUESTIONS_SECTION = re.compile(
+    r"(?:^##?#?[ \t]*Open Questions[ \t]*\n)(.*?)(?=^##|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_UNCHECKED_ITEM = re.compile(r"^- \[ \] ?(.*)$", re.MULTILINE)
+
+
+def fix_none_open_questions(
+    draft: str, ctx: dict[str, Any]
+) -> tuple[str, list[AutoFix]]:
+    """Normalize a "no open questions" checkbox to plain text (#2232).
+
+    The template scaffolds Open Questions as an unchecked box, so a drafter
+    with nothing to ask writes ``- [ ] None``. The reviewer reads the meaning
+    and approves; finalize reads the form and blocks. In run-issue7-234943 an
+    APPROVED draft that had passed mechanical validation and test-plan
+    validation at 22/22 was discarded at the last node in the graph over that
+    one checkbox.
+
+    Repair happens here, at the earliest mechanical point, in one place. The
+    strictness stays in finalize: this rule never checks a box, it removes a
+    placeholder that was never a question. A section holding even one real
+    question is left completely alone, because "None" beside a real question
+    is not an empty state.
+    """
+    match = _OPEN_QUESTIONS_SECTION.search(draft)
+    if not match:
+        return draft, []
+
+    section = match.group(1)
+    items = _UNCHECKED_ITEM.findall(section)
+    if not items:
+        return draft, []
+    if not all(is_none_placeholder(item) for item in items):
+        # At least one real question. Not an empty state; leave it.
+        return draft, []
+
+    repaired = _UNCHECKED_ITEM.sub("None.", section, count=1)
+    repaired = _UNCHECKED_ITEM.sub("", repaired)
+    # Collapse the blank lines the removals leave behind.
+    repaired = re.sub(r"\n{3,}", "\n\n", repaired)
+
+    fixed = draft[: match.start(1)] + repaired + draft[match.end(1) :]
+    return fixed, [
+        AutoFix(
+            rule="none_open_questions",
+            description=(
+                f"Normalized {len(items)} placeholder open-question "
+                f"checkbox(es) to plain 'None.'"
+            ),
+            section="Open Questions",
+        )
+    ]
+
+
 # Registry of all auto-fix rules, applied in order
 PONDER_RULES = [
     fix_title_issue_number,
     fix_section_heading_format,
+    fix_none_open_questions,
     fix_trailing_whitespace,
     fix_missing_blank_before_heading,
     fix_directory_ordering,

--- a/assemblyzero/workflows/requirements/nodes/review.py
+++ b/assemblyzero/workflows/requirements/nodes/review.py
@@ -21,6 +21,7 @@ from assemblyzero.core.verdict_schema import (
     FEEDBACK_SCHEMA,
     FeedbackResult,
     StructuredContractError,
+    is_none_placeholder,
     parse_structured_verdict,
     parse_structured_feedback,
     scan_open_questions_section,
@@ -795,11 +796,12 @@ def _draft_has_open_questions(content: str) -> bool:
     unchecked_lines = re.findall(
         r"^- \[ \] ?(.*)", open_questions_section, re.MULTILINE
     )
-    real_questions = [
-        q
-        for q in unchecked_lines
-        if not re.match(r"^none\b", q.strip(), re.IGNORECASE)
-    ]
+    # #2232: the placeholder test is the shared `is_none_placeholder` rather
+    # than a local regex. This detector and finalize's scan disagreed about
+    # "- [ ] None" for months and an APPROVED draft died in the gap; one
+    # predicate, imported by every caller, is what keeps them aligned. It also
+    # widens the vocabulary the local regex missed, notably "n/a".
+    real_questions = [q for q in unchecked_lines if not is_none_placeholder(q)]
     return len(real_questions) > 0
 
 

--- a/docs/templates/0102-feature-lld-template.md
+++ b/docs/templates/0102-feature-lld-template.md
@@ -16,6 +16,8 @@ Previous: Added sections based on 80 blocking issues from 164 governance verdict
 ### Open Questions
 *Questions that need clarification before or during implementation. Remove when resolved.*
 
+*If there are no open questions, delete the checkboxes and write exactly `None.` as plain text. Do NOT write `- [ ] None`: an unchecked box is read as an unresolved question and blocks finalization, whatever its text says.*
+
 - [ ] {Question 1}
 - [ ] {Question 2}
 

--- a/tests/fixtures/open_questions/boostgauge-7-005-approved-draft.md
+++ b/tests/fixtures/open_questions/boostgauge-7-005-approved-draft.md
@@ -1,0 +1,358 @@
+# Issue #7 - Feature: configuration file and CLI arguments
+
+## 1. Context & Goal
+* **Issue:** #7
+* **Objective:** Implement a configuration system for thresholds, polling intervals, and window behavior, managed via a config file and CLI arguments with specific precedence and write-back rules.
+* **Status:** Draft
+* **Related Issues:** N/A
+
+### Open Questions
+- [ ] None
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Implement Config class, config loading, merging, and saving logic |
+| `src/boostgauge/app.py` | Add | Integrate CLI argument parsing and Config initialization |
+| `tests/unit/test_config.py` | Add | Add unit tests for configuration loading, precedence, and persistence |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks paths.
+
+### 2.2 Dependencies
+
+```toml
+
+# No new dependencies required.
+```
+
+### 2.3 Data Structures
+
+```python
+class ConfigState(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: dict[str, int]
+    thresholds: dict[str, dict[str, int]]
+    telltale_windows: dict[str, int]
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+
+class SessionConfig:
+    file_path: Path
+    file_state_at_launch: ConfigState
+    current_state: ConfigState
+    cli_overrides: set[str]
+    hand_changed_keys: set[str]
+```
+
+### 2.4 Function Signatures
+
+```python
+def load_config(config_path: Path, reset: bool) -> SessionConfig:
+    """Loads configuration, handling auto-create and reset logic."""
+    ...
+
+def apply_cli_overrides(config: SessionConfig, overrides: dict[str, Any]) -> None:
+    """Applies CLI arguments in memory, marking them as overrides."""
+    ...
+
+def record_hand_change(config: SessionConfig, key: str, value: Any) -> None:
+    """Records a user-driven hand change during the session (e.g. position, size)."""
+    ...
+
+def reload_thresholds(config: SessionConfig) -> None:
+    """Re-reads thresholds from file mid-session without modifying the file."""
+    ...
+
+def save_config_on_exit(config: SessionConfig) -> None:
+    """Writes back only hand-changed keys to the config file, preserving external direct edits."""
+    ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. Parse CLI arguments
+2. Determine config file path (default or --config)
+3. IF --reset-config:
+     Write defaults to file
+4. Read file (IF missing, write defaults to file and read)
+5. Apply CLI overrides to session in memory
+6. Run session
+7. ON external file change:
+     Read threshold values into memory
+8. ON drag/resize:
+     Record hand change for 'position' or 'size'
+9. ON exit:
+     IF no hand changes:
+       Exit without writing
+     ELSE:
+       Read current file from disk
+       Apply only hand-changed keys to the read data
+       Write file to disk
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/config.py`
+* **Pattern:** State composition (File State + Overrides + Hand Changes)
+* **Key Decisions:** The session config must track which keys were overridden by CLI (to prevent write-back) and which keys were hand-changed during the session (to trigger write-back). The exit write must read the file immediately before writing to ensure any direct edits made during the session are not blindly overwritten, applying only the `hand_changed_keys` as a patch.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Config File Format | JSON, TOML, YAML | JSON | Simple, built-in standard library, matches issue description. |
+| Persistence Tracking | Boolean flags, dirty sets | Set of hand-changed keys | Precisely isolates only the keys that the app has permission to write back on exit. |
+
+**Architectural Constraints:**
+- Must use purely standard library for configuration (JSON) to avoid dependency bloat.
+- Must read file mid-session to support threshold hot-reloading without independent process walks.
+
+## 3. Requirements
+
+1. First run with no config file creates one with defaults.
+2. Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file.
+3. With no CLI overrides, the window opens at the file's position and size.
+4. Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size.
+5. Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file.
+6. The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size.
+7. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins.
+8. A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit.
+9. Position, no reset, not moved, no direct edits: `position` unchanged.
+10. Position, no reset, moved, no direct edits: `position` holds the new position.
+11. Position, reset, not moved, no direct edits: `position` holds the default.
+12. Position, reset, moved, no direct edits: `position` holds the new position.
+13. Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged.
+14. Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size.
+15. Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written.
+16. Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size.
+17. Size, reset, no `--size`, not resized, no direct edits: `size` holds the default.
+18. Size, reset, no `--size`, resized, no direct edits: `size` holds the new size.
+19. Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written.
+20. Size, reset, `--size` given, resized, no direct edits: `size` holds the new size.
+21. Invalid config values produce clear error messages.
+22. `--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments apply to the selected file.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Overwrite file fully on exit | Simple to implement | Destroys manual user edits during session | **Rejected** |
+| Patch file on exit based on hand-changes | Preserves user edits, meets all criteria | Requires tracking state and re-reading before write | **Selected** |
+
+**Rationale:** The strict persistence criteria necessitate a patch-based write model that respects external user modifications to the JSON file.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Local config file (`config.json` in project root) |
+| Format | JSON |
+| Size | < 1 KB |
+| Refresh | On launch, on file modification (thresholds) |
+| Copyright/License | N/A |
+
+### 5.2 Data Pipeline
+
+```
+Local File ──read──► SessionConfig ──CLI overrides──► Memory
+SessionConfig ──hand changes──► Patch ──write──► Local File
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Mock Config JSON | Hardcoded in tests | Represents default and edge-case states |
+
+### 5.4 Deployment Pipeline
+
+No external deployment required. Operates entirely locally.
+
+## 6. Diagram
+N/A
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Malicious config file injection | Validate JSON schema on read | Addressed |
+| Symlink attacks on config path | Ensure path resolution does not follow insecure links | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Config corruption on exit write | Write to temporary file, then atomic rename | Addressed |
+| Invalid manual config edits | Fallback to defaults or fail with clear error message, leaving file intact | Addressed |
+
+**Fail Mode:** Fail Closed - If the config file is corrupted and unparseable, print a clear error and exit rather than implicitly deleting the user's file.
+
+**Recovery Strategy:** Users can delete the config file or use `--reset-config` to restore the system to a clean state.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Config Load | < 50ms | Use standard `json` library, lazy load where possible |
+| Exit Write | < 50ms | Only write if hand-changed keys exist |
+
+**Bottlenecks:** Minimal. Config read/write is rare.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| N/A | N/A | N/A | $0 |
+
+**Cost Controls:**
+- [ ] N/A
+
+**Worst-Case Scenario:** Config polling could thrash disk if interval is abused. Use file-system watchers or mtime checks instead of continuous reads.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | Config stores only UI preferences |
+| Third-Party Licenses | No | N/A |
+| Terms of Service | No | N/A |
+| Data Retention | No | N/A |
+| Export Controls | No | N/A |
+
+**Data Classification:** Public / Internal (Local only)
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. Manual tests are a last resort for scenarios that genuinely cannot be automated.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+**Coverage Target:** ≥95% for all new code
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | First run no config | Creates file with size 300 | RED |
+| T020 | Launch order reset and read | File rewritten, CLI args apply | RED |
+| T030 | Read window defaults | Opens at size 300 without overrides | RED |
+| T040 | Reset with size N | File size 300, session size 400 | RED |
+| T050 | Threshold reload | File unchanged, memory updated | RED |
+| T060 | Exit write tracking | Only moved position is written | RED |
+| T070 | Direct edit conflict | Hand change wins over direct edit | RED |
+| T080 | Byte identical quit | No changes leaves file byte-identical | RED |
+| T090 | Position rules (no reset) | Position persists only if moved | RED |
+| T100 | Position rules (reset) | Position holds default unless moved | RED |
+| T110 | Size rules (no reset) | Size persists only if resized, CLI ignored | RED |
+| T120 | Size rules (reset) | Size holds default unless resized | RED |
+| T130 | Invalid config | Outputs error message | RED |
+| T140 | Custom path flag | Path resolves and behavior applies | RED |
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | First run with no config (REQ-1) | Auto | No config file present | File created with defaults | File exists, contains `"size": 300` |
+| 020 | Launch order reset/read (REQ-2) | Auto | `--reset-config --size 400` | Session size is 400, file holds 300 | Memory `size` is `400`, JSON `size` is `300` |
+| 030 | Open at file position/size (REQ-3) | Auto | File holds `size` 500, no CLI args | App memory gets size 500 | Memory `size` is `500` |
+| 040 | Reset with CLI size (REQ-4) | Auto | `--reset-config --size 400` | File defaults to 300, app memory 400 | Memory `size` is `400`, JSON `size` is `300` |
+| 050 | Threshold reload without write (REQ-5) | Auto | Write new threshold to file mid-session | Memory updates, file mtime unchanged | Memory `process_count.red` is `600`, file mtime identical |
+| 060 | Exit write patch (REQ-6) | Auto | Direct edit `theme` to `light`, move window to `x: 50` | File retains `light`, gets `x: 50` | JSON `theme` is `"light"`, JSON `position.x` is `50` |
+| 070 | Hand change wins (REQ-7) | Auto | Direct edit `size` to 400, hand resize to 500 | File gets size 500 | JSON `size` is `500` |
+| 080 | Byte-identical exit (REQ-8) | Auto | Launch without changes, exit | File checksum is identical | MD5 before == MD5 after |
+| 090 | Pos: No reset, not moved (REQ-9) | Auto | File `x: 200`, no action | File `x: 200` | JSON `position.x` is `200` |
+| 100 | Pos: No reset, moved (REQ-10) | Auto | File `x: 200`, window moved to 50 | File `x: 50` | JSON `position.x` is `50` |
+| 110 | Pos: Reset, not moved (REQ-11) | Auto | `--reset-config`, no move | File `x: 100` (default) | JSON `position.x` is `100` |
+| 120 | Pos: Reset, moved (REQ-12) | Auto | `--reset-config`, move to 50 | File `x: 50` | JSON `position.x` is `50` |
+| 130 | Size: No reset, no CLI, not resized (REQ-13) | Auto | File `size` 200, no action | File `size` 200 | JSON `size` is `200` |
+| 140 | Size: No reset, no CLI, resized (REQ-14) | Auto | File `size` 200, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 150 | Size: No reset, CLI, not resized (REQ-15) | Auto | File `size` 200, `--size 400` | File `size` 200 | JSON `size` is `200` |
+| 160 | Size: No reset, CLI, resized (REQ-16) | Auto | File `size` 200, `--size 400`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 170 | Size: Reset, no CLI, not resized (REQ-17) | Auto | `--reset-config`, no action | File `size` 300 (default) | JSON `size` is `300` |
+| 180 | Size: Reset, no CLI, resized (REQ-18) | Auto | `--reset-config`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 190 | Size: Reset, CLI, not resized (REQ-19) | Auto | `--reset-config --size 400`, no action | File `size` 300 (default) | JSON `size` is `300` |
+| 200 | Size: Reset, CLI, resized (REQ-20) | Auto | `--reset-config --size 400`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 210 | Invalid config values (REQ-21) | Auto | Corrupt JSON file | App exits with error | Exit code `1`, stdout contains `"Error"` |
+| 220 | Config path selection (REQ-22) | Auto | `--config custom.json` | Write and read from `custom.json` | `custom.json` exists, default missing |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run all automated tests
+poetry run pytest tests/unit/test_config.py -v
+
+# Run only fast/mocked tests (exclude live)
+poetry run pytest tests/unit/test_config.py -v -m "not live"
+
+# Run live integration tests
+poetry run pytest tests/unit/test_config.py -v -m live
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated.
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| JSON parsing failure | High | Low | Catch `json.JSONDecodeError` and print human-readable message, exiting gracefully without overwriting (`load_config`). |
+| Concurrent file writes | Low | Low | Exit write uses patch logic; thresholds reloaded stat checks limit mid-session trashing (`save_config_on_exit`, `reload_thresholds`). |
+| Missing permissions | High | Low | Validate directory existence and permissions before writing (`load_config`, `save_config_on_exit`). |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+- [ ] Test Report (0113) completed if applicable
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks cross-references.
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| None | (auto) | PENDING | Initial draft |
+
+**Final Status:** PENDING

--- a/tests/unit/test_open_questions_none.py
+++ b/tests/unit/test_open_questions_none.py
@@ -1,0 +1,258 @@
+"""The "- [ ] None" empty state, end to end (#2232).
+
+The template scaffolds Open Questions as an unchecked checkbox, so a drafter
+with nothing to ask fills the scaffold rather than deleting it. In
+run-issue7-234943 four drafts out of four wrote `- [ ] None`. The reviewer read
+the meaning and returned APPROVED; finalize read the form and blocked. The
+draft it killed had already passed mechanical validation, passed test-plan
+validation at 22/22, and been approved.
+
+The root cause was two detectors disagreeing about one document: review.py
+filtered none-placeholders, finalize.py did not, and the escape hatch #259
+built for exactly this was wired to RESOLVED while review reports NONE.
+
+`boostgauge-7-005-approved-draft.md` is that killed draft, byte-verbatim.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.verdict_schema import is_none_placeholder
+from assemblyzero.workflows.requirements.nodes.finalize import (
+    open_questions_settled,
+    validate_lld_final,
+)
+from assemblyzero.workflows.requirements.nodes.ponder_rules import (
+    PONDER_RULES,
+    apply_all_rules,
+    fix_none_open_questions,
+)
+from assemblyzero.workflows.requirements.nodes.review import (
+    _check_open_questions_status,
+    _draft_has_open_questions,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "open_questions"
+    / "boostgauge-7-005-approved-draft.md"
+)
+
+REAL_QUESTION = "- [ ] Should the config live in APPDATA?"
+
+
+@pytest.fixture(scope="module")
+def approved_draft() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def _doc(section_body: str) -> str:
+    return f"# Issue #7 - Feature: thing\n\n### Open Questions\n{section_body}\n\n## 2. Proposed Changes\n\nbody\n"
+
+
+# ---------------------------------------------------------------------------
+# One predicate, shared
+# ---------------------------------------------------------------------------
+
+
+class TestNonePlaceholder:
+    @pytest.mark.parametrize(
+        "text",
+        ["None", "none", "NONE", "None.", "N/A", "n/a", "na",
+         "None at this time", "None at this time.", "  none  ",
+         "**None**", "nothing",
+         # A placeholder carrying an aside, which is how drafters write it.
+         "None — scope is well-defined", "None - scope is well-defined",
+         "None: the design is settled", "None, the design is settled",
+         "N/A (nothing outstanding)"],
+    )
+    def test_placeholders(self, text):
+        assert is_none_placeholder(text)
+
+    @pytest.mark.parametrize(
+        "text",
+        ["Should the config live in APPDATA?",
+         "None of the thresholds are specified",
+         "no decision yet on the polling interval",
+         "nothing has been decided about theme precedence",
+         ""],
+    )
+    def test_real_questions_are_not_placeholders(self, text):
+        assert not is_none_placeholder(text)
+
+    def test_review_and_ponder_share_it(self):
+        """The two detectors that disagreed now consume one predicate.
+
+        Imported via importlib because the nodes package re-exports the
+        `review` FUNCTION under its module's name, so a plain import binds
+        the function instead of the module.
+        """
+        from importlib import import_module
+
+        pr = import_module("assemblyzero.workflows.requirements.nodes.ponder_rules")
+        rv = import_module("assemblyzero.workflows.requirements.nodes.review")
+
+        assert pr.is_none_placeholder is is_none_placeholder
+        assert rv.is_none_placeholder is is_none_placeholder
+
+
+# ---------------------------------------------------------------------------
+# Ponder normalization
+# ---------------------------------------------------------------------------
+
+
+class TestPonderNormalization:
+    def test_registered(self):
+        assert fix_none_open_questions in PONDER_RULES
+
+    def test_normalizes_the_placeholder(self):
+        fixed, fixes = fix_none_open_questions(_doc("- [ ] None"), {})
+
+        assert "- [ ] None" not in fixed
+        assert "None." in fixed
+        assert len(fixes) == 1
+        assert fixes[0].section == "Open Questions"
+
+    def test_normalizes_several_placeholders_to_one_line(self):
+        fixed, _ = fix_none_open_questions(_doc("- [ ] None\n- [ ] N/A"), {})
+
+        assert "- [ ]" not in fixed
+        assert fixed.count("None.") == 1
+
+    def test_a_real_question_is_left_completely_alone(self):
+        """The binding negative: this rule must never check off a question."""
+        doc = _doc(REAL_QUESTION)
+
+        fixed, fixes = fix_none_open_questions(doc, {})
+
+        assert fixed == doc
+        assert fixes == []
+        assert "- [x]" not in fixed
+
+    def test_a_mixed_section_is_left_alone(self):
+        """"None" beside a real question is not an empty state."""
+        doc = _doc(f"- [ ] None\n{REAL_QUESTION}")
+
+        fixed, fixes = fix_none_open_questions(doc, {})
+
+        assert fixed == doc
+        assert fixes == []
+
+    def test_no_section_is_a_noop(self):
+        doc = "# Title\n\n## 2. Proposed Changes\n\nbody\n"
+        assert fix_none_open_questions(doc, {}) == (doc, [])
+
+    def test_already_plain_none_is_a_noop(self):
+        doc = _doc("None.")
+        assert fix_none_open_questions(doc, {}) == (doc, [])
+
+    def test_it_runs_in_the_full_ponder_pass(self):
+        fixed, fixes = apply_all_rules(_doc("- [ ] None"), {"issue_number": 7})
+
+        assert "- [ ]" not in fixed
+        assert any(f.rule == "none_open_questions" for f in fixes)
+
+    def test_the_killed_draft_survives_ponder_and_then_finalize(
+        self, approved_draft
+    ):
+        """Defence in depth: the repair alone is enough, flag aside."""
+        fixed, fixes = fix_none_open_questions(approved_draft, {})
+
+        assert any(f.rule == "none_open_questions" for f in fixes)
+        assert "Unresolved open questions remain" not in validate_lld_final(
+            fixed, False
+        )
+
+
+# ---------------------------------------------------------------------------
+# finalize, and the #259 flag
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeGate:
+    def test_the_killed_draft_passes_byte_verbatim_when_review_said_none(
+        self, approved_draft
+    ):
+        """Acceptance 1. The exhibit, unmodified, with the real NONE status."""
+        errors = validate_lld_final(approved_draft, True)
+
+        assert "Unresolved open questions remain" not in errors
+
+    def test_the_same_draft_still_blocks_with_no_review_status(
+        self, approved_draft
+    ):
+        """An absent status is not NONE: a path that never reviewed is gated."""
+        errors = validate_lld_final(approved_draft, False)
+
+        assert "Unresolved open questions remain" in errors
+
+    def test_a_real_unchecked_question_still_blocks(self):
+        """Acceptance 2. Unchanged behavior for a genuine question."""
+        errors = validate_lld_final(_doc(REAL_QUESTION), False)
+
+        assert "Unresolved open questions remain" in errors
+
+
+class TestTwoSixtyNineFlag:
+    """Why the escape hatch did not fire, pinned as behavior."""
+
+    def test_review_reports_none_for_the_placeholder_draft(self, approved_draft):
+        """The review detector already read the draft correctly."""
+        assert not _draft_has_open_questions(approved_draft)
+        assert _check_open_questions_status(approved_draft, "Verdict: APPROVED") == "NONE"
+
+    def test_review_does_not_report_none_for_a_real_question(self):
+        doc = _doc(REAL_QUESTION)
+
+        assert _draft_has_open_questions(doc)
+        assert _check_open_questions_status(doc, "Verdict: APPROVED") != "NONE"
+
+    @pytest.mark.parametrize(
+        "status,settled",
+        [("RESOLVED", True), ("NONE", True), ("UNANSWERED", False),
+         ("HUMAN_REQUIRED", False), ("", False), ("resolved", False)],
+    )
+    def test_which_statuses_are_settled(self, status, settled):
+        """Calls the real decision, so a change to it fails here.
+
+        RESOLVED was the only skip; NONE now joins it and nothing else does.
+        An absent status stays unsettled on purpose.
+        """
+        assert open_questions_settled(status) is settled
+
+        errors = validate_lld_final(
+            _doc("- [ ] None"), open_questions_settled(status)
+        )
+        assert ("Unresolved open questions remain" in errors) is not settled
+
+    def test_the_exhibit_end_to_end_through_the_real_decision(
+        self, approved_draft
+    ):
+        """The killed draft, the real status it got, the real gate."""
+        status = _check_open_questions_status(approved_draft, "Verdict: APPROVED")
+
+        errors = validate_lld_final(
+            approved_draft, open_questions_settled(status)
+        )
+
+        assert status == "NONE"
+        assert "Unresolved open questions remain" not in errors
+
+
+# ---------------------------------------------------------------------------
+# Template
+# ---------------------------------------------------------------------------
+
+
+def test_the_template_tells_the_drafter_the_accepted_empty_state():
+    """Acceptance 4: template instruction and finalize scan must agree."""
+    template = (
+        Path(__file__).resolve().parents[2]
+        / "docs" / "templates" / "0102-feature-lld-template.md"
+    ).read_text(encoding="utf-8")
+
+    assert "`None.`" in template
+    assert "Do NOT write `- [ ] None`" in template


### PR DESCRIPTION
## Why the #259 flag did not fire

This is the part the issue asked to have explained, and the explanation changed the fix.

`_check_open_questions_status` returns one of RESOLVED, HUMAN_REQUIRED, UNANSWERED or **NONE**. It returns NONE when `_draft_has_open_questions` finds nothing — and that function already filtered none-placeholders, at `review.py:793`, under a comment reading *"Drafters write `- [ ] None` to mean 'no open questions'"*.

So the review side read the draft correctly and reported NONE. The console line the issue quotes, `Open Questions: NONE`, is `review.py:315` printing that status; it is not verdict text, and neither verdict file in the exhibit contains the string.

Finalize then asked a different question:

```python
open_questions_resolved = open_questions_status == "RESOLVED"
```

NONE is not RESOLVED, so the scan ran, and the scan had no none-vocabulary of its own. Two detectors over one document, disagreeing, with an approved draft in the gap.

That reframes the defect: #259's escape hatch was correct but covered only one of the two states that mean "nothing is outstanding".

## The three layers

**Template.** The empty state is now stated explicitly: write `None.` as plain text, never `- [ ] None`, because an unchecked box is read as an unresolved question whatever its text says.

**Ponder.** `fix_none_open_questions` normalizes an all-placeholder section to plain `None.` before validation sees it. The strictness stays in finalize; the repair happens at the earliest mechanical point, in one place. The rule never checks a box — it removes a placeholder that was never a question — and a section holding even one real question is returned untouched.

**The flag.** `open_questions_settled(status)` replaces the inline comparison and accepts NONE alongside RESOLVED. It is a named function specifically so the decision is under test: with the comparison inline, no test could reach it.

## One predicate, not three

`is_none_placeholder` now lives in `core/verdict_schema.py` and is imported by both review and Ponder, with a test asserting they are the same object. A second implementation is what caused this defect; a third would have been the same bet again.

Widening it surfaced a pinned behavior I nearly broke. `test_none_with_trailing_text_returns_false` pins `- [ ] None — scope is well-defined`, which a whole-string match rejects. The predicate now accepts a placeholder carrying an aside, separated by a dash, colon, comma or bracket, while still refusing `None of the thresholds are specified` — where the token is the subject of a real sentence rather than followed by an aside.

## Acceptance

| Criterion | Test |
|---|---|
| Draft 005 byte-verbatim passes finalize | `test_the_killed_draft_passes_byte_verbatim_when_review_said_none` |
| A real unchecked question still blocks | `test_a_real_unchecked_question_still_blocks` |
| Normalization never checks off a real question | `test_a_real_question_is_left_completely_alone`, `test_a_mixed_section_is_left_alone` |
| Template instruction and the scan agree | `test_the_template_tells_the_drafter_the_accepted_empty_state` |
| The #259 path is covered | `TestTwoSixtyNineFlag`, including `test_the_exhibit_end_to_end_through_the_real_decision` |

The fixture is the killed draft itself, `boostgauge-7-005-approved-draft.md`, byte-verbatim from the exhibit.

## Verification

- 44 new tests. Full unit suite: **6847 passed, 17 skipped, 5 xfailed**, no failures.
- **Mutation-checked.** Reverting `_SETTLED_STATUSES` to RESOLVED-only fails exactly two tests, both on the NONE path, and nothing else — so the fix is genuinely covered rather than incidentally green.
- Ruff introduces nothing: `verdict_schema.py` and the new test file are clean, and `review.py` and `ponder_rules.py` carry the same counts as `origin/main`.
- An absent status is still unsettled, verified by `test_the_same_draft_still_blocks_with_no_review_status`.

Sibling: #2233 routes a finalize block to the surgical revision instead of regenerating, which is what made this defect cost a whole attempt rather than one edit.

Closes #2232
