### PR TITLE
feat: require a test for every LLD pass criterion (Closes #2239)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/criteria_coverage.py
+++ b/assemblyzero/workflows/implementation_spec/criteria_coverage.py
@@ -1,0 +1,284 @@
+"""Every LLD pass criterion must have a test in the spec (#2239).
+
+The spec stage had no mechanical check that the LLD's pass criteria were each
+tested. That judgment lived only in the adversarial reviewer, which makes a miss
+cost a full review iteration and bounds detection by the iteration cap.
+
+run-issue7-082047 (boostgauge, 2026-08-12) is the exhibit. LLD-007 carries
+twenty-two requirements, twelve of them decision-table rows (REQ-9 through
+REQ-20). The drafter omitted the row tests; the reviewer caught it semantically
+in its second REVISE -- "completely omits 12 required state matrix tests" --
+three iterations were spent, and the stage died at the cap with the omission
+among the reasons. Counting is not what a reviewer is for. In that same run it
+also caught a test feeding malformed JSON to dodge type validation, and an
+exception-handling defect that would crash the app and lose user data; those are
+the catches worth ninety seconds of model time. The twelve-test count was not.
+
+The two join modes
+------------------
+
+**exact** -- the criteria carry ``REQ-N`` tags and the spec's tests cite them, so
+the mapping is a join on identifiers. This is what ADR 0226's exact mode gives
+once boostgauge #284 lands row IDs, and what today's tagged LLDs already permit.
+
+**count-and-outcome** -- no usable tags on one side or the other. Criteria are
+matched to tests by outcome text, using the same maximum bipartite matching the
+form checker uses in its no-ID mode (#2219). Greedy assignment is wrong for the
+same reason there: in LLD-007 "unchanged" is a substring of "unchanged; the CLI
+value is not written", so matching in row order can consume the only test a
+later criterion could have used and report a gap that is not there.
+
+The report always names which mode ran, because the weaker mode must never be
+mistaken for the stronger one.
+
+What exact mode still cannot see
+--------------------------------
+
+Two rows may carry the same tag -- LLD-007's rows 040 and 041 are both REQ-4,
+one for ``--reset-config`` alone and one with ``--size`` -- and a single test
+tagged REQ-4 marks both covered. Joining on a tag can only prove a tag was
+tested. Row-level identity is what boostgauge #284 adds, and this check moves to
+it for free when it lands, since the join key is read from the row. Until then
+the residue is one test short on a shared tag, not twelve missing tests, and it
+stays where it already was: with the semantic reviewer.
+
+Reuse, deliberately
+-------------------
+
+``parse_tables``, ``_max_matching`` and ``_norm`` come from the form checker
+rather than being reimplemented here. One markdown-table parser and one matching
+algorithm, used by both callers: a second copy would drift from the first, which
+is the failure this codebase has already paid for twice (#1586, #1698).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.requirements.form_check import (
+    _max_matching,
+    _norm,
+    parse_tables,
+)
+
+#: A criterion tag as it appears in an LLD row or a spec test docstring.
+REQ_TAG = re.compile(r"\bREQ-(\d+)\b", re.IGNORECASE)
+
+#: Fenced blocks, with or without a language hint. Test docstrings live inside
+#: them; prose outside them does not count. spec-0041 says "All test assertions
+#: trace to requirements REQ-1 through REQ-7" in its closing prose -- a range in
+#: a sentence, naming no test, which must not read as coverage of seven.
+_CODE_FENCE = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
+
+_TEST_DEF = re.compile(r"(?m)^[ \t]*(?:async[ \t]+)?def[ \t]+(test_\w+)")
+
+#: The LLD table that states pass criteria. Both shapes in the fleet today are
+#: "| ID | Scenario | Type | ... |", with the assertion in the last column and a
+#: dedicated "Pass Criteria" column in the newer template.
+_SCENARIO_COLUMN = "scenario"
+_CRITERIA_COLUMN = "pass criteria"
+_ID_COLUMN = "id"
+
+MODE_EXACT = "exact (criterion IDs)"
+MODE_OUTCOME = "count and outcome (no IDs to join on)"
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One row of the LLD's pass-criteria table."""
+
+    key: str          # "REQ-9", or the row's own ID when the row carries no tag
+    row_id: str       # the table's ID column, for a report a human can look up
+    scenario: str     # what the row is about, quoted back in the failure
+    outcome: str      # the assertion text, used by count-and-outcome matching
+    tagged: bool      # whether `key` came from a REQ tag
+
+
+@dataclass
+class CoverageReport:
+    ran: bool = False
+    join_mode: str = ""
+    criteria: list[Criterion] = field(default_factory=list)
+    missing: list[Criterion] = field(default_factory=list)
+    test_count: int = 0
+    reason: str = ""          # why it did not run, when it did not
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing
+
+    @property
+    def covered(self) -> int:
+        return len(self.criteria) - len(self.missing)
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def _column(header: list[str], wanted: str) -> int | None:
+    for index, cell in enumerate(header):
+        if _norm(cell) == wanted:
+            return index
+    return None
+
+
+def _req_key(cells: list[str]) -> str | None:
+    """The first REQ tag anywhere in the row, normalised to upper case."""
+    for cell in cells:
+        found = REQ_TAG.search(cell)
+        if found:
+            return f"REQ-{found.group(1)}"
+    return None
+
+
+def lld_criteria(lld: str) -> list[Criterion]:
+    """Every pass criterion stated by the LLD's test-scenario table.
+
+    A table qualifies when it has a Scenario column, or a Pass Criteria column
+    beside an ID column. Anything else in an LLD -- a risk grid, an alternatives
+    table -- is left alone rather than mis-read as criteria, the same
+    conservatism ``is_decision_table`` applies in the form checker.
+    """
+    criteria: list[Criterion] = []
+
+    for table in parse_tables(lld):
+        header = table.header
+        scenario_at = _column(header, _SCENARIO_COLUMN)
+        criteria_at = _column(header, _CRITERIA_COLUMN)
+        id_at = _column(header, _ID_COLUMN)
+
+        if scenario_at is None and not (criteria_at is not None and id_at is not None):
+            continue
+
+        for row in table.rows:
+            if len(row) != len(header) or not any(cell.strip() for cell in row):
+                continue
+
+            row_id = row[id_at].replace("`", "").strip() if id_at is not None else ""
+            scenario = row[scenario_at] if scenario_at is not None else row_id
+            outcome = row[criteria_at] if criteria_at is not None else row[-1]
+
+            tag = _req_key(row)
+            key = tag or row_id
+            if not key:
+                continue
+
+            criteria.append(
+                Criterion(
+                    key=key,
+                    row_id=row_id,
+                    scenario=scenario,
+                    outcome=outcome,
+                    tagged=tag is not None,
+                )
+            )
+
+    return criteria
+
+
+def spec_tests(spec: str) -> list[tuple[str, str]]:
+    """(test name, test source) for every test function in the spec's fences.
+
+    Everything from one ``def test_`` up to the next belongs to the first, which
+    keeps a docstring with its own function without needing to parse the file --
+    spec snippets are frequently not valid standalone modules.
+    """
+    tests: list[tuple[str, str]] = []
+
+    for fence in _CODE_FENCE.findall(spec):
+        found = list(_TEST_DEF.finditer(fence))
+        for index, match in enumerate(found):
+            end = found[index + 1].start() if index + 1 < len(found) else len(fence)
+            tests.append((match.group(1), fence[match.start():end]))
+
+    return tests
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+
+def criteria_coverage(spec: str, lld: str) -> CoverageReport:
+    """Which LLD pass criteria have no test in the spec."""
+    criteria = lld_criteria(lld)
+    if not criteria:
+        return CoverageReport(
+            ran=False,
+            reason="the LLD states no pass-criteria table to check against",
+        )
+
+    tests = spec_tests(spec)
+    if not tests:
+        return CoverageReport(
+            ran=True,
+            join_mode=MODE_EXACT if all(c.tagged for c in criteria) else MODE_OUTCOME,
+            criteria=criteria,
+            missing=list(criteria),
+            test_count=0,
+        )
+
+    tagged_in_spec = {
+        f"REQ-{n}"
+        for _name, body in tests
+        for n in REQ_TAG.findall(body)
+    }
+
+    if all(c.tagged for c in criteria) and tagged_in_spec:
+        missing = [c for c in criteria if c.key not in tagged_in_spec]
+        return CoverageReport(
+            ran=True,
+            join_mode=MODE_EXACT,
+            criteria=criteria,
+            missing=missing,
+            test_count=len(tests),
+        )
+
+    # Fallback: match each criterion's outcome text into a test, one test per
+    # criterion, maximising the number matched.
+    normalised_tests = [_norm(f"{name} {body}") for name, body in tests]
+    candidates = [
+        [
+            index
+            for index, text in enumerate(normalised_tests)
+            if _norm(c.outcome) and _norm(c.outcome) in text
+        ]
+        for c in criteria
+    ]
+    matching = _max_matching(candidates, len(normalised_tests))
+    missing = [c for c, assigned in zip(criteria, matching, strict=False) if assigned is None]
+
+    return CoverageReport(
+        ran=True,
+        join_mode=MODE_OUTCOME,
+        criteria=criteria,
+        missing=missing,
+        test_count=len(tests),
+    )
+
+
+def format_report(report: CoverageReport) -> str:
+    """The failure text the drafter reads. Names every miss at once, so one
+    revision can address the whole set rather than one per iteration."""
+    if not report.ran:
+        return f"Criterion coverage not applicable: {report.reason}."
+
+    head = (
+        f"{report.covered}/{len(report.criteria)} LLD pass criteria have a test "
+        f"across {report.test_count} spec test(s) [join {report.join_mode}]"
+    )
+    if report.ok:
+        return head + "."
+
+    lines = [
+        f"{len(report.missing)} LLD pass criterion(s) have no test in the spec "
+        f"[join {report.join_mode}]. Add a test for each:",
+    ]
+    for c in report.missing:
+        label = c.key if c.tagged else f"row {c.row_id}"
+        where = f" (row {c.row_id})" if c.tagged and c.row_id else ""
+        lines.append(f"  - {label}{where}: {c.scenario} -- expected: {c.outcome}")
+    return "\n".join(lines)

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -33,6 +33,10 @@ from assemblyzero.workflows.implementation_spec.state import (
     ImplementationSpecState,
     PatternRef,
 )
+from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+    criteria_coverage,
+    format_report as format_coverage_report,
+)
 from assemblyzero.workflows.telemetry import (
     build_hallucination_event,
     record_hallucination_event,
@@ -169,6 +173,11 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     )
     checks.append(check_baselines)
     _log_check(check_baselines)
+
+    # Check 9: Every LLD pass criterion must have a test (Issue #2239)
+    check_criteria = check_criteria_have_tests(spec_draft, state.get("lld_content", ""))
+    checks.append(check_criteria)
+    _log_check(check_criteria)
 
     # Telemetry (#1812): record detector outcomes for the spec draft (every
     # pass) and the LLD (first pass only). Record-only — the try/except
@@ -953,6 +962,36 @@ def check_visual_baselines_not_self_referential(
             f"or name an independent reference source for the baselines in "
             f"such a section."
         ),
+    )
+
+
+def check_criteria_have_tests(spec: str, lld_content: str) -> CompletenessCheck:
+    """Every LLD pass criterion must have a test in the spec (Issue #2239).
+
+    The counting job the adversarial reviewer was doing. In run-issue7-082047 it
+    cost three iterations and the stage still died at the cap with "completely
+    omits 12 required state matrix tests" among the reasons; here it is free and
+    names all twelve at iteration zero, so one revision can fix the whole set.
+
+    An LLD with no pass-criteria table is not applicable rather than a failure --
+    the #1870 convention, so a spec that verified almost nothing cannot report a
+    full house.
+    """
+    if not lld_content.strip():
+        return CompletenessCheck(
+            check_name="criteria_have_tests",
+            passed=True,
+            details=(
+                "Criterion coverage not applicable: the LLD was not available to "
+                "this node, so its pass criteria could not be read."
+            ),
+        )
+
+    report = criteria_coverage(spec, lld_content)
+    return CompletenessCheck(
+        check_name="criteria_have_tests",
+        passed=report.ok,
+        details=format_coverage_report(report),
     )
 
 

--- a/tests/fixtures/criteria_coverage/LLD-001.md
+++ b/tests/fixtures/criteria_coverage/LLD-001.md
@@ -1,0 +1,373 @@
+# 1 - Feature: core gauge renderer — analog tachometer with arc, needle, and tick marks
+
+## 1. Context & Goal
+
+### 1.1 Context
+BoostGauge is a real-time system monitor styled like a racing tachometer. This feature builds the core v1 gauge renderer, Phase 4 of the speedrun arc (`#7 -> #1 -> #4 -> #2 -> #5`). It provides the fundamental rendering engine that takes a metric value (0–100) and peak-hold telltale values, rendering them to a deterministic `PIL.Image`.
+
+Per `docs/design/0001-test-strategy.md` (Option C), the rendering engine is fully decoupled from `tkinter`. The renderer runs off-screen using Pillow, enabling 100% headless automated unit and visual regression testing in CI without display server dependencies or `tkinter.Tk()` instantiation.
+
+### 1.2 Open Questions
+- [x] How will skin module registration work when additional skins are added in #45? (Resolved: A skin registry dict mapping skin names to skin renderer modules, defaulting to `"stingray"`).
+- [x] Should anti-aliasing rely on fixed 2x supersampling or configurable quality settings? (Resolved: Fixed 2x internal supersampling with Pillow `LANCZOS` downsampling to balance crispness and sub-5ms render speed).
+- [x] How to ensure font rendering consistency across operating systems during visual regression testing? (Resolved: Use a cross-platform fallback font stack with bundled font asset fallback and strict pixel layout positioning).
+- [x] How to prevent visual regression baseline drift from Pillow library updates? (Resolved: Strictly pin `pillow (>=12.2.0,<13.0.0)` in `pyproject.toml`).
+
+
+## 2. Proposed Changes
+
+*This section is the **source of truth** for implementation. Describe exactly what will be built.*
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/skins/` | Add (Directory) | Directory for skin renderer implementations |
+| `tests/visual/baselines/` | Add (Directory) | Directory storing visual regression baseline images |
+| `src/boostgauge/gauge.py` | Add | Public entry point and skin dispatch facade exposing `render()` |
+| `src/boostgauge/skins/__init__.py` | Add | Skins package initializer exposing skin registry and dispatch interface |
+| `src/boostgauge/skins/stingray.py` | Add | Stingray v1 analog tachometer renderer using off-screen Pillow drawing |
+| `tests/unit/test_gauge.py` | Add | Unit test suite for `render()` facade, validation, clamping, and logic |
+| `tests/visual/test_gauge_visual.py` | Add | Visual regression test suite validating off-screen PIL output against baselines |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks:
+- All "Modify" files must exist in repository
+- All "Delete" files must exist in repository
+- All "Add" files must have existing parent directories (`src/boostgauge/`, `tests/unit/`, `tests/visual/`)
+- No placeholder prefixes (`src/`, `lib/`, `app/`) unless directory exists
+
+### 2.2 Dependencies
+
+```toml
+
+# pyproject.toml additions (if any)
+
+# Explicitly pinned existing dependencies:
+
+# pillow (>=12.2.0,<13.0.0) — pinned to prevent visual baseline RMS drift across releases
+
+# psutil (>=7.2.2,<8.0.0)
+
+# pystray (>=0.19.5,<0.20.0)
+```
+
+### 2.3 Data Structures
+
+```python
+
+# Pseudocode - NOT implementation
+from typing import Dict, Any, Optional, Protocol, TypedDict
+from PIL import Image
+
+class TelltalePeaks(TypedDict, total=False):
+    m1: Optional[float]       # 1-minute window peak value (0-100)
+    m10: Optional[float]      # 10-minute window peak value (0-100)
+    h1: Optional[float]       # 1-hour window peak value (0-100)
+    all_time: Optional[float] # All-time window peak value (0-100)
+
+class GaugeSkin(Protocol):
+    """Protocol for gauge skin renderers per #45."""
+    def render(
+        self,
+        value: float,
+        telltales: Optional[Dict[str, Optional[float]]] = None,
+        size: int = 256,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> Image.Image:
+        """Render skin to a PIL.Image instance."""
+        ...
+```
+
+### 2.4 Function Signatures
+
+```python
+
+# src/boostgauge/gauge.py
+
+def render(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = 256,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Public entry point for gauge rendering.
+
+    Validates arguments, clamps value to [0.0, 100.0], dispatches to configured
+    skin renderer (defaulting to Stingray), and returns rendered PIL.Image.
+    """
+    ...
+
+# src/boostgauge/skins/stingray.py
+
+def render_stingray(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = 256,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Stingray v1 analog tachometer renderer using 2x supersampled Pillow drawing."""
+    ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```python
+
+# Render logic flow
+1. Input Validation & Clamping:
+   - Check if `value` is numeric (int or float). Raise `TypeError` if not.
+   - Clamp `value` to [0.0, 100.0].
+   - Validate `size` >= 128. Raise `ValueError` if size < 128.
+   - Parse `skin_name` from `config` (default "stingray"). Look up renderer in `SKIN_REGISTRY`.
+
+2. Canvas Setup (2x Supersampling):
+   - Internal render dimension = size * 2.
+   - Create RGBA Pillow Image of size (render_dim, render_dim) with transparent background.
+   - Obtain ImageDraw.Draw context.
+
+3. Housing & Face Rendering:
+   - Draw square chromed-metal outer housing (dark silver gradient/bevel border).
+   - Draw round matte-black dial face centered within housing.
+
+4. Ticks & Numerals:
+   - Compute sweep angles: start_angle = 225 deg (bottom-left), end_angle = -45 deg (bottom-right), total 270 deg sweep.
+   - Draw 11 major tick marks (white, thick) for 0, 10, ..., 100.
+   - Draw 4 minor tick marks (white, thin) between each major pair.
+   - Render Eurostile/fallback font numerals (0, 10, ..., 100) positioned radially inside major ticks.
+
+5. Redline Arc & Wordmark:
+   - Draw thick saturated red arc spanning values 60 to 100.
+   - Draw "BOOSTGAUGE" wordmark in white small-caps font below center pivot.
+
+6. Telltale Needles:
+   - If `telltales` dictionary provided:
+     - For each key in ["m1", "m10", "h1", "all_time"]:
+       - If peak_val is not None:
+         - Clamp peak_val to [0.0, 100.0].
+         - Compute angle for peak_val.
+         - Draw translucent secondary needle (semi-transparent accent color) behind main needle.
+
+7. Main Needle & Cap:
+   - Compute angle for main `value`.
+   - Draw solid red needle with circular black/chrome counterweight cap at pivot.
+   - Draw needle polygon layering on top of redline arc and telltales.
+
+8. Downsampling:
+   - Downscale image from (render_dim, render_dim) to (size, size) using Image.Resampling.LANCZOS.
+   - Return final PIL.Image.
+```
+
+### 2.6 Technical Approach
+The rendering pipeline follows Option C from `docs/design/0001-test-strategy.md`. Off-screen rendering uses Pillow `ImageDraw` with internal 2x supersampling (rendering at 512x512 for a 256x256 requested target), followed by `LANCZOS` downsampling. This achieves crisp anti-aliased arcs, ticks, and text without requiring display server hardware or `tkinter.Canvas` APIs.
+
+Font handling resolves through a robust cross-platform fallback stack (`"Eurostile"`, `"DejaVu Sans"`, `"Liberation Sans"`, `"Arial"`, PIL default bitmap font) with pixel coordinate calculations relative to gauge radius, preventing cross-OS text shifts during visual testing.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| GUI Coupling | Direct Canvas drawing vs. Off-screen Image rendering | Off-screen PIL Image rendering (Option C) | Allows 100% automated headless unit and visual regression testing without instantiating `tkinter.Tk()` |
+| Skin Architecture | Monolithic `gauge.py` vs. Modular Skin Strategy (`skins/stingray.py`) | Modular Skin Strategy | Prepares codebase for multi-skin support (#45) while ensuring v1 Stingray implementation remains isolated |
+| Anti-Aliasing | Default Pillow drawing vs. Internal Supersampling | 2x Supersampling + Lanczos downscaling | Pillow line drawing lacks native subpixel anti-aliasing; supersampling delivers high visual fidelity at fast performance (< 5ms) |
+| Font Stack Strategy | OS default font vs. Hardcoded font path vs. Fallback stack | Fallback stack with PIL default fallback | Prevents visual regression test failures across Windows/Linux/macOS CI environments while avoiding strict OS font dependencies |
+| Dependency Pinning | Floating `pillow` vs. Pinned `pillow (>=12.2.0,<13.0.0)` | Pinned dependency range | Prevents RMS pixel drift in visual regression baselines caused by upstream Pillow rasterization updates |
+
+**Architectural Constraints:**
+- Must adhere strictly to binding visual spec `docs/design/0002-aesthetic-v1-stingray.md`.
+- Must adhere strictly to binding GUI testing strategy `docs/design/0001-test-strategy.md` (Option C, zero `tkinter` imports in renderer or tests).
+
+
+## 3. Requirements
+
+1. `render(value, telltales, size, config) -> PIL.Image` MUST be a pure function callable without hidden state, side effects, or `tkinter` imports per Option C in `docs/design/0001-test-strategy.md`.
+2. Input metric values MUST be clamped to the range [0.0, 100.0], and non-numeric inputs MUST raise a `TypeError`.
+3. Gauge sizing MUST default to 256x256 pixels, support custom sizes with locked 1:1 aspect ratio, and enforce a minimum size of 128x128 pixels (raising `ValueError` if smaller).
+4. The Stingray skin renderer MUST render a square chromed-metal housing, round matte-black dial face, 11 major white tick marks (0 to 100), 4 minor tick marks between each major pair, and Eurostile-adjacent white numerals (0, 10, ..., 100) using a cross-platform fallback font stack.
+5. The gauge face MUST feature a saturated red redline arc spanning the metric range 60 to 100 along the tick arc.
+6. The gauge face MUST feature a "BOOSTGAUGE" wordmark rendered in white small caps centered below the needle pivot.
+7. Telltale needles MUST consume `Telltale` peak values (1m, 10m, 1h, all-time), rendering up to 4 translucent secondary needles at their respective scale angles positioned behind the main needle.
+8. The main needle MUST be rendered in solid red with a circular counterweight at the pivot, pointing deterministically to the angle corresponding to `value` (with value 0 at bottom-left start angle and value 100 at rightmost arc end angle).
+9. Output `PIL.Image` objects MUST be deterministic functions of inputs, where two invocations with identical parameters produce byte-identical pixel outputs.
+10. Setting a telltale peak value to `None` (or post-reset) MUST omit rendering that specific telltale needle on the gauge face.
+11. When `value` is in the redline region (e.g. value=75), the main needle MUST render over the redline arc with clear visual layering distinction.
+12. Visual regression output at value=0 with no telltales MUST match the canonical baseline (`tests/visual/baselines/aesthetic-v1-stingray-canonical.png`) within the RMS tolerance (RMS <= 1.0 / 255) specified in `docs/design/0001-test-strategy.md` §3.
+
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Direct `tkinter.Canvas` drawing | Simple initial implementation | Requires GUI display server; untestable in headless CI; poor anti-aliasing | **Rejected** |
+| Vector (SVG) generation & rendering | Resolution independent | Slow rasterization runtime overhead; external dependency requirements | **Rejected** |
+| Off-screen Pillow `PIL.Image` rendering (Option C) | 100% headless automated testability; crisp anti-aliasing via supersampling; fast rendering (< 5ms) | Requires transferring PIL Image to Canvas via `PhotoImage` in app GUI tier | **Selected** |
+
+**Rationale:** Option C completely decouples the rendering engine from GUI frameworks, allowing rigorous TDD and visual regression testing in headless CI environments.
+
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+Input data to `render()` consists of floating-point metric values (0.0 to 100.0) representing ConPTY/resource utilization and a dictionary of peak-hold telltale values (`m1`, `m10`, `h1`, `all_time`).
+
+### 5.2 Data Pipeline
+`SystemSnapshot` -> `Telltale` tracker -> `render(value, telltales, size, config)` -> `PIL.Image` -> `tkinter.PhotoImage` (UI host tier only).
+
+### 5.3 Test Fixtures
+- Canonical baseline image: `tests/visual/baselines/aesthetic-v1-stingray-canonical.png` (256x256 PNG at value=0, telltales=None).
+- Peak-hold test dictionary fixtures: `{ "m1": 25.0, "m10": 50.0, "h1": 75.0, "all_time": 90.0 }`.
+- Partial telltale dictionary fixture: `{ "m1": 40.0, "m10": None, "h1": None, "all_time": 85.0 }`.
+
+### 5.4 Deployment Pipeline
+Visual baselines are committed directly to repository under `tests/visual/baselines/`. Gated CI runs `pytest tests/unit/` and `pytest tests/visual/` headlessly.
+
+
+## 6. Diagram
+
+### 6.1 Mermaid Quality Gate
+Diagram follows standard top-down layout (`TD`) using explicit node shapes and clean flow.
+
+### 6.2 Diagram
+
+```mermaid
+flowchart TD
+    A[Caller / App UI Tier] -->|value, telltales, size, config| B[src/boostgauge/gauge.py: render]
+    B --> C{Input Validation}
+    C -->|Invalid Type| D[Raise TypeError]
+    C -->|size < 128| E[Raise ValueError]
+    C -->|Valid| F[Clamp value to 0..100]
+    F --> G[Dispatch to Skin: stingray.py]
+    G --> H[Create 2x Supersampled Canvas]
+    H --> I[Draw Housing & Matte Black Face]
+    I --> J[Draw Ticks & Numerals]
+    J --> K[Draw Redline Arc & Wordmark]
+    K --> L[Draw Translucent Telltale Needles]
+    L --> M[Draw Main Red Needle & Pivot Cap]
+    M --> N[Downsample 2x via LANCZOS]
+    N --> O[Return PIL.Image]
+```
+
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+- No network requests, subprocess calls, or IPC inside the rendering module.
+- Render parameters are purely numeric and in-memory; no file paths or executable inputs are passed to Pillow font/image routines from untrusted sources.
+
+### 7.2 Safety
+- Out-of-bounds inputs (< 0 or > 100) are safely clamped without throwing unhandled runtime exceptions.
+- Invalid input types (e.g. strings, `None` for value) raise explicit `TypeError` exceptions immediately before processing.
+
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+- **Latency Target:** Sub-5ms render time per frame at 256x256 resolution.
+- **Supersampling Overhead:** 2x supersampling (512x512 intermediate canvas) adds negligible memory (< 1MB temporary buffer) and stays well within the 5ms per-frame render budget.
+- **GC Management:** Reuses temporary draw contexts to avoid unnecessary garbage collection overhead during rapid UI refresh cycles (e.g., 10-20 Hz updates).
+
+### 8.2 Cost Analysis
+No cloud services or external API calls. 100% local CPU off-screen rendering.
+
+
+## 9. Legal & Compliance
+Code licensed under MIT License. No proprietary assets or third-party fonts are bundled without compatible open-source licensing. Fallback font stack uses system-available fonts or PIL default bitmap renderer.
+
+
+## 10. Verification & Testing
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+- **Unit Tests (`tests/unit/test_gauge.py`):** Verify parameter validation, non-numeric `TypeError`, out-of-range clamping, size enforcement `ValueError`, pure function behavior (no `tkinter` imports), and telltale `None` handling.
+- **Visual Regression Tests (`tests/visual/test_gauge_visual.py`):** Verify rendered `PIL.Image` output against baseline goldens (`aesthetic-v1-stingray-canonical.png`) using `ImageChops.difference()` and `ImageStat.Stat(diff).rms`. Enforce RMS <= 1.0 / 255.
+- **Coverage Goal:** 100% line and branch coverage on touched files (`src/boostgauge/gauge.py`, `src/boostgauge/skins/__init__.py`, `src/boostgauge/skins/stingray.py`).
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Target | Details |
+|----|----------|------|--------|---------|
+| 010 | Pure function call without side effects or tkinter imports (REQ-1) | Auto | Unit | Assert `render()` returns `PIL.Image` and `sys.modules` contains no `tkinter` |
+| 020 | Value clamping to [0.0, 100.0] range (REQ-2) | Auto | Unit | Pass -10.0 and 150.0; verify clamped rendering matches 0.0 and 100.0 outputs |
+| 021 | Non-numeric metric value input raises TypeError (REQ-2) | Auto | Unit | Pass `"invalid"` or `None` as value; assert `TypeError` raised |
+| 030 | Default sizing 256x256 and custom size aspect locking (REQ-3) | Auto | Unit | Call `render(50.0)` -> 256x256; `render(50.0, size=512)` -> 512x512 |
+| 031 | Gauge size below 128x128 minimum raises ValueError (REQ-3) | Auto | Unit | Call `render(50.0, size=64)`; assert `ValueError` raised |
+| 040 | Stingray housing, dial face, tick marks, and fallback font numerals rendering (REQ-4) | Auto | Visual | Verify rendered face elements match design layout using baseline diff |
+| 050 | Saturated red redline arc rendering from 60 to 100 (REQ-5) | Auto | Visual | Verify redline sector arc color and position at range 60-100 |
+| 060 | BOOSTGAUGE wordmark rendering below pivot (REQ-6) | Auto | Visual | Verify wordmark presence and position below pivot center |
+| 070 | Render 4 translucent secondary telltale needles behind main needle (REQ-7) | Auto | Visual | Render with 4 telltales; verify secondary needles are drawn behind main needle |
+| 080 | Solid red main needle with pivot counterweight positioned at value angle (REQ-8) | Auto | Visual | Test needle angles at value=0 (start) and value=100 (end of arc) |
+| 090 | Deterministic rendering producing byte-identical outputs for identical inputs (REQ-9) | Auto | Unit | Two separate `render(50.0)` calls produce identical `image.tobytes()` |
+| 100 | Omit specific telltale needle when value is None or post-reset (REQ-10) | Auto | Visual | Set telltale `m10=None`; verify `m10` needle is omitted from output |
+| 110 | Main needle rendered over redline arc at value 75 with clear layering (REQ-11) | Auto | Visual | Render at value=75; verify main needle layers over redline arc correctly |
+| 120 | Visual regression matching canonical baseline at value 0 within RMS tolerance (REQ-12) | Auto | Visual | Compare output at value=0 against baseline golden; assert RMS diff <= 1.0/255 |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run unit tests with coverage
+poetry run pytest tests/unit/test_gauge.py --cov=src/boostgauge --cov-report=term-missing
+
+# Run visual regression tests
+poetry run pytest tests/visual/test_gauge_visual.py
+
+# Generate/update visual baselines explicitly (human-in-the-loop)
+poetry run pytest tests/visual/test_gauge_visual.py --generate-baselines
+```
+
+### 10.3 Manual Tests
+Not applicable for off-screen renderer. Headless automated tests and visual baseline comparisons provide complete verification.
+
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Font rendering variation across OS platforms | Med | Med | Use fallback font stack (`"Eurostile"`, `"DejaVu Sans"`, `"Liberation Sans"`, `"Arial"`, PIL default) with strict pixel layout positioning in Pillow so visual regression tests render consistently across platforms |
+| Anti-aliasing performance overhead from supersampling | Low | Low | Fixed 2x supersampling factor with Pillow Lanczos downsampling keeps render latency < 5ms per frame |
+| Visual regression drift across Pillow library versions | Med | Low | Strict version pinning on `pillow (>=12.2.0,<13.0.0)` in `pyproject.toml` |
+
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] Unit tests pass with 100% line/branch coverage on touched files
+- [ ] Visual regression test suite passes against committed baselines
+- [ ] Option C constraint verified (zero `tkinter` imports in renderer and tests)
+
+### Documentation
+- [ ] Design documentation updated if implementation details diverged
+
+### Review
+- [ ] Peer/Orchestrator review approved
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+- **Requirement 1** covered by scenario `010` in Section 10.1.
+- **Requirement 2** covered by scenarios `020`, `021` in Section 10.1.
+- **Requirement 3** covered by scenarios `030`, `031` in Section 10.1.
+- **Requirement 4** covered by scenario `040` in Section 10.1.
+- **Requirement 5** covered by scenario `050` in Section 10.1.
+- **Requirement 6** covered by scenario `060` in Section 10.1.
+- **Requirement 7** covered by scenario `070` in Section 10.1.
+- **Requirement 8** covered by scenario `080` in Section 10.1.
+- **Requirement 9** covered by scenario `090` in Section 10.1.
+- **Requirement 10** covered by scenario `100` in Section 10.1.
+- **Requirement 11** covered by scenario `110` in Section 10.1.
+- **Requirement 12** covered by scenario `120` in Section 10.1.
+
+
+## Appendix: Review Log
+
+### Orchestrator Review #1
+- Status: REVISED
+- Feedback addressed: Font rendering fallback stack added; Pillow dependency strictly pinned to (>=12.2.0, <13.0.0).
+
+### Review Summary
+Revision complete. All requirements mapped 1:1 to automated test scenarios.
+
+**Final Status:** APPROVED

--- a/tests/fixtures/criteria_coverage/LLD-007.md
+++ b/tests/fixtures/criteria_coverage/LLD-007.md
@@ -1,0 +1,407 @@
+# Issue #7 - Feature: configuration file and CLI arguments
+
+<!-- Template Metadata
+Last Updated: 2026-02-02
+Updated By: Issue #117 fix
+Update Reason: Moved Verification & Testing to Section 10 (was Section 11) to match 0702c review prompt and testing workflow expectations
+Previous: Added sections based on 80 blocking issues from 164 governance verdicts (2026-02-01)
+-->
+
+## 1. Context & Goal
+* **Issue:** #7
+* **Objective:** Implement a configuration system for BoostGauge supporting a JSON config file and CLI argument overrides with strict read/write lifecycle rules.
+* **Status:** Approved (claude-opus-4-6, 2026-08-12)
+* **Related Issues:** None
+
+### Open Questions
+None.
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Core configuration manager, loading, saving, and merging CLI overrides. |
+| `src/boostgauge/app.py` | Add | Integrate `config.py`, parse CLI args via `argparse`, and pass config to components. |
+| `tests/unit/test_config.py` | Add | Unit tests for configuration logic, lifecycle rules, and persistence matrix. |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+*Mechanical validation automatically checks:*
+- All "Modify" files must exist in repository
+- All "Delete" files must exist in repository
+- All "Add" files must have existing parent directories
+- No placeholder prefixes (`src/`, `lib/`, `app/`) unless directory exists
+
+### 2.2 Dependencies
+
+```toml
+
+# pyproject.toml additions (if any)
+
+# No new dependencies needed (using standard library `json`, `argparse`, `pathlib`).
+```
+
+### 2.3 Data Structures
+
+```python
+from typing import TypedDict, Optional
+
+class Thresholds(TypedDict):
+    yellow: int
+    red: int
+
+class ThresholdConfig(TypedDict):
+    conpty: Thresholds
+    memory_percent: Thresholds
+    process_count: Thresholds
+    handle_count: Thresholds
+
+class PositionConfig(TypedDict):
+    x: int
+    y: int
+
+class TelltaleWindows(TypedDict):
+    short: int
+    medium: int
+    long: int
+
+class BoostGaugeConfig(TypedDict, total=False):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: PositionConfig
+    thresholds: ThresholdConfig
+    telltale_windows: TelltaleWindows
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+
+class AppState:
+    config_path: str
+    active_config: BoostGaugeConfig
+    hand_changed_keys: dict[str, any]
+```
+
+### 2.4 Function Signatures
+
+```python
+
+# src/boostgauge/config.py
+from pathlib import Path
+from typing import Any
+
+def get_default_config_path() -> Path:
+    """Returns ~/.boostgauge/config.json or %APPDATA%/boostgauge/config.json."""
+    ...
+
+def get_default_config() -> BoostGaugeConfig:
+    """Returns the hardcoded default configuration dictionary."""
+    ...
+
+def load_config(path: Path) -> BoostGaugeConfig:
+    """Reads JSON config from path. Raises ValueError on invalid format."""
+    ...
+
+def write_config(path: Path, config_data: BoostGaugeConfig) -> None:
+    """Writes the given config_data to path."""
+    ...
+
+def exit_write(path: Path, hand_changed_keys: dict[str, Any]) -> None:
+    """
+    Reads the file on disk (preserving direct edits) and patches in only the keys
+    present in hand_changed_keys (e.g., position, size), then writes back.
+    """
+    ...
+
+# src/boostgauge/app.py
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    """Parses CLI arguments."""
+    ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. Parse CLI arguments
+2. Determine config_path (use --config PATH if provided, else default path)
+3. IF --reset-config is flag is set:
+   - write_config(config_path, get_default_config())
+4. IF config_path does not exist:
+   - write_config(config_path, get_default_config())
+5. active_config = load_config(config_path)
+6. Apply CLI overrides to active_config IN MEMORY (do not modify disk)
+   - e.g., IF args.size: active_config["size"] = args.size
+7. Initialize AppState with active_config and empty hand_changed_keys
+8. Launch Main Window
+   - Window position = active_config["position"]
+   - Window size = active_config["size"]
+9. DURING SESSION:
+   - On periodic tick: read config file from disk to hot-reload threshold values (no write)
+   - On window drag: AppState.hand_changed_keys["position"] = new_position
+   - On window resize: AppState.hand_changed_keys["size"] = new_size
+10. ON EXIT:
+   - IF hand_changed_keys is NOT empty:
+       exit_write(config_path, hand_changed_keys)
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/config.py`
+* **Pattern:** Functional config loader with explicit state tracking for session modifications.
+* **Key Decisions:**
+  - Using standard library `argparse` for CLI arguments to avoid heavy dependencies.
+  - Track `hand_changed_keys` explicitly in memory during the app lifecycle so the exit hook knows exactly what to patch into the file without disturbing direct user edits.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Config Merging | Deep merge vs. Key patch on exit | Key patch on exit | The exit write touches *only* hand-changed keys. The simplest way to guarantee this is to read the latest file on exit, mutate only the specific keys (position, size) recorded in memory, and write it back. |
+| Hot-reload mechanism | File watcher vs. periodic read on tick | Periodic read | Periodic stat/read on the existing polling interval is extremely cheap and requires no threaded watchers, matching the lightweight goal. |
+| CLI Argument parsing | `argparse` vs `click` | `argparse` | `argparse` is standard library, avoiding extra footprint for a lightweight tool. |
+
+**Architectural Constraints:**
+- Must not perform independent process table sweeps (ADR 0001 compliance - not directly affected by this issue, but must be maintained).
+- `tkinter.Tk()` must never be instantiated in tests.
+
+## 3. Requirements
+
+1. First run with no config file creates one with defaults.
+2. Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file.
+3. With no CLI overrides, the window opens at the file's position and size.
+4. Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size.
+5. Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file.
+6. The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size.
+7. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins.
+8. A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit.
+9. Position, no reset, not moved, no direct edits: position unchanged.
+10. Position, no reset, moved, no direct edits: position holds the new position.
+11. Position, reset, not moved, no direct edits: position holds the default.
+12. Position, reset, moved, no direct edits: position holds the new position.
+13. Size, no reset, no `--size`, not resized, no direct edits: size unchanged.
+14. Size, no reset, no `--size`, resized, no direct edits: size holds the new size.
+15. Size, no reset, `--size` given, not resized, no direct edits: size unchanged; the CLI value is not written.
+16. Size, no reset, `--size` given, resized, no direct edits: size holds the new size.
+17. Size, reset, no `--size`, not resized, no direct edits: size holds the default.
+18. Size, reset, no `--size`, resized, no direct edits: size holds the new size.
+19. Size, reset, `--size` given, not resized, no direct edits: size holds the default; the CLI value is not written.
+20. Size, reset, `--size` given, resized, no direct edits: size holds the new size.
+21. Invalid config values produce clear error messages.
+22. `--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments apply to the selected file.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| In-memory diffing for exit | Simple dictionary diff | Would overwrite user's mid-session config file edits with stale memory values. | **Rejected** |
+| Late-read patching on exit | Safely merges hand-made changes (UI) with direct edits | Requires reading disk on exit block | **Selected** |
+
+**Rationale:** The strict requirement that a user's mid-session edits to the config file survive the exit write (unless the same key was hand-changed via the UI) requires reading the file at exit time and only patching the keys explicitly flagged as changed via UI interaction.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Local file system `~/.boostgauge/config.json` |
+| Format | JSON |
+| Size | < 2KB |
+| Refresh | On app launch, on tick (reads), on exit (conditional writes) |
+| Copyright/License | N/A |
+
+### 5.2 Data Pipeline
+
+```
+{Disk Config} ──load()──► {Memory Config} ──apply CLI──► {Active Config}
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Temp Config Path | Generated | Pytest `tmp_path` fixture for safe filesystem testing |
+
+### 5.4 Deployment Pipeline
+
+N/A - Data remains entirely local.
+
+## 6. Diagram
+N/A
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Path Traversal via `--config` | Standard `pathlib.Path` resolution | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Data loss during exit write | Atomic write pattern (write to temp file, rename) | Addressed |
+| Corrupt config file read | Validate JSON schema on read, fallback to defaults or abort with clear message | Addressed |
+
+**Fail Mode:** Fail Closed - If the config file exists but contains invalid JSON that cannot be parsed, the app raises a clear error and refuses to start, rather than silently overwriting the user's broken file.
+**Recovery Strategy:** The user can fix the JSON or run with `--reset-config` to blast it back to defaults.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Exit Write Latency | < 50ms | Single file read/write sequence on exit |
+| Mid-session Config Read | < 10ms | Single file stat/read on tick; non-blocking |
+| Memory | < 1MB | Small dictionary overhead |
+
+**Bottlenecks:** File I/O on tick for hot-reloading could be slow on loaded disks. Mitigate by checking `os.stat().st_mtime` before parsing JSON.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| N/A | N/A | N/A | $0.00 |
+
+**Cost Controls:**
+- [ ] Budget alerts configured at N/A
+- [ ] Rate limiting prevents runaway costs
+- [ ] Fallback to cheaper alternatives when appropriate
+
+**Worst-Case Scenario:** Config file grows massive due to an external process appending garbage. `json.load()` fails, error logged, no crash of system.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | N/A |
+| Third-Party Licenses | No | N/A |
+| Terms of Service | No | N/A |
+| Data Retention | No | N/A |
+| Export Controls | No | N/A |
+
+**Data Classification:** Internal
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. All tests run locally via pytest with temporary directories.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | First run with no config | Creates config.json with defaults | RED |
+| T020 | Launch order logic | Reads config, applies CLI to active config, does not write CLI to disk | RED |
+| T030 | Reset config without size | Overwrites disk with defaults, launches with defaults | RED |
+| T040 | Reset config with size | Overwrites disk with defaults, launches with size N | RED |
+| T050 | Direct file edit tracking | Exit patching only touches hand_changed_keys, leaving edits | RED |
+| T060 | Mid-session manual vs direct conflict | Manual UI change overwrites direct file edit for the same key | RED |
+| T070 | Untouched session guarantees | No exit write; file is byte-identical to launch state | RED |
+| T080 | Matrix: Position | Verifies position logic combinations | RED |
+| T090 | Matrix: Size | Verifies size logic combinations | RED |
+| T100 | Invalid config | Raises ValueError with clear message | RED |
+| T110 | Config flag | File selection applies to targeted path | RED |
+
+**Coverage Target:** 100% for all new code (no defensive branches without tests).
+
+**TDD Checklist:**
+- [x] All tests written before implementation
+- [x] Tests currently RED (failing)
+- [x] Test IDs match scenario IDs in 10.1
+- [x] Test file created at: `tests/unit/test_config.py`
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | First run no config (REQ-1) | Auto | Empty temp dir, launch app | File created | File contains `{"size": 300}` and other defaults |
+| 020 | Launch order / CLI ephemeral (REQ-2) | Auto | Config has `size=300`. CLI args `--size 400` | App `active_config["size"]` is 400 | File on disk remains `{"size": 300}` |
+| 030 | No CLI overrides (REQ-3) | Auto | Config has `size=350, position={"x": 50, "y": 50}` | App opens at 350 size and 50,50 | `active_config` matches file |
+| 040 | Reset config (REQ-4) | Auto | File has size 500, CLI `--reset-config` | File becomes 300 | File contains `300`, app uses `300` |
+| 041 | Reset config with size (REQ-4) | Auto | File has size 500, CLI `--reset-config --size 400` | File becomes 300, app uses 400 | File contains `300`, app uses `400` |
+| 050 | Hot reload and no file modify (REQ-5) | Auto | Write new threshold to disk during session | App sees new threshold | File modification time unchanged by app read |
+| 060 | Exit write patch (REQ-6) | Auto | Direct edit theme="light". Hand change size=600. | File has theme="light" and size=600 | File theme is "light", size is 600 |
+| 070 | Hand change wins conflict (REQ-7) | Auto | Direct edit size=800. Hand change size=600. | File has size=600 | File size is 600 |
+| 080 | Untouched session byte-identical (REQ-8) | Auto | Valid config file. No UI changes. | Exit write skipped | File checksum matches pre-launch checksum |
+| 090 | Pos matrix: no reset, not moved (REQ-9) | Auto | File pos=10,10 | Pos unchanged | File pos remains 10,10 |
+| 100 | Pos matrix: no reset, moved (REQ-10) | Auto | File pos=10,10. Move to 20,20 | Pos 20,20 | File pos is 20,20 |
+| 110 | Pos matrix: reset, not moved (REQ-11) | Auto | File pos=10,10. CLI `--reset-config` | Pos default | File pos is 100,100 |
+| 120 | Pos matrix: reset, moved (REQ-12) | Auto | File pos=10,10. CLI `--reset-config`. Move to 20,20 | Pos 20,20 | File pos is 20,20 |
+| 130 | Size matrix: no reset, no size, not resized (REQ-13) | Auto | File size=400 | Size unchanged | File size is 400 |
+| 140 | Size matrix: no reset, no size, resized (REQ-14) | Auto | File size=400. Resize to 500 | Size 500 | File size is 500 |
+| 150 | Size matrix: no reset, size given, not resized (REQ-15) | Auto | File size=400. CLI `--size 600` | Size unchanged | File size is 400 |
+| 160 | Size matrix: no reset, size given, resized (REQ-16) | Auto | File size=400. CLI `--size 600`. Resize to 500 | Size 500 | File size is 500 |
+| 170 | Size matrix: reset, no size, not resized (REQ-17) | Auto | File size=400. CLI `--reset-config` | Size default | File size is 300 |
+| 180 | Size matrix: reset, no size, resized (REQ-18) | Auto | File size=400. CLI `--reset-config`. Resize to 500 | Size 500 | File size is 500 |
+| 190 | Size matrix: reset, size given, not resized (REQ-19) | Auto | File size=400. CLI `--reset-config --size 600` | Size default | File size is 300 |
+| 200 | Size matrix: reset, size given, resized (REQ-20) | Auto | File size=400. CLI `--reset-config --size 600`. Resize to 500 | Size 500 | File size is 500 |
+| 210 | Invalid config error (REQ-21) | Auto | Config file with `{"size": "not_an_int"}` | ValueError raised | Exception message specifies invalid type |
+| 220 | Config path routing (REQ-22) | Auto | CLI `--config /tmp/custom.json` | Uses custom path | `custom.json` gets default data created |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run all automated tests
+poetry run pytest tests/unit/test_config.py -v
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated.
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| JSON parse error on hot-reload reading mid-session due to partial user save | Medium | Low | `load_config` traps `json.JSONDecodeError` and keeps old values in memory until the next tick reads a valid JSON. |
+| Race condition where exit write clobbers a direct file edit | Low | Low | Read file right before patch write on exit (`exit_write` atomic block). |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold (100% coverage target hit)
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+*Mechanical validation automatically checks:*
+- Every file mentioned in this section must appear in Section 2.1
+- Every risk mitigation in Section 11 should have a corresponding function in Section 2.4 (warning if not)
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| 1 | 2026-08-12 | APPROVED | `claude-opus-4-6` |
+| None | (auto) | PENDING | Initial Draft |
+
+**Final Status:** APPROVED

--- a/tests/fixtures/criteria_coverage/LLD-041.md
+++ b/tests/fixtures/criteria_coverage/LLD-041.md
@@ -1,0 +1,396 @@
+# #41 - Feature: Telltale peak-hold needle logic (pure, no GUI)
+
+## 1. Context & Goal
+
+* **Issue:** #41
+* **Objective:** Implement pure, headless peak-hold "telltale" needle tracking logic over a sliding time window with optional decay for the boostgauge system monitor.
+* **Status:** Approved (claude-opus-4-6, 2026-08-01) / Revised
+* **Related Issues:** #35, #36
+
+
+### Open Questions
+
+- [x] Should `decay_rate` default to `None` (hard hold)? (Resolved: Yes, `decay_rate=None` defaults to hard hold where peak drops instantly to window maximum upon sample expiration).
+- [x] Is the decay floor strictly the highest value remaining in the active time window? (Resolved: Yes, per operator ruling #125, decay never drops below the window maximum).
+
+
+## 2. Proposed Changes
+
+*This section is the **source of truth** for implementation. Describe exactly what will be built.*
+
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/telltale.py` | Add | Implements `Telltale` class for tracking sliding-window peak-hold state with optional decay rate and O(1) amortized operations. |
+| `tests/unit/test_telltale.py` | Add | Comprehensive unit test suite covering initialization, stream update, window expiration, decay interpolation, floor clamping, and reset logic. |
+
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+- `src/boostgauge/telltale.py`: Add — parent directory `src/boostgauge` exists.
+- `tests/unit/test_telltale.py`: Add — parent directory `tests/unit` exists.
+
+
+### 2.2 Dependencies
+
+No new external dependencies required. Uses Python standard library (`collections.deque`, `dataclasses`, `typing`).
+
+
+### 2.3 Data Structures
+
+```python
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass(frozen=True)
+class Sample:
+    """Single numeric observation with timestamp."""
+    timestamp: float
+    value: float
+```
+
+
+### 2.4 Function Signatures
+
+```python
+
+# Signatures only - implementation in source files
+from typing import Optional
+
+class Telltale:
+    """Pure peak-hold telltale needle tracker over a sliding time window."""
+
+    def __init__(self, window: float, decay_rate: Optional[float] = None) -> None:
+        """Initialize Telltale with window duration in seconds (>0) and optional decay rate (units/sec)."""
+        ...
+
+    def update(self, timestamp: float, value: float) -> None:
+        """Feed a new sample (timestamp, value) and update internal sliding window state."""
+        ...
+
+    def current_peak(self, current_time: Optional[float] = None) -> Optional[float]:
+        """Return highest value in window, accounting for optional decay up to current_time."""
+        ...
+
+    def reset(self) -> None:
+        """Clear all sample history and reset telltale state to initial uninitialized state."""
+        ...
+```
+
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+Algorithm: __init__(window, decay_rate=None)
+1. IF window <= 0 THEN raise ValueError("Window duration must be positive")
+2. IF decay_rate IS NOT None AND decay_rate < 0 THEN raise ValueError("Decay rate cannot be negative")
+3. Set self.window = window
+4. Set self.decay_rate = decay_rate
+5. Initialize self.samples = deque()       # Active window samples: Sample(timestamp, value)
+6. Initialize self.max_deque = deque()     # Monotonic peak candidate queue
+7. Set self.latest_timestamp = None
+
+Algorithm: update(timestamp, value)
+1. IF latest_timestamp IS NOT None AND timestamp < latest_timestamp THEN:
+       raise ValueError("Timestamps must be non-decreasing")
+2. Set latest_timestamp = timestamp
+3. Evict samples from `samples` deque where sample.timestamp < timestamp - window
+4. Set window_max = max(sample.value FOR sample IN samples) IF samples is not empty ELSE None
+5. Evict expired peak candidates from front of `max_deque`:
+   IF decay_rate IS None OR decay_rate == 0.0 THEN:
+       Evict sample from front of `max_deque` WHILE max_deque is not empty AND max_deque.front.timestamp < timestamp - window
+   ELSE:
+       Evict sample from front of `max_deque` WHILE max_deque is not empty AND:
+           (max_deque.front.timestamp < timestamp - window) AND
+           (window_max IS NOT None AND (max_deque.front.value - decay_rate * (timestamp - (max_deque.front.timestamp + window))) <= window_max)
+6. Maintain monotonic candidate property in `max_deque`:
+   WHILE max_deque is not empty AND max_deque.back.value <= value:
+       Pop back of max_deque
+7. Append Sample(timestamp, value) to `samples` and `max_deque`
+
+Algorithm: current_peak(current_time=None)
+1. IF samples is empty THEN Return None
+2. Set eval_time = current_time IF current_time IS NOT None ELSE latest_timestamp
+3. IF eval_time < latest_timestamp THEN raise ValueError("Evaluation time cannot precede latest timestamp")
+4. Set window_max = max(sample.value FOR sample IN samples)
+5. IF decay_rate IS None OR decay_rate == 0.0 THEN Return window_max
+6. Calculate candidate peak from active and decaying candidates in `max_deque`:
+   peak_cand = max(
+       sample.value - decay_rate * max(0.0, eval_time - (sample.timestamp + window))
+       FOR sample IN max_deque
+   )
+7. Return max(peak_cand, window_max)
+
+Algorithm: reset()
+1. Clear `samples` deque
+2. Clear `max_deque` deque
+3. Set latest_timestamp = None
+```
+
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/telltale.py`
+* **Pattern:** Monotonic Sliding Window Deque + Linear Interpolation Decay Model.
+* **Key Decisions:**
+  - Double-ended queues (`collections.deque`) maintain sliding window entries and peak candidates in $O(1)$ amortized time.
+  - A candidate sample $(t_i, v_i)$ remains active in `samples` until $t_i + \text{window}$.
+  - When decay is disabled (`decay_rate=None` or `0.0`), expired samples age out immediately from `max_deque`, dropping the peak instantly to `window_max`.
+  - When decay is enabled (`decay_rate > 0.0`), expired candidates in `max_deque` continue to contribute their decayed value $v_i - \text{decay\_rate} \times (t_{\text{eval}} - (t_i + \text{window}))$ until their decayed value reaches the active `window_max` floor or they are superseded by higher samples.
+  - The decay floor is strictly constrained by `window_max`, ensuring the peak never drops below the highest sample currently active in the sliding window.
+
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Window State Tracking | Array scanning, Polling thread, Monotonic deque | Monotonic deque | Amortized $O(1)$ updates and peak queries without thread synchronization overhead. |
+| Decay Floor Enforcement | Constant floor, Sample floor, Sliding window max floor | Sliding window max floor | Adheres strictly to operator ruling #125: peak never drops below highest sample remaining in window. |
+
+**Architectural Constraints:**
+- Pure logic module with zero GUI or rendering dependencies (`tkinter`, `PIL`).
+- Headless deterministic testing support.
+
+
+## 3. Requirements
+
+1. Expose the `Telltale` class in `src/boostgauge/telltale.py` initialized with a positive `window` duration in seconds and an optional `decay_rate` in units per second.
+2. Maintain O(1) amortized time complexity for `update(timestamp, value)` and `current_peak()` operations over sample streams.
+3. Immediately reset and elevate the peak value when a new sample value exceeds the current peak.
+4. Drop the peak instantly to the highest sample value remaining within the active time window when no decay rate is configured (`decay_rate=None`) and a former peak ages out.
+5. Smoothly decay the peak at `decay_rate` units/sec when a former peak ages out with decay enabled, floored at the highest value still in the active window.
+6. Clear all internal state upon calling `reset()`, causing subsequent `current_peak()` calls to return `None` until the next `update()`.
+7. Return `None` from `current_peak()` before any sample has been supplied after initialization or reset.
+
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Polling timer thread for decay | Real-time continuous state updates | Race conditions, non-deterministic in headless tests | Rejected |
+| Full sample array storage | Simple implementation | Linear memory growth over long runtime | Rejected |
+| Monotonic deque with closed-form decay | $O(1)$ amortized time, memory bounded by window sample count, deterministic | Requires careful candidate math | **Selected** |
+
+**Rationale:** Monotonic deque with closed-form evaluation is fast, headless-friendly, exact, and memory-efficient.
+
+
+## 5. Data & Fixtures
+
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Synthetic numeric time-series streams `(timestamp, value)` |
+| Format | `Tuple[float, float]` |
+| Size | Arbitrary length, sample frequency typically 10Hz–100Hz |
+| Refresh | Real-time stream pushing via `update(t, v)` |
+| Copyright/License | N/A |
+
+
+### 5.2 Data Pipeline
+
+```
+Numeric Stream ──update(timestamp, value)──► Sliding Window Deque & Monotonic Max Deque ──current_peak()──► Peak Value (float or None)
+```
+
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Synthetic time-series samples | Generated in `tests/unit/test_telltale.py` | Deterministic timestamps and float values |
+
+
+### 5.4 Deployment Pipeline
+
+Pure Python module packaged via Poetry in PyPI distribution `boostgauge`.
+
+
+## 6. Diagram
+
+
+### 6.1 Mermaid Quality Gate
+
+- [x] **Simplicity:** Monotonic deque update flow clearly separated.
+- [x] **No touching:** Visual node separation maintained.
+- [x] **No hidden lines:** Arrows visible.
+- [x] **Readable:** Text labels concise and readable.
+
+
+### 6.2 Diagram
+
+```mermaid
+sequenceDiagram
+    participant Collector as Data Stream
+    participant Telltale as Telltale Engine
+    participant Deque as Monotonic Deque
+
+    Collector->>Telltale: update(timestamp, value)
+    Telltale->>Deque: Evict samples older than window
+    Telltale->>Deque: Maintain monotonic candidate ordering
+    Telltale->>Deque: Append Sample(timestamp, value)
+    Collector->>Telltale: current_peak(current_time)
+    Telltale->>Deque: Compute max(decayed candidates, window_max)
+    Telltale-->>Collector: Return peak value
+```
+
+
+## 7. Security & Safety Considerations
+
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Input validation | Enforce non-decreasing timestamps and positive window bounds | Addressed |
+
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Unbounded memory growth | Deque eviction limits memory to window sample count | Addressed |
+
+**Fail Mode:** Fail Closed — Raises `ValueError` on invalid arguments (non-positive window, out-of-order timestamps).
+
+
+## 8. Performance & Cost Considerations
+
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| `update()` latency | < 1 µs | Amortized $O(1)$ deque push/pop |
+| `current_peak()` latency | < 1 µs | Max over bounded candidate deque |
+| Memory usage | < 100 KB per instance | Bounded by maximum samples in window duration |
+
+
+### 8.2 Cost Analysis
+
+Local in-memory computation only. No API calls or network resources.
+
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| Third-Party Licenses | No | Pure stdlib implementation under MIT License |
+
+
+## 10. Verification & Testing
+
+*Ref: `docs/design/0001-test-strategy.md`*
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+**Testing Philosophy:** Unit tests in `tests/unit/test_telltale.py` test pure logic headlessly. Per `docs/design/0001-test-strategy.md` §2 Option C, no `tkinter.Tk()` initialization or GUI rendering is involved.
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | Initialization parameters validation | Store window and decay_rate; reject window <= 0 | RED |
+| T020 | Stream update throughput O(1) | Process 10,000 updates within time budget | RED |
+| T030 | Instant peak elevation on new high | Peak immediately equals new high | RED |
+| T040 | Hard hold peak drop to window max | Peak drops to window max when peak ages out with decay_rate=None | RED |
+| T050 | Smooth decay from departed high | Peak decays at decay_rate units/sec after peak ages out | RED |
+| T051 | Decay floor clamping | Peak never drops below highest value still in active window | RED |
+| T060 | Reset state clearing | State cleared; `current_peak()` returns `None` | RED |
+| T070 | Pre-first-update state | `current_peak()` returns `None` on fresh instance | RED |
+
+**Coverage Target:** 100% line and branch coverage on `src/boostgauge/telltale.py`.
+
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | Initialization with valid window and optional decay rate (REQ-1) | Auto | `window=10.0, decay_rate=15.0` | `Telltale` instance created | Attributes set correctly |
+| 011 | Initialization rejects non-positive window duration (REQ-1) | Auto | `window=0.0` or `window=-1.0` | Raises `ValueError` | Exception raised on invalid window |
+| 020 | High-frequency update stream performance O(1) amortized (REQ-2) | Auto | 10,000 sequential `update(t, v)` calls | Total runtime < 0.1s | O(1) amortized throughput maintained |
+| 030 | Rising series immediately elevates peak (REQ-3) | Auto | Stream (0.0, 10.0), (1.0, 20.0), (2.0, 50.0) | `current_peak()` == 50.0 | Peak updates immediately upward |
+| 031 | New sample exceeding decayed peak resets peak upward immediately (REQ-3) | Auto | Sample (0.0, 100.0), t=12.0 (peak decayed to 70.0), sample (12.1, 80.0) | `current_peak()` == 80.0 | Decayed peak resets immediately to 80.0 |
+| 040 | Hard hold peak drop to window max when peak ages out (REQ-4) | Auto | `window=10.0, decay_rate=None`, samples (0.0, 100.0), (5.0, 40.0), t=10.1 | `current_peak()` == 40.0 | Peak drops instantly to active window max |
+| 041 | Single sample peak drops to None after window duration with hard hold (REQ-4) | Auto | `window=10.0, decay_rate=None`, sample (0.0, 50.0), t=10.1 | `current_peak()` == None | Peak drops to None when window empties |
+| 050 | Former high ages out with decay enabled and peak descends at decay_rate (REQ-5) | Auto | `window=10.0, decay_rate=15.0`, samples (0.0, 100.0), (9.0, 40.0), t=12.0 | `current_peak()` == 70.0 | Peak = 100 - 15 * (12 - 10) = 70.0 |
+| 051 | Decaying peak is strictly floored at active window maximum (REQ-5) | Auto | `window=10.0, decay_rate=15.0`, samples (0.0, 100.0), (9.0, 40.0), t=15.0 | `current_peak()` == 40.0 | Unfloored decay 25.0 floored at window max 40.0 |
+| 060 | Reset clears state and current_peak returns None (REQ-6) | Auto | Samples added, then `reset()`, then `current_peak()` | Returns `None` | Internal deques emptied |
+| 061 | Update after reset re-initializes telltale state (REQ-6) | Auto | `reset()`, then `update(20.0, 15.0)` | `current_peak()` == 15.0 | Peak tracking resumes cleanly |
+| 070 | Pre-first-update current_peak returns None (REQ-7) | Auto | `current_peak()` immediately after `__init__` | Returns `None` | Returns `None` |
+
+
+### 10.2 Test Commands
+
+```bash
+
+# Run unit tests for telltale module with coverage
+poetry run pytest tests/unit/test_telltale.py -v --cov=boostgauge.telltale --cov-report=term-missing
+```
+
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios fully automated.
+
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Out-of-order timestamp inputs | Low | Low | `update()` raises `ValueError` if timestamp < latest_timestamp |
+| Floating point decay rounding errors | Low | Low | Precise linear arithmetic floored with `max()` against exact window maximum |
+
+
+## 12. Definition of Done
+
+
+### Code
+- [ ] Implementation complete in `src/boostgauge/telltale.py` and linted
+- [ ] Code comments reference this LLD
+
+
+### Tests
+- [ ] All unit tests pass in `tests/unit/test_telltale.py`
+- [ ] 100% test coverage target reached on `src/boostgauge/telltale.py`
+
+
+### Documentation
+- [ ] LLD updated with any implementation details
+
+
+### Review
+- [ ] Code review completed
+
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+- `src/boostgauge/telltale.py`: Listed in Section 2.1 Files Changed.
+- `tests/unit/test_telltale.py`: Listed in Section 2.1 Files Changed.
+
+
+## Appendix: Review Log
+
+
+### Technical Architect Review #1 (FEEDBACK)
+
+**Reviewer:** Technical Architect
+**Verdict:** FEEDBACK
+
+#### Comments
+
+| ID | Comment | Implemented? |
+|----|---------|--------------|
+| TA1.1 | In Section 2.5 (Algorithm: update, Step 4), evicting samples from `max_deque` when `sample.timestamp < timestamp - window` prematurely deletes peak candidates while they are still actively decaying. The eviction criteria for `max_deque` must be revised to retain peak candidates until their decayed value drops below the current window maximum or until they are superseded by higher values. | YES - Revised Section 2.5 `max_deque` eviction logic to retain peak candidates while their decayed value exceeds `window_max`. |
+
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| 2 | 2026-08-01 | APPROVED | `claude-opus-4-6` |
+| Technical Architect #1 | 2026-08-01 | FEEDBACK | Premature `max_deque` candidate eviction during active decay phase. |
+| Technical Architect #2 | 2026-08-01 | APPROVED | Addressed `max_deque` candidate retention logic and verified REQ-N test scenario mappings. |
+
+**Final Status:** APPROVED

--- a/tests/fixtures/criteria_coverage/spec-0001.md
+++ b/tests/fixtures/criteria_coverage/spec-0001.md
@@ -1,0 +1,871 @@
+# Implementation Spec: Core Gauge Renderer — Analog Tachometer with Arc, Needle, and Tick Marks
+
+| Field | Value |
+|-------|-------|
+| Issue | #1 |
+| LLD | `docs/lld/done/0001-core-gauge-renderer.md` |
+| Generated | 2026-08-01 |
+| Status | APPROVED |
+
+---
+
+## 1. Overview
+
+This implementation delivers the core off-screen v1 gauge rendering engine for BoostGauge (`#7 -> #1 -> #4 -> #2 -> #5`). It provides a headless Pillow-based rendering facade that converts metric values (0–100) and telltale peak-hold values into deterministic `PIL.Image` objects without any dependency on `tkinter` or active display servers.
+
+**Objective:** Implement `src/boostgauge/gauge.py` facade, skin dispatch mechanism in `src/boostgauge/skins/__init__.py`, and the default Stingray analog tachometer renderer in `src/boostgauge/skins/stingray.py` using 2x internal supersampling with Lanczos downscaling.
+
+**Success Criteria:**
+1. Zero `tkinter` imports in renderer modules or test suites (Option C compliance).
+2. Clamping metric values to [0.0, 100.0] and raising `TypeError` for non-numeric inputs.
+3. Enforcing minimum gauge resolution of 128x128 (`ValueError` if smaller) with default 256x256 pixel output.
+4. Rendering 11 major white tick marks, 4 minor ticks per interval, fallback font radial numerals (0 to 100), redline arc (60 to 100), "BOOSTGAUGE" wordmark, up to 4 translucent telltale needles, and solid red main needle with pivot cap.
+5. Deterministic byte-identical `PIL.Image` output for identical input parameter sets.
+6. Visual regression testing matching baseline `tests/visual/baselines/aesthetic-v1-stingray-canonical.png` within RMS tolerance $\le 1.0 / 255$.
+7. Baseline-independent geometric/trigonometric property assertions verifying needle position and element coordinates without relying on image baseline files.
+
+---
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/skins/__init__.py` | Add | Package initializer defining `GaugeSkin` protocol, skin registry dictionary, and dispatch lookup function |
+| 2 | `src/boostgauge/skins/stingray.py` | Add | Stingray v1 renderer implementing 2x supersampled Pillow drawing for analog tachometer face, ticks, arc, telltales, and needle |
+| 3 | `src/boostgauge/gauge.py` | Add | Public entry point `render()` facade performing argument validation, clamping, size checks, and skin dispatch |
+| 4 | `tests/unit/test_gauge.py` | Add | Unit test suite covering argument validation, clamping, size constraints, deterministic byte output, telltale omission, and zero `tkinter` import checks |
+| 5 | `tests/visual/test_gauge_visual.py` | Add | Visual regression test suite comparing off-screen PIL image output against golden baselines and executing baseline-independent property assertions |
+
+**Implementation Order Rationale:**
+- `skins/__init__.py` defines the protocol and skin registry dict required by all skin modules.
+- `skins/stingray.py` implements the concrete rendering logic matching the `GaugeSkin` protocol.
+- `gauge.py` imports from `skins` to expose the high-level public `render()` facade.
+- Unit and visual regression tests follow implementation to validate functional contracts and visual fidelity.
+
+---
+
+## 3. Current State (for Modify/Delete files)
+
+No existing code files are modified or deleted for this feature. All files listed in Section 2 are new additions (`Add`).
+
+Parent directories `src/boostgauge/`, `tests/unit/`, and `tests/visual/` exist on the target repository branch. New subdirectories `src/boostgauge/skins/` and `tests/visual/baselines/` will be created during implementation.
+
+Existing package dependencies from `pyproject.toml` relevant to this feature:
+```toml
+[project]
+dependencies = [
+    "psutil (>=7.2.2,<8.0.0)",
+    "pillow (>=12.2.0,<13.0.0)",
+    "pystray (>=0.19.5,<0.20.0)"
+]
+```
+
+---
+
+## 4. Data Structures
+
+### 4.1 `TelltalePeaks`
+
+**Definition:**
+
+```python
+from typing import TypedDict, Optional
+
+class TelltalePeaks(TypedDict, total=False):
+    m1: Optional[float]       # 1-minute peak value (0.0 to 100.0)
+    m10: Optional[float]      # 10-minute peak value (0.0 to 100.0)
+    h1: Optional[float]       # 1-hour peak value (0.0 to 100.0)
+    all_time: Optional[float] # All-time peak value (0.0 to 100.0)
+```
+
+**Concrete JSON Example:**
+
+```json
+{
+    "m1": 25.5,
+    "m10": 58.0,
+    "h1": 82.3,
+    "all_time": 95.0
+}
+```
+
+**Partial / None JSON Example:**
+
+```json
+{
+    "m1": 40.0,
+    "m10": null,
+    "h1": null,
+    "all_time": 87.5
+}
+```
+
+### 4.2 `GaugeConfigDict`
+
+**Definition:**
+
+```python
+from typing import TypedDict, Optional
+
+class GaugeConfigDict(TypedDict, total=False):
+    skin: Optional[str]        # Skin name registered in SKIN_REGISTRY (defaults to "stingray")
+    color_scheme: Optional[str]# Reserved for future color overrides
+```
+
+**Concrete JSON Example:**
+
+```json
+{
+    "skin": "stingray",
+    "color_scheme": "default"
+}
+```
+
+---
+
+## 5. Function Specifications
+
+### 5.1 `render()`
+
+**File:** `src/boostgauge/gauge.py`
+
+**Signature:**
+
+```python
+def render(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = 256,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Public entry point for off-screen gauge rendering.
+
+    Validates arguments, clamps `value` to [0.0, 100.0], validates `size` >= 128,
+    dispatches to the configured skin renderer (defaulting to "stingray"), and
+    returns the rendered PIL.Image object.
+    """
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 75.0
+telltales = {"m1": 45.0, "m10": 60.0, "h1": 85.0, "all_time": 95.0}
+size = 256
+config = {"skin": "stingray"}
+```
+
+**Output Example:**
+
+```python
+# Returns PIL.Image.Image instance
+# Mode: "RGBA", Size: (256, 256)
+img = render(75.0, telltales={"m1": 45.0}, size=256)
+assert img.mode == "RGBA"
+assert img.size == (256, 256)
+```
+
+**Edge Cases:**
+- `value` is non-numeric (e.g., `"75"` or `None`): raises `TypeError("Value must be a numeric float or int")`.
+- `value < 0.0`: clamped to `0.0` before rendering.
+- `value > 100.0`: clamped to `100.0` before rendering.
+- `size < 128`: raises `ValueError("Gauge size must be at least 128 pixels")`.
+- `config` is `None` or missing `"skin"` key: defaults skin to `"stingray"`.
+- `config["skin"]` contains unregistered name (e.g., `"unknown"`): raises `ValueError("Unknown skin: 'unknown'. Available skins: ['stingray']")`.
+
+---
+
+### 5.2 `render_stingray()`
+
+**File:** `src/boostgauge/skins/stingray.py`
+
+**Signature:**
+
+```python
+def render_stingray(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = 256,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Stingray v1 analog tachometer renderer using 2x supersampled Pillow drawing."""
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 0.0
+telltales = None
+size = 256
+config = None
+```
+
+**Output Example:**
+
+```python
+# Returns PIL.Image.Image instance
+# Mode: "RGBA", Size: (256, 256)
+```
+
+**Edge Cases:**
+- `telltales` dictionary contains keys mapped to `None`: omits drawing needle for those specific keys.
+- `telltale` values out of range `[0.0, 100.0]`: clamped to `[0.0, 100.0]`.
+
+---
+
+### 5.3 `get_skin()`
+
+**File:** `src/boostgauge/skins/__init__.py`
+
+**Signature:**
+
+```python
+def get_skin(name: str = "stingray") -> GaugeSkin:
+    """Retrieve skin renderer callable from SKIN_REGISTRY by name.
+
+    Raises ValueError if skin name is unregistered.
+    """
+    ...
+```
+
+**Input Example:**
+
+```python
+name = "stingray"
+```
+
+**Output Example:**
+
+```python
+# Returns function `render_stingray` conforming to GaugeSkin protocol
+```
+
+**Edge Cases:**
+- `name="invalid"`: raises `ValueError("Unknown skin: 'invalid'. Available skins: ['stingray']")`.
+
+---
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/skins/__init__.py` (Add)
+
+Create `src/boostgauge/skins/__init__.py` defining the skin protocol, global registry dictionary, and `get_skin()` dispatch function.
+
+```python
+"""Skins package for BoostGauge renderers.
+
+Issue #1: Core gauge renderer — analog tachometer with arc, needle, and tick marks
+"""
+
+from typing import Any, Dict, Optional, Protocol
+from PIL import Image
+
+class GaugeSkin(Protocol):
+    """Protocol for gauge skin renderers per Issue #45 extensibility design."""
+
+    def __call__(
+        self,
+        value: float,
+        telltales: Optional[Dict[str, Optional[float]]] = None,
+        size: int = 256,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> Image.Image:
+        """Render skin to a PIL.Image instance."""
+        ...
+
+SKIN_REGISTRY: Dict[str, GaugeSkin] = {}
+
+def register_skin(name: str, renderer: GaugeSkin) -> None:
+    """Register a skin renderer callable under the given name."""
+    SKIN_REGISTRY[name] = renderer
+
+def get_skin(name: str = "stingray") -> GaugeSkin:
+    """Look up a skin renderer callable by name.
+
+    Raises:
+        ValueError: If `name` is not present in SKIN_REGISTRY.
+    """
+    if name not in SKIN_REGISTRY:
+        available = sorted(list(SKIN_REGISTRY.keys()))
+        raise ValueError(f"Unknown skin: '{name}'. Available skins: {available}")
+    return SKIN_REGISTRY[name]
+```
+
+---
+
+### 6.2 `src/boostgauge/skins/stingray.py` (Add)
+
+Create `src/boostgauge/skins/stingray.py` implementing the Stingray v1 gauge face drawing pipeline.
+
+**Layout & Geometry Math Specifications:**
+- Internal rendering canvas size: `dim = size * 2` (2x supersampling).
+- Center coordinates: `cx = dim / 2`, `cy = dim / 2`.
+- Outer housing: Square with rounded corners (`radius = dim * 0.08`), dark metallic border (`#1E222A` outer background, `#3A3F4D` bevel edge, `#121418` inner face fill).
+- Round matte-black dial face: Circle centered at `(cx, cy)` with radius `r_face = dim * 0.44`. Color `#0E1013`.
+- Angle Mapping: Metric scale `0.0` to `100.0` maps linearly across a 270° arc starting at angle `225°` (7:30 o'clock) to `-45°` / `315°` (4:30 o'clock) clockwise.
+  $$\theta(v) = 225.0 - 2.7 \times v \quad (\text{in degrees})$$
+- Major Ticks (11 ticks for values $0, 10, 20, \dots, 100$):
+  - Inner radius: `dim * 0.34`, Outer radius: `dim * 0.41`. Width: `max(2, int(dim * 0.012))`. Color: `#FFFFFF`.
+- Minor Ticks (4 between each major pair, total 40 minor ticks):
+  - Inner radius: `dim * 0.37`, Outer radius: `dim * 0.41`. Width: `max(1, int(dim * 0.006))`. Color: `#A0A5B5`.
+- Numerals ($0, 10, \dots, 100$):
+  - Radial center distance: `dim * 0.28`.
+  - Font: Load cross-platform fallback stack (`"Eurostile"`, `"DejaVu Sans"`, `"Liberation Sans"`, `"Arial"`). If font files are unavailable, fallback gracefully to `ImageFont.load_default()`. Font size: `int(dim * 0.045)`. Color: `#F0F2F5`.
+- Redline Arc:
+  - Arc sector for values `60.0` to `100.0` (angles $225 - 2.7 \times 60 = 63^\circ$ down to $-45^\circ$).
+  - Arc width: `int(dim * 0.035)`. Radius: `dim * 0.41`. Color: `#E63946`.
+- Wordmark:
+  - Text `"BOOSTGAUGE"` rendered at `(cx, cy + dim * 0.18)` centered horizontally.
+  - Font size: `int(dim * 0.032)`. Color: `#8A91A0`.
+- Telltale Needles:
+  - Peak key colors: `m1` -> `#4CC9F0B3` (cyan, alpha=179), `m10` -> `#7209B7B3` (purple, alpha=179), `h1` -> `#F72585B3` (magenta, alpha=179), `all_time` -> `#FFB703B3` (amber, alpha=179).
+  - Telltale needle length: `dim * 0.36`, width: `max(2, int(dim * 0.008))`.
+- Main Needle & Pivot Cap:
+  - Main needle color: `#FF0033` (solid vivid red).
+  - Needle shape: Tapered polygon from pivot cap to tip at radius `dim * 0.38`. Base width: `dim * 0.025`.
+  - Pivot cap: Outer chrome ring radius `dim * 0.06` (`#4A5061`), inner black cap radius `dim * 0.045` (`#121418`).
+- Downsampling:
+  - Downscale intermediate RGBA image from `(dim, dim)` to `(size, size)` using `Image.Resampling.LANCZOS`.
+
+```python
+"""Stingray v1 analog tachometer skin renderer.
+
+Issue #1: Core gauge renderer — analog tachometer with arc, needle, and tick marks
+"""
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+from PIL import Image, ImageDraw, ImageFont
+
+from boostgauge.skins import register_skin
+
+# Telltale accent colors (RGBA)
+TELLTALE_COLORS: Dict[str, Tuple[int, int, int, int]] = {
+    "m1": (76, 201, 240, 180),       # Cyan
+    "m10": (114, 9, 183, 180),       # Purple
+    "h1": (247, 37, 133, 180),       # Magenta
+    "all_time": (255, 183, 3, 180),  # Amber
+}
+
+def _get_font(size: int) -> ImageFont.ImageFont | ImageFont.FreeTypeFont:
+    """Load font using cross-platform fallback hierarchy."""
+    font_names = ["Eurostile", "DejaVuSans", "LiberationSans-Regular", "arial"]
+    for font_name in font_names:
+        try:
+            return ImageFont.truetype(font_name, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+def _val_to_angle(val: float) -> float:
+    """Map value in [0.0, 100.0] to sweep angle in degrees (225° at 0 to -45° at 100)."""
+    clamped = max(0.0, min(100.0, float(val)))
+    return 225.0 - (2.7 * clamped)
+
+def render_stingray(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = 256,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Stingray v1 analog tachometer renderer using 2x supersampled Pillow drawing."""
+    dim = size * 2
+    cx, cy = dim / 2.0, dim / 2.0
+
+    # 1. Canvas Setup
+    img = Image.new("RGBA", (dim, dim), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    # 2. Housing & Dial Face
+    corner_rad = int(dim * 0.08)
+    draw.rounded_rectangle([0, 0, dim - 1, dim - 1], radius=corner_rad, fill=(30, 34, 42, 255), outline=(58, 63, 77, 255), width=int(dim * 0.015))
+    
+    r_face = dim * 0.44
+    draw.ellipse([cx - r_face, cy - r_face, cx + r_face, cy + r_face], fill=(14, 16, 19, 255), outline=(35, 39, 48, 255), width=int(dim * 0.01))
+
+    # 3. Redline Arc (values 60 to 100 -> angles 63° to -45°, spanning -45° to 63° in Pillow arc terms)
+    # Note: Pillow arc takes start_angle and end_angle measured clockwise from 3 o'clock
+    r_arc = dim * 0.40
+    arc_width = max(2, int(dim * 0.035))
+    # Pillow angle convention: 0 is 3 o'clock, angles go clockwise.
+    # Value 60 -> 225 - 162 = 63° in standard counter-clockwise math -> in Pillow angles: -63° or 297°
+    # Value 100 -> -45° in standard counter-clockwise math -> in Pillow angles: 45°
+    # Sweep from value 60 (angle 297°) to value 100 (angle 45° / 405°)
+    draw.arc(
+        [cx - r_arc, cy - r_arc, cx + r_arc, cy + r_arc],
+        start=297,
+        end=405,
+        fill=(230, 57, 70, 255),
+        width=arc_width
+    )
+
+    # 4. Ticks & Numerals
+    font_numeral = _get_font(int(dim * 0.045))
+    font_wordmark = _get_font(int(dim * 0.030))
+
+    r_tick_outer = dim * 0.41
+    r_tick_major_inner = dim * 0.34
+    r_tick_minor_inner = dim * 0.37
+    r_numeral = dim * 0.27
+
+    # Major ticks (0, 10, ..., 100)
+    for i in range(11):
+        v = i * 10.0
+        angle_deg = _val_to_angle(v)
+        angle_rad = math.radians(angle_deg)
+
+        cos_a = math.cos(angle_rad)
+        sin_a = -math.sin(angle_rad)  # Invert Y for screen coordinates
+
+        x1 = cx + r_tick_major_inner * cos_a
+        y1 = cy + r_tick_major_inner * sin_a
+        x2 = cx + r_tick_outer * cos_a
+        y2 = cy + r_tick_outer * sin_a
+
+        draw.line([(x1, y1), (x2, y2)], fill=(255, 255, 255, 255), width=max(2, int(dim * 0.012)))
+
+        # Numeral text
+        nx = cx + r_numeral * cos_a
+        ny = cy + r_numeral * sin_a
+        num_str = str(int(v))
+        
+        # Use textbbox to center numeral
+        bbox = draw.textbbox((0, 0), num_str, font=font_numeral)
+        tw = bbox[2] - bbox[0]
+        th = bbox[3] - bbox[1]
+        draw.text((nx - tw / 2.0, ny - th / 2.0), num_str, fill=(240, 242, 245, 255), font=font_numeral)
+
+        # Minor ticks (4 per interval)
+        if i < 10:
+            for m in range(1, 5):
+                sub_v = v + m * 2.0
+                sub_angle_deg = _val_to_angle(sub_v)
+                sub_angle_rad = math.radians(sub_angle_deg)
+                s_cos = math.cos(sub_angle_rad)
+                s_sin = -math.sin(sub_angle_rad)
+
+                mx1 = cx + r_tick_minor_inner * s_cos
+                my1 = cy + r_tick_minor_inner * s_sin
+                mx2 = cx + r_tick_outer * s_cos
+                my2 = cy + r_tick_outer * s_sin
+                draw.line([(mx1, my1), (mx2, my2)], fill=(160, 165, 181, 255), width=max(1, int(dim * 0.006)))
+
+    # 5. Wordmark
+    wordmark = "BOOSTGAUGE"
+    w_bbox = draw.textbbox((0, 0), wordmark, font=font_wordmark)
+    ww = w_bbox[2] - w_bbox[0]
+    wh = w_bbox[3] - w_bbox[1]
+    draw.text((cx - ww / 2.0, cy + dim * 0.18 - wh / 2.0), wordmark, fill=(138, 145, 160, 255), font=font_wordmark)
+
+    # 6. Translucent Telltale Needles
+    if telltales:
+        for key in ["m1", "m10", "h1", "all_time"]:
+            peak_val = telltales.get(key)
+            if peak_val is not None:
+                t_angle = math.radians(_val_to_angle(peak_val))
+                t_cos = math.cos(t_angle)
+                t_sin = -math.sin(t_angle)
+                
+                r_tell = dim * 0.36
+                tx = cx + r_tell * t_cos
+                ty = cy + r_tell * t_sin
+                color = TELLTALE_COLORS.get(key, (255, 255, 255, 180))
+                draw.line([(cx, cy), (tx, ty)], fill=color, width=max(2, int(dim * 0.01)))
+
+    # 7. Main Red Needle & Pivot Cap
+    main_angle_rad = math.radians(_val_to_angle(value))
+    main_cos = math.cos(main_angle_rad)
+    main_sin = -math.sin(main_angle_rad)
+
+    r_needle = dim * 0.38
+    tip_x = cx + r_needle * main_cos
+    tip_y = cy + r_needle * main_sin
+
+    # Base perpendicular offset for tapered needle polygon
+    perp_cos = -main_sin
+    perp_sin = main_cos
+    base_w = dim * 0.015
+
+    b1_x = cx + perp_cos * base_w
+    b1_y = cy + perp_sin * base_w
+    b2_x = cx - perp_cos * base_w
+    b2_y = cy - perp_sin * base_w
+
+    draw.polygon([(b1_x, b1_y), (tip_x, tip_y), (b2_x, b2_y)], fill=(255, 0, 51, 255))
+
+    # Pivot Cap
+    r_cap_outer = dim * 0.06
+    r_cap_inner = dim * 0.045
+    draw.ellipse([cx - r_cap_outer, cy - r_cap_outer, cx + r_cap_outer, cy + r_cap_outer], fill=(74, 80, 97, 255))
+    draw.ellipse([cx - r_cap_inner, cy - r_cap_inner, cx + r_cap_inner, cy + r_cap_inner], fill=(18, 20, 24, 255))
+
+    # 8. Downsampling to Target Size
+    return img.resize((size, size), resample=Image.Resampling.LANCZOS)
+
+# Register skin upon module import
+register_skin("stingray", render_stingray)
+```
+
+---
+
+### 6.3 `src/boostgauge/gauge.py` (Add)
+
+Create `src/boostgauge/gauge.py` providing parameter validation, clamping, and public rendering facade.
+
+```python
+"""Public entry point facade for BoostGauge renderer.
+
+Issue #1: Core gauge renderer — analog tachometer with arc, needle, and tick marks
+"""
+
+from typing import Any, Dict, Optional
+from PIL import Image
+
+from boostgauge.skins import get_skin
+
+MIN_GAUGE_SIZE = 128
+DEFAULT_GAUGE_SIZE = 256
+
+def render(
+    value: float,
+    telltales: Optional[Dict[str, Optional[float]]] = None,
+    size: int = DEFAULT_GAUGE_SIZE,
+    config: Optional[Dict[str, Any]] = None,
+) -> Image.Image:
+    """Public entry point for off-screen gauge rendering.
+
+    Validates inputs, clamps metric value to [0.0, 100.0], dispatches to configured
+    skin renderer, and returns a rendered PIL.Image object.
+
+    Args:
+        value: Metric value to display on gauge scale (0.0 to 100.0).
+        telltales: Optional dict of peak-hold window values ('m1', 'm10', 'h1', 'all_time').
+        size: Target image width and height in pixels (must be >= 128).
+        config: Optional configuration dictionary containing skin choice.
+
+    Returns:
+        PIL.Image.Image: Rendered RGBA image of size (size, size).
+
+    Raises:
+        TypeError: If `value` is not an int or float.
+        ValueError: If `size` < 128 or requested skin name is unregistered.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError(f"Value must be a numeric float or int, got {type(value).__name__}")
+
+    if not isinstance(size, int) or size < MIN_GAUGE_SIZE:
+        raise ValueError(f"Gauge size must be an integer >= {MIN_GAUGE_SIZE}, got {size}")
+
+    clamped_value = max(0.0, min(100.0, float(value)))
+
+    cfg = config or {}
+    skin_name = cfg.get("skin", "stingray")
+
+    skin_renderer = get_skin(skin_name)
+    return skin_renderer(
+        value=clamped_value,
+        telltales=telltales,
+        size=size,
+        config=cfg,
+    )
+```
+
+---
+
+### 6.4 `tests/unit/test_gauge.py` (Add)
+
+Create `tests/unit/test_gauge.py` containing unit test cases for logic validation.
+
+```python
+"""Unit test suite for boostgauge.gauge facade.
+
+Issue #1: Core gauge renderer — analog tachometer with arc, needle, and tick marks
+"""
+
+import sys
+import pytest
+from PIL import Image
+
+from boostgauge.gauge import render, MIN_GAUGE_SIZE, DEFAULT_GAUGE_SIZE
+
+def test_render_defaults() -> None:
+    """REQ-1, REQ-3: Test default invocation returns 256x256 RGBA PIL.Image."""
+    img = render(50.0)
+    assert isinstance(img, Image.Image)
+    assert img.size == (DEFAULT_GAUGE_SIZE, DEFAULT_GAUGE_SIZE)
+    assert img.mode == "RGBA"
+
+def test_render_no_tkinter_imports() -> None:
+    """REQ-1: Verify execution causes zero tkinter module imports (Option C constraint)."""
+    render(50.0)
+    imported_modules = set(sys.modules.keys())
+    assert "tkinter" not in imported_modules
+    assert "_tkinter" not in imported_modules
+
+def test_value_type_validation() -> None:
+    """REQ-2: Verify non-numeric input raises TypeError."""
+    with pytest.raises(TypeError, match="Value must be a numeric float or int"):
+        render("50.0")  # type: ignore
+
+    with pytest.raises(TypeError, match="Value must be a numeric float or int"):
+        render(None)  # type: ignore
+
+    with pytest.raises(TypeError, match="Value must be a numeric float or int"):
+        render(True)  # type: ignore
+
+def test_value_clamping() -> None:
+    """REQ-2, REQ-9: Out-of-bounds values produce identical output to boundary values."""
+    img_under = render(-25.0)
+    img_zero = render(0.0)
+    assert img_under.tobytes() == img_zero.tobytes()
+
+    img_over = render(150.0)
+    img_max = render(100.0)
+    assert img_over.tobytes() == img_max.tobytes()
+
+def test_size_validation() -> None:
+    """REQ-3: Custom size locking aspect ratio and minimum size enforcement."""
+    img_custom = render(50.0, size=512)
+    assert img_custom.size == (512, 512)
+
+    with pytest.raises(ValueError, match="Gauge size must be an integer >= 128"):
+        render(50.0, size=64)
+
+def test_deterministic_output() -> None:
+    """REQ-9: Two separate render calls with identical arguments return byte-identical images."""
+    img1 = render(42.0, telltales={"m1": 50.0}, size=256)
+    img2 = render(42.0, telltales={"m1": 50.0}, size=256)
+    assert img1.tobytes() == img2.tobytes()
+
+def test_unregistered_skin_raises() -> None:
+    """Verify requesting invalid skin name raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown skin: 'nonexistent'"):
+        render(50.0, config={"skin": "nonexistent"})
+```
+
+---
+
+### 6.5 `tests/visual/test_gauge_visual.py` (Add)
+
+Create `tests/visual/test_gauge_visual.py` with visual regression tests and baseline-independent trigonometric property assertions.
+
+```python
+"""Visual regression test suite for BoostGauge renderer.
+
+Issue #1: Core gauge renderer — analog tachometer with arc, needle, and tick marks
+"""
+
+import math
+from pathlib import Path
+import pytest
+from PIL import Image, ImageChops, ImageStat
+
+from boostgauge.gauge import render
+
+BASELINE_DIR = Path(__file__).parent / "baselines"
+CANONICAL_BASELINE = BASELINE_DIR / "aesthetic-v1-stingray-canonical.png"
+
+def _compute_rms_diff(img1: Image.Image, img2: Image.Image) -> float:
+    """Compute Root Mean Square (RMS) difference per channel normalized to [0.0, 1.0]."""
+    diff = ImageChops.difference(img1.convert("RGBA"), img2.convert("RGBA"))
+    stat = ImageStat.Stat(diff)
+    sum_sq = sum(rms ** 2 for rms in stat.rms)
+    return math.sqrt(sum_sq / len(stat.rms)) / 255.0
+
+def test_visual_baseline_canonical(request: pytest.FixtureRequest) -> None:
+    """REQ-12: Compare value=0 output against canonical baseline within RMS tolerance <= 1.0 / 255."""
+    img_rendered = render(0.0, telltales=None, size=256)
+
+    # CLI flag --generate-baselines updates stored golden baselines
+    if getattr(request.config.option, "generate_baselines", False):
+        BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+        img_rendered.save(CANONICAL_BASELINE)
+        pytest.skip(f"Updated baseline at {CANONICAL_BASELINE}")
+
+    assert CANONICAL_BASELINE.exists(), f"Baseline missing at {CANONICAL_BASELINE}. Run with --generate-baselines to create."
+    img_baseline = Image.open(CANONICAL_BASELINE)
+
+    rms = _compute_rms_diff(img_rendered, img_baseline)
+    assert rms <= (1.0 / 255.0), f"Visual regression RMS diff {rms:.6f} exceeds tolerance {1.0/255.0:.6f}"
+
+# --- Baseline-Independent Property Assertions ---
+
+def test_baseline_independent_needle_geometry() -> None:
+    """REQ-8 (Baseline-Independent): Assert main needle tip position mathematically at value=50.
+
+    At value=50, needle angle is 90° (pointing straight UP, 12 o'clock).
+    For size=256 (internal dim=512):
+      center (cx, cy) = (128, 128)
+      needle radius = 256 * 0.38 = 97.28
+      needle tip should lie at (128, 128 - 97.28) = (128, 30.72) -> red pixel present.
+    """
+    size = 256
+    img = render(50.0, telltales=None, size=size)
+
+    # Sample pixel along needle ray near tip (x=128, y=45)
+    pixel = img.getpixel((128, 45))
+    # Red main needle color has high R component (R > 200, G < 50, B < 50)
+    r, g, b, a = pixel
+    assert r > 180 and g < 60 and b < 60, f"Expected red needle pixel at (128, 45), got RGBA=({r},{g},{b},{a})"
+
+def test_baseline_independent_dial_center_background() -> None:
+    """REQ-4 (Baseline-Independent): Assert center pivot region contains dark cap colors."""
+    img = render(0.0, size=256)
+    # Center pixel (128, 128) corresponds to inner pivot cap (#121418 -> approx (18, 20, 24))
+    r, g, b, a = img.getpixel((128, 128))
+    assert r < 40 and g < 40 and b < 40 and a == 255, f"Expected dark pivot cap pixel at center (128, 128), got ({r},{g},{b},{a})"
+
+def test_baseline_independent_redline_region_color() -> None:
+    """REQ-5 (Baseline-Independent): Assert redline arc sector contains red pixels at value range 60-100."""
+    # At value 80, redline sector arc passes through top-right quadrant (~30° angle)
+    img = render(0.0, size=256)
+    # Sample point along arc radius (r ~ 102 pixels from center at 30° angle from horizontal)
+    # x = 128 + 102 * cos(30°) = 128 + 88.3 = 216
+    # y = 128 - 102 * sin(30°) = 128 - 51 = 77
+    r, g, b, a = img.getpixel((216, 77))
+    assert r > 180 and g < 80 and b < 80, f"Expected red arc pixel at (216, 77), got ({r},{g},{b},{a})"
+```
+
+---
+
+## 7. Pattern References
+
+### 7.1 Pure Telltale Tracker Pattern
+
+**File:** `src/boostgauge/telltale.py` (lines 10–45)
+
+```python
+class Telltale:
+    """Pure peak-hold telltale needle tracker over a sliding time window."""
+
+    def __init__(self, window: float, decay_rate: Optional[float] = None) -> None:
+        ...
+
+    def current_peak(self, current_time: Optional[float] = None) -> Optional[float]:
+        ...
+```
+
+**Relevance:** Demonstrates the project's zero-GUI pure decoupled component pattern. `gauge.py` follows the exact same decoupled pure interface approach.
+
+### 7.2 Configuration Validation Pattern
+
+**File:** `src/boostgauge/config.py` (lines 40–60)
+
+```python
+def validate_config_dict(raw_config: Dict[str, Any]) -> AppConfig:
+    """Validate types and numerical bounds of raw configuration dict; return typed AppConfig or raise ValueError."""
+    ...
+```
+
+**Relevance:** Establishes the project convention for immediate type checking (`TypeError`) and numerical range validation (`ValueError`) before execution.
+
+---
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `math` | stdlib | `src/boostgauge/skins/stingray.py`, `tests/visual/test_gauge_visual.py` |
+| `sys` | stdlib | `tests/unit/test_gauge.py` |
+| `pathlib.Path` | stdlib | `tests/visual/test_gauge_visual.py` |
+| `typing.Any`, `Dict`, `Optional`, `Protocol`, `Tuple` | stdlib | All files |
+| `PIL.Image`, `ImageDraw`, `ImageFont`, `ImageChops`, `ImageStat` | third-party (`pillow`) | `gauge.py`, `skins/__init__.py`, `skins/stingray.py`, `test_gauge_visual.py` |
+| `pytest` | third-party (`pytest`) | `tests/unit/test_gauge.py`, `tests/visual/test_gauge_visual.py` |
+
+**New Dependencies:** None (uses existing pinned `pillow (>=12.2.0,<13.0.0)`).
+
+---
+
+## 9. Baseline-Independent Property Assertions
+
+To guarantee visual defects are not baked into self-validating golden baseline images (Issue #1902), the following baseline-independent property assertions are explicitly specified and implemented in `tests/visual/test_gauge_visual.py`:
+
+1. **Needle Angular Position Property Assertion:**
+   - At `value = 50.0`, the metric angle maps to $225.0 - (2.7 \times 50) = 90.0^\circ$ (pointing straight UP, 12 o'clock).
+   - For gauge `size = 256` (center at $(128, 128)$), the needle tip ray extends upwards along $x = 128$.
+   - **Assertion:** Sampling pixel $(128, 45)$ MUST yield $R > 180$, $G < 60$, $B < 60$ (verifying the needle tip lies precisely on the 12 o'clock axis).
+
+2. **Dial Pivot Center Geometry Property Assertion:**
+   - The pivot center counterweight cap is centered at $(128, 128)$.
+   - **Assertion:** Sampling pixel $(128, 128)$ MUST yield dark metallic cap RGB values ($R, G, B < 40$, $A = 255$).
+
+3. **Redline Sector Angular Boundary Property Assertion:**
+   - The redline arc spans metric values $60.0$ to $100.0$.
+   - **Assertion:** Sampling pixel $(216, 77)$ (lying along the $30^\circ$ radial arc line) MUST yield saturated red arc color ($R > 180$, $G < 80$, $B < 80$).
+
+---
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output / Behavior |
+|---------|---------------|-------|----------------------------|
+| T010 | `render()` | `value=50.0` | Returns 256x256 RGBA `PIL.Image`; `sys.modules` contains no `tkinter` |
+| T020 | `render()` | `value=-10.0`, `150.0` | Value clamped to [0.0, 100.0]; outputs byte-identical to `0.0` and `100.0` |
+| T021 | `render()` | `value="50.0"`, `None` | Raises `TypeError` |
+| T030 | `render()` | `value=50.0, size=512` | Returns 512x512 RGBA `PIL.Image` |
+| T031 | `render()` | `value=50.0, size=64` | Raises `ValueError` ("Gauge size must be at least 128") |
+| T040 | `render_stingray()` | `value=0.0` | Renders face, ticks, fallback font numerals matching Stingray spec |
+| T050 | `render_stingray()` | `value=0.0` | Renders redline arc across 60-100 metric range |
+| T060 | `render_stingray()` | `value=0.0` | Renders "BOOSTGAUGE" wordmark centered below pivot |
+| T070 | `render_stingray()` | `telltales={"m1": 25.0}` | Renders translucent secondary telltale needle behind main needle |
+| T080 | `render_stingray()` | `value=50.0` | Solid red main needle points to 90° (top center) with pivot cap |
+| T090 | `render()` | Identical parameters | `img1.tobytes() == img2.tobytes()` |
+| T100 | `render_stingray()` | `telltales={"m10": None}` | Omits rendering `m10` needle |
+| T110 | `render_stingray()` | `value=75.0` | Main needle renders on top of redline arc with clear layering |
+| T120 | `test_visual_baseline_canonical` | `value=0.0` | RMS diff against baseline image $\le 1.0 / 255$ |
+
+---
+
+## 11. Implementation Notes
+
+### 11.1 Platform-Independent Path Assertions
+
+All filesystem path comparisons in tests MUST use `pathlib.Path` objects (e.g. `BASELINE_DIR = Path(__file__).parent / "baselines"`). Never compare separator-laden string paths using `.endswith()` or backslash strings to avoid Windows path separator mismatch failures (Issue #1841).
+
+### 11.2 Rendering Performance & Memory Budget
+
+- Internal 2x supersampling renders a $512 \times 512$ canvas for a $256 \times 256$ requested size, using $< 1.5\text{MB}$ memory per frame buffer.
+- `LANCZOS` downsampling executes in $\approx 2.5\text{ms}$ on standard CPU, easily exceeding the sub-5ms total render budget required for smooth 20 Hz updates.
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3)
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every function has input/output examples with realistic values (Section 5)
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)
+- [x] Baseline-independent property assertions explicitly specified (Section 9)
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #1 |
+| Verdict | APPROVED |
+| Date | 2026-08-01 |
+| Iterations | 1 |
+| Finalized | 2026-08-01T10:00:53-05:00 |
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #1 |
+| Verdict | APPROVED |
+| Date | 2026-08-01 |
+| Iterations | 1 |
+| Finalized | 2026-08-01T15:01:54Z |
+
+### Review Feedback Summary
+
+The Implementation Spec is complete, highly detailed, and directly executable by an autonomous AI agent. All proposed modules (gauge.py, skins/__init__.py, skins/stingray.py) and test suites (test_gauge.py, test_gauge_visual.py) provide complete code implementations rather than vague descriptions or placeholders. Every test assertion traces directly to specified functional requirements, Option C (zero tkinter imports) compliance is enforced, and baseline-independent property assertions are expli...

--- a/tests/fixtures/criteria_coverage/spec-0007-reconstruction.md
+++ b/tests/fixtures/criteria_coverage/spec-0007-reconstruction.md
@@ -1,0 +1,204 @@
+# RECONSTRUCTION — not a recovered artifact
+
+**This file is a documented reconstruction, authored 2026-08-12 for the #2239
+regression test. It is NOT the spec that run-issue7-082047 produced.**
+
+The real failing artifact — the iteration-2 spec of `run-issue7-082047`
+(boostgauge, 2026-08-12) — does not exist and cannot be recovered. Orchestrated
+spec runs never persisted their drafts; that gap is #2250, fixed the same day
+this fixture was written, which is why no future failure will need a
+reconstruction.
+
+What the run log does record about that spec, from the reviewer's second REVISE:
+
+> completely omits 12 required state matrix tests
+
+That is the condition this file reproduces: tests for every LLD-007 pass
+criterion **except** the twelve decision-table rows REQ-9 through REQ-20 (the
+position matrix, REQ-9..12, and the size matrix, REQ-13..20). Everything else —
+REQ-1 through REQ-8, REQ-21 and REQ-22 — carries a test, so a check that fires
+here is firing on the row omission specifically and not on a spec that is thin
+everywhere.
+
+Waiting for a real failing artifact would be circular: this check exists to
+prevent the very failure that would produce one. The operator authorised the
+reconstruction on 2026-08-12 on that reasoning.
+
+Paired LLD: `LLD-007.md` in this directory, which IS real — taken verbatim from
+boostgauge PR #285 at `f8018447`.
+
+---
+
+## 1. Files to Modify
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/config.py` | Add | Config load, reset, and patch-write |
+| `src/boostgauge/app.py` | Modify | Wire config into launch and exit |
+| `tests/unit/test_config.py` | Add | Unit tests for the above |
+
+## 2. Implementation
+
+```python
+# src/boostgauge/config.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULTS: dict[str, Any] = {
+    "size": 300,
+    "position": {"x": 100, "y": 100},
+    "theme": "dark",
+}
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    """Read the config file, creating it with defaults when absent."""
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(DEFAULTS, indent=2), encoding="utf-8")
+        return dict(DEFAULTS)
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    for key, value in data.items():
+        if key == "size" and not isinstance(value, int):
+            raise ValueError(
+                f"config key 'size' must be an integer, got {type(value).__name__}"
+            )
+    return {**DEFAULTS, **data}
+
+
+def reset_config(path: Path) -> dict[str, Any]:
+    """Rewrite the file to defaults and return them."""
+    path.write_text(json.dumps(DEFAULTS, indent=2), encoding="utf-8")
+    return dict(DEFAULTS)
+
+
+def write_changed_keys(path: Path, changed: dict[str, Any]) -> None:
+    """Patch only hand-changed keys, preserving direct edits to the rest."""
+    if not changed:
+        return
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    on_disk.update(changed)
+    path.write_text(json.dumps(on_disk, indent=2), encoding="utf-8")
+```
+
+## 3. Tests
+
+```python
+# tests/unit/test_config.py
+import json
+from pathlib import Path
+
+import pytest
+
+from boostgauge.config import DEFAULTS, load_config, reset_config, write_changed_keys
+
+
+def test_first_run_creates_defaults(tmp_path: Path) -> None:
+    """REQ-1: First run with no config file creates one with defaults."""
+    path = tmp_path / "config.json"
+    result = load_config(path)
+    assert path.exists()
+    assert json.loads(path.read_text())["size"] == 300
+    assert result["size"] == 300
+
+
+def test_cli_override_is_ephemeral(tmp_path: Path) -> None:
+    """REQ-2: CLI overrides govern the session and are never written to file."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 300}), encoding="utf-8")
+    active = {**load_config(path), "size": 400}
+    assert active["size"] == 400
+    assert json.loads(path.read_text())["size"] == 300
+
+
+def test_no_overrides_uses_file_values(tmp_path: Path) -> None:
+    """REQ-3: With no CLI overrides the window opens at the file's values."""
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps({"size": 350, "position": {"x": 50, "y": 50}}), encoding="utf-8"
+    )
+    active = load_config(path)
+    assert active["size"] == 350
+    assert active["position"] == {"x": 50, "y": 50}
+
+
+def test_reset_writes_defaults(tmp_path: Path) -> None:
+    """REQ-4: --reset-config restores default position and size on disk."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 500}), encoding="utf-8")
+    reset_config(path)
+    assert json.loads(path.read_text())["size"] == 300
+
+
+def test_reset_with_size_keeps_default_on_disk(tmp_path: Path) -> None:
+    """REQ-4: --reset-config --size N opens at N while the file holds default."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 500}), encoding="utf-8")
+    on_disk = reset_config(path)
+    active = {**on_disk, "size": 400}
+    assert active["size"] == 400
+    assert json.loads(path.read_text())["size"] == 300
+
+
+def test_threshold_edit_read_does_not_touch_file(tmp_path: Path) -> None:
+    """REQ-5: Reading edited thresholds never modifies the file."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 300, "redline": 80}), encoding="utf-8")
+    before = path.stat().st_mtime_ns
+    assert load_config(path)["redline"] == 80
+    assert path.stat().st_mtime_ns == before
+
+
+def test_exit_write_patches_only_changed_keys(tmp_path: Path) -> None:
+    """REQ-6: A direct file edit survives an exit that writes another key."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 300, "theme": "light"}), encoding="utf-8")
+    write_changed_keys(path, {"size": 600})
+    written = json.loads(path.read_text())
+    assert written["theme"] == "light"
+    assert written["size"] == 600
+
+
+def test_hand_change_wins_conflict(tmp_path: Path) -> None:
+    """REQ-7: When both sides changed one key, the hand-made value wins."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": 800}), encoding="utf-8")
+    write_changed_keys(path, {"size": 600})
+    assert json.loads(path.read_text())["size"] == 600
+
+
+def test_untouched_session_is_byte_identical(tmp_path: Path) -> None:
+    """REQ-8: A session with no hand-made changes performs no exit write."""
+    path = tmp_path / "config.json"
+    original = json.dumps({"size": 300}, indent=2)
+    path.write_text(original, encoding="utf-8")
+    before = path.read_bytes()
+    write_changed_keys(path, {})
+    assert path.read_bytes() == before
+
+
+def test_invalid_value_raises_clear_error(tmp_path: Path) -> None:
+    """REQ-21: Invalid config values produce a clear error message."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"size": "not_an_int"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be an integer"):
+        load_config(path)
+
+
+def test_config_path_selects_file(tmp_path: Path) -> None:
+    """REQ-22: --config PATH selects the file in play and writes nothing itself."""
+    chosen = tmp_path / "other.json"
+    chosen.write_text(json.dumps({"size": 512}), encoding="utf-8")
+    untouched = tmp_path / "config.json"
+    assert load_config(chosen)["size"] == 512
+    assert not untouched.exists()
+```
+
+## 4. Known omission
+
+No test is written for the position matrix (REQ-9 through REQ-12) or the size
+matrix (REQ-13 through REQ-20). That omission is the point of this fixture.

--- a/tests/fixtures/criteria_coverage/spec-0041.md
+++ b/tests/fixtures/criteria_coverage/spec-0041.md
@@ -1,0 +1,515 @@
+# Implementation Spec: #41 - Feature: Telltale peak-hold needle logic (pure, no GUI)
+
+| Field | Value |
+|-------|-------|
+| Issue | #41 |
+| LLD | `docs/lld/done/0041-telltale-needle-logic.md` |
+| Generated | 2026-08-01 |
+| Status | APPROVED |
+
+
+## 1. Overview
+
+This implementation adds pure, headless sliding-window peak-hold ("telltale") needle logic with optional linear decay for the `boostgauge` system monitor. It provides an $O(1)$ amortized state tracker capable of maintaining peak values over a configurable time window with exact floor clamping to active window maxima.
+
+**Objective:** Implement pure, headless peak-hold "telltale" needle tracking logic over a sliding time window with optional decay for the boostgauge system monitor in `src/boostgauge/telltale.py` with comprehensive unit tests in `tests/unit/test_telltale.py`.
+
+**Success Criteria:**
+- Expose `Sample` dataclass and `Telltale` class in `src/boostgauge/telltale.py`.
+- Maintain $O(1)$ amortized time complexity for `update()` and `current_peak()` operations.
+- Support hard-hold mode (`decay_rate=None` or `0.0`) with instant drop to window maximum upon peak expiration.
+- Support linear decay mode (`decay_rate > 0.0`) floored strictly by the active sliding window maximum value.
+- Achieve 100% line and branch test coverage in `tests/unit/test_telltale.py` without requiring GUI/Tkinter initialization.
+
+---
+
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/telltale.py` | Add | Implements `Sample` dataclass and `Telltale` class for tracking sliding-window peak-hold state with optional decay rate and $O(1)$ deque eviction. |
+| 2 | `tests/unit/test_telltale.py` | Add | Unit test suite verifying init validation, peak elevation, hard hold drop, smooth decay, floor clamping, reset, error handling, and performance. |
+
+**Implementation Order Rationale:** The core module `src/boostgauge/telltale.py` has no internal project dependencies and must be implemented first so that `tests/unit/test_telltale.py` can import and execute against it directly.
+
+---
+
+
+## 3. Current State (for Modify/Delete files)
+
+There are no files to modify or delete for this feature. Both `src/boostgauge/telltale.py` and `tests/unit/test_telltale.py` are new files being added to the repository.
+
+---
+
+
+## 4. Data Structures
+
+
+### 4.1 `Sample`
+
+**File:** `src/boostgauge/telltale.py`
+
+**Definition:**
+
+```python
+@dataclass(frozen=True)
+class Sample:
+    """Single numeric observation with timestamp."""
+
+    timestamp: float
+    value: float
+```
+
+
+### 4.2 `Telltale` Internal State
+
+**File:** `src/boostgauge/telltale.py`
+
+**Attributes:**
+
+```python
+window: float
+decay_rate: Optional[float]
+samples: deque[Sample]
+max_deque: deque[Sample]
+latest_timestamp: Optional[float]
+```
+
+
+## 5. Function Specifications
+
+
+### 5.1 `Telltale.__init__()`
+
+**File:** `src/boostgauge/telltale.py`
+
+**Signature:**
+
+```python
+def __init__(self, window: float, decay_rate: Optional[float] = None) -> None:
+    """Initialize Telltale with window duration in seconds (>0) and optional decay rate (units/sec)."""
+    ...
+```
+
+
+### 5.2 `Telltale.update()`
+
+**File:** `src/boostgauge/telltale.py`
+
+**Signature:**
+
+```python
+def update(self, timestamp: float, value: float) -> None:
+    """Feed a new sample (timestamp, value) and update internal sliding window state."""
+    ...
+```
+
+
+### 5.3 `Telltale.current_peak()`
+
+**File:** `src/boostgauge/telltale.py`
+
+**Signature:**
+
+```python
+def current_peak(self, current_time: Optional[float] = None) -> Optional[float]:
+    """Return highest value in window, accounting for optional decay up to current_time."""
+    ...
+```
+
+
+### 5.4 `Telltale.reset()`
+
+**File:** `src/boostgauge/telltale.py`
+
+**Signature:**
+
+```python
+def reset(self) -> None:
+    """Clear all sample history and reset telltale state to initial uninitialized state."""
+    ...
+```
+
+**Input Example:**
+
+```python
+# Invoked on an active Telltale instance containing samples
+```
+
+**Output Example:**
+
+```python
+# None (clears self.samples, self.max_deque, and sets self.latest_timestamp = None)
+```
+
+**Edge Cases:**
+- Calling `reset()` on a freshly initialized or already reset `Telltale` -> no-op, state remains clean.
+
+---
+
+
+## 6. Change Instructions
+
+
+### 6.1 `src/boostgauge/telltale.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Pure peak-hold telltale needle tracking logic over a sliding time window.
+
+Issue #41: Feature: Telltale peak-hold needle logic (pure, no GUI)
+"""
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Sample:
+    """Single numeric observation with timestamp."""
+
+    timestamp: float
+    value: float
+
+
+class Telltale:
+    """Pure peak-hold telltale needle tracker over a sliding time window."""
+
+    def __init__(self, window: float, decay_rate: Optional[float] = None) -> None:
+        """Initialize Telltale with window duration in seconds (>0) and optional decay rate (units/sec)."""
+        if window <= 0:
+            raise ValueError("Window duration must be positive")
+        if decay_rate is not None and decay_rate < 0:
+            raise ValueError("Decay rate cannot be negative")
+
+        self.window: float = float(window)
+        self.decay_rate: Optional[float] = float(decay_rate) if decay_rate is not None else None
+        self.samples: deque[Sample] = deque()
+        self.max_deque: deque[Sample] = deque()
+        self.latest_timestamp: Optional[float] = None
+
+    def update(self, timestamp: float, value: float) -> None:
+        """Feed a new sample (timestamp, value) and update internal sliding window state."""
+        timestamp_float = float(timestamp)
+        value_float = float(value)
+
+        if self.latest_timestamp is not None and timestamp_float < self.latest_timestamp:
+            raise ValueError("Timestamps must be non-decreasing")
+
+        self.latest_timestamp = timestamp_float
+
+        # 1. Evict expired samples from active window
+        cutoff = timestamp_float - self.window
+        while self.samples and self.samples[0].timestamp < cutoff:
+            self.samples.popleft()
+
+        # Compute current active window maximum
+        window_max = max((s.value for s in self.samples), default=None)
+
+        # 2. Evict expired candidate peaks from front of max_deque
+        if self.decay_rate is None or self.decay_rate == 0.0:
+            while self.max_deque and self.max_deque[0].timestamp < cutoff:
+                self.max_deque.popleft()
+        else:
+            while self.max_deque:
+                head = self.max_deque[0]
+                is_expired = head.timestamp < cutoff
+                if is_expired:
+                    if window_max is not None:
+                        decayed_val = head.value - self.decay_rate * (timestamp_float - (head.timestamp + self.window))
+                        if decayed_val <= window_max:
+                            self.max_deque.popleft()
+                            continue
+                    else:
+                        self.max_deque.popleft()
+                        continue
+                break
+
+        # 3. Maintain monotonic candidate property in max_deque
+        while self.max_deque and self.max_deque[-1].value <= value_float:
+            self.max_deque.pop()
+
+        # 4. Append new sample to both deques
+        new_sample = Sample(timestamp=timestamp_float, value=value_float)
+        self.samples.append(new_sample)
+        self.max_deque.append(new_sample)
+
+    def current_peak(self, current_time: Optional[float] = None) -> Optional[float]:
+        """Return highest value in window, accounting for optional decay up to current_time."""
+        if not self.samples:
+            return None
+
+        eval_time = float(current_time) if current_time is not None else self.latest_timestamp
+        assert self.latest_timestamp is not None
+
+        if eval_time < self.latest_timestamp:
+            raise ValueError("Evaluation time cannot precede latest timestamp")
+
+        cutoff = eval_time - self.window
+        active_samples = [s for s in self.samples if s.timestamp >= cutoff]
+        window_max = max((s.value for s in active_samples), default=None)
+
+        if self.decay_rate is None or self.decay_rate == 0.0:
+            return window_max
+
+        if not self.max_deque:
+            return window_max
+
+        peak_cand = max(
+            sample.value - self.decay_rate * max(0.0, eval_time - (sample.timestamp + self.window))
+            for sample in self.max_deque
+        )
+
+        if window_max is None:
+            return peak_cand
+
+        return max(peak_cand, window_max)
+
+    def reset(self) -> None:
+        """Clear all sample history and reset telltale state to initial uninitialized state."""
+        self.samples.clear()
+        self.max_deque.clear()
+        self.latest_timestamp = None
+```
+
+---
+
+
+### 6.2 `tests/unit/test_telltale.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Unit tests for telltale peak-hold needle logic module.
+
+Issue #41: Feature: Telltale peak-hold needle logic (pure, no GUI)
+"""
+
+import time
+import pytest
+
+from boostgauge.telltale import Sample, Telltale
+
+
+def test_t010_initialization_validation() -> None:
+    """Test initialization parameters validation and attribute storage (REQ-1)."""
+    t = Telltale(window=10.0, decay_rate=15.0)
+    assert t.window == 10.0
+    assert t.decay_rate == 15.0
+
+    t_default = Telltale(window=5.0)
+    assert t_default.window == 5.0
+    assert t_default.decay_rate is None
+
+    t_zero_decay = Telltale(window=5.0, decay_rate=0.0)
+    assert t_zero_decay.decay_rate == 0.0
+
+    with pytest.raises(ValueError, match="Window duration must be positive"):
+        Telltale(window=0.0)
+
+    with pytest.raises(ValueError, match="Window duration must be positive"):
+        Telltale(window=-1.0)
+
+    with pytest.raises(ValueError, match="Decay rate cannot be negative"):
+        Telltale(window=10.0, decay_rate=-5.0)
+
+
+def test_t020_stream_update_throughput() -> None:
+    """Test high-frequency update stream throughput (REQ-2)."""
+    t = Telltale(window=60.0, decay_rate=1.0)
+    start_time = time.perf_counter()
+
+    for i in range(10_000):
+        t.update(timestamp=i * 0.01, value=float(i % 100))
+        _ = t.current_peak()
+
+    elapsed = time.perf_counter() - start_time
+    assert elapsed < 0.5, f"10,000 updates took {elapsed:.4f}s (budget < 0.5s)"
+
+
+def test_t030_instant_peak_elevation() -> None:
+    """Test rising sample series immediately elevates peak (REQ-3)."""
+    t = Telltale(window=10.0)
+    t.update(0.0, 10.0)
+    assert t.current_peak() == 10.0
+
+    t.update(1.0, 20.0)
+    assert t.current_peak() == 20.0
+
+    t.update(2.0, 50.0)
+    assert t.current_peak() == 50.0
+
+
+def test_t031_new_sample_exceeding_decayed_peak_resets_upward() -> None:
+    """Test new sample exceeding decayed peak resets peak upward immediately (REQ-3)."""
+    t = Telltale(window=10.0, decay_rate=15.0)
+    t.update(0.0, 100.0)
+    assert t.current_peak(12.0) == 70.0  # Decayed from 100 to 70 at t=12
+
+    t.update(12.1, 80.0)
+    assert t.current_peak() == 80.0  # Resets upward immediately to 80
+
+
+def test_t040_hard_hold_peak_drop_to_window_max() -> None:
+    """Test peak drops instantly to window max when peak ages out with decay_rate=None (REQ-4)."""
+    t = Telltale(window=10.0, decay_rate=None)
+    t.update(0.0, 100.0)
+    t.update(5.0, 40.0)
+    assert t.current_peak(5.0) == 100.0
+
+    t.update(10.1, 30.0)
+    assert t.current_peak() == 40.0
+
+
+def test_t041_hard_hold_single_sample_drops_to_none() -> None:
+    """Test single sample peak drops to None when window expires (REQ-4)."""
+    t = Telltale(window=10.0, decay_rate=None)
+    t.update(0.0, 50.0)
+    assert t.current_peak() == 50.0
+
+    assert t.current_peak(10.1) is None
+
+
+def test_t050_smooth_decay_from_departed_high() -> None:
+    """Test smooth decay from departed high at decay_rate units/sec (REQ-5)."""
+    t = Telltale(window=10.0, decay_rate=15.0)
+    t.update(0.0, 100.0)
+    t.update(9.0, 40.0)
+
+    # At t=12.0, peak was at t=0, window ended at t=10.0. Elapsed decay time = 2.0s.
+    # Decayed peak = 100.0 - 15.0 * 2.0 = 70.0
+    assert t.current_peak(12.0) == 70.0
+
+
+def test_t051_decay_floor_clamping() -> None:
+    """Test decaying peak is strictly floored at active window maximum (REQ-5)."""
+    t = Telltale(window=10.0, decay_rate=15.0)
+    t.update(0.0, 100.0)
+    t.update(9.0, 40.0)
+
+    # At t=15.0, unfloored decay = 100.0 - 15.0 * (15.0 - 10.0) = 25.0
+    # Active window max = 40.0 (from sample at 9.0). Peak must be floored at 40.0.
+    assert t.current_peak(15.0) == 40.0
+
+
+def test_t060_reset_clears_state() -> None:
+    """Test reset clears all internal state and current_peak returns None (REQ-6)."""
+    t = Telltale(window=10.0, decay_rate=10.0)
+    t.update(0.0, 100.0)
+    t.update(5.0, 50.0)
+    assert t.current_peak() == 100.0
+
+    t.reset()
+    assert t.current_peak() is None
+    assert len(t.samples) == 0
+    assert len(t.max_deque) == 0
+    assert t.latest_timestamp is None
+
+
+def test_t061_update_after_reset_reinitializes() -> None:
+    """Test update after reset re-initializes telltale state (REQ-6)."""
+    t = Telltale(window=10.0)
+    t.update(0.0, 100.0)
+    t.reset()
+
+    t.update(20.0, 15.0)
+    assert t.current_peak() == 15.0
+
+
+def test_t070_pre_first_update_returns_none() -> None:
+    """Test current_peak returns None prior to first update (REQ-7)."""
+    t = Telltale(window=10.0, decay_rate=5.0)
+    assert t.current_peak() is None
+
+
+def test_out_of_order_timestamps() -> None:
+    """Test out-of-order timestamp rejection in update and current_peak."""
+    t = Telltale(window=10.0)
+    t.update(10.0, 50.0)
+
+    with pytest.raises(ValueError, match="Timestamps must be non-decreasing"):
+        t.update(9.0, 60.0)
+
+    with pytest.raises(ValueError, match="Evaluation time cannot precede latest timestamp"):
+        t.current_peak(8.0)
+
+
+def test_sample_dataclass_immutability() -> None:
+    """Test Sample dataclass creation and immutability."""
+    s = Sample(timestamp=1.0, value=2.0)
+    assert s.timestamp == 1.0
+    assert s.value == 2.0
+    with pytest.raises(AttributeError):
+        s.value = 3.0  # type: ignore[misc]
+```
+
+---
+
+
+## [UNCHANGED] 7. Pattern References
+
+
+### [UNCHANGED] 7.1 Data Structure & Package Export Pattern
+
+
+## [UNCHANGED] 8. Dependencies & Imports
+
+
+## 9. Placeholder
+
+*Reserved for future alignment with LLD section numbering.*
+
+---
+
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| T010 | `Telltale.__init__()` | `window=10.0, decay_rate=15.0` | Attributes initialized; invalid parameters raise `ValueError` |
+| T020 | `Telltale.update()` / `current_peak()` | 10,000 stream updates | Execution completed in < 0.5s ($O(1)$ amortized) |
+| T030 | `Telltale.update()` | `(0, 10), (1, 20), (2, 50)` | `current_peak()` == 50.0 immediately |
+| T031 | `Telltale.update()` | `(0, 100), t=12 (decayed to 70), (12.1, 80)` | `current_peak()` == 80.0 immediately |
+| T040 | `Telltale.current_peak()` | `window=10, decay=None, (0, 100), (5, 40), t=10.1` | `current_peak()` == 40.0 (instant drop to window max) |
+| T041 | `Telltale.current_peak()` | `window=10, decay=None, (0, 50), t=10.1` | `current_peak(10.1)` returns `None` |
+| T050 | `Telltale.current_peak()` | `window=10, decay=15, (0, 100), (9, 40), t=12.0` | `current_peak()` == 70.0 ($100 - 15 \times 2$) |
+| T051 | `Telltale.current_peak()` | `window=10, decay=15, (0, 100), (9, 40), t=15.0` | `current_peak()` == 40.0 (floored at window max 40) |
+| T060 | `Telltale.reset()` | Stream added, then `reset()` | `current_peak()` returns `None`, deques emptied |
+| T061 | `Telltale.update()` | `reset()`, then `update(20, 15)` | `current_peak()` == 15.0 |
+| T070 | `Telltale.current_peak()` | Fresh `Telltale` instance | `current_peak()` returns `None` |
+
+---
+
+
+## 11. Implementation Notes
+
+
+### [UNCHANGED] 11.1 Memory Bounds
+
+
+### [UNCHANGED] 11.2 Monotonic Deque Candidate Eviction Rule
+
+
+## [UNCHANGED] Completeness Checklist
+
+
+## [UNCHANGED] Review Log
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #41 |
+| Verdict | APPROVED |
+| Date | 2026-08-01 |
+| Iterations | 2 |
+| Finalized | 2026-08-01T13:39:46Z |
+
+### Review Feedback Summary
+
+The revised implementation spec for Issue #41 is fully concrete, complete, and ready for execution. Complete source code and comprehensive unit test implementations are provided for both src/boostgauge/telltale.py and tests/unit/test_telltale.py. All test assertions in test_telltale.py directly trace to requirements REQ-1 through REQ-7 and behavior defined in Section 6, with zero contradictions or platform dependencies. An AI agent can implement this spec with a >80% first-try success rate.

--- a/tests/unit/test_criteria_coverage.py
+++ b/tests/unit/test_criteria_coverage.py
@@ -1,0 +1,309 @@
+"""Every LLD pass criterion must have a test in the spec (Closes #2239).
+
+The spec stage had no mechanical criterion-to-test check; the judgment lived
+only in the adversarial reviewer, so a miss cost a full REVISE round and
+detection was bounded by the iteration cap. run-issue7-082047 (boostgauge,
+2026-08-12) spent three iterations and still died at the cap with "completely
+omits 12 required state matrix tests" among the reasons.
+
+The fixtures here are real artifacts, not invented ones:
+
+* ``LLD-007.md`` -- verbatim from boostgauge PR #285 at ``f8018447``. Twenty-two
+  requirements over twenty-three scenario rows, twelve of them decision-table
+  rows (REQ-9..REQ-20).
+* ``spec-0007-reconstruction.md`` -- a **documented reconstruction**, authored
+  for this test under the operator's 2026-08-12 ruling. The real failing spec
+  does not exist: orchestrated runs never persisted their drafts (#2250). The
+  file states its own provenance in its first paragraph.
+* ``LLD-041.md`` / ``spec-0041.md`` -- verbatim from merged boostgauge PR #214,
+  a historically green run, used to pin that full coverage passes unchanged.
+* ``LLD-001.md`` / ``spec-0001.md`` -- verbatim from merged boostgauge PR #220.
+  See ``TestAGreenRunThatWasNotActuallyCovered`` -- measuring this pair is how
+  the check found that a green run shipped with four criteria untested.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+    MODE_EXACT,
+    MODE_OUTCOME,
+    criteria_coverage,
+    format_report,
+    lld_criteria,
+    spec_tests,
+)
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_criteria_have_tests,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "criteria_coverage"
+
+#: The twelve decision-table rows of LLD-007: position matrix + size matrix.
+MATRIX_ROWS = [f"REQ-{n}" for n in range(9, 21)]
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The regression the issue names
+# ---------------------------------------------------------------------------
+
+
+class TestTheOmittedMatrixTests:
+    """LLD-007 against a spec missing exactly the twelve row tests."""
+
+    @pytest.fixture
+    def report(self):
+        return criteria_coverage(
+            _fixture("spec-0007-reconstruction.md"), _fixture("LLD-007.md")
+        )
+
+    def test_all_twelve_row_criteria_are_reported_missing(self, report):
+        assert sorted(c.key for c in report.missing) == sorted(MATRIX_ROWS), (
+            "the check must name every omitted row criterion, not a sample. The "
+            "whole point is that one revision can address the full set instead "
+            "of paying a REVISE round per miss."
+        )
+
+    def test_nothing_else_is_reported_missing(self, report):
+        """A check that fired on a spec thin everywhere would prove nothing
+        about the row omission."""
+        assert len(report.missing) == 12
+
+    def test_the_check_fails(self, report):
+        assert not report.ok
+
+    def test_every_missing_criterion_is_named_in_the_report_text(self, report):
+        text = format_report(report)
+        for key in MATRIX_ROWS:
+            assert key in text, f"{key} is missing from the drafter-facing report"
+
+    def test_the_report_names_the_join_mode(self, report):
+        """#2239: the weaker mode must never be mistaken for the stronger."""
+        assert report.join_mode == MODE_EXACT
+        assert "exact" in format_report(report)
+
+    def test_the_report_carries_the_scenario_text(self, report):
+        """A bare ID list would make the drafter go read the LLD; the point is
+        to hand it what to write."""
+        text = format_report(report)
+        assert "Pos matrix" in text
+        assert "Size matrix" in text
+
+    def test_the_measured_requirement_count_is_twenty_two(self):
+        """The 2026-08-12 correction on the issue: twenty-two, not twenty-one."""
+        keys = {c.key for c in lld_criteria(_fixture("LLD-007.md"))}
+        assert len(keys) == 22, f"expected 22 distinct requirements, got {len(keys)}"
+
+
+# ---------------------------------------------------------------------------
+# A historically green run must still pass
+# ---------------------------------------------------------------------------
+
+
+class TestAGreenRunPassesUnchanged:
+    """boostgauge PR #214: LLD-041 and its final spec, merged and green."""
+
+    def test_full_coverage_passes(self):
+        report = criteria_coverage(_fixture("spec-0041.md"), _fixture("LLD-041.md"))
+
+        assert report.ok, (
+            "a merged, historically green spec must not be failed by this check. "
+            f"Reported missing: {[c.key for c in report.missing]}"
+        )
+        assert report.join_mode == MODE_EXACT
+        assert report.covered == len(report.criteria)
+
+    def test_it_really_had_criteria_and_tests_to_check(self):
+        """A pass proves nothing if either side was empty."""
+        assert len(lld_criteria(_fixture("LLD-041.md"))) == 12
+        assert len(spec_tests(_fixture("spec-0041.md"))) == 13
+
+
+class TestAGreenRunThatWasNotActuallyCovered:
+    """boostgauge PR #220, merged green, is NOT full coverage.
+
+    #2239 named PRs #220 and #214 as green-run specs carrying REQ tags, on the
+    premise that both would pass unchanged. Measured, #214 does and #220 does
+    not: LLD-001 tags all twelve of its scenario rows, and spec-0001's eleven
+    tests cite only eight of them. REQ-6 (wordmark), REQ-7 (telltales behind the
+    main needle), REQ-10 (omit a telltale when None) and REQ-11 (needle over
+    redline) have no test. All twelve rows are type "Auto", so no exemption
+    applies.
+
+    That is the defect this issue exists to catch, shipped in a green run and
+    undetected -- a second exhibit for the thesis rather than a counterexample
+    to it. Pinned here so the finding survives, and so the day someone adds the
+    four tests this test says plainly what changed.
+    """
+
+    def test_exactly_the_four_visual_criteria_are_uncovered(self):
+        report = criteria_coverage(_fixture("spec-0001.md"), _fixture("LLD-001.md"))
+
+        assert sorted(c.key for c in report.missing) == ["REQ-10", "REQ-11", "REQ-6", "REQ-7"]
+
+    def test_the_other_eight_are_covered(self):
+        report = criteria_coverage(_fixture("spec-0001.md"), _fixture("LLD-001.md"))
+        assert report.covered == len(report.criteria) - 4
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+class TestCriterionExtraction:
+    def test_scenario_rows_become_criteria(self):
+        criteria = lld_criteria(_fixture("LLD-007.md"))
+        assert len(criteria) == 23, (
+            "twenty-three scenario rows over twenty-two requirements -- REQ-4 "
+            "has two rows, 040 and 041"
+        )
+
+    def test_row_ids_are_carried_for_the_report(self):
+        by_key = {c.key: c for c in lld_criteria(_fixture("LLD-007.md"))}
+        assert by_key["REQ-9"].row_id == "090"
+
+    def test_non_scenario_tables_are_left_alone(self):
+        """An LLD's Alternatives Considered table is a table, not criteria."""
+        lld = (
+            "## 4. Alternatives Considered\n\n"
+            "| Option | Pros | Cons | Decision |\n"
+            "|---|---|---|---|\n"
+            "| In-memory diffing | Simple | Overwrites edits | **Rejected** |\n"
+        )
+        assert lld_criteria(lld) == []
+
+    def test_an_lld_with_no_table_is_not_applicable(self):
+        report = criteria_coverage("```python\ndef test_x(): pass\n```", "# LLD\n\nProse only.\n")
+        assert not report.ran
+        assert "not applicable" in format_report(report).lower()
+
+
+class TestSpecTestExtraction:
+    def test_tests_are_found_inside_fences(self):
+        names = [n for n, _ in spec_tests(_fixture("spec-0041.md"))]
+        assert "test_t010_initialization_validation" in names
+
+    def test_prose_outside_a_fence_is_not_coverage(self):
+        """spec-0041's closing paragraph says its assertions "trace to
+        requirements REQ-1 through REQ-7". That sentence names no test, and a
+        checker that counted it would call an empty spec fully covered."""
+        spec = (
+            "All test assertions trace to requirements REQ-1 through REQ-7.\n"
+            "\n```python\ndef test_only(self):\n    \"\"\"REQ-1: something.\"\"\"\n```\n"
+        )
+        tagged = spec_tests(spec)
+        assert len(tagged) == 1
+        assert "REQ-7" not in tagged[0][1]
+
+    def test_a_docstring_stays_with_its_own_test(self):
+        spec = (
+            "```python\n"
+            "def test_one():\n    \"\"\"REQ-1: first.\"\"\"\n    pass\n\n"
+            "def test_two():\n    \"\"\"REQ-2: second.\"\"\"\n    pass\n"
+            "```\n"
+        )
+        blocks = dict(spec_tests(spec))
+        assert "REQ-1" in blocks["test_one"] and "REQ-2" not in blocks["test_one"]
+        assert "REQ-2" in blocks["test_two"] and "REQ-1" not in blocks["test_two"]
+
+
+# ---------------------------------------------------------------------------
+# The fallback mode
+# ---------------------------------------------------------------------------
+
+
+class TestCountAndOutcomeFallback:
+    """Used when there are no IDs to join on. #2239 requires the mode be named,
+    and requires matching rather than greedy assignment."""
+
+    UNTAGGED_LLD = (
+        "### 10.1 Test Scenarios\n\n"
+        "| ID | Scenario | Type | Pass Criteria |\n"
+        "|---|---|---|---|\n"
+        "| 010 | Size no reset not resized | Auto | size unchanged |\n"
+        "| 020 | Size no reset size given | Auto | size unchanged; the CLI value is not written |\n"
+    )
+
+    def test_the_mode_is_named(self):
+        spec = (
+            "```python\n"
+            "def test_a():\n    \"\"\"size unchanged.\"\"\"\n\n"
+            "def test_b():\n    \"\"\"size unchanged; the CLI value is not written.\"\"\"\n"
+            "```\n"
+        )
+        report = criteria_coverage(spec, self.UNTAGGED_LLD)
+        assert report.join_mode == MODE_OUTCOME
+        assert "count and outcome" in format_report(report)
+
+    def test_matching_is_not_greedy(self):
+        """'size unchanged' is a substring of 'size unchanged; the CLI value is
+        not written'. Assigning in row order would consume the only test row 020
+        could use and report a gap that is not there -- the exact hazard
+        _max_matching exists for."""
+        spec = (
+            "```python\n"
+            "def test_b():\n    \"\"\"size unchanged; the CLI value is not written.\"\"\"\n\n"
+            "def test_a():\n    \"\"\"size unchanged.\"\"\"\n"
+            "```\n"
+        )
+        report = criteria_coverage(spec, self.UNTAGGED_LLD)
+        assert report.ok, f"false gap reported: {[c.row_id for c in report.missing]}"
+
+    def test_a_genuine_gap_is_still_caught(self):
+        spec = "```python\ndef test_a():\n    \"\"\"size unchanged.\"\"\"\n```\n"
+        report = criteria_coverage(spec, self.UNTAGGED_LLD)
+        assert len(report.missing) == 1
+
+
+# ---------------------------------------------------------------------------
+# Wiring into the node
+# ---------------------------------------------------------------------------
+
+
+class TestTheCompletenessCheck:
+    def test_the_check_fails_the_reconstruction(self):
+        check = check_criteria_have_tests(
+            _fixture("spec-0007-reconstruction.md"), _fixture("LLD-007.md")
+        )
+        assert check["check_name"] == "criteria_have_tests"
+        assert not check["passed"]
+        for key in MATRIX_ROWS:
+            assert key in check["details"]
+
+    def test_the_check_passes_the_green_run(self):
+        check = check_criteria_have_tests(
+            _fixture("spec-0041.md"), _fixture("LLD-041.md")
+        )
+        assert check["passed"]
+
+    def test_an_absent_lld_is_not_applicable_rather_than_a_failure(self):
+        """#1870's convention: nothing to check is not evidence, but it is also
+        not a failure -- a spec must not be blocked because the LLD did not
+        reach this node."""
+        check = check_criteria_have_tests("```python\ndef test_x(): pass\n```", "")
+        assert check["passed"]
+        assert "not applicable" in check["details"].lower()
+
+    def test_the_node_runs_the_check(self):
+        """The check must actually be wired in, not merely defined -- a check
+        nothing calls is the quietest way for this to regress."""
+        import inspect
+
+        from assemblyzero.workflows.implementation_spec.nodes import (
+            validate_completeness as node,
+        )
+
+        source = inspect.getsource(node)
+        assert "check_criteria_have_tests(" in source, (
+            "validate_completeness defines the check but never calls it"
+        )
+        assert "lld_content" in source, (
+            "the check is called without the LLD, so it can only ever report "
+            "'not applicable'"
+        )


### PR DESCRIPTION
## What this adds

A ninth mechanical check in the spec stage's completeness validation:
**every LLD pass criterion must have a test in the spec.**

That judgment previously lived only in the adversarial reviewer, so a miss cost
a full REVISE round and detection was bounded by the iteration cap.
`run-issue7-082047` spent three iterations and still died at the cap with
*"completely omits 12 required state matrix tests"* among the reasons. This
names all twelve at iteration zero, for free, so one revision can address the
whole set.

## Two join modes, always named

| mode | when | strength |
|---|---|---|
| **exact** | criteria carry `REQ` tags and the spec's tests cite them | a join on identifiers |
| **count and outcome** | no usable tags on one side | outcome-text matching |

The report names which one ran. The weaker mode must never be mistaken for the
stronger, which is the same discipline `form_check` applies.

The fallback reuses the form checker's **maximum bipartite matching** (#2219).
Greedy is wrong here for exactly the reason it is wrong there: in LLD-007
`unchanged` is a substring of `unchanged; the CLI value is not written`, so
row-order assignment can consume the only test a later criterion could have used
and report a gap that is not there. A test pins that.

`parse_tables`, `_max_matching` and `_norm` are imported from the form checker
rather than reimplemented — one table parser and one matching algorithm for both
callers. A second copy would drift from the first, which this codebase has
already paid for twice (#1586, #1698).

## Fixtures are real artifacts

| fixture | provenance |
|---|---|
| `LLD-007.md` | verbatim, boostgauge PR #285 at `f8018447` |
| `LLD-041.md` / `spec-0041.md` | verbatim, merged boostgauge PR #214 |
| `LLD-001.md` / `spec-0001.md` | verbatim, merged boostgauge PR #220 |
| `spec-0007-reconstruction.md` | **documented reconstruction**, per the operator's 2026-08-12 ruling |

The real failing draft does not exist — orchestrated runs never persisted their
drafts (tracked in #2250) — and waiting for a real one is circular, since this
check exists to prevent the failure that would produce one. The reconstruction
states its own provenance in its first paragraph, quotes the run log's recorded
condition, and covers every LLD-007 criterion **except** REQ-9…REQ-20, so a
check firing on it is firing on the row omission and not on a spec that is thin
everywhere.

Measured against the real LLD-007: 23 scenario rows over **22** distinct
requirements (REQ-4 has two rows, 040 and 041) — matching the issue's 2026-08-12
correction, and pinned by a test.

## A finding worth your attention

**boostgauge PR #220, a merged green run, is not full coverage.**

The issue named PRs #220 and #214 as green-run specs on the premise that both
would pass unchanged. #214 does. #220 does not: LLD-001 tags all twelve of its
scenario rows, and spec-0001's eleven tests cite only eight. REQ-6 (wordmark),
REQ-7 (telltales behind the main needle), REQ-10 (omit a telltale when `None`)
and REQ-11 (needle over redline) have no test. All twelve rows are type `Auto`,
so no exemption applies.

That is this defect shipping undetected in a green run — a second exhibit for
the issue's thesis rather than a counterexample to it. It is pinned as a test
(`TestAGreenRunThatWasNotActuallyCovered`) so the finding survives and so the
day someone adds those four tests, the test says plainly what changed.
Criterion 4 is therefore verified against #214, which genuinely is full
coverage.

## What exact mode still cannot see

Two rows may share a tag — LLD-007's 040 and 041 are both REQ-4 — and one test
tagged REQ-4 marks both covered. Joining on a tag can only prove a tag was
tested. Row-level identity is what boostgauge #284 adds, and this check moves to
it for free when it lands, since the join key is read from the row. Until then
the residue is one test short on a shared tag, not twelve missing tests, and it
stays where it already was: with the semantic reviewer. Documented in the
module.

## Evidence

- `TestTheOmittedMatrixTests` — all twelve of REQ-9…REQ-20 reported missing by
  name, **and nothing else** (so the check is firing on the omission, not on
  general thinness)
- `TestAGreenRunPassesUnchanged` — #214 passes, with a companion test proving
  both sides were non-empty so the pass is not vacuous
- An LLD with no criteria table is *not applicable* rather than a failure —
  #1870's convention, so a spec cannot be blocked because the LLD never reached
  the node
- `test_the_node_runs_the_check` — a check nothing calls is the quietest way for
  this to regress

Full unit suite: **6966 passed, 17 skipped, 5 xfailed**. `ruff check` clean on
all three changed source files.

Closes #2239
