### PR TITLE
fix(orchestrator): pipeline checkpoints are local and reach no remote (Closes #2339)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -1110,21 +1110,27 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                 capture_output=True,
                 text=True,
             )
-            # #1780: set upstream at creation so checkpoint pushes work.
-            # Without it every [CP:*] push fails until the pr stage's
-            # --set-upstream, losing the crash-resilience checkpoints
-            # exist for. Non-fatal (offline runs stay possible).
-            push_result = run_command(
-                ["git", "-C", str(worktree_path), "push", "-u", "origin", branch_name],
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            if push_result.returncode != 0:
-                print(
-                    f"    [WARN] could not push {branch_name} upstream: "
-                    f"{(push_result.stderr or '').strip()[:200]}"
-                )
+            # #1780 pushed the branch here to set an upstream, so that
+            # checkpoint pushes would work. #2339 removed it, because
+            # checkpoints no longer push.
+            #
+            # The push was the first line of run-issue7-192332 and it was
+            # rejected: origin/issue-7 was a stale remote branch from an
+            # earlier run, diverged from the new local one. No upstream was
+            # set, so all four [[CP:*]] checkpoints then failed the same way
+            # and each printed git's four-line set-upstream advice into the
+            # run log.
+            #
+            # The operator's ruling: checkpoints are local crash resilience
+            # and do not push. The evidence for it is in that same incident.
+            # Every checkpoint commit survived without ever reaching origin,
+            # preserved on graveyard/issue-7-20260814T002812Z by the #2310
+            # disposal discipline, and that local chain is the only reason
+            # the post-mortem had anything to measure.
+            #
+            # Nothing here needs a remote, so nothing here reconciles one.
+            # The pr stage pushes the branch, and that push is the run's
+            # product; its own stale-remote reconcile landed in #2349.
 
             # #1904: provision the worktree's environment. Without this,
             # `poetry run` silently falls through to PATH for missing

--- a/assemblyzero/workflows/testing/checkpoints.py
+++ b/assemblyzero/workflows/testing/checkpoints.py
@@ -6,7 +6,30 @@ premature cleanup at any point loses everything since the last human commit.
 
 The 2026-01-31 incident lost 6,114 lines of working code via worktree
 deletion before commit. This module provides `commit_checkpoint()`, called
-at the end of N2, N4, and N5 to stage + commit + push the current state.
+at the end of N2, N4, and N5 to stage and commit the current state.
+
+Checkpoints are LOCAL (#2339)
+-----------------------------
+
+They do not push, and the worktree is no longer given an upstream at
+creation for their benefit. Both halves of that were removed together.
+
+run-issue7-192332 settled it. `origin/issue-7` was a stale remote branch
+from an earlier run, so the upstream push at worktree creation was rejected
+as non-fast-forward, so every checkpoint push failed with "no upstream
+branch" and printed git's four-line advice into the run log. Four
+checkpoints, four identical failures, and one operator reading a log that
+looked like a broken run.
+
+The same incident is the evidence for going local rather than repairing the
+remote. Every checkpoint commit survived without ever reaching origin. The
+chain was preserved on ``graveyard/issue-7-20260814T002812Z`` by the #2310
+disposal discipline, and it is the only reason the post-mortem behind
+#2337, #2338, #2339 and #2340 had anything to measure. A remote copy would
+have added nothing that mattered on the one day it was tested.
+
+Pushing the branch is the pr stage's job. That push is the run's product,
+it is untouched here, and its own stale-remote reconcile landed in #2349.
 
 Design rules:
 1. **Best-effort.** Checkpoint failures must NOT fail the node they were
@@ -17,9 +40,10 @@ Design rules:
    commits represent ONLY the work the human cares about.
 3. **Squashable.** Commit message prefix `[CP:NAME]` is recognizable so
    the post-merge squash collapses them cleanly.
-4. **Network-tolerant.** `git push` failures are warned but ignored --
-   the local commit is the primary recovery artifact; remote backup is
-   nice-to-have.
+4. **Local only.** No network call, so no network failure to tolerate and
+   no advice text to print. A run with no remote at all behaves the same as
+   one with a healthy remote, which is what makes the checkpoint's outcome
+   readable.
 5. **Idempotent on empty.** If `git diff --cached` is empty after staging,
    skips the commit (no empty-commit pollution).
 """
@@ -36,13 +60,12 @@ _EXCLUDE_PATHSPECS = (
 )
 
 _GIT_TIMEOUT_S = 30
-_PUSH_TIMEOUT_S = 60
 
 
 def commit_checkpoint(worktree_path: str | Path | None,
                        issue_number: int | str | None,
                        name: str) -> bool:
-    """Stage + commit + push the current state of `worktree_path`.
+    """Stage and commit the current state of `worktree_path`. Local only.
 
     Args:
         worktree_path: Path to the git worktree to checkpoint. If None or
@@ -92,15 +115,9 @@ def commit_checkpoint(worktree_path: str | Path | None,
                   f"{(commit.stderr or commit.stdout).strip()[:200]}")
             return False
 
-        # Push -- non-fatal if offline / no upstream / rejected
-        push = _run(
-            ["git", "-C", str(wt), "push"],
-            timeout=_PUSH_TIMEOUT_S,
-        )
-        if push.returncode != 0:
-            print(f"  [CP:{name}] commit OK, push failed (non-fatal): "
-                  f"{(push.stderr or '').strip()[:200]}")
-
+        # No push. See the module docstring (#2339): the local commit IS the
+        # recovery artifact, and the push that used to follow could only ever
+        # fail loudly or succeed silently.
         return True
 
     except (subprocess.TimeoutExpired, OSError) as e:

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -251,12 +251,22 @@ class TestFormatStageTable:
         assert "cleanup" in table
 
 
-class TestImplWorktreeUpstreamPush:
-    """#1780: the impl worktree branch is pushed -u at creation so
-    checkpoint pushes work (crash-resilience)."""
+class TestImplWorktreeDoesNotPush:
+    """#2339: worktree creation touches no remote.
+
+    #1780 pushed the branch here to give checkpoint pushes an upstream. The
+    operator ruled that checkpoints are local, so nothing before the pr stage
+    needs an upstream, and this push goes with them.
+
+    It is also the line that failed first in run-issue7-192332. A stale
+    `origin/issue-7` rejected it non-fast-forward, no upstream was set, and
+    every one of the four later checkpoint pushes failed with git's
+    four-line set-upstream advice in the log. One rejected push, four
+    misleading failures.
+    """
 
     @patch("assemblyzero.workflows.orchestrator.stages.run_command")
-    def test_worktree_creation_pushes_upstream(self, mock_run, tmp_path):
+    def test_worktree_creation_pushes_nothing(self, mock_run, tmp_path):
         from assemblyzero.workflows.orchestrator.stages import run_impl_stage
 
         out = MagicMock()
@@ -289,14 +299,12 @@ class TestImplWorktreeUpstreamPush:
         ):
             run_impl_stage(state)
 
-        push_calls = [
-            c for c in mock_run.call_args_list
-            if len(c.args[0]) >= 4 and c.args[0][3:4] == ["push"]
-            or ("push" in c.args[0] and "-u" in c.args[0])
+        pushes = [
+            c.args[0] for c in mock_run.call_args_list if "push" in c.args[0]
         ]
-        assert any(
-            "-u" in c.args[0] and "issue-4" in c.args[0] for c in push_calls
-        ), f"expected a push -u origin issue-4 at worktree creation; calls: {[c.args[0] for c in mock_run.call_args_list]}"
+        assert pushes == [], (
+            f"the impl stage must reach no remote; pushes: {pushes}"
+        )
 
 
 class TestWorktreeRemovalRetry:

--- a/tests/unit/test_tdd_checkpoints.py
+++ b/tests/unit/test_tdd_checkpoints.py
@@ -55,7 +55,15 @@ def test_creates_commit_when_diff_has_staged_changes(tmp_path):
     assert any("#123" in arg for c in commit_calls for arg in c), commit_calls
 
 
-def test_pushes_after_successful_commit(tmp_path):
+def test_never_pushes(tmp_path):
+    """#2339: checkpoints are local crash resilience and do not push.
+
+    This test asserted the opposite until 2026-08-14. The operator's ruling
+    reversed it on the evidence of run-issue7-192332, where the push could
+    only ever fail: a stale `origin/issue-7` rejected the upstream push at
+    worktree creation, so all four checkpoints failed with "no upstream
+    branch" and each printed git's four-line advice into the run log.
+    """
     wt = tmp_path / "wt"
     wt.mkdir()
 
@@ -68,14 +76,19 @@ def test_pushes_after_successful_commit(tmp_path):
         return _mk_completed(returncode=0)
 
     with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
-        checkpoints.commit_checkpoint(wt, 123, "post-scaffold")
+        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is True
 
     pushes = [c for c in cmds if "push" in c]
-    assert len(pushes) == 1, f"expected exactly one push, got {pushes}"
+    assert pushes == [], f"checkpoints must not push, got {pushes}"
 
 
-def test_returns_true_even_when_push_fails(tmp_path):
-    """commit succeeded -> True. Push failure is logged but not propagated."""
+def test_a_stale_remote_cannot_affect_a_checkpoint(tmp_path, capsys):
+    """The #2339 case, with the network hostile in every way it was.
+
+    Any push here would be rejected non-fast-forward and any upstream lookup
+    would fail. The checkpoint must still commit, still return True, and
+    still print no git advice, because it makes no network call at all.
+    """
     wt = tmp_path / "wt"
     wt.mkdir()
 
@@ -83,11 +96,41 @@ def test_returns_true_even_when_push_fails(tmp_path):
         if "diff" in cmd and "--quiet" in cmd:
             return _mk_completed(returncode=1)
         if "push" in cmd:
-            return _mk_completed(returncode=128, stderr="fatal: could not resolve host")
+            return _mk_completed(
+                returncode=128,
+                stderr=(
+                    "! [rejected] issue-7 -> issue-7 (non-fast-forward)\n"
+                    "fatal: The current branch issue-7 has no upstream branch.\n"
+                    "To push the current branch and set the remote as upstream, use\n"
+                    "    git push --set-upstream origin issue-7\n"
+                ),
+            )
         return _mk_completed(returncode=0)
 
     with patch.object(checkpoints.subprocess, "run", side_effect=fake_run):
-        assert checkpoints.commit_checkpoint(wt, 123, "post-scaffold") is True
+        assert checkpoints.commit_checkpoint(wt, 7, "post-impl") is True
+
+    out = capsys.readouterr().out
+    assert "set-upstream" not in out
+    assert "non-fast-forward" not in out
+    assert "push" not in out
+
+
+def test_the_worktree_is_not_given_an_upstream_at_creation(tmp_path):
+    """The other half of #2339, and the line that actually failed first.
+
+    #1780 added a `push -u origin <branch>` at worktree creation so that
+    checkpoint pushes would work. With checkpoints local, nothing in the run
+    needs an upstream before the pr stage sets one, and that push was the
+    single rejection every later failure descended from.
+    """
+    import inspect
+
+    from assemblyzero.workflows.orchestrator import stages
+
+    source = inspect.getsource(stages)
+    assert '"push", "-u", "origin", branch_name' not in source
+    assert "could not push" not in source
 
 
 def test_returns_false_when_commit_itself_fails(tmp_path):


### PR DESCRIPTION
Closes #2339

Implements the recorded ruling: pipeline checkpoints are local crash resilience and do not push.

## What went

Two things, together, because the second existed only to serve the first:

- `commit_checkpoint`'s `git push`, its failure branch, its advice text, and the now-unused `_PUSH_TIMEOUT_S`.
- The `push -u origin <branch>` at worktree creation (#1780) and its `[WARN]`.

The checkpoint helper now makes no network call. A run with no remote behaves exactly like one with a healthy remote, which is what makes a checkpoint's outcome readable.

## What stayed

The pr stage's `git push --set-upstream origin <branch>`. That push is the run's product, and its stale-remote reconcile landed in #2349. There is a test asserting the impl stage reaches no remote, and it does not touch the pr stage.

## Why local, and not a remote disposal discipline

The issue framed this as a decision about what checkpoints are FOR, and noted the evidence pointing one way. `run-issue7-192332` is that evidence, and it argues both halves.

**The push could only fail.** `origin/issue-7` was a stale remote branch from an earlier run, diverged from the new local one, so the upstream push at worktree creation was rejected non-fast-forward. No upstream was set. All four checkpoints then failed identically:

```
[CP:post-impl] commit OK, push failed (non-fatal): fatal: The current
branch issue-7 has no upstream branch.
```

One rejected push at the top of the run, four misleading failures below it, each dragging git's four-line set-upstream advice into the log.

**The local commits were sufficient, and were tested.** Every checkpoint commit survived without ever reaching origin, preserved on `graveyard/issue-7-20260814T002812Z` by the #2310 disposal discipline. That local chain is the only reason the post-mortem behind #2337, #2338, this issue and #2340 had anything to measure. On the single day the crash-resilience story was exercised, the remote copy would have added nothing.

Teaching the remote the same disposal discipline was the alternative. It is more machinery, on a network path, to protect a case the local half already covered.

## Acceptance

| Item | Where |
|---|---|
| Checkpoints either push successfully or do not attempt to push | `test_never_pushes` |
| A stale remote does not cause a run to lose its lineage silently | `test_a_stale_remote_cannot_affect_a_checkpoint` |
| If pushing stays, a stale remote is disposed of non-destructively | not applicable; pushing did not stay |
| The run log does not carry repeated multi-line git advice | asserted in the same test: no `set-upstream`, no `non-fast-forward`, no `push` in stdout |
| A test covers the stale-remote case | the same test drives a remote that rejects every push |

## Tests

`test_pushes_after_successful_commit` asserted the behaviour this ruling reverses, so it is inverted to `test_never_pushes` rather than deleted; the docstring records that it changed sides and why. `TestImplWorktreeUpstreamPush` becomes `TestImplWorktreeDoesNotPush` for the same reason.

Two new tests. One drives a checkpoint against a remote that rejects every push with the exact stderr from the incident and asserts the commit still succeeds with no advice printed. One asserts the impl stage issues no push at all, and a source-level check pins that the `push -u` line and its WARN are gone, so a later edit cannot quietly restore them.

`tests/unit/test_tdd_checkpoints.py` and `tests/unit/test_orchestrator_stages.py`: 60 passed.
