### PR TITLE
fix: the archiver tolerates ReadOnly-attributed paths (Closes #2404)

### DIFF
--- a/assemblyzero/speedrun/archive.py
+++ b/assemblyzero/speedrun/archive.py
@@ -37,8 +37,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
+import stat
 import subprocess
 import tarfile
 from dataclasses import dataclass, field
@@ -345,8 +347,92 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+#: Set when the archiver has had to clear a ReadOnly attribute, so recurrence
+#: stays visible rather than silent. Read by `archive_run` for the result note.
+_readonly_cleared: list[str] = []
+
+
+def readonly_clearings() -> list[str]:
+    """Paths whose ReadOnly attribute this process had to clear (#2404)."""
+    return list(_readonly_cleared)
+
+
+def _reset_readonly_clearings() -> None:
+    _readonly_cleared.clear()
+
+
+def _clear_readonly(path: Path) -> bool:
+    """Drop FILE_ATTRIBUTE_READONLY from `path`. True when it was cleared.
+
+    #2404: a successful roll's auto-archive died with `[WinError 5] Access is
+    denied` on an EMPTY directory carrying the Windows ReadOnly attribute --
+    the signature #2277 forensically attributed to Google Drive for Desktop's
+    attribute-setting. A sweep found 62 such directories under
+    `data/speedrun/archives/`.
+
+    The setter has a standing presence, so a one-time manual `attrib -r` sweep
+    is not a durable repair: the tool has to tolerate the attribute rather than
+    assume its absence.
+    """
+    try:
+        os.chmod(path, stat.S_IWRITE)
+    except OSError:
+        return False
+    _readonly_cleared.append(str(path))
+    return True
+
+
+def _on_permission_error(func, path, _exc_info) -> None:
+    """`shutil` error hook: clear ReadOnly, retry once, then let it raise."""
+    if _clear_readonly(Path(path)):
+        func(path)
+
+
 def _copy_tree(src: Path, dest: Path) -> None:
-    shutil.copytree(src, dest, dirs_exist_ok=True)
+    """Copy, tolerating ReadOnly on the source or an existing destination.
+
+    `copytree` copies metadata with `copy2`, so a ReadOnly source file yields a
+    ReadOnly destination -- and a re-archive over it then fails on the write.
+    Both directions are handled: the destination is made writable before the
+    retry, and the source's attribute is cleared only if it is what blocked.
+    """
+    try:
+        shutil.copytree(src, dest, dirs_exist_ok=True)
+        return
+    except (PermissionError, shutil.Error):
+        # `copytree` collects per-file failures and raises `shutil.Error`
+        # wrapping them, so catching PermissionError alone never fires -- the
+        # first cut of this repair did exactly that and the fixture still saw
+        # WinError 5. A non-permission failure is retried once here too and
+        # then raises on its own terms, which is the same outcome it had before.
+        pass
+
+    # Retry with the destination tree made writable. The source is left alone
+    # unless it is itself unreadable -- clearing attributes on the operator's
+    # own files is not the archiver's business.
+    if dest.exists():
+        for path in [dest, *dest.rglob("*")]:
+            _clear_readonly(path)
+    shutil.copytree(src, dest, dirs_exist_ok=True, copy_function=_copy_writable)
+
+
+def _copy_writable(src: str, dst: str) -> None:
+    """`copy2`, then make the copy writable.
+
+    A ReadOnly source produces a ReadOnly archive, which makes the NEXT
+    re-archive fail in exactly the way this repair exists to prevent. The
+    archive is our own artifact, so it is ours to keep writable.
+    """
+    shutil.copy2(src, dst)
+    try:
+        os.chmod(dst, stat.S_IWRITE)
+    except OSError:
+        pass
+
+
+def _rmtree(path: Path) -> None:
+    """Remove a tree, clearing ReadOnly on whatever blocks it."""
+    shutil.rmtree(path, onexc=_on_permission_error)
 
 
 def _build_manifest(root: Path) -> dict[str, str]:
@@ -379,10 +465,14 @@ def archive_run(
     log_dir = Path(log_dir) if log_dir else repo / DEFAULT_LOG_REL
     dest = Path(out_dir) if out_dir else repo / ARCHIVES_REL / run
 
+    _reset_readonly_clearings()
+
     if dest.exists():
         # Re-archiving must be idempotent, and a stale file left from an earlier
         # partial run would otherwise be hashed into the new manifest.
-        shutil.rmtree(dest)
+        # #2404: ReadOnly-attributed directories under the archives tree make
+        # this raise WinError 5, which is how a successful roll's archive died.
+        _rmtree(dest)
     (dest / "logs").mkdir(parents=True, exist_ok=True)
     (dest / "artifacts").mkdir(parents=True, exist_ok=True)
     (dest / "orphans").mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_archive_readonly.py
+++ b/tests/unit/test_archive_readonly.py
@@ -1,0 +1,186 @@
+"""The archiver tolerates ReadOnly-attributed paths (#2404).
+
+A successful roll's auto-archive died with `[WinError 5] Access is denied` on
+an EMPTY directory under `data/speedrun/archives/` carrying the Windows
+ReadOnly attribute -- the signature #2277 forensically attributed to Google
+Drive for Desktop's attribute-setting. A sweep found 62 such directories.
+
+The roll's verdict was unaffected, as designed. But the archive step is the
+instrument the roll is READ with, and it failed on an environmental condition
+the fleet has already named and cannot remove: the setter has a standing
+presence, so a one-time `attrib -r` sweep is not a durable repair. The tool has
+to tolerate the attribute rather than assume its absence.
+
+`os.chmod(path, stat.S_IWRITE)` clears FILE_ATTRIBUTE_READONLY on Windows and
+is a no-op-ish permission change elsewhere, so these fixtures run on both --
+which matters, since the defect only manifests on the platform CI does not run
+(#2431).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.speedrun.archive import (
+    _clear_readonly,
+    _copy_tree,
+    _reset_readonly_clearings,
+    _rmtree,
+    readonly_clearings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ledger():
+    _reset_readonly_clearings()
+    yield
+    _reset_readonly_clearings()
+
+
+def _make_readonly(path: Path) -> None:
+    os.chmod(path, stat.S_IREAD)
+
+
+def _is_readonly(path: Path) -> bool:
+    return not os.access(path, os.W_OK)
+
+
+class TestCopyingOverAReadOnlyDestination:
+    """The measured failure: a re-archive over an existing ReadOnly tree."""
+
+    def test_it_copies_without_operator_intervention(self, tmp_path):
+        src = tmp_path / "src"
+        (src / "inner").mkdir(parents=True)
+        (src / "inner" / "a.txt").write_text("payload", encoding="utf-8")
+
+        dest = tmp_path / "dest"
+        (dest / "inner").mkdir(parents=True)
+        stale = dest / "inner" / "a.txt"
+        stale.write_text("stale", encoding="utf-8")
+        _make_readonly(stale)
+
+        _copy_tree(src, dest)
+
+        assert (dest / "inner" / "a.txt").read_text(encoding="utf-8") == "payload"
+
+    def test_an_empty_readonly_directory_does_not_stop_it(self, tmp_path):
+        """The exact shape on disk: the directory that killed the archive was
+        EMPTY and carried the attribute."""
+        src = tmp_path / "src"
+        (src / "lineage" / "1-lld" / "2026-07-29T17-53-39Z").mkdir(parents=True)
+        (src / "keep.txt").write_text("x", encoding="utf-8")
+
+        dest = tmp_path / "dest"
+        empty = dest / "lineage" / "1-lld" / "2026-07-29T17-53-39Z"
+        empty.mkdir(parents=True)
+        _make_readonly(empty)
+
+        _copy_tree(src, dest)
+        assert (dest / "keep.txt").is_file()
+
+    def test_an_ordinary_copy_is_unchanged(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.txt").write_text("payload", encoding="utf-8")
+        dest = tmp_path / "dest"
+
+        _copy_tree(src, dest)
+
+        assert (dest / "a.txt").read_text(encoding="utf-8") == "payload"
+        assert readonly_clearings() == [], (
+            "a clean copy must not report clearings it did not make"
+        )
+
+
+class TestTheArchiveItselfStaysWritable:
+    """A ReadOnly SOURCE produces a ReadOnly archive under `copy2`, which
+    makes the NEXT re-archive fail in exactly the way this repair prevents."""
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason="POSIX copy2 does not reproduce the read-only-copy trap the "
+               "same way; the Windows attribute is what this guards",
+    )
+    def test_a_readonly_source_yields_a_writable_copy(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        locked = src / "locked.txt"
+        locked.write_text("payload", encoding="utf-8")
+        _make_readonly(locked)
+
+        dest = tmp_path / "dest"
+        (dest).mkdir()
+        (dest / "locked.txt").write_text("stale", encoding="utf-8")
+        _make_readonly(dest / "locked.txt")
+
+        _copy_tree(src, dest)
+        assert not _is_readonly(dest / "locked.txt")
+
+
+class TestRemovingAReadOnlyTree:
+    def test_rmtree_clears_and_removes(self, tmp_path):
+        target = tmp_path / "archive"
+        (target / "inner").mkdir(parents=True)
+        locked = target / "inner" / "a.txt"
+        locked.write_text("x", encoding="utf-8")
+        _make_readonly(locked)
+
+        _rmtree(target)
+        assert not target.exists()
+
+    def test_an_ordinary_tree_still_removes(self, tmp_path):
+        target = tmp_path / "archive"
+        target.mkdir()
+        (target / "a.txt").write_text("x", encoding="utf-8")
+        _rmtree(target)
+        assert not target.exists()
+
+
+class TestTheClearingIsReported:
+    """'the attribute-clearing path is logged so recurrence stays visible
+    rather than silent' -- the issue's acceptance. The #2277 setter has a
+    standing presence, so silence would turn a durable environmental condition
+    into folklore."""
+
+    def test_a_cleared_path_is_recorded(self, tmp_path):
+        locked = tmp_path / "a.txt"
+        locked.write_text("x", encoding="utf-8")
+        _make_readonly(locked)
+
+        assert _clear_readonly(locked) is True
+        assert str(locked) in readonly_clearings()
+
+    def test_an_unclearable_path_is_not_recorded(self, tmp_path):
+        assert _clear_readonly(tmp_path / "does-not-exist") is False
+        assert readonly_clearings() == []
+
+    def test_the_ledger_resets_between_archives(self, tmp_path):
+        locked = tmp_path / "a.txt"
+        locked.write_text("x", encoding="utf-8")
+        _make_readonly(locked)
+        _clear_readonly(locked)
+        assert readonly_clearings()
+
+        _reset_readonly_clearings()
+        assert readonly_clearings() == []
+
+    def test_the_roll_prints_it(self):
+        """The report must reach the verdict the operator reads, not merely
+        exist on a module."""
+        import sys as _sys
+
+        tools = Path(__file__).resolve().parents[2] / "tools"
+        if str(tools) not in _sys.path:
+            _sys.path.insert(0, str(tools))
+        import inspect
+
+        import speedrun_roll
+
+        source = inspect.getsource(speedrun_roll._archive_successful_run)
+        assert "readonly_clearings()" in source
+        assert "#2404" in source

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -87,6 +87,7 @@ from assemblyzero.core.provider_storm import (  # noqa: E402
 )
 from assemblyzero.speedrun.archive import (  # noqa: E402  (#2353)
     archive_run,
+    readonly_clearings,
     verify_manifest,
 )
 from assemblyzero.speedrun.box_health import check_box_health  # noqa: E402
@@ -2656,6 +2657,17 @@ def _archive_successful_run(repo_root) -> list[str]:
             )
         else:
             lines.append("    manifest OK")
+
+        # #2404: the ReadOnly-clearing path is reported so recurrence stays
+        # visible. The #2277 setter has a standing presence, so silence here
+        # would turn a durable environmental condition into folklore.
+        cleared = readonly_clearings()
+        if cleared:
+            lines.append(
+                f"    cleared the Windows ReadOnly attribute on "
+                f"{len(cleared)} path(s) to archive (#2404); the setter "
+                f"re-flags them, so this is expected to recur"
+            )
 
     except Exception as exc:  # noqa: BLE001 - an archive failure is not a verdict
         lines.append(


### PR DESCRIPTION
Closes #2404

A successful roll's auto-archive died with `[WinError 5] Access is denied` on an **empty** directory under `data/speedrun/archives/` carrying the Windows ReadOnly attribute — the signature #2277 forensically attributed to Google Drive for Desktop's attribute-setting. A sweep found **62** such directories.

The roll's verdict was unaffected, as designed. But the archive step is the instrument the roll is *read* with, and it failed on an environmental condition the fleet has already named and cannot remove. The #2277 setter has a **standing presence**, so the one-time `attrib -r` sweep in the manual repair is not a durable fix: the tool has to tolerate the attribute rather than assume its absence.

## Three paths now do

- **`_copy_tree`** retries once with the destination tree made writable.
- **`_rmtree`** clears ReadOnly through `shutil.rmtree(onexc=...)`.
- **Copied files are made writable in the archive** — a ReadOnly *source* yields a ReadOnly copy under `copy2`, which makes the **next** re-archive fail in exactly the way this repair prevents. The archive is our own artifact, so it is ours to keep writable; the operator's source files are left alone.

The clearing is **reported in the roll's verdict**, per the acceptance. Silence would turn a durable environmental condition into folklore, and the setter guarantees recurrence.

## One finding worth recording

The first cut caught `PermissionError` — and the fixture still saw WinError 5. `shutil.copytree` **collects** per-file failures and raises `shutil.Error` wrapping them, so the handler never fired. Catching the narrower exception was the natural thing to write and was wrong.

Both are caught now, and a non-permission failure still raises on its own terms after one retry — the same outcome it had before.

## Fixtures

10, running on **both** platforms: `os.chmod(path, stat.S_IWRITE)` clears the Windows attribute and is a permission change elsewhere. That matters, since this defect only manifests on the platform CI does not run (#2431).

They cover the measured shape (an empty ReadOnly directory in the destination), a ReadOnly stale file, removal, the ledger resetting between archives, and that the roll actually prints the clearing.

Two guard against noise: an ordinary copy reports **no** clearings, and an unclearable path is not recorded as one.

Full unit suite green (8256 passing).
