### PR TITLE
fix(testing): both scaffold gates can see stub bodies (Closes #2317, Closes #2322)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -66,6 +66,67 @@ def detect_stub_patterns(test_content: str) -> list[str]:
     return errors
 
 
+def count_stub_tests(test_content: str) -> tuple[int, int, list[str]]:
+    """Count test functions whose BODY can never pass. (#2317)
+
+    Returns (total_tests, stub_tests, stub_names).
+
+    A stub here is a test whose body does nothing but fail: an unconditional
+    `assert False`, a bare `raise NotImplementedError`, or nothing at all
+    beyond a docstring, comments and `pass`. Such a function is not a weak
+    test -- it is a test no implementation can satisfy, so a suite made
+    entirely of them cannot converge no matter what the coder writes.
+
+    Decided on the AST rather than by regex, because the line-based
+    STUB_PATTERNS above cannot tell a placeholder body from a genuine test
+    that merely mentions one of those strings (a test asserting on the text
+    "not implemented", for instance). That imprecision is part of why the
+    detection was blanket-disabled by #386 rather than made accurate.
+    """
+    try:
+        tree = ast.parse(test_content)
+    except SyntaxError:
+        return 0, 0, []
+
+    total = 0
+    stub_names: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        total += 1
+
+        meaningful = []
+        for stmt in node.body:
+            # Docstrings and bare constants carry no behaviour.
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+                continue
+            if isinstance(stmt, ast.Pass):
+                continue
+            meaningful.append(stmt)
+
+        if not meaningful:
+            stub_names.append(node.name)
+            continue
+
+        def _is_dead_end(stmt: ast.stmt) -> bool:
+            if isinstance(stmt, ast.Assert):
+                test = stmt.test
+                return isinstance(test, ast.Constant) and not test.value
+            if isinstance(stmt, ast.Raise) and stmt.exc is not None:
+                exc = stmt.exc
+                name = exc.func if isinstance(exc, ast.Call) else exc
+                return isinstance(name, ast.Name) and name.id == "NotImplementedError"
+            return False
+
+        if all(_is_dead_end(stmt) for stmt in meaningful):
+            stub_names.append(node.name)
+
+    return total, len(stub_names), stub_names
+
+
 # =============================================================================
 # AST Validation
 # =============================================================================
@@ -251,14 +312,57 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
             )
 
     all_errors = []
-    stub_count = 0
 
-    # Issue #386: Skip stub pattern detection for TDD scaffold validation.
-    # The TDD workflow intentionally generates `assert False, 'TDD RED: ...'`
-    # as failing test placeholders. Flagging these as "stubs" creates a
-    # circular rejection loop (scaffold → validate → reject → scaffold).
-    # Stub detection is only useful for non-TDD generated tests.
-    # The red/green phases (N3/N5) validate test behavior instead.
+    # Issue #386 exempted `assert False, 'TDD RED: ...'` from stub detection,
+    # because the TDD scaffold emits such placeholders on purpose and flagging
+    # them created a scaffold -> validate -> reject -> scaffold loop.
+    #
+    # #2317: that exemption was total, so this node could no longer tell a few
+    # placeholders among real tests from a suite that is ENTIRELY placeholders.
+    # It blessed the second case as "36 real tests" on boostgauge #7, and the
+    # implementation stage then spent two iterations against a suite no code
+    # could satisfy.
+    #
+    # The distinction restored here is proportional, not a revert. Individual
+    # placeholders remain acceptable -- that is #386's case and it still
+    # passes. A wholly hollow suite is always NAMED, and is rejected only when
+    # rejecting can actually help.
+    #
+    # That condition is deliberate. `should_regenerate` escalates a
+    # deterministic scaffolder on its hash check, and "escalate" routes to
+    # N4_implement_code (graph.py) -- so for a spec that supplies no test
+    # bodies, failing here reaches implementation anyway, just with the red
+    # phase skipped as well. Rejecting is worth it precisely when regeneration
+    # can produce something better, which since #2316 means: the spec ships
+    # executable Section 10 test functions and the scaffold ignored them.
+    # Where it cannot help, the suite is reported loudly instead of being
+    # bounced around a loop that ends in the same place.
+    total_tests, stub_count, stub_names = count_stub_tests(generated_tests)
+    hollow = total_tests > 0 and stub_count == total_tests
+    spec_has_bodies = bool(
+        (state.get("spec_test_suite") or {}).get("functions")
+    )
+    if hollow:
+        shown = ", ".join(stub_names[:3])
+        more = f" (and {stub_count - 3} more)" if stub_count > 3 else ""
+        # ASCII only: this string is printed, and per #1493 a non-ASCII
+        # character raises UnicodeEncodeError mid-stream on Windows cp1252.
+        description = (
+            f"all {total_tests} generated test(s) fail unconditionally "
+            f"({shown}{more}) -- no implementation can make this suite green"
+        )
+        if spec_has_bodies:
+            all_errors.append(
+                f"{description}. The spec supplies executable Section 10 test "
+                f"functions that were not used; regenerate from those."
+            )
+        else:
+            print(f"    [HOLLOW SCAFFOLD] {description}")
+            print(
+                "    The spec supplies no executable test bodies, so "
+                "re-scaffolding cannot improve on this. Proceeding, but the "
+                "implementation loop cannot converge against these tests."
+            )
 
     # Step 2: Validate structure with AST (imports, test functions exist)
     structure_errors = validate_test_structure(generated_tests, scenarios)
@@ -271,17 +375,10 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
     # Build validation result
     is_valid = len(all_errors) == 0
 
-    # Count real tests (functions without stub patterns)
-    try:
-        tree = ast.parse(generated_tests)
-        total_tests = sum(
-            1 for node in ast.walk(tree)
-            if isinstance(node, ast.FunctionDef) and node.name.startswith('test_')
-        )
-        real_test_count = total_tests - stub_count
-    except SyntaxError:
-        total_tests = 0
-        real_test_count = 0
+    # #2317: `real` now excludes placeholders. It previously could not --
+    # stub_count was pinned at 0, so every stub was reported as a real test
+    # and the number the operator reads was the opposite of the truth.
+    real_test_count = total_tests - stub_count
 
     validation_result = {
         "is_valid": is_valid,
@@ -292,7 +389,16 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
     }
 
     if is_valid:
-        print(f"    Validation PASSED: {real_test_count} real tests")
+        # #2317: name the placeholders when there are any. A bare count of
+        # "real tests" that silently included every stub is what let the
+        # hollow suite through looking healthy.
+        if stub_count:
+            print(
+                f"    Validation PASSED: {real_test_count} real tests "
+                f"({stub_count} placeholder(s) among {total_tests})"
+            )
+        else:
+            print(f"    Validation PASSED: {real_test_count} real tests")
     else:
         print(f"    Validation FAILED: {len(all_errors)} errors")
         for error in all_errors[:5]:

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -34,6 +34,9 @@ from assemblyzero.workflows.testing.exit_code_router import (
     route_by_exit_code,
 )
 from assemblyzero.workflows.testing.framework_detector import CoverageType, TestFramework
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    count_stub_tests,
+)
 from assemblyzero.workflows.testing.runner_registry import get_runner
 from assemblyzero.workflows.testing.state import TestingWorkflowState
 
@@ -524,6 +527,44 @@ def run_pytest(
         }
 
 
+def _describe_hollow_suite(state: TestingWorkflowState) -> str:
+    """Describe a scaffold that cannot pass, or '' when it might (#2322).
+
+    The red phase's job is to confirm the tests fail for the RIGHT reason.
+    An ImportError says only that the module under test is missing; every
+    test body is still unexecuted, so a suite made entirely of unconditional
+    failures is indistinguishable from a healthy red phase at that moment.
+
+    Reads the scaffold's source rather than its behaviour, which is what
+    makes the distinction available at all while the implementation does not
+    yet exist. Anything it cannot parse or find returns '' -- an unreadable
+    suite is not evidence of a hollow one, and this must never invent a
+    failure.
+    """
+    source = state.get("generated_tests", "") or ""
+    if not source:
+        for path in state.get("test_files", []) or []:
+            try:
+                source += Path(path).read_text(encoding="utf-8") + "\n"
+            except OSError:
+                continue
+    if not source.strip():
+        return ""
+
+    total, stubs, names = count_stub_tests(source)
+    if total == 0 or stubs != total:
+        return ""
+
+    shown = ", ".join(names[:3])
+    more = f" (and {stubs - 3} more)" if stubs > 3 else ""
+    # ASCII only: printed to a Windows console, where #1493 showed a non-ASCII
+    # character raises UnicodeEncodeError mid-stream.
+    return (
+        f"all {total} test(s) fail unconditionally ({shown}{more}) -- no "
+        f"implementation can make this suite green"
+    )
+
+
 def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
     """N3: Verify all tests fail (TDD red phase).
 
@@ -629,6 +670,44 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
             output, expected_modules_for_red
         )
         if exp_count_red > 0 and unexp_count_red == 0:
+            # #2322: an ImportError proves the module is ABSENT. It does not
+            # prove the tests discriminate. Collection died before a single
+            # body ran, so a suite of unconditional `assert False` stubs
+            # produces exactly this signal -- and on boostgauge #7 it did,
+            # which is how a suite no implementation could pass reached the
+            # implementation stage and spent two iterations there.
+            #
+            # The bodies are visible statically even while the module is
+            # missing, so the check that collection cannot make is made here.
+            hollow = _describe_hollow_suite(state)
+            if hollow:
+                print(
+                    f"    [EXIT CODE {exit_code}] ImportError on expected "
+                    f"module(s), but the suite cannot pass either: {hollow}"
+                )
+                # Re-scaffold only where it can produce something better --
+                # since #2316 that means the spec ships executable Section 10
+                # functions the scaffold did not use. Otherwise a reroute just
+                # regenerates the same stubs, so the finding is stated and the
+                # run continues rather than circling.
+                if (state.get("spec_test_suite") or {}).get("functions"):
+                    print(
+                        "    the spec supplies executable test functions "
+                        "-> routing to re-scaffold, not to implementation"
+                    )
+                    return {
+                        "red_phase_output": output,
+                        "file_counter": file_num,
+                        "pytest_exit_code": exit_code,
+                        "next_node": "N2_scaffold_tests",
+                        "scaffold_validation_errors": [hollow],
+                        "error_message": "",
+                    }
+                print(
+                    "    the spec supplies no test bodies, so re-scaffolding "
+                    "cannot improve on this -- continuing, but the "
+                    "implementation loop cannot converge against these tests"
+                )
             print(
                 f"    [EXIT CODE {exit_code}] ImportError on expected module(s) "
                 f"-> valid red signal, routing to implementation"

--- a/tests/unit/test_scaffold_gates_see_stubs.py
+++ b/tests/unit/test_scaffold_gates_see_stubs.py
@@ -1,0 +1,232 @@
+"""#2317 / #2322: the two gates that let a hollow suite through.
+
+boostgauge #7 scaffolded 36 tests, every one an unconditional `assert False`.
+Two gates stood between that and the implementation stage, and both passed it:
+
+  #2317  validate_tests_mechanical printed "Validation PASSED: 36 real tests".
+         Issue #386 had exempted the `assert False, 'TDD RED: ...'` pattern
+         wholesale to stop a regeneration loop, so the node could no longer
+         tell a few placeholders among real tests from a suite that is
+         entirely placeholders.
+  #2322  the red phase accepted `exit 2 -> ImportError` as a valid red
+         signal. Collection died before any body ran, so the stubs were
+         invisible to it.
+
+Between them a suite that no implementation could satisfy reached N4, and
+two implementation iterations were spent grading against a constant.
+
+The real defective scaffold is the negative fixture, so these tests fail if
+either gate regresses to blessing it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    count_stub_tests,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _describe_hollow_suite,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "issue7_run153937"
+
+REAL_SUITE = '''
+def test_writes_defaults(tmp_path):
+    path = tmp_path / "c.json"
+    write_config(path)
+    assert path.exists()
+'''
+
+MIXED_SUITE = '''
+def test_real_one(tmp_path):
+    assert compute(2) == 4
+
+def test_placeholder():
+    """Not written yet."""
+    assert False, 'TDD RED: test_placeholder not implemented'
+'''
+
+ALL_STUBS = '''
+def test_a():
+    assert False, 'TDD RED: test_a not implemented'
+
+def test_b():
+    raise NotImplementedError
+
+def test_c():
+    """Nothing here."""
+'''
+
+# Hollow, but structurally well-formed: imports present and every body holds
+# an assert, so it clears the pre-existing structure checks and isolates the
+# hollow-suite behaviour under test. This is the shape the real scaffolder
+# emits, and the shape that shipped on boostgauge #7.
+ALL_STUBS_WELL_FORMED = '''
+import pytest
+
+def test_a():
+    assert False, 'TDD RED: test_a not implemented'
+
+def test_b():
+    assert False, 'TDD RED: test_b not implemented'
+'''
+
+
+# ---------------------------------------------------------------- #2317
+
+
+def test_the_real_defective_scaffold_is_all_stubs() -> None:
+    """The counter sees the actual shipped scaffold for what it was."""
+    source = (FIXTURES / "defective_scaffold.py").read_text(encoding="utf-8")
+    total, stubs, names = count_stub_tests(source)
+
+    assert total == 36
+    assert stubs == 36, "every body was an unconditional failure"
+    assert "test_t010" in names
+
+
+def test_real_tests_are_not_counted_as_stubs() -> None:
+    total, stubs, _ = count_stub_tests(REAL_SUITE)
+    assert (total, stubs) == (1, 0)
+
+
+def test_mixed_suite_counts_only_the_placeholder() -> None:
+    """#386's case: placeholders among real tests remain acceptable."""
+    total, stubs, names = count_stub_tests(MIXED_SUITE)
+    assert (total, stubs) == (2, 1)
+    assert names == ["test_placeholder"]
+
+
+def test_empty_and_notimplemented_bodies_are_stubs() -> None:
+    total, stubs, _ = count_stub_tests(ALL_STUBS)
+    assert (total, stubs) == (3, 3)
+
+
+def test_a_test_merely_mentioning_a_stub_phrase_is_real() -> None:
+    """Why this is decided on the AST and not by regex.
+
+    The line-based STUB_PATTERNS match the words, not the behaviour. A test
+    asserting ON that text is a genuine test, and misreading it as a stub is
+    the kind of false positive that got detection disabled wholesale.
+    """
+    source = '''
+def test_error_message_wording():
+    assert render_error() == "not implemented"
+'''
+    total, stubs, _ = count_stub_tests(source)
+    assert (total, stubs) == (1, 0)
+
+
+def test_unparseable_source_reports_nothing() -> None:
+    """Never invent a finding from input that cannot be read."""
+    assert count_stub_tests("def test_broken(:\n") == (0, 0, [])
+
+
+# ---------------------------------------------------------------- #2322
+
+
+def test_red_phase_names_the_real_defective_scaffold() -> None:
+    """The suite that reached N4 is now named before it."""
+    source = (FIXTURES / "defective_scaffold.py").read_text(encoding="utf-8")
+    described = _describe_hollow_suite({"generated_tests": source})
+
+    assert described
+    assert "36 test(s) fail unconditionally" in described
+    assert "no implementation can make this suite green" in described
+
+
+def test_validator_rejects_a_hollow_suite_when_the_spec_had_bodies() -> None:
+    """The boostgauge case: bodies were available and ignored.
+
+    Rejection is gated on being able to help. `should_regenerate` escalates
+    a deterministic scaffolder on its hash check, and escalate routes to
+    N4_implement_code -- so failing a suite that regeneration cannot improve
+    reaches implementation anyway, minus the red phase. Since #2316 the
+    fixable case is exactly this one.
+    """
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        validate_tests_mechanical_node,
+    )
+
+    state = {
+        "generated_tests": ALL_STUBS_WELL_FORMED,
+        "parsed_scenarios": {"scenarios": []},
+        "scaffold_attempts": 0,
+        "spec_test_suite": {
+            "imports": "",
+            "functions": [{"name": "test_a", "source": "def test_a():\n    assert 1"}],
+        },
+    }
+    result = validate_tests_mechanical_node(state)
+    validation = result["validation_result"]
+
+    assert validation["is_valid"] is False
+    assert validation["stub_count"] == 2
+    assert validation["real_test_count"] == 0
+    assert any("executable Section 10" in e for e in validation["errors"])
+
+
+def test_validator_reports_but_allows_a_hollow_suite_with_no_spec_bodies(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Where rejection cannot help, the suite is named rather than bounced.
+
+    This is also what preserves #386: a stub-only scaffold from a spec that
+    ships no test code is still accepted, so the regeneration loop that
+    issue closed does not reopen.
+    """
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        validate_tests_mechanical_node,
+    )
+
+    state = {
+        "generated_tests": ALL_STUBS_WELL_FORMED,
+        "parsed_scenarios": {"scenarios": []},
+        "scaffold_attempts": 0,
+    }
+    result = validate_tests_mechanical_node(state)
+    validation = result["validation_result"]
+
+    assert validation["is_valid"] is True, "must not reopen the #386 loop"
+    assert validation["stub_count"] == 2
+    assert validation["real_test_count"] == 0, (
+        "the count must stop calling placeholders real tests"
+    )
+    assert "[HOLLOW SCAFFOLD]" in capsys.readouterr().out
+
+
+def test_red_phase_passes_a_legitimate_suite() -> None:
+    """A real red phase -- real tests, module absent -- still proceeds."""
+    assert _describe_hollow_suite({"generated_tests": REAL_SUITE}) == ""
+
+
+def test_red_phase_passes_a_mixed_suite() -> None:
+    """Placeholders alongside real tests are not a hollow suite."""
+    assert _describe_hollow_suite({"generated_tests": MIXED_SUITE}) == ""
+
+
+def test_red_phase_reads_test_files_when_state_lacks_source(
+    tmp_path: Path,
+) -> None:
+    """Resumed runs carry the files but not always the generated source."""
+    path = tmp_path / "test_scaffolded.py"
+    path.write_text(ALL_STUBS, encoding="utf-8")
+
+    described = _describe_hollow_suite({"test_files": [str(path)]})
+    assert "3 test(s) fail unconditionally" in described
+
+
+@pytest.mark.parametrize("state", [
+    {},
+    {"generated_tests": ""},
+    {"generated_tests": "   \n"},
+    {"test_files": ["/nonexistent/path/test_x.py"]},
+    {"generated_tests": "def test_broken(:\n"},
+])
+def test_red_phase_never_invents_a_failure(state: dict) -> None:
+    """Unreadable input is not evidence of a hollow suite."""
+    assert _describe_hollow_suite(state) == ""


### PR DESCRIPTION
Closes #2317
Closes #2322

Two gates stood between a 36-stub scaffold and the implementation stage, and both passed it. `validate_tests_mechanical` printed *"Validation PASSED: 36 real tests"*; the red phase accepted `exit 2 → ImportError` as a valid red signal because collection died before any body ran.

## #2317 — the validator could not see stub bodies

`stub_count` was pinned at `0`, so `real_test_count = total_tests` and every placeholder was reported as a real test. Issue #386 had exempted the `assert False, 'TDD RED: ...'` pattern wholesale to stop a scaffold→validate→reject→scaffold loop, and the exemption was total.

`count_stub_tests()` now counts on the **AST**: a stub is a test whose body does nothing but fail — unconditional `assert False`, bare `raise NotImplementedError`, or nothing beyond a docstring. Decided structurally because the line-based `STUB_PATTERNS` cannot tell a placeholder from a genuine test that merely *mentions* one of those strings, and that imprecision is part of why detection was disabled rather than made accurate.

## #2322 — the red phase could not see them either

An ImportError proves the module is **absent**. It does not prove the tests discriminate. `_describe_hollow_suite()` reads the scaffold's source, which is available even while the implementation is not, so the check collection cannot make is made explicitly.

## Divergence from the issue premise, with evidence

Both issues imply the fix is to *reject* a hollow suite. I built that first, then traced where rejection leads:

```python
# graph.py:264
elif decision == "escalate":
    # Escalate to Claude - skip verify_red and go to implement
    return "N4_implement_code"
```

**"Escalate to Claude" does not escalate to a better test writer — it goes to implementation, skipping the red phase.** A deterministic scaffolder regenerates identical output, `should_regenerate` escalates on its hash check, and the run arrives at `N4_implement_code` anyway, with one fewer check than if the suite had simply passed. Rejection changes the path, not the destination.

So rejection is gated on being able to help:

| Suite | Spec ships executable §10 functions | Outcome |
|---|---|---|
| wholly hollow | yes | **rejected** — regeneration honours them since #2316 |
| wholly hollow | no | **named loudly**, run continues |
| placeholders among real tests | either | accepted (#386's case, unchanged) |

`real_test_count` is honest in every case — that number is what the operator reads, and it previously said the opposite of the truth.

The routing defect is filed separately as **#2331**; when it is repaired, the fixable-only gating here can be reconsidered, because its reason will be gone.

## Also corrected

The hollow-suite description is ASCII-only. My first draft used an em dash, which this same file's #1493 comment warns raises `UnicodeEncodeError` mid-stream on Windows cp1252.

## Tests

`tests/unit/test_scaffold_gates_see_stubs.py`, 15 tests, using the **real defective scaffold** as the negative fixture — both gates fail if either regresses to blessing it.

Covered: the real 36-stub scaffold counted correctly; real tests not miscounted; #386's mixed suite still accepted; a test that merely mentions "not implemented" recognised as real (the false positive that motivated the blanket exemption); unparseable input reporting nothing rather than inventing a finding.

The pre-existing #386 regression test (`test_node_accepts_tdd_red_scaffolds`) still passes unmodified.

## Checks

Full unit suite **7311 passed, 17 skipped, 0 failures**, verified with `CI=true` set. `ruff check` clean on both touched files and the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
