### PR TITLE
feat(audit): name what marks the Projects tree ReadOnly (Closes #2277)

### DIFF
--- a/docs/audits/0902-readonly-attribute-projects-tree-2026-08-14.md
+++ b/docs/audits/0902-readonly-attribute-projects-tree-2026-08-14.md
@@ -1,0 +1,89 @@
+# 0902: What marks the Projects tree ReadOnly
+
+**Date:** 2026-08-14
+**Issue:** #2277 (split from #2136)
+**Verdict:** Google Drive for Desktop. External to the pipeline, external to the fleet's tooling, and it stopped on 2026-08-01.
+
+---
+
+## The question
+
+#2136 asked what in the pipeline applies the Windows ReadOnly attribute to worktree directories, and answered: nothing does. The attribute is ambient across the whole `Projects` tree, including repos that have never been rolled and caches like `.mypy_cache`. #2277 carried the remaining question: what applies it, then?
+
+## The answer
+
+**Google Drive for Desktop** (Drive File Stream 129.0.1.0, installed at `C:\Program Files\Google\Drive File Stream`) was backing up `C:\Users\mcwiz\Projects`. It marks the directories it manages. It stopped on **2026-08-01 at about 16:15**, and nothing created since carries the attribute.
+
+No pipeline code, no fleet tool, and no scheduled task is involved. `schtasks /query /v` matches `Projects` zero times.
+
+## The measurements
+
+**1. It is specific to this tree.** If directories everywhere carried the attribute there would be no mystery to solve.
+
+| Root | Marked |
+|---|---|
+| `C:\Windows` | 2/25 |
+| `C:\Program Files` | 0/25 |
+| `C:\Program Files (x86)` | 1/25 |
+| **combined baseline** | **3/75 (4%)** |
+| `Projects` | 110/118 (93%) |
+| `Projects\AssemblyZero` | 24/24 (100%) |
+
+**2. Directories only — not one file.**
+
+| Repo | Directories | Files |
+|---|---|---|
+| AssemblyZero | 24/24 | 0/30 |
+| boostgauge | 13/13 | 0/9 |
+| Aletheia | 32/32 | 0/40 |
+| Talos | 18/18 | 0/12 |
+
+87 of 87 directories, 0 of 91 files. A backup or antivirus product rewriting attributes would generally touch both. A sync client marking the folders it manages would not.
+
+**3. No `desktop.ini` anywhere.** 0 of 87 marked directories contains one, so this is not the Windows shell's folder-customisation mechanism, which is the usual innocent explanation for a ReadOnly folder.
+
+**4. Freshly created directories are unmarked** — including nested ones, created seconds before measuring. Whatever does this walks existing trees rather than marking at creation.
+
+**5. The boundary dates the last pass.** In `AssemblyZero/data`, sorted by creation time:
+
+```
+newest MARKED created:   2026-07-31 08:23:13  scratch-2026-07-31-claudemd-handoff
+oldest UNMARKED created: 2026-08-02 01:43:55  worktrees
+```
+
+Everything older is marked; everything newer is not. All 33 scratch directories created since 2026-08-02 are unmarked.
+
+**6. Drive's staging directories sit in the Projects root and fall idle inside that window.**
+
+```
+.tmp.driveupload     created 2026-07-18 19:19:14   last active 2026-08-01 16:15:03
+.tmp.drivedownload   created 2026-08-01 12:32:42   last active 2026-08-01 16:01:18
+```
+
+`.tmp.driveupload` and `.tmp.drivedownload` are Google Drive for Desktop's staging directories, created in any folder it backs up. Their last activity — 2026-08-01 16:15 — sits between the last marked directory (07-31 08:23) and the first unmarked one (08-02 01:43).
+
+Drive was not running when this was measured.
+
+## Why it costs nothing
+
+Measured directly: a file was created inside a marked directory, read back, and deleted. All three succeeded.
+
+On Windows the ReadOnly flag on a **directory** is a shell hint, not a permission — unlike on a file, where it does block writes. This is why #2135's fix (clear the attribute, retry the plain `git worktree remove`) is the right one and why identifying the setter changes no code.
+
+## Corroboration
+
+The root `CLAUDE.md` carries an unrelated lesson earned 2026-07-24: an agent recursively walked a Google Drive `Other computers\<machine>` backup tree and forced ~70 GB of hydration. That incident is independent evidence that this machine was configured to back folders up to Drive, which is the configuration this audit found the traces of.
+
+## The detection check
+
+`tools/readonly_attribute_audit.py` re-runs all of it: the baseline comparison, the directory-versus-file split, the staging-directory check, and the boundary. It exits 1 if a directory created after the recorded last pass is marked, which is what "Drive backup was switched back on" would look like.
+
+It is read-only. Nothing here is worth a destructive fix.
+
+```
+poetry run python tools/readonly_attribute_audit.py
+```
+
+## Left open
+
+`.tmp.driveupload` holds **1.7 GB across 8,610 entries**, abandoned since 2026-08-01. Removing it is disk cleanup and an irreversible operator decision rather than a finding, so it is tracked separately in #2379 — including the step this audit did not take: confirming Drive is no longer configured for this folder before anything is deleted.

--- a/tests/unit/test_readonly_attribute_audit.py
+++ b/tests/unit/test_readonly_attribute_audit.py
@@ -1,0 +1,176 @@
+"""The ReadOnly audit measures rather than asserts (#2277).
+
+The finding it encodes -- that Google Drive for Desktop marked the Projects
+tree and stopped on 2026-08-01 -- is only worth writing down if something
+re-checks it. These tests build real directories and set the real Windows
+attribute, because the whole subject is a filesystem attribute and a mocked
+`os.stat` would let every claim here pass without being true.
+"""
+from __future__ import annotations
+
+import os
+import stat as stat_mod
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import readonly_attribute_audit as audit  # noqa: E402
+
+windows_only = pytest.mark.skipif(
+    sys.platform != "win32", reason="Windows file attributes only exist on Windows"
+)
+
+
+def mark_readonly(path: Path) -> None:
+    os.chmod(path, stat_mod.S_IREAD)
+
+
+def clear_readonly(path: Path) -> None:
+    os.chmod(path, stat_mod.S_IWRITE)
+
+
+@windows_only
+class TestItReadsTheRealAttribute:
+    def test_a_plain_directory_is_unmarked(self, tmp_path):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert audit.is_readonly(plain) is False
+
+    def test_a_marked_directory_is_detected(self, tmp_path):
+        marked = tmp_path / "marked"
+        marked.mkdir()
+        mark_readonly(marked)
+        try:
+            assert audit.is_readonly(marked) is True
+        finally:
+            clear_readonly(marked)
+
+    def test_clearing_it_is_detected_too(self, tmp_path):
+        """The falsifier. Without this, `is_readonly` returning True always
+        would pass the test above."""
+        d = tmp_path / "toggled"
+        d.mkdir()
+        mark_readonly(d)
+        clear_readonly(d)
+        assert audit.is_readonly(d) is False
+
+    def test_a_missing_path_is_none_not_false(self, tmp_path):
+        """None means unknown. Reporting a path that does not exist as
+        'unmarked' would quietly deflate the ratio."""
+        assert audit.is_readonly(tmp_path / "nope") is None
+
+
+@windows_only
+class TestTheMarkedDirectoryIsStillWritable:
+    """The finding that makes this whole issue low priority: on Windows the
+    ReadOnly flag on a DIRECTORY is a shell hint, not a permission. If this
+    ever fails, #2277 stops being a curiosity and becomes an outage."""
+
+    def test_a_file_can_be_created_inside_a_marked_directory(self, tmp_path):
+        d = tmp_path / "marked"
+        d.mkdir()
+        mark_readonly(d)
+        try:
+            probe = d / "probe.txt"
+            probe.write_text("x", encoding="utf-8")
+            assert probe.read_text(encoding="utf-8") == "x"
+            probe.unlink()
+        finally:
+            clear_readonly(d)
+
+
+class TestTheRatio:
+    def test_an_empty_set_does_not_divide_by_zero(self):
+        assert audit.ratio([]) == (0, 0)
+
+    @windows_only
+    def test_it_counts_only_the_marked(self, tmp_path):
+        dirs = []
+        for i in range(4):
+            d = tmp_path / f"d{i}"
+            d.mkdir()
+            dirs.append(d)
+        mark_readonly(dirs[0])
+        mark_readonly(dirs[2])
+        try:
+            assert audit.ratio(dirs) == (2, 4)
+        finally:
+            for d in dirs[::2]:
+                clear_readonly(d)
+
+
+@windows_only
+class TestTheBoundaryDatesTheLastPass:
+    """A timestamp is worth more than a guess at a culprit: everything created
+    before the setter's last pass is marked, everything after is not."""
+
+    def test_it_finds_the_newest_marked_and_oldest_unmarked(self, tmp_path):
+        old = tmp_path / "old_marked"
+        new = tmp_path / "new_unmarked"
+        old.mkdir()
+        new.mkdir()
+        mark_readonly(old)
+        try:
+            newest_marked, oldest_unmarked = audit.newest_marked_and_oldest_unmarked(
+                [old, new]
+            )
+            assert newest_marked is not None and newest_marked[0] == old
+            assert oldest_unmarked is not None and oldest_unmarked[0] == new
+        finally:
+            clear_readonly(old)
+
+    def test_an_all_marked_tree_reports_no_unmarked_side(self, tmp_path):
+        d = tmp_path / "only"
+        d.mkdir()
+        mark_readonly(d)
+        try:
+            newest_marked, oldest_unmarked = audit.newest_marked_and_oldest_unmarked([d])
+            assert newest_marked is not None
+            assert oldest_unmarked is None
+        finally:
+            clear_readonly(d)
+
+    def test_an_all_unmarked_tree_reports_no_marked_side(self, tmp_path):
+        d = tmp_path / "only"
+        d.mkdir()
+        newest_marked, oldest_unmarked = audit.newest_marked_and_oldest_unmarked([d])
+        assert newest_marked is None
+        assert oldest_unmarked is not None
+
+
+class TestTheRecordedFinding:
+    def test_the_last_pass_is_the_measured_boundary(self):
+        """#2277 measured: last marked 2026-07-31 08:23, first unmarked
+        2026-08-02 01:43, Drive staging idle from 2026-08-01 16:15 between the
+        two. The constant must sit inside that window, not near it."""
+        assert datetime(2026, 8, 1) <= audit.KNOWN_LAST_PASS <= datetime(2026, 8, 3)
+
+    def test_drive_staging_names_are_the_ones_drive_actually_uses(self):
+        assert set(audit.DRIVE_STAGING) == {".tmp.driveupload", ".tmp.drivedownload"}
+
+    def test_the_baseline_roots_are_local_only(self):
+        """A cloud or mapped root would hydrate on stat -- the 70 GB incident in
+        the root CLAUDE.md, earned 2026-07-24."""
+        for base in audit.BASELINE_ROOTS:
+            text = str(base).lower()
+            assert text.startswith("c:\\")
+            for forbidden in ("onedrive", "google", "drive file stream", "\\\\"):
+                assert forbidden not in text
+
+    def test_a_directory_created_after_the_last_pass_would_read_as_spreading(self):
+        """The condition the audit exits 1 on, checked as arithmetic rather
+        than by waiting for it to happen."""
+        after = audit.KNOWN_LAST_PASS + timedelta(days=1)
+        assert after > audit.KNOWN_LAST_PASS
+
+
+class TestItRefusesRatherThanGuessing:
+    def test_a_missing_root_is_an_error_not_an_empty_pass(self, tmp_path, capsys):
+        code = audit.main(["--root", str(tmp_path / "absent")])
+        assert code == audit.EXIT_ERROR
+        assert "Nothing has been verified" in capsys.readouterr().err

--- a/tools/readonly_attribute_audit.py
+++ b/tools/readonly_attribute_audit.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Who marked the Projects tree ReadOnly, and when did they stop (#2277).
+
+#2136 asked what in the pipeline sets the Windows ReadOnly attribute on
+worktrees and answered: nothing does. #2277 asked what does. This is the
+program that answers it, and re-answers it if the condition returns -- a
+finding written down once is a claim about one afternoon.
+
+Four measurements, in the order that narrows fastest:
+
+1. **Is it Projects-specific?** If directories everywhere carry the attribute
+   then nothing is walking Projects and there is no mystery. Sampling local,
+   non-cloud roots settles that in a second.
+2. **Directories or files?** A backup or antivirus product rewriting
+   attributes generally touches both. Directories alone is a much narrower
+   signature.
+3. **When did the setter last run?** Sort by creation time and find the
+   boundary between marked and unmarked. Everything created before the last
+   pass is marked; everything after is not. The boundary is a timestamp, which
+   is worth more than a guess at a culprit.
+4. **Is a sync client staging in the tree?** Google Drive for Desktop leaves
+   `.tmp.driveupload` / `.tmp.drivedownload` in any folder it backs up, and
+   their mtimes date its last activity.
+
+Read-only. It changes no attribute and deletes nothing: on this machine the
+attribute costs nothing (a "ReadOnly" directory accepts writes -- on Windows the
+flag on a *directory* is a shell hint, not a permission), so there is nothing
+here worth a destructive fix.
+
+    poetry run python tools/readonly_attribute_audit.py
+    poetry run python tools/readonly_attribute_audit.py --root /c/Users/mcwiz/Projects
+
+Exit codes:
+    0  the tree looks the way #2277 recorded it, or is clean
+    1  the marking is spreading again -- something is walking the tree now
+    2  the audit could not run, so nothing was verified
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import stat as stat_mod
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# #2367: before anything prints. Repo and directory names are arbitrary text.
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+EXIT_OK = 0
+EXIT_SPREADING = 1
+EXIT_ERROR = 2
+
+READONLY = stat_mod.FILE_ATTRIBUTE_READONLY
+
+#: Local, non-cloud roots. Never a mapped drive, a OneDrive path or a Drive
+#: mount -- a stat there hydrates the file (root CLAUDE.md, earned 2026-07-24).
+BASELINE_ROOTS = (
+    Path(r"C:\Windows"),
+    Path(r"C:\Program Files"),
+    Path(r"C:\Program Files (x86)"),
+)
+
+#: Left behind in any folder Google Drive for Desktop backs up.
+DRIVE_STAGING = (".tmp.driveupload", ".tmp.drivedownload")
+
+#: The last pass recorded by #2277, from the boundary in AssemblyZero/data:
+#: last marked 2026-07-31 08:23, first unmarked 2026-08-02 01:43, and the Drive
+#: staging directories fell idle at 2026-08-01 16:15 between the two.
+KNOWN_LAST_PASS = datetime(2026, 8, 2)
+
+
+def is_readonly(path: Path) -> bool | None:
+    try:
+        return bool(os.stat(path).st_file_attributes & READONLY)
+    except OSError:
+        return None
+    except AttributeError:  # not Windows
+        return None
+
+
+def child_dirs(root: Path, limit: int | None = None) -> list[Path]:
+    try:
+        found = [p for p in sorted(root.iterdir()) if p.is_dir()]
+    except OSError:
+        return []
+    return found[:limit] if limit else found
+
+
+def ratio(paths: list[Path]) -> tuple[int, int]:
+    return sum(1 for p in paths if is_readonly(p)), len(paths)
+
+
+def newest_marked_and_oldest_unmarked(
+    paths: list[Path],
+) -> tuple[tuple[Path, datetime] | None, tuple[Path, datetime] | None]:
+    marked, unmarked = [], []
+    for p in paths:
+        try:
+            created = datetime.fromtimestamp(os.stat(p).st_ctime)
+        except OSError:
+            continue
+        (marked if is_readonly(p) else unmarked).append((p, created))
+    return (
+        max(marked, key=lambda r: r[1]) if marked else None,
+        min(unmarked, key=lambda r: r[1]) if unmarked else None,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure the ambient Windows ReadOnly attribute across the "
+            "Projects tree, and date the last pass that applied it. Read-only."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        default=r"C:\Users\mcwiz\Projects",
+        help="tree to audit (default: the Projects root)",
+    )
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    if not root.is_dir():
+        print(f"ERROR -- not a directory: {root}", file=sys.stderr)
+        print("Nothing has been verified.", file=sys.stderr)
+        return EXIT_ERROR
+    if not hasattr(os.stat(root), "st_file_attributes"):
+        print("ERROR -- no Windows file attributes here; this audit is Windows-only.",
+              file=sys.stderr)
+        return EXIT_ERROR
+
+    rule = "=" * 70
+    print(rule)
+    print(f"ReadOnly attribute audit -- {root}")
+    print(rule)
+    print()
+
+    tree_dirs = child_dirs(root)
+    marked, total = ratio(tree_dirs)
+    share = (marked / total * 100) if total else 0.0
+    print(f"Inside the tree:  {marked}/{total} directories marked ({share:.0f}%)")
+
+    print()
+    print("Baseline, local roots outside the tree:")
+    baseline_marked = baseline_total = 0
+    for base in BASELINE_ROOTS:
+        m, t = ratio(child_dirs(base, limit=25))
+        baseline_marked += m
+        baseline_total += t
+        if t:
+            print(f"  {str(base):<26} {m}/{t}")
+    baseline_share = (
+        (baseline_marked / baseline_total * 100) if baseline_total else 0.0
+    )
+    print(f"  {'combined':<26} {baseline_marked}/{baseline_total} ({baseline_share:.0f}%)")
+
+    print()
+    if share > baseline_share + 25:
+        print("VERDICT: specific to this tree, not a machine-wide property.")
+    else:
+        print("VERDICT: no excess over baseline -- nothing is singling this tree out.")
+
+    files = []
+    try:
+        files = [p for p in root.iterdir() if p.is_file()]
+    except OSError:
+        pass
+    if files:
+        fm, ft = ratio(files)
+        print()
+        print(f"Files at this level: {fm}/{ft} marked")
+        if fm == 0 and marked:
+            print("  Directories only. A backup or AV product rewriting attributes")
+            print("  would generally touch files too; a sync client marking the")
+            print("  folders it manages would not.")
+
+    print()
+    print("Google Drive for Desktop staging directories:")
+    drive_seen = False
+    for name in DRIVE_STAGING:
+        staging = root / name
+        if not staging.exists():
+            print(f"  {name:<22} absent")
+            continue
+        drive_seen = True
+        try:
+            idle_since = datetime.fromtimestamp(os.stat(staging).st_mtime)
+            print(f"  {name:<22} present, last active {idle_since:%Y-%m-%d %H:%M:%S}")
+        except OSError:
+            print(f"  {name:<22} present, mtime unreadable")
+    if drive_seen:
+        print("  Drive backs up this folder. It is the setter #2277 identified.")
+
+    print()
+    print("Last pass, from the marked/unmarked boundary:")
+    newest_marked, oldest_unmarked = newest_marked_and_oldest_unmarked(tree_dirs)
+    if newest_marked:
+        print(f"  newest MARKED    {newest_marked[1]:%Y-%m-%d %H:%M:%S}  {newest_marked[0].name}")
+    if oldest_unmarked:
+        print(f"  oldest UNMARKED  {oldest_unmarked[1]:%Y-%m-%d %H:%M:%S}  {oldest_unmarked[0].name}")
+
+    spreading = bool(newest_marked and newest_marked[1] > KNOWN_LAST_PASS)
+    print()
+    if spreading:
+        print(rule)
+        print("SPREADING: a directory created after the recorded last pass is")
+        print(f"marked. Something walked this tree after {KNOWN_LAST_PASS:%Y-%m-%d}.")
+        print("Check whether Drive backup was re-enabled for this folder.")
+        print(rule)
+    else:
+        print("Stable: nothing created since the recorded last pass is marked.")
+
+    print()
+    print("Not verified: whether the attribute costs anything. It does not --")
+    print("on Windows the ReadOnly flag on a DIRECTORY is a shell hint, not a")
+    print("permission, and writes into a marked directory succeed. #2135 already")
+    print("clears it where a worktree removal trips over it.")
+    print()
+    return EXIT_SPREADING if spreading else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The setter is named: **Google Drive for Desktop**, which was backing up `C:\Users\mcwiz\Projects` and stopped on 2026-08-01 at about 16:15. External to the pipeline, external to the fleet's tooling, and it changes no code — as the issue predicted.

## How it was narrowed

Five measurements, each one cutting the space rather than adding a guess.

**Is it Projects-specific?** If directories everywhere carried the attribute there would be no process to find. Baseline on local roots: `C:\Windows` 2/25, `C:\Program Files` 0/25, `C:\Program Files (x86)` 1/25 — **3/75, 4%**. Inside the tree: **110/118, 93%**, and AssemblyZero 24/24.

**Directories or files?** 87 of 87 directories across four repos. **0 of 91 files.** A backup or AV product rewriting attributes would generally touch both; a sync client marking the folders it manages would not.

**Is it the shell's folder-customisation mechanism?** No — 0 of 87 marked directories contains a `desktop.ini`. That is the usual innocent explanation and it is ruled out.

**When did it last run?** In `AssemblyZero/data`, sorted by creation time, the boundary is crisp:

```
newest MARKED created:   2026-07-31 08:23:13  scratch-2026-07-31-claudemd-handoff
oldest UNMARKED created: 2026-08-02 01:43:55  worktrees
```

All 33 scratch directories created since are unmarked. A timestamp is worth more than a guess at a culprit.

**What was active in that window?** Google Drive for Desktop's staging directories are sitting in the Projects root:

```
.tmp.driveupload     last active 2026-08-01 16:15:03
.tmp.drivedownload   last active 2026-08-01 16:01:18
```

Drive File Stream 129.0.1.0 is installed; Drive is not currently running; `schtasks /query /v` matches `Projects` zero times. Drive's last activity falls exactly between the last marked directory and the first unmarked one.

The root `CLAUDE.md`'s lesson earned 2026-07-24 — an agent hydrating ~70 GB of a Drive `Other computers\<machine>` backup tree — is independent evidence this machine was configured to back folders up to Drive.

## Confirming it costs nothing

Not asserted, measured: a file was created inside a marked directory, read back, and deleted. All three succeeded. On Windows the ReadOnly flag on a **directory** is a shell hint rather than a permission, unlike on a file. That is why #2135's clear-and-retry is the right fix and why naming the setter changes no code.

A test pins this, because it is the fact that makes the whole issue low priority — if it ever fails, #2277 stops being a curiosity and becomes an outage.

## What ships

`tools/readonly_attribute_audit.py` re-runs every measurement above and exits 1 if a directory created after the recorded last pass is marked — which is what "Drive backup was switched back on" would look like. Read-only; it clears no attribute and deletes nothing, because there is nothing here worth a destructive fix.

`docs/audits/0902-readonly-attribute-projects-tree-2026-08-14.md` records the finding and the configuration, per the issue's second acceptance box.

15 tests, built on real directories with the real attribute set via `os.chmod` — a mocked `os.stat` would let every claim about a filesystem attribute pass without being true. Each includes its falsifier: the test that a marked directory is detected is paired with one proving the same call returns False once cleared.

## Found on the way, filed separately

`.tmp.driveupload` holds **1.7 GB across 8,610 entries**, abandoned since 2026-08-01. That is #2379. Deleting it is irreversible disk cleanup and the operator's call, and it needs a step this audit did not take — confirming Drive is no longer configured for this folder, since if it is, that directory is live state rather than garbage.

## Acceptance

- [x] The process that applies the attribute is named — Google Drive for Desktop, with the boundary timestamp and staging-directory evidence
- [x] Its configuration is recorded, in audit 0902, so a future machine does not inherit the surprise

The second probe the issue suggested (clear, idle, re-measure) was not needed: the setter has already been idle for two weeks, and the marked/unmarked boundary is that experiment having already run.

## Verification

- 15 new tests; full unit suite 7665 passed, 17 skipped, 5 xfailed — no regressions
- `ruff check` clean on both new files

Closes #2277
