### PR TITLE
fix(orchestrator): the impl verdict is measured, not inferred from silence (Closes #2344, Closes #2345)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -119,6 +119,36 @@ def _make_stage_result(
     return result
 
 
+def _unresolved_test_failures(sub_result: dict) -> int:
+    """Failing tests the implementation loop ended holding (#2344).
+
+    Reads the last green-phase measurement the sub-workflow recorded. Returns
+    0 when the run finished clean, when it never measured, or when the state
+    cannot answer -- this must never invent a failure and turn a genuine pass
+    into a spurious halt.
+
+    Two keys, because a clean targeted run is not the same as a clean repo:
+
+    - `previous_green_failures` -- the identity set from the last N5. Preferred
+      over a parsed count because it is what the loop's own stagnation and
+      freeze decisions are made from, so the verdict follows the set the loop
+      actually acted on.
+    - `full_suite_regressions` -- the #842 full-suite gate. Its return sets
+      `previous_green_failures` to `[]` while carrying regression names and an
+      empty error_message, so checking only the first would let a regressed
+      repo through the same cap-and-report-passed hole this closes.
+
+    Both are reset to empty on every genuine success path, so a passing run
+    still reports passed.
+    """
+    total = 0
+    for key in ("previous_green_failures", "full_suite_regressions"):
+        value = sub_result.get(key)
+        if isinstance(value, (list, tuple, set)):
+            total += len(value)
+    return total
+
+
 def _is_non_transient_halt(sub_result: dict) -> bool:
     """Sub-workflow halts write a recovery_plan_path. Non-transient by default
     since the resume command — not a 10-second retry — is the recovery path.
@@ -1137,6 +1167,7 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
 
         # Run implementation workflow
         from assemblyzero.workflows.testing.graph import build_testing_workflow as create_impl_graph
+        from assemblyzero.workflows.testing.state import DEFAULT_MAX_ITERATIONS
 
         spec_path = state.get("spec_path", "")
         # #1440: Plumb orchestrator config into the sub-workflow state.
@@ -1166,6 +1197,12 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # REGENERATED forbids it. Absent on a first attempt, which reuses
             # nothing because there is nothing to reuse.
             "retry_mode": state.get("retry_mode", ""),
+            # #2344: seed the iteration cap explicitly. Left absent, each
+            # reader fell back to its own inline default -- 5 in N5's progress
+            # message, 3 in the router's decision -- so the run announced a
+            # budget it did not have and a freeze's loop-back was dropped at 3
+            # without a word.
+            "max_iterations": DEFAULT_MAX_ITERATIONS,
         })
 
         error_msg = sub_result.get("error_message", "")
@@ -1186,6 +1223,29 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 "Completeness gate BLOCK — implementation halted with "
                 f"unresolved issues: {issue_lines or 'see implementation report'}"
             )
+        # #2344: a verdict must be MEASURED, not inferred from silence.
+        #
+        # run-issue7-231606 ended with `31 passed, 1 failed` as its last N5
+        # result and recorded impl as PASSED. Nothing lied: N5's freeze branch
+        # correctly returned an empty error_message because it was routing to
+        # another revision, not failing. The router then hit the iteration cap
+        # and returned "end" without a word, so the empty error survived to
+        # here and "no error" was read as "tests pass".
+        #
+        # This is the #2297 verdict-integrity class, and #1779's shape: a
+        # stage reporting success without checking the thing it exists to
+        # check. The pr stage would have pushed and opened a PR on a branch
+        # whose suite fails.
+        if not error_msg:
+            unresolved = _unresolved_test_failures(sub_result)
+            if unresolved:
+                error_msg = (
+                    f"Implementation stage ended with {unresolved} failing "
+                    f"test(s) and no further revision available. The last "
+                    f"green-phase measurement did not pass, so the stage did "
+                    f"not pass."
+                )
+
         if not error_msg:
             result = _make_stage_result(
                 status="passed",

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -88,7 +88,10 @@ from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
     validate_tests_mechanical_node,
     should_regenerate,
 )
-from assemblyzero.workflows.testing.state import TestingWorkflowState
+from assemblyzero.workflows.testing.state import (
+    DEFAULT_MAX_ITERATIONS,
+    TestingWorkflowState,
+)
 
 from assemblyzero.workflows.testing.nodes.revise_test_plan import revise_test_plan  # Issue #1072
 
@@ -367,7 +370,7 @@ def route_after_green(
     # -- an LLM that cannot reach the target will not be asked forever.
     if next_node == "N4c_augment_tests":
         iteration = state.get("iteration_count", 0)
-        max_iterations = state.get("max_iterations", 3)
+        max_iterations = state.get("max_iterations", DEFAULT_MAX_ITERATIONS)
         if iteration >= max_iterations:
             return "end"
         if state.get("coverage_augment_attempts", 0) >= MAX_COVERAGE_AUGMENT_ATTEMPTS:
@@ -389,8 +392,19 @@ def route_after_green(
     if next_node == "N4_implement_code":
         # Check max iterations
         iteration = state.get("iteration_count", 0)
-        max_iterations = state.get("max_iterations", 3)
+        max_iterations = state.get("max_iterations", DEFAULT_MAX_ITERATIONS)
         if iteration >= max_iterations:
+            # #2344: N5 asked for another revision and cannot have one. That
+            # is a failure of the loop, not a quiet finish -- returning "end"
+            # silently left an empty error_message, and the stage read empty
+            # as passed while holding a failing test. Say what happened, so
+            # the verdict downstream is built on a stated fact.
+            print(
+                f"    [ITERATION CAP] N5 asked for another implementation "
+                f"revision at iteration {iteration}/{max_iterations}. The cap "
+                f"is reached, so the loop stops here with its last result "
+                f"standing -- this is not a pass."
+            )
             return "end"
         # Issue #640: Budget check before looping back
         budget = state.get("cost_budget_usd", 0.0)
@@ -431,7 +445,7 @@ def route_after_e2e(
     # E2E failure may loop back to implement
     if next_node == "N4_implement_code":
         iteration = state.get("iteration_count", 0)
-        max_iterations = state.get("max_iterations", 3)
+        max_iterations = state.get("max_iterations", DEFAULT_MAX_ITERATIONS)
         if iteration >= max_iterations:
             return "end"
         return "N4_implement_code"

--- a/assemblyzero/workflows/testing/nodes/e2e_validation.py
+++ b/assemblyzero/workflows/testing/nodes/e2e_validation.py
@@ -57,8 +57,22 @@ def _extract_failed_test_names(output: str) -> list[str]:
     """
     # Match patterns like "FAILED tests/test_foo.py::test_bar - AssertionError"
     # or "FAILED tests/test_foo.py::TestClass::test_bar"
-    failures = re.findall(r"FAILED\s+(\S+)", output)
-    return sorted(set(failures))
+    #
+    # #2345: anchored to line start. run_pytest passes -v, so pytest reports
+    # each failure TWICE in different shapes:
+    #
+    #   tests/test_x.py::test_a FAILED                              [ 96%]
+    #   FAILED tests/test_x.py::test_a - pathlib.UnsupportedOperation
+    #
+    # The unanchored pattern matched both, and on the progress line the token
+    # after FAILED is the progress bracket -- so one real failure was counted
+    # as two, one of them named "[". run-issue7-231606 printed "1 failed" and
+    # "same 2 test(s) failing again" in adjacent lines from that.
+    #
+    # The `::` requirement is the second guard: a captured token that is not a
+    # test id is not a test, whatever produced it.
+    failures = re.findall(r"^FAILED\s+(\S+)", output, re.MULTILINE)
+    return sorted({f for f in failures if "::" in f})
 
 
 # Issue #498: Max chars for E2E failure summary

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -38,7 +38,10 @@ from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
     count_stub_tests,
 )
 from assemblyzero.workflows.testing.runner_registry import get_runner
-from assemblyzero.workflows.testing.state import TestingWorkflowState
+from assemblyzero.workflows.testing.state import (
+    DEFAULT_MAX_ITERATIONS,
+    TestingWorkflowState,
+)
 
 
 # Timeout for pytest execution
@@ -1434,7 +1437,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
     # Stagnation detection: coverage must improve by >=1% each iteration
     previous_coverage = state.get("previous_coverage", -1.0)
-    max_iterations = state.get("max_iterations", 5)
+    max_iterations = state.get("max_iterations", DEFAULT_MAX_ITERATIONS)
 
     # Issue #498: Build concise failure summary for N4 feedback
     failure_summary = _build_failure_summary(output)
@@ -2065,7 +2068,7 @@ def _verify_green_non_pytest(
     repo_root_str = state.get("repo_root", "")
     repo_root = Path(repo_root_str) if repo_root_str else get_repo_root()
     iteration_count = state.get("iteration_count", 0)
-    max_iterations = state.get("max_iterations", 5)
+    max_iterations = state.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     total_scenarios = state.get("total_scenarios", 0)
 
     print(f"    Running {framework.value} with coverage target: {coverage_target}%")

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -17,6 +17,17 @@ documentation generation, and post-implementation cleanup.
 from enum import Enum
 from typing import Literal, TypedDict
 
+#: #2344: the single source of truth for the implementation loop's iteration
+#: cap. Every reader imports this rather than inlining a fallback.
+#:
+#: It existed as two inline defaults -- 5 where N5 built its progress message,
+#: 3 where the router decided whether to loop -- with the key itself never
+#: seeded into state. run-issue7-231606 therefore printed "Iteration 2/5"
+#: while being capped at 3: the freeze branch's instruction to revise was
+#: discarded, the run ended with an empty error_message, and the stage
+#: reported passed while holding 31 passed / 1 failed.
+DEFAULT_MAX_ITERATIONS = 5
+
 
 class HumanDecision(str, Enum):
     """User choices at human gate nodes."""
@@ -170,6 +181,12 @@ class TestingWorkflowState(TypedDict, total=False):
     red_phase_output: str
     green_phase_output: str
     coverage_achieved: float
+    #: #2344: how many N5 measurement rounds the implementation loop may take.
+    #: MUST be seeded into state at invoke time. It used to be absent, and the
+    #: two readers guessed differently -- N5 printed "Iteration 2/5" while the
+    #: router capped at 3 -- so a freeze branch's loop-back was silently
+    #: dropped and the stage reported passed holding a failing test.
+    max_iterations: int
     #: #2327: how many rounds of coverage-targeting test additions have run.
     #: Bounds N4c so an LLM that cannot reach the gate is not asked forever,
     #: and so the shortfall never falls through to implementation revision.

--- a/tests/unit/test_impl_verdict_integrity.py
+++ b/tests/unit/test_impl_verdict_integrity.py
@@ -1,0 +1,155 @@
+"""#2344 / #2345: a stage may not report passed while holding a failing test.
+
+`run-issue7-231606` ended with `31 passed, 1 failed` as its last N5 result and
+recorded impl as PASSED. Running its shipped artifact confirms it:
+
+    FAILED tests/test_issue_7.py::test_config_path_non_windows
+    1 failed, 31 passed, config.py 100% coverage
+
+Nothing lied. N5's freeze branch correctly returned an empty error_message --
+it was routing to another revision, not failing. The router then hit an
+iteration cap it computed from a DIFFERENT default than the one N5 had just
+printed, returned "end" without a word, and the empty error survived to a
+verdict that read "no error" as "tests pass".
+
+The pr stage would have pushed and opened a PR from that branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.orchestrator.stages import _unresolved_test_failures
+from assemblyzero.workflows.testing.graph import route_after_green
+from assemblyzero.workflows.testing.nodes.e2e_validation import (
+    _extract_failed_test_names,
+)
+from assemblyzero.workflows.testing.state import DEFAULT_MAX_ITERATIONS
+
+# The real shape of `pytest -v` output: the failure appears twice.
+VERBOSE_OUTPUT = """
+tests/test_issue_7.py::test_req_1 PASSED                                 [  3%]
+tests/test_issue_7.py::test_config_path_non_windows FAILED               [ 96%]
+tests/test_issue_7.py::test_req_22 PASSED                                [100%]
+
+=========================== short test summary info ===========================
+FAILED tests/test_issue_7.py::test_config_path_non_windows - pathlib.UnsupportedOperation
+1 failed, 31 passed in 0.42s
+"""
+
+
+# ---------------------------------------------------------- #2345: the count
+
+
+def test_verbose_output_yields_one_name_per_failure() -> None:
+    """'1 failed' is true; 'same 2 test(s)' was the lie."""
+    names = _extract_failed_test_names(VERBOSE_OUTPUT)
+
+    assert names == ["tests/test_issue_7.py::test_config_path_non_windows"]
+    assert "[" not in names, "the progress bracket is not a test"
+
+
+def test_the_count_matches_pytest() -> None:
+    assert len(_extract_failed_test_names(VERBOSE_OUTPUT)) == 1
+
+
+def test_summary_only_output_still_parses() -> None:
+    output = (
+        "=========================== short test summary info ===========\n"
+        "FAILED tests/a.py::test_x - AssertionError\n"
+        "FAILED tests/b.py::TestC::test_y - ValueError\n"
+    )
+    assert _extract_failed_test_names(output) == [
+        "tests/a.py::test_x", "tests/b.py::TestC::test_y",
+    ]
+
+
+def test_a_clean_run_reports_nothing() -> None:
+    assert _extract_failed_test_names("31 passed in 0.4s") == []
+
+
+# ------------------------------------------------- #2344: one iteration cap
+
+
+def test_the_cap_has_one_value_everywhere() -> None:
+    """Two defaults for one missing key is what dropped the loop-back."""
+    import inspect
+
+    from assemblyzero.workflows.testing import graph
+    from assemblyzero.workflows.testing.nodes import verify_phases
+
+    for module in (graph, verify_phases):
+        source = inspect.getsource(module)
+        assert 'state.get("max_iterations", 3)' not in source, module.__name__
+        assert 'state.get("max_iterations", 5)' not in source, module.__name__
+
+
+def test_the_seeded_cap_governs_the_router() -> None:
+    """With the cap seeded, the freeze's loop-back is honoured."""
+    state = {
+        "error_message": "",
+        "next_node": "N4_implement_code",
+        "iteration_count": 3,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+    }
+    assert route_after_green(state) == "N4_implement_code"
+
+
+def test_the_cap_still_stops_the_loop(capsys: pytest.CaptureFixture[str]) -> None:
+    """And when it does stop, it says so rather than ending silently."""
+    state = {
+        "error_message": "",
+        "next_node": "N4_implement_code",
+        "iteration_count": DEFAULT_MAX_ITERATIONS,
+        "max_iterations": DEFAULT_MAX_ITERATIONS,
+    }
+    assert route_after_green(state) == "end"
+    assert "ITERATION CAP" in capsys.readouterr().out
+
+
+# ------------------------------------------------- #2344: measured verdicts
+
+
+def test_the_run_that_shipped_is_now_a_failure() -> None:
+    """The exact sub-workflow state from run-issue7-231606."""
+    sub_result = {
+        "error_message": "",
+        "previous_green_failures": [
+            "tests/test_issue_7.py::test_config_path_non_windows",
+        ],
+        "coverage_achieved": 100.0,
+    }
+    assert _unresolved_test_failures(sub_result) == 1
+
+
+def test_a_genuine_pass_is_still_a_pass() -> None:
+    """Every success path resets both keys; none may become a false halt."""
+    assert _unresolved_test_failures({
+        "error_message": "",
+        "previous_green_failures": [],
+        "full_suite_regressions": [],
+    }) == 0
+
+
+def test_a_full_suite_regression_is_not_a_pass() -> None:
+    """#842's gate zeroes the green set while carrying regressions.
+
+    Checking only previous_green_failures would let a regressed repo through
+    the same cap-and-report-passed hole.
+    """
+    assert _unresolved_test_failures({
+        "error_message": "",
+        "previous_green_failures": [],
+        "full_suite_regressions": ["tests/other.py::test_z"],
+    }) == 1
+
+
+@pytest.mark.parametrize("sub_result", [
+    {},
+    {"previous_green_failures": None},
+    {"previous_green_failures": "not a list"},
+    {"full_suite_regressions": 3},
+])
+def test_an_unanswerable_state_never_invents_a_failure(sub_result: dict) -> None:
+    """A verdict check must not turn a genuine pass into a spurious halt."""
+    assert _unresolved_test_failures(sub_result) == 0


### PR DESCRIPTION
Closes #2344
Closes #2345

The impl stage recorded **passed** while its own last measurement was `31 passed, 1 failed`. The pr stage would have pushed and opened a PR from that branch.

## Nothing lied — three things compounded

**1. Two defaults for one missing key.** `max_iterations` was never seeded into the impl sub-workflow's state, and the readers disagreed:

| Reader | Default |
|---|---|
| `verify_phases.py` (N5's progress message) | **5** |
| `graph.py` ×3 (the router's decision) | **3** |

So the run printed `Iteration 2/5` while being capped at 3. Executing `route_after_green` with the freeze branch's exact state:

```
max_iterations=5, iteration_count=3 -> N4_implement_code
iteration_count=3, no max_iterations -> end
```

**2. The router dropped a loop-back silently.** The freeze branch returns `next_node: "N4_implement_code"` with `error_message: ""` — an instruction to revise, correctly not an error. At the cap the router returned `"end"` and said nothing.

**3. The verdict was inferred from silence.** `if not error_msg: status="passed"`. The empty error meant "routing", and was read as "tests pass".

That is the **#2297 verdict-integrity class**, the same shape as #1779.

## The fix — all three, because each alone leaves the hole open

- `DEFAULT_MAX_ITERATIONS` in `state.py` is the single source; every reader imports it and the key is **seeded at invoke time** so nobody guesses.
- Hitting the cap now prints what happened and states plainly that it is not a pass.
- `_unresolved_test_failures()` makes the verdict **measured**: `passed` requires the last green-phase measurement to have no failing tests.

It reads **two** keys. `previous_green_failures` is the identity set the loop's own freeze and stagnation decisions are made from. `full_suite_regressions` is #842's gate, whose return sets `previous_green_failures: []` while carrying regression names and an empty error — checking only the first would have left a regressed repo going through the identical hole. Every genuine success path resets both, so a passing run still passes.

Every unanswerable state returns 0. A verdict check must never turn a genuine pass into a spurious halt.

## #2345 — which number lied

```
[N5] Results: 31 passed, 1 failed | Coverage: 100.0%
[N5] same 2 test(s) failing again — freezing tests as the contract
```

**`1 failed` was true.** `run_pytest` passes `-v`, so pytest reports each failure twice:

```
tests/test_issue_7.py::test_config_path_non_windows FAILED       [ 96%]
FAILED tests/test_issue_7.py::test_config_path_non_windows - pathlib.UnsupportedOperation
```

The unanchored `FAILED\s+(\S+)` matched both, capturing `[` from the progress line. Measured: `['[', 'tests/...::test_config_path_non_windows']`.

Now anchored to line start, with a `::` requirement as the second guard. This matters beyond the count — that set feeds the identity-stagnation comparison that decides when to freeze the tests as a contract, and it is now what the verdict above is measured from.

## Tests

14 tests. The extractor against real `-v` output; the cap having one value asserted **against the modules' own source**, so a future inline fallback fails here; the router honouring the seeded cap and announcing it when it stops; and the verdict check — the exact `run-issue7-231606` state now reporting 1 unresolved failure, a genuine pass still passing, a full-suite regression not passing, and four unanswerable states inventing nothing.

## Checks

Full unit suite **7394 passed, 17 skipped, 0 failures**, verified with `CI=true`. ruff: no new findings — 3 pre-existing on the touched files both before and after (#2260); the new test file is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
