### PR TITLE
fix: decline a resume on a missing artifact, never on a missing path (Closes #2414)

### DIFF
--- a/tests/unit/test_resume_artifact_lookup.py
+++ b/tests/unit/test_resume_artifact_lookup.py
@@ -1,0 +1,250 @@
+"""A resume is declined on a missing ARTIFACT, never on a missing path (#2414).
+
+`resume_plan` read one field and abandoned the resume when it held the empty
+string, so the refusal fired on a missing PATH STRING rather than on a missing
+artifact. The artifact is usually committed on the issue's lld branch and
+perfectly restorable; nothing checked.
+
+The acceptance the issue asks for is two-sided, and both sides are here: an
+impl-stage halt with a passed spec RESUMES, and an impl-stage halt whose spec
+artifact genuinely cannot be found still DECLINES.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+SPEC_REL = "docs/lld/drafts/spec-0001-implementation-readiness.md"
+LLD_REL = "docs/lld/active/LLD-001.md"
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A real repo with an issue-1 lld branch carrying both artifacts.
+
+    Real git rather than a mock: the lookup's whole job is to consult the
+    branch, and a stubbed `ls-tree` would be testing the stub.
+    """
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "t")
+    (r / "README.md").write_text("base\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "base")
+    # `git init` names the default branch from the machine's config, so it is
+    # asked rather than assumed -- hardcoding "master" left this fixture on the
+    # lld branch, where the artifacts it is meant to hide were still present.
+    default = _git(r, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    _git(r, "checkout", "-q", "-b", "1-lld")
+    for rel, body in ((LLD_REL, "# LLD one\n"), (SPEC_REL, "# Spec one\n")):
+        target = r / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "artifacts")
+    _git(r, "checkout", "-q", default)
+
+    # The exit janitor clears pipeline-authored untracked files, so the working
+    # tree does NOT have them -- which is the state a resume actually meets.
+    assert not (r / SPEC_REL).exists()
+    return r
+
+
+def _state(repo, **overrides):
+    data = {
+        "issue_number": 1,
+        "current_stage": "impl",
+        "target_repo": str(repo),
+        "base_branch": "hardening-run-17",
+        "lld_path": str(repo / LLD_REL),
+        "spec_path": "",
+        "stage_results": {
+            "triage": {"status": "skipped", "error_message": ""},
+            "lld": {"status": "passed", "error_message": "",
+                    "artifact_path": str(repo / LLD_REL)},
+            "spec": {"status": "passed", "error_message": "",
+                     "artifact_path": ""},
+            "impl": {"status": "failed", "error_message": "green phase"},
+        },
+        "started_at": "2026-08-15T16:42:31+00:00",
+        "completed_at": "",
+    }
+    data.update(overrides)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# The lookup itself
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactLookup:
+    def test_a_recorded_path_is_used_directly(self, repo):
+        data = _state(repo, spec_path="/somewhere/spec.md")
+        assert sr._resolve_stage_artifact(repo, 1, data, "spec") == "/somewhere/spec.md"
+
+    def test_an_empty_path_falls_back_to_the_stage_result(self, repo):
+        """`finalize_spec` populates the top-level field only on a pass; the
+        per-stage `artifact_path` is recorded either way."""
+        data = _state(repo)
+        data["stage_results"]["spec"]["artifact_path"] = str(repo / SPEC_REL)
+        assert sr._resolve_stage_artifact(repo, 1, data, "spec") == str(repo / SPEC_REL)
+
+    def test_an_empty_path_and_empty_result_falls_back_to_the_branch(self, repo):
+        """The case the issue is about: nothing recorded anywhere, and the
+        artifact sitting on the lld branch the whole time."""
+        data = _state(repo)
+        found = sr._resolve_stage_artifact(repo, 1, data, "spec")
+        assert found == str(repo / SPEC_REL)
+
+    def test_a_whitespace_only_path_counts_as_unset(self, repo):
+        data = _state(repo, spec_path="   ")
+        data["stage_results"]["spec"]["artifact_path"] = ""
+        assert sr._resolve_stage_artifact(repo, 1, data, "spec") == str(repo / SPEC_REL)
+
+    def test_a_genuinely_absent_artifact_resolves_to_nothing(self, tmp_path):
+        """The other side of the acceptance. No branch, no record, no file."""
+        bare = tmp_path / "empty"
+        bare.mkdir()
+        _git(bare, "init", "-q")
+        data = _state(bare)
+        data["stage_results"]["spec"]["artifact_path"] = ""
+        assert sr._resolve_stage_artifact(bare, 1, data, "spec") == ""
+
+    def test_the_newest_spec_wins_when_several_exist(self, repo):
+        default = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        _git(repo, "checkout", "-q", "1-lld")
+        (repo / "docs/lld/drafts/spec-0002-later.md").write_text("x", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "second spec")
+        _git(repo, "checkout", "-q", default)
+        data = _state(repo)
+        assert sr._resolve_stage_artifact(repo, 1, data, "spec").endswith(
+            "spec-0002-later.md"
+        )
+
+    def test_the_lld_stage_resolves_the_same_way(self, repo):
+        data = _state(repo, lld_path="")
+        data["stage_results"]["lld"]["artifact_path"] = ""
+        assert sr._resolve_stage_artifact(repo, 1, data, "lld") == str(repo / LLD_REL)
+
+
+class TestBranchSearch:
+    def test_a_missing_branch_is_not_an_error(self, tmp_path):
+        bare = tmp_path / "empty"
+        bare.mkdir()
+        _git(bare, "init", "-q")
+        assert sr._find_on_lld_branch(bare, 1, "docs/**") == ""
+
+    def test_a_non_matching_glob_finds_nothing(self, repo):
+        assert sr._find_on_lld_branch(repo, 1, "docs/nope/*.md") == ""
+
+
+# ---------------------------------------------------------------------------
+# resume_plan end to end -- the two-sided acceptance
+# ---------------------------------------------------------------------------
+
+
+class _Log:
+    def __init__(self):
+        self.lines = []
+
+    def write(self, message):
+        self.lines.append(message)
+
+
+def _plan(repo, data, tmp_path):
+    state_path = tmp_path / "1.json"
+    state_path.write_text(json.dumps(data), encoding="utf-8")
+    log = _Log()
+    with patch.object(sr, "_orchestrator_state_path", return_value=state_path), \
+         patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+         patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+         patch.object(sr, "draft_is_stale", return_value=False):
+        return sr.resume_plan(Path("."), repo, 1, log), log
+
+
+class TestSpecPassedImplHaltedResumes:
+    """The fixture the issue names, and the exact state boostgauge #1 is in
+    after the operator's kill: spec passed, impl halted, spec_path unset."""
+
+    def test_it_resumes_from_impl(self, repo, tmp_path):
+        stage, _log = _plan(repo, _state(repo), tmp_path)
+        assert stage == "impl"
+
+    def test_the_spec_artifact_is_restored_to_disk(self, repo, tmp_path):
+        """Not merely 'resume was allowed' -- the input the impl stage needs
+        is actually put back where it can be read."""
+        assert not (repo / SPEC_REL).exists()
+        stage, _log = _plan(repo, _state(repo), tmp_path)
+        assert stage == "impl"
+        assert (repo / SPEC_REL).is_file()
+        assert (repo / SPEC_REL).read_text(encoding="utf-8") == "# Spec one\n"
+
+    def test_the_old_behaviour_would_have_declined(self, repo, tmp_path):
+        """Pins WHY this issue exists: the pre-#2414 expression is right here,
+        and on this same state it yields the empty string."""
+        data = _state(repo)
+        assert data.get("spec_path", "") == ""  # what the old check read
+        # ...while the artifact was on the branch the entire time.
+        assert sr._resolve_stage_artifact(repo, 1, data, "spec")
+
+
+class TestGenuinelyMissingArtifactStillDeclines:
+    """The other half of the acceptance. A resume into a missing input is
+    worse than a redraw, so this MUST still refuse."""
+
+    def test_no_spec_anywhere_declines(self, repo, tmp_path):
+        _git(repo, "branch", "-m", "1-lld", "1-lld-gone")  # hide the artifacts
+        data = _state(repo)
+        data["stage_results"]["spec"]["artifact_path"] = ""
+        # The lld is still resolvable from its recorded path, so only the spec
+        # is missing -- which isolates the branch under test.
+        (repo / LLD_REL).parent.mkdir(parents=True, exist_ok=True)
+        (repo / LLD_REL).write_text("# LLD one\n", encoding="utf-8")
+        stage, log = _plan(repo, data, tmp_path)
+        assert stage is None
+        assert any("no spec artifact recorded" in line for line in log.lines)
+
+    def test_a_recorded_path_that_cannot_be_restored_declines(self, repo, tmp_path):
+        data = _state(repo, spec_path=str(repo / "docs/lld/drafts/ghost.md"))
+        stage, log = _plan(repo, data, tmp_path)
+        assert stage is None
+        assert any("not restorable" in line for line in log.lines)
+
+    def test_the_decline_names_which_stage_was_missing(self, repo, tmp_path):
+        data = _state(repo, spec_path=str(repo / "docs/lld/drafts/ghost.md"))
+        _stage, log = _plan(repo, data, tmp_path)
+        assert any("spec artifact" in line for line in log.lines)
+
+    def test_a_spec_stage_failure_does_not_need_the_spec_artifact(
+        self, repo, tmp_path
+    ):
+        """Only the impl branch requires the spec. A spec-stage resume must
+        not start demanding an artifact it is about to produce."""
+        data = _state(repo)
+        data["stage_results"]["spec"] = {"status": "failed", "error_message": "cap"}
+        data["stage_results"].pop("impl")
+        stage, _log = _plan(repo, data, tmp_path)
+        assert stage == "spec"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import fnmatch
 import json
 import os
 import re
@@ -593,6 +594,75 @@ def _open_lld_pr_exists(repo_root: Path, issue: int) -> bool:
         return False
 
 
+#: Where a resumable stage's artifact lives on the issue's lld branch, for the
+#: case where the orchestrator recorded no path at all (#2414). The branch is
+#: issue-scoped, so anything matching under it belongs to this issue.
+_STAGE_ARTIFACT_GLOBS = {
+    "lld": ("docs/lld/active/LLD-*.md",),
+    "spec": ("docs/lld/drafts/spec-*.md", "docs/lld/active/spec-*.md"),
+}
+
+
+def _find_on_lld_branch(repo_root: Path, issue: int, pattern: str) -> str:
+    """The repo-relative path of a file matching `pattern` on the lld branch.
+
+    The last match in sort order wins, so a repo carrying spec-0001 and
+    spec-0002 resolves to the newer one rather than to whichever git listed
+    first.
+    """
+    for ref in (f"{issue}-lld", f"origin/{issue}-lld"):
+        result = _run(["git", "ls-tree", "-r", "--name-only", ref], cwd=repo_root)
+        if result.returncode != 0:
+            continue
+        matches = sorted(
+            line.strip() for line in (result.stdout or "").splitlines()
+            if fnmatch.fnmatch(line.strip(), pattern)
+        )
+        if matches:
+            return matches[-1]
+    return ""
+
+
+def _resolve_stage_artifact(
+    repo_root: Path, issue: int, data: dict, stage: str
+) -> str:
+    """Where `stage`'s artifact actually is -- an artifact lookup, not a path
+    string lookup (#2414).
+
+    `resume_plan` used to read one field and abandon the resume when it was the
+    empty string, so a resume was declined on a MISSING PATH rather than on a
+    missing artifact. The artifact may well exist on disk or on the branch;
+    nothing checked. The distinction is the whole issue.
+
+    Three places are consulted, cheapest first:
+
+      1. the top-level `<stage>_path`, which `finalize_spec` populates when the
+         stage passes;
+      2. the stage result's own `artifact_path`, which is recorded per stage
+         and survives cases where the top-level field was never set;
+      3. the issue's lld branch, listed and matched by glob -- the same source
+         `_restore_artifact` already restores from.
+
+    Returns "" only when the artifact cannot be found anywhere, which is the
+    case that SHOULD decline: resuming into a missing input is worse than
+    redrawing.
+    """
+    recorded = (data.get(f"{stage}_path", "") or "").strip()
+    if recorded:
+        return recorded
+
+    results = data.get("stage_results", {}) or {}
+    from_result = ((results.get(stage) or {}).get("artifact_path", "") or "").strip()
+    if from_result:
+        return from_result
+
+    for pattern in _STAGE_ARTIFACT_GLOBS.get(stage, ()):
+        found = _find_on_lld_branch(repo_root, issue, pattern)
+        if found:
+            return str(repo_root / found)
+    return ""
+
+
 def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
     """Materialize a passed stage's file from the issue's lld branch when the
     working tree no longer has it -- the exit janitor clears pipeline-authored
@@ -916,14 +986,26 @@ def resume_plan(
     if draft_is_stale(repo_root, issue, data.get("started_at", ""), base, log):
         return None
 
-    needed = [data.get("lld_path", "")]
+    # #2414: an artifact lookup, not a path-string lookup. The old form read
+    # one field and abandoned on the empty string, so a resume was declined
+    # because no PATH was recorded rather than because no ARTIFACT existed --
+    # and the artifact is usually sitting on the lld branch, restorable. The
+    # decline still happens, but now only when the file genuinely cannot be
+    # found: resuming into a missing input is worse than redrawing.
+    needed = [("lld", _resolve_stage_artifact(repo_root, issue, data, "lld"))]
     if failed == "impl":
-        needed.append(data.get("spec_path", ""))
-    for artifact in needed:
-        if not artifact or not _restore_artifact(repo_root, issue, artifact):
+        needed.append(("spec", _resolve_stage_artifact(repo_root, issue, data, "spec")))
+    for stage, artifact in needed:
+        if not artifact:
             log.write(
-                f"RESUME abandoned for #{issue}: artifact missing and not "
-                f"restorable: {artifact or '<unset>'}"
+                f"RESUME abandoned for #{issue}: no {stage} artifact recorded, "
+                f"and none found on the {issue}-lld branch"
+            )
+            return None
+        if not _restore_artifact(repo_root, issue, artifact):
+            log.write(
+                f"RESUME abandoned for #{issue}: {stage} artifact missing and "
+                f"not restorable: {artifact}"
             )
             return None
 


### PR DESCRIPTION
Closes #2414

`resume_plan` read one field and abandoned the resume when it held the empty string, so the refusal fired on a **missing path string** rather than on a missing artifact. The artifact is usually committed on the issue's lld branch and perfectly restorable — `_restore_artifact` exists to do exactly that — and nothing checked. The distinction is the whole issue.

## The fix

`_resolve_stage_artifact` consults three places, cheapest first:

1. the top-level `<stage>_path`;
2. the stage result's own `artifact_path`, recorded per stage and surviving cases where the top-level field was never set;
3. the issue's lld branch, listed with `git ls-tree` and matched by glob — the same source `_restore_artifact` already restores from.

It returns `""` only when the artifact cannot be found anywhere, which is the case that **should** decline.

## One correction to the issue, which measurement contradicts

The issue states that `spec_path` is unset for a repo whose spec stage has run, and offers that as the reason the next impl failure would decline.

**It is not.** `finalize_spec.py:227` populates `spec_path` on a pass. The empty string the issue measured was because the spec stage had *failed* at that moment. Read now, boostgauge #1's state has `spec` passed and `spec_path` populated, and both artifacts resolve and restore:

```
lld:
  top-level lld_path  : ...\docs\lld\active\LLD-001.md
  stage artifact_path : ...\docs\lld\active\LLD-001.md
  RESOLVED            : ...\docs\lld\active\LLD-001.md
  restorable          : True
spec:
  top-level spec_path : ...\docs\lld\drafts\spec-0001-implementation-readiness.md
  stage artifact_path : ...\docs\lld\drafts\spec-0001-implementation-readiness.md
  RESOLVED            : ...\docs\lld\drafts\spec-0001-implementation-readiness.md
  restorable          : True
```

So the narrow shape the issue offers first — "populate `spec_path` when the spec stage passes" — was already true, and the issue's stated trigger no longer reproduces.

**The fix here is the second shape it offers, and it is still worth landing.** It makes the check consult the artifact rather than a path string, so the decline is correct whichever field happens to be empty. That covers the `artifact_path`-only case, the both-unset case, and the `lld` field the issue itself notes is "unaffected today only because `lld_path` happens to be populated".

## Acceptance — two-sided, as the issue requires

**Resumes:** an impl-stage halt with a passed spec resumes from `impl`, *and* the spec file is put back on disk where the impl stage can read it — not merely "resume was allowed".

**Still declines:** an impl-stage halt whose spec artifact genuinely cannot be found refuses, with a message naming which stage's artifact was missing. A recorded-but-unrestorable path also refuses.

A third case guards scope: a **spec**-stage resume must not start demanding the spec artifact it is about to produce.

## Notes

16 fixtures, built on a real git repo with a real `1-lld` branch rather than a stubbed `ls-tree` — the lookup's entire job is to consult the branch, so a stub would be testing the stub. The fixture asks git for its own default branch name rather than assuming `master`; hardcoding it left the tree on the lld branch where the artifacts it was meant to hide were still present.

Full unit suite green (8004 passing).
