### PR TITLE
fix(scaffolder): new repos are born on the Python the fleet runs (Closes #2274)

### DIFF
--- a/tests/unit/test_new_repo_python_version.py
+++ b/tests/unit/test_new_repo_python_version.py
@@ -1,0 +1,143 @@
+"""New repos are born on the Python the fleet actually runs (#2274).
+
+The scaffolder stamped `^3.10` into every new repo's pyproject and `"3.10"`
+into its release workflow. That is the #2185 defect class built into the
+generator rather than inherited: a floor nothing in the fleet runs lets the
+resolver choose package versions with no cp314 wheels, and on a workstation
+with no C compiler the source build fails, so `poetry install` exits nonzero
+forever.
+
+The pinning here is deliberately not "the two constants are equal". A floor and
+a CI version are different claims and AssemblyZero's own configuration holds
+them at different values. What must never drift is each constant from the
+parent repo's real configuration, so that is what these tests read -- the
+actual `pyproject.toml` and the actual `ci.yml`, not a copy of their values.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import new_repo  # noqa: E402
+
+
+def assemblyzero_floor() -> str:
+    """The floor AssemblyZero itself declares, read from its pyproject."""
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    requires = data["project"]["requires-python"]
+    match = re.search(r">=\s*(\d+\.\d+)", requires)
+    assert match, f"could not read a floor out of {requires!r}"
+    return match.group(1)
+
+
+def assemblyzero_ci_version() -> str:
+    """The version AssemblyZero's own CI installs."""
+    ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    match = re.search(r"python-version:\s*['\"]?(\d+\.\d+)", ci)
+    assert match, "could not read a python-version out of ci.yml"
+    return match.group(1)
+
+
+class TestTheConstantsTrackTheParentRepo:
+    """A comment claiming the constants match is not a check. These read the
+    parent repo's real files, so moving the fleet floor fails the scaffolder
+    until it follows."""
+
+    def test_the_floor_matches_assemblyzeros_own(self):
+        assert new_repo.FLEET_PYTHON_FLOOR == assemblyzero_floor()
+
+    def test_the_ci_version_matches_assemblyzeros_own(self):
+        assert new_repo.FLEET_PYTHON_CI == assemblyzero_ci_version()
+
+    def test_the_ci_version_is_not_below_the_floor(self):
+        """The one relationship between them that must hold whatever they are:
+        a workflow may not run on an interpreter the project disclaims."""
+        as_tuple = lambda v: tuple(int(p) for p in v.split("."))  # noqa: E731
+        assert as_tuple(new_repo.FLEET_PYTHON_CI) >= as_tuple(
+            new_repo.FLEET_PYTHON_FLOOR
+        )
+
+    def test_the_retired_floor_is_gone(self):
+        """#2185's floor, specifically. Nothing in the fleet runs below 3.14 and
+        the ruled floor is 3.12, so a 3.10 anywhere here is the old defect."""
+        assert new_repo.FLEET_PYTHON_FLOOR != "3.10"
+        assert new_repo.FLEET_PYTHON_CI != "3.10"
+
+
+class TestBothSurfacesAreStamped:
+    def test_poetry_init_is_handed_the_floor(self):
+        source = (ROOT / "tools" / "new_repo.py").read_text(encoding="utf-8")
+        assert 'f"^{FLEET_PYTHON_FLOOR}"' in source
+        assert '"--python", "^3.10"' not in source
+
+    def test_the_release_workflow_carries_no_literal_version(self):
+        source = (ROOT / "tools" / "new_repo.py").read_text(encoding="utf-8")
+        assert 'python-version: "3.10"' not in source
+        assert f'python-version: "{new_repo._PYTHON_CI_SENTINEL}"' in source
+
+    def test_no_stray_310_remains_in_the_generator(self):
+        """Catches a third surface nobody remembered, which is how the first two
+        got out of step."""
+        source = (ROOT / "tools" / "new_repo.py").read_text(encoding="utf-8")
+        offenders = [
+            line
+            for line in source.splitlines()
+            if "3.10" in line and not line.lstrip().startswith("#")
+        ]
+        assert not offenders, f"literal 3.10 still stamped: {offenders}"
+
+
+class TestTheSentinelIsActuallySubstituted:
+    """A sentinel that reaches disk is worse than the literal it replaced --
+    `python-version: "__FLEET_PYTHON_CI__"` fails at workflow run time, far
+    from here."""
+
+    @pytest.fixture
+    def rendered(self) -> str:
+        """The template as it reaches disk.
+
+        Taken from source and substituted the way the write site does, rather
+        than by running `create_python_project`, which shells out to poetry and
+        the GitHub API. `test_the_substitution_is_wired_at_the_write_site`
+        below is what ties this rendering to the real one.
+        """
+        source = (ROOT / "tools" / "new_repo.py").read_text(encoding="utf-8")
+        template = source.split("release_yml = '''\\", 1)[1].split("'''", 1)[0]
+        assert new_repo._PYTHON_CI_SENTINEL in template, (
+            "the template no longer carries the sentinel; this fixture is "
+            "rendering the wrong block"
+        )
+        return template.replace(
+            new_repo._PYTHON_CI_SENTINEL, new_repo.FLEET_PYTHON_CI
+        )
+
+    def test_the_sentinel_does_not_survive(self, rendered):
+        assert new_repo._PYTHON_CI_SENTINEL not in rendered
+
+    def test_the_rendered_workflow_names_the_fleet_version(self, rendered):
+        assert f'python-version: "{new_repo.FLEET_PYTHON_CI}"' in rendered
+
+    def test_the_substitution_is_wired_at_the_write_site(self):
+        """The template and the write are far apart in the file; this asserts
+        the write applies the replacement rather than writing the raw template."""
+        source = (ROOT / "tools" / "new_repo.py").read_text(encoding="utf-8")
+        assert "release_yml.replace(_PYTHON_CI_SENTINEL, FLEET_PYTHON_CI)" in source
+
+
+class TestTheFloorSurvivesPep440Normalisation:
+    """`poetry init` writes the caret form and #1573's normaliser rewrites it.
+    The floor has to come out the other side intact."""
+
+    def test_the_caret_floor_normalises_to_the_same_floor(self):
+        floor = new_repo.FLEET_PYTHON_FLOOR
+        text = f'requires-python = "^{floor}"\n'
+        out = new_repo._normalize_requires_python(text)
+        major = floor.split(".")[0]
+        assert out == f'requires-python = ">={floor},<{int(major) + 1}.0"\n'

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -542,6 +542,38 @@ def create_project_json(project_path: Path, name: str, github_user: str) -> None
 
 PROJECT_TYPES = ("minimal", "python", "chrome-extension", "pypi", "cf-worker", "web")
 
+# ---------------------------------------------------------------------------
+# Python versions the fleet actually runs (#2274)
+# ---------------------------------------------------------------------------
+#
+# The scaffolder stamped `^3.10` into every new repo's pyproject and `"3.10"`
+# into its release workflow. That is the #2185 defect class built into the
+# generator: a floor nothing in the fleet runs pushes the resolver toward
+# package versions with no cp314 wheels, and on a machine with no C compiler
+# the source build fails, so `poetry install` exits nonzero forever.
+#
+# These are TWO values on purpose, and the difference is not drift.
+#
+# The FLOOR is a claim about compatibility: the oldest interpreter the project
+# says it supports. It bounds what the resolver may choose.
+#
+# The CI version is what a workflow actually installs and runs on. Testing and
+# building on the version the fleet really uses is what catches the breakage
+# operators hit; a workflow pinned to the floor would go green on an
+# interpreter nobody runs, which is the same blindness #2185 was about, only
+# pointed the other way.
+#
+# Both track AssemblyZero's own configuration, and `tests/unit/test_new_repo_python_version.py`
+# asserts that rather than trusting this comment -- if the parent repo's floor
+# or CI version moves, the scaffolder is failed until it follows.
+FLEET_PYTHON_FLOOR = "3.12"
+FLEET_PYTHON_CI = "3.14"
+
+#: Substituted into the release workflow template. A sentinel rather than an
+#: f-string because GitHub Actions templates carry `${{ }}`, which an f-string
+#: would force every future editor to double.
+_PYTHON_CI_SENTINEL = "__FLEET_PYTHON_CI__"
+
 
 def _project_specific_context(project_type: str, name: str) -> str:
     """Return the "## Project-Specific Context" section for the given project type.
@@ -1372,8 +1404,9 @@ _REQUIRES_PYTHON_CARET = re.compile(
 def _normalize_requires_python(pyproject_text: str) -> str:
     """Rewrite a Poetry-style caret requires-python to valid PEP 440 (#1573).
 
-    `poetry init` writes `requires-python = "^3.10"` into the PEP 621 [project]
-    table. The caret is valid Poetry dependency syntax but INVALID PEP 440 for
+    `poetry init` writes `requires-python = "^X.Y"` into the PEP 621 [project]
+    table -- `^` plus whatever floor it was handed, `FLEET_PYTHON_FLOOR` here
+    (#2274). The caret is valid Poetry dependency syntax but INVALID PEP 440 for
     this field, so ruff and other strict PEP 621 consumers refuse to parse
     pyproject.toml at all. `^X.Y` means `>=X.Y,<(X+1).0`, so rewrite to that
     faithful, valid form. An already-valid specifier is returned unchanged.
@@ -1450,7 +1483,9 @@ def create_python_project(
         "--no-interaction",
         "--name", package_name,
         "--description", "",
-        "--python", "^3.10",
+        # #2274: the ruled fleet floor, not a literal. `_normalize_requires_python`
+        # below rewrites the caret to valid PEP 440.
+        "--python", f"^{FLEET_PYTHON_FLOOR}",
         "--license", poetry_license,
     ]
     try:
@@ -1688,7 +1723,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "__FLEET_PYTHON_CI__"
 
       - name: Install Poetry
         run: pipx install poetry
@@ -1700,8 +1735,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         # No password / token — OIDC Trusted Publisher handles auth.
 '''
+        # #2274: the workflow builds on the version the fleet runs, not on a
+        # floor no machine has.
         (workflows_dir / "release.yml").write_text(
-            release_yml, encoding="utf-8", newline="",
+            release_yml.replace(_PYTHON_CI_SENTINEL, FLEET_PYTHON_CI),
+            encoding="utf-8",
+            newline="",
         )
 
 


### PR DESCRIPTION
Every repo the scaffolder created was born with the #2185 defect: a `^3.10` floor nothing in the fleet runs, which lets the resolver pick package versions with no cp314 wheels — and on a workstation with no C compiler the source build fails, so `poetry install` exits nonzero forever.

Two surfaces carried it: `poetry init --python ^3.10`, and `python-version: "3.10"` in the release workflow.

## One correction to the issue's framing

The issue calls the second surface "a CI matrix testing a version no machine uses". It is the **release** workflow — `on: push: tags`, `environment: pypi`, build distributions and publish. There is no test matrix in the scaffolded repo. The harm is therefore a wheel *built* on a retired interpreter rather than a test suite passing on one. Same fix, different failure, and worth saying plainly since it changes what the version means.

## Two constants, and why that is not the drift

The acceptance asks for one constant feeding both surfaces. Measurement says two, because AssemblyZero itself holds them at different values:

```
pyproject.toml        requires-python = ">=3.12,<4.0"
.github/workflows/ci.yml   python-version: '3.14'
```

They are different claims. The **floor** is a compatibility claim that bounds what the resolver may choose. The **CI version** is what a workflow actually installs. Collapsing them to one value would pin new repos' workflows to 3.12 — green on an interpreter nobody runs, which is the same blindness #2185 was about, only pointed the other way.

```python
FLEET_PYTHON_FLOOR = "3.12"   # -> poetry init --python ^3.12
FLEET_PYTHON_CI    = "3.14"   # -> the release workflow
```

## What is pinned instead

Not "the two constants are equal" — that would be false and would have to be deleted the first time anyone looked. `tests/unit/test_new_repo_python_version.py` reads AssemblyZero's **actual** `pyproject.toml` and **actual** `ci.yml` and asserts each constant matches. Move the fleet floor in the parent repo and the scaffolder fails until it follows. That is the drift the acceptance was reaching for, anchored to a fact rather than to a copy of one.

Plus the invariant that holds whatever the values are: the CI version may never be below the floor — a workflow must not run on an interpreter the project disclaims.

`test_no_stray_310_remains_in_the_generator` scans the whole file for a literal `3.10`, because a third surface nobody remembered is how the first two got out of step. It found one on its first run: `_normalize_requires_python`'s docstring still described poetry writing `^3.10`. Now version-agnostic, so it stays true the next time the floor moves.

## The sentinel

The release template is a plain string containing a YAML `python-version:` line. It is substituted through `_PYTHON_CI_SENTINEL` rather than made an f-string, because GitHub Actions templates carry `${{ }}` and an f-string would force every future editor to double every brace — a trap that pays out silently and much later. A sentinel that survived to disk would be worse than the literal it replaced, so a test asserts it does not, and another asserts the write site applies the replacement rather than writing the raw template.

## Verification

- 11 new tests
- Full unit suite: 7650 passed, 17 skipped, 5 xfailed — no regressions
- `ruff check` clean on both changed files

Not done here: existing repos already scaffolded with the 3.10 floor. This closes the generator so the class stops being minted; the back-fill across already-created repos is a separate sweep and is not in this issue's scope.

Closes #2274
