### PR TITLE
fix: a mid-build repo is no longer blind to its own names (Closes #2412)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -2213,6 +2213,45 @@ def _import_resolves(
 
 
 # Common stdlib top-level module names (subset for fast rejection)
+def _pyproject_declared_package(repo_root: Path) -> set[str]:
+    """Package names the repo DECLARES it ships (#2412).
+
+    The authoritative signal, and the one that needs no filesystem heuristic:
+    `[tool.poetry.packages].include`, `[project].name` and `[tool.poetry].name`
+    all name the package the repo is. A distribution name uses dashes where the
+    import name uses underscores, so both spellings are returned.
+    """
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return set()
+    try:
+        import tomllib
+
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, ValueError, ImportError):
+        return set()
+
+    names: set[str] = set()
+
+    def _add(value: object) -> None:
+        if isinstance(value, str) and value:
+            names.add(value)
+            names.add(value.replace("-", "_"))
+
+    tool = data.get("tool", {}) if isinstance(data.get("tool"), dict) else {}
+    poetry = tool.get("poetry", {}) if isinstance(tool.get("poetry"), dict) else {}
+    _add(poetry.get("name"))
+    project = data.get("project", {}) if isinstance(data.get("project"), dict) else {}
+    _add(project.get("name"))
+
+    packages = poetry.get("packages", [])
+    if isinstance(packages, list):
+        for pkg in packages:
+            if isinstance(pkg, dict):
+                _add(pkg.get("include"))
+    return names
+
+
 def _first_party_tops(repo_root: Path) -> set[str]:
     """Top-level package names that belong to the target repo itself (#1901).
 
@@ -2220,6 +2259,29 @@ def _first_party_tops(repo_root: Path) -> set[str]:
     exists-or-created-by-this-spec rule (#842); anything else is
     third-party and validates against the target environment instead.
     Covers flat layout (pkg at repo root) and src layout.
+
+    #2412: recognising a package ONLY by `__init__.py` made a mid-build repo
+    blind to itself. Measured on boostgauge 2026-08-15: `src/boostgauge/`
+    existed, `src/boostgauge/__init__.py` did not, and this returned the empty
+    set -- so `boostgauge.gauge.nonexistent()` cleared instead of flagging,
+    which is the #1527 founding true positive. Greenfield repos are the
+    population this campaign runs against, so "no `__init__.py` yet" is the
+    normal early state rather than an anomaly.
+
+    Widening is not free in the other direction: a first-party top gets the
+    STRICTER exists-or-created-by-this-spec rule, and over-strictness is what
+    killed five rolls of the receiver-resolution class. So each signal is
+    narrow on its own terms rather than "any directory with a .py in it":
+
+      1. `__init__.py` present -- the original, unchanged;
+      2. the name the repo DECLARES in pyproject.toml -- authoritative, no
+         heuristic;
+      3. a directory under `src/` -- in a src layout its children ARE the
+         packages by definition, which is not true of the repo root, where
+         `tests/`, `scripts/` and `docs/` all sit beside the package.
+
+    Signal 3 is deliberately not applied at the repo root. A flat-layout
+    mid-build repo is covered by signal 2 instead.
     """
     tops: set[str] = set()
     for base in (repo_root, repo_root / "src"):
@@ -2227,10 +2289,19 @@ def _first_party_tops(repo_root: Path) -> set[str]:
             if not base.is_dir():
                 continue
             for child in base.iterdir():
-                if child.is_dir() and (child / "__init__.py").is_file():
+                if not child.is_dir():
+                    continue
+                if (child / "__init__.py").is_file():
+                    tops.add(child.name)
+                elif base.name == "src" and any(child.glob("*.py")):
                     tops.add(child.name)
         except OSError:
             continue
+
+    try:
+        tops |= _pyproject_declared_package(repo_root)
+    except OSError:
+        pass
     return tops
 
 

--- a/tests/unit/test_first_party_mid_build.py
+++ b/tests/unit/test_first_party_mid_build.py
@@ -1,0 +1,177 @@
+"""A mid-build repo must not be blind to its own names (#2412).
+
+`_first_party_tops` recognised a package only by `__init__.py`. Measured on
+boostgauge, 2026-08-15:
+
+    src/boostgauge/            exists
+    src/boostgauge/__init__.py MISSING
+    _first_party_tops(repo) -> set()
+
+So for the campaign's own target repo, nothing was first-party -- and
+`boostgauge.gauge.nonexistent()` cleared instead of flagging, which is the
+#1527 founding true positive. Greenfield repos are the population this campaign
+runs against, so "no `__init__.py` yet" is the normal early state.
+
+The acceptance is two-sided, and the second side is the reason this was not
+folded into #2411: a first-party top gets the STRICTER
+exists-or-created-by-this-spec rule (#1901/#842), and over-strictness is what
+killed five rolls of the receiver-resolution class. Widening must not sweep in
+directories that are not packages.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+vc = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+)
+_first_party_tops = vc._first_party_tops
+
+
+@pytest.fixture
+def repo(tmp_path):
+    return tmp_path / "target"
+
+
+def _make(repo: Path, *relative: str, pyproject: str = "") -> Path:
+    for rel in relative:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+    if pyproject:
+        repo.mkdir(parents=True, exist_ok=True)
+        (repo / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Side one: the mid-build repo is recognised
+# ---------------------------------------------------------------------------
+
+
+class TestTheMeasuredCase:
+    """boostgauge as it stood on 2026-08-15, reconstructed exactly."""
+
+    def test_a_src_package_without_init_is_first_party(self, repo):
+        _make(repo, "src/boostgauge/gauge.py", "src/boostgauge/config.py")
+        assert "boostgauge" in _first_party_tops(repo)
+
+    def test_the_old_rule_would_have_returned_nothing(self, repo):
+        """Pins WHY: no `__init__.py` anywhere, so the pre-#2412 rule found
+        nothing and the test above is not passing for another reason."""
+        _make(repo, "src/boostgauge/gauge.py")
+        assert not (repo / "src" / "boostgauge" / "__init__.py").exists()
+
+    def test_an_init_py_still_works(self, repo):
+        """The original signal is unchanged."""
+        _make(repo, "src/boostgauge/__init__.py")
+        assert "boostgauge" in _first_party_tops(repo)
+
+    def test_a_flat_layout_package_still_works(self, repo):
+        _make(repo, "boostgauge/__init__.py")
+        assert "boostgauge" in _first_party_tops(repo)
+
+
+class TestThePyprojectSignal:
+    """The authoritative signal, needing no filesystem heuristic. It is what
+    covers a FLAT-layout mid-build repo, where the src/ rule cannot apply."""
+
+    def test_a_poetry_name_is_first_party(self, repo):
+        _make(repo, "README.md", pyproject='[tool.poetry]\nname = "boostgauge"\n')
+        assert "boostgauge" in _first_party_tops(repo)
+
+    def test_a_pep621_project_name_is_first_party(self, repo):
+        _make(repo, "README.md", pyproject='[project]\nname = "boostgauge"\n')
+        assert "boostgauge" in _first_party_tops(repo)
+
+    def test_a_dashed_distribution_name_yields_the_import_name(self, repo):
+        """`name = "my-tool"` is imported as `my_tool`."""
+        _make(repo, "README.md", pyproject='[project]\nname = "my-tool"\n')
+        tops = _first_party_tops(repo)
+        assert "my_tool" in tops
+
+    def test_poetry_packages_include_is_first_party(self, repo):
+        _make(
+            repo, "README.md",
+            pyproject=(
+                '[tool.poetry]\nname = "dist-name"\n'
+                'packages = [{include = "realpkg", from = "src"}]\n'
+            ),
+        )
+        assert "realpkg" in _first_party_tops(repo)
+
+    def test_a_malformed_pyproject_is_not_fatal(self, repo):
+        _make(repo, "src/pkg/mod.py", pyproject="this is not toml [[[")
+        assert "pkg" in _first_party_tops(repo)
+
+    def test_a_missing_pyproject_is_not_fatal(self, repo):
+        _make(repo, "src/pkg/mod.py")
+        assert "pkg" in _first_party_tops(repo)
+
+
+# ---------------------------------------------------------------------------
+# Side two: widening must not sweep in what is not a package
+# ---------------------------------------------------------------------------
+
+
+class TestItDoesNotOverInclude:
+    """'the #1901 import check does not start rejecting imports of packages a
+    spec legitimately creates' -- a first-party top gets the STRICTER rule, so
+    every name added here makes that check harsher."""
+
+    @pytest.mark.parametrize("name", ["tests", "scripts", "docs", "examples"])
+    def test_repo_root_siblings_are_not_first_party(self, repo, name):
+        """The `src/` rule is deliberately NOT applied at the repo root, where
+        these all sit beside the package rather than being packages."""
+        _make(repo, f"{name}/thing.py", "src/pkg/mod.py")
+        tops = _first_party_tops(repo)
+        assert "pkg" in tops
+        assert name not in tops
+
+    def test_a_root_directory_with_an_init_is_still_first_party(self, repo):
+        """The original signal is not narrowed -- a real flat-layout package
+        at the root still counts, `tests/` included when it declares itself."""
+        _make(repo, "tests/__init__.py")
+        assert "tests" in _first_party_tops(repo)
+
+    def test_a_src_directory_with_no_python_is_not_first_party(self, repo):
+        _make(repo, "src/assets/logo.svg", "src/pkg/mod.py")
+        tops = _first_party_tops(repo)
+        assert "pkg" in tops
+        assert "assets" not in tops
+
+    def test_a_loose_file_beside_src_packages_is_not_a_top(self, repo):
+        _make(repo, "src/setup_helper.py", "src/pkg/mod.py")
+        tops = _first_party_tops(repo)
+        assert "setup_helper" not in tops
+
+    def test_an_empty_repo_yields_nothing(self, repo):
+        repo.mkdir(parents=True)
+        assert _first_party_tops(repo) == set()
+
+    def test_a_nonexistent_repo_yields_nothing(self, tmp_path):
+        assert _first_party_tops(tmp_path / "nope") == set()
+
+
+# ---------------------------------------------------------------------------
+# The founding true positive, end to end
+# ---------------------------------------------------------------------------
+
+
+class TestTheFoundingTruePositiveIsRestored:
+    def test_a_hallucinated_call_on_a_mid_build_package_is_reachable(self, repo):
+        """#1527's case: `boostgauge.gauge.nonexistent()` must be judged
+        against the repo's symbols rather than exempted as foreign. The
+        judgement needs the root recognised first; this pins that half."""
+        _make(repo, "src/boostgauge/gauge.py")
+        tops = vc._first_party_tops_for(str(repo))
+        assert "boostgauge" in tops
+
+    def test_the_lookup_fails_open_on_a_bad_path(self):
+        """#2411's contract: an unknown root is treated as foreign, never
+        raised over."""
+        assert vc._first_party_tops_for("") == frozenset()


### PR DESCRIPTION
Closes #2412

`_first_party_tops` recognised a package only by `__init__.py`. Measured on boostgauge, 2026-08-15:

```
src/boostgauge/             exists
src/boostgauge/__init__.py  MISSING
_first_party_tops(repo)  -> set()
```

So for the campaign's own target repo **nothing was first-party**, and `boostgauge.gauge.nonexistent()` cleared instead of flagging — the #1527 founding true positive, silently lost. Greenfield repos are the population this campaign runs against, so "no `__init__.py` yet" is the normal early state, and the next target repo will arrive in it.

## Widening is not free in the other direction

Which is why this was not folded into #2411. A first-party top gets the **stricter** exists-or-created-by-this-spec rule (#1901/#842), and over-strictness is what killed five rolls of the receiver-resolution class. So each signal is narrow on its own terms rather than *"any directory containing a `.py` file"*:

1. **`__init__.py` present** — the original, unchanged.
2. **The name the repo declares in `pyproject.toml`** (`[tool.poetry].name`, `[project].name`, `[tool.poetry.packages].include`). Authoritative, no heuristic. Both the dashed distribution spelling and the underscored import spelling are returned. This is what covers a **flat-layout** mid-build repo, where signal 3 cannot apply.
3. **A directory under `src/`** — in a src layout its children *are* the packages by definition. Deliberately **not** applied at the repo root, where `tests/`, `scripts/`, `docs/` and `examples/` all sit beside the package.

## A note on verifying the boostgauge half

The work order records that half as landed on the arc (boostgauge #320, squash `2ae88ba`). My first reading said otherwise, and the correction is worth recording:

```
git ls-tree hardening-run-17 src/boostgauge/   ->  no __init__.py
git branch -a --contains 2ae88ba               ->  remotes/origin/hardening-run-17
```

It **is** on `origin/hardening-run-17`; the local ref was one commit stale. A branch-scoped claim has to be checked against the branch it was made about, and against the remote rather than a local copy of it. Reporting "the fix did not land" from the stale ref would have been wrong and would have sent this work in the wrong direction.

## Acceptance, both sides

**Recognised:** the measured boostgauge state is reconstructed exactly, with a companion test asserting no `__init__.py` exists in that fixture — so the pass cannot be coming from the original signal.

**Not over-included:** parameterised over `tests`, `scripts`, `docs` and `examples` at the repo root, plus a `src/` subdirectory holding no Python, a loose file beside the packages, an empty repo, and a repo that does not exist. A real flat-layout package at the root still counts when it carries `__init__.py`, so the original signal is not narrowed either.

21 fixtures. Full unit suite green (8155 passing).
