### PR TITLE
fix: repair a blocked finalize as edits instead of regenerating (Closes #2233)

### DIFF
--- a/assemblyzero/workflows/requirements/atlas.py
+++ b/assemblyzero/workflows/requirements/atlas.py
@@ -197,10 +197,14 @@ ATLAS: dict[str, dict] = {
         "teach": (
             "An approved LLD lands in the target repo's docs tree; a "
             "drafted issue is filed on GitHub. The artifact, not this run's "
-            "transcript, is what the next stage consumes."
+            "transcript, is what the next stage consumes. This stage carries "
+            "a validation gate of its own, and failing it sends the document "
+            "back for a surgical revision rather than discarding the attempt "
+            "and drafting it again."
         ),
         "successors": {
-            "END": "always",
+            "N1_generate_draft": "finalize's own validation blocked the document",
+            "END": "the artifact is saved, or the repair budget is spent",
         },
     },
     "HALT": {

--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -36,6 +36,10 @@ route_after_validate_mechanical for immediate user feedback.
 Issue #166 addition: N1b validates test plan coverage, vague assertions,
 and human delegation before Gemini review.
 
+#2233 addition: N5 can loop back to N1 when finalize's own validation blocks.
+The errors ride back as revision feedback and are repaired as edit blocks, so
+a blocked finalize no longer fails the stage and costs the whole attempt.
+
 Routing is controlled by:
 - error_message: Non-empty routes to END
 - config_gates_*: Whether human gates are enabled
@@ -454,17 +458,36 @@ def route_from_human_gate_verdict(
 
 def route_after_finalize(
     state: RequirementsWorkflowState,
-) -> Literal["END"]:
+) -> Literal["N1_generate_draft", "END"]:
     """Route after finalize node.
 
-    Always routes to END (workflow complete).
+    #2233: a finalize validation failure goes back to the revision node with
+    the named errors as feedback — the same destination a mechanical-validation
+    failure already takes, and for the same reason. It is a mechanical defect
+    in a finished document, so it is repaired as edits (#2200) rather than
+    paid for again: the run that motivated this discarded an APPROVED draft,
+    re-ran every validated stage, and reached the identical block.
+
+    Everything else ends the workflow exactly as before, including a finalize
+    that stopped with an error, which the orchestrator reads off
+    ``error_message``.
+
+    Routes to:
+    - N1_generate_draft: finalize blocked and repair budget remains (#2233)
+    - END: workflow complete, or finalize stopped with an error
 
     Args:
         state: Current workflow state.
 
     Returns:
-        END.
+        Next node name.
     """
+    if state.get("finalize_repair_pending"):
+        print(
+            "    [ROUTING] Finalize validation failed - returning to the "
+            "revision node with the errors as feedback (#2233)"
+        )
+        return "N1_generate_draft"
     return "END"
 
 
@@ -633,7 +656,18 @@ def create_requirements_graph() -> StateGraph:
         },
     )
 
-    # N5 -> END
-    graph.add_edge(N5_FINALIZE, END)
+    # N5 -> N1 or END
+    # #2233: a blocked finalize is repaired as an edit-script revision, never
+    # by regenerating the attempt. This edge is what makes that possible; the
+    # unconditional N5 -> END it replaces is what forced the orchestrator to
+    # re-pay for an approved draft.
+    graph.add_conditional_edges(
+        N5_FINALIZE,
+        route_after_finalize,
+        {
+            "N1_generate_draft": N1_GENERATE_DRAFT,
+            "END": END,
+        },
+    )
 
     return graph

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -371,6 +371,89 @@ def validate_lld_final(content: str, open_questions_resolved: bool = False) -> l
     return errors
 
 
+#: Hard ceiling on finalize repairs, independent of the iteration cap.
+#:
+#: Measured on the compiled graph: a run costs 9 super-steps to reach finalize
+#: and each repair round trip (N1, Ponder, N1.5, N1b, N3, N5) costs 6 more. The
+#: two callers allow 25 (the orchestrator's `run_lld_stage`, which sets no
+#: limit and takes LangGraph's default) and `(max_iterations * 4) + 10`, which
+#: is 22 at the default cap. A third repair needs 27, so it does not raise the
+#: halt below — it raises GraphRecursionError instead, which says nothing about
+#: what failed. Two repairs cost 21 and fit both.
+#:
+#: Two is also enough to decide: a defect that survives two surgical repairs of
+#: the named errors is systematic, which is the case this issue was filed
+#: about.
+MAX_FINALIZE_REPAIRS = 2
+
+
+def _finalize_repair_budget(state: Dict[str, Any]) -> int:
+    """How many times finalize may hand a draft back for repair.
+
+    #2233 said the iteration cap still bounds the loop, so this reads the
+    workflow's own cap — then clamps it to what the graph's step budget can
+    actually carry (see MAX_FINALIZE_REPAIRS). At least one repair is always
+    allowed: a cap of zero would reproduce the defect.
+    """
+    try:
+        cap = int(state.get("max_iterations", 3) or 3)
+    except (TypeError, ValueError):
+        cap = 3
+    return max(1, min(cap, MAX_FINALIZE_REPAIRS))
+
+
+def _request_finalize_repair(
+    state: Dict[str, Any], validation_errors: list
+) -> Dict[str, Any]:
+    """Hand a blocked finalize back to the revision node, or stop trying.
+
+    #2233: a finalize validation failure is a mechanical property of a
+    finished, and usually APPROVED, document. Failing the stage here made the
+    orchestrator regenerate the whole attempt, discarding every validated
+    stage and re-rolling all of its variance. In run-issue7-234943 that cost a
+    requirements gate, an initial draft, a mechanical-fix revision and a
+    review, and arrived at the identical block, because the defect was
+    systematic rather than draft-specific.
+
+    So the errors become revision feedback instead of a stage failure. The
+    router reads ``finalize_repair_pending``; N1 sees ``validation_errors``,
+    takes the edit-script path (#2200) and repairs the named defects in place.
+    ``error_message`` is deliberately left empty here — that is the channel
+    the orchestrator reads to decide a stage failed, and this stage has not
+    failed.
+
+    Once the budget is spent the run stops with the errors named, because a
+    repair loop that will not converge is a defect to diagnose rather than one
+    to re-pay for.
+    """
+    error_msg = "BLOCKED: " + "; ".join(validation_errors)
+    print(f"    VALIDATION: {error_msg}")
+
+    repairs_done = state.get("finalize_repair_count", 0) or 0
+    budget = _finalize_repair_budget(state)
+
+    if repairs_done >= budget:
+        state["finalize_repair_pending"] = False
+        state["error_message"] = (
+            f"[FINALIZE] {error_msg}. {repairs_done} repair revision(s) were "
+            f"already spent on this draft and finalize still blocks, so the "
+            f"loop stops rather than regenerating (#2233). The draft is "
+            f"unchanged on disk; fix the named defect and relaunch to resume "
+            f"from this stage."
+        )
+        return state
+
+    state["finalize_repair_count"] = repairs_done + 1
+    state["finalize_repair_pending"] = True
+    state["validation_errors"] = list(validation_errors)
+    state["error_message"] = ""
+    print(
+        f"    [FINALIZE] Repair {repairs_done + 1}/{budget}: sending the named "
+        f"errors back as revision feedback, not regenerating (#2233)"
+    )
+    return state
+
+
 def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
     """Save LLD file with embedded review evidence.
 
@@ -411,10 +494,8 @@ def _save_lld_file(state: Dict[str, Any]) -> Dict[str, Any]:
     # Gate 2: Validate LLD structure before finalization (Issue #235)
     validation_errors = validate_lld_final(current_draft, open_questions_resolved)
     if validation_errors:
-        error_msg = "BLOCKED: " + "; ".join(validation_errors)
-        print(f"    VALIDATION: {error_msg}")
-        state["error_message"] = error_msg
-        return state
+        # #2233: route to a surgical revision instead of failing the stage.
+        return _request_finalize_repair(state, validation_errors)
 
     # Embed review evidence with ACTUAL verdict (not hardcoded APPROVED!)
     review_date = datetime.now().strftime("%Y-%m-%d")
@@ -532,6 +613,12 @@ def finalize(state: Dict[str, Any]) -> Dict[str, Any]:
     if workflow_type == "lld":
         # For LLD workflow: save LLD file with embedded review evidence
         state = _save_lld_file(state)
+        # #2233: a blocked finalize is a repair request, not a finished stage.
+        # Return before the completion log, the lineage move and the commit —
+        # none of them describe what happened, and nothing was saved. The
+        # graph sends this draft to the revision node next.
+        if state.get("finalize_repair_pending"):
+            return state
     else:
         # For issue workflow: post comment to GitHub issue
         # _finalize_issue returns only updates, merge them into state

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -432,6 +432,11 @@ Use the template structure provided. Include all sections. Be specific about:
         "previous_review_feedback": state.get("current_verdict", ""),  # Issue #486: Save for two-strike
         "previous_draft": state.get("current_draft", ""),  # Issue #491: Save for diff-aware review
         "validation_errors": [],  # Clear validation errors after use (Issue #294)
+        # #2233: the repair request is consumed here. Leaving it set would
+        # send the next finalize straight back to this node no matter what
+        # finalize decided, and finalize_repair_count is what bounds the loop
+        # — so it is deliberately NOT reset.
+        "finalize_repair_pending": False,
         "error_message": "",
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
@@ -463,30 +468,49 @@ def build_revision_context(state: RequirementsWorkflowState) -> str:
 
     # Issue #294: Include mechanical validation errors FIRST (highest priority)
     # Issue #339: Include repo structure so drafter knows what directories exist
+    # #2233: finalize's own errors arrive on the same channel, so say which
+    # gate spoke. The document reaching a finalize repair has already passed
+    # mechanical and test-plan validation and usually carries an APPROVED
+    # verdict; telling the model it failed "mechanical validation" invites it
+    # to go looking for structural faults that are not there.
+    finalize_repair = bool(state.get("finalize_repair_pending"))
     if validation_errors:
-        revision_context += "## MECHANICAL VALIDATION ERRORS (MUST FIX FIRST)\n\n"
-        revision_context += "The following errors were found by automated validation. "
-        revision_context += "These MUST be fixed before the LLD can proceed:\n\n"
+        if finalize_repair:
+            revision_context += "## FINALIZE VALIDATION ERRORS (MUST FIX FIRST)\n\n"
+            revision_context += (
+                "This document has already passed structural and test-plan "
+                "validation and been reviewed. It is blocked only by the "
+                "final gate below. Fix exactly these errors and change "
+                "nothing else:\n\n"
+            )
+        else:
+            revision_context += "## MECHANICAL VALIDATION ERRORS (MUST FIX FIRST)\n\n"
+            revision_context += "The following errors were found by automated validation. "
+            revision_context += "These MUST be fixed before the LLD can proceed:\n\n"
         for error in validation_errors:
             revision_context += f"- **ERROR:** {error}\n"
         revision_context += "\n"
 
         # Issue #339: Show actual repo structure so drafter can use real paths
         # Issue #490: Use cached repo_structure from state, fallback to inline call
-        target_repo = state.get("target_repo", "")
-        if target_repo:
-            repo_structure = state.get("repo_structure") or get_repo_structure(target_repo)
-            revision_context += "## ACTUAL REPOSITORY STRUCTURE\n\n"
-            revision_context += "**Use ONLY these existing directories** (or explicitly Add new ones):\n\n"
-            revision_context += f"```\n{repo_structure}\n```\n\n"
-            revision_context += "**To add files in a NEW directory:**\n"
-            revision_context += "1. First add the directory itself with Change Type: `Add (Directory)`\n"
-            revision_context += "2. Then add files inside it with Change Type: `Add`\n\n"
-        else:
-            revision_context += "**CRITICAL:** Check that all file paths in Section 2.1 are correct:\n"
-            revision_context += "- 'Modify' files MUST exist in the repository\n"
-            revision_context += "- 'Add' files must have existing parent directories\n"
-            revision_context += "- Use actual file names from the codebase, not generic names\n\n"
+        # #2233: skipped on a finalize repair — the repo dump exists to fix
+        # bad file paths in Section 2.1, which this document's paths already
+        # cleared, so here it is a large prompt for a question nobody asked.
+        if not finalize_repair:
+            target_repo = state.get("target_repo", "")
+            if target_repo:
+                repo_structure = state.get("repo_structure") or get_repo_structure(target_repo)
+                revision_context += "## ACTUAL REPOSITORY STRUCTURE\n\n"
+                revision_context += "**Use ONLY these existing directories** (or explicitly Add new ones):\n\n"
+                revision_context += f"```\n{repo_structure}\n```\n\n"
+                revision_context += "**To add files in a NEW directory:**\n"
+                revision_context += "1. First add the directory itself with Change Type: `Add (Directory)`\n"
+                revision_context += "2. Then add files inside it with Change Type: `Add`\n\n"
+            else:
+                revision_context += "**CRITICAL:** Check that all file paths in Section 2.1 are correct:\n"
+                revision_context += "- 'Modify' files MUST exist in the repository\n"
+                revision_context += "- 'Add' files must have existing parent directories\n"
+                revision_context += "- Use actual file names from the codebase, not generic names\n\n"
 
     # Tiphys (#1688): revision feedback loop — the draft's own Files
     # Changed table declares the change's actual blast radius; refresh

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -237,6 +237,13 @@ class RequirementsWorkflowState(TypedDict, total=False):
     validation_errors: list[str]
     validation_warnings: list[str]
 
+    # Finalize repair loop (#2233). A blocked finalize hands the approved
+    # draft back to the revision node instead of failing the stage, so these
+    # two carry the request across the N5 -> N1 edge: the flag is what the
+    # router reads, and the count is what stops the loop.
+    finalize_repair_pending: bool
+    finalize_repair_count: int
+
     # Test plan validation (Issue #166)
     test_plan_validation_result: dict | None
     test_plan_validation_attempts: int
@@ -369,6 +376,9 @@ def create_initial_state(
         # Mechanical validation (Issue #277)
         "validation_errors": [],
         "validation_warnings": [],
+        # Finalize repair loop (#2233)
+        "finalize_repair_pending": False,
+        "finalize_repair_count": 0,
         # Test plan validation (Issue #166)
         "test_plan_validation_result": None,
         "test_plan_validation_attempts": 0,

--- a/tests/fixtures/lld_revision/boostgauge-7-234943-005-draft.md
+++ b/tests/fixtures/lld_revision/boostgauge-7-234943-005-draft.md
@@ -1,0 +1,358 @@
+# Issue #7 - Feature: configuration file and CLI arguments
+
+## 1. Context & Goal
+* **Issue:** #7
+* **Objective:** Implement a configuration system for thresholds, polling intervals, and window behavior, managed via a config file and CLI arguments with specific precedence and write-back rules.
+* **Status:** Draft
+* **Related Issues:** N/A
+
+### Open Questions
+- [ ] None
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Implement Config class, config loading, merging, and saving logic |
+| `src/boostgauge/app.py` | Add | Integrate CLI argument parsing and Config initialization |
+| `tests/unit/test_config.py` | Add | Add unit tests for configuration loading, precedence, and persistence |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks paths.
+
+### 2.2 Dependencies
+
+```toml
+
+# No new dependencies required.
+```
+
+### 2.3 Data Structures
+
+```python
+class ConfigState(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: dict[str, int]
+    thresholds: dict[str, dict[str, int]]
+    telltale_windows: dict[str, int]
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+
+class SessionConfig:
+    file_path: Path
+    file_state_at_launch: ConfigState
+    current_state: ConfigState
+    cli_overrides: set[str]
+    hand_changed_keys: set[str]
+```
+
+### 2.4 Function Signatures
+
+```python
+def load_config(config_path: Path, reset: bool) -> SessionConfig:
+    """Loads configuration, handling auto-create and reset logic."""
+    ...
+
+def apply_cli_overrides(config: SessionConfig, overrides: dict[str, Any]) -> None:
+    """Applies CLI arguments in memory, marking them as overrides."""
+    ...
+
+def record_hand_change(config: SessionConfig, key: str, value: Any) -> None:
+    """Records a user-driven hand change during the session (e.g. position, size)."""
+    ...
+
+def reload_thresholds(config: SessionConfig) -> None:
+    """Re-reads thresholds from file mid-session without modifying the file."""
+    ...
+
+def save_config_on_exit(config: SessionConfig) -> None:
+    """Writes back only hand-changed keys to the config file, preserving external direct edits."""
+    ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. Parse CLI arguments
+2. Determine config file path (default or --config)
+3. IF --reset-config:
+     Write defaults to file
+4. Read file (IF missing, write defaults to file and read)
+5. Apply CLI overrides to session in memory
+6. Run session
+7. ON external file change:
+     Read threshold values into memory
+8. ON drag/resize:
+     Record hand change for 'position' or 'size'
+9. ON exit:
+     IF no hand changes:
+       Exit without writing
+     ELSE:
+       Read current file from disk
+       Apply only hand-changed keys to the read data
+       Write file to disk
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/config.py`
+* **Pattern:** State composition (File State + Overrides + Hand Changes)
+* **Key Decisions:** The session config must track which keys were overridden by CLI (to prevent write-back) and which keys were hand-changed during the session (to trigger write-back). The exit write must read the file immediately before writing to ensure any direct edits made during the session are not blindly overwritten, applying only the `hand_changed_keys` as a patch.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Config File Format | JSON, TOML, YAML | JSON | Simple, built-in standard library, matches issue description. |
+| Persistence Tracking | Boolean flags, dirty sets | Set of hand-changed keys | Precisely isolates only the keys that the app has permission to write back on exit. |
+
+**Architectural Constraints:**
+- Must use purely standard library for configuration (JSON) to avoid dependency bloat.
+- Must read file mid-session to support threshold hot-reloading without independent process walks.
+
+## 3. Requirements
+
+1. First run with no config file creates one with defaults.
+2. Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file.
+3. With no CLI overrides, the window opens at the file's position and size.
+4. Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size.
+5. Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file.
+6. The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size.
+7. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins.
+8. A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit.
+9. Position, no reset, not moved, no direct edits: `position` unchanged.
+10. Position, no reset, moved, no direct edits: `position` holds the new position.
+11. Position, reset, not moved, no direct edits: `position` holds the default.
+12. Position, reset, moved, no direct edits: `position` holds the new position.
+13. Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged.
+14. Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size.
+15. Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written.
+16. Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size.
+17. Size, reset, no `--size`, not resized, no direct edits: `size` holds the default.
+18. Size, reset, no `--size`, resized, no direct edits: `size` holds the new size.
+19. Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written.
+20. Size, reset, `--size` given, resized, no direct edits: `size` holds the new size.
+21. Invalid config values produce clear error messages.
+22. `--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments apply to the selected file.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Overwrite file fully on exit | Simple to implement | Destroys manual user edits during session | **Rejected** |
+| Patch file on exit based on hand-changes | Preserves user edits, meets all criteria | Requires tracking state and re-reading before write | **Selected** |
+
+**Rationale:** The strict persistence criteria necessitate a patch-based write model that respects external user modifications to the JSON file.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Local config file (`config.json` in project root) |
+| Format | JSON |
+| Size | < 1 KB |
+| Refresh | On launch, on file modification (thresholds) |
+| Copyright/License | N/A |
+
+### 5.2 Data Pipeline
+
+```
+Local File ──read──► SessionConfig ──CLI overrides──► Memory
+SessionConfig ──hand changes──► Patch ──write──► Local File
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Mock Config JSON | Hardcoded in tests | Represents default and edge-case states |
+
+### 5.4 Deployment Pipeline
+
+No external deployment required. Operates entirely locally.
+
+## 6. Diagram
+N/A
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Malicious config file injection | Validate JSON schema on read | Addressed |
+| Symlink attacks on config path | Ensure path resolution does not follow insecure links | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Config corruption on exit write | Write to temporary file, then atomic rename | Addressed |
+| Invalid manual config edits | Fallback to defaults or fail with clear error message, leaving file intact | Addressed |
+
+**Fail Mode:** Fail Closed - If the config file is corrupted and unparseable, print a clear error and exit rather than implicitly deleting the user's file.
+
+**Recovery Strategy:** Users can delete the config file or use `--reset-config` to restore the system to a clean state.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Config Load | < 50ms | Use standard `json` library, lazy load where possible |
+| Exit Write | < 50ms | Only write if hand-changed keys exist |
+
+**Bottlenecks:** Minimal. Config read/write is rare.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| N/A | N/A | N/A | $0 |
+
+**Cost Controls:**
+- [ ] N/A
+
+**Worst-Case Scenario:** Config polling could thrash disk if interval is abused. Use file-system watchers or mtime checks instead of continuous reads.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | Config stores only UI preferences |
+| Third-Party Licenses | No | N/A |
+| Terms of Service | No | N/A |
+| Data Retention | No | N/A |
+| Export Controls | No | N/A |
+
+**Data Classification:** Public / Internal (Local only)
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. Manual tests are a last resort for scenarios that genuinely cannot be automated.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+**Coverage Target:** ≥95% for all new code
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | First run no config | Creates file with size 300 | RED |
+| T020 | Launch order reset and read | File rewritten, CLI args apply | RED |
+| T030 | Read window defaults | Opens at size 300 without overrides | RED |
+| T040 | Reset with size N | File size 300, session size 400 | RED |
+| T050 | Threshold reload | File unchanged, memory updated | RED |
+| T060 | Exit write tracking | Only moved position is written | RED |
+| T070 | Direct edit conflict | Hand change wins over direct edit | RED |
+| T080 | Byte identical quit | No changes leaves file byte-identical | RED |
+| T090 | Position rules (no reset) | Position persists only if moved | RED |
+| T100 | Position rules (reset) | Position holds default unless moved | RED |
+| T110 | Size rules (no reset) | Size persists only if resized, CLI ignored | RED |
+| T120 | Size rules (reset) | Size holds default unless resized | RED |
+| T130 | Invalid config | Outputs error message | RED |
+| T140 | Custom path flag | Path resolves and behavior applies | RED |
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | First run with no config (REQ-1) | Auto | No config file present | File created with defaults | File exists, contains `"size": 300` |
+| 020 | Launch order reset/read (REQ-2) | Auto | `--reset-config --size 400` | Session size is 400, file holds 300 | Memory `size` is `400`, JSON `size` is `300` |
+| 030 | Open at file position/size (REQ-3) | Auto | File holds `size` 500, no CLI args | App memory gets size 500 | Memory `size` is `500` |
+| 040 | Reset with CLI size (REQ-4) | Auto | `--reset-config --size 400` | File defaults to 300, app memory 400 | Memory `size` is `400`, JSON `size` is `300` |
+| 050 | Threshold reload without write (REQ-5) | Auto | Write new threshold to file mid-session | Memory updates, file mtime unchanged | Memory `process_count.red` is `600`, file mtime identical |
+| 060 | Exit write patch (REQ-6) | Auto | Direct edit `theme` to `light`, move window to `x: 50` | File retains `light`, gets `x: 50` | JSON `theme` is `"light"`, JSON `position.x` is `50` |
+| 070 | Hand change wins (REQ-7) | Auto | Direct edit `size` to 400, hand resize to 500 | File gets size 500 | JSON `size` is `500` |
+| 080 | Byte-identical exit (REQ-8) | Auto | Launch without changes, exit | File checksum is identical | MD5 before == MD5 after |
+| 090 | Pos: No reset, not moved (REQ-9) | Auto | File `x: 200`, no action | File `x: 200` | JSON `position.x` is `200` |
+| 100 | Pos: No reset, moved (REQ-10) | Auto | File `x: 200`, window moved to 50 | File `x: 50` | JSON `position.x` is `50` |
+| 110 | Pos: Reset, not moved (REQ-11) | Auto | `--reset-config`, no move | File `x: 100` (default) | JSON `position.x` is `100` |
+| 120 | Pos: Reset, moved (REQ-12) | Auto | `--reset-config`, move to 50 | File `x: 50` | JSON `position.x` is `50` |
+| 130 | Size: No reset, no CLI, not resized (REQ-13) | Auto | File `size` 200, no action | File `size` 200 | JSON `size` is `200` |
+| 140 | Size: No reset, no CLI, resized (REQ-14) | Auto | File `size` 200, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 150 | Size: No reset, CLI, not resized (REQ-15) | Auto | File `size` 200, `--size 400` | File `size` 200 | JSON `size` is `200` |
+| 160 | Size: No reset, CLI, resized (REQ-16) | Auto | File `size` 200, `--size 400`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 170 | Size: Reset, no CLI, not resized (REQ-17) | Auto | `--reset-config`, no action | File `size` 300 (default) | JSON `size` is `300` |
+| 180 | Size: Reset, no CLI, resized (REQ-18) | Auto | `--reset-config`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 190 | Size: Reset, CLI, not resized (REQ-19) | Auto | `--reset-config --size 400`, no action | File `size` 300 (default) | JSON `size` is `300` |
+| 200 | Size: Reset, CLI, resized (REQ-20) | Auto | `--reset-config --size 400`, resize 500 | File `size` 500 | JSON `size` is `500` |
+| 210 | Invalid config values (REQ-21) | Auto | Corrupt JSON file | App exits with error | Exit code `1`, stdout contains `"Error"` |
+| 220 | Config path selection (REQ-22) | Auto | `--config custom.json` | Write and read from `custom.json` | `custom.json` exists, default missing |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run all automated tests
+poetry run pytest tests/unit/test_config.py -v
+
+# Run only fast/mocked tests (exclude live)
+poetry run pytest tests/unit/test_config.py -v -m "not live"
+
+# Run live integration tests
+poetry run pytest tests/unit/test_config.py -v -m live
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated.
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| JSON parsing failure | High | Low | Catch `json.JSONDecodeError` and print human-readable message, exiting gracefully without overwriting (`load_config`). |
+| Concurrent file writes | Low | Low | Exit write uses patch logic; thresholds reloaded stat checks limit mid-session trashing (`save_config_on_exit`, `reload_thresholds`). |
+| Missing permissions | High | Low | Validate directory existence and permissions before writing (`load_config`, `save_config_on_exit`). |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+- [ ] Test Report (0113) completed if applicable
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks cross-references.
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| None | (auto) | PENDING | Initial draft |
+
+**Final Status:** PENDING

--- a/tests/unit/test_finalize_repair_routing.py
+++ b/tests/unit/test_finalize_repair_routing.py
@@ -1,0 +1,696 @@
+"""A blocked finalize is repaired as edits, never regenerated (#2233).
+
+The measured failure is `run-issue7-234943` (boostgauge, 2026-08-11). Draft
+005 passed mechanical validation, passed test-plan validation at 22/22, and
+came back from the adversarial reviewer APPROVED. Finalize's own gate then
+blocked it, the stage failed, and the orchestrator discarded the whole
+attempt:
+
+    VALIDATION: BLOCKED: Unresolved open questions remain
+    [ORCHESTRATOR] Stage 'lld' failed (attempt 1/3). Retrying in 10s...
+    [ORCHESTRATOR] Next attempt will be regenerated (discarding the previous
+    attempt's generated files).
+
+The regenerated attempt re-paid the requirements gate, the initial draft, a
+mechanical-fix revision and a review, and produced the identical block,
+because the defect was systematic rather than draft-specific.
+
+A finalize validation failure is a mechanical property of a finished
+document, so it belongs on the same edge a mechanical-validation failure
+already takes: back to the revision node with the errors as feedback, applied
+as edit blocks (#2200) so everything unnamed survives byte-identical. These
+tests hold that edge open, hold the regeneration shut, and pin the two
+terminal states — a repair that cannot be expressed as edits, and a repair
+budget that runs out.
+
+Fixture note. `boostgauge-7-234943-005-draft.md` is that run's draft 005,
+byte-for-byte, and its role here is the APPROVED document whose content the
+repair must preserve. It is no longer the failure TRIGGER: #2232 (482680dc)
+landed after the issue was filed and normalised the none-vocabulary, so the
+`- [ ] None` scaffold this draft carries no longer blocks once the review
+node reports NONE. Both replacement triggers the issue's fixture note offers
+are exercised below — a genuine unchecked question, which still blocks by
+design, and a directly injected validation error, which covers finalize
+failures that have nothing to do with open questions.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.llm_provider import LLMCallResult
+from assemblyzero.workflows.requirements.graph import (
+    create_requirements_graph,
+    route_after_finalize,
+    route_after_generate_draft,
+)
+from assemblyzero.workflows.requirements.nodes.finalize import (
+    MAX_FINALIZE_REPAIRS,
+    finalize,
+    open_questions_settled,
+    validate_lld_final,
+)
+
+fz = import_module("assemblyzero.workflows.requirements.nodes.finalize")
+gd = import_module("assemblyzero.workflows.requirements.nodes.generate_draft")
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "tests" / "fixtures" / "lld_revision"
+
+#: The one line in draft 005's Open Questions section, and a genuine question
+#: to stand in its place. #2232's own negative tests pin that a real unchecked
+#: question still blocks finalize, which is what makes it a valid trigger.
+NONE_SCAFFOLD = "- [ ] None"
+REAL_QUESTION = "- [ ] Should the config file live in APPDATA instead of the project root?"
+ANSWERED = "- [x] Resolved: the config file lives in the project root."
+
+
+@pytest.fixture(scope="module")
+def draft_005() -> str:
+    return (FIXTURES / "boostgauge-7-234943-005-draft.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def blocked_draft(draft_005) -> str:
+    """Draft 005 with a genuine open question in place of the scaffold."""
+    return draft_005.replace(NONE_SCAFFOLD, REAL_QUESTION, 1)
+
+
+def _result(response: str) -> LLMCallResult:
+    return LLMCallResult(
+        success=True,
+        response=response,
+        raw_response=response,
+        error_message=None,
+        provider="fake",
+        model_used="fake-model",
+        duration_ms=1,
+        attempts=1,
+    )
+
+
+def _edit_block(search: str, replace: str) -> str:
+    return f"<<<<<<< SEARCH\n{search}\n=======\n{replace}\n>>>>>>> REPLACE"
+
+
+class _Recorder:
+    """A drafter that records every call and replays canned responses."""
+
+    def __init__(self, *responses: str) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs) -> LLMCallResult:
+        self.calls.append(kwargs)
+        if not self._responses:
+            raise AssertionError(
+                "drafter invoked more times than the test supplied responses; "
+                "a repair makes exactly one call and never falls back"
+            )
+        return _result(self._responses.pop(0))
+
+
+@pytest.fixture
+def approved_state(tmp_path, blocked_draft):
+    """An APPROVED LLD sitting at finalize with a blocking open question."""
+    audit = tmp_path / "audit"
+    audit.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return {
+        "workflow_type": "lld",
+        "assemblyzero_root": str(ROOT),
+        "target_repo": str(repo),
+        "audit_dir": str(audit),
+        "config_mock_mode": False,
+        "config_drafter": "fake:model",
+        "issue_number": 7,
+        "issue_title": "configuration file and CLI arguments",
+        "issue_body": "the issue body",
+        "current_draft": blocked_draft,
+        "lld_status": "APPROVED",
+        "open_questions_status": "UNANSWERED",
+        "verdict_count": 1,
+        "draft_count": 3,
+        "iteration_count": 5,
+        "max_iterations": 3,
+    }
+
+
+@pytest.fixture
+def quiet_finalize(monkeypatch):
+    """Finalize's real validation and save logic, without git or telemetry."""
+    monkeypatch.setattr(fz, "_commit_and_push_files", lambda state: state)
+    monkeypatch.setattr(fz, "log_workflow_execution", lambda **kw: None)
+    monkeypatch.setattr(fz, "move_lineage_to_done", lambda *a, **k: None)
+    monkeypatch.setattr(fz, "update_lld_status", lambda **kw: None)
+
+
+def _revise(monkeypatch, state, drafter):
+    monkeypatch.setattr(gd, "get_provider", lambda spec, *a, **k: drafter)
+    return gd.generate_draft(state)
+
+
+# ---------------------------------------------------------------------------
+# The regression fixture (acceptance 2)
+# ---------------------------------------------------------------------------
+
+
+class TestTheDiscardedApprovedDraft:
+    def test_the_fixture_is_the_run_issue7_234943_artifact(self, draft_005):
+        """358 lines, the run's title, and the scaffold it died on."""
+        assert len(draft_005.splitlines()) == 358
+        assert draft_005.startswith(
+            "# Issue #7 - Feature: configuration file and CLI arguments"
+        )
+        assert NONE_SCAFFOLD in draft_005
+
+    def test_2232_is_why_the_scaffold_no_longer_triggers_the_block(self, draft_005):
+        """The fixture note, asserted rather than trusted.
+
+        A fresh reader following the issue body literally would use `- [ ]
+        None` as the failing input and find it passes. It passes because the
+        review node reports NONE for a draft that asks nothing, and #2232
+        widened the settled-statuses to include it.
+        """
+        assert open_questions_settled("NONE") is True
+        assert validate_lld_final(draft_005, open_questions_resolved=True) == []
+
+    def test_a_genuine_open_question_still_blocks_finalize(self, blocked_draft):
+        """So it is a valid replacement trigger, per the issue's fixture note."""
+        assert open_questions_settled("UNANSWERED") is False
+        errors = validate_lld_final(blocked_draft, open_questions_resolved=False)
+        assert "Unresolved open questions remain" in errors
+
+    def test_draft_005_plus_its_finalize_error_yields_a_one_edit_repair(
+        self, monkeypatch, approved_state, quiet_finalize, blocked_draft, tmp_path
+    ):
+        """The whole acceptance, end to end, on the real artifact.
+
+        Finalize blocks, the router sends it to the revision node, the model
+        names ONE edit, and the patched document passes the same finalize gate
+        that just rejected it. No stage failed and nothing was regenerated.
+        """
+        blocked = finalize(dict(approved_state))
+        assert blocked["finalize_repair_pending"] is True
+        assert route_after_finalize(blocked) == "N1_generate_draft"
+
+        drafter = _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+        revised = _revise(monkeypatch, blocked, drafter)
+
+        assert len(drafter.calls) == 1
+        assert revised["current_draft"] == blocked_draft.replace(
+            REAL_QUESTION, ANSWERED, 1
+        )
+
+        repaired = dict(blocked)
+        repaired.update(revised)
+        done = finalize(repaired)
+
+        assert done.get("error_message", "") == ""
+        assert not done.get("finalize_repair_pending")
+        assert Path(done["final_lld_path"]).is_file()
+        assert route_after_finalize(done) == "END"
+
+    def test_the_repair_preserves_everything_it_did_not_name(
+        self, monkeypatch, approved_state, quiet_finalize, blocked_draft
+    ):
+        """357 of the fixture's 358 lines come through byte-identical."""
+        blocked = finalize(dict(approved_state))
+        revised = _revise(
+            monkeypatch, blocked, _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+        )
+
+        before = blocked_draft.splitlines()
+        after = revised["current_draft"].splitlines()
+        assert len(before) == len(after) == 358
+        differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+        assert differing == [9]
+
+    def test_an_injected_finalize_error_routes_the_same_way(
+        self, monkeypatch, approved_state, quiet_finalize, draft_005
+    ):
+        """The issue's second reproduction: a failure unrelated to questions.
+
+        The routing is a property of finalize's gate, not of the checkbox that
+        happened to trip it, so an arbitrary validation error must take the
+        identical edge.
+        """
+        state = dict(approved_state)
+        state["current_draft"] = draft_005
+        state["open_questions_status"] = "NONE"
+        monkeypatch.setattr(
+            fz, "validate_lld_final", lambda *a, **k: ["Unresolved TODO in table cell"]
+        )
+
+        blocked = finalize(state)
+
+        assert blocked["finalize_repair_pending"] is True
+        assert blocked["validation_errors"] == ["Unresolved TODO in table cell"]
+        assert route_after_finalize(blocked) == "N1_generate_draft"
+
+
+# ---------------------------------------------------------------------------
+# Routing, not regeneration (acceptance 1)
+# ---------------------------------------------------------------------------
+
+
+class TestRoutesToRevision:
+    def test_the_graph_carries_the_finalize_to_revision_edge(self):
+        """The edge itself. Before #2233 this was an unconditional N5 -> END."""
+        edges = {
+            (e.source, e.target)
+            for e in create_requirements_graph().compile().get_graph().edges
+        }
+
+        assert ("N5_finalize", "N1_generate_draft") in edges
+        assert ("N5_finalize", "__end__") in edges
+
+    def test_a_blocked_finalize_does_not_fail_the_stage(
+        self, approved_state, quiet_finalize
+    ):
+        """error_message is the channel the orchestrator reads to retry.
+
+        Leaving it empty is what stops `Stage 'lld' failed (attempt 1/3)` and
+        the regeneration that followed it.
+        """
+        blocked = finalize(dict(approved_state))
+
+        assert blocked.get("error_message", "") == ""
+        assert "Unresolved open questions remain" in blocked["validation_errors"]
+
+    def test_a_blocked_finalize_saves_nothing(self, approved_state, quiet_finalize):
+        """No LLD on disk, no completion logged, no lineage moved."""
+        blocked = finalize(dict(approved_state))
+
+        assert not blocked.get("final_lld_path")
+        assert not blocked.get("created_files")
+        lld_dir = Path(approved_state["target_repo"]) / "docs" / "lld" / "active"
+        assert not lld_dir.exists()
+
+    def test_the_completion_log_does_not_fire_on_a_repair(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        """A repair request is not a completed workflow.
+
+        The completion log gates on error_message, which this path deliberately
+        leaves empty, so without the early return it would record a blocked
+        draft as a finished LLD.
+        """
+        logged: list[dict] = []
+        monkeypatch.setattr(
+            fz, "log_workflow_execution", lambda **kw: logged.append(kw)
+        )
+
+        finalize(dict(approved_state))
+
+        assert logged == []
+
+    def test_the_revision_takes_the_edit_script_path(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        blocked = finalize(dict(approved_state))
+        drafter = _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+
+        _revise(monkeypatch, blocked, drafter)
+
+        content = drafter.calls[0]["content"]
+        assert "<<<<<<< SEARCH" in content
+        assert "Do NOT rewrite it" in content
+
+    def test_the_errors_arrive_as_feedback_naming_the_gate_that_spoke(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        """The document already passed mechanical validation.
+
+        Labelling finalize's errors as mechanical ones sends the model hunting
+        for structural faults that are not there.
+        """
+        blocked = finalize(dict(approved_state))
+
+        context = gd.build_revision_context(blocked)
+
+        assert context.startswith("## FINALIZE VALIDATION ERRORS")
+        assert "Unresolved open questions remain" in context
+        assert "MECHANICAL VALIDATION ERRORS" not in context
+        assert "ACTUAL REPOSITORY STRUCTURE" not in context
+
+    def test_a_mechanical_failure_still_reads_as_mechanical(self, approved_state):
+        """The shared channel did not swallow the older caller."""
+        state = dict(approved_state)
+        state["validation_errors"] = ["Critical: Section 11 missing from LLD"]
+
+        context = gd.build_revision_context(state)
+
+        assert context.startswith("## MECHANICAL VALIDATION ERRORS")
+
+    def test_the_preservation_ratio_is_logged(
+        self, monkeypatch, approved_state, quiet_finalize, capsys
+    ):
+        blocked = finalize(dict(approved_state))
+        capsys.readouterr()
+
+        _revise(
+            monkeypatch, blocked, _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+        )
+
+        out = capsys.readouterr().out
+        assert "[EDIT-SCRIPT] Applied 1 edit(s);" in out
+        assert "of prior draft preserved byte-identical" in out
+
+    def test_the_repair_request_is_consumed_by_the_revision(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        """A stale flag would send every later finalize back to the drafter."""
+        blocked = finalize(dict(approved_state))
+        revised = _revise(
+            monkeypatch, blocked, _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+        )
+
+        assert revised["finalize_repair_pending"] is False
+        assert revised["validation_errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# A repair that cannot be expressed as edits halts (acceptance 3)
+# ---------------------------------------------------------------------------
+
+
+class TestHaltsRatherThanRegenerating:
+    def test_a_redrawn_document_is_refused_and_names_the_contract(
+        self, monkeypatch, approved_state, quiet_finalize, draft_005
+    ):
+        """The drafter answers a repair with a whole document, as one did.
+
+        That response carries no edit blocks, so it is not a revision at all.
+        Nothing is saved and the halt says so.
+        """
+        blocked = finalize(dict(approved_state))
+        drafter = _Recorder(draft_005)
+
+        out = _revise(monkeypatch, blocked, drafter)
+
+        assert "current_draft" not in out
+        assert out["error_message"].startswith("[EDIT-SCRIPT]")
+        assert "no well-formed SEARCH/REPLACE blocks" in out["error_message"]
+        assert "no full-regeneration fallback" in out["error_message"]
+        assert len(drafter.calls) == 1
+
+    def test_the_halt_leaves_the_graph_rather_than_looping(
+        self, monkeypatch, approved_state, quiet_finalize, draft_005
+    ):
+        blocked = finalize(dict(approved_state))
+        out = _revise(monkeypatch, blocked, _Recorder(draft_005))
+
+        state = dict(blocked)
+        state.update(out)
+        assert route_after_generate_draft(state) == "HALT"
+
+    def test_an_unmatched_search_halts_too(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        blocked = finalize(dict(approved_state))
+        drafter = _Recorder(_edit_block("text that is not in the draft", "x"))
+
+        out = _revise(monkeypatch, blocked, drafter)
+
+        assert "SEARCH text not found" in out["error_message"]
+        assert "current_draft" not in out
+
+
+# ---------------------------------------------------------------------------
+# The budget (acceptance 4)
+# ---------------------------------------------------------------------------
+
+
+class TestRepairBudget:
+    def test_a_successful_repair_costs_the_stage_nothing(
+        self, monkeypatch, approved_state, quiet_finalize
+    ):
+        """The orchestrator's retry budget is spent on failed stages only.
+
+        run_lld_stage marks the stage `failed` when no artifact reaches disk,
+        and that is what triggered the discard-and-regenerate. A repair that
+        lands an LLD is a stage that passed on its first attempt.
+        """
+        blocked = finalize(dict(approved_state))
+        revised = _revise(
+            monkeypatch, blocked, _Recorder(_edit_block(REAL_QUESTION, ANSWERED))
+        )
+        repaired = dict(blocked)
+        repaired.update(revised)
+
+        done = finalize(repaired)
+
+        assert done.get("error_message", "") == ""
+        assert Path(done["final_lld_path"]).is_file()
+
+    def test_each_repair_is_counted(self, approved_state, quiet_finalize):
+        state = dict(approved_state)
+        counts = []
+        for _ in range(MAX_FINALIZE_REPAIRS):
+            state = finalize(state)
+            counts.append(state["finalize_repair_count"])
+            assert state["finalize_repair_pending"] is True
+
+        assert counts == [1, 2]
+
+    def test_the_budget_stops_the_loop_and_names_why(
+        self, approved_state, quiet_finalize
+    ):
+        """A repair loop that will not converge is a defect to diagnose."""
+        state = dict(approved_state)
+        for _ in range(MAX_FINALIZE_REPAIRS + 1):
+            state = finalize(state)
+
+        assert state["finalize_repair_pending"] is False
+        assert state["error_message"].startswith("[FINALIZE]")
+        assert "Unresolved open questions remain" in state["error_message"]
+        assert "rather than regenerating" in state["error_message"]
+        assert route_after_finalize(state) == "END"
+
+    def test_the_budget_is_clamped_to_what_the_graph_can_carry(
+        self, approved_state, quiet_finalize
+    ):
+        """A generous iteration cap does not buy more repairs.
+
+        The clamp is not a preference. A third repair costs more super-steps
+        than either caller allows, so raising the cap past it would trade the
+        halt below for a GraphRecursionError that names nothing.
+        """
+        state = dict(approved_state)
+        state["max_iterations"] = 10
+
+        for _ in range(MAX_FINALIZE_REPAIRS):
+            state = finalize(state)
+            assert state["finalize_repair_pending"] is True
+
+        state = finalize(state)
+        assert state["finalize_repair_pending"] is False
+        assert state["error_message"].startswith("[FINALIZE]")
+
+    def test_the_budget_follows_the_workflow_iteration_cap(
+        self, approved_state, quiet_finalize
+    ):
+        state = dict(approved_state)
+        state["max_iterations"] = 1
+
+        # finalize mutates the dict it is handed, so each call gets its own.
+        first = dict(finalize(dict(state)))
+        second = finalize(dict(first))
+
+        assert first["finalize_repair_pending"] is True
+        assert second["finalize_repair_pending"] is False
+        assert second["error_message"].startswith("[FINALIZE]")
+
+    def test_at_least_one_repair_is_always_allowed(
+        self, approved_state, quiet_finalize
+    ):
+        """A cap of zero would silently restore the defect."""
+        state = dict(approved_state)
+        state["max_iterations"] = 0
+
+        assert finalize(state)["finalize_repair_pending"] is True
+
+
+# ---------------------------------------------------------------------------
+# The repair loop fits the graph's step budget
+# ---------------------------------------------------------------------------
+
+
+class TestStepBudget:
+    """The loop must reach its own halt, not a GraphRecursionError.
+
+    LangGraph bounds a run by super-steps. The orchestrator's `run_lld_stage`
+    passes no `recursion_limit`, so it gets LangGraph's default of 25;
+    `tools/run_requirements_workflow.py` computes `(max_iterations * 4) + 10`,
+    which is 22 at the default cap. Every repair round trip spends six of
+    those, and nothing in the graph notices until it runs out.
+
+    That is what MAX_FINALIZE_REPAIRS is for, and a comment asserting it would
+    rot the first time a node is added to the loop. This measures it.
+    """
+
+    @staticmethod
+    def _drive(monkeypatch, repairs: int, recursion_limit: int) -> int:
+        """Run the real compiled graph with every model call stubbed out.
+
+        Returns the number of super-steps consumed, or raises
+        GraphRecursionError exactly as a live run would.
+        """
+        import assemblyzero.workflows.requirements.graph as gr
+
+        blocked = {"n": 0}
+
+        def passthrough(state):
+            return {}
+
+        def fake_review(state):
+            return {
+                "lld_status": "APPROVED",
+                "open_questions_status": "NONE",
+                "verdict_count": state.get("verdict_count", 0) + 1,
+            }
+
+        def fake_draft(state):
+            return {
+                "current_draft": "# doc\n\n## 1. A\n\nbody\n",
+                "draft_count": state.get("draft_count", 0) + 1,
+                "validation_errors": [],
+                "finalize_repair_pending": False,
+                "error_message": "",
+            }
+
+        def fake_finalize(state):
+            if blocked["n"] < repairs:
+                blocked["n"] += 1
+                return {
+                    "finalize_repair_pending": True,
+                    "finalize_repair_count": blocked["n"],
+                    "validation_errors": ["forced"],
+                    "error_message": "",
+                }
+            return {"finalize_repair_pending": False, "final_lld_path": "x.md"}
+
+        for name in (
+            "load_input",
+            "analyze_codebase",
+            "analyze_requirements",
+            "ponder_stibbons_node",
+            "validate_lld_mechanical",
+            "validate_test_plan_node",
+            "human_gate_draft",
+            "human_gate_verdict",
+        ):
+            monkeypatch.setattr(gr, name, passthrough)
+        monkeypatch.setattr(gr, "review", fake_review)
+        monkeypatch.setattr(gr, "generate_draft", fake_draft)
+        monkeypatch.setattr(gr, "finalize", fake_finalize)
+
+        app = gr.create_requirements_graph().compile()
+        steps = 0
+        for _ in app.stream(
+            {
+                "workflow_type": "lld",
+                "config_gates_draft": False,
+                "config_gates_verdict": False,
+                "max_iterations": 3,
+                "issue_number": 7,
+                "target_repo": "repo",
+                "audit_dir": "audit",
+            },
+            config={"recursion_limit": recursion_limit},
+        ):
+            steps += 1
+        return steps
+
+    def test_a_clean_run_costs_nine_steps(self, monkeypatch, capsys):
+        assert self._drive(monkeypatch, repairs=0, recursion_limit=25) == 9
+        capsys.readouterr()
+
+    def test_each_repair_costs_six_more(self, monkeypatch, capsys):
+        one = self._drive(monkeypatch, repairs=1, recursion_limit=25)
+        two = self._drive(monkeypatch, repairs=2, recursion_limit=25)
+        capsys.readouterr()
+
+        assert (one, two) == (15, 21)
+
+    @pytest.mark.parametrize("limit", [25, 22])
+    def test_a_full_repair_budget_fits_both_callers(
+        self, monkeypatch, capsys, limit
+    ):
+        """The binding property. Both real limits, the budget spent in full."""
+        steps = self._drive(
+            monkeypatch, repairs=MAX_FINALIZE_REPAIRS, recursion_limit=limit
+        )
+        capsys.readouterr()
+
+        assert steps <= limit
+
+    def test_one_repair_past_the_budget_is_what_the_clamp_prevents(
+        self, monkeypatch, capsys
+    ):
+        """Mutation: without the clamp, the loop dies namelessly.
+
+        This is the evidence that MAX_FINALIZE_REPAIRS is load-bearing rather
+        than cautious. A third repair does not produce the halt message; it
+        produces a GraphRecursionError.
+        """
+        from langgraph.errors import GraphRecursionError
+
+        with pytest.raises(GraphRecursionError):
+            self._drive(
+                monkeypatch, repairs=MAX_FINALIZE_REPAIRS + 1, recursion_limit=25
+            )
+        capsys.readouterr()
+
+
+# ---------------------------------------------------------------------------
+# Scope: what the routing must not disturb
+# ---------------------------------------------------------------------------
+
+
+class TestScope:
+    def test_a_clean_finalize_still_ends_the_workflow(
+        self, monkeypatch, approved_state, quiet_finalize, draft_005
+    ):
+        state = dict(approved_state)
+        state["current_draft"] = draft_005
+        state["open_questions_status"] = "NONE"
+
+        done = finalize(state)
+
+        assert not done.get("finalize_repair_pending")
+        assert Path(done["final_lld_path"]).is_file()
+        assert route_after_finalize(done) == "END"
+
+    def test_a_non_validation_finalize_error_still_ends_the_workflow(
+        self, approved_state, quiet_finalize
+    ):
+        """Only the validation gate repairs. Everything else fails as before."""
+        state = dict(approved_state)
+        state["issue_number"] = 0
+
+        out = finalize(state)
+
+        assert out["error_message"] == "No issue number for LLD finalization"
+        assert not out.get("finalize_repair_pending")
+        assert route_after_finalize(out) == "END"
+
+    def test_the_issue_workflow_never_asks_for_a_repair(
+        self, monkeypatch, approved_state
+    ):
+        state = dict(approved_state)
+        state["workflow_type"] = "issue"
+        monkeypatch.setattr(
+            fz, "_finalize_issue", lambda s: {"error_message": "", "issue_url": "u"}
+        )
+        monkeypatch.setattr(fz, "log_workflow_execution", lambda **kw: None)
+        monkeypatch.setattr(fz, "_commit_and_push_files", lambda s: s)
+
+        out = finalize(state)
+
+        assert not out.get("finalize_repair_pending")
+        assert route_after_finalize(out) == "END"


### PR DESCRIPTION
## What changed

A finalize validation failure now routes back to the revision node with the
named errors as feedback, which is the same edge a mechanical-validation
failure already takes. It is no longer a stage failure, so the orchestrator
never sees one and never regenerates the attempt.

Before, `_save_lld_file` set `error_message` and returned. The orchestrator
read that as a failed stage and discarded everything the attempt had built:

```
    VALIDATION: BLOCKED: Unresolved open questions remain
[ORCHESTRATOR] Stage 'lld' failed (attempt 1/3). Retrying in 10s...
[ORCHESTRATOR] Next attempt will be regenerated (discarding the previous
attempt's generated files).
```

In `run-issue7-234943` the discarded artifact was an APPROVED draft that had
passed mechanical validation and test-plan validation at 22/22. The
regenerated attempt re-paid the requirements gate, the initial draft, a
mechanical-fix revision and a review, and produced the identical block.

## How

- `finalize.py` gains `_request_finalize_repair`. On a validation failure it
  sets `finalize_repair_pending` and puts the errors on `validation_errors`,
  and deliberately leaves `error_message` empty, because that is the channel
  the orchestrator reads to decide a stage failed. `finalize()` returns right
  after, so the completion log, the lineage move and the commit do not fire on
  a draft that was never saved.
- `graph.py` replaces the unconditional `N5 -> END` edge with conditional
  edges through `route_after_finalize`, which was already written and had
  never been wired.
- N1 sees `validation_errors`, takes the edit-script path from #2200, and
  repairs the named defects in place. Everything it does not name survives
  byte-identical, and the preservation ratio is logged as it is on any other
  revision.
- The feedback block says which gate spoke. A document arriving at a finalize
  repair has already cleared mechanical and test-plan validation, so calling
  its errors mechanical ones sends the model hunting for structural faults
  that are not there. The repository-structure dump is skipped for the same
  reason: it exists to fix bad paths in Section 2.1, and those already passed.
- `finalize_repair_count` bounds the loop. When the budget is spent the run
  stops and names the errors, because a repair loop that will not converge is
  a defect to diagnose rather than one to re-pay for.
- The atlas gains the new successor, which is how its own test caught the
  missing entry.

A repair that cannot be expressed as edits already halts loudly: N1's
edit-script contract has no regeneration fallback, and the halt names the
contract it broke. That path is now pinned by tests from the finalize
direction as well.

## The budget is two, and that is measured

The issue said the iteration cap still bounds the loop. It does, but the cap
is not the binding constraint — the graph's step budget is, and it was not
stated anywhere.

Driving the real compiled graph with every model call stubbed: a clean run
costs 9 super-steps, and each repair round trip (N1, Ponder, N1.5, N1b, N3,
N5) costs 6 more. The orchestrator's `run_lld_stage` passes no
`recursion_limit`, so it takes LangGraph's default of 25;
`tools/run_requirements_workflow.py` computes `(max_iterations * 4) + 10`,
which is 22 at the default cap. Two repairs cost 21 and fit both. Three cost
27 and fit neither, so a budget of 3 could never reach the halt below — it
would raise `GraphRecursionError`, which names nothing about what failed.

`MAX_FINALIZE_REPAIRS = 2` therefore clamps the cap, and `TestStepBudget`
measures all of the above rather than asserting it in a comment, including a
mutation showing that one repair past the budget dies namelessly.

Two is also enough to decide: a defect that survives two surgical repairs of
the named errors is systematic, which is the case this issue was filed about.

The underlying problem — one unstated step budget shared by every loop in the
graph, unset in the orchestrator and undersized in the runner — is not this
issue's to fix and is filed as #2245, with these measurements.

## Fixture

`tests/fixtures/lld_revision/boostgauge-7-234943-005-draft.md` is that run's
draft 005, byte for byte, 358 lines.

Its role is the approved document whose content the repair must preserve. It
is no longer the failure trigger: #2232 landed after this issue was filed and
normalised the none-vocabulary, so the `- [ ] None` scaffold this draft
carries no longer blocks once the review node reports NONE. A fresh reader
following the issue body literally would find the case passes, so the test
asserts that rather than leaving it to be rediscovered.

Both replacements the issue's fixture note offers are exercised: a genuine
unchecked question, which still blocks by design and is pinned by #2232's own
negative tests, and a directly injected validation error, which covers
finalize failures that have nothing to do with open questions. The one-edit
repair changes exactly one of the fixture's 358 lines and passes the same
finalize gate that had just rejected it.

## Tests

32 new tests in `tests/unit/test_finalize_repair_routing.py`, one class per
acceptance criterion plus the step-budget measurement. Full unit suite green.

The atlas test caught the missing `N5 -> N1` successor on the first run, which
is the check doing exactly what #2157 built it for.

Coverage of the four acceptance criteria:

| Criterion | Test |
|---|---|
| Repair produces an edit-script revision, preservation ratio logged | `TestRoutesToRevision::test_the_revision_takes_the_edit_script_path`, `::test_the_preservation_ratio_is_logged` |
| Draft 005 plus its finalize error yields a one-edit revision that passes finalize | `TestTheDiscardedApprovedDraft::test_draft_005_plus_its_finalize_error_yields_a_one_edit_repair` |
| A repair inexpressible as edits halts naming the contract, no regeneration | `TestHaltsRatherThanRegenerating` (3 tests) |
| The stage retry budget is not consumed by a successful repair | `TestRepairBudget::test_a_successful_repair_costs_the_stage_nothing` |

Closes #2233
