### PR TITLE
fix(testing): a coverage shortfall routes to test additions, never implementation (Closes #2327)

### DIFF
--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -77,6 +77,9 @@ from assemblyzero.workflows.testing.nodes import (
 )
 
 
+from assemblyzero.workflows.testing.nodes.augment_tests import (
+    augment_tests_for_coverage,
+)
 from assemblyzero.workflows.testing.nodes.completeness_gate import (
     completeness_gate,
     route_after_completeness_gate,
@@ -317,9 +320,19 @@ def route_after_implement(
     return "N4b_completeness_gate"
 
 
+#: #2327: how many times to ask for coverage-targeting test additions before
+#: halting. Each attempt is an LLM call; if two rounds of tests aimed at named
+#: uncovered lines have not reached the gate, a third is unlikely to, and the
+#: honest outcome is a halt that says so rather than a route to implementation.
+MAX_COVERAGE_AUGMENT_ATTEMPTS = 2
+
+
 def route_after_green(
     state: TestingWorkflowState,
-) -> Literal["N6_e2e_validation", "N7_finalize", "N4_implement_code", "N2_scaffold_tests", "end"]:
+) -> Literal[
+    "N6_e2e_validation", "N7_finalize", "N4_implement_code",
+    "N4c_augment_tests", "N2_scaffold_tests", "end",
+]:
     """Route after N5 (verify_green_phase).
 
     Issue #292: Added N2_scaffold_tests route for exit codes 4/5.
@@ -339,6 +352,30 @@ def route_after_green(
     # Issue #292: Exit code 4/5 routes back to scaffold
     if next_node == "N2_scaffold_tests":
         return "N2_scaffold_tests"
+
+    # #2327: a green-but-under-covered result routes to test additions, never
+    # to implementation revision. Bounded by the same iteration and budget
+    # limits as the implement loop, and additionally by its own attempt count
+    # -- an LLM that cannot reach the target will not be asked forever.
+    if next_node == "N4c_augment_tests":
+        iteration = state.get("iteration_count", 0)
+        max_iterations = state.get("max_iterations", 3)
+        if iteration >= max_iterations:
+            return "end"
+        if state.get("coverage_augment_attempts", 0) >= MAX_COVERAGE_AUGMENT_ATTEMPTS:
+            print(
+                f"    [COVERAGE] {MAX_COVERAGE_AUGMENT_ATTEMPTS} test-addition "
+                f"attempt(s) did not reach the target. Halting rather than "
+                f"routing to implementation -- the uncovered lines are a test "
+                f"gap, and revising the implementation to close it would "
+                f"reward deleting the code that is not covered."
+            )
+            return "end"
+        budget = state.get("cost_budget_usd", 0.0)
+        if budget > 0 and get_cumulative_cost() > budget:
+            print("    [BUDGET] exceeded. Halting.")
+            return "end"
+        return "N4c_augment_tests"
 
     # Check for iteration loop back to implement
     if next_node == "N4_implement_code":
@@ -459,6 +496,7 @@ def build_testing_workflow() -> StateGraph:
     workflow.add_node("N3_verify_red", verify_red_phase)
     workflow.add_node("N4_implement_code", _wrap_with_checkpoint(implement_code, "post-impl"))
     workflow.add_node("N4b_completeness_gate", completeness_gate)  # Issue #147
+    workflow.add_node("N4c_augment_tests", augment_tests_for_coverage)  # #2327
     workflow.add_node("N5_verify_green", _wrap_with_checkpoint(verify_green_phase, "post-green"))
     workflow.add_node("N6_e2e_validation", e2e_validation)
     # Issue #1626: checkpoint after N7 so the test/implementation reports written
@@ -565,10 +603,16 @@ def build_testing_workflow() -> StateGraph:
             "N6_e2e_validation": "N6_e2e_validation",
             "N7_finalize": "N7_finalize",
             "N4_implement_code": "N4_implement_code",
+            "N4c_augment_tests": "N4c_augment_tests",  # #2327
             "N2_scaffold_tests": "N2_scaffold_tests",
             "end": END,
         },
     )
+
+    # #2327: test additions always return to verification. The node never
+    # routes to implementation, so a coverage shortfall cannot become an
+    # implementation edit by any path.
+    workflow.add_edge("N4c_augment_tests", "N5_verify_green")
 
     # N6 -> N7 or N4 (iteration loop)
     workflow.add_conditional_edges(

--- a/assemblyzero/workflows/testing/nodes/augment_tests.py
+++ b/assemblyzero/workflows/testing/nodes/augment_tests.py
@@ -1,0 +1,220 @@
+"""N4c: add tests for uncovered lines (#2327).
+
+A green-but-under-covered result is a TEST problem wearing an implementation
+problem's clothes. Every test passes; the shortfall is in lines no test
+reaches. Sending that to implementation revision is not merely useless, it is
+dangerous: the cheapest edit that raises statement coverage is to DELETE the
+uncovered code, and the uncovered code is typically the error handling the
+spec mandates. The loop would be rewarded for removing it, and nothing in the
+pipeline would notice.
+
+Measured on boostgauge #7 (`run-issue7-153937`): the spec's own test
+functions run against the implementation give 23 passed and 80% coverage
+against a 95% gate, with all 19 uncovered statements in error paths that
+spec section 11.1 requires the code to have and no requirement asks any test
+to reach.
+
+This node adds tests. It never touches implementation files, and it appends
+rather than rewriting, so tests already proven to pass cannot be lost.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from assemblyzero.workflows.testing.audit import gate_log
+from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+    call_claude_for_file,
+)
+from assemblyzero.workflows.testing.nodes.implementation.parsers import (
+    extract_code_block,
+)
+from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+#: Cap on how many uncovered lines to name in one request. Beyond this the
+#: prompt stops being a specific instruction and becomes a wish.
+MAX_TARGET_LINES = 40
+
+
+def parse_uncovered_lines(output: str) -> dict[str, list[str]]:
+    """Map source file -> uncovered line ranges from `--cov-report=term-missing`.
+
+    The report's last column is the "Missing" list, e.g. `25-27, 53, 88-89`.
+    Rows without one (100% covered files, the TOTAL row) are skipped.
+    """
+    uncovered: dict[str, list[str]] = {}
+    for line in output.splitlines():
+        # Name  Stmts  Miss  Cover  Missing
+        match = re.match(
+            r"^(\S+\.py)\s+\d+\s+\d+\s+\d+%\s+(\S.*)$", line.strip()
+        )
+        if not match:
+            continue
+        path, missing = match.group(1), match.group(2).strip()
+        if not missing or missing == "-":
+            continue
+        ranges = [part.strip() for part in missing.split(",") if part.strip()]
+        if ranges:
+            uncovered[path] = ranges
+    return uncovered
+
+
+def _read_lines(path: Path, ranges: list[str]) -> str:
+    """Quote the uncovered source so the request names real code, not numbers."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ""
+
+    wanted: list[int] = []
+    for part in ranges:
+        if "-" in part:
+            start, _, end = part.partition("-")
+            try:
+                wanted.extend(range(int(start), int(end) + 1))
+            except ValueError:
+                continue
+        else:
+            try:
+                wanted.append(int(part))
+            except ValueError:
+                continue
+
+    out: list[str] = []
+    for number in wanted[:MAX_TARGET_LINES]:
+        if 1 <= number <= len(lines):
+            out.append(f"{number}: {lines[number - 1]}")
+    return "\n".join(out)
+
+
+def build_augment_prompt(
+    test_file: str,
+    existing_tests: str,
+    targets: dict[str, str],
+    coverage_achieved: float,
+    coverage_target: int,
+) -> str:
+    """Ask for ADDITIONAL tests against named lines, and nothing else."""
+    sections = [
+        f"The test suite passes in full. Coverage is {coverage_achieved:.1f}% "
+        f"against a target of {coverage_target}%.",
+        "",
+        "Write ADDITIONAL pytest test functions that exercise the uncovered "
+        "lines quoted below. The uncovered code is usually error handling and "
+        "edge-case branches, so the new tests will mostly drive failure paths: "
+        "missing files, malformed input, permission errors, platform branches.",
+        "",
+        "Rules:",
+        "- Do NOT modify the implementation. It is correct; the tests are the gap.",
+        "- Do NOT rewrite or restate the existing tests. Emit only NEW functions.",
+        "- Every new test must assert real behaviour. Never `assert True`, "
+        "never a test that passes without exercising the target line.",
+        "- Use the same fixtures and import style as the existing tests.",
+        "- Give each test a name that says which condition it covers.",
+        "",
+        f"Test file being extended: {test_file}",
+        "",
+        "Uncovered lines, by file:",
+    ]
+    for path, quoted in targets.items():
+        sections.append(f"\n--- {path} ---\n{quoted}")
+
+    sections.extend([
+        "",
+        "Existing tests (for fixtures and import style — do not repeat them):",
+        "```python",
+        existing_tests[:6000],
+        "```",
+        "",
+        "Return ONLY the new test functions in a single ```python block, with "
+        "any imports they need at the top of that block.",
+    ])
+    return "\n".join(sections)
+
+
+def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
+    """N4c: append tests targeting uncovered lines (#2327).
+
+    Returns to N5 either way. A failure to add tests is reported and leaves
+    the suite untouched -- it must never damage a passing suite, and it must
+    never route the shortfall to implementation revision.
+    """
+    gate_log("[N4c] Adding tests for uncovered lines...")
+
+    output = state.get("green_phase_output", "") or ""
+    coverage_achieved = float(state.get("coverage_achieved", 0) or 0)
+    coverage_target = int(state.get("coverage_target", 90) or 90)
+    test_files = state.get("test_files", []) or []
+    repo_root = Path(state.get("repo_root", "") or ".")
+
+    if not test_files:
+        print("    [N4c] no test file to extend — returning to verification")
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    uncovered = parse_uncovered_lines(output)
+    if not uncovered:
+        print(
+            "    [N4c] coverage report named no uncovered lines; nothing "
+            "specific to target — returning to verification"
+        )
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    targets: dict[str, str] = {}
+    for path, ranges in uncovered.items():
+        quoted = _read_lines(repo_root / path, ranges)
+        if not quoted:
+            quoted = ", ".join(ranges)
+        targets[path] = quoted
+
+    total_lines = sum(len(r) for r in uncovered.values())
+    print(
+        f"    [N4c] {coverage_achieved:.1f}% vs {coverage_target}% target; "
+        f"targeting uncovered lines in {len(uncovered)} file(s)"
+    )
+    for path, ranges in uncovered.items():
+        print(f"      {path}: {', '.join(ranges)}")
+
+    test_path = Path(test_files[0])
+    try:
+        existing = test_path.read_text(encoding="utf-8")
+    except OSError as err:
+        print(f"    [N4c] could not read {test_path}: {err}")
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    prompt = build_augment_prompt(
+        str(test_path), existing, targets, coverage_achieved, coverage_target,
+    )
+    response, error = call_claude_for_file(prompt, file_path=str(test_path))
+    if error or not response:
+        print(f"    [N4c] no new tests generated: {error or 'empty response'}")
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    addition = extract_code_block(response, str(test_path))
+    if not addition or not addition.strip():
+        print("    [N4c] response contained no code block; suite unchanged")
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    # Append. Never rewrite: the existing tests are proven to pass, and a
+    # regeneration that loses one trades a coverage point for a real test.
+    merged = existing.rstrip() + "\n\n\n" + addition.strip() + "\n"
+    try:
+        compile(merged, str(test_path), "exec")
+    except SyntaxError as err:
+        print(f"    [N4c] generated tests do not parse ({err}); suite unchanged")
+        return {"next_node": "N5_verify_green", "error_message": ""}
+
+    test_path.write_text(merged, encoding="utf-8")
+    added = len(re.findall(r"^def\s+test_\w+", addition, re.MULTILINE))
+    print(f"    [N4c] added {added} test(s) targeting {total_lines} uncovered range(s)")
+
+    return {
+        "test_files": [str(test_path)],
+        "generated_tests": merged,
+        "coverage_augment_attempts": int(
+            state.get("coverage_augment_attempts", 0) or 0
+        ) + 1,
+        "next_node": "N5_verify_green",
+        "error_message": "",
+    }

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -1600,7 +1600,21 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             },
         )
 
-        # Loop back to implementation for more coverage
+        # #2327: every test passes and the shortfall is in lines no test
+        # reaches, so this is a TEST gap, not an implementation gap. It used
+        # to route to N4_implement_code, which is worse than useless: the
+        # cheapest edit that raises statement coverage is to DELETE the
+        # uncovered code, and the uncovered code is characteristically the
+        # error handling the spec mandates. The loop was pointed at removing
+        # it, and nothing downstream would have noticed.
+        #
+        # Route to test-side additions instead. The implementation is not
+        # touched on this path at all.
+        print(
+            f"    [N5] all {passed_count} test(s) pass; coverage "
+            f"{coverage_achieved:.1f}% < {coverage_target}% target -- this is "
+            f"a test gap, routing to test additions (never to implementation)"
+        )
         updates = {
             "green_phase_output": output,
             "coverage_achieved": coverage_achieved,
@@ -1611,7 +1625,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
             "iteration_count": iteration_count + 1,
-            "next_node": "N4_implement_code",
+            "next_node": "N4c_augment_tests",
             "error_message": "",
             # All tests pass here; a count plateau is a failing-branch concept.
             "count_plateau_strikes": 0,

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -170,6 +170,10 @@ class TestingWorkflowState(TypedDict, total=False):
     red_phase_output: str
     green_phase_output: str
     coverage_achieved: float
+    #: #2327: how many rounds of coverage-targeting test additions have run.
+    #: Bounds N4c so an LLM that cannot reach the gate is not asked forever,
+    #: and so the shortfall never falls through to implementation revision.
+    coverage_augment_attempts: int
     previous_coverage: float  # Previous iteration coverage for stagnation detection
     previous_passed: int  # Previous iteration pass count for stagnation detection
     e2e_output: str

--- a/tests/unit/test_coverage_routes_to_tests.py
+++ b/tests/unit/test_coverage_routes_to_tests.py
@@ -1,0 +1,185 @@
+"""#2327: a coverage shortfall is a test gap, and must never reach implementation.
+
+Measured on boostgauge #7: the spec's own test functions run against the
+implementation give 23 passed and 80% coverage against a 95% gate, with every
+uncovered statement in error handling that spec section 11.1 requires the code
+to have and no requirement asks any test to reach.
+
+Routing that to implementation revision is worse than useless. The cheapest
+edit that raises statement coverage is to DELETE the uncovered code, so the
+loop would be rewarded for removing exactly the error handling the spec
+mandates -- silently, since every test still passes and the number goes up.
+
+These tests pin the routing and the guarantee that the implementation is never
+touched on this path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.graph import (
+    MAX_COVERAGE_AUGMENT_ATTEMPTS,
+    route_after_green,
+)
+from assemblyzero.workflows.testing.nodes.augment_tests import (
+    augment_tests_for_coverage,
+    build_augment_prompt,
+    parse_uncovered_lines,
+)
+
+# A real `--cov-report=term-missing` tail, matching the shape N5 captures.
+COVERAGE_REPORT = """
+Name                        Stmts   Miss  Cover   Missing
+---------------------------------------------------------
+src/boostgauge/__init__.py      0      0   100%
+src/boostgauge/app.py          50      9    82%   31-33, 77, 84-88
+src/boostgauge/config.py       45     10    78%   25-27, 53, 59, 76-78, 88-89
+---------------------------------------------------------
+TOTAL                          95     19    80%
+"""
+
+
+def test_uncovered_lines_are_parsed_per_file() -> None:
+    uncovered = parse_uncovered_lines(COVERAGE_REPORT)
+
+    assert set(uncovered) == {
+        "src/boostgauge/app.py", "src/boostgauge/config.py",
+    }
+    assert uncovered["src/boostgauge/config.py"] == [
+        "25-27", "53", "59", "76-78", "88-89",
+    ]
+
+
+def test_fully_covered_files_and_total_are_skipped() -> None:
+    """A file with no Missing column is not a target, and TOTAL is not a file."""
+    uncovered = parse_uncovered_lines(COVERAGE_REPORT)
+    assert "src/boostgauge/__init__.py" not in uncovered
+    assert not any("TOTAL" in key for key in uncovered)
+
+
+def test_no_coverage_report_yields_no_targets() -> None:
+    assert parse_uncovered_lines("23 passed in 0.2s") == {}
+
+
+def test_prompt_forbids_touching_the_implementation() -> None:
+    """The instruction that keeps the corruption off the table."""
+    prompt = build_augment_prompt(
+        "tests/test_issue_7.py", "def test_a():\n    assert 1\n",
+        {"src/boostgauge/config.py": "53: raise ValueError('bad json')"},
+        coverage_achieved=80.0, coverage_target=95,
+    )
+
+    assert "Do NOT modify the implementation" in prompt
+    assert "ADDITIONAL" in prompt
+    assert "53: raise ValueError('bad json')" in prompt, (
+        "the request must name real uncovered code, not just line numbers"
+    )
+
+
+# ------------------------------------------------------------------ routing
+
+
+def _green_state(**overrides: object) -> dict:
+    state = {
+        "error_message": "",
+        "next_node": "N4c_augment_tests",
+        "iteration_count": 0,
+        "max_iterations": 3,
+        "coverage_augment_attempts": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+def test_coverage_shortfall_routes_to_test_additions() -> None:
+    assert route_after_green(_green_state()) == "N4c_augment_tests"
+
+
+def test_coverage_shortfall_never_routes_to_implementation() -> None:
+    """The whole point: no state on this path may reach implementation."""
+    for attempts in range(MAX_COVERAGE_AUGMENT_ATTEMPTS + 2):
+        for iteration in range(5):
+            decision = route_after_green(_green_state(
+                coverage_augment_attempts=attempts, iteration_count=iteration,
+            ))
+            assert decision != "N4_implement_code", (
+                f"coverage shortfall reached implementation at "
+                f"attempts={attempts}, iteration={iteration}"
+            )
+
+
+def test_exhausted_attempts_halt_rather_than_fall_through() -> None:
+    state = _green_state(
+        coverage_augment_attempts=MAX_COVERAGE_AUGMENT_ATTEMPTS,
+    )
+    assert route_after_green(state) == "end"
+
+
+def test_iteration_cap_still_applies() -> None:
+    assert route_after_green(_green_state(iteration_count=3)) == "end"
+
+
+def test_a_genuine_implementation_loop_is_unaffected() -> None:
+    """Failing tests still route to implementation, as before."""
+    state = _green_state(next_node="N4_implement_code")
+    assert route_after_green(state) == "N4_implement_code"
+
+
+# ------------------------------------------------------------------ the node
+
+
+def test_node_returns_to_verification_when_nothing_to_target(
+    tmp_path: Path,
+) -> None:
+    """No parseable coverage report: return to N5, change nothing."""
+    test_file = tmp_path / "test_x.py"
+    test_file.write_text("def test_a():\n    assert 1\n", encoding="utf-8")
+    before = test_file.read_text(encoding="utf-8")
+
+    result = augment_tests_for_coverage({
+        "green_phase_output": "23 passed",
+        "test_files": [str(test_file)],
+        "repo_root": str(tmp_path),
+        "coverage_achieved": 80.0,
+        "coverage_target": 95,
+    })
+
+    assert result["next_node"] == "N5_verify_green"
+    assert test_file.read_text(encoding="utf-8") == before
+
+
+def test_node_returns_to_verification_with_no_test_file() -> None:
+    result = augment_tests_for_coverage({
+        "green_phase_output": COVERAGE_REPORT, "test_files": [],
+    })
+    assert result["next_node"] == "N5_verify_green"
+
+
+def test_node_never_names_an_implementation_file_as_its_output() -> None:
+    """Structural guarantee: N4c only ever writes the test file.
+
+    Asserted against the source, so a later edit that starts writing an
+    implementation path fails here rather than in a post-mortem.
+    """
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "assemblyzero" / "workflows" / "testing" / "nodes" / "augment_tests.py"
+    ).read_text(encoding="utf-8")
+
+    assert "write_text" in source
+    # The only write target is the test path.
+    writes = [
+        line.strip() for line in source.splitlines()
+        if ".write_text(" in line
+    ]
+    assert writes == ["test_path.write_text(merged, encoding=\"utf-8\")"], (
+        f"N4c must write only the test file, found: {writes}"
+    )
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "not a table at all"])
+def test_malformed_reports_are_not_targets(bad: str) -> None:
+    assert parse_uncovered_lines(bad) == {}

--- a/tests/unit/test_testing_workflow.py
+++ b/tests/unit/test_testing_workflow.py
@@ -1940,7 +1940,11 @@ class TestVerifyPhasesModule:
 
             result = verify_green_phase(state)
 
-        assert result.get("next_node") == "N4_implement_code"
+        # #2327: all 3 tests pass and coverage is under target, so the
+        # shortfall is a TEST gap. It iterates to test additions rather than
+        # implementation revision -- routing it to the implementation would
+        # reward deleting the uncovered code.
+        assert result.get("next_node") == "N4c_augment_tests"
 
 
 class TestReviewTestPlanModule:

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -62,7 +62,11 @@ class TestProgressTheGuardCouldNotSee:
                    previous_green_failures=["test_decay"])
         )
 
-        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+        # #2327: all tests pass and coverage is under target, so the loop
+        # continues to TEST additions rather than implementation revision.
+        # What this test guards is that it continues at all -- that the
+        # stagnation check does not fire on a run that is making progress.
+        assert result["next_node"] == "N4c_augment_tests", result.get("error_message")
         assert "stagnant" not in result.get("error_message", "").lower()
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
@@ -72,7 +76,8 @@ class TestProgressTheGuardCouldNotSee:
         result = verify_green_phase(
             _state(previous_passed=12, previous_coverage=94.0)
         )
-        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+        # #2327: green-but-under-covered continues to test additions.
+        assert result["next_node"] == "N4c_augment_tests", result.get("error_message")
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_it_says_why_it_kept_going(self, mock_pytest, capsys):


### PR DESCRIPTION
Closes #2327

A green-but-under-covered result is a **test** gap wearing an implementation gap's clothes. Every test passes; the shortfall is in lines no test reaches. It used to route to `N4_implement_code`.

That is worse than useless. The cheapest edit that raises statement coverage is to **delete the uncovered code**, and the uncovered code is characteristically the error handling the spec mandates. The loop was pointed at removing it, every test would still pass, the number would go up, and nothing downstream would notice.

## Measured state

The `run-issue7-153937` spec's own test functions, against the implementation the pipeline produced, with N5's flags:

| Scope | Stmts | Miss | Cover |
|---|---|---|---|
| `boostgauge.config` (what the run measured) | 45 | 10 | 78% |
| `boostgauge` (both modules) | 95 | 19 | 80% |

23/23 pass in both. Gate is 95%. Every uncovered statement is an error path spec §11.1 mandates and no requirement tests.

## The change

| Situation | Before | After |
|---|---|---|
| tests failing | → implementation | → implementation (unchanged) |
| tests pass, coverage short | → **implementation** | → **`N4c_augment_tests`** |
| additions exhausted | — | halt, saying why |

`N4c_augment_tests` parses `--cov-report=term-missing`, quotes the actual uncovered source lines, and asks for **additional** test functions targeting them. It:

- **never touches implementation files** — asserted structurally by a test that greps the node's own source for write targets, so a later edit that starts writing an implementation path fails there rather than in a post-mortem;
- **appends, never rewrites** — tests already proven to pass cannot be traded away for a coverage point;
- **compiles the merged file before writing** — a response that does not parse leaves the suite untouched;
- **returns to N5 on every path**, including every failure path, so it can never strand the run.

Bounded by the existing iteration and budget caps plus `MAX_COVERAGE_AUGMENT_ATTEMPTS = 2`. When those are spent it **halts**, and does not fall through to implementation. `test_coverage_shortfall_never_routes_to_implementation` sweeps the attempt × iteration space asserting that.

## This is containment, not the cause — filed as #2333

Per your directive, saying so rather than papering over it: the root cause is spec-stage. Section 11.1 requires the error handling; section 10.1 writes 23 requirement-driven tests and reaches none of it. The spec stage reports `Coverage: 100.0% (22/22 requirements)`, which is true and says nothing about statement coverage — so a spec can pass its own completeness check and be structurally unable to clear the gate two stages later.

#2333 carries that with the full line-by-line evidence. This PR stops the impl loop doing damage while that stands.

**Consequence for the relaunch, stated plainly:** this makes the coverage wall *safe*, not *gone*. With the spec as it is, the run reaches ~80% and N4c must invent error-path tests the spec never specified. It may clear 95%; it may halt honestly after two attempts. It will not corrupt the implementation either way.

## Tests

15 tests. Report parsing (including fully-covered files and the TOTAL row correctly skipped), prompt content (the "do not modify the implementation" instruction and real quoted source, not bare line numbers), the full routing matrix, and the node's no-op paths.

Three pre-existing tests asserted the old destination on this exact branch (all tests passing, coverage under target). Their intent is stagnation/iteration behaviour, not the destination, so they are updated to the new node with a comment recording why.

## Checks

Full unit suite **7326 passed, 17 skipped, 0 failures**, verified with `CI=true`. `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
