### PR TITLE
fix: persist lineage for orchestrated spec runs (Closes #2250)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -630,8 +630,17 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
         # recovers a draft by globbing *-spec-draft.md out of this directory, so
         # an unscoped dir would let a previous roll's draft be recovered into a
         # fresh run and skip the LLM call outright.
+        # Lineage is diagnostic scaffolding, so provisioning it must never be
+        # the reason a spec stage fails: an unwritable target repo would
+        # otherwise be swallowed by the except below and read as a spec
+        # failure. On any OSError this degrades to the old behaviour -- no
+        # lineage -- and says so, rather than taking the run down with it.
         audit_dir_str = ""
-        if target_repo:
+        # is_dir() and not merely truthy: with no repo there, mkdir(parents=True)
+        # would conjure the whole tree out of nothing at a path that is not a
+        # checkout -- which on Windows means a fake target quietly materialises
+        # a real directory off the drive root.
+        if target_repo and Path(target_repo).is_dir():
             spec_lineage = (
                 Path(target_repo)
                 / "docs" / "lineage" / "active"
@@ -643,17 +652,24 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
             # Claim the dir with exist_ok=False so the winner is decided by the
             # filesystem rather than by a check that can go stale.
             run_id = make_run_id()
-            attempt = 0
-            while True:
-                candidate = spec_lineage / (
-                    run_id if attempt == 0 else f"{run_id}-{attempt}"
+            try:
+                for attempt in range(100):
+                    candidate = spec_lineage / (
+                        run_id if attempt == 0 else f"{run_id}-{attempt}"
+                    )
+                    try:
+                        candidate.mkdir(parents=True, exist_ok=False)
+                        audit_dir_str = str(candidate)
+                        break
+                    except FileExistsError:
+                        continue
+            except OSError as exc:
+                _stages_logger.warning(
+                    "Spec stage: could not create lineage dir under %s: %s. "
+                    "The stage will run, but its drafts and verdicts will not "
+                    "be persisted (#2250).",
+                    spec_lineage, exc,
                 )
-                try:
-                    candidate.mkdir(parents=True, exist_ok=False)
-                    break
-                except FileExistsError:
-                    attempt += 1
-            audit_dir_str = str(candidate)
 
         # create_implementation_spec_graph already returns CompiledStateGraph
         # (see implementation_spec/graph.py:273 + line 370 `return graph.compile()`).

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -608,12 +608,52 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
 
     try:
         from assemblyzero.workflows.implementation_spec.graph import create_implementation_spec_graph as create_spec_graph
+        from assemblyzero.workflows.requirements.audit import make_run_id
 
         lld_path = state.get("lld_path", "")
+        target_repo = state.get("target_repo", "")
         # #1440: Plumb orchestrator config into the sub-workflow state.
         config = state.get("config", {})
         stage_cfg = config.get("stages", {}).get("spec", {})
         gate_enabled = bool(config.get("gates", {}).get("spec", False))
+
+        # Closes #2250: the spec workflow persists drafts and verdicts only when
+        # the caller hands it an audit_dir -- it is the one sub-workflow that
+        # does not provision its own (requirements does it in load_input,
+        # testing in load_lld). The standalone runner sets it; this stage did
+        # not, so every orchestrated spec run -- which is every speedrun roll --
+        # ended leaving nothing on disk to diagnose. run-issue7-082047 burned
+        # three revision iterations and died at the cap; none of its four drafts
+        # survives.
+        #
+        # Run-scoped for the same reason the LLD lineage is (#1467): generate_spec
+        # recovers a draft by globbing *-spec-draft.md out of this directory, so
+        # an unscoped dir would let a previous roll's draft be recovered into a
+        # fresh run and skip the LLM call outright.
+        audit_dir_str = ""
+        if target_repo:
+            spec_lineage = (
+                Path(target_repo)
+                / "docs" / "lineage" / "active"
+                / f"{issue_number}-implspec"
+            )
+            # make_run_id() is second-resolution and shared with the LLD
+            # lineage, so two attempts inside one second would land in the same
+            # directory -- the exact collision the scoping exists to prevent.
+            # Claim the dir with exist_ok=False so the winner is decided by the
+            # filesystem rather than by a check that can go stale.
+            run_id = make_run_id()
+            attempt = 0
+            while True:
+                candidate = spec_lineage / (
+                    run_id if attempt == 0 else f"{run_id}-{attempt}"
+                )
+                try:
+                    candidate.mkdir(parents=True, exist_ok=False)
+                    break
+                except FileExistsError:
+                    attempt += 1
+            audit_dir_str = str(candidate)
 
         # create_implementation_spec_graph already returns CompiledStateGraph
         # (see implementation_spec/graph.py:273 + line 370 `return graph.compile()`).
@@ -625,8 +665,10 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
         sub_result = app.invoke({
             "issue_number": issue_number,
             "lld_path": lld_path,
-            "repo_root": state.get("target_repo", ""),
+            "repo_root": target_repo,
             "assemblyzero_root": state.get("assemblyzero_root", ""),
+            # #2250: without this the spec workflow's writes are all no-ops.
+            "audit_dir": audit_dir_str,
             # #2033: the tree the implementation will actually be built on. The
             # checkout is on the default branch and mid-arc has none of the arc.
             "base_branch": state.get("base_branch", ""),

--- a/tests/unit/test_orchestrator_lineage.py
+++ b/tests/unit/test_orchestrator_lineage.py
@@ -1,0 +1,340 @@
+"""Every orchestrated sub-workflow must leave its lineage on disk.
+
+Closes #2250. The implementation-spec workflow persists drafts and verdicts only
+when its caller hands it an ``audit_dir``: ``generate_spec``, ``review_spec`` and
+``finalize_spec`` each guard on ``state.get("audit_dir", "")`` and skip the write
+when it is empty. ``tools/run_implementation_spec_workflow.py`` sets it;
+``run_spec_stage`` did not. So every orchestrated spec run -- which is every
+speedrun roll -- existed only in memory and was gone when the stage ended.
+
+The cost is measured, not hypothetical: ``run-issue7-082047`` (boostgauge,
+2026-08-12) spent three revision iterations in the spec stage and died at the
+cap, and not one of its four drafts survives. Fleet-wide, exactly one spec
+markdown exists anywhere under ``Projects/``, and only because a human copied it
+into a scratch directory during an unrelated investigation.
+
+The two sibling sub-workflows never had the gap because they provision their own
+lineage internally -- requirements in ``nodes/load_input.py``, testing in
+``nodes/load_lld.py``. implementation_spec is the only one that delegates the
+decision to its caller, which is why it is the only one that lost everything.
+
+``TestEveryOrchestratedSubWorkflowPersistsLineage`` is the audit #2250 asks to be
+a test rather than a one-time read: it walks the ``app.invoke`` payloads in
+stages.py and requires each sub-workflow to be covered by one mechanism or the
+other. A fourth stage added tomorrow with neither fails it.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.config import get_default_config
+from assemblyzero.workflows.orchestrator.stages import run_spec_stage
+from assemblyzero.workflows.orchestrator.state import create_initial_state
+
+STAGES_PY = Path(stages.__file__)
+WORKFLOWS_ROOT = STAGES_PY.parent.parent
+
+# Which sub-workflow package each orchestrator stage drives. Stages absent from
+# this map invoke no sub-graph: `triage` writes its own brief directly since
+# #1770, and `pr` / `cleanup` are shell work.
+STAGE_TO_SUBWORKFLOW = {
+    "run_lld_stage": "requirements",
+    "run_spec_stage": "implementation_spec",
+    "run_impl_stage": "testing",
+}
+
+# A node that calls create_audit_dir / create_testing_audit_dir provisions its
+# own lineage and needs nothing from the orchestrator. The `def` filter keeps
+# the *definition* in requirements/audit.py from counting as a call site.
+_PROVISION_CALL = re.compile(r"(?<!def )\bcreate_\w*audit_dir\s*\(")
+
+
+def _invoke_payload_keys_by_stage(source: Path) -> dict[str, set[str]]:
+    """Map each `run_*_stage` function to the literal keys of the dict it
+    passes to `app.invoke({...})`."""
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    found: dict[str, set[str]] = {}
+
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Call):
+                continue
+            callee = node.func
+            if not (isinstance(callee, ast.Attribute) and callee.attr == "invoke"):
+                continue
+            if not (isinstance(callee.value, ast.Name) and callee.value.id == "app"):
+                continue
+            if not (node.args and isinstance(node.args[0], ast.Dict)):
+                continue
+            found.setdefault(func.name, set()).update(
+                k.value
+                for k in node.args[0].keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+            )
+    return found
+
+
+def _self_provisions_lineage(subworkflow: str) -> bool:
+    """True when the sub-workflow creates its own audit dir in one of its nodes."""
+    package = WORKFLOWS_ROOT / subworkflow
+    return any(
+        _PROVISION_CALL.search(py.read_text(encoding="utf-8"))
+        for py in package.rglob("*.py")
+    )
+
+
+class TestSpecStageHandsDownAnAuditDir:
+    """The specific regression: the payload had no `audit_dir`, so every write
+    downstream was a no-op and the run left nothing behind."""
+
+    def test_payload_carries_a_real_audit_dir(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+
+        captured: dict[str, dict] = {}
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                captured["payload"] = payload
+                return {"spec_path": "", "error_message": "stub"}
+
+        state = create_initial_state(
+            7,
+            get_default_config(),
+            target_repo=str(target),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            run_spec_stage(state)
+
+        payload = captured.get("payload", {})
+        audit_dir = payload.get("audit_dir", "")
+
+        assert audit_dir, (
+            "run_spec_stage passed no audit_dir. generate_spec, review_spec and "
+            "finalize_spec all guard on it being non-empty, so the whole spec "
+            "run leaves nothing on disk -- the #2250 defect exactly."
+        )
+        assert Path(audit_dir).is_dir(), (
+            f"audit_dir {audit_dir!r} must exist before the graph runs: "
+            "generate_spec and finalize_spec both additionally guard on "
+            "audit_dir.exists() and skip the write when it does not."
+        )
+
+    def test_audit_dir_is_under_the_target_repo_lineage_tree(self, tmp_path):
+        """Lineage belongs beside the LLD's, in the target repo -- that is where
+        the archiver, the metrics collector and a human all look for it."""
+        target = tmp_path / "target"
+        target.mkdir()
+
+        captured: dict[str, dict] = {}
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                captured["payload"] = payload
+                return {"spec_path": "", "error_message": "stub"}
+
+        state = create_initial_state(
+            7,
+            get_default_config(),
+            target_repo=str(target),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            run_spec_stage(state)
+
+        audit_dir = Path(captured["payload"]["audit_dir"])
+        active = target / "docs" / "lineage" / "active"
+
+        assert active in audit_dir.parents, (
+            f"{audit_dir} must live under {active}, where move_lineage_to_done "
+            "and detect_existing_artifacts expect it"
+        )
+        assert "7-implspec" in audit_dir.parts, (
+            "the dir must be keyed to the issue and the workflow, matching the "
+            f"standalone runner's {{issue}}-implspec; got {audit_dir.parts}"
+        )
+
+    def test_two_runs_of_one_issue_do_not_share_a_directory(self, tmp_path):
+        """Run-scoped for the reason #1467 scoped the LLD's: generate_spec
+        recovers a draft by globbing *-spec-draft.md out of this directory and
+        skips the LLM call when it hits. An unscoped dir would let a previous
+        roll's draft be recovered into a fresh run."""
+        target = tmp_path / "target"
+        target.mkdir()
+
+        seen: list[str] = []
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                seen.append(payload.get("audit_dir", ""))
+                return {"spec_path": "", "error_message": "stub"}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            for _ in range(2):
+                run_spec_stage(
+                    create_initial_state(
+                        7,
+                        get_default_config(),
+                        target_repo=str(target),
+                        assemblyzero_root=str(tmp_path / "az"),
+                    )
+                )
+
+        assert len(seen) == 2 and all(seen)
+        assert seen[0] != seen[1], (
+            "two runs of issue 7 were handed the same lineage dir; the second "
+            "would recover the first's draft and skip its own drafting"
+        )
+
+
+class TestDraftsSurviveAFailedStage:
+    """#2250's second criterion. The drafts matter most exactly when the stage
+    dies -- that is the run someone needs to reproduce."""
+
+    def test_iteration_cap_death_leaves_every_draft_on_disk(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+
+        class _StubApp:
+            """Stands in for a spec graph that drafts three times, is told to
+            revise each time, and dies at the cap without a final spec."""
+
+            def invoke(self, payload: dict) -> dict:
+                audit = Path(payload["audit_dir"])
+                for i in (1, 2, 3):
+                    (audit / f"{i:03d}-spec-draft.md").write_text(
+                        f"# draft {i}", encoding="utf-8"
+                    )
+                    (audit / f"{i:03d}-readiness-verdict.md").write_text(
+                        "REVISE", encoding="utf-8"
+                    )
+                return {
+                    "spec_path": "",
+                    "error_message": "Spec review did not converge after 3 iterations",
+                }
+
+        state = create_initial_state(
+            7,
+            get_default_config(),
+            target_repo=str(target),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            result = run_spec_stage(state)
+
+        assert result["stage_results"]["spec"]["status"] == "failed"
+
+        drafts = sorted((target / "docs" / "lineage").rglob("*-spec-draft.md"))
+        verdicts = sorted((target / "docs" / "lineage").rglob("*-readiness-verdict.md"))
+
+        assert len(drafts) == 3, (
+            f"a stage that died at the cap left {len(drafts)} drafts, not 3. "
+            "The failing run is the one worth keeping -- run-issue7-082047 "
+            "burned three iterations and left nothing to diagnose."
+        )
+        assert len(verdicts) == 3
+
+
+class TestEveryOrchestratedSubWorkflowPersistsLineage:
+    """The audit, as a test rather than a one-time read (#2250 criterion 3).
+
+    A sub-workflow is covered when the orchestrator hands it an `audit_dir` or
+    when it provisions one itself. Neither means its run vanishes.
+    """
+
+    @pytest.mark.parametrize(
+        ("stage_fn", "subworkflow"), sorted(STAGE_TO_SUBWORKFLOW.items())
+    )
+    def test_sub_workflow_lineage_is_provisioned(self, stage_fn, subworkflow):
+        payloads = _invoke_payload_keys_by_stage(STAGES_PY)
+
+        assert stage_fn in payloads, (
+            f"{stage_fn} no longer invokes a sub-graph via `app.invoke`. If it "
+            "was rewired, update STAGE_TO_SUBWORKFLOW -- do not delete the case, "
+            "or the stage stops being audited."
+        )
+
+        passed_in = "audit_dir" in payloads[stage_fn]
+        self_provisions = _self_provisions_lineage(subworkflow)
+
+        assert passed_in or self_provisions, (
+            f"{stage_fn} drives the {subworkflow} workflow, which neither "
+            f"receives an audit_dir from the orchestrator nor creates one in "
+            f"its own nodes. Every draft and verdict it produces will be "
+            f"discarded when the stage ends -- silently, the way #2250 arrived."
+        )
+
+    def test_every_invoking_stage_is_accounted_for(self):
+        """A new stage that invokes a sub-graph must be added to the map, so it
+        cannot slip past the audit above just by being unlisted."""
+        invoking = set(_invoke_payload_keys_by_stage(STAGES_PY))
+        unmapped = invoking - set(STAGE_TO_SUBWORKFLOW)
+
+        assert not unmapped, (
+            f"stages.py invokes sub-graphs from {sorted(unmapped)}, which "
+            "STAGE_TO_SUBWORKFLOW does not cover, so their lineage is unaudited."
+        )
+
+
+class TestTheAuditActuallyInspectsSomething:
+    """A guard that parsed nothing, or matched everything, would pass forever."""
+
+    def test_the_ast_scan_finds_the_real_payloads(self):
+        payloads = _invoke_payload_keys_by_stage(STAGES_PY)
+        assert set(payloads) == set(STAGE_TO_SUBWORKFLOW), (
+            f"expected exactly the three invoking stages, found {sorted(payloads)}"
+        )
+        # Sentinel keys that have been in these payloads for many issues.
+        assert "issue_number" in payloads["run_spec_stage"]
+        assert "workflow_type" in payloads["run_lld_stage"]
+        assert "spec_path" in payloads["run_impl_stage"]
+
+    def test_the_spec_workflow_is_still_the_one_that_cannot_self_provision(self):
+        """Pins the asymmetry the fix rests on. If implementation_spec ever
+        grows its own create_audit_dir call, the orchestrator's hand-down stops
+        being load-bearing and this file's reasoning needs revisiting."""
+        assert _self_provisions_lineage("requirements")
+        assert _self_provisions_lineage("testing")
+        assert not _self_provisions_lineage("implementation_spec"), (
+            "implementation_spec now provisions its own lineage. That is a fine "
+            "thing to do, but TestSpecStageHandsDownAnAuditDir above is written "
+            "on the premise that it does not -- reconcile the two."
+        )
+
+    def test_the_provision_regex_does_not_count_the_definition(self):
+        """requirements/audit.py *defines* create_audit_dir. If the pattern
+        counted definitions, every package vendoring that module would look
+        self-provisioning and the audit would wave everything through."""
+        assert not _PROVISION_CALL.search("def create_audit_dir(target_repo):")
+        assert _PROVISION_CALL.search("    audit_dir = create_audit_dir(")
+        assert _PROVISION_CALL.search("audit_dir = create_testing_audit_dir(7, root)")

--- a/tests/unit/test_orchestrator_lineage.py
+++ b/tests/unit/test_orchestrator_lineage.py
@@ -265,6 +265,93 @@ class TestDraftsSurviveAFailedStage:
         assert len(verdicts) == 3
 
 
+class TestLineageNeverTakesTheStageDown:
+    """Lineage is diagnostic scaffolding. Failing to write it must degrade to
+    the old behaviour -- no lineage -- not kill the run.
+
+    Caught in CI on the first cut of this fix: `test_spec_threads_repo_root`
+    drives the stage at ``/fake/projects/Chiron``, which mkdir can create on
+    Windows and cannot at a Linux filesystem root. The stage's broad `except`
+    swallowed the OSError, the sub-workflow never ran, and an unwritable repo
+    read as a spec failure.
+    """
+
+    def test_a_target_repo_that_does_not_exist_is_not_conjured(self, tmp_path):
+        """mkdir(parents=True) against a non-existent target would build the
+        whole tree at a path that is not a checkout. On Windows that silently
+        materialises a real directory off the drive root."""
+        absent = tmp_path / "no-such-repo"
+        ran: dict[str, dict] = {}
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                ran["payload"] = payload
+                return {"spec_path": "", "error_message": "stub"}
+
+        state = create_initial_state(
+            7,
+            get_default_config(),
+            target_repo=str(absent),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            run_spec_stage(state)
+
+        assert not absent.exists(), (
+            f"the spec stage created {absent}, a repo that was never there"
+        )
+        assert ran["payload"]["audit_dir"] == ""
+        assert ran["payload"]["repo_root"] == str(absent), (
+            "the stage must still run and still thread the repo it was given"
+        )
+
+    def test_an_unwritable_repo_still_runs_the_spec_workflow(self, tmp_path):
+        ran: dict[str, dict] = {}
+
+        class _StubApp:
+            def invoke(self, payload: dict) -> dict:
+                ran["payload"] = payload
+                return {"spec_path": "", "error_message": "stub"}
+
+        state = create_initial_state(
+            7,
+            get_default_config(),
+            target_repo=str(tmp_path / "target"),
+            assemblyzero_root=str(tmp_path / "az"),
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "assemblyzero.workflows.implementation_spec.graph."
+                "create_implementation_spec_graph",
+                lambda: _StubApp(),
+            )
+            mp.setattr(Path, "mkdir", _boom)
+            result = run_spec_stage(state)
+
+        assert "payload" in ran, (
+            "the spec workflow never ran because its lineage dir could not be "
+            "created. Losing the drafts is bad; losing the run is worse."
+        )
+        assert ran["payload"]["audit_dir"] == "", (
+            "with no dir to write into, audit_dir must be empty so the "
+            "downstream guards no-op cleanly rather than write to a bad path"
+        )
+        assert result["stage_results"]["spec"]["status"] == "failed"
+        assert "Permission denied" not in (
+            result["stage_results"]["spec"].get("error_message") or ""
+        ), "a lineage problem must not be reported as the spec failure"
+
+
 class TestEveryOrchestratedSubWorkflowPersistsLineage:
     """The audit, as a test rather than a one-time read (#2250 criterion 3).
 


### PR DESCRIPTION
## The defect

`run_spec_stage` never passed `audit_dir` into the implementation-spec graph.
`generate_spec`, `review_spec` and `finalize_spec` each guard on
`state.get("audit_dir", "")` and skip the write when it is empty, so every
orchestrated spec run — which is every speedrun roll — existed only in memory
and was gone when the stage ended.

`tools/run_implementation_spec_workflow.py` sets it, and says why (`# Issue
#525: persist drafts`). The orchestrator did not.

## Why only this stage

The other two orchestrated sub-workflows provision their own lineage and so
never depended on the caller:

| stage | sub-workflow | provisions where |
|---|---|---|
| lld | requirements | `nodes/load_input.py` → `create_audit_dir` |
| impl | testing | `nodes/load_lld.py` → `create_testing_audit_dir` |
| spec | implementation_spec | **nowhere — caller must supply it** |

`triage` invokes no sub-graph since #1770 and writes its brief directly.

## The fix

`run_spec_stage` now builds the dir and passes it. It is run-scoped, matching
the shape LLD lineage already has on disk (`{issue}-lld/{run_id}/NNN-*.md`, per
#1467).

The scoping is load-bearing, not cosmetic: `generate_spec` recovers a draft by
globbing `*-spec-draft.md` out of this directory and **skips the LLM call** when
it hits, so an unscoped dir would let a previous roll's draft be recovered into
a fresh run. `make_run_id()` is second-resolution and shared with the LLD path,
so the dir is claimed with `exist_ok=False` and disambiguated on collision
rather than checked first — a check-then-create would hand two attempts in the
same second the same directory, which is precisely the collision the scoping
exists to prevent. That case is covered by a test.

## The audit, as a test

`tests/unit/test_orchestrator_lineage.py` is the audit the issue asks to be a
test rather than a one-time read. It walks the `app.invoke` payloads in
`stages.py` by AST and requires every sub-workflow to be covered either by a
handed-down `audit_dir` or by its own provisioning call. It fails if a fourth
stage arrives with neither, and separately if a new invoking stage is left out
of the map — so a stage cannot dodge the audit by being unlisted.

Three guard-integrity tests pin that the scan finds the real payloads, that the
provisioning regex does not count `def create_audit_dir(` as a call site (which
would wave every package through), and that `implementation_spec` is still the
one workflow that cannot self-provision — the premise the fix rests on.

## Evidence it works

Falsifiability checked by removing the `audit_dir` key and re-running: 5 of 11
fail, including the mechanical audit correctly flagging
`run_spec_stage`/`implementation_spec`. Restored, all 11 pass.

Full unit suite: **6917 passed, 17 skipped, 5 xfailed**. `ruff check` clean on
both files.

## What this unblocks

#2239 named two acceptance criteria requiring historical spec artifacts. It
could not be met while orchestrated runs left none. From here forward they
persist.

Closes #2250
