### PR TITLE
fix: an unreadable target-repo file is reported, never scraped (Closes #2393)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/analyze_codebase.py
@@ -17,6 +17,7 @@ This node populates:
 
 import ast
 import re
+from dataclasses import dataclass
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -298,7 +299,15 @@ def analyze_codebase(state: ImplementationSpecState) -> dict[str, Any]:
     # Closes #1527: Extract symbol names from all gathered Python file content.
     # Runs over the full current_content (before excerpt trimming) so that
     # methods defined deep in a class body are captured.
-    gathered_symbols = _extract_symbols_from_files(updated_files)
+    # #2393: the gather reports what it could NOT read. An unparseable
+    # target-repo file used to be regex-scraped into the symbol universe
+    # silently; now it is named and excluded, and the exclusion is printed
+    # where the operator reads the run rather than discovered downstream as a
+    # mystery hallucination flag.
+    gather = gather_symbols(updated_files)
+    gathered_symbols = gather.symbols
+    if gather.unreadable:
+        print(gather.describe())
 
     # #2052: the plan is not the universe. This gathered only files_to_modify,
     # so a spec CALLING an earlier phase's API without modifying its file was
@@ -1031,27 +1040,63 @@ def _extract_symbols_from_base(repo_root: Path, base_ref_name: str) -> set[str]:
     return symbols
 
 
-def _extract_symbols_from_files(files: list[FileToModify]) -> list[str]:
-    """Extract class and function/method names from gathered Python files.
+@dataclass
+class SymbolGather:
+    """The symbol universe, and what could not be read into it (#2393)."""
 
-    Closes #1527: Produces the symbol set that N3's API-hallucination check
-    uses to detect method calls on target-repo classes that don't actually
-    exist.
+    symbols: list[str]
+    #: (path, parse error) for every `.py` file that would not parse.
+    unreadable: list[tuple[str, str]]
 
-    Uses Python ``ast`` when the content is valid Python.  Falls back to
-    two simple regexes (``^\\s*def (\\w+)`` / ``^\\s*class (\\w+)``) for
-    content that fails to parse (partial snippets, syntax errors).
+    def describe(self) -> str:
+        """One line naming what was excluded, or "" when nothing was."""
+        if not self.unreadable:
+            return ""
+        listed = "; ".join(f"{path} ({err})" for path, err in self.unreadable[:3])
+        more = (
+            f" (and {len(self.unreadable) - 3} more)"
+            if len(self.unreadable) > 3
+            else ""
+        )
+        return (
+            f"    [SYMBOLS] {len(self.unreadable)} target-repo .py file(s) did "
+            f"NOT parse and were EXCLUDED from the symbol universe: "
+            f"{listed}{more}. The spec is judged against a smaller universe "
+            f"than the repo actually has (#2393)."
+        )
 
-    Args:
-        files: Updated list of FileToModify entries with current_content set.
 
-    Returns:
-        Sorted, deduplicated list of identifier names.
+def gather_symbols(files: list[FileToModify]) -> SymbolGather:
+    """Class and function names from gathered Python files, plus the misses.
+
+    Closes #1527: produces the symbol set N3's API-hallucination check judges
+    every spec against.
+
+    #2393 removed a regex fallback that scraped `^\\s*def (\\w+)` and
+    `^\\s*class (\\w+)` out of files that would not parse. That fallback fed
+    the YARDSTICK rather than the document being measured, so its errors were
+    the hardest kind to see: a name regex invents becomes a false clearance,
+    and a name it misses becomes a false hallucination flag. #2391 is a live
+    example of what a wrong symbol universe costs -- three revision cycles and
+    a dead stage -- and that universe was merely incomplete rather than
+    fabricated.
+
+    Standard 0028 section 3 permits deterministic scans of the pipeline's own
+    documents on the condition that they "cannot mask a contract failure
+    because there is no contract: the document is what it is". A `.py` file in
+    the target repo IS a contract that its content is Python. A file that will
+    not parse is a real finding about the target repo, and section 4 is direct:
+    "No function returns an empty result, an UNKNOWN, or a silent downgrade
+    because it could not read its input."
+
+    So an unparseable file is now named and excluded, and the exclusion is
+    counted and reported. Excluded rather than fatal: a target repo mid-build
+    can hold a broken file, and refusing the whole stage over one would trade a
+    quiet wrong answer for a loud useless one. What must not happen is the
+    third option the code took -- inventing symbols and saying nothing.
     """
     symbols: set[str] = set()
-
-    _def_re = re.compile(r"^\s*def\s+(\w+)", re.MULTILINE)
-    _cls_re = re.compile(r"^\s*class\s+(\w+)", re.MULTILINE)
+    unreadable: list[tuple[str, str]] = []
 
     for file_spec in files:
         content = file_spec.get("current_content")
@@ -1062,17 +1107,21 @@ def _extract_symbols_from_files(files: list[FileToModify]) -> list[str]:
 
         try:
             tree = ast.parse(content)
-            for node in ast.walk(tree):
-                if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                    symbols.add(node.name)
-        except SyntaxError:
-            # Fallback: regex-based extraction for partial/broken files
-            for m in _def_re.finditer(content):
-                symbols.add(m.group(1))
-            for m in _cls_re.finditer(content):
-                symbols.add(m.group(1))
+        except SyntaxError as exc:
+            detail = f"line {exc.lineno}: {exc.msg}" if exc.lineno else exc.msg
+            unreadable.append((path, detail))
+            continue
 
-    return sorted(symbols)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                symbols.add(node.name)
+
+    return SymbolGather(symbols=sorted(symbols), unreadable=unreadable)
+
+
+def _extract_symbols_from_files(files: list[FileToModify]) -> list[str]:
+    """The symbol list alone, for callers that do not report exclusions."""
+    return gather_symbols(files).symbols
 
 
 def _names_similar(name_a: str, name_b: str) -> bool:

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -3188,11 +3188,20 @@ class TestExtractSymbolsFromFiles:
         symbols = _extract_symbols_from_files(files)
         assert symbols == []
 
-    def test_fallback_regex_on_syntax_error(self):
-        """Broken Python falls back to regex, still extracts def/class names."""
+    def test_unparseable_python_is_excluded_not_scraped(self):
+        """#2393 retired the regex fallback this test used to pin.
+
+        It asserted that a file which will not parse still yields `my_method`
+        via `^\\s*def (\\w+)` scraping. That scraping fed the YARDSTICK the
+        spec is judged against, so its errors were the hardest kind to see --
+        an invented name is a false clearance, a missed one a false
+        hallucination flag. The behaviour it pinned is the behaviour being
+        retired, so this test is evidence of the old contract rather than an
+        obstacle to changing it, and it now pins the new one.
+        """
         from assemblyzero.workflows.implementation_spec.state import FileToModify
         from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
-            _extract_symbols_from_files,
+            gather_symbols,
         )
 
         # Deliberately broken Python (missing colon on class)
@@ -3211,9 +3220,10 @@ class TestExtractSymbolsFromFiles:
             )
         ]
 
-        symbols = _extract_symbols_from_files(files)
-        # At minimum the method should be found via regex fallback
-        assert "my_method" in symbols
+        gather = gather_symbols(files)
+        assert "my_method" not in gather.symbols
+        assert "BrokenClass" not in gather.symbols
+        assert [path for path, _err in gather.unreadable] == ["broken.py"]
 
     def test_gathered_symbols_stored_in_state(self, tmp_path):
         """N1 analyze_codebase populates gathered_symbols in returned state."""

--- a/tests/unit/test_symbol_gather_reports_unreadable.py
+++ b/tests/unit/test_symbol_gather_reports_unreadable.py
@@ -1,0 +1,164 @@
+"""An unreadable target-repo file is reported, never scraped (#2393).
+
+`_extract_symbols_from_files` degraded to two regexes -- `^\\s*def (\\w+)` and
+`^\\s*class (\\w+)` -- whenever a target-repo `.py` file would not parse. That
+fallback fed the SYMBOL UNIVERSE the completeness gate judges every spec
+against, which makes its errors the hardest kind to see: a name regex invents
+becomes a false clearance, and a name it misses becomes a false hallucination
+flag. #2391 is a live example of what a wrong symbol universe costs -- three
+revision cycles and a dead stage -- and that universe was merely incomplete
+rather than fabricated.
+
+The fence fallback (#2392) mis-reads the SPEC. This one mis-read the TARGET
+REPO, which is the authority the spec is judged against. An error here is an
+error in the yardstick.
+
+Standard 0028 section 3 permits deterministic scans of the pipeline's own
+documents on the condition that they "cannot mask a contract failure because
+there is no contract: the document is what it is". A `.py` file in the target
+repo IS a contract that its content is Python.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.analyze_codebase import (
+    SymbolGather,
+    gather_symbols,
+)
+from assemblyzero.workflows.implementation_spec.state import FileToModify
+
+BROKEN = "class BrokenClass\n    def my_method(self):\n        pass\n"
+GOOD = "class Gauge:\n    def render(self):\n        pass\n\n\ndef helper():\n    pass\n"
+
+
+def _file(path: str, content: str) -> FileToModify:
+    return FileToModify(
+        path=path, change_type="Modify", description="", current_content=content,
+    )
+
+
+class TestTheYardstickIsNotManufactured:
+    def test_a_broken_file_contributes_no_symbols(self):
+        gather = gather_symbols([_file("broken.py", BROKEN)])
+        assert gather.symbols == []
+
+    def test_the_scraped_names_are_specifically_absent(self):
+        """The exact names the retired regexes would have produced."""
+        gather = gather_symbols([_file("broken.py", BROKEN)])
+        assert "my_method" not in gather.symbols
+        assert "BrokenClass" not in gather.symbols
+
+    def test_the_file_is_named_with_its_parse_error(self):
+        gather = gather_symbols([_file("broken.py", BROKEN)])
+        assert len(gather.unreadable) == 1
+        path, error = gather.unreadable[0]
+        assert path == "broken.py"
+        assert error, "an exclusion with no reason is a silent downgrade"
+
+    def test_the_error_carries_a_line_number(self):
+        """'named -- path and parse error' is the issue's wording. A reason
+        that does not locate the problem sends someone hunting."""
+        _path, error = gather_symbols([_file("broken.py", BROKEN)]).unreadable[0]
+        assert "line" in error
+
+
+class TestGoodFilesAreUnaffected:
+    def test_a_parseable_file_yields_its_symbols(self):
+        gather = gather_symbols([_file("good.py", GOOD)])
+        assert gather.symbols == ["Gauge", "helper", "render"]
+        assert gather.unreadable == []
+
+    def test_one_broken_file_does_not_cost_the_others(self):
+        """Excluded rather than fatal: a mid-build target repo can hold a
+        broken file, and refusing the whole stage over one would trade a quiet
+        wrong answer for a loud useless one."""
+        gather = gather_symbols([
+            _file("good.py", GOOD),
+            _file("broken.py", BROKEN),
+        ])
+        assert "Gauge" in gather.symbols
+        assert "render" in gather.symbols
+        assert len(gather.unreadable) == 1
+
+    def test_non_python_files_are_not_reported_as_unreadable(self):
+        """A .md file is not a broken .py file; reporting it would be a false
+        alarm, and this check exists partly to stop those."""
+        gather = gather_symbols([_file("README.md", "# not python {")])
+        assert gather.unreadable == []
+        assert gather.symbols == []
+
+    def test_empty_content_is_not_reported_as_unreadable(self):
+        gather = gather_symbols([_file("empty.py", "")])
+        assert gather.unreadable == []
+
+    def test_async_functions_are_gathered(self):
+        gather = gather_symbols([_file("a.py", "async def fetch():\n    pass\n")])
+        assert gather.symbols == ["fetch"]
+
+
+class TestTheExclusionIsReported:
+    """'the exclusion counted and reported. Never scraped into it silently.'"""
+
+    def test_a_clean_gather_says_nothing(self):
+        assert gather_symbols([_file("good.py", GOOD)]).describe() == ""
+
+    def test_the_line_names_the_count_and_the_file(self):
+        line = gather_symbols([_file("broken.py", BROKEN)]).describe()
+        assert "1 target-repo .py file(s)" in line
+        assert "broken.py" in line
+        assert "EXCLUDED" in line
+
+    def test_the_line_says_what_it_costs(self):
+        """The consequence is the point: the spec is measured against a
+        smaller universe than the repo has."""
+        line = gather_symbols([_file("broken.py", BROKEN)]).describe()
+        assert "smaller universe" in line
+        assert "#2393" in line
+
+    def test_many_exclusions_are_counted_not_all_listed(self):
+        files = [_file(f"b{i}.py", BROKEN) for i in range(6)]
+        line = gather_symbols(files).describe()
+        assert "6 target-repo .py file(s)" in line
+        assert "and 3 more" in line
+
+    def test_the_node_prints_it(self):
+        """The report must reach the run, not merely exist on a dataclass."""
+        import importlib
+        import inspect
+        import types
+
+        # `nodes/__init__` re-exports the FUNCTION `analyze_codebase`, which
+        # shadows the module of the same name (lessons-learned 2026-08-14,
+        # recurrence 2026-08-15). The isinstance guard is the positive control:
+        # without it, a future shadowing would make this test fail for a reason
+        # that looks unrelated.
+        node = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes.analyze_codebase"
+        )
+        assert isinstance(node, types.ModuleType)
+
+        source = inspect.getsource(node.analyze_codebase)
+        assert "gather.describe()" in source
+
+
+class TestTheDataclassContract:
+    def test_unreadable_defaults_are_not_silently_shared(self):
+        first = SymbolGather(symbols=[], unreadable=[])
+        second = SymbolGather(symbols=[], unreadable=[])
+        first.unreadable.append(("a.py", "boom"))
+        assert second.unreadable == []
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "def f(:\n",                 # broken signature
+            "class C:\n  def m(self)\n",  # missing colon on method
+            "if True\n    pass\n",        # missing colon on if
+        ],
+    )
+    def test_various_syntax_errors_all_exclude(self, content):
+        gather = gather_symbols([_file("x.py", content)])
+        assert gather.symbols == []
+        assert len(gather.unreadable) == 1


### PR DESCRIPTION
Closes #2393

`_extract_symbols_from_files` degraded to two regexes — `^\s*def (\w+)` and `^\s*class (\w+)` — whenever a target-repo `.py` file would not parse.

That fallback fed the **symbol universe** the completeness gate judges every spec against, which makes its errors the hardest kind to see: a name regex invents becomes a **false clearance**, and a name it misses becomes a **false hallucination flag**. #2391 is a live example of what a wrong symbol universe costs — three revision cycles and a dead stage — and that universe was merely *incomplete* rather than *fabricated*.

The fence fallback (#2392) mis-reads the **spec**. This one mis-read the **target repo**, which is the authority the spec is judged against. An error here is an error in the yardstick.

## Doctrine

Standard 0028 §3 permits deterministic scans of the pipeline's own documents on the condition that they *"cannot mask a contract failure because there is no contract: the document is what it is"*. A `.py` file in the target repo **is** a contract that its content is Python, so neither condition held. §4 is direct:

> No function returns an empty result, an `UNKNOWN`, or a silent downgrade because it could not read its input.

## The shape

`gather_symbols` now returns the symbols **and** what it could not read — path plus parse error with a line number — and the node prints the exclusion where the operator reads the run, rather than leaving it to surface downstream as a mystery hallucination flag.

```
[SYMBOLS] 1 target-repo .py file(s) did NOT parse and were EXCLUDED from the
symbol universe: broken.py (line 1: expected ':'). The spec is judged against a
smaller universe than the repo actually has (#2393).
```

**Excluded rather than fatal, deliberately.** A target repo mid-build can hold a broken file, and refusing the whole stage over one would trade a quiet wrong answer for a loud useless one. What must not happen is the third option the code took: inventing symbols and saying nothing.

`_extract_symbols_from_files` survives as a thin wrapper, so callers that do not report exclusions are untouched.

## The pinning test

`test_implementation_spec_workflow.py:3191` asserted the scraping as the contract — *"At minimum the method should be found via regex fallback"*. As the issue says, it is evidence of the old contract rather than an obstacle to changing it. It now asserts the new one **by name**: `my_method` and `BrokenClass` are specifically absent, and `broken.py` is specifically listed as unreadable.

## Fixtures

18 new. They cover the retired regexes' exact output being absent, the parse error carrying a line number, one broken file not costing the others their symbols, and three further syntax-error shapes.

Three guard against **new** false alarms, since this check is added to a gate: a `.md` file is not a broken `.py` file, empty content is not unreadable, and a clean gather says nothing at all.

The node-prints-it fixture reaches the module through `importlib` with an `isinstance(node, ModuleType)` positive control — `nodes/__init__` re-exports the *function* `analyze_codebase`, which shadows the module, and without the guard a future shadowing would fail this test for a reason that looks unrelated. Third appearance of that trap this session.

Full unit suite green (8221 passing).
