### PR TITLE
fix: thread filed question numbers through instead of re-querying (Closes #2179)

### DIFF
--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -359,6 +359,12 @@ def file_must_resolve(
                 detail=comment.stderr.strip(),
             )
         log(f"  [{origin.tag}] recurrence recorded on existing must-resolve #{existing}")
+        # #2179: a recurrence is still an OPEN question blocking this run, so
+        # it belongs in the summary and the gate exactly like a fresh filing.
+        record_filed(
+            repo_root, number=existing, title=build_title(source_issue, conflict),
+            fingerprint=fingerprint, run_id=run_id, ts=conflict_ts,
+        )
         return FilingResult(True, "commented", existing, fingerprint)
 
     title = build_title(source_issue, conflict)
@@ -387,6 +393,14 @@ def file_must_resolve(
 
     number = _issue_number_from_url((created.stdout or "").strip())
     log(f"  [{origin.tag}] filed must-resolve issue #{number or '?'} in {slug}")
+    # #2179: record it HERE, where the number is known. The launcher used to
+    # re-derive the list from a live query seconds later, which returns short
+    # while GitHub is still indexing -- and that short answer fed both the
+    # operator summary and the launch gate.
+    record_filed(
+        repo_root, number=number, title=title,
+        fingerprint=fingerprint, run_id=run_id, ts=conflict_ts,
+    )
     return FilingResult(True, "filed", number, fingerprint)
 
 
@@ -418,6 +432,122 @@ def open_must_resolve_issues(
     return [
         {"number": r.get("number"), "title": r.get("title", "")} for r in rows
     ], None
+
+
+# ---------------------------------------------------------------------------
+# The filed-questions ledger (#2179)
+# ---------------------------------------------------------------------------
+#
+# The numbers exist in-process at filing time and were thrown away: this module
+# returns each one on its FilingResult, the N0c node discarded the return value,
+# and the launcher then re-derived the list from a live
+# `gh issue list --label must-resolve --state open` seconds later. That query
+# returns short when GitHub has not finished indexing a just-filed issue, and
+# the one short answer fed BOTH the operator summary and the launch gate file.
+#
+# Six occurrences across 2026-08-09/10/11. The worst listed one question of
+# three (run-issue7-083155 filed #273, #274, #275 within four seconds and
+# printed "Next step: resolve #273."), so the operator would have ruled on a
+# third of the block and been refused on the rest. The same short answer is
+# what wrote an empty `blocking` list into prereqs.json -- the write half of
+# #2196's launch brick.
+#
+# The ledger is a local record of what THIS machine filed, written at the
+# moment the number is known. It does not replace the live query: it is unioned
+# with it, so a question filed by an earlier run still surfaces and a question
+# GitHub has not indexed yet surfaces too.
+
+FILED_LEDGER_REL = Path("data") / "speedrun" / "filed-questions.jsonl"
+
+
+def filed_ledger_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / FILED_LEDGER_REL
+
+
+def record_filed(
+    repo_root: Path | str,
+    *,
+    number: int | None,
+    title: str,
+    fingerprint: str | None = None,
+    run_id: str = "",
+    ts: str | None = None,
+) -> bool:
+    """Append one filed question to the local ledger. Never raises.
+
+    Append-only JSONL so two rolls writing at once cannot lose each other's
+    line, and so a corrupt line costs one entry rather than the file.
+    """
+    if not number:
+        return False
+    try:
+        path = filed_ledger_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "number": int(number),
+                "title": title or "",
+                "fingerprint": fingerprint or "",
+                "run_id": run_id or "",
+                "ts": ts or datetime.now().strftime(_TS_FMT),
+            }) + "\n")
+        return True
+    except OSError:
+        # The roll is already halting. Losing the ledger line costs the
+        # summary a number; raising here would cost the halt.
+        return False
+
+
+def read_filed(repo_root: Path | str, *, since: str = "") -> list[dict]:
+    """Ledger entries, newest last, optionally only those at or after `since`.
+
+    `since` is a `_TS_FMT` stamp, which is lexicographically sortable, so the
+    comparison needs no parsing. Bounding by the launcher's own start is what
+    keeps a question closed last week out of tonight's summary.
+    """
+    path = filed_ledger_path(repo_root)
+    entries: list[dict] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return entries
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue  # one bad line must not cost the rest
+        if not row.get("number"):
+            continue
+        if since and str(row.get("ts", "")) < since:
+            continue
+        entries.append({
+            "number": int(row["number"]),
+            "title": row.get("title", ""),
+        })
+    return entries
+
+
+def merge_questions(live: list[dict], recorded: list[dict]) -> list[dict]:
+    """Union by issue number, preferring the live title, ordered by number.
+
+    The live query is authoritative on titles -- an operator may have renamed
+    the issue since it was filed -- and the ledger is authoritative on
+    existence, because it recorded the number at the moment it was created.
+    """
+    merged: dict[int, dict] = {}
+    for item in list(recorded) + list(live):
+        number = item.get("number")
+        if not number:
+            continue
+        merged[int(number)] = {
+            "number": int(number),
+            "title": item.get("title") or merged.get(int(number), {}).get("title", ""),
+        }
+    return [merged[n] for n in sorted(merged)]
 
 
 def refusal_message(issues: list[dict]) -> str:

--- a/tests/unit/test_filed_questions_ledger.py
+++ b/tests/unit/test_filed_questions_ledger.py
@@ -1,0 +1,261 @@
+"""The verdict block must not under-report the questions a run filed (Closes #2179).
+
+The numbers exist in-process at filing time and were thrown away. `must_resolve`
+returns each one on its `FilingResult`; the N0c node discarded the return value;
+and the launcher then re-derived the list from a live
+`gh issue list --label must-resolve --state open` seconds later. That query
+returns short while GitHub is still indexing a just-created issue, and the one
+short answer fed BOTH the operator summary and the launch gate file.
+
+Six occurrences across 2026-08-09, 08-10 and 08-11. The worst:
+`run-issue7-083155` filed boostgauge #273, #274 and #275 within four seconds and
+the block printed `Next step: resolve #273.` -- the operator would have ruled on
+one question of three and been refused on the other two. The same short answer
+is what wrote an empty `blocking` list into prereqs.json, the write half of
+#2196's launch brick.
+
+The remedy the issue itself proposed -- source the list from the live query --
+was already the implementation and landed before the issue was filed, so it
+would have changed nothing. The fix is to stop discarding the numbers.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.speedrun.must_resolve import (
+    file_must_resolve,
+    filed_ledger_path,
+    merge_questions,
+    read_filed,
+    record_filed,
+)
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+# The run that listed one question of three.
+RUN_083155 = [
+    {"number": 273, "title": "must-resolve: #7 requirements conflict — a"},
+    {"number": 274, "title": "must-resolve: #7 requirements conflict — b"},
+    {"number": 275, "title": "must-resolve: #7 requirements conflict — c"},
+]
+
+
+class TestTheLedgerRecordsWhatWasFiled:
+    def test_a_filed_number_is_recorded_at_filing_time(self, repo):
+        def runner(args):
+            if args[:2] == ["git", "-C"]:
+                return subprocess.CompletedProcess(
+                    args, 0, stdout="https://github.com/martymcenroe/boostgauge.git\n"
+                )
+            if args[:3] == ["gh", "issue", "list"]:
+                return subprocess.CompletedProcess(args, 0, stdout="[]")
+            if args[:3] == ["gh", "issue", "create"]:
+                return subprocess.CompletedProcess(
+                    args, 0,
+                    stdout="https://github.com/martymcenroe/boostgauge/issues/273\n",
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="")
+
+        result = file_must_resolve(
+            repo, 7, {"criterion_a": "A", "criterion_b": "B"},
+            runner=runner, log=lambda *a: None,
+        )
+
+        assert result.issue_number == 273
+        assert [e["number"] for e in read_filed(repo)] == [273], (
+            "the number was known in-process and must be recorded there; "
+            "re-deriving it from GitHub seconds later is what returned short"
+        )
+
+    def test_a_recurrence_is_recorded_too(self, repo):
+        """A commented recurrence is still an OPEN question blocking this run,
+        so it belongs in the summary exactly like a fresh filing."""
+        existing = json.dumps([{
+            "number": 240, "title": "must-resolve: #7 x",
+            "body": "<!-- must-resolve source_issue=7 fingerprint=deadbeef -->",
+        }])
+
+        def runner(args):
+            if args[:2] == ["git", "-C"]:
+                return subprocess.CompletedProcess(
+                    args, 0, stdout="https://github.com/martymcenroe/boostgauge.git\n"
+                )
+            if args[:3] == ["gh", "issue", "list"]:
+                return subprocess.CompletedProcess(args, 0, stdout=existing)
+            return subprocess.CompletedProcess(args, 0, stdout="")
+
+        with patch(
+            "assemblyzero.speedrun.must_resolve.conflict_fingerprint",
+            lambda a, b: "deadbeef",
+        ):
+            result = file_must_resolve(
+                repo, 7, {"criterion_a": "A", "criterion_b": "B"},
+                runner=runner, log=lambda *a: None,
+            )
+
+        assert result.action == "commented"
+        assert [e["number"] for e in read_filed(repo)] == [240]
+
+    def test_recording_never_raises(self, repo):
+        """The roll is already halting. Losing a ledger line costs the summary
+        a number; raising would cost the halt."""
+        with patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+            assert record_filed(repo, number=1, title="t") is False
+
+    def test_a_corrupt_line_costs_one_entry_not_the_file(self, repo):
+        path = filed_ledger_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"number": 273, "title": "a", "ts": "2026-08-11 08:34:45"}\n'
+            "not json at all\n"
+            '{"number": 275, "title": "c", "ts": "2026-08-11 08:34:49"}\n',
+            encoding="utf-8",
+        )
+
+        assert [e["number"] for e in read_filed(repo)] == [273, 275]
+
+    def test_entries_before_the_batch_are_excluded(self, repo):
+        """A question ruled on last week must not reappear in tonight's block."""
+        path = filed_ledger_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"number": 100, "title": "old", "ts": "2026-08-01 10:00:00"}\n'
+            '{"number": 273, "title": "new", "ts": "2026-08-11 08:34:45"}\n',
+            encoding="utf-8",
+        )
+
+        recent = read_filed(repo, since="2026-08-11 08:31:55")
+        assert [e["number"] for e in recent] == [273]
+
+
+class TestTheUnion:
+    def test_a_short_live_query_is_completed_by_the_ledger(self):
+        """The exact 2026-08-11 signature: three filed, one indexed."""
+        live = [RUN_083155[0]]
+        merged = merge_questions(live, RUN_083155)
+
+        assert [q["number"] for q in merged] == [273, 274, 275], (
+            "the block printed 'Next step: resolve #273.' for a run that filed "
+            "three; the operator would have been refused on the other two"
+        )
+
+    def test_the_live_title_wins(self):
+        """An operator may have renamed the issue since it was filed."""
+        merged = merge_questions(
+            [{"number": 273, "title": "renamed by the operator"}],
+            [{"number": 273, "title": "must-resolve: #7 requirements conflict"}],
+        )
+        assert merged == [{"number": 273, "title": "renamed by the operator"}]
+
+    def test_a_live_only_question_still_surfaces(self):
+        """The ledger does not replace the query -- an earlier run's still-open
+        question has no entry from this batch."""
+        merged = merge_questions([{"number": 999, "title": "older"}], [])
+        assert [q["number"] for q in merged] == [999]
+
+    def test_numbers_are_not_duplicated(self):
+        merged = merge_questions(RUN_083155, RUN_083155)
+        assert [q["number"] for q in merged] == [273, 274, 275]
+
+
+class TestTheVerdictBlock:
+    def _blocked_verdict(self, repo, live, recorded, since=""):
+        for entry in recorded:
+            record_filed(
+                repo, number=entry["number"], title=entry["title"],
+                ts="2026-08-11 08:34:45",
+            )
+        with patch.object(
+            sr, "open_must_resolve_issues", lambda r: (live, None)
+        ):
+            sr.print_verdict(
+                repo, requested=[7], rolled=[], blocked=[7],
+                stopped_at=None, code=93, since=since,
+            )
+
+    def test_every_filed_question_is_listed(self, repo, capsys):
+        self._blocked_verdict(repo, live=[RUN_083155[0]], recorded=RUN_083155)
+        out = capsys.readouterr().out
+
+        for number in (273, 274, 275):
+            assert f"#{number}" in out, (
+                f"#{number} was filed by this run and is missing from the block"
+            )
+        assert "resolve #273 and #274 and #275" in out
+
+    def test_the_gate_file_gets_the_same_full_list(self, repo, capsys):
+        """The summary and the gate are fed from one result. Under-reporting
+        wrote a short -- sometimes empty -- blocking list, which is #2196's
+        brick."""
+        self._blocked_verdict(repo, live=[RUN_083155[0]], recorded=RUN_083155)
+        capsys.readouterr()
+
+        data = json.loads(sr.prereqs_path(repo).read_text(encoding="utf-8"))
+        assert [b["number"] for b in data["blocking"]] == [273, 274, 275]
+
+    def test_an_offline_gh_still_names_what_this_machine_filed(self, repo, capsys):
+        """gh unreachable used to mean an empty list for both surfaces."""
+        for entry in RUN_083155:
+            record_filed(
+                repo, number=entry["number"], title=entry["title"],
+                ts="2026-08-11 08:34:45",
+            )
+        with patch.object(
+            sr, "open_must_resolve_issues", lambda r: ([], "no net")
+        ):
+            sr.print_verdict(
+                repo, requested=[7], rolled=[], blocked=[7],
+                stopped_at=None, code=93, since="",
+            )
+
+        out = capsys.readouterr().out
+        assert "#273" in out and "#275" in out
+        assert json.loads(
+            sr.prereqs_path(repo).read_text(encoding="utf-8")
+        )["blocking"]
+
+    def test_no_questions_at_all_says_so_instead_of_resolve_nothing(
+        self, repo, capsys
+    ):
+        """#2224, closed into this issue: the heading printed with nothing
+        under it and 'Next step: resolve .' told the operator to resolve
+        nothing."""
+        with patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)):
+            sr.print_verdict(
+                repo, requested=[7], rolled=[], blocked=[7],
+                stopped_at=None, code=93, since="",
+            )
+
+        out = capsys.readouterr().out
+        assert "Next step: resolve ." not in out
+        assert "must-resolve" in out, "say what to check instead"
+        assert not sr.prereqs_path(repo).exists(), (
+            "#2196: an empty gate must not be written"
+        )
+
+    def test_the_verdict_still_never_raises(self, repo, capsys):
+        with patch.object(
+            sr, "open_must_resolve_issues", side_effect=RuntimeError("boom")
+        ):
+            sr.print_verdict(
+                repo, requested=[7], rolled=[], blocked=[7],
+                stopped_at=None, code=93,
+            )
+        assert "verdict rendering failed" in capsys.readouterr().out

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -87,7 +87,9 @@ from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
 from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     RUN_START_ENV,
     RUN_TAG_ENV,
+    merge_questions,
     open_must_resolve_issues,
+    read_filed,
     refusal_message,
 )
 from assemblyzero.speedrun.healing import record_heal  # noqa: E402
@@ -2050,19 +2052,42 @@ def print_verdict(
     blocked: list[int],
     stopped_at: int | None,
     code: int,
+    since: str = "",
 ) -> None:
     """State the outcome in words, last, with the next step (#2165).
 
     Never raises: a verdict must not cost a run, and it must render even
     when gh is unreachable.
+
+    `since` bounds the filed-questions ledger to this batch (#2179).
     """
     try:
-        _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code)
+        _render_verdict(
+            repo_root, requested, rolled, blocked, stopped_at, code, since,
+        )
     except Exception as exc:  # noqa: BLE001 - the verdict is best-effort display
         print(f"(verdict rendering failed: {exc})")
 
 
-def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code):
+def _blocking_questions(repo_root, since: str) -> tuple[list[dict], str | None]:
+    """The questions blocking this batch: the live list, plus what we filed.
+
+    Closes #2179. The live query alone returned short -- six times across
+    2026-08-09/10/11, once listing one question of three filed four seconds
+    apart -- because GitHub had not finished indexing a just-created issue. The
+    ledger records each number at the moment it is created, so the two together
+    cannot under-report the way one of them does alone.
+
+    The union also covers the offline case: gh unreachable used to mean an
+    empty list for both the summary and the gate, and now means whatever this
+    machine knows it filed.
+    """
+    live, gh_error = open_must_resolve_issues(repo_root)
+    recorded = read_filed(repo_root, since=since)
+    return merge_questions(live or [], recorded), gh_error
+
+
+def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, since=""):
     names = ", ".join(f"#{i}" for i in rolled) or "none"
     print()
     if blocked:
@@ -2074,17 +2099,8 @@ def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code):
                 "issues were not rolled."
             )
         print(f"  Rolled successfully: {names}.")
-        questions, gh_error = open_must_resolve_issues(repo_root)
-        if gh_error:
-            print(
-                "  Questions were filed during this run, but gh was "
-                "unreachable to list them."
-            )
-            write_prereqs(
-                repo_root, [],
-                f"blocked issue(s) {blocked_names}; question numbers unverified",
-            )
-        else:
+        questions, gh_error = _blocking_questions(repo_root, since)
+        if questions:
             print("  This run filed the questions blocking it:")
             for q in questions:
                 print(f"    #{q['number']}  {q['title']}")
@@ -2094,6 +2110,32 @@ def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code):
             )
             shortlist = " and ".join(f"#{q['number']}" for q in questions)
             print(f"\n  Next step: resolve {shortlist}.")
+        else:
+            # #2179 (and #2224, closed into it): printing the heading with
+            # nothing under it, then "Next step: resolve .", told the operator
+            # to resolve nothing. Say what is actually known instead.
+            if gh_error:
+                print(
+                    "  Questions were filed during this run, but gh was "
+                    f"unreachable to list them ({gh_error}), and this machine "
+                    "recorded no numbers locally."
+                )
+            else:
+                print(
+                    "  No open questions were found for this block, which is "
+                    "unexpected -- something stopped the run without leaving a "
+                    "question to rule on."
+                )
+            print(
+                "  Next step: check `gh issue list --label must-resolve "
+                "--state open` before launching again."
+            )
+            # #2196: declines to write an empty gate, which is what bricked
+            # every later launch when this path fired.
+            write_prereqs(
+                repo_root, [],
+                f"blocked issue(s) {blocked_names}; question numbers unverified",
+            )
         print(
             "  Do not re-roll without resolution -- the next launch will "
             "refuse while these stay open (--override-prereqs to run anyway)."
@@ -2416,6 +2458,9 @@ def main(argv: list[str] | None = None) -> int:
     rolled: list[int] = []
     blocked: list[int] = []
     stopped_at: int | None = None
+    # #2179: bounds the filed-questions ledger to this batch, so a question
+    # closed last week cannot reappear in tonight's summary.
+    batch_started = _stamp()
     try:
         for issue in args.issue:
             # #2068: generation quality varies wildly between draws -- the same
@@ -2524,6 +2569,7 @@ def main(argv: list[str] | None = None) -> int:
             blocked=blocked,
             stopped_at=stopped_at,
             code=code,
+            since=batch_started,
         )
 
 


### PR DESCRIPTION
## The defect

The verdict block under-reported the must-resolve questions a run filed. Six
occurrences across 2026-08-09, 08-10 and 08-11. The worst: `run-issue7-083155`
filed boostgauge #273, #274 and #275 within four seconds, and the block's
next-step line named **#273 alone**.

The operator would have ruled on one question of three and been refused on the
other two.

(The launcher's next-step wording is quoted in the test file rather than here:
in a PR body, that verb next to an issue number is a directive GitHub acts on,
and these numbers belong to a different repo.)

## Root cause, as verified in triage

The numbers exist in-process at filing time and were thrown away.
`must_resolve` returns each one on its `FilingResult`; `analyze_requirements`
discarded the return value; and the launcher then re-derived the list from a
live `gh issue list --label must-resolve --state open` seconds later. That query
returns short while GitHub is still indexing a just-created issue.

**The same short answer fed both surfaces** — the operator summary *and*
`write_prereqs`. That is the write half of #2196's launch brick: a run that
filed questions but got an empty re-query wrote `"blocking": []`, which then
refused every later launch.

**The remedy this issue originally proposed would have changed nothing.** It
suggested sourcing the list from the live query; that is already what the code
did, and it landed in #2168 *before* the issue was filed. Correcting that was
part of the triage.

## The fix

Stop discarding the numbers. `must_resolve` records each one to a local
append-only ledger at the moment it is created, and the launcher **unions** that
with the live query at verdict time.

The union matters in both directions. The ledger does not replace the query — a
question filed by an earlier run, still open, has no entry from this batch and
still surfaces. The query does not replace the ledger — a question GitHub has
not indexed yet has no live row. Neither alone is sufficient, which is why one
of them alone kept failing.

Details that are load-bearing:

- **Recurrences are recorded too.** A commented recurrence is still an open
  question blocking this run, so it belongs in the summary exactly like a fresh
  filing.
- **Bounded to this batch.** The launcher stamps its start and the ledger read
  is filtered by it, so a question ruled on last week cannot reappear in
  tonight's block.
- **The live title wins on merge.** An operator may have renamed the issue since
  it was filed; the ledger is authoritative on existence, the query on titles.
- **Recording never raises.** The roll is already halting — losing a ledger line
  costs the summary a number; raising would cost the halt.
- **A corrupt line costs one entry, not the file.** Append-only JSONL, so two
  rolls writing at once cannot lose each other's line either.
- **The ledger survives the restore.** `restore_repo` runs before the verdict
  and sweeps untracked emissions, but `data/speedrun/**` is structurally exempt
  from that delta — not merely gitignored by convention. Checked before relying
  on it.

## Offline is better now too

`gh` unreachable used to mean an empty list for *both* the summary and the gate.
It now means whatever this machine knows it filed, which is exactly the case
where local knowledge is all there is.

## The empty summary, from #2224

#2224 was closed as a duplicate of this issue, so its symptom is fixed here: the
block printed its heading with nothing under it and then `Next step: resolve .`,
telling the operator to resolve nothing. When no questions are known, it now
says so and names the command to check, and — per #2196 — writes no gate file.

## Evidence

14 new tests, including the `run-issue7-083155` signature verbatim (three filed,
one indexed, all three must be listed) and a check that the gate file receives
the same full list rather than a short one.

Falsifiability checked by disabling the ledger read: three tests fail, including
the offline case. Restored, all pass.

Full unit suite: **7022 passed, 17 skipped, 5 xfailed**. Both changed source
files match their `origin/main` ruff counts exactly; the new test file is clean.

Closes #2179
