### PR TITLE
fix(requirements): the gate's one retry escalates instead of re-asking (Closes #2375)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -57,6 +57,34 @@ REQUIREMENTS_CONFLICT_MARKER = "REQUIREMENTS CONFLICT:"
 #: constant, so the next issue with three tables must not re-open this.
 REQUIREMENTS_GATE_TIMEOUT_SECONDS = 600
 
+#: Where a timed-out gate call goes on its one retry (#2375).
+#:
+#: #2290 added a retry for a timeout on a healthy transport, and it re-asked the
+#: SAME model. Measured 2026-08-14 on boostgauge #1's converted body: claude
+#: sonnet timed out at 600s three consecutive times (13:0x, 13:4x, 14:2x
+#: Central), and claude opus returned a CLEAN verdict inside the bound on the
+#: first attempt immediately afterwards. Transport healthy throughout -- a
+#: trivial `claude -p` round-tripped in 5.0s between attempts. The same sonnet
+#: call had completed boostgauge #7, a comparable-size comparably-tabled
+#: document, in about five minutes that morning.
+#:
+#: So on this content class the model is the variable, and a same-model retry
+#: spends a second full 600s budget to reach the same wall. Escalating instead
+#: costs the same one retry and has a measured chance of returning a verdict.
+#:
+#: Deliberately narrow. A spec is escalated only where a measurement says the
+#: escalation helps; everything else keeps #2290's same-model retry, because no
+#: measurement says otherwise for it and inventing a ladder here would be the
+#: guessing this issue's acceptance forbids.
+GATE_DRAFTER_ESCALATION: dict[str, str] = {
+    "claude:sonnet": "claude:opus",
+}
+
+
+def escalated_drafter(spec: str) -> str | None:
+    """The stronger drafter to retry a timeout on, or None to re-ask this one."""
+    return GATE_DRAFTER_ESCALATION.get((spec or "").strip().lower())
+
 ANALYSIS_SYSTEM_PROMPT = """\
 You are a requirements analyst performing a pre-flight consistency check \
 on a GitHub issue before an autonomous pipeline builds from it.
@@ -228,41 +256,72 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
         _record_unverified(state, f"invalid provider '{drafter_spec}': {e}")
         return {}
 
-    schema_kwargs: dict[str, Any] = {}
-    if isinstance(provider, GeminiProvider):
-        schema_kwargs["response_schema"] = ANALYSIS_SCHEMA
-    else:
-        schema_kwargs["json_schema"] = ANALYSIS_SCHEMA
-
     content = f"# Issue: {issue_title}\n\n{issue_body}"
 
-    def _invoke():
-        return provider.invoke(
+    def _invoke(active_provider):
+        schema_kwargs: dict[str, Any] = {}
+        if isinstance(active_provider, GeminiProvider):
+            schema_kwargs["response_schema"] = ANALYSIS_SCHEMA
+        else:
+            schema_kwargs["json_schema"] = ANALYSIS_SCHEMA
+        return active_provider.invoke(
             system_prompt=ANALYSIS_SYSTEM_PROMPT,
             content=content,
             timeout_seconds=REQUIREMENTS_GATE_TIMEOUT_SECONDS,
             **schema_kwargs,
         )
 
-    result = _invoke()
+    answered_by = drafter_spec
+    result = _invoke(provider)
 
     # One retry, and only for a timeout on a healthy transport (#2290). A
     # storm is the condition fail-open exists for -- retrying into it burns
     # another full budget to reach the same wall, which is what the storm
     # counter was built to stop (#2086). A non-timeout failure is not retried
     # either: it failed for a reason a second identical call will not change.
+    #
+    # #2375: the retry escalates where a measurement says escalating helps.
+    # Re-asking the model that just spent the full budget is the same call
+    # again; on boostgauge #1's body sonnet did that three times for three
+    # timeouts while opus answered inside the bound on its first attempt.
     if _is_timeout(result) and not _provider_storm_active():
-        print(
-            f"  [N0c] analysis timed out at {REQUIREMENTS_GATE_TIMEOUT_SECONDS}s "
-            "and the transport is healthy -- retrying once."
-        )
-        result = _invoke()
+        stronger = escalated_drafter(drafter_spec)
+        if stronger:
+            print(
+                f"  [N0c] analysis timed out at {REQUIREMENTS_GATE_TIMEOUT_SECONDS}s "
+                f"on {drafter_spec} and the transport is healthy -- "
+                f"escalating to {stronger} for the one retry (#2375)."
+            )
+            try:
+                provider = get_provider(stronger)
+                answered_by = stronger
+            except ValueError as e:
+                # Keep the retry rather than lose it: a bad escalation entry
+                # must not cost the run the attempt #2290 gave it.
+                print(
+                    f"  [N0c] WARNING: escalation target '{stronger}' is not a "
+                    f"valid provider ({e}); retrying on {drafter_spec}."
+                )
+        else:
+            print(
+                f"  [N0c] analysis timed out at {REQUIREMENTS_GATE_TIMEOUT_SECONDS}s "
+                "and the transport is healthy -- retrying once."
+            )
+        result = _invoke(provider)
 
     # Fail-open: a dead analysis call must not kill the roll (#1899).
     if not result.success or not result.response:
         reason = result.error_message or "empty response"
-        print(f"  [N0c] WARNING: analysis unavailable ({reason}); proceeding.")
-        _record_unverified(state, f"analysis unavailable: {reason}")
+        # #2375: name the model. "The gate did not answer" and "the gate did
+        # not answer ON SONNET" are different facts, and only the second one
+        # tells the next reader whether escalating is worth trying.
+        print(
+            f"  [N0c] WARNING: analysis unavailable on {answered_by} "
+            f"({reason}); proceeding."
+        )
+        _record_unverified(
+            state, f"analysis unavailable on {answered_by}: {reason}"
+        )
         return {}
 
     parsed = _parse_analysis(result.response)
@@ -273,7 +332,10 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
 
     conflicts = parsed.get("conflicts") or []
     if parsed.get("is_consistent", True) or not conflicts:
+        # CLEAN_MARKER is asserted verbatim by the pre-check's tests, so the
+        # drafter goes on its own line rather than into that sentence.
         print("  [N0c] Requirements internally consistent.")
+        print(f"  [N0c] Verdict from {answered_by}.")
         return {}
 
     message = _format_conflict_message(conflicts)

--- a/assemblyzero/workflows/requirements/precheck.py
+++ b/assemblyzero/workflows/requirements/precheck.py
@@ -65,8 +65,19 @@ EXIT_ERROR = 2
 #: silently turning every clean result into an error.
 CLEAN_MARKER = "Requirements internally consistent."
 
-#: Matches ``--drafter`` in ``tools/run_requirements_workflow.py``, so the
-#: pre-check asks the same model the roll's gate will ask.
+#: Matches ``--drafter`` in ``tools/run_requirements_workflow.py``.
+#:
+#: It does NOT match what a roll's gate asks, despite what this comment claimed
+#: until #2375. A roll reaches the requirements graph through the orchestrator's
+#: lld stage, whose ``StageConfig`` has carried ``drafter="gemini:3.1-pro"``
+#: since #1434, and nothing on the roll path overrides it -- ``load_config``
+#: merges only ``skip_existing_*``, ``gates`` and ``mock_mode``. Measured
+#: 2026-08-14.
+#:
+#: So this pre-check predicts the roll's gate on every dimension except the
+#: model, and the model is the dimension #2375 found mattered most: sonnet timed
+#: out three consecutive times on a document opus answered on its first attempt.
+#: Which model the two paths should share is a decision, tracked in #2384.
 DEFAULT_DRAFTER = "claude:sonnet"
 
 _GATE_PATH = "assemblyzero/workflows/requirements/nodes/analyze_requirements.py"

--- a/tests/fixtures/requirements/boostgauge-1-body.md
+++ b/tests/fixtures/requirements/boostgauge-1-body.md
@@ -1,0 +1,109 @@
+## Summary
+
+Build the core gauge renderer for v1. This is Phase 4 of the on-camera speedrun arc (`#7 → #1 → #4 → #2 → #5` per `docs/speedrun/0002-route-v2.md`) and the foundation every other visual feature sits on.
+
+## What this issue ships
+
+A renderer function that takes a metric value (0–100) plus telltale peak values (from #41) and produces a `PIL.Image` of the v1 gauge. The image matches the written specification in `docs/design/0002-aesthetic-v1-stingray.md` — the canonical photograph there is inspiration only, never a comparator (ruling #262).
+
+The renderer is callable as `render(value, telltales, size, config) → PIL.Image` per #45's skin protocol sketch. v1 ships only one skin (Stingray) but the renderer is structured skin-shaped from day one so #45 can add more without rewriting.
+
+## Visual specification
+
+**See `docs/design/0002-aesthetic-v1-stingray.md` — that doc is binding.** No re-specification here. Brief summary for orientation:
+
+- Square chromed-metal housing, round matte-black dial inside.
+- White Eurostile-adjacent numerals 0–100.
+- Bold white tick marks (11 major, 4 minor between each).
+- Luminescent candy-apple-red main needle with counterweight.
+- Brick-red redline ring band occupying the outer 80–100% of dial radius, spanning values 60–100 (a rim band, never a pie segment; the two reds are deliberately distinct hues — rulings #228/#229, 2026-08-09).
+- "BOOSTGAUGE" wordmark in white small caps below the pivot.
+- Telltale needles (per #2) consume #41's `Telltale` outputs; rendered translucent at baseline — fading from baseline at 3 scale units of the main needle to full opacity at 2 units, holding full opacity closer in; opacity is computed per needle from its distance and applied uniformly to the whole needle (rulings #232/#242/#245, doc §Telltale needles) — behind the main needle.
+
+Any divergence from the aesthetic doc requires updating the doc first.
+
+## Requirements
+
+- The renderer shall produce a `PIL.Image` from `render(value, telltales, size, config)` as a pure function: no hidden state, no side effects, no `tkinter` import.
+- The renderer shall produce byte-identical images for identical inputs.
+- The renderer shall draw the main needle, and position every telltale needle, on the axis `angle(value) = 225° − 2.7° × value` (ruling #255's binding mapping: value 0 at 225°, value 50 at 90°, value 100 at −45°; a 270° clockwise sweep).
+- The renderer shall draw the six static elements identically at every value.
+- The renderer shall draw the redline band as a rim band at the outer 80–100% of dial radius, spanning values 60–100.
+- The renderer shall compute each telltale needle's rendering from its own peak per the telltale-opacity table below, applying the resulting opacity uniformly to that whole needle.
+- The renderer shall render at any square size from 128×128 up, defaulting to 256×256, aspect-locked.
+
+Telltale opacity, one row per condition (`d` is the scale distance |peak − main needle value|; baseline is the doc's §Telltale needles translucency):
+
+| ID | Peak state | `d` (scale units) | Rendered opacity |
+|---|---|---|---|
+| T1 | None | — | not rendered |
+| T2 | present | d ≥ 3 | baseline translucency |
+| T3 | present | 2 < d < 3 | linear between baseline and 100% |
+| T4 | present | d ≤ 2 | 100% |
+
+## Implementation notes
+
+- **Option C renderer (per `docs/design/0001-test-strategy.md`):** the renderer produces a `PIL.Image`. The application calls it on each refresh and hands the image to a tkinter Canvas via `PhotoImage`. The Canvas is dumb — it just displays the result. The renderer never imports `tkinter`.
+- **Anti-aliasing:** Pillow handles it (renderer draws on a PIL Image, optionally supersampled internally if needed for crispness). The "tkinter Canvas doesn't anti-alias" concerns from the original body are no longer relevant under Option C.
+- **Sizing:** Default 256×256 px (matches the canonical reference image dimensions). Resizable with aspect lock. Minimum 128×128.
+- **Skin-shape:** Stingray's render logic lives in a module (e.g., `src/boostgauge/skins/stingray.py`) implementing the protocol sketched in #45. Application code calls into the skin module, not into hard-coded drawing logic in `gauge.py`.
+
+## Dependencies
+
+- **`docs/design/0002-aesthetic-v1-stingray.md`** — the binding visual spec.
+- **`docs/design/0001-test-strategy.md`** — the binding test approach (Option C, baseline image policy).
+- **#41** — `Telltale` class. The renderer consumes `Telltale.current_peak()` values to position the four telltale needles. #41 should land before or alongside this issue.
+- **#7** — config (v1 is one skin, but config plumbing for which skin to load lives here).
+- **#45** — skins protocol sketch. v1 follows the structure so #45 can add additional skins without renderer rewrites.
+
+## State Variables and Ownership
+
+Per AssemblyZero ADR 0228: every claim about a variable's fate belongs to its one owning criteria group, named by criterion ID prefix; any other mention cites the owner.
+
+| Variable | Extension | Owner |
+|---|---|---|
+| The output image as a value | the returned `PIL.Image` object: type, purity, determinism, and the absence of `tkinter` | F (the function-contract criteria) |
+| Static-element pixels | the pixels of `housing`, `dial`, `ticks`, `numerals`, `band`, `wordmark` | S (the static-scenery criteria) |
+| Main-needle axis and pixels | the `needle` element: its axis from the angle mapping and its `#F73923` pixels | M (the main-needle criteria) |
+| Telltale-needle visibility and opacity | the four `telltale` needles: drawn or not, and at what opacity | T (the telltale table and criteria) |
+
+- Boundary term: **static elements** are exactly `housing`, `dial`, `ticks`, `numerals`, `band` (the redline ring), and `wordmark` — six, per the aesthetic doc's sections.
+- Boundary term: **scale unit** is one unit of dial value; a **scale distance** `d` is |telltale peak − main needle value|.
+- Boundary term: **baseline translucency** is the doc §Telltale needles value; **full opacity** is 100%.
+- Boundary term: **peak** is a telltale's held maximum on the 0–100 scale (#41's `Telltale.current_peak()`); **coincident** means its peak equals the main needle's value exactly (`d` = 0), and **non-coincident** means `d` > 0.
+
+## Acceptance Criteria
+
+- [ ] F1 — `render(value, telltales, size, config) → PIL.Image` callable as a pure function (no hidden state, no side effects, no `tkinter` imports).
+- [ ] F2 — Needle positions are deterministic functions of value (and per-telltale of peak value); provided the inputs are identical, two calls produce byte-identical output.
+- [ ] S1 — Static gauge image at value=0, all telltales=None renders every element the aesthetic doc's text specifies, verified by doc-text-derived checks (housing and dial present; ticks and numerals per §layout; brick-red band at the ruled radii spanning 60–100; candy-apple needle on the ruled 225° rest axis; wordmark below the pivot) — and pinned thereafter by a SELF-generated visual-regression baseline accepted via the explicit `--generate-baselines` flow (test strategy 0001 §3). The canonical photograph is inspiration only and is never compared against (ruling #262).
+- [ ] S2 — Image at value=100 with no telltales: every static element (housing, dial face, ticks, numerals, redline band, wordmark) renders identically to the value=0 image; per ruling #253 the two images may differ only where the main needle is drawn in either image. Where the needle points is M's.
+- [ ] M1 — The main needle renders on the axis `angle(value) = 225° − 2.7° × value`: at value=0 the 225° rest axis, at value=100 the −45° rightmost axis, and every render-tier position test computes its expected axis from this mapping.
+- [ ] M2 — Image at value=75: the main needle's tip lies inside the redline band; tip pixels (candy-apple `#F73923`) and band pixels (brick `#9B3020`) are distinct hues, verified by the render-tier test sampling both along the needle axis within the band.
+- [ ] T1 — A telltale whose peak is None is not rendered (post-reset hides the needle).
+- [ ] T2 — A telltale at scale distance d ≥ 3 renders at baseline translucency (the far case: value=70, peak=30 samples at the translucent blend).
+- [ ] T3 — A telltale at 2 < d < 3 renders strictly between baseline and full opacity, at the linear midpoint within the visual-regression tolerance for d=2.5 (the mid-fade case: value=70, peak=72.5; ruling #246 — the case that distinguishes the fade from an on/off step).
+- [ ] T4 — A telltale at d ≤ 2 renders at full opacity, applied uniformly to the whole needle — its protruding edge samples at full opacity (the near-overlap case: value=70, peak=72; rulings #242/#245).
+- [ ] T5 — Image with all four telltales at varying NON-COINCIDENT peak values: four secondary needles visible at their angles, colors/widths/translucency per aesthetic doc §Telltale needles. Z-order is a spec convention, not a tested criterion (ruling #232). Full occlusion at exact coincidence is correct by design — at that instant the main needle itself displays the peak.
+- [ ] V1 — Render-tier tests (per `tests/visual/` + strategy 0001) cover: value=0, value=50 (below the redline), value=75 (tip-in-band distinctness), value=80 (mid-arc), value=100, telltale combinations, the T2/T3/T4 distance cases above, and post-reset (T1).
+
+## Out of scope
+
+- Animation / damping curves between values (defer to a follow-on issue).
+- Right-click reset interaction (#2 territory).
+- Multi-skin support (#45 territory; v1 ships only Stingray).
+- Digital readout below the pivot (not in the canonical image; not in the v1 aesthetic).
+
+## Revision history
+
+| Date | Change | Why |
+|---|---|---|
+| 2026-08-09 | Redline codified as brick-red ring band at outer 80–100% of radius; needle as candy-apple red; value=75 criterion made testable (tip-vs-band pixel sampling); render-tier list gains 75 (in-band) and 80 (mid-arc), 50 relabeled below-the-redline. | Rulings on #228 (the planned tests could not detect a same-red needle inside the band; the doc even mandated matching reds) and #229 (value 50 cannot be "mid-arc" when the arc starts at 60). Both conflicts were detected by the pipeline's requirements gate on 2026-08-09's roll. |
+| 2026-08-09 | Telltale criterion made testable: proximity-opacity ramp (100% within 3 scale units of the main needle), coincidence occlusion accepted by design, z-order demoted to spec convention; render-tier list gains the near-overlap and far telltale cases. | Ruling on #232 — the gate caught that z-order had no pixel consequence without overlap and contradicted visibility with it. |
+| 2026-08-10 | The visual-summary telltale line qualified: translucent is the baseline, and the #232 proximity ramp (full opacity within 3 scale units of the main needle) is the governing exception near the needle. | Ruling on #238 — the unqualified "rendered translucent" survived the 2026-08-09 #232 edit and contradicted the near-overlap render-tier case (value=70, peak at 72). The aesthetic doc already carried both rules; only this summary line lagged. |
+| 2026-08-10 | Proximity ramp's completion point specified: opacity fades from baseline at 3 scale units to 100% at 2 units and holds 100% anywhere closer (aesthetic doc updated via PR #243; summary line aligned). The near-overlap test case (value=70, peak at 72 → 100%) is now exact. | Ruling on #242 — "ramping to full opacity" left the completion point unstated; a ramp completing only at coincidence never shows full opacity anywhere visible (coincidence is occluded by design), contradicting the near-overlap test case that samples 100% at 2 units. |
+| 2026-08-10 | AC-2 rewritten: the canonical photograph is inspiration, never a comparator. The value=0 render is verified by doc-text-derived element checks and pinned by a SELF-generated baseline (`--generate-baselines`, strategy 0001 §3). #230 (image regen) superseded and closed. | Operator ruling #262 (aesthetic doc updated via PR #263) — the spec reviewer refused six runs in a row to write the photo-comparison test, because the photo shows retired colors and regenerating an AI photograph to spec is not an achievable task. The picture is not the requirement; the text is. |
+| 2026-08-10 | Opacity declared per-needle: one value computed from the needle's scale distance to the main needle, applied uniformly to every pixel of that needle (aesthetic doc updated via PR #250; summary line aligned). | Ruling on #245 — a strict per-pixel reading would render a boundary needle's protruding tip dimmer than its base, while the near-overlap test case requires the protruding edge to sample at full opacity. One needle, one opacity. |
+| 2026-08-10 | Render-tier list gains the mid-fade case: value=70 with a peak at 72.5 samples strictly between baseline and full opacity, at the linear midpoint within tolerance. | Ruling on #246 — the existing cases sampled only the fade band's endpoints (2 units → full, far → baseline), so an on/off step implementation would pass every planned test; the fade was untestable as written. |
+| 2026-08-10 | The value=100 criterion rephrased: "rest of the gauge unchanged from value=0" became "every static element renders identically to value=0; the two images may differ only where the main needle is drawn in either image." | Ruling on #253 — the spec-stage review caught that the literal reading is unsatisfiable: moving the needle to 100 necessarily changes the pixels it occupied at 0 (needle → background), so "unchanged from value=0" could never hold pixel-for-pixel. The criterion meant the static scenery, and now says so. |
+| 2026-08-14 | Full ADR 0226 + ADR 0228 conversion: a `## Requirements` section (R1–R7, EARS form) importing the binding numbers (the #255 angle mapping, the ramp thresholds, the band geometry); the telltale-opacity decision table (T1–T4, one row per condition); a State Variables and Ownership section (four variables, single tagged owners F/S/M/T, three boundary terms); every acceptance criterion carrying its group ID, with the telltale render-tier cases graduated into per-row criteria T1–T4 and the two red RGBs imported into M2 per the values-not-pointers principle. No requirement's meaning changed — every sentence traces to an existing ruling or the binding doc. | The #7 precedent: eighteen conflicts across twelve halts were what unconverted prose cost that issue. Converting before the roll, checker-clean from the first draft, is the lesson applied. |

--- a/tests/unit/test_requirements_gate_escalation.py
+++ b/tests/unit/test_requirements_gate_escalation.py
@@ -1,0 +1,303 @@
+"""The gate's one retry escalates instead of re-asking the same model (#2375).
+
+#2290 gave the requirements gate a retry for a timeout on a healthy transport,
+and that retry re-asked the SAME model. Measured 2026-08-14 on boostgauge #1's
+converted body: claude sonnet timed out at the 600s bound three consecutive
+times (13:0x, 13:4x, 14:2x Central), and claude opus returned a CLEAN verdict
+inside the same bound on its first attempt immediately afterwards. A trivial
+`claude -p` round-tripped in 5.0s between attempts, so the transport was
+healthy throughout, and the same sonnet call had completed boostgauge #7 -- a
+comparable-size, comparably-tabled document -- in about five minutes that
+morning.
+
+The model is the variable on this content class. A same-model retry therefore
+spends a second full 600s budget to reach the same wall; escalating costs the
+same one retry and has a measured chance of returning a verdict.
+
+Every precondition #2290 set on the retry is unchanged, and is re-asserted here
+rather than assumed -- a fix that quietly widened when the gate retries would be
+a different and worse change.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.core.llm_provider import LLMCallResult  # noqa: E402
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (  # noqa: E402
+    GATE_DRAFTER_ESCALATION,
+    analyze_requirements,
+    escalated_drafter,
+)
+
+BOOSTGAUGE_1 = ROOT / "tests" / "fixtures" / "requirements" / "boostgauge-1-body.md"
+
+CONSISTENT = '{"is_consistent": true, "conflicts": []}'
+
+
+def _result(success, response, error=None):
+    return LLMCallResult(
+        success=success,
+        response=response,
+        raw_response=response,
+        error_message=error,
+        provider="fake",
+        model_used="fake-model",
+        duration_ms=1,
+        attempts=1,
+    )
+
+
+TIMEOUT = _result(False, None, "claude -p timed out after 600s")
+OK = _result(True, CONSISTENT)
+OTHER_FAILURE = _result(False, None, "400 invalid request")
+
+
+class _Provider:
+    """Returns a scripted sequence, one entry per call."""
+
+    def __init__(self, *results):
+        self._results = list(results)
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._results[min(len(self.calls) - 1, len(self._results) - 1)]
+
+
+@pytest.fixture
+def specs(monkeypatch):
+    """Install a provider and record every spec `get_provider` is asked for.
+
+    Recording the spec is the whole point: the retry must ask for a DIFFERENT
+    model, and a factory that ignores its argument cannot show that.
+    """
+
+    def _install(*results, raises_for=()):
+        provider = _Provider(*results)
+        asked: list[str] = []
+
+        def _factory(spec, *args, **kwargs):
+            asked.append(spec)
+            if spec in raises_for:
+                raise ValueError(f"unknown provider spec: {spec}")
+            return provider
+
+        monkeypatch.setattr(
+            "assemblyzero.core.llm_provider.get_provider", _factory
+        )
+        return asked, provider
+
+    return _install
+
+
+@pytest.fixture
+def calm(monkeypatch):
+    """A healthy transport: no provider storm in progress."""
+    monkeypatch.setattr("assemblyzero.core.provider_storm.is_storm", lambda: False)
+
+
+@pytest.fixture
+def storm(monkeypatch):
+    monkeypatch.setattr("assemblyzero.core.provider_storm.is_storm", lambda: True)
+
+
+def _state(tmp_path, drafter):
+    return {
+        "issue_title": "feat: gauge rendering",
+        "issue_body": "The renderer shall draw the needle at the value's angle.",
+        "issue_number": 1,
+        "target_repo": str(tmp_path),
+        "config_drafter": drafter,
+    }
+
+
+class TestTheRetryEscalates:
+    def test_a_sonnet_timeout_retries_on_opus(self, tmp_path, specs, calm):
+        asked, provider = specs(TIMEOUT, OK)
+
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert asked == ["claude:sonnet", "claude:opus"]
+        assert len(provider.calls) == 2
+
+    def test_the_lookup_tolerates_case_and_surrounding_space(
+        self, tmp_path, specs, calm
+    ):
+        asked, _ = specs(TIMEOUT, OK)
+        analyze_requirements(_state(tmp_path, " Claude:Sonnet "))
+        assert asked[1] == "claude:opus"
+
+    def test_a_drafter_with_no_escalation_still_retries_itself(
+        self, tmp_path, specs, calm
+    ):
+        """#2290's behaviour survives wherever no measurement replaces it.
+        Inventing a ladder for every spec is the guessing #2375 forbids."""
+        asked, provider = specs(TIMEOUT, OK)
+
+        analyze_requirements(_state(tmp_path, "fake:model"))
+
+        # The provider object is reused rather than rebuilt -- exactly what
+        # #2290 did. The retry is visible in the call count, not in a second
+        # trip through the factory.
+        assert asked == ["fake:model"]
+        assert len(provider.calls) == 2
+
+    def test_a_broken_escalation_target_falls_back_rather_than_losing_the_retry(
+        self, tmp_path, specs, calm, monkeypatch
+    ):
+        """A bad map entry must not cost the run the attempt #2290 gave it."""
+        # The package re-exports `analyze_requirements` as a FUNCTION, so a
+        # dotted setattr target resolves to it rather than to the module.
+        from importlib import import_module
+
+        module = import_module(
+            "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+        )
+        monkeypatch.setattr(
+            module, "GATE_DRAFTER_ESCALATION", {"claude:sonnet": "bogus:spec"}
+        )
+        asked, provider = specs(TIMEOUT, OK, raises_for=("bogus:spec",))
+
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert asked == ["claude:sonnet", "bogus:spec"]
+        assert len(provider.calls) == 2, "the retry must still happen"
+
+
+class TestWhatEscalationDoesNotChange:
+    """The retry's preconditions are #2290's and stay #2290's."""
+
+    def test_a_storm_still_suppresses_the_retry(self, tmp_path, specs, storm):
+        asked, provider = specs(TIMEOUT, OK)
+
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert asked == ["claude:sonnet"]
+        assert len(provider.calls) == 1, "escalating into a storm is still wrong"
+
+    def test_a_non_timeout_failure_is_still_not_retried(self, tmp_path, specs, calm):
+        asked, provider = specs(OTHER_FAILURE, OK)
+
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert asked == ["claude:sonnet"]
+        assert len(provider.calls) == 1
+
+    def test_a_first_attempt_that_succeeds_never_escalates(
+        self, tmp_path, specs, calm
+    ):
+        asked, provider = specs(OK)
+
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert asked == ["claude:sonnet"]
+        assert len(provider.calls) == 1
+
+    def test_the_gate_still_fails_open_when_both_attempts_die(
+        self, tmp_path, specs, calm
+    ):
+        """Protective, not load-bearing (#1899). Escalation does not make the
+        gate able to kill a roll."""
+        specs(TIMEOUT, TIMEOUT)
+
+        assert analyze_requirements(_state(tmp_path, "claude:sonnet")) == {}
+
+
+class TestTheVerdictNamesItsDrafter:
+    """'The gate did not answer' and 'the gate did not answer ON SONNET' are
+    different facts, and only the second tells the next reader whether
+    escalating is worth trying."""
+
+    def test_a_clean_verdict_names_the_model_that_gave_it(
+        self, tmp_path, specs, calm, capsys
+    ):
+        specs(TIMEOUT, OK)
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+        assert "Verdict from claude:opus." in capsys.readouterr().out
+
+    def test_an_unescalated_clean_verdict_names_the_original(
+        self, tmp_path, specs, calm, capsys
+    ):
+        specs(OK)
+        analyze_requirements(_state(tmp_path, "gemini:3.1-pro"))
+        assert "Verdict from gemini:3.1-pro." in capsys.readouterr().out
+
+    def test_the_clean_marker_itself_is_unchanged(
+        self, tmp_path, specs, calm, capsys
+    ):
+        """The pre-check asserts this sentence verbatim, so the drafter goes on
+        its own line rather than into it."""
+        from assemblyzero.workflows.requirements.precheck import CLEAN_MARKER
+
+        specs(OK)
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+        assert CLEAN_MARKER in capsys.readouterr().out
+
+    def test_an_unavailable_verdict_names_the_model_that_actually_ran(
+        self, tmp_path, specs, calm, capsys
+    ):
+        specs(TIMEOUT, TIMEOUT)
+        analyze_requirements(_state(tmp_path, "claude:sonnet"))
+        assert "analysis unavailable on claude:opus" in capsys.readouterr().out
+
+
+class TestTheEscalationMap:
+    def test_it_holds_the_measured_pair_and_nothing_invented(self):
+        assert GATE_DRAFTER_ESCALATION == {"claude:sonnet": "claude:opus"}
+
+    def test_an_unmapped_spec_returns_none(self):
+        assert escalated_drafter("gemini:3.1-pro") is None
+        assert escalated_drafter("") is None
+
+    def test_the_strongest_model_maps_nowhere(self):
+        assert escalated_drafter("claude:opus") is None, (
+            "a self-map would be an infinite ladder dressed as a fix"
+        )
+
+    def test_no_entry_points_at_itself(self):
+        for source, target in GATE_DRAFTER_ESCALATION.items():
+            assert source != target
+
+    def test_no_entry_forms_a_cycle(self):
+        """One escalation, not a ladder: no target may itself be escalatable."""
+        for target in GATE_DRAFTER_ESCALATION.values():
+            assert escalated_drafter(target) is None
+
+
+class TestTheDocumentThisWasMeasuredOn:
+    """#2375's acceptance: a fixture pins the change against this document."""
+
+    def test_the_converted_body_is_captured(self):
+        assert BOOSTGAUGE_1.is_file(), (
+            "boostgauge #1's converted body is the document the escalation was "
+            "measured on; without it this fix is pinned to nothing"
+        )
+
+    def test_it_is_the_converted_form_not_the_prose_it_replaced(self):
+        body = BOOSTGAUGE_1.read_text(encoding="utf-8")
+        assert "## Requirements" in body
+        assert "## Acceptance Criteria" in body
+        assert "## State Variables and Ownership" in body, "the ADR 0228 table"
+
+    def test_it_is_checker_clean_under_adr_0226_and_0228(self):
+        """#2375 records it as checker-clean, so the timeout is not the document
+        being malformed. Free and deterministic: no model call."""
+        from assemblyzero.workflows.requirements import form_check as fc
+
+        report = fc.check_form(BOOSTGAUGE_1.read_text(encoding="utf-8"))
+        assert report.ok, [v.detail for v in report.violations]
+
+    def test_it_still_carries_the_content_class_that_timed_out(self):
+        """Dense tables and a revision history -- the reasoning surface #2375
+        names. If a later edit strips them the fixture stops representing the
+        case, and this says so rather than passing quietly."""
+        body = BOOSTGAUGE_1.read_text(encoding="utf-8")
+        rows = [ln for ln in body.splitlines() if ln.strip().startswith("|")]
+        assert len(rows) >= 15, f"only {len(rows)} table rows"
+        assert "revision history" in body.lower()


### PR DESCRIPTION
#2290 gave the requirements gate one retry for a timeout on a healthy transport, and that retry re-asked the same model. On boostgauge #1's converted body that is a second full 600s budget spent reaching the same wall.

## The measurement it acts on

From the boostgauge session, on this PR's fixture document:

| Drafter | Result |
|---|---|
| `claude:sonnet` | timed out at 600s — **three consecutive attempts** (13:0x, 13:4x, 14:2x Central) |
| `claude:opus` | **CLEAN verdict inside the bound, first attempt**, immediately after |

Transport healthy throughout (a trivial `claude -p` round-tripped in 5.0s between attempts), and the same sonnet call had completed boostgauge #7 — comparable size, comparably tabled — in about five minutes that morning. The model is the variable on this content class.

## The fix

The one retry escalates instead of repeating:

```python
GATE_DRAFTER_ESCALATION = {"claude:sonnet": "claude:opus"}
```

Deliberately one entry. A spec escalates only where a measurement says escalating helps; everything else keeps #2290's same-model retry, because no measurement covers it and inventing a ladder is the guessing this issue's acceptance forbids. Tests assert no entry self-maps and no target is itself escalatable — one escalation, not a ladder.

Every precondition #2290 put on the retry is unchanged and re-asserted rather than assumed: a storm still suppresses it, a non-timeout failure is still not retried, a first-attempt success never escalates, and the gate still fails open when both attempts die. A broken escalation target falls back to retrying the original rather than costing the run the attempt #2290 gave it.

The verdict now names the model that produced it — `Verdict from claude:opus.` on the clean path, `analysis unavailable on claude:opus` on the fail-open path. "The gate did not answer" and "the gate did not answer *on sonnet*" are different facts, and only the second tells the next reader whether escalating is worth trying. `CLEAN_MARKER` is untouched; the drafter goes on its own line, since the pre-check asserts that sentence verbatim.

## Premise overturned: the measurements are of the pre-check, not the roll's gate

The issue comment reasons that "at roll time the in-gate N0c still runs the default drafter — on this document that means timeout → fail-open → REQUIREMENTS UNVERIFIED." That does not follow, because the roll's gate does not ask sonnet. Measured by building the config a roll actually runs with:

```
STANDALONE PRE-CHECK   precheck.DEFAULT_DRAFTER  = 'claude:sonnet'
A ROLL (lld stage -> N0c)  lld stage drafter     = 'gemini:3.1-pro'
Same model? False
```

`orchestrate.py` and `speedrun_roll.py` reach the requirements graph through the orchestrator's lld stage, whose `StageConfig` has carried `gemini:3.1-pro` since #1434, and `load_config` merges only `skip_existing_*`, `gates` and `mock_mode` — nothing on the roll path overrides it.

So all the sonnet-vs-opus timing is evidence about the **pre-check's** model. Whether `gemini:3.1-pro` also times out on this document is **unmeasured**. The escalation above is independent of that: it helps whichever drafter times out.

`precheck.py` asserted the opposite in a comment — *"so the pre-check asks the same model the roll's gate will ask"*. That claim is now corrected in place, because leaving a known-false statement next to the thing this issue is about would be worse than the drift it caused. **Which** model the two paths should share is a decision rather than a finding, so it is filed as **#2384** with the measurement and the three options.

## The fixture

`tests/fixtures/requirements/boostgauge-1-body.md` — the converted body itself, captured read-only. Both repos are public and `boostgauge-7-body.md` is already committed here, so this follows existing precedent.

Verified rather than assumed: it is checker-clean under ADR 0226 + 0228 (`RESULT: PASS`, 12 criteria all carrying group IDs, 4 variables, 0 ownership violations), so the timeout is not the document being malformed. A test pins that it still carries the content class that timed out — 23 table rows and a revision history — so a later edit that strips them fails loudly instead of leaving the fixture quietly unrepresentative.

Checking it also re-exercised #2368's ruling against a real converted document: its requirement sentences are unprefixed and the matcher correctly leaves them alone.

## What is not verified here

No live gate run. Re-verifying against boostgauge #1 means spending model calls on a document in the boostgauge session's lane, and this batch launches nothing there. The escalation is unit-tested at every branch with a scripted provider; the live confirmation is the opus CLEAN verdict that session already recorded on the issue.

## Verification

- 21 new tests
- Full unit suite: 7686 passed, 17 skipped, 5 xfailed — no regressions
- `ruff check` clean on all three changed code files

Closes #2375
