### PR TITLE
feat(spec): a resume continues the review loop it paid for (Closes #2383)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/lineage_seed.py
+++ b/assemblyzero/workflows/implementation_spec/lineage_seed.py
@@ -1,0 +1,146 @@
+"""Resume the spec review loop where it died, not from zero (#2383).
+
+The spec stage died at the review cap after three rounds of measurably
+converging feedback. Draft 4 existed, the third verdict carried a four-item
+worklist, and every artifact was persisted. The printed resume --
+``orchestrate --issue 1 --resume-from spec`` -- restarted the stage from
+iteration 0 with a fresh draft, because each run claims a NEW run-scoped
+lineage directory and `generate_spec` recovers a draft by globbing the
+directory it was handed. A fresh directory holds nothing, so the glob finds
+nothing, so the run draws again.
+
+Three rounds of paid convergence discarded, the same first-round defect classes
+likely to recur, and a fresh cap likely to die the same way.
+
+The #2233 principle -- repair the artifact, never regenerate the attempt --
+stops one level short of this: it governs the finalize step inside a run, while
+stage RESUME regenerates everything.
+
+What gets seeded, and why each piece
+------------------------------------
+
+``generate_spec`` treats a call as a revision when it has BOTH a draft and
+feedback (``is_revision = existing_draft and (review_feedback or
+completeness_issues)``). Seeding both is therefore not two conveniences but the
+one condition that makes the resumed round a revision rather than a redraw.
+
+``review_feedback_history`` is seeded too, and it matters more than it looks:
+#2382 judges convergence against every prior round. A resumed run without that
+history is a run that cannot tell its first new verdict from a repeat of one it
+never saw, so it would read as converging no matter what it said.
+
+What this does NOT decide
+-------------------------
+
+Whether resuming is appropriate at all. That judgement already exists upstream
+and is deliberately left there: ``speedrun_roll.resume_plan`` refuses a resume
+whose draft predates an issue edit or a binding-doc change, and ``--fresh``
+skips planning entirely. Both express themselves the same way -- no
+``--resume-from`` reaches the orchestrator -- so seeding keyed on an actual
+resume inherits both rules instead of duplicating them into a second copy that
+can drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DRAFT_GLOB = "*-spec-draft.md"
+VERDICT_GLOB = "*-readiness-verdict.md"
+
+
+@dataclass(frozen=True)
+class Seed:
+    """One prior run's resumable state."""
+
+    run_dir: str
+    draft: str
+    draft_path: str
+    feedback: str
+    feedback_path: str
+    #: Every verdict the prior run produced, oldest first, so #2382's
+    #: convergence check is not blind on the resumed round.
+    prior_feedbacks: list[str] = field(default_factory=list)
+
+    @property
+    def rounds_completed(self) -> int:
+        return len(self.prior_feedbacks)
+
+
+def prior_run_dirs(spec_lineage: Path, exclude: Path | None = None) -> list[Path]:
+    """Run directories under an issue's spec lineage, oldest first.
+
+    Named by ``make_run_id()``, which is a zero-padded UTC timestamp, so name
+    order is time order. A collision suffix (``-1``, ``-2``) sorts after the
+    directory it collided with, which is also its real order.
+    """
+    if not spec_lineage.is_dir():
+        return []
+    resolved_exclude = exclude.resolve() if exclude else None
+    found = []
+    for path in sorted(spec_lineage.iterdir()):
+        if not path.is_dir():
+            continue
+        if resolved_exclude and path.resolve() == resolved_exclude:
+            continue
+        found.append(path)
+    return found
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def seed_from_lineage(
+    spec_lineage: Path, exclude: Path | None = None
+) -> Seed | None:
+    """The most recent prior run's resumable state, or None.
+
+    None means there is nothing to resume onto and the caller should draw
+    fresh -- which is always safe, and is what every failure path here returns
+    rather than a half-seed. A draft with no verdict is such a failure: without
+    feedback the seeded round is not a revision, so it would redraw anyway while
+    reporting that it resumed.
+
+    ``exclude`` is the current run's own directory, which the caller has already
+    created and which must never be read as a prior run.
+    """
+    for run_dir in reversed(prior_run_dirs(spec_lineage, exclude)):
+        drafts = sorted(run_dir.glob(DRAFT_GLOB))
+        verdicts = sorted(run_dir.glob(VERDICT_GLOB))
+        if not drafts or not verdicts:
+            continue
+
+        draft_text = _read(drafts[-1])
+        feedback_text = _read(verdicts[-1])
+        if not draft_text.strip() or not feedback_text.strip():
+            continue
+
+        return Seed(
+            run_dir=str(run_dir),
+            draft=draft_text,
+            draft_path=str(drafts[-1]),
+            feedback=feedback_text,
+            feedback_path=str(verdicts[-1]),
+            prior_feedbacks=[
+                text
+                for text in (_read(v) for v in verdicts)
+                if text.strip()
+            ],
+        )
+    return None
+
+
+def describe(seed: Seed) -> str:
+    """What the operator should see when a resume reuses paid work."""
+    return (
+        f"    [spec] resuming from lineage: {Path(seed.draft_path).name} "
+        f"({len(seed.draft.splitlines())} lines) with "
+        f"{Path(seed.feedback_path).name}'s items as feedback, after "
+        f"{seed.rounds_completed} completed review round(s) in "
+        f"{Path(seed.run_dir).name}."
+    )

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -477,6 +477,10 @@ def orchestrate(
             resume_stage = determine_resume_stage(state, resume_from)
             state_dict = dict(state)
             state_dict["current_stage"] = resume_stage
+            # #2383: set from THIS invocation, never inherited from the loaded
+            # state -- a stale marker would make an ordinary later run believe
+            # it was resuming and adopt a previous run's lineage.
+            state_dict["resumed_from"] = resume_stage
             state_dict["config"] = effective_config
             # Repo targeting on resume: explicit arg wins, else keep what was
             # persisted, else fall back to the default (Issue #1374).
@@ -497,6 +501,9 @@ def orchestrate(
                 issue_number, effective_config, resolved_target, resolved_root
             )
             state["base_branch"] = resolved_base
+            # #2383: explicit on the fresh path too, so the field is never
+            # merely absent and a reader cannot mistake missing for "unknown".
+            state["resumed_from"] = ""
             # Detect existing artifacts and skip completed stages
             existing = detect_existing_artifacts(issue_number, state.get("target_repo", ""))
             for stage in STAGE_ORDER:

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -840,8 +840,50 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
 
         spec_max_iterations = int(stage_cfg.get("max_revisions", 3) or 3)
 
+        # #2383: a resume used to restart at iteration 0 with a fresh draft,
+        # discarding every round already paid for -- because each run claims a
+        # NEW run-scoped lineage dir and generate_spec recovers a draft by
+        # globbing the dir it was handed, which is empty. Seed the loop from the
+        # last run instead: its final draft, its final verdict's outstanding
+        # items, and every verdict it produced so #2382's convergence check is
+        # not blind on the resumed round.
+        #
+        # Keyed on an actual resume. Whether resuming is appropriate was already
+        # decided upstream -- resume_plan refuses a resume whose draft predates
+        # an issue edit or binding-doc change, and --fresh skips planning
+        # entirely; both express themselves as no --resume-from arriving here.
+        seed = None
+        if state.get("resumed_from") == "spec" and audit_dir_str:
+            from assemblyzero.workflows.implementation_spec.lineage_seed import (
+                describe as describe_seed,
+                seed_from_lineage,
+            )
+
+            seed = seed_from_lineage(
+                Path(audit_dir_str).parent, exclude=Path(audit_dir_str)
+            )
+            if seed:
+                print(describe_seed(seed))
+            else:
+                print(
+                    "    [spec] resume found no prior draft-and-verdict pair "
+                    "in lineage; drawing fresh."
+                )
+
+        resumed_payload = (
+            {
+                "spec_draft": seed.draft,
+                "review_feedback": seed.feedback,
+                "review_feedback_history": list(seed.prior_feedbacks),
+                "review_iteration": seed.rounds_completed,
+            }
+            if seed
+            else {}
+        )
+
         app = create_spec_graph()
         sub_result = app.invoke({
+            **resumed_payload,
             "issue_number": issue_number,
             "lld_path": lld_path,
             "repo_root": target_repo,

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -32,6 +32,11 @@ class OrchestrationState(TypedDict, total=False):
 
     issue_number: int
     current_stage: str  # "triage", "lld", "spec", "impl", "pr", "cleanup", "done"
+    #: #2383: the stage this invocation was RESUMED into, empty on a fresh run.
+    #: Distinct from `current_stage`, which reaches every stage in the normal
+    #: course and so cannot tell a resume from a pipeline arriving there.
+    #: A stage reads it to decide whether prior lineage is its own to continue.
+    resumed_from: str
 
     # Repo targeting (Issue #1374)
     target_repo: str  # Where the work happens (outputs, worktree, gh CLI)
@@ -132,6 +137,7 @@ def create_initial_state(
     return OrchestrationState(
         issue_number=issue_number,
         current_stage="triage",
+        resumed_from="",
         target_repo=resolved_target,
         assemblyzero_root=resolved_root,
         issue_brief_path="",

--- a/tests/unit/test_spec_resume_seed.py
+++ b/tests/unit/test_spec_resume_seed.py
@@ -1,0 +1,223 @@
+"""A spec resume continues the loop it paid for (#2383).
+
+run-issue1-152716 died at the review cap with draft 4 on disk and a four-item
+worklist in its third verdict. The printed resume restarted at iteration 0 with
+a fresh draft, because every run claims a NEW run-scoped lineage directory and
+`generate_spec` recovers a draft by globbing the directory it was handed -- a
+fresh one holds nothing.
+
+The lineage layout here is that run's, exactly: drafts at 001/004/007/010 and
+verdicts at 006/009/012. Two drafts precede the first verdict (a validation
+loop-back regenerates without a review round), which is precisely the shape
+that makes "the last draft" and "the last verdict" different index arithmetic
+and worth testing rather than assuming.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.workflows.implementation_spec import lineage_seed as ls  # noqa: E402
+
+VERDICTS = ROOT / "tests" / "fixtures" / "spec_review"
+
+
+def real_verdict(n: str) -> str:
+    return (VERDICTS / f"run-issue1-152716-{n}-readiness-verdict.md").read_text(
+        encoding="utf-8"
+    )
+
+
+def build_run(run_dir: Path, drafts: int = 4, verdicts=("006", "009", "012")):
+    """The real run's file layout, with identifiable draft bodies."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for index, seq in enumerate(("001", "004", "007", "010")[:drafts], start=1):
+        (run_dir / f"{seq}-spec-draft.md").write_text(
+            f"# Implementation Spec\n\nDRAFT {index}\n", encoding="utf-8"
+        )
+    for seq in verdicts:
+        (run_dir / f"{seq}-readiness-verdict.md").write_text(
+            real_verdict(seq), encoding="utf-8"
+        )
+    return run_dir
+
+
+@pytest.fixture
+def lineage(tmp_path) -> Path:
+    """An issue's spec lineage holding the dead run, plus this run's empty dir."""
+    root = tmp_path / "docs" / "lineage" / "active" / "1-implspec"
+    build_run(root / "2026-08-14T20-34-14Z")
+    (root / "2026-08-14T22-00-00Z").mkdir(parents=True)  # the resumed run
+    return root
+
+
+class TestItStartsFromTheLastDraftNotTheFirst:
+    """#2383's acceptance, stated in its own terms."""
+
+    def test_the_seed_is_draft_four(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert seed is not None
+        assert "DRAFT 4" in seed.draft
+        assert seed.draft_path.endswith("010-spec-draft.md")
+
+    def test_it_is_emphatically_not_draft_one(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert "DRAFT 1" not in seed.draft
+        assert not seed.draft_path.endswith("001-spec-draft.md")
+
+    def test_the_feedback_is_the_last_verdict(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert seed.feedback_path.endswith("012-readiness-verdict.md")
+        assert "unregistered" in seed.feedback or "pytest_addoption" in seed.feedback
+
+    def test_every_verdict_is_carried_as_history(self, lineage):
+        """#2382 judges convergence against every prior round. A resumed run
+        without this history cannot tell its first new verdict from a repeat of
+        one it never saw, so it would read as converging whatever it said."""
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert seed.rounds_completed == 3
+        assert seed.prior_feedbacks[0] == real_verdict("006")
+        assert seed.prior_feedbacks[-1] == real_verdict("012")
+
+    def test_the_seeded_history_makes_a_repeat_detectable(self, lineage):
+        """The point of carrying it: a resumed round that re-raises round one's
+        objections is stagnation, and must be seen as such."""
+        from assemblyzero.workflows.implementation_spec import review_progress as rp
+
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert (
+            rp.classify(real_verdict("006"), seed.prior_feedbacks) == rp.STAGNATING
+        )
+
+
+class TestTheSeedIsAValidRevisionInput:
+    """`generate_spec` treats a call as a revision only when it has BOTH a draft
+    and feedback. Seeding both is the one condition that makes the resumed round
+    a revision rather than a redraw."""
+
+    def test_both_halves_are_present_and_non_empty(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        is_revision = bool(seed.draft and seed.feedback)
+        assert is_revision
+
+    def test_a_draft_with_no_verdict_is_no_seed_at_all(self, tmp_path):
+        """Half a seed is worse than none: without feedback the round is not a
+        revision, so it would redraw anyway while reporting that it resumed."""
+        root = tmp_path / "1-implspec"
+        build_run(root / "2026-08-14T20-34-14Z", drafts=4, verdicts=())
+        assert ls.seed_from_lineage(root) is None
+
+    def test_an_empty_draft_file_is_not_seeded(self, tmp_path):
+        root = tmp_path / "1-implspec"
+        run = build_run(root / "2026-08-14T20-34-14Z")
+        for draft in run.glob(ls.DRAFT_GLOB):
+            draft.write_text("   \n", encoding="utf-8")
+        assert ls.seed_from_lineage(root) is None
+
+
+class TestWhichRunItReadsFrom:
+    def test_the_current_run_is_never_read_as_a_prior_one(self, lineage):
+        current = lineage / "2026-08-14T22-00-00Z"
+        assert current not in ls.prior_run_dirs(lineage, exclude=current)
+
+    def test_the_most_recent_prior_run_wins(self, tmp_path):
+        root = tmp_path / "1-implspec"
+        build_run(root / "2026-08-13T10-00-00Z")
+        newer = build_run(root / "2026-08-14T20-34-14Z")
+        for draft in newer.glob(ls.DRAFT_GLOB):
+            draft.write_text("NEWER RUN\n", encoding="utf-8")
+
+        seed = ls.seed_from_lineage(root)
+        assert "NEWER RUN" in seed.draft
+
+    def test_a_collision_suffixed_run_sorts_after_the_one_it_collided_with(
+        self, tmp_path
+    ):
+        """make_run_id is second-resolution, so two attempts in one second get
+        a `-1` suffix. That suffix IS the later run."""
+        root = tmp_path / "1-implspec"
+        build_run(root / "2026-08-14T20-34-14Z")
+        later = build_run(root / "2026-08-14T20-34-14Z-1")
+        for draft in later.glob(ls.DRAFT_GLOB):
+            draft.write_text("SUFFIXED RUN\n", encoding="utf-8")
+
+        seed = ls.seed_from_lineage(root)
+        assert "SUFFIXED RUN" in seed.draft
+
+    def test_it_skips_a_barren_newer_run_for_a_usable_older_one(self, tmp_path):
+        """A run that died before producing a verdict has nothing to resume;
+        the round that DID converge is the one worth continuing."""
+        root = tmp_path / "1-implspec"
+        build_run(root / "2026-08-13T10-00-00Z")
+        (root / "2026-08-14T20-34-14Z").mkdir(parents=True)
+
+        assert ls.seed_from_lineage(root) is not None
+
+    def test_no_lineage_at_all_is_none_not_an_error(self, tmp_path):
+        assert ls.seed_from_lineage(tmp_path / "nope") is None
+        assert ls.prior_run_dirs(tmp_path / "nope") == []
+
+
+class TestSeedingIsKeyedOnAnActualResume:
+    """Whether resuming is appropriate is decided upstream -- resume_plan
+    refuses a stale draft, --fresh skips planning -- and both express
+    themselves as no --resume-from arriving. Seeding keyed on the resume
+    inherits both rules instead of duplicating them."""
+
+    def test_the_orchestrator_records_which_stage_it_resumed_into(self):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "graph.py"
+        ).read_text(encoding="utf-8")
+        assert 'state_dict["resumed_from"] = resume_stage' in source
+        assert 'state["resumed_from"] = ""' in source, "explicit on the fresh path"
+
+    def test_a_fresh_run_carries_no_resume_marker(self):
+        from assemblyzero.workflows.orchestrator.config import get_default_config
+        from assemblyzero.workflows.orchestrator.state import create_initial_state
+
+        state = create_initial_state(1, get_default_config())
+        assert state["resumed_from"] == ""
+
+    def test_the_marker_is_not_current_stage(self):
+        """current_stage reaches every stage in the normal course, so it cannot
+        tell a resume from a pipeline arriving there."""
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        spec_stage = source.split("def run_spec_stage", 1)[1].split("\ndef ", 1)[0]
+        assert 'state.get("resumed_from") == "spec"' in spec_stage
+
+    def test_the_stage_seeds_the_four_fields_the_loop_needs(self):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        spec_stage = source.split("def run_spec_stage", 1)[1].split("\ndef ", 1)[0]
+        for field in (
+            '"spec_draft": seed.draft',
+            '"review_feedback": seed.feedback',
+            '"review_feedback_history": list(seed.prior_feedbacks)',
+            '"review_iteration": seed.rounds_completed',
+        ):
+            assert field in spec_stage
+
+    def test_the_stage_excludes_its_own_run_directory(self):
+        source = (
+            ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+        assert "exclude=Path(audit_dir_str)" in source
+
+
+class TestItSaysWhatItReused:
+    def test_the_description_names_the_draft_the_verdict_and_the_rounds(
+        self, lineage
+    ):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        text = ls.describe(seed)
+        assert "010-spec-draft.md" in text
+        assert "012-readiness-verdict.md" in text
+        assert "3 completed review round" in text


### PR DESCRIPTION
The spec stage died at the review cap with draft 4 on disk and a four-item worklist in its third verdict. The printed resume — `orchestrate --issue 1 --resume-from spec` — restarted at iteration 0 with a fresh draft.

## Why it discarded the work

Not an oversight in the resume path; a consequence of two correct things meeting. Every run claims a **new** run-scoped lineage directory (#1467, so a previous roll's draft cannot leak into a fresh run), and `generate_spec` recovers a draft by globbing **the directory it was handed** (#525). A resumed run is handed an empty directory, so the glob finds nothing and it draws again.

The #2233 principle — repair the artifact, never regenerate the attempt — stops one level short of this: it governs the finalize step *inside* a run, while stage resume regenerates everything.

## What gets seeded

`generate_spec` treats a call as a revision only when it has **both** a draft and feedback (`is_revision = existing_draft and (review_feedback or completeness_issues)`). Seeding both is therefore not two conveniences but the single condition that makes the resumed round a revision rather than a redraw.

| Seeded | From |
|---|---|
| `spec_draft` | the prior run's last draft |
| `review_feedback` | its last verdict's outstanding items |
| `review_feedback_history` | **every** verdict it produced |
| `review_iteration` | rounds already completed |

The history matters more than it looks. #2382 judges convergence against every prior round; a resumed run without that history cannot tell its first new verdict from a repeat of one it never saw, so it would read as converging whatever it said. A test asserts that re-raising round one's objections is detected as stagnation *because* the history came across.

Half a seed is refused outright. A draft with no verdict returns `None`, because without feedback the round is not a revision — it would redraw anyway while reporting that it resumed.

## Verified against the real lineage

Not a reconstruction — the actual directory, read-only:

```
run dirs: ['2026-08-14T20-34-14Z']

    [spec] resuming from lineage: 010-spec-draft.md (530 lines) with
    012-readiness-verdict.md's items as feedback, after 3 completed review
    round(s) in 2026-08-14T20-34-14Z.

  is_revision (draft AND feedback both present): True
```

Draft 4, not draft 1 — #2383's acceptance in its own terms. The unit fixtures mirror that layout exactly (drafts at 001/004/007/010, verdicts at 006/009/012), because two drafts precede the first verdict — a validation loop-back regenerates without a review round — and that shape is what makes "the last draft" and "the last verdict" different index arithmetic rather than the same one.

## The ruling-edit case is untouched, deliberately

The second acceptance box asks that a resume after a ruling edit still redraw fresh. That judgement already exists upstream and stays there: `speedrun_roll.resume_plan` refuses a resume whose draft predates an issue edit **or** a binding-doc change on the base branch (the two-input check earned 2026-08-11), and `--fresh` skips resume planning entirely.

Both express themselves the same way — no `--resume-from` reaches the orchestrator. So seeding is keyed on an actual resume and inherits both rules, rather than growing a second staleness check that can drift from the first.

## The marker

`resumed_from` on the orchestration state, set from the invocation rather than inherited from the loaded state — a stale marker would make an ordinary later run believe it was resuming and adopt a previous run's lineage. It is deliberately distinct from `current_stage`, which reaches every stage in the normal course and so cannot tell a resume from a pipeline arriving there. Set explicitly to `""` on the fresh path too, so a reader never has to decide what missing means.

## Verification

- 19 new tests, plus a read-only run against boostgauge's real lineage
- Full unit suite: 7735 passed, 17 skipped, 5 xfailed — no regressions
- `ruff check` clean on every changed file (`orchestrator/graph.py` carries one unused-import finding identical to `origin/main`'s, untouched here)

Not exercised here: a live resumed roll. That would spend model calls on an issue in the boostgauge session's lane, and this batch launches nothing there. The seeding is tested against the exact lineage a live resume would read.

Closes #2383
