### PR TITLE
fix(testing): a failing stage ends at its best measured state (Closes #2338)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -535,6 +535,58 @@ def run_pytest(
         }
 
 
+def restore_best_on_failure(state: TestingWorkflowState) -> str:
+    """Put the best measured state back before the stage ends (#2338).
+
+    `_hill_climb` (#2050) is a WITHIN-loop ratchet: a worse iteration restores
+    the best files so the next revision starts from there. No terminal path
+    consulted it, so a stage that died ended holding the wreckage while a
+    coherent best state sat in the snapshot directory unused.
+
+    On run-issue7-192332 that meant ending on a test file that could not be
+    collected, thirteen seconds after logging "best iteration so far: 23
+    passing at 78.0% — snapshotted 3 file(s)". The worktree is what a resume
+    picks up and what the operator inspects; leaving it at the worst point
+    the run reached is the opposite of what the snapshot exists for.
+
+    Returns a description of what was restored, or '' when there was nothing
+    to restore. Best-effort by design: restoration trouble is reported and
+    must never mask the original failure, which is the thing the operator
+    actually needs to read.
+    """
+    import shutil
+
+    best = state.get("best_iteration") or None
+    if not best:
+        return ""
+    files = best.get("files") or {}
+    if not files:
+        return ""
+
+    restored = 0
+    for src_str, snap_str in files.items():
+        try:
+            if Path(snap_str).is_file():
+                shutil.copy2(snap_str, src_str)
+                restored += 1
+        except OSError as exc:
+            print(f"    [N5] could not restore {src_str} (non-fatal): {exc}")
+
+    if not restored:
+        return ""
+
+    description = (
+        f"{best.get('passed', '?')} passing at "
+        f"{float(best.get('coverage', 0.0)):.1f}% coverage"
+    )
+    print(
+        f"    [N5] restored the best measured state ({description}) from "
+        f"{restored} snapshotted file(s) — the worktree holds that, not the "
+        f"failed attempt"
+    )
+    return description
+
+
 def _implementation_already_exists(state: TestingWorkflowState) -> bool:
     """True when a previous attempt's implementation is present (#2337).
 
@@ -1351,6 +1403,15 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         detail = f" {broken}" if broken else ""
         if broken:
             print(f"    [EXIT CODE {exit_code}] {broken}")
+
+        # #2338: end AT the best measured state rather than on the wreckage.
+        # The snapshot existed and nothing consulted it, so the worktree a
+        # resume picks up was the worst point the run reached.
+        restored = restore_best_on_failure(state)
+        if restored:
+            detail += (
+                f" Worktree restored to the best measured state: {restored}."
+            )
 
         return {
             "green_phase_output": output,

--- a/tests/unit/test_restore_best_on_failure.py
+++ b/tests/unit/test_restore_best_on_failure.py
@@ -1,0 +1,120 @@
+"""#2338: a stage that dies should end at its best measured state.
+
+`run-issue7-192332` logged "best iteration so far: 23 passing at 78.0% —
+snapshotted 3 file(s)", and thirteen seconds later ended holding a test file
+that could not be collected. The snapshot sat unused.
+
+`_hill_climb` (#2050) is a within-loop ratchet -- a worse iteration restores
+the best files so the next revision starts from there -- and it works. What
+no path did was consult it on TERMINAL failure, which is exactly when the
+worktree stops being scratch space and becomes what a resume picks up and
+what the operator inspects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    restore_best_on_failure,
+    verify_green_phase,
+)
+
+
+@pytest.fixture()
+def snapshotted(tmp_path: Path) -> tuple[Path, Path, dict]:
+    """A worktree whose live file is broken and whose snapshot is good."""
+    live = tmp_path / "tests" / "test_issue_7.py"
+    live.parent.mkdir(parents=True)
+    live.write_text(
+        "from pkg.config import does_not_exist\n", encoding="utf-8",
+    )
+
+    snap = tmp_path / "audit" / "best-iteration" / "00-test_issue_7.py"
+    snap.parent.mkdir(parents=True)
+    snap.write_text("def test_real():\n    assert True\n", encoding="utf-8")
+
+    best = {
+        "passed": 23,
+        "coverage": 78.0,
+        "green_failures": [],
+        "files": {str(live): str(snap)},
+    }
+    return live, snap, best
+
+
+def test_the_worktree_ends_holding_the_best_state(snapshotted) -> None:
+    live, _snap, best = snapshotted
+
+    described = restore_best_on_failure({"best_iteration": best})
+
+    assert "23 passing at 78.0% coverage" == described
+    assert "does_not_exist" not in live.read_text(encoding="utf-8"), (
+        "the broken file must not survive the restore"
+    )
+    assert "def test_real" in live.read_text(encoding="utf-8")
+
+
+def test_nothing_to_restore_is_silent() -> None:
+    assert restore_best_on_failure({}) == ""
+    assert restore_best_on_failure({"best_iteration": None}) == ""
+    assert restore_best_on_failure({"best_iteration": {"files": {}}}) == ""
+
+
+def test_a_missing_snapshot_file_is_not_a_restore(tmp_path: Path) -> None:
+    """A manifest pointing at nothing must not claim success."""
+    live = tmp_path / "t.py"
+    live.write_text("broken\n", encoding="utf-8")
+    best = {"passed": 1, "coverage": 1.0,
+            "files": {str(live): str(tmp_path / "gone.py")}}
+
+    assert restore_best_on_failure({"best_iteration": best}) == ""
+    assert live.read_text(encoding="utf-8") == "broken\n"
+
+
+def test_restore_trouble_never_raises(tmp_path: Path) -> None:
+    """Restoration must never mask the failure the operator needs to read."""
+    best = {"passed": 1, "coverage": 1.0,
+            "files": {str(tmp_path / "nope" / "x.py"): str(tmp_path / "s.py")}}
+    (tmp_path / "s.py").write_text("ok\n", encoding="utf-8")
+
+    assert restore_best_on_failure({"best_iteration": best}) == ""
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_collection_death_restores_and_says_so(
+    mock_pytest, snapshotted, tmp_path: Path,
+) -> None:
+    """The live path: exit 2 after a good snapshot."""
+    live, _snap, best = snapshotted
+    mock_pytest.return_value = {
+        "returncode": 2,
+        "stdout": "ImportError: cannot import name 'does_not_exist'",
+        "stderr": "",
+        "parsed": {"passed": 0, "failed": 0, "errors": 0, "coverage": 0},
+    }
+
+    result = verify_green_phase({
+        "repo_root": str(tmp_path),
+        "issue_number": 7,
+        "audit_dir": str(tmp_path / "audit"),
+        "file_counter": 1,
+        "test_files": [str(live)],
+        "implementation_files": [],
+        "coverage_target": 95,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "best_iteration": best,
+    })
+
+    assert result["next_node"] == "end"
+    message = result["error_message"]
+    assert "23 passing at 78.0% coverage" in message, (
+        "the operator should be told what the worktree now holds"
+    )
+    # The original diagnosis must survive alongside it.
+    assert "exit code 2" in message.lower()
+    assert "def test_real" in live.read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #2338

```
[N5] best iteration so far: 23 passing at 78.0% — snapshotted 3 file(s)
...13 seconds later...
[N5] Results: 0 passed, 0 failed | Coverage: 0.0% | Exit: 2
[EXIT CODE 2] test execution interrupted — stopping workflow
```

The stage ended holding a test file that could not be collected, while a coherent 23/23 state sat in the snapshot directory unused.

## Correction to the premise

The hypothesis was that the snapshot "is never consulted". That is too strong, and the distinction decides the fix.

`_hill_climb` (#2050) **is** consulted, on every within-loop measurement: a new best snapshots, a worse iteration restores before N4 revises again. That works and is untouched here.

What no path did was consult it on **terminal** failure. That is exactly when the worktree stops being scratch space and becomes what a resume picks up and what the operator inspects — so the run left the next session starting from the worst point it reached, and the recovery plan described a state no longer on disk.

## The change

`restore_best_on_failure()` puts the best measured state back before the stage ends, and the error message says so:

> Green phase stopped: pytest test execution interrupted (exit code 2). Imports that no longer resolve: … **Worktree restored to the best measured state: 23 passing at 78.0% coverage.**

The original diagnosis survives alongside it — the restore annotates the failure, never replaces it.

## Best-effort by design

Restoration must never mask the failure the operator actually needs to read, so every trouble path degrades to "no restore, no claim":

- no `best_iteration`, or an empty manifest → silent, returns `""`
- a manifest pointing at a snapshot file that is gone → no claim of success
- an unwritable destination → reported per-file, never raised

A restore is only announced when at least one file actually moved.

## Tests

5 tests, including the live path: exit 2 after a good snapshot restores the file, reports what the worktree now holds, and keeps the exit-code diagnosis in the message.

## Checks

Full unit suite **7380 passed, 17 skipped, 0 failures**, verified with `CI=true`. `ruff check` clean on the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
