### PR TITLE
fix(speedrun): RESTORE disposes the branch its worktree carried (Closes #2310)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -19,6 +19,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 from assemblyzero.workflows.orchestrator.artifacts import (
     detect_existing_artifacts,
@@ -887,6 +888,78 @@ def _provision_worktree_env(worktree_path: Path) -> subprocess.CompletedProcess:
     )
 
 
+class _LeftoverBranch(NamedTuple):
+    """What a pre-existing pipeline branch holds, for #2310's decision.
+
+    `absent` is the ordinary case and is neither reusable nor divergent, so
+    the caller falls through to the normal `worktree add -b` path.
+    """
+
+    absent: bool
+    reusable: bool
+    divergent: bool
+    unique_commits: int | None
+
+    def describe_unique(self) -> str:
+        if self.unique_commits is None:
+            return "commits"
+        return f"{self.unique_commits} commit(s)"
+
+
+def _classify_leftover_branch(
+    target_repo: str, branch_name: str, base_branch: str,
+) -> _LeftoverBranch:
+    """Decide whether an existing `branch_name` may be adopted by this roll.
+
+    #2310: `git worktree add -b X` fails with a bare `fatal: a branch named
+    'X' already exists` when a previous failed roll left the name standing.
+    The measured case was pointer-identical to the base with zero unique
+    commits -- a name squatting on the exact SHA the new run wanted, killing
+    a roll for nothing. That case is safe to adopt. A branch holding commits
+    of its own is NOT this roll's to reuse or delete, and gets a halt naming
+    what it holds instead of an exit 255.
+
+    Every git failure here resolves to "not reusable, not divergent", so an
+    unreadable repo keeps the previous behaviour rather than inventing a new
+    failure mode.
+    """
+    def _git(*args: str) -> subprocess.CompletedProcess:
+        cmd = ["git"]
+        if target_repo:
+            cmd += ["-C", target_repo]
+        return run_command(
+            [*cmd, *args], check=False, capture_output=True, text=True,
+        )
+
+    absent = _git(
+        "show-ref", "--verify", "--quiet", f"refs/heads/{branch_name}",
+    ).returncode != 0
+    if absent:
+        return _LeftoverBranch(True, False, False, None)
+
+    if not base_branch:
+        # Nothing to compare against: cannot prove it is safe to adopt, and
+        # cannot prove it diverges. Let git speak, as before.
+        return _LeftoverBranch(False, False, False, None)
+
+    counted = _git(
+        "rev-list", "--count", f"{base_branch}..{branch_name}",
+    )
+    if counted.returncode != 0:
+        return _LeftoverBranch(False, False, False, None)
+    try:
+        unique = int(counted.stdout.strip())
+    except ValueError:
+        return _LeftoverBranch(False, False, False, None)
+
+    return _LeftoverBranch(
+        absent=False,
+        reusable=unique == 0,
+        divergent=unique > 0,
+        unique_commits=unique,
+    )
+
+
 def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     """Execute implementation workflow (TDD).
 
@@ -960,6 +1033,38 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                     "    [WARN] could not resolve a base branch; worktree "
                     "will be carved from the target repo's current HEAD"
                 )
+
+            # #2310: a previous failed roll can leave `issue-{N}` standing.
+            # `worktree add -b` then dies with a bare `fatal: a branch named
+            # 'issue-7' already exists` (exit 255), which killed a roll whose
+            # spec stage had just passed for the first time in campaign
+            # history. Decide from what the leftover actually holds, before
+            # git gets the chance to fail uninformatively.
+            leftover = _classify_leftover_branch(
+                target_repo, branch_name, base_branch,
+            )
+            if leftover.divergent:
+                raise RuntimeError(
+                    f"branch '{branch_name}' already exists and carries "
+                    f"{leftover.describe_unique()} not on "
+                    f"'{base_branch or 'the base'}'. It is not this roll's to "
+                    f"reuse or delete. Preserve it under graveyard/ (a rename "
+                    f"keeps every commit and frees the name), then relaunch."
+                )
+            if leftover.reusable:
+                # Pointer-identical to the base: nothing to lose by adopting
+                # it, and adopting is what keeps the relaunch alive. Rebuild
+                # the command in the `worktree add <path> <existing-branch>`
+                # form -- `-b` would try to create it again and fail.
+                print(
+                    f"    Reusing leftover branch '{branch_name}' "
+                    f"(pointer-identical to {base_branch or 'the base'})"
+                )
+                add_cmd = ["git"]
+                if target_repo:
+                    add_cmd += ["-C", target_repo]
+                add_cmd += ["worktree", "add", str(worktree_path), branch_name]
+
             run_command(
                 add_cmd,
                 check=True,

--- a/tests/unit/test_restore_branch_disposition.py
+++ b/tests/unit/test_restore_branch_disposition.py
@@ -1,0 +1,201 @@
+"""#2310: RESTORE must not strand the branch its worktree carried.
+
+The incident: a failed roll's RESTORE removed the impl worktree but left
+`issue-7` standing on the exact SHA the relaunch wanted to branch from. The
+relaunch's `git worktree add -b issue-7` died with
+
+    fatal: a branch named 'issue-7' already exists
+
+killing a roll whose spec stage had just passed for the first time in
+campaign history.
+
+These tests drive real git repositories rather than mocks, because the
+defect lives entirely in what git does with a branch name -- a mocked
+`_run` would have happily reported success for the code that shipped the bug.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_reset as reset  # noqa: E402
+
+from assemblyzero.workflows.orchestrator.stages import (  # noqa: E402
+    _classify_leftover_branch,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A git repo with one commit on `main`, origin/HEAD resolvable."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", "seed.txt")
+    _git(root, "commit", "-m", "seed")
+    return root
+
+
+def _branches(repo: Path) -> list[str]:
+    out = _git(repo, "branch", "--list", "--format=%(refname:short)").stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def test_pointer_identical_branch_name_is_freed(repo: Path) -> None:
+    """The measured #2310 case: zero unique commits, so the name is freed.
+
+    This is the state that killed the roll -- `issue-7` pointing at the very
+    SHA the relaunch wanted as its base.
+    """
+    _git(repo, "branch", "issue-7")
+    assert "issue-7" in _branches(repo)
+
+    failures = reset.dispose_pipeline_branches(repo, 7)
+
+    assert failures == []
+    assert "issue-7" not in _branches(repo)
+
+
+def test_branch_with_unique_commits_is_preserved_not_deleted(
+    repo: Path,
+) -> None:
+    """Unique work is renamed under graveyard/, never deleted.
+
+    The name is still freed -- that is what unblocks the relaunch -- but
+    every commit survives under the new name.
+    """
+    _git(repo, "checkout", "-b", "issue-7")
+    (repo / "work.txt").write_text("unique work\n", encoding="utf-8")
+    _git(repo, "add", "work.txt")
+    _git(repo, "commit", "-m", "work only on issue-7")
+    tip = _git(repo, "rev-parse", "issue-7").stdout.strip()
+    _git(repo, "checkout", "main")
+
+    failures = reset.dispose_pipeline_branches(repo, 7)
+
+    assert failures == []
+    names = _branches(repo)
+    assert "issue-7" not in names, "the colliding name must be freed"
+
+    parked = [n for n in names if n.startswith("graveyard/issue-7")]
+    assert len(parked) == 1, f"expected one preserved branch, got {names}"
+    preserved_tip = _git(repo, "rev-parse", parked[0]).stdout.strip()
+    assert preserved_tip == tip, "the commit must survive the rename"
+
+
+def test_checked_out_branch_is_never_disposed(repo: Path) -> None:
+    """#1762: never dispose of the branch the checkout is standing on."""
+    _git(repo, "checkout", "-b", "issue-7")
+
+    failures = reset.dispose_pipeline_branches(repo, 7)
+
+    assert failures == []
+    assert "issue-7" in _branches(repo)
+
+
+def test_disposal_never_force_deletes() -> None:
+    """The banned-commands rule, asserted against the source.
+
+    A future edit that reaches for `-D` to make a stubborn branch go away
+    fails here rather than in a post-mortem.
+    """
+    source = (
+        Path(__file__).resolve().parents[2] / "tools" / "speedrun_reset.py"
+    ).read_text(encoding="utf-8")
+    body = source.split("def dispose_pipeline_branches", 1)[1]
+    body = body.split("\ndef delete_remote_branches", 1)[0]
+
+    assert '"-D"' not in body
+    assert "'-D'" not in body
+    assert '"-M"' not in body, "-M would clobber an existing graveyard name"
+
+
+def test_absent_branch_falls_through_to_normal_creation(repo: Path) -> None:
+    """No leftover: neither reusable nor divergent, so `-b` runs as before."""
+    verdict = _classify_leftover_branch(str(repo), "issue-7", "main")
+
+    assert verdict.absent is True
+    assert verdict.reusable is False
+    assert verdict.divergent is False
+
+
+def test_pointer_identical_leftover_is_reusable(repo: Path) -> None:
+    """The measured #2310 case must not kill the roll."""
+    _git(repo, "branch", "issue-7")
+
+    verdict = _classify_leftover_branch(str(repo), "issue-7", "main")
+
+    assert verdict.absent is False
+    assert verdict.reusable is True
+    assert verdict.divergent is False
+    assert verdict.unique_commits == 0
+
+
+def test_divergent_leftover_is_named_not_silently_reused(repo: Path) -> None:
+    """A branch holding work is not this roll's to adopt or destroy."""
+    _git(repo, "checkout", "-b", "issue-7")
+    (repo / "work.txt").write_text("unique\n", encoding="utf-8")
+    _git(repo, "add", "work.txt")
+    _git(repo, "commit", "-m", "someone else's work")
+    _git(repo, "checkout", "main")
+
+    verdict = _classify_leftover_branch(str(repo), "issue-7", "main")
+
+    assert verdict.divergent is True
+    assert verdict.reusable is False
+    assert verdict.unique_commits == 1
+    assert "1 commit(s)" in verdict.describe_unique()
+
+
+def test_unresolvable_base_keeps_previous_behaviour(repo: Path) -> None:
+    """Cannot prove safe or divergent -> let git speak, as before."""
+    _git(repo, "branch", "issue-7")
+
+    verdict = _classify_leftover_branch(str(repo), "issue-7", "")
+
+    assert verdict.reusable is False
+    assert verdict.divergent is False
+
+
+def test_relaunch_sequence_survives_the_incident(repo: Path) -> None:
+    """End to end: run dies leaving a branch, RESTORE sweeps, relaunch works.
+
+    This is the #2310 acceptance case -- the sequence that failed on
+    2026-08-13, driven against real git.
+    """
+    # A roll creates its impl worktree on issue-7, then dies.
+    worktree = repo / "data" / "worktrees" / "7"
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    added = _git(
+        repo, "worktree", "add", str(worktree), "-b", "issue-7", "main",
+    )
+    assert added.returncode == 0, added.stderr
+
+    # RESTORE sweeps: worktree removed, then the branch disposed of.
+    assert reset.remove_worktree(repo, 7) is True
+    assert reset.dispose_pipeline_branches(repo, 7) == []
+
+    # The relaunch carves its worktree from the same base. Before the fix
+    # this failed with "a branch named 'issue-7' already exists".
+    relaunch = _git(
+        repo, "worktree", "add", str(worktree), "-b", "issue-7", "main",
+    )
+    assert relaunch.returncode == 0, (
+        f"relaunch worktree add failed: {relaunch.stderr}"
+    )

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -45,6 +45,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Branch namespace for preserved work. Matches speedrun_new_attempt and the
+# `speedrun_clean_check` exemption, so a parked branch is not later reported
+# as debris.
+GRAVEYARD_PREFIX = "graveyard/"
+
 
 def _rmtree_clearing_readonly(path: Path) -> None:
     """rmtree that survives the ReadOnly attribute (#2162).
@@ -272,6 +277,101 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
                 f"left in place for review)."
             )
     return deleted
+
+
+def dispose_pipeline_branches(repo_root: Path, issue: int) -> list[str]:
+    """
+    Free the pipeline branch names for one issue. Returns failure descriptions.
+
+    #2310: removing a worktree does not remove the branch it carried, so a
+    failed roll left `issue-{N}` standing on the exact SHA the relaunch
+    wanted to branch from, and `git worktree add -b issue-{N}` died with a
+    bare `fatal: a branch named 'issue-7' already exists`. A name squatting
+    on the base killed a roll whose spec stage had just passed for the first
+    time in campaign history.
+
+    Two dispositions, decided by what the branch actually holds:
+
+    - No commits beyond the base: `git branch -d` accepts it, and the name
+      is freed. This is the measured case from #2310 -- the stranded branch
+      was pointer-identical to `origin/hardening-run-17`'s tip.
+    - Commits of its own: the safe delete refuses, and that refusal is the
+      safety net working. The branch is RENAMED under `graveyard/`, which
+      keeps every commit and still frees the name. Never `-D`, never a
+      force delete, per the banned-commands rule and ADR-0217.
+
+    A rename rather than a delete is what makes this safe to run
+    unconditionally from RESTORE: the worst case is a preserved branch under
+    a new name, never lost work.
+    """
+    result = _run(
+        [
+            "git", "branch", "--list", "--format=%(refname:short)",
+            f"{issue}-*", f"issue-{issue}",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return [f"could not list branches for #{issue}"]
+
+    active = current_branch(repo_root)
+    failures: list[str] = []
+    for branch in (line.strip() for line in result.stdout.splitlines()):
+        if not branch or branch.startswith(GRAVEYARD_PREFIX):
+            continue
+        if branch == active:
+            # Never dispose of the branch the checkout is standing on (#1762).
+            print(f"  Skipped branch {branch} (currently checked out).")
+            continue
+
+        deleted = _run(["git", "branch", "-d", branch], cwd=repo_root)
+        if deleted.returncode == 0:
+            print(f"  Freed branch name: {branch} (no unique commits)")
+            continue
+
+        # Safe-delete refused -- the branch carries commits reachable from
+        # nowhere else. Preserve them under a name no relaunch will collide
+        # with. `-m` (not `-M`) so an existing graveyard name is never
+        # clobbered; the collision is reported instead.
+        parked = f"{GRAVEYARD_PREFIX}{branch}-{_disposal_stamp()}"
+        renamed = _run(["git", "branch", "-m", branch, parked], cwd=repo_root)
+        if renamed.returncode == 0:
+            unique = _unique_commit_count(repo_root, parked)
+            detail = f"{unique} commit(s)" if unique is not None else "commits"
+            print(f"  Preserved branch {branch} -> {parked} ({detail} kept)")
+        else:
+            failures.append(
+                f"branch '{branch}' holds unique commits and could not be "
+                f"renamed to '{parked}': "
+                f"{(renamed.stderr or '').strip()[:200]}"
+            )
+    return failures
+
+
+def _disposal_stamp() -> str:
+    """UTC stamp for a graveyard branch name. Sorts, and never collides."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _unique_commit_count(repo_root: Path, branch: str) -> int | None:
+    """Commits on `branch` not reachable from the default branch, or None."""
+    base = _run(
+        ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"], cwd=repo_root
+    )
+    if base.returncode != 0 or not base.stdout.strip():
+        return None
+    counted = _run(
+        ["git", "rev-list", "--count", f"{base.stdout.strip()}..{branch}"],
+        cwd=repo_root,
+    )
+    if counted.returncode != 0:
+        return None
+    try:
+        return int(counted.stdout.strip())
+    except ValueError:
+        return None
 
 
 def delete_remote_branches(repo_root: Path, issue: int) -> int:

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1851,6 +1851,15 @@ def restore_repo(
         return [f"could not check out {base}: {(checkout.stderr or '').strip()}"]
 
     failures: list[str] = []
+
+    # #2310: a removed worktree leaves its branch standing. Dispose of it here
+    # -- AFTER the checkout has moved to the base, so the branch being freed is
+    # never the one HEAD is on. Left alone, `issue-{N}` squats on the SHA the
+    # relaunch wants to branch from and `worktree add -b` dies on it.
+    # Branch names are freed by safe delete when they hold nothing unique, and
+    # preserved under graveyard/ when they hold work. Never a force delete.
+    for issue in issues:
+        failures += reset.dispose_pipeline_branches(repo_root, issue)
     current = attempt.current_branch(repo_root)
     if current != base:
         failures.append(f"expected to end on '{base}', ended on '{current}'")


### PR DESCRIPTION
Closes #2310

A removed worktree left its branch standing. `issue-{N}` then squatted on the exact SHA the relaunch wanted to branch from, and `git worktree add -b` died with a bare `fatal: a branch named 'issue-7' already exists` (exit 255) — killing a roll whose spec stage had just passed for the first time in campaign history.

Both halves land, either sufficient on its own.

## 1. RESTORE finishes what it starts

`dispose_pipeline_branches` in `tools/speedrun_reset.py`, called from RESTORE:

| Branch holds | Disposition |
|---|---|
| Nothing unique (the measured case) | `git branch -d` — name freed |
| Commits of its own | renamed to `graveyard/<branch>-<UTC stamp>` — every commit kept, name still freed |
| Currently checked out | left alone (#1762) |

The rename is what makes this safe to run unconditionally: the worst case is a preserved branch under a new name, never lost work. No `-D`. No `-M` either — an existing graveyard name is reported, never clobbered.

It runs after the checkout has moved to the base, so the branch being freed is never the one HEAD is on.

## 2. Worktree creation tolerates its own leftovers

`_classify_leftover_branch` in `assemblyzero/workflows/orchestrator/stages.py` decides from what the branch actually holds:

- **pointer-identical** → adopted via `worktree add <path> <branch>`, roll continues
- **divergent** → halts naming how many commits it carries and where to park them, instead of `exit 255`
- **any git failure** → resolves to the previous behaviour, so an unreadable repo gains no new failure mode

## Acceptance

- [x] A failed roll's RESTORE leaves no branch that a relaunch's worktree creation collides with
- [x] A pre-existing pointer-identical branch does not kill a roll
- [x] A pre-existing divergent branch halts with the divergence named, not `exit 255`
- [x] A test reproduces the sequence: run dies at impl, RESTORE sweeps, relaunch succeeds

## Tests

`tests/unit/test_restore_branch_disposition.py`, 9 tests, driving **real git repositories rather than mocks** — the defect lives entirely in what git does with a branch name, and a mocked runner would have reported success for the code that shipped the bug.

`test_relaunch_sequence_survives_the_incident` replays the 2026-08-13 sequence end to end. `test_disposal_never_force_deletes` asserts against the source that a force delete cannot reappear in a later edit.

Full unit suite: **7250 passed, 17 skipped, 0 failures**. `ruff check` clean on all four files.

## Provenance

Found in the post-mortem of `run-issue7-153937` (boostgauge #7, 2026-08-13). That post-mortem also filed #2316–#2323 for the defects that made the run halt; this PR addresses only the relaunch blocker, which gates every future roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
