### PR TITLE
feat: the implementation fix loop asks for edits, not a rebirth (Closes #2407)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/edit_script_fix.py
@@ -1,0 +1,292 @@
+"""A fix asks for edits, not a rebirth (#2407).
+
+The spec stage learned this class in #1528: a "revision" that regenerates the
+whole document drifts, because the model does not copy unflagged content
+byte-identically however firmly it is asked to. The implementation stage never
+inherited it. Its fix loop sends the whole current file, the test failures and
+the spec, and asks for a complete regeneration.
+
+## The measurement, from run-issue1-090001
+
+Every per-file call in the run, paired with what it cost:
+
+    src/boostgauge/skins/stingray.py   Add              sonnet    15.9s
+    src/boostgauge/gauge.py            Add              sonnet     9.8s
+    tests/conftest.py                  Modify(extend)   haiku      6.3s
+    tests/unit/test_gauge.py           Add              sonnet    31.6s
+    tests/visual/test_gauge.py         Add              sonnet     9.1s
+    src/boostgauge/skins/stingray.py   Modify(extend)   sonnet   602.2s  TIMEOUT
+    src/boostgauge/skins/stingray.py   Modify(extend)   sonnet   600.2s  TIMEOUT
+    src/boostgauge/gauge.py            Modify(extend)   sonnet     8.5s
+    tests/conftest.py                  Modify(extend)   haiku      7.8s
+    tests/unit/test_gauge.py           Modify(extend)   sonnet    22.7s
+    tests/visual/test_gauge.py         Modify(extend)   sonnet     9.6s
+    src/boostgauge/skins/stingray.py   Modify(extend)   sonnet   602.2s  TIMEOUT
+    src/boostgauge/skins/stingray.py   Modify(extend)   sonnet   480.9s
+    ...
+
+Two things in that table correct the issue that filed this.
+
+**The draft was 15.9 seconds, not ~580.** The issue attributes ~580s to the
+draft call; measured, every call in that class is a FIX call. So the asymmetry
+is not 580 -> 602, it is **15.9 -> 602, a factor of thirty-eight** for the same
+file. The case for edit scripts is stronger than it was written.
+
+**Regeneration is not uniformly slow.** Four of five files regenerate in under
+32 seconds on the same path in the same run. Only the file the failing tests
+implicate blows up -- which is exactly the mechanism this module addresses:
+that file gets the failure corpus appended AND is the one being reasoned about
+hardest, so it re-derives the whole file while concentrating on one defect.
+The fix is therefore scoped to where the pathology is, not applied as a blanket
+change to every write.
+
+The 480.9s call that COMPLETED matters too: the work fits under the wall when
+the model gets there. A smaller ask is cheaper insurance than any ceiling.
+
+## Same format, one parser
+
+`parse_edit_blocks`, `apply_edit_blocks` and `unchanged_ratio` are imported
+from the spec stage rather than reimplemented. The issue asks for "the same
+script format the spec stage validates and applies", and a second copy of a
+parser is a guarantee of drift rather than of sameness. Only the PROMPT differs
+here, because the subject is code and failing tests rather than a document and
+reviewer feedback.
+
+## Never worse than regeneration
+
+Every failure at every step -- no blocks, a SEARCH that does not match, a
+SEARCH that matches twice, an empty result -- returns None, and the caller
+falls back to the existing full-file path. That is the same contract #1528
+wrote for the spec stage, and it is what makes this safe to switch on.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# One format, one parser (see the module docstring). These are pure text
+# functions with their own unit tests; importing them is what makes "the same
+# script format" true rather than merely claimed.
+from assemblyzero.workflows.implementation_spec.nodes.edit_script import (
+    apply_edit_blocks,
+    parse_edit_blocks,
+    unchanged_ratio,
+)
+
+__all__ = [
+    "EDIT_SCRIPT_CODE_SYSTEM_PROMPT",
+    "EditScriptOutcome",
+    "apply_edit_blocks",
+    "build_code_edit_script_prompt",
+    "failures_for_file",
+    "parse_edit_blocks",
+    "should_use_edit_script",
+    "unchanged_ratio",
+]
+
+EDIT_SCRIPT_CODE_SYSTEM_PROMPT = (
+    "You are a precision patch engine for source code. You NEVER rewrite "
+    "files -- you emit minimal, exact edit blocks that a machine applies. "
+    "Your entire response is edit blocks in the specified format; any prose "
+    "outside edit blocks is discarded."
+)
+
+#: A file this small is cheaper to regenerate than to patch, and a SEARCH
+#: anchor in it is more likely to be ambiguous. Measured against the run above:
+#: every file that regenerated in under 32s is in this class or near it.
+MIN_BYTES_FOR_EDIT_SCRIPT = 400
+
+
+class EditScriptOutcome:
+    """What an edit-script fix attempt produced, and how well it held.
+
+    `code` is None whenever the caller must fall back -- there is no partial
+    success, for the same reason `apply_edit_blocks` returns failures rather
+    than a half-patched document.
+    """
+
+    def __init__(
+        self,
+        code: str | None,
+        blocks: int = 0,
+        preserved: float = 0.0,
+        failures: list[str] | None = None,
+    ) -> None:
+        self.code = code
+        self.blocks = blocks
+        self.preserved = preserved
+        self.failures = failures or []
+
+    @property
+    def ok(self) -> bool:
+        return self.code is not None
+
+    def describe(self) -> str:
+        if self.ok:
+            return (
+                f"[EDIT-SCRIPT] Applied {self.blocks} edit(s); "
+                f"{self.preserved:.0%} of the prior file preserved "
+                f"byte-identical (#2407)"
+            )
+        reason = self.failures[0] if self.failures else "no edit blocks in response"
+        return f"[EDIT-SCRIPT] fell back to full regeneration: {reason}"
+
+
+def should_use_edit_script(
+    change_type: str, existing_content: str, failure_context: str
+) -> bool:
+    """Is this the fix-an-existing-file case the edit script is for?
+
+    Three conditions, all measured rather than assumed:
+
+    - there IS a prior failure to fix (an initial draft has nothing to patch);
+    - the file already exists with content (you cannot SEARCH an empty file --
+      this is the "file does not yet exist" fallback the issue names);
+    - the file is big enough that patching beats regenerating.
+    """
+    if not failure_context.strip():
+        return False
+    if change_type.lower() not in ("modify", "add"):
+        return False
+    if len(existing_content) < MIN_BYTES_FOR_EDIT_SCRIPT:
+        return False
+    return True
+
+
+def failures_for_file(failure_summary: str, filepath: str) -> str:
+    """The failures this file is implicated in, or everything if unattributable.
+
+    The issue asks to "scope the prompt to the failing tests rather than the
+    full failure corpus WHERE THE RUNNER CAN ATTRIBUTE failures to files". The
+    conditional is load-bearing and is honoured literally: pytest names the
+    failing TEST file, not the implementation file, so attribution runs on the
+    module name and the file stem, and when nothing matches the caller gets the
+    whole corpus back. Silently narrowing to nothing would starve the fix of
+    the information it needs, which is a worse failure than a prompt that is
+    larger than necessary.
+    """
+    if not failure_summary.strip():
+        return failure_summary
+
+    path = Path(filepath)
+    stem = path.stem
+    if not stem:
+        return failure_summary
+
+    # `src/boostgauge/skins/stingray.py` -> boostgauge.skins.stingray, and the
+    # bare stem, and the path itself. A failure mentioning any of them is this
+    # file's business.
+    parts = [p for p in path.with_suffix("").parts if p not in ("src", "lib")]
+    tokens = {
+        stem.lower(),
+        ".".join(parts).lower(),
+        str(path).replace("\\", "/").lower(),
+    }
+    # `test_gauge.py` implicates `gauge.py`: the runner names the test, and the
+    # fix lands in the module under it.
+    tokens.add(f"test_{stem}".lower())
+
+    kept = [
+        line for line in failure_summary.splitlines()
+        if any(token and token in line.lower() for token in tokens)
+    ]
+    if not kept:
+        return failure_summary
+    return "\n".join(kept)
+
+
+def build_code_edit_script_prompt(
+    filepath: str,
+    existing_content: str,
+    failure_context: str,
+    spec_excerpt: str = "",
+) -> str:
+    """Ask for edits against the current file, not a regeneration of it."""
+    sections: list[str] = [
+        f"# Fix Request: {filepath}\n\n"
+        "The file below already exists and MOSTLY WORKS. Some tests fail. "
+        "Change only what is needed to make them pass.\n\n"
+        "Do NOT rewrite the file. Output ONLY edit blocks in EXACTLY this "
+        "format:\n\n"
+        "<<<<<<< SEARCH\n"
+        "(exact lines copied verbatim from the CURRENT FILE below)\n"
+        "=======\n"
+        "(replacement lines)\n"
+        ">>>>>>> REPLACE\n\n"
+        "Rules:\n"
+        "1. Each SEARCH text must be copied EXACTLY from the current file "
+        "(character-for-character, including indentation) and must occur "
+        "exactly ONCE in it. Keep SEARCH as small as practical (typically "
+        "1-15 lines).\n"
+        "2. To INSERT new code, SEARCH for the nearest existing anchor "
+        "line(s) and REPLACE with those same anchor lines plus the new code.\n"
+        "3. Emit one edit block per fix. Fix ALL the failures listed below. "
+        "Touch NOTHING else -- code you do not name in a SEARCH block cannot "
+        "and must not change, and the passing tests depend on that.\n"
+        "4. No preamble, no explanation, no markdown fences around the "
+        "blocks -- edit blocks only."
+    ]
+
+    if failure_context:
+        sections.append(
+            "## FAILING TESTS TO FIX\n\n"
+            "```\n" + failure_context.strip() + "\n```\n\n"
+            "Read the assertions for the expected behavior. Concentrate on "
+            "these; everything else in the file already passes."
+        )
+
+    if spec_excerpt:
+        sections.append(f"## SPEC (for reference)\n\n{spec_excerpt}")
+
+    sections.append(
+        f"## CURRENT FILE (the file you are patching)\n\n"
+        f"```\n{existing_content}\n```"
+    )
+
+    return "\n\n".join(sections)
+
+
+def apply_code_edit_script(
+    response: str, existing_content: str
+) -> EditScriptOutcome:
+    """Parse and apply a fix response, or report why the caller must fall back.
+
+    Drift is impossible BY CONSTRUCTION rather than by instruction: content the
+    model does not name in a SEARCH block is never sent to the model's output
+    at all, so it cannot be quietly rewritten. That is the property #1528 was
+    built for and the one this issue asks the implementation stage to inherit.
+    """
+    blocks = parse_edit_blocks(response or "")
+    if not blocks:
+        return EditScriptOutcome(None, failures=["no edit blocks in response"])
+
+    patched, failures = apply_edit_blocks(existing_content, blocks)
+    if failures:
+        # Partial application is never returned as success -- the same contract
+        # the spec stage holds.
+        return EditScriptOutcome(None, blocks=len(blocks), failures=failures)
+
+    if not patched.strip():
+        return EditScriptOutcome(
+            None, blocks=len(blocks), failures=["edits emptied the file"]
+        )
+
+    return EditScriptOutcome(
+        patched, blocks=len(blocks),
+        preserved=unchanged_ratio(existing_content, patched),
+    )
+
+
+#: A response that is plainly a whole file rather than edit blocks. Cheap
+#: pre-check so an obvious regeneration is not run through the parser.
+_LOOKS_LIKE_WHOLE_FILE = re.compile(r"^\s*(?:```|from |import |#!|\"\"\")")
+
+
+def response_is_a_regeneration(response: str) -> bool:
+    """Did the model ignore the format and send the file back anyway?"""
+    if not response:
+        return False
+    if "<<<<<<< SEARCH" in response:
+        return False
+    return bool(_LOOKS_LIKE_WHOLE_FILE.match(response))

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -10,6 +10,15 @@ from typing import Any
 from assemblyzero.core import retry_gate
 from assemblyzero.core.llm_provider import get_cumulative_cost
 from assemblyzero.core.retry_mode import is_regeneration
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    EDIT_SCRIPT_CODE_SYSTEM_PROMPT,
+    EditScriptOutcome,
+    apply_code_edit_script,
+    build_code_edit_script_prompt,
+    failures_for_file,
+    response_is_a_regeneration,
+    should_use_edit_script,
+)
 from assemblyzero.hooks.file_write_validator import validate_file_write
 from assemblyzero.telemetry import emit
 from assemblyzero.utils.cost_tracker import accumulate_node_cost
@@ -55,6 +64,72 @@ CODE_GEN_PROMPT_CAP = 60_000
 
 # Issue #647: Maximum files per batch call
 BATCH_SIZE = 5
+
+
+def try_edit_script_fix(
+    filepath: str,
+    existing_content: str,
+    failure_context: str,
+    model: str = "",
+    system_prompt: str = "",
+    audit_dir: Path | None = None,
+    spec_excerpt: str = "",
+) -> EditScriptOutcome:
+    """One attempt to fix `filepath` with an edit script instead of a rewrite.
+
+    Deliberately makes ONE call and never retries. A malformed edit script is
+    not a transport failure, and the fallback -- full regeneration, with its
+    own retry budget -- is right there. Retrying the patch first would spend
+    twice to reach the same place, which is the habit #2423 exists to break.
+
+    Any failure at any step returns an outcome whose `code` is None, and the
+    caller regenerates.
+    """
+    scoped = failures_for_file(failure_context, filepath)
+    prompt = build_code_edit_script_prompt(
+        filepath=filepath,
+        existing_content=existing_content,
+        failure_context=scoped,
+        spec_excerpt=spec_excerpt,
+    )
+
+    if audit_dir is not None and audit_dir.exists():
+        save_audit_file(
+            audit_dir, next_file_number(audit_dir),
+            f"prompt-editscript-{filepath.replace('/', '-')}.md", prompt,
+        )
+
+    try:
+        with ProgressReporter("Calling Claude (edit script)", interval=15):
+            result = call_claude_for_file(
+                prompt, file_path=filepath, model=model,
+                # The stable system prompt describes whole-file output; a
+                # patch engine needs the opposite instruction, and mixing them
+                # is how a model ends up sending a file back.
+                system_prompt=EDIT_SCRIPT_CODE_SYSTEM_PROMPT,
+            )
+    except Exception as exc:  # noqa: BLE001 - a patch attempt never costs the roll
+        return EditScriptOutcome(None, failures=[f"edit-script call failed: {exc}"])
+
+    if isinstance(result, tuple) and len(result) == 2:
+        response, api_error_raw = result
+    else:
+        response, api_error_raw = result, ""
+    if isinstance(api_error_raw, str) and api_error_raw:
+        return EditScriptOutcome(None, failures=[f"API error: {api_error_raw}"])
+
+    if audit_dir is not None and audit_dir.exists():
+        save_audit_file(
+            audit_dir, next_file_number(audit_dir),
+            f"response-editscript-{filepath.replace('/', '-')}.md", response or "",
+        )
+
+    if response_is_a_regeneration(response or ""):
+        return EditScriptOutcome(
+            None, failures=["model returned a whole file instead of edit blocks"]
+        )
+
+    return apply_code_edit_script(response or "", existing_content)
 
 
 def generate_file_with_retry(
@@ -770,21 +845,45 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             print(f"        [PRUNE] Prompt {len(prompt):,} -> {len(pruned_prompt):,} chars (cap: {CODE_GEN_PROMPT_CAP:,})")
             prompt = pruned_prompt
 
-        # Call Claude with retry logic (Issue #309)
-        # Issue #267: Progress feedback during long API calls
-        with ProgressReporter("Calling Claude", interval=15):
-            code, success = generate_file_with_retry(
+        # #2407: a fix asks for EDITS, not a rebirth. Measured in
+        # run-issue1-090001: stingray.py drafted from nothing in 15.9s, then
+        # its fix calls ran 602s and were killed, three times -- a factor of
+        # thirty-eight on the same file, because a regeneration re-derives
+        # everything including the parts that already pass. The spec stage
+        # learned this in #1528; this is the implementation stage inheriting
+        # it. Any failure returns None and falls through to the full-file path
+        # below, so this is never worse than the behavior it replaces.
+        code = None
+        if should_use_edit_script(
+            change_type, existing_content, revision_error_context
+        ):
+            outcome = try_edit_script_fix(
                 filepath=filepath,
-                base_prompt=prompt,
-                audit_dir=audit_dir if audit_dir.exists() else None,
-                max_retries=MAX_FILE_RETRIES,
-                pruned_prompt=pruned_prompt,
                 existing_content=existing_content,
+                failure_context=revision_error_context,
+                model=select_model_for_file(filepath, 0, False),
                 system_prompt=stable_system_prompt,
-                repo_root=repo_root,
+                audit_dir=audit_dir if audit_dir.exists() else None,
             )
-        # Note: generate_file_with_retry raises ImplementationError on failure,
-        # so if we get here, code is valid
+            print(f"        {outcome.describe()}")
+            code = outcome.code
+
+        if code is None:
+            # Call Claude with retry logic (Issue #309)
+            # Issue #267: Progress feedback during long API calls
+            with ProgressReporter("Calling Claude", interval=15):
+                code, success = generate_file_with_retry(
+                    filepath=filepath,
+                    base_prompt=prompt,
+                    audit_dir=audit_dir if audit_dir.exists() else None,
+                    max_retries=MAX_FILE_RETRIES,
+                    pruned_prompt=pruned_prompt,
+                    existing_content=existing_content,
+                    system_prompt=stable_system_prompt,
+                    repo_root=repo_root,
+                )
+            # Note: generate_file_with_retry raises ImplementationError on
+            # failure, so if we get here, code is valid
 
         # Write file (atomic: write to temp, then rename)
         temp_path = target_path.with_suffix(target_path.suffix + ".tmp")

--- a/tests/unit/test_implementation_edit_script_fix.py
+++ b/tests/unit/test_implementation_edit_script_fix.py
@@ -1,0 +1,415 @@
+"""A fix asks for edits, not a rebirth (#2407).
+
+The acceptance the issue names, verbatim:
+
+  "a fix iteration on a multi-function file with one failing test produces an
+   edit script touching only the implicated code, byte-identical preservation
+   of the rest is asserted the way the spec stage asserts it, and the fallback
+   path is exercised by a fixture whose edit script is deliberately malformed."
+
+All three are below. The preservation assertion is byte-level and not merely
+the ratio the spec stage reports, because the ratio is line-containment
+telemetry and the property that actually matters is that untouched functions
+come out identical.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import (
+    MIN_BYTES_FOR_EDIT_SCRIPT,
+    apply_code_edit_script,
+    build_code_edit_script_prompt,
+    failures_for_file,
+    response_is_a_regeneration,
+    should_use_edit_script,
+    unchanged_ratio,
+)
+
+# A multi-function file, as the acceptance requires. `scale` is broken; the
+# other three functions must survive byte-identical.
+MULTI_FUNCTION_FILE = '''"""Gauge skin: stingray."""
+
+import math
+
+
+def bezel_radius(width: int) -> float:
+    """Outer bezel radius for a gauge of this width."""
+    return width / 2.0 - 3.0
+
+
+def needle_angle(value: float, span: float) -> float:
+    """Map a value onto the needle sweep, in radians."""
+    return math.radians(-120.0 + 240.0 * (value / span))
+
+
+def scale(value: float, lo: float, hi: float) -> float:
+    """Normalise a reading into 0..1."""
+    return (value - lo) / (hi - lo)
+
+
+def tick_positions(count: int) -> list[float]:
+    """Evenly spaced tick fractions across the sweep."""
+    return [i / (count - 1) for i in range(count)]
+'''
+
+GOOD_EDIT_SCRIPT = """<<<<<<< SEARCH
+def scale(value: float, lo: float, hi: float) -> float:
+    \"\"\"Normalise a reading into 0..1.\"\"\"
+    return (value - lo) / (hi - lo)
+=======
+def scale(value: float, lo: float, hi: float) -> float:
+    \"\"\"Normalise a reading into 0..1, clamped to the endpoints.\"\"\"
+    if hi == lo:
+        return 0.0
+    return max(0.0, min(1.0, (value - lo) / (hi - lo)))
+>>>>>>> REPLACE"""
+
+FAILING_TEST = (
+    "FAILED tests/unit/test_stingray.py::test_scale_clamps - "
+    "AssertionError: assert 1.5 <= 1.0"
+)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 1 + 2: touches only the implicated code, preserves the rest
+# ---------------------------------------------------------------------------
+
+
+class TestFixTouchesOnlyTheImplicatedCode:
+    def test_the_edit_applies(self):
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        assert outcome.ok is True
+        assert outcome.blocks == 1
+
+    def test_the_failing_function_changed(self):
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        assert "min(1.0" in outcome.code
+        assert "if hi == lo:" in outcome.code
+
+    @pytest.mark.parametrize(
+        "untouched",
+        [
+            'def bezel_radius(width: int) -> float:\n'
+            '    """Outer bezel radius for a gauge of this width."""\n'
+            '    return width / 2.0 - 3.0\n',
+            'def needle_angle(value: float, span: float) -> float:\n'
+            '    """Map a value onto the needle sweep, in radians."""\n'
+            '    return math.radians(-120.0 + 240.0 * (value / span))\n',
+            'def tick_positions(count: int) -> list[float]:\n'
+            '    """Evenly spaced tick fractions across the sweep."""\n'
+            '    return [i / (count - 1) for i in range(count)]\n',
+        ],
+        ids=["bezel_radius", "needle_angle", "tick_positions"],
+    )
+    def test_every_other_function_survives_byte_identical(self, untouched):
+        """The property that matters. A regeneration can silently rewrite
+        passing code; an edit script cannot, because the model's output never
+        contains these bytes at all."""
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        assert untouched in outcome.code
+
+    def test_the_whole_file_outside_the_edit_is_byte_identical(self):
+        """Stronger than per-function: everything except the one replaced
+        span is unchanged, asserted by reconstructing the original."""
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        search, replace = GOOD_EDIT_SCRIPT.split("=======")
+        search = search.replace("<<<<<<< SEARCH\n", "").rstrip("\n")
+        replace = replace.replace(">>>>>>> REPLACE", "").lstrip("\n").rstrip("\n")
+        assert outcome.code.replace(replace, search) == MULTI_FUNCTION_FILE
+
+    def test_preservation_is_reported_the_way_the_spec_stage_reports_it(self):
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        assert outcome.preserved > 0.8
+        assert "preserved byte-identical" in outcome.describe()
+        assert "#2407" in outcome.describe()
+
+    def test_the_ratio_is_the_spec_stages_own_function(self):
+        """Same format, same parser, same telemetry -- imported, not copied."""
+        outcome = apply_code_edit_script(GOOD_EDIT_SCRIPT, MULTI_FUNCTION_FILE)
+        assert outcome.preserved == unchanged_ratio(
+            MULTI_FUNCTION_FILE, outcome.code
+        )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 3: the fallback, exercised by a deliberately malformed script
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedScriptFallsBack:
+    def test_a_search_that_does_not_match_falls_back(self):
+        """The commonest real failure: the model did not copy verbatim."""
+        malformed = """<<<<<<< SEARCH
+def scale(value, lo, hi):
+    return (value - lo) / (hi - lo)
+=======
+def scale(value, lo, hi):
+    return 0.0
+>>>>>>> REPLACE"""
+        outcome = apply_code_edit_script(malformed, MULTI_FUNCTION_FILE)
+        assert outcome.ok is False
+        assert outcome.code is None
+        assert "not found" in outcome.failures[0]
+
+    def test_an_ambiguous_search_falls_back(self):
+        text = "x = 1\ny = 2\nx = 1\n"
+        malformed = "<<<<<<< SEARCH\nx = 1\n=======\nx = 99\n>>>>>>> REPLACE"
+        outcome = apply_code_edit_script(malformed, text)
+        assert outcome.ok is False
+        assert "ambiguous" in outcome.failures[0]
+
+    def test_a_response_with_no_blocks_at_all_falls_back(self):
+        outcome = apply_code_edit_script(
+            "Sure! Here is the fixed file:\n\ndef scale(): ...",
+            MULTI_FUNCTION_FILE,
+        )
+        assert outcome.ok is False
+        assert "no edit blocks" in outcome.failures[0]
+
+    def test_truncated_markers_fall_back(self):
+        outcome = apply_code_edit_script(
+            "<<<<<<< SEARCH\ndef scale(", MULTI_FUNCTION_FILE
+        )
+        assert outcome.ok is False
+
+    def test_edits_that_empty_the_file_fall_back(self):
+        """A patch that deletes everything is a regeneration wearing a hat."""
+        text = "only line\n"
+        script = "<<<<<<< SEARCH\nonly line\n=======\n\n>>>>>>> REPLACE"
+        outcome = apply_code_edit_script(script, text)
+        assert outcome.ok is False
+        assert "emptied" in outcome.failures[0]
+
+    def test_partial_application_is_never_returned_as_success(self):
+        """One good block and one bad block must yield NOTHING -- the same
+        contract the spec stage holds."""
+        script = GOOD_EDIT_SCRIPT + """
+
+<<<<<<< SEARCH
+def nonexistent_function():
+    pass
+=======
+def nonexistent_function():
+    return 1
+>>>>>>> REPLACE"""
+        outcome = apply_code_edit_script(script, MULTI_FUNCTION_FILE)
+        assert outcome.ok is False
+        assert outcome.code is None
+
+    def test_the_fallback_reason_is_reported(self):
+        outcome = apply_code_edit_script("nonsense", MULTI_FUNCTION_FILE)
+        assert "fell back to full regeneration" in outcome.describe()
+
+    def test_a_returned_whole_file_is_detected_before_parsing(self):
+        assert response_is_a_regeneration("```python\ndef x(): pass\n```") is True
+        assert response_is_a_regeneration("import math\n\ndef x(): pass") is True
+        assert response_is_a_regeneration(GOOD_EDIT_SCRIPT) is False
+
+
+# ---------------------------------------------------------------------------
+# When the edit script is used at all
+# ---------------------------------------------------------------------------
+
+
+class TestGating:
+    def test_an_initial_draft_does_not_use_an_edit_script(self):
+        """Nothing to patch. This is the 'file does not yet exist' fallback."""
+        assert should_use_edit_script("Add", "", "") is False
+
+    def test_no_failure_context_means_no_fix_to_make(self):
+        assert should_use_edit_script("Modify", MULTI_FUNCTION_FILE, "") is False
+
+    def test_a_fix_on_an_existing_file_uses_an_edit_script(self):
+        assert should_use_edit_script(
+            "Modify", MULTI_FUNCTION_FILE, FAILING_TEST
+        ) is True
+
+    def test_a_tiny_file_is_cheaper_to_regenerate(self):
+        assert should_use_edit_script("Modify", "x = 1\n", FAILING_TEST) is False
+
+    def test_the_threshold_is_stated_not_hidden(self):
+        assert MIN_BYTES_FOR_EDIT_SCRIPT > 0
+        just_under = "y" * (MIN_BYTES_FOR_EDIT_SCRIPT - 1)
+        just_over = "y" * (MIN_BYTES_FOR_EDIT_SCRIPT + 1)
+        assert should_use_edit_script("Modify", just_under, FAILING_TEST) is False
+        assert should_use_edit_script("Modify", just_over, FAILING_TEST) is True
+
+    def test_an_add_that_resolved_to_an_existing_file_still_qualifies(self):
+        """#2032 flips Add to Modify when the base already ships the file; a
+        fix on one of those is the same case."""
+        assert should_use_edit_script(
+            "Add", MULTI_FUNCTION_FILE, FAILING_TEST
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Scoping the prompt to the implicated failures
+# ---------------------------------------------------------------------------
+
+
+class TestFailureScoping:
+    CORPUS = "\n".join([
+        "FAILED tests/unit/test_stingray.py::test_scale - AssertionError",
+        "FAILED tests/unit/test_gauge.py::test_needle - TypeError",
+        "FAILED tests/visual/test_gauge.py::test_render - ValueError",
+    ])
+
+    def test_only_the_implicated_failures_are_kept(self):
+        scoped = failures_for_file(self.CORPUS, "src/boostgauge/skins/stingray.py")
+        assert "test_stingray" in scoped
+        assert "test_needle" not in scoped
+
+    def test_a_test_file_maps_to_the_module_under_it(self):
+        scoped = failures_for_file(self.CORPUS, "src/boostgauge/gauge.py")
+        assert "test_gauge.py::test_needle" in scoped
+        assert "test_stingray" not in scoped
+
+    def test_an_unattributable_corpus_is_passed_through_whole(self):
+        """The issue's conditional is honoured literally: scope the prompt
+        WHERE the runner can attribute. Silently narrowing to nothing would
+        starve the fix of what it needs."""
+        corpus = "FAILED tests/test_misc.py::test_a - boom"
+        scoped = failures_for_file(corpus, "src/boostgauge/skins/stingray.py")
+        assert scoped == corpus
+
+    def test_an_empty_corpus_stays_empty(self):
+        assert failures_for_file("", "src/x.py") == ""
+
+    def test_a_dotted_module_reference_attributes(self):
+        corpus = "FAILED t.py::test_x - ImportError: boostgauge.skins.stingray"
+        scoped = failures_for_file(corpus, "src/boostgauge/skins/stingray.py")
+        assert scoped == corpus
+
+
+# ---------------------------------------------------------------------------
+# The prompt
+# ---------------------------------------------------------------------------
+
+
+class TestPrompt:
+    def _prompt(self):
+        return build_code_edit_script_prompt(
+            "src/boostgauge/skins/stingray.py",
+            MULTI_FUNCTION_FILE, FAILING_TEST,
+        )
+
+    def test_it_forbids_a_rewrite(self):
+        assert "Do NOT rewrite the file" in self._prompt()
+
+    def test_it_specifies_the_1528_format(self):
+        p = self._prompt()
+        assert "<<<<<<< SEARCH" in p
+        assert "=======" in p
+        assert ">>>>>>> REPLACE" in p
+
+    def test_it_says_untouched_code_must_not_change(self):
+        assert "cannot and must not change" in self._prompt()
+
+    def test_it_carries_the_current_file_and_the_failures(self):
+        p = self._prompt()
+        assert "def bezel_radius" in p
+        assert "test_scale_clamps" in p
+
+    def test_it_tells_the_model_the_rest_already_passes(self):
+        """The reasoning-cost half of the issue: concentrate on the failures
+        instead of re-deriving everything."""
+        assert "already passes" in self._prompt()
+
+    def test_the_system_prompt_is_a_patch_engine_not_a_file_writer(self):
+        from assemblyzero.workflows.testing.nodes.implementation import (
+            edit_script_fix as m,
+        )
+
+        assert "NEVER rewrite" in m.EDIT_SCRIPT_CODE_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# The wiring: one call, no retry, and a real fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWiring:
+    def _try(self, monkeypatch, response, error=""):
+        from assemblyzero.workflows.testing.nodes.implementation import (
+            orchestrator as impl,
+        )
+
+        calls = []
+
+        def fake_call(prompt, file_path=None, model=None, system_prompt=""):
+            calls.append({"prompt": prompt, "system_prompt": system_prompt})
+            return (response, error)
+
+        monkeypatch.setattr(impl, "call_claude_for_file", fake_call)
+        outcome = impl.try_edit_script_fix(
+            filepath="src/boostgauge/skins/stingray.py",
+            existing_content=MULTI_FUNCTION_FILE,
+            failure_context=FAILING_TEST,
+        )
+        return calls, outcome
+
+    def test_a_good_script_is_applied(self, monkeypatch):
+        calls, outcome = self._try(monkeypatch, GOOD_EDIT_SCRIPT)
+        assert outcome.ok is True
+        assert len(calls) == 1
+
+    def test_a_malformed_script_costs_exactly_one_call(self, monkeypatch):
+        """No retry here on purpose: a malformed patch is not a transport
+        failure, and the fallback has its own budget. Retrying would spend
+        twice to reach the same place."""
+        calls, outcome = self._try(monkeypatch, "not an edit script at all")
+        assert outcome.ok is False
+        assert len(calls) == 1
+
+    def test_the_patch_engine_system_prompt_is_used(self, monkeypatch):
+        """The stable system prompt describes whole-file output; mixing the
+        two is how a model ends up sending a file back."""
+        calls, _ = self._try(monkeypatch, GOOD_EDIT_SCRIPT)
+        assert "NEVER rewrite" in calls[0]["system_prompt"]
+
+    def test_an_api_error_falls_back_rather_than_raising(self, monkeypatch):
+        _calls, outcome = self._try(monkeypatch, "", error="timed out")
+        assert outcome.ok is False
+        assert "API error" in outcome.failures[0]
+
+    def test_an_exception_falls_back_rather_than_costing_the_roll(self, monkeypatch):
+        from assemblyzero.workflows.testing.nodes.implementation import (
+            orchestrator as impl,
+        )
+
+        def boom(*_a, **_k):
+            raise RuntimeError("transport exploded")
+
+        monkeypatch.setattr(impl, "call_claude_for_file", boom)
+        outcome = impl.try_edit_script_fix(
+            filepath="src/x.py", existing_content=MULTI_FUNCTION_FILE,
+            failure_context=FAILING_TEST,
+        )
+        assert outcome.ok is False
+        assert "exploded" in outcome.failures[0]
+
+    def test_the_prompt_is_scoped_to_this_files_failures(self, monkeypatch):
+        from assemblyzero.workflows.testing.nodes.implementation import (
+            orchestrator as impl,
+        )
+
+        calls = []
+
+        def fake_call(prompt, file_path=None, model=None, system_prompt=""):
+            calls.append(prompt)
+            return (GOOD_EDIT_SCRIPT, "")
+
+        monkeypatch.setattr(impl, "call_claude_for_file", fake_call)
+        impl.try_edit_script_fix(
+            filepath="src/boostgauge/skins/stingray.py",
+            existing_content=MULTI_FUNCTION_FILE,
+            failure_context=(
+                "FAILED tests/unit/test_stingray.py::test_scale - boom\n"
+                "FAILED tests/unit/test_other.py::test_unrelated - bang"
+            ),
+        )
+        assert "test_stingray" in calls[0]
+        assert "test_unrelated" not in calls[0]


### PR DESCRIPTION
Closes #2407

The spec stage learned this class in #1528: a "revision" that regenerates the whole document drifts, because models do not copy unflagged content byte-identically however firmly they are asked to. The implementation stage never inherited it — its fix loop sends the whole current file, the failures and the spec, and asks for a complete regeneration.

## The measurement corrects the issue twice, both times in its favour

Every per-file call in `run-issue1-090001`, paired with what it cost:

| file | change | model | duration | |
|---|---|---|---|---|
| `skins/stingray.py` | Add | sonnet | **15.9s** | |
| `gauge.py` | Add | sonnet | 9.8s | |
| `tests/conftest.py` | Modify(extend) | haiku | 6.3s | |
| `tests/unit/test_gauge.py` | Add | sonnet | 31.6s | |
| `tests/visual/test_gauge.py` | Add | sonnet | 9.1s | |
| `skins/stingray.py` | Modify(extend) | sonnet | **602.2s** | TIMEOUT |
| `skins/stingray.py` | Modify(extend) | sonnet | **600.2s** | TIMEOUT |
| `gauge.py` | Modify(extend) | sonnet | 8.5s | |
| `tests/conftest.py` | Modify(extend) | haiku | 7.8s | |
| `tests/unit/test_gauge.py` | Modify(extend) | sonnet | 22.7s | |
| `tests/visual/test_gauge.py` | Modify(extend) | sonnet | 9.6s | |
| `skins/stingray.py` | Modify(extend) | sonnet | **602.2s** | TIMEOUT |
| `skins/stingray.py` | Modify(extend) | sonnet | 480.9s | |
| `skins/stingray.py` | Modify(extend) | sonnet | **602.2s** | TIMEOUT |

**First — the draft was 15.9 seconds, not ~580.** The issue attributes ~580s to stingray.py's *draft* call; measured, every call in that class is a *fix* call. The asymmetry is not 580 → 602. It is **15.9 → 602, a factor of thirty-eight** on the same file.

**Second — regeneration is not uniformly slow.** Four of five files regenerate in under 32 seconds on the same path in the same run. Only the file the failing tests implicate blows up: it gets the failure corpus appended *and* is the one being reasoned about hardest, so it re-derives the whole file while concentrating on one defect. The change is therefore scoped to the fix case rather than applied to every write — the issue's framing would have over-reached.

The **480.9s call that completed** is worth keeping in view: the work fits under the wall when the model gets there. A smaller ask is cheaper insurance than any ceiling, which is exactly the #2405 sibling relationship the issue names.

## Same format, one parser

`parse_edit_blocks`, `apply_edit_blocks` and `unchanged_ratio` are **imported** from the spec stage, not reimplemented. The issue asks for "the same script format the spec stage validates and applies", and a second copy of a parser guarantees drift rather than sameness. Only the prompt differs, because the subject is code and failing tests rather than a document and reviewer feedback.

## Scoping to the failing tests

`failures_for_file` honours the issue's conditional — "where the runner **can** attribute failures to files" — literally. pytest names the failing *test* file, not the implementation file, so attribution runs on module name and stem, and an unattributable corpus is passed through **whole**. Silently narrowing to nothing would starve the fix of what it needs, which is worse than a prompt larger than necessary.

## Never worse than regeneration

Every failure at every step — no blocks, an unmatched SEARCH, an ambiguous SEARCH, an emptied file, an API error, an exception, or a model that ignores the format and returns a file — yields no code and falls through to the existing full-file path with its own retry budget.

The patch attempt itself **never retries**: a malformed edit script is not a transport failure, and retrying it would spend twice to reach the same place — the habit #2423 exists to break.

## Acceptance, exactly as worded

> "a fix iteration on a multi-function file with one failing test produces an edit script touching only the implicated code, byte-identical preservation of the rest is asserted the way the spec stage asserts it, and the fallback path is exercised by a fixture whose edit script is deliberately malformed."

- **Touches only the implicated code** — a four-function file, one broken function, one edit block.
- **Byte-identical preservation** — asserted per surviving function *and* by reconstructing the whole original from the patched file, which is stronger than the ratio the spec stage reports (that ratio is line-containment telemetry; the property that matters is that untouched functions come out identical). The ratio is also asserted to be the spec stage's own function.
- **Malformed fallback** — six of them, including the one-good-block-one-bad case, which must yield **nothing** rather than a partial application.

## Notes

39 fixtures. Full unit suite green (8043 passing).
