### PR TITLE
feat(tools): enumerate a stash before dropping it (Closes #2364)

### DIFF
--- a/tests/unit/test_stash_audit.py
+++ b/tests/unit/test_stash_audit.py
@@ -1,0 +1,190 @@
+"""Everything a stash holds, before the drop makes it unrecoverable (#2364).
+
+These tests build real repositories and run real `git stash`. The behaviour
+under test is git's own -- that a stash made with `--include-untracked` files
+its untracked half in a third parent which `git stash show` does not list --
+and a mocked git would let that claim pass without ever being true.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import stash_audit as sa  # noqa: E402
+
+
+def run(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    )
+    return result.stdout
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    """A repo with one commit on `main` and an `origin/main` to land against."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    run(origin, "init", "-q", "--bare")
+
+    work = tmp_path / "work"
+    work.mkdir()
+    run(work, "init", "-q", "-b", "main")
+    run(work, "config", "user.email", "t@example.com")
+    run(work, "config", "user.name", "t")
+    (work / "tracked.txt").write_text("original\n", encoding="utf-8")
+    run(work, "add", "tracked.txt")
+    run(work, "commit", "-qm", "init")
+    run(work, "remote", "add", "origin", str(origin))
+    run(work, "push", "-q", "origin", "main")
+    return work
+
+
+def stash_everything(repo: Path) -> None:
+    run(repo, "stash", "push", "-q", "-m", "wip", "--include-untracked")
+
+
+class TestGitReallyHidesTheUntrackedHalf:
+    """The falsifier for the whole tool. If `git stash show` listed everything,
+    none of this would be worth running."""
+
+    def test_stash_show_under_reports(self, repo):
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        (repo / "other_lane.py").write_text("theirs\n", encoding="utf-8")
+        (repo / "tracked.txt").write_text("edited\n", encoding="utf-8")
+
+        stash_everything(repo)
+
+        listed = run(repo, "stash", "show", "--name-only", "stash@{0}").split()
+        assert listed == ["tracked.txt"], "git's own listing shows one of three"
+
+        audited = {f["path"] for f in sa.audit(repo, "stash@{0}", "origin/main")}
+        assert audited == {"tracked.txt", "mine.py", "other_lane.py"}
+
+
+class TestTheTwoHalvesAreLabelled:
+    def test_each_path_is_attributed_to_its_half(self, repo):
+        (repo / "swept.py").write_text("swept\n", encoding="utf-8")
+        (repo / "tracked.txt").write_text("edited\n", encoding="utf-8")
+        stash_everything(repo)
+
+        halves = {
+            f["path"]: f["half"] for f in sa.audit(repo, "stash@{0}", "origin/main")
+        }
+        assert halves == {"tracked.txt": "tracked", "swept.py": "untracked"}
+
+    def test_a_stash_without_u_has_no_third_parent_and_that_is_fine(self, repo):
+        (repo / "tracked.txt").write_text("edited\n", encoding="utf-8")
+        run(repo, "stash", "push", "-q", "-m", "wip")
+
+        assert sa.untracked_paths(repo, "stash@{0}") == []
+        findings = sa.audit(repo, "stash@{0}", "origin/main")
+        assert [f["path"] for f in findings] == ["tracked.txt"]
+
+
+class TestLandedVersusLost:
+    def test_an_untracked_file_never_landed_is_absent(self, repo):
+        (repo / "other_lane.py").write_text("theirs\n", encoding="utf-8")
+        stash_everything(repo)
+
+        (finding,) = sa.audit(repo, "stash@{0}", "origin/main")
+        assert finding["status"] == sa.ABSENT
+
+    def test_an_untracked_file_that_did_land_is_landed(self, repo):
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        stash_everything(repo)
+
+        # It landed on origin between the stash and the audit, byte for byte.
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        run(repo, "add", "mine.py")
+        run(repo, "commit", "-qm", "land it")
+        run(repo, "push", "-q", "origin", "main")
+
+        (finding,) = sa.audit(repo, "stash@{0}", "origin/main")
+        assert finding["status"] == sa.LANDED
+
+    def test_a_file_that_landed_with_different_content_differs(self, repo):
+        (repo / "mine.py").write_text("version A\n", encoding="utf-8")
+        stash_everything(repo)
+
+        (repo / "mine.py").write_text("version B\n", encoding="utf-8")
+        run(repo, "add", "mine.py")
+        run(repo, "commit", "-qm", "land a different version")
+        run(repo, "push", "-q", "origin", "main")
+
+        (finding,) = sa.audit(repo, "stash@{0}", "origin/main")
+        assert finding["status"] == sa.DIFFERS, (
+            "same path, different bytes -- dropping still loses the stashed one"
+        )
+
+
+class TestTheVerdict:
+    def test_it_refuses_when_anything_is_unaccounted(self, repo, capsys):
+        (repo / "other_lane.py").write_text("theirs\n", encoding="utf-8")
+        stash_everything(repo)
+
+        code = sa.main(["--repo", str(repo)])
+
+        out = capsys.readouterr().out
+        assert code == sa.EXIT_UNACCOUNTED
+        assert "DO NOT DROP" in out
+        assert "other_lane.py" in out
+
+    def test_it_clears_a_stash_whose_every_path_landed(self, repo, capsys):
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        stash_everything(repo)
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        run(repo, "add", "mine.py")
+        run(repo, "commit", "-qm", "land it")
+        run(repo, "push", "-q", "origin", "main")
+
+        code = sa.main(["--repo", str(repo)])
+
+        out = capsys.readouterr().out
+        assert code == sa.EXIT_ACCOUNTED
+        assert "byte-identical" in out
+        assert "DO NOT DROP" not in out
+
+    def test_a_clean_verdict_still_says_what_it_did_not_check(self, repo, capsys):
+        """Presence is not ownership. The #2364 files would each have read as
+        'absent here' and been someone's real work regardless."""
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        stash_everything(repo)
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        run(repo, "add", "mine.py")
+        run(repo, "commit", "-qm", "land it")
+        run(repo, "push", "-q", "origin", "main")
+
+        sa.main(["--repo", str(repo)])
+
+        assert "Not verified" in capsys.readouterr().out
+
+
+class TestItNeverGuessesWhenItCannotRun:
+    def test_an_unknown_stash_is_an_error_not_a_pass(self, repo, capsys):
+        code = sa.main(["--repo", str(repo), "--stash", "stash@{7}"])
+
+        assert code == sa.EXIT_ERROR
+        assert "Nothing about this stash has been verified" in capsys.readouterr().err
+
+    def test_an_unknown_ref_is_an_error_not_a_pass(self, repo, capsys):
+        (repo / "mine.py").write_text("mine\n", encoding="utf-8")
+        stash_everything(repo)
+
+        code = sa.main(["--repo", str(repo), "--ref", "origin/nonexistent"])
+
+        assert code == sa.EXIT_ERROR
+        assert "could not run" in capsys.readouterr().err
+
+    def test_an_empty_stash_reports_that_it_verified_nothing(self, capsys):
+        assert "nothing was verified" in sa.render([], "stash@{0}", "origin/main")

--- a/tests/unit/test_utf8_console.py
+++ b/tests/unit/test_utf8_console.py
@@ -252,6 +252,7 @@ class TestEveryReportRendererInstallsIt:
             "prompt_failure_report.py",
             "prompt_revision_rank.py",
             "speedrun_overlay.py",
+            "stash_audit.py",
         }
 
     @pytest.mark.parametrize(
@@ -263,6 +264,7 @@ class TestEveryReportRendererInstallsIt:
             "prompt_failure_report.py",
             "prompt_revision_rank.py",
             "speedrun_overlay.py",
+            "stash_audit.py",
         ],
     )
     def test_each_renderer_installs_the_widening(self, name):

--- a/tools/stash_audit.py
+++ b/tools/stash_audit.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Enumerate everything a stash holds before you drop it (#2364).
+
+`git stash drop` removes the last named reference to every path in the stash,
+and `git stash show` does not list all of them. A stash made with
+`--include-untracked` keeps its untracked files in a **third parent**, which the
+ordinary listing never mentions:
+
+    $ git stash show --name-only stash@{0}
+    tracked.txt
+    $ git show --name-only --format="" stash@{0}^3
+    mine_wip.py
+    other_lane.py
+
+One of three paths. That gap is the whole of #2364. During the 2026-08-14
+doctrine batch a `git stash push -u` swept eight one-shot landing scripts left
+in `tools/` by other sessions -- a shared checkout cannot tell whose untracked
+files are whose -- and the stash was dropped after verifying that *this
+session's* two files had landed. The other eight had not landed anywhere and
+never would. They survived because nothing had garbage-collected the dropped
+commit yet, which is luck, not design.
+
+The failure was not carelessness. It was scoping: a check that looks for what
+you expect finds nothing you did not expect. So this tool takes the enumeration
+out of memory and does it mechanically -- every path in both halves, each one
+compared against a reference the work was supposed to land on.
+
+Read-only. It runs no destructive command and takes no `--apply`, because there
+is nothing here to apply; the drop stays a human decision made with the full
+list in hand.
+
+    poetry run python tools/stash_audit.py
+    poetry run python tools/stash_audit.py --stash 'stash@{2}' --ref origin/main
+
+Exit codes:
+    0  every path in the stash is present and identical on the reference
+    1  at least one path is missing or differs, so the drop would lose it
+    2  the audit could not run, so nothing was verified
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# #2367: before anything prints. Stashed paths and diffs carry arbitrary text.
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+EXIT_ACCOUNTED = 0
+EXIT_UNACCOUNTED = 1
+EXIT_ERROR = 2
+
+LANDED = "landed"
+DIFFERS = "differs"
+ABSENT = "absent"
+
+
+class AuditError(RuntimeError):
+    """The audit could not run. Never raised to mean 'a path is unaccounted'."""
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        raise AuditError(
+            f"git {' '.join(args)} failed: {result.stderr.strip() or 'no detail'}"
+        )
+    return result.stdout
+
+
+def _lines(text: str) -> list[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def tracked_paths(repo: Path, stash: str) -> list[str]:
+    """The modifications to files git was already tracking."""
+    return _lines(git(repo, "stash", "show", "--name-only", stash))
+
+
+def untracked_paths(repo: Path, stash: str) -> list[str]:
+    """The files swept in by --include-untracked, from the third parent.
+
+    A stash made without -u has no third parent, and that is not an error --
+    it means the stash never swept anything, which is the good case.
+    """
+    try:
+        git(repo, "rev-parse", "--verify", "--quiet", f"{stash}^3")
+    except AuditError:
+        return []
+    return _lines(git(repo, "show", "--name-only", "--format=", f"{stash}^3"))
+
+
+def blob(repo: Path, rev: str, path: str) -> bytes | None:
+    """One file's stored bytes at a revision, or None if it is not there.
+
+    Both sides of every comparison in this tool are git blobs, so no line-ending
+    normalisation belongs here and adding some would be a bug. The CRLF trap
+    documented in the root CLAUDE.md applies to git content compared against a
+    file on disk; a blob is already LF whatever the working tree looks like.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo), "show", f"{rev}:{path}"],
+        capture_output=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def classify(repo: Path, stash_rev: str, ref: str, path: str) -> str:
+    stashed = blob(repo, stash_rev, path)
+    if stashed is None:
+        raise AuditError(f"{path} is listed in the stash but has no blob there")
+    landed = blob(repo, ref, path)
+    if landed is None:
+        return ABSENT
+    return LANDED if landed == stashed else DIFFERS
+
+
+def audit(repo: Path, stash: str, ref: str) -> list[dict]:
+    """One record per path the stash holds, both halves, in a stable order."""
+    findings = []
+    for path in tracked_paths(repo, stash):
+        findings.append(
+            {
+                "path": path,
+                "half": "tracked",
+                "status": classify(repo, stash, ref, path),
+            }
+        )
+    for path in untracked_paths(repo, stash):
+        findings.append(
+            {
+                "path": path,
+                "half": "untracked",
+                "status": classify(repo, f"{stash}^3", ref, path),
+            }
+        )
+    return findings
+
+
+def render(findings: list[dict], stash: str, ref: str) -> str:
+    rule = "=" * 70
+    out = [rule, f"Stash audit -- {stash} against {ref}", rule, ""]
+
+    if not findings:
+        out += [
+            "The stash holds no paths at all. Nothing to lose by dropping it,",
+            "and nothing was verified because there was nothing to verify.",
+            "",
+            rule,
+            "",
+        ]
+        return "\n".join(out)
+
+    for half in ("tracked", "untracked"):
+        rows = [f for f in findings if f["half"] == half]
+        if not rows:
+            continue
+        label = {
+            "tracked": "Tracked modifications (git stash show)",
+            "untracked": "Swept in by --include-untracked (the third parent)",
+        }[half]
+        out.append(f"{label}: {len(rows)}")
+        for row in rows:
+            out.append(f"  [{row['status']:>8}] {row['path']}")
+        out.append("")
+
+    unaccounted = [f for f in findings if f["status"] != LANDED]
+    out.append(f"{len(findings)} path(s) examined, {len(unaccounted)} unaccounted.")
+    out.append("")
+
+    if unaccounted:
+        out += [
+            "DO NOT DROP. These paths are not on the reference, so the stash is",
+            "the last named handle on them:",
+            "",
+        ]
+        out += [f"  {f['path']} ({f['status']})" for f in unaccounted]
+        out += [
+            "",
+            "A path can be absent because it was another session's work that was",
+            "never going to land here at all -- that is exactly what happened in",
+            "#2364. Find its owner before dropping, or copy it out first.",
+            "",
+        ]
+    else:
+        out += [
+            "Every path is present and byte-identical on the reference.",
+            "",
+            "Not verified: whether the reference is the right place for this work",
+            "to have landed. A path that landed somewhere else, or that belongs to",
+            "another session entirely, reads exactly the same as one that landed",
+            "here. This tool checks presence, not ownership.",
+            "",
+        ]
+
+    out += [rule, ""]
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "List every path a stash holds, including the untracked files "
+            "`git stash show` omits, and check each against a reference "
+            "before you drop it. Read-only."
+        )
+    )
+    parser.add_argument("--repo", default=".", help="repository (default: cwd)")
+    parser.add_argument(
+        "--stash", default="stash@{0}", help="stash to audit (default: stash@{0})"
+    )
+    parser.add_argument(
+        "--ref",
+        default="origin/main",
+        help="where the work should have landed (default: origin/main)",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+    try:
+        git(repo, "rev-parse", "--verify", "--quiet", args.stash)
+        git(repo, "rev-parse", "--verify", "--quiet", args.ref)
+        findings = audit(repo, args.stash, args.ref)
+    except AuditError as exc:
+        print(f"ERROR -- the stash audit could not run: {exc}", file=sys.stderr)
+        print("Nothing about this stash has been verified.", file=sys.stderr)
+        return EXIT_ERROR
+
+    print(render(findings, args.stash, args.ref), end="", flush=True)
+    unaccounted = [f for f in findings if f["status"] != LANDED]
+    return EXIT_UNACCOUNTED if unaccounted else EXIT_ACCOUNTED
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`git stash push --include-untracked` removes every untracked file in the tree, which is the operation `git clean -fd` is banned for, and it reads as the safe preserving option while doing it. It is reversible only while you hold the stash. Dropping it removes the last named handle on everything it held — not only the files you remember adding.

## The gap, measured

The reason the pre-drop check missed eight files is not carelessness. `git stash show` does not list the untracked half at all. In a throwaway repo with one tracked edit and two untracked files:

```
$ git stash show --name-only stash@{0}
tracked.txt

$ git show --name-only --format="" stash@{0}^3
mine_wip.py
other_lane.py
```

One of three. A stash made with `-u` files its untracked half in a **third parent**, and nothing in the ordinary listing mentions it exists.

## What landed

**The discipline** is in the universal `CLAUDE.md`, under "Destroying uncommitted state — the principle, not just the table", where the `git restore` and `rm` rows already live. That file is loose on disk and in no git repo, so it cannot be part of this PR; the three acceptance boxes are satisfied there. It adds two rows to the destructive-state table, the path-scoped alternative, the `^3` enumeration obligation, and the shared-checkout reasoning — the hazard only exists because concurrent sessions leave untracked work in one tree and no session can tell whose is whose.

It is deliberately **not** in the banned-commands table, and not in `banned_command_sweep.py`'s `BANNED_PATTERNS`. That list is bound to the "Banned commands (ALWAYS)" table, and the mitigation here is specificity rather than avoidance — `git stash push -m "wip" -- <path>` is the correct form, so a sweep that flagged every `stash -u` mention would be a false-alarm generator.

**The program** is `tools/stash_audit.py`, because a rule that is only prose is the same rule that already failed once:

```
Tracked modifications (git stash show): 1
  [ differs] tracked.txt

Swept in by --include-untracked (the third parent): 2
  [  absent] mine_wip.py
  [  absent] other_lane.py

3 path(s) examined, 3 unaccounted.

DO NOT DROP. These paths are not on the reference, so the stash is
the last named handle on them:
```

Read-only, and it takes no `--apply` because it has nothing to apply — the drop stays a human decision, made with the full list in hand rather than from memory.

A clean verdict states its own limit: presence is not ownership. Every one of the eight files in the original incident would have read as absent-here and still been someone's real work.

## Notes for the reader

`blob()` compares two git blobs, so no line-ending normalisation belongs in it and adding some would be a bug. The CRLF trap in the root CLAUDE.md is about git content compared against a file on disk; a blob is already LF whatever the working tree holds. The docstring says so, because that is exactly the kind of thing a later reader helpfully "fixes".

## Verification

- 12 new tests, built on real repositories running real `git stash` — a mocked git would let the third-parent claim pass without it ever being true
- `TestGitReallyHidesTheUntrackedHalf` asserts git's own listing shows one of three, so the tool cannot become redundant without the suite noticing
- The #2367 renderer guard caught `stash_audit.py` on its first full run and required it be added to the pinned set. That is the guard working; the pin is updated in this PR
- Full unit suite: 7588 passed, 17 skipped, 5 xfailed
- `ruff check` clean

Closes #2364
