### PR TITLE
fix: clear ReadOnly and retry the plain worktree remove (Closes #2135)

### DIFF
--- a/assemblyzero/speedrun/worktrees.py
+++ b/assemblyzero/speedrun/worktrees.py
@@ -29,7 +29,9 @@ to surface, not to overpower -- it is reported by name and the roll continues.
 from __future__ import annotations
 
 import re
+import os
 import shutil
+import stat
 import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -180,6 +182,81 @@ class SweepResult:
         return f"worktree sweep: {len(self.entries)} handled, {len(self.problems)} reported"
 
 
+#: Windows refuses to delete a directory carrying FILE_ATTRIBUTE_READONLY, and
+#: git reports it as `Permission denied` from `worktree remove`. Measured
+#: 2026-08-09 against boostgauge: all 8 registered clean worktrees failed that
+#: way, every directory in each tree carrying the attribute -- the worktree
+#: root, `src`, `.venv`, and the `logs`/`refs` dirs under
+#: `.git/worktrees/<name>`.
+#:
+#: #2136 asked what in the pipeline sets it. Measured 2026-08-12: nothing does.
+#: The attribute is ambient across the whole Projects tree -- 100% of top-level
+#: directories in boostgauge, AssemblyZero, Aletheia and Talos carry it,
+#: including `.mypy_cache`, `.ruff_cache` and `.github`, which no pipeline code
+#: has ever touched -- while a fresh `mkdir` does not. So the pipeline cannot
+#: stop producing these trees, which makes clearing-and-retrying the fix rather
+#: than a mask.
+_READONLY = 0x1
+
+
+def _is_permission_error(stderr: str) -> bool:
+    lowered = (stderr or "").lower()
+    return "permission denied" in lowered or "access is denied" in lowered
+
+
+def clear_readonly(root: Path) -> int:
+    """Clear the ReadOnly attribute across a tree. Returns dirs+files changed.
+
+    Walks bottom-up so a directory is cleared after its children, and never
+    raises: this runs on the failure path of a removal that has already gone
+    wrong, and an unreadable corner must not turn a retry into a crash.
+    """
+    changed = 0
+    if not root.exists():
+        return 0
+
+    targets: list[Path] = [root]
+    try:
+        targets.extend(root.rglob("*"))
+    except OSError:
+        pass
+
+    for target in targets:
+        try:
+            attrs = os.stat(target).st_file_attributes
+        except (OSError, AttributeError):
+            continue
+        if not attrs & _READONLY:
+            continue
+        try:
+            os.chmod(target, stat.S_IWRITE | stat.S_IREAD)
+            changed += 1
+        except OSError:
+            continue
+    return changed
+
+
+def _remove_worktree(repo: Path, path: Path, log) -> subprocess.CompletedProcess:
+    """Plain `git worktree remove`, retried once after clearing ReadOnly.
+
+    NEVER `--force`, here or anywhere in this module. Clearing the attribute
+    makes the PLAIN path work rather than bypassing the check that refuses a
+    dirty tree -- the module's no-force invariant is intact, and its source
+    test still passes.
+    """
+    removed = _run(["git", "-C", str(repo), "worktree", "remove", str(path)])
+    if removed.returncode == 0 or not _is_permission_error(removed.stderr):
+        return removed
+
+    admin = repo / ".git" / "worktrees" / path.name
+    cleared = clear_readonly(path) + clear_readonly(admin)
+    if not cleared:
+        return removed
+
+    log(f"    cleared ReadOnly on {cleared} path(s) under {path.name}; retrying")
+    return _run(["git", "-C", str(repo), "worktree", "remove", str(path)])
+
+
 def _preserve_dirty(repo: Path, path: Path, log) -> SweepEntry:
     """Commit a dirty worktree's content to a graveyard branch, then remove it."""
     branch = current_branch(path) or "detached"
@@ -210,7 +287,7 @@ def _preserve_dirty(repo: Path, path: Path, log) -> SweepEntry:
         # strand the worktree again for a reason unrelated to its content.
         log(f"    push of {grave} failed (content is safe on the local branch)")
 
-    removed = _run(["git", "-C", str(repo), "worktree", "remove", str(path)])
+    removed = _remove_worktree(repo, path, log)
     if removed.returncode != 0:
         return SweepEntry(
             path, "dirty", "reported", ok=False, branch=grave,
@@ -254,7 +331,7 @@ def sweep_pipeline_worktrees(repo: Path | str, *, log=None) -> SweepResult:
             elif is_dirty(resolved):
                 entry = _preserve_dirty(repo, resolved, log)
             else:
-                removed = _run(["git", "-C", str(repo), "worktree", "remove", str(resolved)])
+                removed = _remove_worktree(repo, resolved, log)
                 if removed.returncode == 0:
                     entry = SweepEntry(resolved, "clean", "removed")
                 else:

--- a/tests/unit/test_worktree_readonly_retry.py
+++ b/tests/unit/test_worktree_readonly_retry.py
@@ -1,0 +1,227 @@
+"""A ReadOnly directory must not defeat the worktree sweep (Closes #2135).
+
+First real-state execution of the sweep against boostgauge, 2026-08-09: all 8
+registered clean worktrees failed plain `git worktree remove` with
+
+    error: failed to delete 'C:/Users/mcwiz/Projects/boostgauge-1': Permission denied
+    error: failed to delete '.git/worktrees/boostgauge-1': Permission denied
+
+Every directory in each tree carried the Windows ReadOnly attribute -- the
+worktree root, `src`, `.venv`, and the `logs`/`refs` dirs under the admin
+directory. Windows refuses to delete a ReadOnly directory, so every plain
+removal died with EACCES. That is very likely why worktrees accumulated during
+the campaign at all: any earlier self-heal removal hit the same wall.
+
+The failure is a PARTIAL delete, which is what makes it nasty. git removes what
+it can before erroring, so the worktree ends up deregistered while its directory
+remains on disk.
+
+The fix clears the attribute and retries the PLAIN remove. Never `--force`,
+here or anywhere in this module: clearing the attribute makes the plain path
+work rather than bypassing the check that refuses a dirty tree.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun import worktrees as wt
+
+_READONLY = 0x1
+
+
+def _is_readonly(path: Path) -> bool:
+    try:
+        return bool(os.stat(path).st_file_attributes & _READONLY)
+    except (OSError, AttributeError):
+        return False
+
+
+windows_only = pytest.mark.skipif(
+    not hasattr(os.stat(Path(__file__)), "st_file_attributes"),
+    reason="the ReadOnly attribute is a Windows filesystem concept",
+)
+
+
+@windows_only
+class TestClearingTheAttribute:
+    def test_it_clears_a_readonly_directory(self, tmp_path):
+        d = tmp_path / "tree"
+        d.mkdir()
+        os.chmod(d, stat.S_IREAD)
+        assert _is_readonly(d), "precondition"
+
+        assert wt.clear_readonly(d) >= 1
+        assert not _is_readonly(d)
+
+    def test_it_clears_the_whole_tree(self, tmp_path):
+        """The attribute was on every directory in the tree, not just the root."""
+        root = tmp_path / "tree"
+        (root / "src").mkdir(parents=True)
+        (root / "src" / "deep").mkdir()
+        (root / "src" / "f.txt").write_text("x", encoding="utf-8")
+        for p in (root / "src" / "deep", root / "src", root):
+            os.chmod(p, stat.S_IREAD)
+
+        wt.clear_readonly(root)
+
+        assert not _is_readonly(root)
+        assert not _is_readonly(root / "src")
+        assert not _is_readonly(root / "src" / "deep")
+
+    def test_the_tree_is_removable_afterwards(self, tmp_path):
+        """The property that matters. Without clearing, rmtree raises WinError 5."""
+        import shutil
+
+        root = tmp_path / "tree"
+        (root / "src").mkdir(parents=True)
+        for p in (root / "src", root):
+            os.chmod(p, stat.S_IREAD)
+
+        with pytest.raises(PermissionError):
+            shutil.rmtree(root)
+
+        wt.clear_readonly(root)
+        shutil.rmtree(root)
+        assert not root.exists()
+
+    def test_an_absent_path_is_zero_not_an_error(self, tmp_path):
+        assert wt.clear_readonly(tmp_path / "nope") == 0
+
+    def test_it_never_raises_on_an_unreadable_corner(self, tmp_path):
+        """This runs on the failure path of a removal that has already gone
+        wrong; a crash here would replace a reported problem with a traceback."""
+        d = tmp_path / "tree"
+        d.mkdir()
+
+        def _boom(*_a, **_k):
+            raise OSError("nope")
+
+        original = os.chmod
+        os.chmod = _boom
+        try:
+            assert wt.clear_readonly(d) == 0
+        finally:
+            os.chmod = original
+
+
+class TestTheRetry:
+    """`_remove_worktree` is the single door both removal paths go through."""
+
+    def _fake_run(self, results):
+        calls = []
+
+        def _run(args):
+            calls.append(args)
+            return results[min(len(calls) - 1, len(results) - 1)]
+
+        _run.calls = calls
+        return _run
+
+    def _cp(self, code, stderr=""):
+        return subprocess.CompletedProcess(["git"], code, stdout="", stderr=stderr)
+
+    def test_a_clean_removal_is_not_retried(self, tmp_path, monkeypatch):
+        run = self._fake_run([self._cp(0)])
+        monkeypatch.setattr(wt, "_run", run)
+
+        result = wt._remove_worktree(tmp_path, tmp_path / "1", lambda _m: None)
+
+        assert result.returncode == 0
+        assert len(run.calls) == 1
+
+    def test_a_permission_failure_clears_and_retries_once(self, tmp_path, monkeypatch):
+        path = tmp_path / "1"
+        path.mkdir()
+        if hasattr(os.stat(path), "st_file_attributes"):
+            os.chmod(path, stat.S_IREAD)
+
+        run = self._fake_run([self._cp(1, "Permission denied"), self._cp(0)])
+        monkeypatch.setattr(wt, "_run", run)
+        monkeypatch.setattr(wt, "clear_readonly", lambda _p: 3)
+
+        result = wt._remove_worktree(tmp_path, path, lambda _m: None)
+
+        assert result.returncode == 0
+        assert len(run.calls) == 2, "exactly one retry, never a loop"
+
+    def test_a_non_permission_failure_is_not_retried(self, tmp_path, monkeypatch):
+        """A worktree that resists for another reason is a fact to surface, not
+        to keep hammering."""
+        run = self._fake_run([self._cp(1, "is dirty, use --force")])
+        monkeypatch.setattr(wt, "_run", run)
+
+        result = wt._remove_worktree(tmp_path, tmp_path / "1", lambda _m: None)
+
+        assert result.returncode == 1
+        assert len(run.calls) == 1
+
+    def test_nothing_to_clear_means_no_retry(self, tmp_path, monkeypatch):
+        """If the attribute was not the problem, retrying the identical command
+        would just fail identically."""
+        run = self._fake_run([self._cp(1, "Permission denied")])
+        monkeypatch.setattr(wt, "_run", run)
+        monkeypatch.setattr(wt, "clear_readonly", lambda _p: 0)
+
+        result = wt._remove_worktree(tmp_path, tmp_path / "1", lambda _m: None)
+
+        assert result.returncode == 1
+        assert len(run.calls) == 1
+
+    def test_the_admin_directory_is_cleared_too(self, tmp_path, monkeypatch):
+        """`.git/worktrees/<name>` carried the attribute on its logs/refs dirs,
+        and git names it in the same failure."""
+        cleared = []
+        monkeypatch.setattr(wt, "_run", self._fake_run(
+            [self._cp(1, "Permission denied"), self._cp(0)]
+        ))
+        monkeypatch.setattr(
+            wt, "clear_readonly", lambda p: cleared.append(Path(p)) or 1
+        )
+
+        wt._remove_worktree(tmp_path, tmp_path / "data" / "worktrees" / "1",
+                            lambda _m: None)
+
+        assert any(".git" in p.parts and "worktrees" in p.parts for p in cleared), (
+            f"the admin dir was never cleared; cleared {cleared}"
+        )
+
+    def test_it_says_what_it_did(self, tmp_path, monkeypatch):
+        said = []
+        monkeypatch.setattr(wt, "_run", self._fake_run(
+            [self._cp(1, "Permission denied"), self._cp(0)]
+        ))
+        monkeypatch.setattr(wt, "clear_readonly", lambda _p: 4)
+
+        wt._remove_worktree(tmp_path, tmp_path / "1", said.append)
+
+        assert any("cleared ReadOnly" in m for m in said)
+
+
+class TestTheNoForceInvariantSurvives:
+    def test_the_canonical_guard_still_exists_and_covers_this(self):
+        """The invariant is pinned by `test_sweep_source_contains_no_force` in
+        test_speedrun_worktrees.py, which inspects string literals excluding
+        docstrings -- a duplicate here would be weaker (my first cut matched
+        the module's own prose about never forcing) and would drift.
+
+        Named rather than reimplemented, so the next reader finds the real one.
+        """
+        import tests.unit.test_speedrun_worktrees as canonical
+
+        assert hasattr(canonical, "test_sweep_source_contains_no_force")
+        canonical.test_sweep_source_contains_no_force()  # must still pass
+
+    def test_both_removal_paths_go_through_the_retry(self):
+        import inspect
+
+        for fn in (wt._preserve_dirty, wt.sweep_pipeline_worktrees):
+            source = inspect.getsource(fn)
+            assert '"worktree", "remove"' not in source, (
+                f"{fn.__name__} calls git remove directly, so a ReadOnly tree "
+                "still defeats it"
+            )
+            assert "_remove_worktree(" in source


### PR DESCRIPTION
## The failure

First real-state execution of the sweep against boostgauge, 2026-08-09: **all 8
registered clean worktrees** failed plain `git worktree remove` with

```
error: failed to delete 'C:/Users/mcwiz/Projects/boostgauge-1': Permission denied
error: failed to delete '.git/worktrees/boostgauge-1': Permission denied
```

Every directory in each tree carried the Windows ReadOnly attribute — the
worktree root, `src`, `.venv`, and the `logs`/`refs` dirs under the admin
directory. This is very likely why worktrees accumulated during the campaign at
all: any earlier per-issue self-heal removal hit the same wall.

## Verified before fixing

I reproduced both halves rather than taking them from the report:

- A ReadOnly directory **does** block removal — `shutil.rmtree` raises
  `PermissionError: [WinError 5] Access is denied`, which is what git surfaces
  as `Permission denied`.
- `shutil.copytree` **propagates** the attribute to destination directories via
  `copystat`, which explains why the relocated and archived trees carried it.

## The fix

On a removal failure that names a permission error, clear the ReadOnly attribute
across the worktree tree **and its admin dir**, then retry the **plain** remove
once.

- **Never `--force`.** Clearing the attribute makes the plain path work rather
  than bypassing the check that refuses a dirty tree. The module's no-force
  invariant is intact and its canonical guard
  (`test_sweep_source_contains_no_force`, AST-based) still passes — a test here
  calls it directly rather than reimplementing it.
- **Exactly one retry, never a loop.** A non-permission failure is not retried,
  and neither is a permission failure where nothing was cleared: retrying an
  identical command that failed for another reason just fails identically.
- **Both removal paths** — clean and dirty-after-preserve — go through the one
  door, pinned by a test that fails if either calls git directly again.
- `clear_readonly` never raises. It runs on the failure path of a removal that
  has already gone wrong; a crash there would replace a reported problem with a
  traceback.

## What the sibling investigation found

#2136 asked what in the pipeline sets the attribute. Measured 2026-08-12:
**nothing does.** It is ambient across the entire `Projects` tree — 100% of
top-level directories in boostgauge, AssemblyZero, Aletheia and Talos carry it,
including `.mypy_cache`, `.ruff_cache` and `.github`, which no pipeline code has
ever touched — while a fresh `mkdir` does not.

That upgrades this change from hardening to **the fix**: the pipeline cannot stop
producing ReadOnly trees, so clearing and retrying is the only place the problem
can be solved. Full evidence is on #2136.

## Evidence

13 new tests, including that the tree is genuinely removable after clearing
(and genuinely not, before). The Windows-specific cases skip cleanly on
platforms without `st_file_attributes`.

Full unit suite: **7166 passed, 17 skipped, 5 xfailed**. `ruff check` clean,
matching `origin/main`.

Closes #2135
