### PR TITLE
feat: tell a per-roll heal artifact from a recurring defect (Closes #2269)

### DIFF
--- a/assemblyzero/speedrun/healing.py
+++ b/assemblyzero/speedrun/healing.py
@@ -30,6 +30,79 @@ CATEGORIES = (
 OUTCOMES = ("healed", "partial", "failed")
 
 
+# ---------------------------------------------------------------------------
+# Per-roll artifact vs recurring defect (#2269)
+# ---------------------------------------------------------------------------
+#
+# The recurrence report groups heals by category+target and proposes an issue
+# when one group spans enough runs. That grouping reads a STABLE LABEL as a
+# recurring OBJECT, and those are not the same thing.
+#
+# Measured on boostgauge, 2026-08-10/11:
+#
+#   "reset healed '#1' in 9 distinct runs"        -> nine DIFFERENT LLD PRs
+#                                                    (#244, #251, #254, #257,
+#                                                    #258, #259, #260, #261,
+#                                                    #264), each opened by one
+#                                                    roll and correctly closed
+#                                                    by the next launch.
+#   "restore-reconcile healed
+#    'docs/lld/active/LLD-001.md' in 5 runs"      -> five DIFFERENT emissions of
+#                                                    that path, one per roll,
+#                                                    each correctly preserved
+#                                                    and cleared.
+#
+# Both were root-caused and both were correct-by-design (#2242, #2243). The
+# target string was stable because it is derived from the issue number; the
+# underlying object never was. A campaign that rolls one issue repeatedly makes
+# this the ORDINARY condition, so a stub here trains the reader to skim past
+# the stubs that matter.
+#
+# The rule has two tiers, strongest first.
+#
+# 1. INSTANCE. When a heal records what it actually touched, that is the
+#    answer and no heuristic is consulted: distinct instances across runs is a
+#    per-roll artifact, a repeated instance is a genuine recurrence. This is
+#    the "distinguish the instance, not the label" half, and it is why
+#    `record_heal` takes an optional `instance`.
+#
+# 2. CATEGORY. Older records carry no instance, and back-filling one would be
+#    fabrication. For those, the category says whether a fresh object is
+#    implied: a `reset` targets whatever debris the PREVIOUS roll left, so it
+#    is a new object every time by construction. A `janitor` or `sweep` may
+#    keep finding the same stale thing, which IS a recurrence.
+#
+# Nothing is ever silently dropped -- the report names what it set aside and
+# why, so a suppressed group stays auditable rather than invisible.
+
+#: Categories whose every firing addresses an object the previous roll created.
+#: Membership is a claim about the heal's SUBJECT, not about its importance.
+PER_ROLL_CATEGORIES = frozenset({"reset", "restore-reconcile"})
+
+
+def is_per_roll(category: str, instances: list[str] | None = None) -> bool:
+    """Is this group a per-roll artifact rather than a recurring defect?
+
+    `instances` is one entry PER RECORD in the group, in any order -- a list,
+    not a set, because the whole question is whether any object was healed
+    twice, and a set has already thrown that away.
+
+    When every firing named a different object the group is per-roll, whatever
+    category it came from: recorded fact beats the category heuristic. When two
+    firings name the SAME object it is a real recurrence, which is how a
+    genuinely stuck `reset` still gets surfaced despite its category.
+
+    Records with no instance are ignored for tier 1 rather than treated as a
+    shared blank, since "not recorded" is not evidence of sameness. If that
+    leaves fewer than two known instances there is nothing to compare, and the
+    category decides.
+    """
+    known = [i for i in (instances or []) if i]
+    if len(known) >= 2:
+        return len(set(known)) == len(known)
+    return category in PER_ROLL_CATEGORIES
+
+
 def heals_path(repo_root: Path | str) -> Path:
     return Path(repo_root) / "data" / "speedrun" / "telemetry" / HEALS_FILENAME
 
@@ -42,8 +115,21 @@ def record_heal(
     *,
     detail: str = "",
     run_tag: str = "",
+    instance: str = "",
 ) -> bool:
-    """Append one heal record. Returns False (never raises) on failure."""
+    """Append one heal record. Returns False (never raises) on failure.
+
+    `instance` names the OBJECT this heal touched, when the caller knows it --
+    the PR number a reset closed, the commit a file was preserved at. `target`
+    is the label ("#1", a per-issue artifact path) and is frequently stable
+    across runs by construction; the instance is what actually differs, and
+    recording it is what lets the recurrence report tell a per-roll artifact
+    from a recurring defect (#2269).
+
+    Optional on purpose. A caller that cannot name the instance honestly omits
+    it and the report falls back to the category rule, which is weaker but not
+    a guess dressed as data.
+    """
     try:
         path = heals_path(repo_root)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -55,6 +141,10 @@ def record_heal(
             "outcome": outcome,
             "detail": detail,
         }
+        if instance:
+            # Only when known: an empty key on every record would read as one
+            # shared instance and turn every group into a false recurrence.
+            record["instance"] = instance
         with path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record) + "\n")
         return True

--- a/tests/unit/test_healing_ledger.py
+++ b/tests/unit/test_healing_ledger.py
@@ -20,6 +20,7 @@ import speedrun_roll as sr  # noqa: E402
 
 from assemblyzero.speedrun.healing import (  # noqa: E402
     heals_path,
+    is_per_roll,
     read_heals,
     record_heal,
 )
@@ -92,7 +93,15 @@ class TestReport:
     def test_recurrence_across_three_runs_proposes_an_issue_stub(
         self, tmp_path, capsys
     ):
-        self._seed(tmp_path, ["run-a", "run-b", "run-c"])
+        # A category that can genuinely keep finding the same stale object.
+        # This fixture used to use `reset`, which #2269 reclassified as
+        # per-roll -- that exact fixture is the #2242 false alarm, and it now
+        # has its own test below.
+        for tag in ("run-a", "run-b", "run-c"):
+            record_heal(
+                tmp_path, "janitor", "stale-lockfile.json", "partial",
+                detail="could not remove", run_tag=tag,
+            )
 
         heal_report.main(["--repo", str(tmp_path)])
 
@@ -203,3 +212,142 @@ class TestEvidenceExemption:
         machinery, operator = classify_dirt(repo)
         assert machinery == [] and operator == []
         assert untracked_files(repo) == []
+
+
+class TestPerRollArtifactVsRecurringDefect:
+    """A stable target string is not a recurring object (#2269).
+
+    The two worked examples are the boostgauge signatures that were root-caused
+    to correct-by-design behaviour in #2242 and #2243. Both must stop proposing
+    an issue, and a genuine recurrence must keep proposing one -- suppressing a
+    real defect would be a worse failure than the noise it replaces.
+    """
+
+    def _run(self, tmp_path, capsys, recurrence=3):
+        heal_report.main(["--repo", str(tmp_path), "--recurrence", str(recurrence)])
+        return capsys.readouterr().out
+
+    # -- the two worked examples ------------------------------------------
+    def test_the_2242_signature_proposes_nothing(self, tmp_path, capsys):
+        """reset healed '#1' in 9 distinct runs -- nine DIFFERENT LLD PRs."""
+        for n in range(9):
+            record_heal(tmp_path, "reset", "#1", "healed",
+                        detail="base clean after self-heal", run_tag=f"run-{n}")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "TITLE:" not in out, (
+            "the #2242 signature still proposes an issue -- this is the false "
+            "alarm #2269 exists to remove"
+        )
+        assert "Set aside as per-roll artifacts" in out
+        assert "reset: '#1' in 9 runs" in out
+
+    def test_the_2243_signature_proposes_nothing(self, tmp_path, capsys):
+        """restore-reconcile healed a per-issue LLD path in 5 distinct runs."""
+        for n in range(5):
+            record_heal(
+                tmp_path, "restore-reconcile", "docs/lld/active/LLD-001.md",
+                "healed", detail="preserved-and-cleared", run_tag=f"run-{n}",
+            )
+
+        out = self._run(tmp_path, capsys)
+
+        assert "TITLE:" not in out
+        assert "restore-reconcile: 'docs/lld/active/LLD-001.md' in 5 runs" in out
+
+    # -- the case the report was built for, which must survive -------------
+    def test_a_genuine_recurrence_still_proposes_an_issue(self, tmp_path, capsys):
+        for n in range(4):
+            record_heal(tmp_path, "sweep", "orphaned-worktree", "partial",
+                        detail="could not remove", run_tag=f"run-{n}")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "TITLE: fix: the machinery keeps healing" in out
+        assert "'orphaned-worktree' (sweep)" in out
+
+    # -- instance beats category, in both directions -----------------------
+    def test_a_repeated_instance_fires_even_for_a_per_roll_category(
+        self, tmp_path, capsys
+    ):
+        """The same object healed run after run IS a defect, whatever the
+        category says. Recorded fact outranks the heuristic."""
+        for n in range(4):
+            record_heal(tmp_path, "reset", "#1", "partial",
+                        detail="same PR again", run_tag=f"run-{n}",
+                        instance="PR-244")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "TITLE: fix: the machinery keeps healing" in out, (
+            "a reset that keeps failing on the SAME pull request is a real "
+            "recurrence and must not be set aside by its category"
+        )
+
+    def test_distinct_instances_are_per_roll_even_for_a_recurring_category(
+        self, tmp_path, capsys
+    ):
+        for n in range(4):
+            record_heal(tmp_path, "janitor", "docs/lld/active/LLD-001.md",
+                        "healed", run_tag=f"run-{n}", instance=f"emission-{n}")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "TITLE:" not in out
+        assert "4 distinct recorded instances" in out
+
+    # -- nothing is hidden -------------------------------------------------
+    def test_a_set_aside_group_is_still_named_with_its_reason(
+        self, tmp_path, capsys
+    ):
+        for n in range(3):
+            record_heal(tmp_path, "reset", "#7", "healed", run_tag=f"run-{n}")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "Set aside as per-roll artifacts" in out
+        assert "heals the previous roll's leavings" in out
+        assert "is_per_roll" in out, (
+            "the report must point at where the rule lives, so a reader who "
+            "disagrees knows what to argue with"
+        )
+
+    def test_below_threshold_is_not_reported_as_set_aside(self, tmp_path, capsys):
+        """Set-aside is about groups that DID recur. A group under the
+        threshold was never a candidate and must not appear."""
+        for n in range(2):
+            record_heal(tmp_path, "reset", "#9", "healed", run_tag=f"run-{n}")
+
+        out = self._run(tmp_path, capsys)
+
+        assert "Set aside" not in out
+        assert "nothing proposes an issue" in out
+
+
+class TestIsPerRollDirectly:
+    """The rule itself, away from the report's rendering."""
+
+    def test_no_instances_falls_back_to_category(self):
+        assert is_per_roll("reset", []) is True
+        assert is_per_roll("restore-reconcile", []) is True
+        assert is_per_roll("janitor", []) is False
+        assert is_per_roll("sweep", []) is False
+
+    def test_one_known_instance_is_not_enough_to_compare(self):
+        # A single data point cannot show sameness or difference.
+        assert is_per_roll("janitor", ["only-one"]) is False
+        assert is_per_roll("reset", ["only-one"]) is True
+
+    def test_blank_instances_are_not_treated_as_a_shared_object(self):
+        """"Not recorded" is not evidence of sameness -- otherwise every
+        legacy record would collapse into one instance and read as a
+        recurrence."""
+        assert is_per_roll("reset", ["", "", ""]) is True
+        assert is_per_roll("janitor", ["", "", ""]) is False
+
+    def test_all_distinct_is_per_roll(self):
+        assert is_per_roll("janitor", ["a", "b", "c"]) is True
+
+    def test_any_repeat_is_a_recurrence(self):
+        assert is_per_roll("reset", ["a", "b", "a"]) is False

--- a/tools/heal_report.py
+++ b/tools/heal_report.py
@@ -23,7 +23,11 @@ from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from assemblyzero.speedrun.healing import heals_path, read_heals  # noqa: E402
+from assemblyzero.speedrun.healing import (  # noqa: E402
+    heals_path,
+    is_per_roll,
+    read_heals,
+)
 
 
 def render_report(records: list[dict], recurrence: int) -> str:
@@ -52,17 +56,34 @@ def render_report(records: list[dict], recurrence: int) -> str:
 
     # Cross-run recurrence: the same category+target healed again and again
     # is a defect wearing a bandage.
+    #
+    # ...unless the target is merely a stable LABEL for an object each roll
+    # re-creates, which is the ordinary condition of a hardening campaign that
+    # rolls one issue repeatedly (#2269). `is_per_roll` carries that rule and
+    # states its evidence; the two tiers are instance-first, category-second.
+    # Groups it sets aside are reported below rather than dropped, so the
+    # reader can see what was judged and disagree.
     runs_by_key: dict[tuple, set] = defaultdict(set)
     detail_by_key: dict[tuple, str] = {}
+    instances_by_key: dict[tuple, list[str]] = defaultdict(list)
     for r in records:
         key = (r.get("category"), r.get("target"))
         runs_by_key[key].add(r.get("run_tag") or r.get("ts"))
         detail_by_key[key] = r.get("detail", "")
+        instances_by_key[key].append(r.get("instance", "") or "")
 
-    stubs = [
+    recurring = [
         (key, runs)
         for key, runs in runs_by_key.items()
         if len(runs) >= recurrence
+    ]
+    stubs = [
+        (key, runs) for key, runs in recurring
+        if not is_per_roll(key[0], instances_by_key[key])
+    ]
+    set_aside = [
+        (key, runs) for key, runs in recurring
+        if is_per_roll(key[0], instances_by_key[key])
     ]
     if stubs:
         lines.append(
@@ -88,6 +109,26 @@ def render_report(records: list[dict], recurrence: int) -> str:
             f"No heal recurs across {recurrence}+ runs -- nothing proposes "
             "an issue."
         )
+
+    # Never a silent cap: a group held back is named, with the reason, so the
+    # judgement is auditable and a wrong call is visible rather than absent.
+    if set_aside:
+        lines.append("")
+        lines.append(
+            f"Set aside as per-roll artifacts (recurred across >= {recurrence} "
+            "runs, but each firing addressed a fresh object -- see is_per_roll "
+            "in assemblyzero/speedrun/healing.py):"
+        )
+        for (category, target), runs in sorted(set_aside, key=lambda s: -len(s[1])):
+            known = [i for i in instances_by_key[(category, target)] if i]
+            basis = (
+                f"{len(set(known))} distinct recorded instances"
+                if len(known) >= 2
+                else f"category '{category}' heals the previous roll's leavings"
+            )
+            lines.append(
+                f"  {category}: '{target}' in {len(runs)} runs -- {basis}"
+            )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
Closes #2269

The post-roll heal report is the instrument the roll is read with. It was proposing issues for correct behaviour, and both of its live examples had already been investigated to root cause and come back clean.

## Why the grouping was wrong

The report grouped by `category+target` and proposed a stub when a group spanned enough runs. A target string is a **label**; a recurrence is about the **object**. In a hardening campaign that rolls one issue repeatedly, the label is stable by construction — it is derived from the issue number — so the ordinary condition looked identical to a defect.

| stub it produced | what it actually was |
|---|---|
| `reset` healed `'#1'` in 9 runs | nine **different** LLD PRs, each opened by one roll and correctly closed by the next launch (#2242) |
| `restore-reconcile` healed `docs/lld/active/LLD-001.md` in 5 runs | five **different** emissions of that path, each correctly preserved and cleared (#2243) |

## The rule

Two tiers, strongest first, both stated in `healing.py` beside `CATEGORIES` with the measured evidence.

**1. Instance.** `record_heal` takes an optional `instance` naming the object a heal touched. Different objects across runs → per-roll. The same object twice → a real recurrence. Recorded fact outranks the category **in both directions**: a `reset` that keeps failing on the *same* PR still proposes an issue, which is the case a pure category rule would have buried.

Optional on purpose — a caller that cannot name the instance omits it rather than guessing. It is written only when non-empty, because a blank on every record would read as one shared object and turn every group into a false recurrence.

**2. Category.** Existing records carry no instance and back-filling one would be fabrication. For those the category decides: `reset` and `restore-reconcile` address whatever the previous roll left — a fresh object each time — while `janitor` and `sweep` may keep finding the same stale thing.

## Nothing is suppressed silently

A set-aside group is printed with its run count and the basis for the judgement, and names `is_per_roll` so a reader who disagrees knows where to argue. Groups below the threshold are not listed — they were never candidates, and reporting them would recreate the noise from the other end.

## Verified on live data

Against boostgauge's real ledger (18 records):

```
No heal recurs across 3+ runs -- nothing proposes an issue.

Set aside as per-roll artifacts (recurred across >= 3 runs, but each firing
addressed a fresh object -- see is_per_roll in assemblyzero/speedrun/healing.py):
  reset: '#1' in 9 runs -- category 'reset' heals the previous roll's leavings
  restore-reconcile: 'docs/lld/active/LLD-001.md' in 5 runs -- category ...
```

**Falsified, not assumed.** Neutralising `is_per_roll` against the same ledger brings back exactly the two stubs the issue names:

```
WITH the rule:    stubs proposed: 0
WITHOUT the rule: stubs proposed: 2
   TITLE: fix: the machinery keeps healing '#1' (reset) -- 9 runs
   TITLE: fix: the machinery keeps healing 'docs/lld/active/LLD-001.md' (restore-reconcile) -- 5 runs
```

## One existing test changed meaning

`test_recurrence_across_three_runs_proposes_an_issue_stub` was seeded with a `reset` on a per-issue lineage path — which is precisely the #2242 signature. Under the new rule that fixture correctly stops proposing an issue, so the test now uses a category that can genuinely recur, and the old fixture became the suppression test. Calling this out because it is a test whose expected outcome was inverted, not a cosmetic edit.

## Acceptance

| Criterion | Where |
|---|---|
| distinguishes by instance rather than target string | `is_per_roll`, tier 1 |
| #2242 and #2243 signatures no longer stub | `test_the_2242_signature_proposes_nothing`, `test_the_2243_signature_proposes_nothing` |
| a genuine recurrence still stubs | `test_a_genuine_recurrence_still_proposes_an_issue`, `test_a_repeated_instance_fires_even_for_a_per_roll_category` |
| the rule is stated where it is defined | `healing.py` block comment; report points readers at it |

Suite: 7185 passed, 17 skipped, 5 xfailed. `ruff` clean on all three files.
