### PR TITLE
fix(testing): the reviser is told why a test failed, not just which (Closes #2319, Closes #2320)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -54,6 +54,13 @@ MAX_FAILURE_SUMMARY_CHARS = 12000
 # command, identical config; at 80 columns every reason is gone, at 200 every
 # reason is present. 200 clears a worktree-length path plus a typical assertion
 # message without making pytest's separator rules absurdly wide.
+#
+# Where this bites, and why CI disagrees: pytest skips the trim entirely when
+# it believes it is on CI (`_pytest/terminal.py`: `running_on_ci() or
+# config.option.verbose >= 2`, keyed off CI / BUILD_NUMBER). GitHub Actions
+# sets CI=true, so the defect does NOT reproduce there -- and the speedrun runs
+# on the operator's workstation, where nothing sets it. The one environment
+# that would have shown a green suite is the one the pipeline never runs in.
 PYTEST_OUTPUT_COLUMNS = "200"
 
 # #2320: how many distinct failure tracebacks to carry back. Tracebacks are the

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -47,6 +47,20 @@ PYTEST_TIMEOUT_SECONDS = 300
 # DISTINCT cause of even a large generated test plan.
 MAX_FAILURE_SUMMARY_CHARS = 12000
 
+# #2319: pytest truncates each `short test summary info` line to the terminal
+# width. Captured through a pipe there is no terminal, so it assumes 80 columns
+# and the ` - AssertionError: ...` half is cut off -- leaving the reviser a list
+# of test names with no reason attached. Measured on boostgauge #7: identical
+# command, identical config; at 80 columns every reason is gone, at 200 every
+# reason is present. 200 clears a worktree-length path plus a typical assertion
+# message without making pytest's separator rules absurdly wide.
+PYTEST_OUTPUT_COLUMNS = "200"
+
+# #2320: how many distinct failure tracebacks to carry back. Tracebacks are the
+# only part of pytest's output that states WHY a test failed in full -- they are
+# not width-truncated -- and they were being captured and discarded.
+MAX_TRACEBACK_BLOCKS = 8
+
 # Issue #562: Critical skip keywords (aligned with tools/test-gate.py)
 _CRITICAL_SKIP_KEYWORDS = ["security", "auth", "payment", "critical"]
 
@@ -160,9 +174,103 @@ def _build_failure_summary(output: str) -> str:
     else:
         result = "\n".join(summary_lines)
 
+    # #2320: the short summary says WHICH tests failed. The tracebacks say WHY,
+    # and run_pytest already asks for them with --tb=short. Reading only the
+    # summary section threw the diagnosis away: on boostgauge #7 the discarded
+    # block held `assert False` on the source line, which identified the tests
+    # as unconditional stubs. The reviser instead saw 36 bare names and made a
+    # six-line cosmetic edit, because nothing it was shown was actionable.
+    tracebacks = _extract_traceback_blocks(output)
+    if tracebacks:
+        result = f"{result}\n\nFailure detail (source line and error):\n{tracebacks}"
+
     if len(result) > MAX_FAILURE_SUMMARY_CHARS:
         result = result[:MAX_FAILURE_SUMMARY_CHARS] + "\n... (truncated)"
     return result
+
+
+def _extract_traceback_blocks(output: str) -> str:
+    """Pull distinct failure tracebacks out of pytest's FAILURES section.
+
+    #2320: returns the failing source line and the `E ...` error lines for up
+    to MAX_TRACEBACK_BLOCKS DISTINCT failures. Blocks whose error lines are
+    identical are collapsed with a count, because N tests failing on one cause
+    is one fact and repeating it N times only spends the budget.
+
+    Unlike the short-summary line, traceback content is not truncated to the
+    terminal width, so this is informative regardless of #2319's environment
+    fix -- the two repairs are independent on purpose.
+    """
+    import re
+
+    failures_match = re.search(
+        r"^=+ FAILURES =+$(.*?)(?=^=+ (?:short test summary|warnings summary|"
+        r"ERRORS|[\w ]*coverage)|\Z)",
+        output,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not failures_match:
+        return ""
+
+    section = failures_match.group(1)
+    # Blocks are introduced by a centred `____ test_name ____` rule.
+    parts = re.split(r"^_+ (.+?) _+$", section, flags=re.MULTILINE)
+    if len(parts) < 3:
+        return ""
+
+    seen: dict[str, dict[str, Any]] = {}
+    # parts alternates: [preamble, name, body, name, body, ...]
+    for i in range(1, len(parts) - 1, 2):
+        name = parts[i].strip()
+        body = parts[i + 1]
+
+        error_lines = [
+            line.rstrip() for line in body.splitlines()
+            if line.startswith("E ")
+        ]
+        if not error_lines:
+            continue
+
+        # The last non-E, non-blank line before the errors is the source line
+        # that raised -- the single most useful line in the block.
+        source_line = ""
+        for line in body.splitlines():
+            if line.startswith("E "):
+                break
+            if line.strip():
+                source_line = line.strip()
+
+        signature = "\n".join(error_lines)
+        if signature in seen:
+            seen[signature]["tests"].append(name)
+            continue
+        seen[signature] = {
+            "tests": [name],
+            "source": source_line,
+            "errors": error_lines,
+        }
+
+    if not seen:
+        return ""
+
+    blocks: list[str] = []
+    for entry in list(seen.values())[:MAX_TRACEBACK_BLOCKS]:
+        tests = entry["tests"]
+        header = tests[0]
+        if len(tests) > 1:
+            header = f"{tests[0]} (and {len(tests) - 1} more with the same error)"
+        lines = [header]
+        if entry["source"]:
+            lines.append(f"    {entry['source']}")
+        lines.extend(f"    {e}" for e in entry["errors"])
+        blocks.append("\n".join(lines))
+
+    if len(seen) > MAX_TRACEBACK_BLOCKS:
+        blocks.append(
+            f"... {len(seen) - MAX_TRACEBACK_BLOCKS} further distinct "
+            f"failure cause(s) not shown"
+        )
+    return "\n\n".join(blocks)
 
 
 def _classify_import_errors(
@@ -320,6 +428,25 @@ def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
     return str(rel).replace("\\", "/")
 
 
+def _pytest_env() -> dict[str, str]:
+    """Environment for a captured pytest run (#2319).
+
+    Sets COLUMNS so pytest does not truncate its short-summary lines to the
+    80-column default it assumes when stdout is a pipe. Without this the
+    ` - AssertionError: ...` half of every FAILED line is cut, the reviser
+    receives test names with no reasons, and the #2058 root-cause grouping
+    cannot fire because its regex needs the reason it never receives.
+
+    Inherits the rest of the environment unchanged -- the venv, PATH and any
+    repo-specific variables the run needs are all still required.
+    """
+    import os
+
+    env = os.environ.copy()
+    env["COLUMNS"] = PYTEST_OUTPUT_COLUMNS
+    return env
+
+
 def run_pytest(
     test_files: list[str],
     coverage_module: str | None = None,
@@ -362,6 +489,7 @@ def run_pytest(
             errors="replace",
             timeout=PYTEST_TIMEOUT_SECONDS,
             cwd=str(repo_root) if repo_root else None,
+            env=_pytest_env(),
         )
 
         parsed = parse_pytest_output(result.stdout + result.stderr)

--- a/tests/unit/test_failure_feedback_carries_reasons.py
+++ b/tests/unit/test_failure_feedback_carries_reasons.py
@@ -1,0 +1,181 @@
+"""#2319 / #2320: the reviser must be told WHY a test failed, not just which.
+
+On boostgauge #7 the implementation reviser received 36 bare test names and
+produced a six-line cosmetic diff. Two independent causes:
+
+  #2319  pytest truncates each `short test summary info` line to the terminal
+         width. Captured through a pipe it assumes 80 columns, so the
+         ` - AssertionError: ...` half was cut off.
+  #2320  `--tb=short` tracebacks were captured and then discarded, because
+         the summary builder read only the short-summary section. That block
+         held `assert False` on the source line -- the whole diagnosis.
+
+These tests drive REAL pytest through a REAL pipe, because both defects are
+properties of how pytest behaves when its output is captured. A hand-built
+output string would have been written with the reasons already present and
+would have proved nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    PYTEST_OUTPUT_COLUMNS,
+    _build_failure_summary,
+    _extract_traceback_blocks,
+    _pytest_env,
+)
+
+# pytest prints paths relative to its rootdir, so the DISPLAYED length is what
+# decides whether the reason gets cut. This nesting puts `FAILED <path>::<name>
+# - <reason>` comfortably over 80 columns and comfortably under 200 -- which is
+# what lets one fixture demonstrate both the defect and the repair.
+_DEEP = "generated/worktree/tests"
+
+
+@pytest.fixture(scope="module")
+def failing_suite(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """A suite with two distinct causes and one repeated cause.
+
+    Returns (rootdir, relative test path). Running with cwd=rootdir is what
+    keeps the displayed path realistic; pointing pytest at an absolute path
+    from elsewhere changes rootdir and with it the truncation behaviour.
+    """
+    root = tmp_path_factory.mktemp("suite")
+    nested = root / _DEEP
+    nested.mkdir(parents=True)
+    path = nested / "test_generated_scenarios.py"
+    path.write_text(textwrap.dedent('''
+        def test_scenario_alpha():
+            assert False, 'TDD RED: test_scenario_alpha not implemented'
+
+        def test_scenario_beta():
+            assert False, 'TDD RED: test_scenario_beta not implemented'
+
+        def test_shared_cause_one():
+            raise TypeError("unsupported operand")
+
+        def test_shared_cause_two():
+            raise TypeError("unsupported operand")
+    ''').lstrip(), encoding="utf-8")
+    return root, Path(_DEEP) / "test_generated_scenarios.py"
+
+
+def _run_pytest(suite: tuple[Path, Path], env: dict[str, str] | None) -> str:
+    root, rel = suite
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(rel), "-v", "--tb=short",
+         "-p", "no:cacheprovider", "-o", "addopts="],
+        cwd=str(root),
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        env=env,
+    )
+    return result.stdout + result.stderr
+
+
+def test_default_capture_loses_the_reason(failing_suite: tuple[Path, Path]) -> None:
+    """Characterise #2319 -- at the piped default the reasons are gone.
+
+    If this ever stops holding, pytest changed its truncation behaviour and
+    the fix below may no longer be load-bearing. Failing here is the signal
+    to re-check, not a reason to delete the test.
+    """
+    env = os.environ.copy()
+    env["COLUMNS"] = "80"
+    output = _run_pytest(failing_suite, env)
+
+    summary_lines = [
+        line for line in output.splitlines() if line.startswith("FAILED ")
+    ]
+    assert summary_lines, "expected FAILED lines in the short summary"
+    assert not any(" - " in line for line in summary_lines), (
+        "at 80 columns every reason should be cut, got:\n"
+        + "\n".join(summary_lines)
+    )
+
+
+def test_pytest_env_restores_the_reason(failing_suite: tuple[Path, Path]) -> None:
+    """#2319: the captured summary carries complete reasons again."""
+    output = _run_pytest(failing_suite, _pytest_env())
+
+    summary_lines = [
+        line for line in output.splitlines() if line.startswith("FAILED ")
+    ]
+    assert summary_lines
+    assert any(
+        "AssertionError: TDD RED: test_scenario_alpha not implemented" in line
+        for line in summary_lines
+    ), "the complete assertion reason must survive:\n" + "\n".join(summary_lines)
+    assert any("TypeError: unsupported operand" in line for line in summary_lines)
+
+
+def test_pytest_env_inherits_and_only_sets_columns() -> None:
+    """The venv and PATH must survive -- this replaces the environment."""
+    env = _pytest_env()
+    assert env["COLUMNS"] == PYTEST_OUTPUT_COLUMNS
+    for key in ("PATH", "SYSTEMROOT", "HOME"):
+        if key in os.environ:
+            assert env[key] == os.environ[key]
+
+
+def test_summary_carries_source_line_and_error(failing_suite: tuple[Path, Path]) -> None:
+    """#2320: the acceptance for the pair -- reason AND source line, verbatim."""
+    output = _run_pytest(failing_suite, _pytest_env())
+    summary = _build_failure_summary(output)
+
+    assert "assert False, 'TDD RED: test_scenario_alpha not implemented'" in summary, (
+        "the failing source line must reach the reviser verbatim"
+    )
+    assert "AssertionError: TDD RED: test_scenario_alpha not implemented" in summary
+    assert "TypeError: unsupported operand" in summary
+
+
+def test_summary_survives_an_80_column_capture(failing_suite: tuple[Path, Path]) -> None:
+    """Belt and braces: tracebacks are not width-truncated.
+
+    Even if COLUMNS were lost, the traceback half of the repair still
+    delivers the diagnosis. The two fixes are independent on purpose.
+    """
+    env = os.environ.copy()
+    env["COLUMNS"] = "80"
+    summary = _build_failure_summary(_run_pytest(failing_suite, env))
+
+    assert "assert False" in summary
+    assert "AssertionError" in summary
+
+
+def test_identical_causes_are_collapsed(failing_suite: tuple[Path, Path]) -> None:
+    """#2320: N tests failing on one cause is one fact, stated once."""
+    output = _run_pytest(failing_suite, _pytest_env())
+    blocks = _extract_traceback_blocks(output)
+
+    assert blocks.count("TypeError: unsupported operand") == 1, (
+        "the repeated cause should appear once, not per-test"
+    )
+    assert "and 1 more with the same error" in blocks
+
+
+def test_2058_grouping_revives_once_reasons_arrive(failing_suite: tuple[Path, Path]) -> None:
+    """#2058's root-cause grouping needs the reason its regex parses.
+
+    Verified rather than assumed, per the issue: with reasons present the
+    two same-cause tests collapse into a single `2 test(s):` group.
+    """
+    output = _run_pytest(failing_suite, _pytest_env())
+    summary = _build_failure_summary(output)
+
+    assert "2 test(s): TypeError: unsupported operand" in summary, (
+        f"expected a grouped root cause, got:\n{summary[:600]}"
+    )
+
+
+def test_no_failures_yields_empty_summary() -> None:
+    assert _build_failure_summary("1 passed in 0.01s") == ""
+    assert _extract_traceback_blocks("1 passed in 0.01s") == ""

--- a/tests/unit/test_failure_feedback_carries_reasons.py
+++ b/tests/unit/test_failure_feedback_carries_reasons.py
@@ -68,6 +68,25 @@ def failing_suite(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]
     return root, Path(_DEEP) / "test_generated_scenarios.py"
 
 
+#: pytest disables short-summary trimming entirely when it thinks it is on CI
+#: (`_pytest/terminal.py`: `running_on_ci() or config.option.verbose >= 2`).
+#: These tests must therefore control that signal rather than inherit it: on
+#: GitHub Actions `CI=true` is set, no trimming happens, and a test asserting
+#: the truncation would pass or fail depending on where it ran.
+#:
+#: This is not an artifact of the test. It is why the defect is real WHERE IT
+#: MATTERS: the speedrun executes on the operator's workstation, off CI, so
+#: pytest trims and the reviser loses the reasons. The same pipeline on CI
+#: would not show the bug at all.
+_CI_VARS = ("CI", "BUILD_NUMBER")
+
+
+def _base_env(**overrides: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k not in _CI_VARS}
+    env.update(overrides)
+    return env
+
+
 def _run_pytest(suite: tuple[Path, Path], env: dict[str, str] | None) -> str:
     root, rel = suite
     result = subprocess.run(
@@ -87,9 +106,7 @@ def test_default_capture_loses_the_reason(failing_suite: tuple[Path, Path]) -> N
     the fix below may no longer be load-bearing. Failing here is the signal
     to re-check, not a reason to delete the test.
     """
-    env = os.environ.copy()
-    env["COLUMNS"] = "80"
-    output = _run_pytest(failing_suite, env)
+    output = _run_pytest(failing_suite, _base_env(COLUMNS="80"))
 
     summary_lines = [
         line for line in output.splitlines() if line.startswith("FAILED ")
@@ -103,7 +120,7 @@ def test_default_capture_loses_the_reason(failing_suite: tuple[Path, Path]) -> N
 
 def test_pytest_env_restores_the_reason(failing_suite: tuple[Path, Path]) -> None:
     """#2319: the captured summary carries complete reasons again."""
-    output = _run_pytest(failing_suite, _pytest_env())
+    output = _run_pytest(failing_suite, _base_env(COLUMNS=PYTEST_OUTPUT_COLUMNS))
 
     summary_lines = [
         line for line in output.splitlines() if line.startswith("FAILED ")
@@ -127,7 +144,7 @@ def test_pytest_env_inherits_and_only_sets_columns() -> None:
 
 def test_summary_carries_source_line_and_error(failing_suite: tuple[Path, Path]) -> None:
     """#2320: the acceptance for the pair -- reason AND source line, verbatim."""
-    output = _run_pytest(failing_suite, _pytest_env())
+    output = _run_pytest(failing_suite, _base_env(COLUMNS=PYTEST_OUTPUT_COLUMNS))
     summary = _build_failure_summary(output)
 
     assert "assert False, 'TDD RED: test_scenario_alpha not implemented'" in summary, (
@@ -143,9 +160,9 @@ def test_summary_survives_an_80_column_capture(failing_suite: tuple[Path, Path])
     Even if COLUMNS were lost, the traceback half of the repair still
     delivers the diagnosis. The two fixes are independent on purpose.
     """
-    env = os.environ.copy()
-    env["COLUMNS"] = "80"
-    summary = _build_failure_summary(_run_pytest(failing_suite, env))
+    summary = _build_failure_summary(
+        _run_pytest(failing_suite, _base_env(COLUMNS="80"))
+    )
 
     assert "assert False" in summary
     assert "AssertionError" in summary
@@ -153,7 +170,7 @@ def test_summary_survives_an_80_column_capture(failing_suite: tuple[Path, Path])
 
 def test_identical_causes_are_collapsed(failing_suite: tuple[Path, Path]) -> None:
     """#2320: N tests failing on one cause is one fact, stated once."""
-    output = _run_pytest(failing_suite, _pytest_env())
+    output = _run_pytest(failing_suite, _base_env(COLUMNS=PYTEST_OUTPUT_COLUMNS))
     blocks = _extract_traceback_blocks(output)
 
     assert blocks.count("TypeError: unsupported operand") == 1, (
@@ -168,7 +185,7 @@ def test_2058_grouping_revives_once_reasons_arrive(failing_suite: tuple[Path, Pa
     Verified rather than assumed, per the issue: with reasons present the
     two same-cause tests collapse into a single `2 test(s):` group.
     """
-    output = _run_pytest(failing_suite, _pytest_env())
+    output = _run_pytest(failing_suite, _base_env(COLUMNS=PYTEST_OUTPUT_COLUMNS))
     summary = _build_failure_summary(output)
 
     assert "2 test(s): TypeError: unsupported operand" in summary, (


### PR DESCRIPTION
Closes #2319
Closes #2320

The implementation reviser was told *which* tests failed and nothing about *why*. On boostgauge #7 it revised against 36 bare names and produced a six-line diff that alphabetised an import list and deleted a comment — not laziness, there was nothing actionable in what it received.

Two independent causes, repaired together because either alone leaves the loop half-blind.

## #2319 — the summary line is truncated to the terminal width

`run_pytest` captures through a pipe, so pytest sees no terminal and assumes 80 columns, cutting the ` - AssertionError: ...` half off every `FAILED` line.

`_pytest_env()` sets `COLUMNS=200` and inherits everything else, so the venv, PATH and repo variables are untouched.

Measured on a realistic path, same command, same config:

```
COLUMNS=80   FAILED generated/worktree/tests/test_generated_scenarios.py::test_scenario_alpha
COLUMNS=200  FAILED generated/worktree/tests/test_generated_scenarios.py::test_scenario_alpha - AssertionError: TDD RED: test_scenario_alpha not implemented
```

## #2320 — the tracebacks were captured and thrown away

`run_pytest` already passes `--tb=short`; `_build_failure_summary` read only the short-summary section and discarded the rest. The discarded block held the diagnosis:

```
    assert False, 'TDD RED: test_t010 not implemented'
E   AssertionError: TDD RED: test_t010 not implemented
E   assert False
```

`assert False` on the source line identifies the tests as unconditional stubs — the fact that would have ended the run at iteration 0.

`_extract_traceback_blocks()` now carries the failing source line and the `E` lines for up to 8 **distinct** causes. Blocks with identical error lines are collapsed with a count, so N tests failing on one cause spend one block instead of N.

## Why both, and not just one

Traceback content is **not** width-truncated. So #2320 alone delivers the diagnosis even at 80 columns — proven by `test_summary_survives_an_80_column_capture`. #2319 matters separately because the short-summary line is what #2058's root-cause grouping parses.

## #2058 grouping — verified, not assumed

The issue asked me to check rather than assume it revives. It does:

```
2 test(s): TypeError: unsupported operand
```

Asserted by `test_2058_grouping_revives_once_reasons_arrive`. With reasons absent, the regex's group 2 is `None`, everything falls to `ungrouped`, and the summary is a flat list of names.

## Why CI initially disagreed — and why that makes the defect worse, not milder

The first push failed CI on the characterisation test: on GitHub Actions the reasons were **not** truncated at 80 columns.

Traced to pytest's own source (`_pytest/terminal.py:1543`):

```python
running_on_ci() or config.option.verbose >= 2
```

pytest skips summary trimming entirely when it detects CI (keyed off `CI` / `BUILD_NUMBER`). Verified locally: same command, `CI=true` keeps every reason, `CI` unset cuts them all.

**The speedrun runs on the operator's workstation, where nothing sets `CI`.** So the environment that would have shown a healthy summary is the one the pipeline never runs in, and the one it does run in is where the reasons vanish. The tests now strip `CI`/`BUILD_NUMBER` explicitly rather than inheriting them, so they assert the same thing in both places — and the mechanism is recorded next to the constant it justifies.

## Tests

Eight tests driving **real pytest through a real pipe**, because both defects are properties of how pytest behaves when captured — a hand-built output string would have been written with the reasons already present and proved nothing.

Verified green both off CI and with `CI=true` set, so the suite means the same thing in either environment.

The fixture's path nesting is load-bearing and documented: pytest prints paths relative to rootdir, so the *displayed* length decides truncation. It is sized to exceed 80 columns and stay under 200, which lets one fixture demonstrate both the defect and the repair.

`test_default_capture_loses_the_reason` characterises the bug, so if pytest ever changes its truncation behaviour this fails loudly rather than the repair silently becoming decorative.

## Checks

Full unit suite **7294 passed, 17 skipped, 0 failures**. ruff: new test file clean; `verify_phases.py` unchanged at its pre-existing baseline of 3 findings (tracked in #2260).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
