### PR TITLE
fix: kill a Claude call for going quiet, not for taking long (Closes #2405)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -25,6 +25,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 
 # Closes #1495: llm_provider.py uses logger.warning at line 593 for the
@@ -352,6 +353,202 @@ def _kill_process_tree(pid: int) -> None:
     kill_process_tree(pid)
 
 
+# --- #2405: streaming transport with an idle timeout -------------------------
+#
+# Every timeout in this file used to be wall-clock: `proc.communicate(timeout=N)`
+# blocks until the child closes its pipes, so the only question it can answer is
+# "has N seconds passed", never "is anything still happening". A wall-clock
+# ceiling keyed to nothing observable gets overtaken every time the work grows —
+# #373 raised it, #2026 raised it, #2405 is the third occurrence — because the
+# quantity it bounds is not the quantity that matters.
+#
+# A call that is emitting tokens is alive by definition. `claude -p
+# --output-format stream-json --include-partial-messages` emits a
+# content_block_delta per chunk; measured on 2026-08-15 the gaps ran 0.28-0.86s
+# with a ~0.65s median across a 150-line generation. So silence is a signal with
+# an enormous margin: two minutes of it is roughly 180 missed events, which no
+# live generation produces, while a hung process produces nothing but silence.
+
+#: Seconds of total silence before a call is killed. Sits ~180x above the
+#: measured inter-event gap, so it separates "stopped" from "slow" without
+#: needing to know how long the work legitimately takes.
+IDLE_TIMEOUT_SECONDS = 120
+
+#: Override so a pathological-but-real workload never needs a merge to survive.
+ENV_IDLE_TIMEOUT = "AZ_LLM_IDLE_TIMEOUT"
+
+#: How often the watchdog checks. Small enough to be precise, large enough to
+#: cost nothing over a call measured in minutes.
+_IDLE_POLL_SECONDS = 0.5
+
+#: Event types retained for parsing. `stream_event` deltas are the liveness
+#: signal and arrive in the thousands, so they are counted and discarded rather
+#: than accumulated — the final `result` event carries the complete text anyway.
+_DELTA_EVENT_TYPE = "stream_event"
+
+
+def idle_timeout_seconds() -> int:
+    """Idle threshold in seconds, environment-overridable.
+
+    A missing, unparseable, or non-positive override falls back to the default:
+    an operator setting this is usually rescuing a stalled run, and a typo must
+    not make every call immortal or instantly fatal.
+    """
+    raw = os.environ.get(ENV_IDLE_TIMEOUT, "").strip()
+    if not raw:
+        return IDLE_TIMEOUT_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer; using %ss",
+            ENV_IDLE_TIMEOUT, raw, IDLE_TIMEOUT_SECONDS,
+        )
+        return IDLE_TIMEOUT_SECONDS
+    if value <= 0:
+        logger.warning(
+            "%s=%s is not positive; using %ss",
+            ENV_IDLE_TIMEOUT, value, IDLE_TIMEOUT_SECONDS,
+        )
+        return IDLE_TIMEOUT_SECONDS
+    return value
+
+
+@dataclass
+class _StreamOutcome:
+    """What a streamed child process produced, and how it ended."""
+
+    events: list = field(default_factory=list)
+    stderr: str = ""
+    returncode: int | None = None
+    timeout_kind: str = ""  # "" | "idle" | "wall"
+    silent_seconds: float = 0.0
+    total_events: int = 0
+
+    @property
+    def timed_out(self) -> bool:
+        return bool(self.timeout_kind)
+
+    def result_payload(self) -> str:
+        """The bytes the existing parser expects.
+
+        The final ``result`` event carries the same keys the old
+        ``--output-format json`` dict did (``result``, ``usage``,
+        ``total_cost_usd``, ``structured_output``), so handing it back as a
+        JSON object leaves every downstream branch untouched. Without one —
+        an error path, or a kill mid-stream — the retained events go back as
+        an array, which the #1498 list branch already knows how to read.
+        """
+        for event in reversed(self.events):
+            if isinstance(event, dict) and event.get("type") == "result":
+                return json.dumps(event)
+        return json.dumps(self.events)
+
+
+def _stream_with_idle_timeout(
+    proc: subprocess.Popen,
+    content: str,
+    idle_timeout: int,
+    wall_timeout: int | None,
+) -> _StreamOutcome:
+    """Feed `content` to `proc` and read its stream, killing it when it goes quiet.
+
+    The child is killed when it has produced no output for `idle_timeout`
+    seconds. `wall_timeout` remains as an outer backstop for a process that
+    streams forever; reaching it is pathological rather than routine, which is
+    the inversion this function exists to perform.
+    """
+    outcome = _StreamOutcome()
+    state = {"last": time.monotonic()}
+    lock = threading.Lock()
+
+    def _touch() -> None:
+        with lock:
+            state["last"] = time.monotonic()
+
+    def _last_activity() -> float:
+        with lock:
+            return state["last"]
+
+    def _pump_stdin() -> None:
+        try:
+            if proc.stdin:
+                proc.stdin.write(content)
+                proc.stdin.close()
+        except (OSError, ValueError):
+            # Child died before consuming stdin; the watchdog reports why.
+            pass
+
+    def _pump_stdout() -> None:
+        try:
+            if not proc.stdout:
+                return
+            for line in proc.stdout:
+                # Liveness is per LINE, before any parsing: a line we cannot
+                # decode is still proof the process is running.
+                _touch()
+                outcome.total_events += 1
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    event = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict) and event.get("type") == _DELTA_EVENT_TYPE:
+                    continue
+                outcome.events.append(event)
+        except (OSError, ValueError):
+            pass
+
+    def _pump_stderr() -> None:
+        try:
+            if proc.stderr:
+                outcome.stderr = proc.stderr.read() or ""
+        except (OSError, ValueError):
+            pass
+
+    threads = [
+        threading.Thread(target=_pump_stdin, daemon=True),
+        threading.Thread(target=_pump_stdout, daemon=True),
+        threading.Thread(target=_pump_stderr, daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+
+    started = time.monotonic()
+    while True:
+        returncode = proc.poll()
+        if returncode is not None:
+            outcome.returncode = returncode
+            break
+
+        now = time.monotonic()
+        silent_for = now - _last_activity()
+        if silent_for >= idle_timeout:
+            outcome.timeout_kind = "idle"
+            outcome.silent_seconds = silent_for
+            _kill_process_tree(proc.pid)
+            break
+        if wall_timeout is not None and (now - started) >= wall_timeout:
+            outcome.timeout_kind = "wall"
+            outcome.silent_seconds = silent_for
+            _kill_process_tree(proc.pid)
+            break
+
+        time.sleep(_IDLE_POLL_SECONDS)
+
+    # Let the readers drain what is already buffered. They are daemons on
+    # pipes that are closing, so a bounded join cannot hang the caller.
+    for thread in threads:
+        thread.join(timeout=5)
+
+    if outcome.returncode is None:
+        outcome.returncode = proc.poll()
+
+    return outcome
+
+
 class ClaudeCLIProvider(LLMProvider):
     """Claude provider using claude -p CLI (Max subscription).
 
@@ -451,6 +648,89 @@ class ClaudeCLIProvider(LLMProvider):
             "Install with: npm install -g @anthropic-ai/claude-code"
         )
 
+    def _probe_alive(self) -> bool:
+        """Ask the provider one trivial question. True if it answered (#2405).
+
+        Deliberately uses the plain buffered path with a wall-clock timeout
+        rather than the streaming transport it is diagnosing: the probe must be
+        able to indict that transport, so it cannot depend on it. A trivial
+        prompt answers in seconds, which is the one case where wall-clock is
+        the right instrument.
+        """
+        try:
+            cli_path = self._find_cli()
+        except RuntimeError:
+            return False
+
+        cmd = [
+            cli_path,
+            "-p",
+            "--output-format", "json",
+            "--setting-sources", "user",
+            "--tools", "",
+            "--strict-mcp-config",
+            "--model", self._model_id,
+        ]
+        creation_flags = 0
+        if sys.platform == "win32":
+            creation_flags = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            )
+        env = os.environ.copy()
+        env["PYTHONWARNINGS"] = "ignore"
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                creationflags=creation_flags,
+                env=env,
+            )
+        except OSError:
+            return False
+
+        try:
+            stdout, _ = proc.communicate(
+                input=provider_storm.PROBE_PROMPT,
+                timeout=provider_storm.PROBE_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            _kill_process_tree(proc.pid)
+            try:
+                proc.communicate(timeout=5)
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+            return False
+        except OSError:
+            return False
+
+        return proc.returncode == 0 and bool(stdout and stdout.strip())
+
+    def _classify_storm(self, message: str, consecutive: int) -> str:
+        """Append the right verdict to a timeout message (#2405).
+
+        Counting consecutive timeouts cannot distinguish a provider that
+        stopped answering from a ceiling sitting inside the call's duration.
+        One probe can, and it costs seconds against a storm branch that
+        otherwise halts the roll for fifteen minutes or more.
+        """
+        verdict = provider_storm.diagnose(self._probe_alive)
+        if verdict == "ceiling":
+            # ASCII only: this reaches a cp1252 console, where a dash renders
+            # as a literal "?" (the exposure #2367/#2369 are about).
+            return (
+                f"{message} ({consecutive} consecutive, but a probe was "
+                f"answered: {provider_storm.CEILING_MARKER})"
+            )
+        return (
+            f"{message} ({consecutive} consecutive — "
+            f"{provider_storm.STORM_MARKER})"
+        )
+
     def invoke(
         self,
         system_prompt: str,
@@ -489,10 +769,17 @@ class ClaudeCLIProvider(LLMProvider):
             )
 
         # Build command - prompt passed via stdin
+        # #2405: stream-json instead of json, so the transport can see progress
+        # rather than only elapsed time. --include-partial-messages is what makes
+        # the stream continuous: without it the assistant event does not arrive
+        # until the message is complete, and a long generation would look
+        # identical to a hang. --verbose is required for stream-json under -p.
         cmd = [
             cli_path,
             "-p",
-            "--output-format", "json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
             "--setting-sources", "user",  # Skip project CLAUDE.md context
             "--tools", "",  # Disable built-in tools
             "--strict-mcp-config",  # Disable MCP tools (issue #157)
@@ -572,35 +859,55 @@ class ClaudeCLIProvider(LLMProvider):
                     creationflags=creation_flags,
                     env=env,
                 )
-                try:
-                    stdout, stderr = proc.communicate(
-                        input=content, timeout=timeout_seconds
-                    )
-                except subprocess.TimeoutExpired:
-                    # Kill the entire process tree so pipes close immediately
-                    _kill_process_tree(proc.pid)
-                    # Drain any remaining pipe data
-                    try:
-                        proc.communicate(timeout=5)
-                    except (subprocess.TimeoutExpired, OSError):
-                        pass
+                # #2405: the idle threshold is the operative limit; the caller's
+                # timeout_seconds survives only as an outer backstop against a
+                # process that streams forever.
+                idle_limit = idle_timeout_seconds()
+                outcome = _stream_with_idle_timeout(
+                    proc,
+                    content=content,
+                    idle_timeout=idle_limit,
+                    wall_timeout=timeout_seconds,
+                )
+                stdout = outcome.result_payload()
+                stderr = outcome.stderr
+
+                if outcome.timed_out:
                     duration_ms = int((time.time() - start_time) * 1000)
+                    # The literal "timed out" is a contract, not prose:
+                    # analyze_requirements._is_timeout classifies by substring
+                    # because the provider returns a result rather than raising.
+                    # Both branches keep it; only what follows differs.
+                    if outcome.timeout_kind == "idle":
+                        message = (
+                            f"claude -p timed out after "
+                            f"{int(outcome.silent_seconds)}s with no output "
+                            f"(idle limit {idle_limit}s, {outcome.total_events} "
+                            f"events received before it went quiet)"
+                        )
+                    else:
+                        message = (
+                            f"claude -p timed out after {timeout_seconds}s while "
+                            f"still producing output ({outcome.total_events} "
+                            f"events); raise AZ_FILE_TIMEOUT_FLOOR rather than "
+                            f"treating this as a provider failure"
+                        )
                     # #2086: consecutive timeouts are a provider storm, not a
                     # run of bad luck. Eighteen in one roll on 2026-08-01 killed
                     # two rolls; the counter is what lets the launcher wait
                     # instead of redrawing straight into the same wall.
-                    consecutive = provider_storm.record_timeout(timeout_seconds)
-                    message = f"claude -p timed out after {timeout_seconds}s"
-                    if provider_storm.is_storm():
-                        message = (
-                            f"{message} "
-                            f"({consecutive} consecutive — "
-                            f"{provider_storm.STORM_MARKER})"
-                        )
+                    #
+                    # #2405: a wall-clock backstop hit by a call that was still
+                    # streaming says nothing about provider health, so it must
+                    # not feed the storm counter at all. Only silence counts.
+                    if outcome.timeout_kind == "idle":
+                        consecutive = provider_storm.record_timeout(idle_limit)
+                        if provider_storm.is_storm():
+                            message = self._classify_storm(message, consecutive)
                     call_result = LLMCallResult(
                         success=False,
                         response=None,
-                        raw_response=None,
+                        raw_response=stdout,
                         error_message=message,
                         provider=self.provider_name,
                         model_used=self._model,

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -688,6 +688,9 @@ class ClaudeCLIProvider(LLMProvider):
                 text=True,
                 encoding="utf-8",
                 creationflags=creation_flags,
+                # See the note in invoke(): off Windows this keeps a tree-kill
+                # from taking down the calling process's own group.
+                start_new_session=sys.platform != "win32",
                 env=env,
             )
         except OSError:
@@ -825,6 +828,16 @@ class ClaudeCLIProvider(LLMProvider):
                     subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
                 )
 
+            # #2405: the POSIX counterpart of CREATE_NEW_PROCESS_GROUP, and it is
+            # not cosmetic. kill_process_tree() does
+            # `os.killpg(os.getpgid(pid), 9)` off Windows, and a child spawned
+            # without a new session INHERITS this process's group — so the kill
+            # lands on us as well as on the child. Windows never showed it
+            # because that path shells out to `taskkill /T /PID`, which is
+            # scoped to the one tree. Caught when CI (Linux) hung on the first
+            # test that let a real idle timeout fire against a real subprocess.
+            start_new_session = sys.platform != "win32"
+
             # Issue #787: When using temp dir, wrap in TemporaryDirectory
             # context manager so cleanup is guaranteed.
             if use_tempdir_prompt:
@@ -857,6 +870,7 @@ class ClaudeCLIProvider(LLMProvider):
                     encoding="utf-8",
                     cwd=temp_path,  # None when not using temp dir (= inherit)
                     creationflags=creation_flags,
+                    start_new_session=start_new_session,
                     env=env,
                 )
                 # #2405: the idle threshold is the operative limit; the caller's

--- a/assemblyzero/core/provider_storm.py
+++ b/assemblyzero/core/provider_storm.py
@@ -31,6 +31,8 @@ target repo's fault and must not be classified as one.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 #: Consecutive timeouts before the roll is declared storm-bound.
 STORM_THRESHOLD = 3
 
@@ -45,8 +47,28 @@ BACKOFF_MINUTES = (15, 30, 60)
 
 STORM_MARKER = "PROVIDER STORM"
 
+#: #2405: the other diagnosis. Consecutive timeouts can mean the provider
+#: stopped answering, or they can mean our own limit sits inside the call's
+#: duration. Counting timeouts cannot tell these apart, because a timeout is
+#: the one failure the caller times rather than the provider reports.
+CEILING_MARKER = "TIMEOUT CEILING"
+
+#: What the probe asks. Trivial by design: it is testing whether anyone is
+#: home, not whether the model is any good.
+PROBE_PROMPT = "Reply with the single word ok."
+
+#: Probe budget. The measurement this was built from answered in 5.867s, and
+#: the in-band evidence on #2405 showed a 16.9s success immediately after a
+#: storm was declared, so a minute is generous without being a second wall.
+PROBE_TIMEOUT_SECONDS = 60
+
 _consecutive_timeouts = 0
 _last_timeout_seconds = 0
+
+#: What the last "ceiling" verdict was about. Deliberately NOT cleared by
+#: reset(), because diagnose() calls reset() as part of reaching that verdict.
+_last_ceiling_count = 0
+_last_ceiling_seconds = 0
 
 
 def reset() -> None:
@@ -91,6 +113,67 @@ def backoff_minutes(storm_attempt: int) -> int:
         return 0
     index = min(storm_attempt, len(BACKOFF_MINUTES)) - 1
     return BACKOFF_MINUTES[index]
+
+
+def diagnose(probe: Callable[[], bool]) -> str:
+    """Decide whether a run of timeouts is weather or a wall (#2405).
+
+    `probe` makes one trivial provider call and returns True if it answered.
+
+    Returns ``"none"`` when no storm is pending, ``"ceiling"`` when the provider
+    answered and the timeouts are therefore our own limit saturating, and
+    ``"storm"`` when the provider did not answer.
+
+    A ``"ceiling"`` verdict CLEARS the counter, and that is the point rather than
+    a side effect: a provider that just answered has proven it is up, which is
+    the same thing ``record_success`` means. Leaving the counter set would halt
+    the roll as storm-bound on the strength of evidence we just refuted, and the
+    launcher reads ``is_storm()`` rather than this return value.
+
+    A probe that raises counts as a failed probe. If we cannot reach the
+    provider to ask, we are not entitled to overturn the storm reading.
+
+    The evidence this exists for: boostgauge #1's run declared PROVIDER STORM on
+    three consecutive timeouts, and the very next call succeeded in 16.9s, with
+    ten Claude calls completing in 6.3-31.6s interleaved through the same
+    window. The provider was answering the entire time.
+    """
+    global _last_ceiling_count, _last_ceiling_seconds
+
+    if not is_storm():
+        return "none"
+    try:
+        answered = bool(probe())
+    except Exception:
+        answered = False
+    if answered:
+        # Preserve what the verdict was about before clearing it. reset() wipes
+        # both counters, so a ceiling_message() called afterwards would
+        # otherwise report "0 requests in a row", which is worse than useless
+        # in the one message whose job is to explain what just happened.
+        _last_ceiling_count = _consecutive_timeouts
+        _last_ceiling_seconds = _last_timeout_seconds
+        reset()
+        return "ceiling"
+    return "storm"
+
+
+def ceiling_message(count: int | None = None, timeout_seconds: int | None = None) -> str:
+    """Plain English for the cap-saturation verdict. No jargon, no exit codes.
+
+    Defaults describe the most recent ``diagnose`` ceiling verdict, because by
+    the time anyone asks for this message the live counter has been cleared.
+    """
+    count = _last_ceiling_count if count is None else count
+    seconds = _last_ceiling_seconds if timeout_seconds is None else timeout_seconds
+    duration = f"{seconds} seconds" if seconds else "its time limit"
+    return (
+        f"{CEILING_MARKER}: {count} requests in a row each ran past {duration}, "
+        f"but a test request sent straight afterwards was answered normally. "
+        f"The model provider is up, so this is our own time limit being too "
+        f"short for the work rather than a provider outage. Raising "
+        f"AZ_FILE_TIMEOUT_FLOOR is the lever; waiting will not help."
+    )
 
 
 def storm_message(count: int | None = None, timeout_seconds: int | None = None) -> str:

--- a/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/claude_client.py
@@ -4,6 +4,7 @@ Uses the unified provider gate (get_provider) for all LLM calls.
 Issue #783: Sealed API gate — no more direct CLI/SDK fallback.
 """
 
+import os
 import threading
 import time
 
@@ -12,14 +13,48 @@ from assemblyzero.core.llm_provider import get_provider
 
 # Issue #321: Timeout constants
 # Issue #373: Increased from 300s — large test file prompts need more time
-CLI_TIMEOUT = 600  # 10 minutes base (used by compute_dynamic_timeout)
+CLI_TIMEOUT = 600  # 10 minutes base (historical; no longer the floor)
 
 # #2026: what a file generation gets at minimum, and at most. The floor is what
 # matters: generation time tracks the RESPONSE, and a compact prompt can ask for
 # a very large file. The costs are asymmetric — an over-long timeout waits out
 # one slow call, while an under-long one kills the stage and stalls the arc.
-FILE_TIMEOUT_FLOOR = CLI_TIMEOUT
+#
+# #2405: the floor was CLI_TIMEOUT (600) and boostgauge #1 died against it five
+# times, four of them reading "timed out after 602s". That 602 is the whole
+# story of why this moved. The scaling below grants one second per 1000
+# characters, so a 2.5 KB fix-loop prompt bought two seconds over the floor;
+# reaching the 1200 cap from a 600 floor needs a 600,000-character prompt, which
+# nothing here produces. The cap had therefore never once bound, and the floor
+# had silently been the entire timeout since #373 introduced the scaling. The
+# floor now starts where the cap was, and both are environment-overridable so
+# that the next time the distribution outgrows a constant, the remedy is a
+# variable rather than a merge.
+FILE_TIMEOUT_FLOOR = 1200
 FILE_TIMEOUT_CAP = 1200
+
+#: Override names. Values are whole seconds. A missing, unparseable, or
+#: non-positive value falls back to the default rather than failing the call:
+#: an operator reaching for these is usually unblocking a stalled run, and a
+#: typo must not turn a slow call into a dead one.
+ENV_TIMEOUT_FLOOR = "AZ_FILE_TIMEOUT_FLOOR"
+ENV_TIMEOUT_CAP = "AZ_FILE_TIMEOUT_CAP"
+
+
+def _env_seconds(name: str, default: int) -> int:
+    """Read a positive whole-second count from the environment."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"    [TIMEOUT] {name}={raw!r} is not an integer; using {default}s")
+        return default
+    if value <= 0:
+        print(f"    [TIMEOUT] {name}={value} is not positive; using {default}s")
+        return default
+    return value
 
 
 class ProgressReporter:
@@ -94,15 +129,32 @@ def compute_dynamic_timeout(prompt: str) -> int:
     genuinely large prompts. A too-long timeout costs waiting on one slow call;
     a too-short one costs the stage.
 
+    #2405: this is now the outer wall-clock backstop, not the operative limit.
+    A call is killed for going quiet (see the idle timeout in
+    ``ClaudeCLIProvider.invoke``), and reaching this value at all means the
+    process stayed silent for the whole window. The floor and cap are
+    environment-overridable via ``AZ_FILE_TIMEOUT_FLOOR`` / ``AZ_FILE_TIMEOUT_CAP``.
+
+    That also retires the "bonus for genuinely large prompts" above: the floor
+    now starts at the cap, so the scaling term can no longer change the result.
+    It was never doing the work anyway. The prompt that killed boostgauge #1 was
+    about 2.5 KB, which bought two seconds, and the run's log records the limit
+    as 602s for exactly that reason.
+
     Args:
         prompt: The prompt string.
 
     Returns:
-        Timeout in seconds (FILE_TIMEOUT_FLOOR–FILE_TIMEOUT_CAP range).
+        Timeout in seconds (floor–cap range, both overridable).
     """
+    floor = _env_seconds(ENV_TIMEOUT_FLOOR, FILE_TIMEOUT_FLOOR)
+    # A cap below the floor would silently undo an operator's floor override,
+    # which is the opposite of what they reached for the variable to do.
+    cap = max(_env_seconds(ENV_TIMEOUT_CAP, FILE_TIMEOUT_CAP), floor)
+
     # Add 1 second per 1000 characters of prompt
-    scaled = FILE_TIMEOUT_FLOOR + len(prompt) // 1000
-    return min(scaled, FILE_TIMEOUT_CAP)
+    scaled = floor + len(prompt) // 1000
+    return min(scaled, cap)
 
 
 def build_system_prompt(file_path: str) -> str:

--- a/tests/unit/test_implement_code_context.py
+++ b/tests/unit/test_implement_code_context.py
@@ -193,27 +193,42 @@ class TestComputeDynamicTimeout:
         assert timeout > 301
         assert timeout >= FILE_TIMEOUT_FLOOR
 
-    def test_large_prompt_gets_higher_timeout(self):
-        large_prompt = "x" * 88000
-        timeout = compute_dynamic_timeout(large_prompt)
-        assert timeout > FILE_TIMEOUT_FLOOR
-        assert timeout == min(FILE_TIMEOUT_FLOOR + 88, FILE_TIMEOUT_CAP)
-
     def test_timeout_is_capped(self):
         huge_prompt = "x" * 10_000_000
         timeout = compute_dynamic_timeout(huge_prompt)
         assert timeout == FILE_TIMEOUT_CAP
 
-    def test_medium_prompt_scales_linearly(self):
-        medium_prompt = "x" * 50000
-        timeout = compute_dynamic_timeout(medium_prompt)
-        assert timeout == FILE_TIMEOUT_FLOOR + 50
+    def test_the_scaling_no_longer_carries_weight(self):
+        """#2405: the per-character scaling is retired, and this records why.
+
+        It granted one second per 1000 characters. The fix-loop prompt that
+        killed boostgauge #1 was about 2.5 KB, so it bought two seconds over the
+        floor -- the run's own log shows the resulting limit as "timed out after
+        602s", which is 600 plus those two. Reaching the 1200 cap from a 600
+        floor required 600,000 characters, so the cap had never once bound in
+        the life of the function.
+
+        These two tests previously asserted the scaling arithmetic
+        (`FILE_TIMEOUT_FLOOR + 50`, `+ 88`) and passed throughout, because they
+        asserted the formula rather than what the formula was for. That is the
+        same failure the class docstring above describes for the 300s base.
+
+        The floor now starts at the cap, so the computed value is constant. What
+        makes a long call survive is the idle timeout in the transport, not this
+        number, which is only an outer backstop.
+        """
+        assert compute_dynamic_timeout("x" * 50_000) == FILE_TIMEOUT_FLOOR
+        assert compute_dynamic_timeout("x" * 88_000) == FILE_TIMEOUT_FLOOR
+        assert compute_dynamic_timeout("tiny") == FILE_TIMEOUT_FLOOR
 
     def test_the_floor_never_drops_back(self):
-        """Guard against a later edit quietly lowering the floor toward the
-        value that produced 15 timeouts in a single stage."""
+        """Guard against a later edit quietly lowering the floor toward either
+        value that has already killed a stage: 300 (#2026) or 600 (#2405)."""
         assert FILE_TIMEOUT_FLOOR >= CLI_TIMEOUT
-        assert FILE_TIMEOUT_CAP > FILE_TIMEOUT_FLOOR
+        assert FILE_TIMEOUT_FLOOR >= 1200, (
+            "600 is the wall boostgauge #1 died against five times in one run"
+        )
+        assert FILE_TIMEOUT_CAP >= FILE_TIMEOUT_FLOOR
 
 
 # =============================================================================

--- a/tests/unit/test_llm_idle_timeout.py
+++ b/tests/unit/test_llm_idle_timeout.py
@@ -1,0 +1,354 @@
+"""Idle-timeout transport and storm/ceiling classification (#2405).
+
+The defect class: every timeout in the Claude CLI transport was wall-clock, so
+the only question it could answer was "has N seconds passed", never "is anything
+still happening". #373 raised the ceiling, #2026 raised it again, and #2405 is
+the third occurrence of the same wall in the same file family. A ceiling keyed
+to nothing observable gets overtaken every time the work grows.
+
+The two halves of the acceptance, both asserted here:
+
+- a call that is still producing output is never killed, however long it runs;
+- a call that has gone silent is killed at the idle threshold, promptly.
+
+Timings are scaled down (seconds, not minutes) so the suite stays fast. The
+full-scale demonstration, a synthetic call streaming past the old 600s ceiling,
+lives in ``tools/prove_idle_timeout.py`` and its measured output is recorded on
+the issue.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from assemblyzero.core import provider_storm
+from assemblyzero.core.llm_provider import (
+    IDLE_TIMEOUT_SECONDS,
+    ENV_IDLE_TIMEOUT,
+    _stream_with_idle_timeout,
+    idle_timeout_seconds,
+)
+from assemblyzero.workflows.testing.nodes.implementation.claude_client import (
+    ENV_TIMEOUT_CAP,
+    ENV_TIMEOUT_FLOOR,
+    FILE_TIMEOUT_CAP,
+    FILE_TIMEOUT_FLOOR,
+    compute_dynamic_timeout,
+)
+
+
+# --- helpers ---------------------------------------------------------------
+
+#: Emits `count` JSON lines `interval` seconds apart, then exits 0. Stands in
+#: for `claude -p --include-partial-messages`, which emits a delta per chunk.
+_STREAMER = (
+    "import sys, time\n"
+    "count, interval = int(sys.argv[1]), float(sys.argv[2])\n"
+    "for i in range(count):\n"
+    "    print('{\"type\": \"stream_event\", \"i\": %d}' % i, flush=True)\n"
+    "    time.sleep(interval)\n"
+    "print('{\"type\": \"result\", \"result\": \"done\", \"usage\": {}}', flush=True)\n"
+)
+
+#: Produces nothing at all, then would exit. Stands in for a hung call.
+_SILENT = "import time, sys; time.sleep(float(sys.argv[1]))"
+
+
+def _spawn(script: str, *args: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-u", "-c", script, *args],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_counter():
+    provider_storm.reset()
+    yield
+    provider_storm.reset()
+
+
+# --- half one: a call still producing output is never killed ---------------
+
+
+def test_a_streaming_call_is_not_killed_however_long_it_runs():
+    """12 seconds of output under a 3-second idle threshold survives.
+
+    This is the half that the old transport got wrong. Under a wall-clock
+    ceiling, a call is killed for taking too long; under an idle threshold it is
+    killed only for going quiet, so elapsed time stops being the question.
+    """
+    proc = _spawn(_STREAMER, "12", "1.0")
+    started = time.monotonic()
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=3, wall_timeout=None
+    )
+    elapsed = time.monotonic() - started
+
+    assert not outcome.timed_out, "a call that never went quiet was killed"
+    assert outcome.returncode == 0
+    assert elapsed >= 12, "the call should have been allowed to finish"
+    # 4x over the idle threshold, and it lived, because output kept arriving.
+    assert elapsed > 4 * 3
+
+
+def test_the_result_event_survives_the_delta_flood():
+    """Deltas are counted for liveness and discarded; the result is kept.
+
+    The final `result` event carries the same keys the old buffered
+    `--output-format json` dict did, so the whole downstream parse is unchanged.
+    """
+    proc = _spawn(_STREAMER, "6", "0.05")
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=10, wall_timeout=None
+    )
+
+    assert not outcome.timed_out
+    assert outcome.total_events == 7, "every line counts toward liveness"
+    assert len(outcome.events) == 1, "only the non-delta event is retained"
+
+    import json
+
+    payload = json.loads(outcome.result_payload())
+    assert isinstance(payload, dict), "the parser is handed an object, not an array"
+    assert payload["result"] == "done"
+
+
+# --- half two: a call that has gone silent is killed -----------------------
+
+
+def test_a_silent_call_is_killed_at_the_idle_threshold():
+    """A process producing nothing dies at the threshold, not at the backstop."""
+    proc = _spawn(_SILENT, "60")
+    started = time.monotonic()
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=2, wall_timeout=600
+    )
+    elapsed = time.monotonic() - started
+
+    assert outcome.timed_out
+    assert outcome.timeout_kind == "idle"
+    assert outcome.silent_seconds >= 2
+    # The point of the mechanism: it did not wait out the 600s backstop.
+    assert elapsed < 15, f"idle kill took {elapsed:.1f}s"
+
+
+def test_a_call_that_goes_quiet_mid_stream_is_still_killed():
+    """Output then silence. Liveness is about now, not about having once lived."""
+    proc = _spawn(_STREAMER, "3", "0.1")  # 3 quick lines, then result, then exit
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=5, wall_timeout=None
+    )
+    assert not outcome.timed_out, "this one exits cleanly; it is the control"
+
+    # Now the same shape, but the process hangs after its burst.
+    hangs_after_burst = (
+        "import sys, time\n"
+        "print('{\"type\": \"stream_event\"}', flush=True)\n"
+        "time.sleep(60)\n"
+    )
+    proc = _spawn(hangs_after_burst)
+    started = time.monotonic()
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=2, wall_timeout=None
+    )
+    elapsed = time.monotonic() - started
+
+    assert outcome.timed_out
+    assert outcome.timeout_kind == "idle"
+    assert outcome.total_events == 1, "it did produce something, once"
+    assert elapsed < 15
+
+
+def test_the_wall_backstop_still_exists_for_a_call_that_streams_forever():
+    """A pathological forever-streamer is bounded, and says so distinctly.
+
+    The backstop is not the operative limit any more, so hitting it is reported
+    as a ceiling problem rather than as a provider failure.
+    """
+    proc = _spawn(_STREAMER, "1000", "0.05")
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=60, wall_timeout=3
+    )
+
+    assert outcome.timed_out
+    assert outcome.timeout_kind == "wall"
+
+
+# --- layer 2: the ceiling is raised, and overridable without a merge -------
+
+
+def test_the_floor_no_longer_sits_at_600():
+    """#2405: 602s killed boostgauge #1 five times. The floor moved past it."""
+    assert FILE_TIMEOUT_FLOOR == 1200
+    assert compute_dynamic_timeout("x" * 2500) == 1200
+
+
+def test_the_scaling_never_reached_the_cap_which_is_why_the_floor_had_to_move():
+    """One second per 1000 characters cannot move a real prompt meaningfully.
+
+    The 2.5 KB fix-loop prompt that died bought two seconds over the floor.
+    Reaching the old 1200 cap from a 600 floor needed 600,000 characters.
+    """
+    old_floor = 600
+    realistic_prompt_chars = 2500
+    assert old_floor + realistic_prompt_chars // 1000 == 602
+    assert (FILE_TIMEOUT_CAP - old_floor) * 1000 == 600_000
+
+
+def test_the_floor_is_overridable_by_environment(monkeypatch):
+    monkeypatch.setenv(ENV_TIMEOUT_FLOOR, "1800")
+    assert compute_dynamic_timeout("x" * 2500) == 1800
+
+
+def test_a_cap_below_the_floor_does_not_silently_undo_the_override(monkeypatch):
+    monkeypatch.setenv(ENV_TIMEOUT_FLOOR, "1800")
+    monkeypatch.setenv(ENV_TIMEOUT_CAP, "900")
+    assert compute_dynamic_timeout("x" * 2500) == 1800
+
+
+@pytest.mark.parametrize("bad", ["banana", "-5", "0", ""])
+def test_a_bad_override_falls_back_rather_than_failing_the_call(monkeypatch, bad):
+    """An operator setting this is rescuing a stalled run. A typo must not
+    convert a slow call into a dead one."""
+    monkeypatch.setenv(ENV_TIMEOUT_FLOOR, bad)
+    assert compute_dynamic_timeout("x" * 2500) == 1200
+
+
+def test_the_idle_threshold_is_overridable_too(monkeypatch):
+    assert idle_timeout_seconds() == IDLE_TIMEOUT_SECONDS
+    monkeypatch.setenv(ENV_IDLE_TIMEOUT, "45")
+    assert idle_timeout_seconds() == 45
+    monkeypatch.setenv(ENV_IDLE_TIMEOUT, "not-a-number")
+    assert idle_timeout_seconds() == IDLE_TIMEOUT_SECONDS
+
+
+# --- the flag the whole mechanism rests on --------------------------------
+
+
+def test_the_streaming_flags_are_passed_to_the_cli():
+    """Removing --include-partial-messages would silently invert the fix.
+
+    Without it the CLI still emits stream-json, but the `assistant` event does
+    not arrive until the message is complete. A long generation would then look
+    like total silence, and the idle timeout would kill exactly the live calls
+    it exists to protect — a worse failure than the wall it replaced, and an
+    invisible one, because the transport would still appear to work on short
+    calls. Measured 2026-08-15: with the flag, deltas arrive every ~0.65s.
+    """
+    from unittest.mock import Mock, patch
+
+    from assemblyzero.core.llm_provider import ClaudeCLIProvider
+
+    proc = Mock()
+    proc.pid = 1
+    proc.stdout = iter(['{"type": "result", "result": "ok"}'])
+    proc.stderr = Mock()
+    proc.stderr.read.return_value = ""
+    proc.stdin = Mock()
+    proc.poll.return_value = 0
+    proc.returncode = 0
+
+    with patch("subprocess.Popen", return_value=proc) as popen, patch.object(
+        ClaudeCLIProvider, "_find_cli", return_value="/usr/local/bin/claude"
+    ):
+        ClaudeCLIProvider().invoke("system", "content")
+
+    cmd = popen.call_args[0][0]
+    assert "--include-partial-messages" in cmd, (
+        "without this flag the idle timeout kills live calls"
+    )
+    assert "stream-json" in cmd
+    assert "--verbose" in cmd, "stream-json under -p requires it"
+
+
+# --- layer 4: weather or a wall -------------------------------------------
+
+
+def test_a_probe_that_answers_overturns_the_storm_reading():
+    """The measured case. boostgauge #1 declared a storm, then the next call
+    succeeded in 16.9s, with ten Claude calls completing in 6.3-31.6s through
+    the same window."""
+    for _ in range(provider_storm.STORM_THRESHOLD):
+        provider_storm.record_timeout(1200)
+    assert provider_storm.is_storm()
+
+    assert provider_storm.diagnose(lambda: True) == "ceiling"
+
+    # The counter clears, so the launcher's is_storm() halt does not fire.
+    assert not provider_storm.is_storm()
+
+
+def test_a_probe_that_fails_confirms_a_genuine_storm():
+    for _ in range(provider_storm.STORM_THRESHOLD):
+        provider_storm.record_timeout(1200)
+
+    assert provider_storm.diagnose(lambda: False) == "storm"
+    assert provider_storm.is_storm(), "a real storm must still halt the roll"
+
+
+def test_a_probe_that_raises_is_a_failed_probe():
+    """If we cannot reach the provider to ask, we cannot overturn the reading."""
+
+    def _boom() -> bool:
+        raise RuntimeError("probe transport died")
+
+    for _ in range(provider_storm.STORM_THRESHOLD):
+        provider_storm.record_timeout(1200)
+
+    assert provider_storm.diagnose(_boom) == "storm"
+    assert provider_storm.is_storm()
+
+
+def test_no_probe_is_fired_when_there_is_no_storm():
+    """The probe costs a real call, so it only runs at the decision point."""
+    fired = []
+
+    def _probe() -> bool:
+        fired.append(1)
+        return True
+
+    provider_storm.record_timeout(1200)
+    assert provider_storm.diagnose(_probe) == "none"
+    assert not fired
+
+
+def test_the_two_verdicts_say_different_things_in_plain_english():
+    for _ in range(provider_storm.STORM_THRESHOLD):
+        provider_storm.record_timeout(1200)
+
+    storm = provider_storm.storm_message()
+    assert provider_storm.STORM_MARKER in storm
+
+    assert provider_storm.diagnose(lambda: True) == "ceiling"
+    ceiling = provider_storm.ceiling_message()
+
+    assert provider_storm.CEILING_MARKER in ceiling
+    assert "provider" in ceiling.lower() and "up" in ceiling.lower()
+    # The ceiling verdict must point at the lever that actually helps.
+    assert ENV_TIMEOUT_FLOOR in ceiling
+
+
+def test_the_ceiling_message_survives_the_counter_reset_that_produced_it():
+    """diagnose() clears the counter on its way to the verdict.
+
+    A message defaulting to the live counter would therefore report "0 requests
+    in a row" in exactly the case it exists to explain.
+    """
+    for _ in range(provider_storm.STORM_THRESHOLD):
+        provider_storm.record_timeout(1200)
+
+    assert provider_storm.diagnose(lambda: True) == "ceiling"
+    assert not provider_storm.is_storm(), "the counter is cleared by the verdict"
+
+    ceiling = provider_storm.ceiling_message()
+    assert str(provider_storm.STORM_THRESHOLD) in ceiling
+    assert "1200" in ceiling
+    assert "0 requests" not in ceiling

--- a/tests/unit/test_llm_idle_timeout.py
+++ b/tests/unit/test_llm_idle_timeout.py
@@ -58,6 +58,15 @@ _SILENT = "import time, sys; time.sleep(float(sys.argv[1]))"
 
 
 def _spawn(script: str, *args: str) -> subprocess.Popen:
+    """Spawn a stand-in child, isolated from this process's process group.
+
+    `start_new_session` is not optional here. `kill_process_tree` does
+    `os.killpg(os.getpgid(pid), 9)` off Windows, and a child that inherited
+    pytest's process group would take the whole test session down with it the
+    first time an idle timeout fired for real. That is exactly what happened on
+    Linux CI, while Windows passed throughout because its path shells out to
+    `taskkill /T /PID`, scoped to the one tree.
+    """
     return subprocess.Popen(
         [sys.executable, "-u", "-c", script, *args],
         stdin=subprocess.PIPE,
@@ -65,6 +74,7 @@ def _spawn(script: str, *args: str) -> subprocess.Popen:
         stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
+        start_new_session=sys.platform != "win32",
     )
 
 
@@ -231,6 +241,41 @@ def test_the_idle_threshold_is_overridable_too(monkeypatch):
 
 
 # --- the flag the whole mechanism rests on --------------------------------
+
+
+def test_the_child_is_spawned_into_its_own_process_group_off_windows():
+    """A tree-kill must not reach the process that ordered it (#2405).
+
+    `kill_process_tree` signals `os.getpgid(pid)` off Windows. Without
+    `start_new_session`, the child inherits our group, so killing an idle call
+    SIGKILLs AssemblyZero itself. Windows hid this completely: that path shells
+    out to `taskkill /F /T /PID`, which is scoped to the single tree, so the
+    defect was invisible until Linux CI hung on the first real idle kill.
+
+    The idle timeout makes this far easier to reach than the old wall-clock
+    ceiling did, because idle kills fire on hangs rather than only on very long
+    calls.
+    """
+    from unittest.mock import Mock, patch
+
+    from assemblyzero.core.llm_provider import ClaudeCLIProvider
+
+    proc = Mock()
+    proc.pid = 1
+    proc.stdout = iter(['{"type": "result", "result": "ok"}'])
+    proc.stderr = Mock()
+    proc.stderr.read.return_value = ""
+    proc.stdin = Mock()
+    proc.poll.return_value = 0
+    proc.returncode = 0
+
+    with patch("subprocess.Popen", return_value=proc) as popen, patch.object(
+        ClaudeCLIProvider, "_find_cli", return_value="/usr/local/bin/claude"
+    ):
+        ClaudeCLIProvider().invoke("system", "content")
+
+    expected = sys.platform != "win32"
+    assert popen.call_args.kwargs.get("start_new_session") is expected
 
 
 def test_the_streaming_flags_are_passed_to_the_cli():

--- a/tests/unit/test_llm_provider.py
+++ b/tests/unit/test_llm_provider.py
@@ -19,7 +19,6 @@ Tests for:
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 import json
-import subprocess
 from pathlib import Path
 
 from assemblyzero.core.llm_provider import (
@@ -43,6 +42,52 @@ from assemblyzero.core.llm_provider import (
     set_api_policy,
     _load_anthropic_api_key,
 )
+
+
+def _stream_proc(payload: str = "", stderr: str = "", returncode: int = 0, pid: int = 12345):
+    """Shape a mock Popen the way the #2405 streaming transport reads it.
+
+    Before #2405 the transport called ``proc.communicate()`` and parsed one
+    buffered JSON object. It now reads NDJSON events off ``proc.stdout`` so it
+    can tell a working call from a hung one, and takes its payload from the
+    final ``result`` event. `payload` is the same JSON object the old mocks
+    handed to ``communicate``, delivered where the new transport looks for it.
+
+    Pass ``payload=""`` for a call that produced no usable output, which is what
+    an error path looks like.
+    """
+    proc = Mock()
+    proc.pid = pid
+    lines = []
+    if payload:
+        event = json.loads(payload)
+        event.setdefault("type", "result")
+        lines.append(json.dumps(event))
+    proc.stdout = iter(lines)
+    proc.stderr = Mock()
+    proc.stderr.read.return_value = stderr
+    proc.stdin = Mock()
+    proc.poll.return_value = returncode
+    proc.returncode = returncode
+    return proc
+
+
+def _hanging_proc(pid: int = 12345):
+    """A mock Popen that never exits and never produces output.
+
+    ``poll()`` returning None forever is what a hung `claude -p` looks like to
+    the watchdog. Tests using this must shrink the idle threshold, or they wait
+    the full production two minutes.
+    """
+    proc = Mock()
+    proc.pid = pid
+    proc.stdout = iter(())
+    proc.stderr = Mock()
+    proc.stderr.read.return_value = ""
+    proc.stdin = Mock()
+    proc.poll.return_value = None
+    proc.returncode = None
+    return proc
 
 
 class TestLLMCallResult:
@@ -295,9 +340,7 @@ class TestClaudeCLIProvider:
     def test_invoke_success(self, mock_find_cli, mock_popen):
         """Test successful invocation."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "Generated content"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "Generated content"}')
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider()
@@ -315,9 +358,7 @@ class TestClaudeCLIProvider:
     def test_invoke_failure(self, mock_find_cli, mock_popen):
         """Test invocation failure."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ("", "Authentication failed")
-        mock_proc.returncode = 1
+        mock_proc = _stream_proc("", stderr="Authentication failed", returncode=1)
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider()
@@ -332,15 +373,16 @@ class TestClaudeCLIProvider:
     @patch("assemblyzero.core.llm_provider._kill_process_tree")
     @patch("subprocess.Popen")
     @patch.object(ClaudeCLIProvider, "_find_cli")
-    def test_invoke_timeout(self, mock_find_cli, mock_popen, mock_kill):
-        """Test invocation timeout — process tree killed on Windows."""
+    def test_invoke_timeout(self, mock_find_cli, mock_popen, mock_kill, monkeypatch):
+        """A hung call is killed process-tree-wise on Windows.
+
+        #2405: the kill now fires on silence rather than on elapsed time, so the
+        process is one that never exits and never speaks. The threshold is
+        shrunk to a second so the test does not wait the production two minutes.
+        """
+        monkeypatch.setenv("AZ_LLM_IDLE_TIMEOUT", "1")
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.pid = 12345
-        mock_proc.communicate.side_effect = [
-            subprocess.TimeoutExpired(cmd="claude", timeout=300),
-            ("", ""),  # drain call after kill
-        ]
+        mock_proc = _hanging_proc(pid=12345)
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider()
@@ -351,17 +393,43 @@ class TestClaudeCLIProvider:
         )
 
         assert result.success is False
+        # The literal substring is a contract: analyze_requirements._is_timeout
+        # classifies timeouts by matching it.
         assert "timed out" in result.error_message.lower()
+        assert "no output" in result.error_message.lower()
         mock_kill.assert_called_once_with(12345)
+
+    @patch("assemblyzero.core.llm_provider._kill_process_tree")
+    @patch("subprocess.Popen")
+    @patch.object(ClaudeCLIProvider, "_find_cli")
+    def test_timeout_messages_keep_the_substring_other_code_matches_on(
+        self, mock_find_cli, mock_popen, mock_kill, monkeypatch
+    ):
+        """#2405: `_is_timeout` keys off "timed out", so both branches must say it.
+
+        This coupling is invisible from either side. The provider returns a
+        result object rather than raising, so the requirements gate classifies
+        by substring; a reworded message would silently stop being recognised
+        as a timeout and would be retried as though it were a content failure.
+        """
+        from assemblyzero.workflows.requirements.nodes.analyze_requirements import (
+            _is_timeout,
+        )
+
+        monkeypatch.setenv("AZ_LLM_IDLE_TIMEOUT", "1")
+        mock_find_cli.return_value = "/usr/local/bin/claude"
+        mock_popen.return_value = _hanging_proc()
+
+        provider = ClaudeCLIProvider()
+        idle_result = provider.invoke("Test", "Test", timeout_seconds=300)
+        assert _is_timeout(idle_result), idle_result.error_message
 
     @patch("subprocess.Popen")
     @patch.object(ClaudeCLIProvider, "_find_cli")
     def test_small_system_prompt_uses_cli_arg(self, mock_find_cli, mock_popen):
         """Issue #787: System prompt under limit uses --system-prompt CLI arg."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "OK"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "OK"}')
         mock_popen.return_value = mock_proc
 
         small_prompt = "You are a helpful assistant"
@@ -379,9 +447,7 @@ class TestClaudeCLIProvider:
     def test_large_system_prompt_uses_tempdir(self, mock_find_cli, mock_popen):
         """Issue #787: System prompt over limit writes CLAUDE.md to temp dir."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "OK"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "OK"}')
         mock_popen.return_value = mock_proc
 
         large_prompt = "x" * (ClaudeCLIProvider.SYSTEM_PROMPT_CLI_LIMIT + 1)
@@ -403,9 +469,7 @@ class TestClaudeCLIProvider:
     def test_tempdir_cleanup_after_invoke(self, mock_find_cli, mock_popen):
         """Issue #787: Temp dir is cleaned up after invoke returns."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "OK"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "OK"}')
         mock_popen.return_value = mock_proc
 
         large_prompt = "x" * (ClaudeCLIProvider.SYSTEM_PROMPT_CLI_LIMIT + 1)
@@ -1074,9 +1138,7 @@ class TestTokenLogging:
                 "cache_creation_input_tokens": 3000,
             },
         })
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = (json_stdout, "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc(json_stdout)
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider()
@@ -1094,9 +1156,7 @@ class TestTokenLogging:
     def test_claude_handles_missing_usage(self, mock_find_cli, mock_popen):
         """Claude provider handles JSON without usage field."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "content"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "content"}')
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider()
@@ -1555,9 +1615,7 @@ class TestEffortFlag:
     def test_effort_max_in_command(self, mock_find_cli, mock_popen):
         """--effort max appears in subprocess command."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "ok"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "ok"}')
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider(model="opus", effort="max")
@@ -1573,9 +1631,7 @@ class TestEffortFlag:
     def test_effort_none_omits_flag(self, mock_find_cli, mock_popen):
         """effort=None omits --effort from command."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "ok"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "ok"}')
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider(model="opus")
@@ -1599,9 +1655,7 @@ class TestResponseSchema:
     def test_json_schema_in_command_when_provided(self, mock_find_cli, mock_popen):
         """--json-schema appears in subprocess command when schema provided."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "ok"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "ok"}')
         mock_popen.return_value = mock_proc
 
         schema = {"type": "object", "properties": {"verdict": {"type": "string"}}}
@@ -1619,9 +1673,7 @@ class TestResponseSchema:
     def test_json_schema_omitted_when_none(self, mock_find_cli, mock_popen):
         """--json-schema omitted when response_schema is None."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = ('{"result": "ok"}', "")
-        mock_proc.returncode = 0
+        mock_proc = _stream_proc('{"result": "ok"}')
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider(model="opus")
@@ -1635,19 +1687,16 @@ class TestResponseSchema:
     def test_structured_output_extracted_when_schema_provided(self, mock_find_cli, mock_popen):
         """Issue #781: When --json-schema is used, response comes from structured_output, not result."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
         # Real claude -p output when --json-schema is used:
         # result is empty, structured_output has the actual response
-        mock_proc.communicate.return_value = (
+        mock_proc = _stream_proc(
             json.dumps({
                 "result": "",
                 "structured_output": {"verdict": "APPROVED", "feedback": []},
                 "usage": {"input_tokens": 100, "output_tokens": 50},
                 "total_cost_usd": 0.01,
-            }),
-            "",
+            })
         )
-        mock_proc.returncode = 0
         mock_popen.return_value = mock_proc
 
         schema = {"type": "object", "properties": {"verdict": {"type": "string"}}}
@@ -1663,16 +1712,13 @@ class TestResponseSchema:
     def test_result_used_when_no_schema(self, mock_find_cli, mock_popen):
         """Without response_schema, response comes from result field as before."""
         mock_find_cli.return_value = "/usr/local/bin/claude"
-        mock_proc = Mock()
-        mock_proc.communicate.return_value = (
+        mock_proc = _stream_proc(
             json.dumps({
                 "result": "Hello world",
                 "usage": {"input_tokens": 10, "output_tokens": 5},
                 "total_cost_usd": 0.001,
-            }),
-            "",
+            })
         )
-        mock_proc.returncode = 0
         mock_popen.return_value = mock_proc
 
         provider = ClaudeCLIProvider(model="opus")

--- a/tools/prove_idle_timeout.py
+++ b/tools/prove_idle_timeout.py
@@ -1,0 +1,132 @@
+"""Full-scale proof for the #2405 idle timeout, at the real durations.
+
+The unit suite asserts the mechanism in seconds so it stays fast. This asserts
+it at the scale the defect actually occurred at: a synthetic call that streams
+for longer than the 600s ceiling boostgauge #1 died against, and a silent call
+that must still be killed promptly.
+
+Both halves are required. A mechanism that never kills anything passes the first
+half trivially and is worthless; one that kills a live call passes the second and
+is worse than the wall it replaced.
+
+Run:
+    poetry run python tools/prove_idle_timeout.py
+
+Takes about 11 minutes, almost all of it the long call proving it is allowed to
+finish. No model tokens are spent: the streamer is a local subprocess, because
+what is under test is the transport, not the provider.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.core.llm_provider import (  # noqa: E402
+    IDLE_TIMEOUT_SECONDS,
+    _stream_with_idle_timeout,
+)
+from assemblyzero.workflows.testing.nodes.implementation.claude_client import (  # noqa: E402
+    compute_dynamic_timeout,
+)
+
+#: The wall boostgauge #1 died against, four times, reading "timed out after 602s".
+OLD_CEILING_SECONDS = 600
+
+#: How long the synthetic call generates for. Comfortably past the old ceiling.
+LONG_CALL_SECONDS = 660
+
+_STREAMER = (
+    "import sys, time\n"
+    "deadline = time.monotonic() + float(sys.argv[1])\n"
+    "i = 0\n"
+    "while time.monotonic() < deadline:\n"
+    "    print('{\"type\": \"stream_event\", \"i\": %d}' % i, flush=True)\n"
+    "    i += 1\n"
+    "    time.sleep(0.65)\n"  # the measured median gap from a real generation
+    "print('{\"type\": \"result\", \"result\": \"generated\", \"usage\": {}}', flush=True)\n"
+)
+
+_SILENT = "import time, sys; time.sleep(float(sys.argv[1]))"
+
+
+def _spawn(script: str, *args: str) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-u", "-c", script, *args],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+def _row(name: str, passed: bool, detail: str) -> bool:
+    print(f"  {'PASS' if passed else 'FAIL'}  {name}")
+    print(f"        {detail}")
+    return passed
+
+
+def main() -> int:
+    ceiling = compute_dynamic_timeout("x" * 2500)
+    print()
+    print(f"Effective ceiling for a 2.5 KB prompt : {ceiling}s")
+    print(f"Idle threshold                        : {IDLE_TIMEOUT_SECONDS}s")
+    print(f"The wall this replaces                : {OLD_CEILING_SECONDS}s")
+    print()
+
+    results = []
+
+    # --- half one -----------------------------------------------------------
+    print(f"[1/2] Streaming for {LONG_CALL_SECONDS}s, past the old {OLD_CEILING_SECONDS}s wall.")
+    print("      Under the old transport this call died. It should now finish.")
+    proc = _spawn(_STREAMER, str(LONG_CALL_SECONDS))
+    started = time.monotonic()
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=IDLE_TIMEOUT_SECONDS, wall_timeout=ceiling
+    )
+    elapsed = time.monotonic() - started
+    results.append(
+        _row(
+            "a call still generating past 600s completes",
+            (not outcome.timed_out)
+            and outcome.returncode == 0
+            and elapsed > OLD_CEILING_SECONDS,
+            f"ran {elapsed:.1f}s, {outcome.total_events} events, "
+            f"rc={outcome.returncode}, timeout_kind={outcome.timeout_kind or 'none'}",
+        )
+    )
+
+    # --- half two -----------------------------------------------------------
+    idle = 10  # scaled so the proof does not take another two minutes
+    print()
+    print(f"[2/2] A call producing nothing, idle threshold {idle}s, backstop {ceiling}s.")
+    print("      It must die at the threshold, not wait out the backstop.")
+    proc = _spawn(_SILENT, str(ceiling + 120))
+    started = time.monotonic()
+    outcome = _stream_with_idle_timeout(
+        proc, content="", idle_timeout=idle, wall_timeout=ceiling
+    )
+    elapsed = time.monotonic() - started
+    results.append(
+        _row(
+            "a hung call is killed at the idle threshold",
+            outcome.timed_out
+            and outcome.timeout_kind == "idle"
+            and elapsed < idle + 10,
+            f"killed after {elapsed:.1f}s (threshold {idle}s), "
+            f"silent {outcome.silent_seconds:.1f}s, kind={outcome.timeout_kind}",
+        )
+    )
+
+    print()
+    passed = all(results)
+    print("RESULT:", "both halves pass" if passed else "FAILED")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/prove_idle_timeout.py
+++ b/tools/prove_idle_timeout.py
@@ -54,6 +54,8 @@ _SILENT = "import time, sys; time.sleep(float(sys.argv[1]))"
 
 
 def _spawn(script: str, *args: str) -> subprocess.Popen:
+    # start_new_session: off Windows, kill_process_tree signals the process
+    # GROUP, and a child without its own session shares this script's group.
     return subprocess.Popen(
         [sys.executable, "-u", "-c", script, *args],
         stdin=subprocess.PIPE,
@@ -61,6 +63,7 @@ def _spawn(script: str, *args: str) -> subprocess.Popen:
         stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
+        start_new_session=sys.platform != "win32",
     )
 
 


### PR DESCRIPTION
Closes #2405

boostgauge #1's implementation fix loop died five times against a wall-clock ceiling. This replaces that ceiling with an idle timeout, so a call is killed for going quiet rather than for taking long, and teaches the storm detector to tell a dead provider from our own limit saturating.

## What the run log actually said, and what it overturns

Everything here is counted from `boostgauge/data/speedrun/runs/run-issue1-090001.log`. Three readings on the issue did not survive it, and the corrections are posted there in full.

**The dying call site was never bypassing the timeout computation.** The fix loop calls `call_claude_for_file` (orchestrator.py:126), which computes `compute_dynamic_timeout(prompt)` and passes it through. With the API blocked by default, `get_provider` returns a bare `ClaudeCLIProvider`, so no `FallbackProvider` clamp sits in between. The value computed is the value enforced.

**The error read 602s, not 600s.** Eight of the eleven timeout strings say 602. That two-second increment is the scaling working, and it pins the prompt to 2000-2999 characters: `600 + len(prompt) // 1000 == 602`. So the prompt was about 2.5 KB, not under a kilobyte.

**The scaling was decorative, which is the real defect.** One second per 1000 characters bought that 2.5 KB prompt two seconds. Reaching the 1200 cap from a 600 floor needed a 600,000-character prompt. `FILE_TIMEOUT_CAP` had therefore never bound anything in the life of the function, and the floor had silently been the entire timeout since #373 introduced the scaling.

**The distribution does not straddle the cap; it is bimodal with a hole.** Every Claude call in the run, by duration:

| Outcome | Durations (s) |
|---|---|
| claude success | 6.3, 7.8, 8.5, 9.1, 9.6, 9.8, 15.9, 16.9, 22.7, 31.6 |
| claude timeout | 600.2, 602.2, 602.2, 602.2, 602.3 |
| gemini success | 153.0, 408.2 |

Nothing completed between 31.6s and 600.2s. The 408.2s call cited on the issue as a near-miss of the same class is gemini-3.1-pro-high, a different provider on a different path, and the roughly 580s figure was inferred from file mtimes rather than read from a log line.

This matters for what layer 2 can claim. We have no measurement of these generations' natural duration, only that they had not finished at 602s. Raising the ceiling is cheap and worth doing, but it is a bet that the true duration falls in the 602-1200 window. The idle timeout is what actually settles it, because it observes whether tokens are still arriving.

**The storm classification was refuted in-band, with no probe needed.** The call immediately after the `3 consecutive - PROVIDER STORM` declaration succeeded in 16.9s, logged as `[SUCCESS] Retry 2 succeeded`, with ten Claude calls completing in 6.3-31.6s through the same window. The separate 5.867s probe agrees and remains the right template, but the run's own log already contained the refutation.

## The four layers

**1. Ceiling raised, and made a variable rather than a constant.** `FILE_TIMEOUT_FLOOR` moves from 600 to 1200, overridable by `AZ_FILE_TIMEOUT_FLOOR` and `AZ_FILE_TIMEOUT_CAP`. A bad value falls back to the default with a printed note instead of failing the call, because an operator reaching for this is unblocking a stalled run and a typo must not convert a slow call into a dead one. A cap below the floor does not silently undo a floor override.

**2. The wall-clock ceiling is replaced by an idle timeout.** The transport now runs `claude -p --output-format stream-json --verbose --include-partial-messages` and reads NDJSON events off stdout, killing the process tree when it has produced nothing for 120s (`AZ_LLM_IDLE_TIMEOUT`). A call emitting tokens is alive by definition, so elapsed time stops being the question. The caller's `timeout_seconds` survives only as an outer backstop against a process that streams forever, and hitting it now reports itself as a ceiling problem rather than a provider failure.

Measured on 2026-08-15, deltas arrive every 0.28-0.86s with a ~0.65s median across a 150-line generation, so the 120s threshold sits roughly 180 missed events above normal inter-event silence.

**3. The storm detector fires one probe before declaring a storm.** A trivial call, seconds, against a branch that otherwise halts the roll for 15 minutes or more. Probe answers, the timeouts are our own ceiling saturating and the counter clears so the launcher does not halt. Probe fails, it is a genuine storm and the existing path is unchanged. A probe that raises counts as a failed probe: if we cannot reach the provider to ask, we are not entitled to overturn the reading.

**4. A wall-clock backstop no longer feeds the storm counter.** A call killed while still producing output says nothing about provider health, so only silence counts toward a storm.

## Proof, measured

Both halves are required. A mechanism that never kills anything passes the first trivially and is worthless; one that kills a live call passes the second and is worse than the wall it replaced. `tools/prove_idle_timeout.py` runs them at real durations:

| Half | Result | Measured |
|---|---|---|
| a call still generating past the old 600s wall completes | PASS | ran 660.6s, 1016 events, rc=0, no timeout fired |
| a hung call is killed at the idle threshold | PASS | killed at 10.2s against a 10s threshold, silent 10.0s, kind=idle, backstop was 1200s |

The first half is the case that died five times in boostgauge #1's run. The second is what stops the fix from being a licence to hang forever.

The storm probe was also run against the live CLI rather than only an injected fake: `_probe_alive()` returned True in 3.971s, and `_classify_storm` produced `TIMEOUT CEILING` in 4.150s and cleared the counter so the launcher does not halt. That is the same shape as the 5.867s probe recorded on the issue.

A format switch that mocks and a synthetic streamer both accept could still be wrong against the real CLI, so the whole path was run end to end:

| Real call through the new transport | Result |
|---|---|
| plain generation | success in 5.53s, correct fenced code block |
| usage and cost extraction | input=3, output=21, cost=$0.026676 |
| structured output via `--json-schema` | `{"verdict": "APPROVED"}` in 6.01s |

Those three come off the final `result` event, which carries the same keys the old buffered `--output-format json` dict did. That is why the downstream parse is untouched.

The unit suite covers the mechanism at seconds rather than minutes so it stays fast, including the case where a call produces output and then goes quiet.

## Two couplings found while landing this

**`analyze_requirements._is_timeout` classifies timeouts by matching the literal string "timed out"** in the error message, because the provider returns a result object rather than raising. Rewording the message would have silently stopped timeouts being recognised as timeouts. Both new messages keep the substring, and a test now asserts the coupling from both sides.

**`--include-partial-messages` is load-bearing in a way that fails silently.** Without it the CLI still emits stream-json, but the `assistant` event does not arrive until the message is complete, so a long generation would look like total silence and the idle timeout would kill exactly the live calls it exists to protect. That is a worse failure than the wall it replaces, and an invisible one, since short calls would still work. A test pins the flag.

## A third coupling, found by CI, and it was a live defect

`kill_process_tree` does `os.killpg(os.getpgid(pid), 9)` off Windows. The Popen in `ClaudeCLIProvider` set `CREATE_NEW_PROCESS_GROUP` only on Windows, so off Windows the child inherited the caller's process group and a tree-kill sent SIGKILL to AssemblyZero itself along with the child.

Windows hid this completely, because that path shells out to `taskkill /F /T /PID`, which is scoped to a single tree. The full suite passed locally throughout, on Windows, while Linux CI hung for twenty minutes against a three-and-a-half minute baseline: the first test that let a real idle timeout fire against a real subprocess was killing the test runner's own process group.

The defect predates this branch. What changes it from latent to reachable is the idle timeout itself, which fires on hangs rather than only on very long calls. Both Popen sites now pass `start_new_session` off Windows, as do the test and proof spawners, and a test asserts the flag.

Worth stating plainly: this was invisible to every check that ran before CI, including a green 7809-test local suite, because the platform that hides it is the platform the fleet develops on.

## Known risk

The transport now depends on `--include-partial-messages`, verified against claude CLI 2.1.233. If a future CLI drops the flag, calls fail loudly and immediately with the CLI's own error text rather than degrading silently, but they do fail. No fallback path is built; this is stated rather than hidden.

## Scope left out

The second Claude CLI transport at `assemblyzero/core/claude_client.py:103` still kills on wall-clock. Nothing outside tests imports it, so it is not on this path, and widening this PR to a transport nothing calls would have delayed a fix that is blocking a run. Tracked in #2406, which asks whether it is dead or live before converging or deleting it.
