### PR TITLE
feat: record spec-stage convergence failures in the 0025 loop (Closes #2198)

### DIFF
--- a/assemblyzero/speedrun/prompt_ranking.py
+++ b/assemblyzero/speedrun/prompt_ranking.py
@@ -113,8 +113,17 @@ def rank(rows: list[dict], durations: dict[tuple[int, str], float]) -> list[Rank
 
     ranked: list[Ranked] = []
     for fingerprint, entries in grouped.items():
+        # #2198: a record that measured its own cost is authoritative for
+        # itself; the run table is the fallback for records that did not.
+        # Existing rows carry no `duration_seconds`, so they resolve exactly as
+        # before -- through the run_id lookup.
         seconds = [
-            d for d in (duration_for(e.get("run_id", ""), durations) for e in entries)
+            d for d in (
+                e.get("duration_seconds")
+                if e.get("duration_seconds") is not None
+                else duration_for(e.get("run_id", ""), durations)
+                for e in entries
+            )
             if d is not None
         ]
         models = tuple(sorted({e.get("drafter_model") or "unknown" for e in entries}))

--- a/assemblyzero/speedrun/prompt_telemetry.py
+++ b/assemblyzero/speedrun/prompt_telemetry.py
@@ -75,6 +75,22 @@ def fingerprint(stage: str, check: str, detail: str) -> str:
     return f"{normalize_detail(stage)}:{normalize_detail(check)}:{normalize_detail(detail)}"
 
 
+#: A fingerprint that never repeats cannot be ranked, and ranking is the whole
+#: point. Mechanical details are short by nature ("Section 2.1 table
+#: malformed"); a reviewer's rationale is paragraphs, and normalizing all of it
+#: buckets every run separately. #2198 takes the first line, bounded.
+FINGERPRINT_DETAIL_CHARS = 160
+
+
+def rankable_detail(text: str, limit: int = FINGERPRINT_DETAIL_CHARS) -> str:
+    """The first line of a prose finding, bounded, for use as a detail."""
+    for line in (text or "").strip().splitlines():
+        stripped = line.strip().lstrip("-*# ").strip()
+        if stripped:
+            return stripped[:limit].rstrip()
+    return ""
+
+
 @dataclass
 class PromptFailure:
     ts_local: str
@@ -87,6 +103,10 @@ class PromptFailure:
     drafter_model: str
     run_id: str
     detail_raw: str
+    #: #2198: wall clock the failure cost, where the caller knows it. Optional
+    #: and last, so every historical row still reads and every existing caller
+    #: is unchanged.
+    duration_seconds: float | None = None
 
 
 def telemetry_path(repo_root: Path | str) -> Path:
@@ -103,6 +123,7 @@ def record_failure(
     draft_number: int | None = None,
     drafter_model: str = "",
     run_id: str = "",
+    duration_seconds: float | None = None,
     log=print,
 ) -> PromptFailure | None:
     """Append one record. Never raises; returns None if the write failed."""
@@ -120,6 +141,7 @@ def record_failure(
         drafter_model=drafter_model or "",
         run_id=run_id or "",
         detail_raw=detail,
+        duration_seconds=duration_seconds,
     )
 
     try:

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -593,6 +593,62 @@ def _ride_spec_on_lld_pr(
         return False
 
 
+def _record_spec_convergence_failure(
+    target_repo: str,
+    issue_number: int,
+    sub_result: dict,
+    elapsed: float,
+    stage_cfg: dict,
+) -> None:
+    """One telemetry record when the spec stage burns its budget on REVISE.
+
+    Closes #2198. Standard 0025's loop can only fix what it can rank, and it
+    ranked nothing from spec land: on boostgauge the failure table held 24
+    fingerprints and every one was `lld:*`, while the spec stage's most
+    expensive failure mode -- 685 seconds of drafting and three review rounds
+    all objecting to the same thing -- left no record at all.
+
+    A REVISE verdict that survives to the end of the sub-workflow IS the
+    convergence failure: a REVISE with budget left routes back to the drafter
+    and never terminates the run.
+
+    Recorded here rather than in the reviewer node because this is where the
+    stage's wall clock exists, which is the cost the ranking needs. Never
+    raises -- telemetry that can break the thing it measures is worse than no
+    telemetry (the module's own rule).
+    """
+    if sub_result.get("review_verdict") != "REVISE":
+        return
+
+    try:
+        from assemblyzero.speedrun.must_resolve import run_context
+        from assemblyzero.speedrun.prompt_telemetry import (
+            rankable_detail,
+            record_failure,
+        )
+
+        detail = rankable_detail(
+            sub_result.get("review_feedback", "")
+            or sub_result.get("error_message", "")
+        )
+        if not detail:
+            return
+
+        run_id, _ = run_context()
+        record_failure(
+            target_repo or ".",
+            stage="spec",
+            check="reviewer-revise",
+            detail=detail,
+            issue=issue_number or None,
+            drafter_model=stage_cfg.get("drafter", ""),
+            run_id=run_id,
+            duration_seconds=round(elapsed, 1),
+        )
+    except Exception as exc:  # noqa: BLE001 - telemetry never breaks a stage
+        _stages_logger.warning("Spec convergence telemetry skipped: %s", exc)
+
+
 def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute implementation spec workflow.
 
@@ -722,10 +778,14 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
             )
         else:
             error_msg = sub_result.get("error_message", "Spec workflow completed but no artifact produced")
+            elapsed = time.monotonic() - start_time
+            _record_spec_convergence_failure(
+                target_repo, issue_number, sub_result, elapsed, stage_cfg,
+            )
             result = _make_stage_result(
                 status="failed",
                 error_message=error_msg,
-                duration_seconds=time.monotonic() - start_time,
+                duration_seconds=elapsed,
                 attempts=1,
                 transient=_classify_halt_transience(sub_result),
             )

--- a/tests/unit/test_spec_convergence_telemetry.py
+++ b/tests/unit/test_spec_convergence_telemetry.py
@@ -1,0 +1,265 @@
+"""Spec-stage convergence failures must reach the 0025 loop (Closes #2198).
+
+The prompt-failure telemetry recorded only drafter-side validation failures. A
+spec sub-workflow that burned its whole iteration budget on reviewer REVISE
+verdicts and halted left no record at all.
+
+Measured on boostgauge `run-issue1-124144` (2026-08-10): 685 seconds of spec
+drafting and three Gemini review rounds, every one REVISE for the same objection
+class, halt at the cap. `prompt_revision_rank.py` for that repo showed 24
+fingerprints and every one was `lld:*` -- the spec stage's most expensive
+failure mode was invisible to the loop that exists to fix exactly that.
+
+Standard 0025 can only fix what it can rank, so the record has to carry a
+fingerprint that repeats across runs and the cost that makes it worth ranking.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.speedrun.prompt_telemetry import (
+    fingerprint,
+    rankable_detail,
+    read_failures,
+    record_failure,
+    telemetry_path,
+)
+from assemblyzero.workflows.orchestrator.stages import (
+    _record_spec_convergence_failure,
+)
+
+# The objection class that recurred three times in run-issue1-124144.
+FEEDBACK = (
+    "The spec invents pixel geometry the requirements never pin down.\n"
+    "\n"
+    "Specifically, the needle length of 120px appears in no requirement, and\n"
+    "the test asserts it as though it were specified."
+)
+
+
+class TestTheRecordIsEmitted:
+    def test_a_capped_revise_is_recorded(self, tmp_path):
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "REVISE", "review_feedback": FEEDBACK},
+            685.0, {"drafter": "claude-opus-5"},
+        )
+
+        rows = read_failures(tmp_path)
+        assert len(rows) == 1, (
+            "the spec stage's most expensive failure mode left no record; the "
+            "0025 loop cannot rank what it never sees"
+        )
+        assert rows[0]["stage"] == "spec"
+        assert rows[0]["check"] == "reviewer-revise"
+
+    def test_the_cost_is_carried(self, tmp_path):
+        """Ranking without cost cannot tell an expensive failure from a cheap
+        one, and this one costs eleven minutes."""
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "REVISE", "review_feedback": FEEDBACK},
+            685.0, {},
+        )
+        assert read_failures(tmp_path)[0]["duration_seconds"] == 685.0
+
+    def test_the_fingerprint_is_spec_land(self, tmp_path):
+        """Every fingerprint in the boostgauge table was lld:*. This is the
+        first one that is not."""
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "REVISE", "review_feedback": FEEDBACK},
+            685.0, {},
+        )
+        assert read_failures(tmp_path)[0]["fingerprint"].startswith(
+            "spec:reviewer-revise:"
+        )
+
+    def test_the_issue_and_model_travel(self, tmp_path):
+        _record_spec_convergence_failure(
+            str(tmp_path), 7,
+            {"review_verdict": "REVISE", "review_feedback": FEEDBACK},
+            10.0, {"drafter": "claude-opus-5"},
+        )
+        row = read_failures(tmp_path)[0]
+        assert row["issue"] == 7
+        assert row["drafter_model"] == "claude-opus-5"
+
+
+class TestWhatIsNotRecorded:
+    def test_an_approved_stage_records_nothing(self, tmp_path):
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "APPROVED", "review_feedback": ""},
+            10.0, {},
+        )
+        assert read_failures(tmp_path) == []
+
+    def test_a_blocked_verdict_records_nothing_here(self, tmp_path):
+        """BLOCKED is a requirements conflict -- it files a must-resolve
+        question (#2192) and is a different failure class from a drafter whose
+        prompt keeps producing the same objection."""
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "BLOCKED", "review_feedback": "conflict"},
+            10.0, {},
+        )
+        assert read_failures(tmp_path) == []
+
+    def test_no_feedback_records_nothing(self, tmp_path):
+        """A record whose detail is empty fingerprints to nothing rankable."""
+        _record_spec_convergence_failure(
+            str(tmp_path), 1,
+            {"review_verdict": "REVISE", "review_feedback": ""},
+            10.0, {},
+        )
+        assert read_failures(tmp_path) == []
+
+    def test_telemetry_never_breaks_the_stage(self, tmp_path, caplog):
+        """The module's own rule: telemetry that can break the thing it
+        measures is worse than no telemetry."""
+        with patch(
+            "assemblyzero.speedrun.prompt_telemetry.record_failure",
+            side_effect=RuntimeError("disk gone"),
+        ):
+            _record_spec_convergence_failure(
+                str(tmp_path), 1,
+                {"review_verdict": "REVISE", "review_feedback": FEEDBACK},
+                10.0, {},
+            )  # must not raise
+
+
+class TestTheFingerprintIsRankable:
+    """A fingerprint that never repeats cannot be ranked, and ranking is the
+    whole point of the 0025 loop."""
+
+    def test_the_same_objection_two_runs_running_shares_a_fingerprint(self, tmp_path):
+        second = FEEDBACK.replace("120px", "140px")  # a later paragraph differs
+
+        for feedback in (FEEDBACK, second):
+            _record_spec_convergence_failure(
+                str(tmp_path), 1,
+                {"review_verdict": "REVISE", "review_feedback": feedback},
+                10.0, {},
+            )
+
+        rows = read_failures(tmp_path)
+        assert len(rows) == 2
+        assert rows[0]["fingerprint"] == rows[1]["fingerprint"], (
+            "two runs blocked by the same objection must land in one bucket, "
+            "or the rate this exists to measure is always one"
+        )
+
+    def test_a_different_objection_gets_a_different_fingerprint(self, tmp_path):
+        for feedback in (FEEDBACK, "The spec omits the error path entirely."):
+            _record_spec_convergence_failure(
+                str(tmp_path), 1,
+                {"review_verdict": "REVISE", "review_feedback": feedback},
+                10.0, {},
+            )
+        rows = read_failures(tmp_path)
+        assert rows[0]["fingerprint"] != rows[1]["fingerprint"]
+
+    def test_the_detail_is_bounded(self):
+        assert len(rankable_detail("x" * 900)) <= 160
+
+    def test_leading_list_markers_are_stripped(self):
+        assert rankable_detail("- The spec invents geometry.") == (
+            "The spec invents geometry."
+        )
+
+    def test_blank_leading_lines_are_skipped(self):
+        assert rankable_detail("\n\n  \nReal finding.") == "Real finding."
+
+    def test_it_uses_the_same_normalization_as_the_mechanical_fingerprints(self):
+        detail = rankable_detail(FEEDBACK)
+        assert fingerprint("spec", "reviewer-revise", detail) == (
+            "spec:reviewer-revise:"
+            "the-spec-invents-pixel-geometry-the-requirements-never-pin-down"
+        )
+
+
+class TestTheSchemaStaysBackwardCompatible:
+    def test_a_row_written_without_a_duration_still_reads(self, tmp_path):
+        """#2075 reads this file. Existing rows predate the field."""
+        path = telemetry_path(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "ts_local": "2026-08-01 13:37:46", "repo": "r", "issue": 2,
+                "stage": "lld", "check": "mechanical",
+                "fingerprint": "lld:mechanical:section-2-1-table-malformed",
+                "draft_number": 1, "drafter_model": "", "run_id": "",
+                "detail_raw": "Section 2.1 table malformed",
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        rows = read_failures(tmp_path)
+        assert len(rows) == 1
+        assert rows[0].get("duration_seconds") is None
+
+    def test_existing_callers_need_no_duration(self, tmp_path):
+        record = record_failure(
+            tmp_path, stage="lld", check="mechanical",
+            detail="Section 2.1 table malformed",
+        )
+        assert record is not None
+        assert record.duration_seconds is None
+
+
+class TestTheRankerCostsIt:
+    """A duration nothing reads is dead weight. #2198's point is that the
+    ranking table governs spec prompts as it governs lld ones, and ranking is
+    by cost."""
+
+    def test_a_record_with_its_own_duration_is_costed(self):
+        from assemblyzero.speedrun.prompt_ranking import rank
+
+        ranked = rank(
+            [
+                {"fingerprint": "spec:reviewer-revise:x", "run_id": "",
+                 "duration_seconds": 685.0},
+                {"fingerprint": "spec:reviewer-revise:x", "run_id": "",
+                 "duration_seconds": 685.0},
+            ],
+            durations={},
+        )
+
+        assert ranked[0].duration_known, (
+            "the record measured its own cost; flagging it duration-unknown "
+            "would rank the stage's most expensive failure below a cheap one"
+        )
+        assert ranked[0].cost == pytest.approx(1370.0)
+
+    def test_rows_without_one_still_use_the_run_table(self):
+        """Every historical lld record resolves exactly as before."""
+        from assemblyzero.speedrun.prompt_ranking import rank
+
+        ranked = rank(
+            [{"fingerprint": "lld:mechanical:x", "run_id": "run-issue2-133746"}],
+            durations={(2, "133746"): 86.1},
+        )
+
+        assert ranked[0].duration_known
+        assert ranked[0].mean_wasted_seconds == pytest.approx(86.1)
+
+    def test_an_unknown_duration_is_still_never_costed_at_zero(self):
+        from assemblyzero.speedrun.prompt_ranking import rank
+
+        ranked = rank([{"fingerprint": "spec:x:y", "run_id": ""}], durations={})
+        assert not ranked[0].duration_known
+        assert ranked[0].cost is None
+
+
+@pytest.mark.parametrize("verdict", ["REVISE", "revise"])
+def test_only_the_exact_verdict_records(tmp_path, verdict):
+    """The state field is set from a structured schema, so it is exact. A
+    case-insensitive match here would record on values the graph never emits."""
+    _record_spec_convergence_failure(
+        str(tmp_path), 1,
+        {"review_verdict": verdict, "review_feedback": FEEDBACK}, 10.0, {},
+    )
+    assert len(read_failures(tmp_path)) == (1 if verdict == "REVISE" else 0)


### PR DESCRIPTION
## The defect

The prompt-failure telemetry recorded only drafter-side validation failures. A
spec sub-workflow that burned its whole iteration budget on reviewer REVISE
verdicts and halted left **no record at all**.

Measured on boostgauge `run-issue1-124144` (2026-08-10): 685 seconds of spec
drafting and three Gemini review rounds, every one objecting to the same thing,
halt at the cap. `prompt_revision_rank.py` for that repo showed **24
fingerprints, every one `lld:*`** — the spec stage's most expensive failure mode
was invisible to the loop that exists to fix exactly that.

Standard 0025 can only fix what it can rank.

## The fix

One record per run when the spec stage burns its budget on REVISE:
`stage=spec`, `check=reviewer-revise`, a fingerprint from the final verdict's
feedback under the same normalization as the mechanical fingerprints, and the
stage's wall clock.

**Where it is recorded matters.** It goes in `run_spec_stage` rather than the
reviewer node, because that is where the stage's wall clock exists — and the
cost is what makes the ranking worth having. A REVISE verdict that survives to
the end of the sub-workflow *is* the convergence failure: a REVISE with budget
left routes back to the drafter and never terminates the run.

Never raises — telemetry that can break the thing it measures is worse than no
telemetry, which is the module's own stated rule.

## The fingerprint has to repeat

A fingerprint that never repeats cannot be ranked. Mechanical details are short
by nature (`Section 2.1 table malformed`); a reviewer's rationale is paragraphs,
and normalizing all of it buckets every run separately — the rate this exists to
measure would always be one.

`rankable_detail` takes the first line, bounded to 160 characters. A test proves
two runs blocked by the same objection share a bucket while a different
objection does not, using the real feedback text from `run-issue1-124144`.

## The duration is actually read

`PromptFailure` gains an optional `duration_seconds`, last and defaulted, so
every historical row still reads and every existing caller is unchanged.

The ranker now prefers a record's own duration and falls back to the `runs.csv`
lookup — otherwise the field would be dead weight, recorded and never consumed,
and spec fingerprints would rank `duration-unknown` forever while lld ones rank
by cost. That is not "governed exactly as lld prompts are". Rows without the
field resolve through `run_id` exactly as before, which a test pins.

Verified end to end against the real tool:

```
fingerprint                                                              count  mean_s   cost_s
spec:reviewer-revise:the-spec-invents-pixel-geometry-...                     2   685.0   1370.0
spec:reviewer-revise:the-spec-omits-the-error-path-entirely                  1   685.0    685.0
```

## What is deliberately not recorded

A BLOCKED verdict. That is a requirements conflict — it files a must-resolve
question (#2192) and is a different failure class from a drafter prompt that
keeps producing the same objection. Recording it here would pollute the ranking
with defects the 0025 loop cannot fix by changing a prompt.

## Evidence

21 new tests. Full unit suite: **7089 passed, 17 skipped, 5 xfailed**. All three
changed source files match their `origin/main` ruff counts exactly; the new test
file is clean.

Closes #2198
