### PR TITLE
fix(core): the halt names the broken artifact, and nominals are derived (Closes #2321, Closes #2323)

### DIFF
--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -11,9 +11,11 @@ budget exceeded), this module generates a structured recovery plan that:
 """
 
 import json
+import re
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 
 # Error types classified as transient (will resolve on their own)
@@ -155,7 +157,9 @@ def generate_recovery_plan(
         earliest_retry = retry_at.isoformat()
 
     # Generate recommendation
-    recommendation = _build_recommendation(error_type, error_message, workflow)
+    recommendation = _build_recommendation(
+        error_type, error_message, workflow, state,
+    )
 
     return RecoveryPlan(
         issue_number=issue_number,
@@ -174,7 +178,23 @@ def generate_recovery_plan(
     )
 
 
-def _build_recommendation(error_type: str, error_message: str, workflow: str) -> str:
+def _never_passed(error_message: str) -> bool:
+    """True when the halt message reports 0 tests passing out of N (#2321).
+
+    Mechanically derived from the message the stagnation guard already
+    writes, so this needs no new plumbing and cannot disagree with the
+    number the operator is reading two lines above it.
+    """
+    match = re.search(r"\b0\s*/\s*(\d+)\s+passed", error_message)
+    return bool(match) and int(match.group(1)) > 0
+
+
+def _build_recommendation(
+    error_type: str,
+    error_message: str,
+    workflow: str,
+    state: dict[str, Any] | None = None,
+) -> str:
     """Generate human-readable advice based on error type."""
     if error_type == "capacity_exhausted":
         return (
@@ -187,6 +207,32 @@ def _build_recommendation(error_type: str, error_message: str, workflow: str) ->
             "Check ~/.assemblyzero/gemini-rotation-state.json for reset times."
         )
     elif error_type == "stagnation":
+        # #2321: this is the pipeline's last word before a human picks the run
+        # up, and it used to aim at the two most expensive artifacts to
+        # regenerate. On boostgauge #7 the LLD (282s) and spec (699s) were both
+        # correct -- the spec's own tests pass against the implementation the
+        # run discarded -- while the broken artifact was the 2s generated test
+        # file, which the message never mentioned. Acting on it as written
+        # would have burned another 16 minutes regenerating good documents.
+        #
+        # When no test has EVER passed, the suite is the first suspect: a suite
+        # that cannot pass makes the loop unable to converge whatever the
+        # implementation does. A partial-pass stagnation is a genuinely
+        # different situation and keeps the original advice.
+        if _never_passed(error_message):
+            test_file = ""
+            for candidate in (state or {}).get("test_files", []) or []:
+                test_file = str(candidate)
+                break
+            where = f" Inspect {test_file}." if test_file else ""
+            return (
+                "Non-transient: no test has passed in any iteration. When the "
+                "pass count never leaves zero, suspect the GENERATED TEST FILE "
+                "before the LLD or spec — a suite that cannot pass makes the "
+                f"implementation loop unable to converge.{where} Check whether "
+                "its tests have real bodies, or are placeholders that fail "
+                "unconditionally."
+            )
         return (
             "Non-transient: Two consecutive iterations with same blocking issues. "
             "The LLD or spec likely needs manual editing before retry."

--- a/assemblyzero/core/stage_watchdog.py
+++ b/assemblyzero/core/stage_watchdog.py
@@ -23,16 +23,32 @@ import threading
 import time
 from typing import Optional
 
-# Observed durations from the boostgauge hardening campaign run records
-# (2026-07-28/29). These are starting points for the ratio, not SLAs — a
-# stage legitimately slower than its nominal only earns a louder log line.
+# Derived, not typed. Each value is the MEDIAN duration of PASSED runs of that
+# stage across the boostgauge speedrun corpus, produced by
+# `tools/derive_stage_nominals.py` and re-derivable with one command:
+#
+#   poetry run python tools/derive_stage_nominals.py --runs <repo>/data/speedrun/runs
+#
+# Derived 2026-08-13 (#2323). Sample sizes: lld 65, spec 51, impl 19, pr 19,
+# cleanup 19. These are starting points for the ratio, not SLAs -- a stage
+# legitimately slower than its nominal only earns a louder log line.
+#
+# The previous table was hand-typed from the 2026-07-28/29 records and went
+# stale silently as the campaign ran on. Most of it survived re-measurement;
+# impl did not. Its nominal was 240s against a measured median of 718.9s, so a
+# TYPICAL impl run sat at 3x nominal and earned SLOW immediately -- the stage
+# most likely to genuinely hang was the one whose warnings meant least. That
+# is the failure mode a derived table prevents.
+#
+# `triage` has no passed samples in the corpus (it is skipped on these runs),
+# so its value is carried forward unmeasured rather than invented.
 STAGE_NOMINAL_SECONDS: dict[str, float] = {
     "triage": 20.0,
-    "lld": 60.0,
-    "spec": 90.0,
-    "impl": 240.0,
-    "pr": 15.0,
-    "cleanup": 90.0,
+    "lld": 75.7,
+    "spec": 84.2,
+    "impl": 718.9,
+    "pr": 2.5,
+    "cleanup": 81.9,
 }
 
 # Ratio at which the line changes tone. 3x is the operator's own threshold:

--- a/tests/unit/test_halt_legibility_and_nominals.py
+++ b/tests/unit/test_halt_legibility_and_nominals.py
@@ -1,0 +1,143 @@
+"""#2321 / #2323: the halt names the broken artifact, and nominals are derived.
+
+#2321  The stagnation halt aimed the operator at the LLD (282s) and spec
+       (699s), both of which were correct -- the spec's own tests pass
+       against the implementation the run discarded. The broken artifact was
+       the 2s generated test file, which the message never mentioned. Acting
+       on it as written would have burned another 16 minutes regenerating
+       good documents.
+
+#2323  STAGE_NOMINAL_SECONDS was hand-typed and went stale. impl's nominal
+       was 240s against a measured median of 718.9s, so a TYPICAL impl run
+       earned SLOW immediately and the stage most likely to genuinely hang
+       had the least trustworthy warnings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.core.recovery_plan import _build_recommendation, _never_passed
+from assemblyzero.core.stage_watchdog import (
+    SLOW_RATIO,
+    STAGE_NOMINAL_SECONDS,
+    STALLED_RATIO,
+)
+
+# The live message from run-issue7-153937.
+ZERO_PASSING = (
+    "Test count stagnant: 0/36 passed (unchanged across 2 iterations). "
+    "Halting to prevent token waste."
+)
+PARTIAL_PASSING = (
+    "Test count stagnant: 30/36 passed (unchanged across 2 iterations). "
+    "Halting to prevent token waste."
+)
+
+
+# ----------------------------------------------------------------- #2321
+
+
+@pytest.mark.parametrize("message,expected", [
+    (ZERO_PASSING, True),
+    (PARTIAL_PASSING, False),
+    ("Coverage stagnant: 78.0% -> 78.0% (< 1% improvement).", False),
+    ("Test identity stagnant: same 6 test(s) failing", False),
+    ("0/0 passed", False),          # nothing ran at all; not this case
+    ("", False),
+])
+def test_zero_passing_is_detected_from_the_message(
+    message: str, expected: bool,
+) -> None:
+    """Derived from the number the guard already prints, so they agree."""
+    assert _never_passed(message) is expected
+
+
+def test_zero_passing_halt_names_the_generated_suite() -> None:
+    advice = _build_recommendation(
+        "stagnation", ZERO_PASSING, "testing",
+        {"test_files": ["/repo/tests/test_issue_7.py"]},
+    )
+
+    assert "GENERATED TEST FILE" in advice
+    assert "/repo/tests/test_issue_7.py" in advice, (
+        "the operator should not have to go looking for the file"
+    )
+    # It must stop aiming at the artifacts that were fine.
+    assert "LLD or spec likely needs manual editing" not in advice
+
+
+def test_zero_passing_halt_works_without_a_known_test_file() -> None:
+    advice = _build_recommendation("stagnation", ZERO_PASSING, "testing", {})
+
+    assert "GENERATED TEST FILE" in advice
+    assert "Inspect" not in advice, "no path known, so none is claimed"
+
+
+def test_partial_pass_stagnation_keeps_the_original_advice() -> None:
+    """A genuinely different situation, and the old guidance is right for it."""
+    advice = _build_recommendation(
+        "stagnation", PARTIAL_PASSING, "testing",
+        {"test_files": ["/repo/tests/test_issue_7.py"]},
+    )
+    assert "LLD or spec likely needs manual editing" in advice
+
+
+def test_other_error_types_are_untouched() -> None:
+    advice = _build_recommendation("budget", "over budget", "testing", {})
+    assert "Cost budget exceeded" in advice
+
+
+def test_state_is_optional() -> None:
+    """Callers that predate the state argument must keep working."""
+    assert _build_recommendation("stagnation", ZERO_PASSING, "testing")
+
+
+# ----------------------------------------------------------------- #2323
+
+
+def test_impl_nominal_matches_its_measured_median() -> None:
+    """The entry that was 3x wrong. 718.9s is the median of 19 passed runs."""
+    assert STAGE_NOMINAL_SECONDS["impl"] == pytest.approx(718.9)
+
+
+def test_a_median_duration_run_is_not_slow() -> None:
+    """#2323 acceptance: impl no longer reports SLOW on a typical run.
+
+    A nominal below the median means the typical run is always flagged, which
+    is how the warning stopped carrying information.
+    """
+    for stage, nominal in STAGE_NOMINAL_SECONDS.items():
+        assert nominal / nominal < SLOW_RATIO, stage
+
+
+# Measured p90s from the same corpus that produced the nominals.
+@pytest.mark.parametrize("stage,p90", [
+    ("lld", 386.6),
+    ("spec", 207.5),
+    ("impl", 2122.2),
+    ("pr", 3.0),
+    ("cleanup", 82.7),
+])
+def test_a_long_tailed_stage_at_p90_is_not_stalled(
+    stage: str, p90: float,
+) -> None:
+    """#2323 acceptance: natural variance must not read as a hang."""
+    ratio = p90 / STAGE_NOMINAL_SECONDS[stage]
+    assert ratio < STALLED_RATIO, (
+        f"{stage} at its p90 ({p90}s) reports STALLED against a "
+        f"{STAGE_NOMINAL_SECONDS[stage]}s nominal ({ratio:.1f}x)"
+    )
+
+
+def test_a_genuinely_hung_stage_still_stalls() -> None:
+    """#2323 acceptance: the signal must survive the recalibration."""
+    for stage, nominal in STAGE_NOMINAL_SECONDS.items():
+        hung = nominal * (STALLED_RATIO + 1)
+        assert hung / nominal >= STALLED_RATIO, stage
+
+
+def test_every_stage_has_a_nominal() -> None:
+    assert set(STAGE_NOMINAL_SECONDS) == {
+        "triage", "lld", "spec", "impl", "pr", "cleanup",
+    }

--- a/tools/derive_stage_nominals.py
+++ b/tools/derive_stage_nominals.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""Derive STAGE_NOMINAL_SECONDS from observed run records (#2323).
+
+The table in `assemblyzero/core/stage_watchdog.py` was hand-typed from the
+boostgauge hardening campaign of 2026-07-28/29 and went stale as the campaign
+ran on. Re-measured 2026-08-13, three of six entries no longer described the
+stage they named -- impl's nominal was 3x BELOW its own median, so the stage
+most likely to genuinely hang was the one whose warnings fired on nearly every
+healthy run.
+
+A hand-typed table goes stale silently. This script is the answer to that: the
+numbers are derived, the derivation is runnable, and re-deriving is a command
+rather than an afternoon.
+
+Usage:
+    poetry run python tools/derive_stage_nominals.py \\
+        --runs /c/Users/mcwiz/Projects/boostgauge/data/speedrun/runs
+
+Prints a table of percentiles and the Python literal to paste into
+stage_watchdog.py. Read-only: it never edits the table itself, because a
+nominal is a judgement about what "normal" means and that belongs to a human.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+#: Summary rows look like: `spec      passed     699.0s  C:\\path\\to\\artifact`
+_ROW = re.compile(
+    r"^(triage|lld|spec|impl|pr|cleanup)\s+(passed|failed)\s+([\d.]+)s",
+)
+
+#: The nominal is the MEDIAN of passing runs. Not the mean (one 2711s outlier
+#: drags it), not the minimum (every run then looks slow), not the p90 (the
+#: point is to describe typical, and the ratios above it express the tail).
+NOMINAL_PERCENTILE = 0.50
+
+
+def collect(runs_dir: Path) -> dict[str, list[float]]:
+    """Durations of PASSED stages, per stage, across every run log."""
+    samples: dict[str, list[float]] = {}
+    for log in sorted(runs_dir.glob("run-*.log")):
+        try:
+            text = log.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            match = _ROW.match(line.strip())
+            if not match:
+                continue
+            stage, verdict, seconds = match.groups()
+            # Failed stages stopped early; their duration says nothing about
+            # how long the stage takes when it works.
+            if verdict != "passed":
+                continue
+            samples.setdefault(stage, []).append(float(seconds))
+    return {k: sorted(v) for k, v in samples.items()}
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    """Nearest-rank percentile. Deterministic, and no numpy dependency."""
+    if not values:
+        return 0.0
+    index = max(0, min(len(values) - 1, round(fraction * (len(values) - 1))))
+    return values[index]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runs", required=True, type=Path,
+        help="directory holding run-*.log summary logs",
+    )
+    args = parser.parse_args()
+
+    if not args.runs.is_dir():
+        print(f"not a directory: {args.runs}")
+        return 2
+
+    samples = collect(args.runs)
+    if not samples:
+        print(f"no passed-stage rows found under {args.runs}")
+        return 1
+
+    print(f"{'stage':<9} {'n':>4} {'p50':>9} {'p75':>9} {'p90':>9} {'max':>9}")
+    for stage in ("triage", "lld", "spec", "impl", "pr", "cleanup"):
+        values = samples.get(stage, [])
+        if not values:
+            print(f"{stage:<9} {0:>4}   (no passed samples — keep current)")
+            continue
+        print(
+            f"{stage:<9} {len(values):>4} "
+            f"{percentile(values, 0.50):>9.1f} {percentile(values, 0.75):>9.1f} "
+            f"{percentile(values, 0.90):>9.1f} {max(values):>9.1f}"
+        )
+
+    print("\nSTAGE_NOMINAL_SECONDS: dict[str, float] = {")
+    for stage in ("triage", "lld", "spec", "impl", "pr", "cleanup"):
+        values = samples.get(stage, [])
+        if not values:
+            print(f'    # "{stage}": no passed samples in this corpus')
+            continue
+        print(f'    "{stage}": {percentile(values, NOMINAL_PERCENTILE):.1f},')
+    print("}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #2321
Closes #2323

Legibility and calibration — the two ways the pipeline misdescribed itself on `run-issue7-153937`.

## #2321 — the halt aimed at the healthy artifacts

The stagnation halt printed:

> Non-transient: Two consecutive iterations with same blocking issues. **The LLD or spec likely needs manual editing before retry.**

The LLD (282s) and the spec (699s) were both correct — the spec's own §10.1 tests pass against the implementation the run discarded. The broken artifact was the **2s generated test file**, which the message never mentioned. This is the pipeline's last word before a human picks the run up, and acting on it as written would have burned another 16 minutes regenerating good documents.

When **no test has ever passed**, the suite is now named first, with its path:

> Non-transient: no test has passed in any iteration. When the pass count never leaves zero, suspect the GENERATED TEST FILE before the LLD or spec — a suite that cannot pass makes the implementation loop unable to converge. Inspect `/repo/tests/test_issue_7.py`. Check whether its tests have real bodies, or are placeholders that fail unconditionally.

A **partial**-pass stagnation (30/36) is a genuinely different situation and keeps the original advice.

The 0-passing condition is read off the number the guard already prints (`0/36 passed`), so the recommendation cannot disagree with the count two lines above it, and no new plumbing was needed. The path comes from `state`, which `generate_recovery_plan` already receives.

## #2323 — nominals are now derived, not typed

`STAGE_NOMINAL_SECONDS` was hand-typed from the 2026-07-28/29 records and went stale silently. Re-measured across the full corpus:

| stage | n | p50 | p75 | p90 | max | was | now |
|---|---|---|---|---|---|---|---|
| lld | 65 | 75.7 | 226.2 | 386.6 | 741.1 | 60 | **75.7** |
| spec | 51 | 84.2 | 125.0 | 207.5 | 699.0 | 90 | **84.2** |
| impl | 19 | 718.9 | 1712.8 | 2122.2 | 2711.2 | 240 | **718.9** |
| pr | 19 | 2.5 | 2.9 | 3.0 | 3.2 | 15 | **2.5** |
| cleanup | 19 | 81.9 | 82.4 | 82.7 | 84.2 | 90 | **81.9** |

**impl was the real defect**: 240s against a measured median of 718.9s, so a *typical* impl run sat at 3x nominal and earned SLOW immediately. The stage most likely to genuinely hang had the least trustworthy warnings.

Your read on spec was right and mine in the post-mortem was too: 90 against a median of 84.2 was already fine, and 699s was a genuine outlier correctly flagged.

`tools/derive_stage_nominals.py` is the derivation, runnable in one command. It is deliberately **read-only** — it prints the literal rather than editing the table, because a nominal is a judgement about what "normal" means and that belongs to a human. The median is used (not mean, which one 2711s outlier drags; not p90, since the ratios already express the tail).

`triage` has no passed samples in the corpus, so its value is carried forward **unmeasured rather than invented**, and the script says so.

## Acceptance, asserted numerically

The tests check #2323's criteria against the measured p90s rather than restating them in prose:

- impl no longer reports SLOW on a median-duration run ✓
- every stage at its p90 stays under `STALLED_RATIO` (worst is lld at 5.1x of 6.0) ✓
- a genuinely hung stage still reports STALLED ✓

## Known characteristic

`pr` at a 2.5s nominal is tight: STALLED would fire at 15s. The widest observed is 3.2s (1.28x), so nothing in the corpus trips it, but `pr` makes network calls and a slow GitHub day could earn a loud line for something healthy. Left derived rather than floored, because "derive from the samples, do not pick a constant" is the point — flagging it here so the choice is visible rather than buried.

## Checks

Full unit suite **7346 passed, 17 skipped, 0 failures**, verified with `CI=true`. ruff: new files clean; `recovery_plan.py` unchanged at its pre-existing baseline of 1 finding (tracked in #2260).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
