### PR TITLE
fix(testing): a table column heading is not a test scenario (Closes #2318)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -506,7 +506,12 @@ def parse_test_scenarios(test_plan: str) -> list[TestScenario]:  # pragma: no co
 
         # Detect header row (contains common header words)
         header_words = {"id", "test", "name", "scenario", "type", "description", "input", "output", "criteria"}
-        if any(c.lower() in header_words for c in cols[:3]):
+        # #2318: the exact-match test below misses multi-word headings. The
+        # boostgauge #7 LLD leads with `| Test ID | ...`, and "test id" is in
+        # neither this set nor the tuple further down, so the heading row was
+        # parsed as a scenario and shipped as a test named `test_id` whose
+        # docstring was the remaining column names.
+        if _is_header_cell(cols[0]) or any(c.lower() in header_words for c in cols[:3]):
             # Skip separator rows (----)
             if all("-" in c or not c for c in cols):
                 continue
@@ -526,8 +531,11 @@ def parse_test_scenarios(test_plan: str) -> list[TestScenario]:  # pragma: no co
             # Third column is typically Type
             type_col = cols[2] if len(cols) > 2 else ""
 
-            # Skip if name looks like a header
-            if name_col.lower() in ("id", "test", "name", "scenario", "test name"):
+            # Skip if name looks like a header (#2318: token-aware, so
+            # multi-word headings like "Test ID" are caught too)
+            if _is_header_cell(name_col) or name_col.lower() in (
+                "id", "test", "name", "scenario", "test name"
+            ):
                 continue
 
             # Clean up the name to be a valid test function name
@@ -574,6 +582,40 @@ def parse_test_scenarios(test_plan: str) -> list[TestScenario]:  # pragma: no co
         scenarios.append(scenario)
 
     return scenarios
+
+
+#: Words that appear in test-table COLUMN HEADINGS and never in a scenario id.
+#: Used token-wise so multi-word headings are recognised without enumerating
+#: every phrasing (#2318).
+_HEADER_TOKENS = frozenset({
+    "id", "ids", "test", "tests", "name", "scenario", "scenarios", "type",
+    "description", "input", "inputs", "output", "outputs", "expected",
+    "criteria", "criterion", "behavior", "behaviour", "status", "req",
+    "requirement", "requirements", "pass", "notes", "no", "num", "number",
+})
+
+
+def _is_header_cell(cell: str) -> bool:
+    """True when a table cell is a column HEADING rather than a scenario id.
+
+    #2318: a heading row leaked through as a test. The checks it evaded both
+    compared the whole cell against a fixed list, so `Test ID` -- two header
+    words with a space between them -- matched nothing and became a test
+    function named `test_id`, carrying the remaining column names as its
+    docstring. It was one of the 36 scenarios the boostgauge #7 run planned,
+    scaffolded, reviewed and graded against, and it never existed.
+
+    Deciding token-wise rather than by phrase means `Test ID`, `Test Name`,
+    `Req ID`, `Expected Output` and any other combination are all recognised
+    without a list of phrasings that the next LLD format can slip past.
+
+    A cell qualifies only when it is non-empty and EVERY alphanumeric token
+    in it is a heading word, so `T010` and `First run no config` stay data.
+    """
+    tokens = re.findall(r"[A-Za-z0-9]+", cell.lower())
+    if not tokens:
+        return False
+    return all(token in _HEADER_TOKENS for token in tokens)
 
 
 def _extract_requirement_ref(content: str) -> str:  # pragma: no cover

--- a/tests/unit/test_scaffold_emits_spec_bodies.py
+++ b/tests/unit/test_scaffold_emits_spec_bodies.py
@@ -100,9 +100,11 @@ def test_spec_functions_are_extracted_with_bodies(spec: str) -> None:
 
 def test_scaffold_emits_23_not_36(spec: str, lld: str) -> None:
     """The relaunch gate: the emitted suite is the spec's, not the tables'."""
-    # What the table path yields, for contrast -- this is the 36 that shipped.
+    # What the table path yields, for contrast. 36 shipped; it is 35 since
+    # #2318 stopped the heading row leaking in as `test_id`. Either way the
+    # table path cannot reach the spec's 23.
     table_scenarios = parse_test_scenarios(extract_test_plan_section(lld))
-    assert len(table_scenarios) == 36
+    assert len(table_scenarios) == 35
 
     suite = extract_spec_test_functions(spec)
     content = generate_spec_test_file_content(

--- a/tests/unit/test_table_header_not_a_scenario.py
+++ b/tests/unit/test_table_header_not_a_scenario.py
@@ -1,0 +1,72 @@
+"""#2318: a test-table column HEADING must never become a test scenario.
+
+The boostgauge #7 LLD leads its test plan with
+
+    | Test ID | Test Description | Expected Behavior | Status |
+
+Both guards in `parse_test_scenarios` compared the whole cell against a
+fixed list, and "test id" was in neither. The heading became a scenario, the
+scaffolder emitted a test named `test_id`, and its docstring was the row's
+remaining column names. It was planned, scaffolded, reviewed and graded
+against across two implementation iterations, and it never existed.
+
+Deciding token-wise is what generalises: the fix must hold for `Test Name`,
+`Req ID` and any other heading a future LLD format uses, not just the one
+phrasing that was observed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.load_lld import (
+    _is_header_cell,
+    extract_test_plan_section,
+    parse_test_scenarios,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "issue7_run153937"
+
+
+@pytest.mark.parametrize("cell", [
+    "Test ID", "test id", "TEST ID", "Test  ID",
+    "ID", "Test Name", "Req ID", "Expected Output", "Pass Criteria",
+    "Scenario", "Type", "Description", "Status", "Test Description",
+    "Expected Behavior", "Expected Behaviour",
+])
+def test_headings_are_recognised(cell: str) -> None:
+    assert _is_header_cell(cell) is True
+
+
+@pytest.mark.parametrize("cell", [
+    "T010", "010", "T090", "test_req_1",
+    "First run no config", "Position matrix tests",
+    "Threshold live reload", "",
+])
+def test_scenario_ids_are_not_headings(cell: str) -> None:
+    assert _is_header_cell(cell) is False
+
+
+def test_the_real_lld_no_longer_yields_test_id() -> None:
+    """The regression, against the artifact that produced it."""
+    lld = (FIXTURES / "LLD-007.md").read_text(encoding="utf-8")
+    scenarios = parse_test_scenarios(extract_test_plan_section(lld))
+
+    names = [s["name"] for s in scenarios]
+    assert "test_id" not in names, "the heading row leaked in again"
+
+    # The real scenarios both survive: 12 summary rows + 23 detail rows.
+    assert len(names) == 35, f"expected 35 real scenarios, got {len(names)}"
+    assert sum(1 for n in names if n.startswith("test_t")) == 12
+    assert sum(1 for n in names if n[5:].isdigit()) == 23
+
+
+def test_a_heading_only_table_yields_nothing() -> None:
+    """The degenerate case: headings alone are not scenarios."""
+    table = (
+        "| Test ID | Test Description | Expected Behavior | Status |\n"
+        "|---------|------------------|-------------------|--------|\n"
+    )
+    assert parse_test_scenarios(table) == []


### PR DESCRIPTION
Closes #2318

A test-table column heading became a test. The boostgauge #7 LLD leads its test plan with

```
| Test ID | Test Description | Expected Behavior | Status |
```

and `parse_test_scenarios` shipped a scenario named `test_id` whose docstring was the row's remaining column names. It was planned, scaffolded, reviewed and graded against across two implementation iterations, and it never existed.

## Why both guards missed it

There are two heading checks, and both compared the **whole cell** against a fixed list:

```python
header_words = {"id", "test", "name", "scenario", ...}
if any(c.lower() in header_words for c in cols[:3]):        # "test id" ∉ set
...
if name_col.lower() in ("id", "test", "name", "scenario", "test name"):   # nor here
```

`"test id"` is two heading words with a space between them. Each word is in the set; the phrase is in neither. Enumerating more phrases would fix this LLD and lose to the next format.

## The change

`_is_header_cell()` decides **token-wise**: a cell is a heading when it is non-empty and *every* alphanumeric token in it is a heading word. `Test ID`, `Test Name`, `Req ID`, `Expected Output` and any other combination are recognised without a list of phrasings. `T010`, `010`, and `First run no config` stay data, because they contain at least one token that is not a heading word.

Both call sites keep their original exact-match test alongside the new one, so this strictly adds detection rather than changing existing behaviour.

## Effect on the real artifact

The run's LLD yields **35** scenarios instead of 36 — the 12 summary rows and 23 detail rows all survive, and only the heading is gone.

That number appears in one assertion added by #2316 (`test_scaffold_emits_23_not_36`), which is updated here from 36 to 35 with a comment recording why. The full suite caught it; it was not found by reading.

## Scope note

#2316 already made the spec's executable functions the scaffold source, so on that path no table heading can reach a test. This still matters because the table path remains the fallback for specs that ship no executable functions — which is exactly the shape that produced the defect.

## Checks

Full unit suite **7286 passed, 17 skipped, 0 failures**. `ruff check` clean on the new and touched test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
