### PR TITLE
fix: raise the requirements gate's budget, retry once, and say when it did not run (Closes #2290)

### DIFF
--- a/assemblyzero/speedrun/requirements_status.py
+++ b/assemblyzero/speedrun/requirements_status.py
@@ -1,0 +1,123 @@
+"""Whether the requirements gate actually ran, recorded where the roll can see it (#2290).
+
+The requirements-consistency gate fails open by design: a provider storm must not
+brick a launch (#1899). That policy is right and is unchanged here. What was wrong
+is that failing open was *silent* -- it printed one warning line mid-run and the
+roll then reported exactly like a roll whose requirements had been checked and
+found clean. Those are materially different outcomes and looked identical from
+the outside.
+
+Measured on boostgauge #7, 2026-08-12/13: the same call timed out at 300s on one
+attempt and returned a real CONFLICT verdict in 294s on the next. Inside a roll,
+the first outcome would have carried the issue past a conflict the gate
+demonstrably finds -- and the operator would have read "ROLL SUCCEEDED".
+
+This module is the crossing point. The gate runs inside the LLD sub-workflow,
+which the launcher spawns as a child process, so a state flag cannot reach the
+verdict block. A small append-only ledger can, and it is the same shape the
+launcher already reads for filed questions and heals.
+
+Lives under ``data/speedrun/telemetry/``, structurally exempt from every janitor
+per standard 0027. Recording never raises: a ledger problem must never cost a
+roll, and least of all this one -- the record exists precisely because the run is
+already degraded.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+UNVERIFIED_FILENAME = "requirements-unverified.jsonl"
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def unverified_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / "data" / "speedrun" / "telemetry" / UNVERIFIED_FILENAME
+
+
+def record_unverified(
+    repo_root: Path | str,
+    *,
+    issue: int | None,
+    reason: str,
+    run_id: str = "",
+    ts: str | None = None,
+) -> bool:
+    """Record that a run proceeded WITHOUT a requirements verdict.
+
+    `reason` is the operator-facing explanation, not a stack trace: it is
+    printed verbatim under the banner, so it must say what did not happen.
+    """
+    try:
+        path = unverified_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "ts": ts or datetime.now().strftime(_TS_FMT),
+                "issue": int(issue) if issue else None,
+                "reason": reason or "",
+                "run_id": run_id or "",
+            }) + "\n")
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def read_unverified(repo_root: Path | str, since: str = "") -> list[dict]:
+    """Every record, or only those at/after `since` (a "%Y-%m-%d %H:%M:%S" stamp).
+
+    Corrupt lines are skipped rather than fatal, for the same reason the heal
+    ledger skips them: one bad line must cost one entry, not the file.
+
+    The `since` comparison is lexicographic, which is exact for this fixed-width
+    format and avoids a parse that could raise inside a reporting path.
+    """
+    path = unverified_path(repo_root)
+    if not path.exists():
+        return []
+    out: list[dict] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        if since and str(record.get("ts", "")) < since:
+            continue
+        out.append(record)
+    return out
+
+
+def format_banner(records: list[dict]) -> list[str]:
+    """The operator-facing banner, as lines. Empty list when nothing to say.
+
+    Deliberately loud and deliberately first-person about what was NOT done.
+    "Requirements were not checked on this run" is the sentence that has to
+    survive being skimmed at 3am.
+    """
+    if not records:
+        return []
+    lines = [
+        "",
+        "  !! REQUIREMENTS UNVERIFIED -- the consistency gate did not return a "
+        "verdict.",
+        "     The run proceeded anyway (the gate fails open so a provider storm "
+        "cannot brick a launch),",
+        "     so this is NOT the same as a clean requirements check. Nothing "
+        "about the issue text was verified.",
+    ]
+    for r in records:
+        issue = f"#{r['issue']}" if r.get("issue") else "(issue unknown)"
+        lines.append(f"       - {issue}: {r.get('reason', '') or 'no reason recorded'}")
+    lines.append(
+        "     Next step: re-run `tools/check_requirements.py --repo <repo> "
+        "--issue <N>` before trusting this roll."
+    )
+    return lines

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -28,6 +28,12 @@ Fail-open by design: this gate is protective, not load-bearing. If the
 analysis call itself fails (provider storm, parse noise), the workflow
 proceeds to drafting with a printed warning rather than dying in a
 pre-flight check.
+
+Failing open is not the same as failing silently (#2290). Every path that
+proceeds without a verdict records that fact where the roll's verdict block
+and the operator summary will print it, because "requirements were not
+checked" and "requirements were checked and were clean" are different roll
+outcomes that used to look identical from the outside.
 """
 
 from __future__ import annotations
@@ -36,6 +42,20 @@ import json
 from typing import Any
 
 REQUIREMENTS_CONFLICT_MARKER = "REQUIREMENTS CONFLICT:"
+
+#: Wall-clock budget for the single analysis call.
+#:
+#: #2290, operator ruling. The previous bound was the provider default of 300s.
+#: Measured on boostgauge #7 -- two decision tables, 21 acceptance criteria,
+#: near the top of the size distribution this gate sees -- the same call timed
+#: out at 300s on one attempt and returned a real CONFLICT verdict in 294s on
+#: the next. Six seconds of margin, on opposite sides of the bound, minutes
+#: apart, with a healthy transport throughout.
+#:
+#: 600s is sized to clear that measurement with room for a longer issue rather
+#: than to sit just above it. Duration scales with issue size and the bound is a
+#: constant, so the next issue with three tables must not re-open this.
+REQUIREMENTS_GATE_TIMEOUT_SECONDS = 600
 
 ANALYSIS_SYSTEM_PROMPT = """\
 You are a requirements analyst performing a pre-flight consistency check \
@@ -125,6 +145,66 @@ def _parse_analysis(raw: str) -> dict | None:
     return parsed
 
 
+def _is_timeout(result: Any) -> bool:
+    """Did this call fail by exceeding its budget, as opposed to any other way?
+
+    Keyed off the message the provider layer writes ("claude -p timed out after
+    Ns", "agy spawn timed out") rather than an exception type, because the
+    provider returns a result object instead of raising.
+    """
+    if getattr(result, "success", False):
+        return False
+    return "timed out" in (getattr(result, "error_message", "") or "").lower()
+
+
+def _provider_storm_active() -> bool:
+    """Is the provider in a storm right now? False if the counter is unavailable.
+
+    Unavailable means we cannot prove a storm, and the retry is the cheaper
+    error in that direction: one extra call, versus never retrying because a
+    telemetry import failed.
+    """
+    try:
+        from assemblyzero.core import provider_storm
+
+        return bool(provider_storm.is_storm())
+    except Exception:  # noqa: BLE001 - a storm probe must not break the gate
+        return False
+
+
+def _record_unverified(state: dict, reason: str) -> None:
+    """Record a fail-open so the roll can say so. Never raises (#2290).
+
+    Recorded on EVERY path that proceeds without a verdict, not only on the
+    exhausted retry: an unparseable response and an invalid provider leave the
+    requirements exactly as unchecked as a timeout does, and the operator's
+    question is "were they checked", not "which way did the check fail".
+
+    Not recorded for the standalone pre-check, which is not a roll: it reports
+    its own failure with a non-zero exit and its own report, and a record
+    written there would sit in the ledger waiting to mislabel some later roll.
+    """
+    if state.get("standalone_precheck"):
+        return
+
+    try:
+        from assemblyzero.speedrun.must_resolve import run_context
+        from assemblyzero.speedrun.requirements_status import record_unverified
+
+        try:
+            run_id, _ = run_context()
+        except Exception:  # noqa: BLE001
+            run_id = ""
+        record_unverified(
+            state.get("target_repo") or ".",
+            issue=int(state.get("issue_number") or 0) or None,
+            reason=reason,
+            run_id=run_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - never costs the run
+        print(f"  [N0c] WARNING: could not record the unverified state: {exc}")
+
+
 def analyze_requirements(state: dict) -> dict[str, Any]:
     """N0c node body. Returns {} to proceed, or error_message to halt."""
     if state.get("config_mock_mode"):
@@ -145,6 +225,7 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
         provider = get_provider(drafter_spec)
     except ValueError as e:
         print(f"  [N0c] WARNING: analysis skipped (invalid provider: {e})")
+        _record_unverified(state, f"invalid provider '{drafter_spec}': {e}")
         return {}
 
     schema_kwargs: dict[str, Any] = {}
@@ -154,23 +235,40 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
         schema_kwargs["json_schema"] = ANALYSIS_SCHEMA
 
     content = f"# Issue: {issue_title}\n\n{issue_body}"
-    result = provider.invoke(
-        system_prompt=ANALYSIS_SYSTEM_PROMPT,
-        content=content,
-        **schema_kwargs,
-    )
+
+    def _invoke():
+        return provider.invoke(
+            system_prompt=ANALYSIS_SYSTEM_PROMPT,
+            content=content,
+            timeout_seconds=REQUIREMENTS_GATE_TIMEOUT_SECONDS,
+            **schema_kwargs,
+        )
+
+    result = _invoke()
+
+    # One retry, and only for a timeout on a healthy transport (#2290). A
+    # storm is the condition fail-open exists for -- retrying into it burns
+    # another full budget to reach the same wall, which is what the storm
+    # counter was built to stop (#2086). A non-timeout failure is not retried
+    # either: it failed for a reason a second identical call will not change.
+    if _is_timeout(result) and not _provider_storm_active():
+        print(
+            f"  [N0c] analysis timed out at {REQUIREMENTS_GATE_TIMEOUT_SECONDS}s "
+            "and the transport is healthy -- retrying once."
+        )
+        result = _invoke()
 
     # Fail-open: a dead analysis call must not kill the roll (#1899).
     if not result.success or not result.response:
-        print(
-            f"  [N0c] WARNING: analysis unavailable "
-            f"({result.error_message or 'empty response'}); proceeding."
-        )
+        reason = result.error_message or "empty response"
+        print(f"  [N0c] WARNING: analysis unavailable ({reason}); proceeding.")
+        _record_unverified(state, f"analysis unavailable: {reason}")
         return {}
 
     parsed = _parse_analysis(result.response)
     if parsed is None:
         print("  [N0c] WARNING: analysis response unparseable; proceeding.")
+        _record_unverified(state, "analysis response was unparseable")
         return {}
 
     conflicts = parsed.get("conflicts") or []

--- a/assemblyzero/workflows/requirements/precheck.py
+++ b/assemblyzero/workflows/requirements/precheck.py
@@ -233,6 +233,10 @@ def run_gate(
         "issue_number": issue_number,
         "target_repo": str(repo),
         "config_drafter": drafter,
+        # #2290: this run's failure is reported by its own exit code and
+        # report. Writing a roll-scoped unverified record here would leave a
+        # line in the ledger that mislabels whichever roll happens to run next.
+        "standalone_precheck": True,
     }
 
     capture = io.StringIO()

--- a/tests/unit/test_requirements_gate_timeout.py
+++ b/tests/unit/test_requirements_gate_timeout.py
@@ -1,0 +1,311 @@
+"""The requirements gate's budget, its one retry, and saying so out loud (#2290).
+
+The gate fails open by design so a provider storm cannot brick a launch (#1899),
+and that policy is unchanged. What changed is that failing open is no longer
+silent: a run that proceeded without a verdict says so in the roll's verdict
+block and in the orchestrator summary, because "requirements were not checked"
+and "requirements were checked and were clean" used to look identical.
+
+The measured case is boostgauge #7 -- two decision tables, 21 acceptance
+criteria -- which timed out at the old 300s bound on one attempt and returned a
+real CONFLICT verdict in 294s on the next, minutes apart, transport healthy
+throughout.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.core.llm_provider import LLMCallResult  # noqa: E402
+from assemblyzero.speedrun.requirements_status import (  # noqa: E402
+    format_banner,
+    read_unverified,
+    record_unverified,
+    unverified_path,
+)
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (  # noqa: E402
+    REQUIREMENTS_GATE_TIMEOUT_SECONDS,
+    analyze_requirements,
+)
+
+#: What the gate's own call actually took on boostgauge #7, wall clock.
+MEASURED_ISSUE_7_SECONDS = 294
+
+CONSISTENT = '{"is_consistent": true, "conflicts": []}'
+
+
+def _result(success, response, error=None):
+    return LLMCallResult(
+        success=success, response=response, raw_response=response,
+        error_message=error, provider="fake", model_used="fake-model",
+        duration_ms=1, attempts=1,
+    )
+
+
+class _Provider:
+    """Returns a scripted sequence, one entry per call."""
+
+    def __init__(self, *results):
+        self._results = list(results)
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._results[min(len(self.calls) - 1, len(self._results) - 1)]
+
+
+TIMEOUT = _result(False, None, "claude -p timed out after 600s")
+OK = _result(True, CONSISTENT)
+OTHER_FAILURE = _result(False, None, "400 invalid request")
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    def _install(*results):
+        p = _Provider(*results)
+        monkeypatch.setattr(
+            "assemblyzero.core.llm_provider.get_provider",
+            lambda spec, *a, **k: p,
+        )
+        return p
+
+    return _install
+
+
+@pytest.fixture
+def calm(monkeypatch):
+    """A healthy transport: no provider storm in progress."""
+    monkeypatch.setattr("assemblyzero.core.provider_storm.is_storm", lambda: False)
+
+
+@pytest.fixture
+def storm(monkeypatch):
+    monkeypatch.setattr("assemblyzero.core.provider_storm.is_storm", lambda: True)
+
+
+def _state(tmp_path, **over):
+    base = {
+        "issue_title": "feat: config persistence",
+        "issue_body": "The app shall persist window position on exit.",
+        "issue_number": 7,
+        "target_repo": str(tmp_path),
+        "config_drafter": "fake:model",
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The budget
+# ---------------------------------------------------------------------------
+
+
+class TestTheBudget:
+    def test_the_measured_issue_7_call_fits_within_budget(self):
+        """The regression fixture. 294s must not be near the bound again.
+
+        This is the whole defect in one assertion: the old 300s bound sat six
+        seconds above the real duration, so the same call landed on either side
+        of it depending on the minute.
+        """
+        assert MEASURED_ISSUE_7_SECONDS < REQUIREMENTS_GATE_TIMEOUT_SECONDS
+        margin = REQUIREMENTS_GATE_TIMEOUT_SECONDS - MEASURED_ISSUE_7_SECONDS
+        assert margin >= MEASURED_ISSUE_7_SECONDS, (
+            f"only {margin}s of headroom above the measured {MEASURED_ISSUE_7_SECONDS}s. "
+            "Duration scales with issue size and the bound is a constant, so a "
+            "margin thinner than the measurement itself will be spent by the "
+            "next issue with three tables."
+        )
+
+    def test_the_gate_asks_for_its_own_bound_not_the_provider_default(
+        self, tmp_path, provider, calm
+    ):
+        p = provider(OK)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert p.calls[0]["timeout_seconds"] == REQUIREMENTS_GATE_TIMEOUT_SECONDS
+
+    def test_the_standalone_precheck_measures_the_same_thing(self, tmp_path, provider, calm):
+        """The offline pre-check runs the same node, so a clean pass there
+        means what it means in a roll. Pinned because the two drifting apart
+        is exactly what makes a pre-check worthless."""
+        from assemblyzero.workflows.requirements import precheck
+
+        p = provider(OK)
+        precheck.run_gate(tmp_path, 7, "t", "The app shall persist state.")
+
+        assert p.calls[0]["timeout_seconds"] == REQUIREMENTS_GATE_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# The one retry
+# ---------------------------------------------------------------------------
+
+
+class TestTheRetry:
+    def test_a_timeout_on_a_healthy_transport_retries_once(
+        self, tmp_path, provider, calm
+    ):
+        p = provider(TIMEOUT, OK)
+
+        result = analyze_requirements(_state(tmp_path))
+
+        assert len(p.calls) == 2, "a healthy-transport timeout must be retried once"
+        assert result == {}, "the retry succeeded, so the gate proceeds normally"
+
+    def test_it_retries_only_once(self, tmp_path, provider, calm):
+        p = provider(TIMEOUT)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert len(p.calls) == 2, "one retry, not a loop"
+
+    def test_a_storm_is_not_retried_into(self, tmp_path, provider, storm):
+        """The storm is the condition fail-open exists for. Retrying burns
+        another full budget to reach the same wall (#2086)."""
+        p = provider(TIMEOUT)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert len(p.calls) == 1
+
+    def test_a_non_timeout_failure_is_not_retried(self, tmp_path, provider, calm):
+        p = provider(OTHER_FAILURE)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert len(p.calls) == 1, (
+            "it failed for a reason an identical second call will not change"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Saying so
+# ---------------------------------------------------------------------------
+
+
+class TestItSaysSoWhenItDidNotRun:
+    def test_an_exhausted_retry_records_the_unverified_state(
+        self, tmp_path, provider, calm
+    ):
+        provider(TIMEOUT)
+
+        analyze_requirements(_state(tmp_path))
+
+        records = read_unverified(tmp_path)
+        assert len(records) == 1
+        assert records[0]["issue"] == 7
+        assert "timed out" in records[0]["reason"]
+
+    def test_an_unparseable_response_records_it_too(self, tmp_path, provider, calm):
+        provider(_result(True, "not json at all"))
+
+        analyze_requirements(_state(tmp_path))
+
+        records = read_unverified(tmp_path)
+        assert len(records) == 1 and "unparseable" in records[0]["reason"]
+
+    def test_a_verdict_records_nothing(self, tmp_path, provider, calm):
+        provider(OK)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert read_unverified(tmp_path) == []
+        assert not unverified_path(tmp_path).exists()
+
+    def test_the_standalone_precheck_does_not_write_roll_records(
+        self, tmp_path, provider, calm
+    ):
+        """Its own exit code is the signal. A record here would sit in the
+        ledger waiting to mislabel whichever roll runs next."""
+        from assemblyzero.workflows.requirements import precheck
+
+        provider(TIMEOUT)
+        precheck.run_gate(tmp_path, 7, "t", "The app shall persist state.")
+
+        assert read_unverified(tmp_path) == []
+
+    def test_recording_never_raises(self, tmp_path):
+        blocker = tmp_path / "data"
+        blocker.write_text("not a directory", encoding="utf-8")
+        assert record_unverified(tmp_path, issue=7, reason="x") is False
+
+    def test_since_filters_older_records(self, tmp_path):
+        record_unverified(tmp_path, issue=1, reason="old", ts="2026-08-01 00:00:00")
+        record_unverified(tmp_path, issue=2, reason="new", ts="2026-08-13 00:00:00")
+
+        recent = read_unverified(tmp_path, since="2026-08-12 00:00:00")
+
+        assert [r["issue"] for r in recent] == [2]
+
+
+class TestTheBanner:
+    def test_no_records_says_nothing(self):
+        assert format_banner([]) == []
+
+    def test_the_banner_names_the_state_and_the_issue(self):
+        lines = format_banner([{"issue": 7, "reason": "analysis unavailable: timed out"}])
+        text = "\n".join(lines)
+
+        assert "REQUIREMENTS UNVERIFIED" in text
+        assert "#7" in text
+        assert "timed out" in text
+        assert "NOT the same as a clean requirements check" in text
+
+
+class TestTheVerdictBlockCarriesIt:
+    def _verdict(self, capsys, repo, **over):
+        kwargs = dict(
+            requested=[7], rolled=[7], blocked=[], stopped_at=None, code=0, since="",
+        )
+        kwargs.update(over)
+        sr._render_verdict(repo, **kwargs)
+        return capsys.readouterr().out
+
+    def test_a_successful_roll_still_reports_unverified_requirements(
+        self, tmp_path, capsys
+    ):
+        """The case that matters. A roll whose gate failed open used to print
+        an unqualified ROLL SUCCEEDED and read exactly like a verified run."""
+        record_unverified(tmp_path, issue=7, reason="analysis unavailable: timed out")
+
+        out = self._verdict(capsys, tmp_path)
+
+        assert "ROLL SUCCEEDED" in out
+        assert "REQUIREMENTS UNVERIFIED" in out
+
+    def test_a_clean_roll_says_nothing_extra(self, tmp_path, capsys):
+        out = self._verdict(capsys, tmp_path)
+
+        assert "ROLL SUCCEEDED" in out
+        assert "REQUIREMENTS UNVERIFIED" not in out
+
+    def test_a_failed_roll_carries_it_too(self, tmp_path, capsys):
+        record_unverified(tmp_path, issue=7, reason="analysis unavailable: timed out")
+
+        out = self._verdict(capsys, tmp_path, rolled=[], stopped_at=7, code=1)
+
+        assert "ROLL FAILED" in out
+        assert "REQUIREMENTS UNVERIFIED" in out
+
+    def test_an_unreadable_ledger_never_costs_the_verdict(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        def _boom(*a, **k):
+            raise OSError("ledger unreadable")
+
+        monkeypatch.setattr(
+            "assemblyzero.speedrun.requirements_status.read_unverified", _boom
+        )
+
+        out = self._verdict(capsys, tmp_path)
+
+        assert "ROLL SUCCEEDED" in out

--- a/tools/check_requirements.py
+++ b/tools/check_requirements.py
@@ -9,9 +9,14 @@ defect in an edit is found while the editor still holds the context.
     poetry run python tools/check_requirements.py \\
         --repo /c/Users/mcwiz/Projects/boostgauge --issue 7
 
-The call costs one drafter-class model request (roughly 200 seconds). What it
-saves is the launch around it: the codebase-analysis node, the blocked
-launcher, the filed issues, and the operator round-trip.
+The call costs one drafter-class model request. Measured on boostgauge #7 --
+two decision tables, 21 acceptance criteria -- it took 294 seconds; the budget
+is 600 with one retry on a timeout, so allow up to about twenty minutes in the
+worst case before concluding it has hung (#2290). It runs the SAME node the
+roll runs, with the same bound, so a clean pass here means what it means there.
+
+What the call saves is the launch around it: the codebase-analysis node, the
+blocked launcher, the filed issues, and the operator round-trip.
 
 Exit codes:
     0  clean    -- the gate ran and found no contradictions

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -209,6 +209,12 @@ Examples:
             )
             print("=" * 58 + "\n")
             sys.exit(2)
+    # #2290: stamped before any stage runs, so the unverified-requirements
+    # banner below reports only what THIS invocation recorded.
+    from datetime import datetime as _dt
+
+    orchestration_started_at = _dt.now().strftime("%Y-%m-%d %H:%M:%S")
+
     if args.dry_run:
         print("[ORCHESTRATOR] DRY RUN -- no stages will execute")
     if args.resume_from:
@@ -230,6 +236,24 @@ Examples:
         from assemblyzero.workflows.orchestrator.graph import format_stage_table
         print()
         print(format_stage_table(result["stage_results"]))
+
+        # #2290: the stage table says which stages passed, not whether the
+        # requirements were ever checked. A gate that failed open leaves every
+        # stage green, so without this the summary reads as a fully verified
+        # run. Scoped to this invocation's start so an older record cannot
+        # re-flag a clean run.
+        try:
+            from assemblyzero.speedrun.requirements_status import (
+                format_banner,
+                read_unverified,
+            )
+
+            for line in format_banner(
+                read_unverified(target_repo, since=orchestration_started_at)
+            ):
+                print(line)
+        except Exception:  # noqa: BLE001 - the summary always prints
+            pass
 
         if result["success"]:
             print(f"\n[ORCHESTRATOR] All stages passed.")

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -2205,8 +2205,31 @@ def _blocking_questions(repo_root, since: str) -> tuple[list[dict], str | None]:
     return merge_questions(live or [], recorded), gh_error
 
 
+def _requirements_unverified_lines(repo_root, since: str) -> list[str]:
+    """The REQUIREMENTS UNVERIFIED banner for this batch, or no lines (#2290).
+
+    Read from the ledger rather than from run state: the gate executes inside a
+    child process, so its warning cannot otherwise reach this block. Never
+    raises -- the verdict must print even if the ledger cannot be read.
+    """
+    try:
+        from assemblyzero.speedrun.requirements_status import (
+            format_banner,
+            read_unverified,
+        )
+
+        return format_banner(read_unverified(repo_root, since=since))
+    except Exception:  # noqa: BLE001 - the verdict always prints
+        return []
+
+
 def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, since=""):
     names = ", ".join(f"#{i}" for i in rolled) or "none"
+    # #2290: computed before the branches so no verdict path can omit it. The
+    # SUCCEEDED branch is the one that matters -- a roll whose requirements were
+    # never checked used to print an unqualified success and read exactly like
+    # a roll that had been checked and was clean.
+    unverified = _requirements_unverified_lines(repo_root, since)
     print()
     if blocked:
         blocked_names = ", ".join(f"#{i}" for i in blocked)
@@ -2286,6 +2309,12 @@ def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, sin
             "  Next step: hand an agent runbook 0952 section Inspect; the "
             "events logs say where it died."
         )
+
+    # #2290: last, so it is the final thing on screen -- the operator's eye
+    # lands at the bottom, which is the same reason the verdict itself moved
+    # here (#2165). Prints on every branch, success included.
+    for line in unverified:
+        print(line)
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Closes #2290

Implements the operator ruling in three parts: raise the bound, retry once on a healthy transport, and make a fail-open loud instead of silent.

## The measurement this is sized against

boostgauge #7 — two decision tables, 21 acceptance criteria, near the top of the size distribution this gate sees:

| Attempt | Duration | Outcome |
|---|---|---|
| 1 | timed out at 300s | `ERROR -- no verdict. Nothing about this issue was verified.` |
| 2 | **294s** | `CONFLICT` — with the conflicting pair named |

Six seconds of margin, same issue, same machine, minutes apart. `claude -p` returned a trivial prompt in 8.9s immediately before attempt 2, so the transport was healthy — the call genuinely takes about five minutes and the bound sat just above it.

## 1. Budget

`REQUIREMENTS_GATE_TIMEOUT_SECONDS = 600`, named in the node so both callers share one number.

Sized to clear the measurement **with room**, not to sit above it. Duration scales with issue size and the bound is a constant, so the next issue with three tables must not reopen this. The test pins the margin against the measured 294s rather than merely asserting an ordering:

```python
margin = REQUIREMENTS_GATE_TIMEOUT_SECONDS - MEASURED_ISSUE_7_SECONDS
assert margin >= MEASURED_ISSUE_7_SECONDS
```

## 2. Retry

One retry, and only for a **timeout on a healthy transport**.

- **Storm → no retry.** A storm is the condition fail-open exists for; retrying into it burns another full budget to reach the same wall, which is what the storm counter was built to stop (#2086).
- **Non-timeout failure → no retry.** It failed for a reason an identical second call will not change.

## 3. Saying so

Fail-open stays exactly as it was — a provider storm must not brick a launch (#1899). Failing **silently** does not.

Every path that proceeds without a verdict records it, and both operator-facing surfaces print:

```
  !! REQUIREMENTS UNVERIFIED -- the consistency gate did not return a verdict.
     The run proceeded anyway (the gate fails open so a provider storm cannot brick a launch),
     so this is NOT the same as a clean requirements check. Nothing about the issue text was verified.
       - #7: analysis unavailable: claude -p timed out after 600s
     Next step: re-run `tools/check_requirements.py --repo <repo> --issue <N>` before trusting this roll.
```

The banner is computed **before** the verdict's branches so no path can omit it, and printed last so it is the final thing on screen. The `ROLL SUCCEEDED` branch is the one that mattered: a roll whose gate failed open printed an unqualified success and read exactly like a verified run.

Recorded on **every** fail-open path, not only the exhausted retry — an unparseable response and an invalid provider leave the requirements as unchecked as a timeout does, and the operator's question is "were they checked", not "which way did the check fail". This is a superset of the directive and cannot hide anything the directive asked for.

**Why a ledger.** The gate runs inside a child process, so a state flag cannot reach the verdict block. The record is a small append-only JSONL under `data/speedrun/telemetry/`, the same shape the launcher already reads for filed questions and heals, and structurally janitor-exempt per standard 0027. It never raises, and an unreadable ledger cannot cost the verdict — pinned by a test.

## Same bound for the offline pre-check

`tools/check_requirements.py` runs the **same node** via `precheck.run_gate`, so it inherits the bound and the retry by construction. Pinned by a test, because the two drifting apart is precisely what would make a pre-check worthless.

It does **not** write roll-scoped records: its own non-zero exit is its signal, and a record written there would sit in the ledger waiting to mislabel whichever roll ran next. The stale "roughly 200 seconds" note in its docstring is corrected to the measured figure and the new worst case.

## Falsified, not assumed

| Reverted | Result |
|---|---|
| bound back to 300 | 1 failed — the margin test |
| retry removed | 2 failed |
| recording removed | 1 failed |
| banner dropped from the verdict | 2 failed |

All restore to 19 passed.

## Verification

Full unit suite **7204 passed**, 17 skipped, 5 xfailed. `ruff` reports the same 2 pre-existing findings in `orchestrate.py` before and after — none added.

## Not in scope

#2285, #2286, #2288 and #2289 are deferred until after the roll by operator decision and are untouched.
