### PR TITLE
fix: the pre-check asks what the roll's gate asks, by derivation (Closes #2384)

### DIFF
--- a/assemblyzero/workflows/requirements/precheck.py
+++ b/assemblyzero/workflows/requirements/precheck.py
@@ -65,20 +65,42 @@ EXIT_ERROR = 2
 #: silently turning every clean result into an error.
 CLEAN_MARKER = "Requirements internally consistent."
 
-#: Matches ``--drafter`` in ``tools/run_requirements_workflow.py``.
+def _roll_gate_drafter() -> str:
+    """The model a ROLL's requirements gate actually asks (#2384).
+
+    Read from the orchestrator's own config rather than restated here. The
+    previous arrangement stated `claude:sonnet` beside a comment claiming it
+    matched the roll; it did not, and nobody re-checked because the comment
+    said there was nothing to check. A constant that is DERIVED cannot drift
+    from the thing it claims to mirror -- there is no second copy to update.
+
+    `orchestrator.config` imports only stdlib, so this cannot cycle.
+    """
+    from assemblyzero.workflows.orchestrator.config import get_default_config
+
+    return get_default_config()["stages"]["lld"]["drafter"]
+
+
+#: The model this pre-check asks, which is by construction the model a roll's
+#: N0c will ask.
 #:
-#: It does NOT match what a roll's gate asks, despite what this comment claimed
-#: until #2375. A roll reaches the requirements graph through the orchestrator's
-#: lld stage, whose ``StageConfig`` has carried ``drafter="gemini:3.1-pro"``
-#: since #1434, and nothing on the roll path overrides it -- ``load_config``
-#: merges only ``skip_existing_*``, ``gates`` and ``mock_mode``. Measured
-#: 2026-08-14.
+#: The decision this settles (#2384): a roll reaches the requirements graph
+#: through the orchestrator's lld stage, whose `StageConfig` has carried
+#: `drafter="gemini:3.1-pro"` since #1434, and nothing on the roll path
+#: overrides it -- `load_config` merges only `skip_existing_*`, `gates` and
+#: `mock_mode`. The pre-check exists to tell an operator what the roll's gate
+#: will do BEFORE paying for a roll, so its value is entirely predictive and
+#: the roll is the thing being predicted. Aligning the roll to the pre-check
+#: instead would change what every stage drafts with and reopen #1431, the
+#: Claude `json_schema` crash that is the documented reason the roll defaults
+#: to Gemini at all.
 #:
-#: So this pre-check predicts the roll's gate on every dimension except the
-#: model, and the model is the dimension #2375 found mattered most: sonnet timed
-#: out three consecutive times on a document opus answered on its first attempt.
-#: Which model the two paths should share is a decision, tracked in #2384.
-DEFAULT_DRAFTER = "claude:sonnet"
+#: One consequence, stated because it invalidates evidence rather than because
+#: it is convenient: #2375's measurements -- sonnet timing out three
+#: consecutive times on boostgauge #1's body where opus answered inside the
+#: bound -- were measurements of the PRE-CHECK's old model. They no longer
+#: predict roll behaviour on the drafter dimension.
+DEFAULT_DRAFTER = _roll_gate_drafter()
 
 _GATE_PATH = "assemblyzero/workflows/requirements/nodes/analyze_requirements.py"
 _FILING_FAILED_MARKER = "must-resolve filing failed"

--- a/tests/unit/test_precheck_predicts_the_roll.py
+++ b/tests/unit/test_precheck_predicts_the_roll.py
@@ -1,0 +1,103 @@
+"""The pre-check must ask what the roll's gate asks (#2384).
+
+The pre-check's entire purpose is to tell an operator what the roll's gate will
+do before paying for a roll. On the drafter dimension it did not, and its
+docstring asserted the opposite -- so nobody re-checked, for however long it had
+been wrong.
+
+Measured 2026-08-14 by building the config a roll actually runs with:
+
+    precheck.DEFAULT_DRAFTER            = 'claude:sonnet'
+    lld stage drafter (no overrides)    = 'gemini:3.1-pro'
+    lld stage drafter (full override)   = 'gemini:3.1-pro'
+    Same model?                           False
+
+The settlement is that the ROLL is correct and the pre-check follows it: the
+pre-check is the predictor, the roll is the thing predicted, and the roll's
+choice is grounded in #1431's Claude `json_schema` crash. `DEFAULT_DRAFTER` is
+now derived from the orchestrator config rather than restated, so the two
+cannot diverge -- and these pin that the derivation stays real.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+from assemblyzero.workflows.orchestrator.config import get_default_config, load_config
+
+precheck = importlib.import_module("assemblyzero.workflows.requirements.precheck")
+
+
+class TestTheTwoPathsAgree:
+    def test_the_precheck_asks_the_lld_stage_drafter(self):
+        assert (
+            precheck.DEFAULT_DRAFTER
+            == get_default_config()["stages"]["lld"]["drafter"]
+        )
+
+    def test_it_is_the_gemini_the_roll_defaults_to(self):
+        """Named explicitly so a change to either side is visible in the diff
+        rather than only in an equality that still holds after both move."""
+        assert precheck.DEFAULT_DRAFTER == "gemini:3.1-pro"
+
+    def test_a_rolls_full_override_set_does_not_change_it(self):
+        """`load_config` merges only `skip_existing_*`, `gates` and
+        `mock_mode`, so nothing on the roll path overrides the drafter. This is
+        the measurement the issue made, kept runnable."""
+        rolled = load_config({
+            "skip_existing_lld": False,
+            "skip_existing_spec": False,
+            "mock_mode": False,
+            "gates": {},
+        })
+        assert rolled["stages"]["lld"]["drafter"] == precheck.DEFAULT_DRAFTER
+
+
+class TestTheClaimIsEnforcedByConstruction:
+    def test_the_default_is_derived_not_restated(self):
+        """A second copy of a value is a second thing to update. The previous
+        arrangement had one, and it went stale silently."""
+        source = inspect.getsource(precheck)
+        assert "DEFAULT_DRAFTER = _roll_gate_drafter()" in source
+
+    def test_the_derivation_reads_the_orchestrator_config(self):
+        source = inspect.getsource(precheck._roll_gate_drafter)
+        assert "get_default_config()" in source
+        assert '["stages"]["lld"]["drafter"]' in source
+
+    def test_no_hardcoded_model_literal_remains_for_the_default(self):
+        """The specific rot this issue is about: a literal beside a comment
+        claiming it matched something it did not."""
+        source = inspect.getsource(precheck)
+        assert 'DEFAULT_DRAFTER = "claude:sonnet"' not in source
+
+    def test_the_derivation_survives_a_change_to_the_orchestrator(self, monkeypatch):
+        """The point of deriving: move the roll and the pre-check follows,
+        with no second edit."""
+        import assemblyzero.workflows.orchestrator.config as cfg
+
+        real = cfg.get_default_config
+
+        def _moved():
+            config = real()
+            config["stages"]["lld"]["drafter"] = "gemini:9.9-pro"
+            return config
+
+        monkeypatch.setattr(cfg, "get_default_config", _moved)
+        assert precheck._roll_gate_drafter() == "gemini:9.9-pro"
+
+
+class TestTheInvalidatedEvidenceIsRecorded:
+    def test_the_docstring_says_2375s_measurements_no_longer_predict(self):
+        """#2375 measured sonnet against opus on boostgauge #1's body. Those
+        were measurements of the pre-check's OLD model. Saying so is the
+        difference between a settled decision and a silent one."""
+        # Normalised: the comment wraps, and `#: ` continuations would
+        # otherwise split the phrase and fail an assertion about prose that is
+        # actually present.
+        source = " ".join(
+            inspect.getsource(precheck).replace("#:", " ").split()
+        )
+        assert "#2375" in source
+        assert "no longer predict" in source


### PR DESCRIPTION
Closes #2384

The pre-check exists to tell an operator what the roll's gate will do *before* paying for a roll. On the drafter dimension it did not, and its docstring asserted the opposite — so nobody re-checked.

## The decision, settled rather than merely aligned

**The roll is correct and the pre-check follows it.** The pre-check is the predictor; the roll is the thing predicted. Aligning the other way would change what every stage drafts with and reopen #1431 — the Claude `json_schema` crash that is the documented reason the roll defaults to Gemini at all.

`DEFAULT_DRAFTER` is now **derived** from the orchestrator's lld `StageConfig` rather than restated beside a comment claiming they match. A constant with a second copy is a second thing to update, and that copy went stale silently. There is no copy now — the claim is enforced by construction, not by a comment. (`orchestrator.config` imports only stdlib, so this cannot cycle.)

## The measurement the acceptance asks for

Run against boostgauge #1's real body with the newly-aligned drafter:

```
Drafter: gemini:3.1-pro
elapsed: 292s
verdict: CONFLICT (returned, not timed out)
```

**It did not time out.** That overturns the issue's stated worry —

> "Whether `gemini:3.1-pro` also times out on that document is **unmeasured**, so the conclusion 'at roll time this document means timeout → fail-open → REQUIREMENTS UNVERIFIED' does not follow from the evidence gathered."

— in the reassuring direction: the evidence now exists, and the conclusion does not hold for Gemini. #2375's sonnet-timeout measurements were measurements of the pre-check's **old** model; the docstring says so, because a settled decision that quietly invalidates prior evidence is worse than an unsettled one.

**No new timeout finding.** 292s against the gate's **600s** bound is better than 2× margin. #2290 already raised that bound from 300s after measuring the same call time out at 300s and answer in 294s minutes apart; this sits well clear of the raised one.

## Side effect, stated plainly

The pre-check **filed boostgauge #324** — a real requirements conflict on #1 (the renderer's shared-axis requirement against `T5`'s non-coincident telltale angles).

That is the tool's designed behaviour — it files "exactly as a roll would file them" — and it is the pre-check earning its keep: finding *before* the LLD stage is paid for what the roll would have found after. **It also means boostgauge #1 will refuse to launch until #324 is ruled on.**

## Fixtures

8. Four pin the agreement, including against a roll's full override set (`load_config` merges only `skip_existing_*`, `gates` and `mock_mode`, so nothing on the roll path touches the drafter). Three pin that the value stays *derived* rather than restated — one by moving the orchestrator's default under a monkeypatch and asserting the pre-check follows with no second edit. One pins that the invalidation of #2375's evidence stays recorded.

Full unit suite green (8163 passing).
