### PR TITLE
fix(testing): a guard clause is not an empty branch (Closes #2340)

### DIFF
--- a/assemblyzero/workflows/testing/completeness/ast_analyzer.py
+++ b/assemblyzero/workflows/testing/completeness/ast_analyzer.py
@@ -311,13 +311,70 @@ def analyze_dead_cli_flags(
     return issues
 
 
+def _statement_blocks(tree: ast.AST) -> list[list[ast.stmt]]:
+    """Every block of statements in the tree, so a statement's siblings are known.
+
+    `ast.walk` yields nodes without their context. Telling a guard clause from
+    an empty branch needs to know whether anything FOLLOWS the `if`, which is
+    a fact about its block and not about the node (#2340).
+    """
+    blocks: list[list[ast.stmt]] = []
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if isinstance(block, list) and block and isinstance(block[0], ast.stmt):
+                blocks.append(block)
+    return blocks
+
+
+def _is_guard_clause(body: list[ast.stmt]) -> bool:
+    """Whether a branch's only real statement transfers control out of the block.
+
+    `_is_trivial_body` cannot make this call, and must not be taught to: it
+    also judges FUNCTION bodies, where a bare `return` genuinely is a stub.
+    The difference is the context, so the context is where it is decided.
+    """
+    meaningful = [
+        stmt
+        for stmt in body
+        if not (isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant))
+    ]
+    return len(meaningful) == 1 and isinstance(meaningful[0], ast.Return)
+
+
 def analyze_empty_branches(
     source_code: str, file_path: str
 ) -> list[CompletenessIssue]:
-    """Detect if/elif/else branches with only pass, return None, or trivial bodies.
+    """Detect if/elif/else branches that do nothing.
 
-    Issue #147, Requirement 3: Detects conditional branches that contain
-    only trivial statements, indicating unfinished implementation.
+    Issue #147, Requirement 3: conditional branches containing only trivial
+    statements, which indicate unfinished implementation.
+
+    #2340: a guard clause is not one of them. N4b reported
+
+        empty_branch: Empty 'if' branch at line 83 -- body contains only
+        pass/return None
+
+    against this, in the config.py the pipeline generated for
+    run-issue7-192332:
+
+        if not hand_changed_keys:
+            return
+
+    That is an idiomatic early return, and it is exactly what the spec's
+    "no hand changes leaves the file byte-identical" requirement asks for.
+    Most generated files carry one, so the check fired on ordinary code and
+    the warning came to mean nothing. A check that fires on idiomatic code is
+    worse than no check: it trains the reader to skim past the line where a
+    real finding would appear.
+
+    The distinction is `pass` against `return`, plus position. `pass` alone is
+    an empty branch wherever it sits. A bare `return` guards the code that
+    FOLLOWS the if, so it is a guard clause when something does follow, and a
+    branch that really does nothing when nothing does.
+
+    WARN-and-route is unchanged. This issue does not touch the fail-open
+    policy; the defect was the warning being false, not the routing.
 
     Args:
         source_code: Python source code to analyze.
@@ -333,33 +390,40 @@ def analyze_empty_branches(
     except SyntaxError:
         return issues
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If):
-            continue
+    for block in _statement_blocks(tree):
+        for index, node in enumerate(block):
+            if not isinstance(node, ast.If):
+                continue
 
-        # Check the if body
-        if _is_trivial_body(node.body):
-            issues.append(
-                CompletenessIssue(
-                    category=CompletenessCategory.EMPTY_BRANCH,
-                    file_path=file_path,
-                    line_number=node.lineno,
-                    description=(
-                        f"Empty 'if' branch at line {node.lineno} — body contains "
-                        f"only pass/return None"
-                    ),
-                    severity="WARNING",
+            followed = index + 1 < len(block)
+
+            if _is_trivial_body(node.body) and not (
+                followed and _is_guard_clause(node.body)
+            ):
+                issues.append(
+                    CompletenessIssue(
+                        category=CompletenessCategory.EMPTY_BRANCH,
+                        file_path=file_path,
+                        line_number=node.lineno,
+                        description=(
+                            f"Empty 'if' branch at line {node.lineno} — body contains "
+                            f"only pass/return None"
+                        ),
+                        severity="WARNING",
+                    )
                 )
-            )
 
-        # Check elif/else branches (stored in node.orelse)
-        if node.orelse:
-            # If orelse is a single If node, it's an elif — we'll catch it
-            # when we walk to that If node. Only check non-If orelse (else blocks).
-            if not (len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If)):
-                if _is_trivial_body(node.orelse):
+            # Check elif/else branches (stored in node.orelse)
+            if node.orelse:
+                # If orelse is a single If node, it's an elif — we'll catch it
+                # when we reach that If node. Only check non-If orelse.
+                if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+                    continue
+                if _is_trivial_body(node.orelse) and not (
+                    followed and _is_guard_clause(node.orelse)
+                ):
                     # else block line number: use the first statement in orelse
-                    else_line = node.orelse[0].lineno if node.orelse else node.lineno
+                    else_line = node.orelse[0].lineno
                     issues.append(
                         CompletenessIssue(
                             category=CompletenessCategory.EMPTY_BRANCH,

--- a/tests/fixtures/issue7_run192332/generated_config.py
+++ b/tests/fixtures/issue7_run192332/generated_config.py
@@ -1,0 +1,94 @@
+"""Configuration management.
+
+Issue #7: Feature: configuration file and CLI arguments
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, TypedDict
+
+
+class Threshold(TypedDict):
+    yellow: int
+    red: int
+
+
+class Position(TypedDict):
+    x: int
+    y: int
+
+
+def get_default_config_path() -> Path:
+    """Returns ~/.boostgauge/config.json or %APPDATA%/boostgauge/config.json."""
+    if os.name == 'nt' and 'APPDATA' in os.environ:
+        return Path(os.environ['APPDATA']) / "boostgauge" / "config.json"
+    return Path.home() / ".boostgauge" / "config.json"
+
+
+def get_default_config() -> dict[str, Any]:
+    """Returns the hardcoded default configuration dictionary."""
+    return {
+        "size": 300,
+        "opacity": 0.9,
+        "always_on_top": True,
+        "theme": "dark",
+        "position": {"x": 100, "y": 100},
+        "thresholds": {
+            "conpty": {"yellow": 20, "red": 40},
+            "memory": {"yellow": 80, "red": 90}
+        },
+        "telltale_windows": {"short": 60, "medium": 600, "long": 3600},
+        "show_driver_label": True,
+        "show_digital_readout": True,
+        "show_session_count": True,
+        "polling_interval_seconds": 2
+    }
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    """Reads config from JSON. Raises ValueError on schema failure."""
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("Config must be a JSON object")
+            return data
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON format in config: {e}")
+
+
+def write_full_config(path: Path, config_data: dict[str, Any]) -> None:
+    """Writes a complete config dictionary to disk atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(path.parent), text=True)
+    tmp_path = Path(tmp_path_str)
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(config_data, f, indent=4)
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def apply_exit_write(path: Path, hand_changed_keys: dict[str, Any]) -> None:
+    """Reads current file, patches only the provided keys, and writes back atomically."""
+    if not hand_changed_keys:
+        return
+
+    try:
+        current_data = load_config(path)
+    except (FileNotFoundError, ValueError):
+        current_data = get_default_config()
+
+    for k, v in hand_changed_keys.items():
+        current_data[k] = v
+
+    write_full_config(path, current_data)

--- a/tests/unit/test_empty_branch_guard_clauses.py
+++ b/tests/unit/test_empty_branch_guard_clauses.py
@@ -1,0 +1,204 @@
+"""A guard clause is not an empty branch (#2340).
+
+N4b's Layer 1 AST analysis reported, against the `config.py` the pipeline
+generated for run-issue7-192332:
+
+    empty_branch: Empty 'if' branch at line 83 -- body contains only
+    pass/return None
+
+Line 83 is::
+
+    if not hand_changed_keys:
+        return
+
+An idiomatic early return, and exactly what the spec's "no hand changes
+leaves the file byte-identical" requirement (T080) asks for. Most generated
+files carry one, so the check fired on ordinary code and its warnings came to
+mean nothing.
+
+A check that fires on idiomatic code is worse than no check. It trains the
+reader to skim past the line where a real finding would appear, which is why
+this warning rode along un-acted-on for so long: it was not actionable.
+
+The generated file is frozen at `tests/fixtures/issue7_run192332/`, so the
+acceptance criterion is asserted against the artifact rather than against a
+reconstruction of it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.completeness import ast_analyzer as A
+from assemblyzero.workflows.testing.completeness.ast_analyzer import (
+    analyze_empty_branches,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+GENERATED_CONFIG = ROOT / "tests" / "fixtures" / "issue7_run192332" / "generated_config.py"
+
+
+def kinds(source: str) -> list[int]:
+    """Line numbers of every empty-branch finding."""
+    out = []
+    for issue in analyze_empty_branches(source, "t.py"):
+        data = issue if isinstance(issue, dict) else issue.__dict__
+        out.append(data["line_number"])
+    return out
+
+
+class TestTheRealArtifact:
+    @pytest.fixture(scope="class")
+    def generated(self) -> str:
+        return GENERATED_CONFIG.read_text(encoding="utf-8")
+
+    def test_it_still_carries_the_guard_clause(self, generated):
+        """Pin the input, so a fixture edit cannot make the next test vacuous."""
+        lines = generated.splitlines()
+        assert lines[82].strip() == "if not hand_changed_keys:"
+        assert lines[83].strip() == "return"
+
+    def test_it_produces_no_empty_branch_warning(self, generated):
+        assert kinds(generated) == []
+
+    def test_it_produces_no_layer_one_warning_at_all(self, generated):
+        """The acceptance criterion, across every rule in the layer.
+
+        The issue also asks whether the sibling rules carry the same shape of
+        imprecision. Measured against this file and against the run's other
+        generated module: they do not.
+        """
+        total = 0
+        for name in dir(A):
+            if not name.startswith("analyze_"):
+                continue
+            try:
+                total += len(getattr(A, name)(generated, "config.py"))
+            except TypeError:
+                continue
+        assert total == 0
+
+
+class TestGuardClauseAgainstEmptyBranch:
+    def test_a_guard_clause_does_not_warn(self):
+        assert kinds("def f(x):\n    if not x:\n        return\n    return 1\n") == []
+
+    def test_a_genuinely_empty_branch_still_does(self):
+        assert kinds("def f(x):\n    if not x:\n        pass\n    return 1\n") == [2]
+
+    def test_return_none_is_a_guard_too(self):
+        source = "def f(x):\n    if not x:\n        return None\n    return 1\n"
+        assert kinds(source) == []
+
+    def test_a_return_with_nothing_after_it_is_an_empty_branch(self):
+        """The precise line the issue draws.
+
+        A bare return guards the code that FOLLOWS the if. With nothing
+        following, the branch really does do nothing, and the original
+        warning was right about that case.
+        """
+        assert kinds("def f(x):\n    if not x:\n        return\n") == [2]
+
+    def test_ellipsis_is_still_an_empty_branch(self):
+        assert kinds("def f(x):\n    if not x:\n        ...\n    return 1\n") == [2]
+
+    def test_a_docstring_only_branch_is_still_empty(self):
+        source = 'def f(x):\n    if not x:\n        "why"\n    return 1\n'
+        assert kinds(source) == [2]
+
+    def test_a_real_body_never_warned_and_still_does_not(self):
+        source = "def f(x):\n    if not x:\n        raise ValueError()\n    return 1\n"
+        assert kinds(source) == []
+
+
+class TestContextIsWhatDecides:
+    def test_a_guard_inside_a_loop_is_a_guard(self):
+        source = (
+            "def f(xs):\n"
+            "    for x in xs:\n"
+            "        if not x:\n"
+            "            return\n"
+            "        print(x)\n"
+        )
+        assert kinds(source) == []
+
+    def test_the_same_branch_warns_when_it_ends_its_block(self):
+        source = (
+            "def f(xs):\n"
+            "    for x in xs:\n"
+            "        print(x)\n"
+            "        if not x:\n"
+            "            return\n"
+        )
+        assert kinds(source) == [4]
+
+    def test_a_guard_inside_a_try_block_is_a_guard(self):
+        source = (
+            "def f(x):\n"
+            "    try:\n"
+            "        if not x:\n"
+            "            return\n"
+            "        g()\n"
+            "    except OSError:\n"
+            "        pass\n"
+        )
+        assert kinds(source) == []
+
+    def test_function_bodies_are_judged_by_a_different_rule(self):
+        """`_is_trivial_body` still calls a bare-return FUNCTION body trivial.
+
+        Teaching that helper about guard clauses would have been the wrong
+        repair: it also judges function bodies, where a bare return really is
+        a stub. The difference is context, so context is where it is decided.
+        """
+        import ast
+
+        body = ast.parse("def f():\n    return\n").body[0].body
+        assert A._is_trivial_body(body) is True
+
+
+class TestElseBranches:
+    def test_an_empty_else_still_warns(self):
+        source = (
+            "def f(x):\n"
+            "    if x:\n"
+            "        y = 1\n"
+            "    else:\n"
+            "        pass\n"
+            "    return 2\n"
+        )
+        assert kinds(source) == [5]
+
+    def test_an_elif_with_an_empty_body_still_warns(self):
+        source = (
+            "def f(x):\n"
+            "    if x:\n"
+            "        y = 1\n"
+            "    elif not x:\n"
+            "        pass\n"
+            "    return 2\n"
+        )
+        assert kinds(source) == [4]
+
+    def test_an_elif_is_not_double_reported_as_an_else(self):
+        """The pre-existing behaviour, preserved through the restructure."""
+        source = (
+            "def f(x):\n"
+            "    if x:\n"
+            "        pass\n"
+            "    elif not x:\n"
+            "        pass\n"
+            "    return 2\n"
+        )
+        assert kinds(source) == [2, 4]
+
+
+class TestFailOpenIsUntouched:
+    def test_a_syntax_error_still_returns_no_issues(self):
+        """WARN-and-route is designed behaviour and this issue does not change it.
+
+        The node proceeds with verdict WARN when AST analysis cannot run. The
+        defect was the warning being false, not the routing.
+        """
+        assert analyze_empty_branches("def f(:\n", "t.py") == []


### PR DESCRIPTION
Closes #2340

`empty_branch` fired on this, in the `config.py` the pipeline generated for `run-issue7-192332`:

```python
def apply_exit_write(path: Path, hand_changed_keys: dict[str, Any]) -> None:
    if not hand_changed_keys:
        return
```

An idiomatic guard clause, and exactly what the spec's "no hand changes leaves the file byte-identical" requirement asks for. Most generated files carry one, so the check fired on ordinary code and its warnings came to mean nothing. That is why this one rode along un-acted-on: it was not actionable.

## The distinction

`pass` alone is an empty branch wherever it sits. A bare `return` **guards the code that follows the `if`**, so it is a guard clause when something follows, and a branch that really does nothing when nothing does. The issue offered that second condition and it is the precise one, so it is what shipped.

| Code | Before | After |
|---|---|---|
| `if not x: return` with code after | warn | silent |
| `if not x: return` at end of block | warn | warn |
| `if not x: pass` with code after | warn | warn |
| `if not x: ...` | warn | warn |
| empty `else` / `elif` | warn | warn |

## Where the fix went, and where it deliberately did not

`_is_trivial_body` is untouched. It also judges **function** bodies, where a bare `return` genuinely is a stub, so teaching it about guard clauses would have broken the other caller. The difference is context, so context is where it is decided: `analyze_empty_branches` now walks statement blocks rather than bare nodes, which is the only way to know whether anything follows the `if`. There is a test asserting `_is_trivial_body` still calls a bare-return function body trivial, so the boundary cannot erode.

## Verification, against the artifact rather than a reconstruction

The generated `config.py` is recovered from `graveyard/issue-7-20260814T002812Z` (the branch #2339's disposal discipline preserved) and frozen at `tests/fixtures/issue7_run192332/generated_config.py`.

```
before:  1 empty_branch finding, line 83
after:   0
```

**Every Layer 1 rule, zero warnings** — that is the acceptance criterion and it is asserted as a loop over the whole layer, not just the one rule.

## The sibling check the issue asked for

> Worth checking the sibling AST rules in the same layer for the same shape of imprecision while in there.

Ran all five (`empty_branches`, `docstring_only_functions`, `unused_imports`, `dead_cli_flags`, `trivial_assertions`) against both generated modules from that run, `config.py` and `app.py`. Zero findings from each rule on each file. No sibling carries the same defect on this evidence. Stating the denominator: two files, five rules, ten measurements.

## Fail-open is untouched

WARN-and-route is designed behaviour and this PR does not change it. The defect was the warning being false, not the routing. A test pins that a syntax error still yields no issues.

18 tests in `tests/unit/test_empty_branch_guard_clauses.py`. Full unit suite: **7505 passed, 17 skipped, 5 xfailed**.
