### PR TITLE
fix: the resume path actually resumes — pr-stage failures and graveyard restore (Closes #2194, Closes #2459)

### DIFF
--- a/tests/unit/test_restore_from_graveyard.py
+++ b/tests/unit/test_restore_from_graveyard.py
@@ -1,0 +1,159 @@
+"""The resume reads back from where the janitor preserves to (#2459).
+
+`_restore_artifact` searched only the issue's `{N}-lld` branch. The file
+janitor preserves what it clears onto `graveyard/leavings-*` refs. Those are
+different places, and the second was never consulted -- so an artifact that was
+preserved, committed and pushed read as missing, and the resume was abandoned
+for a file one `git show` away.
+
+Measured on boostgauge #1, 2026-08-15: neither `LLD-001.md` nor
+`spec-0001-implementation-readiness.md` was on disk, and NEITHER was on
+`1-lld`. Both were on `graveyard/leavings-20260815-161853` and `...-161847`,
+pushed. The next relaunch would have redrawn the LLD and the spec both.
+
+Neither existing repair covers it. #2414 turned a path-string lookup into an
+artifact lookup, and the path here is recorded and real -- the ARTIFACT is what
+is missing. #2311 stopped the spec being lost in FUTURE runs, cannot un-clear
+what earlier runs swept, and does not cover the LLD, which still lives under
+`docs/lld/active/` inside the janitor's allowlist.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+LLD_REL = "docs/lld/active/LLD-001.md"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo whose artifact exists ONLY on a graveyard leavings ref.
+
+    Built the way the janitor builds it: the file is committed onto a
+    `graveyard/leavings-*` branch and then absent from the working tree and
+    from the lld branch.
+    """
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "t")
+    (r / "README.md").write_text("base\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "base")
+    default = _git(r, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    # The lld branch exists but does NOT carry the artifact -- the measured shape.
+    _git(r, "checkout", "-q", "-b", "1-lld")
+    (r / "unrelated.md").write_text("x\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "lld branch without the draft")
+    _git(r, "checkout", "-q", default)
+
+    _git(r, "checkout", "-q", "-b", "graveyard/leavings-20260815-161853")
+    target = r / LLD_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("# LLD one\n\nreal content\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "preserved leavings")
+    _git(r, "checkout", "-q", default)
+
+    assert not (r / LLD_REL).exists(), "fixture must start with the file cleared"
+    return r
+
+
+class TestTheMeasuredShapeRestores:
+    def test_an_artifact_only_on_a_graveyard_ref_is_restored(self, repo):
+        assert sr._restore_artifact(repo, 1, str(repo / LLD_REL)) is True
+        assert (repo / LLD_REL).is_file()
+
+    def test_the_content_is_the_preserved_content(self, repo):
+        sr._restore_artifact(repo, 1, str(repo / LLD_REL))
+        assert "real content" in (repo / LLD_REL).read_text(encoding="utf-8")
+
+    def test_the_old_behaviour_would_have_declined(self, repo):
+        """Pins WHY: the lld branch exists and does not carry the file, so a
+        lld-branch-only search returns nothing. Without this the test above
+        could be passing for an unrelated reason."""
+        show = _git(repo, "show", f"1-lld:{LLD_REL}")
+        assert show.returncode != 0
+
+    def test_the_refs_are_discovered(self, repo):
+        refs = sr._graveyard_leavings_refs(repo)
+        assert any("leavings-20260815-161853" in r for r in refs)
+
+
+class TestTheNewestRefWins:
+    def test_a_later_leavings_ref_supersedes_an_earlier_one(self, repo):
+        """An older ref may hold a stale draft from a superseded attempt."""
+        default = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        _git(repo, "checkout", "-q", "-b", "graveyard/leavings-20260815-999999")
+        target = repo / LLD_REL
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# LLD one\n\nNEWER content\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "newer leavings")
+        _git(repo, "checkout", "-q", default)
+        target.unlink(missing_ok=True)
+
+        sr._restore_artifact(repo, 1, str(target))
+        assert "NEWER content" in target.read_text(encoding="utf-8")
+
+
+class TestItStillDeclinesWhenNothingHasIt:
+    def test_absent_everywhere_declines(self, repo):
+        missing = repo / "docs" / "lld" / "active" / "LLD-999.md"
+        assert sr._restore_artifact(repo, 1, str(missing)) is False
+
+    def test_a_repo_with_no_graveyard_refs_is_not_an_error(self, tmp_path):
+        bare = tmp_path / "plain"
+        bare.mkdir()
+        _git(bare, "init", "-q")
+        assert sr._graveyard_leavings_refs(bare) == []
+        assert sr._restore_artifact(bare, 1, str(bare / "a.md")) is False
+
+    def test_a_path_outside_the_repo_declines(self, repo):
+        assert sr._restore_artifact(repo, 1, "C:/elsewhere/a.md") is False
+
+
+class TestTheLldBranchStillWinsFirst:
+    """The graveyard is the FALLBACK. A committed draft on the lld branch is
+    the authoritative copy and must still be preferred."""
+
+    def test_the_lld_branch_copy_is_used_when_present(self, repo):
+        default = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        _git(repo, "checkout", "-q", "1-lld")
+        target = repo / LLD_REL
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# LLD one\n\nBRANCH content\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "draft on the lld branch")
+        _git(repo, "checkout", "-q", default)
+        target.unlink(missing_ok=True)
+
+        sr._restore_artifact(repo, 1, str(target))
+        assert "BRANCH content" in target.read_text(encoding="utf-8")
+
+    def test_a_file_already_on_disk_is_left_alone(self, repo):
+        target = repo / LLD_REL
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("ON DISK\n", encoding="utf-8")
+
+        assert sr._restore_artifact(repo, 1, str(target)) is True
+        assert target.read_text(encoding="utf-8") == "ON DISK\n"

--- a/tests/unit/test_resume_from_pr_stage.py
+++ b/tests/unit/test_resume_from_pr_stage.py
@@ -1,0 +1,222 @@
+"""A pr-stage failure resumes instead of redrawing the pipeline (#2194).
+
+#2193 shipped resume for `spec` and `impl` and deferred `pr`/`cleanup`, naming
+the evidence it wanted first: "the first observed relaunch-after-pr-failure
+that redraws an expensive impl is the evidence to build from".
+
+`run-issue7-231606` is that observation, and it is the only one in the corpus
+(21 pr passes, 1 pr failure, 0 cleanup failures across 21 passes):
+
+    lld     passed    281.9s
+    spec    passed    699.0s
+    impl    passed    363.6s
+    pr      failed      0.7s   ! [rejected] issue-7 -> issue-7 (non-fast-forward)
+
+1344.5 seconds of paid work discarded to retry a git push that failed in under
+a second, on a branch-state rejection rather than anything about the content.
+
+`cleanup` is deliberately still excluded: zero observed failures means no shape
+to design its integrity checks against, which is the same standard that kept
+`pr` out until now.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+
+class _Log:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def write(self, message):
+        self.lines.append(message)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    r = tmp_path / "boostgauge"
+    (r / ".git").mkdir(parents=True)
+    return r
+
+
+def _state(tmp_path, repo, worktree: str | None, **overrides):
+    """The measured run-issue7-231606 shape: everything passed but pr."""
+    data = {
+        "issue_number": 7,
+        "current_stage": "pr",
+        "target_repo": str(repo),
+        "base_branch": "hardening-run-17",
+        "lld_path": str(repo / "docs" / "lld" / "LLD-007.md"),
+        "spec_path": str(repo / "docs" / "lld" / "spec-0007.md"),
+        "worktree_path": worktree if worktree is not None else "",
+        "stage_results": {
+            "triage": {"status": "skipped", "error_message": ""},
+            "lld": {"status": "passed", "error_message": ""},
+            "spec": {"status": "passed", "error_message": ""},
+            "impl": {"status": "passed", "error_message": ""},
+            "pr": {
+                "status": "failed",
+                "error_message": (
+                    "PR creation error: ! [rejected] issue-7 -> issue-7 "
+                    "(non-fast-forward)"
+                ),
+            },
+        },
+        "started_at": "2026-08-14T04:00:00+00:00",
+        "completed_at": "",
+    }
+    data.update(overrides)
+    path = tmp_path / "7.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _plan(repo, state_path):
+    log = _Log()
+    with patch.object(sr, "_orchestrator_state_path", return_value=state_path), \
+         patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+         patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+         patch.object(sr, "draft_is_stale", return_value=False), \
+         patch.object(sr, "_restore_artifact", return_value=True):
+        return sr.resume_plan(Path("."), repo, 7, log), log
+
+
+class TestTheMeasuredRunResumes:
+    def test_a_pr_failure_resumes_from_pr(self, tmp_path, repo):
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        stage, _log = _plan(repo, _state(tmp_path, repo, str(worktree)))
+        assert stage == "pr"
+
+    def test_pr_is_in_the_resumable_set(self):
+        assert "pr" in sr.RESUMABLE_STAGES
+
+    def test_the_spec_artifact_is_required_for_pr_too(self):
+        """The pr stage reads the impl worktree, which exists only because
+        spec produced what impl built from."""
+        assert "pr" in sr._STAGES_NEEDING_SPEC
+        assert "impl" in sr._STAGES_NEEDING_SPEC
+
+
+class TestTheWorktreeGuard:
+    """`run_pr_stage` fails immediately with "No worktree path available for
+    PR creation" without one, so resuming into a missing worktree costs more
+    than the redraw it saves."""
+
+    def test_a_missing_worktree_declines(self, tmp_path, repo):
+        stage, log = _plan(repo, _state(tmp_path, repo, str(tmp_path / "gone")))
+        assert stage is None
+        assert any("worktree" in line for line in log.lines)
+
+    def test_an_unset_worktree_declines(self, tmp_path, repo):
+        stage, log = _plan(repo, _state(tmp_path, repo, ""))
+        assert stage is None
+        assert any("worktree" in line for line in log.lines)
+
+    def test_a_whitespace_worktree_declines(self, tmp_path, repo):
+        stage, _log = _plan(repo, _state(tmp_path, repo, "   "))
+        assert stage is None
+
+    def test_the_decline_names_what_is_missing(self, tmp_path, repo):
+        _stage, log = _plan(repo, _state(tmp_path, repo, ""))
+        assert any("pr stage needs the impl worktree" in line for line in log.lines)
+
+    def test_a_spec_failure_does_not_demand_a_worktree(self, tmp_path, repo):
+        """The guard must be scoped to pr. A spec-stage resume has no
+        worktree yet and must not start requiring one."""
+        state = _state(
+            tmp_path, repo, "",
+            current_stage="spec",
+            stage_results={
+                "triage": {"status": "skipped", "error_message": ""},
+                "lld": {"status": "passed", "error_message": ""},
+                "spec": {"status": "failed", "error_message": "cap"},
+            },
+        )
+        stage, _log = _plan(repo, state)
+        assert stage == "spec"
+
+
+class TestCleanupIsStillExcluded:
+    """Zero observed failures means no shape to design against -- the same
+    standard that kept `pr` out until its evidence arrived."""
+
+    def test_cleanup_is_not_resumable(self):
+        assert "cleanup" not in sr.RESUMABLE_STAGES
+
+    def test_a_cleanup_failure_declines(self, tmp_path, repo):
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        state = _state(
+            tmp_path, repo, str(worktree),
+            current_stage="cleanup",
+            stage_results={
+                "triage": {"status": "skipped", "error_message": ""},
+                "lld": {"status": "passed", "error_message": ""},
+                "spec": {"status": "passed", "error_message": ""},
+                "impl": {"status": "passed", "error_message": ""},
+                "pr": {"status": "passed", "error_message": ""},
+                "cleanup": {"status": "failed", "error_message": "boom"},
+            },
+        )
+        stage, _log = _plan(repo, state)
+        assert stage is None
+
+
+class TestTheExistingGuardsStillApply:
+    """#2193's guards are not weakened by adding a stage."""
+
+    def test_a_requirements_conflict_still_declines(self, tmp_path, repo):
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        state = _state(
+            tmp_path, repo, str(worktree),
+            stage_results={
+                "triage": {"status": "skipped", "error_message": ""},
+                "lld": {"status": "passed", "error_message": ""},
+                "spec": {"status": "passed", "error_message": ""},
+                "impl": {"status": "passed", "error_message": ""},
+                "pr": {
+                    "status": "failed",
+                    "error_message": "REQUIREMENTS CONFLICT: two readings",
+                },
+            },
+        )
+        stage, _log = _plan(repo, state)
+        assert stage is None
+
+    def test_a_closed_lld_pr_still_declines(self, tmp_path, repo):
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        state_path = _state(tmp_path, repo, str(worktree))
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state_path), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=False), \
+             patch.object(sr, "draft_is_stale", return_value=False), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 7, log) is None
+
+    def test_a_stale_draft_still_declines(self, tmp_path, repo):
+        worktree = tmp_path / "worktrees" / "7"
+        worktree.mkdir(parents=True)
+        state_path = _state(tmp_path, repo, str(worktree))
+        log = _Log()
+        with patch.object(sr, "_orchestrator_state_path", return_value=state_path), \
+             patch.object(sr, "resolve_attempt_branch", return_value="hardening-run-17"), \
+             patch.object(sr, "_open_lld_pr_exists", return_value=True), \
+             patch.object(sr, "draft_is_stale", return_value=True), \
+             patch.object(sr, "_restore_artifact", return_value=True):
+            assert sr.resume_plan(Path("."), repo, 7, log) is None

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -567,10 +567,32 @@ def replace_or_refuse(
 # =============================================================================
 
 # Stages a relaunch may resume from. lld failing means nothing expensive
-# passed (a redraw IS the restart), and pr/cleanup resumes are deferred --
-# their preserved state (impl worktree, opened PRs) has more unverified
-# surface than the savings justify today.
-RESUMABLE_STAGES = ("spec", "impl")
+# passed (a redraw IS the restart).
+#
+# #2194 added `pr` on the evidence it asked to wait for: "the first observed
+# relaunch-after-pr-failure that redraws an expensive impl is the evidence to
+# build from". run-issue7-231606 is that observation, and it is the only one in
+# the corpus:
+#
+#     lld     passed    281.9s
+#     spec    passed    699.0s
+#     impl    passed    363.6s
+#     pr      failed      0.7s   ! [rejected] issue-7 -> issue-7 (non-fast-forward)
+#
+# 1344.5 seconds of paid work discarded to retry a git push that failed in
+# under a second, and the failure was a branch-state rejection rather than
+# anything about the content.
+#
+# `cleanup` is NOT added. The corpus holds zero cleanup failures across 21
+# passes, so there is no observed shape to design its integrity checks against
+# -- which is the same standard that kept `pr` out until today. Adding it now
+# would be guessing at what survives, and a resume into missing state costs
+# more than the redraw it saves.
+RESUMABLE_STAGES = ("spec", "impl", "pr")
+
+#: Stages whose inputs include the finalized spec. `pr` reads the impl stage's
+#: worktree, which only exists because spec produced what impl built from.
+_STAGES_NEEDING_SPEC = ("impl", "pr")
 
 
 def _orchestrator_state_path(az_root: Path, issue: int) -> Path:
@@ -994,8 +1016,24 @@ def resume_plan(
     # decline still happens, but now only when the file genuinely cannot be
     # found: resuming into a missing input is worse than redrawing.
     needed = [("lld", _resolve_stage_artifact(repo_root, issue, data, "lld"))]
-    if failed == "impl":
+    if failed in _STAGES_NEEDING_SPEC:
         needed.append(("spec", _resolve_stage_artifact(repo_root, issue, data, "spec")))
+
+    # #2194: the pr stage reads `state["worktree_path"]` and derives its head
+    # branch from whatever is checked out there -- it fails immediately with
+    # "No worktree path available for PR creation" without one. That worktree
+    # is the "unverified surface" #2194 deferred on; it is verified now, both
+    # by run-issue7-231606 and by boostgauge #1's worktree surviving an
+    # operator kill intact. Checked rather than assumed, because a resume into
+    # a missing worktree costs more than the redraw it saves.
+    if failed == "pr":
+        worktree = (data.get("worktree_path", "") or "").strip()
+        if not worktree or not Path(worktree).is_dir():
+            log.write(
+                f"RESUME abandoned for #{issue}: the pr stage needs the impl "
+                f"worktree and it is gone ({worktree or '<unset>'})"
+            )
+            return None
     for stage, artifact in needed:
         if not artifact:
             log.write(

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -686,11 +686,62 @@ def _resolve_stage_artifact(
     return ""
 
 
+def _graveyard_leavings_refs(repo_root: Path) -> list[str]:
+    """Every `graveyard/leavings-*` ref, newest first.
+
+    These are where the file janitor PRESERVES what it clears. Nothing is
+    deleted -- preserve-then-clear is structural (standard 0027) -- so a
+    cleared artifact is always on one of these, and the newest is the one the
+    last run wrote.
+    """
+    result = _run(
+        [
+            "git", "for-each-ref", "--format=%(refname:short)",
+            "refs/heads/graveyard/leavings-*",
+            "refs/remotes/origin/graveyard/leavings-*",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    refs = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
+    # Sorted on the timestamp in the NAME, not on committerdate. Two leavings
+    # refs cut in the same second tie under `--sort=-committerdate` and git
+    # then falls back to refname ASCENDING -- oldest first, the wrong way
+    # round, which a fixture caught. The name carries `-YYYYMMDD-HHMMSS` by
+    # construction, so it orders these exactly and cannot be perturbed by a
+    # rewrite that changes commit times.
+    def _stamp(ref: str) -> str:
+        _, _, tail = ref.rpartition("leavings-")
+        return tail
+
+    return sorted(refs, key=_stamp, reverse=True)
+
+
 def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
-    """Materialize a passed stage's file from the issue's lld branch when the
-    working tree no longer has it -- the exit janitor clears pipeline-authored
-    untracked files (standard 0027), but the draft itself is committed on the
-    branch and can be shown back into place."""
+    """Materialize a passed stage's file so the next stage can read it.
+
+    The exit janitor clears pipeline-authored untracked files (standard 0027).
+    Two places hold what it cleared, and BOTH are searched:
+
+    * the issue's lld branch, when the draft was committed there;
+    * the `graveyard/leavings-*` refs the janitor preserves onto.
+
+    The second was missing, and it is the difference between a resume and a
+    redraw. Measured on boostgauge #1, 2026-08-15: neither `LLD-001.md` nor
+    `spec-0001-implementation-readiness.md` was on disk, and NEITHER was on
+    `1-lld` -- they were on `graveyard/leavings-20260815-161853` and
+    `...-161847`. `_restore_artifact` consulted only the lld branch, so it
+    returned False and the resume was abandoned for artifacts that were
+    preserved, pushed, and one `git show` away.
+
+    #2311 stopped the SPEC being lost in future runs by writing it somewhere
+    the janitor does not sweep. It could not un-clear what earlier runs had
+    already swept, and it does not cover the LLD, which still lives under
+    `docs/lld/active/` inside the janitor's allowlist. This closes that gap
+    from the other side: whatever was preserved can be restored.
+    """
     path = Path(artifact)
     if path.is_file():
         return True
@@ -698,7 +749,12 @@ def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
         rel = path.relative_to(repo_root)
     except ValueError:
         return False
-    for ref in (f"{issue}-lld", f"origin/{issue}-lld"):
+    refs = [f"{issue}-lld", f"origin/{issue}-lld"]
+    # Newest leavings first: the last run's copy is the current one, and an
+    # older ref may hold a stale draft from a superseded attempt.
+    refs += _graveyard_leavings_refs(repo_root)
+
+    for ref in refs:
         show = _run(["git", "show", f"{ref}:{rel.as_posix()}"], cwd=repo_root)
         if show.returncode == 0 and show.stdout:
             path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #2194
Closes #2459

Two repairs to the same resume path, landed together because the second was found while verifying the first and the first is worthless without it.

---

# #2194 — resume a pr-stage failure

#2193 shipped resume for `spec` and `impl` and deferred `pr`/`cleanup`, naming the evidence it wanted first:

> the first observed relaunch-after-pr-failure that redraws an expensive impl is the evidence to build from

**That observation now exists**, and it is the only one in the corpus — `run-issue7-231606`:

```
lld     passed    281.9s
spec    passed    699.0s
impl    passed    363.6s
pr      failed      0.7s   ! [rejected] issue-7 -> issue-7 (non-fast-forward)
```

**1344.5 seconds of paid work discarded to retry a git push that failed in under a second**, on a branch-state rejection rather than anything about the content.

`run_pr_stage` reads `state["worktree_path"]` and derives its head branch from whatever is checked out there — failing immediately with *"No worktree path available for PR creation"* without one. That worktree is precisely the "unverified surface" #2194 deferred on, and it is verified now: by `run-issue7-231606`, and by boostgauge #1's worktree surviving an operator kill intact. **Checked rather than assumed.**

**`cleanup` is deliberately not added**, departing from the work-order framing of *"a death at pr **or cleanup**"*:

| stage | passed | failed |
|---|---|---|
| pr | 21 | **1** |
| cleanup | 21 | **0** |

Zero cleanup failures means no observed shape to design its integrity checks against — the same standard that kept `pr` out until today.

---

# #2459 — read back from the graveyard refs

`_restore_artifact` searched only the issue's `{N}-lld` branch. The janitor preserves what it clears onto `graveyard/leavings-*` refs. **Those are different places, and the second was never consulted.**

Measured on boostgauge #1. Neither artifact is on disk, and **neither is on `1-lld`**:

```
git cat-file -e 1-lld:docs/lld/active/LLD-001.md        -> NO
git cat-file -e 1-lld:docs/lld/drafts/spec-0001-...md   -> NO

LLD-001.md     -> graveyard/leavings-20260815-161853
spec-0001-...  -> graveyard/leavings-20260815-161847
```

Neither existing repair covers it. **#2414** turned a path-string lookup into an artifact lookup — the path here is recorded and real, and the *artifact* is what is missing. **#2311** stopped the spec being lost in *future* runs; it cannot un-clear what earlier runs swept, and it does not cover the LLD, which still lives under `docs/lld/active/` inside the janitor's allowlist.

Verified against the live repo with the change in place:

```
graveyard leavings refs found: 42
lld  : on disk before False -> restored True (15977 bytes)
spec : on disk before False -> restored True (21323 bytes)
```

**This is what unblocks boostgauge #1's resume.** Without it the next relaunch redraws the LLD and the spec both, whatever else this batch repaired.

Refs are sorted on the timestamp in the **name**, not `committerdate`: two leavings refs cut in the same second tie, and git then falls back to refname *ascending* — oldest first, exactly the wrong way round. A fixture caught it.

---

## Fixtures

23 across two files. Beyond the happy paths: #2193's four existing guards are re-asserted against the new stage rather than assumed; the pr worktree guard is scoped so a **spec** resume does not start demanding one; and four negatives keep the graveyard fallback from becoming a licence — absent everywhere still declines, no graveyard refs is not an error, a path outside the repo declines, and the lld branch still wins when it has the draft.

Full unit suite green (8280 passing).
