### PR TITLE
feat: enforce the ADR 0228 variable-ownership discipline in the form check (Closes #2315)

### DIFF
--- a/assemblyzero/workflows/requirements/form_check.py
+++ b/assemblyzero/workflows/requirements/form_check.py
@@ -46,6 +46,12 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
+from assemblyzero.workflows.requirements.ownership_check import (
+    OwnershipReport,
+    check_ownership,
+    render_ownership,
+)
+
 # ---------------------------------------------------------------------------
 # EARS (ADR 0226 section 3.1)
 # ---------------------------------------------------------------------------
@@ -147,6 +153,7 @@ class FormReport:
     tables: list[TableReport] = field(default_factory=list)
     non_decision_tables: int = 0
     violations: list[Violation] = field(default_factory=list)
+    ownership: OwnershipReport = field(default_factory=OwnershipReport)
 
     @property
     def ok(self) -> bool:
@@ -526,13 +533,24 @@ def _check_rows_by_count_and_outcome(
             )
 
 
+def acceptance_criteria(body: str) -> tuple[list[str], bool]:
+    """(the criteria list items, whether the section exists at all).
+
+    Both the table checks and the ADR 0228 ownership checks read this list, so
+    it is parsed once and handed to each. An absent section is a different fact
+    from an empty one and stays distinguishable.
+    """
+    lines = section_lines(body, CRITERIA_HEADING)
+    if lines is None:
+        return [], False
+    items, _ = list_items(lines)
+    return items, True
+
+
 def check_tables(body: str, report: FormReport) -> None:
     """Completeness, disjointness and row coverage for every decision table."""
-    criteria_lines = section_lines(body, CRITERIA_HEADING)
-    report.criteria_section_found = criteria_lines is not None
-    criteria: list[str] = []
-    if criteria_lines is not None:
-        criteria, _ = list_items(criteria_lines)
+    criteria, found = acceptance_criteria(body)
+    report.criteria_section_found = found
     report.criteria_examined = len(criteria)
 
     all_tables = parse_tables(body)
@@ -598,10 +616,24 @@ def check_tables(body: str, report: FormReport) -> None:
 
 
 def check_form(body: str) -> FormReport:
-    """Run every form check over one issue body."""
+    """Run every form check over one issue body.
+
+    ADR 0226's three rules bind conditions; ADR 0228's five bind outcomes. An
+    issue owes both, and one report carries both so a single revision can
+    address the whole set.
+    """
     report = FormReport()
     check_ears(body, report)
     check_tables(body, report)
+
+    criteria, _ = acceptance_criteria(body)
+    report.ownership = check_ownership(
+        parse_tables(body), criteria, report, Violation, body
+    )
+    if report.ownership.table_found:
+        # The variable table is checked on its own account, so counting it
+        # among the tables nothing looked at would be false.
+        report.non_decision_tables = max(0, report.non_decision_tables - 1)
     return report
 
 
@@ -655,12 +687,21 @@ def render_report(report: FormReport, label: str) -> str:
     else:
         out.append(f"Acceptance criteria: no '## {CRITERIA_HEADING}' section found.")
 
+    out.append("")
+    out += render_ownership(report.ownership, report.violations)
+
     out += ["", "Not verified"]
     out += [
         "  - Whether any requirement, row or criterion states the CORRECT",
         "    behavior. Completeness is a property of form. A table can",
         "    enumerate every combination and be wrong in every row.",
     ]
+    if report.ownership.ran:
+        out += [
+            "  - Whether each variable's owner is the RIGHT owner. One owner per",
+            "    variable is a property of form; a table can name the wrong group",
+            "    in every row.",
+        ]
     if any(not t.exact_join for t in report.tables):
         weak = ", ".join(t.subject for t in report.tables if not t.exact_join)
         out += [

--- a/assemblyzero/workflows/requirements/ownership_check.py
+++ b/assemblyzero/workflows/requirements/ownership_check.py
@@ -1,0 +1,673 @@
+"""Deterministic ownership checker for the ADR 0228 discipline (#2315).
+
+ADR 0226 gave requirements a checkable form for their conditions. ADR 0228 is
+its sibling and does the same for outcomes: one variable, one owner, and only
+the owner asserts. This is the program that enforces it.
+
+Zero model calls, the same trajectory as the ADR 0226 table checks. Variables
+are literal key names, so per-criterion extraction is lexical rather than
+semantic: a criterion asserts ``theme`` when it writes ``theme`` in code ticks.
+
+The five checks
+---------------
+
+1. **Table well-formedness** (clause 1). Each row names a variable, defines its
+   extension by naming at least one literal key, and gives exactly one owner
+   group. No variable is declared twice.
+2. **Undeclared assertion** (clause 1). A criterion that names a key the table
+   does not declare is asserting a variable whose extension nobody wrote down.
+3. **Non-owner assertion** (clause 2). A criterion outside a variable's owner
+   group may cite the owner. It may not name the variable on its own account.
+4. **Boundary terms** (clause 4). A term used to partition variables
+   (``threshold values``, ``a non-threshold key``) owes the table a membership
+   test.
+5. **Unscoped universals** (clause 3). ``never``, ``always``, ``only``,
+   ``byte-identical``, ``nothing else`` and ``no other`` carry their held-fixed
+   conditions in the same claim, or cite the exception that limits them.
+
+Everything is reported in one pass, so one revision addresses the whole set
+(the #2239 pattern). A checker that surfaces one violation per run turns a
+converted issue into a queue of round trips.
+
+The vacuous state
+-----------------
+
+An issue with no variable table gets ``ownership was not checked``, never a
+bare pass. This follows the #2227 ruling on the vacuous EARS state and exists
+for the same reason: silence over an unchecked document reads as assurance,
+and it is not.
+
+None of the five checks runs without a variable table. Clause 3 could in
+principle be checked on any prose, but ADR 0226 section 8 converts an issue
+when it next rolls rather than in a sweep, so nearly every issue in the fleet
+is unconverted. A universal-quantifier check sprayed across all of them would
+fire on the ordinary case, and a gate that fires on the ordinary case is one
+people learn to wave through.
+
+What it cannot do
+-----------------
+
+Report that an owner is the RIGHT owner. A table can assign exactly one owner
+per variable, be well formed in every respect, and name the wrong group in
+every row. Ownership is a property of form. Review adjudicates content, and
+the semantic gate remains the backstop for what these clauses cannot express.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+#: The header signature that identifies a variable table. A decision table
+#: never carries these three, so detection needs no heading convention.
+_VARIABLE_HEADERS = ("variable", "extension", "owner")
+
+#: Universals from ADR 0228 clause 3. The first four are the set #2315 names.
+#: "nothing" and "no other" are added because boostgauge #277, a corpus member,
+#: is exactly "Nothing else touches it" and would otherwise escape.
+_UNIVERSALS: tuple[str, ...] = (
+    "never",
+    "always",
+    "only",
+    "byte-identical",
+    "byte for byte",
+    "nothing",
+    "no other",
+)
+
+#: An exception marker limits a universal wherever it sits in the claim, because
+#: naming the exception is the whole job: "only hand-changed keys, unless the
+#: user reset the config" is scoped by a clause that comes after the "only".
+_EXCEPTION_MARKERS: tuple[str, ...] = (
+    "unless",
+    "except",
+    "other than",
+    "apart from",
+    "aside from",
+    "besides",
+    "subject to",
+    "governed by",
+    "save for",
+    "see ",
+    "per ",
+)
+
+#: A condition marker limits a universal only when it comes BEFORE it. A leading
+#: condition scopes what follows ("WHEN the app exits, only hand-changed keys
+#: are written"). A trailing one conditions something else, which is how
+#: boostgauge #290 escaped review: its "while the app ran" qualifies a direct
+#: file edit, not the "only" three clauses earlier.
+_CONDITION_MARKERS: tuple[str, ...] = (
+    "when",
+    "while",
+    "if ",
+    "where ",
+    "provided",
+    "given that",
+)
+
+#: Words the classifier regex can grab in front of "keys" or "values" that are
+#: not partitioning terms. Without these the check reports "the keys" and
+#: "these values" as undefined partitions, which is noise, and a check that
+#: cries wolf is one people stop reading.
+_CLASSIFIER_STOPWORDS = frozenset(
+    """the a an its it their this that these those any all each both other same
+    such new old every no non and or but with for from into only first last more
+    most own two three four config file session default current given whose
+    which what when where while than then also just even""".split()
+)
+
+#: Classifier shapes. A term standing in front of one of these nouns, or
+#: negated with a ``non-`` prefix, is sorting keys into groups.
+_CLASSIFIED_NOUNS = (
+    "key",
+    "keys",
+    "value",
+    "values",
+    "setting",
+    "settings",
+    "field",
+    "fields",
+    "entry",
+    "entries",
+)
+
+_CODE_SPAN = re.compile(r"`([^`]+)`")
+_LEADING_ID = re.compile(r"^([A-Z][A-Za-z]*)([0-9]+)[.):]?\s+")
+_GROUP_TAG = re.compile(r"^([A-Z][A-Za-z]*)$")
+#: A config key: an identifier, optionally dotted for a nested path. Excludes
+#: command-line flags, which start with a dash and are not config state.
+_KEY_LIKE = re.compile(r"^[a-z_][a-z0-9_]*(\.[a-z_*][a-z0-9_*]*)*$")
+
+_NON_PREFIXED = re.compile(r"\bnon-([a-z][a-z_-]{2,})\b")
+
+
+def _norm(text: str) -> str:
+    """Compare text the way a reader does: no ticks, no case, one space."""
+    stripped = text.replace("`", "").replace("*", "")
+    return re.sub(r"\s+", " ", stripped).strip().casefold()
+
+
+def _singular(term: str) -> str:
+    return term[:-1] if len(term) > 3 and term.endswith("s") else term
+
+
+def _partition_term(term: str) -> str:
+    """The classifying term a modifier carries, or "" when it classifies nothing.
+
+    Two reductions. A ``non-`` prefix negates a partition rather than naming a
+    second one, so ``non-threshold`` and ``threshold`` are one finding and not
+    two. A bare past participle (``the edited value``) points back at something
+    the claim already named, so it partitions nothing; a hyphenated compound
+    (``hand-changed keys``) names a class and does.
+    """
+    term = _singular(term.strip("-"))
+    if term.startswith("non-"):
+        term = term[4:]
+    if not term:
+        return ""
+    if "-" not in term and term.endswith("ed"):
+        return ""
+    return term
+
+
+# ---------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Variable:
+    """One row of the variable table."""
+
+    name: str
+    extension: str
+    owner_prefix: str
+    owner_gloss: str
+    line_no: int
+    owner_source: str = ""
+
+    @property
+    def declared_keys(self) -> set[str]:
+        """Every literal key this row puts under one owner.
+
+        The name itself plus every key named in the extension, so a table
+        saying ``position`` covers ``the x and y keys under position`` owns
+        all three spellings a criterion might use.
+        """
+        keys = {_norm(self.name)}
+        for span in _CODE_SPAN.findall(self.extension):
+            token = _norm(span)
+            if _KEY_LIKE.match(token):
+                keys.add(token)
+        return keys
+
+
+@dataclass
+class OwnershipReport:
+    """What was checked about ownership, and how much of it ran.
+
+    Three states, not two. No table at all is one. A table whose owners are
+    named in prose is a second: it declares ownership honestly and supplies no
+    handle a checker can join a criterion to, so the per-criterion clauses
+    cannot run against it. A table carrying group tags is the third, and only
+    there does the full set run.
+    """
+
+    table_found: bool = False
+    table_line_no: int = 0
+    variables: list[Variable] = field(default_factory=list)
+    criteria_examined: int = 0
+    criteria_with_group: int = 0
+    boundary_terms: list[str] = field(default_factory=list)
+
+    @property
+    def joinable(self) -> bool:
+        """Whether any row names its owner by group tag rather than in prose."""
+        return any(v.owner_prefix for v in self.variables)
+
+    @property
+    def ran(self) -> bool:
+        return self.table_found and self.joinable
+
+
+# ---------------------------------------------------------------------------
+# Parsing the variable table
+# ---------------------------------------------------------------------------
+
+
+def find_variable_table(tables) -> tuple[object | None, dict[str, int]]:
+    """The first table whose header carries Variable, Extension and Owner.
+
+    Returns the table and a map from column name to index, so the columns may
+    appear in any order and extra columns are ignored rather than misread.
+    """
+    for table in tables:
+        headers = [_norm(cell) for cell in table.header]
+        columns = {}
+        for wanted in _VARIABLE_HEADERS:
+            for index, header in enumerate(headers):
+                if header == wanted or header.startswith(wanted + " "):
+                    columns[wanted] = index
+                    break
+        if len(columns) == len(_VARIABLE_HEADERS):
+            return table, columns
+    return None, {}
+
+
+def _split_owner(cell: str) -> tuple[str, str]:
+    """(group prefix, gloss) from an owner cell such as ``E`` (the exit-write criteria).
+
+    The prefix is what makes the join mechanical: ADR 0226 gives every criterion
+    a leading ID, so a group is the criteria sharing a prefix. The gloss is for
+    the reader, and a criterion may cite either.
+    """
+    gloss = ""
+    match = re.search(r"\(([^)]*)\)", cell)
+    if match:
+        gloss = match.group(1).strip()
+        cell = cell[: match.start()] + cell[match.end() :]
+    spans = _CODE_SPAN.findall(cell)
+    candidate = spans[0].strip() if spans else cell.strip()
+    prefix = candidate if _GROUP_TAG.match(candidate) else ""
+    return prefix, gloss
+
+
+def parse_variable_table(table, columns: dict[str, int]) -> list[Variable]:
+    rows = []
+    for offset, row in enumerate(table.rows):
+        if max(columns.values()) >= len(row):
+            rows.append(
+                Variable("", "", "", "", table.line_no + 2 + offset)
+            )
+            continue
+        name = row[columns["variable"]].strip()
+        extension = row[columns["extension"]].strip()
+        owner_cell = row[columns["owner"]].strip()
+        prefix, gloss = _split_owner(owner_cell)
+        rows.append(
+            Variable(
+                name=name,
+                extension=extension,
+                owner_prefix=prefix,
+                owner_gloss=gloss or _norm(owner_cell),
+                line_no=table.line_no + 2 + offset,
+                owner_source=owner_cell,
+            )
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# The checks
+# ---------------------------------------------------------------------------
+
+
+def _named_owner_groups(cell: str) -> int:
+    """How many distinct criteria groups one owner cell names.
+
+    Two signals, both decidable without reading the prose. Criterion IDs give
+    their groups away by prefix, so "P1-P4, S1-S8" names two. A semicolon in an
+    owner cell separates owners; commas do not, because a single group's gloss
+    routinely carries one.
+    """
+    prefixes = {
+        match.group(1)
+        for match in re.finditer(r"\b([A-Z][A-Za-z]*)[0-9]+\b", cell)
+    }
+    by_id = len(prefixes)
+    by_list = cell.count(";") + 1
+    return max(by_id, by_list, 1)
+
+
+def check_table_form(report, own: OwnershipReport, violation_cls) -> None:
+    """Clause 1: named, mechanically extended, exactly one owner, no repeats."""
+    where = f"variable table (line {own.table_line_no})"
+    seen: dict[str, int] = {}
+
+    for variable in own.variables:
+        row_where = f"{where} row {variable.line_no}"
+
+        if not variable.name:
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-table",
+                    where=row_where,
+                    detail="the row names no variable",
+                )
+            )
+            continue
+
+        key = _norm(variable.name)
+
+        if not variable.extension:
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-table",
+                    where=row_where,
+                    detail=(
+                        f"variable {variable.name} has no extension, so which "
+                        f"keys it covers is undefined"
+                    ),
+                )
+            )
+        elif own.joinable and not any(
+            _KEY_LIKE.match(_norm(span))
+            for span in _CODE_SPAN.findall(variable.extension)
+        ) and not _KEY_LIKE.match(key):
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-table",
+                    where=row_where,
+                    detail=(
+                        f"the extension of {variable.name} names no literal key, "
+                        f"so it is not a mechanical definition: "
+                        f"{variable.extension!r}"
+                    ),
+                )
+            )
+
+        owners = _named_owner_groups(variable.owner_source)
+        if owners > 1:
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-table",
+                    where=row_where,
+                    detail=(
+                        f"variable {variable.name} names {owners} owner groups. "
+                        f"ADR 0228 clause 1 permits one, because two owners for "
+                        f"one variable is the defect the discipline removes: "
+                        f"{variable.owner_source!r}"
+                    ),
+                )
+            )
+
+        if key in seen:
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-table",
+                    where=row_where,
+                    detail=(
+                        f"variable {variable.name} is declared twice (also at row "
+                        f"{seen[key]}); ADR 0228 clause 1 permits one owner per "
+                        f"variable"
+                    ),
+                )
+            )
+        else:
+            seen[key] = variable.line_no
+
+
+def _criterion_keys(text: str) -> set[str]:
+    """Every literal config key a criterion names, read from its code spans."""
+    keys = set()
+    for span in _CODE_SPAN.findall(text):
+        token = _norm(span)
+        if _KEY_LIKE.match(token):
+            keys.add(token)
+    return keys
+
+
+def _cites(text: str, variable: Variable) -> bool:
+    """Whether a criterion points at the owner instead of stating a value."""
+    normalized = _norm(text)
+    if variable.owner_gloss and _norm(variable.owner_gloss) in normalized:
+        return True
+    if variable.owner_prefix:
+        return bool(
+            re.search(rf"\b{re.escape(variable.owner_prefix)}[0-9]*\b", text)
+        )
+    return False
+
+
+def check_criteria(report, own: OwnershipReport, criteria, violation_cls) -> None:
+    """Clauses 1 and 2, per criterion: undeclared keys, and non-owner claims."""
+    owner_of: dict[str, Variable] = {}
+    for variable in own.variables:
+        for key in variable.declared_keys:
+            owner_of.setdefault(key, variable)
+
+    for index, text in enumerate(criteria, 1):
+        match = _LEADING_ID.match(text)
+        group = match.group(1) if match else ""
+        label = match.group(0).strip() if match else f"criterion {index}"
+        if group:
+            own.criteria_with_group += 1
+        where = f"acceptance criterion {label}"
+
+        for key in sorted(_criterion_keys(text)):
+            variable = owner_of.get(key)
+
+            if variable is None:
+                report.violations.append(
+                    violation_cls(
+                        kind="ownership-undeclared",
+                        where=where,
+                        detail=(
+                            f"asserts `{key}`, which the variable table does not "
+                            f"declare. Its extension and its owner are undefined"
+                        ),
+                    )
+                )
+                continue
+
+            if not variable.owner_prefix:
+                continue  # already reported as a malformed row
+
+            if group == variable.owner_prefix:
+                continue
+
+            if _cites(text, variable):
+                continue
+
+            owner_name = variable.owner_gloss or variable.owner_prefix
+            in_group = f"in group {group}" if group else "with no group ID"
+            report.violations.append(
+                violation_cls(
+                    kind="ownership-non-owner",
+                    where=where,
+                    detail=(
+                        f"states the fate of `{key}`, which is owned by "
+                        f"{variable.owner_prefix} ({owner_name}). This criterion "
+                        f"is {in_group}. A non-owner may cite the owner and may "
+                        f"not state a value"
+                    ),
+                )
+            )
+
+
+#: A line declaring what a partitioning term covers. boostgauge #7's retrofit
+#: invented this form on its own ("Boundary term: **threshold values** are
+#: exactly the keys under the `thresholds` object"), which is the evidence that
+#: it is the natural place to put a membership test that is not itself a
+#: variable. Terms such as "hand-changed" belong here: they partition the keys
+#: without being one, and #290 turned on nobody having written the test down.
+_BOUNDARY_DECLARATION = re.compile(
+    r"^\s*(?:[-*+]\s+)?\**boundary\s+terms?\**\s*[:.]", re.IGNORECASE
+)
+
+
+def declared_boundary_terms(body: str) -> set[str]:
+    """Terms given a membership test by a Boundary term line."""
+    terms: set[str] = set()
+    for line in body.splitlines():
+        if not _BOUNDARY_DECLARATION.match(line):
+            continue
+        for span in re.findall(r"\*\*([^*]+)\*\*", line) + _CODE_SPAN.findall(line):
+            for word in re.findall(r"[a-z][a-z_-]{2,}", span.casefold()):
+                terms.add(_singular(word))
+    return terms
+
+
+def check_boundary_terms(
+    report, own: OwnershipReport, criteria, violation_cls, extra: set[str] | None = None
+) -> None:
+    """Clause 4: a term that partitions variables owes a membership test."""
+    declared: set[str] = set(extra or ())
+    for variable in own.variables:
+        for key in variable.declared_keys:
+            declared.add(_singular(key))
+            for part in key.split("."):
+                declared.add(_singular(part))
+        for word in re.findall(r"[a-z_]{3,}", _norm(variable.extension)):
+            declared.add(_singular(word))
+
+    nouns = "|".join(_CLASSIFIED_NOUNS)
+    classifier = re.compile(rf"\b([a-z][a-z_-]{{2,}})\s+(?:{nouns})\b")
+
+    found: dict[str, str] = {}
+    for index, text in enumerate(criteria, 1):
+        match = _LEADING_ID.match(text)
+        label = match.group(0).strip() if match else f"criterion {index}"
+        plain = _norm(text)
+        terms = set(_NON_PREFIXED.findall(plain))
+        terms |= set(classifier.findall(plain))
+        for term in terms:
+            term = _partition_term(term)
+            if not term or term in declared or term in _CLASSIFIER_STOPWORDS:
+                continue
+            found.setdefault(term, label)
+
+    for term, label in sorted(found.items()):
+        own.boundary_terms.append(term)
+        report.violations.append(
+            violation_cls(
+                kind="ownership-boundary",
+                where=f"acceptance criterion {label}",
+                detail=(
+                    f"partitions variables by {term!r}, and the variable table "
+                    f"gives it no membership test. Which keys are {term} keys "
+                    f"cannot be decided, so neither can their owner"
+                ),
+            )
+        )
+
+
+def _unscoped_universals(plain: str) -> list[str]:
+    """Universals in this claim that carry no scope, in order of appearance.
+
+    An exception marker anywhere in the claim scopes every universal in it. A
+    condition marker scopes only the universals that come after it.
+    """
+    if any(marker in plain for marker in _EXCEPTION_MARKERS):
+        return []
+
+    conditions = [
+        match.start()
+        for marker in _CONDITION_MARKERS
+        for match in re.finditer(re.escape(marker), plain)
+    ]
+    earliest = min(conditions) if conditions else None
+
+    unscoped = []
+    for word in _UNIVERSALS:
+        for match in re.finditer(rf"\b{re.escape(word)}\b", plain):
+            if earliest is not None and earliest < match.start():
+                continue
+            unscoped.append(word)
+            break
+    return unscoped
+
+
+def check_universals(report, own: OwnershipReport, criteria, violation_cls) -> None:
+    """Clause 3: a blanket carries its scope, or cites its exception."""
+    for index, text in enumerate(criteria, 1):
+        match = _LEADING_ID.match(text)
+        label = match.group(0).strip() if match else f"criterion {index}"
+
+        hits = _unscoped_universals(_norm(text))
+        if not hits:
+            continue
+
+        report.violations.append(
+            violation_cls(
+                kind="ownership-universal",
+                where=f"acceptance criterion {label}",
+                detail=(
+                    f"claims {', '.join(repr(h) for h in hits)} with no scope in "
+                    f"the same claim. A universal carries the conditions it holds "
+                    f"fixed, or cites the exception that limits it"
+                ),
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def check_ownership(tables, criteria, report, violation_cls, body="") -> OwnershipReport:
+    """Run every ADR 0228 check. Absence of a table is disclosed, not passed."""
+    own = OwnershipReport()
+    own.criteria_examined = len(criteria)
+
+    table, columns = find_variable_table(tables)
+    if table is None:
+        return own
+
+    own.table_found = True
+    own.table_line_no = table.line_no
+    own.variables = parse_variable_table(table, columns)
+
+    check_table_form(report, own, violation_cls)
+    check_universals(report, own, criteria, violation_cls)
+
+    if not own.joinable:
+        # The table declares ownership in prose. Clause 2 asks which criteria
+        # are outside a variable's owner group, and prose supplies no answer,
+        # so the per-criterion clauses would report every criterion as a
+        # violation. That is a false alarm about the table's form, not a
+        # finding about its ownership, and a check that floods is one people
+        # stop reading. The state is disclosed instead.
+        return own
+
+    check_criteria(report, own, criteria, violation_cls)
+    check_boundary_terms(
+        report, own, criteria, violation_cls, declared_boundary_terms(body)
+    )
+    return own
+
+
+def render_ownership(own: OwnershipReport, violations) -> list[str]:
+    """The ownership section of the operator-facing report."""
+    out = ["Variable ownership (ADR 0228)"]
+    failures = sum(1 for v in violations if v.kind.startswith("ownership-"))
+
+    if not own.table_found:
+        out += [
+            "  Ownership was not checked: no variable table exists.",
+            f"  0 variables examined out of 0, and 0 of {own.criteria_examined}",
+            "  acceptance criteria were checked for ownership. That is an honest",
+            "  vacuous result, not a pass.",
+        ]
+        return out
+
+    if not own.joinable:
+        out += [
+            f"  {len(own.variables)} variable(s) declared at line "
+            f"{own.table_line_no}, every owner named in prose.",
+            "  Ownership was NOT checked per criterion: no owner cell carries a",
+            "  group tag, so no criterion can be joined to an owner. Clauses 2",
+            f"  and 4 did not run against any of the {own.criteria_examined}",
+            "  acceptance criteria. That is a vacuous result, not a pass.",
+            "  To make it checkable, give each owner cell the ID prefix of its",
+            "  criteria group, as in `E` (the exit-write criteria).",
+            f"  {failures} finding(s) below are the ones this form can support.",
+        ]
+        return out
+
+    out.append(
+        f"  {len(own.variables)} variable(s) declared; "
+        f"{own.criteria_examined} acceptance criteria examined, "
+        f"{own.criteria_with_group} carrying a group ID."
+    )
+    for variable in own.variables:
+        owner = variable.owner_prefix or "(no group tag)"
+        out.append(f"    `{variable.name}` -> {owner}")
+    out.append(f"  {failures} ownership violation(s).")
+    return out

--- a/tests/fixtures/requirements/ownership/bg-290-unscoped-blanket.md
+++ b/tests/fixtures/requirements/ownership/bg-290-unscoped-blanket.md
@@ -1,0 +1,25 @@
+# Config persistence
+
+Reconstructed from boostgauge #290, ruled 2026-08-13. The gate's criterion A is
+kept verbatim; the variable table around it is what ADR 0228 would require.
+
+ADR 0228 clause 3 kills it. "Touches only hand-changed keys" is a blanket whose
+held-fixed condition (that no direct file edit hit the same key) is nowhere in
+the claim. The trailing "while the app ran" conditions the direct file edit,
+not the "only", which is why the sentence read as complete to five reviewers.
+
+## Requirements
+
+- The app shall write the config file on exit.
+
+## Variables
+
+| Variable | Extension | Owner |
+|---|---|---|
+| `position` | the `x` and `y` keys under `position` | `E` (the exit-write criteria) |
+| `size` | the `width` and `height` keys under `size` | `E` (the exit-write criteria) |
+
+## Acceptance Criteria
+
+- [ ] E1. The exit write touches only hand-changed keys: a direct file edit made while the app ran survives an exit that also writes a new `position` or `size`
+- [ ] E2. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins

--- a/tests/fixtures/requirements/ownership/bg-291-undefined-extension.md
+++ b/tests/fixtures/requirements/ownership/bg-291-undefined-extension.md
@@ -1,0 +1,28 @@
+# Config persistence
+
+Reconstructed from boostgauge #291, ruled 2026-08-13. Criterion A came from the
+Reads section and criterion B was acceptance criterion 5.
+
+ADR 0228 clauses 1 and 2 kill it. The original A said the app "re-reads it
+during the session", and no reader could tell whether "it" was the whole file
+or the thresholds section. Here the table declares `thresholds` under the live
+re-read criteria. E1 is an exit-write criterion stating that variable's fate
+anyway, which is clause 2. R2 names `telltale_windows.short`, which no row
+declares, so its extension and its owner are undefined, which is clause 1.
+
+## Requirements
+
+- WHILE the app is running the app shall re-read the config file.
+
+## Variables
+
+| Variable | Extension | Owner |
+|---|---|---|
+| `thresholds` | every key under `thresholds` | `R` (the live re-read criteria) |
+| `theme` | the `theme` key | `E` (the exit-write criteria) |
+
+## Acceptance Criteria
+
+- [ ] R1. The app re-reads `thresholds` during the session, so an edit takes effect without a restart
+- [ ] R2. An edit to `telltale_windows.short` during the session takes effect without a restart
+- [ ] E1. `thresholds` values edited directly in the config file take effect without restart, and reading them does not modify the file

--- a/tests/fixtures/requirements/ownership/bg-292-boundary-term.md
+++ b/tests/fixtures/requirements/ownership/bg-292-boundary-term.md
@@ -1,0 +1,27 @@
+# Config persistence
+
+Reconstructed from boostgauge #292, ruled 2026-08-13. Both criteria are the
+gate's verbatim A and B.
+
+ADR 0228 clause 4 kills it. The criteria partition the config into threshold
+keys and non-threshold keys, and nothing defines the partition. The config also
+carries `telltale_windows`, which is not under `thresholds` and which governs
+how threshold values are evaluated, so the term decides its behaviour and
+cannot classify it. A table row reading "every key under `thresholds`" settles
+the case and is what this fixture is missing.
+
+## Requirements
+
+- WHILE the app is running the app shall apply threshold edits without a restart.
+
+## Variables
+
+| Variable | Extension | Owner |
+|---|---|---|
+| `position` | the `x` and `y` keys under `position` | `E` (the exit-write criteria) |
+| `telltale_windows` | the `short`, `medium` and `long` keys under `telltale_windows` | `R` (the live re-read criteria) |
+
+## Acceptance Criteria
+
+- [ ] R1. Threshold values edited directly in the config file take effect without restart, and reading them does not modify the file
+- [ ] R2. A non-threshold key edited directly in the config file while the app runs leaves the running session unchanged

--- a/tests/fixtures/requirements/ownership/bg-294-annexation.md
+++ b/tests/fixtures/requirements/ownership/bg-294-annexation.md
@@ -1,0 +1,28 @@
+# Config persistence
+
+Reconstructed from boostgauge #294, ruled 2026-08-13. Both criteria are the
+gate's verbatim A and B.
+
+ADR 0228 clause 2 kills it. R2 is a live re-read criterion, and its second
+half promises what the file holds at the next launch. That outcome belongs to
+the exit-write criteria, which own `theme` and `size`, and they say the
+hand-made value wins. The annexation is the defect; the contradiction is only
+its symptom.
+
+## Requirements
+
+- WHEN the app exits the app shall write the config file.
+
+## Variables
+
+| Variable | Extension | Owner |
+|---|---|---|
+| `theme` | the `theme` key | `E` (the exit-write criteria) |
+| `size` | the `width` and `height` keys under `size` | `E` (the exit-write criteria) |
+| `thresholds` | every key under `thresholds` | `R` (the live re-read criteria) |
+
+## Acceptance Criteria
+
+- [ ] R1. An edit to `thresholds` during the session takes effect without a restart
+- [ ] R2. A non-`thresholds` key such as `theme` or `size`, edited directly in the config file while the app runs, leaves the running session unchanged; the edited value takes effect at the next launch
+- [ ] E1. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins

--- a/tests/fixtures/requirements/ownership/boostgauge-7-retrofit.md
+++ b/tests/fixtures/requirements/ownership/boostgauge-7-retrofit.md
@@ -1,0 +1,147 @@
+## Summary
+
+BoostGauge needs a configuration system for thresholds, polling intervals, visual preferences, and window behavior.
+
+## Config file
+
+Location: `~/.boostgauge/config.json` (or `%APPDATA%/boostgauge/config.json` on Windows)
+
+```json
+{
+  "polling_interval_seconds": 2,
+  "theme": "dark",
+  "size": 300,
+  "opacity": 0.9,
+  "always_on_top": true,
+  "position": {"x": 100, "y": 100},
+  "thresholds": {
+    "conpty": {"yellow": 30, "red": 60},
+    "memory_percent": {"yellow": 60, "red": 80},
+    "process_count": {"yellow": 300, "red": 500},
+    "handle_count": {"yellow": 30000, "red": 50000}
+  },
+  "telltale_windows": {
+    "short": 60,
+    "medium": 600,
+    "long": 3600
+  },
+  "show_driver_label": true,
+  "show_digital_readout": true,
+  "show_session_count": true
+}
+```
+
+## CLI arguments
+
+```
+boostgauge [OPTIONS]
+
+Options:
+  --theme THEME          Visual theme (dark, light, neon, classic)
+  --size PIXELS          Gauge diameter in pixels (default: 300)
+  --poll SECONDS         Polling interval (default: 2)
+  --opacity FLOAT        Window opacity 0.0-1.0 (default: 0.9)
+  --no-topmost           Don't keep window on top
+  --config PATH          Path to config file
+  --reset-config         Reset config to defaults
+```
+
+## Config persistence
+
+**Writes.** The app writes to the config file at exactly three moments and at no other time:
+
+1. **First-run auto-create.** Launch finds no config file and creates one with defaults.
+2. **Launch reset.** `--reset-config` rewrites the file to defaults before the app reads it. The flag has no further effect; the rest of the session proceeds as any other.
+3. **Exit write.** The app writes the keys the user changed by hand during the session, and only those keys: `position` if the window was moved, `size` if it was resized. Every other key keeps whatever the file already holds, including edits made directly to the file while the app ran. Position and size are the only keys with a hand-change mechanism, so they are the only keys the exit write can ever touch. A session with no hand-made changes skips the exit write entirely.
+
+**Reads are not restricted.** Launch reads the file after step 2, and the app re-reads it during the session; of the re-read values, only the threshold values — the keys under the `thresholds` object — are applied to the running session, so threshold edits take effect without a restart, while a direct edit to any non-threshold key (any key outside the `thresholds` object, `telltale_windows` included) leaves the running session unchanged; it is never applied mid-session, and the next launch reads the file as the exit-write rules leave it. Reading never modifies the file.
+
+**Direct edits to the file while the app runs are the user's writes, not the app's.** The three moments above are the app's complete write behavior. After launch, the app's only write is the exit write, and the exit write never overwrites a key the user did not change by hand during the session. The launch writes (auto-create, reset) happen before the app reads the file and before any session activity exists. The file's content after quit is therefore the composition of the app's writes and the user's.
+
+**Launch order** is: reset if flagged, then read the file (auto-create if missing), then apply CLI overrides in memory. CLI value overrides (`--theme`, `--size`, `--poll`, `--opacity`, `--no-topmost`) govern the running session; the app never writes them to the file. The window opens at the file's position, since no position flag exists, and at the CLI size when `--size` is given, otherwise the file's size. After a `--reset-config` launch the file holds defaults when it is read, so the window opens at the default position, and at the default size unless `--size` overrides it for the session.
+
+**Persistence of `position` and `size` is independent**, each governed by its own table. Every row follows from the write rules above, and each row is an acceptance criterion below. Both tables hold one further condition fixed: no direct edit to the file during the session. The composition criterion in the acceptance list governs a session with one.
+
+Position, which has no CLI flag and only ever changes by hand:
+
+| ID | `--reset-config`? | Window moved by hand? | `position` in the file after quit (no direct edits) |
+|---|---|---|---|
+| P1 | no | no | unchanged |
+| P2 | no | yes | the new position |
+| P3 | yes | no | default |
+| P4 | yes | yes | the new position |
+
+Size, which has a CLI flag:
+
+| ID | `--reset-config`? | `--size` given? | Window resized by hand? | `size` in the file after quit (no direct edits) |
+|---|---|---|---|---|
+| S1 | no | no | no | unchanged |
+| S2 | no | no | yes | the new size |
+| S3 | no | yes | no | unchanged; the CLI value is not written |
+| S4 | no | yes | yes | the new size |
+| S5 | yes | no | no | default |
+| S6 | yes | no | yes | the new size |
+| S7 | yes | yes | no | default; the CLI value is not written |
+| S8 | yes | yes | yes | the new size |
+
+`--config PATH` selects which config file is in play for the session and writes nothing by itself; the three write moments above apply to the selected file.
+
+## State Variables and Ownership
+
+Per AssemblyZero's variable-ownership discipline (the sibling ADR to ADR 0226): every claim about a variable's fate belongs to that variable's owner; any other mention cites the owner instead of asserting a value.
+
+| Variable | Extension | Owner |
+|---|---|---|
+| File content per key at quit | every key in the config file | The three write moments, the exit-write criteria (including the collision rule for a key both directly edited and hand-changed), and the position/size tables (P1–P4, S1–S8) for their keys; all other content follows by composition |
+| File bytes after an untouched session | the file verbatim | The byte-identical criterion, with its inline scope |
+| Running-session values | the in-memory value of every key | The launch-order criterion and CLI overrides; the threshold hot-reload criterion for keys under `thresholds`; the non-threshold reload criterion for timing only — it states when file content is read, never what the file holds |
+| Window geometry on screen | the window's position and size | The launch-behavior criteria and the hand-change mechanisms (drag, resize) |
+
+Boundary term: **threshold values** are exactly the keys under the `thresholds` object (defined in the Reads paragraph); every other key is non-threshold.
+
+## Acceptance Criteria
+
+- [ ] First run with no config file creates one with defaults
+- [ ] Launch order is reset, then read, then CLI overrides in memory; CLI value overrides govern the session and the app never writes them to the file
+- [ ] With no CLI overrides, the window opens at the file's position and size
+- [ ] Launched with `--reset-config` and no `--size`, the window opens at the default position and default size; launched with `--reset-config --size N`, it opens at the default position and size N while the file holds the default size
+- [ ] Threshold values (the keys under the `thresholds` object) edited directly in the config file take effect without restart, and reading them never modifies the file
+- [ ] The exit write writes exactly the keys the user hand-changed during the session and touches no other key: a direct file edit made while the app ran survives the exit write for every key the user did not also hand-change
+- [ ] With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-made value wins
+- [ ] A session with no hand-made changes performs no exit write; if the session also found an existing config file at launch, was launched without `--reset-config`, and the file was not edited directly, the file is byte-identical after quit
+- [ ] P1 — Position, no reset, not moved, no direct edits: `position` unchanged
+- [ ] P2 — Position, no reset, moved, no direct edits: `position` holds the new position
+- [ ] P3 — Position, reset, not moved, no direct edits: `position` holds the default
+- [ ] P4 — Position, reset, moved, no direct edits: `position` holds the new position
+- [ ] S1 — Size, no reset, no `--size`, not resized, no direct edits: `size` unchanged
+- [ ] S2 — Size, no reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] S3 — Size, no reset, `--size` given, not resized, no direct edits: `size` unchanged; the CLI value is not written
+- [ ] S4 — Size, no reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] S5 — Size, reset, no `--size`, not resized, no direct edits: `size` holds the default
+- [ ] S6 — Size, reset, no `--size`, resized, no direct edits: `size` holds the new size
+- [ ] S7 — Size, reset, `--size` given, not resized, no direct edits: `size` holds the default; the CLI value is not written
+- [ ] S8 — Size, reset, `--size` given, resized, no direct edits: `size` holds the new size
+- [ ] Invalid config values produce clear error messages
+- [ ] A non-threshold key (e.g. `theme` or `telltale_windows.short`) edited directly in the config file while the app runs leaves the running session unchanged; the running session never applies it, and the next launch reads whatever the file holds at that point — content governed by the exit-write criteria above (a direct edit to a key the user also hand-changed is overwritten at quit; every other direct edit survives)
+
+## Revision History
+
+- **2026-08-09 — ruling on #235 (filed by run-issue7-181229's requirements-consistency gate):** The original text held both "CLI args override config" and "Position/size saved on exit" with no rule for a session that exits under an untouched CLI override. Operator ruling: CLI overrides are session-scoped and never persisted. On exit the app writes only hand-made changes (drag/resize) to the config file; a CLI-injected value the user never touched leaves the config file unchanged. Acceptance criteria 2 and 3 rewritten to carry the ruling.
+- **2026-08-10 — ruling on #240 (filed by run-issue7-233727's requirements-consistency gate):** The #235 ruling's blanket sentence ("an override is never written back to the config file") contradicted `--reset-config`, whose entire purpose is to write defaults into the config file. Operator ruling: the session-only rule governs value overrides; `--reset-config` is the one deliberate exception and rewrites the config file to defaults. `--config` selects the file and writes nothing by itself.
+- **2026-08-10 — ruling on #249 (filed by run-issue7-031357's requirements-consistency gate):** "Position always persists on exit" read as an unconditional write, contradicting "persists only changes the user made by hand" for a session in which the window was never moved. Operator ruling: persistence is change-driven — exit writes only hand-made changes, and an untouched session leaves the config file byte-identical, preserving any direct edits made to the file while the app ran. The "always persists" sentence rephrased to its intent: position only ever changes by hand, so a moved window always keeps its new position.
+- **2026-08-10 — ruling on #252 (filed by run-issue7-094316's requirements-consistency gate):** The #249 sentence's byte-identical guarantee, written without its exception, contradicted the #240 carve-out when the app is launched with `--reset-config` and exited untouched. Operator ruling: the reset wins — `--reset-config` is a config-file command and rewrites the file regardless of hand-made changes; the byte-identical guarantee is scoped to sessions launched without a config-file command. Both sentences now carry the exception inline.
+- **2026-08-11 — ruling on #273/#274/#275 (filed by run-issue7-083155's requirements-consistency gate):** Three conflicts from one run, each pitting a persistence sentence against `--reset-config`'s "rewrites the file regardless." Operator ruling: **the reset happens at launch.** `--reset-config` rewrites the file to defaults before the app reads it; the session then behaves normally and exit writes hand-made changes as usual, so a window moved during a reset session keeps its new position, and that session's own window opens at the defaults. The prose paragraph that produced seven conflicts across five rulings was replaced by an ordered rule and a decision table.
+- **2026-08-11 — repair after #277/#278/#279 (filed by run-issue7-140703's requirements-consistency gate):** All three conflicts were in text introduced by the #273/#274/#275 rewrite itself, and none required a new behavioral decision. (1) "Nothing else touches it" accidentally forbade the mid-session reads that hot threshold reload requires; the constraint is now scoped to writes, with reads explicitly unrestricted (#277). (2) The single table bundled position and size into one "moved or resized" condition, so a session launched with `--size` whose window was only moved appeared to write the CLI size to the file; position and size are independent variables with different rules, because size has a CLI flag and position does not, and each now has its own table (#278). The four-condition count that forced the split is AssemblyZero ADR 0226's split rule applied. (3) "Opens at the default position and size" overstated the reset launch by one noun; with `--reset-config --size N` the session runs at the CLI size while the file holds the default (#279). Two latent gaps no run had yet reported were closed in the same pass: the exit write is defined as a per-key patch, so direct file edits survive an exit that writes position or size; and the byte-identical guarantee is stated with its no-reset scope inline, so the #252 collision shape cannot recur. First-run auto-create was also added to the enumerated write moments, which the previous "exactly three things" sentence omitted.
+- **2026-08-11 — repair after #280/#281 (filed by run-issue7-152239's requirements-consistency gate):** Both conflicts paired a table row's final-state claim against #249's standing rule that direct file edits survive. The rows were written as if the app were the file's only writer; the user can edit the file while the app runs, so the file's final content is a composition of the app's writes and the user's, and a row claiming "holds the default" is false when a direct edit lands after the launch reset. No behavior changed and no new ruling was needed: the app's writes were already fully specified, and #249 already governed direct edits. The repair is scope. Every table row now names its held-fixed condition ("no direct edits"), a composition criterion states what a direct edit leaves behind, and the byte-identical guarantee carries the same scope. The underlying rule, from the same body of work ADR 0226 draws on: state post-conditions only over variables the system controls. The config file is shared with the user, so the app's requirement is its write behavior; file content follows by composition.
+- **2026-08-11 — repair after #282/#283 (filed by the standalone pre-check, AssemblyZero #2221, on its first run against this issue):** The first conflicts caught without spending a roll: the pre-check invokes the same gate a roll runs, offline, and it found two overclaimed guarantees in the prose around the tables. (1) "The app never overwrites a key the user did not change by hand" was written as a blanket claim about the app; the launch reset exists to overwrite untouched keys. The claim is now scoped to the exit write, which is what it was always about (#282). (2) The byte-identical guarantee did not exclude a first run, where auto-create writes a file from nothing; it now requires that the session found an existing config file at launch (#283). No behavior changed and no ruling was needed. Both defects are the universal-dressed-as-conditional disease recurring in the prose that remains around the tables.
+- **2026-08-13 — ruling on #290 (filed by the standalone pre-check during the pre-roll verification pass):** Criterion A's survival claim was unqualified — "a direct file edit survives an exit that also writes a new position or size" — while criterion B ruled that the hand-made value wins a same-key collision. An implementer following A would suppress the exit write for any directly-edited key; one following B would let it win. Operator ruling: B's semantics stand — the exit write's read-then-patch design produces them by composition — and A now carries the per-key qualifier: the exit write writes exactly the hand-changed keys, and a direct edit survives for every key not also hand-changed. Repaired in both this issue and LLD-007 criterion 6 (commit `92821f8` on PR #285), because the roll resumes at the spec stage reusing the LLD.
+- **2026-08-13 — ruling on #291 (filed by the standalone pre-check's second verification run):** "The app re-reads it during the session so that threshold edits take effect" left two readings for a mid-session direct edit to a non-threshold key: whole-file hot-reload or threshold-only. Acceptance criterion 5 tests only thresholds, which pass under both readings, so no criterion discriminated. Operator ruling: threshold-only, matching the approved design — LLD-007's tick applies re-read threshold values and nothing else. The prose now scopes the live effect to thresholds (the re-read itself stays unrestricted, per #277), a discriminating criterion pins the non-threshold case, and LLD-007 gains matching criterion 23 and test row 051.
+- **2026-08-13 — ruling on #292 (filed by the standalone pre-check's third verification run):** "Threshold" was never defined, and `telltale_windows` — a separate config object whose durations govern how threshold computations window their samples — was arguably either side of the #291 split: not named `thresholds`, but threshold-adjacent in function. Operator ruling: **threshold values are exactly the keys under the `thresholds` object**; every other key, `telltale_windows` included, is non-threshold and defers to the next launch. Grounds: the term now maps mechanically to the config's own structure, and the approved design already reads this way — LLD-007 types `TelltaleWindows` apart from thresholds, its reload path applies threshold values only, and live-resizing a peak-hold window would force re-deriving the telltale buffers mid-session. The definition landed in the prose and in acceptance criterion 5; criterion 23's exemplars now include `telltale_windows.short`, pinning the discriminating instance.
+- **2026-08-13 — ruling on #294 (filed by the roll's launch gate, the fourth conflict pairing):** The #291 repair's own criterion carried an unconditional promise — a directly edited non-threshold key "takes effect at the next launch" — which is false for `position` and `size`, non-threshold keys WITH hand-change mechanisms, when the same key is also hand-changed in the session: criterion 7's collision rule overwrites the edit at quit. The universal-dressed-as-conditional disease this history already records twice, this time introduced by a repair. Operator ruling: the reload criterion states only WHEN file content is read — never mid-session for non-threshold keys, at the next launch from whatever the file then holds — and never claims WHAT the file will hold; persistence stays owned by criteria 6 and 7. Criterion 23 and the Reads prose both rescoped. The LLD was deliberately not hand-edited this round: a conflict ruling makes the next launch redraw it fresh from this corrected text, so LLD edits would be discarded by the machine's own rule.
+- **2026-08-14 — post-roll retrofit per #284 and #296 (no behavior change):** With the pipeline run complete (PR #298 merged to the arc), the two graduations deferred to protect the certified chain landed together. The decision tables carry row IDs (P1–P4, S1–S8) and each row criterion carries its ID, per ADR 0226's exact mode — the criterion-to-test join becomes an exact ID join. A State Variables and Ownership section declares each variable's extension and owning criteria group per AssemblyZero's variable-ownership discipline (AZ #2314), making the conflict class behind rulings #235 through #294 structurally unwritable rather than serially findable. No requirement's meaning changed; both edits are form.
+
+
+
+
+
+

--- a/tests/fixtures/requirements/ownership/clean-ownership.md
+++ b/tests/fixtures/requirements/ownership/clean-ownership.md
@@ -1,0 +1,31 @@
+# Config persistence
+
+The negative case. Every clause of ADR 0228 holds, so the ownership check must
+report nothing. A checker whose passing result has never been made to fail is
+not a check, and this fixture is the other half of the four kill tests.
+
+It is boostgauge #294's material written under the discipline: the same two
+domains, the same keys, and no conflict, because the reload criteria cite the
+exit-write criteria rather than stating what the file holds.
+
+## Requirements
+
+- WHEN the app exits the app shall write the keys the user hand-changed.
+- WHILE the app is running the app shall apply edits to `thresholds` without a restart.
+
+## Variables
+
+| Variable | Extension | Owner |
+|---|---|---|
+| `theme` | the `theme` key | `E` (the exit-write criteria) |
+| `size` | the `width` and `height` keys under `size` | `E` (the exit-write criteria) |
+| `thresholds` | every key under `thresholds` | `R` (the live re-read criteria) |
+
+Boundary term: a **hand-changed** key is one the user altered through the app's own controls during the session, such as dragging or resizing the window. A direct edit to the config file is not a hand change.
+
+## Acceptance Criteria
+
+- [ ] R1. An edit to `thresholds` during the session takes effect without a restart
+- [ ] R2. An edit to any key other than `thresholds` during the session leaves the running session unchanged; what the file holds afterwards is governed by the exit-write criteria
+- [ ] E1. With a direct file edit during the session, the edited key holds the edited value after quit, unless the user also hand-changed that same key, in which case the hand-changed value wins
+- [ ] E2. `theme` and `size` hold their hand-changed values after quit, except where the session made no hand change, in which case they hold what the file already held

--- a/tests/unit/test_ownership_check.py
+++ b/tests/unit/test_ownership_check.py
@@ -1,0 +1,352 @@
+"""Unit tests for the ADR 0228 variable-ownership checker (#2315).
+
+The kill test from ADR 0228 section 4, executed. Four fixtures reconstruct the
+2026-08-13 conflicts from the gate's own verbatim text, and each must be caught
+by the clause the ADR names for it. A fifth fixture is the same material
+written under the discipline and must report nothing, because a checker whose
+passing result has never been made to fail is not a check.
+
+`boostgauge-7-retrofit.md` is the real-document case: issue #7's body as it
+stood on 2026-08-14, after the retrofit that gave it row IDs and a State
+Variables and Ownership section. It is frozen here rather than fetched, so the
+suite pins what the checker said about a document that exists.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.workflows.requirements import form_check as fc  # noqa: E402
+from assemblyzero.workflows.requirements import ownership_check as oc  # noqa: E402
+
+FIXTURES = ROOT / "tests" / "fixtures" / "requirements" / "ownership"
+
+
+def body(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def kinds(report: fc.FormReport) -> list[str]:
+    return [v.kind for v in report.violations]
+
+
+def ownership_kinds(report: fc.FormReport) -> list[str]:
+    return [k for k in kinds(report) if k.startswith("ownership-")]
+
+
+def details(report: fc.FormReport, kind: str) -> str:
+    """Every finding of one kind, rendered whole so `where` is assertable too."""
+    return " || ".join(str(v) for v in report.violations if v.kind == kind)
+
+
+# ---------------------------------------------------------------------------
+# The kill test (ADR 0228 section 4), one fixture per clause
+# ---------------------------------------------------------------------------
+
+
+class TestKillTest:
+    def test_290_unscoped_blanket_dies_by_clause_3(self):
+        report = fc.check_form(body("bg-290-unscoped-blanket.md"))
+
+        assert "ownership-universal" in ownership_kinds(report)
+        detail = details(report, "ownership-universal")
+        assert "'only'" in detail
+        assert "E1" in detail
+
+    def test_290s_only_is_not_rescued_by_a_later_while(self):
+        """The trailing "while the app ran" qualifies the direct file edit.
+
+        This is how #290 survived review: a condition marker sits in the same
+        sentence as the universal, four clauses after it, conditioning
+        something else entirely. A scope check that searched the whole claim
+        would pass this and the corpus would keep one member.
+        """
+        text = (
+            "E1. The exit write touches only hand-changed keys: a direct file "
+            "edit made while the app ran survives an exit"
+        )
+        assert oc._unscoped_universals(oc._norm(text)) == ["only"]
+
+    def test_291_undefined_extension_dies_by_clauses_1_and_2(self):
+        report = fc.check_form(body("bg-291-undefined-extension.md"))
+        found = ownership_kinds(report)
+
+        assert "ownership-undeclared" in found
+        assert "telltale_windows.short" in details(report, "ownership-undeclared")
+
+        assert "ownership-non-owner" in found
+        assert "`thresholds`" in details(report, "ownership-non-owner")
+
+    def test_292_undefined_boundary_term_dies_by_clause_4(self):
+        report = fc.check_form(body("bg-292-boundary-term.md"))
+
+        assert "ownership-boundary" in ownership_kinds(report)
+        assert "'threshold'" in details(report, "ownership-boundary")
+
+    def test_294_annexation_dies_by_clause_2(self):
+        report = fc.check_form(body("bg-294-annexation.md"))
+
+        assert "ownership-non-owner" in ownership_kinds(report)
+        detail = details(report, "ownership-non-owner")
+        assert "`theme`" in detail
+        assert "`size`" in detail
+        assert "owned by E" in detail
+
+    @pytest.mark.parametrize(
+        "fixture",
+        [
+            "bg-290-unscoped-blanket.md",
+            "bg-291-undefined-extension.md",
+            "bg-292-boundary-term.md",
+            "bg-294-annexation.md",
+        ],
+    )
+    def test_every_corpus_fixture_is_caught(self, fixture):
+        report = fc.check_form(body(fixture))
+        assert ownership_kinds(report), f"{fixture} escaped every clause"
+
+
+# ---------------------------------------------------------------------------
+# The negative half
+# ---------------------------------------------------------------------------
+
+
+class TestCleanDocument:
+    def test_the_discipline_applied_reports_nothing(self):
+        report = fc.check_form(body("clean-ownership.md"))
+        assert ownership_kinds(report) == [], details(report, "ownership-boundary")
+
+    def test_a_citation_is_not_an_assertion(self):
+        """R2 names no owned key's value; it points at the exit-write criteria.
+
+        This is the whole of clause 2. If the citation form were read as an
+        assertion, the discipline would forbid a non-owner from mentioning a
+        variable at all, which no requirement can be written under.
+        """
+        report = fc.check_form(body("clean-ownership.md"))
+        assert "ownership-non-owner" not in ownership_kinds(report)
+
+    def test_removing_the_citation_makes_it_a_violation(self):
+        clean = body("clean-ownership.md")
+        broken = clean.replace(
+            "what the file holds afterwards is governed by the exit-write criteria",
+            "`theme` holds the edited value at the next launch",
+        )
+        assert broken != clean
+
+        report = fc.check_form(broken)
+        assert "ownership-non-owner" in ownership_kinds(report)
+
+    def test_a_declared_boundary_term_is_accepted(self):
+        """"hand-changed" partitions the keys and is not itself a variable.
+
+        boostgauge #290 turned on whether a direct file edit counts as one, so
+        the term needs a membership test. The Boundary term line is where a
+        test that is not a variable row goes.
+        """
+        clean = body("clean-ownership.md")
+        assert "ownership-boundary" not in ownership_kinds(fc.check_form(clean))
+
+        stripped = "\n".join(
+            line for line in clean.splitlines() if not line.startswith("Boundary term")
+        )
+        assert "ownership-boundary" in ownership_kinds(fc.check_form(stripped))
+
+
+# ---------------------------------------------------------------------------
+# The vacuous states -- two of them, and neither is a pass
+# ---------------------------------------------------------------------------
+
+
+class TestVacuousStates:
+    def test_no_variable_table_says_so(self):
+        report = fc.check_form(
+            "## Acceptance Criteria\n\n- [ ] E1. `theme` holds its value\n"
+        )
+
+        assert not report.ownership.table_found
+        assert not report.ownership.ran
+        assert ownership_kinds(report) == []
+
+        text = fc.render_report(report, "x")
+        assert "Ownership was not checked: no variable table exists" in text
+        assert "vacuous result, not a pass" in text
+
+    def test_no_variable_table_never_reads_as_an_ownership_pass(self):
+        """The failure this disclosure exists to prevent (#2227).
+
+        The document below is silent about ownership. A report saying only
+        "PASS" would be read as a clean bill by anyone skimming, and the
+        checker would be asserting something it never looked at.
+        """
+        report = fc.check_form("## Acceptance Criteria\n\n- [ ] one thing\n")
+        text = fc.render_report(report, "x")
+
+        assert "PASS" in text
+        assert "Ownership was not checked" in text
+
+    def test_a_prose_owner_table_is_disclosed_not_flooded(self):
+        """The real-document state, and the reason it is a third state.
+
+        A table whose owners are prose declares ownership honestly and gives a
+        checker nothing to join a criterion to. Running clause 2 against it
+        reports every criterion in the document, which is a finding about the
+        table's form dressed up as twenty-nine findings about its ownership.
+        """
+        report = fc.check_form(body("boostgauge-7-retrofit.md"))
+
+        assert report.ownership.table_found
+        assert not report.ownership.joinable
+        assert not report.ownership.ran
+        assert "ownership-non-owner" not in ownership_kinds(report)
+        assert "ownership-undeclared" not in ownership_kinds(report)
+
+        text = fc.render_report(report, "boostgauge #7")
+        assert "Ownership was NOT checked per criterion" in text
+        assert "vacuous result, not a pass" in text
+
+
+# ---------------------------------------------------------------------------
+# The real document
+# ---------------------------------------------------------------------------
+
+
+class TestRetrofittedBoostgaugeSeven:
+    def test_it_declares_four_variables(self):
+        report = fc.check_form(body("boostgauge-7-retrofit.md"))
+        assert len(report.ownership.variables) == 4
+
+    def test_two_rows_name_more_than_one_owner(self):
+        """Clause 1's one-owner rule, decidable even without group tags.
+
+        A criterion ID gives its group away by prefix, so a cell citing
+        P1-P4 and S1-S8 names two groups whatever its prose says. A semicolon
+        separates owners. Both are facts about the cell, not readings of it.
+        """
+        report = fc.check_form(body("boostgauge-7-retrofit.md"))
+        table_findings = [
+            v for v in report.violations if v.kind == "ownership-table"
+        ]
+
+        assert len(table_findings) == 2
+        detail = " || ".join(v.detail for v in table_findings)
+        assert "File content per key at quit" in detail
+        assert "Running-session values" in detail
+        assert "names 2 owner groups" in detail
+        assert "names 3 owner groups" in detail
+
+    def test_it_carries_three_unscoped_universals(self):
+        report = fc.check_form(body("boostgauge-7-retrofit.md"))
+        universals = [
+            v for v in report.violations if v.kind == "ownership-universal"
+        ]
+        assert len(universals) == 3
+
+    def test_the_whole_report_is_five_findings_not_twenty_nine(self):
+        """The measurement that shaped the third state.
+
+        Before the prose-owner state existed, this document produced 29
+        findings, 24 of them restatements of "your owners are prose". A check
+        that floods is one people stop reading, and this number is the
+        regression guard on that.
+        """
+        report = fc.check_form(body("boostgauge-7-retrofit.md"))
+        assert len(ownership_kinds(report)) == 5
+
+
+# ---------------------------------------------------------------------------
+# One pass, every violation (#2239)
+# ---------------------------------------------------------------------------
+
+
+class TestOnePass:
+    def test_all_five_checks_report_together(self):
+        """One revision addresses the set, so all five must run every time."""
+        text = (
+            "## Variables\n\n"
+            "| Variable | Extension | Owner |\n|---|---|---|\n"
+            "| `theme` | the `theme` key | `E` (the exit-write criteria) |\n"
+            "| `theme` | the `theme` key | `R` (the re-read criteria) |\n"
+            "| `size` |  | `E` (the exit-write criteria) |\n"
+            "\n## Acceptance Criteria\n\n"
+            "- [ ] R1. `theme` always holds the default\n"
+            "- [ ] R2. `opacity` holds the file value\n"
+            "- [ ] R3. A non-visual key is left alone\n"
+        )
+        report = fc.check_form(text)
+        found = set(ownership_kinds(report))
+
+        assert "ownership-table" in found        # duplicate row, empty extension
+        assert "ownership-non-owner" in found    # R1 states `theme`, owned by E
+        assert "ownership-undeclared" in found   # R2 states undeclared `opacity`
+        assert "ownership-boundary" in found     # "non-visual key"
+        assert "ownership-universal" in found    # "always" with no scope
+
+    def test_it_is_deterministic(self):
+        text = body("bg-294-annexation.md")
+        first = [str(v) for v in fc.check_form(text).violations]
+        second = [str(v) for v in fc.check_form(text).violations]
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Scope-marker behaviour, where the false-positive risk lives
+# ---------------------------------------------------------------------------
+
+
+class TestUniversalScoping:
+    @pytest.mark.parametrize(
+        "claim",
+        [
+            "only hand-changed keys are written",
+            "the file is byte-identical after quit",
+            "nothing else touches the config file",
+            "the app never writes CLI values",
+        ],
+    )
+    def test_a_bare_universal_is_flagged(self, claim):
+        assert oc._unscoped_universals(oc._norm(claim))
+
+    @pytest.mark.parametrize(
+        "claim",
+        [
+            "when the app exits, only hand-changed keys are written",
+            "only hand-changed keys are written, unless the user reset the config",
+            "nothing other than the launch read touches the config file",
+            "the file is byte-identical, except where a direct edit occurred",
+            "while the app runs it never writes, governed by the exit-write criteria",
+        ],
+    )
+    def test_a_scoped_universal_is_not(self, claim):
+        assert oc._unscoped_universals(oc._norm(claim)) == []
+
+
+class TestBoundaryTermExtraction:
+    @pytest.mark.parametrize(
+        "phrase,expected",
+        [
+            ("a non-threshold key", "threshold"),
+            ("threshold values", "threshold"),
+            ("hand-changed keys", "hand-changed"),
+            ("the edited value", ""),      # a participle points back, partitions nothing
+            ("these values", ""),          # a stopword, not a term
+        ],
+    )
+    def test_only_real_partitions_survive(self, phrase, expected):
+        table = (
+            "| Variable | Extension | Owner |\n|---|---|---|\n"
+            "| `theme` | the `theme` key | `E` (the exit criteria) |\n"
+        )
+        text = f"## Variables\n\n{table}\n## Acceptance Criteria\n\n- [ ] E1. {phrase}\n"
+        report = fc.check_form(text)
+        terms = report.ownership.boundary_terms
+
+        if expected:
+            assert terms == [expected]
+        else:
+            assert terms == []


### PR DESCRIPTION
Closes #2315

The enforcement half of ADR 0228 (merged as PR #2356). Five deterministic checks in a new `ownership_check` module, called from `form_check` so `tools/check_requirements_form.py` and the launcher preflight both get them. Zero model calls.

| Check | Clause | Kind |
|---|---|---|
| Table well-formedness: named, mechanically extended, one owner, no repeats | 1 | `ownership-table` |
| A criterion asserts a key the table does not declare | 1 | `ownership-undeclared` |
| A criterion outside the owner group states a variable's value | 2 | `ownership-non-owner` |
| A partitioning term has no membership test | 4 | `ownership-boundary` |
| A universal carries no scope in the same claim | 3 | `ownership-universal` |

All five run in one pass (#2239), so one revision addresses the set.

## The kill test, executed

Four fixtures reconstruct the 2026-08-13 conflicts from the gate's verbatim A/B text, and each is caught by the clause ADR 0228 names for it:

| Fixture | Clause | What fires |
|---|---|---|
| boostgauge #290 | 3 | `'only'` with no scope |
| boostgauge #291 | 1 and 2 | undeclared `telltale_windows.short`; a group E criterion stating `thresholds` |
| boostgauge #292 | 4 | `'threshold'` with no membership test |
| boostgauge #294 | 2 | a group R criterion stating `theme` and `size`, owned by E |

`clean-ownership.md` is the same material written under the discipline and reports nothing, so the passing result has been made to fail.

## Two behaviours came from measuring the real document

**The prose-owner state, and 29 findings that were one finding.** The retrofitted boostgauge #7 landed while this was being built, and I ran against it as the real-document case. The first build reported **29 violations**, 24 of them restatements of "your owners are prose, not group tags". Clause 2 asks which criteria fall outside a variable's owner group; prose answers nothing, so every criterion in the issue came back as a violation.

That is a finding about the table's form dressed as findings about its ownership, and it would have blocked #7 at preflight forever. Ownership now has three states rather than two: no table; a table whose owners cannot be joined; a joinable table. Only the third runs the per-criterion clauses, and the first two are disclosed as vacuous per the #2227 ruling, never as a pass.

Against the same document the report is now **five findings**, and the two `ownership-table` ones are real defects clause 1 forbids:

```
row 95: variable File content per key at quit names 2 owner groups
row 97: variable Running-session values names 3 owner groups
```

Those are decidable without group tags: a criterion ID gives its group away by prefix, so a cell citing P1-P4 and S1-S8 names two, and a semicolon separates owners. Surfacing here rather than acting on it, since boostgauge #7 belongs to the orchestration session.

**Scope detection keys on position.** An exception marker (`unless`, `except`, `other than`) scopes a universal anywhere in the claim. A condition marker (`when`, `while`, `if`) scopes only what comes after it. boostgauge #290 is why: its `while the app ran` sits four clauses after the `only` and qualifies a direct file edit, so a whole-claim search passes it and the corpus keeps a member. There is a test pinning exactly that sentence.

## Noise removal, because a check that floods is one people skip

Boundary-term extraction drops bare past participles (`the edited value` points back at something already named) and keeps hyphenated compounds (`hand-changed keys` names a class). `non-X` folds into `X` so one defect is one finding.

A partitioning term that is not itself a variable is declared on a `Boundary term` line, the form boostgauge #7's retrofit invented for this. It is not decoration: `hand-changed` decides outcomes throughout that issue, and #290 turned on nobody having written down whether a direct file edit counts as one.

## Verification

`tests/unit/test_ownership_check.py`, 36 tests. Full unit suite green: **7453 passed, 17 skipped, 5 xfailed**. `ruff check` clean on both changed files.

Acceptance item 3 asked for boostgauge #7 plus its future variable table as the first real-document validation. The retrofit had landed by the time this ran, so the fixture is #7's body as of 2026-08-14, frozen rather than fetched.
