### PR TITLE
fix: unresolvable is not hallucinated — exempt framework-injected receivers (Closes #2391)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1126,6 +1126,46 @@ _DIFF_MARKER_RE = re.compile(r"(?m)^[+-](?![+-])")
 # names are exempt receivers whether or not any fence shows the import.
 _STDLIB_MODULE_NAMES: frozenset[str] = frozenset(sys.stdlib_module_names)
 
+# ---- framework-injected parameters: a fourth wrong universe (#2391) ---------
+#
+# #1948 named three universes the target repo's symbol table has no authority
+# over — imports, stdlib, spec-defined names. This is the fourth: a parameter
+# the FRAMEWORK supplies, whose type the target repo does not own and never
+# will.
+#
+# The founding case is pytest's own plugin API. boostgauge ruling #271 mandates
+# registering custom flags via `pytest_addoption`, and the spec reviewer duly
+# demanded it; the symbol check then rejected `parser.addoption(` because
+# `parser` — injected by pytest, of type `_pytest.config.argparsing.Parser` —
+# resolves to nothing in the target repo's 21 gathered symbols. One gate
+# demanded the line and the other forbade it, so no draft could satisfy both
+# and the stage died at the iteration cap three times over.
+#
+# The exemption is deliberately narrow. It does NOT say "parameters are
+# unresolvable", which is true but useless: every true positive this check has
+# ever caught arrives as a bare parameter receiver — #1527's founding
+# `state.model_dump()`, and `win.model_dump()` in #1952's regression set.
+# Exempting all of them would widen the check into uselessness. What is exempt
+# is the parameter of a function whose NAME declares the framework owns the
+# call: pluggy's `pytest_*` hook convention, and pytest's builtin fixture names
+# wherever they appear as parameters.
+_PYTEST_HOOK_PREFIX = "pytest_"
+
+#: Fixtures pytest injects by parameter name. A test taking `tmp_path` is
+#: handed a `pathlib.Path` by pytest; the target repo has no say in its API.
+_PYTEST_BUILTIN_FIXTURES: frozenset[str] = frozenset({
+    "request", "monkeypatch", "pytestconfig", "cache",
+    "tmp_path", "tmp_path_factory", "tmpdir", "tmpdir_factory",
+    "capsys", "capsysbinary", "capfd", "capfdbinary",
+    "caplog", "recwarn", "doctest_namespace",
+    "record_property", "record_testsuite_property", "record_xml_attribute",
+})
+
+#: Never treated as receivers carrying an exemption. `self` is the spec's own
+#: object — exempting it would hand the whole target-repo surface a free pass,
+#: which is precisely the check's jurisdiction.
+_NON_RECEIVER_PARAMS: frozenset[str] = frozenset({"self", "cls"})
+
 # ---- regex fallback collectors: pre-#1956 behaviour, unchanged --------------
 _IMPORT_RE = re.compile(
     r"^\s*(?:from\s+([\w.]+)\s+import\s+([\w ,]+)|import\s+([\w.]+)(?:\s+as\s+(\w+))?)",
@@ -1155,6 +1195,9 @@ class _FenceFacts(NamedTuple):
     # exemption once every fence has been read.
     assignments: tuple[tuple[frozenset[str], frozenset[str]], ...]
     calls: tuple[_CallSite, ...]
+    # Parameters a framework injects, whose type the target repo does not own
+    # (#2391) — `parser` in `def pytest_addoption(parser)`, `tmp_path` in a test.
+    framework_params: frozenset[str]
     parsed: bool  # False when this fence fell back to the regex collectors
 
 
@@ -1268,6 +1311,7 @@ class _FenceVisitor(ast.NodeVisitor):
         self.defined: set[str] = set()
         self.assignments: list[tuple[frozenset[str], frozenset[str]]] = []
         self.calls: list[_CallSite] = []
+        self.framework_params: set[str] = set()
 
     # ---- imports: receivers the target repo has no authority over (#1948) ----
 
@@ -1288,11 +1332,42 @@ class _FenceVisitor(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self.defined.add(node.name)
+        self._record_framework_params(node)
         self.generic_visit(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self.defined.add(node.name)
+        self._record_framework_params(node)
         self.generic_visit(node)
+
+    def _record_framework_params(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        """Parameters this function receives from a framework, not the repo (#2391).
+
+        Two sources, both declared by naming convention rather than inferred:
+
+        * a pluggy hook (``pytest_addoption``, ``pytest_collection_modifyitems``)
+          receives every one of its parameters from pytest;
+        * a pytest builtin fixture name (``tmp_path``, ``monkeypatch``) is
+          framework-supplied in whatever function requests it.
+
+        An ordinary function's ordinary parameter is NOT recorded. ``state`` in
+        ``def apply(state)`` stays judged, which is what keeps #1527's founding
+        true positive — pydantic methods on a plain dataclass — catchable.
+        """
+        args = node.args
+        collected = [*args.posonlyargs, *args.args, *args.kwonlyargs]
+        if args.vararg is not None:
+            collected.append(args.vararg)
+        if args.kwarg is not None:
+            collected.append(args.kwarg)
+        names = {a.arg for a in collected} - _NON_RECEIVER_PARAMS
+
+        if node.name.startswith(_PYTEST_HOOK_PREFIX):
+            self.framework_params |= names
+        else:
+            self.framework_params |= names & _PYTEST_BUILTIN_FIXTURES
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.defined.add(node.name)
@@ -1370,6 +1445,7 @@ def _fence_facts_ast(block: str) -> _FenceFacts | None:
         defined=frozenset(visitor.defined),
         assignments=tuple(visitor.assignments),
         calls=tuple(visitor.calls),
+        framework_params=frozenset(visitor.framework_params),
         parsed=True,
     )
 
@@ -1414,6 +1490,9 @@ def _fence_facts_regex(block: str) -> _FenceFacts:
         defined=frozenset(defined),
         assignments=assignments,
         calls=tuple(calls),
+        # The regex collectors cannot see a function signature's parameters,
+        # so they contribute no framework exemptions. #2392 retires this path.
+        framework_params=frozenset(),
         parsed=False,
     )
 
@@ -1441,10 +1520,14 @@ def _flag_calls(
     # over — the phase-5 kill was this check rejecting Pillow's documented API
     # (ImageDraw.Draw, alpha_composite), pathlib, and a method the spec itself
     # defined. Same wrong-universe disease #1901 fixed for imports.
+    # #2391 adds the fourth: parameters a framework injects. `parser` inside
+    # `def pytest_addoption(parser)` is pytest's object, so `parser.addoption(`
+    # is pytest's API to be right or wrong about — not the target repo's.
     exempt: set[str] = set(_STDLIB_MODULE_NAMES)
     spec_defined: set[str] = set()
     for fence in facts:
         exempt |= fence.imported
+        exempt |= fence.framework_params
         spec_defined |= fence.defined
 
     # Exemption propagates through bindings to a fixed point rather than the

--- a/tests/fixtures/boostgauge1_spec_deadlock/001-spec-draft.md
+++ b/tests/fixtures/boostgauge1_spec_deadlock/001-spec-draft.md
@@ -1,0 +1,583 @@
+# Implementation Spec: Issue #1 - Feature: core gauge renderer — analog tachometer with arc, needle, and tick marks
+
+## 1. Overview
+
+Build the core gauge renderer to produce a `PIL.Image` of the v1 Stingray tachometer without `tkinter` dependencies.
+
+**Objective:** Build the core gauge renderer to produce a `PIL.Image` of the v1 Stingray tachometer without `tkinter` dependencies.
+
+**Success Criteria:**
+- The renderer shall produce a `PIL.Image` from `render(value, telltales, size, config)` as a pure function.
+- Given identical inputs, `render` shall produce byte-identical output images.
+- The main needle shall render on the axis `angle(value) = 225° − 2.7° × value`.
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/skins/__init__.py` | Add | Skin protocol interface definition |
+| 2 | `src/boostgauge/skins/stingray.py` | Add | Stingray aesthetic implementation drawing operations |
+| 3 | `src/boostgauge/gauge.py` | Add | Main renderer orchestration module |
+| 4 | `tests/conftest.py` | Add | Pytest configuration to register custom flags |
+| 5 | `tests/unit/test_gauge.py` | Add | Unit tests for pure function contract and determinism |
+| 6 | `tests/visual/test_gauge.py` | Add | Visual regression tests using explicit `--generate-baselines` |
+
+**Implementation Order Rationale:** Define the skin protocol first, then implement the specific Stingray skin. The main `gauge.py` orchestrator relies on the skin. Finally, implement tests to verify functionality and add `conftest.py` to support visual test flags.
+
+## 3. Current State (for Modify/Delete files)
+
+N/A - All files in this issue are new additions ("Add").
+
+## 4. Data Structures
+
+### 4.1 SkinConfig
+
+**Definition:**
+
+```python
+class SkinConfig(TypedDict):
+    skin_name: str
+```
+
+**Concrete Example:**
+
+```json
+{
+    "skin_name": "stingray"
+}
+```
+
+## 5. Function Specifications
+
+### 5.1 `render()`
+
+**File:** `src/boostgauge/gauge.py`
+
+**Signature:**
+
+```python
+def render(value: float, telltales: list[float | None], size: int = 256, config: dict = None) -> Image.Image:
+    """Orchestrates rendering by delegating to the active skin."""
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 75.0
+telltales = [10.0, 50.0, 90.0, None]
+size = 256
+config = {"skin_name": "stingray"}
+```
+
+**Output Example:**
+
+```text
+<PIL.Image.Image image mode=RGBA size=256x256 at 0x1A2B3C4D5E6>
+```
+
+**Edge Cases:**
+- `value < 0` or `value > 100` -> raises `ValueError`
+- `size < 128` -> raises `ValueError`
+
+### 5.2 `_validate_inputs()`
+
+**File:** `src/boostgauge/gauge.py`
+
+**Signature:**
+
+```python
+def _validate_inputs(value: float, size: int) -> None:
+    """Validates bounds of metric value and gauge size to prevent rendering OOM/NaNS."""
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 75.0
+size = 256
+```
+
+**Output Example:**
+
+```python
+None
+```
+
+**Edge Cases:**
+- `value < 0` or `value > 100` -> raises `ValueError`
+- `size < 128` -> raises `ValueError`
+
+### 5.3 `render_skin()`
+
+**File:** `src/boostgauge/skins/stingray.py`
+
+**Signature:**
+
+```python
+def render_skin(value: float, telltales: list[float | None], size: int) -> Image.Image:
+    """Renders the Stingray aesthetic skin with arc, needle, and telltales."""
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 50.0
+telltales = [10.0, None]
+size = 256
+```
+
+**Output Example:**
+
+```text
+<PIL.Image.Image image mode=RGBA size=256x256 at 0x1A2B3C4D5E6>
+```
+
+**Edge Cases:**
+- Validations are assumed complete by the time this is called via `gauge.py`.
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/skins/__init__.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Skin protocol definitions for gauge rendering.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+from typing import Protocol
+from PIL import Image
+
+class GaugeSkin(Protocol):
+    def render_skin(self, value: float, telltales: list[float | None], size: int) -> Image.Image:
+        """Render the gauge with the specific skin."""
+        ...
+```
+
+### 6.2 `src/boostgauge/skins/stingray.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Stingray skin implementation.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+import math
+from PIL import Image, ImageDraw
+
+def render_skin(value: float, telltales: list[float | None], size: int) -> Image.Image:
+    """Renders the Stingray aesthetic skin."""
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    
+    # Static elements
+    center_x, center_y = size / 2, size / 2
+    radius = size / 2
+    redline_outer = radius * 1.0
+    
+    # Housing and Dial
+    draw.ellipse([0, 0, size, size], fill="#111111", outline="#333333", width=2)
+    
+    def val_to_angle(v: float) -> float:
+        return 225.0 - 2.7 * v
+
+    # Draw redline band (value 60 to 100)
+    # PIL arc expects bounding box and angles in degrees
+    # PIL angles are measured clockwise from 3 o'clock
+    bbox = [center_x - redline_outer, center_y - redline_outer, 
+            center_x + redline_outer, center_y + redline_outer]
+    
+    # Just to meet the in-band distinctness requirement color
+    draw.arc(bbox, start=-val_to_angle(60), end=-val_to_angle(100), fill="#9B3020", width=int(radius*0.2))
+
+    # Ticks and numerals
+    for v in range(0, 101, 10):
+        a = val_to_angle(v)
+        rad_a = math.radians(a)
+        is_major = (v % 20 == 0)
+        tick_len = radius * 0.15 if is_major else radius * 0.08
+        start_x = center_x + math.cos(rad_a) * (radius * 0.8)
+        start_y = center_y - math.sin(rad_a) * (radius * 0.8)
+        end_x = center_x + math.cos(rad_a) * (radius * 0.8 - tick_len)
+        end_y = center_y - math.sin(rad_a) * (radius * 0.8 - tick_len)
+        draw.line([(start_x, start_y), (end_x, end_y)], fill="#FFFFFF", width=3 if is_major else 1)
+        
+        if is_major:
+            text_x = center_x + math.cos(rad_a) * (radius * 0.5)
+            text_y = center_y - math.sin(rad_a) * (radius * 0.5)
+            draw.text((text_x, text_y), str(v), fill="#FFFFFF", anchor="mm")
+
+    # Wordmark
+    draw.text((center_x, center_y + radius * 0.4), "STINGRAY", fill="#888888", anchor="mm")
+
+    # Telltales
+    for peak in telltales:
+        if peak is not None:
+            d = abs(peak - value)
+            if d >= 3:
+                opacity = int(255 * 0.2) # baseline translucency
+            elif d > 2:
+                # linear midpoint at d=2.5
+                factor = 1.0 - ((d - 2.0) / 1.0) * 0.8 
+                opacity = int(255 * factor)
+            else:
+                opacity = 255
+            
+            t_angle = val_to_angle(peak)
+            rad = math.radians(t_angle)
+            end_x = center_x + math.cos(rad) * radius * 0.9
+            end_y = center_y - math.sin(rad) * radius * 0.9
+            draw.line([(center_x, center_y), (end_x, end_y)], fill=(255, 255, 255, opacity), width=2)
+            
+    # Main needle
+    m_angle = val_to_angle(value)
+    rad = math.radians(m_angle)
+    end_x = center_x + math.cos(rad) * radius * 0.95
+    end_y = center_y - math.sin(rad) * radius * 0.95
+    draw.line([(center_x, center_y), (end_x, end_y)], fill="#F73923", width=4)
+
+    return img
+```
+
+### 6.3 `src/boostgauge/gauge.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Main gauge orchestration module.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+from typing import TypedDict
+from PIL import Image
+from boostgauge.skins.stingray import render_skin
+
+class SkinConfig(TypedDict):
+    skin_name: str
+
+def _validate_inputs(value: float, size: int) -> None:
+    """Validates bounds of metric value and gauge size."""
+    if not (0 <= value <= 100):
+        raise ValueError(f"Value must be between 0 and 100, got {value}")
+    if size < 128:
+        raise ValueError(f"Size must be at least 128, got {size}")
+
+def render(value: float, telltales: list[float | None], size: int = 256, config: dict = None) -> Image.Image:
+    """Orchestrates rendering by delegating to the active skin."""
+    _validate_inputs(value, size)
+    
+    if config is None:
+        config = {"skin_name": "stingray"}
+        
+    if config.get("skin_name") == "stingray":
+        return render_skin(value, telltales, size)
+    
+    raise ValueError(f"Unknown skin: {config.get('skin_name')}")
+```
+
+### 6.4 `tests/unit/test_gauge.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Unit tests for gauge orchestration and pure functions.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+import sys
+import pytest
+from PIL import Image, ImageChops
+from boostgauge.gauge import render, _validate_inputs
+
+# INSTRUCTION TO AGENT: You MUST append all non-visual test functions from Section 10.1 here.
+```
+
+### 6.5 `tests/visual/test_gauge.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Visual regression tests for gauge rendering.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+import pytest
+from pathlib import Path
+from PIL import Image, ImageChops
+from boostgauge.gauge import render
+
+# INSTRUCTION TO AGENT: You MUST append the visual test function `test_req_120_visual` from Section 10.1 here.
+```
+
+### 6.6 `tests/conftest.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Pytest configuration for custom flags.
+
+Issue #1: Feature: core gauge renderer
+"""
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--generate-baselines",
+        action="store_true",
+        default=False,
+        help="Generate visual regression baseline images"
+    )
+```
+
+## 7. Pattern References
+
+### 7.1 Typing Definitions
+
+**File:** `src/boostgauge/config.py` (lines 13-25)
+
+```text
+class PositionConfig(TypedDict):
+
+class ThresholdConfig(TypedDict):
+
+class Thresholds(TypedDict):
+
+class TelltaleWindows(TypedDict):
+
+class AppConfig(TypedDict):
+
+class SessionState(TypedDict):
+```
+
+**Relevance:** Demonstrates the use of `TypedDict` for configuration structures within the codebase, which is directly mirrored in the definition of `SkinConfig`.
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import math` | stdlib | `src/boostgauge/skins/stingray.py` |
+| `from typing import Protocol, TypedDict` | stdlib | `src/boostgauge/skins/__init__.py`, `src/boostgauge/gauge.py` |
+| `from PIL import Image, ImageDraw, ImageChops` | `pillow` | All implemented modules |
+| `from pathlib import Path` | stdlib | `tests/visual/test_gauge.py` |
+| `import pytest` | `pytest` | Test modules |
+| `import sys` | stdlib | Test modules |
+
+**New Dependencies:** None (pillow is already included in pyproject.toml).
+
+## 9. Placeholder
+
+*Reserved for future use to maintain alignment with LLD section numbering.*
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| T010 | `render()` | `value=0, telltales=[]` | `PIL.Image` |
+| T020 | `render()` | `value=50, telltales=[]` | Identical PIL images for two calls |
+| T030 | `render()` | `value=0, 50, 100` | Needle exactly at 225°, 90°, -45° |
+| T040 | `render()` | `value=0 vs 100` | Diff only in pixels of `#F73923` |
+| T050 | `render()` | `value=75` | Band spans 60-100 at 0.8-1.0 R |
+| T060 | `render()` | `value=50, telltales=[None]` | No telltale pixels |
+| T070 | `render()` | `value=70, telltales=[30]` | d=40 -> 20% opacity |
+| T080 | `render()` | `value=70, telltales=[72.5]` | d=2.5 -> linear midpoint opacity |
+| T090 | `render()` | `value=70, telltales=[72]` | d=2 -> 100% opacity |
+| T100 | `render()` | `value=75` | Tip `#F73923`, band `#9B3020` |
+| T110 | `render()` | `size=128`, `size=512` | 128x128 and 512x512 images |
+| T120 | `render()` | `--generate-baselines` flag | Saved baseline |
+| T130 | `render()` | `value=50, telltales=[10,20,80,90]` | 4 distinct needles rendered |
+| T140 | `render()` | Invalid bounds | `ValueError` raised |
+
+### 10.1 Per-criterion test functions
+
+```python
+def test_req_010():
+    # Pure function check (REQ-1) -- expected: Returns PIL.Image, no tkinter import
+    img = render(0, [], 256)
+    assert isinstance(img, Image.Image)
+
+def test_req_020():
+    # Deterministic output (REQ-2) -- expected: ImageChops.difference(im1, im2) is exactly 0
+    img1 = render(50, [10], 256)
+    img2 = render(50, [10], 256)
+    diff = ImageChops.difference(img1, img2)
+    assert not diff.getbbox()
+
+def test_req_030_baseline_independent():
+    # Needle angle mapping (REQ-3) -- expected: Needle exactly at 225°, 90°, -45°
+    import math
+    def get_tip(v, size=256):
+        angle = 225.0 - 2.7 * v
+        rad = math.radians(angle)
+        return (int(size/2 + math.cos(rad) * size/2 * 0.95), int(size/2 - math.sin(rad) * size/2 * 0.95))
+    
+    assert render(0, [], 256).getpixel(get_tip(0)) == (247, 57, 35, 255)
+    assert render(50, [], 256).getpixel(get_tip(50)) == (247, 57, 35, 255)
+    assert render(100, [], 256).getpixel(get_tip(100)) == (247, 57, 35, 255)
+
+def test_req_040():
+    # Static element consistency (REQ-4) -- expected: Images differ only in pixels occupied by the candy-apple #F73923 needle
+    img_0 = render(0, [], 256)
+    img_100 = render(100, [], 256)
+    diff = ImageChops.difference(img_0, img_100)
+    assert diff.getbbox()
+    
+    # Verify that all differences are restricted to the candy-apple needle (#F73923)
+    for y in range(256):
+        for x in range(256):
+            if diff.getpixel((x, y)) != (0, 0, 0, 0):
+                p0 = img_0.getpixel((x, y))
+                p100 = img_100.getpixel((x, y))
+                # Check for strong red component characteristic of #F73923
+                p0_is_needle = p0[0] > 150 and p0[1] < 100 and p0[2] < 100
+                p100_is_needle = p100[0] > 150 and p100[1] < 100 and p100[2] < 100
+                assert p0_is_needle or p100_is_needle, f"Unexpected diff at ({x},{y})"
+
+def test_req_050():
+    # Redline band bounds (REQ-5) -- expected: Band spans 60-100 at 0.8-1.0 R
+    import math
+    img = render(75, [], 256)
+    angle = 225.0 - 2.7 * 80
+    rad = math.radians(angle)
+    px = (int(128 + math.cos(rad) * 128 * 0.9), int(128 - math.sin(rad) * 128 * 0.9))
+    assert img.getpixel(px) == (155, 48, 32, 255)
+
+def test_req_060():
+    # Hidden missing telltales (REQ-6) -- expected: Telltale pixels are completely absent
+    img_none = render(50, [None], 256)
+    img_empty = render(50, [], 256)
+    diff = ImageChops.difference(img_none, img_empty)
+    assert not diff.getbbox()
+
+def test_req_070():
+    # Far telltale translucency (REQ-7) -- expected: d>=3 samples at baseline translucency
+    import math
+    img = render(70, [30], 256)
+    angle = 225.0 - 2.7 * 30
+    rad = math.radians(angle)
+    px = (int(128 + math.cos(rad) * 128 * 0.9), int(128 - math.sin(rad) * 128 * 0.9))
+    assert img.getpixel(px)[3] == int(255 * 0.2)
+
+def test_req_080():
+    # Mid-fade telltale opacity (REQ-8) -- expected: d=2.5 samples strictly at linear midpoint opacity
+    import math
+    img = render(70, [72.5], 256)
+    angle = 225.0 - 2.7 * 72.5
+    rad = math.radians(angle)
+    px = (int(128 + math.cos(rad) * 128 * 0.9), int(128 - math.sin(rad) * 128 * 0.9))
+    assert img.getpixel(px)[3] == int(255 * (1.0 - 0.5 * 0.8))
+
+def test_req_090():
+    # Near telltale opacity (REQ-9) -- expected: d<=2 samples at 100% opacity
+    import math
+    img = render(70, [72], 256)
+    angle = 225.0 - 2.7 * 72
+    rad = math.radians(angle)
+    px = (int(128 + math.cos(rad) * 128 * 0.9), int(128 - math.sin(rad) * 128 * 0.9))
+    assert img.getpixel(px)[3] == 255
+
+def test_req_100():
+    # In-band distinctness (REQ-10) -- expected: Tip sampled at candy-apple #F73923, band sampled at brick #9B3020
+    import math
+    img = render(75, [], 256)
+    angle = 225.0 - 2.7 * 75
+    rad = math.radians(angle)
+    tip_px = (int(128 + math.cos(rad) * 128 * 0.95), int(128 - math.sin(rad) * 128 * 0.95))
+    band_angle = 225.0 - 2.7 * 80
+    band_rad = math.radians(band_angle)
+    band_px = (int(128 + math.cos(band_rad) * 128 * 0.9), int(128 - math.sin(band_rad) * 128 * 0.9))
+    assert img.getpixel(tip_px) == (247, 57, 35, 255)
+    assert img.getpixel(band_px) == (155, 48, 32, 255)
+
+def test_req_110():
+    # Aspect lock resizing (REQ-11) -- expected: Output is 128x128 and 512x512 with matching proportion
+    img_128 = render(50, [], 128)
+    img_512 = render(50, [], 512)
+    assert img_128.size == (128, 128)
+    assert img_512.size == (512, 512)
+
+def test_req_120_visual(tmp_path):
+    # Explicit baseline generation (REQ-12) -- expected: --generate-baselines explicitly generates file, no auto-accept
+    import sys
+    generate = "--generate-baselines" in sys.argv
+    img = render(0, [], 256)
+    baseline_path = Path("tests/visual/baselines/baseline_0.png")
+    if generate:
+        baseline_path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(baseline_path)
+    else:
+        assert baseline_path.exists(), "Baseline missing, run with --generate-baselines"
+        baseline = Image.open(baseline_path)
+        diff = ImageChops.difference(img, baseline)
+        assert not diff.getbbox(), "Visual regression detected"
+
+def test_req_130():
+    # Multiple telltales (REQ-13) -- expected: Four distinct telltale needles rendered
+    import math
+    img = render(50, [10, 20, 80, 90], 256)
+    for v in [10, 20, 80, 90]:
+        angle = 225.0 - 2.7 * v
+        rad = math.radians(angle)
+        px = (int(128 + math.cos(rad) * 128 * 0.9), int(128 - math.sin(rad) * 128 * 0.9))
+        assert img.getpixel(px)[3] > 0
+
+def test_value_errors():
+    # ValueError tests -- expected: ValueErrors are raised
+    with pytest.raises(ValueError):
+        render(-1, [], 256)
+    with pytest.raises(ValueError):
+        render(50, [], 100)
+    with pytest.raises(ValueError):
+        render(50, [], 256, config={"skin_name": "unknown"})
+```
+
+## 11. Implementation Notes
+
+### 11.1 Error Handling Convention
+
+Input bounds are checked in `_validate_inputs` before any `PIL.Image` allocations to avoid OOM or negative rendering sizes. Malformed inputs explicitly raise `ValueError`.
+
+### 11.2 Geometry Calculation
+
+Needle angle mapping `angle(value) = 225° − 2.7° × value` translates real-world coordinates into mathematical mapping. Trigonometry `sin` and `cos` are used to map polar to cartesian coordinates for lines.
+
+### 11.3 Constants
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `MIN_SIZE` | `128` | Prevent rendering artifacts on too small constraints |
+| `NEEDLE_COLOR` | `"#F73923"` | Candy-apple color for main needle |
+| `BAND_COLOR` | `"#9B3020"` | Brick color for redline band |
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3)
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every **non-test** function has input/output examples with realistic values (Section 5)
+- [x] Every LLD pass criterion has a test function (Section 10.1) — these are exempt from the rule above
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #1 |
+| Verdict | DRAFT |
+| Date | 2026-08-14 |
+| Iterations | 1 |
+| Finalized | 2026-08-14T15:34:19-05:00 |

--- a/tests/unit/test_framework_injected_receivers.py
+++ b/tests/unit/test_framework_injected_receivers.py
@@ -1,0 +1,178 @@
+"""Unresolvable is not hallucinated: framework-injected receivers (#2391).
+
+boostgauge #1's resumed roll (run-issue1-173403) died at the completeness cap
+in 91 seconds, three identical failures, on a GATE DEADLOCK rather than a
+drafting defect:
+
+* Gemini's spec review DEMANDED a `conftest.py` registering the custom flag via
+  `pytest_addoption` — pytest crashes on unregistered flags, and boostgauge
+  ruling #271 mandates the registration.
+* The symbol check REJECTED the obedient spec, because `parser.addoption(` names
+  a method absent from the target repo's 21 gathered symbols.
+
+`parser` is injected by pytest and typed `_pytest.config.argparsing.Parser`. It
+was never going to be in boostgauge's surface. One gate demanded the line, the
+other forbade it, and no draft could satisfy both.
+
+The two-sided proof is the point of this module. Widening the check until the
+deadlock clears is trivial and worthless; these tests pin BOTH that the real
+rejected draft now passes AND that a hallucinated method on a class the target
+repo genuinely owns is still caught by name.
+"""
+
+from pathlib import Path
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+#: Stand-in for boostgauge's gathered surface. The only property that matters is
+#: the one the live run had: `addoption` is not in it, and never could be.
+TARGET_SYMBOLS = ["GaugeWindow", "render", "to_dict", "update", "SkinConfig"]
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "boostgauge1_spec_deadlock"
+    / "001-spec-draft.md"
+)
+
+
+def _flag(spec: str) -> dict[str, list[str]]:
+    return detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
+
+
+# =============================================================================
+# Half one: the deadlock ends
+# =============================================================================
+
+
+class TestTheDeadlockedDraftClears:
+    """The exact artifact the live run rejected, byte for byte."""
+
+    def test_fixture_still_contains_the_call_that_deadlocked(self):
+        """Guards the guard: if the fixture loses the line, the rest proves nothing."""
+        assert "parser.addoption(" in FIXTURE.read_text(encoding="utf-8")
+
+    def test_addoption_no_longer_flagged(self):
+        flagged = _flag(FIXTURE.read_text(encoding="utf-8"))
+        assert "addoption" not in flagged, (
+            f"the deadlock survives; flagged={flagged}"
+        )
+
+    def test_the_draft_passes_the_check(self):
+        result = check_api_symbols_exist(
+            FIXTURE.read_text(encoding="utf-8"), TARGET_SYMBOLS
+        )
+        assert result["passed"] is True, result["details"]
+
+
+class TestFrameworkInjectionIsExempt:
+    def test_pytest_hook_parameter_is_exempt(self):
+        spec = (
+            "# S\n\n```python\n"
+            "def pytest_addoption(parser):\n"
+            '    parser.addoption("--generate-baselines", action="store_true")\n'
+            "```\n"
+        )
+        assert "addoption" not in _flag(spec)
+
+    def test_every_parameter_of_a_hook_is_exempt(self):
+        """pluggy hands the hook all of its arguments, not just the first."""
+        spec = (
+            "# S\n\n```python\n"
+            "def pytest_collection_modifyitems(config, items):\n"
+            "    config.getoption('--slow')\n"
+            "    items.remove(items[0])\n"
+            "```\n"
+        )
+        flagged = _flag(spec)
+        assert "getoption" not in flagged
+
+    def test_builtin_fixture_parameter_is_exempt_outside_a_hook(self):
+        spec = (
+            "# S\n\n```python\n"
+            "def test_writes_config(tmp_path, monkeypatch):\n"
+            "    monkeypatch.setenv('BG_HOME', str(tmp_path))\n"
+            "    tmp_path.joinpath('x.json').write_text('{}')\n"
+            "```\n"
+        )
+        flagged = _flag(spec)
+        assert "setenv" not in flagged
+        assert "joinpath" not in flagged
+
+
+# =============================================================================
+# Half two: the check did not become useless
+# =============================================================================
+
+
+class TestTruePositivesSurvive:
+    """A fix that only clears the deadlock has widened the gate into nothing."""
+
+    def test_hallucinated_method_on_an_owned_class_still_flagged(self):
+        """The operator's second half: the receiver resolves to a target class.
+
+        `GaugeWindow` is in the target repo's surface, so `gauge` is the target
+        repo's object and `model_dump` is the target repo's business — exactly
+        #1527's founding case, pydantic methods on a plain dataclass.
+        """
+        spec = (
+            "# S\n\n```python\n"
+            "def build():\n"
+            "    gauge = GaugeWindow()\n"
+            "    return gauge.model_dump()\n"
+            "```\n"
+        )
+        flagged = _flag(spec)
+        assert "model_dump" in flagged, flagged
+
+    def test_check_blocks_on_the_owned_class_hallucination(self):
+        spec = (
+            "# S\n\n```python\n"
+            "def build():\n"
+            "    gauge = GaugeWindow()\n"
+            "    return gauge.model_dump()\n"
+            "```\n"
+        )
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is False
+        assert "model_dump" in result["details"]
+
+    def test_an_ordinary_parameter_is_still_judged(self):
+        """`state` is unresolvable too, and stays judged on purpose.
+
+        Exempting every parameter would be defensible in the abstract and fatal
+        in practice: #1527's founding true positive and #1952's regression set
+        both arrive as bare parameter receivers. Only a parameter a framework
+        NAMES itself as owning is exempt.
+        """
+        spec = "# S\n\n```python\ndef apply(state):\n    state.model_dump()\n```\n"
+        assert "model_dump" in _flag(spec)
+
+    def test_self_is_never_exempted(self):
+        """A blanket parameter exemption would free the entire target surface."""
+        spec = (
+            "# S\n\n```python\n"
+            "class Gauge:\n"
+            "    def draw(self):\n"
+            "        self.model_dump()\n"
+            "```\n"
+        )
+        assert "model_dump" in _flag(spec)
+
+    def test_a_hook_does_not_exempt_names_beyond_its_own_parameters(self):
+        """The exemption is scoped to what pytest actually injects."""
+        spec = (
+            "# S\n\n```python\n"
+            "def pytest_addoption(parser):\n"
+            '    parser.addoption("--x")\n'
+            "\n"
+            "def apply(state):\n"
+            "    state.model_dump()\n"
+            "```\n"
+        )
+        flagged = _flag(spec)
+        assert "addoption" not in flagged
+        assert "model_dump" in flagged


### PR DESCRIPTION
## The deadlock

boostgauge #1's resumed roll (`run-issue1-173403`) died at the completeness cap in 91 seconds, three identical failures. Not a drafting defect — a gate deadlock:

- The spec review **demanded** a `conftest.py` registering the custom flag via `pytest_addoption`. pytest crashes on unregistered flags, and boostgauge ruling #271 mandates the registration.
- The symbol check **rejected** the obedient spec: ``Spec calls methods not found in the target project's gathered symbols: `addoption` (e.g. `parser.addoption(`)``.

`parser` is injected by pytest and typed `_pytest.config.argparsing.Parser`. The gatherer collects target-repo symbols only — the run log's N1 line reads `Gathered 0 planned-file symbol(s) + 21 from origin/hardening-run-17` — so pytest's plugin API was never going to be in that universe. One gate demanded the line, the other forbade it, and no draft could satisfy both.

## The repair

#1948 named three universes the target repo's symbol table has no authority over: imports, stdlib, and spec-defined names. This adds **the fourth — parameters a framework injects** — as one more exempt universe in machinery that already exists, alongside `_STDLIB_MODULE_NAMES`.

Deliberately narrow. "Parameters are unresolvable" is true and useless: every true positive this check has ever caught arrives as a bare parameter receiver, including #1527's founding `state.model_dump()` and #1952's `win.model_dump()`. Exempting all of them would widen the gate into nothing. What is exempt is a parameter of a function whose **name declares framework ownership**:

- pluggy's `pytest_*` hook convention — pytest supplies every argument to `pytest_addoption(parser)`;
- pytest's builtin fixture names (`tmp_path`, `monkeypatch`, `capsys`, …) wherever they appear as parameters.

`self` and `cls` are never exempt, so the target repo's own surface stays entirely in jurisdiction.

## Proof, both halves

The operator's condition was that half one alone is not a fix. Both are pinned in `tests/unit/test_framework_injected_receivers.py`:

| Half | Test | Result |
|---|---|---|
| Deadlock ends | the exact rejected draft no longer flags `addoption` | pass |
| Deadlock ends | the exact rejected draft passes `check_api_symbols_exist` | pass |
| Gate survives | hallucinated method on a target-owned class still flagged by name | pass |
| Gate survives | ordinary parameter (`state`) still judged | pass |
| Gate survives | `self` never exempted | pass |
| Gate survives | a hook exempts its own parameters and nothing further | pass |

The fixture is the live artifact, byte for byte from the run's lineage (`2026-08-14T22-34-04Z/001-spec-draft.md`), copied to `tests/fixtures/boostgauge1_spec_deadlock/` so the reproduction does not depend on boostgauge being present. A guard test asserts the fixture still contains `parser.addoption(`, so the proof cannot quietly become vacuous.

`_FenceFacts` gained a field, so the full unit suite was run rather than the touched files: **7746 passed, 17 skipped, 5 xfailed, 0 failures.** Ruff clean.

## Independence

The natural assumption is that the flagged symbol was scraped out of one of the three fences that fail to parse, which would make the sibling fence-analysis defect upstream of this one. It is not: `parser.addoption(` sits at line 333 of the draft, inside a `python` fence spanning 326–339 that parses cleanly. Measured through the production code path — 19 fences, 15 `python` all parsing, 1 `json`, 3 `text` all failing at 75–77 / 134–136 / 347–359. The two defects are independent and share only a file.

## Judgment call worth review

Issue acceptance asked that "a call the gatherer cannot resolve is reported as unresolved (if at all), never as hallucinated." Read strictly, that covers `state` and `win` too — both are unresolvable parameters. Implementing it that strictly would delete the check's entire true-positive surface, since all four existing true-positive fixtures use bare parameter receivers. I implemented the narrow reading and left ordinary parameters judged. If the strict reading was intended, say so and it becomes a follow-up: the change is a one-line widening, and the cost is that the check stops catching anything.

Closes #2391
