### PR TITLE
fix: stop speedrun unit tests measuring the host (Closes #2248)

### DIFF
--- a/assemblyzero/speedrun/box_health.py
+++ b/assemblyzero/speedrun/box_health.py
@@ -169,13 +169,26 @@ def run_canary(
     return elapsed, ""
 
 
-def snapshot_resources() -> tuple[dict[str, float], list[str]]:
-    """(metrics, unreadable metric names). Never raises."""
+def _import_psutil():
+    """The default reader. Separated so tests can supply their own (#2248)."""
+    import psutil
+    return psutil
+
+
+def snapshot_resources(*, reader=None) -> tuple[dict[str, float], list[str]]:
+    """(metrics, unreadable metric names). Never raises.
+
+    `reader` returns the psutil-like module to measure with, and raises
+    ImportError when there is none. Injecting it lets a caller's tests drive
+    every branch here -- including the no-psutil one -- without patching
+    `psutil` or `builtins.__import__` globally, which is a session-wide change
+    made from inside one test (#2248).
+    """
     metrics: dict[str, float] = {}
     unreadable: list[str] = []
 
     try:
-        import psutil
+        psutil = (reader or _import_psutil)()
     except ImportError:
         return {}, ["memory in use", "running programs", "console windows"]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for unit tests."""
 
+import sys
 from dataclasses import dataclass, field
 from unittest.mock import patch
 
@@ -22,5 +23,44 @@ def _bypass_gemini_preflight():
     with patch(
         "assemblyzero.core.preflight.check_gemini_available",
         return_value=_FakePreflightResult(),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _bypass_box_health_preflight():
+    """Unit tests never depend on the health of the machine running them (#2248).
+
+    `speedrun_roll.main()` runs the real #1920 preflight, which reads live memory
+    with psutil and refuses above 90%, and then spends a full pytest subprocess on
+    the canary. So a test's verdict became a statement about how loaded the box
+    was: two concurrent `pytest tests/unit -k speedrun` runs failed 16 and 17
+    tests, each alone passed, and the failing set differed every time because the
+    second pytest process was itself the load.
+
+    That is the no-false-alarms rule turned on the suite. The gate is right and
+    must stay right for real rolls -- what was missing is the test's isolation --
+    so this stubs the gate rather than loosening it. Ruling the noise out cost
+    about fifteen minutes of control runs while shipping #2234.
+
+    Autouse rather than a per-file `patch.object` because three of the seven
+    speedrun test files already stubbed it by hand and four did not: the eighth
+    file, written next month, would forget too.
+
+    `test_box_health.py` is deliberately unaffected -- it imports
+    `check_box_health` from `assemblyzero.speedrun.box_health` directly, and this
+    rebinds only the name `speedrun_roll` calls through.
+    """
+    module = sys.modules.get("speedrun_roll")
+    if module is None:
+        # Nothing in this session imports the launcher. Test modules are imported
+        # at collection, before any fixture runs, so absence here is real.
+        yield
+        return
+
+    from assemblyzero.speedrun.box_health import BoxHealth
+
+    with patch.object(
+        module, "check_box_health", lambda *a, **k: BoxHealth(True, [], "")
     ):
         yield

--- a/tests/unit/test_box_health.py
+++ b/tests/unit/test_box_health.py
@@ -300,21 +300,16 @@ def test_unreadable_metric_aborts_and_names_it(tmp_path):
     assert "could not be read" in health.message
 
 
-def test_missing_psutil_is_unreadable_not_healthy(monkeypatch, tmp_path):
-    import builtins
-
-    real_import = builtins.__import__
-
-    def no_psutil(name, *args, **kwargs):
-        if name == "psutil":
-            raise ImportError("no psutil")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", no_psutil)
-
+def test_missing_psutil_is_unreadable_not_healthy(tmp_path):
+    """#2248: injected through `reader=` rather than by swapping
+    `builtins.__import__`, which is a session-wide change made from inside one
+    test and can strand any import that runs while it is in place."""
     from assemblyzero.speedrun.box_health import snapshot_resources
 
-    values, unreadable = snapshot_resources()
+    def no_psutil():
+        raise ImportError("no psutil")
+
+    values, unreadable = snapshot_resources(reader=no_psutil)
     assert values == {}
     assert "memory in use" in unreadable
 

--- a/tests/unit/test_speedrun_tests_are_host_independent.py
+++ b/tests/unit/test_speedrun_tests_are_host_independent.py
@@ -1,0 +1,127 @@
+"""A speedrun test's verdict must not depend on the machine running it.
+
+Closes #2248. `speedrun_roll.main()` runs the real #1920 box-health preflight:
+it reads live memory through psutil and refuses above 90%, then spends a whole
+pytest subprocess on the canary. Tests that call `main()` therefore measured the
+host, not the code.
+
+Measured 2026-08-12 on c83f9aff with no source changes: `pytest tests/unit -k
+speedrun` passed alone, twice; two copies run concurrently failed 16 and 17
+tests. The failing set differed every time, because the second pytest process
+was itself the load that pushed the box over the ceiling.
+
+The gate is correct and stays correct for real rolls. What was missing is the
+tests' isolation, so `tests/unit/conftest.py` stubs the gate for every test that
+imports the launcher. These are the guards on that arrangement -- without them
+the fixture could stop engaging and nothing would say so until the next loaded
+afternoon.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+UNIT_DIR = Path(__file__).resolve().parent
+
+# The reads that make a verdict a statement about the host.
+HOST_READS = ("virtual_memory", "process_iter", "cpu_percent", "psutil")
+
+# This file names every needle above -- in HOST_READS itself and in the
+# injection tests, which build a fake psutil on purpose. It is the audit, so it
+# is the one file exempt from it.
+SELF = Path(__file__).name
+
+
+def _audited_files() -> list[Path]:
+    return sorted(p for p in UNIT_DIR.glob("test_speedrun*.py") if p.name != SELF)
+
+
+class TestTheFixtureActuallyEngages:
+    """A stub that quietly stopped applying would look exactly like a pass."""
+
+    def test_the_launcher_gate_is_not_the_real_one(self):
+        assert sr.check_box_health.__module__ != "assemblyzero.speedrun.box_health", (
+            "speedrun_roll.check_box_health is the real preflight during a unit "
+            "test, so this test's verdict depends on how much memory the "
+            "machine happens to be using -- the #2248 defect exactly."
+        )
+
+    def test_the_stub_reports_a_healthy_box(self, tmp_path):
+        health = sr.check_box_health(tmp_path, tmp_path)
+        assert health.ok
+        assert health.message == ""
+
+    def test_the_real_gate_is_still_reachable_where_it_is_tested(self):
+        """The fixture must rebind only the launcher's name. test_box_health.py
+        imports the gate directly and has to get the real one."""
+        from assemblyzero.speedrun import box_health
+
+        assert box_health.check_box_health.__module__ == (
+            "assemblyzero.speedrun.box_health"
+        ), "the fixture leaked past speedrun_roll and blinded box_health's own tests"
+
+
+class TestNoSpeedrunTestReadsTheHost:
+    """The audit, mechanically. A new test file that reaches for psutil fails
+    here rather than on the next loaded afternoon."""
+
+    @pytest.mark.parametrize("path", _audited_files(), ids=lambda p: p.name)
+    def test_no_direct_host_measurement(self, path):
+        source = path.read_text(encoding="utf-8")
+        found = [needle for needle in HOST_READS if needle in source]
+
+        assert not found, (
+            f"{path.name} names {found}, so it measures the machine running it. "
+            "Drive box_health with injected metrics instead -- check_box_health "
+            "takes canary= and resources=, and snapshot_resources takes reader=."
+        )
+
+    def test_the_audit_covers_every_speedrun_file(self):
+        """Pins that the glob finds the files it claims to; a typo'd pattern
+        would make the parametrised test above vacuously green."""
+        names = {p.name for p in _audited_files()}
+        assert len(names) >= 7, f"expected the speedrun test files, found {names}"
+        assert "test_speedrun_roll_attempts.py" in names, (
+            "the file whose failure opened #2248 is not being audited"
+        )
+        assert SELF not in names, "the audit must not audit itself"
+
+
+class TestTheGateItselfIsStillInjectable:
+    """#2248 asks that a future caller be able to do this without a global patch."""
+
+    def test_resources_reader_can_be_supplied(self):
+        from assemblyzero.speedrun.box_health import snapshot_resources
+
+        class _FakePsutil:
+            @staticmethod
+            def virtual_memory():
+                return type("_M", (), {"percent": 42.0})()
+
+            @staticmethod
+            def process_iter(_fields):
+                return [type("_P", (), {"info": {"name": "conhost.exe"}})()]
+
+        values, unreadable = snapshot_resources(reader=lambda: _FakePsutil())
+
+        assert unreadable == []
+        assert values["memory in use"] == 42.0
+        assert values["console windows"] == 1.0
+
+    def test_absent_psutil_needs_no_builtins_patch(self):
+        from assemblyzero.speedrun.box_health import snapshot_resources
+
+        def _no_psutil():
+            raise ImportError("no psutil")
+
+        values, unreadable = snapshot_resources(reader=_no_psutil)
+
+        assert values == {}
+        assert "memory in use" in unreadable


### PR DESCRIPTION
## The defect

`speedrun_roll.main()` runs the real #1920 box-health preflight. It reads live
memory through `psutil.virtual_memory().percent` and refuses above 90%, then
spends a whole pytest subprocess on the canary. Tests that call `main()`
therefore measured the machine rather than the code:

```
tests\unit\test_speedrun_roll_attempts.py:52: in test_a_failed_draw_is_not_redrawn
    assert code == 1
E   assert 91 == 1
BLOCKED: this machine is not healthy enough to run right now.
  memory in use: 90.1% measured, against a normal of 90.0% (above the 90% ceiling)
```

Not a wrong answer — the gate working exactly as designed, in a place it was
never meant to run.

## The fix

**The gate is correct and stays correct for real rolls.** What was missing is
the tests' isolation, so this stubs the gate rather than loosening it. Nothing
about the refusal thresholds changes.

`tests/unit/conftest.py` gains an autouse fixture beside the Gemini-preflight
one already there, on the same principle already established in that file: a
unit test never depends on the environment running it.

Autouse rather than a per-file `patch.object` because **three of the seven
speedrun test files already stubbed it by hand and four did not** — the eighth
file, written next month, would forget too. The acceptance criterion is about
every such test, present and future, so the countermeasure has to be structural.

`test_box_health.py` is deliberately unaffected: it imports `check_box_health`
from `assemblyzero.speedrun.box_health` directly, and the fixture rebinds only
the name `speedrun_roll` calls through. A test pins that separation, so the
fixture cannot silently blind the gate's own tests.

## Injectable reader

`snapshot_resources()` now takes a `reader=`, so a caller's tests can drive
every branch — including the no-psutil one — without a global patch.
`test_missing_psutil_is_unreadable_not_healthy` previously swapped
`builtins.__import__`, a session-wide change made from inside one test that
strands any import running while it is in place. It now injects.

`check_box_health` was already injectable via `canary=` / `resources=`, and the
refusal path already had tests driven by injected metrics — those stay.

## Evidence

Run against the issue's own reproduction, two concurrent copies:

| run | result |
|---|---|
| A | **285 passed, 0 failed** |
| B | **285 passed, 0 failed** |

`grep -c "BLOCKED: this machine"` is `0` in both logs.

The guards are falsifiable: neutering the fixture fails
`test_the_launcher_gate_is_not_the_real_one` and
`test_the_stub_reports_a_healthy_box`. A mechanical audit fails any
`test_speedrun*.py` that names `psutil`, `virtual_memory`, `process_iter` or
`cpu_percent` (the audit file itself is the one documented exemption, and a
separate test pins that the glob still covers the real files — including the one
whose failure opened this issue).

Full unit suite: **6941 passed, 17 skipped, 5 xfailed** — and about 30 seconds
faster, since the canary subprocess is no longer spawned once per test.

Closes #2248
