### PR TITLE
test: assert the spec reviewer and symbol checker agree on valid code (Closes #2397)

### DIFF
--- a/tests/fixtures/reviewer_idioms/framework_idioms.py
+++ b/tests/fixtures/reviewer_idioms/framework_idioms.py
@@ -1,0 +1,145 @@
+"""Framework idioms the spec reviewer recommends, which the symbol checker must accept.
+
+Issue #2397. This corpus is the contract between two gates that have twice
+deadlocked the drafter against each other:
+
+* the spec reviewer (N5) tells the drafter to write a framework call;
+* the symbol checker (N3) rejects it as a hallucinated API, because the method
+  is absent from the target repo's gathered symbols.
+
+Neither gate's own suite can see the disagreement — each pins its own behaviour
+against its own fixtures, and the fault lives in the relationship. When the sets
+diverge the drafter is handed a contradiction it cannot satisfy at any iteration
+count, so the loop burns its budget and the stage dies at the cap. That has cost
+two rolls: 91 seconds (#2391) and 13m 12s (#2396).
+
+PROVENANCE, and a correction to #2397's own proposal
+----------------------------------------------------
+The issue proposed sourcing this list from the reviewer's prompt "where it
+enumerates them". No such enumeration exists. Neither `review_spec.py` nor
+`generate_spec.py` names these idioms; the reviewer is a general model applying
+its own knowledge of pytest best practice, so the population is not derivable
+from our code at all.
+
+The corpus is therefore sourced EMPIRICALLY, from readiness verdicts the
+reviewer actually produced, harvested by `tools/harvest_reviewer_idioms.py`.
+Entries marked OBSERVED are verbatim reviewer instructions from a real run.
+Entries marked SURFACE are the rest of the documented API of a fixture the
+checker already exempts — included because a reviewer that recommended one
+method of an object can recommend its siblings, and the point of this file is to
+stop meeting shapes one roll at a time.
+
+Each entry is a complete snippet, not a bare expression: `tmp_path.replace()` is
+only exempt when `tmp_path` is a declared parameter, which is exactly the
+distinction the checker draws and the contract must preserve.
+
+ADDING TO THIS CORPUS
+---------------------
+When a roll dies on a reviewer-dictated idiom, add it here with its run and
+verdict line. Run `poetry run python tools/harvest_reviewer_idioms.py --repo
+<target>` to list candidates in that repo's verdicts that this corpus does not
+yet cover.
+"""
+
+#: (name, provenance, snippet). The snippet is a complete Python fence body.
+FRAMEWORK_IDIOMS: list[tuple[str, str, str]] = [
+    (
+        "pytest_addoption registration",
+        "OBSERVED — run-issue1-173403, the #2391 deadlock. Reviewer demanded a "
+        "conftest.py registering the custom flag; boostgauge ruling #271 "
+        "mandates it and pytest crashes on unregistered flags.",
+        'def pytest_addoption(parser):\n'
+        '    parser.addoption(\n'
+        '        "--generate-baselines",\n'
+        '        action="store_true",\n'
+        '        default=False,\n'
+        '        help="Generate visual regression baseline images",\n'
+        '    )\n',
+    ),
+    (
+        "request.config.getoption",
+        "OBSERVED — run-issue1-193349, the #2396 deadlock. "
+        "012-readiness-verdict.md line 7, verbatim: 'use "
+        '`request.config.getoption("--generate-baselines", False)` to read the '
+        "custom flag reliably'.",
+        'def test_req_120_visual(request, tmp_path):\n'
+        '    generate = request.config.getoption("--generate-baselines", False)\n'
+        '    return generate\n',
+    ),
+    (
+        "tmp_path filesystem methods",
+        "OBSERVED — `tmp_path.replace()` appears in a boostgauge readiness "
+        "verdict. tmp_path is a pathlib.Path supplied by pytest.",
+        'def test_writes(tmp_path):\n'
+        '    target = tmp_path / "cfg.json"\n'
+        '    target.write_text("{}")\n'
+        '    target.replace(tmp_path / "cfg.bak")\n',
+    ),
+    (
+        "monkeypatch",
+        "SURFACE — pytest builtin fixture already exempt by name; these are its "
+        "documented core methods, which a reviewer recommending one can "
+        "recommend instead.",
+        'def test_env(monkeypatch, tmp_path):\n'
+        '    monkeypatch.setenv("BG_HOME", str(tmp_path))\n'
+        '    monkeypatch.delenv("BG_DEBUG", raising=False)\n'
+        '    monkeypatch.setattr("sys.platform", "linux")\n'
+        '    monkeypatch.chdir(tmp_path)\n',
+    ),
+    (
+        "capsys / capfd",
+        "SURFACE — pytest builtin output-capture fixtures.",
+        'def test_output(capsys):\n'
+        '    captured = capsys.readouterr()\n'
+        '    return captured.out\n',
+    ),
+    (
+        "caplog",
+        "SURFACE — pytest builtin logging fixture.",
+        'def test_logs(caplog):\n'
+        '    caplog.set_level("INFO")\n'
+        '    return caplog.records\n',
+    ),
+    (
+        "request attributes beyond config",
+        "SURFACE — the #2396 class at other depths. `request` is exempt; every "
+        "attribute reached from it is pytest's, not the target repo's.",
+        'def test_meta(request):\n'
+        '    request.config.getoption("--x")\n'
+        '    request.node.get_closest_marker("slow")\n'
+        '    request.config.option.verbose\n'
+        '    request.addfinalizer(lambda: None)\n',
+    ),
+    (
+        "pytest_collection_modifyitems hook",
+        "SURFACE — pluggy hook; pytest supplies every argument.",
+        'def pytest_collection_modifyitems(config, items):\n'
+        '    if config.getoption("--slow"):\n'
+        '        return\n'
+        '    for item in items:\n'
+        '        item.add_marker("skip")\n',
+    ),
+    (
+        "Pillow object returned by a repo function",
+        "OBSERVED — `img.getpixel(px)[3] == int(255 * 0.2)` and "
+        "`draw.arc(..., start=-val_to_angle(100), ...)` appear verbatim in "
+        "boostgauge readiness verdicts. Carried in its real import-bearing "
+        "form, which is what draft 013 has. The import-less form deadlocks "
+        "today — see #2399 and the xfail in test_gate_agreement.py.",
+        'from PIL import Image, ImageDraw\n'
+        'from boostgauge.gauge import render, val_to_angle\n'
+        '\n'
+        'def test_req_070():\n'
+        '    img = render(50, [], 256)\n'
+        '    draw = ImageDraw.Draw(img)\n'
+        '    draw.arc((0, 0, 10, 10), start=-val_to_angle(100), end=0)\n'
+        '    assert img.getpixel((10, 10)) == (255, 255, 255, 255)\n',
+    ),
+    (
+        "pytest_configure hook",
+        "SURFACE — pluggy hook; the marker-registration idiom a reviewer "
+        "recommends alongside pytest_addoption.",
+        'def pytest_configure(config):\n'
+        '    config.addinivalue_line("markers", "visual: visual regression")\n',
+    ),
+]

--- a/tests/unit/test_gate_agreement.py
+++ b/tests/unit/test_gate_agreement.py
@@ -1,0 +1,209 @@
+"""The two spec gates must agree about what valid code looks like (#2397).
+
+The spec reviewer (N5) and the symbol checker (N3) are each individually correct
+and individually well tested. Twice now they have disagreed, and each time the
+drafter was handed a contradiction it could not satisfy at any iteration count:
+
+    run-issue1-173403  reviewer demanded `pytest_addoption` registration
+                       checker flagged `addoption` as hallucinated      (#2391)
+
+    run-issue1-193349  reviewer dictated `request.config.getoption(...)`
+                       verbatim, 012-readiness-verdict.md line 7
+                       checker flagged `getoption` as hallucinated      (#2396)
+
+Both were repaired at the resolver. Neither repair could have PREVENTED the
+other, because the fault is not in either gate — it is in the relationship, and
+a relationship is what neither gate's unit tests can assert. This module is that
+assertion.
+
+It fails on the commit that introduces a disagreement, in CI, instead of in a
+roll, at the cap, after the operator has spent the launch.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "fixtures" / "reviewer_idioms"))
+from framework_idioms import FRAMEWORK_IDIOMS  # noqa: E402
+
+#: A target repo's surface. Deliberately small and deliberately containing NONE
+#: of the framework methods below — which is the whole point. The live runs
+#: gathered 21 symbols and none of them was `addoption` or `getoption`.
+TARGET_SYMBOLS = ["GaugeWindow", "render", "to_dict", "update", "SkinConfig"]
+
+
+def _spec_around(snippet: str) -> str:
+    """Wrap a snippet the way a real spec presents it — a tagged Python fence."""
+    return f"# Implementation Spec\n\n## 6. Files\n\n```python\n{snippet}```\n"
+
+
+class TestReviewerIdiomsAreAccepted:
+    """Every idiom the reviewer recommends must clear the symbol checker."""
+
+    def test_the_corpus_is_not_empty(self):
+        """Guards the guard: a corpus that failed to import proves nothing."""
+        assert len(FRAMEWORK_IDIOMS) >= 9
+
+    def test_every_idiom_passes_the_check(self):
+        failures = []
+        for name, provenance, snippet in FRAMEWORK_IDIOMS:
+            result = check_api_symbols_exist(_spec_around(snippet), TARGET_SYMBOLS)
+            if not result["passed"]:
+                failures.append(f"{name}: {result['details']}")
+        assert not failures, (
+            "The symbol checker rejects idioms the spec reviewer recommends. "
+            "Any drafter told to write one of these will deadlock:\n"
+            + "\n".join(failures)
+        )
+
+    def test_every_idiom_flags_nothing(self):
+        """Same contract at the detector level, so a skip cannot hide a flag."""
+        failures = []
+        for name, provenance, snippet in FRAMEWORK_IDIOMS:
+            flagged = detect_unknown_method_calls(
+                _spec_around(snippet), set(TARGET_SYMBOLS)
+            )
+            if flagged:
+                failures.append(f"{name}: {flagged}")
+        assert not failures, "\n".join(failures)
+
+    def test_the_two_deadlock_idioms_are_in_the_corpus(self):
+        """The regressions that cost two rolls stay pinned by name."""
+        joined = "\n".join(snippet for _, _, snippet in FRAMEWORK_IDIOMS)
+        assert "parser.addoption(" in joined, "#2391's idiom left the corpus"
+        assert "request.config.getoption(" in joined, "#2396's idiom left the corpus"
+
+
+class TestTheContractCanActuallyFail:
+    """A green suite that cannot go red is decoration.
+
+    Every assertion above is a negative — 'nothing was flagged'. If the fences
+    stopped parsing, or the checker started skipping, all of them would pass
+    while proving nothing. That is the exact shape of the empty-symbol-universe
+    PASS that nearly shipped as evidence in the #2392 round.
+    """
+
+    def test_a_genuine_hallucination_is_still_rejected(self):
+        """The instrument is capable of failing."""
+        spec = _spec_around(
+            "def build():\n"
+            "    gauge = GaugeWindow()\n"
+            "    return gauge.model_dump()\n"
+        )
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is False
+        assert "model_dump" in result["details"]
+
+    def test_the_corpus_snippets_actually_parse(self):
+        """A snippet that does not parse would be skipped, not cleared."""
+        import importlib
+
+        vc = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes"
+            ".validate_completeness"
+        )
+        for name, _, snippet in FRAMEWORK_IDIOMS:
+            scan = vc._scan_fences(_spec_around(snippet))
+            assert scan.failures == [], f"{name} does not parse: {scan.failures}"
+            assert len(scan.facts) == 1, f"{name} produced no facts"
+
+    def test_the_corpus_snippets_contain_judgeable_calls(self):
+        """Each snippet must present at least one method call to judge.
+
+        Without this, an idiom could be 'accepted' because it contains nothing
+        the checker looks at.
+        """
+        import importlib
+
+        vc = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes"
+            ".validate_completeness"
+        )
+        for name, _, snippet in FRAMEWORK_IDIOMS:
+            scan = vc._scan_fences(_spec_around(snippet))
+            calls = [c for f in scan.facts for c in f.calls]
+            assert calls, f"{name} has no method calls — it proves nothing"
+
+
+class TestKnownGaps:
+    """Disagreements the corpus has found but that are not repaired yet.
+
+    Recorded as xfail rather than as a comment, so the gap is in the suite and
+    flips to green on the day it is closed — instead of being rediscovered by a
+    roll.
+    """
+
+    @pytest.mark.xfail(
+        reason=(
+            "#2399: a third-party object returned by a REPO function is flagged. "
+            "`img = render(...)` then `img.getpixel(...)` clears today only "
+            "because draft 013 happens to import `render`, which exempts `img` "
+            "by assignment propagation. Specs legitimately omit import headers "
+            "(#1952's own words), and the import-less form deadlocks."
+        ),
+        strict=True,
+    )
+    def test_third_party_object_from_a_repo_call_without_the_import(self):
+        spec = _spec_around(
+            "def test_req_070():\n"
+            "    img = render(50, [], 256)\n"
+            "    assert img.getpixel((10, 10)) == (255, 255, 255, 255)\n"
+        )
+        result = check_api_symbols_exist(spec, [*TARGET_SYMBOLS, "render"])
+        assert result["passed"] is True, result["details"]
+
+    def test_the_same_shape_WITH_the_import_does_clear(self):
+        """Control: proves the xfail above is about the import, not the shape."""
+        spec = _spec_around(
+            "from boostgauge.gauge import render\n"
+            "\n"
+            "def test_req_070():\n"
+            "    img = render(50, [], 256)\n"
+            "    assert img.getpixel((10, 10)) == (255, 255, 255, 255)\n"
+        )
+        result = check_api_symbols_exist(spec, [*TARGET_SYMBOLS, "render"])
+        assert result["passed"] is True, result["details"]
+
+
+class TestCheckerExemptionsAreReachable:
+    """The exemption must survive the way a spec actually presents code.
+
+    The checker pools facts across ALL fences, so a spec that declares the hook
+    in one snippet and uses it in another must still clear. Both real deadlocks
+    arrived as multi-fence documents.
+    """
+
+    def test_exemption_survives_across_separate_fences(self):
+        spec = (
+            "# Spec\n\n### conftest\n\n```python\n"
+            "def pytest_addoption(parser):\n"
+            '    parser.addoption("--generate-baselines", action="store_true")\n'
+            "```\n\n### the test\n\n```python\n"
+            "def test_req_120_visual(request, tmp_path):\n"
+            '    generate = request.config.getoption("--generate-baselines", False)\n'
+            "    return generate\n"
+            "```\n"
+        )
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_exemption_survives_alongside_non_python_fences(self):
+        """#2392 skips non-Python fences by tag; that must not drop the facts."""
+        spec = (
+            "# Spec\n\n```text\nclass PositionConfig(TypedDict):\n```\n\n"
+            "```json\n{\"skin\": \"stingray\"}\n```\n\n"
+            "```python\n"
+            "def test_req_120_visual(request, tmp_path):\n"
+            '    return request.config.getoption("--generate-baselines", False)\n'
+            "```\n"
+        )
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is True, result["details"]
+        assert "skipped by language tag" in result["details"]

--- a/tools/harvest_reviewer_idioms.py
+++ b/tools/harvest_reviewer_idioms.py
@@ -1,0 +1,117 @@
+"""Harvest framework idioms the spec reviewer dictates, for the #2397 contract.
+
+Read-only. Scans a target repo's readiness verdicts for call expressions the
+reviewer names in backticks, and reports which ones the gate-agreement corpus
+(tests/fixtures/reviewer_idioms/framework_idioms.py) does not yet cover.
+
+WHY THIS EXISTS RATHER THAN READING A PROMPT
+--------------------------------------------
+#2397 proposed sourcing the corpus from the reviewer's prompt "where it
+enumerates" the idioms. It does not enumerate them. Neither review_spec.py nor
+generate_spec.py names a single one — the reviewer is a general model applying
+its own knowledge of pytest best practice, so the population is not derivable
+from our code. The only honest source is what the reviewer has actually said,
+which is on disk in the lineage.
+
+WHAT IT CANNOT DO
+-----------------
+It cannot tell a framework idiom from a repo-owned one. `apply_exit_write()` and
+`request.config.getoption(...)` are the same shape to a regex, and only the
+first is the target repo's business. Output is a triage list for a human, not an
+auto-updater. Nothing is written.
+
+Usage:
+    poetry run python tools/harvest_reviewer_idioms.py --repo /c/.../boostgauge
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+#: A backticked call expression: `receiver.method(args)` or `func(args)`.
+_IDIOM_RE = re.compile(r"`([a-zA-Z_][a-zA-Z0-9_.]*\([^`]*\))`")
+
+_CORPUS = (
+    Path(__file__).parent.parent
+    / "tests" / "fixtures" / "reviewer_idioms" / "framework_idioms.py"
+)
+
+
+def _corpus_text() -> str:
+    if not _CORPUS.exists():
+        print(f"corpus not found: {_CORPUS}", file=sys.stderr)
+        return ""
+    return _CORPUS.read_text(encoding="utf-8")
+
+
+def _call_key(idiom: str) -> str:
+    """`request.config.getoption("--x", False)` -> `request.config.getoption(`."""
+    return idiom.split("(", 1)[0] + "("
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="Target repo root")
+    ap.add_argument(
+        "--all",
+        action="store_true",
+        help="List every harvested idiom, not just uncovered ones",
+    )
+    args = ap.parse_args()
+
+    repo = Path(args.repo)
+    lineage = repo / "docs" / "lineage"
+    if not lineage.is_dir():
+        print(f"no lineage directory under {repo}", file=sys.stderr)
+        return 2
+
+    verdicts = sorted(lineage.rglob("*readiness-verdict*.md"))
+    if not verdicts:
+        print(f"no readiness verdicts under {lineage}", file=sys.stderr)
+        return 2
+
+    corpus = _corpus_text()
+    found: dict[str, set[str]] = {}
+    for verdict in verdicts:
+        try:
+            text = verdict.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in _IDIOM_RE.finditer(text):
+            idiom = m.group(1)
+            found.setdefault(idiom, set()).add(
+                str(verdict.relative_to(repo)).replace("\\", "/")
+            )
+
+    covered, uncovered = [], []
+    for idiom in sorted(found):
+        (covered if _call_key(idiom) in corpus else uncovered).append(idiom)
+
+    print(f"verdicts scanned : {len(verdicts)}")
+    print(f"idioms harvested : {len(found)}")
+    print(f"covered by corpus: {len(covered)}")
+    print(f"NOT covered      : {len(uncovered)}")
+
+    if args.all and covered:
+        print("\n-- covered --")
+        for idiom in covered:
+            print(f"  {idiom}")
+
+    if uncovered:
+        print("\n-- candidates for triage --")
+        print("   (a repo-owned call belongs here and needs no action; a")
+        print("    FRAMEWORK call does not, and is a deadlock waiting to happen)")
+        for idiom in uncovered:
+            sources = sorted(found[idiom])
+            print(f"  {idiom}")
+            print(f"      seen in: {sources[0]}"
+                  + (f" (+{len(sources) - 1} more)" if len(sources) > 1 else ""))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The fault neither gate can see

Two rolls of boostgauge #1 died at the spec stage on the same structural fault: **the reviewer dictated a call the checker then rejected as hallucinated.**

| Run | Reviewer instructed | Checker flagged | Cost |
|---|---|---|---|
| `run-issue1-173403` | `pytest_addoption` registration (ruling #271; pytest crashes on unregistered flags) | `addoption` | 91s, #2391 |
| `run-issue1-193349` | `012-readiness-verdict.md` line 7, verbatim: "use `request.config.getoption("--generate-baselines", False)`" | `getoption` | 13m 12s, #2396 |

Both were repaired at the resolver. **Neither repair could have prevented the other**, because the fault is not in either gate — each is individually correct and individually well tested. It lives in the *relationship*, and a relationship is what neither gate's own suite can assert. When the sets diverge the drafter gets a contradiction it cannot satisfy at any iteration count, so the loop burns its budget and dies at the cap.

This adds the missing assertion. It fails on the commit that introduces a disagreement, in CI, instead of in a roll after the launch is spent.

## Correction to this issue's own proposal

#2397 proposed sourcing the corpus from the reviewer prompt "where it enumerates them, so the fixture list cannot silently drift."

**No such enumeration exists.** Neither `review_spec.py` nor `generate_spec.py` names a single one of these idioms — the reviewer is a general model applying its own knowledge of pytest best practice, so the population is not derivable from our code at all. Verified by grep across both prompts.

The corpus is therefore sourced **empirically**, from readiness verdicts the reviewer actually produced. Entries carry provenance: `OBSERVED` (verbatim from a real run) or `SURFACE` (documented API of a fixture the checker already exempts — a reviewer that recommends one method can recommend its siblings, and the point is to stop meeting shapes one roll at a time).

`tools/harvest_reviewer_idioms.py` scans a target repo's verdicts and reports idioms the corpus does not cover. Read-only; its output is a triage list, because a regex cannot tell `apply_exit_write()` from `request.config.getoption(...)` and only the second is a deadlock risk. Against boostgauge:

```
verdicts scanned : 13
idioms harvested : 14
covered by corpus: 2      <- both deadlock idioms
NOT covered      : 12     <- 10 repo-owned, 2 framework (triaged below)
```

## The harvester found a third instance immediately — filed as #2399

Of the twelve uncovered candidates, ten are repo-owned and need no action. Two are Pillow: `img.getpixel(px)[3] == int(255 * 0.2)` and `draw.arc(..., start=-val_to_angle(100), ...)`, both verbatim from real verdicts.

`img.getpixel(...)` is the same class one step further out — the receiver's *type* is not the target repo's even though the expression producing it is. Measured:

```
with import of render        flagged={}
WITHOUT import of render     flagged={'getpixel': ['assert img.getpixel((10, 10)) == ...']}
render in imported names of draft 013 : True
```

**Draft 013 clears it by luck.** It survives only because that draft happens to carry `from boostgauge.gauge import render`, which exempts `img` by assignment propagation. `_normalize_fence`'s own #1952 comment states the opposite expectation in as many words: *"A spec snippet legitimately omits its import header."* A revision that tightens a snippet lights this up.

The draft the next roll resumes from is on the lucky side, so **this does not block the launch**. It is filed as #2399 with the three candidate cuts argued, and deliberately not fixed here — it is a resolver change with its own false-clearance risk and does not belong under this issue's acceptance.

It is pinned in the suite as a **strict xfail** pointing at #2399, with a passing control proving the xfail is about the missing import rather than the shape. It flips to green the day #2399 lands.

## Vacuity guards

Every idiom assertion is a negative — "nothing was flagged" — and a fence that failed to parse would satisfy all of them while proving nothing. That is the shape of the empty-symbol-universe PASS from the #2392 round. So the suite also asserts:

- every corpus snippet parses (`scan.failures == []`, one fact per snippet);
- every corpus snippet contains at least one judgeable method call;
- a genuine hallucination is still rejected, so the instrument is known capable of failing;
- both deadlock idioms are still present in the corpus by name;
- the exemption survives across separate fences, and alongside `text`/`json` fences skipped by tag under #2392.

Full unit suite: **7773 passed, 17 skipped, 6 xfailed, 0 failures.** Ruff clean.

Closes #2397
