### PR TITLE
feat: make the non-discriminating-test class unwritable (Closes #2387)

### DIFF
--- a/assemblyzero/workflows/requirements/discrimination_check.py
+++ b/assemblyzero/workflows/requirements/discrimination_check.py
@@ -1,0 +1,328 @@
+"""Make the non-discriminating-test class unwritable (#2387).
+
+The semantic gate found the same defect four times across six samples of
+boostgauge #2 and #7: a criterion whose test points all sit at COINCIDENCE
+POINTS -- values where a correct implementation and a degenerate one produce
+identical output. Each instance was real; each cost a gate round (~5 minutes of
+model call) to find; and the class is mechanically characterizable, which by
+ADR 0228's own doctrine means it should be unwritable rather than serially
+findable.
+
+Rounds on boostgauge #2 went 3, 3, 1, 2, 1, 1 findings. The tail is entirely
+this class. A deterministic check would have named all of them in one free pass.
+
+## The two shapes, both mechanical
+
+**Coincidence-point coverage.** A criterion pins its expected outputs *at
+default config* and nowhere else. boostgauge #308, verbatim from the gate:
+
+    "The U1 test plan checks only the four default-config strings; at those
+     exact values a hardcoded implementation ('1m — cyan', '10m — orange',
+     '1h — magenta', 'All-time — coral red') and a genuine dynamic formatter
+     produce identical output."
+
+The repair that satisfied the gate is the shape this check demands: the
+criterion carries a non-default case as well ("short at 90 seconds must read
+'90s — cyan'").
+
+**Absence-only oracle.** A criterion asserts only that nothing changed, so it
+passes under an implementation that ignores the input entirely. boostgauge
+#300, verbatim:
+
+    "S3 passes identically under both readings -- it checks only that the
+     file's `size` key remains 300 and that 500 is not written to the file,
+     which is equally true whether the window displayed 500 or 300."
+
+A no-change assertion is a real thing to test and is not banned. What is
+flagged is a criterion that has *nothing else* -- no positive observation of
+the value actually taking effect.
+
+## Why it is narrow on purpose
+
+A check that cries wolf gets switched off within a day, and this session has
+already had to retract one audit for reporting seven suspects of which zero
+were real. So each rule fires only on POSITIVE evidence: the criterion must
+itself declare that its values are default-config ones, or must itself consist
+of nothing but absence assertions. A criterion that pins no values at all is
+not guessed about -- it is out of scope and said so.
+
+The vacuous state is disclosed rather than passed, per the #2227 ruling:
+"checked and found nothing to check" and "checked and found none" are different
+facts and are printed differently.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.requirements.form_check import (
+    Violation,
+    acceptance_criteria,
+)
+
+#: The criterion says, in its own words, that these outputs are what default
+#: configuration produces. Written as the ADR 0226/0228 convention writes it.
+_DEFAULT_ANCHOR = re.compile(
+    r"\b(?:at|under|with)\s+(?:the\s+)?default(?:\s+config(?:uration)?)?\b"
+    r"|\bdefault\s+config(?:uration)?\s+(?:renders|reads|gives|produces)\b"
+    r"|\bdefault-config\b",
+    re.IGNORECASE,
+)
+
+#: The criterion also pins a value away from the defaults. Any one of these is
+#: enough -- the point is that SOME non-coincident point is covered, not that
+#: it is covered in a particular phrasing.
+_NON_DEFAULT_ANCHOR = re.compile(
+    r"\bnon-?default\b"
+    r"|\boff\s+the\s+defaults?\b"
+    r"|\bdiscriminating\s+case\b"
+    r"|\bother\s+than\s+(?:the\s+)?defaults?\b",
+    re.IGNORECASE,
+)
+
+#: An assertion that nothing happened. These are legitimate individually; a
+#: criterion built ONLY from them has no oracle for the value taking effect.
+_ABSENCE = re.compile(
+    r"\bunchanged\b|\bnot\s+written\b|\bnever\s+written\b|\bno\s+\w+\s+is\s+"
+    r"written\b|\bremains?\b|\bis\s+not\s+(?:changed|modified|updated)\b"
+    r"|\buntouched\b|\bnot\s+persisted\b",
+    re.IGNORECASE,
+)
+
+#: A positive observation -- something is rendered, returned, displayed, held,
+#: or equals a value. Presence of one of these means the criterion is not
+#: absence-only.
+#:
+#: `holds` earns its place from boostgauge #7's S7: "`size` holds the default;
+#: the CLI value is not written". That states what the value IS, which an
+#: implementation ignoring the input can fail. The gate flagged S3 and not S7,
+#: and this is the difference between them.
+_POSITIVE = re.compile(
+    r"\brenders?\b|\breads?\b|\bdisplays?\b|\bshows?\b|\breturns?\b"
+    r"|\bopens?\s+at\b|\bemits?\b|\bcalls?\b|\breceives?\b|\bequals?\b"
+    r"|\bmust\s+be\b|\bproduces?\b|\bconstructed\b|\bpasses\s+all\b"
+    r"|\bholds?\b",
+    re.IGNORECASE,
+)
+
+#: The scenario actually supplies an input that could be ignored. Without one,
+#: "nothing changed" is the whole truth rather than a weak oracle.
+#:
+#: Measured on boostgauge #7: S3 ("`--size` given ... `size` unchanged; the CLI
+#: value is not written") is the real defect the gate found. P1 ("no reset, not
+#: moved, no direct edits: `position` unchanged") and S1 ("no `--size` ...
+#: unchanged") are not -- nothing was supplied, so there is nothing an
+#: implementation could be ignoring. A first cut without this condition flagged
+#: all three.
+#: The negative lookbehinds are load-bearing. These scenarios are written as
+#: matched pairs -- "`--size` given" against "not resized", "no `--size`" --
+#: so a bare verb match reads "no `--size`, not resized" as an input being
+#: supplied, which is the exact opposite of what it says.
+_INPUT_SUPPLIED = re.compile(
+    r"(?<!not )(?<!no )"
+    r"\b(?:given|supplied|provided|passed|specified|resized|moved)\b"
+    r"|\bwith\s+--[\w-]+",
+    re.IGNORECASE,
+)
+
+#: Criteria that pin no expected value at all are out of scope: there is
+#: nothing to judge the discrimination of. A quoted or backticked literal is
+#: the signal that the criterion states an expected output.
+_LITERAL = re.compile(r"'[^']+'|\"[^\"]+\"|`[^`]+`")
+
+#: The ID a criterion leads with, so a violation can name it.
+_CRITERION_ID = re.compile(r"^\s*([A-Z][A-Za-z]*[0-9]+)\b")
+
+
+@dataclass
+class DiscriminationReport:
+    """What was judged about a document's discriminating coverage."""
+
+    criteria_examined: int = 0
+    criteria_pinning_values: int = 0
+    default_anchored: int = 0
+    absence_only: int = 0
+    violations: list[Violation] = field(default_factory=list)
+    criteria_section_found: bool = True
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+    @property
+    def vacuous(self) -> bool:
+        """Nothing was judged -- which is NOT the same as nothing was wrong."""
+        return self.criteria_pinning_values == 0
+
+    def disclosure(self) -> str:
+        """One line stating what the check actually did (#2227).
+
+        A check with nothing to check must say so. Reporting "no findings" for
+        a document it never judged is how a gate reads as thorough validation
+        while verifying nothing.
+        """
+        if not self.criteria_section_found:
+            return (
+                "discrimination coverage: NOT CHECKED — no Acceptance Criteria "
+                "section found."
+            )
+        if self.vacuous:
+            return (
+                f"discrimination coverage: nothing to check — "
+                f"{self.criteria_examined} criterion(s) examined, none pins an "
+                f"expected value, so none can be judged for discrimination."
+            )
+        return (
+            f"discrimination coverage: {self.criteria_pinning_values} of "
+            f"{self.criteria_examined} criterion(s) pin expected values; "
+            f"{self.default_anchored} anchored at default config, "
+            f"{len(self.violations)} finding(s)."
+        )
+
+
+def criterion_id(text: str) -> str:
+    match = _CRITERION_ID.match(text)
+    return match.group(1) if match else text[:24].strip()
+
+
+def pins_a_value(text: str) -> bool:
+    """Does this criterion state an expected output at all?"""
+    return bool(_LITERAL.search(text))
+
+
+def is_default_anchored(text: str) -> bool:
+    """Does the criterion itself say its values are default-config ones?"""
+    return bool(_DEFAULT_ANCHOR.search(text))
+
+
+def has_non_default_case(text: str) -> bool:
+    """Does the criterion also pin a value away from the defaults?
+
+    Two ways to qualify, both taken from how the boostgauge repairs were
+    actually written: an explicit non-default marker, or a concrete magnitude
+    stated alongside a unit ("short at 90 seconds reads 'Reset 90s'"). The
+    second is what a real discriminating case looks like when the author does
+    not use the word "non-default".
+    """
+    if _NON_DEFAULT_ANCHOR.search(text):
+        return True
+    # "at 90 seconds", "at 900 seconds", "configured to 90s"
+    if re.search(
+        r"\b(?:at|to|of)\s+\d+\s*(?:s\b|ms\b|seconds?\b|minutes?\b|hours?\b|px\b|%)",
+        text,
+        re.IGNORECASE,
+    ):
+        return True
+    # A SYMBOLIC value supplied through a flag -- "`--reset-config --size N`,
+    # it opens at the default position and size N". Boostgauge #7's L4 states
+    # its discriminating case this way, with a placeholder rather than a
+    # number, and a literal-only rule reported it as uncovered. A placeholder
+    # standing for "any value" is a stronger discriminating claim than one
+    # number, not a weaker one.
+    return bool(re.search(r"--[\w-]+\s+([A-Z])\b", text))
+
+
+def is_absence_only(text: str) -> bool:
+    """Are ALL this criterion's assertions no-change assertions, on a scenario
+    that actually supplies an input?
+
+    A no-change assertion is legitimate and common. What is flagged is the
+    combination boostgauge #300 found: a value IS supplied, and the only thing
+    asserted is that nothing was written -- which is equally true whether the
+    value took effect or was ignored entirely.
+
+    Both conditions are required. Dropping the supplied-input condition flags
+    "no reset, not moved, no direct edits: `position` unchanged", where nothing
+    was supplied and "unchanged" is the whole truth.
+    """
+    if not _ABSENCE.search(text):
+        return False
+    if _POSITIVE.search(text):
+        return False
+    return bool(_INPUT_SUPPLIED.search(text))
+
+
+def family_of(criterion: str) -> str:
+    """The ID prefix a criterion belongs to: RS1 -> RS, U1 -> U.
+
+    ADR 0228 names one owning criteria group per variable by ID prefix, so the
+    prefix IS the surface. Coverage is judged per family for that reason -- see
+    `check_discrimination`.
+    """
+    ident = criterion_id(criterion)
+    match = re.match(r"^([A-Z][A-Za-z]*)", ident)
+    return match.group(1) if match else ident
+
+
+def check_discrimination(body: str) -> DiscriminationReport:
+    """Judge a document's criteria for discriminating coverage (#2387).
+
+    Coverage is judged PER FAMILY, not per criterion, and that is the whole
+    difference between a usable check and a wolf. Measured against boostgauge
+    #2 as a human left it after seven gate rounds: a per-criterion rule flagged
+    RS1, RS2 and RS3 because each pins only its default-config label -- while
+    RS6, in the same family, carries the non-default case for every window on
+    that surface. The document is correctly covered; the coverage simply lives
+    in a sibling. Three findings, all false.
+
+    An absence-only oracle stays per-criterion, because each criterion is its
+    own scenario and needs its own oracle -- a sibling asserting something
+    positive about a different scenario does not rescue it.
+    """
+    report = DiscriminationReport()
+
+    criteria, section_found = acceptance_criteria(body)
+    report.criteria_section_found = section_found
+    if not section_found:
+        return report
+
+    report.criteria_examined = len(criteria)
+
+    valued = [c for c in criteria if pins_a_value(c)]
+    report.criteria_pinning_values = len(valued)
+
+    # Which families have a discriminating case anywhere in them.
+    covered: set[str] = {
+        family_of(c) for c in valued if has_non_default_case(c)
+    }
+
+    flagged_families: set[str] = set()
+    for text in valued:
+        where = criterion_id(text)
+        family = family_of(text)
+
+        if is_default_anchored(text):
+            report.default_anchored += 1
+            if family not in covered and family not in flagged_families:
+                flagged_families.add(family)
+                report.violations.append(
+                    Violation(
+                        kind="non-discriminating",
+                        where=where,
+                        detail=(
+                            f"every expected value in the {family} family is "
+                            f"pinned at default config, so an implementation "
+                            f"that hardcodes the default outputs passes every "
+                            f"planned assertion. Add at least one case at a "
+                            f"non-default value, per branch and per surface."
+                        ),
+                    )
+                )
+
+        if is_absence_only(text):
+            report.absence_only += 1
+            report.violations.append(
+                Violation(
+                    kind="absence-only-oracle",
+                    where=where,
+                    detail=(
+                        "an input is supplied and every assertion is a "
+                        "no-change assertion, which is equally true under an "
+                        "implementation that ignores the input entirely. Add a "
+                        "positive observation of the value taking effect."
+                    ),
+                )
+            )
+
+    return report

--- a/assemblyzero/workflows/requirements/form_gate.py
+++ b/assemblyzero/workflows/requirements/form_gate.py
@@ -51,6 +51,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from assemblyzero.workflows.requirements.discrimination_check import (  # noqa: E402  (#2387)
+    DiscriminationReport,
+    check_discrimination,
+)
 from assemblyzero.workflows.requirements.form_check import (
     FormReport,
     check_form,
@@ -77,6 +81,10 @@ class IssueForm:
     error: str = ""            # the check could not run at all
     refusing: list = field(default_factory=list)   # violations that refuse
     reporting: list = field(default_factory=list)  # violations that only report
+    #: #2387: the discrimination-coverage extension. Report-only, like the rest
+    #: of the non-counting findings -- it reads intent from prose, so a refusal
+    #: on it would block a roll over a phrasing choice.
+    discrimination: DiscriminationReport | None = None
 
     @property
     def has_tables(self) -> bool:
@@ -128,6 +136,11 @@ def check_issue(repo_root, issue: int, fetch) -> IssueForm:
 
     result.report = check_form(body)
     result.refusing, result.reporting = classify(result.report)
+    # #2387: never allowed to cost the form check its verdict.
+    try:
+        result.discrimination = check_discrimination(body)
+    except Exception:  # noqa: BLE001 - an extension is not the gate
+        result.discrimination = None
     return result
 
 
@@ -179,6 +192,14 @@ def render(results: list[IssueForm]) -> tuple[str, bool]:
 
         for note in notes:
             lines.append(f"      note: {note}")
+
+        # #2387: printed on EVERY issue, pass or fail. A check that speaks only
+        # when it complains leaves silence to mean two different things, which
+        # is the same complaint #2381 makes about box health.
+        if item.discrimination is not None:
+            lines.append(f"      {item.discrimination.disclosure()}")
+            for violation in item.discrimination.violations:
+                lines.append(f"        {violation}")
 
         if item.reporting and item.refusing:
             lines.append(

--- a/tests/unit/test_discrimination_check.py
+++ b/tests/unit/test_discrimination_check.py
@@ -1,0 +1,359 @@
+"""The non-discriminating-test class, made unwritable (#2387).
+
+The semantic gate found this class FOUR times across six samples of boostgauge
+#2 and #7, at roughly a five-minute model call per round. Rounds went 3, 3, 1,
+2, 1, 1 findings and the tail is entirely this class.
+
+Every fixture below is the real text. The pre-repair criteria are reconstructed
+from the gate's own verbatim findings and the issue's revision history (the
+acceptance asks for exactly that); the post-repair criteria are copied from
+boostgauge #2 as it stands today, so "a criterion with per-branch non-default
+coverage passes" is tested against text that a human already accepted rather
+than against text written to satisfy this checker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.requirements.discrimination_check import (
+    check_discrimination,
+    has_non_default_case,
+    is_absence_only,
+    is_default_anchored,
+    pins_a_value,
+)
+
+
+def _doc(*criteria: str) -> str:
+    lines = ["# Issue", "", "## Acceptance Criteria", ""]
+    lines += [f"- [ ] {c}" for c in criteria]
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Instance 1 -- boostgauge #308, the U1 tooltip surface
+# ---------------------------------------------------------------------------
+
+U1_BEFORE = (
+    "U1 — Hovering the gauge shows a tooltip identifying each window, one line "
+    "per window in the form '<window label> — <color name>'. The identification "
+    "text comes from a pure function that unit tests call directly against the "
+    "four expected strings at default config ('1m — cyan', '10m — orange', "
+    "'1h — magenta', 'All-time — coral red'); no `tkinter` in tests, per "
+    "strategy 0001."
+)
+
+U1_AFTER = (
+    "U1 — Hovering the gauge shows a tooltip identifying each window, one line "
+    "per window in the form '<window label> — <color name>'. The identification "
+    "text comes from a pure function that unit tests call directly against the "
+    "four expected strings at default config ('1m — cyan', '10m — orange', "
+    "'1h — magenta', 'All-time — coral red') AND against a non-default "
+    "configuration for EACH configured window, covering every formatter branch "
+    "— short at 90 seconds must read '90s — cyan', medium at 900 seconds must "
+    "read '15m — orange', long at 7200 seconds must read '2h — magenta' — so a "
+    "formatter that hardcodes any window's label fails while the one pure "
+    "formatter passes."
+)
+
+
+class TestInstanceOneTooltipSurface:
+    """'The U1 test plan checks only the four default-config strings; at those
+    exact values a hardcoded implementation and a genuine dynamic formatter
+    produce identical output.' -- the gate, boostgauge #308."""
+
+    def test_the_pre_repair_criterion_is_flagged(self):
+        report = check_discrimination(_doc(U1_BEFORE))
+        assert not report.ok
+        assert report.violations[0].where == "U1"
+        assert report.violations[0].kind == "non-discriminating"
+
+    def test_the_finding_says_why(self):
+        report = check_discrimination(_doc(U1_BEFORE))
+        assert "hardcodes the default" in report.violations[0].detail
+
+    def test_the_repaired_criterion_passes(self):
+        report = check_discrimination(_doc(U1_AFTER))
+        assert report.ok, [str(v) for v in report.violations]
+
+
+# ---------------------------------------------------------------------------
+# Instances 2 and 3 -- the RS menu surface, rounds 5 and 6 on boostgauge #2
+# ---------------------------------------------------------------------------
+
+RS_BEFORE = (
+    "RS1 — The short-window menu entry, labelled 'Reset 1m' at default config, "
+    "calls `reset()` on the short-window instance; the remaining three are "
+    "untouched."
+)
+
+RS6_AFTER = (
+    "RS6 — The menu entry labels come from the same pure formatter as the "
+    "tooltip lines, asserted at a non-default value for EVERY configured "
+    "window, covering every branch on the menu surface: short at 90 seconds "
+    "reads 'Reset 90s', medium at 900 seconds reads 'Reset 15m', long at 7200 "
+    "seconds reads 'Reset 2h' — so a hardcoded label for any window fails "
+    "where the one formatter passes."
+)
+
+
+class TestInstancesTwoAndThreeMenuSurface:
+    """Round 5: 'the RS menu-entry labels were stated as literals and tested
+    only at default config — the same coincidence-point escape U1 just closed
+    for tooltip lines.' Round 6 extended it to every window."""
+
+    def test_the_pre_repair_menu_criterion_is_flagged(self):
+        report = check_discrimination(_doc(RS_BEFORE))
+        assert not report.ok
+        assert report.violations[0].where == "RS1"
+
+    def test_the_repaired_menu_criterion_passes(self):
+        report = check_discrimination(_doc(RS6_AFTER))
+        assert report.ok, [str(v) for v in report.violations]
+
+    def test_both_surfaces_are_flagged_when_both_are_bad(self):
+        """The class recurred BECAUSE closing it on one surface left the
+        other open. The check must not have the same blind spot."""
+        report = check_discrimination(_doc(U1_BEFORE, RS_BEFORE))
+        assert len(report.violations) == 2
+        assert {v.where for v in report.violations} == {"U1", "RS1"}
+
+
+# ---------------------------------------------------------------------------
+# Instance 4 -- boostgauge #300, the absence-only oracle
+# ---------------------------------------------------------------------------
+
+S3_BEFORE = (
+    "S3 — Size, no reset, `--size` given, not resized, no direct edits: the "
+    "file's `size` key remains '300' and the CLI value '500' is not written."
+)
+
+S3_AFTER = (
+    "S3 — Size, no reset, `--size` given, not resized, no direct edits: the "
+    "window opens at '500', while the file's `size` key remains '300' and the "
+    "CLI value is not written."
+)
+
+
+class TestInstanceFourAbsenceOnlyOracle:
+    """'S3 passes identically under both readings -- it checks only that the
+    file's `size` key remains 300 and that 500 is not written, which is equally
+    true whether the window displayed 500 or 300.' -- the gate, boostgauge #300."""
+
+    def test_the_absence_only_criterion_is_flagged(self):
+        report = check_discrimination(_doc(S3_BEFORE))
+        assert not report.ok
+        assert report.violations[0].kind == "absence-only-oracle"
+
+    def test_the_finding_says_why(self):
+        report = check_discrimination(_doc(S3_BEFORE))
+        assert "ignores the input entirely" in report.violations[0].detail
+
+    def test_adding_a_positive_observation_passes(self):
+        report = check_discrimination(_doc(S3_AFTER))
+        assert report.ok, [str(v) for v in report.violations]
+
+
+# ---------------------------------------------------------------------------
+# All four together -- the acceptance's first item
+# ---------------------------------------------------------------------------
+
+
+class TestAllFourHistoricalInstances:
+    def test_every_one_is_flagged_in_a_single_free_pass(self):
+        """'A deterministic check would have named all of them in one free
+        pass.' Six gate rounds, ~5 minutes of model call each; this is the
+        claim, tested."""
+        report = check_discrimination(_doc(U1_BEFORE, RS_BEFORE, S3_BEFORE))
+        assert len(report.violations) == 3
+        kinds = {v.kind for v in report.violations}
+        assert kinds == {"non-discriminating", "absence-only-oracle"}
+
+    def test_every_repair_passes(self):
+        report = check_discrimination(_doc(U1_AFTER, RS6_AFTER, S3_AFTER))
+        assert report.ok, [str(v) for v in report.violations]
+
+
+# ---------------------------------------------------------------------------
+# The vacuous state is disclosed, never silently passed (#2227 ruling)
+# ---------------------------------------------------------------------------
+
+
+class TestTheVacuousStateIsDisclosed:
+    def test_no_criteria_section_is_reported_as_not_checked(self):
+        report = check_discrimination("# Issue\n\nSome prose.\n")
+        assert report.criteria_section_found is False
+        assert "NOT CHECKED" in report.disclosure()
+
+    def test_criteria_that_pin_no_values_are_reported_as_nothing_to_check(self):
+        report = check_discrimination(
+            _doc("W1 — Four instances are constructed from config.")
+        )
+        assert report.vacuous is True
+        assert report.ok is True
+        assert "nothing to check" in report.disclosure()
+
+    def test_a_clean_document_says_it_checked_and_found_none(self):
+        """'checked and found nothing to check' and 'checked and found none'
+        are different facts and must print differently."""
+        report = check_discrimination(_doc(U1_AFTER))
+        assert report.vacuous is False
+        assert report.ok is True
+        disclosure = report.disclosure()
+        assert "0 finding(s)" in disclosure
+        assert "nothing to check" not in disclosure
+
+    def test_the_disclosure_counts_what_it_judged(self):
+        report = check_discrimination(_doc(U1_AFTER, RS6_AFTER))
+        assert "2 of 2 criterion(s) pin expected values" in report.disclosure()
+
+
+# ---------------------------------------------------------------------------
+# Narrowness -- the check must not cry wolf
+# ---------------------------------------------------------------------------
+
+
+class TestItDoesNotCryWolf:
+    """This session already had to retract one audit for reporting seven
+    suspects of which zero were real. Each rule fires on positive evidence
+    only."""
+
+    def test_a_criterion_with_no_literals_is_out_of_scope(self):
+        report = check_discrimination(
+            _doc("W2 — Every collector sample reaches all four instances.")
+        )
+        assert report.ok
+
+    def test_a_criterion_pinning_values_without_a_default_anchor_is_not_flagged(self):
+        """No claim that these are default-config values, so there is no
+        evidence of a coincidence point. Silence is the honest answer."""
+        report = check_discrimination(
+            _doc("W1 — Four instances are constructed with windows '60', "
+                 "'600', '3600' and `None`.")
+        )
+        assert report.ok
+
+    def test_a_no_change_assertion_beside_a_positive_one_is_fine(self):
+        """No-change assertions are legitimate. Only a criterion made of
+        NOTHING else has no oracle."""
+        report = check_discrimination(
+            _doc("RS1 — The entry calls `reset()` on the short-window "
+                 "instance; the remaining three are 'untouched'.")
+        )
+        assert report.ok
+
+    def test_a_family_is_covered_by_any_of_its_members(self):
+        """The false positive that mattered most, pinned.
+
+        Measured against boostgauge #2 as a human left it after seven gate
+        rounds: a per-criterion rule flagged RS1, RS2 and RS3 -- each pins only
+        its own default-config label -- while RS6, in the same family, carries
+        the non-default case for every window on that surface. Three findings,
+        all false. Coverage is judged per family for this reason.
+        """
+        report = check_discrimination(_doc(RS_BEFORE, RS6_AFTER))
+        assert report.ok, [str(v) for v in report.violations]
+
+    def test_a_sibling_in_a_DIFFERENT_family_does_not_rescue_it(self):
+        """The family rule must not become 'one non-default case anywhere'.
+        The class recurred precisely because closing it on the tooltip surface
+        left the menu surface open."""
+        report = check_discrimination(_doc(U1_BEFORE, RS6_AFTER))
+        assert len(report.violations) == 1
+        assert report.violations[0].where == "U1"
+
+    def test_a_symbolic_placeholder_counts_as_a_discriminating_case(self):
+        """boostgauge #7's L4 states its case as `--size N` rather than a
+        number. A placeholder standing for any value is a stronger claim than
+        one number, not a weaker one -- a literal-only rule flagged it."""
+        report = check_discrimination(_doc(
+            "L4 — Launched with `--reset-config` and no `--size`, the window "
+            "opens at the default position and default size; launched with "
+            "`--reset-config --size N`, it opens at the default position and "
+            "size N."
+        ))
+        assert report.ok, [str(v) for v in report.violations]
+
+    def test_an_absence_only_criterion_with_no_supplied_input_is_fine(self):
+        """boostgauge #7's P1 and S1. Nothing was supplied, so there is
+        nothing an implementation could be ignoring."""
+        report = check_discrimination(_doc(
+            "P1 — Position, no reset, not moved, no direct edits: `position` "
+            "unchanged",
+            "S1 — Size, no reset, no `--size`, not resized, no direct edits: "
+            "`size` unchanged",
+        ))
+        assert report.ok, [str(v) for v in report.violations]
+
+    def test_the_real_repaired_issue_body_is_clean(self):
+        """The strongest anti-noise evidence available: boostgauge #2's whole
+        Acceptance Criteria section as a human left it after seven gate rounds.
+        A checker that fires on this is a checker nobody will keep."""
+        report = check_discrimination(_doc(
+            "W1 — Four `Telltale` instances are constructed: three with "
+            "durations read from `telltale_windows.short`, "
+            "`telltale_windows.medium`, `telltale_windows.long` (defaults 60, "
+            "600, 3600 seconds), one with window `None` for all-time.",
+            "W2 — Every collector sample reaches all four instances via "
+            "`Telltale.update(timestamp, value)`.",
+            RS6_AFTER,
+            U1_AFTER,
+        ))
+        assert report.ok, [str(v) for v in report.violations]
+
+
+# ---------------------------------------------------------------------------
+# The predicates, directly
+# ---------------------------------------------------------------------------
+
+
+class TestThePredicates:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("reads 'Reset 1m' at default config", True),
+            ("at the default config the labels read '1m'", True),
+            ("the default config renders exactly '1m'", True),
+            ("checked against the 'default-config' strings", True),
+            ("reads '90s' when configured to 90 seconds", False),
+        ],
+    )
+    def test_default_anchor_detection(self, text, expected):
+        assert is_default_anchored(text) is expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("AND against a non-default configuration", True),
+            ("short at 90 seconds reads 'Reset 90s'", True),
+            ("medium at 900 seconds reads '15m'", True),
+            ("adds the discriminating case", True),
+            ("only the four default strings", False),
+        ],
+    )
+    def test_non_default_case_detection(self, text, expected):
+        assert has_non_default_case(text) is expected
+
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            # An input IS supplied and only its non-effect is asserted.
+            ("`--size` given: the key remains '300' and '500' is not written", True),
+            ("with --size supplied, the file is 'unchanged'", True),
+            # A positive observation rescues it.
+            ("`--size` given: the window opens at '500', file unchanged", False),
+            ("`--size` given: `size` holds the default", False),
+            # NOTHING is supplied, so "unchanged" is the whole truth. Flagging
+            # these is what a first cut did, on boostgauge #7's P1 and S1.
+            ("no reset, not moved, no direct edits: `position` unchanged", False),
+            ("no `--size`, not resized: `size` unchanged", False),
+            ("the entry calls `reset()`; the rest are untouched", False),
+        ],
+    )
+    def test_absence_only_detection(self, text, expected):
+        assert is_absence_only(text) is expected
+
+    def test_pins_a_value_needs_a_literal(self):
+        assert pins_a_value("reads '90s'") is True
+        assert pins_a_value("reads the configured label") is False


### PR DESCRIPTION
Closes #2387

The semantic gate found this class **four times across six samples** of boostgauge #2 and #7, at roughly a five-minute model call per round. Rounds went 3, 3, 1, 2, 1, 1 findings; the tail is entirely this class.

## Two shapes, both mechanical

Both are drawn from the gate's own verbatim findings, not invented:

**Coincidence-point coverage** — a criterion pins its expected outputs at default config and nowhere else, so a hardcoded implementation passes every planned assertion.

> "The U1 test plan checks only the four default-config strings; at those exact values a hardcoded implementation and a genuine dynamic formatter produce identical output." — boostgauge #308

**Absence-only oracle** — an input *is* supplied and the only thing asserted is that nothing was written.

> "S3 passes identically under both readings — it checks only that the file's `size` key remains 300 and that 500 is not written, which is equally true whether the window displayed 500 or 300." — boostgauge #300

## The calibration is the substance

Measured against four real issue bodies:

| issue | findings | |
|---|---|---|
| boostgauge #1 | **0** | |
| boostgauge #2 | **0** | repaired through seven gate rounds, human-accepted |
| boostgauge #41 | **0** | |
| boostgauge #7 | **1** | `S3` — the real #300 instance, on the unrepaired document |

That result took **four corrections**, each one a false positive found by running against real text rather than by reasoning about it:

**1. Coverage is per FAMILY, not per criterion.** A per-criterion rule flagged #2's `RS1`, `RS2`, `RS3` — each pins only its own default-config label — while `RS6`, *in the same family*, carries the non-default case for every window on that surface. **Three findings, all false, on a document a human had already accepted.** ADR 0228 names one owning criteria group per variable by ID prefix, so the prefix *is* the surface. A sibling in a **different** family does not rescue it — the class recurred precisely because closing it on the tooltip surface left the menu surface open.

**2. Absence-only requires a supplied input.** Without that condition the rule flagged #7's `P1` ("no reset, not moved, no direct edits: `position` unchanged") and `S1` ("no `--size` ... unchanged"), where nothing was supplied and "unchanged" is the whole truth. The gate flagged `S3` and not those; this is the difference.

**3. The negation matters.** These scenarios are written as matched pairs, so a bare verb match read *"no `--size`, not resized"* as an input being supplied — the exact opposite of what it says. Negative lookbehinds for `no ` and `not `.

**4. A symbolic placeholder is a discriminating case.** #7's `L4` states its case as `--reset-config --size N` rather than a number, and a literal-only rule reported it uncovered. A placeholder standing for *any* value is a stronger claim than one number, not a weaker one. Relatedly, "`size` holds the default" is a positive assertion about what the value **is** — which is why the gate flagged `S3` and not `S7`.

## Report-only, and it always speaks

Wired into the existing ADR 0226 preflight. It reads intent from prose, so refusing on it would block a roll over a phrasing choice — and the argument for a deterministic check is that it is *free*, not that it is authoritative.

The disclosure prints on **every** issue, pass or fail, per the #2227 ruling and the same complaint #2381 makes about box health: a check that speaks only when it complains leaves silence meaning two different things.

```
discrimination coverage: 11 of 11 criterion(s) pin expected values; 4 anchored at default config, 0 finding(s).
discrimination coverage: nothing to check — 3 criterion(s) examined, none pins an expected value, so none can be judged.
```

## Acceptance

- **The four historical instances, reconstructed as fixtures, are each flagged** — and in one pass, which is the claim the issue makes about a deterministic check versus six gate rounds.
- **A criterion with per-branch non-default coverage passes** — tested against the repaired text copied from boostgauge #2 as it stands today, not text written to satisfy this checker.
- **The vacuous state is disclosed, never silently passed.**

41 fixtures. The four false positives above are pinned as regression tests, so the calibration cannot quietly loosen. Full unit suite green (8134 passing).
