### PR TITLE
feat(speedrun): a successful roll archives and verifies itself (Closes #2353)

### DIFF
--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -351,20 +351,50 @@ Empty output means none are open. Anything listed is answered by working
 § Rule above — decide, edit, pre-check, close — and the pre-check is what keeps
 the answer from costing a launch to verify.
 
-**6. Archive the run.** Last, because it is the only step that is unrecoverable
-if skipped — arcs are never merged to main, so a run's product lives only on
-branches and in logs.
+**6. Confirm the archive.** A successful roll archives itself and verifies the
+result (#2353), so on that path this step is a read, not a run. The launcher
+prints the verdict under `ROLL SUCCEEDED`:
+
+```
+  Archive: C:\Users\mcwiz\Projects\<repo>\data\speedrun\archives\<run>
+    rolls 6 | branches 1 integration + 64 graveyard | files 542
+    complete yes
+    manifest OK
+```
+
+Confirm two lines: `complete yes` and `manifest OK`. Anything else is named in
+the same block, and an archive failure never changes the roll's own verdict —
+the roll succeeded; a failed archive is its own problem.
+
+Archive by hand when there is no launcher verdict to read: a failed or
+interrupted roll, an archive that reported a problem, or a re-archive after
+adding branches.
 
 ```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
 poetry run python tools/speedrun_archive.py \
     --repo /c/Users/mcwiz/Projects/<repo> --run <integration-branch> --dry-run
+```
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
 poetry run python tools/speedrun_archive.py \
     --repo /c/Users/mcwiz/Projects/<repo> --run <integration-branch>
 ```
 
-**Verify `"complete": true` in the archive's `index.json`.** The command exits
-nonzero and names the missing component when it is not. A partial archive never
-authorizes deleting anything.
+Then assert the archive is sound. `--verify` checks both dimensions in one
+exit code: that the archive records itself complete, naming any missing
+component, and that every captured file still matches its recorded sha256.
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/speedrun_archive.py \
+    --verify /c/Users/mcwiz/Projects/<repo>/data/speedrun/archives/<run>
+```
+
+A partial archive never authorizes deleting anything. Archiving is the only
+step that is unrecoverable if skipped — arcs are never merged to main, so a
+run's product lives only on branches and in logs.
 
 ### The paste block
 
@@ -386,7 +416,7 @@ delete any branch or worktree. Work steps 1 through 6 in order and report:
      plus the healing ledger's recurring-heal issue stubs, or "no recurrences"
   5. run time vs diagnose+fix time for the run's dates
   6. any must-resolve issues now open
-  7. the archive path and whether index.json says complete: true
+  7. the archive path, and the `--verify` exit status for it
 
 Finish with the single highest-value change to make before the next run, and
 the evidence for it.

--- a/tests/unit/test_roll_archives_itself.py
+++ b/tests/unit/test_roll_archives_itself.py
@@ -1,0 +1,178 @@
+"""A successful roll archives and verifies itself (#2353).
+
+Operator, 2026-08-14, reading "Next step: archive the run": "why am I being
+the monkey here anyway. the roll succeeded. why isn't the archive step
+automatic?" There was no good answer. The archive tool is deterministic,
+exit-coded, and only ever writes, and the launcher already knew the roll had
+succeeded, because it had just printed the instruction.
+
+The synthetic run is built the same way `test_speedrun_archive.py` builds
+its own: a real git repository in a temp dir, never live campaign state.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+RUN = "hardening-run-test"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
+    return result
+
+
+def _events(log_dir: Path, tag: str, issue: int, base: str) -> None:
+    lines = [
+        f"2026-08-14 01:00:00 START issue=#{issue} repo=C:\\repo pid=1234",
+        f"2026-08-14 01:00:02 BASE '{base}' verified clean for #{issue}",
+        f"2026-08-14 01:00:02 LAUNCH base={base} -> {tag}.log",
+        "2026-08-14 01:07:36 CHILD EXITED rc=0",
+        "2026-08-14 01:07:36 EXIT rc=0",
+    ]
+    (log_dir / f"{tag}-events.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    (log_dir / f"{tag}.log").write_text(f"stdout for {tag}\n", encoding="utf-8")
+    (log_dir / f"{tag}-heartbeat.log").write_text("alive\n", encoding="utf-8")
+
+
+@pytest.fixture
+def succeeded_run(tmp_path: Path, monkeypatch) -> Path:
+    """A repo in the state a roll leaves behind when it succeeds."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-q", "-b", RUN)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "arc work")
+
+    _git(repo, "checkout", "-q", "-b", f"graveyard/{RUN}-attempt1")
+    (repo / "abandoned.py").write_text("nope = True\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "abandoned attempt")
+    _git(repo, "checkout", "-q", RUN)
+
+    log_dir = repo / "data" / "speedrun" / "runs"
+    log_dir.mkdir(parents=True)
+    _events(log_dir, "run-issue1-010000", 1, RUN)
+    _events(log_dir, "run-issue4-020000", 4, RUN)
+
+    # There is no origin in a temp repo, so the launcher's ref-based lookup
+    # has nothing to read. The run's identity is not what this test is about.
+    monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _root: RUN)
+    return repo
+
+
+class TestArchiveOnSuccess:
+    def test_it_archives_with_no_operator_action(self, succeeded_run):
+        lines = sr._archive_successful_run(succeeded_run)
+        text = "\n".join(lines)
+
+        assert "Archive:" in text
+        archive = succeeded_run / "data" / "speedrun" / "archives" / RUN
+        assert archive.is_dir()
+        assert (archive / "index.json").is_file()
+
+    def test_the_verdict_carries_every_number_the_issue_named(self, succeeded_run):
+        """Archive path, rolls captured, branches bundled, complete, manifest."""
+        text = "\n".join(sr._archive_successful_run(succeeded_run))
+
+        assert "Archive:" in text
+        assert "rolls 2" in text
+        assert "1 integration + 1 graveyard" in text
+        assert "complete yes" in text
+        assert "manifest OK" in text
+
+    def test_it_verifies_what_it_just_wrote(self, succeeded_run):
+        """--verify is run, not merely offered. Audits are programs."""
+        from assemblyzero.speedrun.archive import verify_manifest
+
+        sr._archive_successful_run(succeeded_run)
+        archive = succeeded_run / "data" / "speedrun" / "archives" / RUN
+
+        assert verify_manifest(archive) == []
+        assert "manifest OK" in "\n".join(sr._archive_successful_run(succeeded_run))
+
+    def test_a_corrupted_archive_is_reported_not_hidden(self, succeeded_run):
+        sr._archive_successful_run(succeeded_run)
+        archive = succeeded_run / "data" / "speedrun" / "archives" / RUN
+
+        target = next(p for p in (archive / "logs").glob("*.log"))
+        target.write_text("tampered\n", encoding="utf-8")
+
+        # Re-verify the existing archive rather than re-archiving over it.
+        from assemblyzero.speedrun.archive import verify_manifest
+
+        assert verify_manifest(archive) != []
+
+
+class TestArchiveFailureDoesNotAlterTheVerdict:
+    def test_a_failure_is_named_and_loud(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _root: RUN)
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("disk full")
+
+        monkeypatch.setattr(sr, "archive_run", boom)
+
+        lines = sr._archive_successful_run(tmp_path)
+        text = "\n".join(lines)
+
+        assert "ARCHIVE FAILED" in text
+        assert "disk full" in text
+        assert "The roll still succeeded" in text
+        assert "runbook 0952" in text
+
+    def test_it_never_raises(self, tmp_path, monkeypatch):
+        """The verdict must render even when everything below it is broken.
+
+        A roll that succeeded and then lost its summary to an archiver
+        traceback would be worse than the manual step this replaces.
+        """
+        monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _root: RUN)
+        monkeypatch.setattr(
+            sr, "archive_run", lambda *a, **k: (_ for _ in ()).throw(OSError("x"))
+        )
+        assert sr._archive_successful_run(tmp_path)
+
+    def test_an_unresolvable_run_name_says_so(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sr, "resolve_attempt_branch", lambda _root: "")
+
+        text = "\n".join(sr._archive_successful_run(tmp_path))
+
+        assert "ARCHIVE SKIPPED" in text
+        assert "no attempt branch" in text
+        assert "runbook 0952" in text
+
+
+class TestTheVerdictBlock:
+    def test_success_no_longer_tells_the_operator_to_archive(self, succeeded_run):
+        """The instruction this issue exists to delete."""
+        import inspect
+
+        source = inspect.getsource(sr._render_verdict)
+        assert "Next step: archive the run" not in source
+        assert "_archive_successful_run" in source

--- a/tests/unit/test_solo_runbook.py
+++ b/tests/unit/test_solo_runbook.py
@@ -120,14 +120,63 @@ def test_the_inspect_section_covers_all_six_steps():
     assert "campaign_timing_dashboard.py" in lowered
     assert "must-resolve" in lowered
     assert "speedrun_archive.py" in lowered
-    assert "complete" in lowered and "index.json" in lowered
+    assert "complete" in lowered and "--verify" in lowered
+
+
+def _step_six() -> str:
+    section = _text()[_text().index("## § Inspect"):]
+    start = section.index("**6.")
+    return section[start:section.index("### The paste block")]
 
 
 def test_the_archive_step_requires_verifying_completeness():
-    section = _text()[_text().index("## § Inspect"):]
-    assert '"complete": true' in section, (
+    """#2353 changed HOW completeness is asserted, not whether it is.
+
+    This asserted `"complete": true` appeared in the section, which was the
+    old instruction to open index.json and read a value. The step now
+    prescribes `--verify`, which checks the same thing and cannot be skimmed
+    past. Audits are programs.
+    """
+    step = _step_six().lower()
+    assert "--verify" in step, "completeness must be asserted by a command"
+    assert "partial archive" in step and "deleting anything" in step, (
         "a partial archive must never be reported as done"
     )
+
+
+def test_no_step_prescribes_reading_a_value_out_of_a_file():
+    """The operator's second complaint, as an acceptance criterion (#2353).
+
+    No step may tell a human to open a file and eyeball a value that a
+    command can assert.
+    """
+    step = _step_six()
+    assert "index.json" not in step, (
+        "step 6 must not send the operator digging in a file for a value"
+    )
+
+
+def test_every_command_block_in_step_six_states_its_working_directory():
+    """The operator's first complaint, as an acceptance criterion (#2353).
+
+    Step 6's block was the only one in the section with no `cd`, so an
+    operator arriving at it fresh had no stated cwd. Operator hit this
+    2026-08-14.
+    """
+    blocks = re.findall(r"```bash\n(.*?)```", _step_six(), re.DOTALL)
+    assert blocks, "step 6 should still document the manual invocation"
+    for block in blocks:
+        assert block.lstrip().startswith("cd "), (
+            f"command block does not state its working directory:\n{block}"
+        )
+
+
+def test_step_six_reads_the_launcher_verdict_first():
+    """A successful roll archives itself (#2353), so the step is a read."""
+    step = _step_six().lower()
+    assert "roll succeeded" in step or "launcher" in step
+    assert "complete yes" in step
+    assert "manifest ok" in step
 
 
 # --- "babysit-protocol.md gains the pointer" ----------------------------

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -83,6 +83,10 @@ from assemblyzero.core.provider_storm import (  # noqa: E402
     # provider_storm for a future deliberate wait, but nothing here waits.
     STORM_EXIT_CODE,
 )
+from assemblyzero.speedrun.archive import (  # noqa: E402  (#2353)
+    archive_run,
+    verify_manifest,
+)
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
 from assemblyzero.speedrun.successes import (  # noqa: E402  (#2191)
     completed_on,
@@ -2236,6 +2240,69 @@ def _requirements_unverified_lines(repo_root, since: str) -> list[str]:
         return []
 
 
+def _archive_successful_run(repo_root) -> list[str]:
+    """Archive and verify the run that just succeeded (#2353).
+
+    Operator, 2026-08-14, on reading "Next step: archive the run": "why am I
+    being the monkey here anyway. the roll succeeded. why isn't the archive
+    step automatic?" There was no good answer. The tool is deterministic,
+    exit-coded, and only ever writes; the launcher already knew the roll had
+    succeeded, because it had just printed the instruction. A step the
+    runbook itself calls unrecoverable if skipped should not depend on a
+    human remembering it.
+
+    Never raises. The roll succeeded, and a failed archive is its own
+    problem: named here, loudly, and never allowed to alter the verdict
+    above it.
+    """
+    lines: list[str] = []
+    try:
+        run = resolve_attempt_branch(repo_root)
+        if not run:
+            return [
+                "  ARCHIVE SKIPPED: no attempt branch could be resolved, so "
+                "there is no run name to archive under. Archive by hand per "
+                "runbook 0952 section Inspect, step 6.",
+            ]
+
+        result = archive_run(Path(repo_root), run)
+        graves = len(result.index["branches"]["graveyard"])
+        integration = 1 if result.index["branches"]["integration"]["sha"] else 0
+
+        lines.append(f"  Archive: {result.path}")
+        lines.append(
+            f"    rolls {len(result.index['rolls'])} | branches "
+            f"{integration} integration + {graves} graveyard | "
+            f"files {len(result.index['manifest'])}"
+        )
+
+        if result.complete:
+            lines.append("    complete yes")
+        else:
+            lines.append(
+                "    complete NO -- this archive does not authorize deleting "
+                "anything"
+            )
+            for name in result.missing:
+                lines.append(f"      missing: {name}")
+
+        mismatched = verify_manifest(result.path)
+        if mismatched:
+            lines.append(
+                f"    manifest MISMATCH on {len(mismatched)} file(s): "
+                f"{', '.join(mismatched[:3])}"
+            )
+        else:
+            lines.append("    manifest OK")
+
+    except Exception as exc:  # noqa: BLE001 - an archive failure is not a verdict
+        lines.append(
+            f"  ARCHIVE FAILED: {exc}. The roll still succeeded. Archive by "
+            f"hand per runbook 0952 section Inspect, step 6."
+        )
+    return lines
+
+
 def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, since=""):
     names = ", ".join(f"#{i}" for i in rolled) or "none"
     # #2290: computed before the branches so no verdict path can omit it. The
@@ -2309,10 +2376,9 @@ def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, sin
         )
     elif rolled == requested and code == 0:
         print(f"ROLL SUCCEEDED: all {len(rolled)} issue(s) rolled ({names}).")
-        print(
-            "  Next step: archive the run (runbook 0952 section Inspect, "
-            "step 6), then roll the next batch."
-        )
+        for line in _archive_successful_run(repo_root):
+            print(line)
+        print("  Next step: roll the next batch.")
     else:
         print(
             f"ROLL DID NOT COMPLETE (exit {code}) -- interrupted or errored "


### PR DESCRIPTION
Closes #2353

On `ROLL SUCCEEDED` the launcher now archives the run, verifies the manifest, and prints the verdict. No operator action.

```
ROLL SUCCEEDED: all 6 issue(s) rolled (#1, #2, #4, #7, #9, #11).
  Archive: C:\Users\mcwiz\Projects\boostgauge\data\speedrun\archives\hardening-run-18
    rolls 6 | branches 1 integration + 64 graveyard | files 542
    complete yes
    manifest OK
  Next step: roll the next batch.
```

Dry-run rules do not apply; success is the trigger. The instruction the operator was reading is gone from the success path.

## An archive failure never changes the roll's verdict

The roll succeeded. A failed archive is its own problem, named loudly:

```
  ARCHIVE FAILED: disk full. The roll still succeeded. Archive by hand per
  runbook 0952 section Inspect, step 6.
```

`_archive_successful_run` never raises. A roll that succeeded and then lost its summary to an archiver traceback would be worse than the manual step this replaces, so there is a test for that specifically. An unresolvable run name gets its own `ARCHIVE SKIPPED` line rather than a confusing failure.

## Runbook 0952 § Inspect step 6, rewritten in this PR

The docs change ships with the behaviour, as the issue requires. Step 6 becomes **confirm the archive**: read the launcher's verdict, which the step now shows inline so the operator knows what they are confirming. The manual invocation stays documented for the cases with no verdict to read — a failed or interrupted roll, a reported problem, a re-archive after adding branches.

**Both operator complaints are treated as acceptance criteria.**

*Every command block states its working directory.* Step 6's was the only block in the section with no `cd`, so an operator arriving at it fresh had no stated cwd. All three blocks in the rewritten step now open with `cd /c/Users/mcwiz/Projects/AssemblyZero`.

*No step prescribes opening a file to eyeball a value a command can assert.* The manual "Verify `complete: true` in the archive's `index.json`" is replaced by the `--verify` command. The paste block's item 7 changes from "whether index.json says complete: true" to "the `--verify` exit status".

**Sequencing note.** `--verify` today re-hashes the manifest and does not read `complete`; #2354 is the sibling that makes it check both dimensions. The runbook is written for the behaviour #2354 lands, and the launcher verdict above already reports `complete` separately from the manifest, so the operator sees both numbers on the success path either way.

## Verification

`tests/unit/test_roll_archives_itself.py`, 8 tests against a synthetic run built from a real git repository in a temp dir, never live campaign state — the same construction `test_speedrun_archive.py` uses.

Covered: the archive appears on disk with no operator action; the verdict carries every number the issue named (path, rolls, branches, complete, manifest); the verify actually runs; a corrupted archive is reported rather than hidden; a failure is loud, named, and includes the runbook pointer; the helper never raises; an unresolvable run name is disclosed; and the "Next step: archive the run" instruction is gone from `_render_verdict`.

`tests/unit/test_speedrun_roll_verdict.py` still passes unchanged: 25 tests.
