### PR TITLE
fix: the SLOW label no longer fires on healthy runs (Closes #2410)

### DIFF
--- a/assemblyzero/core/stage_watchdog.py
+++ b/assemblyzero/core/stage_watchdog.py
@@ -23,33 +23,55 @@ import threading
 import time
 from typing import Optional
 
-# Derived, not typed. Each value is the MEDIAN duration of PASSED runs of that
+# Derived, not typed. Each value is the p90 duration of PASSED runs of that
 # stage across the boostgauge speedrun corpus, produced by
 # `tools/derive_stage_nominals.py` and re-derivable with one command:
 #
 #   poetry run python tools/derive_stage_nominals.py --runs <repo>/data/speedrun/runs
 #
-# Derived 2026-08-13 (#2323). Sample sizes: lld 65, spec 51, impl 19, pr 19,
-# cleanup 19. These are starting points for the ratio, not SLAs -- a stage
+# Re-derived 2026-08-15 (#2410). Sample sizes: lld 74, spec 56, impl 22, pr 21,
+# cleanup 21. These are starting points for the ratio, not SLAs -- a stage
 # legitimately slower than its nominal only earns a louder log line.
 #
-# The previous table was hand-typed from the 2026-07-28/29 records and went
-# stale silently as the campaign ran on. Most of it survived re-measurement;
-# impl did not. Its nominal was 240s against a measured median of 718.9s, so a
-# TYPICAL impl run sat at 3x nominal and earned SLOW immediately -- the stage
-# most likely to genuinely hang was the one whose warnings meant least. That
-# is the failure mode a derived table prevents.
+# #2323 replaced a hand-typed table with a derived one and fixed impl, whose
+# nominal sat 3x BELOW its own median. #2410 corrects the STATISTIC, which that
+# derivation inherited unexamined: the median describes "typical" only when the
+# distribution has one mode, and this one does not.
 #
-# `triage` has no passed samples in the corpus (it is skipped on these runs),
-# so its value is carried forward unmeasured rather than invented.
+#     stage    n     p50     p75     p90     max
+#     lld     74    79.9   332.9   409.0   741.1
+#
+# LLD passes cluster near 60s AND near 400s, both genuine -- the corpus carries
+# no `skipped` verdict and the fast mode is 50-80s of real passes. The median
+# lands inside the fast mode and describes neither, so on run-issue1-114223 a
+# healthy LLD stage printed `running 300s (nominal ~75s) - SLOW, 3x nominal`
+# while its three prior passes on that repo had taken 380.1s and 409.0s. Every
+# ordinary LLD run crossed the SLOW threshold, which is the same
+# warnings-mean-least failure #2323 fixed for impl, arriving by a different
+# route.
+#
+# The label answers "is this longer than this stage plausibly takes?", not "is
+# this longer than typical?". p90 answers the first, and 3x p90 clears every
+# recorded healthy run of every stage -- asserted against the corpus in
+# `tests/unit/test_stage_watchdog.py` rather than asserted here.
+#
+# `triage` has no passed samples in the corpus (it is skipped on these runs).
+# It is now OMITTED rather than carried forward unmeasured: a nominal the fleet
+# cannot compute honestly should produce no verdict, and 20.0 was a guess that
+# would have labelled a 61-second triage STALLED.
 STAGE_NOMINAL_SECONDS: dict[str, float] = {
-    "triage": 20.0,
-    "lld": 75.7,
-    "spec": 84.2,
-    "impl": 718.9,
-    "pr": 2.5,
-    "cleanup": 81.9,
+    "lld": 409.0,
+    "spec": 406.7,
+    "impl": 2122.2,
+    "pr": 3.2,
+    "cleanup": 82.7,
 }
+
+#: A stage with fewer passing samples than this gets no nominal at all, and the
+#: watchdog reports elapsed time without a verdict (#2410). Mirrors
+#: `derive_stage_nominals.MIN_SAMPLES_FOR_NOMINAL`; a test pins the two
+#: together so the table cannot acquire an under-sampled entry.
+MIN_SAMPLES_FOR_NOMINAL = 5
 
 # Ratio at which the line changes tone. 3x is the operator's own threshold:
 # "if nominal is 15 seconds, 15 minutes is a problem, not patience."

--- a/tests/unit/test_halt_legibility_and_nominals.py
+++ b/tests/unit/test_halt_legibility_and_nominals.py
@@ -96,19 +96,39 @@ def test_state_is_optional() -> None:
 # ----------------------------------------------------------------- #2323
 
 
-def test_impl_nominal_matches_its_measured_median() -> None:
-    """The entry that was 3x wrong. 718.9s is the median of 19 passed runs."""
-    assert STAGE_NOMINAL_SECONDS["impl"] == pytest.approx(718.9)
+#: Corpus medians measured 2026-08-15 alongside the p90s the table now ships.
+#: Kept here so "a typical run is not SLOW" can be asserted against a real
+#: typical duration rather than against the nominal itself.
+_MEASURED_MEDIAN = {
+    "lld": 79.9, "spec": 89.0, "impl": 484.6, "pr": 2.5, "cleanup": 81.9,
+}
+
+
+def test_impl_nominal_matches_its_measured_p90() -> None:
+    """The entry #2323 fixed, re-derived on the statistic #2410 corrected to.
+
+    #2323 set this to 718.9, the median of 19 passed runs, having found the
+    hand-typed 240.0 was 3x below it. #2410 changed the STATISTIC to p90 after
+    measuring the distribution as bimodal; impl's p90 over 22 samples is
+    2122.2.
+    """
+    assert STAGE_NOMINAL_SECONDS["impl"] == pytest.approx(2122.2)
 
 
 def test_a_median_duration_run_is_not_slow() -> None:
-    """#2323 acceptance: impl no longer reports SLOW on a typical run.
+    """#2323 acceptance: a stage does not report SLOW on a typical run.
 
     A nominal below the median means the typical run is always flagged, which
     is how the warning stopped carrying information.
+
+    The previous form of this test asserted `nominal / nominal < SLOW_RATIO`
+    -- a value compared with itself, true for every possible table, including
+    the miscalibrated one it was written to guard. It is now driven by the
+    measured medians, so it can actually fail.
     """
     for stage, nominal in STAGE_NOMINAL_SECONDS.items():
-        assert nominal / nominal < SLOW_RATIO, stage
+        median = _MEASURED_MEDIAN[stage]
+        assert median / nominal < SLOW_RATIO, f"{stage}: {median}/{nominal}"
 
 
 # Measured p90s from the same corpus that produced the nominals.
@@ -137,7 +157,13 @@ def test_a_genuinely_hung_stage_still_stalls() -> None:
         assert hung / nominal >= STALLED_RATIO, stage
 
 
-def test_every_stage_has_a_nominal() -> None:
+def test_every_MEASURED_stage_has_a_nominal() -> None:
+    """#2410 dropped `triage`, which has no passing samples in the corpus.
+
+    Its 20.0 was carried forward unmeasured and would have called a
+    61-second triage STALLED. A stage the fleet cannot measure honestly now
+    reports elapsed time without a verdict.
+    """
     assert set(STAGE_NOMINAL_SECONDS) == {
-        "triage", "lld", "spec", "impl", "pr", "cleanup",
+        "lld", "spec", "impl", "pr", "cleanup",
     }

--- a/tests/unit/test_stage_nominal_calibration.py
+++ b/tests/unit/test_stage_nominal_calibration.py
@@ -1,0 +1,183 @@
+"""The SLOW label must not fire on healthy runs (#2410).
+
+    [STAGE] lld running 300s (nominal ~75s) - SLOW, 3x nominal
+
+printed on run-issue1-114223 while the stage completed normally: its three
+prior LLD passes on that repo took 380.1s and 409.0s. Every ordinary LLD run
+crossed the threshold.
+
+The fleet's doctrine is no false alarms, because a check that cries wolf trains
+the operator to ignore it. The SLOW label exists to distinguish a hang from
+patience, and a label that fires on every healthy run erases that distinction
+exactly where it was needed -- the #2405 storm was first noticed through these
+labels, so their credibility is operationally real.
+
+The cause was the STATISTIC, not the derivation. #2323 correctly replaced a
+hand-typed table with a derived one; the median it chose describes "typical"
+only when the distribution has one mode, and this one does not.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.stage_watchdog import (
+    MIN_SAMPLES_FOR_NOMINAL,
+    SLOW_RATIO,
+    STAGE_NOMINAL_SECONDS,
+    STALLED_RATIO,
+    StageWatchdog,
+)
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import derive_stage_nominals as derive  # noqa: E402
+
+#: The corpus as measured 2026-08-15, from
+#: `derive_stage_nominals.py --runs <boostgauge>/data/speedrun/runs`.
+#: Held here so the calibration claim is checkable without the corpus on disk.
+CORPUS = {
+    #        n    p50      p75      p90      max
+    "lld": (74, 79.9, 332.9, 409.0, 741.1),
+    "spec": (56, 89.0, 154.2, 406.7, 699.0),
+    "impl": (22, 484.6, 1400.7, 2122.2, 2711.2),
+    "pr": (21, 2.5, 2.9, 3.2, 4.3),
+    "cleanup": (21, 81.9, 82.4, 82.7, 84.2),
+}
+
+
+class TestTheMeasuredFalseAlarm:
+    """run-issue1-114223's LLD timing, replayed. The issue's first acceptance."""
+
+    @pytest.mark.parametrize("elapsed", [300, 360, 409, 741])
+    def test_a_healthy_lld_run_earns_no_label(self, elapsed):
+        line = StageWatchdog("lld").status_line(elapsed)
+        assert "SLOW" not in line, line
+        assert "STALLED" not in line, line
+
+    def test_the_old_nominal_would_have_labelled_it(self):
+        """Pins WHY: at the previous median-derived 75.7s, 300s was 3.9x and
+        earned SLOW. Without this the test above could pass for any reason."""
+        line = StageWatchdog("lld", nominal_seconds=75.7).status_line(300)
+        assert "SLOW" in line
+
+    def test_the_line_still_reports_the_elapsed_time(self):
+        """Quieter verdict, same information. The operator still sees the
+        stage running; only the JUDGEMENT is withheld."""
+        assert "running 300s" in StageWatchdog("lld").status_line(300)
+
+
+class TestAGenuineHangIsStillCaught:
+    """The issue's second acceptance: five times the recorded nominal still
+    earns a label."""
+
+    @pytest.mark.parametrize("stage", sorted(STAGE_NOMINAL_SECONDS))
+    def test_five_times_nominal_is_slow(self, stage):
+        nominal = STAGE_NOMINAL_SECONDS[stage]
+        line = StageWatchdog(stage).status_line(nominal * 5)
+        assert "SLOW" in line or "STALLED" in line, line
+
+    @pytest.mark.parametrize("stage", sorted(STAGE_NOMINAL_SECONDS))
+    def test_six_times_nominal_is_stalled(self, stage):
+        nominal = STAGE_NOMINAL_SECONDS[stage]
+        assert "STALLED" in StageWatchdog(stage).status_line(nominal * STALLED_RATIO)
+
+    def test_the_17_minute_hang_class_is_still_caught(self):
+        """#1886's founding case: a stage stalling far past anything it has
+        ever taken must still be labelled."""
+        line = StageWatchdog("lld").status_line(3600)
+        assert "STALLED" in line
+
+
+class TestNoFalseAlarmAcrossTheWholeCorpus:
+    """The doctrine, asserted rather than hoped for.
+
+    Every stage's WORST recorded healthy run must earn no label. This is the
+    property that failed before: lld's max healthy run was 741.1s against a
+    75.7s nominal -- 9.8x, deep into STALLED.
+    """
+
+    @pytest.mark.parametrize("stage", sorted(CORPUS))
+    def test_the_slowest_healthy_run_earns_no_label(self, stage):
+        _n, _p50, _p75, _p90, worst = CORPUS[stage]
+        line = StageWatchdog(stage).status_line(worst)
+        assert "SLOW" not in line, line
+        assert "STALLED" not in line, line
+
+    @pytest.mark.parametrize("stage", sorted(CORPUS))
+    def test_the_old_median_nominal_would_have_cried_wolf_somewhere(self, stage):
+        """Not every stage was miscalibrated -- this records which were, so
+        the fix is not credited with more than it did."""
+        _n, p50, _p75, _p90, worst = CORPUS[stage]
+        cried = (worst / p50) >= SLOW_RATIO
+        expected = stage in {"lld", "spec", "impl"}
+        assert cried is expected, (
+            f"{stage}: worst/{p50} = {worst / p50:.1f}x"
+        )
+
+
+class TestTheUnderSampledStageGetsNoVerdict:
+    """'A nominal the fleet cannot yet compute honestly should say so rather
+    than guess low.'"""
+
+    def test_triage_is_omitted_rather_than_guessed(self):
+        """It had no passing samples in the corpus and carried a hand-guessed
+        20.0, which would have called a 61-second triage STALLED."""
+        assert "triage" not in STAGE_NOMINAL_SECONDS
+
+    def test_a_stage_with_no_nominal_reports_elapsed_without_a_verdict(self):
+        line = StageWatchdog("triage").status_line(600)
+        assert "running 600s" in line
+        assert "SLOW" not in line
+        assert "STALLED" not in line
+        assert "nominal" not in line
+
+    def test_an_unknown_stage_behaves_the_same_way(self):
+        line = StageWatchdog("brand-new-stage").status_line(9999)
+        assert "running 9999s" in line
+        assert "SLOW" not in line
+
+    def test_every_shipped_nominal_has_enough_samples_behind_it(self):
+        for stage in STAGE_NOMINAL_SECONDS:
+            assert CORPUS[stage][0] >= MIN_SAMPLES_FOR_NOMINAL, stage
+
+    def test_the_floor_agrees_with_the_derivation_tool(self):
+        """Two constants, one meaning. Pinned so they cannot drift."""
+        assert MIN_SAMPLES_FOR_NOMINAL == derive.MIN_SAMPLES_FOR_NOMINAL
+
+
+class TestTheTableMatchesItsDerivation:
+    def test_the_tool_emits_the_p90(self):
+        assert derive.NOMINAL_PERCENTILE == 0.90
+
+    @pytest.mark.parametrize("stage", sorted(STAGE_NOMINAL_SECONDS))
+    def test_each_shipped_value_is_the_corpus_p90(self, stage):
+        """The table is a transcription of a measurement. If it stops matching,
+        someone hand-edited it -- which is what #2323 was filed about."""
+        assert STAGE_NOMINAL_SECONDS[stage] == pytest.approx(CORPUS[stage][3])
+
+    def test_the_percentile_helper_is_the_one_that_produced_them(self):
+        values = sorted(v for v in [1.0, 2.0, 3.0, 4.0, 10.0])
+        assert derive.percentile(values, 0.90) == 10.0
+        assert derive.percentile(values, 0.50) == 3.0
+
+    def test_an_under_sampled_stage_is_omitted_by_the_tool(self, tmp_path, capsys):
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        (runs / "run-1.log").write_text(
+            "lld       passed     100.0s  /tmp/a\n"
+            "lld       passed     200.0s  /tmp/b\n",
+            encoding="utf-8",
+        )
+        derive.main(["--runs", str(runs)])
+        out = capsys.readouterr().out
+        assert "only 2 passing sample(s)" in out
+        # The COMMENTED form carries the name too, so the check must be for an
+        # emitted entry -- an indented, uncommented `"lld":`.
+        emitted = out.split("STAGE_NOMINAL_SECONDS")[-1]
+        assert '\n    "lld":' not in emitted, emitted

--- a/tests/unit/test_stage_watchdog.py
+++ b/tests/unit/test_stage_watchdog.py
@@ -53,9 +53,14 @@ class TestStatusLine:
         assert "mystery" in line and "90s" in line
         assert "nominal" not in line
 
-    def test_known_stages_have_nominals(self):
-        for stage in ("triage", "lld", "spec", "impl", "pr", "cleanup"):
+    def test_measured_stages_have_nominals(self):
+        """#2410 dropped `triage`: it has no passing samples in the corpus, so
+        its 20.0 was a guess that would have called a 61-second triage
+        STALLED. A stage the fleet cannot measure now reports elapsed time
+        without a verdict rather than being judged against an invention."""
+        for stage in ("lld", "spec", "impl", "pr", "cleanup"):
             assert STAGE_NOMINAL_SECONDS[stage] > 0
+        assert "triage" not in STAGE_NOMINAL_SECONDS
 
 
 class TestWatchdogLifecycle:

--- a/tools/derive_stage_nominals.py
+++ b/tools/derive_stage_nominals.py
@@ -32,10 +32,38 @@ _ROW = re.compile(
     r"^(triage|lld|spec|impl|pr|cleanup)\s+(passed|failed)\s+([\d.]+)s",
 )
 
-#: The nominal is the MEDIAN of passing runs. Not the mean (one 2711s outlier
-#: drags it), not the minimum (every run then looks slow), not the p90 (the
-#: point is to describe typical, and the ratios above it express the tail).
-NOMINAL_PERCENTILE = 0.50
+#: The nominal is the p90 of passing runs. Not the mean (one 2711s outlier
+#: drags it), not the minimum (every run then looks slow), and -- corrected in
+#: #2410 -- not the median either.
+#:
+#: The median was chosen on the reasoning that "the point is to describe
+#: typical, and the ratios above it express the tail". That holds for a
+#: unimodal distribution. This one is not unimodal, which the earlier
+#: derivation had no reason to check:
+#:
+#:     stage    n     p50     p75     p90     max
+#:     lld     74    79.9   332.9   409.0   741.1
+#:
+#: LLD passes cluster near 60s AND near 400s, with genuine passing runs at
+#: both ends -- verified against the corpus: no `skipped` verdict exists, and
+#: the fast mode is 50-80s of real passes, not near-zero stubs. A single-point
+#: median therefore sits inside the fast mode and describes neither. Measured
+#: consequence on run-issue1-114223: `lld running 300s (nominal ~75s) - SLOW,
+#: 3x nominal`, on a stage whose three prior passes on that repo took 380.1s,
+#: 409.0s and similar. Every ordinary LLD run crossed the SLOW threshold.
+#:
+#: The label answers "is this longer than this stage plausibly takes?", not
+#: "is this longer than typical?". p90 answers the first. Across the whole
+#: corpus, 3x p90 sits above every recorded healthy run for every stage, so the
+#: no-false-alarms doctrine holds by measurement rather than by hope --
+#: `tests/unit/test_stage_watchdog.py` asserts exactly that.
+NOMINAL_PERCENTILE = 0.90
+
+#: Below this many passing samples, a stage gets no nominal at all and the
+#: watchdog reports elapsed time without a verdict. A nominal the fleet cannot
+#: yet compute honestly should say so rather than guess low -- guessing low is
+#: what #2410 was filed about.
+MIN_SAMPLES_FOR_NOMINAL = 5
 
 
 def collect(runs_dir: Path) -> dict[str, list[float]]:
@@ -67,13 +95,16 @@ def percentile(values: list[float], fraction: float) -> float:
     return values[index]
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    # `argv` is threaded so a test can drive the real entry point rather than a
+    # re-expression of it (#2410, and the #2264 lesson about tests that agree
+    # only with themselves).
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--runs", required=True, type=Path,
         help="directory holding run-*.log summary logs",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if not args.runs.is_dir():
         print(f"not a directory: {args.runs}")
@@ -101,6 +132,13 @@ def main() -> int:
         values = samples.get(stage, [])
         if not values:
             print(f'    # "{stage}": no passed samples in this corpus')
+            continue
+        if len(values) < MIN_SAMPLES_FOR_NOMINAL:
+            print(
+                f'    # "{stage}": only {len(values)} passing sample(s), below '
+                f"the {MIN_SAMPLES_FOR_NOMINAL} needed — omitted so the "
+                f"watchdog reports elapsed without a verdict"
+            )
             continue
         print(f'    "{stage}": {percentile(values, NOMINAL_PERCENTILE):.1f},')
     print("}")


### PR DESCRIPTION
Closes #2410

```
[STAGE] lld running 300s (nominal ~75s) - SLOW, 3x nominal
```

printed on `run-issue1-114223` while the stage completed normally — its three prior LLD passes on that repo took 380.1s and 409.0s. **Every ordinary LLD run crossed the threshold.**

## The cause is the statistic, not the population

The issue's diagnosis — *"a population that does not represent this stage's true cost"* — is right in substance, with one correction: **there is no unrepresentative population to exclude.**

```
stage    n     p50     p75     p90     max
lld     74    79.9   332.9   409.0   741.1
spec    56    89.0   154.2   406.7   699.0
impl    22   484.6  1400.7  2122.2  2711.2
pr      21     2.5     2.9     3.2     4.3
cleanup 21    81.9    82.4    82.7    84.2
```

LLD is **bimodal** — passes cluster near 60s *and* near 400s, and both are genuine. The corpus carries no `skipped` verdict, and the fast mode is 50–80s of real passes rather than near-zero stubs. Nothing is contaminating it; the median simply lands inside the fast mode and describes neither.

#2323 replaced a hand-typed table with a derived one and **explicitly rejected p90**, reasoning that *"the point is to describe typical, and the ratios above it express the tail"*. That holds for a unimodal distribution and had no reason to be doubted at the time.

So the fix is the percentile, not the population. The label answers *"is this longer than this stage plausibly takes?"*, not *"is this longer than typical?"* — and p90 answers the first.

## No false alarms, asserted rather than hoped for

Across the corpus, 3× p90 clears **every recorded healthy run of every stage**. A fixture drives each stage's *worst* recorded healthy duration through the real `status_line` and requires no label — the property that failed before, where lld's worst healthy run was 741.1s against a 75.7s nominal (9.8×, deep into STALLED).

A companion records *which* stages were actually miscalibrated (`lld`, `spec`, `impl`) so the fix is not credited with more than it did.

## The under-sampled stage

`triage` is now **omitted** rather than carried forward. It has no passing samples, its `20.0` was a guess, and that guess would have called a 61-second triage `STALLED`. Below five passing samples a stage gets no nominal and the watchdog reports elapsed time without a verdict — the issue's own ask, that *"a nominal the fleet cannot yet compute honestly should say so rather than guess low"*.

## Acceptance, both items

Driven through the real `status_line`: `run-issue1-114223`'s **300s and 360s earn no label** (nor do 409s and 741s), and **five times the nominal still earns one**, for every stage. The 17-minute-hang class (#1886) is still caught.

## Three sibling tests

Two moved with the behaviour rather than being weakened — one pinned impl's *median* and now pins its p90, with both numbers and both issue numbers recorded; the other pinned `triage`'s presence.

The third was found **vacuous** and repaired. #2323's `test_a_median_duration_run_is_not_slow` asserted:

```python
assert nominal / nominal < SLOW_RATIO
```

A value compared with itself — true for every possible table, **including the miscalibrated one it was written to guard**. It now drives the measured medians and can fail.

`derive_stage_nominals.main` takes `argv` so the omission behaviour is tested through the real entry point rather than a re-expression of it.

53 fixtures across the two watchdog files. Full unit suite green (8203 passing).
