### PR TITLE
fix(speedrun): measure before disposing — branch -d is not the verdict (Closes #2325)

### DIFF
--- a/tests/unit/test_restore_branch_disposition.py
+++ b/tests/unit/test_restore_branch_disposition.py
@@ -109,6 +109,82 @@ def test_checked_out_branch_is_never_disposed(repo: Path) -> None:
     assert "issue-7" in _branches(repo)
 
 
+def test_branch_with_upstream_and_unique_work_is_preserved(
+    tmp_path: Path,
+) -> None:
+    """#2325: an upstream must not make unique work deletable.
+
+    `git branch -d` accepts any branch merged into its UPSTREAM, and every
+    pipeline branch gets one at creation (`push -u`, #1780). Delegating the
+    decision to `-d` therefore deleted exactly the branches worth keeping --
+    observed against the boostgauge #7 branches, which held 3 and 2 commits
+    and were both reported as "no unique commits".
+
+    The upstream is the whole point of this test: without a real remote the
+    bug is invisible, which is why the earlier tests did not catch it.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        capture_output=True, text=True,
+    )
+    root = tmp_path / "clone"
+    root.mkdir()
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", "seed.txt")
+    _git(root, "commit", "-m", "seed")
+    _git(root, "remote", "add", "origin", str(origin))
+    _git(root, "push", "-u", "origin", "main")
+
+    # A pipeline branch with real work, pushed with an upstream.
+    _git(root, "checkout", "-b", "issue-7")
+    (root / "work.txt").write_text("unique work\n", encoding="utf-8")
+    _git(root, "add", "work.txt")
+    _git(root, "commit", "-m", "work only on issue-7")
+    tip = _git(root, "rev-parse", "issue-7").stdout.strip()
+    _git(root, "push", "-u", "origin", "issue-7")
+    _git(root, "checkout", "main")
+
+    # Precondition: bare `-d` WOULD accept it. If this ever stops being
+    # true the test below is no longer proving anything.
+    probe = _git(root, "branch", "-d", "issue-7")
+    assert probe.returncode == 0, (
+        "expected `branch -d` to accept an upstream-merged branch; "
+        f"got: {probe.stderr}"
+    )
+    _git(root, "branch", "issue-7", tip)
+
+    failures = reset.dispose_pipeline_branches(root, 7, "main")
+
+    assert failures == []
+    names = _branches(root)
+    assert "issue-7" not in names, "the name must still be freed"
+    parked = [n for n in names if n.startswith("graveyard/issue-7")]
+    assert len(parked) == 1, f"work must be preserved, got {names}"
+    assert _git(root, "rev-parse", parked[0]).stdout.strip() == tip
+
+
+def test_unmeasurable_comparison_preserves(repo: Path) -> None:
+    """#2325: an unknown count preserves rather than deletes.
+
+    A base that cannot be resolved makes the count unknowable. Preserving
+    costs a less tidy graveyard; deleting could cost the work.
+    """
+    _git(repo, "branch", "issue-7")
+
+    failures = reset.dispose_pipeline_branches(
+        repo, 7, "no-such-base-ref-exists",
+    )
+
+    assert failures == []
+    names = _branches(repo)
+    assert "issue-7" not in names
+    assert any(n.startswith("graveyard/issue-7") for n in names)
+
+
 def test_disposal_never_force_deletes() -> None:
     """The banned-commands rule, asserted against the source.
 

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -279,7 +279,9 @@ def delete_local_branches(repo_root: Path, issue: int) -> int:
     return deleted
 
 
-def dispose_pipeline_branches(repo_root: Path, issue: int) -> list[str]:
+def dispose_pipeline_branches(
+    repo_root: Path, issue: int, base: str | None = None,
+) -> list[str]:
     """
     Free the pipeline branch names for one issue. Returns failure descriptions.
 
@@ -290,19 +292,35 @@ def dispose_pipeline_branches(repo_root: Path, issue: int) -> list[str]:
     on the base killed a roll whose spec stage had just passed for the first
     time in campaign history.
 
-    Two dispositions, decided by what the branch actually holds:
+    Two dispositions, decided by MEASURING what the branch holds:
 
-    - No commits beyond the base: `git branch -d` accepts it, and the name
-      is freed. This is the measured case from #2310 -- the stranded branch
-      was pointer-identical to `origin/hardening-run-17`'s tip.
-    - Commits of its own: the safe delete refuses, and that refusal is the
-      safety net working. The branch is RENAMED under `graveyard/`, which
-      keeps every commit and still frees the name. Never `-D`, never a
-      force delete, per the banned-commands rule and ADR-0217.
+    - Zero commits beyond `base`: safe-delete, and the name is freed. This
+      is the measured case from #2310 -- the stranded branch was
+      pointer-identical to `origin/hardening-run-17`'s tip.
+    - Anything else, INCLUDING a count that cannot be established: the
+      branch is RENAMED under `graveyard/`, which keeps every commit and
+      still frees the name. Never `-D`, never a force delete, per the
+      banned-commands rule and ADR-0217.
 
-    A rename rather than a delete is what makes this safe to run
-    unconditionally from RESTORE: the worst case is a preserved branch under
-    a new name, never lost work.
+    #2325: the decision must NOT be delegated to `git branch -d`. That
+    command accepts any branch merged into its UPSTREAM, and every pipeline
+    branch gets an upstream at creation (`push -u` in stages.py, #1780), so
+    `-d` accepts branches carrying arbitrary unique work. Asking it for the
+    verdict inverted this function: run against the boostgauge #7 branches
+    it deleted both while reporting "no unique commits", when they held 3
+    and 2 commits respectively. Nothing was lost only because the remote
+    refs still existed -- the brittle upstream-tracking path ADR-0217
+    rejects. Measure against `base` first; `-d` then merely executes a
+    decision already made.
+
+    Defaulting to preservation when the count is unknown costs a less tidy
+    graveyard and nothing else, which is the right side to err on: a rename
+    is non-destructive and still frees the name.
+
+    `base` should be the branch the pipeline cut from. It falls back to
+    `origin/HEAD`, which is right for a repo rolling on its default branch
+    and wrong for one rolling on an integration branch -- so callers that
+    know their base should pass it.
     """
     result = _run(
         [
@@ -314,6 +332,7 @@ def dispose_pipeline_branches(repo_root: Path, issue: int) -> list[str]:
     if result.returncode != 0:
         return [f"could not list branches for #{issue}"]
 
+    base_ref = base or _default_base_ref(repo_root)
     active = current_branch(repo_root)
     failures: list[str] = []
     for branch in (line.strip() for line in result.stdout.splitlines()):
@@ -324,26 +343,41 @@ def dispose_pipeline_branches(repo_root: Path, issue: int) -> list[str]:
             print(f"  Skipped branch {branch} (currently checked out).")
             continue
 
-        deleted = _run(["git", "branch", "-d", branch], cwd=repo_root)
-        if deleted.returncode == 0:
-            print(f"  Freed branch name: {branch} (no unique commits)")
+        unique = _unique_commit_count(repo_root, branch, base_ref)
+        if unique == 0:
+            # Proven to add nothing beyond the base. `-d` cannot refuse this,
+            # and if it somehow does, the refusal is reported rather than
+            # escalated.
+            deleted = _run(["git", "branch", "-d", branch], cwd=repo_root)
+            if deleted.returncode == 0:
+                print(
+                    f"  Freed branch name: {branch} "
+                    f"(no commits beyond {base_ref})"
+                )
+                continue
+            failures.append(
+                f"branch '{branch}' measured empty against '{base_ref}' but "
+                f"the safe delete refused: "
+                f"{(deleted.stderr or '').strip()[:200]}"
+            )
             continue
 
-        # Safe-delete refused -- the branch carries commits reachable from
-        # nowhere else. Preserve them under a name no relaunch will collide
-        # with. `-m` (not `-M`) so an existing graveyard name is never
-        # clobbered; the collision is reported instead.
+        # Unique work, or a count that could not be established. Preserve it
+        # under a name no relaunch will collide with. `-m` (not `-M`) so an
+        # existing graveyard name is never clobbered; the collision is
+        # reported instead.
         parked = f"{GRAVEYARD_PREFIX}{branch}-{_disposal_stamp()}"
         renamed = _run(["git", "branch", "-m", branch, parked], cwd=repo_root)
         if renamed.returncode == 0:
-            unique = _unique_commit_count(repo_root, parked)
-            detail = f"{unique} commit(s)" if unique is not None else "commits"
+            detail = (
+                f"{unique} commit(s)" if unique is not None
+                else f"commits (count against '{base_ref}' unavailable)"
+            )
             print(f"  Preserved branch {branch} -> {parked} ({detail} kept)")
         else:
             failures.append(
-                f"branch '{branch}' holds unique commits and could not be "
-                f"renamed to '{parked}': "
-                f"{(renamed.stderr or '').strip()[:200]}"
+                f"branch '{branch}' holds work and could not be renamed to "
+                f"'{parked}': {(renamed.stderr or '').strip()[:200]}"
             )
     return failures
 
@@ -355,15 +389,27 @@ def _disposal_stamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
-def _unique_commit_count(repo_root: Path, branch: str) -> int | None:
-    """Commits on `branch` not reachable from the default branch, or None."""
-    base = _run(
+def _default_base_ref(repo_root: Path) -> str:
+    """`origin/HEAD` as a name, or 'HEAD' when it cannot be resolved."""
+    result = _run(
         ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"], cwd=repo_root
     )
-    if base.returncode != 0 or not base.stdout.strip():
-        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return "HEAD"
+    return result.stdout.strip()
+
+
+def _unique_commit_count(
+    repo_root: Path, branch: str, base_ref: str,
+) -> int | None:
+    """
+    Commits on `branch` not reachable from `base_ref`, or None if unknown.
+
+    None means "could not measure" and is deliberately distinct from 0 --
+    the caller preserves on None and only deletes on a proven 0 (#2325).
+    """
     counted = _run(
-        ["git", "rev-list", "--count", f"{base.stdout.strip()}..{branch}"],
+        ["git", "rev-list", "--count", f"{base_ref}..{branch}"],
         cwd=repo_root,
     )
     if counted.returncode != 0:

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1858,8 +1858,12 @@ def restore_repo(
     # relaunch wants to branch from and `worktree add -b` dies on it.
     # Branch names are freed by safe delete when they hold nothing unique, and
     # preserved under graveyard/ when they hold work. Never a force delete.
+    # #2325: `base` is passed explicitly. The disposition is decided by
+    # counting commits against it, never by asking `git branch -d` -- that
+    # command accepts anything merged to its upstream, and every pipeline
+    # branch has one, so it would delete exactly the branches worth keeping.
     for issue in issues:
-        failures += reset.dispose_pipeline_branches(repo_root, issue)
+        failures += reset.dispose_pipeline_branches(repo_root, issue, base)
     current = attempt.current_branch(repo_root)
     if current != base:
         failures.append(f"expected to end on '{base}', ended on '{current}'")


### PR DESCRIPTION
Closes #2325

Follow-up correcting a defect in the function merged by PR #2324.

`dispose_pipeline_branches` asked `git branch -d` whether a branch held unique work, and treated its refusal as the signal to preserve. `-d` accepts any branch merged into its **upstream**, and every pipeline branch gets one at creation (`push -u` in `stages.py`, #1780). So it accepts branches carrying arbitrary unique work, and the function did the opposite of its purpose: it deleted exactly what it existed to keep.

## Observed

Run against the boostgauge `run-issue7-153937` branches:

```
  Freed branch name: 7-lld (no unique commits)
  Freed branch name: issue-7 (no unique commits)
```

Both messages false. Measured immediately before:

| branch | unique commits vs `origin/hardening-run-17` |
|---|---|
| `issue-7` | 3 |
| `7-lld` | 2 |

No commit was lost — `origin/issue-7` and `origin/7-lld` still held every SHA, and both branches were restored under `graveyard/` from those refs. But recovery depended on the remote ref happening to exist, which is the brittle upstream-tracking path ADR-0217 rejects.

## The change

The disposition is now decided by counting against an explicit base:

| Measured | Disposition |
|---|---|
| proven 0 beyond the base | safe delete, name freed |
| any other count | renamed under `graveyard/` |
| **count unavailable** | renamed under `graveyard/` |

`-d` now only executes a decision already made, and a refusal is reported rather than escalated. Preserving on an unknown count costs a less tidy graveyard and nothing else — a rename is non-destructive and still frees the name, which is the whole requirement.

RESTORE passes the base it already resolved instead of assuming `origin/HEAD`, which is wrong for any repo rolling on an integration branch — the observed case (`hardening-run-17`).

## Tests

The regression test builds a **real bare remote and sets a real upstream**, because the bug is invisible without one — which is precisely why the tests shipped with #2324 passed. It asserts as a precondition that `git branch -d` *would* accept the branch, so it cannot quietly stop proving the defect if git's behaviour changes.

A second test covers the unmeasurable-base path.

Full unit suite: **7252 passed, 17 skipped, 0 failures**. `ruff check` clean.

## Note on the earlier acceptance claims

PR #2324 ticked "a failed roll's RESTORE leaves no branch that a relaunch collides with". That remains true — names were freed either way. What was wrong is *how*: by deletion where preservation was required. This PR makes the preserve path actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
