### PR TITLE
fix(orchestrator): the dry run tells the truth and the spec stage can be rehearsed (Closes #2288, Closes #2289)

### DIFF
--- a/assemblyzero/workflows/orchestrator/config.py
+++ b/assemblyzero/workflows/orchestrator/config.py
@@ -27,6 +27,9 @@ class OrchestratorConfig(TypedDict, total=False):
     max_stage_retries: int
     retry_delay_seconds: int
     capacity_retry_delays: list[int]
+    #: #2288: rehearsal. Mock providers for the sub-workflow stages, and no
+    #: outward effect anywhere -- no branch, no PR, no merge.
+    mock_mode: bool
 
 
 VALID_STAGES = ["triage", "lld", "spec", "impl", "pr"]

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -31,8 +31,10 @@ from assemblyzero.workflows.orchestrator.resume import (
     save_orchestration_state,
 )
 from assemblyzero.workflows.orchestrator.stages import (
+    MOCK_FORBIDDEN_STAGES,
     STAGE_RUNNERS,
     check_human_gate,
+    mock_mode,
     should_skip_stage,
 )
 from assemblyzero.workflows.orchestrator.state import (
@@ -59,6 +61,10 @@ class OrchestrationResult(TypedDict):
     total_duration_seconds: float
     stage_results: dict[str, StageResult]
     error_summary: str
+    #: #2289: a dry run reports success for having rehearsed, which is not the
+    #: same claim as a pipeline that passed. The caller must be able to tell
+    #: them apart before printing a banner, because the sentences differ.
+    dry_run: bool
 
 
 class ConcurrentOrchestrationError(RuntimeError):
@@ -82,6 +88,28 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
     config = state.get("config", {})
     max_retries = config.get("max_stage_retries", 3)
     retry_delay = config.get("retry_delay_seconds", 10)
+
+    # #2288: refused at the dispatch point rather than inside each runner, so
+    # the guard holds for a stage nobody remembers to check. These stages exist
+    # to reach outward and have no mock form.
+    if mock_mode(state) and current_stage in MOCK_FORBIDDEN_STAGES:
+        print(
+            f"[ORCHESTRATOR] Mock run: stage '{current_stage}' not entered. "
+            f"It opens or merges pull requests, which a rehearsal must not do."
+        )
+        refused = StageResult(
+            status="skipped",
+            artifact_path="",
+            error_message=(
+                f"mock mode: '{current_stage}' performs outward effects "
+                f"(branch push, PR creation, PR merge) and is never rehearsed"
+            ),
+            duration_seconds=0.0,
+            attempts=0,
+        )
+        new_state = update_stage_result(state, current_stage, refused)
+        save_orchestration_state(new_state)
+        return dict(new_state)
 
     # Check human gate
     if not check_human_gate(state, current_stage):
@@ -251,6 +279,74 @@ def create_orchestration_graph() -> StateGraph:
     return workflow
 
 
+#: What a dry run can say about one stage. NOT_REACHED is a fact -- the graph
+#: enters at `current_stage` and walks forward, so an earlier stage is never
+#: entered. RUNS is also a fact, but a narrower one than it looks: see
+#: format_dry_run_plan's closing note.
+NOT_REACHED = "not reached"
+RUNS = "RUNS"
+
+
+def dry_run_plan(state: OrchestrationState) -> list[dict]:
+    """What a launch would actually do, stage by stage (#2289).
+
+    The previous display mapped every status that was not the literal string
+    ``"skipped"`` onto ``EXECUTE``, so a resumed run whose LLD had passed
+    announced that the LLD would be redrawn -- the single most expensive stage,
+    and the one the operator runs a dry run to confirm is being reused. The
+    same command's second table said ``lld passed 327.4s`` directly underneath.
+
+    The graph enters at ``current_stage`` and routes forward from there, so
+    position relative to that stage is what decides whether a stage is entered
+    at all. The recorded status is reported as itself rather than translated,
+    because a status is what the operator is asking about.
+    """
+    start = state.get("current_stage") or STAGE_ORDER[0]
+    start_index = STAGE_ORDER.index(start) if start in STAGE_ORDER else 0
+    results = state.get("stage_results", {}) or {}
+
+    plan = []
+    for index, stage in enumerate(STAGE_ORDER):
+        result = results.get(stage) or {}
+        plan.append(
+            {
+                "stage": stage,
+                "recorded": result.get("status", "pending"),
+                "action": NOT_REACHED if index < start_index else RUNS,
+                "artifact": result.get("artifact_path", ""),
+            }
+        )
+    return plan
+
+
+def format_dry_run_plan(state: OrchestrationState, issue_number: int) -> str:
+    """Render the plan, including what a dry run cannot settle."""
+    start = state.get("current_stage") or STAGE_ORDER[0]
+    plan = dry_run_plan(state)
+
+    lines = [
+        f"\n[ORCHESTRATOR] Dry run for issue #{issue_number}",
+        f"[ORCHESTRATOR] Execution begins at: {start}",
+        "",
+        f"{'Stage':<10} {'Recorded':<12} {'Plan':<12} Artifact",
+        "-" * 70,
+    ]
+    for row in plan:
+        lines.append(
+            f"{row['stage']:<10} {row['recorded']:<12} "
+            f"{row['action']:<12} {row['artifact'] or '-'}"
+        )
+
+    lines += [
+        "",
+        "A stage marked RUNS is entered. Whether it repeats work already done",
+        "depends on artifact detection at the time it runs, which a dry run",
+        "cannot settle. A stage marked 'not reached' is never entered at all.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def format_stage_table(stage_results: dict) -> str:
     """#1785: per-stage run record — the summary IS the evidence.
 
@@ -344,6 +440,7 @@ def orchestrate(
             total_duration_seconds=0.0,
             stage_results={},
             error_summary=f"Base-branch resolution failed: {e}",
+            dry_run=False,
         )
 
     # Load configuration
@@ -358,6 +455,7 @@ def orchestrate(
             total_duration_seconds=0.0,
             stage_results={},
             error_summary=f"Configuration errors: {'; '.join(errors)}",
+            dry_run=False,
         )
 
     # Acquire lock
@@ -417,19 +515,7 @@ def orchestrate(
 
         # Dry run
         if dry_run:
-            print(f"\n[ORCHESTRATOR] Dry run for issue #{issue_number}")
-            print(f"{'Stage':<10} {'Status':<12} {'Artifact'}")
-            print("-" * 60)
-            existing = detect_existing_artifacts(issue_number, state.get("target_repo", ""))
-            for stage in STAGE_ORDER:
-                stage_result = state.get("stage_results", {}).get(stage, {})
-                status = stage_result.get("status", "pending")
-                artifact = stage_result.get("artifact_path", "")
-                if status == "skipped":
-                    print(f"{stage:<10} {'SKIP':<12} {artifact}")
-                else:
-                    print(f"{stage:<10} {'EXECUTE':<12} -")
-            print()
+            print(format_dry_run_plan(state, issue_number), end="")
 
             release_orchestration_lock(issue_number)
             return OrchestrationResult(
@@ -440,6 +526,7 @@ def orchestrate(
                 total_duration_seconds=time.monotonic() - start_time,
                 stage_results=state.get("stage_results", {}),
                 error_summary="",
+                dry_run=True,
             )
 
         # Run the graph
@@ -478,6 +565,7 @@ def orchestrate(
             total_duration_seconds=time.monotonic() - start_time,
             stage_results=stage_results,
             error_summary=error_summary,
+            dry_run=False,
         )
 
     finally:

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -37,6 +37,24 @@ import logging
 
 _stages_logger = logging.getLogger(__name__)
 
+#: Stages a mock run must never enter (#2288). They exist to reach outward --
+#: pushing a branch, opening a PR, merging the LLD PR per ADR 0221 -- and none
+#: of that has a mock form. The value of a rehearsal is in exercising the graph
+#: wiring, not in producing artifacts, and an artifact produced by a rehearsal
+#: is worse than none because someone has to work out where it came from.
+MOCK_FORBIDDEN_STAGES = ("pr", "cleanup")
+
+
+def mock_mode(state: OrchestrationState) -> bool:
+    """Whether this run is a rehearsal.
+
+    Read from config rather than passed down, because all three sub-workflow
+    stages build their sub-state independently and a parameter would have to be
+    remembered at each one. It was forgotten at exactly one of them before, and
+    that hardcoded ``False`` is what made the spec stage unrehearsable.
+    """
+    return bool((state.get("config", {}) or {}).get("mock_mode", False))
+
 
 def should_skip_stage(
     state: OrchestrationState,
@@ -480,6 +498,7 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
             "config_effort": stage_cfg.get("effort", ""),
             "config_gates_draft": gate_enabled,
             "config_gates_verdict": gate_enabled,
+            "config_mock_mode": mock_mode(state),
             "previous_draft_path": previous_draft_path,
             "previous_verdict_text": previous_verdict_text,
         }, stage="lld")
@@ -823,7 +842,10 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
             "config_drafter": stage_cfg.get("drafter", ""),
             "config_reviewer": stage_cfg.get("reviewer", ""),
             "config_effort": stage_cfg.get("effort", ""),
-            "config_mock_mode": False,
+            # #2288: was a hardcoded False, so the spec stage could not be
+            # rehearsed and every change to it was first executed by the roll
+            # it was meant to protect.
+            "config_mock_mode": mock_mode(state),
             "human_gate_enabled": gate_enabled,
         })
 
@@ -842,11 +864,20 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
             # ride it on the LLD PR so it lands on target main (ADR 0221). The
             # working-tree copy stays for the impl stage to read; the terminal
             # cleanup removes it after the LLD PR merges.
-            _ride_spec_on_lld_pr(
-                spec_path=spec_path,
-                target_repo=state.get("target_repo", ""),
-                issue_number=issue_number,
-            )
+            # #2288: the spec is written either way -- that is the part a
+            # rehearsal exercises. Riding it onto the LLD PR is a commit and a
+            # push, so a mock run stops short of it.
+            if mock_mode(state):
+                print(
+                    f"    [mock] spec written to {spec_path}; not committed "
+                    f"and not pushed to the LLD PR."
+                )
+            else:
+                _ride_spec_on_lld_pr(
+                    spec_path=spec_path,
+                    target_repo=state.get("target_repo", ""),
+                    issue_number=issue_number,
+                )
             result = _make_stage_result(
                 status="passed",
                 artifact_path=spec_path,
@@ -1209,6 +1240,7 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
             # budget it did not have and a freeze's loop-back was dropped at 3
             # without a word.
             "max_iterations": DEFAULT_MAX_ITERATIONS,
+            "config_mock_mode": mock_mode(state),
         })
 
         error_msg = sub_result.get("error_message", "")

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -165,6 +165,17 @@ def _commit_and_push_files(state: Dict[str, Any]) -> Dict[str, Any]:
     if not created_files:
         return state
 
+    # #2288: mock mode swaps the model providers, and until now swapped nothing
+    # else -- a rehearsal would still cut a branch and open a real LLD PR. A
+    # rehearsal that leaves a PR behind is not one, so the outward half stops
+    # here. The files are still written, which is what the rehearsal exercises.
+    if state.get("config_mock_mode"):
+        print(
+            f"    [mock] {len(created_files)} file(s) written; no branch cut, "
+            f"no PR opened."
+        )
+        return state
+
     workflow_type = state.get("workflow_type", "lld")
     target_repo = state.get("target_repo", ".")
     issue_number = state.get("issue_number")

--- a/tests/unit/test_rehearsal_pair.py
+++ b/tests/unit/test_rehearsal_pair.py
@@ -1,0 +1,257 @@
+"""The two instruments a campaign rehearses with (#2288, #2289).
+
+Both had the same defect from opposite ends. The dry run said an expensive
+stage would re-execute when it would not be entered at all, and then printed a
+completed pipeline's success banner over a state whose spec was recorded
+failed. The mock path could not be reached at all, because the orchestrator
+hardcoded ``config_mock_mode: False`` -- so every change to the orchestrated
+spec stage was first executed by the roll it was meant to protect.
+
+A rehearsal instrument that lies is worse than none, because the system behaves
+correctly while its preview says otherwise.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.workflows.orchestrator import graph as g  # noqa: E402
+from assemblyzero.workflows.orchestrator import stages as st  # noqa: E402
+from assemblyzero.workflows.orchestrator.state import STAGE_ORDER  # noqa: E402
+
+
+def state_with(current_stage: str, **statuses) -> dict:
+    """An orchestration state carrying recorded stage results."""
+    return {
+        "current_stage": current_stage,
+        "stage_results": {
+            stage: {"status": status, "artifact_path": f"{stage}.md"}
+            for stage, status in statuses.items()
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# #2289 -- the dry run tells the truth
+# ---------------------------------------------------------------------------
+
+
+class TestAPassedStageIsNotAnnouncedAsExecuting:
+    """The reported case: boostgauge #7, lld passed, spec failed, resumed."""
+
+    @pytest.fixture
+    def resumed(self) -> dict:
+        return state_with("spec", triage="skipped", lld="passed", spec="failed")
+
+    def test_the_passed_lld_is_not_reached(self, resumed):
+        plan = {row["stage"]: row["action"] for row in g.dry_run_plan(resumed)}
+        assert plan["lld"] == g.NOT_REACHED
+        assert plan["triage"] == g.NOT_REACHED
+
+    def test_the_failed_spec_and_everything_after_it_runs(self, resumed):
+        plan = {row["stage"]: row["action"] for row in g.dry_run_plan(resumed)}
+        assert plan["spec"] == g.RUNS
+        assert plan["impl"] == g.RUNS
+        assert plan["pr"] == g.RUNS
+        assert plan["cleanup"] == g.RUNS
+
+    def test_the_rendered_plan_does_not_say_the_lld_will_execute(self, resumed):
+        """The literal #2289 assertion, against the rendered text an operator
+        actually reads rather than the structure underneath it."""
+        rendered = g.format_dry_run_plan(resumed, 7)
+        lld_line = next(
+            line for line in rendered.splitlines() if line.startswith("lld")
+        )
+        assert g.RUNS not in lld_line
+        assert "not reached" in lld_line
+
+    def test_the_recorded_status_is_shown_rather_than_translated(self, resumed):
+        rendered = g.format_dry_run_plan(resumed, 7)
+        assert "passed" in rendered
+        assert "failed" in rendered
+
+    def test_it_says_where_execution_begins(self, resumed):
+        assert "Execution begins at: spec" in g.format_dry_run_plan(resumed, 7)
+
+    def test_the_old_mapping_would_fail_this(self, resumed):
+        """The falsifier #2289 asked for: restoring 'anything not skipped is
+        EXECUTE' must break the assertions above."""
+        old = {
+            stage: (
+                "SKIP"
+                if resumed["stage_results"].get(stage, {}).get("status") == "skipped"
+                else "EXECUTE"
+            )
+            for stage in STAGE_ORDER
+        }
+        assert old["lld"] == "EXECUTE", "the old display announced the redraw"
+        new = {row["stage"]: row["action"] for row in g.dry_run_plan(resumed)}
+        assert new["lld"] != old["lld"]
+
+
+class TestAFreshRunStillReadsCorrectly:
+    def test_leading_skipped_stages_are_not_reached(self):
+        fresh = state_with("triage", triage="skipped")
+        plan = {row["stage"]: row["action"] for row in g.dry_run_plan(fresh)}
+        # current_stage is still triage on a fresh run, so position cannot be
+        # the whole story -- a recorded 'skipped' has to count on its own.
+        assert plan["lld"] == g.RUNS
+
+    def test_an_empty_state_runs_everything(self):
+        plan = {row["stage"]: row["action"] for row in g.dry_run_plan({})}
+        assert set(plan.values()) == {g.RUNS}
+
+
+class TestADryRunDoesNotClaimAPipelinePassed:
+    def test_the_result_is_marked_as_a_dry_run(self):
+        assert "dry_run" in g.OrchestrationResult.__annotations__
+
+    def test_the_launcher_prints_a_rehearsal_banner_not_a_success_one(self):
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+        dry_at = source.index('if result.get("dry_run")')
+        passed_at = source.index("All stages passed.")
+        assert dry_at < passed_at, (
+            "the dry-run branch must be taken before the success banner"
+        )
+
+    def test_the_rehearsal_banner_makes_no_claim_about_passing(self):
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+        assert "No stage was executed." in source
+        assert "no claim is made about whether it would pass" in source
+
+
+# ---------------------------------------------------------------------------
+# #2288 -- the spec stage can be rehearsed
+# ---------------------------------------------------------------------------
+
+
+class TestMockModeIsReadFromConfig:
+    def test_it_is_off_by_default(self):
+        assert st.mock_mode({}) is False
+        assert st.mock_mode({"config": {}}) is False
+
+    def test_the_flag_turns_it_on(self):
+        assert st.mock_mode({"config": {"mock_mode": True}}) is True
+
+    def test_a_missing_config_is_not_an_error(self):
+        assert st.mock_mode({"config": None}) is False
+
+
+class TestEverySubWorkflowStageGetsTheFlag:
+    """The hardcoded False was at exactly one of three sites, which is the
+    argument for reading it from config rather than passing it to each."""
+
+    @pytest.mark.parametrize("stage", ["lld", "spec", "impl"])
+    def test_the_stage_passes_mock_mode_through(self, stage):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        assert source.count('"config_mock_mode": mock_mode(state)') == 3, (
+            "all three sub-workflow stages must source the flag from config"
+        )
+
+    def test_no_site_hardcodes_it_any_more(self):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        assert '"config_mock_mode": False' not in source
+
+
+class TestARehearsalReachesNothingOutward:
+    def test_the_pr_and_cleanup_stages_are_forbidden(self):
+        assert set(st.MOCK_FORBIDDEN_STAGES) == {"pr", "cleanup"}
+
+    @pytest.mark.parametrize("stage", ["pr", "cleanup"])
+    def test_a_forbidden_stage_is_never_entered(self, stage, monkeypatch):
+        """The runner must not be called at all -- not called and then made to
+        behave, which would leave the refusal depending on the runner."""
+        entered = []
+        monkeypatch.setitem(
+            st.STAGE_RUNNERS, stage, lambda s: entered.append(stage) or s
+        )
+        monkeypatch.setattr(g, "save_orchestration_state", lambda s: None)
+
+        result = g._run_stage_node(
+            {
+                "current_stage": stage,
+                "config": {"mock_mode": True},
+                "stage_results": {},
+            }
+        )
+
+        assert entered == [], f"{stage} runner ran during a rehearsal"
+        assert result["stage_results"][stage]["status"] == "skipped"
+        assert "outward effects" in result["stage_results"][stage]["error_message"]
+
+    @pytest.mark.parametrize("stage", ["pr", "cleanup"])
+    def test_the_same_stage_runs_normally_without_mock_mode(
+        self, stage, monkeypatch
+    ):
+        """The falsifier: the refusal is mock mode's doing, not the stage's."""
+        entered = []
+        monkeypatch.setitem(
+            st.STAGE_RUNNERS, stage, lambda s: entered.append(stage) or dict(s)
+        )
+        monkeypatch.setattr(g, "save_orchestration_state", lambda s: None)
+        monkeypatch.setattr(g, "check_human_gate", lambda s, c: True)
+
+        g._run_stage_node(
+            {"current_stage": stage, "config": {}, "stage_results": {}}
+        )
+
+        # Entered at least once. The stub records no verdict, so the retry loop
+        # re-enters it -- the count is the retry policy's business, not this
+        # test's. What matters is that without mock mode the stage IS entered.
+        assert entered and set(entered) == {stage}
+
+
+class TestTheOutwardEffectsInsideAllowedStages:
+    def test_the_lld_finalizer_cuts_no_branch_in_mock_mode(self):
+        # The package re-exports a `finalize` FUNCTION under that name, and
+        # `import a.b.finalize as x` resolves via getattr, so it hands back the
+        # function. import_module is the only form that returns the module.
+        from importlib import import_module
+
+        finalize = import_module(
+            "assemblyzero.workflows.requirements.nodes.finalize"
+        )
+
+        called = []
+        state = {
+            "created_files": ["docs/lld/LLD-007.md"],
+            "workflow_type": "lld",
+            "issue_number": 7,
+            "target_repo": ".",
+            "config_mock_mode": True,
+        }
+        # If it reached the worktree path it would raise long before returning.
+        result = finalize._commit_and_push_files(state)
+
+        assert called == []
+        assert "commit_sha" not in result
+        assert "final_lld_pr_url" not in result
+
+    def test_the_spec_does_not_ride_the_lld_pr_in_mock_mode(self):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        guard_at = source.index("if mock_mode(state):\n                print(\n"
+                                "                    f\"    [mock] spec written")
+        ride_at = source.index("_ride_spec_on_lld_pr(\n                    spec_path=")
+        assert guard_at < ride_at, "the mock check must gate the commit + push"
+
+
+class TestTheLauncherExposesIt:
+    def test_the_flag_exists_and_sets_config(self):
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+        assert '"--mock"' in source
+        assert 'overrides["mock_mode"] = True' in source
+
+    def test_capacity_does_not_block_a_run_that_spends_nothing(self):
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+        assert "not args.dry_run and not args.mock and not args.ignore_capacity" in source

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -130,6 +130,15 @@ Examples:
     parser.add_argument("--issue", type=int, required=True, help="GitHub issue number")
     parser.add_argument("--repo", type=str, default=None, help="Target repository path to build (default: AssemblyZero)")
     parser.add_argument("--dry-run", action="store_true", help="Show planned stages without execution")
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help=(
+            "Rehearse: mock model providers for the lld, spec and impl stages, "
+            "no branch cut, no PR opened or merged. Exercises the graph wiring "
+            "without spending a roll"
+        ),
+    )
     parser.add_argument("--resume-from", type=str, default=None, choices=STAGE_ORDER, help="Stage to resume from")
     parser.add_argument("--skip-lld", action="store_true", help="Skip LLD stage if artifact exists")
     parser.add_argument("--no-skip-lld", action="store_true", help="Force LLD regeneration")
@@ -173,6 +182,10 @@ Examples:
         overrides.setdefault("gates", {})["pr"] = False
     elif args.gate_pr:
         overrides.setdefault("gates", {})["pr"] = True
+    # #2288: reaches all three sub-workflow stages, since each reads it from
+    # config rather than being handed it separately.
+    if args.mock:
+        overrides["mock_mode"] = True
 
     config = overrides if overrides else None
 
@@ -189,7 +202,9 @@ Examples:
     # implements. Starting one while either is exhausted spends the healthy
     # provider's quota just to discover the dry one, and on a recorded take
     # that is a dead run. Read-only, zero API calls.
-    if not args.dry_run and not args.ignore_capacity:
+    # #2288: a mock run makes no provider call, so provider capacity cannot
+    # block it. Gating it would refuse the one run that costs nothing.
+    if not args.dry_run and not args.mock and not args.ignore_capacity:
         from assemblyzero.core.capacity import blocked_providers
 
         blocked = blocked_providers()
@@ -217,6 +232,11 @@ Examples:
 
     if args.dry_run:
         print("[ORCHESTRATOR] DRY RUN -- no stages will execute")
+    if args.mock:
+        print(
+            "[ORCHESTRATOR] MOCK RUN -- mock model providers; no branch cut, "
+            "no PR opened or merged"
+        )
     if args.resume_from:
         print(f"[ORCHESTRATOR] Resuming from stage: {args.resume_from}")
 
@@ -255,8 +275,17 @@ Examples:
         except Exception:  # noqa: BLE001 - the summary always prints
             pass
 
-        if result["success"]:
-            print(f"\n[ORCHESTRATOR] All stages passed.")
+        if result.get("dry_run"):
+            # #2289: a dry run ran nothing, so it has no stage outcomes to
+            # report. Printing a completed pipeline's banner over a state whose
+            # spec is recorded failed is how a rehearsal reads as an all-clear.
+            print("\n[ORCHESTRATOR] Dry run complete. No stage was executed.")
+            print(
+                "[ORCHESTRATOR] The plan above is what a launch would do; "
+                "no claim is made about whether it would pass."
+            )
+        elif result["success"]:
+            print("\n[ORCHESTRATOR] All stages passed.")
             if result["pr_url"]:
                 print(f"[ORCHESTRATOR] PR: {result['pr_url']}")
             print(f"[ORCHESTRATOR] Duration: {result['total_duration_seconds']:.1f}s")


### PR DESCRIPTION
Two instruments a campaign rehearses with, broken from opposite ends. The dry run lied about what a launch would do; the mock path could not be reached at all. Landed together because they are the same capability — checking a change before a roll pays for it.

## #2289 — the dry run tells the truth

On boostgauge #7, resumed with `lld` passed and `spec` failed, the plan said the LLD would be redrawn. It would not: the graph enters at `current_stage` and walks forward, so `lld` is never entered. The same command's second table said `lld passed 327.4s` directly underneath. Two tables, one command, opposite answers — and the wrong one was about the most expensive stage in the pipeline, which is the stage an operator runs a dry run to confirm is being reused.

The cause was a one-line mapping: everything whose status was not the literal string `"skipped"` printed `EXECUTE`, including `"passed"`.

Now:

```
[ORCHESTRATOR] Dry run for issue #7
[ORCHESTRATOR] Execution begins at: spec

Stage      Recorded     Plan         Artifact
----------------------------------------------------------------------
triage     skipped      not reached  docs/lineage/7/issue-brief.md
lld        passed       not reached  LLD-007.md
spec       failed       RUNS         -
impl       pending      RUNS         -
pr         pending      RUNS         -
cleanup    pending      RUNS         -

A stage marked RUNS is entered. Whether it repeats work already done
depends on artifact detection at the time it runs, which a dry run
cannot settle. A stage marked 'not reached' is never entered at all.
```

The recorded status is shown as itself rather than translated, since a status is what the operator is asking about. `dry_run_plan()` is pure and unit-tested apart from its rendering.

**The closing note is deliberate.** A dry run genuinely cannot tell whether a stage marked RUNS will repeat work — that depends on artifact detection at the time it runs. Saying so is the difference between this display and the one it replaces, which stated an unknowable as fact.

**The banner.** `success=True` from the dry-run branch made the launcher print `All stages passed.` over a state whose spec was recorded failed. `OrchestrationResult` now carries `dry_run`, and the launcher prints a rehearsal line that makes no claim about passing.

## #2288 — the spec stage can be rehearsed

`config_mock_mode` was hardcoded `False` at the spec stage, so the orchestrated spec path could not be exercised without spending a roll. The #2250 lineage fix — the one that makes a failed spec run diagnosable — had never executed in a real orchestrated run before the roll it exists to protect.

`--mock` on `orchestrate.py` sets `config["mock_mode"]`, and all three sub-workflow stages now read it from config rather than being handed it separately. That is the point: the flag was forgotten at exactly one of three sites, and a parameter would have to be remembered at each one.

**The hazard the issue named is guarded, and measured.** `mock_mode` in the sub-workflows swaps the model providers and *nothing else* — verified by grep, there is no side-effect suppression in `finalize.py` or `git_operations.py`. A rehearsal would have cut a branch and opened a real LLD PR. So:

| Outward effect | Guard |
|---|---|
| `pr` and `cleanup` stages | Refused at the dispatch point in `_run_stage_node`, recorded `skipped`. Not inside each runner, so the guard holds for a stage nobody remembers to check |
| LLD branch + PR | `_commit_and_push_files` returns before `setup_lld_worktree`. Files are still written — that is the part being rehearsed |
| Spec riding the LLD PR | The commit + push is skipped; the spec is still written |

A test asserts the forbidden runners are **never called**, rather than called and made to behave — a refusal that depends on the runner is not a refusal. Its falsifier asserts the same stages run normally without `--mock`.

Capacity gating is bypassed for mock runs: a run that makes no provider call cannot be blocked by provider exhaustion, and gating it would refuse the one run that costs nothing.

## Verification

- 27 new tests
- #2289's requested falsifier is included: `test_the_old_mapping_would_fail_this` reconstructs the previous mapping and asserts it disagrees, so the fix cannot silently revert
- `test_no_site_hardcodes_it_any_more` asserts `"config_mock_mode": False` appears nowhere, and that all three stages source it from config
- Full unit suite: 7616 passed, 17 skipped, 5 xfailed — no regressions
- Rendered plan verified against the exact state shape #2289 reported

Not done here: an actual end-to-end `--mock` roll against a live issue. The wiring is unit-tested at every site the issue named, but the first real rehearsal is the operator's to run when a target issue is free — this batch launches no roll.

Closes #2288
Closes #2289
