### PR TITLE
fix: judge a receiver only when its type resolves — unresolved is not hallucinated (Closes #2399)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1221,6 +1221,14 @@ class _FenceFacts(NamedTuple):
     # Parameters a framework injects, whose type the target repo does not own
     # (#2391) — `parser` in `def pytest_addoption(parser)`, `tmp_path` in a test.
     framework_params: frozenset[str]
+    # (function name, root name of its return annotation) for functions the SPEC
+    # itself defines (#2399). `def render(...) -> Image.Image` yields
+    # ("render", "Image"), which is how a binding from render() learns it holds
+    # a Pillow object rather than one of the target repo's.
+    returns: tuple[tuple[str, str], ...]
+    # Classes the spec defines (#2399). A class is the one callee whose return
+    # type is known without an annotation: `Gauge()` is a Gauge.
+    classes: frozenset[str]
 
 
 class _FenceParseFailure(NamedTuple):
@@ -1360,6 +1368,8 @@ class _FenceVisitor(ast.NodeVisitor):
         self.assignments: list[tuple[frozenset[str], frozenset[str]]] = []
         self.calls: list[_CallSite] = []
         self.framework_params: set[str] = set()
+        self.returns: dict[str, str] = {}
+        self.classes: set[str] = set()
 
     # ---- imports: receivers the target repo has no authority over (#1948) ----
 
@@ -1381,12 +1391,34 @@ class _FenceVisitor(ast.NodeVisitor):
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self.defined.add(node.name)
         self._record_framework_params(node)
+        self._record_return(node)
         self.generic_visit(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self.defined.add(node.name)
         self._record_framework_params(node)
+        self._record_return(node)
         self.generic_visit(node)
+
+    def _record_return(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        """What a spec-defined function declares it returns (#2399).
+
+        `def render(...) -> Image.Image` records ("render", "Image"). The root
+        of the annotation is what matters: whoever owns `Image` owns what
+        `render()` hands back, which is the question a binding from that call
+        needs answered.
+
+        Only spec-declared annotations are read. Nothing is inferred from a
+        function body, and an unannotated function records nothing — it is left
+        unresolved rather than guessed at.
+        """
+        if node.returns is None:
+            return
+        root = _leftmost_name(node.returns)
+        if root is not None:
+            self.returns[node.name] = root
 
     def _record_framework_params(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef
@@ -1419,6 +1451,10 @@ class _FenceVisitor(ast.NodeVisitor):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.defined.add(node.name)
+        # #2399: a class is the one callee whose return type is known without an
+        # annotation — `Gauge()` is a Gauge. Recorded separately from `defined`,
+        # which mixes classes, functions and self-attributes.
+        self.classes.add(node.name)
         self.generic_visit(node)
 
     # ---- bindings: what each name actually holds ----
@@ -1501,6 +1537,8 @@ def _fence_facts_ast(block: str) -> _FenceFacts:
         assignments=tuple(visitor.assignments),
         calls=tuple(visitor.calls),
         framework_params=frozenset(visitor.framework_params),
+        returns=tuple(sorted(visitor.returns.items())),
+        classes=frozenset(visitor.classes),
     )
 
 
@@ -1585,12 +1623,79 @@ def _flag_calls(
     assignments = [
         (bound, source) for fence in facts for bound, source in fence.assignments
     ]
+    # #2399: a spec-defined function's DECLARED return type answers what a
+    # binding from it holds. `def render(...) -> Image.Image` means
+    # `img = render(...)` holds a Pillow object, so `img.getpixel(...)` is
+    # Pillow's API to be right or wrong about — even though `render` itself is
+    # the target repo's. Only declared annotations are read; nothing is inferred
+    # from a body, and an unannotated function resolves to nothing.
+    return_root: dict[str, str] = {}
+    for fence in facts:
+        for func_name, annotation_root in fence.returns:
+            return_root[func_name] = annotation_root
+
     changed = True
     while changed:
         changed = False
         for bound, source in assignments:
-            if source & exempt and not bound <= exempt:
+            if bound <= exempt:
+                continue
+            if source & exempt:
                 exempt |= bound
+                changed = True
+                continue
+            # The value came from calling a spec-defined function that declares
+            # it returns something the target repo does not own.
+            if any(return_root.get(name) in exempt for name in source):
+                exempt |= bound
+                changed = True
+
+    # #2399, the honest default. `unresolved is not hallucinated` is the
+    # principle #2391 was titled for; this is its third shape. A binding whose
+    # provenance the checker cannot place AT ALL — not an import, not stdlib,
+    # not a framework injection, not a gathered symbol, not something the spec
+    # defines — holds a value of unknown type, and a method on an unknown type
+    # cannot be called absent from anything.
+    #
+    # Note what stays JUDGED. `gauge = GaugeWindow()` where `GaugeWindow` is a
+    # gathered symbol resolves to the target repo, so `gauge.model_dump()` is
+    # still #1527's founding true positive. So does `g = Gauge()` for a class
+    # the spec itself defines. The rule removes guesses, not jurisdiction.
+    # What "resolvable" means for a binding from a call. The target repo owning
+    # the CALLEE is not the test — it owns `render`, and `render` returns a
+    # Pillow image. What resolves a binding is knowing the TYPE it holds:
+    #
+    #   * a constructor: `Gauge()` is a Gauge, no annotation needed;
+    #   * a declared return: `def render(...) -> Image.Image`, handled above.
+    #
+    # Classes the spec defines are known exactly. For the gathered surface the
+    # symbols are bare strings carrying no kind, so class-hood is read from the
+    # PEP 8 CapWords convention — which holds across the whole of the live run's
+    # 21 (`AppConfig`, `SessionState`, `WindowsCollector` against `load_config`,
+    # `start`, `stop`). A lowercase class would be missed and its instances left
+    # unresolved, which fails OPEN — the direction this issue's own title rules
+    # correct, since unresolved is not hallucinated.
+    spec_classes: set[str] = set()
+    for fence in facts:
+        spec_classes |= fence.classes
+    constructor_like = spec_classes | {s for s in symbol_set if s[:1].isupper()}
+
+    unresolved: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for bound, source in assignments:
+            if bound <= unresolved or bound <= exempt or not source:
+                continue
+            # Resolved, so judged: a constructor names its own type, and a
+            # declared return names some type. WHICH type decides the verdict,
+            # and the exemption loop above already applied it — an annotation
+            # rooted in an import exempts the binding, one rooted in a gathered
+            # symbol leaves it in jurisdiction. Either way it is not a guess.
+            if source & constructor_like or any(n in return_root for n in source):
+                continue
+            if not (source & exempt) or source <= unresolved:
+                unresolved |= bound
                 changed = True
 
     flagged: dict[str, list[str]] = {}  # method_name -> list of call sites
@@ -1614,6 +1719,12 @@ def _flag_calls(
             # since a first-party import is the one case where the target
             # repo's symbol table DOES have authority.
             if call.root is not None and call.root in framework_roots:
+                continue
+            # #2399: the receiver holds a value of unknown type. Unresolved is a
+            # distinct, honest category from wrong, and only wrong is a finding.
+            if call.receiver in unresolved or (
+                call.root is not None and call.root in unresolved
+            ):
                 continue
             if call.method in symbol_set or call.method in spec_defined:
                 continue

--- a/tests/unit/test_ast_symbol_analysis.py
+++ b/tests/unit/test_ast_symbol_analysis.py
@@ -397,7 +397,24 @@ class TestTruePositivesSurvive:
         assert "_mystery_hook" in _flag(spec)
 
     def test_handle_from_an_unexempt_root_still_judged(self):
-        """Provenance exempts only what descends from an exempt universe."""
+        """Provenance exempts only what descends from an exempt universe.
+
+        BEHAVIOUR CHANGED BY #2399, deliberately, and narrowed rather than lost.
+
+        This used to assert that BOTH `make` and `invented_method` were named.
+        `widget` is bound from `factory.make()`, where `factory` is a bare
+        parameter of unknown type — so `factory.make()` returns an unknown type,
+        and `widget` holds a value the checker cannot place. Naming
+        `invented_method` as a hallucinated API was the checker asserting
+        something it had no basis for, which is the exact error #2391 was titled
+        against and #2399 ruled on for the third time: unresolved is not
+        hallucinated.
+
+        What matters is preserved and is asserted below: the spec STILL FAILS
+        the gate. The hallucination is caught one hop earlier, at `make` on the
+        unresolvable parameter, so a bad spec is still blocked and still gets a
+        named reason. Only the second-hop guess is gone.
+        """
         spec = (
             "# S\n\n```python\n"
             "def build(factory):\n"
@@ -406,8 +423,13 @@ class TestTruePositivesSurvive:
             "```\n"
         )
         flagged = _flag(spec)
-        assert "invented_method" in flagged
         assert "make" in flagged
+        # The gate's job is to block the spec, and it still does.
+        result = check_api_symbols_exist(spec, TARGET_SYMBOLS)
+        assert result["passed"] is False
+        assert "make" in result["details"]
+        # No longer claimed, on purpose — widget's type is unresolvable.
+        assert "invented_method" not in flagged
 
     def test_call_site_names_the_method(self):
         spec = (

--- a/tests/unit/test_gate_agreement.py
+++ b/tests/unit/test_gate_agreement.py
@@ -23,7 +23,6 @@ roll, at the cap, after the operator has spent the launch.
 import sys
 from pathlib import Path
 
-import pytest
 
 from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
     check_api_symbols_exist,
@@ -133,23 +132,15 @@ class TestTheContractCanActuallyFail:
 
 
 class TestKnownGaps:
-    """Disagreements the corpus has found but that are not repaired yet.
+    """Disagreements the corpus found. #2399's is closed; the class is pinned.
 
-    Recorded as xfail rather than as a comment, so the gap is in the suite and
-    flips to green on the day it is closed — instead of being rediscovered by a
-    roll.
+    This class was added carrying one strict xfail — `img.getpixel(...)` on an
+    object returned by a repo function, which cleared only when the draft
+    happened to import the producing function. #2399 closed it and the xfail was
+    flipped to a live assertion rather than deleted, because the shape is what
+    keeps costing rolls and it should stay named in the suite.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "#2399: a third-party object returned by a REPO function is flagged. "
-            "`img = render(...)` then `img.getpixel(...)` clears today only "
-            "because draft 013 happens to import `render`, which exempts `img` "
-            "by assignment propagation. Specs legitimately omit import headers "
-            "(#1952's own words), and the import-less form deadlocks."
-        ),
-        strict=True,
-    )
     def test_third_party_object_from_a_repo_call_without_the_import(self):
         spec = _spec_around(
             "def test_req_070():\n"

--- a/tests/unit/test_unresolved_receiver_types.py
+++ b/tests/unit/test_unresolved_receiver_types.py
@@ -1,0 +1,212 @@
+"""Unresolved is not hallucinated, third shape: the receiver's TYPE (#2399).
+
+Three rounds, three shapes of one class, each found only after the previous fix
+shipped:
+
+    #2391  the receiver's NAME          `parser` in a pytest_* hook
+    #2396  the receiver chain's ROOT    `request.config.getoption(...)`
+    #2399  the receiver's TYPE          `img = render(...)`, `img.getpixel(...)`
+
+All three are the same question — does the target repo own this receiver? — and
+this module pins the answer as ONE rule rather than three patches:
+
+    Judge a receiver only when the checker can resolve what it holds to
+    something the target repo owns. Otherwise it is unresolved, and unresolved
+    is a distinct, honest category from wrong.
+
+WHY THIS SHAPE WAS URGENT RATHER THAN THEORETICAL
+-------------------------------------------------
+Draft 013 of boostgauge #1 carries nine such calls — `img.getpixel` seven times,
+`img_base.getpixel`, `img.save` — all inside one fence spanning lines 389-531.
+That fence imports only `math`; the `from boostgauge.gauge import render` that
+was clearing them sits at lines 290 and 309, in two different fences. Neither
+`getpixel` nor `save` is in the 21 gathered symbols, and `save` is not
+allowlisted either.
+
+The reviewer was already rewriting the inside of that fence — verdict 012 line 3
+orders `test_req_070` to sample a different pixel because `v=30` lands on a tick
+mark — while the clearance rested on imports elsewhere that it had no reason to
+preserve, across up to nine revision rounds.
+"""
+
+import re
+from pathlib import Path
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+)
+
+#: The live run's 21, verbatim. `render`, `getpixel` and `save` are all absent —
+#: which is the condition the fix has to survive, not a simplification of it.
+GATHERED_21 = [
+    "AppConfig", "DataCollector", "PositionConfig", "SessionState",
+    "SystemSnapshot", "TelltaleWindows", "ThresholdConfig", "Thresholds",
+    "WindowsCollector", "__init__", "_atomic_write", "_collect_snapshot",
+    "_deep_merge", "_normalize", "_poll_loop", "apply_threshold_updates",
+    "load_config", "mitigate_invalid_config", "save_session_changes",
+    "start", "stop",
+]
+
+FIXTURE_013 = (
+    Path(__file__).parent.parent
+    / "fixtures" / "boostgauge1_spec_deadlock" / "013-spec-draft.md"
+)
+
+
+def _spec(body: str) -> str:
+    return "# S\n\n```python\n" + body + "```\n"
+
+
+def _flag(body: str, symbols=None) -> dict[str, list[str]]:
+    return detect_unknown_method_calls(_spec(body), set(symbols or GATHERED_21))
+
+
+def _stripped_013() -> str:
+    """Draft 013 as a revision would leave it: the producing import gone."""
+    text = FIXTURE_013.read_text(encoding="utf-8")
+    stripped = re.sub(r"(?m)^from boostgauge\.gauge import .*\n", "", text)
+    assert "from boostgauge.gauge import" not in stripped
+    return stripped
+
+
+class TestTheStrippedDraftClears:
+    """The real first half. Draft 013 AS IT STANDS already passes, so proving
+    that again proves nothing — it is an input that was never going to fail."""
+
+    def test_the_strip_actually_removed_something(self):
+        """Guards the guard: a no-op strip would make every assertion vacuous."""
+        text = FIXTURE_013.read_text(encoding="utf-8")
+        removed = len(text.splitlines()) - len(_stripped_013().splitlines())
+        assert removed == 2, f"expected 2 import lines removed, got {removed}"
+
+    def test_the_stripped_draft_still_contains_the_calls(self):
+        stripped = _stripped_013()
+        assert stripped.count("img.getpixel(") == 7
+        assert "img_base.getpixel(" in stripped
+        assert "img.save(" in stripped
+
+    def test_stripped_draft_flags_nothing(self):
+        flagged = detect_unknown_method_calls(_stripped_013(), set(GATHERED_21))
+        assert flagged == {}, flagged
+
+    def test_stripped_draft_passes_the_check(self):
+        result = check_api_symbols_exist(_stripped_013(), GATHERED_21)
+        assert result["passed"] is True, result["details"]
+
+    def test_neither_method_is_in_the_gathered_surface(self):
+        """The clearance must not be an artefact of a generous symbol list."""
+        assert "getpixel" not in GATHERED_21
+        assert "save" not in GATHERED_21
+        assert "render" not in GATHERED_21
+
+
+class TestUnresolvedProducers:
+    def test_free_producer_is_unresolved(self):
+        """`render` is not imported, not gathered, not defined here."""
+        assert "getpixel" not in _flag(
+            "def test_x():\n"
+            "    img = render(50, [], 256)\n"
+            "    assert img.getpixel((1, 1)) == (1, 2, 3, 4)\n"
+        )
+
+    def test_annotated_spec_defined_producer_resolves_to_its_owner(self):
+        """`def render(...) -> Image.Image` says the result is Pillow's."""
+        assert _flag(
+            "from PIL import Image\n"
+            "\n"
+            "def render(v: float) -> Image.Image:\n"
+            "    ...\n"
+            "\n"
+            "def test_x():\n"
+            "    img = render(50)\n"
+            "    img.save('out.png')\n"
+            "    assert img.getpixel((1, 1)) == (1, 2, 3, 4)\n"
+        ) == {}
+
+    def test_third_party_constructor_without_its_import(self):
+        """`draw = ImageDraw.Draw(img)` — the other at-risk idiom the harvester
+        surfaced, same class, and it must clear for the same reason."""
+        assert "arc" not in _flag(
+            "def test_x():\n"
+            "    draw = ImageDraw.Draw(img_in)\n"
+            "    draw.arc((0, 0, 1, 1), start=0, end=1)\n"
+        )
+
+
+class TestTruePositivesSurvive:
+    """The half that decides whether the check still checks anything.
+
+    #1527's founding case has the identical bound-from-a-call shape, which is
+    exactly why the obvious version of this fix inverts the check.
+    """
+
+    def test_gathered_class_still_flagged(self):
+        """#1527's founding true positive, stated as the guard."""
+        assert "model_dump" in _flag(
+            "def build():\n"
+            "    gauge = GaugeWindow()\n"
+            "    return gauge.model_dump()\n",
+            symbols=[*GATHERED_21, "GaugeWindow"],
+        )
+
+    def test_check_blocks_on_the_gathered_class_hallucination(self):
+        result = check_api_symbols_exist(
+            _spec(
+                "def build():\n"
+                "    gauge = GaugeWindow()\n"
+                "    return gauge.model_dump()\n"
+            ),
+            [*GATHERED_21, "GaugeWindow"],
+        )
+        assert result["passed"] is False
+        assert "model_dump" in result["details"]
+
+    def test_spec_defined_class_still_flagged(self):
+        """A class the spec defines is placeable, so its instances are judged."""
+        assert "model_dump" in _flag(
+            "class Gauge:\n"
+            "    def draw(self):\n"
+            "        pass\n"
+            "\n"
+            "def build():\n"
+            "    g = Gauge()\n"
+            "    return g.model_dump()\n"
+        )
+
+    def test_bare_parameter_still_flagged(self):
+        assert "model_dump" in _flag(
+            "def apply(state):\n    state.model_dump()\n"
+        )
+
+    def test_annotation_pointing_at_a_REPO_type_still_flagged(self):
+        """The annotation rule resolves to the OWNER; it does not blanket-clear.
+
+        `-> SessionState` names a gathered symbol, so the result belongs to the
+        target repo and a method absent from its surface is still a finding.
+        """
+        assert "model_dump" in _flag(
+            "def make() -> SessionState:\n"
+            "    ...\n"
+            "\n"
+            "def build():\n"
+            "    s = make()\n"
+            "    return s.model_dump()\n"
+        )
+
+    def test_unannotated_spec_function_does_not_clear_by_being_defined(self):
+        """Defining a function says nothing about what it returns.
+
+        Without an annotation the binding is unresolved rather than exempt, so
+        this clears — but it must clear as UNRESOLVED, not because the spec
+        happened to mention the name. The sibling assertion above proves an
+        annotated repo type is still judged, which is what separates the two.
+        """
+        assert "getpixel" not in _flag(
+            "def render(v):\n"
+            "    ...\n"
+            "\n"
+            "def test_x():\n"
+            "    img = render(1)\n"
+            "    img.getpixel((1, 1))\n"
+        )


### PR DESCRIPTION
## Why this landed before the roll

The "does not block the launch" call was overridden on measured risk, and the measurement holds. Verified independently:

| Claim | Verdict |
|---|---|
| Nine calls on repo-returned objects at 410–521 | CONFIRMED — `img.getpixel`×7, `img.save`×1, `img_base.getpixel`×1 |
| All inside one fence spanning 389–531, opening on `def test_req_010():` | CONFIRMED |
| Nearest `from boostgauge.gauge import render` at line 309, different fence | CONFIRMED — at 290 and 309, fences 281–294 and 300–313 |
| `gauge.py` and `def render` absent from `origin/hardening-run-17`, 7 `.py` files | CONFIRMED |
| Verdict 012 line 3 orders `test_req_070` to resample | CONFIRMED |

**One correction.** That fence is not import-free — it carries seven `import math` lines. Nothing downstream changes: it imports no `render`, and `math` is stdlib and already exempt. But the statement as written was wrong, so it is corrected here rather than passed along.

Two findings the measurement added: **`save` is not in the 21 either**, and it is not allowlisted, so `img.save` was exposed on the same footing as `getpixel`. And the symbols are bare strings carrying **no kind information**, which constrains what "resolvable" can mean.

## Item 1 — the cut

**Option (a) is inert here, exactly as ruled.** `def render` appears nowhere on the ref. But draft 013 **defines** `def render(...) -> Image.Image:` at lines 59 and 264 — the return type is available from the *spec's own text*, which the checker already parses. That is a fourth option the issue did not name, and it is the one that fits greenfield specs precisely where (a) cannot.

Layered over (c) as recommended:

1. a spec-defined function's **declared return** resolves the binding to its annotation's owner — `-> Image.Image` makes `img` Pillow's;
2. a **constructor** resolves to its own type — `Gauge()` is a Gauge;
3. anything the checker cannot place is **unresolved**, and not judged.

Class-hood for gathered symbols is read from PEP 8 CapWords, since the symbols carry no kind. The convention holds across the whole of the live 21 (`AppConfig`, `SessionState`, `WindowsCollector` against `load_config`, `start`, `stop`). A lowercase class would be missed and its instances left unresolved — failing **open**, the direction this issue's title rules correct.

## Item 2 — acceptance, both halves

**First half is the stripped draft, not draft 013 as it stands.**

| | Result |
|---|---|
| strip removed exactly 2 import lines (guard against a no-op strip) | PASS |
| stripped draft still contains all 9 calls | PASS |
| stripped draft flags nothing | PASS |
| stripped draft passes `check_api_symbols_exist` | PASS |
| `getpixel`, `save`, `render` all absent from the 21 | PASS |

**Second half — the check still checks:**

| Case | Flagged |
|---|---|
| `gauge = GaugeWindow()` → `gauge.model_dump()` (#1527's founding case) | YES |
| spec-defined `class Gauge` → `g.model_dump()` | YES |
| bare parameter `state.model_dump()` | YES |
| `def make() -> SessionState` → `s.model_dump()` | YES |

That last one is the discriminating case: the annotation rule resolves to the **owner** rather than blanket-clearing, so an annotation pointing at a gathered symbol keeps the binding in jurisdiction.

## Item 3 — one rule, and what it cost

**One rule.** All three shapes ask the same question, and the resolver now states it once:

> Judge a receiver only when the checker can resolve what it holds to something the target repo owns. Otherwise it is unresolved, and unresolved is a distinct, honest category from wrong.

`#2391` (name), `#2396` (chain root) and `#2399` (type) are three places that question gets asked, not three rules.

**What it cost, stated plainly: one existing true-positive assertion changed.** `test_handle_from_an_unexempt_root_still_judged` asserted that

```python
def build(factory):
    widget = factory.make()
    widget.invented_method()
```

names **both** methods. `factory` is a bare parameter of unknown type, so `factory.make()` returns an unknown type and naming `invented_method` was the checker asserting what it had no basis for — the error #2391 was titled against.

The spec **still fails the gate**, flagged on `make` one hop earlier, so a bad spec is still blocked with a named reason. Only the second-hop guess is gone. The test now asserts that, with the reasoning recorded in place rather than deleted. **This is the one place the fix narrowed the check, and it is the part worth your review.**

## Item 4 — mining, before fixing

Harvester run across every available readiness verdict. Only boostgauge has lineage: **13 verdicts, 14 idioms, 4 surviving only via receiver exemption** — `getoption` (#2396, in the corpus), `draw.arc` (in the corpus, same class, now covered by a test), and `img.getpixel` twice, which is this issue. **Nothing new to file.**

## Item 6 — proof on the real inputs

Stripped draft, real LLD, real base ref `origin/hardening-run-17`:

```
import lines removed  : 2      img.getpixel( : 7   img.save( : True
GATHERED SYMBOL COUNT : 21
  'render'   present  : False   <- the returning function is absent entirely
  'getpixel' present  : False
  'save'     present  : False
[PASS] api_symbols_exist
Results: 8/10 checks passed, 2 not applicable
validation_passed : True   issues: 0
```

**What the check does when the returning function is absent from the symbol table entirely** — this roll's actual condition, not a hypothetical: the binding is unresolved, so methods on it are not judged. That is rule 3 above, and it is the greenfield default rather than an edge case.

Full unit suite: **7788 passed, 17 skipped, 5 xfailed, 0 failures.** Ruff clean on every changed file. The #2397 xfail is flipped to a live assertion.

## Not proven

Nothing past N3. **The review stage has never been cleared on this issue**, and nothing here implies it has.

Closes #2399
