### PR TITLE
fix(orchestrator): the pr stage reconciles a stale same-name remote before pushing (Closes #2346)

### DIFF
--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -157,9 +157,20 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
             # never reached -- the red phase saw the surviving implementation
             # and ended the stage first. A reader diagnosing that run would
             # have believed the files were gone.
+            # #2346: and it described the IMPLEMENTATION stage's semantics
+            # whatever stage had failed. On run-issue7-231606's pr failure it
+            # announced "rewriting generated files" for a retry that rewrites
+            # nothing -- a pr retry re-attempts a push and a PR creation. Only
+            # the stages that actually generate files get that wording.
+            if current_stage in ("impl", "lld", "spec"):
+                detail = (
+                    "reusing generated files where they exist" if mode == RESUMED
+                    else "rewriting generated files rather than skipping them"
+                )
+            else:
+                detail = f"re-running the {current_stage} stage"
             print(
-                f"[ORCHESTRATOR] Next attempt will be {mode.lower()} "
-                f"({'reusing generated files where they exist' if mode == RESUMED else 'rewriting generated files rather than skipping them'})."
+                f"[ORCHESTRATOR] Next attempt will be {mode.lower()} ({detail})."
             )
             time.sleep(delay)
             last_state = dict(new_state)

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1289,6 +1289,77 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
     return update_stage_result(state, stage, result)
 
 
+#: #2346: a non-fast-forward rejection cannot change between attempts. Same
+#: rule as #2298/#2337, pr-stage edition -- the remote's divergence is not
+#: something re-running the push can resolve.
+NON_FAST_FORWARD = "non-fast-forward"
+
+
+def _reconcile_stale_remote_branch(worktree_path, branch: str) -> str:
+    """Clear a same-name remote branch out of the push's way (#2346).
+
+    Returns a description of what was done, or '' when nothing was needed.
+
+    Three cases, decided by measurement rather than assumption:
+
+    - the remote branch does not exist -> nothing to do
+    - it is an ANCESTOR of what we are about to push -> the push
+      fast-forwards, so leave it alone
+    - it has DIVERGED -> preserve it under `graveyard/<branch>-<stamp>` on the
+      remote and delete the old name, so the push is clean
+
+    Preserve-and-rename, never force-push: the same discipline #2310/#2324
+    settled for local branches, which exists because a name in the way is not
+    a reason to destroy whatever is standing on it. A remote rename is a push
+    of the same commit under a new ref followed by a delete of the old ref, so
+    nothing is ever unreachable in between.
+
+    Best-effort by design. Every git failure returns '' and lets the push
+    proceed to fail on its own terms -- a reconcile that cannot read the
+    remote must not invent a destructive action, and the push's own error is
+    a better diagnosis than anything guessed here.
+    """
+    from datetime import datetime, timezone
+
+    def _git(*args: str):
+        return run_command(
+            ["git", *args], check=False, capture_output=True, text=True,
+            cwd=worktree_path,
+        )
+
+    fetched = _git("fetch", "origin", branch)
+    if fetched.returncode != 0:
+        # No such branch on origin (or the remote is unreachable). Either way
+        # there is nothing to reconcile; the push will say so if it matters.
+        return ""
+
+    remote_tip = _git("rev-parse", "FETCH_HEAD")
+    local_tip = _git("rev-parse", "HEAD")
+    if remote_tip.returncode != 0 or local_tip.returncode != 0:
+        return ""
+    remote_sha = remote_tip.stdout.strip()
+    if not remote_sha or remote_sha == local_tip.stdout.strip():
+        return ""
+
+    if _git("merge-base", "--is-ancestor", remote_sha, "HEAD").returncode == 0:
+        return ""  # fast-forwardable; the ordinary push handles it
+
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    parked = f"graveyard/{branch}-{stamp}"
+    if _git("push", "origin", f"{remote_sha}:refs/heads/{parked}").returncode != 0:
+        return ""  # could not preserve it, so do not delete it
+
+    if _git("push", "origin", f":refs/heads/{branch}").returncode != 0:
+        return (
+            f"stale origin/{branch} preserved as {parked}, but the old name "
+            f"could not be removed; the push may still be rejected"
+        )
+    return (
+        f"stale origin/{branch} ({remote_sha[:8]}) had diverged — preserved "
+        f"as {parked} and cleared; nothing was force-pushed"
+    )
+
+
 def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
     """Create and submit the PR via the gh CLI.
 
@@ -1326,6 +1397,15 @@ def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
             cwd=worktree_path,
         )
         branch = branch_result.stdout.strip()
+
+        # #2346: a same-name branch left on origin by an earlier run makes this
+        # push fail non-fast-forward, and run-issue7-231606 died there on the
+        # first pr stage the campaign ever reached. #2310/#2324/#2325 taught
+        # RESTORE this discipline for the LOCAL branch; origin never learned
+        # it, so leftovers outlive every run and collide with the next.
+        reconcile_note = _reconcile_stale_remote_branch(worktree_path, branch)
+        if reconcile_note:
+            print(f"    {reconcile_note}")
 
         # Push branch
         run_command(
@@ -1378,11 +1458,19 @@ def run_pr_stage(state: OrchestrationState) -> OrchestrationState:
             attempts=1,
         )
     except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr or ""
+        # #2346: a rejected push is deterministic -- the remote's divergence
+        # is not something another attempt can resolve. run-issue7-231606
+        # spent three attempts on one, ten seconds apart. Reconciliation above
+        # should now prevent it; this is the guard for when it cannot (a
+        # protected ref, a permissions failure, a race with another push).
+        deterministic = NON_FAST_FORWARD in stderr.lower()
         result = _make_stage_result(
             status="failed",
-            error_message=f"PR creation error: {exc.stderr}",
+            error_message=f"PR creation error: {stderr}",
             duration_seconds=time.monotonic() - start_time,
             attempts=1,
+            transient=False if deterministic else None,
         )
     except Exception as exc:
         result = _make_stage_result(

--- a/tests/unit/test_pr_stale_remote.py
+++ b/tests/unit/test_pr_stale_remote.py
@@ -1,0 +1,158 @@
+"""#2346: the pr stage must survive a same-name branch left on origin.
+
+`run-issue7-231606` reached the pr stage for the first time in campaign
+history and died on `! [rejected] issue-7 -> issue-7 (non-fast-forward)`.
+`origin/issue-7` was a leftover from an earlier run; the new local branch was
+cut fresh from the arc, so the two had diverged.
+
+#2310/#2324/#2325 taught RESTORE this discipline for the LOCAL branch --
+preserve under graveyard/, never force. The remote never learned it, so
+leftovers outlive every run and collide with the next.
+
+These tests drive real git against a real bare remote, because the defect is
+entirely about what git does with two diverged refs of the same name.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.orchestrator.graph import RESUMED
+from assemblyzero.workflows.orchestrator.stages import (
+    NON_FAST_FORWARD,
+    _reconcile_stale_remote_branch,
+)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True,
+    )
+
+
+@pytest.fixture()
+def remote_and_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """A bare origin plus a clone sitting on `issue-7`."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        capture_output=True, text=True,
+    )
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-b", "main")
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "T")
+    (work / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(work, "add", "seed.txt")
+    _git(work, "commit", "-m", "seed")
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-u", "origin", "main")
+    _git(work, "checkout", "-b", "issue-7")
+    return origin, work
+
+
+def _remote_branches(origin: Path) -> list[str]:
+    out = _git(origin, "branch", "--list", "--format=%(refname:short)").stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def test_no_remote_branch_needs_no_reconcile(remote_and_worktree) -> None:
+    _origin, work = remote_and_worktree
+    assert _reconcile_stale_remote_branch(work, "issue-7") == ""
+
+
+def test_an_ancestor_remote_is_left_alone(remote_and_worktree) -> None:
+    """A fast-forwardable remote is not debris — the ordinary push handles it."""
+    origin, work = remote_and_worktree
+    _git(work, "push", "origin", "issue-7")
+    (work / "more.txt").write_text("more\n", encoding="utf-8")
+    _git(work, "add", "more.txt")
+    _git(work, "commit", "-m", "ahead of origin")
+
+    assert _reconcile_stale_remote_branch(work, "issue-7") == ""
+    assert _remote_branches(origin) == sorted(["issue-7", "main"])
+
+
+def test_a_diverged_remote_is_preserved_and_cleared(remote_and_worktree) -> None:
+    """The live case, and the push must succeed afterwards."""
+    origin, work = remote_and_worktree
+    (work / "old.txt").write_text("earlier run\n", encoding="utf-8")
+    _git(work, "add", "old.txt")
+    _git(work, "commit", "-m", "an earlier run's work")
+    stale_sha = _git(work, "rev-parse", "HEAD").stdout.strip()
+    _git(work, "push", "origin", "issue-7")
+
+    # A fresh branch of the same name, cut from main — diverged.
+    _git(work, "checkout", "main")
+    _git(work, "checkout", "-B", "issue-7", "main")
+    (work / "new.txt").write_text("this run\n", encoding="utf-8")
+    _git(work, "add", "new.txt")
+    _git(work, "commit", "-m", "this run's work")
+
+    # Precondition: without reconciliation the push is rejected.
+    rejected = _git(work, "push", "origin", "issue-7")
+    assert rejected.returncode != 0
+    assert NON_FAST_FORWARD in rejected.stderr.lower()
+
+    note = _reconcile_stale_remote_branch(work, "issue-7")
+
+    assert "preserved as graveyard/issue-7-" in note
+    assert "nothing was force-pushed" in note
+
+    branches = _remote_branches(origin)
+    assert "issue-7" not in branches, "the colliding name must be cleared"
+    parked = [b for b in branches if b.startswith("graveyard/issue-7-")]
+    assert len(parked) == 1
+    assert _git(origin, "rev-parse", parked[0]).stdout.strip() == stale_sha, (
+        "the earlier run's commit must survive"
+    )
+
+    # And the push now works.
+    assert _git(work, "push", "-u", "origin", "issue-7").returncode == 0
+
+
+def test_reconcile_never_force_pushes() -> None:
+    """Asserted against the source, per the banned-commands discipline."""
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+    ).read_text(encoding="utf-8")
+    body = source.split("def _reconcile_stale_remote_branch", 1)[1]
+    body = body.split("\ndef run_pr_stage", 1)[0]
+
+    for banned in ('"--force"', "'--force'", '"-f"', "'-f'",
+                   '"--force-with-lease"'):
+        assert banned not in body, banned
+
+
+def test_an_unreachable_remote_invents_nothing(tmp_path: Path) -> None:
+    """A reconcile that cannot read the remote must not act destructively."""
+    work = tmp_path / "solo"
+    work.mkdir()
+    _git(work, "init", "-b", "main")
+    _git(work, "config", "user.email", "t@example.com")
+    _git(work, "config", "user.name", "T")
+    (work / "a.txt").write_text("a\n", encoding="utf-8")
+    _git(work, "add", "a.txt")
+    _git(work, "commit", "-m", "a")
+
+    assert _reconcile_stale_remote_branch(work, "issue-7") == ""
+
+
+# --------------------------------------------------- honest retry messaging
+
+
+def test_the_retry_message_is_stage_appropriate() -> None:
+    """A pr retry rewrites no generated files; the message used to say it did."""
+    import inspect
+
+    from assemblyzero.workflows.orchestrator import graph
+
+    source = inspect.getsource(graph)
+    assert 'current_stage in ("impl", "lld", "spec")' in source
+    assert 're-running the {current_stage} stage' in source
+    assert RESUMED  # the mode names still drive the wording


### PR DESCRIPTION
Closes #2346

The pr stage ran for the first time in campaign history and died on leftovers:

```
! [rejected]        issue-7 -> issue-7 (non-fast-forward)
```

`origin/issue-7` was a stale branch from an earlier run. The new local branch was cut fresh from the arc, so the two had diverged.

## The remote never learned the discipline

#2310/#2324/#2325 taught RESTORE to dispose of the **local** branch a worktree carried — safe-delete when it holds nothing unique, preserve under `graveyard/` when it does, never force. Origin was never given the same treatment, so a same-name remote outlives every run and collides with the next one's push.

`_reconcile_stale_remote_branch()` runs before the push and decides by **measurement**:

| Remote state | Action |
|---|---|
| absent | nothing |
| an **ancestor** of what we're pushing | nothing — the push fast-forwards |
| **diverged** | preserved as `graveyard/<branch>-<UTC stamp>` on origin, old name cleared |

Preserve-and-rename, **never force-push**. The remote rename is a push of the same commit under a new ref *followed by* the delete, so nothing is unreachable in between. Asserted against the source, so a later edit reaching for `--force` fails in the suite rather than in a post-mortem.

Best-effort throughout: every git failure returns `""` and lets the push proceed to fail on its own terms. A reconcile that cannot read the remote must not invent a destructive action, and the push's own error is a better diagnosis than a guess.

This holds regardless of what #2339 decides about checkpoint pushes — the pr stage still has to push a branch, and will still meet leftovers.

## Two smaller repairs in the same failure

**The rejection was retried three times.** Nothing between attempts could change the remote's divergence. Classified non-transient now — #2298/#2337's rule, pr-stage edition. Reconciliation should prevent it reaching this point; the classification is the guard for when it cannot (a protected ref, a permissions failure, a race).

**The retry message described the wrong stage.** *"rewriting generated files rather than skipping them"* is the implementation stage's regenerate semantics — the exact wording #2337 corrected *for that stage* — and it was printed on a **pr** failure, where nothing is regenerated. Now only `impl`/`lld`/`spec` get that wording; others say what they actually redo.

## Tests

6 tests driving **real git against a real bare remote**, because the defect is entirely about what git does with two diverged refs of the same name. The diverged case asserts the precondition (the push *is* rejected without reconciliation), that the earlier run's commit survives at its exact SHA under the graveyard name, and that the push then succeeds.

## Checks

Full unit suite **7400 passed, 17 skipped, 0 failures**, verified with `CI=true`. ruff: no new findings — 1 pre-existing on the touched files both before and after (#2260); the new test file is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
