### PR TITLE
fix: a launch refuses rather than resetting an in-flight issue (Closes #2409)

### DIFF
--- a/tests/unit/test_resume_versus_residue.py
+++ b/tests/unit/test_resume_versus_residue.py
@@ -1,0 +1,269 @@
+"""A launch must not destroy an in-flight issue's resume state (#2409).
+
+On 2026-08-15 the launcher's self-heal gate found three things for boostgauge
+#1 -- the open LLD PR the requirements workflow keeps open by design, that PR's
+branch, and an untracked LLD the halt path left behind -- classified all three
+as contamination, and reset the issue. That closed the PR, deleted the remote
+branch, deleted the lineage dirs, and removed the worktree holding checkpoint
+`d1e9269 [CP:post-impl]`.
+
+What it destroyed was a passed spec stage carrying five review iterations, impl
+iteration 0, and the #2383 resume seeds: roughly forty-five to sixty minutes of
+machine time, and a fresh spec redraw that then ran without its verdict history.
+The checkpoint survived only as an unreferenced object that nothing had
+garbage-collected yet.
+
+The same command had resumed the same issue two and a half hours earlier, so
+the gate was inconsistent on nearly identical state. The deciding delta was not
+the untracked artifact: it was whether `resume_plan` happened to return a stage,
+which routes to `ensure_base_for_resume` (verify, never reset) instead of
+`ensure_base` (self-heal, which reset).
+
+These tests pin the four rules the issue asks for.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_reset as reset  # noqa: E402
+import speedrun_roll as roll  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A git repo with one commit, on a branch named like a pipeline branch."""
+    r = tmp_path / "target"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "T")
+    (r / "README.md").write_text("x\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "initial")
+    return r
+
+
+def _checkpoint_on(repo: Path, branch: str, name: str = "post-impl") -> str:
+    """Put a real `[CP:*]` commit on `branch`, the way checkpoints.py does."""
+    _git(repo, "checkout", "-b", branch)
+    (repo / f"{branch}.py").write_text("work\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", f"[CP:{name}] issue #1: workflow checkpoint")
+    sha = _git(repo, "log", "-1", "--format=%h").stdout.strip()
+    _git(repo, "checkout", "main")
+    return sha
+
+
+class TestTheCheckpointIsWhatDecides:
+    """Rule 2: resume versus residue is decided by the checkpoint, not cosmetics."""
+
+    def test_a_checkpoint_is_found_on_the_impl_branch(self, repo: Path):
+        sha = _checkpoint_on(repo, "1-impl")
+        assert roll.find_checkpoint(repo, 1) == sha
+
+    def test_a_checkpoint_is_found_on_any_pipeline_branch(self, repo: Path):
+        sha = _checkpoint_on(repo, "1-spec", name="post-scaffold")
+        assert roll.find_checkpoint(repo, 1) == sha
+
+    def test_no_checkpoint_when_the_branch_carries_ordinary_commits(
+        self, repo: Path
+    ):
+        _git(repo, "checkout", "-b", "1-impl")
+        (repo / "a.py").write_text("x\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-m", "ordinary work, not a checkpoint")
+        _git(repo, "checkout", "main")
+        assert roll.find_checkpoint(repo, 1) is None
+
+    def test_another_issues_checkpoint_is_not_this_issues(self, repo: Path):
+        _checkpoint_on(repo, "41-impl")
+        assert roll.find_checkpoint(repo, 1) is None
+
+    def test_an_empty_repo_answers_none_rather_than_raising(self, repo: Path):
+        assert roll.find_checkpoint(repo, 1) is None
+
+
+class TestTheResetIsChosenNeverInferred:
+    """Rules 1 and 3, asserted at the decision point in ensure_base."""
+
+    @pytest.fixture
+    def gated(self, repo: Path, monkeypatch):
+        """A base that is structurally sound but has debris findings.
+
+        Stands in for 2026-08-15's three findings: an open LLD PR, its branch,
+        and an untracked LLD.
+        """
+        monkeypatch.setattr(roll, "resolve_attempt_branch", lambda r: "attempt-1")
+        monkeypatch.setattr(roll, "base_is_structurally_sound", lambda r, b: [])
+        monkeypatch.setattr(
+            roll.gate, "check_repo",
+            lambda r, issues, base: [
+                "remote branch: origin/1-lld",
+                "open PR: #301",
+                "untracked artifact: docs/lld/active/LLD-001.md",
+            ],
+        )
+        monkeypatch.setattr(roll, "record_heal", lambda *a, **k: None)
+        return repo
+
+    def test_a_checkpoint_preserves_the_work_and_rolls_on(
+        self, gated: Path, monkeypatch
+    ):
+        """The 2026-08-15 fixture: open PR, its branch, and a checkpoint.
+
+        Acceptance leg one, verbatim from the issue: resumes untouched.
+        """
+        _checkpoint_on(gated, "1-impl")
+        called: list[str] = []
+        monkeypatch.setattr(
+            roll.reset, "reset_one_issue",
+            lambda *a, **k: called.append("reset"),
+        )
+        log = _RecordingLog()
+
+        base = roll.ensure_base(gated, 1, log, fresh=False)
+
+        assert base == "attempt-1", "the roll must proceed on the existing base"
+        assert not called, "a checkpoint must never be reset away"
+        assert any("preserving, no reset" in line for line in log.lines)
+
+    def test_without_a_checkpoint_a_plain_launch_refuses(
+        self, gated: Path, monkeypatch
+    ):
+        """Acceptance leg two: refuses, with both exits named."""
+        called: list[str] = []
+        monkeypatch.setattr(
+            roll.reset, "reset_one_issue",
+            lambda *a, **k: called.append("reset"),
+        )
+        log = _RecordingLog()
+
+        base = roll.ensure_base(gated, 1, log, fresh=False)
+
+        assert base is None, "refusal must abort the roll, not proceed"
+        assert not called, "a plain launch must not reset"
+        joined = "\n".join(log.lines)
+        assert "REFUSING to reset" in joined
+        assert "repair the findings" in joined, "exit 1 must be named"
+        assert "--fresh" in joined, "exit 2 must be named"
+        for finding in ("origin/1-lld", "#301", "LLD-001.md"):
+            assert finding in joined, f"finding {finding} must be listed"
+
+    def test_fresh_performs_the_reset(self, gated: Path, monkeypatch):
+        """Acceptance leg three: the destructive path exists, behind the flag."""
+        called: list[str] = []
+        monkeypatch.setattr(
+            roll.reset, "reset_one_issue",
+            lambda *a, **k: called.append("reset"),
+        )
+        monkeypatch.setattr(roll.reset, "_gh_repo", lambda r: "owner/repo")
+        monkeypatch.setattr(
+            roll.gate, "check_repo", lambda r, issues, base: []
+        )
+        # check_repo is consulted twice: once for the findings, once after the
+        # reset. Return findings first, clean second.
+        findings = iter([
+            ["remote branch: origin/1-lld", "open PR: #301"],
+            [],
+        ])
+        monkeypatch.setattr(
+            roll.gate, "check_repo", lambda r, issues, base: next(findings)
+        )
+        log = _RecordingLog()
+
+        base = roll.ensure_base(gated, 1, log, fresh=True)
+
+        assert called == ["reset"], "--fresh must actually reset"
+        assert base == "attempt-1"
+
+    def test_fresh_resets_even_with_a_checkpoint(self, gated: Path, monkeypatch):
+        """The operator's explicit instruction outranks the checkpoint.
+
+        It is not ignored: the reset pins it to a rescue ref first.
+        """
+        _checkpoint_on(gated, "1-impl")
+        called: list[str] = []
+        monkeypatch.setattr(
+            roll.reset, "reset_one_issue",
+            lambda *a, **k: called.append("reset"),
+        )
+        monkeypatch.setattr(roll.reset, "_gh_repo", lambda r: "owner/repo")
+        findings = iter([["open PR: #301"], []])
+        monkeypatch.setattr(
+            roll.gate, "check_repo", lambda r, issues, base: next(findings)
+        )
+        log = _RecordingLog()
+
+        roll.ensure_base(gated, 1, log, fresh=True)
+
+        assert called == ["reset"]
+        assert any("will be pinned" in line for line in log.lines)
+
+
+class TestNothingIsDeletedThatCouldBeArchived:
+    """Rule 1: the remedy preserves, and it does so consistently."""
+
+    def test_a_checkpoint_is_pinned_before_the_branches_go(self, repo: Path):
+        """`d1e9269` survived by luck. This makes it survive by design."""
+        sha = _checkpoint_on(repo, "1-impl")
+
+        rescue = reset.pin_checkpoint(repo, 1)
+
+        assert rescue is not None
+        resolved = _git(repo, "rev-parse", "--short", rescue).stdout.strip()
+        assert resolved == sha
+
+        # The pin must outlive the branch deletion that follows it in
+        # reset_one_issue, which is the whole point of the ordering.
+        _git(repo, "branch", "-D", "1-impl")
+        still = _git(repo, "rev-parse", "--short", rescue).stdout.strip()
+        assert still == sha, "the checkpoint was orphaned despite the pin"
+
+    def test_pinning_is_a_no_op_without_a_checkpoint(self, repo: Path):
+        assert reset.pin_checkpoint(repo, 1) is None
+
+    def test_the_reset_leaves_no_artifact_behind(self, repo: Path):
+        """Acceptance leg four: every pre-reset artifact exists afterwards.
+
+        The 2026-08-15 remedy relocated the LLD while deleting the lineage,
+        which is two principles in one function.
+        """
+        lineage = repo / "docs" / "lineage" / "active" / "1-lld"
+        lineage.mkdir(parents=True)
+        (lineage / "verdict.md").write_text("five iterations\n", encoding="utf-8")
+        (lineage / "draft.md").write_text("spec draft\n", encoding="utf-8")
+
+        before = {p.name: p.read_text(encoding="utf-8")
+                  for p in lineage.rglob("*") if p.is_file()}
+
+        reset.archive_lineage_dirs(repo, 1)
+
+        holder = (
+            repo / "data" / "speedrun" / "reset-artifacts" / "issue-1"
+            / "lineage" / "1-lld"
+        )
+        after = {p.name: p.read_text(encoding="utf-8")
+                 for p in holder.rglob("*") if p.is_file()}
+        assert after == before, "the post-reset tree lost content"
+
+
+class _RecordingLog:
+    """Stand-in for EventLog that keeps what was written."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write(self, message: str) -> None:
+        self.lines.append(message)

--- a/tests/unit/test_speedrun_reset_readonly.py
+++ b/tests/unit/test_speedrun_reset_readonly.py
@@ -61,22 +61,59 @@ class TestClearingRmtree:
         assert not target.exists()
 
 
-class TestLineageDeletion:
+class TestLineageArchival:
+    """#2409 turned deletion into archival. The ReadOnly hazard #2162 found is
+    unchanged by that: a dir that would not delete will not move either."""
+
     def test_todays_incident_replayed(self, tmp_path, capsys):
-        """A ReadOnly lineage dir left by a prior attempt deletes cleanly,
+        """A ReadOnly lineage dir left by a prior attempt archives cleanly,
         with no WARNING line."""
         repo = _lineage_tree(tmp_path)
         target = repo / "docs" / "lineage" / "active" / "1-lld"
         _protect(target)
         _protect(target / "phase")
 
-        count = reset.delete_lineage_dirs(repo, 1)
+        count = reset.archive_lineage_dirs(repo, 1)
 
         out = capsys.readouterr().out
         assert count == 1
         assert not target.exists()
         assert "WARNING" not in out
-        assert "Deleted lineage dir" in out
+        assert "Archived lineage dir" in out
+
+    def test_the_content_survives_the_reset(self, tmp_path):
+        """The whole point of #2409: displaced, never destroyed.
+
+        The 2026-08-15 reset deleted a passed spec stage carrying five review
+        iterations, which the fresh redraw then paid for again without them.
+        """
+        repo = _lineage_tree(tmp_path)
+        target = repo / "docs" / "lineage" / "active" / "1-lld"
+        (target / "verdict.md").write_text("iteration 5 verdict\n", encoding="utf-8")
+
+        reset.archive_lineage_dirs(repo, 1)
+
+        archived = (
+            repo / "data" / "speedrun" / "reset-artifacts" / "issue-1"
+            / "lineage" / "1-lld" / "verdict.md"
+        )
+        assert archived.is_file(), "lineage content did not survive the reset"
+        assert archived.read_text(encoding="utf-8") == "iteration 5 verdict\n"
+
+    def test_a_second_reset_does_not_clobber_the_first(self, tmp_path):
+        """Two resets produce two archives, not one overwritten one."""
+        repo = _lineage_tree(tmp_path)
+        reset.archive_lineage_dirs(repo, 1)
+
+        again = repo / "docs" / "lineage" / "active" / "1-lld"
+        again.mkdir(parents=True)
+        (again / "second.md").write_text("second attempt\n", encoding="utf-8")
+        reset.archive_lineage_dirs(repo, 1)
+
+        holder = (
+            repo / "data" / "speedrun" / "reset-artifacts" / "issue-1" / "lineage"
+        )
+        assert len(list(holder.iterdir())) == 2
 
     def test_only_the_issues_dirs_are_touched(self, tmp_path):
         repo = _lineage_tree(tmp_path)
@@ -84,6 +121,6 @@ class TestLineageDeletion:
         other.mkdir()
         (other / "keep.md").write_text("other issue\n", encoding="utf-8")
 
-        reset.delete_lineage_dirs(repo, 1)
+        reset.archive_lineage_dirs(repo, 1)
 
-        assert other.exists(), "issue 41's lineage is not issue 1's to delete"
+        assert other.exists(), "issue 41's lineage is not issue 1's to archive"

--- a/tests/unit/test_speedrun_roll.py
+++ b/tests/unit/test_speedrun_roll.py
@@ -160,9 +160,12 @@ class TestEnsureBaseDecides:
         with _no_network():
             assert sr.ensure_base(repo, 4, log) == "hardening-run-11"
 
-    def test_recoverable_debris_is_self_healed_not_reported(self, repo, log):
+    def test_recoverable_debris_is_reset_under_fresh(self, repo, log):
         """The old wrapper printed 'run speedrun_reset.py, verify clean,
-        relaunch' and quit. That instruction is now a code path."""
+        relaunch' and quit. That instruction became a code path, and #2409
+        put it back behind a flag: the reset closes a PR, deletes a remote
+        branch and removes a worktree, so it is chosen rather than inferred.
+        The mechanics are unchanged; only the authorization moved."""
         _git(repo, "branch", "issue-4")
         healed = {}
 
@@ -173,10 +176,28 @@ class TestEnsureBaseDecides:
         with _no_network(), \
              patch.object(sr.reset, "reset_one_issue", fake_reset), \
              patch.object(sr.reset, "_gh_repo", lambda p: "o/r"):
-            base = sr.ensure_base(repo, 4, log)
+            base = sr.ensure_base(repo, 4, log, True)
 
         assert healed["called"] == 4
         assert base == "hardening-run-11"
+
+    def test_recoverable_debris_without_fresh_refuses(self, repo, log):
+        """#2409: the same debris, no flag. Nothing is reset and the roll stops.
+
+        This is the 2026-08-15 shape: findings that are an in-flight issue's own
+        products, which the gate used to treat as authority to destroy them.
+        """
+        _git(repo, "branch", "issue-4")
+        called = []
+
+        with _no_network(), \
+             patch.object(sr.reset, "reset_one_issue",
+                          lambda *a: called.append("reset")), \
+             patch.object(sr.reset, "_gh_repo", lambda p: "o/r"):
+            base = sr.ensure_base(repo, 4, log)
+
+        assert base is None, "a refusal must abort, not proceed"
+        assert not called, "a plain launch must not reset"
 
     def test_debris_that_survives_reset_escalates_to_a_fresh_attempt(
         self, repo, log
@@ -186,7 +207,7 @@ class TestEnsureBaseDecides:
         with _no_network(), \
              patch.object(sr.reset, "reset_one_issue", lambda *a: None), \
              patch.object(sr.reset, "_gh_repo", lambda p: "o/r"):
-            base = sr.ensure_base(repo, 4, log)
+            base = sr.ensure_base(repo, 4, log, True)
 
         assert base == "hardening-run-12"
 

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -478,22 +478,87 @@ def delete_remote_branches(repo_root: Path, issue: int) -> int:
     return deleted
 
 
-def delete_lineage_dirs(repo_root: Path, issue: int) -> int:
-    """Delete docs/lineage/active/{issue}-* directories. Returns count deleted."""
+def archive_lineage_dirs(repo_root: Path, issue: int) -> int:
+    """Move docs/lineage/active/{issue}-* into reset-artifacts. Returns count.
+
+    #2409: this deleted outright, in the same reset that RELOCATED the LLD two
+    steps later. The remedy was internally inconsistent -- preservation was the
+    principle for one artifact and destruction for another -- and what it
+    destroyed was the most expensive thing the campaign produces: on
+    2026-08-15 a passed spec stage carrying five review iterations of verdict
+    history, which the fresh redraw then had to pay for again without it.
+
+    If preservation is the principle for one artifact it is the principle for
+    all of them. Same destination as `relocate_lld_artifacts`, so everything a
+    reset displaces lands in one place the operator can find.
+    """
     lineage_active = repo_root / "docs" / "lineage" / "active"
     if not lineage_active.exists():
         return 0
-    deleted = 0
-    for d in lineage_active.glob(f"{issue}-*"):
+
+    destination = (
+        repo_root / "data" / "speedrun" / "reset-artifacts"
+        / f"issue-{issue}" / "lineage"
+    )
+    archived = 0
+    for d in sorted(lineage_active.glob(f"{issue}-*")):
         if not d.is_dir():
             continue
         try:
-            _rmtree_clearing_readonly(d)
-            print(f"  Deleted lineage dir: {d.relative_to(repo_root)}")
-            deleted += 1
+            destination.mkdir(parents=True, exist_ok=True)
+            target = destination / d.name
+            if target.exists():
+                # A second reset must not clobber the first one's evidence.
+                target = destination / f"{d.name}-{_disposal_stamp()}"
+            try:
+                shutil.move(str(d), str(target))
+            except OSError:
+                # #2162: lineage dirs can carry the ReadOnly attribute, and
+                # shutil.move falls back to copy-then-rmtree across
+                # filesystems, where a plain rmtree dies on them. Copy, then
+                # remove with the attribute-clearing variant.
+                shutil.copytree(str(d), str(target), dirs_exist_ok=True)
+                _rmtree_clearing_readonly(d)
+            print(f"  Archived lineage dir: {d.relative_to(repo_root)} -> "
+                  f"{target.relative_to(repo_root)}")
+            archived += 1
         except OSError as e:
-            print(f"  WARNING: could not delete {d}: {e}")
-    return deleted
+            print(f"  WARNING: could not archive {d}: {e}")
+    return archived
+
+
+def pin_checkpoint(repo_root: Path, issue: int) -> str | None:
+    """Stamp a rescue ref over this issue's newest checkpoint, before branches go.
+
+    #2409: `d1e9269 [CP:post-impl]` survived the 2026-08-15 reset only as an
+    unreferenced object, recoverable because nothing had garbage-collected it
+    yet. That is luck, not design. A checkpoint is reachable from the issue's
+    pipeline branches and from nothing else, so deleting those branches orphans
+    it; pinning first makes the survival deliberate.
+
+    Returns the rescue ref name, or None when there was no checkpoint to pin.
+    """
+    for ref in (
+        f"{issue}-impl", f"origin/{issue}-impl",
+        f"{issue}-lld", f"origin/{issue}-lld",
+        f"{issue}-spec", f"origin/{issue}-spec",
+        f"{issue}-fix", f"origin/{issue}-fix",
+    ):
+        found = _run(
+            ["git", "log", "-1", "--format=%H", "--grep=^\\[CP:", ref],
+            cwd=repo_root,
+        )
+        sha = found.stdout.strip() if found.returncode == 0 else ""
+        if not sha:
+            continue
+        rescue = f"refs/rescue/issue-{issue}-{_disposal_stamp()}"
+        made = _run(["git", "update-ref", rescue, sha], cwd=repo_root)
+        if made.returncode == 0:
+            print(f"  Pinned checkpoint {sha[:7]} at {rescue}")
+            return rescue
+        print(f"  WARNING: could not pin checkpoint {sha[:7]}: {made.stderr.strip()}")
+        return None
+    return None
 
 
 def _is_git_tracked(repo_root: Path, file_path: Path) -> bool:
@@ -590,13 +655,19 @@ def reopen_issue(repo: str, issue: int) -> bool:
 
 
 def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
-    """Run all reset steps for one issue."""
+    """Run all reset steps for one issue.
+
+    #2409: the checkpoint is pinned FIRST, before anything that could orphan
+    it. Branch deletion is what unreferences a checkpoint commit, so the pin
+    has to precede it or the ordering is the bug.
+    """
     print(f"\nResetting issue #{issue}:")
+    pin_checkpoint(repo_root, issue)
     close_open_prs(repo, issue)
     remove_worktree(repo_root, issue)
     delete_local_branches(repo_root, issue)
     delete_remote_branches(repo_root, issue)
-    delete_lineage_dirs(repo_root, issue)
+    archive_lineage_dirs(repo_root, issue)
     relocate_lld_artifacts(repo_root, issue)
     reopen_issue(repo, issue)
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -299,7 +299,70 @@ def base_is_structurally_sound(repo_root: Path, base: str) -> list[str]:
     return problems
 
 
-def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
+def find_checkpoint(repo_root: Path, issue: int) -> str | None:
+    """The newest `[CP:*]` commit for this issue, or None (#2409).
+
+    A checkpoint is the workflow's own statement that a stage completed and its
+    work is worth keeping: `[CP:post-impl] issue #1: workflow checkpoint`. It is
+    an ordinary commit on the issue's pipeline branches, so it survives the
+    worktree being removed but NOT the branches being deleted, which is exactly
+    how `d1e9269` became unreferenced on 2026-08-15.
+
+    This is the fact the resume-versus-residue decision turns on. An open LLD
+    PR, its branch and an untracked LLD are all normal mid-issue state and say
+    nothing either way; a checkpoint says work exists that a reset would
+    destroy. Cosmetics do not get a vote.
+
+    Every ref that could carry one is searched, including the worktree's own
+    branch, because the checkpointing commit lands wherever the stage ran.
+    """
+    refs = [
+        f"{issue}-impl", f"origin/{issue}-impl",
+        f"{issue}-lld", f"origin/{issue}-lld",
+        f"{issue}-spec", f"origin/{issue}-spec",
+        f"{issue}-fix", f"origin/{issue}-fix",
+    ]
+    for ref in refs:
+        found = _run(
+            ["git", "log", "-1", "--format=%h", "--grep=^\\[CP:", ref],
+            cwd=repo_root,
+        )
+        if found.returncode == 0 and found.stdout.strip():
+            return found.stdout.strip()
+    return None
+
+
+def refuse_with_exits(
+    repo_root: Path, issue: int, debris: list[str], log: EventLog,
+    checkpoint: str | None,
+) -> None:
+    """Name the findings and both exits, then let the caller abort (#2409).
+
+    A plain launch that would otherwise reset says what it found and what the
+    operator can do about it. The destructive path is chosen, never inferred:
+    the reset closes a PR, deletes a remote branch and removes a worktree, and
+    on 2026-08-15 it did all three to an in-flight issue as a silent side
+    effect of an ordinary launch command.
+    """
+    log.write(
+        f"GATE {len(debris)} finding(s) for #{issue} -- REFUSING to reset"
+    )
+    for d in debris:
+        log.write(f"  {d}")
+    if checkpoint:
+        log.write(
+            f"  a checkpoint exists ({checkpoint}); a reset would destroy it"
+        )
+    log.write("  exit 1: repair the findings above, then relaunch to resume")
+    log.write(
+        "  exit 2: relaunch with --fresh to reset this issue and redraw "
+        "(archives, never deletes)"
+    )
+
+
+def ensure_base(
+    repo_root: Path, issue: int, log: EventLog, fresh: bool = False
+) -> str | None:
     """A base this issue can actually be rolled on. Heals what it can.
 
     Order matters: structure first (a base that cannot receive PRs is useless
@@ -343,11 +406,55 @@ def ensure_base(repo_root: Path, issue: int, log: EventLog) -> str | None:
         )
         return fresh
 
-    # Recoverable debris. The old wrapper printed "run speedrun_reset.py,
-    # verify clean, relaunch" and quit; that instruction is now the code path.
-    log.write(f"GATE {len(debris)} finding(s) for #{issue} -- self-healing")
+    # #2409: recoverable debris is NOT authority to reset. On 2026-08-15 this
+    # branch read an in-flight issue's own products -- the open LLD PR the
+    # requirements workflow keeps open by design, that PR's branch, and an
+    # untracked LLD the halt path left behind -- as contamination, and its
+    # remedy destroyed a passed spec stage, impl iteration 0, and the resume
+    # seeds. The same command had resumed the same issue two and a half hours
+    # earlier, so the gate was inconsistent on nearly identical state.
+    #
+    # The deciding fact is the checkpoint, not the findings. A checkpoint means
+    # work exists that a reset would destroy, so heal around it and let the
+    # roll resume. Without one, a plain launch still refuses rather than
+    # inferring the destructive path: fleet doctrine is that destructive
+    # operations default to dry-run and mutate only under an explicit flag, and
+    # a reset that closes a PR and deletes a remote branch as a side effect of
+    # `speedrun_roll --issue N` is the opposite of that.
+    checkpoint = find_checkpoint(repo_root, issue)
+    if checkpoint and not fresh:
+        log.write(
+            f"GATE {len(debris)} finding(s) for #{issue}, but checkpoint "
+            f"{checkpoint} exists -- preserving, no reset"
+        )
+        for d in debris:
+            log.write(f"  {d}")
+        log.write(
+            f"BASE '{base}' accepted for #{issue} with its work preserved "
+            "(--fresh to reset and redraw)"
+        )
+        record_heal(
+            repo_root, "reset-declined", f"#{issue}", "healed",
+            detail=f"checkpoint {checkpoint} present; {len(debris)} finding(s) left in place",
+        )
+        return base
+
+    if not fresh:
+        refuse_with_exits(repo_root, issue, debris, log, checkpoint)
+        record_heal(
+            repo_root, "reset-refused", f"#{issue}", "refused",
+            detail=f"{len(debris)} finding(s); --fresh not given",
+        )
+        return None
+
+    # --fresh: the operator chose this explicitly. The reset preserves rather
+    # than deletes (see speedrun_reset.archive_lineage_dirs) and stamps a
+    # rescue ref over any checkpoint before the branches go.
+    log.write(f"GATE {len(debris)} finding(s) for #{issue} -- --fresh, resetting")
     for d in debris:
         log.write(f"  {d}")
+    if checkpoint:
+        log.write(f"  checkpoint {checkpoint} will be pinned before the reset")
     try:
         repo_slug = reset._gh_repo(repo_root)
     except RuntimeError as err:
@@ -812,8 +919,12 @@ def ensure_base_for_resume(
 
 def roll_issue(
     repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str],
-    resume_from: str | None = None,
+    resume_from: str | None = None, *, fresh: bool = False,
 ) -> int:
+    # #2409: `fresh` is keyword-only and passed by the caller ONLY when true,
+    # for the same reason resume_from travels only when a resume fires -- test
+    # stubs replace this function with bare *args lambdas and fixed five-arg
+    # defs, so the ordinary path must keep its exact historical call shape.
     tag = f"run-issue{issue}-{datetime.now().strftime('%H%M%S')}"
     run_start = _stamp()
     log = EventLog(log_dir / f"{tag}-events.log")
@@ -830,7 +941,15 @@ def roll_issue(
                 log.write(f"RESUME fell back to a fresh draw for #{issue}")
                 resume_from = None
         if base is None:
-            base = ensure_base(repo_root, issue, log)
+            # The fourth argument travels ONLY when --fresh was given, and
+            # positionally, for the reason stated above: test stubs replace
+            # ensure_base with bare *args lambdas, which take any number of
+            # positional arguments and no keyword ones.
+            base = (
+                ensure_base(repo_root, issue, log, True)
+                if fresh
+                else ensure_base(repo_root, issue, log)
+            )
         if base is None:
             log.write("ABORT could not establish a usable base")
             return 91
@@ -2468,9 +2587,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--fresh", action="store_true",
         help=(
             "Redraw every stage from scratch, ignoring any resumable state "
-            "(#2193). Without it, a launch that finds a prior non-conflict "
-            "failure with the lld already passed resumes from the failed "
-            "stage instead of paying for the passed stages again."
+            "(#2193), AND authorize the destructive reset of this issue "
+            "(#2409): closing its open PRs, deleting its branches, removing "
+            "its worktree. Displaced artifacts are archived to "
+            "data/speedrun/reset-artifacts/, never deleted, and any checkpoint "
+            "is pinned to a rescue ref first. Without this flag a launch that "
+            "finds gate findings REFUSES and names both exits rather than "
+            "resetting on its own initiative."
         ),
     )
     parser.add_argument(
@@ -2771,12 +2894,21 @@ def main(argv: list[str] | None = None) -> int:
             # five-arg defs, so the non-resume path must keep the exact
             # pre-#2193 call shape (same convention as the positional
             # restore_repo call below).
+            #
+            # #2409: `fresh` travels the same way and for the same reason. It
+            # is what authorizes the destructive reset, so it is passed only
+            # when the operator actually typed --fresh; every other launch
+            # reaches ensure_base with fresh=False and gets the refusal.
+            fresh_kw = {"fresh": True} if getattr(args, "fresh", False) else {}
             if resume_from:
                 code = roll_issue(
                     repo_root, issue, log_dir, az_root, extra, resume_from,
+                    **fresh_kw,
                 )
             else:
-                code = roll_issue(repo_root, issue, log_dir, az_root, extra)
+                code = roll_issue(
+                    repo_root, issue, log_dir, az_root, extra, **fresh_kw
+                )
 
             # #2166: a requirements conflict means the ISSUE needs an operator
             # ruling. The auto-filer (#2072) has already raised the questions.


### PR DESCRIPTION
Closes #2409

The launcher's self-heal gate reset an in-flight issue and destroyed its resume state, twice, with no confirmation. This makes the destructive path something the operator chooses rather than something the gate infers, and makes the remedy preserve consistently instead of deleting some artifacts while relocating others.

## What measurement overturned

The issue read the 09:00 acceptance against the 11:42 reset and concluded:

> The deciding delta appears to be the untracked artifact the halt path itself created.

It is not. The delta is whether `resume_plan` returns a stage:

```python
if resume_from:
    base = ensure_base_for_resume(repo_root, issue, log)   # verify, never reset
if base is None:
    base = ensure_base(repo_root, issue, log)              # self-heal, which reset
```

The gate findings never got a vote in either direction. At 09:00 `resume_plan` returned a stage and the safe path ran; at 11:42 it returned None and the self-heal ran. The untracked artifact was present in the findings list but was not what selected the branch.

That matters for the fix, because it means hardening `ensure_base` is the whole job: any future path that reaches it, for any reason, must not destroy an in-flight issue.

## Four rules

**1. The checkpoint decides resume versus residue.** `find_checkpoint()` looks for the workflow's own `[CP:*]` commits on the issue's pipeline branches. A checkpoint is the workflow stating that a stage completed and its work is worth keeping, so the gate heals around it and the roll proceeds on the existing base. An open LLD PR, its branch, and an untracked LLD are ordinary mid-issue state and decide nothing.

**2. A plain launch refuses.** Without a checkpoint and without `--fresh`, the gate lists every finding, names both exits, and aborts:

```
GATE 3 finding(s) for #1 -- REFUSING to reset
  remote branch: origin/1-lld
  open PR: #301
  untracked artifact: docs/lld/active/LLD-001.md
  exit 1: repair the findings above, then relaunch to resume
  exit 2: relaunch with --fresh to reset this issue and redraw (archives, never deletes)
```

A reset closes a PR, deletes a remote branch and removes a worktree. Fleet doctrine is that destructive operations default to dry-run and mutate only under an explicit flag; doing all three as a side effect of `speedrun_roll --issue N` is the opposite of that.

**3. `--fresh` authorizes the reset, and the reset preserves.** `delete_lineage_dirs` becomes `archive_lineage_dirs`, moving to the same `data/speedrun/reset-artifacts/issue-N/` destination `relocate_lld_artifacts` already used. The old remedy deleted the lineage and relocated the LLD, which is two principles inside one function. A second reset does not clobber the first one's archive.

**4. The checkpoint is pinned before anything can orphan it.** `d1e9269` survived the 2026-08-15 reset only as an unreferenced object that nothing had garbage-collected yet. A checkpoint is reachable from the issue's pipeline branches and nothing else, so branch deletion is what orphans it, and `pin_checkpoint` therefore runs first in `reset_one_issue`. Survival by design rather than by luck.

## What was NOT implemented, and why

Point 4 of the proposed shape, the halt path cleaning up its own untracked artifacts, is already done by existing machinery:

- `docs/lld/active/` is in the janitor's `EMISSION_ALLOWLIST`;
- the restore janitor runs from a `finally`, so on success, on failure, and on any exception including SignalExit;
- boostgauge's working tree carried **no** untracked LLD when measured today. The one that appears in the findings below exists because a diagnostic in this session called `_restore_artifact` and created it. It has been moved aside again.

Adding a second cleaner on top of a working one would be noise, and the risk is not zero: the artifact it would clear is an input `resume_plan` looks for. Stated rather than silently skipped.

## The relaunch surface, from the code

Measured against the live repo rather than predicted:

| What the gate sees for boostgauge #1 | Value |
|---|---|
| attempt branch | `hardening-run-17`, structurally sound |
| gate findings | remote branch `origin/1-lld`; open PR #319 |
| `find_checkpoint` on pipeline refs | `None` (d1e9269 is reachable only from `refs/rescue/issue-1-post-impl`) |
| `resume_plan` | `'spec'` |

So the next launch takes `ensure_base_for_resume`, verifies the base, and resumes from the spec stage with the LLD preserved. That outcome does not depend on this PR. What this PR guarantees is the other branch: had `resume_plan` declined, the launch would now refuse rather than destroy.

## Acceptance

`tests/unit/test_resume_versus_residue.py`, the fixtures the issue asks for:

| Fixture | Result |
|---|---|
| open LLD PR, its branch, and a checkpoint | resumes untouched, no reset called |
| the same fixture without a checkpoint | refuses, both exits named, every finding listed |
| `--fresh` | performs the reset |
| `--fresh` with a checkpoint | resets, pinning the checkpoint first |
| a pinned checkpoint survives branch deletion | passes |
| post-reset tree vs pre-reset tree | identical content, relocated |

Unit suite green.

## Follow-up filed

`resume_plan` abandons an impl-stage resume when `spec_path` is the empty string, before `_restore_artifact` is ever consulted. `spec_path` is currently empty for boostgauge #1 while `lld_path` is populated, so the first impl-stage halt after the spec passes will decline to resume. Under this PR that becomes a refusal rather than a reset, which is safer but still blocks. Tracked in #2414, with the caveat that it is consistent-with rather than confirmed as the 11:42 cause, since that state file has been overwritten.
