### PR TITLE
fix: extract the issue number from the title the drafter actually writes (Closes #2234)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -78,6 +78,33 @@ def _edit_script_halt(reason: str) -> str:
     )
 
 
+#: A conventional-commit type at the head of a title: ``feat:``, ``fix(api):``,
+#: ``refactor!:``. Only the eleven standard types are stripped, so an issue
+#: titled ``config: reload on SIGHUP`` keeps its first word — that is prose,
+#: not a commit convention, and guessing at it would silently rewrite titles.
+_CONVENTIONAL_COMMIT_PREFIX = re.compile(
+    r"^\s*(?:feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)"
+    r"(?:\([^)]*\))?!?:\s*",
+    re.IGNORECASE,
+)
+
+
+def strip_conventional_commit_prefix(title: str) -> str:
+    """Drop a leading conventional-commit type from an issue title (#2234).
+
+    The LLD template's title line is ``# {IssueID} - Feature: {Title}``, so it
+    supplies the label itself. Handing it a title that already begins with
+    ``feat:`` produced ``Feature: feat: configuration file and CLI arguments``
+    on every draft of run-issue7-234943.
+
+    Only the leading type is removed, and only once: a title is not a commit
+    message and the second colon in ``feat: fix: thing`` is the author's.
+    """
+    if not title:
+        return title
+    return _CONVENTIONAL_COMMIT_PREFIX.sub("", title, count=1).strip()
+
+
 def _extract_open_questions(
     provider,
     response: str,
@@ -582,7 +609,12 @@ def _build_prompt(
         input_label = "Brief (user's ideation notes)"
     else:
         issue_number = state.get("issue_number", 0)
-        issue_title = state.get("issue_title", "")
+        # #2234: the template's title slot already reads "Feature: {Title}", so
+        # an issue titled "feat: configuration file" produced
+        # "Feature: feat: configuration file" on every draft. The label is the
+        # template's to supply; the conventional-commit type is the commit
+        # convention's and carries nothing the drafter needs.
+        issue_title = strip_conventional_commit_prefix(state.get("issue_title", ""))
         issue_body = state.get("issue_body", "")
         context_content = state.get("context_content", "")
 

--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -133,8 +133,16 @@ APPROACH_MITIGATION_PATTERNS = [
 # Issue #306: Pattern for extracting issue number from LLD title
 # Supports: hyphen (-), en-dash (–), em-dash (—)
 # Handles leading zeros: # 099 - Feature or # 99 - Feature
+#
+# #2234: the drafter renders the template's `{IssueID}` slot as "Issue #7", not
+# as a bare "7", so every healthy draft of run-issue7-234943 was titled
+# "# Issue #7 - Feature: ..." and warned "Could not extract issue number from
+# title" — with the number sitting at the fourth character. The optional
+# "Issue" word and "#" sigil below are what the drafter actually emits; the
+# digits, the separator and the leading-zero handling are unchanged.
 TITLE_ISSUE_NUMBER_PATTERN = re.compile(
-    r'^#\s+0*(\d+)\s+[-–—]',  # Matches "# 0099 -" or "# 99 –" or "# 99 —"
+    # Matches "# 0099 -", "# 99 –", "# 99 —", "# Issue #7 -", "# issue 7 -"
+    r'^#\s+(?:[Ii]ssue\s+)?#?\s*0*(\d+)\s+[-–—]',
     re.MULTILINE
 )
 
@@ -520,6 +528,7 @@ def extract_title_issue_number(content: str) -> int | None:
     
     Handles:
         - Standard format: # 306 - Feature: Title
+        - Drafter format: # Issue #306 - Feature: Title (#2234)
         - Leading zeros: # 099 - Feature: Title
         - Various dashes: hyphen (-), en-dash (–), em-dash (—)
         

--- a/tests/unit/test_draft_title_composition.py
+++ b/tests/unit/test_draft_title_composition.py
@@ -1,0 +1,118 @@
+"""The drafter is not handed a title that fights the template (#2234).
+
+The LLD template's first line is ``# {IssueID} - Feature: {Title}``, so the
+template supplies the "Feature:" label. Handing it an issue title that already
+begins with a conventional-commit type produced, on every draft of
+run-issue7-234943 (boostgauge, 2026-08-11):
+
+    # Issue #7 - Feature: feat: configuration file and CLI arguments
+
+Cosmetic, and the smaller half of #2234 — but the prefix is the commit
+convention's, not the document's, and it carries nothing the drafter needs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.requirements.nodes.generate_draft import (
+    _build_prompt,
+    strip_conventional_commit_prefix,
+)
+
+
+class TestStripConventionalCommitPrefix:
+    @pytest.mark.parametrize(
+        "title,expected",
+        [
+            # The observed case, from boostgauge #7.
+            (
+                "feat: configuration file and CLI arguments",
+                "configuration file and CLI arguments",
+            ),
+            ("fix: crash on empty config", "crash on empty config"),
+            ("chore: bump deps", "bump deps"),
+            ("docs: explain the gate", "explain the gate"),
+            # Scoped and breaking-change forms.
+            ("feat(config): add a flag", "add a flag"),
+            ("fix(api)!: drop the legacy route", "drop the legacy route"),
+            ("REFACTOR: rename the node", "rename the node"),
+            # Leading whitespace is the author's slip, not a reason to skip.
+            ("  feat: a thing", "a thing"),
+        ],
+    )
+    def test_strips_the_type(self, title, expected):
+        assert strip_conventional_commit_prefix(title) == expected
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            # Not a conventional-commit type — this is prose with a colon, and
+            # rewriting it would silently damage the title.
+            "config: reload on SIGHUP",
+            "Feature: configuration file",
+            "windows: paths are backslashed",
+            # No colon at all.
+            "configuration file and CLI arguments",
+            # A type-like word that is not the prefix.
+            "make the fix: apply it twice",
+        ],
+    )
+    def test_leaves_everything_else_alone(self, title):
+        assert strip_conventional_commit_prefix(title) == title
+
+    def test_strips_only_the_first(self):
+        """A title is not a commit message; the second colon is the author's."""
+        assert (
+            strip_conventional_commit_prefix("feat: fix: the thing")
+            == "fix: the thing"
+        )
+
+    @pytest.mark.parametrize("title", ["", None])
+    def test_tolerates_an_absent_title(self, title):
+        assert strip_conventional_commit_prefix(title) == title
+
+
+class TestPromptComposition:
+    @staticmethod
+    def _state(issue_title: str) -> dict:
+        return {
+            "workflow_type": "lld",
+            "issue_number": 7,
+            "issue_title": issue_title,
+            "issue_body": "the issue body",
+            "current_draft": "",
+            "verdict_history": [],
+            "validation_errors": [],
+            "user_feedback": "",
+            "target_repo": "",
+        }
+
+    def test_the_drafter_never_sees_the_doubled_prefix(self):
+        """The composed input, against the real boostgauge #7 title."""
+        prompt = _build_prompt(
+            self._state("feat: configuration file and CLI arguments"),
+            template="# {IssueID} - Feature: {Title}\n",
+            workflow_type="lld",
+        )
+
+        assert "# Issue #7: configuration file and CLI arguments" in prompt
+        assert "feat:" not in prompt
+
+    def test_a_title_needing_no_strip_is_unchanged(self):
+        prompt = _build_prompt(
+            self._state("configuration file and CLI arguments"),
+            template="# {IssueID} - Feature: {Title}\n",
+            workflow_type="lld",
+        )
+
+        assert "# Issue #7: configuration file and CLI arguments" in prompt
+
+    def test_the_issue_workflow_is_untouched(self):
+        """Issue drafting reads brief_content and has no issue_title path."""
+        state = self._state("feat: a thing")
+        state["workflow_type"] = "issue"
+        state["brief_content"] = "feat: this is the operator's own prose"
+
+        prompt = _build_prompt(state, template="tpl\n", workflow_type="issue")
+
+        assert "feat: this is the operator's own prose" in prompt

--- a/tests/unit/test_validate_mechanical.py
+++ b/tests/unit/test_validate_mechanical.py
@@ -884,6 +884,67 @@ class TestExtractTitleIssueNumber:
         assert result is None
 
 
+class TestDrafterTitleFormat:
+    """The format the drafter actually produces (#2234).
+
+    The template's title line is ``# {IssueID} - Feature: {Title}`` and the
+    drafter renders the slot as "Issue #7", so the number arrives behind a
+    word and a sigil. The pattern expected a bare number, so every healthy
+    draft of run-issue7-234943 (boostgauge, 2026-08-11) warned "Could not
+    extract issue number from title" with the number at character four.
+
+    A warning that fires on every healthy draft is worse than one that never
+    fires: it teaches the operator to skim the warnings channel, and this one
+    did that while a genuine failure was in the same log.
+    """
+
+    #: The two title lines observed on that run, verbatim. They differ only in
+    #: the doubled conventional-commit prefix, which is the cosmetic half of
+    #: the issue and must not affect extraction either way.
+    OBSERVED = [
+        "# Issue #7 - Feature: configuration file and CLI arguments",
+        "# Issue #7 - Feature: feat: configuration file and CLI arguments",
+    ]
+
+    @pytest.mark.parametrize("title", OBSERVED)
+    def test_extracts_from_the_observed_titles(self, title):
+        assert extract_title_issue_number(f"{title}\n\n## 1. Context") == 7
+
+    @pytest.mark.parametrize("title", OBSERVED)
+    def test_the_observed_titles_raise_no_warning(self, title):
+        """The acceptance: zero "could not extract" warnings on a real draft."""
+        errors = validate_title_issue_number(f"{title}\n\n## 1. Context", 7)
+
+        assert [e for e in errors if "Could not extract" in e.message] == []
+        assert errors == []
+
+    def test_extracts_without_the_sigil(self):
+        content = "# Issue 306 - Feature: Test Title\n\n## 1. Context"
+        assert extract_title_issue_number(content) == 306
+
+    def test_extracts_with_leading_zeros_behind_the_word(self):
+        content = "# Issue #0099 - Feature: Test Title\n\n## 1. Context"
+        assert extract_title_issue_number(content) == 99
+
+    def test_a_title_with_no_number_still_warns(self):
+        """The negative case: the check must still be able to fail.
+
+        Widening a pattern until nothing can fail it is not a fix.
+        """
+        content = "# Issue - Feature: configuration file\n\n## 1. Context"
+
+        assert extract_title_issue_number(content) is None
+        errors = validate_title_issue_number(content, 7)
+        assert any("Could not extract" in e.message for e in errors)
+
+    def test_a_wrong_number_is_still_an_error(self):
+        content = "# Issue #8 - Feature: Test Title\n\n## 1. Context"
+
+        errors = validate_title_issue_number(content, 7)
+
+        assert any("doesn't match workflow issue" in e.message for e in errors)
+
+
 class TestValidateTitleIssueNumber:
     """Tests for validate_title_issue_number function."""
 


### PR DESCRIPTION
## What changed

`TITLE_ISSUE_NUMBER_PATTERN` now accepts the title format the drafter actually
produces, so mechanical validation stops warning about a number it can see.

The template's title line is `# {IssueID} - Feature: {Title}`, and the drafter
renders the slot as `Issue #7` rather than a bare `7`. The pattern required a
bare number immediately after the hash, so every healthy draft of
run-issue7-234943 (boostgauge, 2026-08-11) warned:

```
# Issue #7 - Feature: configuration file and CLI arguments
    WARNING [Title]: Could not extract issue number from title
```

with the number at the fourth character.

The optional `Issue` word and `#` sigil are added; the digits, the separator
alternatives and the leading-zero handling are untouched.

## Why a warning-level defect was worth fixing

It never blocked anything, which is what made it corrosive. A warning that
fires on every healthy draft teaches the operator to skim the warnings
channel, and on the night it was noticed it fired alongside a genuine failure
and made the pipeline look broadly broken. Fix the check rather than let it
cry.

## The doubled prefix

The issue's cosmetic half, done in the same pass. `Feature: feat: ...` came
from composing the template's own `Feature:` label with an issue title that
already carried a conventional-commit type. `strip_conventional_commit_prefix`
removes the leading type when the title is composed into the drafter's input,
so the label the template supplies is the only one.

Only the eleven standard types are stripped, only at the head, and only once.
An issue titled `config: reload on SIGHUP` keeps its first word — that is prose
with a colon, not a commit convention, and guessing at it would silently
rewrite titles.

## Tests

`tests/unit/test_validate_mechanical.py::TestDrafterTitleFormat` carries the
two observed title lines verbatim, asserts extraction and a clean error list
for each, and keeps the negative cases: a title genuinely lacking a number
still warns, and a title carrying the wrong number is still an error. Widening
a pattern until nothing can fail it is not a fix, so both negatives are pinned.

`tests/unit/test_draft_title_composition.py` covers the prefix strip, both what
it removes and what it must leave alone.

Cross-checked against the real artifact rather than only against constructed
strings: `tests/fixtures/lld_revision/boostgauge-7-234943-005-draft.md`, the
draft that produced the warning, now extracts 7 with an empty error list.

Full unit suite green.

| Criterion | Test |
|---|---|
| The extractor accepts the observed formats, with the two title lines as test cases | `TestDrafterTitleFormat::test_extracts_from_the_observed_titles` |
| Zero "Could not extract issue number" warnings on a draft titled in either format | `TestDrafterTitleFormat::test_the_observed_titles_raise_no_warning` |
| A title genuinely lacking a number still warns, covered by a negative test | `TestDrafterTitleFormat::test_a_title_with_no_number_still_warns` |
| Conventional-commit prefix stripped when composing the draft title | `TestPromptComposition::test_the_drafter_never_sees_the_doubled_prefix` |

Closes #2234
