### PR TITLE
fix(adversarial): choose the model through the selection layer, not a literal (Closes #2286)

### DIFF
--- a/assemblyzero/workflows/testing/adversarial_gemini.py
+++ b/assemblyzero/workflows/testing/adversarial_gemini.py
@@ -43,6 +43,76 @@ class GeminiModelDowngradeError(Exception):
     pass
 
 
+class ForbiddenModelError(Exception):
+    """Raised when the model this call would REQUEST is not permitted.
+
+    Distinct from GeminiModelDowngradeError, which is about what came back.
+    Both checks are needed and neither substitutes for the other: a call can
+    request a forbidden model and a call can be answered by one.
+    """
+
+
+#: #2286: the alias, not an identifier. Three call sites previously spelled out
+#: `gemini-2.5-pro-preview-05-06` -- a dated preview whose validity was never
+#: established, because the call died in local validation before #2281 and at
+#: authentication after it. Naming a tier instead means `MODEL_MAP` supersession
+#: notes and `FORBIDDEN_MODELS` both reach this path, and a fleet-wide migration
+#: cannot miss it.
+ADVERSARIAL_MODEL_ALIAS = "3.1-pro"
+
+
+def resolve_adversarial_model() -> str:
+    """The model this call will request, resolved and checked.
+
+    Two things the old call site did not do. The alias goes through the same
+    map every other Gemini caller uses, so a retired preview remaps rather than
+    404s. And the result is checked against FORBIDDEN_MODELS *before* the
+    request, where the existing `verify_model_is_pro` only inspects the reply.
+
+    Raises:
+        ForbiddenModelError: if the resolved identifier is forbidden.
+    """
+    from assemblyzero.core.config import FORBIDDEN_MODELS
+    from assemblyzero.core.llm_provider import GeminiProvider
+
+    alias = ADVERSARIAL_MODEL_ALIAS.lower()
+    model_id = GeminiProvider.MODEL_MAP.get(alias)
+    if model_id is None:
+        valid = ", ".join(sorted(GeminiProvider.MODEL_MAP))
+        raise ForbiddenModelError(
+            f"Adversarial model alias {alias!r} is not in the selection map. "
+            f"Valid aliases: {valid}"
+        )
+
+    # Exact match, then family. FORBIDDEN_MODELS carries both specific ids
+    # ("gemini-3-pro") and family names ("gemini-flash", "gemini-lite"), and a
+    # family entry is only meaningful as a substring.
+    lowered = model_id.lower()
+    for forbidden in FORBIDDEN_MODELS:
+        entry = forbidden.lower()
+        if lowered == entry or entry in lowered:
+            raise ForbiddenModelError(
+                f"Adversarial alias {alias!r} resolves to {model_id!r}, which "
+                f"is forbidden by FORBIDDEN_MODELS entry {forbidden!r}"
+            )
+
+    # FORBIDDEN_MODELS does not catch every Flash: its entries are
+    # `gemini-flash` and `gemini-2.5-flash`, and neither is a substring of
+    # `gemini-3.1-flash-preview`, so a 3.1-line Flash passes the list (#2374).
+    # `verify_model_is_pro` right below rejects any "flash" in the RESPONSE, so
+    # without this the request gate would be looser than the response gate and
+    # this call could ask for a model its own reply check would then refuse.
+    # The two ends of one call must agree; the list's gap is #2374's to close.
+    for tier in ("flash", "lite"):
+        if tier in lowered:
+            raise ForbiddenModelError(
+                f"Adversarial alias {alias!r} resolves to {model_id!r}, a "
+                f"{tier} tier. Governance calls run on Pro; verify_model_is_pro "
+                f"would reject this model's own response."
+            )
+    return model_id
+
+
 class AdversarialGeminiClient:
     """Wrapper around the project's existing GeminiProvider for adversarial test generation.
 
@@ -261,8 +331,12 @@ class AdversarialGeminiClient:
         if hasattr(provider, "models") and hasattr(
             getattr(provider, "models", None), "generate_content"
         ):
+            # #2286: resolved once, then reused for the metadata fallbacks
+            # below. They previously repeated the literal, so a change here
+            # alone would have left them reporting a model never requested.
+            model_id = resolve_adversarial_model()
             response = provider.models.generate_content(
-                model="gemini-2.5-pro-preview-05-06",
+                model=model_id,
                 contents=user_prompt,
                 config={
                     "system_instruction": system_prompt,
@@ -286,11 +360,9 @@ class AdversarialGeminiClient:
             if hasattr(response, "model"):
                 metadata["model"] = response.model
             elif hasattr(response, "candidates") and response.candidates:
-                metadata["model"] = getattr(
-                    response, "model_version", "gemini-2.5-pro-preview-05-06"
-                )
+                metadata["model"] = getattr(response, "model_version", model_id)
             else:
-                metadata["model"] = "gemini-2.5-pro-preview-05-06"
+                metadata["model"] = model_id
             return text, metadata
 
         # Strategy 2: LangChain-style provider with invoke()

--- a/assemblyzero/workflows/testing/nodes/adversarial_node.py
+++ b/assemblyzero/workflows/testing/nodes/adversarial_node.py
@@ -16,6 +16,7 @@ import logging
 import os
 from assemblyzero.workflows.testing.adversarial_gemini import (
     AdversarialGeminiClient,
+    ForbiddenModelError,
     GeminiModelDowngradeError,
     GeminiQuotaExhaustedError,
     GeminiTimeoutError,
@@ -120,6 +121,21 @@ def run_adversarial_node(state: AdversarialNodeState) -> AdversarialNodeState:
         return {
             **state,
             "adversarial_skipped_reason": "Gemini quota exhausted",
+            "adversarial_verdict": "error",
+            "adversarial_test_count": 0,
+            "adversarial_error": None,
+            "generated_test_files": {},
+        }
+    except ForbiddenModelError as e:
+        # #2286: the requested model is checked before the call now. This node
+        # is non-blocking by design, and the surrounding handlers name specific
+        # Gemini errors rather than catching broadly, so a new exception type
+        # would otherwise escape and halt a pipeline that is supposed to
+        # continue without adversarial coverage.
+        logger.warning("[ADV] Adversarial model not permitted — skipping: %s", e)
+        return {
+            **state,
+            "adversarial_skipped_reason": f"adversarial model not permitted: {e}",
             "adversarial_verdict": "error",
             "adversarial_test_count": 0,
             "adversarial_error": None,

--- a/tests/unit/test_adversarial_gemini.py
+++ b/tests/unit/test_adversarial_gemini.py
@@ -431,3 +431,123 @@ class TestClientSideErrorsAreNotReportedAsOutages:
 
         with pytest.raises(GeminiTimeoutError):
             _invoke(provider, timeout=120)
+
+class TestTheRequestedModelIsChosenNotSpelled:
+    """#2286: three call sites spelled out `gemini-2.5-pro-preview-05-06`.
+
+    That identifier's validity was never established -- before #2281 the call
+    died in local validation, after it the request was rejected at
+    authentication (#2285), so Google never resolved it once. A dated preview
+    is exactly the kind of identifier that gets retired, and this call site
+    consulted neither the alias map that would have remapped it nor the
+    forbidden list that would have caught a bad tier.
+    """
+
+    def test_the_alias_is_in_the_selection_map(self):
+        from assemblyzero.core.llm_provider import GeminiProvider
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            ADVERSARIAL_MODEL_ALIAS,
+        )
+
+        assert ADVERSARIAL_MODEL_ALIAS in GeminiProvider.MODEL_MAP, (
+            "the alias must resolve through the map, or supersession notes and "
+            "fleet migrations cannot reach this call"
+        )
+
+    def test_it_resolves_to_a_pro_identifier(self):
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            resolve_adversarial_model,
+        )
+
+        model_id = resolve_adversarial_model()
+        assert "pro" in model_id
+        assert "flash" not in model_id
+        assert "preview" not in model_id, (
+            "a path that fails open should not run on a dated preview"
+        )
+
+    def test_the_requested_model_is_not_forbidden(self):
+        """The check #2286 asked for: the REQUEST is validated, where
+        verify_model_is_pro only ever inspected the reply."""
+        from assemblyzero.core.config import FORBIDDEN_MODELS
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            resolve_adversarial_model,
+        )
+
+        assert resolve_adversarial_model() not in FORBIDDEN_MODELS
+
+    @pytest.mark.parametrize("alias", ["flash", "2.5-flash", "3.1-flash-preview"])
+    def test_a_forbidden_tier_is_refused_before_any_request(self, alias):
+        """Including 3.1-flash-preview, which FORBIDDEN_MODELS does not catch
+        (#2374) but which verify_model_is_pro would reject in the response.
+        The two ends of one call have to agree."""
+        from assemblyzero.workflows.testing import adversarial_gemini as ag
+
+        with patch.object(ag, "ADVERSARIAL_MODEL_ALIAS", alias):
+            with pytest.raises(ag.ForbiddenModelError):
+                ag.resolve_adversarial_model()
+
+    def test_an_unknown_alias_is_refused_rather_than_passed_through(self):
+        from assemblyzero.workflows.testing import adversarial_gemini as ag
+
+        with patch.object(ag, "ADVERSARIAL_MODEL_ALIAS", "gemini-9.9-imaginary"):
+            with pytest.raises(ag.ForbiddenModelError):
+                ag.resolve_adversarial_model()
+
+    def test_the_dated_preview_is_gone_from_every_call_site(self):
+        """It appeared three times: the model argument and two metadata
+        fallbacks. Changing only the first would have left the fallbacks
+        reporting a model that was never requested."""
+        from pathlib import Path
+
+        import assemblyzero.workflows.testing.adversarial_gemini as ag
+
+        source = Path(ag.__file__).read_text(encoding="utf-8")
+        code = [
+            line
+            for line in source.splitlines()
+            if not line.lstrip().startswith("#")
+        ]
+        assert not [line for line in code if "gemini-2.5-pro-preview" in line]
+
+
+class TestTheResolvedModelReachesTheWireAndTheMetadata:
+    def _client_with_fake_genai(self, response):
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            AdversarialGeminiClient,
+        )
+
+        provider = MagicMock()
+        provider.models.generate_content.return_value = response
+        return AdversarialGeminiClient(provider=provider), provider
+
+    def test_the_request_carries_the_resolved_identifier(self):
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            resolve_adversarial_model,
+        )
+
+        response = MagicMock()
+        response.text = "{}"
+        response.model = resolve_adversarial_model()
+        client, provider = self._client_with_fake_genai(response)
+
+        client._invoke_provider("sys", "user", 120)
+
+        kwargs = provider.models.generate_content.call_args.kwargs
+        assert kwargs["model"] == resolve_adversarial_model()
+
+    def test_the_metadata_fallback_reports_the_model_actually_requested(self):
+        """The old fallbacks repeated the literal, so after a change at the
+        call site they would have named a model nobody asked for."""
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            resolve_adversarial_model,
+        )
+
+        response = MagicMock(spec=["text", "candidates"])
+        response.text = "{}"
+        response.candidates = []
+        client, _ = self._client_with_fake_genai(response)
+
+        _, metadata = client._invoke_provider("sys", "user", 120)
+
+        assert metadata["model"] == resolve_adversarial_model()

--- a/tests/unit/test_adversarial_node.py
+++ b/tests/unit/test_adversarial_node.py
@@ -651,3 +651,67 @@ class TestCollectContext:
         assert impl == ""
         assert lld == ""
         assert tests == ""
+
+class TestARefusedModelDoesNotHaltThePipeline:
+    """#2286 added a pre-request model check, and this node is non-blocking.
+
+    The handlers around the generate call name specific Gemini errors rather
+    than catching broadly, which is deliberate -- but it means a NEW exception
+    type escapes and halts a pipeline that is meant to continue without
+    adversarial coverage. The check and its handler ship together for that
+    reason.
+    """
+
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
+    )
+    def test_it_skips_rather_than_raising(self, mock_client_cls):
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            ForbiddenModelError,
+        )
+
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.generate_adversarial_tests.side_effect = ForbiddenModelError(
+            "alias '3.1-flash-preview' resolves to a flash tier"
+        )
+
+        state = {
+            "implementation_files": ["/fake/module.py"],
+            "lld_content": "# LLD",
+            "test_files": [],
+            "issue_id": 2286,
+        }
+
+        result = run_adversarial_node(state)
+
+        assert result["adversarial_verdict"] == "error"
+        assert result["adversarial_test_count"] == 0
+        assert "not permitted" in result["adversarial_skipped_reason"]
+
+    @patch(
+        "assemblyzero.workflows.testing.nodes.adversarial_node.AdversarialGeminiClient"
+    )
+    def test_the_reason_is_distinct_from_a_downgrade(self, mock_client_cls):
+        """A refused REQUEST and a downgraded RESPONSE are different failures
+        and must not be reported with each other's wording."""
+        from assemblyzero.workflows.testing.adversarial_gemini import (
+            ForbiddenModelError,
+        )
+
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.generate_adversarial_tests.side_effect = ForbiddenModelError(
+            "nope"
+        )
+
+        result = run_adversarial_node(
+            {
+                "implementation_files": ["/fake/module.py"],
+                "lld_content": "# LLD",
+                "test_files": [],
+                "issue_id": 2286,
+            }
+        )
+
+        assert "downgraded to Flash" not in result["adversarial_skipped_reason"]


### PR DESCRIPTION
Plumbing only. The node stays non-blocking, still skips cleanly when the credential is missing, and this PR neither provisions nor works around that credential — #2285 stays with the operator, because a valid key is a provisioning decision and switching adversarial generation on mid-MVP is a behaviour change the operator times.

## What was wrong

`gemini-2.5-pro-preview-05-06` was spelled out at three sites: the `model=` argument and two metadata fallbacks. Its validity was never established — before #2281 the call died in local validation, after it the request was rejected at authentication — so Google has never once resolved that identifier, and a dated preview is exactly the kind that gets retired.

It also consulted neither the alias map that would have remapped a retired preview nor `FORBIDDEN_MODELS`, so it could not be steered by configuration and a fleet-wide migration would have missed it.

## The fix

One constant naming a **tier**, not an identifier:

```python
ADVERSARIAL_MODEL_ALIAS = "3.1-pro"      # -> gemini-3.1-pro-high
```

`resolve_adversarial_model()` resolves it through `GeminiProvider.MODEL_MAP` — the same map every other Gemini caller uses, so supersession notes reach this path — and then checks the result before the request, which is the check #2286 said was missing. `verify_model_is_pro` inspects only the reply.

The three literals collapse to one resolution, reused for both metadata fallbacks. A test asserts the dated preview appears on no non-comment line, because changing the call site alone would have left the fallbacks reporting a model nobody requested.

## Two things measurement changed

**`FORBIDDEN_MODELS` does not catch every Flash.** Checking every alias in the map against the list:

```
  2.5-flash            -> gemini-2.5-flash             FORBIDDEN via 'gemini-2.5-flash'
  flash                -> gemini-2.5-flash             FORBIDDEN via 'gemini-2.5-flash'
  3.1-flash-preview    -> gemini-3.1-flash-preview     permitted        <-- a Flash tier
```

The entries are `gemini-flash` and `gemini-2.5-flash`; neither is a substring of `gemini-3.1-flash-preview`, because the version sits between the vendor prefix and the tier word. Meanwhile `verify_model_is_pro`, twenty lines away, rejects any `"flash"` in the response. Left alone, this call's request gate would have been looser than its own response gate — it could ask for a model its own reply check would refuse.

So `resolve_adversarial_model` applies the family rule too, and the list's gap is filed as #2374 with the note that this local rule should be deleted once the list carries it. One rule, not two, is the goal; two is the honest interim.

**The node would have stopped being non-blocking.** The handlers around the generate call name specific Gemini errors rather than catching broadly. A new exception type escapes them and halts a pipeline that is supposed to continue without adversarial coverage. `ForbiddenModelError` therefore ships with its own handler in `adversarial_node`, and a test asserts the node skips rather than raising — with a reason distinct from the downgrade wording, since a refused request and a downgraded response are different failures.

## What is still unverified

The live half. No request has been sent, so `gemini-3.1-pro-high` is resolved and permitted but not yet *proven* to answer — that is blocked on #2285 and stays there. What this PR establishes is that the identifier is chosen by the selection layer rather than guessed, which is the part that was making the call site look maintained while being unverified.

## Verification

- 12 new tests
- Every alias in `MODEL_MAP` checked against the gate, including the three that must be refused
- Full unit suite: 7628 passed, 17 skipped, 5 xfailed — no regressions
- `ruff check` clean on both changed files

Closes #2286
