### PR TITLE
fix(speedrun): --verify asserts the archive is complete, not merely unrotted (Closes #2354)

### DIFF
--- a/assemblyzero/speedrun/archive.py
+++ b/assemblyzero/speedrun/archive.py
@@ -593,3 +593,73 @@ def verify_manifest(archive_dir: Path) -> list[str]:
         if not path.is_file() or _sha256(path) != expected:
             mismatched.append(rel)
     return mismatched
+
+
+@dataclass
+class VerifyResult:
+    """Both dimensions of "is this archive trustworthy", in one answer."""
+
+    complete: bool
+    missing: list[str] = field(default_factory=list)
+    mismatched: list[str] = field(default_factory=list)
+    file_count: int = 0
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.complete and not self.mismatched and not self.error
+
+
+def verify_archive(archive_dir: Path) -> VerifyResult:
+    """Whether an archive is complete AND intact (#2354).
+
+    `verify_manifest` answers only "the files I did capture have not rotted".
+    An archive marked incomplete at archive time -- a named component that
+    could not be read -- passed with "manifest OK" if its captured files
+    hashed correctly. That is the vacuous-pass class: the one command whose
+    name promises the archive is trustworthy answered a narrower question
+    than the one being asked.
+
+    Completeness used to live only in the archive-time exit code, which is
+    gone by the time anyone re-verifies. It is recorded in index.json, so it
+    is read here.
+
+    Both dimensions are reported. They fail independently and the caller gets
+    one exit code, because an operator asking "can I trust this box" wants an
+    answer, not two.
+    """
+    archive_dir = Path(archive_dir)
+    index_path = archive_dir / INDEX_NAME
+
+    try:
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        # No index is not an intact archive with a missing extra. It is an
+        # archive that cannot state anything about itself, and reporting that
+        # as a pass would be the same vacuous answer one level up.
+        return VerifyResult(
+            complete=False,
+            error=f"{INDEX_NAME} could not be read: {exc}",
+        )
+
+    complete = index.get("complete") is True
+    missing = [
+        entry.get("name", "(unnamed)")
+        for entry in index.get("incomplete_components", [])
+    ]
+    if not complete and not missing:
+        missing = ["(the index records no component detail)"]
+
+    mismatched = []
+    manifest = index.get("manifest", {})
+    for rel, expected in manifest.items():
+        path = archive_dir / rel
+        if not path.is_file() or _sha256(path) != expected:
+            mismatched.append(rel)
+
+    return VerifyResult(
+        complete=complete,
+        missing=missing,
+        mismatched=mismatched,
+        file_count=len(manifest),
+    )

--- a/tests/unit/test_archive_verify_completeness.py
+++ b/tests/unit/test_archive_verify_completeness.py
@@ -1,0 +1,172 @@
+"""`--verify` answers both dimensions of trustworthy (#2354).
+
+It used to re-hash the manifest and return 0 on intact hashes, never reading
+`complete`. An archive marked incomplete at archive time -- a named component
+that could not be read -- passed with "manifest OK" as long as the files it
+DID capture hashed correctly.
+
+That is the vacuous-pass class. The one command whose name promises "this
+archive is trustworthy" was answering only "the files I did capture have not
+rotted", and completeness lived only in the archive-time exit code, which is
+gone by the time anyone re-verifies.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_archive as cli  # noqa: E402
+
+from assemblyzero.speedrun.archive import (  # noqa: E402
+    INDEX_NAME,
+    verify_archive,
+    verify_manifest,
+)
+
+
+def _write_archive(root: Path, *, complete: bool, missing: list[str] | None = None) -> Path:
+    """A minimal archive: one captured file, plus an index describing it."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "logs").mkdir(exist_ok=True)
+    captured = root / "logs" / "run-events.log"
+    captured.write_text("EXIT rc=0\n", encoding="utf-8")
+
+    import hashlib
+
+    digest = hashlib.sha256(captured.read_bytes()).hexdigest()
+    index = {
+        "index_version": 1,
+        "run": "hardening-run-test",
+        "complete": complete,
+        "incomplete_components": [
+            {"name": n, "ok": False, "detail": "could not be read"}
+            for n in (missing or [])
+        ],
+        "manifest": {"logs/run-events.log": digest},
+    }
+    (root / INDEX_NAME).write_text(json.dumps(index, indent=2), encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def complete_archive(tmp_path: Path) -> Path:
+    return _write_archive(tmp_path / "complete", complete=True)
+
+
+@pytest.fixture
+def incomplete_archive(tmp_path: Path) -> Path:
+    """Hash-intact, and marked incomplete. The case that used to pass."""
+    return _write_archive(
+        tmp_path / "incomplete", complete=False, missing=["bundle", "orphans/wt.tar"]
+    )
+
+
+class TestTheVacuousPass:
+    def test_an_incomplete_hash_intact_archive_fails(self, incomplete_archive):
+        result = verify_archive(incomplete_archive)
+
+        assert result.complete is False
+        assert result.mismatched == []
+        assert result.ok is False
+
+    def test_it_names_the_missing_components(self, incomplete_archive):
+        result = verify_archive(incomplete_archive)
+        assert result.missing == ["bundle", "orphans/wt.tar"]
+
+    def test_the_cli_exits_nonzero_and_names_them(self, incomplete_archive, capsys):
+        code = cli.main(["--verify", str(incomplete_archive)])
+        out = capsys.readouterr().out
+
+        assert code == 1
+        assert "complete  NO" in out
+        assert "bundle" in out
+        assert "orphans/wt.tar" in out
+        assert "does not authorize deleting anything" in out
+
+    def test_the_old_check_alone_would_still_have_passed_it(self, incomplete_archive):
+        """The measurement behind the issue, pinned.
+
+        `verify_manifest` is unchanged and still reports the narrower fact.
+        This asserts the two answers genuinely differ on this fixture, so a
+        future refactor cannot quietly collapse them back into one.
+        """
+        assert verify_manifest(incomplete_archive) == []
+        assert verify_archive(incomplete_archive).ok is False
+
+
+class TestHashesStillChecked:
+    def test_a_complete_archive_passes(self, complete_archive, capsys):
+        code = cli.main(["--verify", str(complete_archive)])
+        out = capsys.readouterr().out
+
+        assert code == 0
+        assert "complete  yes" in out
+        assert "manifest  OK" in out
+
+    def test_a_complete_archive_with_a_corrupted_file_still_fails(
+        self, complete_archive, capsys
+    ):
+        (complete_archive / "logs" / "run-events.log").write_text(
+            "tampered\n", encoding="utf-8"
+        )
+        code = cli.main(["--verify", str(complete_archive)])
+        out = capsys.readouterr().out
+
+        assert code == 1
+        assert "complete  yes" in out
+        assert "manifest  MISMATCH" in out
+        assert "logs/run-events.log" in out
+
+    def test_a_missing_file_counts_as_a_mismatch(self, complete_archive):
+        (complete_archive / "logs" / "run-events.log").unlink()
+        assert verify_archive(complete_archive).mismatched == ["logs/run-events.log"]
+
+    def test_both_dimensions_report_together(self, tmp_path, capsys):
+        """Incomplete AND corrupted. One exit code, two findings."""
+        archive = _write_archive(tmp_path / "both", complete=False, missing=["bundle"])
+        (archive / "logs" / "run-events.log").write_text("x\n", encoding="utf-8")
+
+        code = cli.main(["--verify", str(archive)])
+        out = capsys.readouterr().out
+
+        assert code == 1
+        assert "complete  NO" in out
+        assert "manifest  MISMATCH" in out
+
+
+class TestUnreadableIndex:
+    def test_a_missing_index_cannot_be_a_pass(self, tmp_path):
+        """An archive that cannot state anything about itself is not sound.
+
+        Reporting it as verified would be the same vacuous answer one level
+        up from the one this issue removed.
+        """
+        empty = tmp_path / "no-index"
+        empty.mkdir()
+
+        result = verify_archive(empty)
+        assert result.ok is False
+        assert INDEX_NAME in result.error
+
+    def test_the_cli_says_so_and_exits_nonzero(self, tmp_path, capsys):
+        empty = tmp_path / "no-index2"
+        empty.mkdir()
+
+        code = cli.main(["--verify", str(empty)])
+        assert code == 1
+        assert "CANNOT VERIFY" in capsys.readouterr().out
+
+    def test_incomplete_with_no_recorded_detail_still_names_the_gap(self, tmp_path):
+        """`complete: false` and an empty component list is still a failure."""
+        archive = _write_archive(tmp_path / "bare", complete=False, missing=[])
+        result = verify_archive(archive)
+
+        assert result.ok is False
+        assert result.missing, "a failure with no named cause is not a report"

--- a/tools/speedrun_archive.py
+++ b/tools/speedrun_archive.py
@@ -40,7 +40,7 @@ from assemblyzero.speedrun.archive import (  # noqa: E402
     find_orphan_worktrees,
     graveyard_branches_for,
     restore_archive,
-    verify_manifest,
+    verify_archive,
 )
 
 
@@ -122,13 +122,41 @@ def cmd_restore(args: argparse.Namespace) -> int:
 
 
 def cmd_verify(args: argparse.Namespace) -> int:
-    mismatched = verify_manifest(Path(args.verify))
-    if not mismatched:
-        _log("manifest OK -- every recorded file matches its sha256")
+    """Both dimensions, one exit code (#2354).
+
+    This used to re-hash the manifest and return 0 on intact hashes, never
+    reading `complete`. An archive marked incomplete whose captured files
+    were hash-intact passed with "manifest OK" -- the one command whose name
+    promises the archive is trustworthy answering only "the files I did
+    capture have not rotted".
+    """
+    result = verify_archive(Path(args.verify))
+
+    if result.error:
+        _log(f"CANNOT VERIFY: {result.error}")
+        return 1
+
+    if result.complete:
+        _log("complete  yes -- every named component was captured")
+    else:
+        _log("complete  NO -- this archive is missing named component(s):")
+        for name in result.missing:
+            _log(f"  {name}")
+
+    if result.mismatched:
+        _log(f"manifest  MISMATCH on {len(result.mismatched)} of "
+             f"{result.file_count} file(s):")
+        for rel in result.mismatched:
+            _log(f"  {rel}")
+    else:
+        _log(f"manifest  OK -- all {result.file_count} recorded file(s) match "
+             f"their sha256")
+
+    if result.ok:
         return 0
-    _log(f"MANIFEST MISMATCH on {len(mismatched)} file(s):")
-    for rel in mismatched:
-        _log(f"  {rel}")
+
+    _log("")
+    _log("This archive does not authorize deleting anything.")
     return 1
 
 
@@ -148,7 +176,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--dry-run", action="store_true", help="report what would be captured")
     parser.add_argument("--restore", nargs=2, metavar=("ARCHIVE", "DEST"))
     parser.add_argument("--force", action="store_true", help="restore an incomplete archive anyway")
-    parser.add_argument("--verify", metavar="ARCHIVE", help="re-hash an archive against its manifest")
+    parser.add_argument(
+        "--verify",
+        metavar="ARCHIVE",
+        help=(
+            "assert an archive is trustworthy: complete per its index AND "
+            "every recorded file still matching its sha256"
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.restore:


### PR DESCRIPTION
Closes #2354

`--verify` re-hashed the manifest and returned 0 on intact hashes, never reading `complete`. An archive marked incomplete at archive time whose captured files were hash-intact passed with "manifest OK".

That is the vacuous-pass class. The one command whose name promises "this archive is trustworthy" was answering only "the files I did capture have not rotted", and completeness lived solely in the archive-time exit code, which is gone by the time anyone re-verifies.

## Both dimensions, one exit code

`verify_archive` reads `index.json` alongside the hash check. They fail independently and report together, because an operator asking "can I trust this box" wants an answer, not two.

```
$ speedrun_archive.py --verify .../archives/hardening-run-17
complete  NO -- this archive is missing named component(s):
  bundle
  orphans/boostgauge-2.tar
manifest  OK -- all 542 recorded file(s) match their sha256

This archive does not authorize deleting anything.
```

`verify_manifest` is unchanged and still answers the narrower question. There is a test asserting the two genuinely differ on the incomplete fixture, so a later refactor cannot quietly collapse them back into one.

## Two judgement calls

**An unreadable index cannot be a pass.** An archive with no `index.json`, or an unparseable one, reports `CANNOT VERIFY` and exits nonzero. Treating it as "intact, just missing an extra" would be the same vacuous answer one level up from the one this issue removes.

**`complete: false` with an empty component list still names a gap.** The index should always carry `incomplete_components`, but a failure with no stated cause is not a report, so the output says the index records no detail rather than printing an empty list.

## Acceptance

| Item | Test |
|---|---|
| `--verify` on an incomplete, hash-intact archive exits nonzero and names the missing components | `test_the_cli_exits_nonzero_and_names_them` |
| `--verify` on a complete archive with a corrupted file still fails on the hash mismatch as today | `test_a_complete_archive_with_a_corrupted_file_still_fails` |
| A test builds each fixture archive and pins both behaviours | both fixtures are built from a real index and a real sha256 |

`tests/unit/test_archive_verify_completeness.py` (12 tests) and the existing `tests/unit/test_speedrun_archive.py` (12): 24 passed.

Sibling: #2353 rewrote runbook 0952 step 6 to prescribe this command in place of a manual `index.json` read, on the strength of the behaviour landing here.
