### PR TITLE
fix: make an iteration-cap halt say why it stopped (Closes #2197)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -8,6 +8,18 @@ Creates a LangGraph-compatible node that:
 3. Generates a structured recovery plan
 4. Prints a human-readable summary
 5. Returns paths for downstream consumption
+
+#2197: a halt that reports "Error: unknown" is the one thing this node must
+never do -- it exists to make a stop legible. A router's state writes are
+discarded at the graph boundary (#2018), so a halt reached by routing alone
+arrived here with an empty error_message and printed exactly that. Nodes now
+record the reason where they know it, and `describe_halt_from_state` below
+synthesizes one from the state when they do not, so no path can print "unknown"
+again.
+
+The fallback is deliberately scoped to HALT. A finalize repair (#2233) leaves
+error_message empty ON PURPOSE -- an in-flight repair is not a failure -- and
+routes to the drafter, never here, so that emptiness is untouched.
 """
 
 from pathlib import Path
@@ -96,6 +108,65 @@ def classify_error(error_message: str) -> str:
     return "unknown"
 
 
+def describe_iteration_cap(
+    max_iterations: int, verdict: str, feedback: str = "", limit: int = 300
+) -> str:
+    """The message an iteration-cap halt should have carried (#2197).
+
+    Names the cap, what the last round said, and the first line of the reason,
+    so the operator reads a verdict instead of scrolling a transcript.
+    """
+    rounds = "round" if max_iterations == 1 else "rounds"
+    reason = (feedback or "").strip().splitlines()
+    head = reason[0].strip() if reason else ""
+    if len(head) > limit:
+        head = head[:limit].rstrip() + "..."
+
+    message = (
+        f"Iteration cap: {max_iterations} review {rounds} ended {verdict}, "
+        "so the run stopped rather than spend another round on the same "
+        "objection."
+    )
+    return f"{message} Last feedback: {head}" if head else message
+
+
+def describe_halt_from_state(state: dict, workflow_name: str) -> str:
+    """A best-effort reason when a halt arrived with no error_message (#2197).
+
+    Reports what the state SAYS rather than re-deciding why routing halted: a
+    synthesized message that disagreed with the real reason would be worse than
+    the blank it replaces. Every branch names the field it read.
+    """
+    verdict = state.get("review_verdict") or state.get("lld_status") or ""
+    iteration = state.get("review_iteration") or state.get("iteration_count") or 0
+    cap = state.get("max_iterations", 0)
+
+    if verdict and cap and iteration >= cap:
+        return describe_iteration_cap(
+            cap, verdict,
+            state.get("review_feedback") or state.get("current_verdict") or "",
+        )
+
+    issues = state.get("completeness_issues") or state.get("validation_errors") or []
+    if issues:
+        listed = "; ".join(str(i) for i in list(issues)[:3])
+        return (
+            f"Halted with {len(issues)} unresolved check(s) after "
+            f"{iteration} round(s): {listed}"
+        )
+
+    if verdict:
+        return (
+            f"Halted after {iteration} round(s) with verdict {verdict} and no "
+            "recorded reason; see the state snapshot for the full transcript."
+        )
+
+    return (
+        f"The {workflow_name} workflow halted without recording a reason. "
+        "The state snapshot beside this plan holds everything it knew."
+    )
+
+
 def create_halt_node(workflow_name: str):
     """Factory: returns a LangGraph-compatible node function.
 
@@ -117,7 +188,12 @@ def create_halt_node(workflow_name: str):
             Dict with recovery_plan_path and state_snapshot_path keys.
         """
         issue_number = state.get("issue_number", 0)
-        error_message = state.get("error_message", "Unknown error")
+        # #2197: "Unknown error" was the default AND the common case, because a
+        # halt reached by routing alone carries nothing. Synthesize from state
+        # rather than print a word that tells the operator nothing.
+        error_message = (state.get("error_message") or "").strip()
+        if not error_message:
+            error_message = describe_halt_from_state(state, workflow_name)
         cost_budget = state.get("cost_budget_usd", 0.0)
 
         # 1. Classify the error

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -25,6 +25,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.core.halt_node import describe_iteration_cap  # #2197
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
 from assemblyzero.core.verdict_schema import (
@@ -402,6 +403,16 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
             f"Spec review BLOCKED: {feedback or spec_result['rationale'] or 'no reason given'}"
         )
         _file_conflict_if_any(state, spec_result.get("rationale", "") or feedback)
+    elif verdict_status == "REVISE" and review_iteration >= max_iterations:
+        # Closes #2197: this is the halt, and it recorded nothing. The router
+        # sends a capped REVISE to HALT, but a router's state writes are
+        # discarded at the graph boundary (#2018), so error_message stayed
+        # empty and the banner read "Error: unknown" at both the workflow and
+        # the orchestrator level -- a failure the operator had to diagnose by
+        # scrolling the raw log. The reason was in the transcript all along.
+        blocked_reason = describe_iteration_cap(
+            max_iterations, verdict_status, feedback
+        )
 
     return {
         "review_verdict": verdict_status,

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -234,11 +234,28 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
             "failures": list(completeness_issues),
         })
 
+    # Closes #2197: when this failure is the LAST one the budget allows, the
+    # router sends it to HALT -- and a router's state writes are discarded at
+    # the graph boundary (#2018), so the halt recorded nothing and the banner
+    # read "Error: unknown". Below the cap the message stays empty: the run is
+    # still going, and a pending revision is not a failure.
+    cap_message = ""
+    if not validation_passed:
+        iteration = state.get("review_iteration", 0)
+        max_iterations = state.get("max_iterations", 3)
+        if iteration >= max_iterations:
+            listed = "; ".join(completeness_issues[:3])
+            cap_message = (
+                f"Iteration cap: {max_iterations} revision(s) ended with "
+                f"{len(completeness_issues)} unresolved completeness check(s). "
+                f"Unfixed: {listed}"
+            )
+
     return {
         "completeness_issues": completeness_issues,
         "validation_passed": validation_passed,
         "prior_completeness_breakdown": prior_breakdown,
-        "error_message": "",
+        "error_message": cap_message,
     }
 
 

--- a/tests/unit/test_halt_legibility.py
+++ b/tests/unit/test_halt_legibility.py
@@ -1,0 +1,280 @@
+"""A halt must say why (Closes #2197).
+
+A spec sub-workflow that halted at its iteration cap recorded an empty
+error_message. The banner printed `Error: unknown`, `Stage: orchestrator_unknown`
+at the orchestrator level, the stage table's error column was blank, and the
+persisted orchestration state carried `error_message: ""`. Observed on
+boostgauge `run-issue1-124144` (2026-08-10), whose own narration knew exactly
+why it stopped: "Max iterations (3) reached with verdict REVISE - halting".
+
+The cause is structural. The routers decide the halt, and a router's state
+writes are discarded at the graph boundary (#2018), so nothing reached
+error_message. The fix is in two layers: the nodes record the reason where they
+know it, and the HALT node synthesizes one from state when they do not.
+
+What must NOT change: #2233 leaves error_message empty on purpose for a
+finalize repair, because an in-flight repair is not a failure. That path routes
+to the drafter and never reaches HALT, which is why the fallback is scoped to
+the HALT node. `TestTheRepairPathIsUntouched` pins it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.core.halt_node import (
+    describe_halt_from_state,
+    describe_iteration_cap,
+)
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    validate_completeness,
+)
+
+
+class TestTheCapMessage:
+    def test_it_names_the_cap_and_the_verdict(self):
+        message = describe_iteration_cap(3, "REVISE", "The spec invents pixel geometry.")
+
+        assert "3" in message
+        assert "REVISE" in message
+        assert "pixel geometry" in message
+
+    def test_one_round_reads_as_singular(self):
+        assert "1 review round" in describe_iteration_cap(1, "REVISE")
+
+    def test_only_the_first_feedback_line_is_carried(self):
+        """The banner is a verdict, not a transcript."""
+        message = describe_iteration_cap(
+            3, "REVISE", "First objection.\nSecond objection.\nThird."
+        )
+        assert "First objection." in message
+        assert "Second objection." not in message
+
+    def test_a_long_line_is_truncated(self):
+        message = describe_iteration_cap(3, "REVISE", "x" * 900)
+        assert len(message) < 500
+        assert message.endswith("...")
+
+    def test_no_feedback_still_names_the_cap(self):
+        message = describe_iteration_cap(3, "REVISE", "")
+        assert "3" in message and "REVISE" in message
+        assert "Last feedback" not in message
+
+
+class TestTheHaltNodeFallback:
+    """No halt path may print "unknown" again, including ones no node
+    anticipated -- two-strike stagnation reaches HALT from the router alone."""
+
+    def test_a_capped_review_is_described(self):
+        message = describe_halt_from_state(
+            {
+                "review_verdict": "REVISE",
+                "review_iteration": 3,
+                "max_iterations": 3,
+                "review_feedback": "The spec invents pixel geometry.",
+            },
+            "implementation_spec",
+        )
+        assert "REVISE" in message and "pixel geometry" in message
+
+    def test_unresolved_checks_are_described(self):
+        message = describe_halt_from_state(
+            {"completeness_issues": ["a", "b", "c", "d"], "review_iteration": 2},
+            "implementation_spec",
+        )
+        assert "4 unresolved check(s)" in message
+        assert "a; b; c" in message
+
+    def test_a_verdict_without_a_cap_is_still_described(self):
+        """Two-strike stagnation: the router halts, the node recorded nothing,
+        and the iteration count is below the cap."""
+        message = describe_halt_from_state(
+            {"review_verdict": "REVISE", "review_iteration": 2, "max_iterations": 3},
+            "implementation_spec",
+        )
+        assert "REVISE" in message
+        assert "no recorded reason" in message
+
+    def test_an_empty_state_says_so_rather_than_unknown(self):
+        message = describe_halt_from_state({}, "implementation_spec")
+
+        assert "unknown" not in message.lower()
+        assert "implementation_spec" in message
+        assert "state snapshot" in message
+
+    def test_it_reports_state_rather_than_re_deciding(self):
+        """A synthesized message that disagreed with the real reason would be
+        worse than the blank it replaces, so every branch names a field it
+        read. Pinned by the requirements workflow's own field names working
+        too -- the fallback is not spec-specific."""
+        message = describe_halt_from_state(
+            {"lld_status": "BLOCKED", "iteration_count": 3, "max_iterations": 3,
+             "current_verdict": "Two criteria contradict."},
+            "requirements",
+        )
+        assert "BLOCKED" in message and "contradict" in message
+
+
+class TestTheHaltNodeUsesIt:
+    def test_an_empty_error_message_is_replaced(self, tmp_path, monkeypatch):
+        from assemblyzero.core import halt_node
+
+        captured = {}
+
+        class _Plan:
+            state_path = ""
+
+            def save(self, _dir):
+                return tmp_path / "plan.md"
+
+            def print_summary(self):
+                pass
+
+        def _generate(**kwargs):
+            captured.update(kwargs)
+            return _Plan()
+
+        monkeypatch.setattr(halt_node, "generate_recovery_plan", _generate)
+        monkeypatch.setattr(
+            halt_node, "save_state_snapshot",
+            lambda *a, **k: tmp_path / "state.json",
+        )
+
+        node = halt_node.create_halt_node("implementation_spec")
+        node({
+            "issue_number": 1,
+            "error_message": "",
+            "review_verdict": "REVISE",
+            "review_iteration": 3,
+            "max_iterations": 3,
+            "review_feedback": "The spec invents pixel geometry.",
+        })
+
+        assert "unknown" not in captured["error_message"].lower(), (
+            'the halt banner printed "Error: unknown", which is the defect'
+        )
+        assert "REVISE" in captured["error_message"]
+
+    def test_a_real_error_message_is_left_alone(self, tmp_path, monkeypatch):
+        from assemblyzero.core import halt_node
+
+        captured = {}
+
+        class _Plan:
+            state_path = ""
+
+            def save(self, _dir):
+                return tmp_path / "plan.md"
+
+            def print_summary(self):
+                pass
+
+        monkeypatch.setattr(
+            halt_node, "generate_recovery_plan",
+            lambda **kw: (captured.update(kw), _Plan())[1],
+        )
+        monkeypatch.setattr(
+            halt_node, "save_state_snapshot",
+            lambda *a, **k: tmp_path / "state.json",
+        )
+
+        halt_node.create_halt_node("implementation_spec")({
+            "issue_number": 1,
+            "error_message": "Spec review BLOCKED: REQUIREMENTS CONFLICT: ...",
+        })
+
+        assert captured["error_message"].startswith("Spec review BLOCKED")
+
+
+class TestTheCompletenessCap:
+    """The other iteration-cap halt in the same workflow."""
+
+    def _state(self, iteration, max_iterations=3):
+        return {
+            "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+            "review_iteration": iteration,
+            "max_iterations": max_iterations,
+        }
+
+    def test_a_failure_at_the_cap_records_a_reason(self, capsys):
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False, "details": "missing excerpt for a.py"},
+        ):
+            out = validate_completeness(self._state(iteration=3))
+        capsys.readouterr()
+
+        assert out["error_message"], (
+            "the last failure the budget allows goes to HALT, and it recorded "
+            "nothing"
+        )
+        assert "Iteration cap" in out["error_message"]
+        assert "missing excerpt" in out["error_message"]
+
+    def test_a_failure_below_the_cap_records_nothing(self, capsys):
+        """The run is still going. A pending revision is not a failure, and a
+        message here would halt a loop that should keep turning."""
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False, "details": "missing excerpt"},
+        ):
+            out = validate_completeness(self._state(iteration=1))
+        capsys.readouterr()
+
+        assert out["error_message"] == ""
+        assert out["validation_passed"] is False
+
+    def test_a_pass_at_the_cap_records_nothing(self, capsys):
+        out = validate_completeness(self._state(iteration=3))
+        capsys.readouterr()
+
+        if out["validation_passed"]:
+            assert out["error_message"] == ""
+
+
+class TestTheRepairPathIsUntouched:
+    """#2233 leaves error_message empty ON PURPOSE for a finalize repair: an
+    in-flight repair is not a failure. The operator flagged this explicitly as
+    the thing not to regress."""
+
+    def test_a_repair_still_routes_to_the_drafter_not_halt(self):
+        from assemblyzero.workflows.requirements.graph import route_after_finalize
+
+        assert route_after_finalize({
+            "finalize_repair_pending": True,
+            "error_message": "",
+        }) == "N1_generate_draft"
+
+    def test_the_fallback_cannot_reach_a_repair(self):
+        """The synthesis lives in the HALT node, and a pending repair never
+        arrives there. That is why it is safe."""
+        from assemblyzero.workflows.requirements.graph import route_after_finalize
+
+        for pending in (True, False):
+            assert route_after_finalize({
+                "finalize_repair_pending": pending, "error_message": "",
+            }) != "HALT"
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {},
+        {"review_verdict": "REVISE"},
+        {"completeness_issues": []},
+        {"review_iteration": 3, "max_iterations": 3},
+    ],
+)
+def test_no_synthesized_message_is_ever_the_word_unknown(state):
+    """The whole point. Whatever the state, the operator gets a sentence."""
+    message = describe_halt_from_state(state, "implementation_spec")
+
+    assert message.strip()
+    assert message.strip().lower() != "unknown"
+    assert "Error: unknown" not in message


### PR DESCRIPTION
## The defect

A spec sub-workflow that halted at its iteration cap recorded an **empty**
`error_message`. The banner printed `Error: unknown`, `Stage:
orchestrator_unknown` at the orchestrator level, the stage table's error column
was blank, and the persisted state carried `error_message: ""` — while the
run's own narration knew exactly why it stopped:

```
[ROUTING] Max iterations (3) reached with verdict REVISE - halting
```

Observed on boostgauge `run-issue1-124144` (2026-08-10).

## Why it happened

Structural, not an oversight. **The routers decide these halts, and a router's
state writes are discarded at the graph boundary (#2018)**, so nothing the
router knew ever reached `error_message`. Every halt reached by routing alone
arrived at HALT carrying nothing.

## The fix, in two layers

**Nodes record the reason where they know it.** Both iteration-cap paths in the
spec workflow now do: a capped `REVISE` in `review_spec`, and a completeness
failure at the cap in `validate_completeness`. Below the cap they stay silent —
the run is still going, and a pending revision is not a failure.

**The HALT node synthesizes one when they do not.** `describe_halt_from_state`
covers paths no node anticipated — two-strike stagnation halts from the router
alone, below the cap, with no node in a position to know. It reports what the
state *says* rather than re-deciding why routing halted: a synthesized message
that disagreed with the real reason would be worse than the blank it replaces,
so every branch names the field it read. It is workflow-agnostic (a test drives
it with the requirements workflow's field names too).

Together, no halt path can print "unknown" again — pinned by a parametrised test
over degenerate states.

## What this deliberately does not regress

You flagged it, and it is the reason the fallback is scoped where it is:
**#2233 leaves `error_message` empty on purpose for a finalize repair**, because
an in-flight repair is not a failure. That path routes to the drafter and
**never reaches HALT**, so the fallback cannot touch it.
`TestTheRepairPathIsUntouched` pins both halves — the repair still routes to
`N1_generate_draft`, and `route_after_finalize` never returns `HALT` for either
value of `finalize_repair_pending`.

The same reasoning governs the node-level messages: they fire only at the cap,
which is exactly when the router sends the run to HALT anyway. Routing is
unchanged everywhere.

## Evidence

21 new tests. Full unit suite: **7068 passed, 17 skipped, 5 xfailed**. All three
changed source files match their `origin/main` ruff counts exactly; the new test
file is clean.

## Scope

The prompt-failure telemetry for these same convergence failures is #2198 and
lands next, separately.

Closes #2197
