### PR TITLE
fix: route fences by language tag and delete the regex fallback (Closes #2392)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1108,12 +1108,41 @@ def check_error_paths_have_tests(spec: str) -> CompletenessCheck:
 # content carries no nodes at all, which is why docstring stripping stops being
 # a special case here.
 #
-# A fence that will not parse (a genuinely malformed snippet, or a diff whose
-# context lines cannot be reconciled into valid Python) falls back to the
-# original regex collectors below, so it degrades to the previous behaviour
-# instead of going unscanned.
+# A fence that will not parse used to fall back to regex collectors. #2392
+# retired that: standard 0028 is absolute that "regex is not a safety fallback",
+# and §4 that no function "returns ... a silent downgrade because it could not
+# read its input". The fallback did not provide resilience, it provided silence —
+# it fed the symbol check a confident, wrong call list and converted "this spec
+# contains code that does not parse", a first-class defect in an implementation
+# spec, into a footnote.
+#
+# What replaces it is the fence's own LANGUAGE TAG, which is a declaration:
+#
+#   python/py/python3  the fence CLAIMS to be Python. It must parse. A parse
+#                      failure is a named completeness failure carrying the
+#                      fence's line span and the parse error.
+#   text/json/bash/... the fence declares it is something else. Skipped by tag,
+#                      never parsed, never a failure.
+#   diff, untagged     undeclared. Parsed opportunistically for facts; a parse
+#                      failure is counted and reported, never a hard failure,
+#                      because nothing claimed it was Python.
+#
+# The tag filter is load-bearing and must come FIRST. The rejected boostgauge #1
+# draft carries three correctly-authored ```text fences (lines 75-77, 134-136,
+# 347-359) holding bodyless class declarations. They are not malformed Python;
+# they were never Python. Killing the fallback without filtering on the tag
+# would convert an otherwise clean draft into a hard failure — replacing a
+# silent wrong answer with a loud one.
 
-_CODE_FENCE_RE = re.compile(r"```[\w]*\s*\n(.*?)```", re.DOTALL)
+_CODE_FENCE_RE = re.compile(r"```([\w]*)\s*\n(.*?)```", re.DOTALL)
+
+#: Tags whose fence CLAIMS to be Python. Parse failure here is a named failure.
+_PYTHON_FENCE_TAGS: frozenset[str] = frozenset({"python", "py", "python3"})
+
+#: Tags that declare a fence is Python-adjacent but not a Python claim. A diff
+#: fence normalizes into parseable Python often enough to be worth reading
+#: (#1954), and legitimately does not when it diffs a non-Python file.
+_UNDECLARED_FENCE_TAGS: frozenset[str] = frozenset({"", "diff"})
 
 # Diff decoration has to come off before a fence can parse: the spec template
 # REQUIRES before/after snippets (#1954). Drop the ---/+++ file headers, DELETE
@@ -1166,18 +1195,6 @@ _PYTEST_BUILTIN_FIXTURES: frozenset[str] = frozenset({
 #: which is precisely the check's jurisdiction.
 _NON_RECEIVER_PARAMS: frozenset[str] = frozenset({"self", "cls"})
 
-# ---- regex fallback collectors: pre-#1956 behaviour, unchanged --------------
-_IMPORT_RE = re.compile(
-    r"^\s*(?:from\s+([\w.]+)\s+import\s+([\w ,]+)|import\s+([\w.]+)(?:\s+as\s+(\w+))?)",
-    re.MULTILINE,
-)
-_DEF_RE = re.compile(r"^\s*(?:def|class)\s+(\w+)", re.MULTILINE)
-_SELF_ASSIGN_RE = re.compile(r"^\s*self\.(\w+)\s*=", re.MULTILINE)
-_ASSIGN_RE = re.compile(r"^\s*(?:self\.)?(\w+)\s*=\s*(\w+)[.(]", re.MULTILINE)
-_METHOD_CALL_RE = re.compile(r"\b(\w+)\.(\w+)\s*\(")
-_DOCSTRING_RE = re.compile(r'""".*?"""|\'\'\'.*?\'\'\'', re.DOTALL)
-
-
 class _CallSite(NamedTuple):
     """One ``<receiver>.<method>(...)`` call found inside a fence."""
 
@@ -1198,7 +1215,32 @@ class _FenceFacts(NamedTuple):
     # Parameters a framework injects, whose type the target repo does not own
     # (#2391) — `parser` in `def pytest_addoption(parser)`, `tmp_path` in a test.
     framework_params: frozenset[str]
-    parsed: bool  # False when this fence fell back to the regex collectors
+
+
+class _FenceParseFailure(NamedTuple):
+    """A fence that CLAIMED to be Python and would not parse (#2392).
+
+    Carries what a revision needs to act: which fence, and why the parser
+    refused. There is no third option where the content gets read anyway.
+    """
+
+    start_line: int
+    end_line: int
+    tag: str
+    error: str
+
+
+class _ScanResult(NamedTuple):
+    """Everything one pass over a document's fences established."""
+
+    facts: list[_FenceFacts]
+    #: Declared-Python fences that would not parse — named failures.
+    failures: list[_FenceParseFailure]
+    #: Fences skipped because their tag declares a non-Python language.
+    skipped_by_tag: int
+    #: Undeclared fences (untagged, diff) that would not parse. Counted and
+    #: reported, never a failure: nothing claimed they were Python.
+    undeclared_unparsed: int
 
 
 def _normalize_fence(block: str) -> str:
@@ -1432,12 +1474,14 @@ class _FenceVisitor(ast.NodeVisitor):
         return ""
 
 
-def _fence_facts_ast(block: str) -> _FenceFacts | None:
-    """Facts from a parsed fence, or None when the snippet will not parse."""
-    try:
-        tree = ast.parse(block)
-    except (SyntaxError, ValueError, RecursionError):
-        return None
+def _fence_facts_ast(block: str) -> _FenceFacts:
+    """Facts from a parsed fence.
+
+    Raises whatever ``ast.parse`` raises. #2392: a parse failure is not a value —
+    the caller decides whether this fence claimed to be Python, and names the
+    failure if it did. It never degrades to a guess.
+    """
+    tree = ast.parse(block)
     visitor = _FenceVisitor(block)
     visitor.visit(tree)
     return _FenceFacts(
@@ -1446,65 +1490,54 @@ def _fence_facts_ast(block: str) -> _FenceFacts | None:
         assignments=tuple(visitor.assignments),
         calls=tuple(visitor.calls),
         framework_params=frozenset(visitor.framework_params),
-        parsed=True,
     )
 
 
-def _fence_facts_regex(block: str) -> _FenceFacts:
-    """The pre-#1956 collectors, kept as the fallback for unparseable fences."""
-    # #1950: docstrings inside fences quote code ('No tkinter.Tk() instantiated'
-    # — the test-strategy rule itself). The AST path never needs this; a string
-    # holds no call nodes.
-    block = _DOCSTRING_RE.sub("", block)
+def _scan_fences(text: str) -> _ScanResult:
+    """Read every code fence in ``text``, routed by its language tag (#2392).
 
-    imported: set[str] = set()
-    for imp in _IMPORT_RE.finditer(block):
-        if imp.group(1):  # from X import a, b — names land in scope
-            imported.add(imp.group(1).split(".")[0])
-            for raw_name in imp.group(2).split(","):
-                name = raw_name.strip().split(" as ")[-1].strip()
-                if name:
-                    imported.add(name)
-        elif imp.group(3):  # import X [as y]
-            imported.add(imp.group(4) or imp.group(3).split(".")[0])
-
-    defined = {m.group(1) for m in _DEF_RE.finditer(block)}
-    defined |= {m.group(1) for m in _SELF_ASSIGN_RE.finditer(block)}
-
-    assignments = tuple(
-        (frozenset({m.group(1)}), frozenset({m.group(2)}))
-        for m in _ASSIGN_RE.finditer(block)
-    )
-
-    calls: list[_CallSite] = []
-    for call in _METHOD_CALL_RE.finditer(block):
-        site = (
-            block[max(0, call.start() - 10) : call.end() + 20]
-            .strip()
-            .replace("\n", " ")[:80]
-        )
-        calls.append(_CallSite(call.group(1), call.group(2), site))
-
-    return _FenceFacts(
-        imported=frozenset(imported),
-        defined=frozenset(defined),
-        assignments=assignments,
-        calls=tuple(calls),
-        # The regex collectors cannot see a function signature's parameters,
-        # so they contribute no framework exemptions. #2392 retires this path.
-        framework_params=frozenset(),
-        parsed=False,
-    )
-
-
-def _scan_fences(text: str) -> list[_FenceFacts]:
-    """Read every code fence in ``text`` — AST where it parses, regex where not."""
+    There is no fallback. A fence is parsed as Python, skipped because its tag
+    says it is not Python, or named as a failure — never pattern-scraped into a
+    confident guess.
+    """
     facts: list[_FenceFacts] = []
+    failures: list[_FenceParseFailure] = []
+    skipped_by_tag = 0
+    undeclared_unparsed = 0
+
     for match in _CODE_FENCE_RE.finditer(text):
-        block = _normalize_fence(match.group(1))
-        parsed = _fence_facts_ast(block)
-        facts.append(parsed if parsed is not None else _fence_facts_regex(block))
-    return facts
+        tag = (match.group(1) or "").lower()
+        declares_python = tag in _PYTHON_FENCE_TAGS
+        undeclared = tag in _UNDECLARED_FENCE_TAGS
+
+        if not declares_python and not undeclared:
+            # ```text, ```json, ```bash — the tag is the author telling us this
+            # is not Python. Believe it.
+            skipped_by_tag += 1
+            continue
+
+        block = _normalize_fence(match.group(2))
+        try:
+            facts.append(_fence_facts_ast(block))
+        except (SyntaxError, ValueError, RecursionError) as e:
+            if declares_python:
+                failures.append(
+                    _FenceParseFailure(
+                        start_line=text.count("\n", 0, match.start()) + 1,
+                        end_line=text.count("\n", 0, match.end()) + 1,
+                        tag=tag,
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                )
+            else:
+                undeclared_unparsed += 1
+
+    return _ScanResult(
+        facts=facts,
+        failures=failures,
+        skipped_by_tag=skipped_by_tag,
+        undeclared_unparsed=undeclared_unparsed,
+    )
 
 
 def _flag_calls(
@@ -1579,7 +1612,7 @@ def detect_unknown_method_calls(
         Mapping of unknown method name -> truncated example call sites.
         Empty when every call resolves to a known or allowlisted symbol.
     """
-    return _flag_calls(_scan_fences(text), symbol_set)
+    return _flag_calls(_scan_fences(text).facts, symbol_set)
 
 
 def check_api_symbols_exist(
@@ -1627,19 +1660,50 @@ def check_api_symbols_exist(
         )
 
     symbol_set: set[str] = set(gathered_symbols)
-    facts = _scan_fences(spec)
-    flagged = _flag_calls(facts, symbol_set)
+    scan = _scan_fences(spec)
 
-    # #1870's honesty rule applied to the scan itself: a fence that fell back
-    # to the regex collectors was read with the weaker instrument, and saying
-    # so keeps "checked" from overstating what was verified.
-    fell_back = sum(1 for fence in facts if not fence.parsed)
-    scan_note = (
-        f" {fell_back} of {len(facts)} fence(s) would not parse as Python and "
-        f"were read with the regex fallback."
-        if fell_back
-        else ""
-    )
+    # #2392: a fence that CLAIMED to be Python and would not parse is a
+    # first-class defect in an implementation spec, and it is reported before
+    # anything else. It used to be scraped with regex and mentioned in a
+    # footnote, which fed this very check a confident, wrong call list.
+    if scan.failures:
+        listed = "; ".join(
+            f"lines {f.start_line}-{f.end_line} (```{f.tag}) — {f.error}"
+            for f in scan.failures[:5]
+        )
+        suffix = (
+            f" (and {len(scan.failures) - 5} more)"
+            if len(scan.failures) > 5
+            else ""
+        )
+        return CompletenessCheck(
+            check_name="api_symbols_exist",
+            passed=False,
+            details=(
+                f"{len(scan.failures)} code fence(s) tagged as Python do not "
+                f"parse as Python: {listed}{suffix}. Fix the snippet, or tag "
+                f"the fence with the language it actually contains (```text, "
+                f"```json, ```bash) if it was never meant to be Python."
+            ),
+        )
+
+    flagged = _flag_calls(scan.facts, symbol_set)
+
+    # #1870's honesty rule applied to the scan itself: say what was NOT read,
+    # so "checked" never overstates what was verified.
+    notes: list[str] = []
+    if scan.skipped_by_tag:
+        notes.append(
+            f"{scan.skipped_by_tag} fence(s) skipped by language tag "
+            f"(not Python)"
+        )
+    if scan.undeclared_unparsed:
+        notes.append(
+            f"{scan.undeclared_unparsed} untagged/diff fence(s) did not parse "
+            f"and were not read (no Python was claimed, so this is not a "
+            f"failure)"
+        )
+    scan_note = f" {'; '.join(notes)}." if notes else ""
 
     if not flagged:
         return CompletenessCheck(

--- a/tests/unit/test_ast_symbol_analysis.py
+++ b/tests/unit/test_ast_symbol_analysis.py
@@ -13,8 +13,9 @@ shapes regex got wrong now resolve correctly, and the true positives #1527 was
 built to catch still block the gate.
 """
 
+import re
+
 from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
-    _fence_facts_regex,
     _normalize_fence,
     _scan_fences,
     check_api_symbols_exist,
@@ -28,22 +29,57 @@ def _flag(spec: str) -> dict[str, list[str]]:
     return detect_unknown_method_calls(spec, set(TARGET_SYMBOLS))
 
 
-def _regex_flagged_methods(spec: str) -> set[str]:
-    """Method names the pre-#1956 collectors would have reported for one fence.
+# =============================================================================
+# Historical replica — NOT production code (#2392)
+# =============================================================================
+#
+# The pre-#1956 regex collectors lived in validate_completeness as the fallback
+# for unparseable fences until #2392 deleted them: standard 0028 is absolute
+# that regex is not a safety fallback, and the fallback was feeding the symbol
+# check confident, wrong call lists.
+#
+# They are reproduced here, and ONLY here, so the contrast tests below keep
+# working. Their entire job is to show that a shape the AST path now handles
+# correctly was genuinely mishandled before — an improvement no test could
+# otherwise see. Nothing in the pipeline calls this.
 
-    Used to show that a shape now handled correctly was genuinely mishandled
-    before, rather than asserting an improvement no test can see.
-    """
+_H_IMPORT_RE = re.compile(
+    r"^\s*(?:from\s+([\w.]+)\s+import\s+([\w ,]+)|import\s+([\w.]+)(?:\s+as\s+(\w+))?)",
+    re.MULTILINE,
+)
+_H_DEF_RE = re.compile(r"^\s*(?:def|class)\s+(\w+)", re.MULTILINE)
+_H_SELF_ASSIGN_RE = re.compile(r"^\s*self\.(\w+)\s*=", re.MULTILINE)
+_H_METHOD_CALL_RE = re.compile(r"\b(\w+)\.(\w+)\s*\(")
+_H_DOCSTRING_RE = re.compile(r'""".*?"""|\'\'\'.*?\'\'\'', re.DOTALL)
+
+
+def _regex_flagged_methods(spec: str) -> set[str]:
+    """Method names the pre-#1956 collectors would have reported for one fence."""
     fence = spec.split("```")[1]
-    body = fence.split("\n", 1)[1]
-    facts = _fence_facts_regex(_normalize_fence(body))
+    body = _normalize_fence(fence.split("\n", 1)[1])
+    body = _H_DOCSTRING_RE.sub("", body)
+
+    imported: set[str] = set()
+    for imp in _H_IMPORT_RE.finditer(body):
+        if imp.group(1):
+            imported.add(imp.group(1).split(".")[0])
+            for raw_name in imp.group(2).split(","):
+                name = raw_name.strip().split(" as ")[-1].strip()
+                if name:
+                    imported.add(name)
+        elif imp.group(3):
+            imported.add(imp.group(4) or imp.group(3).split(".")[0])
+
+    defined = {m.group(1) for m in _H_DEF_RE.finditer(body)}
+    defined |= {m.group(1) for m in _H_SELF_ASSIGN_RE.finditer(body)}
+
     known = set(TARGET_SYMBOLS)
     return {
-        call.method
-        for call in facts.calls
-        if call.receiver not in facts.imported
-        and call.method not in known
-        and call.method not in facts.defined
+        call.group(2)
+        for call in _H_METHOD_CALL_RE.finditer(body)
+        if call.group(1) not in imported
+        and call.group(2) not in known
+        and call.group(2) not in defined
     }
 
 
@@ -53,12 +89,13 @@ def _regex_flagged_methods(spec: str) -> set[str]:
 
 
 class TestParsePathIsTaken:
-    """If every fence quietly fell back, the redesign would be inert."""
+    """If every fence were skipped or unread, the redesign would be inert."""
 
     def test_plain_python_fence_parses(self):
         spec = "# S\n\n```python\ndef f(win):\n    win.render()\n```\n"
-        facts = _scan_fences(spec)
-        assert [fence.parsed for fence in facts] == [True]
+        scan = _scan_fences(spec)
+        assert len(scan.facts) == 1
+        assert scan.failures == []
 
     def test_diff_fence_parses_after_normalization(self):
         spec = (
@@ -70,8 +107,9 @@ class TestParsePathIsTaken:
             "+    root.after(10, None)\n"
             "```\n"
         )
-        facts = _scan_fences(spec)
-        assert [fence.parsed for fence in facts] == [True]
+        scan = _scan_fences(spec)
+        assert len(scan.facts) == 1
+        assert scan.failures == []
 
     def test_indented_fence_body_parses(self):
         """A fence holding only an indented method body dedents into valid code."""
@@ -81,30 +119,100 @@ class TestParsePathIsTaken:
             "        win.render()\n"
             "```\n"
         )
-        assert [fence.parsed for fence in _scan_fences(spec)] == [True]
+        scan = _scan_fences(spec)
+        assert len(scan.facts) == 1
+        assert scan.failures == []
 
-    def test_unparseable_fence_falls_back(self):
-        """Broken Python degrades to the regex collectors, never to no scan."""
+    def test_unparseable_python_fence_is_a_named_failure(self):
+        """#2392: broken Python is named, never scraped into a guess."""
         spec = "# S\n\n```python\nclass Broken\n    win.model_dump()\n```\n"
-        facts = _scan_fences(spec)
-        assert [fence.parsed for fence in facts] == [False]
+        scan = _scan_fences(spec)
+        assert scan.facts == []
+        assert len(scan.failures) == 1
+        failure = scan.failures[0]
+        assert failure.tag == "python"
+        assert "SyntaxError" in failure.error
 
-    def test_fallback_still_flags_the_hallucination(self):
+    def test_unparseable_python_fence_blocks_the_check_by_name(self):
         spec = "# S\n\n```python\nclass Broken\n    win.model_dump()\n```\n"
-        assert "model_dump" in _flag(spec)
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is False
+        assert "do not parse as Python" in result["details"]
+        assert "SyntaxError" in result["details"]
 
-    def test_fallback_is_reported_in_the_details(self):
-        """#1870's honesty rule: say when a fence was read with the weaker tool."""
-        spec = "# S\n\n```python\nclass Broken\n    win.render()\n```\n"
+    def test_the_broken_fence_is_no_longer_scraped(self):
+        """The old fallback reported `model_dump` from this fence. It cannot now."""
+        assert "model_dump" in _regex_flagged_methods(
+            "# S\n\n```python\nclass Broken\n    win.model_dump()\n```\n"
+        )
+        spec = "# S\n\n```python\nclass Broken\n    win.model_dump()\n```\n"
+        assert _flag(spec) == {}
+
+    def test_non_python_tags_are_skipped_not_parsed(self):
+        """A ```text fence is not an unparseable Python fence."""
+        spec = (
+            "# S\n\n```text\n"
+            "class PositionConfig(TypedDict):\n"
+            "\n"
+            "class Thresholds(TypedDict):\n"
+            "```\n"
+        )
+        scan = _scan_fences(spec)
+        assert scan.failures == []
+        assert scan.facts == []
+        assert scan.skipped_by_tag == 1
+
+    def test_skipped_tags_are_reported_in_the_details(self):
+        """#1870's honesty rule: say what was NOT read."""
+        spec = (
+            "# S\n\n```python\ndef f(win):\n    win.render()\n```\n"
+            "\n```text\nclass A(TypedDict):\n```\n"
+        )
         result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
         assert result["passed"] is True, result["details"]
-        assert "regex fallback" in result["details"]
+        assert "skipped by language tag" in result["details"]
 
-    def test_clean_scan_says_nothing_about_fallback(self):
+    def test_clean_scan_says_nothing_about_skips(self):
         spec = "# S\n\n```python\ndef f(win):\n    win.render()\n```\n"
         result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
         assert result["passed"] is True
-        assert "fallback" not in result["details"]
+        assert "skipped" not in result["details"]
+
+    def test_no_regex_fallback_survives_in_production(self):
+        """Acceptance: the code path is deleted, not gated.
+
+        The module must be reached through ``importlib``. ``nodes/__init__.py``
+        re-exports the FUNCTION ``validate_completeness``, which shadows the
+        module of the same name — so the obvious
+        ``from ...nodes import validate_completeness as vc`` binds a function,
+        every ``hasattr`` below is False for it whatever the module contains,
+        and this test passes while proving nothing. The type assertion keeps it
+        from silently going vacuous again.
+        """
+        import importlib
+        import types
+
+        vc = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes"
+            ".validate_completeness"
+        )
+        assert isinstance(vc, types.ModuleType), (
+            "resolved a non-module; the hasattr assertions would be vacuous"
+        )
+        # Positive control: a symbol that DOES exist, so the assertions below
+        # are known to be capable of failing.
+        assert hasattr(vc, "_scan_fences")
+
+        for retired in (
+            "_fence_facts_regex",
+            "_METHOD_CALL_RE",
+            "_IMPORT_RE",
+            "_DEF_RE",
+            "_SELF_ASSIGN_RE",
+            "_ASSIGN_RE",
+            "_DOCSTRING_RE",
+        ):
+            assert not hasattr(vc, retired), f"{retired} still exists"
 
 
 # =============================================================================


### PR DESCRIPTION
## The defect

A code fence that would not parse as Python was silently re-read with regex collectors, and the fact reported as a footnote: `3 of 19 fence(s) would not parse as Python and were read with the regex fallback.` That is manufactured evidence — it feeds the symbol check confident, wrong call lists, and converts "this spec contains code that does not parse" into silence.

## The caveat the obvious implementation gets wrong

Killing the fallback outright breaks a clean document. Measured over all 19 fences of the rejected boostgauge #1 draft, through the production code path:

| tag | fences | parse | fail |
|---|---|---|---|
| `python` | 15 | 15 | 0 |
| `json` | 1 | 1 | 0 |
| `text` | 3 | 0 | 3 |

Those three are exactly the "3 of 19" in the halt message. They sit at lines 75–77, 134–136 and 347–359, they hold bodyless `class X(TypedDict):` declarations, and **they were never Python** — they are correctly-authored `text` fences. The analyzer was attempting a Python parse on every fence regardless of its tag. Hard-failing without filtering on the tag first would convert an otherwise clean draft into a hard failure: a loud wrong answer replacing a silent one.

## The repair

Fences route by language tag, tag first:

- **`python` / `py` / `python3`** — the fence *claims* to be Python. It must parse. A parse failure is a named completeness failure carrying the fence's line span and the parse error, routed to revision like any other miss.
- **`text` / `json` / `bash` / …** — the tag is the author declaring another language. Skipped, never parsed, never a failure.
- **`diff`, untagged** — undeclared. Parsed opportunistically for facts; a parse failure is counted and reported but never fatal, because nothing claimed it was Python. (`diff` normalizes into parseable Python often enough to be worth reading per #1954, and legitimately does not when it diffs a non-Python file. Untagged opening fences do not occur in any lineage draft — every opening fence in every one carries a tag.)

**Deleted, not gated:** `_fence_facts_regex` and all six collectors (`_IMPORT_RE`, `_DEF_RE`, `_SELF_ASSIGN_RE`, `_ASSIGN_RE`, `_METHOD_CALL_RE`, `_DOCSTRING_RE`). `_fence_facts_ast` now raises rather than returning `None`.

## Proof

| Proof | Result |
|---|---|
| Census reproduced independently through the production path | 19 fences, 15 `python` all parse, 1 `json`, 3 `text` all fail |
| Every retired symbol absent from the module | 7/7 absent |
| Fixed analyzer on the same draft | 15 parsed, 4 skipped by tag, **0 failures, 0 fallback invocations** |
| The draft passes `check_api_symbols_exist` | pass |
| Deliberately corrupted ```python fence | named `SyntaxError: '(' was never closed` at lines 326–339, check blocks |

Full unit suite: **7749 passed, 17 skipped, 5 xfailed, 0 failures.** Ruff clean.

## Doctrine: how this sits with standard 0028 §3

The operator asked whether 0028's carve-out for deterministic scans of the pipeline's own documents ever licensed this fallback. **It did not**, and the carve-out's own wording is what rules it out.

§3 permits document-structure scans on two conditions. This fallback fails both:

1. *"named as scans, and **never framed as fallbacks**"* — it was named `_fence_facts_regex`, documented as "kept as the fallback for unparseable fences", and its result carried a field literally named `parsed` recording that the fence "fell back". It was a fallback by name, by construction, and by self-description.
2. *"They cannot mask a contract failure **because there is no contract: the document is what it is**"* — a fence tagged `python` **is** a contract. It is the drafter asserting the content is Python. Content that will not parse violates that assertion, and the fallback masked exactly that.

§4 condemns it directly without needing §3 at all: *"No function returns an empty result, an `UNKNOWN`, or a silent downgrade because it could not read its input."* `_fence_facts_regex` returned a degraded value precisely because `ast.parse` could not read the input.

So the doctrine comes out coherent with no amendment: §3 covers *structure* scans over documents that assert nothing (finding a `## Open Questions` section), not *content* parsing of a fence that carries a language claim. The surviving replica of the old collectors lives in the test module, labelled as a historical replica, and nothing in the pipeline calls it.

## Related, filed separately

A second regex fallback exists in the symbol **gatherer** (`analyze_codebase._extract_symbols_from_files`), outside this issue's fence-analysis scope. It is arguably worse — it mis-reads the target repo, which is the authority specs are judged against — and is tracked in #2393 rather than widened into this PR.

Closes #2392
