### PR TITLE
fix(testing): generated tests are checked for real symbols before they run (Closes #2336)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/augment_tests.py
+++ b/assemblyzero/workflows/testing/nodes/augment_tests.py
@@ -32,10 +32,17 @@ from assemblyzero.workflows.testing.nodes.implementation.parsers import (
     extract_code_block,
 )
 from assemblyzero.workflows.testing.state import TestingWorkflowState
+from assemblyzero.workflows.testing.symbol_validator import validate_test_imports
 
 #: Cap on how many uncovered lines to name in one request. Beyond this the
 #: prompt stops being a specific instruction and becomes a wish.
 MAX_TARGET_LINES = 40
+
+#: #2336: how many times to ask, counting the first. A hallucinated symbol is
+#: a near-miss an explicit correction usually fixes; a model that cannot
+#: produce an importable file in two tries is not going to on the third, and
+#: the passing suite is worth more than another 194-second call.
+MAX_GENERATION_ATTEMPTS = 2
 
 
 def parse_uncovered_lines(output: str) -> dict[str, list[str]]:
@@ -134,6 +141,33 @@ def build_augment_prompt(
     return "\n".join(sections)
 
 
+def build_revision_prompt(
+    original_prompt: str, rejected: str, problems: list[str],
+) -> str:
+    """Re-ask, naming exactly what was wrong (#2336).
+
+    The rejected code is included because the failure is nearly always a
+    single wrong name in an otherwise usable file -- asking for a fresh start
+    would discard work that was substantially correct.
+    """
+    return "\n".join([
+        original_prompt,
+        "",
+        "=" * 60,
+        "Your previous attempt was REJECTED before it ran. Problems:",
+        *(f"  - {problem}" for problem in problems),
+        "",
+        "Fix exactly those problems. Import only names that exist in the "
+        "module. Keep everything else about the tests the same -- the rest of "
+        "the previous attempt was accepted.",
+        "",
+        "Previous attempt:",
+        "```python",
+        rejected[:6000],
+        "```",
+    ])
+
+
 def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
     """N4c: append tests targeting uncovered lines (#2327).
 
@@ -186,24 +220,65 @@ def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
     prompt = build_augment_prompt(
         str(test_path), existing, targets, coverage_achieved, coverage_target,
     )
-    response, error = call_claude_for_file(prompt, file_path=str(test_path))
-    if error or not response:
-        print(f"    [N4c] no new tests generated: {error or 'empty response'}")
-        return {"next_node": "N5_verify_green", "error_message": ""}
 
-    addition = extract_code_block(response, str(test_path))
-    if not addition or not addition.strip():
-        print("    [N4c] response contained no code block; suite unchanged")
-        return {"next_node": "N5_verify_green", "error_message": ""}
+    # #2336: validate BEFORE writing, and revise in place.
+    #
+    # The first live N4c run spent 194s producing 12 good tests whose import
+    # block asked for `default_config_path` when the module exports
+    # `get_default_config_path`. One name in one shared import statement, so
+    # collection died for the whole file: the 23 tests already passing were
+    # destroyed along with the 12 new ones, and the stage ended. Correcting
+    # only that name gives 34 passed and 100% coverage on the target module.
+    #
+    # Validating before the write is what makes "tests already passing are
+    # never destroyed by a later addition" absolute rather than likely: a
+    # file that does not import cleanly is never written at all.
+    merged = ""
+    addition = ""
+    for attempt in range(1, MAX_GENERATION_ATTEMPTS + 1):
+        response, error = call_claude_for_file(prompt, file_path=str(test_path))
+        if error or not response:
+            print(f"    [N4c] no new tests generated: {error or 'empty response'}")
+            return {"next_node": "N5_verify_green", "error_message": ""}
 
-    # Append. Never rewrite: the existing tests are proven to pass, and a
-    # regeneration that loses one trades a coverage point for a real test.
-    merged = existing.rstrip() + "\n\n\n" + addition.strip() + "\n"
-    try:
-        compile(merged, str(test_path), "exec")
-    except SyntaxError as err:
-        print(f"    [N4c] generated tests do not parse ({err}); suite unchanged")
-        return {"next_node": "N5_verify_green", "error_message": ""}
+        addition = extract_code_block(response, str(test_path)) or ""
+        if not addition.strip():
+            print("    [N4c] response contained no code block; suite unchanged")
+            return {"next_node": "N5_verify_green", "error_message": ""}
+
+        # Append. Never rewrite: the existing tests are proven to pass, and a
+        # regeneration that loses one trades a coverage point for a real test.
+        candidate = existing.rstrip() + "\n\n\n" + addition.strip() + "\n"
+
+        try:
+            compile(candidate, str(test_path), "exec")
+        except SyntaxError as err:
+            problems = [f"the file does not parse: {err}"]
+        else:
+            problems = validate_test_imports(candidate, repo_root)
+
+        if not problems:
+            merged = candidate
+            break
+
+        for problem in problems:
+            print(f"    [N4c] rejected: {problem}")
+        if attempt >= MAX_GENERATION_ATTEMPTS:
+            print(
+                f"    [N4c] {MAX_GENERATION_ATTEMPTS} attempt(s) did not "
+                f"produce importable tests; suite left unchanged so the "
+                f"passing tests survive"
+            )
+            return {
+                "coverage_augment_attempts": int(
+                    state.get("coverage_augment_attempts", 0) or 0
+                ) + 1,
+                "next_node": "N5_verify_green",
+                "error_message": "",
+            }
+
+        print(f"    [N4c] revising (attempt {attempt + 1}/{MAX_GENERATION_ATTEMPTS})")
+        prompt = build_revision_prompt(prompt, addition, problems)
 
     test_path.write_text(merged, encoding="utf-8")
     added = len(re.findall(r"^def\s+test_\w+", addition, re.MULTILINE))

--- a/assemblyzero/workflows/testing/symbol_validator.py
+++ b/assemblyzero/workflows/testing/symbol_validator.py
@@ -1,0 +1,118 @@
+"""Verify that a generated test file imports symbols that actually exist (#2336).
+
+`run-issue7-192332` ran opus for 194.1 seconds to add 12 coverage-targeting
+tests. Its import block asked for `default_config_path`; the module exports
+`get_default_config_path`. The import is one top-level statement, so
+collection died for the whole file: 0 tests ran, the 23 already passing were
+destroyed with it, and the stage ended.
+
+Correcting that single name in the generated file gives 34 passed and
+`config.py` at 100% coverage -- past the 95% gate. The work was substantially
+right and the stage died on a name.
+
+A near-miss like `default_config_path` for `get_default_config_path` is
+exactly the shape an LLM produces and exactly the shape a suggestion can
+repair, so this reports the available near-matches rather than only the
+failure.
+
+Static by construction: the target module is PARSED, never imported. Importing
+generated code to check it would execute it, and the code under test is the
+thing being validated.
+"""
+
+from __future__ import annotations
+
+import ast
+import difflib
+from pathlib import Path
+
+#: Where a package's source is conventionally rooted, most specific first.
+_SOURCE_ROOTS = ("src", "")
+
+
+def module_source_path(module: str, repo_root: Path) -> Path | None:
+    """Locate `a.b.c` under the repo, or None when it is not ours.
+
+    Third-party and stdlib modules resolve to None and are skipped -- this
+    validates the code the pipeline is writing, not the ecosystem.
+    """
+    parts = module.split(".")
+    if not parts:
+        return None
+    for root in _SOURCE_ROOTS:
+        base = repo_root / root if root else repo_root
+        candidate = base.joinpath(*parts).with_suffix(".py")
+        if candidate.is_file():
+            return candidate
+        package_init = base.joinpath(*parts) / "__init__.py"
+        if package_init.is_file():
+            return package_init
+    return None
+
+
+def exported_names(source_path: Path) -> set[str] | None:
+    """Top-level names a module defines, or None if it cannot be parsed.
+
+    None means "could not tell", and the caller must treat that as no
+    finding: a module this cannot read is not evidence of a bad import.
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return None
+
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            # Re-exports are importable from here too.
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[0])
+    return names
+
+
+def validate_test_imports(test_source: str, repo_root: Path) -> list[str]:
+    """Names a generated test imports that its target module does not export.
+
+    Returns one message per bad symbol, each naming the module, the missing
+    name and the closest available matches. An empty list means either
+    everything resolves or nothing could be checked -- this never guesses.
+    """
+    try:
+        tree = ast.parse(test_source)
+    except SyntaxError:
+        # A file that does not parse is a different failure, reported
+        # elsewhere. Returning findings here would be noise on top of it.
+        return []
+
+    errors: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level:
+            continue
+        module = node.module or ""
+        source_path = module_source_path(module, repo_root)
+        if source_path is None:
+            continue  # not ours to check
+        available = exported_names(source_path)
+        if available is None:
+            continue  # could not read it; not evidence of a fault
+
+        for alias in node.names:
+            if alias.name == "*" or alias.name in available:
+                continue
+            close = difflib.get_close_matches(alias.name, sorted(available), n=3)
+            hint = (
+                f" Did you mean: {', '.join(close)}?" if close
+                else f" Available: {', '.join(sorted(available)[:8])}"
+            )
+            errors.append(
+                f"{module} has no '{alias.name}'.{hint}"
+            )
+    return errors

--- a/tests/fixtures/issue7_run192332/n4c_generated_tests.py
+++ b/tests/fixtures/issue7_run192332/n4c_generated_tests.py
@@ -1,0 +1,418 @@
+"""Test file for Issue #7.
+
+Emitted by AssemblyZero from the implementation spec's Section 10
+test functions. Bodies are the spec's own, verbatim (#2316).
+"""
+
+import json
+import argparse
+from pathlib import Path
+import pytest
+from boostgauge.config import get_default_config, write_full_config, load_config, apply_exit_write
+from boostgauge.app import main, SessionState, update_thresholds_from_file, parse_args, init_session
+
+
+def test_req_1(tmp_path):
+    # First run with no config file creates one with defaults (REQ-1)
+    # Expected output: File exists and matches get_default_config()
+    config_path = tmp_path / "config.json"
+    init_session(["--config", str(config_path)])
+    assert config_path.exists()
+    assert load_config(config_path) == get_default_config()
+
+
+def test_req_2(tmp_path):
+    # Launch order and CLI overrides (REQ-2)
+    # Expected output: Session size is 400, file remains default size (300)
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    state = init_session(["--config", str(config_path), "--size", "400"])
+    
+    assert state.in_memory_config["size"] == 400
+    assert load_config(config_path)["size"] == 300
+
+
+def test_req_3(tmp_path):
+    # Base launch window props (REQ-3)
+    # Expected output: Memory size and position match file
+    config_path = tmp_path / "config.json"
+    custom_cfg = get_default_config()
+    custom_cfg["size"] = 250
+    custom_cfg["position"] = {"x": 10, "y": 20}
+    write_full_config(config_path, custom_cfg)
+    
+    state = init_session(["--config", str(config_path)])
+    assert state.in_memory_config["size"] == 250
+    assert state.in_memory_config["position"] == {"x": 10, "y": 20}
+
+
+def test_req_4_no_size(tmp_path):
+    # Reset config flag effects without CLI size (REQ-4)
+    # Expected output: File size is 300, memory size is 300
+    config_path = tmp_path / "config.json"
+    custom_cfg = get_default_config()
+    custom_cfg["size"] = 250
+    write_full_config(config_path, custom_cfg)
+    
+    state = init_session(["--config", str(config_path), "--reset-config"])
+    assert load_config(config_path)["size"] == 300
+    assert state.in_memory_config["size"] == 300
+
+
+def test_req_4_with_size(tmp_path):
+    # Reset config flag effects with CLI size (REQ-4)
+    # Expected output: File size is 300, memory size is 500
+    config_path = tmp_path / "config.json"
+    state = init_session(["--config", str(config_path), "--reset-config", "--size", "500"])
+    assert load_config(config_path)["size"] == 300
+    assert state.in_memory_config["size"] == 500
+
+
+def test_req_5(tmp_path):
+    # Threshold live reload (REQ-5)
+    # Expected output: Memory threshold is 40, file is unmodified by read
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    state = SessionState(config_file_path=config_path, in_memory_config=get_default_config())
+    
+    disk_cfg = load_config(config_path)
+    disk_cfg["thresholds"]["conpty"]["yellow"] = 40
+    write_full_config(config_path, disk_cfg)
+    
+    update_thresholds_from_file(config_path, state)
+    assert state.in_memory_config["thresholds"]["conpty"]["yellow"] == 40
+
+
+def test_req_6(tmp_path):
+    # Exit write patch logic (REQ-6)
+    # Expected output: File size is 999 and position is updated
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    # Direct edit mid-session
+    disk_cfg = load_config(config_path)
+    disk_cfg["size"] = 999
+    write_full_config(config_path, disk_cfg)
+    
+    # Hand change position
+    apply_exit_write(config_path, {"position": {"x": 5, "y": 5}})
+    
+    final_cfg = load_config(config_path)
+    assert final_cfg["size"] == 999
+    assert final_cfg["position"] == {"x": 5, "y": 5}
+
+
+def test_req_7(tmp_path):
+    # Exit write collision logic (REQ-7)
+    # Expected output: File size is 600
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    # Direct edit mid-session
+    disk_cfg = load_config(config_path)
+    disk_cfg["size"] = 999
+    write_full_config(config_path, disk_cfg)
+    
+    # Hand change size collision
+    apply_exit_write(config_path, {"size": 600})
+    
+    assert load_config(config_path)["size"] == 600
+
+
+def test_req_8(tmp_path):
+    # Untouched session (REQ-8)
+    # Expected output: File hash before matches file hash after
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    content_before = config_path.read_bytes()
+    
+    apply_exit_write(config_path, {})
+    assert config_path.read_bytes() == content_before
+
+
+def test_req_9(tmp_path):
+    # Position: no reset, not moved, no direct edits (REQ-9)
+    # Expected output: File position matches initial
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["position"] == {"x": 100, "y": 100}
+
+
+def test_req_10(tmp_path):
+    # Position: no reset, moved, no direct edits (REQ-10)
+    # Expected output: File position is {"x": 5, "y": 5}
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    apply_exit_write(config_path, {"position": {"x": 5, "y": 5}})
+    assert load_config(config_path)["position"] == {"x": 5, "y": 5}
+
+
+def test_req_11(tmp_path):
+    # Position: reset, not moved, no direct edits (REQ-11)
+    # Expected output: File position is {"x": 100, "y": 100}
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config"])
+    
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["position"] == {"x": 100, "y": 100}
+
+
+def test_req_12(tmp_path):
+    # Position: reset, moved, no direct edits (REQ-12)
+    # Expected output: File position matches hand-changed pos
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config"])
+    
+    apply_exit_write(config_path, {"position": {"x": 50, "y": 50}})
+    assert load_config(config_path)["position"] == {"x": 50, "y": 50}
+
+
+def test_req_13(tmp_path):
+    # Size: no reset, no size, not resized, no edits (REQ-13)
+    # Expected output: File size matches initial
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["size"] == 300
+
+
+def test_req_14(tmp_path):
+    # Size: no reset, no size, resized, no edits (REQ-14)
+    # Expected output: File size is 700
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    apply_exit_write(config_path, {"size": 700})
+    assert load_config(config_path)["size"] == 700
+
+
+def test_req_15(tmp_path):
+    # Size: no reset, size given, not resized, no edits (REQ-15)
+    # Expected output: File size matches initial, not 450
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    # CLI size 450 happens via init_session() but user doesn't hand-resize
+    init_session(["--config", str(config_path), "--size", "450"])
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["size"] == 300
+
+
+def test_req_16(tmp_path):
+    # Size: no reset, size given, resized, no edits (REQ-16)
+    # Expected output: File size is 800
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    
+    init_session(["--config", str(config_path), "--size", "450"])
+    apply_exit_write(config_path, {"size": 800})
+    assert load_config(config_path)["size"] == 800
+
+
+def test_req_17(tmp_path):
+    # Size: reset, no size, not resized, no edits (REQ-17)
+    # Expected output: File size is 300
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config"])
+    
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["size"] == 300
+
+
+def test_req_18(tmp_path):
+    # Size: reset, no size, resized, no edits (REQ-18)
+    # Expected output: File size is 800
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config"])
+    
+    apply_exit_write(config_path, {"size": 800})
+    assert load_config(config_path)["size"] == 800
+
+
+def test_req_19(tmp_path):
+    # Size: reset, size given, not resized, no edits (REQ-19)
+    # Expected output: File size is 300
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config", "--size", "450"])
+    
+    apply_exit_write(config_path, {})
+    assert load_config(config_path)["size"] == 300
+
+
+def test_req_20(tmp_path):
+    # Size: reset, size given, resized, no edits (REQ-20)
+    # Expected output: File size is 800
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    main(["--config", str(config_path), "--reset-config", "--size", "450"])
+    
+    apply_exit_write(config_path, {"size": 800})
+    assert load_config(config_path)["size"] == 800
+
+
+def test_req_21(tmp_path):
+    # Invalid config values (REQ-21)
+    # Expected output: ValueError raised
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{invalid json")
+    
+    with pytest.raises(ValueError):
+        load_config(config_path)
+
+
+def test_req_22(tmp_path):
+    # Non-threshold live edit ignored (REQ-22)
+    # Expected output: Memory telltale_windows.short matches initial
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    state = SessionState(config_file_path=config_path, in_memory_config=get_default_config())
+    
+    disk_cfg = load_config(config_path)
+    disk_cfg["telltale_windows"]["short"] = 999
+    write_full_config(config_path, disk_cfg)
+    
+    update_thresholds_from_file(config_path, state)
+    assert state.in_memory_config["telltale_windows"]["short"] == 60
+
+
+import os
+from unittest.mock import patch
+from pathlib import Path
+import pytest
+from boostgauge.config import (
+    get_default_config,
+    write_full_config,
+    load_config,
+    apply_exit_write,
+    default_config_path,
+)
+
+
+def test_default_config_path_windows_with_appdata(tmp_path):
+    """Lines 25-26: On Windows with APPDATA, returns APPDATA-based path."""
+    fake_appdata = str(tmp_path / "AppData")
+    with patch("boostgauge.config.os.name", "nt"), \
+         patch.dict(os.environ, {"APPDATA": fake_appdata}, clear=False):
+        result = default_config_path()
+    assert result == Path(fake_appdata) / "boostgauge" / "config.json"
+
+
+def test_default_config_path_non_windows():
+    """Line 27: On non-Windows, returns ~/.boostgauge/config.json."""
+    with patch("boostgauge.config.os.name", "posix"):
+        result = default_config_path()
+    assert result == Path.home() / ".boostgauge" / "config.json"
+
+
+def test_default_config_path_windows_without_appdata():
+    """Line 27: On Windows without APPDATA, falls through to home-based path."""
+    env_copy = {k: v for k, v in os.environ.items() if k != "APPDATA"}
+    with patch("boostgauge.config.os.name", "nt"), \
+         patch.dict(os.environ, env_copy, clear=True):
+        result = default_config_path()
+    assert result == Path.home() / ".boostgauge" / "config.json"
+
+
+def test_load_config_raises_on_missing_file(tmp_path):
+    """Line 53: load_config raises FileNotFoundError for nonexistent path."""
+    path = tmp_path / "nonexistent.json"
+    with pytest.raises(FileNotFoundError, match="Config file not found"):
+        load_config(path)
+
+
+def test_load_config_raises_on_json_array(tmp_path):
+    """Line 59: load_config raises ValueError when file contains a JSON array."""
+    path = tmp_path / "config.json"
+    path.write_text("[1, 2, 3]")
+    with pytest.raises(ValueError, match="Config must be a JSON object"):
+        load_config(path)
+
+
+def test_load_config_raises_on_json_string(tmp_path):
+    """Line 59: load_config raises ValueError when file contains a JSON string."""
+    path = tmp_path / "config.json"
+    path.write_text('"hello"')
+    with pytest.raises(ValueError, match="Config must be a JSON object"):
+        load_config(path)
+
+
+def test_load_config_raises_on_json_number(tmp_path):
+    """Line 59: load_config raises ValueError when file contains a JSON number."""
+    path = tmp_path / "config.json"
+    path.write_text("42")
+    with pytest.raises(ValueError, match="Config must be a JSON object"):
+        load_config(path)
+
+
+def test_write_full_config_removes_temp_on_serialization_error(tmp_path):
+    """Lines 76-77: Temp file is cleaned up when json.dump raises."""
+    config_path = tmp_path / "config.json"
+    write_full_config(config_path, get_default_config())
+    original = config_path.read_text()
+
+    bad_data = get_default_config()
+    bad_data["unserializable"] = object()
+    with pytest.raises(TypeError):
+        write_full_config(config_path, bad_data)
+
+    # Original config is preserved
+    assert config_path.read_text() == original
+    # No temp files left behind
+    remaining = {f.name for f in tmp_path.iterdir()}
+    assert remaining == {"config.json"}
+
+
+def test_write_full_config_removes_temp_no_preexisting_file(tmp_path):
+    """Lines 76-77: Temp file cleanup when no original config existed."""
+    config_path = tmp_path / "config.json"
+    bad_data = {"unserializable": object()}
+    with pytest.raises(TypeError):
+        write_full_config(config_path, bad_data)
+
+    # No files should remain
+    assert not config_path.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_apply_exit_write_falls_back_on_missing_config(tmp_path):
+    """Lines 88-89: Missing config file causes fallback to defaults."""
+    path = tmp_path / "absent.json"
+    apply_exit_write(path, {"size": 450})
+    result = load_config(path)
+    defaults = get_default_config()
+    assert result["size"] == 450
+    for key in defaults:
+        if key != "size":
+            assert result[key] == defaults[key]
+
+
+def test_apply_exit_write_falls_back_on_corrupt_json(tmp_path):
+    """Lines 88-89: Corrupt JSON triggers fallback to defaults."""
+    path = tmp_path / "config.json"
+    path.write_text("{broken json!!!}")
+    apply_exit_write(path, {"size": 600})
+    result = load_config(path)
+    defaults = get_default_config()
+    assert result["size"] == 600
+    assert result["thresholds"] == defaults["thresholds"]
+
+
+def test_apply_exit_write_falls_back_on_non_object_json(tmp_path):
+    """Lines 88-89: JSON array triggers ValueError fallback to defaults."""
+    path = tmp_path / "config.json"
+    path.write_text("[1, 2, 3]")
+    apply_exit_write(path, {"position": {"x": 7, "y": 8}})
+    result = load_config(path)
+    defaults = get_default_config()
+    assert result["position"] == {"x": 7, "y": 8}
+    assert result["size"] == defaults["size"]

--- a/tests/unit/test_generated_test_symbols.py
+++ b/tests/unit/test_generated_test_symbols.py
@@ -1,0 +1,153 @@
+"""#2336: a generated test must not import a symbol that does not exist.
+
+`run-issue7-192332` ran opus for 194.1s to add 12 coverage-targeting tests.
+The import block asked for `default_config_path`; the module exports
+`get_default_config_path`. One name, one shared import statement, and
+collection died for the whole file -- 0 tests ran, the 23 already passing
+were destroyed with it, and the stage ended.
+
+Correcting only that name in the generated file gives 34 passed and 100%
+coverage on the target module, past the 95% gate. The work was substantially
+correct; the stage died on a name.
+
+The fixture is the real generated file, preserved from boostgauge's
+`graveyard/issue-7-20260814T002812Z` checkpoint chain.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.augment_tests import (
+    MAX_GENERATION_ATTEMPTS,
+    build_revision_prompt,
+)
+from assemblyzero.workflows.testing.symbol_validator import (
+    exported_names,
+    module_source_path,
+    validate_test_imports,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "issue7_run192332"
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A src-layout repo whose config module mirrors the real one."""
+    pkg = tmp_path / "src" / "boostgauge"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "config.py").write_text(
+        "import json\n"
+        "DEFAULT_SIZE = 300\n"
+        "def get_default_config_path():\n    return None\n"
+        "def get_default_config():\n    return {}\n"
+        "def load_config(p):\n    return {}\n"
+        "class Threshold:\n    pass\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_the_real_hallucination_is_caught(repo: Path) -> None:
+    """The exact import block that killed the stage."""
+    source = (FIXTURES / "n4c_generated_tests.py").read_text(encoding="utf-8")
+
+    errors = validate_test_imports(source, repo)
+
+    assert errors, "the bad symbol must be reported"
+    joined = "\n".join(errors)
+    assert "default_config_path" in joined
+    assert "get_default_config_path" in joined, (
+        "a near-miss must be offered, not just the failure"
+    )
+
+
+def test_valid_imports_produce_no_findings(repo: Path) -> None:
+    source = (
+        "from boostgauge.config import get_default_config_path, load_config\n"
+        "def test_x():\n    assert get_default_config_path() is None\n"
+    )
+    assert validate_test_imports(source, repo) == []
+
+
+def test_constants_and_classes_count_as_exports(repo: Path) -> None:
+    source = "from boostgauge.config import DEFAULT_SIZE, Threshold\n"
+    assert validate_test_imports(source, repo) == []
+
+
+def test_reexported_imports_count(repo: Path) -> None:
+    """`config` imports json, so `from boostgauge.config import json` works."""
+    assert validate_test_imports(
+        "from boostgauge.config import json\n", repo,
+    ) == []
+
+
+@pytest.mark.parametrize("source", [
+    "import pytest\n",                          # plain import, not checked
+    "from unittest.mock import patch\n",        # third-party / stdlib
+    "from boostgauge.config import *\n",        # star import
+    "from . import sibling\n",                  # relative
+    "def test_broken(:\n",                      # unparseable
+    "",
+])
+def test_never_invents_a_finding(repo: Path, source: str) -> None:
+    """Anything it cannot decide must produce no finding, never a guess."""
+    assert validate_test_imports(source, repo) == []
+
+
+def test_unreadable_module_is_not_evidence(tmp_path: Path) -> None:
+    pkg = tmp_path / "src" / "boostgauge"
+    pkg.mkdir(parents=True)
+    (pkg / "config.py").write_text("def broken(:\n", encoding="utf-8")
+
+    assert exported_names(pkg / "config.py") is None
+    assert validate_test_imports(
+        "from boostgauge.config import anything\n", tmp_path,
+    ) == []
+
+
+def test_module_outside_the_repo_is_skipped(repo: Path) -> None:
+    assert module_source_path("numpy.linalg", repo) is None
+    assert validate_test_imports(
+        "from numpy.linalg import solve\n", repo,
+    ) == []
+
+
+def test_flat_layout_is_found(tmp_path: Path) -> None:
+    """Not every repo is src-layout."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir()
+    (pkg / "thing.py").write_text("def real():\n    pass\n", encoding="utf-8")
+
+    assert validate_test_imports(
+        "from mypkg.thing import real\n", tmp_path,
+    ) == []
+    assert validate_test_imports(
+        "from mypkg.thing import imaginary\n", tmp_path,
+    )
+
+
+def test_revision_prompt_names_the_problem_and_keeps_the_work() -> None:
+    """The failure is one wrong name in an otherwise usable file."""
+    prompt = build_revision_prompt(
+        "original request",
+        "from boostgauge.config import default_config_path\n",
+        ["boostgauge.config has no 'default_config_path'. "
+         "Did you mean: get_default_config_path?"],
+    )
+
+    assert "REJECTED before it ran" in prompt
+    assert "default_config_path" in prompt
+    assert "get_default_config_path" in prompt
+    assert "Keep everything else about the tests the same" in prompt, (
+        "a fresh start would discard work that was substantially correct"
+    )
+    assert "original request" in prompt
+
+
+def test_a_bounded_number_of_attempts() -> None:
+    """Another 194-second call is worth less than the passing suite."""
+    assert MAX_GENERATION_ATTEMPTS == 2


### PR DESCRIPTION
Closes #2336

**The relaunch gate.** N4c's generated tests reached pytest unvalidated. On its first live run it produced 12 good tests whose import block asked for `default_config_path`; the module exports `get_default_config_path`. One name, one shared import statement, and collection died for the whole file.

```
[N5] Results: 0 passed, 0 failed | Coverage: 0.0% | Exit: 2 (test execution interrupted)
[EXIT CODE 2] Imports that no longer resolve: boostgauge.config.default_config_path no longer exists
```

The 23 tests that were already passing died with it.

## What it cost — measured

Correcting **only** that one name in the generated file:

```
34 passed, 1 failed
config.py    45 stmts    0 miss    100%
```

78% → **100%**, past the 95% gate. 3 of the 12 generated tests used the bad symbol; the other 9 were fine and were destroyed anyway. **The stage died on a name.**

## Correction to the premise

The hypothesis was to route N4c through N2.5, "`api_symbols_exist` among the checks". **N2.5 has no such check** — `check_api_symbols_exist` lives in the *implementation_spec* workflow (`nodes/validate_completeness.py`), while `validate_tests_mechanical` does structure validation, scenario coverage and stub detection.

Routing N4c through N2.5 unchanged would not have caught this. The fix is a new capability.

## The change

`symbol_validator.py` parses a generated test's `from X import a, b` statements, locates `X` under the repo (src- and flat-layout), parses the target module, and reports names it does not export — with near-matches from `difflib`, because `default_config_path` → `get_default_config_path` is precisely the shape a suggestion repairs.

The target module is **parsed, never imported**: importing generated code to check it would execute it, and that code is the thing under validation.

N4c now validates **before writing**, and revises in place with the problem named:

```
[N4c] rejected: boostgauge.config has no 'default_config_path'. Did you mean: get_default_config_path?
[N4c] revising (attempt 2/2)
```

Validating before the write is what makes *"tests already passing are never destroyed by a later addition"* **absolute rather than likely** — a file that does not import cleanly is never written at all. If two attempts fail, the suite is left untouched and N5 reports the honest coverage shortfall instead of a collection death.

## Never invents a finding

Every undecidable case yields no finding: plain `import x`, stdlib and third-party modules, star imports, relative imports, an unparseable test file, an unparseable target module. `exported_names` returns `None` for "could not tell", kept distinct from an empty set.

## Tests

15 tests. The fixture is the **real generated file** (418 lines, 35 tests), preserved from boostgauge's `graveyard/issue-7-20260814T002812Z` — which survived only because #2325 made branch disposal preserve-not-delete.

Covered: the real hallucination caught with its near-match offered; constants, classes and re-exports counted as exports; flat layout; and the six undecidable shapes above.

## Checks

Full unit suite **7361 passed, 17 skipped, 0 failures**, verified with `CI=true`. `ruff check` clean. Fixture confirmed not collected by pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
