### PR TITLE
fix(testing): green-at-red is only fatal when nothing is implemented yet (Closes #2337)

### DIFF
--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -150,10 +150,16 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
             # says which happened without anyone reading transcripts.
             mode = retry_mode_for(stage_result)
             stage_result["retry_mode"] = mode
+            # #2337: this used to say REGENERATED "discards the previous
+            # attempt's generated files". It discards nothing. The mode's only
+            # effect is to stop N4 SKIPPING files that already exist
+            # (implementation/orchestrator.py), and on run-issue7-192332 N4 was
+            # never reached -- the red phase saw the surviving implementation
+            # and ended the stage first. A reader diagnosing that run would
+            # have believed the files were gone.
             print(
                 f"[ORCHESTRATOR] Next attempt will be {mode.lower()} "
-                f"({'reusing' if mode == RESUMED else 'discarding'} "
-                f"the previous attempt's generated files)."
+                f"({'reusing generated files where they exist' if mode == RESUMED else 'rewriting generated files rather than skipping them'})."
             )
             time.sleep(delay)
             last_state = dict(new_state)

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -168,6 +168,15 @@ def _classify_halt_transience(sub_result: dict) -> bool | None:
 
         if MISSING_REQUIRED_INPUT.lower() in message:
             return False
+        # #2337: same rule, different cause. Green-at-red on an unchanged
+        # worktree is deterministic -- attempts 2 and 3 of run-issue7-192332
+        # reproduced attempt 2's outcome exactly, twelve seconds apart.
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            DETERMINISTIC_FAILURE,
+        )
+
+        if DETERMINISTIC_FAILURE.lower() in message:
+            return False
         return None
     try:
         plan = json.loads(Path(plan_path).read_text(encoding="utf-8"))

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -274,7 +274,9 @@ def route_after_validate(
 
 def route_after_red(
     state: TestingWorkflowState,
-) -> Literal["N4_implement_code", "N2_scaffold_tests", "end"]:
+) -> Literal[
+    "N4_implement_code", "N2_scaffold_tests", "N5_verify_green", "end",
+]:
     """Route after N3 (verify_red_phase).
 
     Issue #292: Added N2_scaffold_tests route for exit codes 4/5.
@@ -293,6 +295,12 @@ def route_after_red(
 
     if next_node == "N4_implement_code":
         return "N4_implement_code"
+
+    # #2337: a retry whose implementation survived is not a failed red phase.
+    # The tests and the implementation agree, which is the state N4 exists to
+    # reach, so the coverage gate judges it rather than the stage ending.
+    if next_node == "N5_verify_green":
+        return "N5_verify_green"
 
     # Issue #292: Exit code 4/5 routes back to scaffold
     if next_node == "N2_scaffold_tests":
@@ -569,6 +577,7 @@ def build_testing_workflow() -> StateGraph:
         route_after_red,
         {
             "N4_implement_code": "N4_implement_code",
+            "N5_verify_green": "N5_verify_green",  # #2337
             "N2_scaffold_tests": "N2_scaffold_tests",
             "end": END,
         },

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -71,6 +71,14 @@ PYTEST_OUTPUT_COLUMNS = "200"
 # not width-truncated -- and they were being captured and discarded.
 MAX_TRACEBACK_BLOCKS = 8
 
+#: #2337: marks a failure the same stage cannot fix by running again. Same
+#: rule as #2298's MISSING_REQUIRED_INPUT, different cause: green-at-red on an
+#: unchanged worktree is deterministic, and run-issue7-192332 retried it three
+#: times in twelve seconds. The orchestrator's transience classifier keys off
+#: this token, so retry behaviour follows from the failure's kind rather than
+#: from prose a later reword could silently change.
+DETERMINISTIC_FAILURE = "DETERMINISTIC FAILURE"
+
 # Issue #562: Critical skip keywords (aligned with tools/test-gate.py)
 _CRITICAL_SKIP_KEYWORDS = ["security", "auth", "payment", "critical"]
 
@@ -527,6 +535,32 @@ def run_pytest(
         }
 
 
+def _implementation_already_exists(state: TestingWorkflowState) -> bool:
+    """True when a previous attempt's implementation is present (#2337).
+
+    Two conditions, both required. This is NOT a first attempt -- a retry sets
+    retry_mode, and a resume carries an iteration count -- AND the files the
+    spec says to write are actually on disk. Either alone is too weak: a first
+    attempt against a repo that happens to have the file is the pre-existing
+    implementation the guard was built for, and a retry whose files were
+    cleared genuinely needs the red phase.
+    """
+    is_later_attempt = bool(state.get("retry_mode")) or int(
+        state.get("iteration_count", 0) or 0
+    ) > 0
+    if not is_later_attempt:
+        return False
+
+    repo_root = Path(state.get("repo_root", "") or ".")
+    targets = [
+        f.get("path", "") for f in (state.get("files_to_modify") or [])
+        if f.get("path", "").endswith(".py")
+    ]
+    if not targets:
+        return False
+    return all((repo_root / path).is_file() for path in targets)
+
+
 def _describe_hollow_suite(state: TestingWorkflowState) -> str:
     """Describe a scaffold that cannot pass, or '' when it might (#2322).
 
@@ -785,6 +819,41 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
     # Red phase success = ALL tests fail or error (none pass)
     if passed_count > 0:
+        # #2337: green-at-red is fatal on a FIRST attempt -- tests that pass
+        # before any code exists are not testing anything. It is the wrong
+        # reading whenever implementation legitimately exists: a retry after
+        # an N4c failure, or a resume into a worktree carrying prior work.
+        #
+        # On run-issue7-192332 attempt 1 died at N5, and attempts 2 and 3 both
+        # scaffolded, found the surviving implementation, went green here and
+        # ended the stage -- roughly two seconds of work each. The correct
+        # reading of "23 passed" there is: the previous attempt's
+        # implementation is still present and still works, which is the state
+        # N4 is trying to reach.
+        if _implementation_already_exists(state):
+            print(
+                f"    [N3] {passed_count} test(s) already pass, and the "
+                f"implementation from a previous attempt is present."
+            )
+            print(
+                "    Not a failed red phase: the tests and the implementation "
+                "agree. Verifying against the coverage gate instead."
+            )
+            log_workflow_execution(
+                target_repo=repo_root,
+                issue_number=state.get("issue_number", 0),
+                workflow_type="testing",
+                event="red_phase_implementation_present",
+                details={"passed": passed_count, "retry": True},
+            )
+            return {
+                "red_phase_output": output,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "error_message": "",
+                "next_node": "N5_verify_green",
+            }
+
         print(f"    [GUARD] WARNING: {passed_count} tests passed unexpectedly!")
         print("    This may indicate pre-existing implementation.")
 
@@ -800,8 +869,15 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "red_phase_output": output,
             "file_counter": file_num,
             "pytest_exit_code": exit_code,
-            "error_message": f"Red phase failed: {passed_count} tests passed unexpectedly. "
-                           "Tests should fail before implementation.",
+            # #2337: deterministic on an unchanged worktree -- running the same
+            # stage again reproduces it exactly, which is the #2298 rule. The
+            # token keeps it out of the retry loop that spent three attempts
+            # on it in twelve seconds.
+            "error_message": (
+                f"{DETERMINISTIC_FAILURE}: Red phase failed: {passed_count} "
+                f"tests passed unexpectedly. Tests should fail before "
+                f"implementation exists."
+            ),
             "next_node": "END",
         }
 

--- a/tests/unit/test_red_phase_retry_semantics.py
+++ b/tests/unit/test_red_phase_retry_semantics.py
@@ -1,0 +1,178 @@
+"""#2337: green-at-red is only fatal when nothing has been implemented yet.
+
+`run-issue7-192332` died at N5 on attempt 1. Attempts 2 and 3 then scaffolded
+23 tests, found the implementation attempt 1 had written, went green at the
+red phase, and ended the stage -- about two seconds of work each, twelve
+seconds apart. Nothing had changed between them, so nothing could have.
+
+Two defects:
+  - green-at-red was fatal unconditionally, even when the implementation
+    legitimately existed (a retry, or a resume into a worktree with prior
+    work), and
+  - the failure was retried, though it is deterministic on an unchanged
+    worktree -- the #2298 rule with a new cause.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.orchestrator.stages import _is_non_transient_halt
+from assemblyzero.workflows.testing.graph import route_after_red
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    DETERMINISTIC_FAILURE,
+    _implementation_already_exists,
+    verify_red_phase,
+)
+
+
+@pytest.fixture()
+def worktree(tmp_path: Path) -> Path:
+    src = tmp_path / "src" / "boostgauge"
+    src.mkdir(parents=True)
+    (src / "config.py").write_text("def get_default_config():\n    return {}\n",
+                                   encoding="utf-8")
+    (src / "app.py").write_text("def main():\n    return 0\n", encoding="utf-8")
+    # The node checks the test file exists before running pytest, so the
+    # fixture has to be a plausible worktree rather than just source files.
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_issue_7.py").write_text(
+        "def test_placeholder():\n    assert True\n", encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _state(worktree: Path, **overrides: object) -> dict:
+    state = {
+        "repo_root": str(worktree),
+        "issue_number": 7,
+        "audit_dir": str(worktree),
+        "file_counter": 1,
+        "test_files": [str(worktree / "tests" / "test_issue_7.py")],
+        "files_to_modify": [
+            {"path": "src/boostgauge/config.py"},
+            {"path": "src/boostgauge/app.py"},
+        ],
+        "retry_mode": "REGENERATED",
+        "iteration_count": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+# ------------------------------------------------- detecting prior work
+
+
+def test_a_retry_with_files_present_is_recognised(worktree: Path) -> None:
+    assert _implementation_already_exists(_state(worktree)) is True
+
+
+def test_a_first_attempt_is_not(worktree: Path) -> None:
+    """The pre-existing-implementation guard still applies on attempt 1."""
+    state = _state(worktree, retry_mode="", iteration_count=0)
+    assert _implementation_already_exists(state) is False
+
+
+def test_a_retry_whose_files_were_cleared_is_not(tmp_path: Path) -> None:
+    """Files genuinely absent -> the red phase is meaningful again."""
+    assert _implementation_already_exists(_state(tmp_path)) is False
+
+
+def test_a_resume_counts_as_a_later_attempt(worktree: Path) -> None:
+    state = _state(worktree, retry_mode="", iteration_count=2)
+    assert _implementation_already_exists(state) is True
+
+
+def test_partial_implementation_is_not_enough(worktree: Path) -> None:
+    """One of two files present is not a surviving implementation."""
+    (worktree / "src" / "boostgauge" / "app.py").unlink()
+    assert _implementation_already_exists(_state(worktree)) is False
+
+
+def test_no_declared_targets_is_not_enough(worktree: Path) -> None:
+    assert _implementation_already_exists(
+        _state(worktree, files_to_modify=[])
+    ) is False
+
+
+# ------------------------------------------------- the node's behaviour
+
+
+def _pytest_result(passed: int) -> dict:
+    return {
+        "returncode": 0,
+        "stdout": f"{passed} passed",
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": 0, "errors": 0, "coverage": 0},
+    }
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_retry_with_surviving_implementation_proceeds(
+    mock_pytest, worktree: Path,
+) -> None:
+    """The live case: 23 pass, implementation is there, so verify it."""
+    mock_pytest.return_value = _pytest_result(23)
+
+    result = verify_red_phase(_state(worktree))
+
+    assert result["next_node"] == "N5_verify_green"
+    assert result["error_message"] == ""
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_first_attempt_green_at_red_still_ends_the_stage(
+    mock_pytest, worktree: Path,
+) -> None:
+    """Tests that pass before any code exists are not testing anything."""
+    mock_pytest.return_value = _pytest_result(23)
+
+    result = verify_red_phase(_state(worktree, retry_mode="", iteration_count=0))
+
+    assert result["next_node"] == "END"
+    assert "passed unexpectedly" in result["error_message"]
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_that_failure_is_marked_deterministic(
+    mock_pytest, worktree: Path,
+) -> None:
+    """#2298's rule: a failure a re-run cannot change is not retried."""
+    mock_pytest.return_value = _pytest_result(23)
+
+    result = verify_red_phase(_state(worktree, retry_mode="", iteration_count=0))
+
+    assert DETERMINISTIC_FAILURE in result["error_message"]
+    assert _is_non_transient_halt(
+        {"error_message": result["error_message"]}
+    ) is False, "a deterministic failure must not be retried"
+
+
+# ------------------------------------------------- routing
+
+
+def test_route_accepts_the_verify_destination() -> None:
+    assert route_after_red(
+        {"error_message": "", "next_node": "N5_verify_green"}
+    ) == "N5_verify_green"
+
+
+@pytest.mark.parametrize("next_node,expected", [
+    ("N4_implement_code", "N4_implement_code"),
+    ("N2_scaffold_tests", "N2_scaffold_tests"),
+    ("END", "end"),
+])
+def test_existing_routes_are_unchanged(next_node: str, expected: str) -> None:
+    assert route_after_red(
+        {"error_message": "", "next_node": next_node}
+    ) == expected
+
+
+def test_an_error_still_ends_regardless() -> None:
+    assert route_after_red(
+        {"error_message": "boom", "next_node": "N5_verify_green"}
+    ) == "end"


### PR DESCRIPTION
Closes #2337

Attempts 2 and 3 of `run-issue7-192332` each did about two seconds of work and failed identically: scaffold 23 tests, find the implementation attempt 1 wrote, go green at the red phase, end the stage.

## The message discarded nothing

```
[ORCHESTRATOR] Next attempt will be regenerated (discarding the previous attempt's generated files).
```

`REGENERATED`'s only consumer is `_should_skip_existing_file` — it makes **N4** rewrite files instead of skipping them. Nothing is deleted. And N4 was never reached: the retry restarts at N0, so N3 (red phase) runs first and ended the stage. A reader diagnosing that run would have believed the files were gone.

The message now says what the mode does — *"rewriting generated files rather than skipping them"*.

## Green-at-red is only fatal when nothing exists yet

On a first attempt, tests that pass before any code exists are not testing anything, and that guard stays. It is the wrong reading whenever implementation legitimately exists — a retry after an N4c failure, or a resume into a worktree with prior work. There, "23 passed" means *the previous attempt's implementation is still present and still works*, which is the state N4 exists to reach.

`_implementation_already_exists` requires **both** conditions:

| | |
|---|---|
| not a first attempt | `retry_mode` set, or `iteration_count > 0` |
| the files are really there | every `.py` in `files_to_modify` exists on disk |

Either alone is too weak. A first attempt against a repo that happens to have the file is exactly the pre-existing-implementation case the original guard was built for; a retry whose files *were* cleared genuinely needs the red phase. Partial presence (one of two files) does not qualify.

When both hold, the run routes to `N5_verify_green` and the coverage gate judges — rather than the stage ending on a phase-ordering assumption.

## The cascade is stopped separately

Green-at-red on an unchanged worktree is **deterministic**: attempts 2 and 3 could not have gone differently. That is #2298's rule with a new cause, so the failure now carries a `DETERMINISTIC FAILURE` token that the orchestrator's transience classifier keys off — the same mechanism as `MISSING_REQUIRED_INPUT`, not prose a later reword could silently break.

Both halves matter independently: the semantics fix means the retry does not happen; the token means that if some other deterministic green-at-red arises, it is not retried three times in twelve seconds.

## Tests

14 tests. Prior-work detection across all six combinations (retry with files, first attempt, retry with files cleared, resume, partial implementation, no declared targets); the node's behaviour on retry vs first attempt; the deterministic token actually reaching `_is_non_transient_halt`; and the routing table, with the existing routes asserted unchanged.

## Checks

Full unit suite **7375 passed, 17 skipped, 0 failures**, verified with `CI=true`. ruff: no new findings — 4 pre-existing on the touched files both before and after (tracked in #2260); the new test file is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
