### PR TITLE
fix(spec-stage): an unusable scaffold halts, and requirement coverage stops predicting the gate (Closes #2331, Closes #2333)

### DIFF
--- a/assemblyzero/core/validation/test_plan_validator.py
+++ b/assemblyzero/core/validation/test_plan_validator.py
@@ -561,8 +561,17 @@ def validate_test_plan(
     elapsed_ms = (time.perf_counter() - start) * 1000
 
     # Build summary
+    #
+    # #2333: this line used to read "Coverage: 100.0% (22/22 requirements
+    # mapped)". Every word of it was true, and run-issue7-153937 read it as a
+    # forecast of the 95 percent statement gate two stages later, where the
+    # same spec measured 80 percent. Nothing reconciles the two numbers, so the
+    # label now says which one this is and states plainly that it does not
+    # predict the other.
     summary_parts = [
-        f"Coverage: {cov_pct}% ({mapped_count}/{len(requirements)} requirements mapped)",
+        f"Requirement coverage: {cov_pct}% ({mapped_count}/{len(requirements)} "
+        f"requirements mapped; statement coverage is a separate number and is "
+        f"not measured here)",
         f"Tests: {len(tests)}",
         f"Errors: {error_count}",
         f"Warnings: {sum(1 for v in all_violations if v['severity'] == 'warning')}",

--- a/assemblyzero/workflows/implementation_spec/error_path_coverage.py
+++ b/assemblyzero/workflows/implementation_spec/error_path_coverage.py
@@ -1,0 +1,200 @@
+"""Error paths a spec mandates and never tests (#2333).
+
+The spec stage reports requirement coverage. A spec can be complete by that
+measure, internally consistent, and structurally unable to clear the statement
+coverage gate it is graded against two stages later.
+
+run-issue7-153937 is the exhibit. Its Section 10.1 supplies twenty-three tests,
+all passing, and its own Section 11.1 mandates an error-handling convention no
+test reaches. Measured against the implementation the pipeline produced, with
+the flags N5 uses:
+
+    boostgauge.config    45 statements, 10 missed, 78%
+    boostgauge (both)    95 statements, 19 missed, 80%
+
+The gate is 95 percent. Every missed statement is an error path or a platform
+branch. The spec reported ``Coverage: 100.0% (22/22 requirements)``, which was
+true and said nothing about any of them.
+
+What this checks, and what it cannot
+------------------------------------
+
+Two gaps here are decidable by reading the spec, and both were real in that
+run:
+
+1. **An exception type the spec's own code raises, with no test asserting it.**
+   spec-0007 raises ``FileNotFoundError`` once and ``ValueError`` twice, and
+   writes a single ``pytest.raises(ValueError)``. The unasserted
+   ``FileNotFoundError`` is ``config.py`` line 53 in the coverage report.
+2. **A platform branch with no test that varies the platform.** spec-0007
+   branches on ``os.name`` once and no test mentions it. Those are lines 25
+   through 27 of the same report.
+
+A third gap is real and NOT decidable here. Reaching an ``except`` handler
+needs a test that constructs the failure, and no lexical signal says whether
+one does. Handlers are therefore counted and disclosed, never failed. Guessing
+would produce findings this module cannot defend, and a check that cries wolf
+is one the drafter learns to skip.
+
+Nothing here measures statement coverage. It finds specific error paths that
+provably have no test, which is a lower bound on the gap and enough to stop a
+requirement-complete spec from reaching implementation with an unreachable
+gate.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+    _CODE_FENCE,
+    _TEST_DEF,
+)
+
+#: An exception type raised by the spec's implementation code.
+_RAISE = re.compile(r"\braise\s+([A-Z][A-Za-z0-9_]*)")
+
+#: An exception type a test asserts. Both the pytest form and the unittest one,
+#: because specs in this fleet have used each.
+_ASSERTED = re.compile(
+    r"(?:pytest\.raises|assertRaises)\s*\(\s*([A-Z][A-Za-z0-9_]*)"
+)
+
+#: A branch on the host platform. These are the three spellings the fleet's
+#: specs use; each produces a branch only one platform ever executes.
+_PLATFORM = re.compile(r"\b(os\.name|sys\.platform|platform\.system)\b")
+
+#: A test that varies the platform. `patch("os.name")` is caught by the pattern
+#: above, since the target is a string holding the dotted name. The monkeypatch
+#: form splits the module from the attribute -- `setattr(os, "name", "nt")` --
+#: so the dotted name never appears and it needs its own pattern. Missing it
+#: would report a covered branch as uncovered, which is the false alarm this
+#: module is otherwise built to avoid.
+_PLATFORM_PATCHED = re.compile(
+    r"setattr\(\s*(?:os|sys|platform)\s*,\s*['\"](?:name|platform|system)['\"]"
+)
+
+_EXCEPT = re.compile(r"(?m)^[ \t]*except\b")
+
+#: Raised to signal control flow rather than an error condition, so a test can
+#: exercise the path without asserting the type. StopIteration ends a generator
+#: and SystemExit is argparse's normal exit, which a test asserts by exit code.
+_CONTROL_FLOW = frozenset({"StopIteration", "SystemExit", "GeneratorExit", "KeyboardInterrupt"})
+
+
+@dataclass
+class ErrorPathReport:
+    """Which mandated error paths have a test, and which provably do not."""
+
+    ran: bool = False
+    reason: str = ""
+    raised: dict[str, int] = field(default_factory=dict)
+    asserted: set[str] = field(default_factory=set)
+    untested: list[str] = field(default_factory=list)
+    platform_branches: int = 0
+    platform_tested: bool = False
+    handlers: int = 0
+    test_count: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return not self.untested and not self.platform_gap
+
+    @property
+    def platform_gap(self) -> bool:
+        return self.platform_branches > 0 and not self.platform_tested
+
+
+def split_fences(spec: str) -> tuple[str, str]:
+    """(implementation code, test code) from the spec's fenced blocks.
+
+    A fence holding a ``def test_`` is test code and the rest is
+    implementation. Classification is per fence rather than per function
+    because a spec snippet is frequently not a valid standalone module, which
+    is the same reason `spec_tests` does not parse them.
+    """
+    implementation, tests = [], []
+    for fence in _CODE_FENCE.findall(spec):
+        (tests if _TEST_DEF.search(fence) else implementation).append(fence)
+    return "\n".join(implementation), "\n".join(tests)
+
+
+def error_path_coverage(spec: str) -> ErrorPathReport:
+    """Error paths the spec mandates, against the tests it writes for them."""
+    code, tests = split_fences(spec)
+    if not code.strip():
+        return ErrorPathReport(
+            ran=False,
+            reason="the spec carries no implementation code fence to read",
+        )
+
+    raised: dict[str, int] = {}
+    for name in _RAISE.findall(code):
+        if name not in _CONTROL_FLOW:
+            raised[name] = raised.get(name, 0) + 1
+
+    asserted = set(_ASSERTED.findall(tests))
+    platform_branches = len(_PLATFORM.findall(code))
+
+    return ErrorPathReport(
+        ran=True,
+        raised=raised,
+        asserted=asserted,
+        untested=sorted(name for name in raised if name not in asserted),
+        platform_branches=platform_branches,
+        platform_tested=bool(
+            _PLATFORM.search(tests) or _PLATFORM_PATCHED.search(tests)
+        ),
+        handlers=len(_EXCEPT.findall(code)),
+        test_count=len(_TEST_DEF.findall(tests)),
+    )
+
+
+def format_report(report: ErrorPathReport) -> str:
+    """The failure text the drafter reads. Every gap named in one pass.
+
+    The disclosure at the end is the point of the check as much as the
+    failures are. Requirement coverage and statement coverage are different
+    numbers, and the spec stage reported only the first as though it settled
+    the second.
+    """
+    if not report.ran:
+        return f"Error-path coverage not applicable: {report.reason}."
+
+    lines: list[str] = []
+
+    if report.untested:
+        lines.append(
+            f"{len(report.untested)} exception type(s) the spec raises have no "
+            f"test asserting them. Section 10 owes each a test:"
+        )
+        for name in report.untested:
+            times = report.raised[name]
+            occurrence = "once" if times == 1 else f"{times} times"
+            lines.append(
+                f"  - {name}: raised {occurrence} by the spec's own code, and no "
+                f"test uses pytest.raises({name})"
+            )
+
+    if report.platform_gap:
+        lines.append(
+            f"{report.platform_branches} platform branch(es) in the spec's code, "
+            f"and no test varies the platform. One side of each branch cannot "
+            f"execute on the machine the gate runs on."
+        )
+
+    if not lines:
+        covered = len(report.raised)
+        lines.append(
+            f"Every error path the spec mandates has a test: {covered} exception "
+            f"type(s) raised, {covered} asserted, across {report.test_count} test(s)."
+        )
+
+    lines.append(
+        f"Not measured here: statement coverage. This spec's code carries "
+        f"{report.handlers} except handler(s), and whether a test reaches one "
+        f"cannot be read from the text. Requirement coverage is a different "
+        f"number from statement coverage and does not predict it."
+    )
+    return "\n".join(lines)

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -37,6 +37,10 @@ from assemblyzero.workflows.implementation_spec.criteria_coverage import (
     criteria_coverage,
     format_report as format_coverage_report,
 )
+from assemblyzero.workflows.implementation_spec.error_path_coverage import (
+    error_path_coverage,
+    format_report as format_error_path_report,
+)
 from assemblyzero.workflows.telemetry import (
     build_hallucination_event,
     record_hallucination_event,
@@ -178,6 +182,11 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     check_criteria = check_criteria_have_tests(spec_draft, state.get("lld_content", ""))
     checks.append(check_criteria)
     _log_check(check_criteria)
+
+    # Check 10: Error paths the spec mandates must have tests (Issue #2333)
+    check_error_paths = check_error_paths_have_tests(spec_draft)
+    checks.append(check_error_paths)
+    _log_check(check_error_paths)
 
     # Telemetry (#1812): record detector outcomes for the spec draft (every
     # pass) and the LLD (first pass only). Record-only — the try/except
@@ -1061,6 +1070,27 @@ def check_criteria_have_tests(spec: str, lld_content: str) -> CompletenessCheck:
         check_name="criteria_have_tests",
         passed=report.ok,
         details=format_coverage_report(report),
+    )
+
+
+def check_error_paths_have_tests(spec: str) -> CompletenessCheck:
+    """Error paths the spec mandates must have tests (Issue #2333).
+
+    A spec can pass every check above, report full requirement coverage, and
+    still be unable to clear the 95 percent statement gate it is graded
+    against two stages later. run-issue7-153937 did exactly that: twenty-three
+    tests, all green, 80 percent statements, and every missed statement an
+    error path or a platform branch its Section 11.1 conventions had mandated.
+
+    The failure surfaced at N5, in a loop that can add tests but cannot add
+    the requirement that justifies them. Here it surfaces at iteration zero,
+    where the drafter is still writing Section 10.
+    """
+    report = error_path_coverage(spec)
+    return CompletenessCheck(
+        check_name="error_paths_have_tests",
+        passed=report.ok,
+        details=format_error_path_report(report),
     )
 
 

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -239,16 +239,27 @@ def route_after_scaffold(
 
 def route_after_validate(
     state: TestingWorkflowState,
-) -> Literal["N3_verify_red", "N2_scaffold_tests", "N4_implement_code", "end"]:
+) -> Literal["N3_verify_red", "N2_scaffold_tests", "end"]:
     """Route after N2.5 (validate_tests_mechanical).
 
     Issue #335: Routes based on test validation results.
 
     Routes to:
     - N3_verify_red: Validation passed, continue normal flow
-    - N2_scaffold_tests: Validation failed, attempts < 3, retry
-    - N4_implement_code: Validation failed, attempts >= 3, escalate to Claude
-    - END: Error
+    - N2_scaffold_tests: Validation failed, attempts remain, retry
+    - END: Validation failed and regeneration is exhausted, or an error
+
+    #2331: this used to route an exhausted scaffold to N4_implement_code, and
+    the comment there said "escalate to Claude". It escalated to nothing. A
+    suite the validator had just judged unusable entered implementation
+    HAVING SKIPPED verify_red, so it arrived with one fewer check than a suite
+    that passed, and the implementation loop then spent its budget against
+    tests no code could satisfy.
+
+    The name promised a stronger test generator and the graph has none, so the
+    honest route is to stop. The node writes a DETERMINISTIC FAILURE naming
+    the tests as the wrong side, which is also what keeps the orchestrator
+    from retrying a deterministic scaffolder.
 
     Args:
         state: Current workflow state.
@@ -267,10 +278,6 @@ def route_after_validate(
         return "N3_verify_red"
     elif decision == "regenerate":
         return "N2_scaffold_tests"
-    elif decision == "escalate":
-        # Escalate to Claude - skip verify_red and go to implement
-        print("    [ESCALATE] Skipping verify_red, escalating to Claude implementation")
-        return "N4_implement_code"
 
     return "end"
 

--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -21,6 +21,17 @@ from assemblyzero.workflows.testing.runner_registry import get_runner
 
 logger = logging.getLogger(__name__)
 
+#: How many times the scaffolder may fail validation before the run stops
+#: trying to generate its way out.
+MAX_SCAFFOLD_ATTEMPTS = 3
+
+#: #2337 defined this token, and #2331 moved it here. The orchestrator's
+#: transience classifier keys off it, so a halt carrying it is not retried.
+#: It lives in this module because `verify_phases` already imports from here
+#: and the reverse import would be a cycle; `verify_phases` re-exports it, so
+#: every existing import keeps working.
+DETERMINISTIC_FAILURE = "DETERMINISTIC FAILURE"
+
 
 # =============================================================================
 # Stub Pattern Detection
@@ -328,15 +339,24 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
     # passes. A wholly hollow suite is always NAMED, and is rejected only when
     # rejecting can actually help.
     #
-    # That condition is deliberate. `should_regenerate` escalates a
-    # deterministic scaffolder on its hash check, and "escalate" routes to
-    # N4_implement_code (graph.py) -- so for a spec that supplies no test
-    # bodies, failing here reaches implementation anyway, just with the red
-    # phase skipped as well. Rejecting is worth it precisely when regeneration
-    # can produce something better, which since #2316 means: the spec ships
-    # executable Section 10 test functions and the scaffold ignored them.
-    # Where it cannot help, the suite is reported loudly instead of being
-    # bounced around a loop that ends in the same place.
+    # #2331 reconsidered this condition, as that issue's acceptance asked, and
+    # kept it. The routing reason IS gone: "escalate" now halts instead of
+    # entering implementation with the red phase skipped, so rejecting would
+    # change the destination and not merely the path.
+    #
+    # The condition survives on its other reason, which #2331 does not touch.
+    # A scaffold of nothing but `assert False, "TDD RED: ..."` is what the TDD
+    # scaffolder is SUPPOSED to emit before any implementation exists, and
+    # #386 closed the reject -> scaffold -> reject loop that rejecting it
+    # created. That case is wholly hollow by count, so a blanket "hollow is
+    # invalid" rule reopens #386 exactly. Two tests pin it, and they are
+    # right to.
+    #
+    # So the split stands on what regeneration can achieve. The spec ships
+    # executable Section 10 functions and the scaffold ignored them: fixable,
+    # reject and say so. The spec ships none: this is the best the scaffolder
+    # can do, name it loudly and let the red phase judge it, which it now
+    # does, because nothing skips that phase any more.
     total_tests, stub_count, stub_names = count_stub_tests(generated_tests)
     hollow = total_tests > 0 and stub_count == total_tests
     spec_has_bodies = bool(
@@ -360,8 +380,9 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
             print(f"    [HOLLOW SCAFFOLD] {description}")
             print(
                 "    The spec supplies no executable test bodies, so "
-                "re-scaffolding cannot improve on this. Proceeding, but the "
-                "implementation loop cannot converge against these tests."
+                "re-scaffolding cannot improve on this. Proceeding to the red "
+                "phase, which is no longer skipped (#2331), so this suite gets "
+                "the same checks as any other."
             )
 
     # Step 2: Validate structure with AST (imports, test functions exist)
@@ -418,6 +439,14 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
         result_dict["scaffold_validation_errors"] = all_errors
     else:
         result_dict["scaffold_validation_errors"] = []  # Clear on success
+
+    # #2331: name the halt BEFORE the hash is overwritten. `exhausted_reason`
+    # compares this attempt against the previous one, and the line below
+    # replaces the previous with this one.
+    if not is_valid:
+        _halt_if_exhausted(
+            state, result_dict, generated_tests, new_attempts, all_errors
+        )
 
     # Issue #502: Store hash for stagnation detection
     if generated_tests:
@@ -483,7 +512,7 @@ def _validate_non_pytest(
 
     new_attempts = scaffold_attempts + 1 if not is_valid else scaffold_attempts
 
-    return {
+    result: dict[str, Any] = {
         "validation_result": {
             "is_valid": is_valid,
             "errors": all_errors,
@@ -494,6 +523,12 @@ def _validate_non_pytest(
         "scaffold_attempts": new_attempts,
         "scaffold_validation_errors": all_errors if not is_valid else [],  # Issue #500
     }
+    # #2331: the non-pytest path escalates through the same routing, so it
+    # owes the same named halt. Leaving it out would make the defect a
+    # property of the framework the run happens to use.
+    if not is_valid:
+        _halt_if_exhausted(state, result, generated_tests, new_attempts, all_errors)
+    return result
 
 
 # =============================================================================
@@ -501,17 +536,81 @@ def _validate_non_pytest(
 # =============================================================================
 
 
+def exhausted_reason(
+    state: dict[str, Any], generated_tests: str, attempts: int
+) -> str:
+    """Why mechanical generation is out of moves, or "" while it is not.
+
+    #2331 gave this its own function because two callers need the same answer.
+    `should_regenerate` decides the route from it, and the validation node
+    writes the halt message from it. When the two computed it separately they
+    could disagree, and a route that ends a run whose state says nothing went
+    wrong is the silent degradation this issue is about.
+    """
+    if generated_tests:
+        current = hashlib.sha256(generated_tests.encode()).hexdigest()
+        previous = state.get("previous_scaffold_hash", "")
+        if previous and current == previous:
+            return (
+                "the scaffolder reproduced its previous output byte for byte, "
+                "so regenerating again produces the same suite"
+            )
+
+    if attempts >= MAX_SCAFFOLD_ATTEMPTS:
+        return (
+            f"the scaffold failed validation {attempts} times, which is the "
+            f"limit of {MAX_SCAFFOLD_ATTEMPTS}"
+        )
+
+    return ""
+
+
+def _halt_if_exhausted(
+    state: dict[str, Any],
+    result: dict[str, Any],
+    generated_tests: str,
+    attempts: int,
+    errors: list[str],
+) -> None:
+    """Name the halt in state when regeneration cannot help, per #2331.
+
+    Before this, an unusable suite routed to N4_implement_code and skipped the
+    red phase on the way, so a suite the validator had just called unusable
+    reached implementation with one fewer check than a suite that passed. The
+    run then burned its implementation budget against tests no code could
+    satisfy. Now it stops, and says which side is wrong.
+    """
+    reason = exhausted_reason(state, generated_tests, attempts)
+    if not reason:
+        return
+
+    shown = "; ".join(errors[:3]) if errors else "no specific error was recorded"
+    result["error_message"] = (
+        f"{DETERMINISTIC_FAILURE}: the generated test suite cannot be "
+        f"validated and {reason}. The tests are the wrong side here, not the "
+        f"implementation: {shown}. Repair the spec's Section 10 test "
+        f"functions, then resume."
+    )
+    result["next_node"] = "end"
+    print(f"    [HALT] {result['error_message']}")
+
+
 def should_regenerate(state: dict[str, Any]) -> Literal["regenerate", "continue", "escalate"]:
     """Conditional edge: return routing decision based on validation.
 
     Issue #335: Routes the workflow based on validation results:
-    - "regenerate": Validation failed, attempts < 3, retry scaffold
+    - "regenerate": Validation failed, attempts remain, retry scaffold
     - "continue": Validation passed, proceed to verify_red
-    - "escalate": Validation failed, attempts >= 3, use Claude
+    - "escalate": Validation failed and regeneration is exhausted
 
     Issue #502: Hash-based stagnation detection. If scaffold output is
     identical to the previous attempt, escalate immediately instead of
     wasting another generation cycle.
+
+    #2331: "escalate" no longer means "hand this to Claude". It means
+    mechanical generation is out of moves, and the run halts. The condition
+    lives in `exhausted_reason` so this function and the node that writes the
+    halt message cannot disagree about when it holds.
 
     Args:
         state: Workflow state with validation_result and scaffold_attempts.
@@ -521,24 +620,19 @@ def should_regenerate(state: dict[str, Any]) -> Literal["regenerate", "continue"
     """
     validation_result = state.get("validation_result", {})
     is_valid = validation_result.get("is_valid", False)
-    scaffold_attempts = state.get("scaffold_attempts", 0)
 
     if is_valid:
         return "continue"
 
-    # Issue #502: Hash-based stagnation detection
-    generated_tests = state.get("generated_tests", "")
-    if generated_tests:
-        current_hash = hashlib.sha256(generated_tests.encode()).hexdigest()
-        previous_hash = state.get("previous_scaffold_hash", "")
-        if previous_hash and current_hash == previous_hash:
-            print("    [STAGNANT] Scaffold produced identical output. Escalating immediately.")
-            return "escalate"
-
-    # Max 3 attempts before escalation
-    if scaffold_attempts >= 3:
-        print(f"    [ESCALATE] Max attempts ({scaffold_attempts}) reached, escalating to Claude")
+    reason = exhausted_reason(
+        state,
+        state.get("generated_tests", ""),
+        state.get("scaffold_attempts", 0),
+    )
+    if reason:
+        print(f"    [EXHAUSTED] {reason}")
         return "escalate"
 
-    print(f"    [REGENERATE] Attempt {scaffold_attempts}/3, returning to scaffold")
+    attempts = state.get("scaffold_attempts", 0)
+    print(f"    [REGENERATE] Attempt {attempts}/{MAX_SCAFFOLD_ATTEMPTS}, returning to scaffold")
     return "regenerate"

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -35,6 +35,7 @@ from assemblyzero.workflows.testing.exit_code_router import (
 )
 from assemblyzero.workflows.testing.framework_detector import CoverageType, TestFramework
 from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    DETERMINISTIC_FAILURE,
     count_stub_tests,
 )
 from assemblyzero.workflows.testing.runner_registry import get_runner
@@ -80,7 +81,12 @@ MAX_TRACEBACK_BLOCKS = 8
 #: times in twelve seconds. The orchestrator's transience classifier keys off
 #: this token, so retry behaviour follows from the failure's kind rather than
 #: from prose a later reword could silently change.
-DETERMINISTIC_FAILURE = "DETERMINISTIC FAILURE"
+#:
+#: #2331 moved the definition down to validate_tests_mechanical, which now
+#: writes a halt of the same kind and cannot import from here without a cycle.
+#: It is imported at the top of this module and named here so every existing
+#: import of it from verify_phases keeps working.
+_ = DETERMINISTIC_FAILURE
 
 # Issue #562: Critical skip keywords (aligned with tools/test-gate.py)
 _CRITICAL_SKIP_KEYWORDS = ["security", "auth", "payment", "critical"]

--- a/tests/unit/test_spec_stage_pair.py
+++ b/tests/unit/test_spec_stage_pair.py
@@ -1,0 +1,332 @@
+"""The spec-stage pair: escalation routing (#2331) and error paths (#2333).
+
+Two defects with one shape. A spec that cannot produce a usable suite was
+degrading quietly instead of stopping, and a spec that could not clear the
+coverage gate was reporting a number that read as though it would.
+
+`tests/fixtures/issue7_run153937/spec-0007.md` is the real artifact behind
+both. Its twenty-three tests all pass, its requirement coverage was reported
+as 100 percent, and it measured 80 percent statements against the
+implementation the pipeline produced from it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+from assemblyzero.workflows.implementation_spec.error_path_coverage import (  # noqa: E402
+    error_path_coverage,
+    format_report,
+    split_fences,
+)
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (  # noqa: E402
+    check_error_paths_have_tests,
+)
+from assemblyzero.workflows.testing.graph import route_after_validate  # noqa: E402
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (  # noqa: E402
+    DETERMINISTIC_FAILURE,
+    MAX_SCAFFOLD_ATTEMPTS,
+    exhausted_reason,
+    should_regenerate,
+    validate_tests_mechanical_node,
+)
+
+SPEC_0007 = ROOT / "tests" / "fixtures" / "issue7_run153937" / "spec-0007.md"
+
+HOLLOW = '''
+import pytest
+
+def test_a():
+    assert False, "TDD RED: not implemented"
+
+def test_b():
+    assert False, "TDD RED: not implemented"
+'''
+
+SPEC_WITH_BODIES = {
+    "imports": "",
+    "functions": [{"name": "test_a", "source": "def test_a():\n    assert 1"}],
+}
+
+
+@pytest.fixture(scope="module")
+def spec_0007() -> str:
+    return SPEC_0007.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #2331: escalation is a named halt, not a quieter route to implementation
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationHalts:
+    def test_an_exhausted_scaffold_no_longer_reaches_implementation(self):
+        """The defect itself. This used to return N4_implement_code."""
+        state = {
+            "validation_result": {"is_valid": False},
+            "scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS,
+            "generated_tests": HOLLOW,
+        }
+        assert should_regenerate(state) == "escalate"
+        assert route_after_validate(state) == "end"
+
+    def test_a_valid_suite_still_goes_to_the_red_phase(self):
+        state = {"validation_result": {"is_valid": True}, "scaffold_attempts": 0}
+        assert route_after_validate(state) == "N3_verify_red"
+
+    def test_attempts_remaining_still_regenerate(self):
+        state = {
+            "validation_result": {"is_valid": False},
+            "scaffold_attempts": 1,
+            "generated_tests": HOLLOW,
+        }
+        assert should_regenerate(state) == "regenerate"
+        assert route_after_validate(state) == "N2_scaffold_tests"
+
+    def test_the_halt_is_named_and_marked_deterministic(self):
+        """An unnamed halt is the silent degradation wearing a different hat.
+
+        The token is what keeps the orchestrator from retrying it. A
+        deterministic scaffolder reproducing its own output will reproduce it
+        again, and #2337 paid three attempts in twelve seconds to learn that.
+        """
+        state = {
+            "generated_tests": HOLLOW,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS,
+            "spec_test_suite": SPEC_WITH_BODIES,
+        }
+        result = validate_tests_mechanical_node(state)
+
+        assert DETERMINISTIC_FAILURE in result["error_message"]
+        assert "wrong side" in result["error_message"]
+        assert result["next_node"] == "end"
+
+    def test_a_stagnant_scaffold_halts_before_the_attempt_limit(self):
+        import hashlib
+
+        previous = hashlib.sha256(HOLLOW.encode()).hexdigest()
+        state = {
+            "generated_tests": HOLLOW,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 0,
+            "previous_scaffold_hash": previous,
+            "spec_test_suite": SPEC_WITH_BODIES,
+        }
+        result = validate_tests_mechanical_node(state)
+
+        assert DETERMINISTIC_FAILURE in result["error_message"]
+        assert "byte for byte" in result["error_message"]
+
+    def test_a_valid_suite_is_never_halted(self):
+        real = "import pytest\n\ndef test_a():\n    assert 1 == 1\n"
+        state = {
+            "generated_tests": real,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS,
+        }
+        result = validate_tests_mechanical_node(state)
+        assert "error_message" not in result
+
+    def test_one_condition_serves_both_callers(self):
+        """The route and the halt message must never disagree.
+
+        They are computed from `exhausted_reason` for that reason: a route
+        that ends a run whose state records no failure is exactly the silent
+        degradation #2331 is about.
+        """
+        state = {"scaffold_attempts": MAX_SCAFFOLD_ATTEMPTS}
+        assert exhausted_reason(state, HOLLOW, MAX_SCAFFOLD_ATTEMPTS)
+        assert exhausted_reason(state, HOLLOW, 0) == ""
+
+    def test_the_hash_is_compared_before_it_is_overwritten(self):
+        """Order matters: the node stores this attempt's hash on the way out.
+
+        Naming the halt after that store would compare the attempt against
+        itself, which always matches, and every failed first attempt would
+        halt as stagnant.
+        """
+        state = {
+            "generated_tests": HOLLOW,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 0,
+            "spec_test_suite": SPEC_WITH_BODIES,
+        }
+        result = validate_tests_mechanical_node(state)
+
+        assert "error_message" not in result
+        assert result["previous_scaffold_hash"]
+
+
+class TestThreeEightySixSurvives:
+    """The reason #2317's gating was reconsidered and kept.
+
+    A scaffold of nothing but `assert False, "TDD RED: ..."` is what the
+    scaffolder is supposed to emit before any implementation exists. #386
+    closed the reject-and-regenerate loop that rejecting it created, and a
+    blanket "hollow is invalid" rule reopens that loop exactly.
+    """
+
+    def test_a_hollow_suite_with_no_spec_bodies_stays_valid(self):
+        state = {
+            "generated_tests": HOLLOW,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 0,
+        }
+        result = validate_tests_mechanical_node(state)
+        assert result["validation_result"]["is_valid"] is True
+
+    def test_a_hollow_suite_the_spec_could_fix_is_rejected(self):
+        state = {
+            "generated_tests": HOLLOW,
+            "parsed_scenarios": {"scenarios": []},
+            "scaffold_attempts": 0,
+            "spec_test_suite": SPEC_WITH_BODIES,
+        }
+        result = validate_tests_mechanical_node(state)
+        assert result["validation_result"]["is_valid"] is False
+
+
+# ---------------------------------------------------------------------------
+# #2333: error paths the spec mandates and never tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPathCoverageOnTheRealSpec:
+    def test_the_spec_that_could_not_clear_the_gate_is_caught(self, spec_0007):
+        """Acceptance: the gap is identified at the spec stage, not two later."""
+        report = error_path_coverage(spec_0007)
+        assert report.ran
+        assert not report.ok
+
+    def test_the_unasserted_exception_is_the_one_coverage_missed(self, spec_0007):
+        """`FileNotFoundError` is config.py line 53 in the run's own report."""
+        report = error_path_coverage(spec_0007)
+
+        assert report.raised == {"FileNotFoundError": 1, "ValueError": 2}
+        assert report.asserted == {"ValueError"}
+        assert report.untested == ["FileNotFoundError"]
+
+    def test_the_platform_branch_is_the_other_one(self, spec_0007):
+        """One `os.name` branch, no test varying it: config.py lines 25-27."""
+        report = error_path_coverage(spec_0007)
+
+        assert report.platform_branches == 1
+        assert report.platform_tested is False
+        assert report.platform_gap is True
+
+    def test_handlers_are_disclosed_and_never_failed(self, spec_0007):
+        """Whether a test reaches an except cannot be read from the text.
+
+        Reporting them as violations would produce findings this module
+        cannot defend, so they are counted and named as not measured.
+        """
+        report = error_path_coverage(spec_0007)
+        assert report.handlers == 5
+
+        text = format_report(report)
+        assert "Not measured here: statement coverage" in text
+        assert "5 except handler(s)" in text
+
+    def test_it_names_every_gap_in_one_pass(self, spec_0007):
+        text = format_report(error_path_coverage(spec_0007))
+        assert "FileNotFoundError" in text
+        assert "platform branch" in text
+
+    def test_the_node_check_fails_on_it(self, spec_0007):
+        check = check_error_paths_have_tests(spec_0007)
+        assert check["check_name"] == "error_paths_have_tests"
+        assert check["passed"] is False
+        assert "FileNotFoundError" in check["details"]
+
+
+class TestErrorPathCoverageNegatives:
+    def test_a_spec_that_tests_its_error_paths_passes(self):
+        spec = (
+            "## 5. Functions\n\n```python\n"
+            "def load(path):\n"
+            "    if not path.exists():\n"
+            "        raise FileNotFoundError(path)\n"
+            "    return 1\n"
+            "```\n\n"
+            "## 10.1 Tests\n\n```python\n"
+            "def test_missing_file():\n"
+            "    with pytest.raises(FileNotFoundError):\n"
+            "        load(missing)\n"
+            "```\n"
+        )
+        report = error_path_coverage(spec)
+
+        assert report.ok
+        assert report.untested == []
+        assert "Every error path the spec mandates has a test" in format_report(report)
+
+    def test_the_unittest_form_counts_too(self):
+        spec = (
+            "```python\ndef f():\n    raise ValueError('x')\n```\n"
+            "```python\ndef test_f():\n    self.assertRaises(ValueError, f)\n```\n"
+        )
+        assert error_path_coverage(spec).untested == []
+
+    def test_control_flow_raises_are_not_error_paths(self):
+        """SystemExit is argparse's normal exit, asserted by code not by type."""
+        spec = (
+            "```python\ndef main():\n    raise SystemExit(0)\n```\n"
+            "```python\ndef test_main():\n    assert True\n```\n"
+        )
+        report = error_path_coverage(spec)
+        assert report.raised == {}
+        assert report.ok
+
+    def test_a_platform_branch_with_a_test_that_varies_it_passes(self):
+        spec = (
+            "```python\ndef p():\n    if os.name == 'nt':\n        return 1\n```\n"
+            "```python\ndef test_p(monkeypatch):\n"
+            "    monkeypatch.setattr(os, 'name', 'nt')\n```\n"
+        )
+        report = error_path_coverage(spec)
+        assert report.platform_tested is True
+        assert report.platform_gap is False
+
+    def test_a_spec_with_no_implementation_fence_is_not_applicable(self):
+        """The #1870 convention: a vacuous check reports so, never a pass."""
+        report = error_path_coverage("## 10.1\n\n```python\ndef test_a():\n    pass\n```\n")
+
+        assert report.ran is False
+        assert "not applicable" in format_report(report)
+
+    def test_test_fences_are_not_read_as_implementation(self):
+        """A `raise` inside a test is the test's own setup, not a mandate."""
+        spec = (
+            "```python\ndef f():\n    return 1\n```\n"
+            "```python\ndef test_f():\n    raise RuntimeError('setup')\n```\n"
+        )
+        code, tests = split_fences(spec)
+
+        assert "raise RuntimeError" in tests
+        assert "raise RuntimeError" not in code
+        assert error_path_coverage(spec).raised == {}
+
+
+class TestRequirementCoverageStopsPredictingTheGate:
+    def test_the_summary_names_which_coverage_it_reports(self):
+        """The number was true; what it implied was not (#2333).
+
+        A fully covered LLD is the case that matters. That is precisely when
+        the old wording read as a clean forecast of a gate it never measured.
+        """
+        from assemblyzero.core.validation.test_plan_validator import (
+            validate_test_plan,
+        )
+        from tests.unit.test_test_plan_validator import LLD_FULL_COVERAGE
+
+        result = validate_test_plan(LLD_FULL_COVERAGE)
+        summary = result["summary"]
+
+        assert result["coverage_percentage"] == 100.0
+        assert "Requirement coverage:" in summary
+        assert "statement coverage is a separate number" in summary
+        assert "requirements mapped" in summary


### PR DESCRIPTION
Closes #2331
Closes #2333

The spec-stage pair. Two defects with one shape: a spec that could not produce a usable suite degraded quietly instead of stopping, and a spec that could not clear the coverage gate reported a number that read as though it would. Every #1, #4 and #2 roll re-derives its spec and meets both.

## #2331: escalation is a named halt

`should_regenerate` escalates when the scaffold cannot be validated, and the branch was documented as *escalate to Claude*. It escalated to nothing. The route was `N4_implement_code`, and it **skipped `verify_red` on the way**, so a suite the validator had just judged unusable entered implementation with one fewer check than a suite that passed.

The graph has no stronger test generator to escalate to, so the honest route is to stop:

```
route_after_validate:  escalate -> "end"   (was N4_implement_code)
```

The node writes a `DETERMINISTIC FAILURE` naming the tests as the wrong side. That token is what keeps the orchestrator from retrying a deterministic scaffolder, the same reasoning as #2337.

The condition lives in one function, `exhausted_reason`, because the router and the node that writes the halt message both need it. Computed separately they could disagree, and a route that ends a run whose state records no failure is the silent degradation this issue is about.

**#2317's gating was reconsidered and kept, which the issue did not anticipate.** Its acceptance says the fixable-only gating "can then be reconsidered, since its reason would be gone". The routing reason is gone. A second reason is not, and #2331 does not touch it: a scaffold of nothing but `assert False, "TDD RED: ..."` is what the scaffolder is *supposed* to emit before any implementation exists, and #386 closed the reject-and-regenerate loop that rejecting it created. That case is wholly hollow by count, so a blanket "hollow is invalid" rule reopens #386 exactly.

I removed the gating first. Two existing tests failed, and they were right to. The comment in the node now records both reasons so the next reader does not repeat the attempt.

`DETERMINISTIC_FAILURE` moved from `verify_phases` down to `validate_tests_mechanical`, which now writes a halt of the same kind and cannot import upward without a cycle. `verify_phases` re-exports it, so every existing import keeps working.

## #2333: error paths the spec mandates and never tests

A new `error_path_coverage` module, wired in as completeness check 10. Two gaps are decidable from the spec text, and both were real in `run-issue7-153937`. Measured against that run's actual spec, recovered from `graveyard/7-lld-run153937` and already frozen at `tests/fixtures/issue7_run153937/spec-0007.md`:

```
raised     FileNotFoundError x1, ValueError x2
asserted   ValueError
untested   FileNotFoundError
platform   1 branch on os.name, no test varies it
handlers   5 except blocks
tests      23
```

`FileNotFoundError` is `config.py` line 53 in that run's own coverage report. The `os.name` branch is lines 25 through 27. Two of the ten missed statements that put it at 78 percent against a 95 percent gate, both now named at iteration zero instead of two stages later in a loop that cannot fix them.

**Handlers are disclosed, never failed.** Reaching an `except` needs a test that constructs the failure, and no lexical signal says whether one does. Guessing would produce findings this module cannot defend, and a check that cries wolf is one the drafter learns to skip. The report says so explicitly rather than staying silent about the third of the gap it cannot see.

**The misleading number.** The LLD test-plan summary read `Coverage: 100.0% (22/22 requirements mapped)`. True, and read as a forecast of a statement gate it never measured. It now names which coverage it reports and states that statement coverage is a separate number.

## On acceptance item 3

#2333 asks that replaying the spec produce a suite clearing the 95 percent gate. Replaying needs a roll, and no roll runs during this batch. What is verified instead is the mechanical half: the gap that made the gate unreachable is now caught while reading the spec, with the run's own artifact as the fixture and the run's own coverage report as the check on the finding. Writing the tests that close it is the drafter's job at spec time, which is the change.

## Verification

`tests/unit/test_spec_stage_pair.py`, 23 tests: routing in both directions, the halt message and its token, hash-order (the halt is named before this attempt's hash overwrites the previous one, or every failed first attempt would read as stagnant), #386's two cases, the real spec's four measurements, and six negatives including a spec that tests its error paths, the `unittest` assertion form, control-flow raises, and a test fence's own `raise` not counting as a mandate.

Full unit suite on this branch: **7440 passed, 17 skipped, 5 xfailed**. `ruff check` clean on the changed files; the three findings in `verify_phases` are present on `main` unchanged.
