### PR TITLE
fix: send a request google-genai accepts, and stop renaming our bugs as outages (Closes #2281, Closes #2282)

### DIFF
--- a/assemblyzero/workflows/testing/adversarial_gemini.py
+++ b/assemblyzero/workflows/testing/adversarial_gemini.py
@@ -10,6 +10,8 @@ provider infrastructure.
 import logging
 from typing import Any
 
+from pydantic import ValidationError as PydanticValidationError
+
 from assemblyzero.core.errors import (
     RateLimitError,
     TimeoutError_ as TypedTimeoutError,
@@ -203,6 +205,16 @@ class AdversarialGeminiClient:
             ) from e
         except TypeError:
             raise  # Unsupported provider type — propagate as-is
+        except PydanticValidationError:
+            # A validation error is raised locally, before anything is sent, so
+            # it can only mean this repo built the request wrong. Classifying it
+            # below would rename it to a timeout with `status=None` -- and both
+            # consumers treat a timeout as "Gemini was unavailable": the
+            # integration test skips, and the adversarial node records a benign
+            # skip reason and proceeds. That is a false all-clear, and it hid
+            # #2281 (an invalid `timeout` kwarg) through every roll that ran
+            # this node. Propagate as-is, like the TypeError above (#2282).
+            raise
         except Exception as e:
             # Issue #546: Classify through the typed error hierarchy
             classified = classify_gemini_error(e)
@@ -255,7 +267,16 @@ class AdversarialGeminiClient:
                 config={
                     "system_instruction": system_prompt,
                     "response_mime_type": "application/json",
-                    "timeout": timeout,
+                    # `timeout` is NOT a GenerateContentConfig field -- the model
+                    # forbids extras, so passing it there raised a pydantic
+                    # ValidationError before any request was sent, and every
+                    # adversarial invocation failed locally (#2281). The
+                    # per-request timeout lives in http_options, in
+                    # MILLISECONDS: the SDK documents the field as "Timeout for
+                    # the request in milliseconds." A test pins the unit,
+                    # because a version bump that changed it to seconds would
+                    # otherwise silently make this a 2-minute-to-120ms cut.
+                    "http_options": {"timeout": timeout * 1000},
                 },
             )
             text = response.text if hasattr(response, "text") else str(response)

--- a/tests/unit/test_adversarial_gemini.py
+++ b/tests/unit/test_adversarial_gemini.py
@@ -6,6 +6,7 @@ Issue #352: Multi-Model Adversarial Testing Node (Gemini vs Claude)
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
+from pydantic import BaseModel, ValidationError as PydanticValidationError
 
 from assemblyzero.workflows.testing.adversarial_gemini import (
     AdversarialGeminiClient,
@@ -287,3 +288,146 @@ class TestIsQuotaError:
         """'quota' in response text is detected."""
         client = AdversarialGeminiClient(provider=MagicMock())
         assert client._is_quota_error("quota exceeded for project", {}) is True
+
+
+# ---------------------------------------------------------------------------
+# The request we build must be one the SDK accepts (#2281)
+# ---------------------------------------------------------------------------
+
+_VALID_RESPONSE = (
+    '{"uncovered_edge_cases": [], "false_claims": [], '
+    '"missing_error_handling": [], "implicit_assumptions": [], "test_cases": []}'
+)
+
+
+def _capturing_genai_provider() -> tuple[MagicMock, dict]:
+    """A stand-in for a google.genai Client that records the kwargs it is given.
+
+    Shaped to take strategy 1 in `_invoke_provider` (`provider.models.generate_content`),
+    which is the path a real google.genai Client takes.
+    """
+    captured: dict = {}
+
+    def generate_content(*, model, contents, config):
+        captured["model"] = model
+        captured["contents"] = contents
+        captured["config"] = config
+        response = MagicMock()
+        response.text = _VALID_RESPONSE
+        response.model = "gemini-2.5-pro"
+        return response
+
+    provider = MagicMock()
+    provider.models.generate_content = generate_content
+    return provider, captured
+
+
+def _invoke(provider, **kwargs) -> str:
+    return AdversarialGeminiClient(provider=provider).generate_adversarial_tests(
+        implementation_code="def foo(): pass",
+        lld_content="# LLD",
+        existing_tests="",
+        **kwargs,
+    )
+
+
+class TestGenerateContentConfigIsAcceptedBySdk:
+    """The config dict this module builds is validated by the real SDK type.
+
+    Before #2281 the call site put `timeout` inside the config dict.
+    `GenerateContentConfig` forbids extra fields, so every adversarial
+    invocation raised a pydantic ValidationError locally, before any request
+    was sent. The integration test could not catch it -- it skips on the very
+    exception the defect raises -- so this offline check is the one that must.
+    """
+
+    def test_config_validates_against_the_real_sdk_type(self):
+        from google.genai.types import GenerateContentConfig
+
+        provider, captured = _capturing_genai_provider()
+        _invoke(provider, timeout=120)
+
+        # Must not raise. This is the whole defect: the dict below was rejected.
+        GenerateContentConfig(**captured["config"])
+
+    def test_timeout_is_not_passed_as_a_config_field(self):
+        provider, captured = _capturing_genai_provider()
+        _invoke(provider, timeout=120)
+
+        assert "timeout" not in captured["config"], (
+            "`timeout` is not a GenerateContentConfig field and the model forbids "
+            "extras -- putting it back here breaks every adversarial call (#2281)."
+        )
+
+    def test_timeout_reaches_http_options_in_milliseconds(self):
+        provider, captured = _capturing_genai_provider()
+        _invoke(provider, timeout=120)
+
+        assert captured["config"]["http_options"]["timeout"] == 120_000
+
+    def test_sdk_still_documents_http_options_timeout_in_milliseconds(self):
+        """Pin the UNIT, not just the field.
+
+        A version bump that redefined `http_options.timeout` as seconds would
+        turn our 120-second budget into 120000 seconds, or a 120ms one if the
+        conversion were dropped. Neither would fail any other test here, and
+        both would present as a Gemini problem rather than ours.
+        """
+        from google.genai.types import HttpOptions
+
+        description = (HttpOptions.model_fields["timeout"].description or "").lower()
+        assert "millisecond" in description, (
+            f"google-genai no longer documents http_options.timeout in "
+            f"milliseconds (got: {description!r}). The `* 1000` conversion in "
+            f"adversarial_gemini.py must be re-derived before this ships."
+        )
+
+
+class TestClientSideErrorsAreNotReportedAsOutages:
+    """A local validation error is our bug, and must not read as a Gemini outage.
+
+    Before #2282 any non-rate-limit exception became a GeminiTimeoutError with
+    `status=None`. Both consumers treat a timeout as "Gemini was unavailable":
+    the integration test skips and the adversarial node records a benign skip
+    reason and proceeds. That false all-clear is what hid #2281.
+    """
+
+    @staticmethod
+    def _real_validation_error() -> PydanticValidationError:
+        class _Forbidding(BaseModel):
+            model_config = {"extra": "forbid"}
+            a: int
+
+        try:
+            _Forbidding(a=1, b=2)
+        except PydanticValidationError as exc:
+            return exc
+        raise AssertionError("expected a ValidationError from the probe model")
+
+    def test_validation_error_propagates_unconverted(self):
+        provider = MagicMock(spec=[])
+        provider.side_effect = self._real_validation_error()
+
+        with pytest.raises(PydanticValidationError):
+            _invoke(provider, timeout=120)
+
+    def test_validation_error_is_not_a_timeout_or_quota_error(self):
+        provider = MagicMock(spec=[])
+        provider.side_effect = self._real_validation_error()
+
+        with pytest.raises(Exception) as excinfo:
+            _invoke(provider, timeout=120)
+
+        assert not isinstance(excinfo.value, GeminiTimeoutError), (
+            "a locally-raised validation error was renamed to a timeout -- the "
+            "misclassification that made a broken call site look like an outage"
+        )
+        assert not isinstance(excinfo.value, GeminiQuotaExhaustedError)
+
+    def test_genuine_transport_errors_still_classify_as_before(self):
+        """The narrowing must not swallow the behaviour #546 built."""
+        provider = MagicMock(spec=[])
+        provider.side_effect = RuntimeError("503 backend unavailable")
+
+        with pytest.raises(GeminiTimeoutError):
+            _invoke(provider, timeout=120)


### PR DESCRIPTION
Closes #2281
Closes #2282

Two defects in one call path, filed separately because they are different mistakes — one builds the request wrong, the other is why nobody noticed for as long as it did.

## The request was rejected before it was sent

`adversarial_gemini.py` passed `timeout` inside the `config` dict handed to `generate_content`. `GenerateContentConfig` forbids extra fields:

```
timeout
  Extra inputs are not permitted [type=extra_forbidden, input_value=120, input_type=int]
```

Every adversarial invocation died there, locally, with no request sent. The per-request timeout belongs in `http_options`, in **milliseconds** — the SDK documents the field as *"Timeout for the request in milliseconds."*

## The misclassification that hid it

Any non-rate-limit exception became a `GeminiTimeoutError`, so a locally-raised `ValidationError` surfaced as `Gemini API error (status=None)`. The `status=None` was the tell: no HTTP status, because there was no HTTP call.

Both consumers treat a timeout as an outage. The integration test skips (`Gemini unavailable: ...`), and the adversarial node records a benign `adversarial_skipped_reason` and proceeds. So a broken call site read, at every layer, as *"Gemini was unavailable today."*

A validation error is raised before transport and can only mean this repo built the request wrong. It now propagates unconverted, alongside the `TypeError` clause that already followed exactly this rule. Genuine transport errors classify as before — pinned by a test.

## The guards

Four new checks, all offline, none needing credentials:

| Guard | Catches |
|---|---|
| the built config validates against the real `GenerateContentConfig` | the defect itself, on day one |
| `timeout` absent from the config dict | its reintroduction |
| reaches `http_options` as `120000` for a 120s budget | a dropped conversion |
| the SDK still documents that field in milliseconds | a version bump redefining the unit |

That last one matters more than it looks: if a future `google-genai` made the field seconds, our 120-second budget becomes 120000 seconds, and nothing else here would fail.

The existing integration test **could not** have caught any of this — it skips on the very exception the defect raised. That is the shape worth remembering: the test guarding this path was disarmed by the classification bug, so the two defects protected each other.

**Falsified, not assumed.** Reverting the config fix fails 3 of the 4 new config tests. Reverting the propagate clause fails 2 of the 3 classification tests. Both restore clean.

## Verification

| Check | Result |
|---|---|
| full unit suite | 7173 passed, 17 skipped, 5 xfailed |
| `pytest tests/unit/test_adversarial_gemini.py` | 32 passed (was 25) |
| adversarial integration test | `status=400` — was `status=None` |
| `ruff` on both files | 1 pre-existing finding, unchanged |

`status=400` is the end-to-end proof: the request now leaves the machine and is answered by Google.

## What this does not do

Google answers with `API key not valid`. The credential on this workstation is rejected — filed as #2285 as a provisioning decision, not repaired here.

Consequently the hardcoded `gemini-2.5-pro-preview-05-06` remains **unverified**: authentication fails before model resolution, so that ID has still never been exercised. It also bypasses the alias map in `llm_provider.py` and the `FORBIDDEN_MODELS` gate. Filed as #2286. Guessing a replacement would have produced a call site that looks maintained while being exactly as unproven.

## Risk

The adversarial node is non-blocking by design (#1602, #352) — `route_after_adversarial` proceeds to N8 on any verdict. This changes what that node *reports*, not whether a roll proceeds. No roll outcome changes either way.
