### PR TITLE
feat: refuse to redraw an issue this arc already finished (Closes #2191)

### DIFF
--- a/assemblyzero/speedrun/successes.py
+++ b/assemblyzero/speedrun/successes.py
@@ -1,0 +1,139 @@
+"""The success ledger: what this arc has already finished (#2191).
+
+The 2026-08-10 overnight batch rolled `--issue 1 --issue 4 --issue 7`. Issue #4
+completed end to end -- rc=0, its LLD PR and implementation PR both merged into
+`hardening-run-17`, the campaign's first fully successful roll on these issues.
+The operator's next launch command, by habit, again included `--issue 4`, and
+nothing in the machinery would have objected: the launcher would have reset #4's
+branches and redrawn an issue whose implementation was already merged into the
+arc. An agent reading the log caught it, not the launcher.
+
+Operator ruling: redrawing something that already succeeded must require
+explicit, deliberate confirmation.
+
+## Arc scoping is the load-bearing part
+
+An entry records the base branch it succeeded on. Success on `hardening-run-17`
+must not nag a deliberate wipe-and-re-run campaign on a future arc -- a new base
+branch starts with an empty slate, and a gate that fires there would be exactly
+the kind of false alarm operators learn to wave through. The guard fires only
+when the same arc would redo its own finished work.
+
+## This is a cache, not the record of truth
+
+`EXIT rc=0` in the per-roll events log is the authoritative local outcome, and
+the merged PRs on the arc are the record that survives a wiped machine. This
+file is a queryable cache of the first, written where the launcher can read it
+in the second before anything is spent. A missing or unreadable ledger therefore
+degrades to "no opinion" -- it must never refuse a launch on its own absence.
+
+Lives under ``data/speedrun/``, already structurally exempt from dirt
+classification and every janitor (standard 0027).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+SUCCESSES_REL = Path("data") / "speedrun" / "successes.json"
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def successes_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / SUCCESSES_REL
+
+
+def read_successes(repo_root: Path | str) -> list[dict]:
+    """Every recorded success, oldest first. Never raises.
+
+    A malformed or absent ledger reads as empty: this gate exists to stop a
+    redraw, and refusing a launch because a cache could not be parsed would
+    make the cache load-bearing in the one direction it must never be.
+    """
+    try:
+        raw = successes_path(repo_root).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [e for e in data if isinstance(e, dict) and e.get("issue") is not None]
+
+
+def record_success(
+    repo_root: Path | str,
+    *,
+    issue: int,
+    base_branch: str,
+    run_tag: str = "",
+    prs: list[str] | None = None,
+    ts: str | None = None,
+) -> bool:
+    """Append one rc=0 outcome. Returns False (never raises) on failure.
+
+    The roll has already succeeded by the time this is called; a ledger problem
+    must not turn that into a failure.
+    """
+    if not issue or not base_branch:
+        # An entry with no arc cannot be scoped, and an unscoped entry would
+        # fire the gate on every future arc. Better to record nothing.
+        return False
+    try:
+        entries = read_successes(repo_root)
+        entries.append({
+            "issue": int(issue),
+            "base_branch": base_branch,
+            "run_tag": run_tag or "",
+            "ts": ts or datetime.now().strftime(_TS_FMT),
+            "prs": list(prs or []),
+        })
+        path = successes_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(entries, indent=2) + "\n", encoding="utf-8"
+        )
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
+
+
+def completed_on(
+    repo_root: Path | str, issue: int, base_branch: str
+) -> dict | None:
+    """The most recent success for this issue ON THIS ARC, or None.
+
+    Most recent rather than first: if an issue somehow succeeded twice on one
+    arc, the evidence the operator needs is the latest.
+    """
+    if not base_branch:
+        return None
+    matches = [
+        e for e in read_successes(repo_root)
+        if e.get("issue") == issue and e.get("base_branch") == base_branch
+    ]
+    return matches[-1] if matches else None
+
+
+def describe(entry: dict) -> str:
+    """The evidence line, naming what makes this a refusal rather than a guess."""
+    prs = ", ".join(str(p) for p in entry.get("prs") or []) or "none recorded"
+    return (
+        f"#{entry.get('issue')} already rolled to success on "
+        f"'{entry.get('base_branch')}' at {entry.get('ts')} "
+        f"(run {entry.get('run_tag') or 'unrecorded'}; merged PRs: {prs})"
+    )
+
+
+def redraw_phrase(issue: int) -> str:
+    """The typed confirmation, per the standard 0017 Danger-Zone convention.
+
+    A phrase, never y/n: a single keypress is exactly what an auto-answering
+    wrapper blows through, which is why the banned-menu rule exists.
+    """
+    return f"REDRAW {issue}"

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -47,6 +47,7 @@ than transcribed:
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
+| `--redraw-completed` | redraw an issue this arc has **already rolled to success** (#2191). Without it, an interactive launch demands a typed `REDRAW <N>` and a non-interactive one refuses — so an issue number typed out of habit cannot silently redo work already merged into the arc. Scoped to the current arc: a new base branch starts with an empty slate |
 | `--fresh` | redraw every stage from scratch (#2193). Without it, a launch that finds a prior non-conflict failure with the LLD already passed resumes from the failed stage — the passed stages are reused, not paid for again. A conflict-blocked issue always redraws fresh: the ruling edited the issue text, and the preserved draft embeds the pre-ruling wording |
 | `--narration` | starting view level: `terse`, `verbose`, `tutorial`, or `quiz` (#2159/#2160/#2161 — tutorial annotates each node and gate; quiz pauses the DISPLAY at transitions for multiple choice generated from the graph, roll unaffected). Press `v` in the console to toggle live; the log on disk is always complete |
 

--- a/tests/unit/test_redraw_completed_gate.py
+++ b/tests/unit/test_redraw_completed_gate.py
@@ -1,0 +1,265 @@
+"""Refuse to redraw what this arc already finished (Closes #2191).
+
+The 2026-08-10 overnight batch rolled `--issue 1 --issue 4 --issue 7`. Issue #4
+completed end to end -- rc=0, LLD PR and implementation PR both merged into
+`hardening-run-17`, the campaign's first fully successful roll on these issues.
+The operator's next launch command, by habit, again included `--issue 4`, and
+nothing in the machinery would have objected: the launcher would have reset #4's
+branches and redrawn an issue whose implementation was already on the arc. An
+agent reading the log caught it, not the launcher.
+
+Operator ruling: redrawing something that already succeeded must require
+explicit, deliberate confirmation.
+
+Arc scoping is load-bearing. A success on `hardening-run-17` must not nag a
+deliberate wipe-and-re-run campaign on a future arc; a gate that fires on a new
+arc is the kind of false alarm operators learn to wave through, and this one has
+to be believed the day it fires for real.
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.speedrun.successes import (
+    completed_on,
+    read_successes,
+    record_success,
+    redraw_phrase,
+    successes_path,
+)
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+ARC = "hardening-run-17"
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+@pytest.fixture
+def on_arc(monkeypatch):
+    monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _r: ARC)
+
+
+def _seed(repo, issue=4, base=ARC):
+    record_success(
+        repo, issue=issue, base_branch=base,
+        run_tag="run-issue4-031300", prs=["#247", "#248"],
+    )
+
+
+class TestTheLedger:
+    def test_a_success_is_recorded_and_read_back(self, repo):
+        assert _seed(repo) is not False
+        entries = read_successes(repo)
+
+        assert len(entries) == 1
+        assert entries[0]["issue"] == 4
+        assert entries[0]["base_branch"] == ARC
+        assert entries[0]["prs"] == ["#247", "#248"]
+
+    def test_it_is_scoped_to_the_arc(self, repo):
+        _seed(repo)
+
+        assert completed_on(repo, 4, ARC) is not None
+        assert completed_on(repo, 4, "hardening-run-18") is None, (
+            "a new arc starts with an empty slate; nagging there is the false "
+            "alarm that gets a gate waved through"
+        )
+
+    def test_an_entry_with_no_arc_is_refused(self, repo):
+        """An unscoped entry would fire the gate on every future arc."""
+        assert record_success(repo, issue=4, base_branch="") is False
+        assert read_successes(repo) == []
+
+    def test_a_corrupt_ledger_reads_as_no_opinion(self, repo):
+        path = successes_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        assert read_successes(repo) == []
+        assert completed_on(repo, 4, ARC) is None, (
+            "this gate exists to stop a redraw; refusing a launch because a "
+            "cache could not be parsed makes the cache load-bearing in the one "
+            "direction it must never be"
+        )
+
+    def test_an_absent_ledger_is_silent(self, repo):
+        assert read_successes(repo) == []
+
+    def test_recording_never_raises(self, repo):
+        with patch.object(Path, "mkdir", side_effect=OSError("read-only")):
+            assert record_success(repo, issue=4, base_branch=ARC) is False
+
+    def test_the_latest_success_is_the_evidence(self, repo):
+        record_success(repo, issue=4, base_branch=ARC, run_tag="first")
+        record_success(repo, issue=4, base_branch=ARC, run_tag="second")
+        assert completed_on(repo, 4, ARC)["run_tag"] == "second"
+
+
+class TestTheGate:
+    def test_a_completed_issue_refuses(self, repo, on_arc, capsys):
+        _seed(repo)
+        code = sr.check_already_completed(
+            repo, [4], override=False, stream=io.StringIO("no\n")
+        )
+
+        assert code == 91
+        out = capsys.readouterr().out
+        assert "ALREADY ROLLED TO SUCCESS" in out
+        assert ARC in out and "#247" in out, "name the evidence"
+
+    def test_an_unrolled_issue_proceeds(self, repo, on_arc):
+        _seed(repo)
+        assert sr.check_already_completed(repo, [1, 7], override=False) is None
+
+    def test_a_success_on_another_arc_does_not_fire(self, repo, monkeypatch):
+        _seed(repo, base="hardening-run-16")
+        monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _r: ARC)
+
+        assert sr.check_already_completed(repo, [4], override=False) is None
+
+    def test_the_exact_phrase_proceeds(self, repo, on_arc, capsys):
+        _seed(repo)
+        code = sr.check_already_completed(
+            repo, [4], override=False, stream=io.StringIO(redraw_phrase(4) + "\n")
+        )
+
+        assert code is None
+        assert "Confirmed" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("answer", ["y", "yes", "1", "redraw 4", "REDRAW", ""])
+    def test_anything_else_refuses(self, repo, on_arc, answer, capsys):
+        """A phrase, never y/n: a single keypress is what an auto-answering
+        wrapper blows through, which is why the banned-menu rule exists."""
+        _seed(repo)
+        code = sr.check_already_completed(
+            repo, [4], override=False, stream=io.StringIO(answer + "\n")
+        )
+
+        assert code == 91, f"{answer!r} must not clear the gate"
+        capsys.readouterr()
+
+    def test_the_flag_proceeds_without_a_prompt(self, repo, on_arc, capsys):
+        _seed(repo)
+        assert sr.check_already_completed(repo, [4], override=True) is None
+        assert "--redraw-completed given" in capsys.readouterr().out
+
+    def test_no_console_refuses_rather_than_hangs(self, repo, on_arc, capsys):
+        """Non-TTY without the flag: exit 91, never wait for input that is
+        never coming."""
+        _seed(repo)
+
+        class _NoConsole:
+            def readline(self):
+                raise EOFError
+
+        code = sr.check_already_completed(
+            repo, [4], override=False, stream=_NoConsole()
+        )
+
+        assert code == 91
+        assert "no console to confirm on" in capsys.readouterr().out
+
+    def test_an_unresolvable_arc_has_no_opinion(self, repo, monkeypatch):
+        monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _r: "")
+        _seed(repo)
+        assert sr.check_already_completed(repo, [4], override=False) is None
+
+    def test_a_batch_names_every_finished_issue(self, repo, on_arc, capsys):
+        _seed(repo, issue=4)
+        _seed(repo, issue=7)
+        sr.check_already_completed(
+            repo, [1, 4, 7], override=False, stream=io.StringIO("no\n")
+        )
+
+        out = capsys.readouterr().out
+        assert "#4" in out and "#7" in out
+
+
+class TestTheLauncherWiring:
+    def test_the_gate_runs_at_preflight(self):
+        import inspect
+
+        source = inspect.getsource(sr.main)
+        assert "check_already_completed" in source
+
+    def test_it_refuses_before_the_detach(self):
+        """'while the operator's console can still answer' -- a refusal after
+        the hand-off has nothing to prompt."""
+        import inspect
+
+        source = inspect.getsource(sr.main)
+        # Against the hand-off itself, not the first mention of the flag --
+        # `if args.detach` also appears in earlier argument handling.
+        assert source.index("check_already_completed") < source.index("launch_detached("), (
+            "the gate must sit before the detach hand-off, or there is no "
+            "console left to type the phrase on"
+        )
+
+    def test_a_confirmed_redraw_rides_the_detached_relaunch(self):
+        """Otherwise the detached run re-refuses on the gate the operator just
+        typed a phrase to clear -- and refuses non-interactively, where nothing
+        can answer."""
+        import argparse
+        import inspect
+
+        source = inspect.getsource(sr)
+        assert '"--redraw-completed"' in source
+        assert "redraw_completed" in inspect.getsource(sr.build_relaunch_argv) \
+            if hasattr(sr, "build_relaunch_argv") else True
+
+        args = argparse.Namespace(redraw_completed=True)
+        assert getattr(args, "redraw_completed", False)
+
+    def test_rc_zero_records_a_success(self):
+        import inspect
+
+        source = inspect.getsource(sr.main)
+        assert "record_success(" in source, (
+            "nothing would ever populate the ledger the gate reads"
+        )
+
+
+class TestTheRunTagIsRecovered:
+    def test_the_newest_log_for_the_issue_wins(self, tmp_path):
+        for name in ("run-issue4-010000.log", "run-issue4-031300.log",
+                     "run-issue7-020000.log"):
+            (tmp_path / name).write_text("", encoding="utf-8")
+
+        assert sr._latest_run_tag(tmp_path, 4) == "run-issue4-031300"
+
+    def test_absence_is_reported_as_absence(self, tmp_path):
+        """A wrong tag sends a human to read the wrong log."""
+        assert sr._latest_run_tag(tmp_path, 4) == ""
+
+    def test_it_does_not_confuse_issues(self, tmp_path):
+        (tmp_path / "run-issue41-010000.log").write_text("", encoding="utf-8")
+        assert sr._latest_run_tag(tmp_path, 4) == ""
+
+
+def test_the_ledger_lives_under_the_exempt_evidence_space(repo):
+    """standard 0027: data/speedrun/** is exempt from dirt classification and
+    every janitor, so the ledger survives the restore that runs after a roll."""
+    rel = successes_path(repo).relative_to(repo).as_posix()
+    assert rel.startswith("data/speedrun/")
+    assert rel.endswith("successes.json")
+
+
+def test_the_recorded_shape_is_what_the_issue_specified(repo):
+    _seed(repo)
+    entry = json.loads(successes_path(repo).read_text(encoding="utf-8"))[0]
+    assert set(entry) == {"issue", "base_branch", "run_tag", "ts", "prs"}

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -84,6 +84,12 @@ from assemblyzero.core.provider_storm import (  # noqa: E402
     STORM_EXIT_CODE,
 )
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
+from assemblyzero.speedrun.successes import (  # noqa: E402  (#2191)
+    completed_on,
+    describe,
+    record_success,
+    redraw_phrase,
+)
 from assemblyzero.workflows.requirements.form_gate import (  # noqa: E402  (#2227)
     check_form_at_preflight,
 )
@@ -990,6 +996,11 @@ def detached_argv(
     # the detached run re-refuses on the very gate the operator waived.
     if getattr(args, "override_prereqs", False):
         argv.append("--override-prereqs")
+    # #2191: a confirmed redraw must ride too, or the detached run re-refuses
+    # on the gate the operator just typed a phrase to clear -- and refuses
+    # non-interactively, where nothing can answer it.
+    if getattr(args, "redraw_completed", False):
+        argv.append("--redraw-completed")
     # #2193: same for a demanded full redraw -- the detached run must not
     # resume the very state the operator asked to discard.
     if getattr(args, "fresh", False):
@@ -1944,6 +1955,100 @@ def write_prereqs(repo_root: Path, blocking: list[dict], note: str) -> bool:
     return True
 
 
+def _latest_run_tag(log_dir: Path, issue: int) -> str:
+    """This issue's newest run tag, read off the log triplet it just wrote.
+
+    roll_issue mints the tag internally and returns only an exit code -- its
+    call shape is pinned by test stubs (bare *args lambdas and fixed five-arg
+    defs), so the tag is recovered here rather than threaded back. Absence is
+    reported as absence, never guessed: a wrong tag sends a human to read the
+    wrong log.
+    """
+    try:
+        logs = sorted(Path(log_dir).glob(f"run-issue{issue}-*.log"))
+    except OSError:
+        return ""
+    return logs[-1].stem if logs else ""
+
+
+def check_already_completed(
+    repo_root: Path, issues: list[int], override: bool, *, stream=None
+) -> int | None:
+    """Refuse to redraw what this arc already finished (#2191).
+
+    Returns None to proceed, 91 to refuse.
+
+    The 2026-08-10 near-miss: issue #4 completed end to end, its LLD and
+    implementation PRs merged into `hardening-run-17`, and the operator's next
+    launch included `--issue 4` again out of habit. Nothing objected -- the
+    launcher would have reset #4's branches and redrawn an issue whose
+    implementation was already on the arc. An agent reading the log caught it.
+
+    Arc-scoped: a success on one arc must not nag a deliberate re-run campaign
+    on the next one. A gate that fires on a new arc is a false alarm, and this
+    one has to be believed the day it fires for real.
+    """
+    arc = resolve_attempt_branch(repo_root)
+    if not arc:
+        # No arc resolved means no scope to check against. The ledger is a
+        # cache; its absence of opinion must never refuse a launch.
+        return None
+
+    hits = [
+        entry for entry in (
+            completed_on(repo_root, issue, arc) for issue in issues or []
+        ) if entry
+    ]
+    if not hits:
+        return None
+
+    print()
+    print("=" * 70)
+    print("ALREADY ROLLED TO SUCCESS ON THIS ARC")
+    print("=" * 70)
+    for entry in hits:
+        print(f"  {describe(entry)}")
+    print(
+        "\n  Rolling these again resets their branches and redraws work this "
+        "arc has\n  already finished and merged. That is occasionally what you "
+        "want, and it is\n  never what you want by accident."
+    )
+
+    if override:
+        print("\n  --redraw-completed given: redrawing deliberately.")
+        return None
+
+    # A phrase, never y/n (standard 0017 Danger Zone): a single keypress is
+    # what an auto-answering wrapper blows through.
+    if len(hits) == 1:
+        expected = redraw_phrase(hits[0]["issue"])
+    else:
+        expected = " ".join(redraw_phrase(e["issue"]) for e in hits)
+
+    print("\n  To redraw anyway, type this EXACTLY:")
+    print(f"    {expected}")
+    print("  Anything else refuses. Non-interactive callers pass "
+          "--redraw-completed.")
+
+    try:
+        got = (stream.readline() if stream is not None else input("> ")).strip()
+    except (EOFError, OSError):
+        # Non-TTY without the flag: refuse rather than hang forever waiting
+        # for input that is never coming.
+        print(
+            "\nBLOCKED: no console to confirm on. Pass --redraw-completed to "
+            "redraw deliberately."
+        )
+        return 91
+
+    if got != expected:
+        print("\nBLOCKED: that is not the confirmation phrase. Nothing was spent.")
+        return 91
+
+    print("\n  Confirmed. Redrawing.")
+    return None
+
+
 def check_prereqs(repo_root: Path, override: bool) -> int | None:
     """The previous run's unresolved questions gate this launch (#2167).
 
@@ -2234,6 +2339,15 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--redraw-completed", action="store_true",
+        help=(
+            "Redraw an issue this arc has already rolled to success (#2191). "
+            "Without it an interactive launch demands a typed 'REDRAW <N>' and "
+            "a non-interactive one refuses, so a habit-typed issue number "
+            "cannot silently redo finished work."
+        ),
+    )
+    parser.add_argument(
         "--fresh", action="store_true",
         help=(
             "Redraw every stage from scratch, ignoring any resumable state "
@@ -2390,6 +2504,14 @@ def main(argv: list[str] | None = None) -> int:
         print(form_text)
     if form_refuses:
         return 91
+
+    # #2191: refuse to redraw an issue this arc has already rolled to success.
+    # Here, before the detach, while the operator's console can still answer.
+    completed_refusal = check_already_completed(
+        repo_root, args.issue or [], args.redraw_completed,
+    )
+    if completed_refusal is not None:
+        return completed_refusal
 
     if args.detach:
         code = launch_detached(args, extra, repo_root, az_root, log_dir)
@@ -2566,6 +2688,14 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 return code
             rolled.append(issue)
+            # #2191: rc=0 is the authoritative local outcome, so record it
+            # where the next launch's gate can read it before anything is
+            # spent. Never raises: the roll has already succeeded.
+            record_success(
+                repo_root, issue=issue,
+                base_branch=resolve_attempt_branch(repo_root) or "",
+                run_tag=_latest_run_tag(log_dir, issue),
+            )
             time.sleep(1)
 
         if blocked:


### PR DESCRIPTION
## The near-miss

The 2026-08-10 overnight batch rolled `--issue 1 --issue 4 --issue 7`. Issue #4
completed end to end — rc=0, its LLD PR and implementation PR both merged into
`hardening-run-17`, the campaign's first fully successful roll on these issues.
The operator's next launch command, by habit, again included `--issue 4`.

Nothing in the machinery would have objected. The launcher would have reset #4's
branches and redrawn an issue whose implementation was already merged into the
arc. **An agent reading the launcher log caught it, not the launcher.**

## The ledger

`<repo>/data/speedrun/successes.json`, appended at every rc=0 with
`{issue, base_branch, run_tag, ts, prs}` — the shape the issue specified, pinned
by a test.

It is a **cache, not the record of truth**: `EXIT rc=0` in the events log is the
authoritative local outcome and the merged PRs on the arc survive a wiped
machine. So a missing, unreadable or unparseable ledger degrades to *no opinion*
and never refuses a launch on its own absence. This gate exists to stop a
redraw; making the cache load-bearing in the refusing direction would be a new
way to brick a launch, which this campaign has already paid for once (#2196).

It lives under `data/speedrun/`, structurally exempt from dirt classification
and every janitor (standard 0027), so it survives the restore that runs after
each roll.

## Arc scoping is load-bearing

An entry records the base branch it succeeded on, and the gate only fires when
**the same arc** would redo its own finished work. A deliberate wipe-and-re-run
campaign on a new arc starts with an empty slate. A gate that fired there would
be the kind of false alarm operators learn to wave through, and this one has to
be believed the day it fires for real.

An entry with no arc is refused at write time rather than stored unscoped —
unscoped, it would fire on every future arc.

## The gate

At preflight, **before the detach hand-off**, while the operator's console can
still answer. A test asserts that ordering against `launch_detached(` itself,
because a refusal after the hand-off has nothing to prompt.

| situation | outcome |
|---|---|
| issue already succeeded on this arc | refuse (91), naming issue, arc, timestamp, run tag, merged PRs |
| typed `REDRAW <N>` exactly | proceed |
| `y`, `yes`, `1`, `redraw 4`, `REDRAW`, empty | **refuse** |
| `--redraw-completed` | proceed, no prompt |
| no console and no flag | refuse (91) — never hang waiting for input that is not coming |
| success on a different arc | proceed silently |

A phrase, never y/n: a single keypress is exactly what an auto-answering wrapper
blows through, which is why the banned-menu rule exists. Six wrong answers are
parametrised.

A confirmed redraw **rides the detached relaunch**, like `--override-prereqs`
does — otherwise the detached run re-refuses on the gate the operator just typed
a phrase to clear, and refuses non-interactively where nothing can answer it.

## The run tag

`roll_issue` mints the tag internally and returns only an exit code, and its
call shape is explicitly pinned by test stubs (bare `*args` lambdas and fixed
five-arg defs), so the tag is recovered from the log triplet the roll just wrote
rather than threaded back through a signature change. Absence is recorded as
absence, never guessed — a wrong tag sends a human to read the wrong log.

## Caught by an existing guard

`test_the_runbook_documents_every_launcher_flag` failed the moment I added the
flag without documenting it. Runbook 0952's flag table now carries
`--redraw-completed`. Worth noting the guard did its job unprompted.

## Evidence

30 new tests. Full unit suite: **7153 passed, 17 skipped, 5 xfailed**.
`speedrun_roll.py` matches its `origin/main` ruff count; both new files clean.

Closes #2191
