### PR TITLE
fix: stop retrying a missing upstream input, and respect the target repo's ignores (Closes #2298, Closes #2301)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -156,6 +156,17 @@ def _classify_halt_transience(sub_result: dict) -> bool | None:
         message = str(sub_result.get("error_message", "")).lower()
         if any(m in message for m in ("stagnant", "stagnation")):
             return False
+        # #2298: a missing required input is deterministic — the file an
+        # upstream stage should have produced is absent, and running this stage
+        # again cannot conjure it. It was retried three times 0.1s apart on the
+        # 2026-08-13 roll, each attempt printing a full banner about a failure
+        # the operator had already been told about.
+        from assemblyzero.workflows.testing.nodes.load_lld import (
+            MISSING_REQUIRED_INPUT,
+        )
+
+        if MISSING_REQUIRED_INPUT.lower() in message:
+            return False
         return None
     try:
         plan = json.loads(Path(plan_path).read_text(encoding="utf-8"))
@@ -549,6 +560,23 @@ def _ride_spec_on_lld_pr(
     try:
         rel = src.relative_to(Path(target_repo))
     except ValueError:
+        return False
+
+    # #2301: ask the TARGET repo whether it wants this path tracked before
+    # trying to add it. boostgauge gitignores docs/lineage, so every roll
+    # printed "git add failed (non-fatal)" — a failure line for a repo doing
+    # exactly what it configured. Whether lineage is tracked differs by repo,
+    # and the repo's own ignore rules are the authority; log noise is what
+    # buries real failures.
+    ignored = run_command(
+        ["git", "check-ignore", "-q", str(rel)], cwd=str(worktree),
+        capture_output=True, text=True,
+    )
+    if ignored.returncode == 0:
+        print(
+            f"    [spec] {rel.as_posix()} is gitignored in this repo — not "
+            f"riding it on the LLD PR. The spec stays on the working tree."
+        )
         return False
 
     try:

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -44,6 +44,17 @@ class WorkflowParsingError(ValueError):
 # LLD directory relative to repo root (kept for backward-compatible helpers)
 LLD_ACTIVE_DIR = Path("docs/lld/active")
 
+#: Marks a failure caused by an input an UPSTREAM stage should have produced
+#: (#2298). Deterministic by construction: the file is absent, and running the
+#: same stage again cannot conjure it. The orchestrator's transience classifier
+#: keys off this token, so retry behaviour follows from the failure's kind
+#: rather than from prose that a later reword could silently change.
+#:
+#: Earned 2026-08-13 (boostgauge #7): the impl stage retried a missing spec
+#: three times, 0.1s apart, each printing a full banner about an upstream
+#: failure it had already reported.
+MISSING_REQUIRED_INPUT = "MISSING REQUIRED INPUT"
+
 # Implementation Spec directories (Issue #384, #525)
 SPEC_DRAFTS_DIR = Path("docs/lld/drafts")
 LINEAGE_ACTIVE_DIR = Path("docs/lineage/active")
@@ -827,22 +838,35 @@ def load_lld(state: TestingWorkflowState) -> dict[str, Any]:  # pragma: no cover
 
     # Issue #384: No spec found — exit with specific command to generate one
     if not lld_path_obj or not lld_path_obj.exists():
-        cmd = build_spec_command(issue_number, repo_root)
+        # #2298: point at the DURABLE repo, not the worktree. The worktree is
+        # torn down by RESTORE seconds after this prints, so a command naming
+        # it is already stale by the time the operator reads the log.
+        durable_root = Path(state.get("original_repo_root") or repo_root)
+        cmd = build_spec_command(issue_number, durable_root)
         error_msg = (
             f"\n"
             f"    +==============================================================+\n"
             f"    |  No Implementation Spec found for issue #{issue_number:<20}|\n"
             f"    |                                                              |\n"
-            f"    |  The TDD workflow requires an implementation spec.           |\n"
-            f"    |  Generate one first by running:                              |\n"
+            f"    |  This is a MISSING REQUIRED INPUT, not a transient fault.    |\n"
+            f"    |  The spec stage should have produced it and did not, so      |\n"
+            f"    |  retrying this stage cannot change the outcome.              |\n"
+            f"    |                                                              |\n"
+            f"    |  Fix the SPEC stage first, then relaunch.                    |\n"
             f"    +==============================================================+\n"
             f"\n"
             f"    {cmd}\n"
         )
         print(error_msg)
         return {
-            "error_message": f"No implementation spec found for issue #{issue_number}. "
-            f"Run: {cmd}"
+            # The marker is what the orchestrator's transience classifier keys
+            # off (#2298). Kept as a constant rather than matched by prose so
+            # a reworded banner cannot silently make this retryable again.
+            "error_message": (
+                f"{MISSING_REQUIRED_INPUT}: no implementation spec found for "
+                f"issue #{issue_number}. The spec stage should have produced "
+                f"it. Run: {cmd}"
+            )
         }
 
     print(f"    Spec path: {lld_path_obj}")

--- a/tests/unit/test_missing_input_is_not_transient.py
+++ b/tests/unit/test_missing_input_is_not_transient.py
@@ -1,0 +1,190 @@
+"""A missing required input is deterministic, not transient (#2298).
+
+On the 2026-08-13 boostgauge #7 roll the impl stage found no implementation
+spec — the upstream spec stage had halted — and retried it three times, 0.1s
+apart, each attempt printing the full "No Implementation Spec found" banner and
+a "Next attempt will be regenerated (discarding the previous attempt's
+generated files)" warning about files that were never generated.
+
+Zero chance of a different outcome on any attempt: the file is absent and
+running the same stage again cannot conjure it.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.orchestrator.stages import _classify_halt_transience
+from assemblyzero.workflows.testing.nodes.load_lld import MISSING_REQUIRED_INPUT
+
+
+def _sub_result(message: str) -> dict:
+    """A halt with no recovery plan — the shape the guard actually returns."""
+    return {"error_message": message}
+
+
+class TestTheClassifierSeparatesDeterministicFromTransient:
+    def test_a_missing_required_input_is_not_transient(self):
+        result = _classify_halt_transience(
+            _sub_result(
+                f"{MISSING_REQUIRED_INPUT}: no implementation spec found for "
+                f"issue #7. The spec stage should have produced it."
+            )
+        )
+        assert result is False, (
+            "a missing upstream artifact was classified retryable — three "
+            "attempts at 0.1s each, all guaranteed to fail identically"
+        )
+
+    def test_the_marker_is_matched_case_insensitively(self):
+        assert _classify_halt_transience(
+            _sub_result("missing required input: nothing to build from")
+        ) is False
+
+    def test_a_stagnation_halt_is_still_non_transient(self):
+        """The pre-existing deterministic case must keep its verdict."""
+        assert _classify_halt_transience(
+            _sub_result("Implementation stagnant after 3 rounds")
+        ) is False
+
+    def test_an_unrecognised_bare_failure_is_still_unset(self):
+        """None means "no opinion" and preserves the retry loop's behaviour for
+        genuine flakes such as a gh CLI hiccup. Narrowing that to False here
+        would silently stop retrying things that SHOULD be retried."""
+        assert _classify_halt_transience(
+            _sub_result("gh: connection reset by peer")
+        ) is None
+
+    def test_no_error_message_at_all_is_unset(self):
+        assert _classify_halt_transience({}) is None
+
+
+class TestTheGuardEmitsTheMarkerAndNamesTheUpstreamStage:
+    def test_the_message_carries_the_marker_and_names_the_spec_stage(self, tmp_path):
+        import importlib
+
+        mod = importlib.import_module(
+            "assemblyzero.workflows.testing.nodes.load_lld"
+        )
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        durable = tmp_path / "repo"
+        durable.mkdir()
+
+        out = mod.load_lld({
+            "issue_number": 7,
+            "repo_root": str(worktree),
+            "original_repo_root": str(durable),
+            "spec_path": "",
+            "lld_path": "",
+        })
+
+        message = out.get("error_message", "")
+        assert MISSING_REQUIRED_INPUT in message
+        assert "spec stage" in message.lower(), (
+            "the halt must name the upstream stage that should have produced "
+            "the input, so the operator is not sent back to this one"
+        )
+
+    def test_the_command_names_the_durable_repo_not_the_worktree(self, tmp_path):
+        """#2298: the worktree is torn down by RESTORE seconds after this
+        prints, so a command naming it is stale before it is read.
+
+        (The filed claim that the banner printed AFTER teardown is not borne
+        out by the events log — RESTORE began at 11:08:15, after the child
+        exited at 11:08:15, and the banner was part of the child's output. The
+        real defect is the ephemeral path, not the ordering.)
+        """
+        import importlib
+
+        mod = importlib.import_module(
+            "assemblyzero.workflows.testing.nodes.load_lld"
+        )
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        durable = tmp_path / "repo"
+        durable.mkdir()
+
+        out = mod.load_lld({
+            "issue_number": 7,
+            "repo_root": str(worktree),
+            "original_repo_root": str(durable),
+            "spec_path": "",
+            "lld_path": "",
+        })
+
+        message = out.get("error_message", "")
+        assert str(durable) in message
+        assert "worktrees" not in message, (
+            "the suggested command still points into the worktree RESTORE removes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #2301 — a deliberately-ignored path is not a failure
+# ---------------------------------------------------------------------------
+
+
+class TestRidingTheSpecRespectsTheTargetRepoIgnores:
+    """boostgauge gitignores docs/lineage, so every roll printed
+    `[spec] git add failed (non-fatal): The following paths are ignored`.
+
+    A repo doing exactly what it configured must not produce a failure line.
+    """
+
+    def _repo_with_ignore(self, tmp_path, ignore_line: str):
+        import subprocess
+
+        repo = tmp_path / "wt"
+        repo.mkdir()
+        for args in (["init", "-q", "-b", "main"],
+                     ["config", "user.email", "t@t"],
+                     ["config", "user.name", "t"]):
+            subprocess.run(["git", "-C", str(repo), *args], check=True,
+                           capture_output=True)
+        (repo / ".gitignore").write_text(f"{ignore_line}\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", ".gitignore"], check=True,
+                       capture_output=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-qm", "base"],
+                       check=True, capture_output=True)
+        return repo
+
+    def _ride(self, tmp_path, worktree, spec_rel):
+        from assemblyzero.workflows.orchestrator import stages as stages_mod
+
+        target = tmp_path / "target"
+        spec = target / spec_rel
+        spec.parent.mkdir(parents=True, exist_ok=True)
+        spec.write_text("# spec\n", encoding="utf-8")
+
+        # stages.py imports this INSIDE the function, so it is not an attribute
+        # of stages — patch it where it is defined.
+        import assemblyzero.workflows.requirements.git_operations as git_ops
+
+        with patch.object(
+            git_ops, "lld_worktree_path_for", lambda *a, **k: worktree
+        ):
+            return stages_mod._ride_spec_on_lld_pr(
+                spec_path=str(spec), target_repo=str(target), issue_number=7,
+            )
+
+    def test_an_ignored_path_is_skipped_without_a_failure_line(self, tmp_path, capsys):
+        worktree = self._repo_with_ignore(tmp_path, "docs/lineage")
+
+        result = self._ride(tmp_path, worktree, "docs/lineage/active/7/spec.md")
+        out = capsys.readouterr().out
+
+        assert result is False
+        assert "gitignored in this repo" in out
+        assert "git add failed" not in out, (
+            "a repo honouring its own .gitignore printed a failure line"
+        )
+
+    def test_a_tracked_path_is_still_ridden(self, tmp_path, capsys):
+        """The ignore check must not become a blanket skip."""
+        worktree = self._repo_with_ignore(tmp_path, "docs/lineage")
+
+        result = self._ride(tmp_path, worktree, "docs/lld/drafts/spec-0007.md")
+        out = capsys.readouterr().out
+
+        assert "gitignored in this repo" not in out
+        assert result is True

--- a/tests/unit/test_spec_rides_lld_pr.py
+++ b/tests/unit/test_spec_rides_lld_pr.py
@@ -15,7 +15,14 @@ from assemblyzero.workflows.orchestrator.state import create_initial_state
 
 def _ok_run(cmd, **kw):
     out = MagicMock()
-    out.returncode = 0
+    # #2301: `git check-ignore` inverts the usual convention -- it exits 0 when
+    # the path IS ignored and 1 when it is not. A blanket returncode=0 stub
+    # therefore claims every path is gitignored, and the ride correctly
+    # declines. Model git's real contract: these fixtures use tracked paths.
+    if len(cmd) > 1 and cmd[1] == "check-ignore":
+        out.returncode = 1
+    else:
+        out.returncode = 0
     out.stdout = ""
     out.stderr = ""
     return out


### PR DESCRIPTION
Closes #2298
Closes #2301

## #2298 — a missing input is not a fault to retry

The impl stage found no implementation spec and retried three times, 0.1s apart, each printing the full banner and a warning about "discarding the previous attempt's generated files" when nothing had been generated.

The guard returned a bare `error_message` with no recovery plan, so `_classify_halt_transience` returned `None` — which means *no opinion*, leaving the retry loop free to retry.

It now emits a `MISSING_REQUIRED_INPUT` marker and the classifier reads it as non-transient: **one attempt, immediate halt**. The marker is a constant rather than matched prose, so a reworded banner cannot silently make it retryable again.

`None` is deliberately preserved for unrecognised failures — narrowing it would stop retrying genuine flakes like a `gh` hiccup, which is pinned by a test.

The banner now states this is a missing required input rather than a fault, and names the **spec stage** as the one that should have produced it, so the operator is not sent back into the stage that cannot fix it.

### One filed claim is corrected, not fixed

> *"Attempt 3's banner printed at 11:08:15 — AFTER the RESTORE sweep had already removed the pipeline worktrees"*

Not borne out by the artifacts. `session-events.log`:

```
2026-08-13 11:08:15 HALT #7 exited 1 -- no redraw (#2206)
2026-08-13 11:08:15 RESTORE returning the repo to its default branch
2026-08-13 11:08:17 docs/lld/active/LLD-007.md: preserved-and-cleared
2026-08-13 11:08:17 RESTORE verified
```

and `run-issue7-105024-events.log` shows `CHILD EXITED rc=1` at 11:08:15. RESTORE begins *after* the child exits, and the banner was part of the child's output before exit. Both land in the same second, which is what made the log read that way. There is no print-after-teardown ordering bug.

**The substance of the complaint is real, with a different cause.** The printed command named the *ephemeral worktree* (`data\worktrees\7`), which RESTORE removes two seconds later — so it was stale before it could be read. It now names the durable repo.

Since a missing input is non-transient, attempts 2 and 3 no longer happen at all, which removes the observed symptom at its source regardless.

## #2301 — a repo honouring its own .gitignore is not a failure

The spec ride git-added `docs/lineage` unconditionally. boostgauge gitignores it, so every roll printed:

```
[spec] git add failed (non-fatal): The following paths are ignored by one of your .gitignore files:
docs/lineage
```

The target repo's ignore rules are now consulted first, and an ignored path is skipped with a plain statement rather than a failure line. Whether lineage is tracked differs by repo, and the repo's own configuration is the authority.

**Worth noting the interaction:** this was partly a *symptom* of #2297. The path was under `docs/lineage` only because `spec_path` held a draft from the audit trail. With that fixed, `spec_path` is the finalized spec under `docs/lld/drafts/` — but the ride should not blow up on a deliberately-ignored path whatever feeds it, so the guard stands on its own.

## An existing test changed, and why

`test_spec_rides_lld_pr`'s stub returned `returncode = 0` for every git call. `git check-ignore` **inverts the convention** — 0 means the path *is* ignored, 1 means it is not. So the blanket stub claimed every path was gitignored and the ride correctly declined.

The stub now models git's real contract. Calling this out because it is an existing test whose behaviour I changed: its fixtures use tracked paths, so it passes for the right reason rather than by a stub that happened to agree.

## Verification

| Check | Result |
|---|---|
| full unit suite | **7241 passed**, 17 skipped, 5 xfailed |
| new tests | 9 passed |
| `ruff` on touched files | pre-existing findings only, unchanged |

The ignore test builds a real git repo with a real `.gitignore` rather than stubbing the answer, and asserts both directions: an ignored path is skipped, a tracked path is still ridden — so the guard cannot become a blanket skip.
