### PR TITLE
fix: derive the requirements graph's step budget and halt by name (Closes #2245)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -406,9 +406,17 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
         previous_draft_path = state.get("previous_lld_draft_path", "")
         previous_verdict_text = state.get("previous_lld_verdict_text", "")
 
+        # #2245: this stage passed no config at all, so every orchestrated roll
+        # took LangGraph's default of 25 super-steps by accident -- and a run
+        # that spent its loops raised GraphRecursionError, which names no stage,
+        # no loop and no document. The budget is derived from the loop costs and
+        # the caps that bound them; exhausting it now halts with what consumed
+        # it.
+        from assemblyzero.workflows.requirements.step_budget import invoke_with_budget
+
         graph = create_requirements_graph()
         app = graph.compile()
-        sub_result = app.invoke({
+        sub_result = invoke_with_budget(app, {
             "issue_number": issue_number,
             "workflow_type": "lld",
             "target_repo": state.get("target_repo", ""),
@@ -423,7 +431,7 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
             "config_gates_verdict": gate_enabled,
             "previous_draft_path": previous_draft_path,
             "previous_verdict_text": previous_verdict_text,
-        })
+        }, stage="lld")
 
         # The requirements workflow's finalize node writes the saved LLD
         # path as `final_lld_path` and the verdict as `final_verdict`

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -373,17 +373,21 @@ def validate_lld_final(content: str, open_questions_resolved: bool = False) -> l
 
 #: Hard ceiling on finalize repairs, independent of the iteration cap.
 #:
-#: Measured on the compiled graph: a run costs 9 super-steps to reach finalize
-#: and each repair round trip (N1, Ponder, N1.5, N1b, N3, N5) costs 6 more. The
-#: two callers allow 25 (the orchestrator's `run_lld_stage`, which sets no
-#: limit and takes LangGraph's default) and `(max_iterations * 4) + 10`, which
-#: is 22 at the default cap. A third repair needs 27, so it does not raise the
-#: halt below — it raises GraphRecursionError instead, which says nothing about
-#: what failed. Two repairs cost 21 and fit both.
+#: Two is what a repair loop should try, not what happened to fit.
 #:
-#: Two is also enough to decide: a defect that survives two surgical repairs of
-#: the named errors is systematic, which is the case this issue was filed
-#: about.
+#: #2233 set this to 2 for two reasons at once: two repairs cost 21 super-steps
+#: and fit both callers' limits, and two is enough to decide. #2245 removed the
+#: first reason -- the step budget is now derived from the loop costs and the
+#: caps that bound them (assemblyzero/workflows/requirements/step_budget.py), so
+#: a third repair fits comfortably and would raise this loop's own halt rather
+#: than a nameless GraphRecursionError. A test pins that, so the value below is
+#: a judgment about repairs and provably not a constraint about steps.
+#:
+#: The judgment stands on its own: the repair is surgical -- finalize names the
+#: exact validation errors and hands them back -- so a defect that survives two
+#: repairs of named errors is systematic, and a third attempt at the same
+#: surgery buys a round trip rather than a different answer. That is the case
+#: #2233 was filed about.
 MAX_FINALIZE_REPAIRS = 2
 
 

--- a/assemblyzero/workflows/requirements/step_budget.py
+++ b/assemblyzero/workflows/requirements/step_budget.py
@@ -1,0 +1,164 @@
+"""The requirements graph's step budget, in one place (#2245).
+
+LangGraph bounds a run by super-steps. Exhausting that bound raises
+``GraphRecursionError``, which names no stage, no loop and no document -- the
+opposite of the halts this graph is otherwise careful to produce.
+
+Before this module the two callers disagreed and neither sized the bound against
+what the loops cost. ``run_lld_stage`` passed no ``config`` at all, so every
+orchestrated roll -- the path that matters most -- silently took LangGraph's
+default of 25. ``tools/run_requirements_workflow.py`` computed
+``(max_iterations * 4) + 10``, which is 22 at the default cap: *smaller* than the
+default it was presumably raising.
+
+Measured costs
+--------------
+
+Driving the real compiled graph with every model call stubbed and counting
+super-steps (``app.stream``, one count per step). ``TestStepBudget`` in
+``tests/unit/test_step_budget.py`` re-measures all of these, so a node added to
+any loop fails a test instead of silently eating headroom:
+
+===========================================  =====
+a clean pass, no loops                           9
+each reviewer revise round (N3 -> N1 -> N3)     +5
+each finalize repair round trip                 +6
+===========================================  =====
+
+They are additive: two revise rounds and two repairs measured 31, and
+``9 + 2*5 + 2*6`` is 31.
+
+Why a headroom term
+-------------------
+
+The three numbers above cover the ungated LLD path. The human gates add a step
+each when enabled, ``HALT`` adds one, and the issue-drafting path differs. Rather
+than model every combination -- which would rot the first time the graph is
+rewired -- the derivation carries a stated margin. It is not a fudge factor for
+"maybe there are more loops": every loop that exists is counted above.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: A clean LLD pass: load, codebase, requirements, draft, ponder, mechanical,
+#: test-plan, review, finalize.
+CLEAN_RUN_STEPS = 9
+
+#: One reviewer REVISE round: N3 sends the draft back to N1, which costs
+#: N1 -> Ponder -> N1.5 -> N1b -> N3.
+REVISE_ROUND_STEPS = 5
+
+#: One finalize repair round trip: N1, Ponder, N1.5, N1b, N3, N5.
+FINALIZE_REPAIR_STEPS = 6
+
+#: The human gates when enabled, HALT, and the issue-drafting path's shape.
+HEADROOM_STEPS = 10
+
+#: What the graph itself falls back to (`state.get("max_iterations", 3)` in
+#: every router). Kept here so a caller that does not set the cap still sizes
+#: the budget against the cap the graph will actually enforce.
+DEFAULT_MAX_ITERATIONS = 3
+
+
+def recursion_limit(
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    max_finalize_repairs: int | None = None,
+) -> int:
+    """Super-steps to allow a run whose loops all run to their caps.
+
+    Sized so that every loop reaches ITS OWN halt -- the one that names the
+    document and the unfixed errors -- rather than being cut off by a bound
+    nothing states.
+    """
+    if max_finalize_repairs is None:
+        from assemblyzero.workflows.requirements.nodes.finalize import (
+            MAX_FINALIZE_REPAIRS,
+        )
+        max_finalize_repairs = MAX_FINALIZE_REPAIRS
+
+    try:
+        iterations = max(0, int(max_iterations))
+    except (TypeError, ValueError):
+        iterations = DEFAULT_MAX_ITERATIONS
+
+    return (
+        CLEAN_RUN_STEPS
+        + iterations * REVISE_ROUND_STEPS
+        + max(0, int(max_finalize_repairs)) * FINALIZE_REPAIR_STEPS
+        + HEADROOM_STEPS
+    )
+
+
+def describe_budget_exhaustion(
+    state: dict[str, Any], limit: int, steps: int, stage: str
+) -> str:
+    """Say which loop spent the budget, in the register the other halts use.
+
+    The counters are already on the state -- ``verdict_count`` is incremented
+    once per review, ``finalize_repair_count`` once per repair -- so the run can
+    name what it was doing instead of reporting a bare recursion error.
+    """
+    revise_rounds = state.get("verdict_count", 0) or 0
+    repairs = state.get("finalize_repair_count", 0) or 0
+    drafts = state.get("draft_count", 0) or 0
+
+    if repairs and revise_rounds > 1:
+        culprit = "the reviewer revise loop and the finalize repair loop together"
+    elif repairs:
+        culprit = "the finalize repair loop"
+    elif revise_rounds > 1:
+        culprit = "the reviewer revise loop"
+    else:
+        culprit = "a loop that reported no round counter"
+
+    return (
+        f"BLOCKED: the {stage} stage ran out of graph steps after {steps} of "
+        f"{limit}, spent by {culprit}.\n"
+        f"  drafts generated: {drafts}\n"
+        f"  reviewer verdicts: {revise_rounds} (each revise round costs "
+        f"{REVISE_ROUND_STEPS} steps)\n"
+        f"  finalize repairs: {repairs} (each costs {FINALIZE_REPAIR_STEPS} steps)\n"
+        "\n"
+        "  This is a loop that did not converge, not a crash. The document and "
+        "every draft are in the run's lineage directory. If the loop legitimately "
+        "needs more room, raise the cap that bounds it rather than the step "
+        "budget -- the budget is derived from the caps in "
+        "assemblyzero/workflows/requirements/step_budget.py."
+    )
+
+
+def invoke_with_budget(
+    app: Any,
+    state: dict[str, Any],
+    *,
+    stage: str = "lld",
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    max_finalize_repairs: int | None = None,
+) -> dict[str, Any]:
+    """Run the compiled graph under an explicit, derived step budget.
+
+    Streams rather than invokes so that when the budget IS exhausted the last
+    state is still in hand and the halt can name what consumed it. The final
+    streamed value is the same object ``invoke`` would have returned; a test
+    pins that equivalence, because the whole caller contract rests on it.
+    """
+    from langgraph.errors import GraphRecursionError
+
+    limit = recursion_limit(max_iterations, max_finalize_repairs)
+
+    last: dict[str, Any] = {}
+    steps = 0
+    try:
+        for values in app.stream(
+            state, config={"recursion_limit": limit}, stream_mode="values"
+        ):
+            last = values
+            steps += 1
+    except GraphRecursionError:
+        halt = describe_budget_exhaustion(last, limit, steps, stage)
+        print(halt)
+        return {**last, "error_message": halt}
+
+    return last

--- a/tests/unit/test_cleanup_stage.py
+++ b/tests/unit/test_cleanup_stage.py
@@ -200,13 +200,20 @@ def test_lld_stage_captures_lld_pr_url(tmp_path):
     lld_file.parent.mkdir(parents=True)
     lld_file.write_text("# LLD\n\nAPPROVED")
 
+    result = {
+        "final_lld_path": str(lld_file),
+        "final_verdict": "APPROVED",
+        "final_lld_pr_url": "https://github.com/o/r/pull/9",
+    }
+
     class _App:
-        def invoke(self, payload):
-            return {
-                "final_lld_path": str(lld_file),
-                "final_verdict": "APPROVED",
-                "final_lld_pr_url": "https://github.com/o/r/pull/9",
-            }
+        # #2245: the lld stage streams through invoke_with_budget under a
+        # derived step budget, so a spent budget can name the loop.
+        def invoke(self, payload, *args, **kwargs):
+            return result
+
+        def stream(self, payload, *args, **kwargs):
+            yield result
 
     class _Graph:
         def compile(self):

--- a/tests/unit/test_finalize_repair_routing.py
+++ b/tests/unit/test_finalize_repair_routing.py
@@ -523,14 +523,18 @@ class TestRepairBudget:
 class TestStepBudget:
     """The loop must reach its own halt, not a GraphRecursionError.
 
-    LangGraph bounds a run by super-steps. The orchestrator's `run_lld_stage`
-    passes no `recursion_limit`, so it gets LangGraph's default of 25;
-    `tools/run_requirements_workflow.py` computes `(max_iterations * 4) + 10`,
-    which is 22 at the default cap. Every repair round trip spends six of
-    those, and nothing in the graph notices until it runs out.
+    LangGraph bounds a run by super-steps, and every repair round trip spends
+    six of them. A comment asserting that would rot the first time a node joined
+    the loop, so this measures it.
 
-    That is what MAX_FINALIZE_REPAIRS is for, and a comment asserting it would
-    rot the first time a node is added to the loop. This measures it.
+    When #2233 wrote these, the two callers allowed 25 (the orchestrator's
+    `run_lld_stage`, which passed no config and took LangGraph's default by
+    accident) and `(max_iterations * 4) + 10`, which is 22 at the default cap --
+    smaller than the default it was raising. #2245 replaced both with a budget
+    derived from these measured costs, in
+    `assemblyzero/workflows/requirements/step_budget.py`, and the cases below
+    that name 25 and 22 are kept as the historical measurement that motivated
+    the clamp rather than as a description of what any caller does now.
     """
 
     @staticmethod
@@ -618,10 +622,10 @@ class TestStepBudget:
         assert (one, two) == (15, 21)
 
     @pytest.mark.parametrize("limit", [25, 22])
-    def test_a_full_repair_budget_fits_both_callers(
+    def test_a_full_repair_budget_fit_the_old_caller_limits(
         self, monkeypatch, capsys, limit
     ):
-        """The binding property. Both real limits, the budget spent in full."""
+        """Why the clamp was two: both pre-#2245 limits, budget spent in full."""
         steps = self._drive(
             monkeypatch, repairs=MAX_FINALIZE_REPAIRS, recursion_limit=limit
         )
@@ -629,14 +633,19 @@ class TestStepBudget:
 
         assert steps <= limit
 
-    def test_one_repair_past_the_budget_is_what_the_clamp_prevents(
+    def test_one_repair_past_the_old_limit_died_namelessly(
         self, monkeypatch, capsys
     ):
-        """Mutation: without the clamp, the loop dies namelessly.
+        """Why #2233 clamped, and what #2245 then removed the need for.
 
-        This is the evidence that MAX_FINALIZE_REPAIRS is load-bearing rather
-        than cautious. A third repair does not produce the halt message; it
-        produces a GraphRecursionError.
+        At the accidental limit of 25 a third repair produced no halt message at
+        all -- it produced a GraphRecursionError, which names no stage, no loop
+        and no document. That is what made MAX_FINALIZE_REPAIRS load-bearing.
+
+        It is no longer load-bearing for that reason: the derived budget carries
+        a third repair comfortably, so the cap is now a judgment about repairs.
+        `tests/unit/test_step_budget.py::TestTheDerivedLimit` pins that, and this
+        case stays as the measurement of the state it replaced.
         """
         from langgraph.errors import GraphRecursionError
 

--- a/tests/unit/test_orchestrator_lineage.py
+++ b/tests/unit/test_orchestrator_lineage.py
@@ -53,9 +53,27 @@ STAGE_TO_SUBWORKFLOW = {
 _PROVISION_CALL = re.compile(r"(?<!def )\bcreate_\w*audit_dir\s*\(")
 
 
+def _is_subworkflow_call(node: ast.Call) -> bool:
+    """Either shape a stage uses to drive its sub-graph.
+
+    `app.invoke({...})` is the plain one. `invoke_with_budget(app, {...})` is
+    the lld stage since #2245, which streams under a derived step budget so an
+    exhausted budget can name the loop that spent it.
+    """
+    callee = node.func
+    if (
+        isinstance(callee, ast.Attribute)
+        and callee.attr == "invoke"
+        and isinstance(callee.value, ast.Name)
+        and callee.value.id == "app"
+    ):
+        return True
+    return isinstance(callee, ast.Name) and callee.id == "invoke_with_budget"
+
+
 def _invoke_payload_keys_by_stage(source: Path) -> dict[str, set[str]]:
-    """Map each `run_*_stage` function to the literal keys of the dict it
-    passes to `app.invoke({...})`."""
+    """Map each `run_*_stage` function to the literal keys of the state dict it
+    hands its sub-workflow."""
     tree = ast.parse(source.read_text(encoding="utf-8"))
     found: dict[str, set[str]] = {}
 
@@ -63,18 +81,16 @@ def _invoke_payload_keys_by_stage(source: Path) -> dict[str, set[str]]:
         if not isinstance(func, ast.FunctionDef):
             continue
         for node in ast.walk(func):
-            if not isinstance(node, ast.Call):
+            if not isinstance(node, ast.Call) or not _is_subworkflow_call(node):
                 continue
-            callee = node.func
-            if not (isinstance(callee, ast.Attribute) and callee.attr == "invoke"):
-                continue
-            if not (isinstance(callee.value, ast.Name) and callee.value.id == "app"):
-                continue
-            if not (node.args and isinstance(node.args[0], ast.Dict)):
+            payload = next(
+                (arg for arg in node.args if isinstance(arg, ast.Dict)), None
+            )
+            if payload is None:
                 continue
             found.setdefault(func.name, set()).update(
                 k.value
-                for k in node.args[0].keys
+                for k in payload.keys
                 if isinstance(k, ast.Constant) and isinstance(k.value, str)
             )
     return found

--- a/tests/unit/test_orchestrator_repo_targeting.py
+++ b/tests/unit/test_orchestrator_repo_targeting.py
@@ -37,14 +37,25 @@ AZ_ROOT = str(Path("/fake/projects/AssemblyZero"))
 
 
 def _capturing_graph(captured: dict, return_value: dict):
-    """A mock create_graph() whose compiled app.invoke captures its payload."""
+    """A mock create_graph() whose compiled app captures the payload it is given.
+
+    Both drive shapes are wired. The spec and impl stages call `app.invoke`; the
+    lld stage streams through `invoke_with_budget` since #2245, so that an
+    exhausted step budget can name the loop that spent it rather than raising a
+    bare GraphRecursionError.
+    """
     app = MagicMock()
 
-    def _invoke(payload):
+    def _invoke(payload, *args, **kwargs):
         captured.update(payload)
         return return_value
 
+    def _stream(payload, *args, **kwargs):
+        captured.update(payload)
+        yield return_value
+
     app.invoke.side_effect = _invoke
+    app.stream.side_effect = _stream
     graph = MagicMock()
     graph.compile.return_value = app
     return graph

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -454,14 +454,22 @@ class TestLldStageBaseBranchThreading:
         final_lld = tmp_path / "LLD-007.md"
         final_lld.write_text("# LLD")
 
+        result = {
+            "error_message": "",
+            "final_lld_path": str(final_lld),
+            "final_verdict": "APPROVED",
+        }
+
         class _StubApp:
-            def invoke(self, payload: dict) -> dict:
+            # #2245: the lld stage streams through invoke_with_budget under a
+            # derived step budget. invoke stays for any caller that still uses it.
+            def invoke(self, payload: dict, *args, **kwargs) -> dict:
                 captured["payload"] = payload
-                return {
-                    "error_message": "",
-                    "final_lld_path": str(final_lld),
-                    "final_verdict": "APPROVED",
-                }
+                return result
+
+            def stream(self, payload: dict, *args, **kwargs):
+                captured["payload"] = payload
+                yield result
 
         class _StubGraph:
             def compile(self) -> _StubApp:

--- a/tests/unit/test_requirements_cli.py
+++ b/tests/unit/test_requirements_cli.py
@@ -260,12 +260,16 @@ class TestMainFunction:
 
         mock_roots.return_value = (tmp_path, tmp_path)
 
-        # Create mock compiled graph
-        mock_compiled = Mock()
-        mock_compiled.invoke.return_value = {
+        # Create mock compiled graph. #2245: the runner drives the graph through
+        # invoke_with_budget, which streams under a derived step budget so an
+        # exhausted budget names the loop that spent it.
+        final = {
             "error_message": "",
             "issue_url": "https://github.com/test/repo/issues/123",
         }
+        mock_compiled = Mock()
+        mock_compiled.invoke.return_value = final
+        mock_compiled.stream.return_value = iter([final])
         mock_graph.return_value.compile.return_value = mock_compiled
 
         # Create brief file
@@ -276,9 +280,9 @@ class TestMainFunction:
         with patch("sys.argv", ["prog", "--type", "issue", "--brief", str(brief), "--mock"]):
             result = main()
 
-        # Verify graph was created and invoked
+        # Verify graph was created and driven
         mock_graph.assert_called_once()
-        mock_compiled.invoke.assert_called_once()
+        mock_compiled.stream.assert_called_once()
 
 
 class TestSelectFlag:

--- a/tests/unit/test_step_budget.py
+++ b/tests/unit/test_step_budget.py
@@ -1,0 +1,381 @@
+"""The graph's step budget is derived, explicit, and halts by name (Closes #2245).
+
+LangGraph bounds a run by super-steps, and running out raises
+``GraphRecursionError`` -- which names no stage, no loop and no document. Before
+this, ``run_lld_stage`` passed no config at all and every orchestrated roll took
+the default of 25 by accident, while ``tools/run_requirements_workflow.py``
+computed ``(max_iterations * 4) + 10``: 22 at the default cap, smaller than the
+default it was raising.
+
+The per-loop costs are measured here rather than asserted in a comment, because
+a comment would rot the first time a node joined a loop. The technique is
+``TestStepBudget``'s in ``test_finalize_repair_routing.py``: drive the real
+compiled graph with every model call stubbed and count super-steps.
+"""
+
+import pytest
+
+from assemblyzero.workflows.requirements.nodes.finalize import MAX_FINALIZE_REPAIRS
+from assemblyzero.workflows.requirements.step_budget import (
+    CLEAN_RUN_STEPS,
+    FINALIZE_REPAIR_STEPS,
+    HEADROOM_STEPS,
+    REVISE_ROUND_STEPS,
+    describe_budget_exhaustion,
+    invoke_with_budget,
+    recursion_limit,
+)
+
+
+def _drive(monkeypatch, *, repairs=0, revisions=0, max_iterations=3, limit=500):
+    """The real compiled graph, every model call stubbed. Returns super-steps."""
+    import assemblyzero.workflows.requirements.graph as gr
+
+    blocked = {"n": 0}
+    revised = {"n": 0}
+
+    def passthrough(state):
+        return {}
+
+    def fake_mechanical(state):
+        # The real node clears the reviewer's stale BLOCKED (#302,
+        # validate_mechanical.py:1597). A passthrough leaves it set and the
+        # router bounces every revise round back to the drafter forever, which
+        # measures the stub instead of the graph.
+        return {"lld_status": "PENDING", "validation_errors": []}
+
+    def fake_review(state):
+        n = state.get("verdict_count", 0) + 1
+        if revised["n"] < revisions:
+            revised["n"] += 1
+            return {
+                "lld_status": "BLOCKED",
+                "open_questions_status": "NONE",
+                "verdict_count": n,
+                # Distinct each round, so two-strike stagnation does not fire
+                # and the loop itself is what is being measured.
+                "current_verdict": f"blocking issue number {revised['n']} " * 3,
+                "previous_review_feedback": "",
+            }
+        return {
+            "lld_status": "APPROVED",
+            "open_questions_status": "NONE",
+            "verdict_count": n,
+        }
+
+    def fake_draft(state):
+        return {
+            "current_draft": "# doc\n\n## 1. A\n\nbody\n",
+            "draft_count": state.get("draft_count", 0) + 1,
+            "validation_errors": [],
+            "finalize_repair_pending": False,
+            "error_message": "",
+        }
+
+    def fake_finalize(state):
+        if blocked["n"] < repairs:
+            blocked["n"] += 1
+            return {
+                "finalize_repair_pending": True,
+                "finalize_repair_count": blocked["n"],
+                "validation_errors": ["forced"],
+                "error_message": "",
+            }
+        return {"finalize_repair_pending": False, "final_lld_path": "x.md"}
+
+    for name in (
+        "load_input", "analyze_codebase", "analyze_requirements",
+        "ponder_stibbons_node", "validate_test_plan_node",
+        "human_gate_draft", "human_gate_verdict",
+    ):
+        monkeypatch.setattr(gr, name, passthrough)
+    monkeypatch.setattr(gr, "validate_lld_mechanical", fake_mechanical)
+    monkeypatch.setattr(gr, "review", fake_review)
+    monkeypatch.setattr(gr, "generate_draft", fake_draft)
+    monkeypatch.setattr(gr, "finalize", fake_finalize)
+
+    app = gr.create_requirements_graph().compile()
+    steps = 0
+    for _ in app.stream(
+        _state(max_iterations), config={"recursion_limit": limit}
+    ):
+        steps += 1
+    return steps
+
+
+def _state(max_iterations=3):
+    return {
+        "workflow_type": "lld",
+        "config_gates_draft": False,
+        "config_gates_verdict": False,
+        "max_iterations": max_iterations,
+        "issue_number": 7,
+        "target_repo": "repo",
+        "audit_dir": "audit",
+    }
+
+
+class TestTheMeasuredCosts:
+    """The constants must equal what the graph actually spends. A node added to
+    a loop fails one of these rather than quietly eating headroom."""
+
+    def test_a_clean_pass_costs_what_the_constant_says(self, monkeypatch, capsys):
+        steps = _drive(monkeypatch)
+        capsys.readouterr()
+        assert steps == CLEAN_RUN_STEPS
+
+    @pytest.mark.parametrize("repairs", [1, 2, 3])
+    def test_each_repair_costs_what_the_constant_says(
+        self, monkeypatch, capsys, repairs
+    ):
+        steps = _drive(monkeypatch, repairs=repairs)
+        capsys.readouterr()
+        assert steps == CLEAN_RUN_STEPS + repairs * FINALIZE_REPAIR_STEPS
+
+    @pytest.mark.parametrize("revisions", [1, 2, 3, 4])
+    def test_each_revise_round_costs_what_the_constant_says(
+        self, monkeypatch, capsys, revisions
+    ):
+        steps = _drive(monkeypatch, revisions=revisions, max_iterations=99)
+        capsys.readouterr()
+        assert steps == CLEAN_RUN_STEPS + revisions * REVISE_ROUND_STEPS
+
+    def test_the_costs_are_additive(self, monkeypatch, capsys):
+        """The derivation sums the loops, so it is only right if they add."""
+        steps = _drive(monkeypatch, revisions=2, repairs=2, max_iterations=99)
+        capsys.readouterr()
+        assert steps == CLEAN_RUN_STEPS + 2 * REVISE_ROUND_STEPS + 2 * FINALIZE_REPAIR_STEPS
+
+
+class TestTheDerivedLimit:
+    def test_it_covers_every_loop_run_to_its_cap(self, monkeypatch, capsys):
+        """The binding property: a run that spends everything must still fit."""
+        limit = recursion_limit(max_iterations=3)
+        steps = _drive(monkeypatch, revisions=3, repairs=MAX_FINALIZE_REPAIRS,
+                       max_iterations=99, limit=limit)
+        capsys.readouterr()
+        assert steps <= limit
+
+    def test_it_is_bigger_than_both_limits_it_replaces(self):
+        """25 by accident, and 22 from a formula smaller than the default it
+        was raising."""
+        assert recursion_limit(max_iterations=3) > 25
+        assert recursion_limit(max_iterations=3) > (3 * 4) + 10
+
+    def test_it_grows_with_each_cap(self):
+        base = recursion_limit(max_iterations=3, max_finalize_repairs=2)
+        assert recursion_limit(max_iterations=4, max_finalize_repairs=2) == (
+            base + REVISE_ROUND_STEPS
+        )
+        assert recursion_limit(max_iterations=3, max_finalize_repairs=3) == (
+            base + FINALIZE_REPAIR_STEPS
+        )
+
+    def test_it_carries_the_stated_headroom(self):
+        assert recursion_limit(max_iterations=0, max_finalize_repairs=0) == (
+            CLEAN_RUN_STEPS + HEADROOM_STEPS
+        )
+
+    def test_a_junk_cap_falls_back_rather_than_raising(self):
+        assert recursion_limit("not a number") == recursion_limit(3)
+
+    def test_the_repair_cap_is_a_judgment_not_a_constraint(self, monkeypatch, capsys):
+        """#2245's last criterion. MAX_FINALIZE_REPAIRS was 2 partly because a
+        third did not fit. It fits now, so the value stands on its own."""
+        limit = recursion_limit(max_iterations=3)
+        steps = _drive(monkeypatch, repairs=MAX_FINALIZE_REPAIRS + 1, limit=limit)
+        capsys.readouterr()
+        assert steps <= limit, (
+            "a repair past the cap still does not fit the derived budget, so "
+            "the cap is being set by the step budget rather than by what a "
+            "repair loop should try"
+        )
+
+
+class TestExhaustionHaltsByName:
+    """#2245's third criterion: a spent budget must name the stage and the loop."""
+
+    def test_a_spent_budget_returns_a_halt_not_an_exception(self, monkeypatch, capsys):
+        import assemblyzero.workflows.requirements.graph as gr
+
+        # A cap far above the budget, so the revise loop outruns the steps.
+        monkeypatch.setattr(
+            "assemblyzero.workflows.requirements.step_budget.recursion_limit",
+            lambda *a, **k: 20,
+        )
+        _stub_graph(monkeypatch, revisions=50)
+        app = gr.create_requirements_graph().compile()
+
+        result = invoke_with_budget(app, _state(max_iterations=99), stage="lld")
+        capsys.readouterr()
+
+        assert result["error_message"], "a spent budget must produce a halt"
+        assert "GraphRecursionError" not in result["error_message"]
+
+    def test_the_halt_names_the_stage_and_the_loop(self, monkeypatch, capsys):
+        import assemblyzero.workflows.requirements.graph as gr
+
+        monkeypatch.setattr(
+            "assemblyzero.workflows.requirements.step_budget.recursion_limit",
+            lambda *a, **k: 20,
+        )
+        _stub_graph(monkeypatch, revisions=50)
+        app = gr.create_requirements_graph().compile()
+
+        message = invoke_with_budget(
+            app, _state(max_iterations=99), stage="lld"
+        )["error_message"]
+        capsys.readouterr()
+
+        assert "lld" in message
+        assert "revise loop" in message
+        assert "ran out of graph steps" in message
+
+    def test_the_halt_reports_the_counters(self):
+        message = describe_budget_exhaustion(
+            {"verdict_count": 4, "finalize_repair_count": 2, "draft_count": 6},
+            limit=40, steps=40, stage="lld",
+        )
+        assert "4" in message and "2" in message and "6" in message
+        assert "40" in message
+
+    def test_a_repair_only_exhaustion_names_the_repair_loop(self):
+        message = describe_budget_exhaustion(
+            {"verdict_count": 1, "finalize_repair_count": 5}, 40, 40, "lld"
+        )
+        assert "finalize repair loop" in message
+        assert "revise loop and" not in message
+
+
+class TestTheStreamContract:
+    """invoke_with_budget streams so it can name the loop on exhaustion. That is
+    only safe if the last streamed value is what invoke would have returned."""
+
+    def test_the_last_streamed_value_equals_invoke(self, monkeypatch, capsys):
+        import assemblyzero.workflows.requirements.graph as gr
+
+        _stub_graph(monkeypatch, revisions=0)
+        app = gr.create_requirements_graph().compile()
+
+        direct = app.invoke(_state(), config={"recursion_limit": 100})
+        streamed = invoke_with_budget(app, _state(), stage="lld")
+        capsys.readouterr()
+
+        assert streamed.get("final_lld_path") == direct.get("final_lld_path")
+        assert streamed.get("lld_status") == direct.get("lld_status")
+        assert set(direct) <= set(streamed), (
+            "streaming dropped keys invoke returns; every caller reads this dict"
+        )
+
+    def test_a_clean_run_carries_no_error_message(self, monkeypatch, capsys):
+        import assemblyzero.workflows.requirements.graph as gr
+
+        _stub_graph(monkeypatch, revisions=0)
+        app = gr.create_requirements_graph().compile()
+        result = invoke_with_budget(app, _state(), stage="lld")
+        capsys.readouterr()
+
+        assert not result.get("error_message")
+        assert result.get("final_lld_path") == "x.md"
+
+
+class TestBothCallersPassAnExplicitLimit:
+    """#2245's second criterion: no caller inherits the default silently."""
+
+    def test_the_orchestrator_uses_the_derived_budget(self):
+        import inspect
+
+        from assemblyzero.workflows.orchestrator.stages import run_lld_stage
+
+        source = inspect.getsource(run_lld_stage)
+        assert "invoke_with_budget" in source, (
+            "run_lld_stage invokes the graph without a derived budget, so an "
+            "orchestrated roll silently takes LangGraph's default of 25"
+        )
+
+    def test_the_standalone_runner_uses_the_derived_budget(self):
+        from pathlib import Path
+
+        import assemblyzero  # noqa: F401  (anchor the repo root)
+
+        runner = (
+            Path(__file__).resolve().parents[2] / "tools" / "run_requirements_workflow.py"
+        )
+        source = runner.read_text(encoding="utf-8")
+        assert "invoke_with_budget" in source
+
+        # Comments quote the old formula deliberately, to say what changed.
+        # Only live code counts.
+        code = [
+            line for line in source.splitlines()
+            if not line.lstrip().startswith("#")
+        ]
+        offenders = [line for line in code if "* 4) + 10" in line]
+        assert not offenders, (
+            f"the undersized formula is still live in the runner: {offenders}"
+        )
+        assert not [
+            line for line in code
+            if "recursion_limit" in line and "=" in line and "step_budget" not in line
+        ], "the runner still computes a recursion limit of its own"
+
+
+def _stub_graph(monkeypatch, *, revisions=0, repairs=0):
+    """Shared stubbing for the invoke-level tests."""
+    import assemblyzero.workflows.requirements.graph as gr
+
+    state_counters = {"revised": 0, "blocked": 0}
+
+    def passthrough(state):
+        return {}
+
+    def fake_mechanical(state):
+        return {"lld_status": "PENDING", "validation_errors": []}
+
+    def fake_review(state):
+        n = state.get("verdict_count", 0) + 1
+        if state_counters["revised"] < revisions:
+            state_counters["revised"] += 1
+            return {
+                "lld_status": "BLOCKED",
+                "open_questions_status": "NONE",
+                "verdict_count": n,
+                "current_verdict": f"blocking issue {state_counters['revised']} " * 3,
+                "previous_review_feedback": "",
+            }
+        return {
+            "lld_status": "APPROVED",
+            "open_questions_status": "NONE",
+            "verdict_count": n,
+        }
+
+    def fake_draft(state):
+        return {
+            "current_draft": "# doc\n\n## 1. A\n\nbody\n",
+            "draft_count": state.get("draft_count", 0) + 1,
+            "validation_errors": [],
+            "finalize_repair_pending": False,
+            "error_message": "",
+        }
+
+    def fake_finalize(state):
+        if state_counters["blocked"] < repairs:
+            state_counters["blocked"] += 1
+            return {
+                "finalize_repair_pending": True,
+                "finalize_repair_count": state_counters["blocked"],
+                "validation_errors": ["forced"],
+                "error_message": "",
+            }
+        return {"finalize_repair_pending": False, "final_lld_path": "x.md"}
+
+    for name in (
+        "load_input", "analyze_codebase", "analyze_requirements",
+        "ponder_stibbons_node", "validate_test_plan_node",
+        "human_gate_draft", "human_gate_verdict",
+    ):
+        monkeypatch.setattr(gr, name, passthrough)
+    monkeypatch.setattr(gr, "validate_lld_mechanical", fake_mechanical)
+    monkeypatch.setattr(gr, "review", fake_review)
+    monkeypatch.setattr(gr, "generate_draft", fake_draft)
+    monkeypatch.setattr(gr, "finalize", fake_finalize)

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -64,6 +64,10 @@ from assemblyzero.utils.git import current_branch, validate_integration_branch
 from assemblyzero.workflows.requirements.config import GateConfig
 from assemblyzero.workflows.requirements.graph import create_requirements_graph
 from assemblyzero.workflows.requirements.state import create_initial_state, RequirementsWorkflowState
+from assemblyzero.workflows.requirements.step_budget import (  # noqa: E402  (#2245)
+    DEFAULT_MAX_ITERATIONS,
+    invoke_with_budget,
+)
 
 
 # =============================================================================
@@ -772,13 +776,16 @@ def run_single_workflow(
         print("Starting workflow...")
         print()
 
-        # Calculate recursion limit
-        max_iters = state.get("max_iterations", 20)
-        recursion_limit = (max_iters * 4) + 10
-
-        final_state = compiled.invoke(
+        # #2245: this was `(max_iters * 4) + 10` -- 22 at the default cap of 3,
+        # SMALLER than the LangGraph default of 25 it was presumably raising,
+        # and unrelated to what the loops actually cost. The budget is now
+        # derived from measured per-loop step costs, and exhausting it halts
+        # naming the loop that spent it instead of raising GraphRecursionError.
+        final_state = invoke_with_budget(
+            compiled,
             state,
-            config={"recursion_limit": recursion_limit}
+            stage="lld" if state.get("workflow_type") == "lld" else "issue",
+            max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
         )
 
         print_result(final_state)
@@ -1008,12 +1015,12 @@ def run_resume_review(
             print("Starting review (resume mode)...")
             print()
 
-            max_iters = state.get("max_iterations", 20)
-            recursion_limit = (max_iters * 4) + 10
-
-            final_state = compiled_resume.invoke(
+            # #2245: same derived budget as the full run above.
+            final_state = invoke_with_budget(
+                compiled_resume,
                 state,
-                config={"recursion_limit": recursion_limit},
+                stage="lld resume",
+                max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
             )
 
             print_result(final_state)


### PR DESCRIPTION
## The defect

LangGraph bounds a run by super-steps. Running out raises `GraphRecursionError`,
which names no stage, no loop and no document — the opposite of the halts this
graph is otherwise careful to produce.

Neither caller sized the bound against what the loops cost, and the one that
matters most set nothing at all:

| caller | limit before | how |
|---|---|---|
| `run_lld_stage` (every orchestrated roll) | 25 | passed no `config`; LangGraph's default, by accident |
| `tools/run_requirements_workflow.py` | 22 at the default cap | `(max_iterations * 4) + 10` — *smaller* than the default it was raising |

## Measured, not asserted

Driving the real compiled graph with every model call stubbed and counting
super-steps:

| | steps |
|---|---|
| clean pass, no loops | **9** |
| each reviewer revise round (N3 → N1 → N3) | **+5** |
| each finalize repair round trip | **+6** |

Additive: two revise rounds and two repairs measured **31**, and `9 + 2*5 + 2*6`
is 31. `tests/unit/test_step_budget.py` re-measures every one of these against
the constants, so a node added to any loop fails a test rather than quietly
eating headroom.

**Measuring the revise loop needed a correct stub.** The real mechanical node
clears the reviewer's stale `BLOCKED` (#302, `validate_mechanical.py:1597`). A
passthrough leaves it set, and `route_after_mechanical` then bounces every
revise round back to the drafter forever — so the naive harness measures the
stub instead of the graph and reports a runaway that is not there. The stub
carries a comment saying so, because the next person to write one will hit it.

## The fix

`assemblyzero/workflows/requirements/step_budget.py` is the single source: the
limit is derived from the measured costs and the caps that bound each loop, with
a stated headroom term for the human gates, `HALT`, and the issue-drafting
path's shape. Both callers now pass it explicitly; neither inherits a default.

**Exhausting it halts by name.** The message reports the stage and which loop
spent the budget, read from the round counters already on the state:

```
BLOCKED: the lld stage ran out of graph steps after 44 of 44, spent by
the reviewer revise loop.
  drafts generated: 8
  reviewer verdicts: 7 (each revise round costs 5 steps)
  finalize repairs: 0 (each costs 6 steps)
```

That is why `invoke_with_budget` streams rather than invokes: on
`GraphRecursionError` the last state is still in hand. **A test pins that the
final streamed value is what `invoke` would have returned**, including that no
keys are dropped — every caller reads that dict, so the equivalence is the whole
contract.

## MAX_FINALIZE_REPAIRS, re-derived

It stays **2**, but no longer for two reasons at once. #2233 chose it partly
because a third repair cost 27 and did not fit. It fits comfortably now, and
`test_the_repair_cap_is_a_judgment_not_a_constraint` asserts exactly that — so
the value is a judgment about repairs, provably not a constraint about steps.

The judgment stands on its own: the repair is surgical (finalize names the exact
validation errors and hands them back), so a defect surviving two repairs of
named errors is systematic, and a third attempt at the same surgery buys a round
trip rather than a different answer.

## Blast radius

Switching the lld stage from `.invoke` to streaming broke six tests that stubbed
`.invoke`. All six are updated to wire both shapes — the spec and impl stages
still invoke — and the pre-existing `TestStepBudget` cases naming 25 and 22 are
kept as the historical measurement that motivated the clamp, with their framing
corrected. One was titled for a clamp that no longer prevents what it describes,
which would have misled the next reader.

## Evidence

Full unit suite: **6989 passed, 17 skipped, 5 xfailed**.

Lint checked per file against `origin/main` rather than in aggregate: every
changed file matches its origin count exactly, and both new files are clean.
(This repo has pre-existing ruff findings in these areas; comparing totals would
have hidden whether I added one. I did not.)

Closes #2245
