### PR TITLE
fix: root call ownership in every foreign import, not just framework params (Closes #2411)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -166,7 +166,9 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
 
     # Check 7: Spec must not call methods absent from target repo (Issue #1527)
     gathered_symbols: list[str] = state.get("gathered_symbols", [])  # type: ignore[assignment]
-    check_symbols = check_api_symbols_exist(spec_draft, gathered_symbols)
+    check_symbols = check_api_symbols_exist(
+        spec_draft, gathered_symbols, repo_root_str
+    )
     checks.append(check_symbols)
     _log_check(check_symbols)
 
@@ -316,7 +318,11 @@ def _record_hallucination_telemetry(
                 skipped=True,
             )
         else:
-            flagged = detect_unknown_method_calls(text, symbol_set)
+            # #2411: the same repo root the gate uses. The docstring's promise
+            # that both consumers "measure with the identical yardstick" stops
+            # being true the moment one of them can tell first-party from
+            # foreign and the other cannot.
+            flagged = detect_unknown_method_calls(text, symbol_set, repo)
             event = build_hallucination_event(
                 repo=repo,
                 issue=issue,
@@ -1592,11 +1598,21 @@ def _scan_fences(text: str) -> _ScanResult:
 def _flag_calls(
     facts: list[_FenceFacts],
     symbol_set: set[str],
+    first_party_tops: frozenset[str] = frozenset(),
 ) -> dict[str, list[str]]:
     """Judge every collected call against the target repo's symbol table.
 
     Facts are pooled across ALL fences before anything is judged: a spec
     routinely shows its imports in one snippet and the usage in another.
+
+    Args:
+        facts: Pooled per-fence facts from :func:`_scan_fences`.
+        symbol_set: Identifier names gathered from the target repo.
+        first_party_tops: Top-level package names the target repo itself owns
+            (#2411). A chain rooted in one of these is the repo's to be right
+            or wrong about; a chain rooted in any other imported name is not.
+            Empty means "cannot tell", which deliberately treats every imported
+            root as foreign — see the note on the foreign-root set below.
     """
     # #1948: three universes the target repo's symbol table has no authority
     # over — the phase-5 kill was this check rejecting Pillow's documented API
@@ -1605,14 +1621,48 @@ def _flag_calls(
     # #2391 adds the fourth: parameters a framework injects. `parser` inside
     # `def pytest_addoption(parser)` is pytest's object, so `parser.addoption(`
     # is pytest's API to be right or wrong about — not the target repo's.
-    exempt: set[str] = set(_STDLIB_MODULE_NAMES)
+    exempt: set[str] = set(_STDLIB_MODULE_NAMES) - first_party_tops
     spec_defined: set[str] = set()
     framework_roots: set[str] = set()
+    imported_roots: set[str] = set()
     for fence in facts:
-        exempt |= fence.imported
+        # #2411: `- first_party_tops` is the same discrimination the root test
+        # below makes, applied one level up. The blanket import exemption was
+        # written for #1948's third-party universes; it was never meant to
+        # exempt the target repo's OWN package, and doing so blinded the check
+        # to `import gauge; gauge.no_such_marker()` — a one-hop first-party
+        # chain, which is the founding true positive of #1527 wearing an import.
+        exempt |= fence.imported - first_party_tops
         exempt |= fence.framework_params
         framework_roots |= fence.framework_params
+        imported_roots |= fence.imported
         spec_defined |= fence.defined
+
+    # #2411: the fifth kill of this class, and the first that was not positional.
+    # `@pytest.mark.parametrize(...)` flagged `parametrize` because ownership was
+    # only ever rooted for framework-INJECTED PARAMETERS. `_receiver_key` returns
+    # the last attribute by design, so a two-hop chain keys on `mark`, which is
+    # exempt in nobody's book, while the root `pytest` sits in `exempt` as an
+    # import and was never consulted. Any call rooted in an imported name and
+    # reached through more than one hop fell through to the symbol test.
+    #
+    # It was never about decorators: measured 16 of 16 AST positions collecting
+    # the call and 16 of 16 flagging it. One hop had always cleared because the
+    # receiver IS the import (`pytest.raises`), and the obvious stdlib instance
+    # `os.path.join` was masked only by `join` sitting in the allowlist.
+    #
+    # The line 1717 objection below stands and is why this is not simply
+    # `call.root in exempt`: a chain rooted in the target repo's OWN package is
+    # the one case where its symbol table has authority, so first-party roots
+    # stay judged and `boostgauge.gauge.nonexistent()` remains a true positive.
+    #
+    # An empty `first_party_tops` means the caller could not tell us (the #1812
+    # telemetry consumer has no repo root). That treats every imported root as
+    # foreign, which fails OPEN — the direction this class's governing principle
+    # has ruled correct four times: unresolved is not hallucinated.
+    foreign_roots: set[str] = set(framework_roots)
+    foreign_roots |= imported_roots - first_party_tops
+    foreign_roots |= set(_STDLIB_MODULE_NAMES) - first_party_tops
 
     # Exemption propagates through bindings to a fixed point rather than the
     # single level the old regex managed: `self.root = tk.Tk()` exempts `root`,
@@ -1712,13 +1762,18 @@ def _flag_calls(
             # exemption holds `request`. pytest owns `request.config` exactly as
             # it owns `request`, and it owns everything further down that chain.
             #
-            # Deliberately keyed on framework roots ONLY, not the full `exempt`
-            # set. Rooting the test in `exempt` would also clear
-            # `boostgauge.gauge.nonexistent()` whenever the target repo's own
-            # package is imported in a fence — a real false-clearance surface,
-            # since a first-party import is the one case where the target
-            # repo's symbol table DOES have authority.
-            if call.root is not None and call.root in framework_roots:
+            # Deliberately NOT the full `exempt` set. Rooting the test in
+            # `exempt` would also clear `boostgauge.gauge.nonexistent()`
+            # whenever the target repo's own package is imported in a fence — a
+            # real false-clearance surface, since a first-party import is the
+            # one case where the target repo's symbol table DOES have authority.
+            #
+            # #2411 widened this from framework parameters to every FOREIGN
+            # root: framework injections, plus imported names the target repo
+            # does not own, plus stdlib. First-party roots are excluded from the
+            # set above, so the false-clearance surface this comment names stays
+            # closed while `pytest.mark.parametrize` clears.
+            if call.root is not None and call.root in foreign_roots:
                 continue
             # #2399: the receiver holds a value of unknown type. Unresolved is a
             # distinct, honest category from wrong, and only wrong is a finding.
@@ -1737,6 +1792,7 @@ def _flag_calls(
 def detect_unknown_method_calls(
     text: str,
     symbol_set: set[str],
+    repo_root_str: str = "",
 ) -> dict[str, list[str]]:
     """Scan code fences in ``text`` for method calls absent from ``symbol_set``.
 
@@ -1748,17 +1804,38 @@ def detect_unknown_method_calls(
     Args:
         text: Markdown to scan. Only content inside ``` fences is examined.
         symbol_set: Real symbol names extracted from the target repo.
+        repo_root_str: Target repo root, used to tell the repo's own packages
+            from foreign ones (#2411). Optional because the telemetry consumer
+            has no repo root; omitting it treats every imported root as foreign,
+            which fails open rather than manufacturing findings.
 
     Returns:
         Mapping of unknown method name -> truncated example call sites.
         Empty when every call resolves to a known or allowlisted symbol.
     """
-    return _flag_calls(_scan_fences(text).facts, symbol_set)
+    return _flag_calls(
+        _scan_fences(text).facts, symbol_set, _first_party_tops_for(repo_root_str)
+    )
+
+
+def _first_party_tops_for(repo_root_str: str) -> frozenset[str]:
+    """First-party package names for a repo root string, empty when unknown.
+
+    Never raises: a symbol check must not fail because a path was unreadable,
+    and an empty answer is the fail-open direction (#2411).
+    """
+    if not repo_root_str:
+        return frozenset()
+    try:
+        return frozenset(_first_party_tops(Path(repo_root_str)))
+    except OSError:
+        return frozenset()
 
 
 def check_api_symbols_exist(
     spec: str,
     gathered_symbols: list[str],
+    repo_root_str: str = "",
 ) -> CompletenessCheck:
     """Spec must not call methods absent from the target project's gathered symbols.
 
@@ -1786,6 +1863,9 @@ def check_api_symbols_exist(
         spec: Implementation Spec markdown content.
         gathered_symbols: Sorted list of identifier names extracted by N1 from
             the target repo's gathered .py files.
+        repo_root_str: Target repo root. Used to tell the repo's own top-level
+            packages from foreign ones, so a chain rooted in an import the repo
+            does not own is not judged against the repo's symbols (#2411).
 
     Returns:
         CompletenessCheck with pass/fail result and details.
@@ -1828,7 +1908,9 @@ def check_api_symbols_exist(
             ),
         )
 
-    flagged = _flag_calls(scan.facts, symbol_set)
+    flagged = _flag_calls(
+        scan.facts, symbol_set, _first_party_tops_for(repo_root_str)
+    )
 
     # #1870's honesty rule applied to the scan itself: say what was NOT read,
     # so "checked" never overstates what was verified.

--- a/tests/fixtures/reviewer_idioms/framework_idioms.py
+++ b/tests/fixtures/reviewer_idioms/framework_idioms.py
@@ -142,4 +142,103 @@ FRAMEWORK_IDIOMS: list[tuple[str, str, str]] = [
         'def pytest_configure(config):\n'
         '    config.addinivalue_line("markers", "visual: visual regression")\n',
     ),
+
+    # ---- STANDARD, seeded rather than harvested (#2411) -------------------
+    #
+    # Harvesting from readiness verdicts has a structural blind spot: an idiom
+    # too standard for any reviewer to bother demanding never appears in a
+    # verdict, so it never enters this corpus, so nothing covers it, so it kills
+    # a roll. `@pytest.mark.parametrize` did exactly that, on the fifth kill of
+    # the receiver-resolution class. These entries are seeded from pytest's
+    # documented surface independent of the harvest, and the parametrize shape
+    # is carried in BOTH decorator and expression position, because the defect
+    # turned out to be about attribute-chain depth rather than AST position.
+    (
+        "pytest.mark.parametrize, decorator position",
+        "STANDARD — the #2411 kill. run-issue1-114223 flagged `parametrize`, "
+        'exemplar `@pytest.mark.parametrize("value,expected_angle", '
+        "[(0, 225.0), (50, 90.0), (100, ...`. Two hops from an imported root.",
+        'import pytest\n'
+        '\n'
+        '@pytest.mark.parametrize("value,expected_angle", [(0, 225.0), (50, 90.0)])\n'
+        'def test_val_to_angle(value, expected_angle):\n'
+        '    assert value >= 0\n',
+    ),
+    (
+        "pytest.mark.parametrize, expression position",
+        "STANDARD — the same chain outside a decorator. Proves the exemption "
+        "is about provenance, not position.",
+        'import pytest\n'
+        '\n'
+        'def test_builds_marks():\n'
+        '    marker = pytest.mark.parametrize("value", [1, 2])\n'
+        '    return marker\n',
+    ),
+    (
+        "pytest.mark custom marker chains",
+        "STANDARD — `@pytest.mark.<anything>` is open-ended by design; a "
+        "marker name is never a repo symbol and can be arbitrary.",
+        'import pytest\n'
+        '\n'
+        '@pytest.mark.slow\n'
+        '@pytest.mark.visual\n'
+        '@pytest.mark.usefixtures("tmp_path")\n'
+        'def test_marked():\n'
+        '    pass\n',
+    ),
+    (
+        "pytest.fixture, bare and parameterised",
+        "STANDARD — one hop, so it already cleared; carried so that a future "
+        "refactor cannot lose it silently.",
+        'import pytest\n'
+        '\n'
+        '@pytest.fixture\n'
+        'def plain():\n'
+        '    return 1\n'
+        '\n'
+        '@pytest.fixture(scope="module", params=[1, 2])\n'
+        'def parameterised(request):\n'
+        '    return request.param\n',
+    ),
+    (
+        "pytest.raises / warns / approx",
+        "STANDARD — the assertion surface essentially every test file uses.",
+        'import pytest\n'
+        '\n'
+        'def test_assertions():\n'
+        '    with pytest.raises(ValueError):\n'
+        '        raise ValueError("x")\n'
+        '    with pytest.warns(UserWarning):\n'
+        '        pass\n'
+        '    assert 0.1 + 0.2 == pytest.approx(0.3)\n',
+    ),
+    (
+        "pytest.mark.skip / skipif / xfail",
+        "STANDARD — two hops from an imported root, the #2411 shape exactly.",
+        'import sys\n'
+        'import pytest\n'
+        '\n'
+        '@pytest.mark.skip(reason="not ready")\n'
+        'def test_skipped():\n'
+        '    pass\n'
+        '\n'
+        '@pytest.mark.skipif(sys.platform == "win32", reason="posix only")\n'
+        'def test_conditional():\n'
+        '    pass\n'
+        '\n'
+        '@pytest.mark.xfail(strict=True)\n'
+        'def test_expected_failure():\n'
+        '    pass\n',
+    ),
+    (
+        "pytest.skip / xfail / fail called in a body",
+        "STANDARD — the imperative forms, one hop, expression position.",
+        'import pytest\n'
+        '\n'
+        'def test_imperative(flag):\n'
+        '    if flag:\n'
+        '        pytest.skip("nope")\n'
+        '        pytest.xfail("known")\n'
+        '        pytest.fail("boom")\n',
+    ),
 ]

--- a/tests/unit/test_call_provenance_positions.py
+++ b/tests/unit/test_call_provenance_positions.py
@@ -1,0 +1,234 @@
+"""The provenance rule must run in every AST position a Call can occupy (#2411).
+
+Five kills of one class, four fixes each narrower than the class. #2411 was
+filed on the hypothesis that the one-rule refactor had an unswept AST position,
+decorators, because the checker's source contains no occurrence of the word.
+
+Measurement refuted that. `ast.walk` reaches `decorator_list` without anyone
+naming decorators, and the sweep below found the call collected and judged
+identically in 16 of 16 positions. The traversal was complete; the RULE was
+incomplete.
+
+What the rule was missing: ownership was rooted only for framework-INJECTED
+PARAMETERS. `_receiver_key` returns the last attribute by design, so
+`pytest.mark.parametrize(...)` keys on `mark`, which is exempt in nobody's
+book, while the root `pytest` sat in `exempt` as an import and was never
+consulted. Any call rooted in an imported name and reached through more than
+one hop fell through to the symbol test.
+
+One hop had always cleared, because the receiver IS the import
+(`pytest.raises`). The obvious stdlib instance, `os.path.join`, was masked by
+`join` sitting in the allowlist. `parametrize` appears to be the first
+non-allowlisted method behind a multi-hop foreign root that a draft produced.
+
+This file exists so the sixth costume is found here rather than by a roll.
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    _scan_fences,
+    detect_unknown_method_calls,
+)
+
+REPO_SYMBOLS = {"Gauge", "GaugeWindow", "render", "load_config"}
+
+
+@pytest.fixture(scope="module")
+def first_party_repo() -> str:
+    """A target repo that genuinely owns a top-level package named `gauge`.
+
+    First-party detection reads the filesystem, so a true positive rooted in the
+    repo's own package cannot be asserted against a path that does not exist.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "gauge").mkdir()
+    (tmp / "gauge" / "__init__.py").write_text("")
+    return str(tmp)
+
+
+def fence(body: str, preamble: str = "import pytest\n\n") -> str:
+    return "```python\n" + preamble + body.strip() + "\n```\n"
+
+
+#: The same foreign-rooted two-hop chain in every position a Call can occupy.
+#: Identical payload throughout, so any difference in verdict is attributable
+#: to position alone.
+CALL_POSITIONS: dict[str, str] = {
+    "expression statement": "pytest.mark.parametrize('a', [1])",
+    "assignment RHS": "m = pytest.mark.parametrize('a', [1])",
+    "decorator": "@pytest.mark.parametrize('a', [1])\ndef t(a): pass",
+    "default argument": "def f(x=pytest.mark.parametrize('a', [1])): pass",
+    "comprehension": "ys = [pytest.mark.parametrize('a', [i]) for i in range(3)]",
+    "lambda body": "f = lambda: pytest.mark.parametrize('a', [1])",
+    "nested call argument": "print(pytest.mark.parametrize('a', [1]))",
+    "return value": "def f():\n    return pytest.mark.parametrize('a', [1])",
+    "with statement": "with pytest.mark.parametrize('a', [1]):\n    pass",
+    "conditional test": "if pytest.mark.parametrize('a', [1]):\n    pass",
+    "f-string": "s = f'{pytest.mark.parametrize(\"a\", [1])}'",
+    "class body": "class C:\n    x = pytest.mark.parametrize('a', [1])",
+    "try body": "try:\n    pytest.mark.parametrize('a', [1])\nexcept Exception:\n    pass",
+    "augmented assign": "acc = 0\nacc += pytest.mark.parametrize('a', [1])",
+    "keyword argument": "print(x=pytest.mark.parametrize('a', [1]))",
+    "chained on a call": "pytest.mark.parametrize('a', [1]).twice()",
+}
+
+
+class TestEveryPositionIsReached:
+    """The rule runs everywhere a Call can appear, and answers the same."""
+
+    @pytest.mark.parametrize("position", sorted(CALL_POSITIONS))
+    def test_the_call_is_collected(self, position: str):
+        """A position that collects no call cannot be judged at all.
+
+        This is the failure the issue hypothesised. It does not occur, but a
+        future change to the visitor could introduce it silently, and a rule
+        that never runs looks exactly like a rule that passes.
+        """
+        scan = _scan_fences(fence(CALL_POSITIONS[position]))
+        assert not scan.failures, f"fence did not parse: {scan.failures}"
+        calls = [c for f in scan.facts for c in f.calls]
+        assert calls, f"no call collected in {position}"
+        assert any(c.method == "parametrize" for c in calls)
+
+    @pytest.mark.parametrize("position", sorted(CALL_POSITIONS))
+    def test_a_foreign_rooted_chain_clears(self, position: str):
+        """`pytest` is imported, so nothing down that chain is the repo's."""
+        flagged = detect_unknown_method_calls(
+            fence(CALL_POSITIONS[position]), REPO_SYMBOLS
+        )
+        assert not flagged, f"{position} flagged {sorted(flagged)}"
+
+    @pytest.mark.parametrize("position", sorted(CALL_POSITIONS))
+    def test_the_root_is_what_carries_ownership(self, position: str):
+        """Receiver keys on the last attribute; the root is the deciding fact.
+
+        Pinned because the whole defect was a rule that consulted the receiver
+        where it needed the root.
+        """
+        scan = _scan_fences(fence(CALL_POSITIONS[position]))
+        call = next(
+            c for f in scan.facts for c in f.calls if c.method == "parametrize"
+        )
+        assert call.receiver == "mark"
+        assert call.root == "pytest"
+
+
+class TestTruePositivesSurviveInEveryPosition:
+    """The check must not go blind in the positions it was just taught."""
+
+    @pytest.mark.parametrize(
+        "position",
+        ["expression statement", "assignment RHS", "decorator", "return value"],
+    )
+    def test_a_first_party_chain_is_still_judged(
+        self, position: str, first_party_repo: str
+    ):
+        """Rooted in the repo's OWN package, so its symbol table has authority.
+
+        This is the false-clearance surface the pre-#2411 comment protected by
+        keying only on framework roots. Widening to foreign roots keeps it
+        closed, because first-party tops are excluded from that set.
+        """
+        body = CALL_POSITIONS[position].replace(
+            "pytest.mark.parametrize('a', [1])", "gauge.sub.no_such_call()"
+        )
+        flagged = detect_unknown_method_calls(
+            fence(body, preamble="import gauge\n\n"),
+            REPO_SYMBOLS,
+            first_party_repo,
+        )
+        assert "no_such_call" in flagged, f"{position} went blind"
+
+    def test_a_one_hop_first_party_call_is_judged(self, first_party_repo: str):
+        """`import gauge; gauge.no_such_marker()` is #1527 wearing an import.
+
+        The blanket import exemption written for #1948's third-party universes
+        was never meant to cover the target repo's own package, and covering it
+        blinded the check to this shape.
+        """
+        flagged = detect_unknown_method_calls(
+            fence(
+                "@gauge.no_such_marker()\ndef t(): pass",
+                preamble="import gauge\n\n",
+            ),
+            REPO_SYMBOLS,
+            first_party_repo,
+        )
+        assert "no_such_marker" in flagged
+
+    def test_the_founding_true_positive_still_fires(self, first_party_repo: str):
+        """#1527: a gathered class's instance calling a method it lacks."""
+        flagged = detect_unknown_method_calls(
+            fence(
+                "def t():\n    g = GaugeWindow()\n    g.model_dump()",
+                preamble="",
+            ),
+            REPO_SYMBOLS,
+            first_party_repo,
+        )
+        assert "model_dump" in flagged
+
+
+class TestTheFailOpenDirection:
+    """Without a repo root the checker cannot tell first-party from foreign."""
+
+    def test_an_unknown_repo_treats_imported_roots_as_foreign(self):
+        """Unresolved is not hallucinated, ruled correct four times.
+
+        The #1812 telemetry consumer used to call the shared core with no repo
+        root. Failing closed there would manufacture findings on every spec that
+        imports anything.
+        """
+        flagged = detect_unknown_method_calls(
+            fence("@pytest.mark.parametrize('a', [1])\ndef t(a): pass"),
+            REPO_SYMBOLS,
+            "",
+        )
+        assert not flagged
+
+    def test_but_a_gathered_constructor_is_still_judged(self):
+        """Failing open on IMPORTS does not surrender jurisdiction generally."""
+        flagged = detect_unknown_method_calls(
+            fence("def t():\n    g = GaugeWindow()\n    g.model_dump()", preamble=""),
+            REPO_SYMBOLS,
+            "",
+        )
+        assert "model_dump" in flagged
+
+    def test_a_missing_repo_path_does_not_raise(self):
+        """A symbol check must not fail because a path was unreadable."""
+        flagged = detect_unknown_method_calls(
+            fence("@pytest.mark.parametrize('a', [1])\ndef t(a): pass"),
+            REPO_SYMBOLS,
+            r"C:\no\such\directory\anywhere",
+        )
+        assert not flagged
+
+
+class TestTheMaskThatHidThisForFourFixes:
+    """Why a two-hop foreign chain never surfaced before `parametrize`."""
+
+    def test_one_hop_clears_because_the_receiver_is_the_import(self):
+        scan = _scan_fences(fence("def t():\n    pytest.raises(ValueError)"))
+        call = next(c for f in scan.facts for c in f.calls)
+        assert call.receiver == "pytest", "one hop keys on the import itself"
+        assert not detect_unknown_method_calls(
+            fence("def t():\n    pytest.raises(ValueError)"), REPO_SYMBOLS
+        )
+
+    def test_the_stdlib_instance_was_masked_by_the_allowlist(self):
+        """`os.path.join` is the same two-hop shape and always looked fine.
+
+        It cleared on `join` being allowlisted rather than on the rule working,
+        which is why the class survived four fixes. Asserted with a method that
+        is NOT allowlisted so the rule is what answers.
+        """
+        text = fence(
+            "def t():\n    os.path.nonexistent_thing()", preamble="import os\n\n"
+        )
+        assert not detect_unknown_method_calls(text, REPO_SYMBOLS)

--- a/tests/unit/test_framework_injected_receivers.py
+++ b/tests/unit/test_framework_injected_receivers.py
@@ -322,13 +322,24 @@ class TestTruePositivesSurvive:
         )
         assert "model_dump" in _flag(spec)
 
-    def test_chain_off_a_first_party_import_still_flagged(self):
-        """The reason the root rule is keyed on framework roots, not `exempt`.
+    def test_chain_off_a_first_party_import_still_flagged(self, tmp_path):
+        """The reason the root rule is not simply keyed on `exempt`.
 
         A first-party import is the one case where the target repo's symbol
         table DOES have authority. Rooting the exemption in the full exempt set
         would clear this, which is a real false-clearance surface.
+
+        #2411 widened the root rule from framework parameters to every FOREIGN
+        root, and this surface stays closed because first-party tops are
+        excluded from that set. That requires knowing which tops are
+        first-party, so the repo root is now supplied. Without it the checker
+        cannot tell `boostgauge` from `pytest`, and the honest answer to a
+        question it cannot answer is to fail open, which is asserted separately
+        in test_call_provenance_positions.py::TestTheFailOpenDirection.
         """
+        (tmp_path / "boostgauge").mkdir()
+        (tmp_path / "boostgauge" / "__init__.py").write_text("")
+
         spec = (
             "# S\n\n```python\n"
             "import boostgauge\n"
@@ -337,7 +348,10 @@ class TestTruePositivesSurvive:
             "    boostgauge.gauge.model_dump()\n"
             "```\n"
         )
-        assert "model_dump" in _flag(spec), _flag(spec)
+        flagged = detect_unknown_method_calls(
+            spec, set(TARGET_SYMBOLS), str(tmp_path)
+        )
+        assert "model_dump" in flagged, flagged
 
     def test_config_is_not_on_a_whitelist(self):
         """`config` is an ordinary attribute name and must stay judged.


### PR DESCRIPTION
Closes #2411

Fifth kill of the receiver-resolution class, and the first that was not positional. The issue ranked two hypotheses. Measurement refuted both, and the full findings are on the issue.

## What was measured

**Hypothesis 1, an unswept AST position: refuted.** The scanner collects the call from decorator position exactly as from expression position:

```
CALL method='parametrize' receiver='mark' root='pytest'
```

Sweeping the same foreign-rooted two-hop chain through every position a `Call` can occupy gave 16 of 16 collecting it and 16 of 16 flagging it, identically. `ast.walk` reaches `decorator_list` without anyone naming decorators, which is why grepping the checker for "decorator" returns nothing and proves nothing. The traversal was complete; the rule was incomplete.

**Hypothesis 2, symbol-table pollution: refuted.**

| Gathered symbols | Verdict |
|---|---|
| without `pytest` | FLAGGED `parametrize` |
| with `pytest` added | FLAGGED `parametrize` |
| with `parametrize` added | clean |

Adding `pytest` to the twenty-one changes nothing, because the root is never tested against the symbol table at all. The third acceptance leg is not needed as written.

**The actual mechanism.** Ownership was rooted only for framework-INJECTED PARAMETERS. `_receiver_key` returns the last attribute by design, so a two-hop chain keys on `mark`, which is exempt in nobody's book, while the root `pytest` sat in `exempt` as an import and was never consulted. Any call rooted in an imported name and reached through more than one hop fell straight through to the symbol test.

**Why four fixes missed it.** One hop clears because the receiver IS the import (`pytest.raises`, `@pytest.fixture`). The obvious stdlib instance is masked by coincidence: `os.path.join` is the identical two-hop shape and comes back clean only because `join` sits in `_API_SYMBOL_ALLOWLIST`. `parametrize` appears to be the first non-allowlisted method behind a multi-hop foreign root that a draft has produced.

## The fix

The root rule widens from framework parameters to every FOREIGN root: framework injections, imported names the target repo does not own, and stdlib.

The objection in the old comment stands and is why this is not simply `call.root in exempt`:

> Rooting the test in `exempt` would also clear `boostgauge.gauge.nonexistent()` whenever the target repo's own package is imported in a fence.

First-party tops are excluded from the foreign set, so that surface stays closed. `_first_party_tops` already existed in this file for the #1901 import check and is now wired to the call rule, with `repo_root` threaded through both consumers so the gate and the #1812 telemetry keep the identical yardstick they are documented to share.

The same discrimination is applied one level up, to the blanket import exemption. It was written for #1948's third-party universes and was never meant to cover the target repo's own package. Covering it blinded the check to `import gauge; gauge.no_such_marker()`, a one-hop first-party chain that is #1527's founding true positive wearing an import.

**Without a repo root** the checker cannot tell first-party from foreign, and treats every imported root as foreign. That fails OPEN, the direction this class's governing principle has ruled correct four times: unresolved is not hallucinated. One existing test asserted the first-party true positive through a helper that passed no repo root; it now supplies one, because asserting that the checker can identify first-party without being told the repo is asserting something false.

## Acceptance, measured

| Leg | Result | Evidence |
|---|---|---|
| the failing draft, unchanged, clears | PASS | boostgauge `1-implspec/2026-08-15T16-49-37Z/010-spec-draft.md`, 19274 chars, run through `check_api_symbols_exist` with boostgauge's real repo root: passed = True |
| a decorator on a genuinely absent repo-owned attribute still flags | PASS | `@gauge.no_such_marker()` with `gauge` first-party flags `no_such_marker` |
| the #1527 founding true positive still fires | PASS | `g = GaugeWindow(); g.model_dump()` flags |
| a first-party chain is judged in every position | PASS | expression, assignment, decorator, return |
| fail-open without a repo root | PASS | imported roots clear; a gathered constructor is still judged |

Leg 2 as written could not pass, for a reason unrelated to the bug. `@gauge.no_such_marker` with no parentheses is not a `Call` node, so the checker never sees it: it judges calls only, by design. The call form is pinned instead, and the non-call form is stated as out of scope rather than left to pass silently.

Unit suite 7869 passed, 0 failed.

## The corpus

Seeded with the standard pytest surface independent of the verdict harvest, in both decorator and expression position: `parametrize` in each, `mark` chains, `fixture` bare and parameterised, `raises`/`warns`/`approx`, `skip`/`skipif`/`xfail`, and the imperative `pytest.skip`/`xfail`/`fail`.

Harvesting from readiness verdicts has a structural blind spot: an idiom too standard for any reviewer to bother demanding never appears in a verdict, so it never enters the corpus, so nothing covers it. That is how `parametrize` reached a fifth kill uncovered.

## The sweep, kept

`tests/unit/test_call_provenance_positions.py` asserts the rule runs and answers correctly in all sixteen positions, that the root rather than the receiver carries ownership, that true positives survive in each, and that the allowlist mask on `os.path.join` is not what the stdlib case rests on. The sixth costume gets found there rather than by a roll.

## One finding worth carrying forward

`_first_party_tops` requires an `__init__.py`, and boostgauge's `src/boostgauge/` currently has none, so first-party detection returns empty for that repo today. The fix is unaffected for the unblock, which fails open, but the true-positive half of the protection does not currently apply there. Tracked separately in #2412 rather than widened into this PR, because loosening first-party detection also makes the #1901 import check stricter and that deserves its own risk assessment.
