### PR TITLE
fix: stop the narration advertising a human gate that never waits (Closes #2188)

### DIFF
--- a/assemblyzero/workflows/narration.py
+++ b/assemblyzero/workflows/narration.py
@@ -15,8 +15,48 @@ from __future__ import annotations
 
 _warned: set[str] = set()
 
+#: Nodes that are a human checkpoint only while their gate is configured on,
+#: mapped to the state key that says so. Closes #2188.
+#:
+#: The campaign runs every roll with these off, and a watching operator read
+#: `NEXT human gate: verdict (the verdict gate is on, or a question needs a
+#: human)` as "this roll might stop and wait for me". It never will: with the
+#: gate off, `human_gate_verdict` auto-routes on the verdict and returns
+#: without asking anything. Operator ruling, 2026-08-10: no human gates, ever.
+#:
+#: The edge is NOT hidden, because it is genuinely reachable -- a reviewer
+#: marking a question HUMAN_REQUIRED routes here whatever the config says. What
+#: was wrong is calling a pass-through a gate. Hiding a live edge would trade
+#: this misreading for a worse one.
+GATE_NODES: dict[str, str] = {
+    "N2_human_gate_draft": "config_gates_draft",
+    "N4_human_gate_verdict": "config_gates_verdict",
+    "N4_human_gate": "human_gate_enabled",  # implementation_spec's own gate
+}
 
-def _line_for(node_id: str, atlas: dict, total: int) -> list[str]:
+#: What a config-dead gate actually does, said plainly.
+GATE_OFF_NOTE = "GATE OFF -- passes straight through, never waits"
+
+
+def _gate_is_off(node_id: str, state) -> bool:
+    """True only when the state SAYS the gate is off.
+
+    An absent key means unknown, and an unknown gate is left described as the
+    atlas describes it -- announcing OFF on a run that might actually stop
+    would be the same defect pointed the other way.
+    """
+    key = GATE_NODES.get(node_id)
+    if key is None:
+        return False
+    try:
+        if key not in state:
+            return False
+        return not state[key]
+    except TypeError:  # a state that does not support `in`
+        return False
+
+
+def _line_for(node_id: str, atlas: dict, total: int, state=None) -> list[str]:
     entry = atlas.get(node_id)
     if entry is None:
         if node_id not in _warned:
@@ -26,13 +66,22 @@ def _line_for(node_id: str, atlas: dict, total: int) -> list[str]:
 
     ordinal = entry.get("ordinal")
     position = f"[{ordinal}/{total}] " if ordinal else ""
-    lines = [f"NODE {position}{entry['title']} -- {entry['goal']}"]
+    node_line = f"NODE {position}{entry['title']} -- {entry['goal']}"
+    if state is not None and _gate_is_off(node_id, state):
+        node_line += f" [{GATE_OFF_NOTE}]"
+    lines = [node_line]
 
     successors = entry.get("successors") or {}
     parts = []
     for successor, condition in successors.items():
         name = atlas.get(successor, {}).get("title", successor)
-        parts.append(f"{name} ({condition})")
+        if state is not None and _gate_is_off(successor, state):
+            # The atlas condition here reads "the verdict gate is on, or a
+            # question needs a human" -- half of which cannot happen. Replace
+            # it rather than append to it.
+            parts.append(f"{name} ({GATE_OFF_NOTE})")
+        else:
+            parts.append(f"{name} ({condition})")
     if parts:
         lines.append(f"NEXT {' | '.join(parts)}")
     return lines
@@ -43,7 +92,7 @@ def narrated(node_id: str, fn, atlas: dict, total: int):
 
     def _wrapped(state, *args, **kwargs):
         try:
-            for line in _line_for(node_id, atlas, total):
+            for line in _line_for(node_id, atlas, total, state):
                 print(line, flush=True)
         except Exception:  # noqa: BLE001 - narration never costs a run
             pass

--- a/tests/unit/test_narration_gates_off.py
+++ b/tests/unit/test_narration_gates_off.py
@@ -1,0 +1,147 @@
+"""A live watch must never advertise a stop that cannot happen (Closes #2188).
+
+During a watched roll (boostgauge, 2026-08-10 ~01:00) the follower's NEXT line
+at the adversarial-review node read:
+
+    NEXT human gate: verdict (the verdict gate is on, or a question needs a
+    human) | finalize (approved with the verdict gate off) | ...
+
+The campaign runs every roll with the verdict gate off. Operator ruling: no
+human gates, ever -- and an operator reading "human gate: verdict" during a live
+watch is being told the roll might stop and wait for them, which it never will.
+
+The edge is deliberately NOT hidden. It is genuinely reachable: a reviewer
+marking a question HUMAN_REQUIRED routes there whatever the config says
+(`route_after_review`). What was wrong is calling a pass-through a gate --
+with the gate off, `human_gate_verdict` auto-routes on the verdict and returns
+without asking anything. Hiding a live edge would trade this misreading for a
+worse one.
+"""
+
+import pytest
+
+from assemblyzero.workflows.narration import (
+    GATE_NODES,
+    GATE_OFF_NOTE,
+    _line_for,
+    narrated,
+)
+from assemblyzero.workflows.requirements.atlas import ATLAS, TOTAL_STEPS
+
+GATES_OFF = {"config_gates_draft": False, "config_gates_verdict": False}
+GATES_ON = {"config_gates_draft": True, "config_gates_verdict": True}
+
+
+def _render(node_id: str, state) -> str:
+    return "\n".join(_line_for(node_id, ATLAS, TOTAL_STEPS, state))
+
+
+class TestTheReviewNodesNextLine:
+    """The exact line the operator was reading."""
+
+    def test_it_no_longer_advertises_a_stop(self):
+        out = _render("N3_review", GATES_OFF)
+
+        assert "the verdict gate is on, or a question needs a human" not in out, (
+            "half that condition cannot happen with the gate off, and the "
+            "operator read the whole line as 'this may stop and wait for me'"
+        )
+        assert GATE_OFF_NOTE in out
+
+    def test_the_edge_is_still_shown(self):
+        """Reachable via HUMAN_REQUIRED whatever the config says. Hiding it
+        would be the same defect pointed the other way."""
+        assert "human gate: verdict" in _render("N3_review", GATES_OFF)
+
+    def test_the_live_branches_are_untouched(self):
+        out = _render("N3_review", GATES_OFF)
+        assert "approved with the verdict gate off" in out
+        assert "blocked or unanswered questions; revise" in out
+
+
+class TestEnteringAConfigDeadGate:
+    """Filtering NEXT alone is not enough: the run can still ENTER the node,
+    and its own NODE line called it a human checkpoint."""
+
+    def test_the_node_line_says_it_does_not_wait(self):
+        out = _render("N4_human_gate_verdict", GATES_OFF)
+        assert GATE_OFF_NOTE in out
+
+    def test_with_the_gate_on_it_is_described_as_a_gate(self):
+        out = _render("N4_human_gate_verdict", GATES_ON)
+        assert GATE_OFF_NOTE not in out
+        assert "optional human checkpoint" in out
+
+
+class TestTheDraftGateToo:
+    def test_the_draft_gate_is_annotated_when_off(self):
+        assert GATE_OFF_NOTE in _render("N1b_validate_test_plan", GATES_OFF)
+
+    def test_and_not_when_on(self):
+        assert GATE_OFF_NOTE not in _render("N1b_validate_test_plan", GATES_ON)
+
+
+class TestUnknownIsNotOff:
+    """Announcing OFF on a run that might actually stop is the same defect
+    pointed the other way, so an absent key changes nothing."""
+
+    def test_an_absent_key_leaves_the_atlas_description(self):
+        out = _render("N3_review", {})
+        assert GATE_OFF_NOTE not in out
+        assert "the verdict gate is on, or a question needs a human" in out
+
+    def test_no_state_at_all_leaves_it_alone(self):
+        out = "\n".join(_line_for("N3_review", ATLAS, TOTAL_STEPS))
+        assert GATE_OFF_NOTE not in out
+
+    @pytest.mark.parametrize("state", [None, {}, 0, "not a mapping"])
+    def test_a_useless_state_never_raises(self, state):
+        assert _line_for("N3_review", ATLAS, TOTAL_STEPS, state)
+
+
+class TestNarrationStillNeverCostsARun:
+    def test_a_node_still_runs_when_narration_explodes(self, capsys):
+        class _Exploding:
+            def __contains__(self, _key):
+                raise RuntimeError("state is on fire")
+
+        ran = []
+        wrapped = narrated(
+            "N3_review", lambda s: ran.append(s) or {"ok": True}, ATLAS, TOTAL_STEPS
+        )
+        out = wrapped(_Exploding())
+        capsys.readouterr()
+
+        assert out == {"ok": True}
+        assert len(ran) == 1
+
+    def test_the_node_still_narrates_normally(self, capsys):
+        wrapped = narrated("N3_review", lambda s: {}, ATLAS, TOTAL_STEPS)
+        wrapped(GATES_OFF)
+
+        printed = capsys.readouterr().out
+        assert "NODE" in printed and "NEXT" in printed
+        assert GATE_OFF_NOTE in printed
+
+
+class TestTheMapMatchesTheGraph:
+    def test_every_gate_node_is_in_the_atlas(self):
+        """A renamed node would silently stop being annotated."""
+        from assemblyzero.workflows.implementation_spec.atlas import (
+            ATLAS as SPEC_ATLAS,
+        )
+
+        known = set(ATLAS) | set(SPEC_ATLAS)
+        missing = set(GATE_NODES) - known
+        assert not missing, (
+            f"GATE_NODES names {sorted(missing)}, which no atlas declares -- "
+            "so those gates would never be annotated"
+        )
+
+    def test_every_atlas_gate_node_is_covered(self):
+        """A gate added later must not quietly go back to advertising a stop."""
+        gates = {n for n in ATLAS if "human_gate" in n}
+        assert gates <= set(GATE_NODES), (
+            f"{sorted(gates - set(GATE_NODES))} is a human gate the narration "
+            "does not know how to describe when it is switched off"
+        )


### PR DESCRIPTION
## The symptom

During a watched roll (boostgauge, 2026-08-10 ~01:00) the follower's NEXT line
at the adversarial-review node read:

```
NEXT human gate: verdict (the verdict gate is on, or a question needs a human) | finalize (approved with the verdict gate off) | ...
```

The campaign runs every roll with the verdict gate off. Your ruling: no human
gates, ever — and an operator reading "human gate: verdict" during a live watch
is being told the roll might stop and wait for them, which it never will.

## Why the edge is annotated rather than hidden

The issue offered two directions and suggested removing the node. I checked what
that node actually does before choosing, and the answer changes the fix:

- **The edge is genuinely reachable with the gate off.** `route_after_review`
  sends a `HUMAN_REQUIRED` question there regardless of config. Hiding it would
  trade this misreading for a worse one — an operator told an edge does not
  exist, watching the run take it.
- **It never stops, though.** With `config_gates_verdict` false,
  `human_gate_verdict` auto-routes on the verdict and returns without asking
  anything.

So what was wrong is not that the edge is shown — it is that a pass-through was
being called a gate, using a condition string ("the verdict gate is on, or a
question needs a human") whose first half cannot happen.

## What changed

A config-dead gate is now described as what it does:

```
NEXT human gate: verdict (GATE OFF -- passes straight through, never waits) | finalize (approved with the verdict gate off) | ...
```

**Filtering NEXT alone would not have been enough.** The run can still *enter*
that node, and its own NODE line called it "An optional human checkpoint on the
review verdict" — so the same misreading survives one line later. The annotation
applies in both places.

`GATE_NODES` maps each gate node to the state key that governs it, covering the
draft gate and the implementation-spec workflow's own gate too, so this is not a
one-line patch over one message.

## Unknown is not off

An absent key leaves the atlas description exactly as it was. Announcing
`GATE OFF` on a run that might actually stop is the same defect pointed the
other way, so the annotation fires only when the state *says* the gate is off.

## Evidence

17 tests, including the exact line from the live watch, that the live branches
are untouched, that gates-on runs still read as gates, and that a gate added
later cannot quietly go back to advertising a stop (a guard requires every
`human_gate` node in the atlas to be covered by the map).

Narration still never costs a run: a state object that raises on every access
is exercised, and the node runs and returns normally.

Full unit suite: **7123 passed, 17 skipped, 5 xfailed**. `ruff check` clean on
both files.

## Still open, if you want it

The graph still contains the human-gate nodes. Removing them outright is the
other direction the issue raised, and it is a real behavioural change — the
`HUMAN_REQUIRED` escalation path would need somewhere else to go. That needs
your ruling rather than my guess, so I have not done it here.

Closes #2188
