### PR TITLE
fix: file the must-resolve question for a spec-stage conflict (Closes #2192)

### DIFF
--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -143,6 +143,83 @@ def run_context(env: dict[str, str] | None = None) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class Origin:
+    """Which gate found the conflict (#2192).
+
+    The body used to state "Found by N0c" unconditionally. That is false on a
+    filing from the spec reviewer, and the operator reading the issue needs to
+    know which gate ruled -- an LLD-stage conflict and a spec-stage one are
+    found against different documents.
+    """
+
+    tag: str        # short label for log lines
+    sentence: str   # the provenance sentence that opens the issue body
+
+
+N0C_ORIGIN = Origin(
+    "N0c",
+    "Found by N0c (requirements-consistency gate, #1899) during a live roll. "
+    "The gate's own verdict: an operator ruling on the issue text is required "
+    "before any roll.",
+)
+
+SPEC_REVIEW_ORIGIN = Origin(
+    "spec review",
+    "Found by the implementation-spec reviewer (#1900 escalation) during a live "
+    "roll, after the LLD had already passed. The reviewer's verdict: two source "
+    "requirements specify different outcomes for the same situation, so no spec "
+    "can satisfy both and an operator ruling is required before any roll.",
+)
+
+
+#: The reviewer is told to quote the two conflicting sentences verbatim, so
+#: quoted spans are the signal. Straight and curly pairs both appear in model
+#: output, and a run that files nothing because of a typographic quote would
+#: reproduce the very defect this exists to close.
+_QUOTED = re.compile(r'"([^"]{8,})"|“([^”]{8,})”')
+_DIVERGE = re.compile(r"[^.!?]*\bdiverge\w*\b[^.!?]*[.!?]", re.IGNORECASE)
+
+
+def conflict_from_rationale(rationale: str, marker: str = "REQUIREMENTS CONFLICT:") -> dict:
+    """A conflict dict from the spec reviewer's free-text rationale (#2192).
+
+    N0c hands over a structured conflict; the spec reviewer writes prose behind
+    a marker. Parsing is best-effort ON PURPOSE: when the two sentences cannot
+    be separated, the whole finding becomes criterion A rather than the filing
+    being skipped. A slightly coarse issue is worth having; a missing one is the
+    defect -- it left a blocked roll with no question to resolve, an empty
+    launch gate, and a re-roll straight back into the same wall.
+
+    The result is deterministic for the same text, so the fingerprint is stable
+    and a repeat detection comments on the existing issue instead of duplicating.
+    """
+    text = (rationale or "").strip()
+    head, sep, tail = text.partition(marker)
+    body = (tail if sep else text).strip()
+
+    quotes = [a or b for a, b in _QUOTED.findall(body)]
+    if len(quotes) >= 2:
+        diverge = _DIVERGE.search(body)
+        return {
+            "criterion_a": quotes[0].strip(),
+            "criterion_b": quotes[1].strip(),
+            "diverging_situation": (
+                diverge.group(0).strip() if diverge
+                else "see the reviewer's finding above"
+            ),
+        }
+
+    return {
+        "criterion_a": body or text,
+        "criterion_b": "",
+        "diverging_situation": (
+            "the reviewer did not quote two separable sentences; its full "
+            "finding is recorded above"
+        ),
+    }
+
+
 def _first_line_summary(conflict: dict, limit: int = 60) -> str:
     text = normalize_criterion(conflict.get("criterion_a", "")) or "requirements conflict"
     text = text.splitlines()[0] if text else "requirements conflict"
@@ -164,11 +241,10 @@ def build_body(
     run_start: str,
     conflict_ts: str,
     fingerprint: str,
+    origin: Origin = N0C_ORIGIN,
 ) -> str:
     return "\n".join([
-        "Found by N0c (requirements-consistency gate, #1899) during a live roll. "
-        "The gate's own verdict: an operator ruling on the issue text is required "
-        "before any roll.",
+        origin.sentence,
         "",
         f"**Run:** {run_id} | **Start:** {run_start} | **Conflict reported:** {conflict_ts}",
         "",
@@ -233,6 +309,7 @@ def file_must_resolve(
     run_id: str | None = None,
     run_start: str | None = None,
     conflict_ts: str | None = None,
+    origin: Origin = N0C_ORIGIN,
     runner=_default_runner,
     log=print,
 ) -> FilingResult:
@@ -240,6 +317,11 @@ def file_must_resolve(
 
     Never raises. The roll is already halting; a filing problem is reported and
     the halt outcome is unchanged.
+
+    `origin` says which gate found it (#2192). The fingerprint deliberately does
+    NOT include it: the same contradiction found at the LLD stage and again at
+    the spec stage is one question for the operator, so the second detection
+    comments on the first issue instead of opening a duplicate.
     """
     if not source_issue:
         # Brief and idea entry paths carry file input, not an issue number.
@@ -257,7 +339,7 @@ def file_must_resolve(
 
     slug = repo_slug(repo_root, runner=runner)
     if not slug:
-        log(f"  [N0c] could not file must-resolve: no GitHub remote for {repo_root}")
+        log(f"  [{origin.tag}] could not file must-resolve: no GitHub remote for {repo_root}")
         return FilingResult(
             False, "failed", fingerprint=fingerprint, detail="no origin remote"
         )
@@ -271,18 +353,18 @@ def file_must_resolve(
             f"Still unresolved; the source issue text has not been ruled on.",
         ])
         if comment.returncode != 0:
-            log(f"  [N0c] could not comment on #{existing}: {comment.stderr.strip()}")
+            log(f"  [{origin.tag}] could not comment on #{existing}: {comment.stderr.strip()}")
             return FilingResult(
                 False, "failed", issue_number=existing, fingerprint=fingerprint,
                 detail=comment.stderr.strip(),
             )
-        log(f"  [N0c] recurrence recorded on existing must-resolve #{existing}")
+        log(f"  [{origin.tag}] recurrence recorded on existing must-resolve #{existing}")
         return FilingResult(True, "commented", existing, fingerprint)
 
     title = build_title(source_issue, conflict)
     body = build_body(
         source_issue, conflict, run_id=run_id, run_start=run_start,
-        conflict_ts=conflict_ts, fingerprint=fingerprint,
+        conflict_ts=conflict_ts, fingerprint=fingerprint, origin=origin,
     )
     create_args = [
         "gh", "issue", "create", "--repo", slug,
@@ -298,13 +380,13 @@ def file_must_resolve(
         created = runner(create_args)
 
     if created.returncode != 0:
-        log(f"  [N0c] could not file must-resolve issue: {created.stderr.strip()}")
+        log(f"  [{origin.tag}] could not file must-resolve issue: {created.stderr.strip()}")
         return FilingResult(
             False, "failed", fingerprint=fingerprint, detail=created.stderr.strip()
         )
 
     number = _issue_number_from_url((created.stdout or "").strip())
-    log(f"  [N0c] filed must-resolve issue #{number or '?'} in {slug}")
+    log(f"  [{origin.tag}] filed must-resolve issue #{number or '?'} in {slug}")
     return FilingResult(True, "filed", number, fingerprint)
 
 
@@ -374,6 +456,7 @@ def file_all_conflicts(
     source_issue: int,
     conflicts: list[dict],
     *,
+    origin: Origin = N0C_ORIGIN,
     runner=_default_runner,
     log=print,
 ) -> list[FilingResult]:
@@ -383,10 +466,11 @@ def file_all_conflicts(
         try:
             results.append(
                 file_must_resolve(
-                    repo_root, source_issue, conflict, runner=runner, log=log
+                    repo_root, source_issue, conflict,
+                    origin=origin, runner=runner, log=log
                 )
             )
         except Exception as exc:  # noqa: BLE001 - filing must never kill a halt
-            log(f"  [N0c] must-resolve filing raised, continuing: {exc}")
+            log(f"  [{origin.tag}] must-resolve filing raised, continuing: {exc}")
             results.append(FilingResult(False, "failed", detail=str(exc)))
     return results

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -401,6 +401,7 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         blocked_reason = (
             f"Spec review BLOCKED: {feedback or spec_result['rationale'] or 'no reason given'}"
         )
+        _file_conflict_if_any(state, spec_result.get("rationale", "") or feedback)
 
     return {
         "review_verdict": verdict_status,
@@ -409,6 +410,49 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
     }
+
+
+def _file_conflict_if_any(state, rationale: str) -> None:
+    """File the must-resolve question for a spec-stage requirements conflict.
+
+    Closes #2192. A conflict found HERE exited 93 -- "blocked on an operator
+    ruling, no redraw can help" -- and filed nothing, unlike the LLD stage's N0c
+    gate which files one per conflict. Exit 93's meaning is only real if the
+    thing to rule on exists. Observed 2026-08-10 on boostgauge
+    `run-issue1-092650`: the LLD passed, spec review blocked on a contradiction
+    between two requirements, no issue was created, the verdict block printed
+    "Next step: resolve ." with nothing in it, and the question had to be filed
+    by hand for the block to be tracked at all.
+
+    Same contract as N0c's filing: never raises, never changes the halt. The
+    roll is already stopping; a filing problem is loud in the log and nothing
+    more.
+    """
+    from assemblyzero.core.exit_codes import CONFLICT_MARKER
+
+    if CONFLICT_MARKER not in (rationale or ""):
+        # An ordinary BLOCKED verdict. Only the escalation marker means the
+        # SOURCE REQUIREMENTS are at fault and a human must rule.
+        return
+
+    try:
+        from assemblyzero.speedrun.must_resolve import (
+            SPEC_REVIEW_ORIGIN,
+            conflict_from_rationale,
+            file_must_resolve,
+        )
+
+        file_must_resolve(
+            state.get("repo_root") or ".",
+            int(state.get("issue_number") or 0),
+            conflict_from_rationale(rationale, CONFLICT_MARKER),
+            origin=SPEC_REVIEW_ORIGIN,
+        )
+    except Exception as exc:  # noqa: BLE001 - filing must never mask the halt
+        print(
+            f"    [spec review] WARNING: must-resolve filing failed ({exc}); "
+            "halting anyway."
+        )
 
 
 # =============================================================================

--- a/tests/unit/test_spec_conflict_filing.py
+++ b/tests/unit/test_spec_conflict_filing.py
@@ -1,0 +1,260 @@
+"""A spec-stage requirements conflict must file its question (Closes #2192).
+
+A conflict found at the LLD stage files a must-resolve issue per conflict; the
+same conflict found at the SPEC stage exited 93 -- "blocked on an operator
+ruling, no redraw can help" -- and filed nothing.
+
+Observed 2026-08-10 on boostgauge `run-issue1-092650`: the LLD passed, spec
+review blocked on a contradiction between two requirements, and no issue was
+created. Three things followed from the one omission. The verdict block printed
+"Next step: resolve ." with nothing in it. The launch gate recorded no numbers,
+which is how the empty-blocking brick (#2196) got seeded. And the question had
+to be filed by hand for the block to be tracked at all.
+
+Exit 93 means "a human must rule before any roll". That is only real if the
+thing to rule on exists.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core.exit_codes import CONFLICT_MARKER
+from assemblyzero.speedrun.must_resolve import (
+    N0C_ORIGIN,
+    SPEC_REVIEW_ORIGIN,
+    build_body,
+    conflict_fingerprint,
+    conflict_from_rationale,
+    file_must_resolve,
+)
+from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+    _file_conflict_if_any,
+)
+
+# The reviewer's real shape, per the #1900 escalation instruction: the marker,
+# the two conflicting sentences quoted verbatim, then where they diverge.
+REVIEWER_RATIONALE = (
+    f"{CONFLICT_MARKER} The LLD contains an unresolvable contradiction between "
+    'REQ-2 and REQ-4. REQ-2 states "CLI values govern the session and are never '
+    'written to the file", while REQ-4 states "launched with --reset-config '
+    '--size N, the file holds size N". They diverge when the app is launched '
+    "with both --reset-config and --size."
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+class _Runner:
+    """Records gh calls. Returns success with a created-issue URL."""
+
+    def __init__(self, existing_search_output="[]"):
+        self.calls: list[list[str]] = []
+        self.existing = existing_search_output
+
+    def __call__(self, args):
+        self.calls.append(args)
+        if args[:3] == ["git", "-C"] or args[:2] == ["git", "-C"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="https://github.com/martymcenroe/boostgauge.git\n"
+            )
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, stdout=self.existing)
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(
+                args, 0, stdout="https://github.com/martymcenroe/boostgauge/issues/253\n"
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(args, 0, stdout="")
+        return subprocess.CompletedProcess(args, 0, stdout="")
+
+    def created(self):
+        return [c for c in self.calls if c[:3] == ["gh", "issue", "create"]]
+
+
+class _Spy:
+    """Stands in for file_must_resolve. `_default_runner` cannot be patched at
+    module level -- it is bound as a default argument, so a patch never reaches
+    an already-defined signature and the real `git` runs instead."""
+
+    def __init__(self, boom=False):
+        self.calls: list[tuple] = []
+        self.kwargs: list[dict] = []
+        self.boom = boom
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append(args)
+        self.kwargs.append(kwargs)
+        if self.boom:
+            raise RuntimeError("gh exploded")
+        return None
+
+
+class TestTheSpecStageFilesItsQuestion:
+    def test_a_conflict_verdict_files_a_must_resolve_issue(self, repo):
+        spy = _Spy()
+        with patch("assemblyzero.speedrun.must_resolve.file_must_resolve", spy):
+            _file_conflict_if_any(
+                {"repo_root": str(repo), "issue_number": 1}, REVIEWER_RATIONALE
+            )
+
+        assert len(spy.calls) == 1, (
+            "a spec-stage requirements conflict must file exactly one question; "
+            "filing none is what left run-issue1-092650 with nothing to resolve"
+        )
+        repo_arg, issue_arg, conflict_arg = spy.calls[0]
+        assert int(issue_arg) == 1
+        assert "never written to the file" in conflict_arg["criterion_a"]
+        assert spy.kwargs[0]["origin"] is SPEC_REVIEW_ORIGIN
+
+    def test_an_ordinary_blocked_verdict_files_nothing(self, repo):
+        """Only the escalation marker means the SOURCE requirements are at
+        fault. A normal BLOCKED is a spec problem, and filing a question about
+        the issue text would be a false alarm at the operator."""
+        spy = _Spy()
+        with patch("assemblyzero.speedrun.must_resolve.file_must_resolve", spy):
+            _file_conflict_if_any(
+                {"repo_root": str(repo), "issue_number": 1},
+                "Spec omits the error path for a malformed config file.",
+            )
+
+        assert spy.calls == []
+
+    def test_filing_never_masks_the_halt(self, repo, capsys):
+        """Same contract as N0c's. The roll is already stopping; a filing
+        problem is loud and nothing more."""
+        spy = _Spy(boom=True)
+        with patch("assemblyzero.speedrun.must_resolve.file_must_resolve", spy):
+            _file_conflict_if_any(
+                {"repo_root": str(repo), "issue_number": 1}, REVIEWER_RATIONALE
+            )
+
+        assert "WARNING" in capsys.readouterr().out
+
+    def test_it_really_reaches_gh_issue_create(self, repo):
+        """End to end through the filer, with the runner injected explicitly,
+        so the wiring above is not the only thing under test."""
+        runner = _Runner()
+        conflict = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+
+        file_must_resolve(
+            repo, 1, conflict, origin=SPEC_REVIEW_ORIGIN,
+            runner=runner, log=lambda *a: None,
+        )
+
+        created = runner.created()
+        assert len(created) == 1
+        assert "--label" in created[0] and "must-resolve" in created[0]
+        body = created[0][created[0].index("--body") + 1]
+        assert "implementation-spec reviewer" in body
+
+    def test_a_missing_issue_number_is_skipped_not_crashed(self, repo):
+        """Brief and idea entry paths carry file input, not an issue number."""
+        runner = _Runner()
+        result = file_must_resolve(
+            repo, 0, conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER),
+            origin=SPEC_REVIEW_ORIGIN, runner=runner, log=lambda *a: None,
+        )
+
+        assert result.action == "skipped"
+        assert runner.created() == []
+
+
+class TestParsingTheReviewersProse:
+    """N0c hands over a structured conflict; the reviewer writes prose."""
+
+    def test_the_two_quoted_criteria_are_separated(self):
+        conflict = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+
+        assert "never written to the file" in conflict["criterion_a"]
+        assert "the file holds size N" in conflict["criterion_b"]
+
+    def test_the_diverging_situation_is_captured(self):
+        conflict = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+        assert "--reset-config" in conflict["diverging_situation"]
+
+    def test_curly_quotes_parse_too(self):
+        """A run that filed nothing because of a typographic quote would
+        reproduce the defect this closes."""
+        rationale = (
+            f"{CONFLICT_MARKER} REQ-1 says “the window opens at the saved "
+            "position” but REQ-3 says “the window always opens "
+            "centred”. They diverge on every launch with a saved position."
+        )
+        conflict = conflict_from_rationale(rationale, CONFLICT_MARKER)
+
+        assert "saved position" in conflict["criterion_a"]
+        assert "centred" in conflict["criterion_b"]
+
+    def test_unquoted_prose_still_yields_a_filable_conflict(self):
+        """Best-effort on purpose. A slightly coarse issue is worth having; a
+        missing one is the defect."""
+        rationale = (
+            f"{CONFLICT_MARKER} REQ-2 and REQ-4 cannot both hold when the app "
+            "is launched with both flags."
+        )
+        conflict = conflict_from_rationale(rationale, CONFLICT_MARKER)
+
+        assert conflict["criterion_a"].strip()
+        assert "did not quote two separable sentences" in conflict["diverging_situation"]
+
+    def test_parsing_is_deterministic_so_the_fingerprint_is_stable(self):
+        """A redraw storm must not file twenty copies of one ambiguity."""
+        a = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+        b = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+
+        assert conflict_fingerprint(
+            a["criterion_a"], a["criterion_b"]
+        ) == conflict_fingerprint(b["criterion_a"], b["criterion_b"])
+
+
+class TestTheIssueSaysWhichGateFoundIt:
+    def test_a_spec_filing_does_not_claim_to_be_n0c(self):
+        """The body stated "Found by N0c" unconditionally. On a spec-stage
+        filing that is simply false, and the operator needs to know which
+        document the ruling is against."""
+        body = build_body(
+            1, conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER),
+            run_id="run-issue1-092650", run_start="2026-08-10 09:26",
+            conflict_ts="2026-08-10 09:43", fingerprint="abc123",
+            origin=SPEC_REVIEW_ORIGIN,
+        )
+
+        assert "Found by N0c" not in body
+        assert "implementation-spec reviewer" in body
+
+    def test_the_lld_filing_is_unchanged(self):
+        """The default must stay N0c's, so every existing caller reads the same."""
+        body = build_body(
+            1, {"criterion_a": "a", "criterion_b": "b"},
+            run_id="r", run_start="s", conflict_ts="t", fingerprint="f",
+        )
+        assert "Found by N0c" in body
+        assert N0C_ORIGIN.tag == "N0c"
+
+    def test_both_gates_share_one_question(self, repo):
+        """The fingerprint excludes the origin deliberately. One contradiction
+        found at both stages is ONE question for the operator, so the second
+        detection comments rather than opening a duplicate."""
+        conflict = conflict_from_rationale(REVIEWER_RATIONALE, CONFLICT_MARKER)
+        fp = conflict_fingerprint(conflict["criterion_a"], conflict["criterion_b"])
+
+        existing = (
+            '[{"number": 253, "title": "must-resolve: #1 requirements conflict", '
+            f'"body": "<!-- must-resolve source_issue=1 fingerprint={fp} -->"}}]'
+        )
+        runner = _Runner(existing_search_output=existing)
+
+        result = file_must_resolve(
+            repo, 1, conflict, origin=SPEC_REVIEW_ORIGIN, runner=runner, log=lambda *a: None
+        )
+
+        assert result.action == "commented"
+        assert result.issue_number == 253
+        assert runner.created() == [], "a duplicate question is noise at the operator"


### PR DESCRIPTION
## The defect

A requirements conflict detected at the **spec stage** exits 93 — "blocked on
an operator ruling, no redraw can help" — and filed **no must-resolve question**,
unlike the LLD stage's N0c gate which files one per conflict.

Observed 2026-08-10 on boostgauge `run-issue1-092650`: the LLD passed, spec
review blocked on a contradiction between two requirements, and no issue was
created. Three things followed from the one omission — the verdict block printed
`Next step: resolve .` with nothing in it, the launch gate recorded no numbers
(which is how #2196's empty-blocking brick got seeded), and the question had to
be filed by hand for the block to be tracked at all.

Exit 93 means *a human must rule before any roll*. That is only real if the
thing to rule on exists.

## The fix

`review_spec` files the question when its verdict is BLOCKED **and** carries the
`REQUIREMENTS CONFLICT:` escalation marker. Same contract as N0c's filing: never
raises, never changes the halt — the roll is already stopping, so a filing
problem is loud in the log and nothing more.

An ordinary BLOCKED verdict files nothing. Only the marker means the *source
requirements* are at fault; a normal BLOCKED is a spec-authoring problem, and
filing a question about the issue text would be a false alarm at the operator.
A test pins that.

## Parsing the reviewer's prose

N0c hands over a structured conflict; the spec reviewer writes prose behind the
marker (its instruction is to quote the two conflicting sentences verbatim and
name where they diverge). `conflict_from_rationale` separates them, handling
curly quotes as well as straight — a run that filed nothing because of a
typographic quote would reproduce the very defect this closes.

**Parsing is best-effort on purpose.** When two sentences cannot be separated,
the whole finding becomes criterion A rather than the filing being skipped. A
slightly coarse issue is worth having; a missing one is the defect. The result
is deterministic for the same text, so the fingerprint is stable and a redraw
storm comments on the existing question instead of filing twenty copies.

## The issue now says which gate found it

`build_body` opened with "Found by N0c" unconditionally, which is false on a
spec-stage filing — and the operator needs to know which document the ruling is
against. An `Origin` now carries the provenance sentence and the log tag, with
`N0C_ORIGIN` as the default so **every existing caller is byte-identical**
(pinned by `test_the_lld_filing_is_unchanged`).

**The fingerprint deliberately excludes the origin.** One contradiction found at
the LLD stage and again at the spec stage is *one* question for the operator, so
the second detection comments on the first issue rather than opening a duplicate.
That is `test_both_gates_share_one_question`.

## A note on the test approach

`_default_runner` cannot be patched at module level — it is bound as a default
argument, so the patch never reaches an already-defined signature and the real
`git` runs instead. My first cut did exactly that and silently tested nothing
(it "passed" by finding no remote). The tests now either inject the runner
explicitly or spy at the boundary the node actually calls, and one case drives
all the way to `gh issue create` so the wiring is not the only thing covered.

## Evidence

13 new tests. Full unit suite: **7008 passed, 17 skipped, 5 xfailed**. Both
changed source files match their `origin/main` ruff counts exactly; the new test
file is clean.

## Scope

The empty terminal summary is the same lost hand-off but belongs to #2179 —
#2224 was closed as its duplicate — and is untouched here.

Closes #2192
