### PR TITLE
fix(speedrun): the archive bundles the branches the pipeline actually writes (Closes #2355)

### DIFF
--- a/assemblyzero/speedrun/archive.py
+++ b/assemblyzero/speedrun/archive.py
@@ -45,6 +45,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from assemblyzero.speedrun.preserved import (
+    claimed_by_other_run,
+    recorded_for,
+)
+
 ARCHIVES_REL = Path("data/speedrun/archives")
 DEFAULT_LOG_REL = Path("data/speedrun/runs")
 RESET_ARTIFACTS_REL = Path("data/speedrun/reset-artifacts")
@@ -159,19 +164,47 @@ def local_branches(repo: Path) -> list[str]:
 
 
 def graveyard_branches_for(repo: Path, run: str) -> list[str]:
-    """Graveyard branches belonging to `run`, by documented prefix rule.
+    """Graveyard branches to bundle with `run`. Recorded fact, then measurement.
 
-    Attempt branches are parked as `graveyard/<run>`, `graveyard/<run>-<suffix>`
-    or `graveyard/<run><separator><suffix>`. The rule is recorded in
-    `index.json` so a human can audit what was and was not swept in; anything
-    outside it must be passed explicitly via `extra_branches`.
+    This matched ``graveyard/<run>*`` until #2355. The pipeline never writes
+    that name. It writes ``graveyard/issue-7-<stamp>`` from the worktree
+    preserve step, ``graveyard/7-lld-<stamp>``, and
+    ``graveyard/leavings-<stamp>`` from the leavings sweep, none of which
+    carry the run prefix. Archiving hardening-run-17 on 2026-08-14 reported
+    ``graveyard 0`` against a campaign holding sixty-four of them, and still
+    called the archive complete.
+
+    Two sources now, in this order:
+
+    1. **The ledger** (`preserved.py`), written by the preserve steps as they
+       preserve. A recorded fact about what this pipeline actually did, which
+       a naming convention never was.
+    2. **Measured discovery** of every ``graveyard/*`` branch the ledger does
+       not attribute to a DIFFERENT run. The sixty-four branches that already
+       exist predate the ledger, and losing them is the failure being
+       repaired. Only a positive attribution elsewhere excludes a branch:
+       over-inclusion costs disk in a tool that only ever writes, while
+       under-inclusion costs the evidence record.
+
+    `index.json` records which source produced each branch, so an audit can
+    tell a recorded preservation from a discovered one.
     """
-    prefix = f"graveyard/{run}"
-    matched = []
-    for branch in local_branches(repo):
-        if branch == prefix or branch.startswith(prefix + "-"):
-            matched.append(branch)
+    recorded = recorded_for(repo, run)
+    claimed = claimed_by_other_run(repo, run)
+
+    matched = {
+        branch
+        for branch in local_branches(repo)
+        if branch.startswith("graveyard/") and branch not in claimed
+    }
+    matched |= {b for b in recorded if b in set(local_branches(repo))}
     return sorted(matched)
+
+
+def graveyard_sources(repo: Path, run: str, branches: list[str]) -> dict[str, str]:
+    """Where each bundled branch came from, for the index's audit trail."""
+    recorded = recorded_for(repo, run)
+    return {b: ("ledger" if b in recorded else "discovered") for b in branches}
 
 
 # ---------------------------------------------------------------------------
@@ -359,9 +392,11 @@ def archive_run(
     # --- branches + bundle ------------------------------------------------
     integration_sha = _rev(repo, run) if _ref_exists(repo, run) else None
     graveyard = graveyard_branches_for(repo, run)
+    graveyard_source = graveyard_sources(repo, run, graveyard)
     for extra in extra_branches or []:
         if extra not in graveyard and extra != run:
             graveyard.append(extra)
+            graveyard_source[extra] = "explicit"
     graveyard = sorted(set(graveyard))
 
     refs = ([run] if integration_sha else []) + graveyard
@@ -474,8 +509,21 @@ def archive_run(
         "components": [c.as_dict() for c in components],
         "branches": {
             "integration": {"name": run, "sha": integration_sha},
-            "graveyard": [{"name": b, "sha": _rev(repo, b)} for b in graveyard],
-            "graveyard_match_rule": f"refs/heads/graveyard/{run} and graveyard/{run}-*",
+            "graveyard": [
+                {
+                    "name": b,
+                    "sha": _rev(repo, b),
+                    "source": graveyard_source.get(b, "explicit"),
+                }
+                for b in graveyard
+            ],
+            # #2355: the rule used to be a prefix the pipeline never writes.
+            # It is now what was recorded plus what was measured, and each
+            # branch above says which of the two produced it.
+            "graveyard_match_rule": (
+                "the preserved-branch ledger for this run, plus every "
+                "refs/heads/graveyard/* not attributed to another run"
+            ),
         },
         "bundle": bundle_rel if bundle_path.exists() else None,
         "rolls": [r.as_dict() for r in rolls],

--- a/assemblyzero/speedrun/leavings.py
+++ b/assemblyzero/speedrun/leavings.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from assemblyzero.speedrun.preserved import record_preserved
+
 #: Where the pipeline writes files into a target repo's main checkout.
 #: Grounded in the actual write sites: `workflows/requirements/audit.py`
 #: saves approved LLDs to docs/lld/active/; draft specs land in
@@ -232,6 +234,12 @@ def preserve_and_clear(
             return _fail_all("push", pushed.stderr.strip())
     finally:
         index.unlink(missing_ok=True)
+
+    # #2355: the archiver reads this record. `graveyard/leavings-<stamp>`
+    # carries no run prefix, so the old bundle rule could never find it.
+    record_preserved(
+        repo, branch, source="leavings", detail=f"{len(files)} file(s)"
+    )
 
     result.branch = branch
     for f in files:

--- a/assemblyzero/speedrun/preserved.py
+++ b/assemblyzero/speedrun/preserved.py
@@ -1,0 +1,162 @@
+"""The record of what the pipeline preserved, so the archiver can find it (#2355).
+
+Measured 2026-08-14, archiving hardening-run-17: the campaign held **64**
+graveyard branches, the entire evidence record the preserve-not-delete
+discipline had built all week, and the archiver's dry run reported
+``graveyard 0``.
+
+The bundle rule matched ``graveyard/<run>*``. The pipeline names its preserved
+branches ``graveyard/issue-7-<stamp>``, ``graveyard/7-lld-<stamp>`` and
+``graveyard/leavings-<stamp>``, and not one of them carries the run prefix. An
+archive built by the default rule bundled zero evidence branches and still
+reported ``complete: true``: the box labelled full, holding the logs and none
+of the branch record.
+
+The workaround that day was sixty-four explicit ``--branch`` flags. It worked
+and it does not survive the next operator who trusts the default.
+
+Why a record rather than a better prefix
+----------------------------------------
+
+A naming convention is a claim about what some other code does. It was wrong
+here, silently, for a week, and the next namespace the preserve step invents
+would break it again the same way. So the branches the pipeline preserves are
+WRITTEN DOWN as it preserves them, and the archiver reads the record. The
+bundle set becomes a recorded fact.
+
+The ledger is append-only JSONL under the target repo's gitignored
+``data/speedrun/runs/``, one object per preserved branch, next to the run logs
+the archiver already reads.
+
+Recording never fails a caller
+------------------------------
+
+Every writer here is in the middle of preserving someone's work. A ledger that
+could raise would turn a bookkeeping problem into lost evidence, which is the
+exact inversion of what it exists to prevent. `record_preserved` swallows its
+own errors and says so.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+LEDGER_NAME = "preserved-branches.jsonl"
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass(frozen=True)
+class Preserved:
+    """One branch the pipeline preserved, and what it knows about it."""
+
+    branch: str
+    run: str = ""
+    source: str = ""
+    detail: str = ""
+    at: str = ""
+
+
+def ledger_path(repo: Path | str) -> Path:
+    """Where the record lives, beside the run logs the archiver already reads."""
+    return Path(repo) / "data" / "speedrun" / "runs" / LEDGER_NAME
+
+
+def record_preserved(
+    repo: Path | str,
+    branch: str,
+    *,
+    run: str = "",
+    source: str = "",
+    detail: str = "",
+) -> bool:
+    """Append one preserved branch to the ledger. Never raises.
+
+    Returns whether the record landed, so a caller that wants to say so can,
+    and a caller in the middle of saving work can ignore it.
+    """
+    if not branch:
+        return False
+
+    record = {
+        "branch": branch,
+        "run": run,
+        "source": source,
+        "detail": detail,
+        "at": datetime.now().strftime(_TS_FMT),
+    }
+    try:
+        path = ledger_path(repo)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        return True
+    except OSError:
+        return False
+
+
+def read_ledger(repo: Path | str) -> list[Preserved]:
+    """Every recorded preservation, oldest first. A bad line is skipped.
+
+    One malformed line must not hide the other sixty-three. The archiver's
+    discovery pass covers whatever a skipped line would have named, so a
+    partial read degrades to the pre-ledger behaviour rather than to nothing.
+    """
+    path = ledger_path(repo)
+    if not path.is_file():
+        return []
+
+    records: list[Preserved] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except ValueError:
+            continue
+        branch = data.get("branch")
+        if not isinstance(branch, str) or not branch:
+            continue
+        records.append(
+            Preserved(
+                branch=branch,
+                run=str(data.get("run") or ""),
+                source=str(data.get("source") or ""),
+                detail=str(data.get("detail") or ""),
+                at=str(data.get("at") or ""),
+            )
+        )
+    return records
+
+
+def claimed_by_other_run(repo: Path | str, run: str) -> set[str]:
+    """Branches the ledger attributes to a DIFFERENT run.
+
+    Everything else is fair game for this run's archive. Over-inclusion costs
+    disk in a tool that only ever writes; under-inclusion costs the evidence
+    record, which is what #2355 is about. Only a positive attribution to
+    another run excludes a branch.
+    """
+    return {
+        record.branch
+        for record in read_ledger(repo)
+        if record.run and record.run != run
+    }
+
+
+def recorded_for(repo: Path | str, run: str) -> set[str]:
+    """Branches the ledger attributes to this run, or to no run at all."""
+    return {
+        record.branch
+        for record in read_ledger(repo)
+        if not record.run or record.run == run
+    }

--- a/assemblyzero/speedrun/worktrees.py
+++ b/assemblyzero/speedrun/worktrees.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from assemblyzero.speedrun.preserved import record_preserved
+
 WORKTREES_REL = Path("data/worktrees")
 ORPHANED_DIRNAME = "orphaned"
 
@@ -286,6 +288,13 @@ def _preserve_dirty(repo: Path, path: Path, log) -> SweepEntry:
         # push failure is reported and the sweep proceeds; refusing here would
         # strand the worktree again for a reason unrelated to its content.
         log(f"    push of {grave} failed (content is safe on the local branch)")
+
+    # #2355: write down what was preserved, as it is preserved. The archiver
+    # used to infer the set from a `graveyard/<run>*` prefix this line has
+    # never produced, so it bundled none of them.
+    record_preserved(
+        repo, grave, source="sweep", detail=f"stranded worktree {path.name}"
+    )
 
     removed = _remove_worktree(repo, path, log)
     if removed.returncode != 0:

--- a/tests/unit/test_archive_bundles_graveyard.py
+++ b/tests/unit/test_archive_bundles_graveyard.py
@@ -1,0 +1,252 @@
+"""The archive bundles the branches the pipeline actually writes (#2355).
+
+Measured 2026-08-14, archiving hardening-run-17: the campaign held **64**
+graveyard branches, the whole evidence record the preserve-not-delete
+discipline had built that week, and the archiver's dry run reported
+``graveyard 0``.
+
+The bundle rule matched ``graveyard/<run>*``. The pipeline writes
+``graveyard/issue-7-<stamp>``, ``graveyard/7-lld-<stamp>`` and
+``graveyard/leavings-<stamp>``. Not one carries the run prefix, so the default
+archive bundled zero evidence branches and reported ``complete: true`` anyway.
+
+These tests use the names the pipeline demonstrably produces, not names
+invented to match the rule. A fixture that spells its branches
+``graveyard/<run>-attempt1`` proves the old rule works and proves nothing
+about the pipeline.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun.archive import (
+    archive_run,
+    graveyard_branches_for,
+)
+from assemblyzero.speedrun.preserved import (
+    read_ledger,
+    record_preserved,
+)
+
+RUN = "hardening-run-17"
+
+#: Verbatim shapes from the incident. `issue-7` is the worktree sweep's
+#: preserve step, `7-lld` its LLD sibling, `leavings` the file janitor's.
+PIPELINE_BRANCHES = (
+    "graveyard/issue-7-20260814T002812Z",
+    "graveyard/7-lld-20260814T063916Z",
+    "graveyard/leavings-20260813-221501",
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
+    return result
+
+
+def _events(log_dir: Path, tag: str, issue: int, base: str) -> None:
+    (log_dir / f"{tag}-events.log").write_text(
+        f"2026-08-14 01:00:00 START issue=#{issue} repo=C:\\repo pid=1\n"
+        f"2026-08-14 01:00:02 BASE '{base}' verified clean for #{issue}\n"
+        f"2026-08-14 01:00:02 LAUNCH base={base} -> {tag}.log\n"
+        "2026-08-14 01:07:36 EXIT rc=0\n",
+        encoding="utf-8",
+    )
+    (log_dir / f"{tag}.log").write_text("stdout\n", encoding="utf-8")
+    (log_dir / f"{tag}-heartbeat.log").write_text("alive\n", encoding="utf-8")
+
+
+@pytest.fixture
+def campaign(tmp_path: Path) -> dict:
+    """A repo carrying pipeline-named graveyard branches, as run-17 did."""
+    repo = tmp_path / "boostgauge"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-q", "-b", RUN)
+    (repo / "feature.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "arc work")
+
+    for branch in PIPELINE_BRANCHES:
+        _git(repo, "branch", branch, RUN)
+
+    log_dir = repo / "data" / "speedrun" / "runs"
+    log_dir.mkdir(parents=True)
+    _events(log_dir, "run-issue7-153937", 7, RUN)
+
+    return {"repo": repo, "log_dir": log_dir}
+
+
+class TestTheDefaultRuleFindsThem:
+    def test_pipeline_named_branches_need_no_branch_flags(self, campaign):
+        """The acceptance criterion, and the measurement that produced it."""
+        found = graveyard_branches_for(campaign["repo"], RUN)
+        assert sorted(found) == sorted(PIPELINE_BRANCHES)
+
+    def test_the_old_prefix_rule_would_have_found_none(self, campaign):
+        """Pin the defect so a regression is visible, not just absent.
+
+        `graveyard/<run>*` against these three names is the exact comparison
+        that returned `graveyard 0` on a campaign holding sixty-four.
+        """
+        prefix = f"graveyard/{RUN}"
+        assert [b for b in PIPELINE_BRANCHES if b.startswith(prefix)] == []
+
+    def test_a_default_archive_captures_them(self, campaign):
+        result = archive_run(campaign["repo"], RUN, log_dir=campaign["log_dir"])
+        bundled = {e["name"] for e in result.index["branches"]["graveyard"]}
+
+        assert bundled == set(PIPELINE_BRANCHES)
+        assert result.complete
+
+    def test_complete_now_means_the_evidence_is_in_the_box(self, campaign):
+        """`complete: true` with `graveyard 0` was the vacuous-complete case."""
+        result = archive_run(campaign["repo"], RUN, log_dir=campaign["log_dir"])
+
+        assert result.complete
+        assert len(result.index["branches"]["graveyard"]) == 3
+
+
+class TestTheBundleSourceIsRecordedOrMeasured:
+    def test_the_index_no_longer_states_a_prefix_convention(self, campaign):
+        result = archive_run(campaign["repo"], RUN, log_dir=campaign["log_dir"])
+        rule = result.index["branches"]["graveyard_match_rule"]
+
+        assert f"graveyard/{RUN}-*" not in rule
+        assert "ledger" in rule
+
+    def test_each_branch_records_where_it_came_from(self, campaign):
+        record_preserved(
+            campaign["repo"], PIPELINE_BRANCHES[0], run=RUN, source="sweep"
+        )
+        result = archive_run(campaign["repo"], RUN, log_dir=campaign["log_dir"])
+        sources = {
+            e["name"]: e["source"] for e in result.index["branches"]["graveyard"]
+        }
+
+        assert sources[PIPELINE_BRANCHES[0]] == "ledger"
+        assert sources[PIPELINE_BRANCHES[1]] == "discovered"
+
+    def test_an_explicit_branch_flag_is_labelled_as_such(self, campaign):
+        _git(campaign["repo"], "branch", "salvage/by-hand", RUN)
+        result = archive_run(
+            campaign["repo"], RUN,
+            log_dir=campaign["log_dir"],
+            extra_branches=["salvage/by-hand"],
+        )
+        sources = {
+            e["name"]: e["source"] for e in result.index["branches"]["graveyard"]
+        }
+        assert sources["salvage/by-hand"] == "explicit"
+
+
+class TestAttributionToAnotherRun:
+    def test_another_runs_recorded_branch_is_left_alone(self, campaign):
+        """The only thing that excludes a branch is a positive attribution.
+
+        Over-inclusion costs disk in a tool that only ever writes.
+        Under-inclusion costs the evidence record, which is the failure here.
+        """
+        record_preserved(
+            campaign["repo"], PIPELINE_BRANCHES[2],
+            run="hardening-run-16", source="leavings",
+        )
+        found = graveyard_branches_for(campaign["repo"], RUN)
+
+        assert PIPELINE_BRANCHES[2] not in found
+        assert PIPELINE_BRANCHES[0] in found
+
+    def test_an_unattributed_record_still_belongs_to_this_run(self, campaign):
+        """Pre-ledger branches carry no run, and losing them is the defect."""
+        record_preserved(campaign["repo"], PIPELINE_BRANCHES[0], source="sweep")
+        assert PIPELINE_BRANCHES[0] in graveyard_branches_for(campaign["repo"], RUN)
+
+
+class TestTheLedger:
+    def test_the_sweep_records_what_it_preserves(self, tmp_path):
+        assert record_preserved(
+            tmp_path, "graveyard/issue-7-20260814T002812Z",
+            run=RUN, source="sweep", detail="stranded worktree 7",
+        )
+        records = read_ledger(tmp_path)
+
+        assert len(records) == 1
+        assert records[0].branch == "graveyard/issue-7-20260814T002812Z"
+        assert records[0].source == "sweep"
+        assert records[0].at
+
+    def test_it_appends_rather_than_replaces(self, tmp_path):
+        record_preserved(tmp_path, "graveyard/a", run=RUN)
+        record_preserved(tmp_path, "graveyard/b", run=RUN)
+        assert [r.branch for r in read_ledger(tmp_path)] == [
+            "graveyard/a", "graveyard/b",
+        ]
+
+    def test_recording_never_raises_on_a_caller_saving_work(self, tmp_path):
+        """A bookkeeping failure must never become lost evidence."""
+        blocked = tmp_path / "file-not-dir"
+        blocked.write_text("x", encoding="utf-8")
+
+        assert record_preserved(blocked, "graveyard/x") is False
+
+    def test_a_malformed_line_does_not_hide_the_others(self, tmp_path):
+        record_preserved(tmp_path, "graveyard/good-1", run=RUN)
+        from assemblyzero.speedrun.preserved import ledger_path
+
+        with ledger_path(tmp_path).open("a", encoding="utf-8") as handle:
+            handle.write("{not json\n")
+        record_preserved(tmp_path, "graveyard/good-2", run=RUN)
+
+        assert [r.branch for r in read_ledger(tmp_path)] == [
+            "graveyard/good-1", "graveyard/good-2",
+        ]
+
+    def test_a_record_without_a_branch_is_not_a_record(self, tmp_path):
+        assert record_preserved(tmp_path, "") is False
+        assert read_ledger(tmp_path) == []
+
+    def test_no_ledger_reads_as_empty_not_as_an_error(self, tmp_path):
+        assert read_ledger(tmp_path) == []
+
+
+class TestTheWritersRecord:
+    def test_the_worktree_sweep_writes_the_ledger(self):
+        import inspect
+
+        from assemblyzero.speedrun import worktrees
+
+        source = inspect.getsource(worktrees._preserve_dirty)
+        assert "record_preserved" in source
+
+    def test_the_file_janitor_writes_the_ledger(self):
+        import inspect
+
+        from assemblyzero.speedrun import leavings
+
+        source = inspect.getsource(leavings.preserve_and_clear)
+        assert "record_preserved" in source
+
+    def test_the_ledger_is_json_lines(self, tmp_path):
+        """Append-only and line-delimited, so a crash mid-write loses one row."""
+        from assemblyzero.speedrun.preserved import ledger_path
+
+        record_preserved(tmp_path, "graveyard/x", run=RUN, source="sweep")
+        text = ledger_path(tmp_path).read_text(encoding="utf-8")
+
+        assert text.endswith("\n")
+        assert json.loads(text.strip())["branch"] == "graveyard/x"


### PR DESCRIPTION
Closes #2355

Measured 2026-08-14, archiving hardening-run-17: the campaign held **64** graveyard branches, the whole evidence record the preserve-not-delete discipline had built that week, and the archiver's dry run reported `graveyard 0`.

The bundle rule matched `graveyard/<run>*`. The pipeline writes `graveyard/issue-7-<stamp>`, `graveyard/7-lld-<stamp>` and `graveyard/leavings-<stamp>`. Not one carries the run prefix, so the default archive bundled zero evidence branches and reported `complete: true` anyway — the box labelled full, holding the logs and none of the branch record.

## A recorded fact, not a convention

The issue offered two fixes and preferred the second. This is the second, with the first as its fallback.

**The ledger.** `assemblyzero/speedrun/preserved.py` is an append-only JSONL under the target repo's gitignored `data/speedrun/runs/`, beside the run logs the archiver already reads. The two preserve steps write to it as they preserve: the worktree sweep's `_preserve_dirty` and the file janitor's `preserve_and_clear`.

A naming convention is a claim about what some other code does. It was wrong here, silently, for a week, and the next namespace a preserve step invents would break it the same way.

**Measured discovery, for what the ledger cannot know.** The sixty-four branches that already exist predate the ledger, and losing them is the failure being repaired. So the bundle is the ledger's entries for this run plus every `graveyard/*` branch the ledger does not attribute to a **different** run.

Only a positive attribution elsewhere excludes a branch. Over-inclusion costs disk in a tool that only ever writes and deletes nothing on any path; under-inclusion costs the evidence record. Given that asymmetry, over-inclusion is the safe error.

**The index says which source produced each branch**, so an audit can tell a recorded preservation from a discovered one:

```json
{"name": "graveyard/issue-7-20260814T002812Z", "sha": "...", "source": "ledger"},
{"name": "graveyard/leavings-20260813-221501", "sha": "...", "source": "discovered"}
```

and `graveyard_match_rule` no longer states a prefix the pipeline never writes.

## Recording never fails a caller

Every writer is in the middle of preserving someone's work. A ledger that could raise would turn a bookkeeping problem into lost evidence, which inverts what it exists to prevent. `record_preserved` swallows its own errors and returns whether the record landed. `read_ledger` skips a malformed line rather than losing the other sixty-three, and a partial read degrades to the discovery pass rather than to nothing.

## Acceptance

| Item | Test |
|---|---|
| Archiving a run with pipeline-named graveyard branches bundles them without `--branch` flags | `test_pipeline_named_branches_need_no_branch_flags`, `test_a_default_archive_captures_them` |
| The bundle source is measured discovery or a RESTORE-written record, not a prefix convention | `test_the_index_no_longer_states_a_prefix_convention`, `test_each_branch_records_where_it_came_from` |
| A test creates pipeline-named branches and asserts the default archive captures them | the whole fixture |

The fixture uses the three names the pipeline demonstrably produced in the incident, verbatim. A fixture spelling its branches `graveyard/<run>-attempt1` would prove the old rule works and prove nothing about the pipeline. `test_the_old_prefix_rule_would_have_found_none` pins the defect itself, so a regression is visible rather than merely absent.

## Verification

`tests/unit/test_archive_bundles_graveyard.py`, 18 tests. Existing archive tests unchanged and passing. Full unit suite: **7517 passed, 17 skipped, 5 xfailed**. `ruff check` clean on all five files.
