### PR TITLE
fix: derive the e2e harness step budget instead of hand-rolling it (Closes #2280)

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -142,6 +142,10 @@ def run_workflow_to_completion(
     """
     from assemblyzero.workflows.requirements.graph import create_requirements_graph
     from assemblyzero.workflows.requirements.state import create_initial_state
+    from assemblyzero.workflows.requirements.step_budget import (
+        DEFAULT_MAX_ITERATIONS,
+        recursion_limit,
+    )
 
     nodes_visited: list[str] = []
     start_time = time.monotonic()
@@ -154,9 +158,20 @@ def run_workflow_to_completion(
         # Create initial state using the proper factory function
         initial_state = create_initial_state(**config)
 
-        # Execute with streaming to capture node visit order
+        # Execute with streaming to capture node visit order.
+        #
+        # The step budget is DERIVED, never hand-rolled (#2280). `max_iterations`
+        # is a loop cap -- how many revise rounds a loop may take -- while
+        # `recursion_limit` is the super-step budget for the whole run. Setting
+        # the second from the first capped this harness at five node executions,
+        # which is fewer than the nine a clean pass costs, so every e2e mock run
+        # died of GraphRecursionError before mechanical validation was reached.
+        # `recursion_limit()` is the same single source the production callers
+        # use (#2245), so a node added to the graph re-sizes this automatically.
         thread_config = {
-            "recursion_limit": config.get("max_iterations", 20),
+            "recursion_limit": recursion_limit(
+                max_iterations=config.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            ),
         }
 
         final_state = {}

--- a/tests/e2e/test_lld_workflow_mock.py
+++ b/tests/e2e/test_lld_workflow_mock.py
@@ -8,9 +8,17 @@ No API credentials are required.
 
 Note: The mock:draft provider returns a minimal document that does NOT
 pass the LLD mechanical validation (N1.5). This is expected — the tests
-verify that the graph correctly loops (N1 → N1.5 → N1) and eventually
-hits the recursion limit. This exercises the real graph wiring, error
-handling, and routing logic.
+verify that the graph correctly loops (N1 → N_ponder → N1.5 → N1) until
+the iteration cap, then terminates through HALT. This exercises the real
+graph wiring, error handling, and routing logic.
+
+The terminal state is a NAMED HALT, not a bare recursion error (#2280).
+Under #2245 the step budget is derived from the loop caps, and under #2197
+a loop that reaches its cap halts with a message naming the document and
+the unfixed errors. A `GraphRecursionError` here means the budget is wrong,
+not that the loop worked — this file previously asserted the opposite, and
+the harness capped the run at five super-steps so N1.5 was never reached at
+all.
 
 Run with:
     poetry run pytest tests/e2e/test_lld_workflow_mock.py -v -m e2e
@@ -28,7 +36,7 @@ from tests.e2e.conftest import API_KEY_ENV_VARS, run_workflow_to_completion
 
 # ------------------------------------------------------------------
 # Expected nodes in the LLD workflow graph path.
-# Mock mode: N0 → N1 → N1.5 (fail) → N1 → N1.5 (fail) → ... recursion limit
+# Mock mode: N0 → N0b → N0c → N1 → N_ponder → N1.5 (fail) → N1 → ... → HALT
 # ------------------------------------------------------------------
 
 
@@ -38,25 +46,39 @@ def test_lld_workflow_mock_graph_executes(
     mock_workspace: Path,
     mock_workflow_config: dict,
 ) -> None:
-    """E2E: LLD workflow graph starts execution and visits nodes. (REQ-1)
+    """E2E: LLD workflow graph runs the whole mock path and terminates. (REQ-1)
 
-    T010: Verifies the graph invokes nodes and returns a result.
-    The mock draft fails mechanical validation, so the graph loops
-    until recursion limit — this is expected behavior.
+    T010: Verifies the graph invokes nodes and returns a result. The mock
+    draft fails mechanical validation, so the graph loops to the iteration
+    cap and then HALTs.
+
+    This test asserted only that N0 and N1 were reached until #2280. Those
+    two assertions were satisfied by a truncated five-node run that died of
+    GraphRecursionError before validation, so the test passed for two years
+    of graph changes without noticing that the path it names was never taken.
+    It now asserts the terminal node, which is what makes it non-vacuous.
     """
     result = run_workflow_to_completion(
         config=mock_workflow_config,
         workspace=mock_workspace,
     )
 
-    # The graph executes but hits recursion limit because mock draft
-    # doesn't pass mechanical validation — this is expected
-    assert len(result["nodes_visited"]) > 0, "No nodes were visited"
-    assert "N0_load_input" in result["nodes_visited"], (
-        f"N0_load_input not visited. Nodes: {result['nodes_visited']}"
+    nodes = result["nodes_visited"]
+
+    assert len(nodes) > 0, "No nodes were visited"
+    for expected in ("N0_load_input", "N1_generate_draft", "N1_5_validate_mechanical"):
+        assert expected in nodes, f"{expected} not visited. Nodes: {nodes}"
+
+    # The run must reach a stop condition the graph itself names. A budget
+    # too small to reach one is the #2280 defect, and it presents as a
+    # truncated node list with no terminal node rather than as an error here.
+    assert nodes[-1] == "HALT", (
+        f"the run did not terminate through HALT — last node was {nodes[-1]!r}. "
+        f"A GraphRecursionError means the derived step budget is too small, "
+        f"not that the loop behaved. Nodes: {nodes}"
     )
-    assert "N1_generate_draft" in result["nodes_visited"], (
-        f"N1_generate_draft not visited. Nodes: {result['nodes_visited']}"
+    assert "Recursion limit" not in str(result["final_state"].get("error_message", "")), (
+        f"the run died on the step budget instead of halting: {result['final_state']}"
     )
 
 


### PR DESCRIPTION
Closes #2280

## The defect

`tests/e2e/conftest.py` set the LangGraph super-step budget from `max_iterations`:

```python
thread_config = {"recursion_limit": config.get("max_iterations", 20)}
```

`max_iterations` is a **loop cap** — how many revise rounds a loop may take. `recursion_limit` is the **super-step budget** for the entire run. The mock config sets `max_iterations: 5`, so the whole graph was allowed five node executions. A clean LLD pass costs nine before any loop runs.

Every e2e mock run therefore died of `GraphRecursionError` at node five, having visited `N0_load_input`, `N0b_analyze_codebase`, `N0c_analyze_requirements`, `N1_generate_draft`, `N_ponder_stibbons` — and never reaching `N1_5_validate_mechanical`.

## Why it started failing

Nothing regressed in the graph. Nodes were **added** ahead of validation over time — the requirements-consistency gate and the auto-fix pass both sit between load and validation. Each addition pushed the validation node one step further out, and at five it fell off the end.

This is the defect class #2245 repaired for production. All three production call sites derive their budget through `invoke_with_budget` / `recursion_limit()`; the harness was the last hand-rolled limit in the tree, and is the one place `step_budget.py`'s guarantee — *"a node added to any loop fails a test instead of silently eating headroom"* — did not hold.

## The fix

The harness calls `recursion_limit()`, the same single source. A node added to the graph now re-sizes the harness automatically.

## The vacuity this exposed

One test asserted the loop is reached, and it was **failing on main** — the only failure in the tier. It was correct; it was the only test strong enough to notice.

`test_lld_workflow_mock_graph_executes` asserted only `len(nodes) > 0`, `N0_load_input in nodes`, `N1_generate_draft in nodes`. All three were satisfied by the truncated run, so it passed throughout while the path it names was never taken. It now asserts the run reaches `N1_5_validate_mechanical`, terminates on `HALT`, and that the terminal state is not a recursion error.

The module docstring claimed the graph was *expected* to die on the recursion limit. Under #2245 and #2197 the intended terminal state is a named halt naming the document and the unfixed errors. Corrected, with the reason recorded.

## Verification

| Check | Before | After |
|---|---|---|
| `pytest -m e2e -q` | 18 passed, 1 failed | **19 passed** |
| `N1_5_validate_mechanical` reached | no | yes |
| terminal node | `GraphRecursionError` | `HALT` |
| `ruff check tests/e2e/` | 5 findings | 5 findings (pre-existing, none added) |

**Falsified, not assumed.** Reverting the harness to `max_iterations` and re-running makes `test_lld_workflow_mock_mechanical_validation_loop` fail again, so the guard is proven non-vacuous rather than presumed so.

## Scope left out

Five of the remaining e2e tests still assert only weak node-presence conditions. They pass correctly now, but would keep passing if the graph changed shape again. Not strengthened here — that is test-design work rather than this defect, and this PR is already the one that makes the tier honest about the loop.

The structural reason this rotted — CI runs neither the e2e nor the adversarial tier, and runs integration only after merge — is filed as #2283. It needs a workflow-file edit, which lands through the classic-PAT path rather than a push.

Two further defects surfaced in the same pre-roll sweep and are filed separately: #2281 and #2282.

## Risk

Test-only. No production path is touched; the harness is `tests/e2e/conftest.py` and the two edited tests. The production callers already used the derived budget before this change.
