### PR TITLE
fix: stop the empty prereqs gate bricking every launch (Closes #2196)

### DIFF
--- a/tests/unit/test_speedrun_roll_verdict.py
+++ b/tests/unit/test_speedrun_roll_verdict.py
@@ -229,12 +229,104 @@ class TestPrereqGate:
         assert sr.prereqs_path(repo).exists(), "override is not forgetting"
         assert "OVERRIDE" in capsys.readouterr().out
 
-    def test_an_unreadable_file_refuses_rather_than_guessing(self, repo, capsys):
+    def test_an_unreadable_file_asks_the_live_query_rather_than_guessing(
+        self, repo, capsys
+    ):
+        """#2196 changed this. Refusing outright on an unreadable list was a
+        wall that could not self-clear -- the refusal sat above the closure
+        loop, and the unlink that clears the file sat below it. The live query
+        is consulted instead, and still refuses while questions are open."""
         path = sr.prereqs_path(repo)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("not json", encoding="utf-8")
-        assert sr.check_prereqs(repo, override=False) == 91
-        assert "could not be read" in capsys.readouterr().out
+
+        with patch.object(sr, "open_must_resolve_issues",
+                          lambda r: (QUESTIONS, None)):
+            assert sr.check_prereqs(repo, override=False) == 91
+
+        out = capsys.readouterr().out
+        assert "#228" in out and "#229" in out
+        assert path.exists(), "a real block must keep the gate in place"
+
+    # -- #2196: the empty-blocking-list brick ------------------------------
+    #
+    # A blocked batch whose question numbers went missing wrote
+    # `"blocking": []`. check_prereqs refused on the empty list, and could
+    # only self-delete after verifying recorded numbers closed -- which an
+    # empty list can never do. Every later launch refused, permanently, and
+    # --override-prereqs was no exit either because it keeps the file.
+    # Measured on boostgauge 2026-08-10: the machine sat idle about an hour
+    # and forty-five minutes on a gate with nothing behind it, every
+    # must-resolve issue having been closed within half an hour of the write.
+
+    def test_an_empty_blocking_list_is_never_written(self, repo, capsys):
+        """Half one: do not create the unverifiable file in the first place."""
+        written = sr.write_prereqs(repo, [], "blocked issue(s) #1, #7")
+
+        assert written is False
+        assert not sr.prereqs_path(repo).exists(), (
+            "a gate with no numbers records 'something blocked but I do not "
+            "know what', which no later launch can ever verify closed"
+        )
+        assert "Not recording a launch gate" in capsys.readouterr().out
+
+    def test_a_real_blocking_list_is_still_written(self, repo):
+        """The guard must not swallow the gate it exists to protect."""
+        assert sr.write_prereqs(repo, QUESTIONS, "blocked issue(s) #1") is True
+        assert sr.prereqs_path(repo).exists()
+
+    def test_an_empty_gate_clears_itself_when_nothing_is_open(self, repo, capsys):
+        """Half two: the brick already on disk heals. This is the boostgauge
+        file verbatim."""
+        path = sr.prereqs_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "created": "2026-08-10 09:44:38",
+            "note": "blocked issue(s) #1, #7",
+            "blocking": [],
+        }), encoding="utf-8")
+
+        with patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)):
+            assert sr.check_prereqs(repo, override=False) is None
+
+        assert not path.exists(), "the empty gate must remove itself"
+        assert "proceeding" in capsys.readouterr().out
+
+    def test_an_empty_gate_still_blocks_on_live_open_questions(self, repo, capsys):
+        """Healing must not mean opening. The fallback is a real check."""
+        path = sr.prereqs_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"blocking": []}), encoding="utf-8")
+
+        with patch.object(sr, "open_must_resolve_issues",
+                          lambda r: (QUESTIONS, None)):
+            assert sr.check_prereqs(repo, override=False) == 91
+
+        out = capsys.readouterr().out
+        assert "#228" in out and "#229" in out
+        assert "--override-prereqs" in out
+
+    def test_an_empty_gate_offline_still_refuses(self, repo, capsys):
+        """Unverifiable stays unverifiable. Falling back to a query that
+        cannot run is not a reason to roll into a wall."""
+        path = sr.prereqs_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"blocking": []}), encoding="utf-8")
+
+        with patch.object(sr, "open_must_resolve_issues",
+                          lambda r: ([], "no net")):
+            assert sr.check_prereqs(repo, override=False) == 91
+
+        assert path.exists(), "an unverified gate must not be removed"
+        assert "gh was unreachable" in capsys.readouterr().out
+
+    def test_the_brick_is_gone_end_to_end(self, repo):
+        """The whole failure: a run blocks with no numbers, and the NEXT
+        launch proceeds instead of refusing forever."""
+        sr.write_prereqs(repo, [], "blocked issue(s) #1, #7")
+
+        with patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)):
+            assert sr.check_prereqs(repo, override=False) is None
 
     def test_the_gate_runs_before_anything_is_spent(self, repo, capsys):
         self._seed(repo)

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1893,7 +1893,30 @@ def prereqs_path(repo_root: Path) -> Path:
     return Path(repo_root) / "data" / "speedrun" / PREREQS_FILENAME
 
 
-def write_prereqs(repo_root: Path, blocking: list[dict], note: str) -> None:
+def write_prereqs(repo_root: Path, blocking: list[dict], note: str) -> bool:
+    """Record the questions that gate the next launch. Returns True if written.
+
+    #2196: an empty `blocking` list is never written. It records "something
+    blocked but I do not know what", and the reader cannot verify an empty list
+    closed -- so every later launch refuses, permanently, with no way to
+    self-clear. Observed on boostgauge 2026-08-10, where a batch wrote
+    `"blocking": []` and the machine then sat idle about an hour and forty-five
+    minutes on a gate with nothing behind it; every must-resolve issue had been
+    closed within half an hour of the write.
+
+    Declining to write is safe because the launcher still runs the live
+    open-must-resolve query on every launch. That query is the same source of
+    truth this file caches, so the repo stays guarded -- what is lost is only
+    the cached certainty, which in this case was certainty of nothing.
+    """
+    if not blocking:
+        print(
+            "  (Not recording a launch gate: this run blocked but produced no "
+            "question numbers to record. The live must-resolve query still "
+            "guards the next launch.)"
+        )
+        return False
+
     path = prereqs_path(repo_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -1903,6 +1926,7 @@ def write_prereqs(repo_root: Path, blocking: list[dict], note: str) -> None:
         ) + "\n",
         encoding="utf-8",
     )
+    return True
 
 
 def check_prereqs(repo_root: Path, override: bool) -> int | None:
@@ -1913,6 +1937,14 @@ def check_prereqs(repo_root: Path, override: bool) -> int | None:
     certain knowledge of a known block -- unverifiable closure REFUSES.
     The override runs anyway ONCE and leaves the file, so the following
     launch re-checks: override means "run anyway", never "forget".
+
+    #2196: with ONE exception. A file whose blocking list is empty or
+    unreadable is not certain knowledge of a block -- it is certain knowledge
+    of nothing, and refusing on it cannot self-heal, because the refusal sat
+    above the closure loop while the unlink that clears the file sat below it.
+    That state falls back to the live must-resolve query, which is the same
+    source of truth this file caches. The gate is not weakened: open questions
+    still refuse, by name, and an unreachable gh still refuses.
     """
     path = prereqs_path(repo_root)
     if not path.exists():
@@ -1932,12 +1964,47 @@ def check_prereqs(repo_root: Path, override: bool) -> int | None:
         blocking = []
 
     if not blocking:
+        # #2196: an empty or unreadable list is certain knowledge of NOTHING,
+        # and refusing on it converts an upstream numbers-lost bug into a total
+        # launch outage that cannot self-heal -- the refusal sits above the
+        # closure loop, and the unlink that clears the file sits below it.
+        # Fall back to the live query, which is the same source of truth this
+        # file caches. Open questions still block, by name; none means the
+        # cached gate was empty and can go.
         print(
-            "BLOCKED: a previous run recorded unresolved questions but their "
-            f"numbers could not be read from {path}. Check "
-            "must-resolve issues by hand, or pass --override-prereqs to run anyway."
+            f"A previous run recorded a launch gate in {path.name} with no "
+            "readable question numbers. Consulting the live must-resolve "
+            "query instead."
         )
-        return 91
+        questions, gh_error = open_must_resolve_issues(repo_root)
+
+        if gh_error:
+            print(
+                "BLOCKED: that file records unresolved questions whose numbers "
+                f"could not be read, and gh was unreachable to check for open "
+                f"questions directly ({gh_error}). This launch refuses rather "
+                "than roll into a wall it cannot see. Resolve the questions and "
+                "delete the file, or pass --override-prereqs to run anyway."
+            )
+            return 91
+
+        if questions:
+            print("BLOCKED: the repo has open questions awaiting a ruling:")
+            for item in questions:
+                print(f"  #{item.get('number')}  {item.get('title', '')}")
+            print(
+                "\n  Resolve them (edit the source issue, close each question), "
+                "then launch again.\n  Deliberately rolling anyway: "
+                "--override-prereqs."
+            )
+            return 91
+
+        path.unlink(missing_ok=True)
+        print(
+            "No open must-resolve questions remain, so that gate recorded "
+            "nothing that is still blocking -- removing it and proceeding."
+        )
+        return None
 
     still_open: list[dict] = []
     for item in blocking:


### PR DESCRIPTION
## The brick

A blocked batch whose question numbers went missing wrote
`data/speedrun/prereqs.json` with an empty blocking list:

```json
{
  "created": "2026-08-10 09:44:38",
  "note": "blocked issue(s) #1, #7",
  "blocking": []
}
```

`check_prereqs` refused on the empty list, and could only self-delete the file
*after* verifying recorded numbers closed — which an empty list can never do.
The refusal sat above the closure loop; the `unlink` that clears the file sat
below it. So every later launch refused, permanently, and `--override-prereqs`
was no exit either, because it deliberately keeps the file.

Measured on boostgauge 2026-08-10: the machine sat idle about **an hour and
forty-five minutes** on a gate with nothing behind it. Every must-resolve issue
had been closed within half an hour of the write.

## Both halves

**1. Never write an unverifiable gate file.** `write_prereqs` now declines an
empty blocking list and says so, returning whether it wrote. An empty list
records "something blocked but I do not know what" — a wall with nothing behind
it. Declining is safe because the launcher still runs the live must-resolve
query on every launch: that query is the same source of truth this file caches,
so the repo stays guarded. What is lost is only cached certainty, which here was
certainty of nothing.

The guard lives in `write_prereqs` rather than at its two call sites, so a third
caller cannot reintroduce it.

**2. An empty or unreadable list falls back to the live query.** This heals the
bricks already on disk, which half 1 alone cannot do. The gate is not weakened:

| state | before | after |
|---|---|---|
| empty list, questions open | refuse (unclearable) | **refuse, by name** |
| empty list, nothing open | refuse (unclearable) | **delete the file, proceed** |
| empty list, gh unreachable | refuse | **refuse** |
| real list | unchanged | unchanged |

`--override-prereqs` semantics are untouched. It still runs once and keeps the
file — override means "run anyway", never "forget". With half 2 the file
self-clears on the next launch when nothing is open, so the symptom resolves
without weakening the override.

## One superseded test, updated rather than deleted

`test_an_unreadable_file_refuses_rather_than_guessing` asserted exactly the
behaviour this issue removes. It is now
`test_an_unreadable_file_asks_the_live_query_rather_than_guessing`, asserting
the fallback still refuses while questions are open — the property that
mattered — with a comment recording what changed and why.

## Evidence

Six new tests, including the boostgauge file verbatim and an end-to-end case
(`test_the_brick_is_gone_end_to_end`) that writes an empty gate and asserts the
next launch proceeds. Both halves are covered separately, so either could
regress alone and be caught.

Full unit suite: **6995 passed, 17 skipped, 5 xfailed**. Both changed files match
their `origin/main` ruff counts exactly.

## Scope

The empty terminal summary ("This run filed the questions blocking it:" with no
items, "Next step: resolve .") is the same lost hand-off, but it belongs to
#2179 — #2224 was closed as a duplicate of it — and is deliberately untouched
here. This PR changes the gate's handling only.

Closes #2196
