### PR TITLE
fix: judge io-examples at the definition site and exempt test stubs (Closes #2302, Closes #2303)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -501,11 +501,63 @@ def check_data_structures_have_examples(spec: str) -> CompletenessCheck:
     )
 
 
-def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
-    """Every function must have input/output examples.
+#: Words that mark a region as stating a function's inputs or outputs.
+#:
+#: `expected` is here because it is what drafters actually write (#2302). Draft
+#: 008 of the 2026-08-13 boostgauge #7 roll documented every test stub as
+#: `-- expected: File contains "position": {"x": 250, "y": 350}` -- a concrete
+#: input and a concrete output, three characters from the signature, invisible
+#: to a vocabulary that did not include the word.
+_IO_WORDS = re.compile(
+    r"(?:input|output|returns?|result|example|usage|call|expected|asserts?)",
+    re.IGNORECASE,
+)
 
-    Scans the spec for function signatures and verifies each has at least
-    one concrete input/output example showing actual values.
+_CONCRETE_VALUES = re.compile(r'(?:\d+|"[^"]+"|True|False|None|\[.*\]|\{.*\})')
+
+#: How far either side of a definition to look for its example.
+_WINDOW = 2000
+
+
+def _is_inside_code_fence(spec: str, offset: int) -> bool:
+    """Is `offset` inside a fenced code block?
+
+    Counted by fence parity up to the offset, which is the question the check
+    is actually asking. The previous implementation searched FORWARD for a
+    fence, which answers "is there a fence later in the document" -- a
+    different question that diverges exactly when the block is long, and long
+    blocks are what specs with many functions have (#2302).
+    """
+    return spec.count("```", 0, offset) % 2 == 1
+
+
+def _is_test_function(name: str) -> bool:
+    """Test stubs are documented by their own body, not by example blocks.
+
+    `check_criteria_have_tests` (#2239) requires one test function per LLD pass
+    criterion, and the drafter duly writes them. Template 0701 specifies tests
+    as a TABLE (its section 8), never as functions carrying the
+    `**Input Example:**` / `**Output Example:**` blocks section 5 demands of API
+    functions -- so grading a test stub by section 5's rule fails the drafter
+    for following its instructions (#2303).
+
+    A test's body IS its input and its assertion IS its expected output, which
+    is the documentation this check exists to require. They are exempt, and the
+    report says so out loud rather than passing them silently.
+    """
+    return name.startswith("test_") or name.endswith("_test")
+
+
+def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
+    """Every non-test function must have input/output examples.
+
+    Judged at each function's DEFINITION SITE, once per function. The previous
+    implementation scanned a forward-only window from every textual occurrence
+    of the name and passed the function if any one of them looked documented,
+    which made the verdict depend on how often a name happened to be repeated:
+    in draft 008 `save_on_exit` occurred 34 times and passed on the strength of
+    a few lucky windows, while each `test_req_N` occurred exactly once and
+    failed. Same documentation, opposite verdicts (#2302).
 
     Args:
         spec: Implementation Spec markdown content.
@@ -513,67 +565,65 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
     Returns:
         CompletenessCheck with pass/fail result and details.
     """
-    # Find function signatures in the spec (within code blocks or inline)
-    # Match "def function_name(" patterns
-    func_pattern = re.compile(r"(?:async\s+)?def\s+(\w+)\s*\(")
-    all_functions = func_pattern.findall(spec)
+    definitions = [
+        (m.group(1), m.start())
+        for m in re.finditer(r"(?:async\s+)?def\s+(\w+)\s*\(", spec)
+    ]
 
-    # Deduplicate and filter private/dunder methods
-    public_functions = sorted(set(
-        f for f in all_functions
-        if not f.startswith("_") and f not in ("__init__", "__str__", "__repr__")
-    ))
+    graded: list[tuple[str, int]] = []
+    exempt_tests: set[str] = set()
+    for name, pos in definitions:
+        if name.startswith("_") or name in ("__init__", "__str__", "__repr__"):
+            continue
+        if _is_test_function(name):
+            exempt_tests.add(name)
+            continue
+        graded.append((name, pos))
 
-    if not public_functions:
+    def _exempt_note() -> str:
+        if not exempt_tests:
+            return ""
+        return (
+            f" {len(exempt_tests)} test function(s) were NOT checked: a test's "
+            f"body is its input and its assertion is its expected output "
+            f"(template 0701 section 8 specifies tests as a table, not as "
+            f"functions carrying example blocks)."
+        )
+
+    if not graded:
         return CompletenessCheck(
             check_name="functions_have_io_examples",
             passed=True,
-            details="No public function signatures found in spec — check not applicable.",
+            details=(
+                "No public non-test function signatures found in spec — check "
+                "not applicable." + _exempt_note()
+            ),
         )
 
     missing_examples: list[str] = []
+    seen: set[str] = set()
 
-    for func_name in public_functions:
-        # Find where this function is discussed in the spec
-        # Look for the function name outside of code block definitions
-        positions = [m.start() for m in re.finditer(re.escape(func_name), spec)]
+    for func_name, pos in graded:
+        if func_name in seen:
+            continue
+        seen.add(func_name)
 
-        if not positions:
+        # Both directions: an example placed ABOVE the signature counts, and a
+        # function inside a long fenced block can no longer be judged by
+        # whether the closing fence happens to fall within reach.
+        region = spec[max(0, pos - _WINDOW) : pos + _WINDOW]
+
+        has_values = bool(_CONCRETE_VALUES.search(region))
+        if not has_values:
+            missing_examples.append(func_name)
             continue
 
-        # Check if ANY occurrence has a nearby I/O example
-        has_example = False
+        if _is_inside_code_fence(spec, pos) or "```" in region:
+            continue
+        if _IO_WORDS.search(region):
+            continue
 
-        for pos in positions:
-            search_region = spec[pos : pos + 4000]
-
-            # Check for I/O example indicators
-            has_input_output = bool(
-                re.search(
-                    r"(?:input|output|returns?|result|example|usage|call)",
-                    search_region,
-                    re.IGNORECASE,
-                )
-            )
-            has_code_block = "```" in search_region
-            has_concrete_values = bool(
-                re.search(
-                    r'(?:\d+|"[^"]+"|True|False|None|\[.*\]|\{.*\})',
-                    search_region,
-                )
-            )
-
-            # Must have at least a code block with concrete values,
-            # or an input/output section with values
-            if has_code_block and has_concrete_values:
-                has_example = True
-                break
-            if has_input_output and has_concrete_values:
-                has_example = True
-                break
-
-        if not has_example:
-            missing_examples.append(func_name)
+        missing_examples.append(func_name)
 
     if missing_examples:
         func_list = ", ".join(f"`{f}()`" for f in missing_examples[:5])
@@ -589,6 +639,7 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
                 f"Functions missing input/output examples: "
                 f"{func_list}{suffix}. Each function MUST have at least one "
                 f"example with concrete input values and expected output."
+                + _exempt_note()
             ),
         )
 
@@ -596,7 +647,8 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
         check_name="functions_have_io_examples",
         passed=True,
         details=(
-            f"All {len(public_functions)} public functions have I/O examples."
+            f"All {len(seen)} public non-test functions have I/O examples."
+            + _exempt_note()
         ),
     )
 

--- a/docs/standards/0701-implementation-spec-template.md
+++ b/docs/standards/0701-implementation-spec-template.md
@@ -132,6 +132,21 @@ class AnotherStructure(TypedDict):
 
 *Every function must include: signature, docstring summary, input example with realistic values, output example with realistic values, and edge cases.*
 
+> **This section governs implementation functions, not test functions (#2303).**
+> Section 10 requires one test function per LLD pass criterion. A test function
+> is exempt from the input/output-example rule above, because its body already
+> carries its input and its assertion already carries its expected output —
+> that is the documentation this rule exists to demand.
+>
+> `validate_completeness`'s `functions_have_io_examples` implements exactly this
+> split: it grades every non-test function at its definition site and reports
+> how many test functions it skipped, rather than passing them silently.
+>
+> Earned 2026-08-13 (boostgauge #7): the drafter added 22 per-criterion test
+> stubs to satisfy the coverage check, each carrying a concrete input and an
+> expected output inline, and the spec stage then failed them for lacking
+> Section 5's example blocks — blocks this template never asked of a test.
+
 ### 5.1 `function_name()`
 
 **File:** `path/to/file.py`
@@ -304,6 +319,27 @@ def similar_function(state: SomeState) -> dict[str, Any]:
 | T020 | `function_name()` | `arg1=""` | Raises `ValueError` |
 | T030 | `another_function()` | `state={...}` | `{"spec_draft": "...", "error_message": ""}` |
 
+### 10.1 Per-criterion test functions
+
+*Required by `criteria_have_tests`: every LLD pass criterion must have a test in
+the spec, joined by criterion ID where the LLD carries them.*
+
+The table above maps tests; this section is where the test functions themselves
+go. Write one per criterion, naming it for the criterion it covers, with the
+concrete input and the expected output stated on the function:
+
+```python
+def test_req_10(tmp_path):
+    # Position persistence — no reset, moved (REQ-10) -- expected: File contains "position": {"x": 250, "y": 350}
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    ...
+```
+
+These are **not** governed by Section 5's example-block rule — see the note
+there. State the expectation in a comment on the function or in the assertion;
+both are read as the test's output.
+
 ## 11. Implementation Notes
 
 *Any additional context that helps implementation but doesn't fit above sections.*
@@ -333,7 +369,8 @@ def similar_function(state: SomeState) -> dict[str, Any]:
 
 - [ ] Every "Modify" file has a current state excerpt (Section 3)
 - [ ] Every data structure has a concrete JSON/YAML example (Section 4)
-- [ ] Every function has input/output examples with realistic values (Section 5)
+- [ ] Every **non-test** function has input/output examples with realistic values (Section 5)
+- [ ] Every LLD pass criterion has a test function (Section 10.1) — these are exempt from the rule above
 - [ ] Change instructions are diff-level specific (Section 6)
 - [ ] Pattern references include file:line and are verified to exist (Section 7)
 - [ ] All imports are listed and verified (Section 8)

--- a/tests/fixtures/io_examples/boostgauge-7-spec-draft-006.md
+++ b/tests/fixtures/io_examples/boostgauge-7-spec-draft-006.md
@@ -1,0 +1,599 @@
+# Implementation Spec: Issue #7 - Feature: configuration file and CLI arguments
+
+<!-- Standard: 0701 -->
+<!-- Version: 1.1 -->
+<!-- Last Updated: 2026-08-13 -->
+<!-- Issue: #7 -->
+
+| Field | Value |
+|-------|-------|
+| Issue | #7 |
+| LLD | `docs/lld/done/7-feature-config.md` |
+| Generated | 2026-08-13 |
+| Status | DRAFT |
+
+## 1. Overview
+
+**Objective:** Implement a configuration system that supports file-based persistence, CLI overrides, and independent save rules for hand-changed settings.
+
+**Success Criteria:** First run with no config file creates one with defaults. CLI arguments override file values in memory but are never written to disk. Threshold values edited directly in the config file take effect without restart (`reload_thresholds`), while other non-threshold values edited during the session survive the exit write as long as the application didn't hand-change those specific keys. Corrupt config files fail-fast with clear errors.
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/config.py` | Add | Configuration manager implementing file load, CLI overlay, read-patch-write exit saving, and threshold hot-reloads |
+| 2 | `src/boostgauge/app.py` | Add | Main entry point parsing CLI args and initializing the configuration |
+
+**Implementation Order Rationale:** The configuration manager provides the necessary state object for the main application entry point to parse CLI arguments into.
+
+## 3. Current State
+
+*No existing files to modify or delete. Both files are new additions (Add).*
+
+## 4. Data Structures
+
+### 4.1 Position
+
+**Definition:**
+```python
+class Position(TypedDict):
+    x: int
+    y: int
+```
+
+**Concrete Example:**
+```json
+{
+    "x": 200,
+    "y": 150
+}
+```
+
+### 4.2 Threshold
+
+**Definition:**
+```python
+class Threshold(TypedDict):
+    yellow: int
+    red: int
+```
+
+**Concrete Example:**
+```json
+{
+    "yellow": 75,
+    "red": 90
+}
+```
+
+### 4.3 ThresholdsConfig
+
+**Definition:**
+```python
+class ThresholdsConfig(TypedDict):
+    conpty: Threshold
+    memory_percent: Threshold
+    process_count: Threshold
+    handle_count: Threshold
+```
+
+**Concrete Example:**
+```json
+{
+    "conpty": {"yellow": 10, "red": 20},
+    "memory_percent": {"yellow": 80, "red": 95},
+    "process_count": {"yellow": 300, "red": 500},
+    "handle_count": {"yellow": 20000, "red": 30000}
+}
+```
+
+### 4.4 TelltaleWindows
+
+**Definition:**
+```python
+class TelltaleWindows(TypedDict):
+    short: int
+    medium: int
+    long: int
+```
+
+**Concrete Example:**
+```json
+{
+    "short": 60,
+    "medium": 600,
+    "long": 3600
+}
+```
+
+### 4.5 AppConfig
+
+**Definition:**
+```python
+class AppConfig(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: Position
+    thresholds: ThresholdsConfig
+    telltale_windows: TelltaleWindows
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+```
+
+**Concrete Example:**
+```json
+{
+    "polling_interval_seconds": 2,
+    "theme": "dark",
+    "size": 300,
+    "opacity": 0.9,
+    "always_on_top": true,
+    "position": {"x": 100, "y": 100},
+    "thresholds": {
+        "conpty": {"yellow": 10, "red": 20},
+        "memory_percent": {"yellow": 80, "red": 95},
+        "process_count": {"yellow": 300, "red": 500},
+        "handle_count": {"yellow": 20000, "red": 30000}
+    },
+    "telltale_windows": {
+        "short": 60,
+        "medium": 600,
+        "long": 3600
+    },
+    "show_driver_label": true,
+    "show_digital_readout": true,
+    "show_session_count": true
+}
+```
+
+## 5. Function Specifications
+
+### 5.1 `ConfigManager.__init__()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def __init__(self, config_path: str | None = None) -> None:
+    """Initializes configuration paths and state dictionaries."""
+```
+
+**Input Example:**
+```python
+config_path = "C:/custom/path/config.json"
+```
+
+**Output Example:** 
+*(None - initializes class attributes `self.config_path`, `self._session_config`, `self._cli_overrides`, `self._hand_changes`)*
+
+### 5.2 `ConfigManager._resolve_path()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def _resolve_path(self, path: str | None) -> Path:
+    """Determines OS-specific config location or uses provided path."""
+```
+
+**Input Example:**
+```python
+path = None
+```
+
+**Output Example:**
+```python
+Path.home() / ".boostgauge" / "config.json"
+```
+
+**Edge Cases:**
+- If an absolute path is provided, it returns a resolved `Path` object of that string.
+
+### 5.3 `ConfigManager.initialize()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def initialize(self, reset: bool, cli_args: dict[str, Any]) -> None:
+    """Applies reset logic if needed, loads config, overlays CLI arguments."""
+```
+
+**Input Example:**
+```python
+reset = True
+cli_args = {"size": 400}
+```
+
+**Output Example:** 
+*(None - updates in-memory dictionaries and disk if reset is True)*
+
+**Edge Cases:**
+- Keys in `cli_args` with `None` values are ignored and not placed in `_cli_overrides`.
+
+### 5.4 `ConfigManager.get()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def get(self, key: str) -> Any:
+    """Returns CLI override if present, else session config, else default."""
+```
+
+**Input Example:**
+```python
+key = "size"
+```
+
+**Output Example:**
+```python
+400
+```
+
+### 5.5 `ConfigManager.update_hand_change()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def update_hand_change(self, key: str, value: Any) -> None:
+    """Records a user-driven hand change to be written on exit."""
+```
+
+**Input Example:**
+```python
+key = "size"
+value = 450
+```
+
+**Output Example:** 
+*(None - internal state mutated)*
+
+### 5.6 `ConfigManager.reload_thresholds()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def reload_thresholds(self) -> None:
+    """Re-reads the config file and updates only the 'thresholds' dictionary in memory."""
+```
+
+**Input Example:**
+*(None)*
+
+**Output Example:** 
+*(None - mutates `self._session_config["thresholds"]`)*
+
+**Edge Cases:**
+- Mid-session JSON parse errors (e.g. while the user is actively typing in the file) are caught and ignored, keeping the old thresholds loaded.
+
+### 5.7 `ConfigManager.save_on_exit()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def save_on_exit(self) -> None:
+    """Performs a read-patch-write to persist only hand-changed keys."""
+```
+
+**Input Example:**
+*(None)*
+
+**Output Example:** 
+*(None - file written to disk atomically using `os.replace`)*
+
+**Edge Cases:**
+- Empty `self._hand_changes` returns early and skips touching the disk entirely.
+- Corrupted mid-session disk JSON results in rewriting defaults + hand patches.
+
+### 5.8 `parse_args()`
+
+**File:** `src/boostgauge/app.py`
+
+**Signature:**
+```python
+def parse_args() -> argparse.Namespace:
+    """Parses CLI arguments."""
+```
+
+**Input Example:** 
+```python
+# Assuming sys.argv = ["boostgauge", "--size", "400", "--reset-config"]
+```
+
+**Output Example:**
+```python
+argparse.Namespace(config=None, reset_config=True, size=400, theme=None)
+```
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/config.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Configuration manager handling load, CLI memory overlay, threshold reload, and exit writing.
+
+Issue #7: Configuration file and CLI arguments
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, TypedDict
+
+class Position(TypedDict):
+    x: int
+    y: int
+
+class Threshold(TypedDict):
+    yellow: int
+    red: int
+
+class ThresholdsConfig(TypedDict):
+    conpty: Threshold
+    memory_percent: Threshold
+    process_count: Threshold
+    handle_count: Threshold
+
+class TelltaleWindows(TypedDict):
+    short: int
+    medium: int
+    long: int
+
+class AppConfig(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: Position
+    thresholds: ThresholdsConfig
+    telltale_windows: TelltaleWindows
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+
+DEFAULT_CONFIG: AppConfig = {
+    "polling_interval_seconds": 2,
+    "theme": "dark",
+    "size": 300,
+    "opacity": 0.9,
+    "always_on_top": True,
+    "position": {"x": 100, "y": 100},
+    "thresholds": {
+        "conpty": {"yellow": 10, "red": 20},
+        "memory_percent": {"yellow": 80, "red": 95},
+        "process_count": {"yellow": 300, "red": 500},
+        "handle_count": {"yellow": 20000, "red": 30000}
+    },
+    "telltale_windows": {
+        "short": 60,
+        "medium": 600,
+        "long": 3600
+    },
+    "show_driver_label": True,
+    "show_digital_readout": True,
+    "show_session_count": True
+}
+
+logger = logging.getLogger(__name__)
+
+class ConfigManager:
+    def __init__(self, config_path: str | None = None) -> None:
+        """Initializes configuration paths."""
+        self.config_path = self._resolve_path(config_path)
+        self._session_config: dict[str, Any] = {}
+        self._cli_overrides: dict[str, Any] = {}
+        self._hand_changes: dict[str, Any] = {}
+
+    def _resolve_path(self, path: str | None) -> Path:
+        """Determines OS-specific config location or uses provided path."""
+        if path:
+            return Path(path).resolve()
+        return Path.home() / ".boostgauge" / "config.json"
+
+    def initialize(self, reset: bool, cli_args: dict[str, Any]) -> None:
+        """Applies reset logic if needed, loads config, overlays CLI arguments."""
+        self._cli_overrides = {k: v for k, v in cli_args.items() if v is not None}
+        
+        if reset or not self.config_path.exists():
+            self._write_defaults()
+            
+        self._load()
+
+    def _write_defaults(self) -> None:
+        """Writes DEFAULT_CONFIG to disk and creates parent directories."""
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            json.dump(DEFAULT_CONFIG, f, indent=4)
+        logger.info(f"Wrote default config to {self.config_path}")
+
+    def _load(self) -> None:
+        """Reads config from disk into session memory. Raises ValueError on bad JSON."""
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                self._session_config = json.load(f)
+            logger.info(f"Loaded config from {self.config_path}")
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse config: {e}")
+            raise ValueError("Invalid configuration format") from e
+
+    def get(self, key: str) -> Any:
+        """Returns CLI override if present, else session config, else default."""
+        if key in self._cli_overrides:
+            return self._cli_overrides[key]
+        if key in self._session_config:
+            return self._session_config[key]
+        return DEFAULT_CONFIG.get(key)
+
+    def update_hand_change(self, key: str, value: Any) -> None:
+        """Records a user-driven hand change to be written on exit."""
+        self._session_config[key] = value
+        self._hand_changes[key] = value
+
+    def reload_thresholds(self) -> None:
+        """Re-reads the config file and updates only the 'thresholds' dictionary in memory."""
+        if not self.config_path.exists():
+            return
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                disk_config = json.load(f)
+                if "thresholds" in disk_config:
+                    self._session_config["thresholds"] = disk_config["thresholds"]
+        except json.JSONDecodeError:
+            pass  # Mid-session editing error; ignore and keep current thresholds
+
+    def save_on_exit(self) -> None:
+        """Performs a read-patch-write to persist only hand-changed keys."""
+        if not self._hand_changes:
+            return
+            
+        current_disk = {}
+        if self.config_path.exists():
+            try:
+                with open(self.config_path, "r", encoding="utf-8") as f:
+                    current_disk = json.load(f)
+            except json.JSONDecodeError:
+                current_disk = dict(DEFAULT_CONFIG)
+        else:
+            current_disk = dict(DEFAULT_CONFIG)
+            
+        for key, value in self._hand_changes.items():
+            current_disk[key] = value
+            
+        tmp_path = self.config_path.parent / (self.config_path.name + ".tmp")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(current_disk, f, indent=4)
+            os.replace(tmp_path, self.config_path)
+            logger.info(f"Saved hand changes {list(self._hand_changes.keys())} to {self.config_path}")
+        except Exception as e:
+            logger.error(f"Failed to save config: {e}")
+            if tmp_path.exists():
+                tmp_path.unlink()
+```
+
+### 6.2 `src/boostgauge/app.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Main entry point parsing CLI arguments.
+
+Issue #7: Configuration file and CLI arguments
+"""
+
+import argparse
+import logging
+from typing import Any
+
+from boostgauge.config import ConfigManager
+
+logging.basicConfig(level=logging.INFO)
+
+def parse_args() -> argparse.Namespace:
+    """Parses CLI arguments."""
+    parser = argparse.ArgumentParser(description="BoostGauge: System tachometer")
+    parser.add_argument("--config", type=str, help="Path to config file")
+    parser.add_argument("--reset-config", action="store_true", help="Reset configuration to defaults")
+    parser.add_argument("--size", type=int, help="Window size override")
+    parser.add_argument("--theme", type=str, help="UI theme override")
+    return parser.parse_args()
+
+def main() -> None:
+    args = parse_args()
+    
+    config = ConfigManager(config_path=args.config)
+    cli_args: dict[str, Any] = {}
+    
+    if hasattr(args, "size") and args.size is not None:
+        cli_args["size"] = args.size
+    if hasattr(args, "theme") and args.theme is not None:
+        cli_args["theme"] = args.theme
+        
+    config.initialize(reset=args.reset_config, cli_args=cli_args)
+    # App logic starts here
+
+if __name__ == "__main__":
+    main()
+```
+
+## 7. Pattern References
+
+*No existing custom patterns applied for standard IO or argument parsing. We use stdlib components (`argparse`, `json`, `os.replace`) to achieve atomic file saves and argument parsing natively.*
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import json` | stdlib | `src/boostgauge/config.py` |
+| `import logging` | stdlib | `src/boostgauge/config.py`, `src/boostgauge/app.py` |
+| `import os` | stdlib | `src/boostgauge/config.py` |
+| `from pathlib import Path` | stdlib | `src/boostgauge/config.py` |
+| `from typing import Any, TypedDict` | stdlib | `src/boostgauge/config.py`, `src/boostgauge/app.py` |
+| `import argparse` | stdlib | `src/boostgauge/app.py` |
+
+**New Dependencies:** None (stdlib only)
+
+## 9. Placeholder
+
+*Reserved for alignment with LLD numbering.*
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| REQ-1 | `initialize()` | First run with no config (REQ-1) | File exists, content includes `"size": 300` and `"theme": "dark"` |
+| REQ-2 | `initialize()`, `get()` | Launch order and CLI override memory (REQ-2) | `config.get('size') == 400`, file on disk contains `"size": 300` |
+| REQ-3 | `_load()`, `get()` | Open at file position/size (REQ-3) | `config.get('size') == 350`, `config.get('position') == {"x": 200, "y": 200}` |
+| REQ-4 | `initialize()` | Reset-config with size N (REQ-4) | `config.get('size') == 500`, file on disk contains `"size": 300` |
+| REQ-5 | `reload_thresholds()` | Threshold live reload (REQ-5) | `config.get('thresholds')['process_count']['red'] == 999` |
+| REQ-6 | `save_on_exit()` | Exit write only hand-changed (REQ-6) | File contains `"theme": "neon"` and `"size": 450` |
+| REQ-7 | `save_on_exit()` | Hand-made edit wins over direct edit (REQ-7) | File contains `"size": 450` |
+| REQ-8 | `save_on_exit()` | Byte-identical file on no changes (REQ-8) | `os.stat().st_mtime` unchanged |
+| REQ-9 | `save_on_exit()` | Position persistence - no reset, not moved (REQ-9) | File contains `"position": {"x": 100, "y": 100}` |
+| REQ-10 | `save_on_exit()` | Position persistence - no reset, moved (REQ-10) | File contains `"position": {"x": 250, "y": 350}` |
+| REQ-11 | `save_on_exit()` | Position persistence - reset, not moved (REQ-11) | File contains `"position": {"x": 100, "y": 100}` |
+| REQ-12 | `save_on_exit()` | Position persistence - reset, moved (REQ-12) | File contains `"position": {"x": 250, "y": 350}` |
+| REQ-13 | `save_on_exit()` | Size persistence - no reset, no size, not resized (REQ-13) | File contains `"size": 300` |
+| REQ-14 | `save_on_exit()` | Size persistence - no reset, no size, resized (REQ-14) | File contains `"size": 550` |
+| REQ-15 | `save_on_exit()` | Size persistence - no reset, --size, not resized (REQ-15) | File contains `"size": 300` |
+| REQ-16 | `save_on_exit()` | Size persistence - no reset, --size, resized (REQ-16) | File contains `"size": 550` |
+| REQ-17 | `save_on_exit()` | Size persistence - reset, no size, not resized (REQ-17) | File contains `"size": 300` |
+| REQ-18 | `save_on_exit()` | Size persistence - reset, no size, resized (REQ-18) | File contains `"size": 550` |
+| REQ-19 | `save_on_exit()` | Size persistence - reset, --size, not resized (REQ-19) | File contains `"size": 300` |
+| REQ-20 | `save_on_exit()` | Size persistence - reset, --size, resized (REQ-20) | File contains `"size": 550` |
+| REQ-21 | `_load()` | Invalid config values (REQ-21) | `ValueError("Invalid configuration format")` raised |
+| REQ-22 | `reload_thresholds()` | Non-threshold live edit ignored (REQ-22) | `config.get('theme') == "dark"` |
+
+## 11. Implementation Notes
+
+### 11.1 File Operations
+- We strictly use `os.replace` (atomic file replacement) during `save_on_exit()` to mitigate the risk of creating a zero-byte file if the app crashes right when writing out changes.
+- The `.tmp` file MUST be placed in the same directory as the target configuration file to ensure `os.replace` doesn't throw a cross-device link error if the temp directory is mounted on a separate block device.
+
+### 11.2 File Path Comparisons in Testing
+- Test suite files should NEVER compare against hardcoded string paths that include directory separators (e.g. `/` or `\`). Use the `pathlib.Path` objects to evaluate test fixtures (`path == Path.home() / ".boostgauge" / "config.json"`), as monkeypatching the OS does not resolve path formatting variations.
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3) *(N/A - Adds only)*
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every function has input/output examples with realistic values (Section 5)
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)

--- a/tests/fixtures/io_examples/boostgauge-7-spec-draft-008.md
+++ b/tests/fixtures/io_examples/boostgauge-7-spec-draft-008.md
@@ -1,0 +1,806 @@
+# Implementation Spec: Issue #7 - Feature: configuration file and CLI arguments
+
+<!-- Standard: 0701 -->
+<!-- Version: 1.1 -->
+<!-- Last Updated: 2026-08-13 -->
+<!-- Issue: #7 -->
+
+| Field | Value |
+|-------|-------|
+| Issue | #7 |
+| LLD | `docs/lld/done/7-feature-config.md` |
+| Generated | 2026-08-13 |
+| Status | DRAFT |
+
+## 1. Overview
+
+**Objective:** Implement a configuration system that supports file-based persistence, CLI overrides, and independent save rules for hand-changed settings.
+
+**Success Criteria:** First run with no config file creates one with defaults. CLI arguments override file values in memory but are never written to disk. Threshold values edited directly in the config file take effect without restart (`reload_thresholds`), while other non-threshold values edited during the session survive the exit write as long as the application didn't hand-change those specific keys. Corrupt config files fail-fast with clear errors.
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/config.py` | Add | Configuration manager implementing file load, CLI overlay, read-patch-write exit saving, and threshold hot-reloads |
+| 2 | `src/boostgauge/app.py` | Add | Main entry point parsing CLI args and initializing the configuration |
+| 3 | `tests/test_config.py` | Add | Tests covering configuration manager and all LLD pass criteria |
+
+**Implementation Order Rationale:** The configuration manager provides the necessary state object for the main application entry point to parse CLI arguments into. The tests verify functionality.
+
+## 3. Current State
+
+*No existing files to modify or delete. Both files are new additions (Add).*
+
+## 4. Data Structures
+
+### 4.1 Position
+
+**Definition:**
+```python
+class Position(TypedDict):
+    x: int
+    y: int
+```
+
+**Concrete Example:**
+```json
+{
+    "x": 200,
+    "y": 150
+}
+```
+
+### 4.2 Threshold
+
+**Definition:**
+```python
+class Threshold(TypedDict):
+    yellow: int
+    red: int
+```
+
+**Concrete Example:**
+```json
+{
+    "yellow": 75,
+    "red": 90
+}
+```
+
+### 4.3 ThresholdsConfig
+
+**Definition:**
+```python
+class ThresholdsConfig(TypedDict):
+    conpty: Threshold
+    memory_percent: Threshold
+    process_count: Threshold
+    handle_count: Threshold
+```
+
+**Concrete Example:**
+```json
+{
+    "conpty": {"yellow": 10, "red": 20},
+    "memory_percent": {"yellow": 80, "red": 95},
+    "process_count": {"yellow": 300, "red": 500},
+    "handle_count": {"yellow": 20000, "red": 30000}
+}
+```
+
+### 4.4 TelltaleWindows
+
+**Definition:**
+```python
+class TelltaleWindows(TypedDict):
+    short: int
+    medium: int
+    long: int
+```
+
+**Concrete Example:**
+```json
+{
+    "short": 60,
+    "medium": 600,
+    "long": 3600
+}
+```
+
+### 4.5 AppConfig
+
+**Definition:**
+```python
+class AppConfig(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: Position
+    thresholds: ThresholdsConfig
+    telltale_windows: TelltaleWindows
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+```
+
+**Concrete Example:**
+```json
+{
+    "polling_interval_seconds": 2,
+    "theme": "dark",
+    "size": 300,
+    "opacity": 0.9,
+    "always_on_top": true,
+    "position": {"x": 100, "y": 100},
+    "thresholds": {
+        "conpty": {"yellow": 10, "red": 20},
+        "memory_percent": {"yellow": 80, "red": 95},
+        "process_count": {"yellow": 300, "red": 500},
+        "handle_count": {"yellow": 20000, "red": 30000}
+    },
+    "telltale_windows": {
+        "short": 60,
+        "medium": 600,
+        "long": 3600
+    },
+    "show_driver_label": true,
+    "show_digital_readout": true,
+    "show_session_count": true
+}
+```
+
+## 5. Function Specifications
+
+### 5.1 `ConfigManager.__init__()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def __init__(self, config_path: str | None = None) -> None:
+    """Initializes configuration paths and state dictionaries."""
+```
+
+**Input Example:**
+```python
+config_path = "C:/custom/path/config.json"
+```
+
+**Output Example:** 
+*(None - initializes class attributes `self.config_path`, `self._session_config`, `self._cli_overrides`, `self._hand_changes`)*
+
+### 5.2 `ConfigManager._resolve_path()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def _resolve_path(self, path: str | None) -> Path:
+    """Determines OS-specific config location or uses provided path."""
+```
+
+**Input Example:**
+```python
+path = None
+```
+
+**Output Example:**
+```python
+Path.home() / ".boostgauge" / "config.json"
+```
+
+**Edge Cases:**
+- If an absolute path is provided, it returns a resolved `Path` object of that string.
+
+### 5.3 `ConfigManager.initialize()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def initialize(self, reset: bool, cli_args: dict[str, Any]) -> None:
+    """Applies reset logic if needed, loads config, overlays CLI arguments."""
+```
+
+**Input Example:**
+```python
+reset = True
+cli_args = {"size": 400}
+```
+
+**Output Example:** 
+*(None - updates in-memory dictionaries and disk if reset is True)*
+
+**Edge Cases:**
+- Keys in `cli_args` with `None` values are ignored and not placed in `_cli_overrides`.
+
+### 5.4 `ConfigManager.get()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def get(self, key: str) -> Any:
+    """Returns CLI override if present, else session config, else default."""
+```
+
+**Input Example:**
+```python
+key = "size"
+```
+
+**Output Example:**
+```python
+400
+```
+
+### 5.5 `ConfigManager.update_hand_change()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def update_hand_change(self, key: str, value: Any) -> None:
+    """Records a user-driven hand change to be written on exit."""
+```
+
+**Input Example:**
+```python
+key = "size"
+value = 450
+```
+
+**Output Example:** 
+*(None - internal state mutated)*
+
+### 5.6 `ConfigManager.reload_thresholds()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def reload_thresholds(self) -> None:
+    """Re-reads the config file and updates only the 'thresholds' dictionary in memory."""
+```
+
+**Input Example:**
+*(None)*
+
+**Output Example:** 
+*(None - mutates `self._session_config["thresholds"]`)*
+
+**Edge Cases:**
+- Mid-session JSON parse errors (e.g. while the user is actively typing in the file) are caught and ignored, keeping the old thresholds loaded.
+
+### 5.7 `ConfigManager.save_on_exit()`
+
+**File:** `src/boostgauge/config.py`
+
+**Signature:**
+```python
+def save_on_exit(self) -> None:
+    """Performs a read-patch-write to persist only hand-changed keys."""
+```
+
+**Input Example:**
+*(None)*
+
+**Output Example:** 
+*(None - file written to disk atomically using `os.replace`)*
+
+**Edge Cases:**
+- Empty `self._hand_changes` returns early and skips touching the disk entirely.
+- Corrupted mid-session disk JSON results in rewriting defaults + hand patches.
+
+### 5.8 `parse_args()`
+
+**File:** `src/boostgauge/app.py`
+
+**Signature:**
+```python
+def parse_args() -> argparse.Namespace:
+    """Parses CLI arguments."""
+```
+
+**Input Example:** 
+```python
+# Assuming sys.argv = ["boostgauge", "--size", "400", "--reset-config"]
+```
+
+**Output Example:**
+```python
+argparse.Namespace(config=None, reset_config=True, size=400, theme=None)
+```
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/config.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Configuration manager handling load, CLI memory overlay, threshold reload, and exit writing.
+
+Issue #7: Configuration file and CLI arguments
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, TypedDict
+
+class Position(TypedDict):
+    x: int
+    y: int
+
+class Threshold(TypedDict):
+    yellow: int
+    red: int
+
+class ThresholdsConfig(TypedDict):
+    conpty: Threshold
+    memory_percent: Threshold
+    process_count: Threshold
+    handle_count: Threshold
+
+class TelltaleWindows(TypedDict):
+    short: int
+    medium: int
+    long: int
+
+class AppConfig(TypedDict):
+    polling_interval_seconds: int
+    theme: str
+    size: int
+    opacity: float
+    always_on_top: bool
+    position: Position
+    thresholds: ThresholdsConfig
+    telltale_windows: TelltaleWindows
+    show_driver_label: bool
+    show_digital_readout: bool
+    show_session_count: bool
+
+DEFAULT_CONFIG: AppConfig = {
+    "polling_interval_seconds": 2,
+    "theme": "dark",
+    "size": 300,
+    "opacity": 0.9,
+    "always_on_top": True,
+    "position": {"x": 100, "y": 100},
+    "thresholds": {
+        "conpty": {"yellow": 10, "red": 20},
+        "memory_percent": {"yellow": 80, "red": 95},
+        "process_count": {"yellow": 300, "red": 500},
+        "handle_count": {"yellow": 20000, "red": 30000}
+    },
+    "telltale_windows": {
+        "short": 60,
+        "medium": 600,
+        "long": 3600
+    },
+    "show_driver_label": True,
+    "show_digital_readout": True,
+    "show_session_count": True
+}
+
+logger = logging.getLogger(__name__)
+
+class ConfigManager:
+    def __init__(self, config_path: str | None = None) -> None:
+        """Initializes configuration paths."""
+        self.config_path = self._resolve_path(config_path)
+        self._session_config: dict[str, Any] = {}
+        self._cli_overrides: dict[str, Any] = {}
+        self._hand_changes: dict[str, Any] = {}
+
+    def _resolve_path(self, path: str | None) -> Path:
+        """Determines OS-specific config location or uses provided path."""
+        if path:
+            return Path(path).resolve()
+        return Path.home() / ".boostgauge" / "config.json"
+
+    def initialize(self, reset: bool, cli_args: dict[str, Any]) -> None:
+        """Applies reset logic if needed, loads config, overlays CLI arguments."""
+        self._cli_overrides = {k: v for k, v in cli_args.items() if v is not None}
+        
+        if reset or not self.config_path.exists():
+            self._write_defaults()
+            
+        self._load()
+
+    def _write_defaults(self) -> None:
+        """Writes DEFAULT_CONFIG to disk and creates parent directories."""
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            json.dump(DEFAULT_CONFIG, f, indent=4)
+        logger.info(f"Wrote default config to {self.config_path}")
+
+    def _load(self) -> None:
+        """Reads config from disk into session memory. Raises ValueError on bad JSON."""
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                self._session_config = json.load(f)
+            logger.info(f"Loaded config from {self.config_path}")
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse config: {e}")
+            raise ValueError("Invalid configuration format") from e
+
+    def get(self, key: str) -> Any:
+        """Returns CLI override if present, else session config, else default."""
+        if key in self._cli_overrides:
+            return self._cli_overrides[key]
+        if key in self._session_config:
+            return self._session_config[key]
+        return DEFAULT_CONFIG.get(key)
+
+    def update_hand_change(self, key: str, value: Any) -> None:
+        """Records a user-driven hand change to be written on exit."""
+        self._session_config[key] = value
+        self._hand_changes[key] = value
+
+    def reload_thresholds(self) -> None:
+        """Re-reads the config file and updates only the 'thresholds' dictionary in memory."""
+        if not self.config_path.exists():
+            return
+        try:
+            with open(self.config_path, "r", encoding="utf-8") as f:
+                disk_config = json.load(f)
+                if "thresholds" in disk_config:
+                    self._session_config["thresholds"] = disk_config["thresholds"]
+        except json.JSONDecodeError:
+            pass  # Mid-session editing error; ignore and keep current thresholds
+
+    def save_on_exit(self) -> None:
+        """Performs a read-patch-write to persist only hand-changed keys."""
+        if not self._hand_changes:
+            return
+            
+        current_disk = {}
+        if self.config_path.exists():
+            try:
+                with open(self.config_path, "r", encoding="utf-8") as f:
+                    current_disk = json.load(f)
+            except json.JSONDecodeError:
+                current_disk = dict(DEFAULT_CONFIG)
+        else:
+            current_disk = dict(DEFAULT_CONFIG)
+            
+        for key, value in self._hand_changes.items():
+            current_disk[key] = value
+            
+        tmp_path = self.config_path.parent / (self.config_path.name + ".tmp")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(current_disk, f, indent=4)
+            os.replace(tmp_path, self.config_path)
+            logger.info(f"Saved hand changes {list(self._hand_changes.keys())} to {self.config_path}")
+        except Exception as e:
+            logger.error(f"Failed to save config: {e}")
+            if tmp_path.exists():
+                tmp_path.unlink()
+```
+
+### 6.2 `src/boostgauge/app.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Main entry point parsing CLI arguments.
+
+Issue #7: Configuration file and CLI arguments
+"""
+
+import argparse
+import logging
+from typing import Any
+
+from boostgauge.config import ConfigManager
+
+logging.basicConfig(level=logging.INFO)
+
+def parse_args() -> argparse.Namespace:
+    """Parses CLI arguments."""
+    parser = argparse.ArgumentParser(description="BoostGauge: System tachometer")
+    parser.add_argument("--config", type=str, help="Path to config file")
+    parser.add_argument("--reset-config", action="store_true", help="Reset configuration to defaults")
+    parser.add_argument("--size", type=int, help="Window size override")
+    parser.add_argument("--theme", type=str, help="UI theme override")
+    return parser.parse_args()
+
+def main() -> None:
+    args = parse_args()
+    
+    config = ConfigManager(config_path=args.config)
+    cli_args: dict[str, Any] = {}
+    
+    if hasattr(args, "size") and args.size is not None:
+        cli_args["size"] = args.size
+    if hasattr(args, "theme") and args.theme is not None:
+        cli_args["theme"] = args.theme
+        
+    config.initialize(reset=args.reset_config, cli_args=cli_args)
+    # App logic starts here
+
+if __name__ == "__main__":
+    main()
+```
+
+### 6.3 `tests/test_config.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Tests for configuration manager.
+
+Issue #7: Configuration file and CLI arguments
+"""
+
+import json
+import os
+from pathlib import Path
+import pytest
+from boostgauge.config import ConfigManager
+
+def test_req_1(tmp_path):
+    # First run with no config (REQ-1) -- expected: File exists, content includes "size": 300 and "theme": "dark"
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    with open(config.config_path, "r") as f:
+        data = json.load(f)
+    assert data["size"] == 300
+    assert data["theme"] == "dark"
+
+def test_req_2(tmp_path):
+    # Launch order and CLI override memory (REQ-2) -- expected: config.get('size') == 400, file on disk contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={"size": 400})
+    assert config.get("size") == 400
+    with open(config.config_path, "r") as f:
+        data = json.load(f)
+    assert data["size"] == 300
+
+def test_req_3(tmp_path):
+    # Open at file position/size (REQ-3) -- expected: config.get('size') == 350, config.get('position') == {"x": 200, "y": 200}
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps({"size": 350, "position": {"x": 200, "y": 200}}))
+    config = ConfigManager(str(cfg_file))
+    config.initialize(reset=False, cli_args={})
+    assert config.get("size") == 350
+    assert config.get("position") == {"x": 200, "y": 200}
+
+def test_req_4(tmp_path):
+    # Reset-config with size N (REQ-4) -- expected: config.get('size') == 500, file on disk contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={"size": 500})
+    assert config.get("size") == 500
+    with open(config.config_path, "r") as f:
+        data = json.load(f)
+    assert data["size"] == 300
+
+def test_req_5(tmp_path):
+    # Threshold live reload (REQ-5) -- expected: config.get('thresholds')['process_count']['red'] == 999
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    cfg_data = json.loads((tmp_path / "config.json").read_text())
+    cfg_data["thresholds"]["process_count"]["red"] = 999
+    (tmp_path / "config.json").write_text(json.dumps(cfg_data))
+    config.reload_thresholds()
+    assert config.get("thresholds")["process_count"]["red"] == 999
+
+def test_req_6(tmp_path):
+    # Exit write only hand-changed (REQ-6) -- expected: File contains "theme": "neon" and "size": 450
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.update_hand_change("size", 450)
+    config.update_hand_change("theme", "neon")
+    config.save_on_exit()
+    with open(config.config_path, "r") as f:
+        data = json.load(f)
+    assert data["size"] == 450
+    assert data["theme"] == "neon"
+
+def test_req_7(tmp_path):
+    # Hand-made edit wins over direct edit (REQ-7) -- expected: File contains "size": 450
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.update_hand_change("size", 450)
+    cfg_data = json.loads((tmp_path / "config.json").read_text())
+    cfg_data["size"] = 999
+    (tmp_path / "config.json").write_text(json.dumps(cfg_data))
+    config.save_on_exit()
+    with open(config.config_path, "r") as f:
+        data = json.load(f)
+    assert data["size"] == 450
+
+def test_req_8(tmp_path):
+    # Byte-identical file on no changes (REQ-8) -- expected: os.stat().st_mtime unchanged
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    mtime1 = os.stat(config.config_path).st_mtime
+    config.save_on_exit()
+    mtime2 = os.stat(config.config_path).st_mtime
+    assert mtime1 == mtime2
+
+def test_req_9(tmp_path):
+    # Position persistence - no reset, not moved (REQ-9) -- expected: File contains "position": {"x": 100, "y": 100}
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["position"] == {"x": 100, "y": 100}
+
+def test_req_10(tmp_path):
+    # Position persistence - no reset, moved (REQ-10) -- expected: File contains "position": {"x": 250, "y": 350}
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.update_hand_change("position", {"x": 250, "y": 350})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["position"] == {"x": 250, "y": 350}
+
+def test_req_11(tmp_path):
+    # Position persistence - reset, not moved (REQ-11) -- expected: File contains "position": {"x": 100, "y": 100}
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["position"] == {"x": 100, "y": 100}
+
+def test_req_12(tmp_path):
+    # Position persistence - reset, moved (REQ-12) -- expected: File contains "position": {"x": 250, "y": 350}
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={})
+    config.update_hand_change("position", {"x": 250, "y": 350})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["position"] == {"x": 250, "y": 350}
+
+def test_req_13(tmp_path):
+    # Size persistence - no reset, no size, not resized (REQ-13) -- expected: File contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 300
+
+def test_req_14(tmp_path):
+    # Size persistence - no reset, no size, resized (REQ-14) -- expected: File contains "size": 550
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    config.update_hand_change("size", 550)
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 550
+
+def test_req_15(tmp_path):
+    # Size persistence - no reset, --size, not resized (REQ-15) -- expected: File contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={"size": 400})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 300
+
+def test_req_16(tmp_path):
+    # Size persistence - no reset, --size, resized (REQ-16) -- expected: File contains "size": 550
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={"size": 400})
+    config.update_hand_change("size", 550)
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 550
+
+def test_req_17(tmp_path):
+    # Size persistence - reset, no size, not resized (REQ-17) -- expected: File contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 300
+
+def test_req_18(tmp_path):
+    # Size persistence - reset, no size, resized (REQ-18) -- expected: File contains "size": 550
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={})
+    config.update_hand_change("size", 550)
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 550
+
+def test_req_19(tmp_path):
+    # Size persistence - reset, --size, not resized (REQ-19) -- expected: File contains "size": 300
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={"size": 400})
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 300
+
+def test_req_20(tmp_path):
+    # Size persistence - reset, --size, resized (REQ-20) -- expected: File contains "size": 550
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=True, cli_args={"size": 400})
+    config.update_hand_change("size", 550)
+    config.save_on_exit()
+    assert json.loads(Path(config.config_path).read_text())["size"] == 550
+
+def test_req_21(tmp_path):
+    # Invalid config values (REQ-21) -- expected: ValueError("Invalid configuration format") raised
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{bad json")
+    config = ConfigManager(str(cfg))
+    with pytest.raises(ValueError, match="Invalid configuration format"):
+        config.initialize(reset=False, cli_args={})
+
+def test_req_22(tmp_path):
+    # Non-threshold live edit ignored (REQ-22) -- expected: config.get('theme') == "dark"
+    config = ConfigManager(str(tmp_path / "config.json"))
+    config.initialize(reset=False, cli_args={})
+    cfg_data = json.loads(Path(config.config_path).read_text())
+    cfg_data["theme"] = "light"
+    Path(config.config_path).write_text(json.dumps(cfg_data))
+    config.reload_thresholds()
+    assert config.get("theme") == "dark"
+```
+
+## 7. Pattern References
+
+*No existing custom patterns applied for standard IO or argument parsing. We use stdlib components (`argparse`, `json`, `os.replace`) to achieve atomic file saves and argument parsing natively.*
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import json` | stdlib | `src/boostgauge/config.py` |
+| `import logging` | stdlib | `src/boostgauge/config.py`, `src/boostgauge/app.py` |
+| `import os` | stdlib | `src/boostgauge/config.py` |
+| `from pathlib import Path` | stdlib | `src/boostgauge/config.py` |
+| `from typing import Any, TypedDict` | stdlib | `src/boostgauge/config.py`, `src/boostgauge/app.py` |
+| `import argparse` | stdlib | `src/boostgauge/app.py` |
+| `import pytest` | pypi | `tests/test_config.py` |
+
+**New Dependencies:** `pytest`
+
+## 9. Placeholder
+
+*Reserved for alignment with LLD numbering.*
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| REQ-1 | `initialize()` | First run with no config (REQ-1) | File exists, content includes `"size": 300` and `"theme": "dark"` |
+| REQ-2 | `initialize()`, `get()` | Launch order and CLI override memory (REQ-2) | `config.get('size') == 400`, file on disk contains `"size": 300` |
+| REQ-3 | `_load()`, `get()` | Open at file position/size (REQ-3) | `config.get('size') == 350`, `config.get('position') == {"x": 200, "y": 200}` |
+| REQ-4 | `initialize()` | Reset-config with size N (REQ-4) | `config.get('size') == 500`, file on disk contains `"size": 300` |
+| REQ-5 | `reload_thresholds()` | Threshold live reload (REQ-5) | `config.get('thresholds')['process_count']['red'] == 999` |
+| REQ-6 | `save_on_exit()` | Exit write only hand-changed (REQ-6) | File contains `"theme": "neon"` and `"size": 450` |
+| REQ-7 | `save_on_exit()` | Hand-made edit wins over direct edit (REQ-7) | File contains `"size": 450` |
+| REQ-8 | `save_on_exit()` | Byte-identical file on no changes (REQ-8) | `os.stat().st_mtime` unchanged |
+| REQ-9 | `save_on_exit()` | Position persistence - no reset, not moved (REQ-9) | File contains `"position": {"x": 100, "y": 100}` |
+| REQ-10 | `save_on_exit()` | Position persistence - no reset, moved (REQ-10) | File contains `"position": {"x": 250, "y": 350}` |
+| REQ-11 | `save_on_exit()` | Position persistence - reset, not moved (REQ-11) | File contains `"position": {"x": 100, "y": 100}` |
+| REQ-12 | `save_on_exit()` | Position persistence - reset, moved (REQ-12) | File contains `"position": {"x": 250, "y": 350}` |
+| REQ-13 | `save_on_exit()` | Size persistence - no reset, no size, not resized (REQ-13) | File contains `"size": 300` |
+| REQ-14 | `save_on_exit()` | Size persistence - no reset, no size, resized (REQ-14) | File contains `"size": 550` |
+| REQ-15 | `save_on_exit()` | Size persistence - no reset, --size, not resized (REQ-15) | File contains `"size": 300` |
+| REQ-16 | `save_on_exit()` | Size persistence - no reset, --size, resized (REQ-16) | File contains `"size": 550` |
+| REQ-17 | `save_on_exit()` | Size persistence - reset, no size, not resized (REQ-17) | File contains `"size": 300` |
+| REQ-18 | `save_on_exit()` | Size persistence - reset, no size, resized (REQ-18) | File contains `"size": 550` |
+| REQ-19 | `save_on_exit()` | Size persistence - reset, --size, not resized (REQ-19) | File contains `"size": 300` |
+| REQ-20 | `save_on_exit()` | Size persistence - reset, --size, resized (REQ-20) | File contains `"size": 550` |
+| REQ-21 | `_load()` | Invalid config values (REQ-21) | `ValueError("Invalid configuration format")` raised |
+| REQ-22 | `reload_thresholds()` | Non-threshold live edit ignored (REQ-22) | `config.get('theme') == "dark"` |
+
+## 11. Implementation Notes
+
+### 11.1 File Operations
+- We strictly use `os.replace` (atomic file replacement) during `save_on_exit()` to mitigate the risk of creating a zero-byte file if the app crashes right when writing out changes.
+- The `.tmp` file MUST be placed in the same directory as the target configuration file to ensure `os.replace` doesn't throw a cross-device link error if the temp directory is mounted on a separate block device.
+
+### 11.2 File Path Comparisons in Testing
+- Test suite files should NEVER compare against hardcoded string paths that include directory separators (e.g. `/` or `\`). Use the `pathlib.Path` objects to evaluate test fixtures (`path == Path.home() / ".boostgauge" / "config.json"`), as monkeypatching the OS does not resolve path formatting variations.
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3) *(N/A - Adds only)*
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every function has input/output examples with realistic values (Section 5)
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)

--- a/tests/unit/test_io_examples_detection.py
+++ b/tests/unit/test_io_examples_detection.py
@@ -1,0 +1,166 @@
+"""functions_have_io_examples: judged at the definition site (#2302, #2303).
+
+The fixtures are the real drafts from the 2026-08-13 boostgauge #7 roll, the
+first spec-stage failure in campaign history with its drafts on disk (#2250):
+
+* ``boostgauge-7-spec-draft-008.md`` -- the draft the stage died on. 29 public
+  functions, 22 of them per-criterion test stubs the drafter added to satisfy
+  ``criteria_have_tests``. Every stub carries a concrete input and an expected
+  output inline; the check failed them anyway.
+* ``boostgauge-7-spec-draft-006.md`` -- the revision before it. 7 functions,
+  no test stubs, and it PASSED this check. Kept so a repair cannot be shown
+  green merely by passing everything.
+
+Two defects are pinned here. The detection was forward-only from every textual
+occurrence of a name, so a function inside a long fenced block could not see
+the fence it was inside, and a name repeated often got more chances than a name
+written once (#2302). And test stubs were graded by the rule template 0701
+writes for API functions, which it never asks of a test (#2303).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_functions_have_io_examples as check,
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "io_examples"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+class TestTheDraftTheStageDiedOn:
+    """Draft 008 is the regression fixture. It was correct; the check was not."""
+
+    @pytest.fixture
+    def draft008(self):
+        return _fixture("boostgauge-7-spec-draft-008.md")
+
+    def test_it_passes(self, draft008):
+        result = check(draft008)
+        assert result["passed"], result["details"]
+
+    def test_the_named_stubs_are_no_longer_reported(self, draft008):
+        details = check(draft008)["details"]
+        for stub in ("test_req_3", "test_req_10", "test_req_11", "test_req_12"):
+            assert stub not in details, (
+                f"{stub} is still reported missing. It carries a concrete input "
+                f"and an expected output on its own signature line."
+            )
+
+    def test_the_skipped_tests_are_reported_not_silent(self, draft008):
+        """A silent exemption is indistinguishable from a check that ran."""
+        details = check(draft008)["details"]
+        assert "22 test function(s) were NOT checked" in details
+
+    def test_the_earlier_draft_still_passes(self):
+        """006 passed before this repair and must still pass -- otherwise the
+        change is a rewrite whose agreement with the old behaviour is unknown."""
+        assert check(_fixture("boostgauge-7-spec-draft-006.md"))["passed"]
+
+
+class TestItStillFailsUndocumentedFunctions:
+    """A repair that passes everything is worse than the defect it replaced."""
+
+    def test_bare_signature_in_prose_fails(self):
+        spec = "# Spec\n\nThe module exposes a helper.\n\ndef compute_ratio(n, d):\n    ...\n"
+        result = check(spec)
+        assert not result["passed"]
+        assert "compute_ratio" in result["details"]
+
+    def test_signature_in_a_fence_without_concrete_values_fails(self):
+        spec = "# Spec\n\n```python\ndef compute_ratio(n, d):\n    ...\n```\n"
+        assert not check(spec)["passed"]
+
+    def test_the_test_exemption_does_not_cover_neighbours(self):
+        """An exempt test in the file must not launder the API function beside it."""
+        spec = (
+            "# Spec\n\ndef test_req_1(tmp_path):\n    pass\n\n"
+            "def compute_ratio(n, d):\n    ...\n"
+        )
+        result = check(spec)
+        assert not result["passed"]
+        assert "compute_ratio" in result["details"]
+
+
+class TestTheDetectionItself:
+    """The two mechanical defects, isolated from the fixtures."""
+
+    def test_an_example_above_the_signature_counts(self):
+        """The old window started AT the name and ran forward, so anything
+        documented above it was unreachable."""
+        spec = (
+            "# Spec\n\n**Input Example:** n=3, d=4\n**Output Example:** 0.75\n\n"
+            "def compute_ratio(n, d):\n    ...\n"
+        )
+        assert check(spec)["passed"]
+
+    def test_a_function_deep_inside_a_long_fence_counts(self):
+        """The #2302 case. The opening fence is behind the definition and the
+        closing fence is far ahead, so a forward search for a fence found
+        neither -- while the function sat inside one the whole time."""
+        spec = (
+            "# Spec\n\n```python\n"
+            + "# filler\n" * 400
+            + "def compute_ratio(n, d):\n"
+            "    # -- expected: 0.75 for n=3, d=4\n"
+            "    return n / d\n"
+            + "# filler\n" * 400
+            + "```\n"
+        )
+        assert check(spec)["passed"]
+
+    def test_the_verdict_does_not_depend_on_repetition(self):
+        """Two functions documented identically must get the same verdict, no
+        matter how often one of their names appears elsewhere.
+
+        This is the `save_on_exit` asymmetry from draft 008: it occurred 34
+        times and passed on a few lucky windows, while each test stub occurred
+        once and failed on the same evidence.
+        """
+        documented = (
+            "```python\ndef {name}(a):\n    # -- expected: 4 for a=2\n"
+            "    return a * 2\n```\n"
+        )
+        once = "# Spec\n\n" + documented.format(name="alpha")
+        many = (
+            "# Spec\n\n"
+            + documented.format(name="beta")
+            + "\n".join(f"See beta for detail {i}." for i in range(30))
+        )
+
+        assert check(once)["passed"] == check(many)["passed"]
+
+    def test_expected_is_recognised_as_an_io_word(self):
+        """The drafter's own idiom. Without it, `-- expected: ...` beside a
+        signature reads as no documentation at all."""
+        spec = "# Spec\n\ndef compute_ratio(n, d):\n\nexpected: 0.75 when n=3 and d=4\n"
+        assert check(spec)["passed"]
+
+
+class TestTestFunctionsAreExempt:
+    """#2303: required by one check, graded by another's rule, described by
+    neither section of the template until now."""
+
+    @pytest.mark.parametrize("name", ["test_req_1", "test_position_resets", "roundtrip_test"])
+    def test_test_functions_are_not_graded(self, name):
+        spec = f"# Spec\n\ndef {name}(tmp_path):\n    pass\n"
+        result = check(spec)
+        assert result["passed"]
+        assert "NOT checked" in result["details"]
+
+    def test_a_spec_of_only_tests_is_not_applicable_and_says_so(self):
+        spec = "# Spec\n\ndef test_a():\n    pass\n\ndef test_b():\n    pass\n"
+        result = check(spec)
+        assert result["passed"]
+        assert "not applicable" in result["details"].lower()
+        assert "2 test function(s) were NOT checked" in result["details"]
+
+    def test_private_and_dunder_are_still_skipped(self):
+        spec = "# Spec\n\ndef _helper(a):\n    ...\n\ndef __init__(self):\n    ...\n"
+        assert check(spec)["passed"]


### PR DESCRIPTION
Closes #2302
Closes #2303

Two defects in one check, filed separately because they are different mistakes: one is that the check cannot see examples that are present, the other is that it grades test stubs by a rule the template writes for API functions.

Both were found by answering #2300 from the first spec-stage drafts ever persisted to disk (#2250 working as designed). The findings comment there corrects that issue's premise: `io_examples` failed **once**, on the final draft — the check that failed three times was `criteria_have_tests`.

## What actually happened on the roll

| draft | public fns | `io_examples` | `criteria_have_tests` |
|---|---|---|---|
| 001 | 7 | PASS | FAIL (22 criteria) |
| 004 | 7 | PASS | FAIL (22 criteria) |
| 006 | 7 | PASS | FAIL (22 criteria) |
| 008 | 29 | **FAIL** | PASS |

The drafter spent three revisions failing to add per-criterion tests, finally added 22 `test_req_N` stubs — and the act of satisfying one check broke the other, at the cap.

## #2302 — the detection

The stubs were documented. Each carried a concrete input and an expected output on its own signature line:

```python
def test_req_10(tmp_path):
    # Position persistence - no reset, moved (REQ-10) -- expected: File contains "position": {"x": 250, "y": 350}
```

Three mechanical reasons the check could not see it:

**The window looked only forward.** `spec[pos : pos + 4000]` starts at the name. The 22 stubs sit inside one ~8 kB fenced block whose opening fence is *behind* them and whose closing fence is 4,933–8,110 chars *ahead* — so the window contained no fence at all. The check was asking "is this function inside a code block" and answering it with "is there a fence later in the document". Those diverge exactly when the block is long, which is when a spec has many functions.

Now: enclosure is decided by **fence parity up to the definition offset**, and the window spans **both directions**, so an example above the signature counts.

**Repetition decided the verdict.** Any single passing occurrence passed the function. `save_on_exit` occurs 34 times in draft 008 — six of its windows fail with the identical signature as the stubs, but others land near a fence, so it passed. Each `test_req_N` occurs once and failed. Same documentation, opposite verdicts.

Now: each function is graded **once, at its definition site**. One function, one verdict.

**`expected` was not an I/O word.** The vocabulary was `input|output|returns?|result|example|usage|call`. The drafter's word is `expected`. Added, with `asserts?`.

## #2303 — the contract

`criteria_have_tests` (#2239) requires a per-criterion test **function**. Template 0701 §5 demands `**Input Example:**` / `**Output Example:**` blocks of functions; §10 specifies tests as a **table**. So the drafter was compelled to emit a construct the template never describes, and graded by §5's rule for API functions — the #2232 shape one layer along.

**Ruling applied, stated as an assumption:** test functions are exempt, because a test's body *is* its input and its assertion *is* its expected output — the documentation the rule exists to demand. This is option 1 of the two in #2303; it is the smaller change and matches what the drafter already does naturally. If you prefer option 2 (tests in scope, template amended to demand blocks of them), say so and I will invert it — the exemption is one predicate.

The exemption is **reported, never silent**: `22 test function(s) were NOT checked: a test's body is its input and its assertion is its expected output`. A silent exemption is indistinguishable from a check that ran.

Template 0701 now carries the split: a note in §5, a new §10.1 showing the per-criterion test-function form with a worked example, and the completeness checklist amended.

## It is not vacuous

The risk in this repair is passing everything. It does not:

| case | verdict |
|---|---|
| bare signature in prose, no values | **FAIL** |
| signature in a fence, no concrete values | **FAIL** |
| undocumented API fn beside an exempt test | **FAIL** |
| documented above the signature | PASS (new) |
| documented deep inside a long fence | PASS (the #2302 case) |
| test stub | PASS (exempt, reported) |

Draft **006** is kept as a fixture precisely for this: it passed before this change and must still pass, so the repair cannot be shown green merely by passing everything.

**Falsified.** Removing the exemption fails 5 tests; reverting to the forward-only window fails 1. Both restore to 16 passed.

## Verification

Full unit suite **7220 passed**, 17 skipped, 5 xfailed. `ruff` clean. Both real drafts are frozen as fixtures under `tests/fixtures/io_examples/`.

Under the repaired check, draft 008 — the draft the stage died on — passes all four completeness checks.

## Not addressed here

#2304, the scheduling defect: the revision budget was entirely consumed by `criteria_have_tests`, so `io_examples` first failed at the cap with zero revisions left and was never once put in front of the drafter. That is why a one-round fix became a stage failure, and it remains open.
