### PR TITLE
feat: put the standalone runners under the stage watchdog (Closes #2231)

### DIFF
--- a/tests/unit/test_standalone_runner_heartbeat.py
+++ b/tests/unit/test_standalone_runner_heartbeat.py
@@ -1,0 +1,135 @@
+"""The standalone runners must show a stall while it stalls (Closes #2231).
+
+#1367 asked for intra-stage heartbeat output during long model calls. It
+shipped for orchestrator runs as `StageWatchdog` (#1886) and never reached the
+standalone runners -- so `tools/run_requirements_workflow.py` and
+`tools/run_implement_from_lld.py` emitted nothing during a multi-minute model
+call.
+
+Those are the two entry points the babysit protocol and the CLAUDE.md workflow
+section actually tell an operator to run, which makes them the surface where
+silence is most likely to be misread as a hang. Runbook 0952's doctrine -- a
+stage past three times nominal is a fault rather than patience -- needs elapsed
+time to be visible to be applied at all.
+
+The wiring is what these pin. The watchdog's own behaviour is covered by
+`tests/unit/test_stage_watchdog.py`; this file asserts the runners are under it
+and that the observable contract still holds at the boundary.
+"""
+
+import ast
+import time
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.stage_watchdog import StageWatchdog
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+RUNNERS = {
+    "run_requirements_workflow.py": "lld / issue drafting",
+    "run_implement_from_lld.py": "implementation",
+}
+
+
+def _source(name: str) -> str:
+    return (TOOLS / name).read_text(encoding="utf-8")
+
+
+def _guards_the_invocation(name: str) -> bool:
+    """True when a `with StageWatchdog(...)` encloses the graph invocation.
+
+    Asserted structurally rather than by substring: a runner that imported the
+    watchdog and never entered it would pass a grep and emit nothing, which is
+    the exact defect.
+    """
+    tree = ast.parse(_source(name))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        enters_watchdog = any(
+            isinstance(item.context_expr, ast.Call)
+            and isinstance(item.context_expr.func, ast.Name)
+            and item.context_expr.func.id == "StageWatchdog"
+            for item in node.items
+        )
+        if not enters_watchdog:
+            continue
+        # Something inside must actually drive the graph.
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Attribute):
+                if inner.func.attr in ("invoke", "stream"):
+                    return True
+            if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name):
+                if inner.func.id == "invoke_with_budget":
+                    return True
+    return False
+
+
+@pytest.mark.parametrize("runner", sorted(RUNNERS), ids=lambda r: r)
+class TestBothRunnersAreUnderTheWatchdog:
+    def test_it_imports_the_watchdog(self, runner):
+        assert "stage_watchdog import StageWatchdog" in _source(runner)
+
+    def test_a_watchdog_encloses_the_graph_invocation(self, runner):
+        assert _guards_the_invocation(runner), (
+            f"{runner} invokes its graph without entering StageWatchdog, so a "
+            "multi-minute model call prints nothing and reads as a hang"
+        )
+
+
+class TestTheAuditInspectsSomething:
+    """A structural check that matched anything would pass forever."""
+
+    def test_a_runner_without_the_wiring_fails_the_check(self, tmp_path, monkeypatch):
+        naked = tmp_path / "tools"
+        naked.mkdir()
+        (naked / "run_requirements_workflow.py").write_text(
+            "app.invoke({'x': 1})\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "tests.unit.test_standalone_runner_heartbeat.TOOLS", naked
+        )
+        assert not _guards_the_invocation("run_requirements_workflow.py")
+
+    def test_a_watchdog_around_nothing_does_not_count(self, tmp_path, monkeypatch):
+        naked = tmp_path / "tools"
+        naked.mkdir()
+        (naked / "run_requirements_workflow.py").write_text(
+            "with StageWatchdog('lld'):\n    print('hello')\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "tests.unit.test_standalone_runner_heartbeat.TOOLS", naked
+        )
+        assert not _guards_the_invocation("run_requirements_workflow.py"), (
+            "entering the watchdog around something other than the graph would "
+            "satisfy a grep and still emit nothing during the model call"
+        )
+
+
+class TestTheObservableContract:
+    """Mirrors test_stage_watchdog.py's lifecycle cases at the boundary the
+    runners rely on: a slow stage speaks, a fast one stays quiet."""
+
+    def test_a_slow_stage_prints_a_heartbeat(self, capsys):
+        with StageWatchdog("lld", nominal_seconds=1, interval=0.05):
+            time.sleep(0.2)
+        out = capsys.readouterr().out
+
+        assert "[STAGE] lld running" in out
+        assert "s" in out, "elapsed time is the whole point"
+
+    def test_a_fast_stage_stays_quiet(self, capsys):
+        with StageWatchdog("lld", interval=5):
+            pass
+        assert "[STAGE]" not in capsys.readouterr().out
+
+    def test_the_impl_runner_uses_the_impl_nominal(self):
+        """A heartbeat with the wrong nominal would mislabel a normal stage as
+        stalled, which is the noise the doctrine cannot survive."""
+        assert "StageWatchdog(\"impl\")" in _source("run_implement_from_lld.py")
+
+    def test_the_requirements_runner_names_its_stage(self):
+        source = _source("run_requirements_workflow.py")
+        assert "StageWatchdog(stage_name)" in source or 'StageWatchdog("lld")' in source

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -57,6 +57,7 @@ configure_langsmith()
 
 # Issue #424: Telemetry instrumentation
 from assemblyzero.telemetry import emit, flush, track_tool
+from assemblyzero.core.stage_watchdog import StageWatchdog  # noqa: E402  (#2231)
 from assemblyzero.core.llm_provider import get_cumulative_cost
 from assemblyzero.utils.git import is_generated_work_branch, is_issue_work_branch
 atexit.register(flush)
@@ -916,7 +917,13 @@ def main():
         speedrun_logger = None
 
     try:
-      with WorkflowTimeout(minutes=args.timeout):
+      # #2231: under a watchdog, so a stalled model call is visible WHILE it
+      # stalls. Streaming prints a line per node, but a single node can run for
+      # many minutes -- the case #1886 was built for, and the one an operator
+      # misreads as a hang. This is one of the two entry points the babysit
+      # protocol tells an operator to run, which makes it the surface where
+      # silence is most costly.
+      with WorkflowTimeout(minutes=args.timeout), StageWatchdog("impl"):
         with SqliteSaver.from_conn_string(str(db_path)) as memory:
             app = workflow.compile(checkpointer=memory)
 

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -64,6 +64,7 @@ from assemblyzero.utils.git import current_branch, validate_integration_branch
 from assemblyzero.workflows.requirements.config import GateConfig
 from assemblyzero.workflows.requirements.graph import create_requirements_graph
 from assemblyzero.workflows.requirements.state import create_initial_state, RequirementsWorkflowState
+from assemblyzero.core.stage_watchdog import StageWatchdog  # noqa: E402  (#2231)
 from assemblyzero.workflows.requirements.step_budget import (  # noqa: E402  (#2245)
     DEFAULT_MAX_ITERATIONS,
     invoke_with_budget,
@@ -781,12 +782,20 @@ def run_single_workflow(
         # and unrelated to what the loops actually cost. The budget is now
         # derived from measured per-loop step costs, and exhausting it halts
         # naming the loop that spent it instead of raising GraphRecursionError.
-        final_state = invoke_with_budget(
-            compiled,
-            state,
-            stage="lld" if state.get("workflow_type") == "lld" else "issue",
-            max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
-        )
+        #
+        # #2231: and it says so while it runs. This runner emitted nothing
+        # during a multi-minute model call, which is exactly where silence gets
+        # misread as a hang -- and it is one of the two entry points the
+        # babysit protocol tells an operator to run. Same watchdog the
+        # orchestrator has had since #1886.
+        stage_name = "lld" if state.get("workflow_type") == "lld" else "issue"
+        with StageWatchdog(stage_name):
+            final_state = invoke_with_budget(
+                compiled,
+                state,
+                stage=stage_name,
+                max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+            )
 
         print_result(final_state)
 
@@ -1016,12 +1025,14 @@ def run_resume_review(
             print()
 
             # #2245: same derived budget as the full run above.
-            final_state = invoke_with_budget(
-                compiled_resume,
-                state,
-                stage="lld resume",
-                max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
-            )
+            # #2231: and the same heartbeat.
+            with StageWatchdog("lld"):
+                final_state = invoke_with_budget(
+                    compiled_resume,
+                    state,
+                    stage="lld resume",
+                    max_iterations=state.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+                )
 
             print_result(final_state)
 


### PR DESCRIPTION
## The gap

#1367 asked for intra-stage heartbeat output during long model calls. It shipped
for orchestrator runs as `StageWatchdog` (#1886) and never reached the standalone
runners, so `tools/run_requirements_workflow.py` and
`tools/run_implement_from_lld.py` emitted **nothing** during a multi-minute model
call.

Those are the two entry points the babysit protocol and the CLAUDE.md workflow
section actually tell an operator to run — the surface where silence is most
likely to be misread as a hang. Runbook 0952's doctrine (a stage past three
times nominal is a fault, not patience) needs elapsed time to be visible before
it can be applied at all.

## The wiring

Both runners now enter the same watchdog the orchestrator has used since #1886.

- `run_requirements_workflow.py` wraps both the full run and the resume path,
  naming the stage it is actually running (`lld` or `issue`) so the nominal
  matches.
- `run_implement_from_lld.py` joins the watchdog onto its existing
  `WorkflowTimeout` `with` statement and carries the `impl` nominal.

Joining the existing `with` rather than nesting a new block was deliberate: the
stream loop's body is long, and re-indenting it to fit a new block is a large
diff that risks a silent scoping mistake for no behavioural gain.

## The test checks the wiring, not the grep

`_guards_the_invocation` parses each runner and requires a `with
StageWatchdog(...)` that **encloses an actual graph invocation** (`.invoke`,
`.stream`, or `invoke_with_budget`). A runner that imported the watchdog and
never entered it, or entered it around something else, emits nothing during the
model call while satisfying any substring check — so two negative cases pin that
the audit rejects both shapes.

The watchdog's own behaviour stays covered by `tests/unit/test_stage_watchdog.py`;
this file adds the boundary contract the acceptance asks for (a slow stage
prints with elapsed time, a fast stage stays quiet).

## Evidence

10 new tests. Full unit suite: **7106 passed, 17 skipped, 5 xfailed**. Both
runners match their `origin/main` ruff counts exactly; the new test file is
clean.

Closes #2231
