### PR TITLE
fix: add the write bit rather than replacing the POSIX mode (Closes #2456)

### DIFF
--- a/assemblyzero/speedrun/archive.py
+++ b/assemblyzero/speedrun/archive.py
@@ -373,9 +373,18 @@ def _clear_readonly(path: Path) -> bool:
     The setter has a standing presence, so a one-time manual `attrib -r` sweep
     is not a durable repair: the tool has to tolerate the attribute rather than
     assume its absence.
+
+    The mode is ADDED to, never replaced. `os.chmod(path, stat.S_IWRITE)` --
+    the stdlib idiom, and what this function did first -- REPLACES the mode on
+    POSIX, so a directory becomes 0o200: write-only, no read, no execute, and
+    therefore untraversable. The copy then fails harder than the attribute it
+    was clearing. On Windows `chmod` only toggles the readonly bit, so a local
+    Windows suite passes and Linux CI is what catches it -- the mirror of
+    #2431, where a POSIX-only defect hid behind a Windows-only code path.
     """
     try:
-        os.chmod(path, stat.S_IWRITE)
+        current = os.stat(path).st_mode
+        os.chmod(path, current | stat.S_IWUSR)
     except OSError:
         return False
     _readonly_cleared.append(str(path))
@@ -425,7 +434,9 @@ def _copy_writable(src: str, dst: str) -> None:
     """
     shutil.copy2(src, dst)
     try:
-        os.chmod(dst, stat.S_IWRITE)
+        # Added, not replaced -- see `_clear_readonly` on why the stdlib
+        # `chmod(path, S_IWRITE)` idiom is wrong on POSIX.
+        os.chmod(dst, os.stat(dst).st_mode | stat.S_IWUSR)
     except OSError:
         pass
 

--- a/tests/unit/test_archive_readonly.py
+++ b/tests/unit/test_archive_readonly.py
@@ -141,6 +141,66 @@ class TestRemovingAReadOnlyTree:
         assert not target.exists()
 
 
+class TestClearingAddsToTheModeRatherThanReplacingIt:
+    """The cross-platform bug the first cut shipped, caught by Linux CI.
+
+    `os.chmod(path, stat.S_IWRITE)` is the stdlib idiom and REPLACES the mode
+    on POSIX: a directory becomes 0o200 -- write-only, no read, no execute, and
+    therefore untraversable -- so the copy fails harder than the attribute it
+    was clearing. On Windows `chmod` only toggles the readonly bit, so the
+    local Windows suite passed and CI is what found it.
+
+    That is the mirror of #2431: there, a POSIX defect hid behind a
+    Windows-only path; here, a POSIX defect hid behind a Windows-only chmod
+    semantic.
+    """
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows chmod only toggles the readonly bit; the mode-replacement "
+               "hazard is POSIX-only",
+    )
+    def test_a_directory_stays_traversable_after_clearing(self, tmp_path):
+        target = tmp_path / "dir"
+        target.mkdir()
+        (target / "child.txt").write_text("x", encoding="utf-8")
+        os.chmod(target, 0o500)  # r-x, no write
+
+        assert _clear_readonly(target) is True
+
+        assert os.access(target, os.W_OK), "write was not granted"
+        assert os.access(target, os.R_OK), "read was destroyed"
+        assert os.access(target, os.X_OK), "traversal was destroyed"
+        assert [p.name for p in target.iterdir()] == ["child.txt"]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+    def test_existing_permission_bits_survive(self, tmp_path):
+        target = tmp_path / "a.txt"
+        target.write_text("x", encoding="utf-8")
+        os.chmod(target, 0o444)  # r--r--r--
+
+        _clear_readonly(target)
+
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode & stat.S_IWUSR, "write was not granted"
+        assert mode & stat.S_IRGRP, "group read was destroyed"
+        assert mode & stat.S_IROTH, "other read was destroyed"
+
+    def test_a_readonly_directory_holding_a_file_copies(self, tmp_path):
+        """End to end on both platforms: the shape CI actually failed on was a
+        read-only DESTINATION DIRECTORY, not a read-only file."""
+        src = tmp_path / "src"
+        (src / "inner").mkdir(parents=True)
+        (src / "inner" / "a.txt").write_text("payload", encoding="utf-8")
+
+        dest = tmp_path / "dest"
+        (dest / "inner").mkdir(parents=True)
+        os.chmod(dest / "inner", 0o500 if sys.platform != "win32" else stat.S_IREAD)
+
+        _copy_tree(src, dest)
+        assert (dest / "inner" / "a.txt").read_text(encoding="utf-8") == "payload"
+
+
 class TestTheClearingIsReported:
     """'the attribute-clearing path is logged so recurrence stays visible
     rather than silent' -- the issue's acceptance. The #2277 setter has a


### PR DESCRIPTION
Closes #2456

`main` is red. #2455 merged with its `test` check failing, and the failure is a real cross-platform defect in that change rather than a flake.

## The defect

`_clear_readonly` used the stdlib idiom #2404 itself suggested:

```python
os.chmod(path, stat.S_IWRITE)
```

On Windows, `chmod` only toggles `FILE_ATTRIBUTE_READONLY`, so this clears the attribute and nothing else. **On POSIX it replaces the mode.** A directory becomes `0o200` — write-only, no read, no execute, therefore untraversable — so the copy fails harder than the attribute it was clearing.

```
FAILED test_it_copies_without_operator_intervention
  shutil.Error: [Errno 13] Permission denied: '/tmp/.../dest/inner'
```

The local Windows suite passed 8256 tests, because the bug cannot manifest there.

## The mirror of #2431

There, a POSIX defect (`killpg` reaching its own caller) hid behind a Windows-only code path and only Linux CI found it. Here, a POSIX defect hides behind a Windows-only `chmod` **semantic**. Same asymmetry, opposite direction, ten hours apart.

The lesson is not *"be careful with chmod"*. It is that this repo's two platforms disagree about what a stdlib call **means**, not merely about which branch runs — so a local pass on either one is evidence about that one only.

## The fix

`os.chmod(path, os.stat(path).st_mode | stat.S_IWUSR)` — add the write bit, never replace the mode. Correct on both: Windows clears the attribute on any write bit, POSIX gains owner-write and keeps read, execute, group and other.

## Fixtures

Three. A directory stays readable and traversable after clearing; existing group and other bits survive; and the end-to-end read-only-**directory** copy that CI actually failed on runs on both platforms.

The first two are POSIX-only and skip on Windows — which is the point. They are the ones that would have caught this.

## How it merged

Recorded so the sequence is not blamed for holding: the merge was issued in the **same tool call** that printed the checks, so the `test  fail` line was produced but not read before `gh pr merge` ran. The universal merge sequence requires polling to `clean` and then merging as a **separate** call, for exactly this reason.
