### PR TITLE
feat: an emergency stop the operator can reach without an agent (Closes #2422)

### DIFF
--- a/assemblyzero/speedrun/emergency_stop.py
+++ b/assemblyzero/speedrun/emergency_stop.py
@@ -1,0 +1,292 @@
+"""An emergency stop the operator can reach without an agent (#2422).
+
+2026-08-15: the operator ordered a live roll killed and had no way to do it.
+The detached run streams into the console it was launched from, so there was no
+free prompt; the detach wrapper makes the run immune to casual interruption by
+design; and the stop that did exist was neither taught nor findable. The kill
+was finally performed by an agent reading a pid out of the events log and
+running a manual tree-kill -- which required knowing the log layout, the pid
+convention, and that Git Bash mangles `taskkill /F` into a drive path. The
+operator's stated fallback was rebooting the machine.
+
+None of that is an operator interface. This module is the interface.
+
+## The two paths, and why both are needed
+
+**A command** (`--kill`) is the path when a prompt exists. It is exact: it
+knows which pid, it stamps the run's own events log, and it returns a
+distinguishable code.
+
+**A kill file** is the path when no prompt exists, which was the actual
+situation. `data/speedrun/KILL-<issue>` (or a bare `KILL` for any issue) is
+something a file manager, a second agent session, or `touch` can create. The
+launcher watches for it WHILE a child call is in flight, not merely between
+stages -- a stop that only lands at a stage boundary is no use against a call
+that has thirteen minutes left to run, which is the case that produced this
+issue.
+
+## Killed is a verdict, not a crash
+
+An ordered stop is reported distinctly (`KILL_EXIT_CODE`), stamped into the
+run's own events log with `KILLED BY OPERATOR`, and leaves the resume surfaces
+readable -- so the postmortem and the healing ledger see a decision rather than
+a corpse, and the next launch resumes instead of refusing or resetting.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Callable
+from pathlib import Path
+
+#: The launcher's exit code for an operator-ordered stop. Distinct from 0
+#: (success), 91 (a gate problem), 92 (a provider storm) and 93 (a requirements
+#: conflict), so a stop is never read as any kind of failure.
+KILL_EXIT_CODE = 94
+
+#: Stamped into the run's events log. The postmortem and the healing ledger
+#: both grep for it, so it is a contract rather than prose.
+KILLED_MARKER = "KILLED BY OPERATOR"
+
+#: Where kill files live -- beside `runs/`, under the target repo's data dir.
+KILL_DIR_PARTS = ("data", "speedrun")
+
+#: How often the watch looks. A stop the operator has already decided on should
+#: land in seconds, and a stat every two seconds costs nothing beside a call
+#: measured in minutes.
+KILL_POLL_SECONDS = 2.0
+
+
+def kill_dir(repo_root: Path) -> Path:
+    """Directory the operator drops a kill file into."""
+    return Path(repo_root).joinpath(*KILL_DIR_PARTS)
+
+
+def kill_file_candidates(repo_root: Path, issue: int | None = None) -> list[Path]:
+    """Every path that means stop, most specific first.
+
+    The bare `KILL` is deliberate: under stress the operator should not have to
+    remember which issue number is currently rolling, and a batch is stopped as
+    a batch. The issue-scoped name exists so a machine running two campaigns can
+    stop one of them.
+    """
+    base = kill_dir(repo_root)
+    names = [f"KILL-{issue}"] if issue is not None else []
+    names.append("KILL")
+    return [base / name for name in names]
+
+
+def find_kill_file(repo_root: Path, issue: int | None = None) -> Path | None:
+    """The kill file the operator has dropped, or None."""
+    for candidate in kill_file_candidates(repo_root, issue):
+        try:
+            if candidate.exists():
+                return candidate
+        except OSError:
+            # An unreadable data dir must never be the reason a roll cannot be
+            # stopped, but it is equally never a reason to stop one.
+            continue
+    return None
+
+
+def clear_kill_files(repo_root: Path, issue: int | None = None) -> list[Path]:
+    """Remove kill files after acting on them, returning what was removed.
+
+    Load-bearing: a kill file that outlives the run it stopped would stop the
+    NEXT launch too, which the operator would experience as a launcher that
+    refuses to start and says nothing useful about why.
+    """
+    removed: list[Path] = []
+    for candidate in kill_file_candidates(repo_root, issue):
+        try:
+            if candidate.exists():
+                candidate.unlink()
+                removed.append(candidate)
+        except OSError:
+            continue
+    return removed
+
+
+def stop_command(repo_root: Path, issue: int | None = None) -> str:
+    """The exact command that stops this roll, ready to paste."""
+    issue_part = f" --issue {issue}" if issue is not None else ""
+    return (
+        f"poetry run python tools/speedrun_roll.py --repo {repo_root} "
+        f"--kill{issue_part}"
+    )
+
+
+def kill_file_command(repo_root: Path, issue: int | None = None) -> str:
+    """The promptless stop, as a command that creates the file."""
+    target = kill_file_candidates(repo_root, issue)[0]
+    return f"touch {target.as_posix()}"
+
+
+def banner_lines(
+    repo_root: Path, issue: int | None, log_path: Path | None = None
+) -> list[str]:
+    """The stop instructions every launch prints in its first lines.
+
+    An emergency control the operator cannot remember under stress does not
+    exist, so it is taught at the moment of launch beside the log path -- not
+    filed in a runbook they would have to already be calm enough to find.
+    """
+    lines = [
+        "",
+        "  TO STOP THIS ROLL:",
+        f"    {stop_command(repo_root, issue)}",
+        "",
+        "  If this console has no free prompt, create the stop file instead",
+        "  (from any other window, or any file manager):",
+        f"    {kill_file_command(repo_root, issue)}",
+    ]
+    if log_path is not None:
+        lines += ["", f"  Log: {log_path}"]
+    lines.append("")
+    return lines
+
+
+def tree_kill(pid: int | str) -> tuple[bool, str]:
+    """Kill a process and everything it spawned.
+
+    The pipeline is four to eight processes deep, so killing the parent alone
+    leaves model-calling orphans reparented to nothing that keep writing to the
+    target repo. Measured 2026-08-15: eight processes in one roll's tree.
+    """
+    pid = str(pid)
+    if sys.platform == "win32":
+        # /T for the tree, /F because a python child mid-subprocess does not
+        # answer a polite close. MSYS_NO_PATHCONV is set for the child so Git
+        # Bash cannot rewrite `/F` into a drive path -- the exact trap that made
+        # the operator's first manual attempt fail.
+        env = os.environ.copy()
+        env["MSYS_NO_PATHCONV"] = "1"
+        result = subprocess.run(
+            ["taskkill", "/PID", pid, "/T", "/F"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            env=env,
+        )
+        detail = ((result.stdout or "") + (result.stderr or "")).strip()
+        return result.returncode == 0, detail
+    try:
+        os.killpg(os.getpgid(int(pid)), 9)
+        return True, ""
+    except (OSError, ValueError) as exc:
+        return False, str(exc)
+
+
+class KillWatch:
+    """Watches for a kill file while a child runs, and kills it mid-call.
+
+    The child is a blocking `subprocess` call that can legitimately run for ten
+    minutes, so the watch has to be concurrent with it rather than sequenced
+    around it. A thread polling `find_kill_file` is the whole mechanism: when
+    the file appears it tree-kills the child, which makes the launcher's wait
+    return normally, and `fired` tells the caller the death was ordered rather
+    than a crash.
+
+    Deliberately NOT a signal handler: on Windows a signal cannot interrupt a
+    blocking wait, which is the platform this runs on.
+    """
+
+    def __init__(
+        self,
+        repo_root: Path,
+        issue: int | None,
+        on_kill: Callable[[str], None] | None = None,
+        poll_seconds: float = KILL_POLL_SECONDS,
+    ) -> None:
+        self.repo_root = Path(repo_root)
+        self.issue = issue
+        self.on_kill = on_kill or (lambda _m: None)
+        self.poll_seconds = poll_seconds
+        self.fired = False
+        self.kill_file: Path | None = None
+        self._proc: subprocess.Popen | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def watch(self, proc: subprocess.Popen) -> KillWatch:
+        """Begin watching on behalf of `proc`."""
+        self._proc = proc
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        return self
+
+    def __enter__(self) -> KillWatch:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.stop()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.poll_seconds + 5)
+            self._thread = None
+
+    def check_now(self) -> bool:
+        """One synchronous look, for stage boundaries and between issues."""
+        found = find_kill_file(self.repo_root, self.issue)
+        if found is None:
+            return False
+        self.fired = True
+        self.kill_file = found
+        return True
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            proc = self._proc
+            if proc is not None and proc.poll() is not None:
+                return  # the child finished on its own; nothing to stop
+            found = find_kill_file(self.repo_root, self.issue)
+            if found is not None:
+                self._fire(found)
+                return
+            self._stop.wait(self.poll_seconds)
+
+    def _fire(self, found: Path) -> None:
+        self.fired = True
+        self.kill_file = found
+        proc = self._proc
+        if proc is None or proc.poll() is not None:
+            self.on_kill(f"{KILLED_MARKER}: stop file {found.name} seen")
+            return
+        ok, detail = tree_kill(proc.pid)
+        if ok:
+            self.on_kill(
+                f"{KILLED_MARKER}: stop file {found.name} seen; tree-killed "
+                f"pid {proc.pid} mid-call"
+            )
+        else:
+            self.on_kill(
+                f"{KILLED_MARKER}: stop file {found.name} seen; pid "
+                f"{proc.pid} would not die ({detail or 'no detail'})"
+            )
+            # A tree-kill that failed still means the operator said stop, so
+            # the wait must not be allowed to run to completion.
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+
+def killed_verdict_lines(issue: int | None, kill_file: Path | None) -> list[str]:
+    """What the operator reads after an ordered stop.
+
+    Says stopped rather than failed, and names the resume: the next launch
+    reuses the stages that passed, so nothing already paid for is re-paid.
+    """
+    who = f"#{issue}" if issue is not None else "the roll"
+    source = f"stop file {kill_file.name}" if kill_file else "--kill"
+    return [
+        "",
+        f"STOPPED BY OPERATOR: {who} was stopped on purpose ({source}).",
+        "  This is not a failure. The stages that had already passed are",
+        "  preserved, and the next launch resumes from where this one stopped",
+        "  rather than redrawing them.",
+        "",
+    ]

--- a/assemblyzero/speedrun/emergency_stop.py
+++ b/assemblyzero/speedrun/emergency_stop.py
@@ -36,6 +36,7 @@ a corpse, and the next launch resumes instead of refusing or resetting.
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -171,10 +172,28 @@ def tree_kill(pid: int | str) -> tuple[bool, str]:
         )
         detail = ((result.stdout or "") + (result.stderr or "")).strip()
         return result.returncode == 0, detail
+
+    # POSIX. Kill the child's process GROUP only when it has one of its own,
+    # and never otherwise.
+    #
+    # A child spawned without `start_new_session` INHERITS our process group,
+    # so `killpg(getpgid(child))` names the group this process is in and takes
+    # us down with the target. Caught on CI: ubuntu-latest ran the mid-call
+    # fixtures, the group kill reached pytest, and the job hung at three times
+    # its normal duration. An emergency stop whose blast radius includes its
+    # own caller is not a stop.
     try:
-        os.killpg(os.getpgid(int(pid)), 9)
-        return True, ""
+        target = int(pid)
+        group = os.getpgid(target)
     except (OSError, ValueError) as exc:
+        return False, str(exc)
+    try:
+        if group != os.getpgid(0):
+            os.killpg(group, signal.SIGKILL)
+        else:
+            os.kill(target, signal.SIGKILL)
+        return True, ""
+    except OSError as exc:
         return False, str(exc)
 
 

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -46,6 +46,7 @@ the verification is re-run rather than asserted (#2295):
 | `--follow` | re-attach to a roll already running and stream its output here. Takes no `--issue` |
 | `--log-dir` | where the triplets land. Default `<repo>/data/speedrun/runs` |
 | `--assemblyzero-root` | checkout that owns `orchestrate.py`. Default: the tool's own repo |
+| `--kill` | **emergency stop** (#2422) — kill the running roll and its whole process tree, stamping `KILLED BY OPERATOR` into the run's own events log so the stop is recorded as ordered rather than as a crash. Takes an optional `--issue`. Runs before every gate, so a stale or dirty tree cannot refuse it. When this console has no free prompt, create `data/speedrun/KILL` instead — the launcher watches for it **while a call is in flight**, not only between stages |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
 | `--redraw-completed` | redraw an issue this arc has **already rolled to success** (#2191). Without it, an interactive launch demands a typed `REDRAW <N>` and a non-interactive one refuses — so an issue number typed out of habit cannot silently redo work already merged into the arc. Scoped to the current arc: a new base branch starts with an empty slate |
@@ -252,6 +253,39 @@ AZ-SpeedrunRoll                          N/A                    Ready
 ## § Stop
 
 **Operator.**
+
+### The emergency stop (#2422)
+
+```bash
+cd /c/Users/mcwiz/Projects/AssemblyZero
+poetry run python tools/speedrun_roll.py \
+    --repo /c/Users/mcwiz/Projects/boostgauge --kill --issue 1
+```
+
+This is the one to reach for. It kills the tree, stamps `KILLED BY OPERATOR`
+into the run's own events log so the postmortem reads an ordered stop rather
+than a crash, clears any stop file, and exits 0. It runs **before every gate**,
+so a stale or dirty tree cannot refuse it.
+
+**When this console has no free prompt** — which was the actual situation on
+2026-08-15, because the launching console was streaming the roll — create the
+stop file from any other window, or any file manager:
+
+```bash
+touch /c/Users/mcwiz/Projects/boostgauge/data/speedrun/KILL
+```
+
+The launcher watches for that file **while a model call is in flight**, not
+only at stage boundaries. A stop that waited for a boundary would not have
+touched the call that produced this issue, which had thirteen minutes left to
+run. `KILL-<issue>` stops one issue; the bare `KILL` stops whatever is running,
+because under stress you should not have to remember which issue is rolling.
+
+The roll exits **94**, which is a verdict and not a failure: the stages that
+passed are preserved, and the next launch resumes from the stage that was
+interrupted rather than redrawing what was already paid for.
+
+### The older detach-only stop
 
 ```bash
 cd /c/Users/mcwiz/Projects/AssemblyZero

--- a/tests/unit/test_resume_after_failure.py
+++ b/tests/unit/test_resume_after_failure.py
@@ -255,14 +255,34 @@ def test_resume_base_accepts_sound_base_without_reset(repo, log, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+class _FakeChild:
+    """Stands in for the orchestrator child.
+
+    #2422 moved `roll_issue` from `subprocess.run` to `Popen` so the kill
+    watch has a live process to stop while a call is in flight. The subject of
+    these tests is the child's argv, not the transport, so the stub follows.
+    """
+
+    def __init__(self, cmd, returncode=0):
+        self.args = list(cmd)
+        self.pid = -1
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+
 def _capture_child(monkeypatch):
     captured: list[list[str]] = []
 
-    def fake_run(cmd, **_kw):
+    def fake_popen(cmd, **_kw):
         captured.append(list(cmd))
-        return subprocess.CompletedProcess(cmd, 0)
+        return _FakeChild(cmd)
 
-    monkeypatch.setattr(speedrun_roll.subprocess, "run", fake_run)
+    monkeypatch.setattr(speedrun_roll.subprocess, "Popen", fake_popen)
     return captured
 
 

--- a/tests/unit/test_speedrun_emergency_stop.py
+++ b/tests/unit/test_speedrun_emergency_stop.py
@@ -14,6 +14,7 @@ the call that produced this issue, which had thirteen minutes left to run.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import threading
@@ -98,11 +99,22 @@ class TestKillWatchMidCall:
     """
 
     def _sleeper(self, seconds: float = 30) -> subprocess.Popen:
-        """A real child that will outlive the test unless something kills it."""
+        """A real child that will outlive the test unless something kills it.
+
+        `start_new_session` on POSIX is not incidental: it gives the child its
+        OWN process group, which is both what the launcher does for the real
+        pipeline and what makes the group-kill path safe to exercise. Without
+        it the child shares this process's group, and a group kill would take
+        the test runner down -- see `test_tree_kill_never_kills_its_own_group`.
+        """
+        kwargs = {}
+        if sys.platform != "win32":
+            kwargs["start_new_session"] = True
         return subprocess.Popen(
             [sys.executable, "-c", f"import time; time.sleep({seconds})"],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            **kwargs,
         )
 
     def test_child_is_killed_while_still_running(self, repo):
@@ -168,6 +180,65 @@ class TestKillWatchMidCall:
         (repo / "data" / "speedrun" / "KILL-1").write_text("", encoding="utf-8")
         assert watch.check_now() is True
         assert watch.fired is True
+
+
+class TestTreeKillBlastRadius:
+    """A stop whose blast radius includes its own caller is not a stop.
+
+    Caught on CI rather than reasoned about in advance: the first version of
+    `tree_kill` called `os.killpg(os.getpgid(pid), SIGKILL)` unconditionally.
+    A child spawned without `start_new_session` INHERITS the caller's process
+    group, so on ubuntu-latest that named the group pytest was running in and
+    SIGKILLed the test runner. The job hung at three times its usual duration.
+    """
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_tree_kill_never_kills_its_own_group(self):
+        """A child sharing our group is killed ALONE, never by group."""
+        from assemblyzero.speedrun import emergency_stop as es
+
+        # No start_new_session: this child shares the test runner's group,
+        # which is precisely the dangerous shape.
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        assert os.getpgid(proc.pid) == os.getpgid(0), "fixture assumes a shared group"
+        try:
+            ok, _detail = es.tree_kill(proc.pid)
+            assert ok is True
+            assert proc.wait(timeout=15) is not None
+            # The whole point: we are still here to make this assertion.
+            assert os.getpid() == os.getpid()
+        finally:
+            if proc.poll() is None:  # pragma: no cover
+                proc.kill()
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_a_child_in_its_own_group_is_killed_by_group(self):
+        """The real launcher's shape: the whole tree goes, not just the top."""
+        from assemblyzero.speedrun import emergency_stop as es
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        assert os.getpgid(proc.pid) != os.getpgid(0)
+        try:
+            ok, _detail = es.tree_kill(proc.pid)
+            assert ok is True
+            assert proc.wait(timeout=15) is not None
+        finally:
+            if proc.poll() is None:  # pragma: no cover
+                proc.kill()
+
+    def test_a_pid_that_does_not_exist_is_reported_not_raised(self):
+        from assemblyzero.speedrun import emergency_stop as es
+
+        ok, detail = es.tree_kill(999999999)
+        assert ok is False
+        assert detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_speedrun_emergency_stop.py
+++ b/tests/unit/test_speedrun_emergency_stop.py
@@ -1,0 +1,221 @@
+"""The emergency stop must work when the operator has no prompt (#2422).
+
+2026-08-15: a live roll had to be stopped and there was no operator interface
+to stop it with. The console was streaming the detached run, the detach wrapper
+is immune to casual interruption by design, and the kill was finally performed
+by an agent reading a pid out of the events log and running a manual tree-kill
+-- whose first attempt failed because Git Bash rewrote `taskkill /F` into a
+drive path. The operator's stated fallback was rebooting the machine.
+
+These pin the four parts of the interface, and the one that matters most is
+the mid-call kill: a stop that only lands between stages would not have touched
+the call that produced this issue, which had thirteen minutes left to run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun.emergency_stop import (
+    KILL_EXIT_CODE,
+    KILLED_MARKER,
+    KillWatch,
+    banner_lines,
+    clear_kill_files,
+    find_kill_file,
+    kill_file_candidates,
+    killed_verdict_lines,
+    stop_command,
+)
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / "data" / "speedrun").mkdir(parents=True)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Part 3: the kill file -- the promptless path
+# ---------------------------------------------------------------------------
+
+
+class TestKillFileDiscovery:
+    def test_issue_scoped_file_is_found(self, repo):
+        target = repo / "data" / "speedrun" / "KILL-1"
+        target.write_text("", encoding="utf-8")
+        assert find_kill_file(repo, 1) == target
+
+    def test_bare_kill_stops_any_issue(self, repo):
+        """Under stress the operator should not have to remember which issue
+        is rolling. `touch data/speedrun/KILL` stops whatever is running."""
+        target = repo / "data" / "speedrun" / "KILL"
+        target.write_text("", encoding="utf-8")
+        assert find_kill_file(repo, 7) == target
+
+    def test_another_issues_file_does_not_stop_this_one(self, repo):
+        """A machine running two campaigns must be able to stop one of them."""
+        (repo / "data" / "speedrun" / "KILL-2").write_text("", encoding="utf-8")
+        assert find_kill_file(repo, 1) is None
+
+    def test_no_file_is_not_a_stop(self, repo):
+        assert find_kill_file(repo, 1) is None
+
+    def test_issue_scoped_name_is_offered_first(self, repo):
+        names = [p.name for p in kill_file_candidates(repo, 1)]
+        assert names == ["KILL-1", "KILL"]
+
+    def test_clear_removes_both_forms(self, repo):
+        base = repo / "data" / "speedrun"
+        (base / "KILL-1").write_text("", encoding="utf-8")
+        (base / "KILL").write_text("", encoding="utf-8")
+        removed = clear_kill_files(repo, 1)
+        assert len(removed) == 2
+        assert find_kill_file(repo, 1) is None
+
+    def test_clearing_nothing_is_not_an_error(self, repo):
+        assert clear_kill_files(repo, 1) == []
+
+
+class TestKillWatchMidCall:
+    """The case the issue exists for: the child is RUNNING when the stop lands.
+
+    A stop that only fires at a stage boundary is no use against a call with
+    thirteen minutes left, which is exactly the call the operator could not
+    stop. So these start a real child process, let it run, drop the stop file
+    while it is still alive, and assert it died before finishing.
+    """
+
+    def _sleeper(self, seconds: float = 30) -> subprocess.Popen:
+        """A real child that will outlive the test unless something kills it."""
+        return subprocess.Popen(
+            [sys.executable, "-c", f"import time; time.sleep({seconds})"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def test_child_is_killed_while_still_running(self, repo):
+        proc = self._sleeper()
+        messages: list[str] = []
+        watch = KillWatch(repo, 1, on_kill=messages.append, poll_seconds=0.05)
+        try:
+            with watch.watch(proc):
+                # The child is genuinely mid-call here -- not at a boundary,
+                # not between stages, not waiting on anything we control.
+                time.sleep(0.2)
+                assert proc.poll() is None, "child should still be running"
+                (repo / "data" / "speedrun" / "KILL-1").write_text("", encoding="utf-8")
+                returncode = proc.wait(timeout=15)
+        finally:
+            if proc.poll() is None:  # pragma: no cover - only on a failed test
+                proc.kill()
+
+        assert watch.fired is True
+        assert returncode is not None
+        assert watch.kill_file is not None and watch.kill_file.name == "KILL-1"
+        assert any(KILLED_MARKER in m for m in messages)
+        assert any("mid-call" in m for m in messages)
+
+    def test_stop_lands_within_a_poll_interval(self, repo):
+        """The operator has already decided; the stop should land in seconds."""
+        proc = self._sleeper()
+        watch = KillWatch(repo, 1, poll_seconds=0.05)
+        try:
+            with watch.watch(proc):
+                time.sleep(0.1)
+                dropped = time.monotonic()
+                (repo / "data" / "speedrun" / "KILL").write_text("", encoding="utf-8")
+                proc.wait(timeout=15)
+                elapsed = time.monotonic() - dropped
+        finally:
+            if proc.poll() is None:  # pragma: no cover
+                proc.kill()
+        assert watch.fired is True
+        assert elapsed < 10, f"stop took {elapsed:.1f}s to land"
+
+    def test_child_finishing_on_its_own_does_not_fire(self, repo):
+        """No stop file, no kill -- the watch must not invent one."""
+        proc = self._sleeper(0.1)
+        watch = KillWatch(repo, 1, poll_seconds=0.05)
+        with watch.watch(proc):
+            returncode = proc.wait(timeout=15)
+        assert watch.fired is False
+        assert returncode == 0
+
+    def test_watch_thread_stops_with_the_context(self, repo):
+        proc = self._sleeper(0.1)
+        watch = KillWatch(repo, 1, poll_seconds=0.05)
+        before = threading.active_count()
+        with watch.watch(proc):
+            proc.wait(timeout=15)
+        assert threading.active_count() <= before
+
+    def test_check_now_is_the_boundary_path(self, repo):
+        """Stage boundaries and between-issue gaps use the synchronous look."""
+        watch = KillWatch(repo, 1, poll_seconds=0.05)
+        assert watch.check_now() is False
+        (repo / "data" / "speedrun" / "KILL-1").write_text("", encoding="utf-8")
+        assert watch.check_now() is True
+        assert watch.fired is True
+
+
+# ---------------------------------------------------------------------------
+# Part 2: the banner
+# ---------------------------------------------------------------------------
+
+
+class TestBanner:
+    def test_banner_names_the_exact_stop_command(self, repo):
+        text = "\n".join(banner_lines(repo, 1, repo / "data" / "speedrun" / "runs"))
+        assert "--kill" in text
+        assert "--issue 1" in text
+        assert str(repo) in text
+
+    def test_banner_teaches_the_promptless_path(self, repo):
+        """The operator's actual situation was NO available prompt."""
+        text = "\n".join(banner_lines(repo, 1, None))
+        assert "KILL-1" in text
+        assert "no free prompt" in text
+
+    def test_banner_still_works_without_an_issue(self, repo):
+        text = "\n".join(banner_lines(repo, None, None))
+        assert "--kill" in text
+        assert "KILL" in text
+
+    def test_stop_command_is_pasteable(self, repo):
+        cmd = stop_command(repo, 1)
+        assert cmd.startswith("poetry run python tools/speedrun_roll.py")
+        assert "&&" not in cmd and ";" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# Part 4: killed is a clean verdict
+# ---------------------------------------------------------------------------
+
+
+class TestKilledVerdict:
+    def test_exit_code_is_distinct_from_every_failure_class(self):
+        from assemblyzero.core.exit_codes import CONFLICT_EXIT_CODE
+        from assemblyzero.core.provider_storm import STORM_EXIT_CODE
+
+        assert KILL_EXIT_CODE not in (0, 91, STORM_EXIT_CODE, CONFLICT_EXIT_CODE)
+
+    def test_verdict_says_stopped_not_failed(self):
+        text = "\n".join(killed_verdict_lines(1, None))
+        assert "not a failure" in text
+        assert "FAILED" not in text
+
+    def test_verdict_promises_the_resume(self):
+        text = "\n".join(killed_verdict_lines(1, None))
+        assert "resumes" in text

--- a/tests/unit/test_speedrun_roll_kill.py
+++ b/tests/unit/test_speedrun_roll_kill.py
@@ -1,0 +1,348 @@
+"""The launcher's half of the emergency stop (#2422).
+
+The module-level fixtures in `test_speedrun_emergency_stop.py` pin the stop
+mechanism. These pin the launcher wiring: that `--kill` reaches the process
+tree and stamps the RUN's own events log, that a killed roll is reported as a
+verdict rather than a failure, and -- the part boostgauge #1 is sitting in
+right now -- that the next launch RESUMES a run that was stopped mid-stage
+instead of redrawing everything it had already paid for.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.speedrun.emergency_stop import KILL_EXIT_CODE, KILLED_MARKER
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    (r / "data" / "speedrun").mkdir(parents=True)
+    return r
+
+
+@pytest.fixture
+def log_dir(repo):
+    d = repo / "data" / "speedrun" / "runs"
+    d.mkdir(parents=True)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Part 1: the kill command stamps the RUN's log, not just the wrapper's
+# ---------------------------------------------------------------------------
+
+
+class TestKillCommand:
+    def test_stamps_killed_by_operator_into_the_runs_own_events_log(
+        self, repo, log_dir
+    ):
+        """`--detach-stop` wrote only `detach-events.log`, which is the
+        wrapper's record. A postmortem reads the run's log, and an ordered
+        stop that never appears there is indistinguishable from a crash."""
+        run_log = log_dir / "run-issue1-132000-events.log"
+        run_log.write_text("13:20:00 START issue=#1\n", encoding="utf-8")
+        sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+
+        with patch.object(sr, "is_live_python", return_value=True), \
+             patch.object(sr, "tree_kill", return_value=(True, "")), \
+             patch.object(sr, "_run"):
+            code = sr.kill_roll(repo, log_dir, 1)
+
+        assert code == 0
+        assert KILLED_MARKER in run_log.read_text(encoding="utf-8")
+
+    def test_stamp_names_the_pid_that_was_killed(self, repo, log_dir):
+        run_log = log_dir / "run-issue1-132000-events.log"
+        run_log.write_text("", encoding="utf-8")
+        sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+
+        with patch.object(sr, "is_live_python", return_value=True), \
+             patch.object(sr, "tree_kill", return_value=(True, "")), \
+             patch.object(sr, "_run"):
+            sr.kill_roll(repo, log_dir, 1)
+
+        assert "48324" in run_log.read_text(encoding="utf-8")
+
+    def test_another_issues_log_is_not_stamped(self, repo, log_dir):
+        mine = log_dir / "run-issue1-132000-events.log"
+        theirs = log_dir / "run-issue2-140000-events.log"
+        mine.write_text("", encoding="utf-8")
+        theirs.write_text("", encoding="utf-8")
+        sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+
+        with patch.object(sr, "is_live_python", return_value=True), \
+             patch.object(sr, "tree_kill", return_value=(True, "")), \
+             patch.object(sr, "_run"):
+            sr.kill_roll(repo, log_dir, 1)
+
+        assert KILLED_MARKER in mine.read_text(encoding="utf-8")
+        assert KILLED_MARKER not in theirs.read_text(encoding="utf-8")
+
+    def test_a_stale_pid_is_not_killed(self, repo, log_dir):
+        """Windows recycles pids. A stale file plus an unlucky reuse would
+        tree-kill somebody else's work on a shared machine."""
+        sr.pid_file(log_dir).write_text("48324", encoding="utf-8")
+        killed = []
+
+        with patch.object(sr, "is_live_python", return_value=False), \
+             patch.object(sr, "tree_kill", side_effect=lambda p: killed.append(p)), \
+             patch.object(sr, "_run"):
+            code = sr.kill_roll(repo, log_dir, 1)
+
+        assert code == 0
+        assert killed == []
+
+    def test_kill_clears_the_stop_file(self, repo, log_dir):
+        """A stop file that outlived its run would stop the NEXT launch, which
+        the operator would experience as a launcher that refuses to start."""
+        stop = repo / "data" / "speedrun" / "KILL-1"
+        stop.write_text("", encoding="utf-8")
+
+        with patch.object(sr, "_run"):
+            sr.kill_roll(repo, log_dir, 1)
+
+        assert not stop.exists()
+
+    def test_kill_without_a_running_roll_is_not_an_error(self, repo, log_dir):
+        with patch.object(sr, "_run"):
+            assert sr.kill_roll(repo, log_dir, 1) == 0
+
+    def test_kill_is_dispatched_before_any_gate(self, repo, log_dir):
+        """An emergency stop a gate could refuse is not an emergency stop."""
+        called = {}
+
+        def _kill(repo_root, ld, issue):
+            called["issue"] = issue
+            return 0
+
+        with patch.object(sr, "kill_roll", side_effect=_kill), \
+             patch.object(sr, "check_assemblyzero_tree") as tree, \
+             patch.object(sr, "check_box_health") as health:
+            code = sr.main(["--repo", str(repo), "--kill", "--issue", "1"])
+
+        assert code == 0
+        assert called["issue"] == 1
+        # Neither gate was consulted -- the stop does not depend on a clean tree.
+        tree.assert_not_called()
+        health.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Part 4: the next launch RESUMES a run that was stopped mid-stage
+# ---------------------------------------------------------------------------
+
+
+def _state(tmp_path, **overrides) -> Path:
+    """boostgauge #1's state as measured after the 2026-08-15 kill.
+
+    spec passed, impl was in flight, and impl has NO stage_results entry --
+    because an ordered stop never gets to record one.
+    """
+    data = {
+        "issue_number": 1,
+        "current_stage": "impl",
+        "resumed_from": "spec",
+        "target_repo": str(tmp_path / "boostgauge"),
+        "base_branch": "hardening-run-17",
+        "lld_path": str(tmp_path / "boostgauge" / "docs" / "lld" / "LLD-001.md"),
+        "spec_path": str(tmp_path / "boostgauge" / "docs" / "lld" / "spec-0001.md"),
+        "stage_results": {
+            "triage": {"status": "skipped", "error_message": ""},
+            "lld": {"status": "passed", "error_message": ""},
+            "spec": {"status": "passed", "error_message": ""},
+        },
+        "started_at": "2026-08-15T16:42:31+00:00",
+        "completed_at": "",
+    }
+    data.update(overrides)
+    path = tmp_path / "1.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class _Log:
+    def __init__(self):
+        self.lines = []
+
+    def write(self, message):
+        self.lines.append(message)
+
+
+@pytest.fixture
+def resumable(tmp_path, repo):
+    """Everything resume_plan checks, held true except the stage selection."""
+    state = _state(tmp_path)
+    with patch.object(sr, "_orchestrator_state_path", return_value=state), \
+         patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+         patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+         patch.object(sr, "draft_is_stale", return_value=False), \
+         patch.object(sr, "_restore_artifact", return_value=True):
+        yield state
+
+
+class TestKilledRunResumes:
+    def test_a_run_stopped_mid_impl_resumes_from_impl(self, resumable, repo):
+        """The live defect: `resume_plan` chose the stage by scanning for a
+        FAILED status. A killed run has none, so it matched nothing, returned
+        None, and the next launch redrew the LLD and the spec both."""
+        log = _Log()
+        assert sr.resume_plan(Path("."), repo, 1, log) == "impl"
+
+    def test_the_log_says_it_was_stopped_rather_than_failed(self, resumable, repo):
+        log = _Log()
+        sr.resume_plan(Path("."), repo, 1, log)
+        assert any("stopped mid-stage" in line for line in log.lines)
+
+    def test_a_failed_stage_still_wins_over_the_in_flight_one(
+        self, tmp_path, repo
+    ):
+        """The pre-existing path must not change: a recorded failure is the
+        stage to resume from, whatever `current_stage` happens to say."""
+        state = _state(
+            tmp_path,
+            stage_results={
+                "triage": {"status": "skipped", "error_message": ""},
+                "lld": {"status": "passed", "error_message": ""},
+                "spec": {"status": "failed", "error_message": "cap"},
+            },
+        )
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+             patch.object(sr, "draft_is_stale", return_value=False), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 1, log) == "spec"
+
+    def test_a_completed_run_is_not_resumed(self, tmp_path, repo):
+        """`completed_at` means finished, not halted. Without this guard a
+        successful roll would look resumable forever."""
+        state = _state(tmp_path, completed_at="2026-08-15T19:00:00+00:00")
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+             patch.object(sr, "draft_is_stale", return_value=False), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 1, log) is None
+
+    def test_a_gap_before_the_in_flight_stage_is_not_resumed(
+        self, tmp_path, repo
+    ):
+        """If an earlier stage never passed, the in-flight stage has an input
+        nobody produced. Resuming into that is worse than redrawing."""
+        state = _state(
+            tmp_path,
+            stage_results={
+                "triage": {"status": "skipped", "error_message": ""},
+                "lld": {"status": "passed", "error_message": ""},
+                # spec never ran at all
+            },
+        )
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+             patch.object(sr, "draft_is_stale", return_value=False), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 1, log) is None
+
+    def test_an_unresumable_in_flight_stage_is_declined(self, tmp_path, repo):
+        """`lld` is not in RESUMABLE_STAGES; being mid-flight does not make
+        it one."""
+        state = _state(
+            tmp_path,
+            current_stage="lld",
+            stage_results={"triage": {"status": "skipped", "error_message": ""}},
+        )
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+             patch.object(sr, "draft_is_stale", return_value=False), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 1, log) is None
+
+
+class TestHaltedStageUnit:
+    """`_halted_stage` in isolation -- the guards are the whole point."""
+
+    def test_in_flight_stage_is_returned(self):
+        results = {
+            "triage": {"status": "skipped"},
+            "lld": {"status": "passed"},
+            "spec": {"status": "passed"},
+        }
+        data = {"current_stage": "impl", "completed_at": ""}
+        assert sr._halted_stage(data, results) == "impl"
+
+    def test_finished_current_stage_is_not_in_flight(self):
+        results = {
+            "triage": {"status": "skipped"},
+            "lld": {"status": "passed"},
+            "spec": {"status": "passed"},
+        }
+        data = {"current_stage": "spec", "completed_at": ""}
+        assert sr._halted_stage(data, results) is None
+
+    def test_an_unrecorded_earlier_stage_is_a_gap(self):
+        """Conservative by design: resume is an optimization, fresh is always
+        correct, so an unexplained hole declines rather than guessing."""
+        results = {"lld": {"status": "passed"}, "spec": {"status": "passed"}}
+        data = {"current_stage": "impl", "completed_at": ""}
+        assert sr._halted_stage(data, results) is None
+
+    def test_unknown_stage_name_is_declined(self):
+        data = {"current_stage": "nonsense", "completed_at": ""}
+        assert sr._halted_stage(data, {}) is None
+
+    def test_missing_current_stage_is_declined(self):
+        assert sr._halted_stage({"completed_at": ""}, {}) is None
+
+
+# ---------------------------------------------------------------------------
+# The verdict
+# ---------------------------------------------------------------------------
+
+
+class TestKilledVerdictRendering:
+    def test_a_kill_is_not_rendered_as_a_failure(self, repo, capsys):
+        with patch.object(sr, "_requirements_unverified_lines", return_value=[]):
+            sr._render_verdict(
+                repo, requested=[1], rolled=[], blocked=[], stopped_at=1,
+                code=KILL_EXIT_CODE,
+            )
+        out = capsys.readouterr().out
+        assert "STOPPED BY OPERATOR" in out
+        assert "FAILED" not in out
+        assert "exhausting" not in out
+
+    def test_the_verdict_promises_the_resume(self, repo, capsys):
+        with patch.object(sr, "_requirements_unverified_lines", return_value=[]):
+            sr._render_verdict(
+                repo, requested=[1], rolled=[], blocked=[], stopped_at=1,
+                code=KILL_EXIT_CODE,
+            )
+        assert "resumes" in capsys.readouterr().out
+
+    def test_an_ordinary_failure_still_reads_as_a_failure(self, repo, capsys):
+        """The kill branch must not swallow real failures."""
+        with patch.object(sr, "_requirements_unverified_lines", return_value=[]):
+            sr._render_verdict(
+                repo, requested=[1], rolled=[], blocked=[], stopped_at=1, code=1,
+            )
+        assert "ROLL FAILED" in capsys.readouterr().out

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -88,6 +88,16 @@ from assemblyzero.speedrun.archive import (  # noqa: E402  (#2353)
     verify_manifest,
 )
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
+from assemblyzero.speedrun.emergency_stop import (  # noqa: E402  (#2422)
+    KILL_EXIT_CODE,
+    KILLED_MARKER,
+    KillWatch,
+    banner_lines,
+    clear_kill_files,
+    find_kill_file,
+    killed_verdict_lines,
+    tree_kill,
+)
 from assemblyzero.speedrun.successes import (  # noqa: E402  (#2191)
     completed_on,
     describe,
@@ -806,6 +816,36 @@ def draft_is_stale(
     return False
 
 
+def _halted_stage(data: dict, results: dict) -> str | None:
+    """The stage a killed run was in the middle of when it was stopped (#2422).
+
+    An ordered stop never gets to record a result. `stage_results` holds the
+    stages that FINISHED; `current_stage` names the one that was in flight; and
+    nothing is marked failed, because nothing failed. `resume_plan` chose the
+    stage to resume by scanning for a failed status, so a killed run matched
+    nothing, resumed from nowhere, and redrew every passed stage -- which is
+    the opposite of what an ordered stop is supposed to guarantee.
+
+    Measured on boostgauge #1 after the 2026-08-15 kill: `spec` passed, `impl`
+    had no entry at all, and `current_stage` read `impl`.
+
+    Two guards keep this from inventing a resume over a gap: a run that
+    recorded `completed_at` is finished rather than halted, and every stage
+    before the in-flight one must have passed or been skipped.
+    """
+    if data.get("completed_at"):
+        return None
+    current = data.get("current_stage", "")
+    if current not in STAGE_ORDER:
+        return None
+    if results.get(current, {}).get("status") in ("passed", "skipped"):
+        return None  # it finished; nothing was in flight
+    for earlier in STAGE_ORDER[: STAGE_ORDER.index(current)]:
+        if results.get(earlier, {}).get("status") not in ("passed", "skipped"):
+            return None
+    return current
+
+
 def resume_plan(
     az_root: Path, repo_root: Path, issue: int, log: EventLog
 ) -> str | None:
@@ -853,6 +893,13 @@ def resume_plan(
          if results.get(s, {}).get("status") in ("failed", "blocked")),
         None,
     )
+    # #2422: no failed stage does not mean nothing to resume. A run stopped on
+    # the operator's order was in the MIDDLE of a stage, which records no
+    # result at all -- so the stage in flight is the stage to resume from.
+    halted = False
+    if failed is None:
+        failed = _halted_stage(data, results)
+        halted = failed is not None
     if failed not in RESUMABLE_STAGES:
         return None
 
@@ -880,7 +927,9 @@ def resume_plan(
             return None
 
     log.write(
-        f"RESUME planned for #{issue}: from '{failed}' (state {state_path.name})"
+        f"RESUME planned for #{issue}: from '{failed}' "
+        f"({'stopped mid-stage' if halted else 'failed stage'}, "
+        f"state {state_path.name})"
     )
     return failed
 
@@ -970,11 +1019,18 @@ def roll_issue(
             )
         log.write(f"LAUNCH base={base} -> {out_path.name}")
 
+        # #2422: the stop the operator can reach without a prompt. The watch
+        # runs CONCURRENTLY with the child, not around it -- the call that
+        # produced this issue had thirteen minutes left to run, and a check
+        # that only fires at a stage boundary would not have touched it.
+        watch = KillWatch(repo_root, issue, on_kill=log.write)
+
         # Direct redirect: the child's stdout goes straight to the file with no
         # pipe in the path. Restoring a pipe here reintroduces the teardown that
-        # killed campaign runs.
+        # killed campaign runs. Popen rather than run() so the watch has the
+        # child to kill while it is still running; the redirect is unchanged.
         with out_path.open("w", encoding="utf-8", errors="replace") as fh:
-            proc = subprocess.run(
+            proc = subprocess.Popen(
                 cmd, cwd=str(az_root), stdout=fh, stderr=subprocess.STDOUT,
                 env=_child_env(tag, run_start),
                 # #2037: no console for the pipeline either. Under Task
@@ -984,10 +1040,23 @@ def roll_issue(
                     subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
                 ),
             )
-        log.write(f"CHILD EXITED rc={proc.returncode}")
+            with watch.watch(proc):
+                returncode = proc.wait()
+        log.write(f"CHILD EXITED rc={returncode}")
 
-    log.write(f"EXIT rc={proc.returncode}")
-    return proc.returncode
+        if watch.fired:
+            # The child's own rc after a tree-kill is whatever Windows chose;
+            # it says nothing. The verdict is the operator's order.
+            log.write(
+                f"{KILLED_MARKER}: #{issue} stopped by operator "
+                f"(child rc={returncode} discarded)"
+            )
+            clear_kill_files(repo_root, issue)
+            log.write(f"EXIT rc={KILL_EXIT_CODE}")
+            return KILL_EXIT_CODE
+
+    log.write(f"EXIT rc={returncode}")
+    return returncode
 
 
 def _child_env(tag: str = "", start: str = "") -> dict[str, str]:
@@ -1294,6 +1363,89 @@ def stop_detached(log_dir: Path) -> int:
     if ended.returncode != 0 and not killed:
         log.write("DETACH-STOP nothing was running")
         print(f"Task '{TASK_NAME}' was not running.")
+    return 0
+
+
+def _active_run_event_logs(log_dir: Path, issue: int | None) -> list[Path]:
+    """The run's OWN events logs, newest last.
+
+    `stop_detached` stamps `detach-events.log`, which is the wrapper's record,
+    not the run's. A postmortem reads `run-issue<N>-<time>-events.log`, and an
+    ordered stop that never appears there is indistinguishable from a crash --
+    which is exactly what the 2026-08-15 kill looked like afterwards (#2422).
+    """
+    pattern = f"run-issue{issue}-*-events.log" if issue is not None else "run-*-events.log"
+    try:
+        return sorted(Path(log_dir).glob(pattern), key=lambda p: p.stat().st_mtime)
+    except OSError:
+        return []
+
+
+def kill_roll(repo_root: Path, log_dir: Path, issue: int | None) -> int:
+    """Stop a running roll on the operator's order, and say so in the record.
+
+    The difference from `--detach-stop` is not the killing -- it is that this
+    stamps `KILLED BY OPERATOR` into the run's own events log, so the
+    postmortem and the healing ledger read an ordered stop rather than a
+    corpse, and clears any stop file so the next launch is not stopped by a
+    leftover.
+    """
+    log_dir = Path(log_dir)
+    stamped: list[Path] = []
+
+    def _stamp_run_logs(message: str) -> None:
+        for path in _active_run_event_logs(log_dir, issue):
+            try:
+                with path.open("a", encoding="utf-8") as fh:
+                    fh.write(f"{_stamp()} {message}\n")
+                stamped.append(path)
+            except OSError:
+                continue
+
+    who = f"#{issue}" if issue is not None else "all issues"
+    path = pid_file(log_dir)
+    killed = False
+    pid = ""
+    if path.exists():
+        pid = path.read_text(encoding="utf-8").strip()
+        if not is_live_python(pid):
+            # Windows recycles pids; a stale file plus an unlucky reuse would
+            # tree-kill somebody else's work on a shared machine.
+            print(f"Recorded pid {pid} is not a running python process.")
+            print("Nothing to stop -- the roll is already gone.")
+            path.unlink(missing_ok=True)
+        else:
+            ok, detail = tree_kill(pid)
+            killed = ok
+            if ok:
+                print(f"Stopped the roll and its process tree (pid {pid}).")
+            else:
+                print(f"No live tree for pid {pid} ({detail or 'no detail'}).")
+            path.unlink(missing_ok=True)
+    else:
+        print(f"No roll is recorded as running here ({path}).")
+
+    if killed:
+        _stamp_run_logs(
+            f"{KILLED_MARKER}: --kill for {who} tree-killed pid {pid}"
+        )
+    # The stop file is cleared whether or not a tree was found: the operator's
+    # order has been carried out either way, and a surviving file would stop
+    # the NEXT launch for a reason nobody would connect to today.
+    for removed in clear_kill_files(repo_root, issue):
+        print(f"Cleared stop file {removed}.")
+
+    if sys.platform == "win32":
+        # Return the scheduled task to Ready when one was used. Absence is
+        # normal -- a foreground roll never registered one.
+        _run(["schtasks", "/End", "/TN", TASK_NAME])
+
+    if stamped:
+        print(f"Stamped '{KILLED_MARKER}' into {len(stamped)} run log(s).")
+    print(
+        "\n  This was an ordered stop, not a failure. The stages that passed "
+        "are preserved;\n  the next launch resumes from where this one stopped."
+    )
     return 0
 
 
@@ -2480,6 +2632,21 @@ def _render_verdict(repo_root, requested, rolled, blocked, stopped_at, code, sin
             "  Do not re-roll without resolution -- the next launch will "
             "refuse while these stay open (--override-prereqs to run anyway)."
         )
+    elif code == KILL_EXIT_CODE:
+        # #2422: an ordered stop reads as a decision, never as a failure. The
+        # branch below would have called it "FAILED ... after exhausting its
+        # attempts", which is untrue in both halves.
+        who = f"#{stopped_at}" if stopped_at is not None else "the batch"
+        print(f"ROLL STOPPED BY OPERATOR at {who}.")
+        remaining = [i for i in requested if i not in rolled and i != stopped_at]
+        if remaining:
+            print(f"  Not rolled: {', '.join(f'#{i}' for i in remaining)}.")
+        print(f"  Rolled successfully before the stop: {names}.")
+        print(
+            "  The stages that passed are preserved. Next step: relaunch when "
+            "ready -- it resumes\n  from where this stopped rather than "
+            "redrawing what was already paid for."
+        )
     elif stopped_at is not None:
         print(
             f"ROLL FAILED at #{stopped_at} (exit {code}) after exhausting "
@@ -2567,6 +2734,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Stop a detached roll and every process it spawned (#2016)",
     )
     parser.add_argument(
+        "--kill", action="store_true",
+        help=(
+            "EMERGENCY STOP: kill the running roll and its whole process "
+            "tree, stamping KILLED BY OPERATOR into the run's events log so "
+            "the stop is recorded as ordered rather than as a crash (#2422). "
+            "Takes an optional --issue. When this console has no free prompt, "
+            "create data/speedrun/KILL instead -- the launcher watches for it "
+            "while a call is in flight."
+        ),
+    )
+    parser.add_argument(
         "--override-prereqs", action="store_true",
         help=(
             "Launch even though a previous run's questions are still open "
@@ -2650,7 +2828,12 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # Stopping is about processes, not code: it must work even from a stale or
-    # dirty tree, so it comes before the staleness gate.
+    # dirty tree, so it comes before the staleness gate. #2422 adds --kill for
+    # the same reason and one more: an emergency stop that a gate could refuse
+    # is not an emergency stop.
+    if getattr(args, "kill", False):
+        return kill_roll(repo_root, log_dir, args.issue[0] if args.issue else None)
+
     if args.detach_stop:
         return stop_detached(log_dir)
 
@@ -2757,6 +2940,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     if completed_refusal is not None:
         return completed_refusal
+
+    # #2422: a stop file left by a previous kill would silently stop this roll
+    # seconds after it started. Clear it here, in the console the operator is
+    # standing in, and say so -- rather than in the detached task where the
+    # explanation is invisible.
+    leftover = find_kill_file(repo_root, args.issue[0] if args.issue else None)
+    if leftover is not None:
+        for removed in clear_kill_files(
+            repo_root, args.issue[0] if args.issue else None
+        ):
+            print(f"Cleared a leftover stop file from an earlier kill: {removed}")
+
+    # #2422: the emergency stop is taught at the moment of launch, beside the
+    # log path. An emergency control the operator cannot remember under stress
+    # does not exist, and the 2026-08-15 kill needed an agent to perform.
+    for line in banner_lines(
+        repo_root, args.issue[0] if args.issue else None, log_dir
+    ):
+        print(line)
 
     if args.detach:
         code = launch_detached(args, extra, repo_root, az_root, log_dir)
@@ -2926,6 +3128,19 @@ def main(argv: list[str] | None = None) -> int:
                     f"STORM ended #{issue} -- the provider stopped answering; "
                     "nothing was redrawn (#2206). Relaunch when it recovers."
                 )
+            # #2422: an ordered stop is a verdict, not a failure. It gets its
+            # own branch BEFORE the generic halt below, so the operator is
+            # never told to diagnose a cause they created on purpose.
+            elif code == KILL_EXIT_CODE:
+                session.write(
+                    f"{KILLED_MARKER}: #{issue} stopped on the operator's "
+                    "order. Passed stages preserved; the next launch resumes "
+                    "from where this stopped."
+                )
+                for line in killed_verdict_lines(issue, None):
+                    print(line)
+                stopped_at = issue
+                return code
             elif code not in (0, 91):
                 session.write(
                     f"HALT #{issue} exited {code} -- no redraw (#2206). "


### PR DESCRIPTION
Closes #2422

The operator ordered a live roll killed and had no way to do it. The console was streaming the detached run, so there was no free prompt; the detach wrapper makes the run immune to casual interruption by design; and the stop that did exist was neither taught nor findable. The kill was performed by an agent reading a pid out of the events log and running a manual tree-kill, whose first attempt failed because Git Bash rewrote `taskkill /F` into a drive path. The stated fallback was rebooting the machine.

## The four parts

**1. The kill command.** `--kill [--issue N]` kills the tree and stamps `KILLED BY OPERATOR` into the **run's own** events log — not the wrapper's `detach-events.log`, which is what `--detach-stop` wrote. An ordered stop that never appears where the postmortem reads is indistinguishable from a crash. It is dispatched before every gate, because an emergency stop a stale tree can refuse is not an emergency stop. `MSYS_NO_PATHCONV` is set for the `taskkill` child so the path-conversion trap cannot recur.

**2. The banner.** Every launch prints the stop command in its first lines, beside the log path. An emergency control the operator cannot remember under stress does not exist.

**3. The stop file.** `data/speedrun/KILL-<issue>`, or a bare `KILL` for whatever is rolling — because *no prompt* was the actual situation, and a file manager or a second session is the one interface always available. The launcher watches for it **while a call is in flight**, not only at stage boundaries: a boundary-only check would not have touched the call that produced this issue, which had thirteen minutes left to run.

**4. Killed is a verdict.** Exit `94`, distinct from `0`/`91`/`92`/`93`, rendered as `ROLL STOPPED BY OPERATOR` instead of `ROLL FAILED ... after exhausting its attempts` — which was untrue in both halves.

## Item 4 needed a resume fix, and the measurement is why

`resume_plan` chose the stage to resume by scanning `stage_results` for a `failed`/`blocked` status. **An ordered stop never records one.** It interrupts a stage mid-flight, so `stage_results` holds only the stages that *finished* and `current_stage` names the one that did not. The scan matched nothing, returned `None`, and the next launch redrew everything.

Verified against boostgauge #1's live state after the 2026-08-15 kill:

```
current_stage      : impl
recorded results   : {'triage': 'skipped', 'lld': 'passed', 'spec': 'passed'}
failed-scan finds  : None    <- what resume_plan keyed off before
_halted_stage finds: impl    <- the new fallback
```

Without this, the relaunch re-pays the LLD **and** the spec. Two guards keep the fallback from inventing a resume over a gap: a run with `completed_at` set is finished rather than halted, and every stage before the in-flight one must have passed or been skipped.

## Evidence

Live run of the new command, which found and cleared the stale pid file left by the incident — pid `48324`, the exact pid named in the issue:

```
Recorded pid 48324 is not a running python process.
Nothing to stop -- the roll is already gone.
```

The stale-pid guard correctly refused to kill it (Windows recycles pids; a reuse would tree-kill somebody else's work).

## Fixtures

40 across two files, all passing.

The mid-call test is the one that matters and is not stubbed: it starts a real child process, lets it run, asserts `proc.poll() is None` so the child is provably still alive, drops the stop file, and asserts the child died. `test_stop_lands_within_a_poll_interval` bounds the latency.

The rest cover kill-file discovery and scoping (another issue's file must not stop this one), the stamp landing in the right log and not in a sibling issue's, the stale-pid refusal, gate-free dispatch, the banner's two paths, the verdict rendering, and six resume cases including the two negative guards.

## Notes

`roll_issue` moved from `subprocess.run` to `Popen` so the watch has a live child to stop. The direct stdout redirect is unchanged — no pipe was reintroduced, which the surrounding comment warns against. `test_resume_after_failure`'s child stub follows the transport; its subject was always the child's argv.

Runbook 0952 documents the flag and the stop file. Two existing gates (`test_runbook_0952_flags`, `test_solo_runbook`) enforce that the runbook matches `--help`, and both were red until it did.

Full unit suite green (7922 passing before this branch; the four failures this work introduced are all fixed here).
