### PR TITLE
fix: make the stage verdict explicit and print the halt's real reason (Closes #2297, Closes #2299)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -228,6 +228,15 @@ def create_halt_node(workflow_name: str):
         return {
             "recovery_plan_path": str(plan_path),
             "state_snapshot_path": str(state_path),
+            # #2297: an explicit terminal verdict every caller can read. A
+            # halted workflow used to be distinguishable from a successful one
+            # only by inspecting artifacts, and after #2250 made drafts persist
+            # a cap-halt left the same evidence a success does.
+            "workflow_status": "halted",
+            # Carry the synthesized reason out of the halt as well, so a caller
+            # that only reads error_message sees what the block printed rather
+            # than the empty string routing left behind (#2299).
+            "error_message": error_message,
         }
 
     return halt_with_plan

--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -63,6 +63,24 @@ class RecoveryPlan:
             json.dump(asdict(self), f, indent=2)
         return plan_path
 
+    #: How much of the reason the halt block shows before pointing at the plan.
+    ERROR_LINE_LIMIT = 400
+
+    def _error_line(self) -> str:
+        """The real reason, first line first, bounded so the block stays a block.
+
+        Falls back to the classification only when there is genuinely no
+        message -- and says so in words, because a bare "unknown" is what
+        #2299 was filed about.
+        """
+        message = (self.error_message or "").strip()
+        if not message:
+            return f"(no reason recorded; classified as '{self.error_type}')"
+        head = message.splitlines()[0].strip()
+        if len(head) > self.ERROR_LINE_LIMIT:
+            head = head[: self.ERROR_LINE_LIMIT].rstrip() + "..."
+        return head
+
     def print_summary(self) -> None:
         """Print a human-readable summary to stdout."""
         border = "=" * 60
@@ -72,7 +90,15 @@ class RecoveryPlan:
         print(f"  Issue:     #{self.issue_number}")
         print(f"  Workflow:  {self.workflow}")
         print(f"  Stage:     {self.stage}")
-        print(f"  Error:     {self.error_type}")
+        # #2299: this line printed `error_type` -- the CLASSIFIER's bucket --
+        # under a label that reads as the error itself. `classify_error`
+        # returns "unknown" for anything it has no bucket for, and an
+        # iteration-cap message is exactly that, so every cap halt announced
+        # "Error: unknown" while the real reason sat two lines below in the
+        # recommendation. The message was never missing; the field was showing
+        # a different quantity than its label promised.
+        print(f"  Error:     {self._error_line()}")
+        print(f"  Class:     {self.error_type}")
         print(f"  Transient: {'Yes' if self.is_transient else 'No'}")
         if self.cost_spent_usd > 0:
             print(f"  Cost:      ${self.cost_spent_usd:.2f} / ${self.cost_budget_usd:.2f}")

--- a/assemblyzero/workflows/implementation_spec/nodes/finalize_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/finalize_spec.py
@@ -225,6 +225,10 @@ def finalize_spec(state: ImplementationSpecState) -> dict[str, Any]:
     # -------------------------------------------------------------------------
     return {
         "spec_path": str(spec_path),
+        # #2297: the only place this is set to "completed". The orchestrator
+        # requires it, so a run that never reached finalize cannot be recorded
+        # as a passed stage however many draft files it left on disk.
+        "workflow_status": "completed",
         "error_message": "",
     }
 

--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -210,7 +210,10 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
                         print(f"\n[N2] Recovered existing draft from {drafts[0].name} ({lines} lines) — skipping LLM call")
                         return {
                             "spec_draft": recovered,
-                            "spec_path": str(drafts[0]),
+                            # #2297: a DRAFT path, so it goes in the draft
+                            # field. `spec_path` means "the finalized spec"
+                            # (state.py) and only finalize_spec may set it.
+                            "spec_draft_path": str(drafts[0]),
                             "review_iteration": review_iteration,
                             "completeness_issues": [],
                             "error_message": "",
@@ -434,7 +437,14 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
 
     return {
         "spec_draft": spec_content,
-        "spec_path": str(spec_path) if spec_path else "",
+        # #2297: the audit-trail DRAFT, not the finalized spec. Writing this to
+        # `spec_path` made a cap-halted run indistinguishable from a successful
+        # one at the stage boundary: run_spec_stage accepts the stage when
+        # `spec_path` names an existing file, and after #2250 gave orchestrated
+        # runs an audit_dir this draft is always an existing file. Before #2250
+        # there was no audit_dir, so this was "" and a halt correctly failed --
+        # the lineage repair turned a correct failure into a false success.
+        "spec_draft_path": str(spec_path) if spec_path else "",
         "review_iteration": review_iteration,
         "completeness_issues": [],  # Clear after use
         "previous_review_feedback": review_feedback,  # Issue #486: Save for two-strike

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -145,7 +145,17 @@ class ImplementationSpecState(TypedDict, total=False):
 
     # Generated spec (N2)
     spec_draft: str
+    #: Audit-trail path of the LATEST DRAFT. Written by generate_spec on every
+    #: iteration; a draft existing says nothing about the run succeeding (#2297).
+    spec_draft_path: str
+    #: The FINALIZED spec. Set by finalize_spec alone, and empty unless the
+    #: review approved the draft -- which is what makes it safe for the
+    #: orchestrator to treat as the stage's artifact.
     spec_path: str
+    #: Explicit terminal verdict: "" while running, "completed" when finalize
+    #: approved, "halted" when the workflow stopped. The orchestrator reads
+    #: this rather than inferring success from an artifact's existence (#2297).
+    workflow_status: str
 
     # Validation (N3)
     completeness_issues: list[str]

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -760,7 +760,16 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
         })
 
         spec_path = sub_result.get("spec_path", "")
-        if spec_path and Path(spec_path).is_file():
+        # #2297: the stage verdict is the workflow's OWN explicit status, not an
+        # inference from an artifact existing. A cap-halted run was recorded as
+        # `passed` because generate_spec wrote each draft's audit path into
+        # `spec_path` and the file was really there -- so the roll proceeded to
+        # impl on a spec that was never finalized, and the true failure was
+        # buried five screens up. `halted` is authoritative and refuses the
+        # stage even if an artifact is present.
+        workflow_status = str(sub_result.get("workflow_status", ""))
+        halted = workflow_status == "halted"
+        if not halted and spec_path and Path(spec_path).is_file():
             # Closes #1625: the spec is a permanent artifact paired with the LLD;
             # ride it on the LLD PR so it lands on target main (ADR 0221). The
             # working-tree copy stays for the impl stage to read; the terminal
@@ -777,7 +786,13 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                 attempts=1,
             )
         else:
-            error_msg = sub_result.get("error_message", "Spec workflow completed but no artifact produced")
+            error_msg = sub_result.get("error_message", "")
+            if not error_msg:
+                error_msg = (
+                    "Spec workflow halted before finalizing"
+                    if halted
+                    else "Spec workflow completed but no artifact produced"
+                )
             elapsed = time.monotonic() - start_time
             _record_spec_convergence_failure(
                 target_repo, issue_number, sub_result, elapsed, stage_cfg,

--- a/tests/unit/test_stage_verdict_is_explicit.py
+++ b/tests/unit/test_stage_verdict_is_explicit.py
@@ -1,0 +1,261 @@
+"""A halted workflow is never a passed stage, and a halt says why (#2297, #2299).
+
+The 2026-08-13 boostgauge #7 roll recorded `spec passed 287.5s` against a HALT
+block from the same run, then ran impl against a spec that was never finalized
+and died there with the true failure five screens up.
+
+The cause was not the hypothesized empty `error_message`. `run_spec_stage`
+accepted the stage when `spec_path` named an existing file, and `generate_spec`
+wrote every DRAFT's audit path into `spec_path`. Before #2250 orchestrated runs
+had no `audit_dir`, so that value was "" and a cap-halt correctly failed; the
+lineage repair made the draft a real file and turned the correct failure into a
+false success.
+
+Two paths leave `error_message` empty on purpose and must never read alike:
+a finalize repair in flight (#2233) and a successful finalize. Neither is a
+halt, and `workflow_status` is what separates all three.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from assemblyzero.core.recovery_plan import RecoveryPlan
+from assemblyzero.workflows.orchestrator import stages as stages_mod
+
+
+# ---------------------------------------------------------------------------
+# #2299 — the halt block's Error field
+# ---------------------------------------------------------------------------
+
+
+def _plan(**over) -> RecoveryPlan:
+    base = dict(
+        issue_number=7,
+        workflow="implementation_spec",
+        stage="N5_review_iter3",
+        error_type="unknown",
+        error_message=(
+            "Iteration cap: 3 revision(s) ended with 1 unresolved completeness "
+            "check(s). Unfixed: Functions missing input/output examples: "
+            "`test_req_10()`, `test_req_11()`"
+        ),
+        is_transient=False,
+        state_path="/tmp/state.json",
+        cost_spent_usd=0.0,
+        cost_budget_usd=0.0,
+        halted_at="2026-08-13T16:07:00Z",
+        resume_command="orchestrate --issue 7 --resume-from spec",
+        earliest_retry="",
+        recommendation="Fix the unresolved checks and re-run.",
+    )
+    base.update(over)
+    return RecoveryPlan(**base)
+
+
+class TestTheHaltBlockPrintsTheReason:
+    def test_the_error_field_carries_the_real_reason(self, capsys):
+        _plan().print_summary()
+        out = capsys.readouterr().out
+
+        assert "Error:     Iteration cap: 3 revision(s)" in out, (
+            "the Error field must print the reason, not the classifier's bucket"
+        )
+
+    def test_the_classification_is_still_shown_but_not_as_the_error(self, capsys):
+        _plan().print_summary()
+        out = capsys.readouterr().out
+
+        assert "Class:     unknown" in out
+        # The exact string #2299 was filed about must not reappear.
+        assert "Error:     unknown" not in out
+
+    def test_a_genuinely_absent_reason_says_so_in_words(self, capsys):
+        _plan(error_message="").print_summary()
+        out = capsys.readouterr().out
+
+        assert "no reason recorded" in out
+        assert "Error:     unknown" not in out
+
+    def test_a_long_reason_is_bounded_so_the_block_stays_a_block(self, capsys):
+        _plan(error_message="x" * 5000).print_summary()
+        line = next(
+            ln for ln in capsys.readouterr().out.splitlines()
+            if ln.startswith("  Error:")
+        )
+
+        assert len(line) < RecoveryPlan.ERROR_LINE_LIMIT + 60
+        assert line.endswith("...")
+
+    def test_only_the_first_line_is_used(self, capsys):
+        _plan(error_message="the real reason\nstack frame 1\nstack frame 2").print_summary()
+        out = capsys.readouterr().out
+
+        assert "Error:     the real reason" in out
+        assert "stack frame 1" not in out.split("Class:")[0]
+
+
+# ---------------------------------------------------------------------------
+# #2297 — the stage verdict
+# ---------------------------------------------------------------------------
+
+
+class _FakeApp:
+    def __init__(self, result):
+        self._result = result
+
+    def invoke(self, state):
+        return self._result
+
+
+def _run_spec_stage(tmp_path, sub_result):
+    repo = tmp_path / "repo"
+    (repo / "docs" / "lld" / "active").mkdir(parents=True, exist_ok=True)
+    lld = repo / "docs" / "lld" / "active" / "LLD-007.md"
+    lld.write_text("# LLD\n", encoding="utf-8")
+
+    state = {
+        "issue_number": 7,
+        "lld_path": str(lld),
+        "target_repo": str(repo),
+        "assemblyzero_root": str(Path(__file__).resolve().parents[2]),
+        "base_branch": "hardening-run-17",
+        "config": {"stages": {"spec": {}}, "gates": {}, "skip_existing_spec": False},
+        "stage_results": {},
+    }
+
+    import assemblyzero.workflows.implementation_spec.graph as specgraph
+
+    with patch.object(
+        specgraph, "create_implementation_spec_graph", lambda: _FakeApp(sub_result)
+    ), patch.object(stages_mod, "_ride_spec_on_lld_pr", lambda **k: None), \
+            patch.object(stages_mod, "_record_spec_convergence_failure", lambda *a, **k: None):
+        out = stages_mod.run_spec_stage(state)
+    return out["stage_results"]["spec"]
+
+
+class TestAHaltedWorkflowIsNeverAPassedStage:
+    def test_the_roll_ending_case(self, tmp_path):
+        """The exact shape of the 2026-08-13 roll: a halt that still left a
+        real draft file behind in the audit trail."""
+        draft = tmp_path / "008-spec-draft.md"
+        draft.parent.mkdir(parents=True, exist_ok=True)
+        draft.write_text("# draft\n", encoding="utf-8")
+
+        result = _run_spec_stage(tmp_path, {
+            "workflow_status": "halted",
+            "spec_path": str(draft),          # a real file, as after #2250
+            "error_message": "Iteration cap: 3 revision(s) ended with 1 unresolved check",
+        })
+
+        assert result["status"] == "failed", (
+            "a halted workflow was recorded as a passed stage -- the defect "
+            "that sent the roll on to impl"
+        )
+        assert "Iteration cap" in result["error_message"]
+
+    def test_a_halt_with_no_artifact_also_fails(self, tmp_path):
+        result = _run_spec_stage(tmp_path, {
+            "workflow_status": "halted", "spec_path": "", "error_message": "",
+        })
+
+        assert result["status"] == "failed"
+        assert "halted before finalizing" in result["error_message"]
+
+    def test_a_completed_workflow_with_its_artifact_passes(self, tmp_path):
+        spec = tmp_path / "spec-0007.md"
+        spec.write_text("# spec\n", encoding="utf-8")
+
+        result = _run_spec_stage(tmp_path, {
+            "workflow_status": "completed",
+            "spec_path": str(spec),
+            "error_message": "",
+        })
+
+        assert result["status"] == "passed"
+        assert result["artifact_path"] == str(spec)
+
+    def test_the_2233_empty_error_success_path_still_passes(self, tmp_path):
+        """#2233 leaves error_message empty ON PURPOSE on the repaired-finalize
+        path. That emptiness must keep meaning success, while the halt path's
+        emptiness means failure -- the two can no longer read alike because the
+        verdict is `workflow_status`, not the message."""
+        spec = tmp_path / "spec-0007.md"
+        spec.write_text("# spec\n", encoding="utf-8")
+
+        repaired = _run_spec_stage(tmp_path, {
+            "workflow_status": "completed", "spec_path": str(spec), "error_message": "",
+        })
+        halted = _run_spec_stage(tmp_path, {
+            "workflow_status": "halted", "spec_path": str(spec), "error_message": "",
+        })
+
+        assert repaired["status"] == "passed"
+        assert halted["status"] == "failed"
+
+    def test_a_draft_path_alone_cannot_pass_the_stage(self, tmp_path):
+        """generate_spec no longer writes a draft into spec_path, but the stage
+        must not depend on that: an unfinalized run reports no spec_path at all."""
+        result = _run_spec_stage(tmp_path, {
+            "workflow_status": "",
+            "spec_draft_path": str(tmp_path / "008-spec-draft.md"),
+            "spec_path": "",
+        })
+
+        assert result["status"] == "failed"
+
+
+class TestTheResumeHintNamesTheFailedStage:
+    """The hint inherited the lie: with spec recorded as passed, the roll died
+    at impl and told the operator to resume from impl -- straight back into the
+    same missing-spec wall. It is derived from the failed stage, so fixing the
+    verdict fixes the hint; this pins that it stays derived."""
+
+    def test_the_hint_names_spec_when_spec_failed(self):
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+        from orchestrate import format_error_message
+
+        rendered = format_error_message("spec", {
+            "status": "failed",
+            "error_message": "Iteration cap: 3 revision(s) ended with 1 unresolved check",
+            "attempts": 1,
+            "duration_seconds": 287.5,
+        })
+
+        assert "--resume-from spec" in rendered
+        assert "--resume-from impl" not in rendered
+        assert "ORCHESTRATION FAILED at stage: spec" in rendered
+
+
+class TestGenerateSpecKeepsTheFieldsApart:
+    def test_the_draft_goes_to_the_draft_field(self, tmp_path):
+        """The regression in one assertion: a draft written to `spec_path` is
+        what let an existing file stand in for a finalized spec."""
+        # The package re-exports the FUNCTION under the module's name, so the
+        # module has to be imported explicitly.
+        import importlib
+
+        gs = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec"
+        )
+
+        audit = tmp_path / "audit"
+        audit.mkdir()
+        (audit / "001-spec-draft.md").write_text("# recovered draft\n" * 5, encoding="utf-8")
+
+        out = gs.generate_spec({
+            "audit_dir": str(audit),
+            "spec_draft": "",
+            "review_iteration": 0,
+            "lld_content": "# LLD\n",
+            "repo_root": str(tmp_path),
+            "assemblyzero_root": str(Path(__file__).resolve().parents[2]),
+        })
+
+        assert out.get("spec_draft_path", "").endswith("001-spec-draft.md")
+        assert not out.get("spec_path"), (
+            "generate_spec must never set spec_path -- state.py reserves it for "
+            "the finalized spec, and finalize_spec is its only writer"
+        )


### PR DESCRIPTION
Closes #2297
Closes #2299

Both issues asked for the hypothesis to be verified before building. It was, and **both hypotheses were wrong** — in ways that matter.

## #2297: not the empty error_message

The hypothesis was that stage success is inferred from an empty `error_message`, which #2233 deliberately empties on the repaired-finalize path.

What `run_spec_stage` actually did:

```python
spec_path = sub_result.get("spec_path", "")
if spec_path and Path(spec_path).is_file():
    status = "passed"
```

Success was inferred from **an artifact existing**. And `generate_spec` wrote every *draft's* audit-trail path into `spec_path` — the field `state.py` documents as *"Output path for the final spec file"*.

**The regression came from the #2250 lineage repair.** Before it, orchestrated runs had no `audit_dir`, so `save_audit_file` never ran, `spec_path` was `""`, and a cap-halt correctly recorded as failed. Once drafts persisted, the draft became a real file and the same halt began reading as success. The repair that made spec failures diagnosable for the first time is what made this one invisible — worth stating plainly, because #2250 was verified working during the pre-roll pass and that verification was correct about what it did.

### The fix

The verdict is the workflow's own **explicit status**, not an inference:

- `finalize_spec` sets `workflow_status="completed"` — the only writer of success.
- The HALT node sets `"halted"` and carries its synthesized reason out with it.
- `run_spec_stage` refuses a halted workflow **even when an artifact is present**, so no future artifact can stand in for a verdict.
- `generate_spec` writes `spec_draft_path`, restoring `spec_path` to its documented meaning with `finalize_spec` as its only writer.

## #2299: not a missed surface

The issue read this as the #2197 repair failing to reach the halt block. It isn't. `recovery_plan.print_summary` printed `error_type` — the **classifier's bucket** — under a label reading `Error:`:

```python
print(f"  Error:     {self.error_type}")
```

`classify_error` returns `"unknown"` for anything it has no bucket for, and an iteration-cap message is exactly that. So every cap halt announced `Error: unknown` while the real reason sat two lines below in the recommendation. The message was never missing — the field was showing a different quantity than its label promised.

Now:

```
  Error:     Iteration cap: 3 revision(s) ended with 1 unresolved completeness check(s)...
  Class:     unknown
```

Bounded to the first line and 400 chars so the block stays a block, and a genuinely absent reason says `(no reason recorded; classified as 'unknown')` rather than printing the word this issue was filed about.

## The two empty-error paths, pinned together

The issue asked for exactly this and it is the load-bearing test:

| path | `error_message` | verdict |
|---|---|---|
| #2233 repaired finalize | empty **on purpose** | passed |
| cap halt | may be empty | **failed** |

They can no longer read alike because neither is what decides the verdict. `test_the_2233_empty_error_success_path_still_passes` drives both with identical empty messages and identical artifacts, and asserts opposite verdicts.

## The resume hint

Derived from the failed stage at both sites (`orchestrate.py:109`, `graph.py:446`), so correcting the verdict corrects the hint by construction. Pinned anyway: a cap-halted spec now yields `--resume-from spec` instead of sending the operator back into the missing-spec wall at impl.

## Verification

| Check | Result |
|---|---|
| full unit suite | **7232 passed**, 17 skipped, 5 xfailed |
| new tests | 12 passed |
| `ruff` | same 4 pre-existing findings before and after |

The roll's exact shape is a test: a halt that still left a real draft file behind must fail the stage.

## Still open

#2304 — the revision budget was entirely consumed by `criteria_have_tests`, so `io_examples` first failed at the cap with zero revisions left. That is why a one-round fix became a stage failure.
