### PR TITLE
feat: run the ADR 0226 form check at launcher preflight (Closes #2227)

### DIFF
--- a/assemblyzero/workflows/requirements/form_gate.py
+++ b/assemblyzero/workflows/requirements/form_gate.py
@@ -1,0 +1,214 @@
+"""The ADR 0226 form check as a launcher preflight (#2227).
+
+#2219 built the checker and deliberately left this question open. The operator
+ruled on 2026-08-12:
+
+    The form check RUNS at launcher preflight, report-only by default. The
+    launch refuses only when the issue carries at least one decision table and
+    that table is malformed. An unconverted prose issue never refuses -- a
+    refusal there is a false alarm by definition. The vacuous-EARS state is
+    surfaced out loud. Form-check findings are labelled as the form check's,
+    distinct from the semantic gate's output.
+
+Why report-only is the default
+------------------------------
+
+ADR 0226 section 8 converts an issue when it next rolls, not in a sweep, so
+nearly every issue in the fleet is still prose. A preflight that hard-refused on
+form would block almost all of them, and a gate that fires on the ordinary case
+is a gate people learn to wave through -- the same reasoning that scoped the
+ADR-0217 equivalence check.
+
+Why silence is not a pass
+-------------------------
+
+An issue with no ``## Requirements`` section passes every EARS check while
+verifying nothing about its sentences. Reporting that as a clean bill would be
+reading silence as assurance, which is the exact failure the checker's own
+report is written to prevent. So the vacuous result is stated at launch.
+
+What refuses, and what only reports
+-----------------------------------
+
+The ruling says "carries at least one decision table and that table is
+malformed". Malformation is read as the table's OWN shape -- ADR 0226's second
+check, completeness and disjointness -- because that is what a table can be
+malformed about, and because a refusal has to be an unambiguous fact.
+
+Row-to-criterion coverage is ADR 0226's third check and is treated separately,
+on the checker's own account of its two join modes. With row IDs the join is
+exact and a missing criterion is a hard fact, so it refuses. Without them the
+join rests on count and outcome text, which the checker's docstring already
+delegates to the semantic gate -- so it reports and does not refuse. EARS
+findings never refuse: they are about prose sentences, which is precisely where
+unconverted issues live.
+
+`REFUSING_KINDS` and `EXACT_JOIN_REFUSES` are the two knobs. Widening the
+refusal is a one-line change if the operator wants it wider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.requirements.form_check import (
+    FormReport,
+    check_form,
+)
+
+#: Violations of the table's own shape: wrong row count for its condition
+#: count, or a repeated combination. These are what "malformed table" means.
+REFUSING_KINDS = frozenset({"table-rows", "table-duplicate"})
+
+#: Row-to-criterion coverage refuses only where the join is exact, i.e. the
+#: table carries row IDs. Without IDs the checker itself calls the join weaker
+#: and delegates combination correctness to the semantic gate.
+EXACT_JOIN_REFUSES = True
+
+LABEL = "Requirements form check (ADR 0226)"
+
+
+@dataclass
+class IssueForm:
+    """One issue's form verdict at preflight."""
+
+    issue: int
+    report: FormReport | None = None
+    error: str = ""            # the check could not run at all
+    refusing: list = field(default_factory=list)   # violations that refuse
+    reporting: list = field(default_factory=list)  # violations that only report
+
+    @property
+    def has_tables(self) -> bool:
+        return bool(self.report and self.report.tables)
+
+    @property
+    def vacuous_ears(self) -> bool:
+        return bool(self.report and not self.report.ears_ran)
+
+
+def classify(report: FormReport) -> tuple[list, list]:
+    """(refusing, reporting) violations, per the ruling.
+
+    A table's own malformation refuses. A missing row criterion refuses only
+    when the table it came from carries row IDs, because only then is the join
+    exact enough for the finding to be a fact rather than a text-match.
+    """
+    exact_join_everywhere = bool(report.tables) and all(
+        t.exact_join for t in report.tables
+    )
+
+    refusing, reporting = [], []
+    for violation in report.violations:
+        if violation.kind in REFUSING_KINDS:
+            refusing.append(violation)
+        elif (
+            violation.kind == "row-criterion"
+            and EXACT_JOIN_REFUSES
+            and exact_join_everywhere
+        ):
+            refusing.append(violation)
+        else:
+            reporting.append(violation)
+    return refusing, reporting
+
+
+def check_issue(repo_root, issue: int, fetch) -> IssueForm:
+    """Run the form check for one issue. Never raises."""
+    result = IssueForm(issue=issue)
+    try:
+        _title, body = fetch(repo_root, issue)
+    except Exception as exc:  # noqa: BLE001 - a read failure is not a verdict
+        result.error = str(exc)
+        return result
+
+    if not (body or "").strip():
+        result.error = "the issue body is empty, so there was nothing to check"
+        return result
+
+    result.report = check_form(body)
+    result.refusing, result.reporting = classify(result.report)
+    return result
+
+
+def render(results: list[IssueForm]) -> tuple[str, bool]:
+    """(operator-facing text, refuse). Labelled as the form check's own.
+
+    The semantic gate's refusal opens "BLOCKED: this repository has N unanswered
+    questions". This one always names itself, so one defect never reads as two
+    complaints in two formats.
+    """
+    lines = [f"{LABEL} -- deterministic, no model calls:"]
+    refuse = False
+
+    for item in results:
+        head = f"  #{item.issue}: "
+
+        if item.error:
+            lines.append(
+                head + f"could not be checked ({item.error}). Nothing about "
+                "this issue's form has been verified."
+            )
+            continue
+
+        notes = []
+        if item.vacuous_ears:
+            # Load-bearing: a pass here verified nothing about any sentence.
+            notes.append(
+                "no '## Requirements' section, so NO sentence in it was checked "
+                "-- this is a vacuous pass, not a clean bill"
+            )
+        if not item.has_tables:
+            notes.append("no decision table, so none was checked")
+
+        if item.refusing:
+            refuse = True
+            lines.append(head + f"{len(item.refusing)} form violation(s) that "
+                                "block a roll:")
+            for violation in item.refusing:
+                lines.append(f"      {violation}")
+        elif item.reporting:
+            lines.append(head + f"{len(item.reporting)} form finding(s), "
+                                "reported only:")
+            for violation in item.reporting:
+                lines.append(f"      {violation}")
+        elif not notes:
+            lines.append(head + "form holds.")
+        else:
+            lines.append(head + "no form violations.")
+
+        for note in notes:
+            lines.append(f"      note: {note}")
+
+        if item.reporting and item.refusing:
+            lines.append(
+                f"      plus {len(item.reporting)} further finding(s) reported "
+                "but not blocking"
+            )
+
+    if refuse:
+        lines += [
+            "",
+            "  BLOCKED by the form check: a decision table above is malformed.",
+            "  This is a counting result, not a judgment -- the table does not",
+            "  carry the rows its own conditions require, or a row has no",
+            "  acceptance criterion. Fix the table in the issue, then launch",
+            "  again. Nothing has been spent.",
+        ]
+    else:
+        lines += [
+            "",
+            "  Reported only; the roll proceeds. The form check cannot report",
+            "  CORRECTNESS -- a table can enumerate every combination and state",
+            "  the wrong outcome in every row.",
+        ]
+
+    return "\n".join(lines), refuse
+
+
+def check_form_at_preflight(repo_root, issues: list[int], fetch) -> tuple[str, bool]:
+    """The whole preflight step: (text to print, whether to refuse)."""
+    results = [check_issue(repo_root, issue, fetch) for issue in issues or []]
+    if not results:
+        return "", False
+    return render(results)

--- a/docs/adrs/0226-checkable-requirements-ears-tables-split.md
+++ b/docs/adrs/0226-checkable-requirements-ears-tables-split.md
@@ -216,6 +216,20 @@ The mechanical checker is built (#2219): `tools/check_requirements_form.py --rep
 
 The full pre-roll sequence is this form check, then the semantic requirements-consistency gate via `tools/check_requirements.py` (#2221, one model call), then the roll.
 
+### The form check at launcher preflight (operator ruling, 2026-08-12, #2227)
+
+#2219 built the checker and left one question open: whether it should also run inside the launcher's preflight, where a refusal costs nothing because no branch exists and no token has been spent. The ruling:
+
+**The form check runs at launcher preflight, report-only by default.** It joins the existing refusals — an untrustworthy tree, a sick machine, the previous run's unresolved questions, open must-resolve issues — and runs before the detach hand-off, so a batch is judged as a whole before anything is spent.
+
+**It refuses only when the issue carries at least one decision table and that table is malformed.** An unconverted prose issue never refuses; a refusal there is a false alarm by definition. This matters because conversion happens when an issue next rolls rather than as a sweep, so nearly every issue in the fleet is still prose. A gate that fired on the ordinary case would be waved through, which is the same reasoning that scoped the ADR-0217 equivalence gate to the paths a branch actually changed.
+
+Malformation is read as the table's own shape — the second of the three rules, completeness and disjointness — because that is what a table can be malformed about and because a refusal must be an unambiguous fact. The third rule, row-to-criterion coverage, is treated on the checker's own account of its two join modes: with row IDs the join is exact and a missing criterion refuses; without them it rests on count and outcome text, which this ADR already delegates to the semantic gate, so it reports and does not refuse. EARS findings never refuse, since prose sentences are exactly where unconverted issues live. The two knobs are `REFUSING_KINDS` and `EXACT_JOIN_REFUSES` in `assemblyzero/workflows/requirements/form_gate.py`; widening the refusal is a one-line change.
+
+**The vacuous-EARS state is surfaced out loud.** An issue with no `## Requirements` section passes every EARS check while verifying nothing about its sentences. The preflight says so explicitly rather than letting a silent pass read as a clean bill — the failure mode the checker's report format exists to prevent.
+
+**Form-check findings are labelled as the form check's own**, distinct from the semantic gate's refusal, so one defect never reaches the operator as two complaints in two formats.
+
 boostgauge #7 is the first converted requirement and was rolling as of 2026-08-11. Its result is the first evidence about whether this form prevents what it was adopted to prevent.
 
 ## 9. References
@@ -235,4 +249,5 @@ Bibliographic details below are recorded from recall. Confirm them against the p
 | Date | Author | Change |
 |---|---|---|
 | 2026-08-11 | Claude Opus 5 | Initial draft |
+| 2026-08-12 | Claude Opus 5 | Operator ruling on #2227 recorded in section 8: the form check runs at launcher preflight, report-only, refusing only on a malformed decision table so unconverted prose issues never trip it; the vacuous-EARS state is surfaced explicitly; findings are labelled distinctly from the semantic gate's. |
 | 2026-08-11 | Claude Fable 5 | Building the checker (#2219) surfaced a contradiction between rule 1 and this ADR's own worked example: boostgauge #7's row criteria are mandated by section 3.2 and match no EARS pattern, so an EARS check over acceptance criteria would fail the fixture the ADR cites as its first success. Operator rulings on #2219 scoped EARS to the bullets of a marked `## Requirements` section, exempted row criteria explicitly, and adopted a row ID convention that makes the grid-to-criteria join exact. Sections 3.1, 3.2 and 8 carry those rulings. |

--- a/tests/fixtures/form_gate/boostgauge-7-converted.md
+++ b/tests/fixtures/form_gate/boostgauge-7-converted.md
@@ -1,0 +1,123 @@
+## Summary
+
+BoostGauge needs a configuration system for thresholds, polling intervals, visual preferences, and window behavior.
+
+## Config file
+
+Location: `~/.boostgauge/config.json` (or `%APPDATA%/boostgauge/config.json` on Windows)
+
+```json
+{
+  "polling_interval_seconds": 2,
+  "theme": "dark",
+  "size": 300,
+  "opacity": 0.9,
+  "always_on_top": true,
+  "position": {"x": 100, "y": 100},
+  "thresholds": {
+    "conpty": {"yellow": 30, "red": 60},
+    "memory_percent": {"yellow": 60, "red": 80},
+    "process_count": {"yellow": 300, "red": 500},
+    "handle_count": {"yellow": 30000, "red": 50000}
+  },
+  "telltale_windows": {
+    "short": 60,
+    "medium": 600,
+    "long": 3600
+  },
+  "show_driver_label": true,
+  "show_digital_readout": true,
+  "show_session_count": true
+}
+```
+
+## CLI arguments
+
+```
+boostgauge [OPTIONS]
+
+Options:
+  --theme THEME          Visual theme (dark, light, neon, classic)
+  --size PIXELS          Gauge diameter in pixels (default: 300)
+  --poll SECONDS         Polling interval (default: 2)
+  --opacity FLOAT        Window opacity 0.0-1.0 (default: 0.9)
+  --no-topmost           Don't keep window on top
+  --config PATH          Path to config file
+  --reset-config         Reset config to defaults
+```
+
+## Config persistence
+
+**Writes.** The app writes to the config file at exactly three moments and at no other time:
+
+1. **First-run auto-create.** Launch finds no config file and creates one with defaults.
+2. **Launch reset.** `--reset-config` rewrites the file to defaults before the app reads it. The flag has no further effect; the rest of the session proceeds as any other.
+3. **Exit write.** The app writes the keys the user changed by hand during the session, and only those keys: `position` if the window was moved, `size` if it was resized. Every other key keeps whatever the file already holds, including edits made directly to the file while the app ran. Position and size are the only keys with a hand-change mechanism, so they are the only keys the exit write can ever touch. A session with no hand-made changes skips the exit write entirely.
+
+**Reads are not restricted.** Launch reads the file after step 2, and the app re-reads it during the session so that threshold edits take effect without a restart. Reading never modifies the file.
+
+**Direct edits to the file while the app runs are the user's writes, not the app's.** The three moments above are the app's complete write behavior. After launch, the app's only write is the exit write, and the exit write never overwrites a key the user did not change by hand during the session. The launch writes (auto-create, reset) happen before the app reads the file and before any session activity exists. The file's content after quit is therefore the composition of the app's writes and the user's.
+
+**Launch order** is: reset if flagged, then read the file (auto-create if missing), then apply CLI overrides in memory. CLI value overrides (`--theme`, `--size`, `--poll`, `--opacity`, `--no-topmost`) govern the running session; the app never writes them to the file. The window opens at the file's position, since no position flag exists, and at the CLI size when `--size` is given, otherwise the file's size. After a `--reset-config` launch the file holds defaults when it is read, so the window opens at the default position, and at the default size unless `--size` overrides it for the session.
+
+**Persistence of `position` and `size` is independent**, each governed by its own table. Every row follows from the write rules above, and each row is an acceptance criterion below. Both tables hold one further condition fixed: no direct edit to the file during the session. The composition criterion in the acceptance list governs a session with one.
+
+Position, which has no CLI flag and only ever changes by hand:
+
+| `--reset-config`? | Window moved by hand? | `position` in the file after quit (no direct edits) |
+|---|---|---|
+| no | no | unchanged |
+| no | yes | the new position |
+| yes | no | default |
+| yes | yes | the new position |
+
+Size, which has a CLI flag:
+
+| `--reset-config`? | `--size` given? | Window resized by hand? | `size` in the file after quit (no direct edits) |
+|---|---|---|---|
+| no | no | no | unchanged |
+| no | no | yes | the new size |
+| no | yes | no | unchanged; the CLI value is not written |
+| no | yes | yes | the new size |
+| yes | no | no | default |
+| yes | no | yes | the new size |
+| yes | yes | no | default; the CLI value is not written |
+| yes | yes | yes | the new size |
+
+`--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments above apply to the selected file.
+
+## Acceptance Criteria
+
+- [ ] First run with no config file creates one with defaults
+- [ ] Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file
+- [ ] With no CLI overrides, the window opens at the file's position and size
+- [ ] Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size
+- [ ] Threshold values edited directly in the config file take effect without restart, and reading them never modifies the file
+- [ ] The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new position or size
+- [ ] With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins
+- [ ] A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit
+- [ ] Position, no reset, not moved, no direct edits: `position` unchanged
+- [ ] Position, no reset, moved, no direct edits: `position` holds the new position
+- [ ] Position, reset, not moved, no direct edits: `position` holds the default
+- [ ] Position, reset, moved, no direct edits: `position` holds the new position
+- [ ] Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged
+- [ ] Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written
+- [ ] Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] Size, reset, no `--size`, not resized, no direct edits: `size` holds the default
+- [ ] Size, reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written
+- [ ] Size, reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] Invalid config values produce clear error messages
+
+## Revision History
+
+- **2026-08-09 — ruling on #235 (filed by run-issue7-181229's requirements-consistency gate):** The original text held both "CLI args override config" and "Position/size saved on exit" with no rule for a session that exits under an untouched CLI override. Operator ruling: CLI overrides are session-scoped and never persisted. On exit the app writes only hand-made changes (drag/resize) to the config file; a CLI-injected value the user never touched leaves the config file unchanged. Acceptance criteria 2 and 3 rewritten to carry the ruling.
+- **2026-08-10 — ruling on #240 (filed by run-issue7-233727's requirements-consistency gate):** The #235 ruling's blanket sentence ("an override is never written back to the config file") contradicted `--reset-config`, whose entire purpose is to write defaults into the config file. Operator ruling: the session-only rule governs value overrides; `--reset-config` is the one deliberate exception and rewrites the config file to defaults. `--config` selects the file and writes nothing by itself.
+- **2026-08-10 — ruling on #249 (filed by run-issue7-031357's requirements-consistency gate):** "Position always persists on exit" read as an unconditional write, contradicting "persists only changes the user made by hand" for a session in which the window was never moved. Operator ruling: persistence is change-driven — exit writes only hand-made changes, and an untouched session leaves the config file byte-identical, preserving any direct edits made to the file while the app ran. The "always persists" sentence rephrased to its intent: position only ever changes by hand, so a moved window always keeps its new position.
+- **2026-08-10 — ruling on #252 (filed by run-issue7-094316's requirements-consistency gate):** The #249 sentence's byte-identical guarantee, written without its exception, contradicted the #240 carve-out when the app is launched with `--reset-config` and exited untouched. Operator ruling: the reset wins — `--reset-config` is a config-file command and rewrites the file regardless of hand-made changes; the byte-identical guarantee is scoped to sessions launched without a config-file command. Both sentences now carry the exception inline.
+- **2026-08-11 — ruling on #273/#274/#275 (filed by run-issue7-083155's requirements-consistency gate):** Three conflicts from one run, each pitting a persistence sentence against `--reset-config`'s "rewrites the file regardless." Operator ruling: **the reset happens at launch.** `--reset-config` rewrites the file to defaults before the app reads it; the session then behaves normally and exit writes hand-made changes as usual, so a window moved during a reset session keeps its new position, and that session's own window opens at the defaults. The prose paragraph that produced seven conflicts across five rulings was replaced by an ordered rule and a decision table.
+- **2026-08-11 — repair after #277/#278/#279 (filed by run-issue7-140703's requirements-consistency gate):** All three conflicts were in text introduced by the #273/#274/#275 rewrite itself, and none required a new behavioral decision. (1) "Nothing else touches it" accidentally forbade the mid-session reads that hot threshold reload requires; the constraint is now scoped to writes, with reads explicitly unrestricted (#277). (2) The single table bundled position and size into one "moved or resized" condition, so a session launched with `--size` whose window was only moved appeared to write the CLI size to the file; position and size are independent variables with different rules, because size has a CLI flag and position does not, and each now has its own table (#278). The four-condition count that forced the split is AssemblyZero ADR 0226's split rule applied. (3) "Opens at the default position and size" overstated the reset launch by one noun; with `--reset-config --size N` the session runs at the CLI size while the file holds the default (#279). Two latent gaps no run had yet reported were closed in the same pass: the exit write is defined as a per-key patch, so direct file edits survive an exit that writes position or size; and the byte-identical guarantee is stated with its no-reset scope inline, so the #252 collision shape cannot recur. First-run auto-create was also added to the enumerated write moments, which the previous "exactly three things" sentence omitted.
+- **2026-08-11 — repair after #280/#281 (filed by run-issue7-152239's requirements-consistency gate):** Both conflicts paired a table row's final-state claim against #249's standing rule that direct file edits survive. The rows were written as if the app were the file's only writer; the user can edit the file while the app runs, so the file's final content is a composition of the app's writes and the user's, and a row claiming "holds the default" is false when a direct edit lands after the launch reset. No behavior changed and no new ruling was needed: the app's writes were already fully specified, and #249 already governed direct edits. The repair is scope. Every table row now names its held-fixed condition ("no direct edits"), a composition criterion states what a direct edit leaves behind, and the byte-identical guarantee carries the same scope. The underlying rule, from the same body of work ADR 0226 draws on: state post-conditions only over variables the system controls. The config file is shared with the user, so the app's requirement is its write behavior; file content follows by composition.
+- **2026-08-11 — repair after #282/#283 (filed by the standalone pre-check, AssemblyZero #2221, on its first run against this issue):** The first conflicts caught without spending a roll: the pre-check invokes the same gate a roll runs, offline, and it found two overclaimed guarantees in the prose around the tables. (1) "The app never overwrites a key the user did not change by hand" was written as a blanket claim about the app; the launch reset exists to overwrite untouched keys. The claim is now scoped to the exit write, which is what it was always about (#282). (2) The byte-identical guarantee did not exclude a first run, where auto-create writes a file from nothing; it now requires that the session found an existing config file at launch (#283). No behavior changed and no ruling was needed. Both defects are the universal-dressed-as-conditional disease recurring in the prose that remains around the tables.
+

--- a/tests/unit/test_form_gate.py
+++ b/tests/unit/test_form_gate.py
@@ -1,0 +1,373 @@
+"""The ADR 0226 form check at launcher preflight (Closes #2227).
+
+#2219 built the checker and deliberately left this open. The operator ruled on
+2026-08-12: it RUNS at preflight, report-only by default; the launch refuses
+only when the issue carries at least one decision table and that table is
+malformed; an unconverted prose issue never refuses; the vacuous-EARS state is
+surfaced out loud; and findings are labelled as the form check's own so one
+defect never reads as two complaints beside the semantic gate's.
+
+These pin all four halves of that ruling. The bodies are ADR 0226 shaped rather
+than minimal fixtures, because the interesting cases -- a prose issue, a table
+missing a row, a table whose rows carry IDs -- are distinguished by their form.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from assemblyzero.workflows.requirements.form_check import check_form
+from assemblyzero.workflows.requirements.form_gate import (
+    LABEL,
+    check_form_at_preflight,
+    check_issue,
+    classify,
+)
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+# An unconverted issue: prose only, no Requirements section, no table. This is
+# nearly every issue in the fleet, because ADR 0226 converts on the next roll
+# rather than in a sweep.
+PROSE_ISSUE = """\
+The gauge needle flickers at high update rates.
+
+It should be smoothed. See the attached video for what it looks like now.
+"""
+
+# A converted issue whose table is complete: two binary conditions, four rows.
+# Shaped like boostgauge #7, the issue ADR 0226 cites as its first conversion --
+# no ID column, so the row join is count-and-outcome, and the outcome column's
+# header supplies the subject word its criteria must open with.
+GOOD_ISSUE = """\
+## Requirements
+
+- The system shall persist the window size on exit.
+- WHEN the user resizes the window the system shall record the new size.
+
+## Size
+
+| `--reset-config`? | Window resized by hand? | `size` in the file after quit |
+|---|---|---|
+| no | no | unchanged |
+| no | yes | the new size |
+| yes | no | default |
+| yes | yes | the new size |
+
+## Acceptance Criteria
+
+- size unchanged
+- size the new size
+- size default
+- size the new size again
+"""
+
+# The same table with one row removed: two binary conditions require 2^2 rows
+# and it carries three. This is a malformed table, and the case that refuses.
+MALFORMED_TABLE_ISSUE = GOOD_ISSUE.replace("| yes | yes | the new size |\n", "")
+
+# The ID convention adopted on #2219, which makes the row join exact. IDs carry
+# a letter prefix -- bare digits are not row IDs to the checker.
+IDS_ISSUE = """\
+## Requirements
+
+- The system shall persist the window size on exit.
+
+## Size
+
+| ID | `--reset-config`? | Window resized by hand? | `size` in the file after quit |
+|---|---|---|---|
+| R010 | no | no | unchanged |
+| R020 | no | yes | the new size |
+| R030 | yes | no | default |
+| R040 | yes | yes | the new size |
+
+## Acceptance Criteria
+
+- R010 size unchanged
+- R020 size the new size
+- R030 size default
+- R040 size the new size
+"""
+
+# One row left without its criterion, with IDs present so the join is exact.
+MISSING_CRITERION_ISSUE = IDS_ISSUE.replace("- R040 size the new size\n", "")
+
+# A Requirements section whose bullets are not EARS. Findings here must report
+# and never refuse: prose sentences are where unconverted issues live.
+NON_EARS_ISSUE = """\
+## Requirements
+
+- Make the needle smoother.
+- Nobody wants a flickering gauge.
+"""
+
+
+def _fetch(bodies):
+    def fetch(repo_root, issue):
+        if issue not in bodies:
+            raise RuntimeError(f"no such issue #{issue}")
+        return (f"issue {issue}", bodies[issue])
+    return fetch
+
+
+class TestTheRefusalCondition:
+    """"...only when the issue carries at least one decision table and that
+    table is malformed." """
+
+    def test_a_malformed_table_refuses(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: MALFORMED_TABLE_ISSUE})
+        )
+        assert refuse, "three rows for two binary conditions is a malformed table"
+        assert "BLOCKED by the form check" in text
+
+    def test_an_unconverted_prose_issue_never_refuses(self, tmp_path):
+        """The load-bearing case. Conversion happens on the next roll, not as a
+        sweep, so nearly every issue is still prose -- refusing here would block
+        almost all of them, and a gate that fires on the ordinary case is one
+        people learn to wave through."""
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: PROSE_ISSUE})
+        )
+        assert not refuse
+        assert "no decision table" in text
+
+    def test_a_well_formed_table_does_not_refuse(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: GOOD_ISSUE})
+        )
+        assert not refuse, text
+
+    def test_non_ears_prose_reports_but_does_not_refuse(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: NON_EARS_ISSUE})
+        )
+        assert not refuse, (
+            "EARS findings are about prose sentences, which is exactly where "
+            "unconverted issues live"
+        )
+        assert "reported only" in text
+
+    def test_a_missing_row_criterion_refuses_when_ids_make_the_join_exact(
+        self, tmp_path
+    ):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: MISSING_CRITERION_ISSUE})
+        )
+        assert refuse
+        assert "R040" in text
+
+    def test_one_bad_issue_in_a_batch_refuses_the_batch(self, tmp_path):
+        """A batch is judged as a whole before anything is spent, like every
+        other preflight refusal."""
+        _text, refuse = check_form_at_preflight(
+            tmp_path, [1, 7],
+            _fetch({1: PROSE_ISSUE, 7: MALFORMED_TABLE_ISSUE}),
+        )
+        assert refuse
+
+
+class TestClassification:
+    def test_table_shape_violations_refuse(self):
+        report = check_form(MALFORMED_TABLE_ISSUE)
+        refusing, _reporting = classify(report)
+
+        assert refusing, "a table missing a row must refuse"
+        assert all(v.kind in ("table-rows", "table-duplicate", "row-criterion")
+                   for v in refusing)
+
+    def test_ears_violations_only_report(self):
+        report = check_form(NON_EARS_ISSUE)
+        refusing, reporting = classify(report)
+
+        assert refusing == []
+        assert reporting, "the non-EARS bullets must still be reported"
+        assert all(v.kind == "ears" for v in reporting)
+
+    def test_a_missing_criterion_refuses_when_the_join_is_exact(self):
+        """With row IDs, "row R040 has no criterion opening with R040" is a
+        hard fact, and catching it before a roll is the point."""
+        report = check_form(MISSING_CRITERION_ISSUE)
+        refusing, _ = classify(report)
+
+        assert [v.kind for v in refusing] == ["row-criterion"]
+        assert all(t.exact_join for t in report.tables)
+
+    def test_the_same_gap_only_reports_without_row_ids(self):
+        """The checker calls the no-ID join weaker and delegates combination
+        correctness to the semantic gate, so a text-matched gap is not the
+        unambiguous fact a refusal needs."""
+        without_ids = GOOD_ISSUE.replace("- size the new size again\n", "")
+
+        report = check_form(without_ids)
+        refusing, reporting = classify(report)
+
+        assert not any(t.exact_join for t in report.tables)
+        assert all(v.kind != "row-criterion" for v in refusing)
+        assert any(v.kind == "row-criterion" for v in reporting), (
+            "it must still be reported -- only the refusal is withheld"
+        )
+
+
+class TestTheFleetsOneConvertedIssue:
+    """boostgauge #7, frozen from the live issue on 2026-08-12.
+
+    ADR 0226 cites it as the first requirement converted to this form, so it is
+    the strongest regression anchor available: if the preflight ever refuses
+    THIS, the gate is wrong. It is also the vacuous case in the wild -- its
+    criteria live under `## Acceptance Criteria` and it has no
+    `## Requirements` section at all, so no sentence in it is EARS-checked.
+    """
+
+    BODY = (
+        Path(__file__).parent.parent
+        / "fixtures" / "form_gate" / "boostgauge-7-converted.md"
+    ).read_text(encoding="utf-8")
+
+    def test_it_does_not_refuse(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: self.BODY})
+        )
+        assert not refuse, text
+
+    def test_its_two_tables_are_read_as_decision_tables(self, tmp_path):
+        result = check_issue(tmp_path, 7, _fetch({7: self.BODY}))
+        assert len(result.report.tables) == 2
+        assert result.report.ok, "the converted issue must pass the form check"
+
+    def test_its_vacuous_ears_state_is_announced(self, tmp_path):
+        """It passes every EARS check while verifying nothing about any
+        sentence. The launch must say so rather than let that read as clean."""
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: self.BODY}))
+        assert "vacuous pass" in text
+
+
+class TestSilenceIsNotAPass:
+    """"An issue with no ## Requirements section passes the form check while
+    verifying nothing about its sentences." """
+
+    def test_the_vacuous_result_is_stated_out_loud(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: PROSE_ISSUE})
+        )
+        assert not refuse
+        assert "vacuous pass" in text
+        assert "NO sentence" in text
+
+    def test_a_converted_issue_does_not_carry_the_vacuous_note(self, tmp_path):
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
+        assert "vacuous pass" not in text
+
+    def test_the_report_says_it_cannot_report_correctness(self, tmp_path):
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
+        assert "CORRECTNESS" in text
+
+
+class TestPresentation:
+    """"...labelled as the form check's, distinct from the semantic gate's
+    output, so one defect never reads as two complaints in two formats." """
+
+    def test_every_report_names_the_form_check(self, tmp_path):
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
+        assert text.startswith(LABEL)
+
+    def test_the_refusal_is_distinguishable_from_the_semantic_gate(self, tmp_path):
+        from assemblyzero.speedrun.must_resolve import refusal_message
+
+        text, refuse = check_form_at_preflight(
+            tmp_path, [7], _fetch({7: MALFORMED_TABLE_ISSUE})
+        )
+        semantic = refusal_message([{"number": 1, "title": "t"}])
+
+        assert refuse
+        assert "BLOCKED by the form check" in text
+        assert "BLOCKED by the form check" not in semantic
+        assert "unanswered" not in text, (
+            "the semantic gate's wording must not appear in the form check's"
+        )
+
+    def test_it_says_no_model_calls_were_made(self, tmp_path):
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
+        assert "no model calls" in text
+
+
+class TestAReadFailureIsNotAVerdict:
+    def test_an_unreadable_issue_reports_and_proceeds(self, tmp_path):
+        """Offline must not brick a local roll -- the same stance the
+        must-resolve gate takes. But it must not read as a pass either."""
+        text, refuse = check_form_at_preflight(tmp_path, [7], _fetch({}))
+
+        assert not refuse
+        assert "could not be checked" in text
+        assert "Nothing about this issue's form has been verified" in text
+
+    def test_an_empty_body_is_not_a_pass(self, tmp_path):
+        result = check_issue(tmp_path, 7, _fetch({7: "   \n"}))
+        assert result.error
+        assert result.report is None
+
+    def test_no_issues_produces_no_output(self, tmp_path):
+        text, refuse = check_form_at_preflight(tmp_path, [], _fetch({}))
+        assert text == "" and refuse is False
+
+
+class TestTheLauncherRunsIt:
+    def test_the_preflight_calls_the_gate(self):
+        import inspect
+
+        source = inspect.getsource(sr.main)
+        assert "check_form_at_preflight" in source, (
+            "the ruling is that it runs at launcher preflight"
+        )
+
+    def test_it_refuses_before_anything_is_spent(self, tmp_path):
+        """91, and no roll -- the same shape as every other preflight refusal."""
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        rolled = []
+
+        def _healthy(*_a, **_k):
+            from assemblyzero.speedrun.box_health import BoxHealth
+            return BoxHealth(True, [], "")
+
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy), \
+                patch.object(sr, "check_prereqs", lambda *a: None), \
+                patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+                patch.object(sr, "roll_issue",
+                             lambda *a: rolled.append(a) or 0), \
+                patch.object(sr, "fetch_issue",
+                             lambda r, i: ("t", MALFORMED_TABLE_ISSUE)):
+            code = sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert code == 91
+        assert rolled == [], "a form refusal must spend nothing"
+
+    def test_a_prose_issue_still_rolls(self, tmp_path):
+        """The regression that would matter most: blocking the whole fleet."""
+        repo = tmp_path / "r"
+        (repo / ".git").mkdir(parents=True)
+        rolled = []
+
+        def _healthy(*_a, **_k):
+            from assemblyzero.speedrun.box_health import BoxHealth
+            return BoxHealth(True, [], "")
+
+        with patch.object(sr, "check_assemblyzero_tree", lambda p: []), \
+                patch.object(sr, "check_box_health", _healthy), \
+                patch.object(sr, "check_prereqs", lambda *a: None), \
+                patch.object(sr, "open_must_resolve_issues", lambda r: ([], None)), \
+                patch.object(sr, "restore_repo", lambda *a: []), \
+                patch.object(sr, "roll_issue",
+                             lambda *a: rolled.append(a) or 0), \
+                patch.object(sr, "fetch_issue", lambda r, i: ("t", PROSE_ISSUE)):
+            code = sr.main(["--repo", str(repo), "--issue", "7"])
+
+        assert code == 0
+        assert len(rolled) == 1

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -84,6 +84,10 @@ from assemblyzero.core.provider_storm import (  # noqa: E402
     STORM_EXIT_CODE,
 )
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
+from assemblyzero.workflows.requirements.form_gate import (  # noqa: E402  (#2227)
+    check_form_at_preflight,
+)
+from assemblyzero.workflows.requirements.precheck import fetch_issue  # noqa: E402
 from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     RUN_START_ENV,
     RUN_TAG_ENV,
@@ -2361,6 +2365,21 @@ def main(argv: list[str] | None = None) -> int:
         print(f"WARNING: could not check for unresolved questions ({gh_error}); proceeding.")
     elif blocking:
         print(refusal_message(blocking))
+        return 91
+
+    # #2227: the ADR 0226 form check, report-only by default. Free and instant
+    # -- no model calls -- so it runs before anything is spent, like every
+    # refusal above it. It refuses ONLY on a malformed decision table: nearly
+    # every issue in the fleet is still unconverted prose (ADR 0226 section 8
+    # converts on the next roll, not in a sweep), and a gate that fired on the
+    # ordinary case would be waved through. Its output names itself so one
+    # defect never reads as two complaints beside the semantic gate's.
+    form_text, form_refuses = check_form_at_preflight(
+        repo_root, args.issue or [], fetch_issue,
+    )
+    if form_text:
+        print(form_text)
+    if form_refuses:
         return 91
 
     if args.detach:


### PR DESCRIPTION
Implements the operator ruling recorded on the issue 2026-08-12, and records it
in ADR 0226 section 8.

## The ruling, as implemented

**The form check runs at launcher preflight, report-only by default.** It joins
the existing refusals — untrustworthy tree, sick machine, the previous run's
unresolved questions, open must-resolve issues — and runs before the detach
hand-off, so a batch is judged as a whole before a branch exists or a token is
spent. It is free and instant: no model calls.

**It refuses only on a malformed decision table.** An unconverted prose issue
never refuses. That is the load-bearing half: ADR 0226 converts an issue when it
next rolls rather than in a sweep, so nearly every issue in the fleet is still
prose, and a gate that fired on the ordinary case would be waved through — the
same reasoning that scoped the ADR-0217 equivalence gate.

**The vacuous-EARS state is announced.** An issue with no `## Requirements`
section passes every EARS check while verifying nothing about its sentences. The
preflight says so out loud instead of letting silence read as assurance.

**Findings are labelled as the form check's own**, so one defect never reaches
the operator as two complaints in two formats beside the semantic gate's.

## What refuses, and what only reports

| finding | refuses? | why |
|---|---|---|
| table shape (`table-rows`, `table-duplicate`) | **yes** | what a table can be *malformed* about; a counting fact |
| missing row criterion, table has row IDs | **yes** | exact join — "row R040 has no criterion opening with R040" is a fact |
| missing row criterion, no row IDs | no | the join rests on outcome text; ADR 0226 already delegates that to the semantic gate |
| EARS | no | prose sentences are exactly where unconverted issues live |

The ruling says "that table is malformed", which does not by itself settle
row-to-criterion coverage — ADR 0226's third rule, about the criteria list
rather than the table's shape. Rather than pick arbitrarily, I split it on the
checker's own account of its two join modes: it refuses where the checker calls
the join exact and reports where the checker itself calls it weaker. That
reasoning is written into ADR 0226 section 8, and the two knobs
(`REFUSING_KINDS`, `EXACT_JOIN_REFUSES`) make widening it a one-line change if
you read the ruling differently.

## The regression anchor

`tests/fixtures/form_gate/boostgauge-7-converted.md` is the live body of
boostgauge #7 — the first issue converted to this form, and the one ADR 0226
cites as its evidence — frozen 2026-08-12. If the preflight ever refuses *that*,
the gate is wrong.

It is also the vacuous case in the wild: its criteria live under
`## Acceptance Criteria` and it has **no** `## Requirements` section, so no
sentence in it is EARS-checked. Verified against the real checker: 2 decision
tables, 0 violations, EARS did not run. The tests assert it passes *and* that
the launch announces the vacuity.

## A note on the fixtures

My first cut invented plausible-looking fixtures and they were wrong in two ways
the checker caught: row IDs need a letter prefix (`R010`, not bare `010`), and
the EARS keywords are uppercase-anchored (`WHEN`, not `When`). Both fixtures
silently produced "no decision table found", which would have made several tests
vacuously green. They are now shaped against the real converted issue and each
shape was verified against the checker before being relied on.

## Evidence

25 tests covering all four halves of the ruling, including the two cases that
matter most in opposite directions: a malformed table refuses and spends nothing
(exit 91, no roll), and a prose issue still rolls.

Full unit suite: **7047 passed, 17 skipped, 5 xfailed**. `speedrun_roll.py`
matches its `origin/main` ruff count; both new files are clean.

Closes #2227
