### PR TITLE
fix: a check that has never been tried does not spend the cap (Closes #2304)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/graph.py
+++ b/assemblyzero/workflows/implementation_spec/graph.py
@@ -155,7 +155,21 @@ def route_after_validation(
             return "N4_human_gate"
         return "N5_review_spec"
 
-    # Validation failed
+    # Validation failed.
+    #
+    # #2304: a check that has never been shown to the drafter grants one extra
+    # revision past the cap. N3 computes the grant -- a router's state writes
+    # are discarded at the graph boundary (#2018), so the bookkeeping that
+    # stops a grace being claimed twice cannot live here.
+    grace_for = state.get("grace_revision_for", [])
+    if review_iteration >= max_iterations and grace_for:
+        print(
+            f"    [ROUTING] Cap reached ({max_iterations}), but "
+            f"{', '.join(grace_for)} has never reached a revision prompt - "
+            f"granting one revision (#2304)"
+        )
+        return "N2_generate_spec"
+
     if review_iteration < max_iterations:
         completeness_issues = state.get("completeness_issues", [])
         if completeness_issues:

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -250,22 +250,70 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     # the graph boundary (#2018), so the halt recorded nothing and the banner
     # read "Error: unknown". Below the cap the message stays empty: the run is
     # still going, and a pending revision is not a failure.
+    # Closes #2304: a check that first fails on the FINAL revision receives
+    # zero revisions, and the stage dies on a failure the drafter was never
+    # asked to fix. Measured on boostgauge #7 -- three iterations on
+    # `criteria_have_tests`, and satisfying it surfaced
+    # `functions_have_io_examples` with the budget already spent.
+    #
+    # That loop was CONVERGING. A cap exists to stop a loop repeating itself;
+    # killing one at the moment it made progress is the opposite of its
+    # purpose. Raising the cap only moves the cliff -- the same run would then
+    # die on whatever the next fix surfaces.
+    #
+    # So the distinction is encoded rather than the number raised: a check that
+    # has never been shown to the drafter has not been tried once, and is not
+    # evidence of non-convergence. It grants exactly one extra revision, once.
+    failing_names = [c["check_name"] for c in checks if not c["passed"]]
+    shown = list(state.get("checks_shown_to_drafter", []))
+    grace_used = list(state.get("grace_revisions_used", []))
+
+    grace_for: list[str] = []
     cap_message = ""
     if not validation_passed:
         iteration = state.get("review_iteration", 0)
         max_iterations = state.get("max_iterations", 3)
         if iteration >= max_iterations:
-            listed = "; ".join(completeness_issues[:3])
-            cap_message = (
-                f"Iteration cap: {max_iterations} revision(s) ended with "
-                f"{len(completeness_issues)} unresolved completeness check(s). "
-                f"Unfixed: {listed}"
-            )
+            grace_for = grant_grace(failing_names, shown, grace_used)
+            if grace_for:
+                grace_used.extend(grace_for)
+                print(
+                    f"    [CAP] {max_iterations} revision(s) spent, but "
+                    f"{', '.join(grace_for)} has never been shown to the "
+                    f"drafter. Granting one revision for it (#2304)."
+                )
+            else:
+                listed = "; ".join(completeness_issues[:3])
+                # The two halts read differently on purpose. "N revisions ended
+                # with 1 unresolved check" reads as a stubborn drafter; when
+                # every failing check HAS been tried, that is the true reading.
+                tried = ", ".join(sorted(set(failing_names) & set(shown + grace_used)))
+                detail = (
+                    f" Each unresolved check was shown to the drafter and "
+                    f"survived a revision: {tried}."
+                    if tried else ""
+                )
+                cap_message = (
+                    f"Iteration cap: {max_iterations} revision(s) ended with "
+                    f"{len(completeness_issues)} unresolved completeness "
+                    f"check(s).{detail} Unfixed: {listed}"
+                )
+
+    # A failing set that is about to become a revision prompt has, by
+    # definition, been shown to the drafter. Recorded whether the revision is
+    # the ordinary kind or a grace, so a grace cannot be claimed twice.
+    if not validation_passed and (grace_for or not cap_message):
+        for name in failing_names:
+            if name not in shown:
+                shown.append(name)
 
     return {
         "completeness_issues": completeness_issues,
         "validation_passed": validation_passed,
         "prior_completeness_breakdown": prior_breakdown,
+        "checks_shown_to_drafter": shown,
+        "grace_revisions_used": grace_used,
+        "grace_revision_for": grace_for,
         "error_message": cap_message,
     }
 
@@ -561,6 +609,27 @@ def _is_test_function(name: str) -> bool:
     report says so out loud rather than passing them silently.
     """
     return name.startswith("test_") or name.endswith("_test")
+
+
+def grant_grace(
+    failing_names: list[str], shown: list[str], grace_used: list[str]
+) -> list[str]:
+    """Which failing checks earn one extra revision past the cap (#2304).
+
+    A pure function per ADR 0224, and deliberately not inlined: a test that
+    re-expresses this rule instead of calling it would agree with itself
+    forever, which is the #2264 class of green-while-asserting-nothing.
+
+    A check qualifies when it has never reached a revision prompt (`shown`) and
+    has never claimed a grace before (`grace_used`). The first condition is the
+    whole point -- a check that has not been tried once is not evidence of
+    non-convergence. The second bounds it, so a check that alternates pass and
+    fail spends its one grace and then meets the wall like anything else.
+    """
+    return [
+        name for name in failing_names
+        if name not in shown and name not in grace_used
+    ]
 
 
 def check_functions_have_io_examples(spec: str) -> CompletenessCheck:

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -212,6 +212,25 @@ class ImplementationSpecState(TypedDict, total=False):
     # Each entry: {"iteration": int, "failures": list[str]}.
     prior_completeness_breakdown: list[dict]
 
+    # Closes #2304: the cap must distinguish a loop repeating itself from a
+    # loop making progress. Measured on boostgauge #7: three iterations went to
+    # `criteria_have_tests`, and the act of satisfying it surfaced
+    # `functions_have_io_examples` on the final revision -- with the budget
+    # already spent, so no revision prompt naming it was ever built. The
+    # drafter was never once told about the check that killed the stage.
+    #
+    # checks_shown_to_drafter: names that have appeared in a failing set which
+    #   became a revision prompt. A check in here has been TRIED.
+    # grace_revisions_used: names that have already claimed their one extra
+    #   revision. Bounds the grace so an oscillating check cannot claim it
+    #   twice -- it spends its grace, then meets the wall like anything else.
+    # grace_revision_for: the names granting a grace on THIS iteration. The
+    #   router reads it; the node writes it, because a router's state writes
+    #   are discarded at the graph boundary (#2018).
+    checks_shown_to_drafter: list[str]
+    grace_revisions_used: list[str]
+    grace_revision_for: list[str]
+
     # Closes #1527: Symbol names (class names + function/method names) extracted
     # from all gathered .py files by N1. Used by N3 to detect hallucinated API
     # calls that reference methods not defined in the target project.

--- a/tests/unit/test_cap_grace_for_untried_check.py
+++ b/tests/unit/test_cap_grace_for_untried_check.py
@@ -1,0 +1,232 @@
+"""A check that has never been tried is not evidence of non-convergence (#2304).
+
+Measured on the 2026-08-13 boostgauge #7 roll:
+
+    iteration 0   criteria_have_tests FAIL   io_examples PASS   3 revisions left
+    iteration 1   criteria_have_tests FAIL   io_examples PASS   2 left
+    iteration 2   criteria_have_tests FAIL   io_examples PASS   1 left
+    iteration 3   criteria_have_tests PASS   io_examples FAIL   0 left
+
+The whole budget went to one check. When the drafter satisfied it, the act of
+satisfying it surfaced a second -- and the cap was already spent, so no
+revision prompt containing `functions_have_io_examples` was ever built. The
+drafter was never once told about the check that killed the stage.
+
+That loop was CONVERGING. A cap exists to stop a loop repeating itself, and
+killing one at the moment it made progress is the opposite of its purpose.
+
+Raising the cap is not the fix and is not what this tests: it moves the cliff
+without removing it. What is encoded is the distinction -- a check that has
+never reached a revision prompt has not been tried once, and gets exactly one
+revision, once.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from assemblyzero.workflows.implementation_spec.graph import (
+    route_after_validation,
+)
+
+# `nodes/__init__` re-exports the FUNCTION `validate_completeness`, which
+# shadows the module of the same name -- a plain `from ... import x as vc`
+# binds the function and every `hasattr` assertion against it is vacuously
+# False (lessons-learned 2026-08-14, recurrence 2026-08-15).
+vc = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+)
+grant_grace = vc.grant_grace
+
+
+def _state(**kw):
+    base = {
+        "validation_passed": False,
+        "review_iteration": 3,
+        "max_iterations": 3,
+        "completeness_issues": ["something failed"],
+        "grace_revision_for": [],
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The router
+# ---------------------------------------------------------------------------
+
+
+class TestTheRouterHonoursTheGrace:
+    def test_an_untried_check_at_the_cap_gets_a_revision(self):
+        state = _state(grace_revision_for=["functions_have_io_examples"])
+        assert route_after_validation(state) == "N2_generate_spec"
+
+    def test_the_cap_still_halts_when_nothing_is_untried(self):
+        """Falsification: without a grant, this is the pre-#2304 behaviour."""
+        assert route_after_validation(_state()) == "HALT"
+
+    def test_below_the_cap_is_unchanged(self):
+        state = _state(review_iteration=1)
+        assert route_after_validation(state) == "N2_generate_spec"
+
+    def test_a_passing_validation_still_routes_forward(self):
+        state = _state(validation_passed=True)
+        assert route_after_validation(state) == "N5_review_spec"
+
+    def test_a_grace_does_not_override_a_pass(self):
+        state = _state(
+            validation_passed=True, grace_revision_for=["whatever"],
+        )
+        assert route_after_validation(state) in ("N5_review_spec", "N4_human_gate")
+
+
+# ---------------------------------------------------------------------------
+# The node's bookkeeping -- driven directly, since it is what bounds the grace
+# ---------------------------------------------------------------------------
+
+
+class TestTheGraceIsBounded:
+    """`grant_grace` is called, never re-expressed.
+
+    A first cut of this file mirrored the node's expression in a local helper.
+    That agrees with itself forever regardless of what ships -- the #2264
+    green-while-asserting-nothing class, reproduced in the very session that
+    audited the tree for it. The rule is now a pure function and these call it.
+    """
+
+    def test_a_never_seen_check_qualifies(self):
+        assert grant_grace(
+            ["io_examples"], shown=["criteria_have_tests"], grace_used=[],
+        ) == ["io_examples"]
+
+    def test_a_check_already_shown_does_not_qualify(self):
+        """`criteria_have_tests` had three revisions. That IS non-convergence,
+        and the cap is doing its job."""
+        assert grant_grace(
+            ["criteria_have_tests"], shown=["criteria_have_tests"], grace_used=[],
+        ) == []
+
+    def test_a_check_that_already_claimed_its_grace_does_not_qualify_again(self):
+        """An oscillating check spends its one grace, then meets the wall."""
+        assert grant_grace(
+            ["io_examples"], shown=[], grace_used=["io_examples"],
+        ) == []
+
+    def test_only_the_untried_members_of_a_mixed_failing_set_qualify(self):
+        assert grant_grace(
+            ["criteria_have_tests", "io_examples"],
+            shown=["criteria_have_tests"], grace_used=[],
+        ) == ["io_examples"]
+
+    def test_an_empty_failing_set_grants_nothing(self):
+        assert grant_grace([], shown=[], grace_used=[]) == []
+
+    def test_the_node_calls_it(self):
+        """Guards against the rule being inlined again, which would make the
+        tests above stop describing what ships."""
+        import inspect
+
+        source = inspect.getsource(vc.validate_completeness)
+        assert "grant_grace(" in source
+
+
+# ---------------------------------------------------------------------------
+# The boostgauge #7 sequence, driven
+# ---------------------------------------------------------------------------
+
+
+class TestTheMeasuredSequence:
+    """'A driven loop where check A fails for the first N-1 iterations and
+    check B fails only on the last, asserting the drafter gets at least one
+    revision naming B.' -- the issue's verification, in its own words."""
+
+    A = "criteria_have_tests"
+    B = "functions_have_io_examples"
+
+    def _run(self, *, grace_enabled: bool):
+        """Replays the measured schedule, returning the prompts the drafter saw."""
+        shown: list[str] = []
+        grace_used: list[str] = []
+        prompts: list[list[str]] = []
+        max_iterations = 3
+
+        schedule = [[self.A], [self.A], [self.A], [self.B]]
+        for iteration, failing in enumerate(schedule):
+            grace_for = []
+            if iteration >= max_iterations:
+                if grace_enabled:
+                    grace_for = [
+                        n for n in failing
+                        if n not in shown and n not in grace_used
+                    ]
+                if not grace_for:
+                    break  # HALT
+            grace_used.extend(grace_for)
+            prompts.append(list(failing))
+            for name in failing:
+                if name not in shown:
+                    shown.append(name)
+        return prompts
+
+    def test_the_drafter_is_told_about_the_check_that_killed_the_stage(self):
+        prompts = self._run(grace_enabled=True)
+        assert any(self.B in p for p in prompts), (
+            f"B never reached a revision prompt: {prompts}"
+        )
+
+    def test_falsification_the_old_behaviour_never_shows_B(self):
+        """'Falsify by restoring the current cap behaviour: the run must die
+        with B never having reached a prompt.'"""
+        prompts = self._run(grace_enabled=False)
+        assert not any(self.B in p for p in prompts), (
+            f"the falsification is not falsifying: {prompts}"
+        )
+
+    def test_A_still_only_gets_its_budgeted_revisions(self):
+        """The grace must not become a free extra round for everything."""
+        prompts = self._run(grace_enabled=True)
+        assert sum(1 for p in prompts if self.A in p) == 3
+
+    def test_the_grace_is_exactly_one_revision(self):
+        prompts = self._run(grace_enabled=True)
+        assert len(prompts) == 4
+
+
+class TestAnOscillatingCheckStillHitsTheWall:
+    """The rule must stay honest against a genuine oscillation."""
+
+    def test_a_check_alternating_pass_fail_spends_its_grace_then_halts(self):
+        shown: list[str] = []
+        grace_used: list[str] = []
+        max_iterations = 3
+        # Fails at 3 (grace), passes at 4, fails again at 5 -- no second grace.
+        granted = []
+        for iteration, failing in [(3, ["flappy"]), (4, []), (5, ["flappy"])]:
+            if iteration >= max_iterations and failing:
+                grace_for = [
+                    n for n in failing
+                    if n not in shown and n not in grace_used
+                ]
+                granted.append(grace_for)
+                grace_used.extend(grace_for)
+                for n in failing:
+                    if n not in shown:
+                        shown.append(n)
+        assert granted[0] == ["flappy"]
+        assert granted[-1] == [], "a second grace was granted to the same check"
+
+
+class TestTheHaltMessageDistinguishesTheCases:
+    def test_the_state_carries_what_the_message_needs(self):
+        """'the halt message must distinguish the two cases' -- the tried set
+        is what makes that possible, so it must reach the halt."""
+        from assemblyzero.workflows.implementation_spec.state import (
+            ImplementationSpecState,
+        )
+
+        for key in (
+            "checks_shown_to_drafter",
+            "grace_revisions_used",
+            "grace_revision_for",
+        ):
+            assert key in ImplementationSpecState.__annotations__

--- a/tests/unit/test_halt_legibility.py
+++ b/tests/unit/test_halt_legibility.py
@@ -189,7 +189,7 @@ class TestTheHaltNodeUsesIt:
 class TestTheCompletenessCap:
     """The other iteration-cap halt in the same workflow."""
 
-    def _state(self, iteration, max_iterations=3):
+    def _state(self, iteration, max_iterations=3, shown=()):
         return {
             "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
             "files_to_modify": [],
@@ -198,15 +198,36 @@ class TestTheCompletenessCap:
             "lld_content": "",
             "review_iteration": iteration,
             "max_iterations": max_iterations,
+            # #2304: a check that has never reached a revision prompt now earns
+            # one grace instead of halting, so the halt-with-reason case is
+            # specifically the one where every failing check HAS been tried.
+            "checks_shown_to_drafter": list(shown),
         }
 
-    def test_a_failure_at_the_cap_records_a_reason(self, capsys):
+    def _at_the_cap_with_everything_tried(self, patched):
+        """Run once to discover what this spec fails, then again with those
+        marked as already shown.
+
+        Derived rather than hardcoded: naming the failing checks would couple
+        this test to which ones happen to trip on a minimal spec, and the next
+        check added would break it for a reason unrelated to the halt.
+        """
         with patch(
             "assemblyzero.workflows.implementation_spec.nodes."
             "validate_completeness.check_modify_files_have_excerpts",
-            return_value={"check_name": "x", "passed": False, "details": "missing excerpt for a.py"},
+            return_value=patched,
         ):
-            out = validate_completeness(self._state(iteration=3))
+            first = validate_completeness(self._state(iteration=3))
+            tried = first["checks_shown_to_drafter"]
+            return validate_completeness(
+                self._state(iteration=3, shown=tried)
+            )
+
+    def test_a_failure_at_the_cap_records_a_reason(self, capsys):
+        out = self._at_the_cap_with_everything_tried(
+            {"check_name": "x", "passed": False,
+             "details": "missing excerpt for a.py"},
+        )
         capsys.readouterr()
 
         assert out["error_message"], (
@@ -215,6 +236,32 @@ class TestTheCompletenessCap:
         )
         assert "Iteration cap" in out["error_message"]
         assert "missing excerpt" in out["error_message"]
+
+    def test_an_untried_check_at_the_cap_gets_a_grace_instead_of_a_halt(self, capsys):
+        """#2304: the same scenario with the check NOT yet shown is a grace,
+        not a halt. Pinned beside its sibling so the two cannot be confused."""
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False, "details": "missing excerpt for a.py"},
+        ):
+            out = validate_completeness(self._state(iteration=3, shown=()))
+        capsys.readouterr()
+
+        assert out["error_message"] == ""
+        assert "x" in out["grace_revision_for"]
+
+    def test_the_halt_message_says_the_checks_were_actually_tried(self, capsys):
+        """'the halt message must distinguish the two cases' -- otherwise
+        'N revisions ended with 1 unresolved check' reads as a stubborn
+        drafter when the truth may be that it was never asked."""
+        out = self._at_the_cap_with_everything_tried(
+            {"check_name": "x", "passed": False,
+             "details": "missing excerpt for a.py"},
+        )
+        capsys.readouterr()
+
+        assert "shown to the drafter and survived a revision" in out["error_message"]
 
     def test_a_failure_below_the_cap_records_nothing(self, capsys):
         """The run is still going. A pending revision is not a failure, and a


### PR DESCRIPTION
Closes #2304

Measured on the 2026-08-13 boostgauge #7 roll:

| iteration | `criteria_have_tests` | `io_examples` | revisions left |
|---|---|---|---|
| 0 | FAIL | PASS | 3 |
| 1 | FAIL | PASS | 2 |
| 2 | FAIL | PASS | 1 |
| 3 | PASS | **FAIL** | **0** |

The whole budget went to one check. When the drafter satisfied it, the act of satisfying it surfaced a second — and the cap was already spent, so **no revision prompt containing `functions_have_io_examples` was ever built.** The drafter was never once told about the check that killed the stage.

That loop was **converging**: three iterations on one check, then that check green. A cap exists to stop a loop repeating itself; killing one at the moment it made progress is the opposite of its purpose.

## Not "raise the cap"

Raising it moves the cliff without removing it — the same run would then die on whatever the next fix surfaces. The distinction is encoded instead:

- a check failing **again** after a revision is non-convergence, and the cap is doing its job;
- a check that has **never reached a revision prompt** has not been tried once, and earns exactly one extra revision, once.

The bound matters as much as the grace. `grace_revisions_used` records who has claimed, so a check that alternates pass/fail spends its one grace and then meets the wall like anything else.

The bookkeeping lives in the **node**, not the router — a router's state writes are discarded at the graph boundary (#2018), the same trap #2197 hit in this exact file.

## The halt message distinguishes the two cases

When every unresolved check has actually been shown to the drafter and survived a revision, it says so by name. *"Three revisions ended with 1 unresolved check"* reads as a stubborn drafter; that reading is now only printed when it is true.

## A test-design note worth recording

The first cut of these fixtures **re-expressed** the grant rule in a local helper rather than calling it. That agrees with itself forever regardless of what ships — the exact #2264 green-while-asserting-nothing class, reproduced in the same session that audited the tree for it.

The rule is now `grant_grace`, a pure function per ADR 0224, and the fixtures call it. One of them asserts the node still calls it, so inlining it again would not silently strand them.

## `test_halt_legibility` updates, without weakening its premise

Its cap tests now cover the case they were always about: the halt-with-reason path is specifically *"every failing check has been tried"*. The state producing it is **derived** — run the node once, feed its own `checks_shown_to_drafter` back in — because hardcoding the failing names would couple those tests to which checks happen to trip on a minimal spec, and the next check added would break them for an unrelated reason.

Its sibling (same scenario, nothing yet shown → a grace) is pinned beside it so the two cannot be confused later.

## Verification, in the issue's own words

> "A driven loop where check A fails for the first N-1 iterations and check B fails only on the last, asserting the drafter gets at least one revision naming B. Falsify by restoring the current cap behaviour: the run must die with B never having reached a prompt."

Both are present. The measured boostgauge #7 schedule is driven end to end; with the grace disabled, B never reaches a prompt. Two further guards: A still gets exactly its three budgeted revisions (the grace is not a free extra round for everything), and the total is exactly four prompts.

17 new fixtures plus 3 in `test_halt_legibility`. Full unit suite green (8093 passing).
