### PR TITLE
feat: refuse to launch while a known roll-killer is open (Closes #2436)

### DIFF
--- a/assemblyzero/speedrun/roll_blockers.py
+++ b/assemblyzero/speedrun/roll_blockers.py
@@ -1,0 +1,251 @@
+"""Refuse to launch while a known roll-killer is open, in either repo (#2436).
+
+On 2026-08-15 a boostgauge relaunch aborted at exit 91 because #2311 -- filed
+two days earlier, acceptance criteria already written -- cleared the resume's
+spec artifact before the resume gate read it. Nothing in the machine knew #2311
+existed. The audit that eventually found it was a human reading 127 open
+issues, which by the fleet's own rule 6 is an inspection: it proves the state of
+one moment and nothing about the next launch.
+
+That audit left behind the thing that makes the question answerable -- the
+`roll-blocker` label, created the same day in BOTH repos. This module asks it.
+
+## The operator's ruling, 2026-08-15 (recorded on #2436)
+
+Refuse, with an explicit override:
+
+- An open `roll-blocker` in **either** the target repo or AssemblyZero halts the
+  launch before the first paid model call, naming every blocker by number and
+  title.
+- ``--ignore-blockers`` proceeds anyway, and the launch record states that the
+  override was used and which blockers were overridden. An override that leaves
+  no trace is the accident the ruling exists to stop.
+- The list prints on **every** launch, pass or fail. The clean case says it
+  checked and found none, because silence is not evidence -- the same complaint
+  #2381 makes about box health printing only when it refuses.
+
+## Design decisions
+
+**Both repos, because a roll executes both.** The pipeline code is
+AssemblyZero's and the product code is the target's, so a killer in either one
+kills the roll. The two slugs are derived from the two checkouts' own remotes
+rather than hardcoded: a hardcoded `martymcenroe/AssemblyZero` would query the
+wrong board the first time this runs from a fork or a second clone.
+
+**Slug derivation is imported, never re-derived.** `must_resolve.repo_slug`
+already turns a checkout into `owner/name`. A second copy here would be a
+second parser of one fact, and the two would drift.
+
+**GitHub being unreachable is reported, never fatal.** The sibling gate settled
+this: the availability of GitHub must not brick a local roll. An unreachable
+board is printed by name and the launch proceeds -- which is honest, and is not
+silence. It is also the conservative direction: this gate exists to stop a roll
+that is known to be doomed, and "could not ask" is not knowledge.
+
+**No model call.** Two `gh issue list` queries and two `git remote` reads. The
+cost is the same whether it passes or refuses, which is what lets it print
+every time.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from assemblyzero.speedrun.must_resolve import repo_slug
+
+#: Created 2026-08-15 in both repos by the audit that #2436 was filed from.
+#: Its meaning is narrow and load-bearing: this issue KILLS A ROLL. A feature
+#: the next roll exists to build is not a blocker, and labelling one that way
+#: refuses the launch that would have built it.
+ROLL_BLOCKER_LABEL = "roll-blocker"
+
+#: The flag that overrides a refusal, quoted in the messages so the operator
+#: never has to go and look it up.
+OVERRIDE_FLAG = "--ignore-blockers"
+
+
+def _default_runner(args: list[str]) -> subprocess.CompletedProcess:
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, encoding="utf-8", errors="replace"
+        )
+    except OSError as exc:
+        # `gh` not installed. Modelled as a failed call rather than an
+        # exception so every caller path stays identical.
+        return subprocess.CompletedProcess(args, 127, "", str(exc))
+
+
+@dataclass(frozen=True)
+class Blocker:
+    """One open issue that is known to kill a roll."""
+
+    repo: str
+    number: int
+    title: str
+
+    def describe(self) -> str:
+        return f"{self.repo}#{self.number}  {self.title}"
+
+
+@dataclass(frozen=True)
+class BlockerScan:
+    """What the board said, and which boards could be reached at all."""
+
+    blockers: tuple[Blocker, ...] = ()
+    consulted: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+    @property
+    def refuses(self) -> bool:
+        """Whether this scan halts a launch that did not override it."""
+        return bool(self.blockers)
+
+
+def _list_blockers(
+    slug: str, runner
+) -> tuple[list[Blocker], str | None]:
+    result = runner([
+        "gh", "issue", "list", "--repo", slug,
+        "--label", ROLL_BLOCKER_LABEL, "--state", "open",
+        "--limit", "100", "--json", "number,title",
+    ])
+    if result.returncode != 0:
+        return [], (result.stderr or "gh issue list failed").strip()
+    try:
+        rows = json.loads(result.stdout or "[]")
+    except ValueError:
+        return [], "could not read the issue list response"
+    found = []
+    for row in rows:
+        number = row.get("number")
+        if not number:
+            continue
+        found.append(Blocker(slug, int(number), row.get("title", "")))
+    return found, None
+
+
+def scan_roll_blockers(
+    target_root: Path | str,
+    az_root: Path | str,
+    *,
+    runner=_default_runner,
+) -> BlockerScan:
+    """Open `roll-blocker` issues across the target repo and AssemblyZero.
+
+    Both checkouts are asked for their own remote, so the same tree rolling
+    itself is consulted once rather than listed twice.
+    """
+    slugs: list[str] = []
+    errors: list[str] = []
+    for root in (target_root, az_root):
+        slug = repo_slug(root, runner=runner)
+        if not slug:
+            errors.append(f"{root}: no GitHub remote, so its board was not checked")
+        elif slug not in slugs:
+            slugs.append(slug)
+
+    blockers: list[Blocker] = []
+    consulted: list[str] = []
+    for slug in slugs:
+        found, error = _list_blockers(slug, runner)
+        if error:
+            errors.append(f"{slug}: {error}")
+            continue
+        consulted.append(slug)
+        blockers.extend(found)
+
+    blockers.sort(key=lambda b: (b.repo, b.number))
+    return BlockerScan(tuple(blockers), tuple(consulted), tuple(errors))
+
+
+def _joined(slugs: tuple[str, ...]) -> str:
+    if not slugs:
+        return "no repository"
+    if len(slugs) == 1:
+        return slugs[0]
+    return " and ".join([", ".join(slugs[:-1]), slugs[-1]])
+
+
+def blocker_report_lines(scan: BlockerScan, *, overridden: bool = False) -> list[str]:
+    """What prints on EVERY launch, pass or fail.
+
+    The clean case is the whole point of printing unconditionally: a check that
+    is silent when it passes cannot be distinguished from a check that never
+    ran, which is the defect #2381 names for box health.
+    """
+    lines: list[str] = []
+    count = len(scan.blockers)
+
+    if not count:
+        lines.append(
+            f"ROLL BLOCKERS: checked {_joined(scan.consulted)} -- none open."
+        )
+    else:
+        noun = "issue" if count == 1 else "issues"
+        verb = "OVERRIDDEN" if overridden else "OPEN"
+        lines.append(
+            f"ROLL BLOCKERS {verb}: {count} open {noun} known to kill a roll "
+            f"(checked {_joined(scan.consulted)}):"
+        )
+        for blocker in scan.blockers:
+            lines.append(f"  {blocker.describe()}")
+
+    for error in scan.errors:
+        lines.append(f"  WARNING: could not check {error}")
+
+    if count and overridden:
+        lines.append(
+            f"  Rolling anyway because {OVERRIDE_FLAG} was given. This is "
+            "recorded in the launch record."
+        )
+    return lines
+
+
+def blocker_refusal_message(scan: BlockerScan) -> str:
+    """Plain English. No stage names, no internal identifiers, no jargon.
+
+    The operator reads this at a terminal and must be able to act on it without
+    opening any code or document.
+    """
+    count = len(scan.blockers)
+    noun = "problem is" if count == 1 else "problems are"
+    lines = [
+        "",
+        f"BLOCKED: {count} known {noun} open that will kill this roll.",
+        "",
+    ]
+    for blocker in scan.blockers:
+        lines.append(f"  {blocker.describe()}")
+    lines += [
+        "",
+        "  Each of these was marked as something that stops a roll outright, so",
+        "  launching now spends time and money on a run whose ending is already",
+        "  known. Fix and close it, or -- if it does not apply to what you are",
+        "  about to roll -- take the `roll-blocker` mark off it.",
+        "",
+        f"  To roll into it deliberately anyway, relaunch with {OVERRIDE_FLAG}.",
+        "  The launch will say that you did, and name what you rolled past.",
+    ]
+    return "\n".join(lines)
+
+
+def blocker_trace_line(scan: BlockerScan, *, overridden: bool) -> str:
+    """The single line the launch record carries, for either outcome.
+
+    The override half is the operator's ruling: an override that leaves no
+    trace is the accident this gate exists to stop. The clean half is here for
+    the same reason the report prints unconditionally -- so a reader of the
+    record can tell "checked, found none" from "never asked".
+    """
+    if not scan.blockers:
+        return f"ROLL-BLOCKERS checked {_joined(scan.consulted)}: none open"
+    numbers = ", ".join(f"{b.repo}#{b.number}" for b in scan.blockers)
+    if overridden:
+        return (
+            f"ROLL-BLOCKERS OVERRIDDEN ({OVERRIDE_FLAG}) -- rolled past "
+            f"{len(scan.blockers)}: {numbers}"
+        )
+    return f"ROLL-BLOCKERS open, launch refused -- {numbers}"

--- a/docs/runbooks/0952-speedrun-operator-solo.md
+++ b/docs/runbooks/0952-speedrun-operator-solo.md
@@ -50,6 +50,7 @@ the verification is re-run rather than asserted (#2295):
 | `--kill` | **emergency stop** (#2422) — kill the running roll and its whole process tree, stamping `KILLED BY OPERATOR` into the run's own events log so the stop is recorded as ordered rather than as a crash. Takes an optional `--issue`. Runs before every gate, so a stale or dirty tree cannot refuse it. When this console has no free prompt, create `data/speedrun/KILL` instead — the launcher watches for it **while a call is in flight**, not only between stages |
 | `--detach-stop` | stop a detached roll and everything it spawned |
 | `--override-prereqs` | launch even though the previous run's unresolved questions are still open (#2167) — runs anyway once; the next launch re-checks |
+| `--ignore-blockers` | launch even though an issue marked `roll-blocker` is open in this repo or in AssemblyZero (#2436). The launch names every blocker it rolled past and records the override in `session-events.log`, so rolling into known-broken ground stays possible — not every blocker bites every issue — but can never happen by accident. It rides a `--detach` relaunch, so the detached run does not re-refuse |
 | `--redraw-completed` | redraw an issue this arc has **already rolled to success** (#2191). Without it, an interactive launch demands a typed `REDRAW <N>` and a non-interactive one refuses — so an issue number typed out of habit cannot silently redo work already merged into the arc. Scoped to the current arc: a new base branch starts with an empty slate |
 | `--fresh` | redraw every stage from scratch (#2193). Without it, a launch that finds a prior non-conflict failure with the LLD already passed resumes from the failed stage — the passed stages are reused, not paid for again. A conflict-blocked issue always redraws fresh: the ruling edited the issue text, and the preserved draft embeds the pre-ruling wording |
 | `--narration` | starting view level: `terse`, `verbose`, `tutorial`, or `quiz` (#2159/#2160/#2161 — tutorial annotates each node and gate; quiz pauses the DISPLAY at transitions for multiple choice generated from the graph, roll unaffected). Press `v` in the console to toggle live; the log on disk is always complete |
@@ -79,7 +80,35 @@ tokens are used. All exit **91**.
 | The AssemblyZero tree is not trustworthy | this checkout is behind or dirty, so the roll would execute pipeline code that `main` does not describe | bring it level with `origin/main`, or point `--assemblyzero-root` at a tree that is |
 | This machine is not healthy enough | a quick self-check ran far slower than normal, or memory is at or above **94%** (operator ruling 2026-08-15, #2296 — raised from 90%) | close a browser or an idle session and relaunch; the 2026-08-13 firing cleared in six seconds that way. Otherwise wait for the machine to recover, or find what is loading it. Do not override it — a roll on a sick box wastes hours *and* makes every failure look like a target-repo problem |
 | The repository has unanswered questions | one or more issues are open asking you to rule on ambiguous issue text | work § Rule below — decide, edit, **pre-check**, then close the question |
+| A known roll-killer is open | an issue marked `roll-blocker` is open in the target repo **or** in AssemblyZero (operator ruling 2026-08-15, #2436) — the roll executes both trees, so either one kills it | fix and close it, or take the `roll-blocker` mark off it if it does not apply to what you are rolling. To roll into it deliberately, relaunch with `--ignore-blockers` |
 | The arc's binding docs conflict with the default branch | design docs or ADRs were ruled on both branches and the two edits collide (#2205) | merge them by hand, then roll. Nothing was changed — the launcher refuses rather than resolving a ruling on your behalf |
+
+**The roll-blocker check prints on every launch, pass or fail (#2436).** A
+check that is silent when it passes cannot be told apart from one that never
+ran, so the clean case says so out loud and names the boards it read:
+
+```
+ROLL BLOCKERS: checked martymcenroe/boostgauge and martymcenroe/AssemblyZero -- none open.
+```
+
+It costs two `gh` queries and no model call — measured at 1.0s against both
+live boards on 2026-08-16 — which is what lets it run every time. If GitHub
+cannot be reached the launch says which board it could not read and proceeds:
+"could not ask" is not knowledge that something is broken, and an unreachable
+GitHub must never brick a local roll.
+
+`--ignore-blockers` is a deliberate act and is recorded as one. The launch names
+every blocker it rolled past, and the line lands in `session-events.log` as
+well as on your console:
+
+```
+ROLL-BLOCKERS OVERRIDDEN (--ignore-blockers) -- rolled past 1: martymcenroe/boostgauge#341
+```
+
+Rolling into known-broken ground stays possible, because not every blocker
+bites every issue. What the ruling removes is doing it by accident — and,
+because the flag rides the detached relaunch, doing it without the record
+saying who chose to.
 
 **Binding docs sync themselves (#2205).** The roll reads design docs and ADRs
 from the attempt branch, not from `main` — issue text arrives live from

--- a/tests/unit/test_roll_blocker_preflight.py
+++ b/tests/unit/test_roll_blocker_preflight.py
@@ -1,0 +1,481 @@
+"""Acceptance tests for the roll-blocker launch gate (#2436).
+
+The operator's 2026-08-15 ruling is the specification: refuse when an open
+`roll-blocker` exists in EITHER the target repo or AssemblyZero, let
+``--ignore-blockers`` override it explicitly, leave a trace in the launch record
+when it is used, and print the result on every launch including the clean case.
+
+The gate is exercised through `speedrun_roll.main` wherever the claim is about
+the launcher's behaviour, so "nothing is spent" and "the refusal beats the
+detach hand-off" are assertions about what the launcher did rather than claims
+about a helper.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+import speedrun_roll  # noqa: E402
+
+from assemblyzero.speedrun.roll_blockers import (  # noqa: E402
+    OVERRIDE_FLAG,
+    ROLL_BLOCKER_LABEL,
+    Blocker,
+    BlockerScan,
+    blocker_refusal_message,
+    blocker_report_lines,
+    blocker_trace_line,
+    scan_roll_blockers,
+)
+
+TARGET = "martymcenroe/boostgauge"
+AZ = "martymcenroe/AssemblyZero"
+
+IN_TARGET = Blocker(TARGET, 341, "the renderer writes no PNG, so every roll ships blind")
+IN_AZ = Blocker(AZ, 2311, "the resume gate reads a spec the reset already cleared")
+
+
+def scan(*blockers: Blocker, errors: tuple[str, ...] = ()) -> BlockerScan:
+    return BlockerScan(tuple(blockers), (TARGET, AZ), errors)
+
+
+class FakeGh:
+    """A `gh`/`git` runner with a distinct board per repository.
+
+    Keyed by checkout path for the remote lookups and by slug for the issue
+    lists, so the two-repo behaviour can be exercised without a network.
+    """
+
+    def __init__(
+        self,
+        *,
+        remotes: dict[str, str] | None = None,
+        boards: dict[str, list[dict]] | None = None,
+        fails: tuple[str, ...] = (),
+    ) -> None:
+        self.remotes = remotes or {}
+        self.boards = boards or {}
+        self.fails = fails
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+        if args[0] == "git":
+            root = args[args.index("-C") + 1]
+            url = self.remotes.get(str(root))
+            if not url:
+                return subprocess.CompletedProcess(args, 1, "", "no remote")
+            return subprocess.CompletedProcess(args, 0, url, "")
+        if args[0] == "gh":
+            slug = args[args.index("--repo") + 1]
+            if slug in self.fails:
+                return subprocess.CompletedProcess(
+                    args, 1, "", "could not connect to github.com"
+                )
+            rows = self.boards.get(slug, [])
+            return subprocess.CompletedProcess(args, 0, json.dumps(rows), "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+
+@pytest.fixture
+def target_repo(tmp_path) -> Path:
+    """The launcher validates --repo is a git repository root before the gate."""
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["config", "user.email", "t@example.com"],
+        ["config", "user.name", "Test"],
+    ):
+        subprocess.run(["git", "-C", str(tmp_path), *args], capture_output=True, text=True)
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-qm", "base"], capture_output=True
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def launcher(monkeypatch, target_repo):
+    """speedrun_roll.main with everything past the gate stubbed out."""
+    state = {"rolls": [], "detached": 0, "base_calls": 0}
+
+    monkeypatch.setattr(speedrun_roll, "check_assemblyzero_tree", lambda _root: [])
+    monkeypatch.setattr(
+        speedrun_roll, "sweep_pipeline_worktrees",
+        lambda *_a, **_k: type("Sweep", (), {"problems": []})(),
+    )
+    monkeypatch.setattr(speedrun_roll, "install_signal_handlers", lambda _s: None)
+    # The sibling gate is not under test here; it must never be what refuses.
+    monkeypatch.setattr(
+        speedrun_roll, "open_must_resolve_issues", lambda _r: ([], None)
+    )
+
+    def fake_roll(repo_root, issue, log_dir, az_root, extra):
+        state["rolls"].append(issue)
+        return 0
+
+    def fake_ensure_base(*_a, **_kw):
+        state["base_calls"] += 1
+        return "hardening-run-1"
+
+    def fake_detach(*_a, **_kw):
+        state["detached"] += 1
+        return 0
+
+    monkeypatch.setattr(speedrun_roll, "roll_issue", fake_roll)
+    monkeypatch.setattr(speedrun_roll, "ensure_base", fake_ensure_base)
+    monkeypatch.setattr(speedrun_roll, "launch_detached", fake_detach)
+    return state
+
+
+def _argv(target_repo, *issues, detach=False, ignore=False):
+    args = ["--repo", str(target_repo), "--log-dir", str(target_repo / "logs")]
+    for issue in issues:
+        args += ["--issue", str(issue)]
+    if detach:
+        args.append("--detach")
+    if ignore:
+        args.append("--ignore-blockers")
+    return args
+
+
+def _session_log(target_repo) -> str:
+    path = target_repo / "logs" / "session-events.log"
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+# --- "surfaces every one of them, by number and title" --------------------
+
+
+def test_open_blocker_refuses_with_91_naming_number_and_title(
+    launcher, monkeypatch, target_repo, capsys
+):
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET, IN_AZ)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331))
+
+    assert code == 91
+    out = capsys.readouterr().out
+    assert "341" in out and "ships blind" in out
+    assert "2311" in out and "already cleared" in out
+
+
+def test_a_blocker_in_assemblyzero_alone_refuses(
+    launcher, monkeypatch, target_repo, capsys
+):
+    """The roll executes both trees, so a killer in either one kills it."""
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_AZ)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331))
+
+    assert code == 91
+    assert "2311" in capsys.readouterr().out
+    assert launcher["rolls"] == []
+
+
+# --- "a launch with none prints that it checked and found none" -----------
+
+
+def test_the_clean_case_says_it_checked_and_found_none(
+    launcher, monkeypatch, target_repo, capsys
+):
+    """Silence is not evidence -- #2381's complaint about box health."""
+    monkeypatch.setattr(speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan())
+
+    code = speedrun_roll.main(_argv(target_repo, 331))
+
+    assert code == 0
+    assert launcher["rolls"] == [331]
+    out = capsys.readouterr().out
+    assert "ROLL BLOCKERS" in out
+    assert "none open" in out
+    assert TARGET in out and AZ in out, "it must say WHICH boards it checked"
+
+
+def test_the_clean_case_is_recorded_in_the_launch_record(
+    launcher, monkeypatch, target_repo
+):
+    monkeypatch.setattr(speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan())
+
+    speedrun_roll.main(_argv(target_repo, 331))
+
+    record = _session_log(target_repo)
+    assert "ROLL-BLOCKERS checked" in record and "none open" in record
+
+
+# --- "--ignore-blockers overrides it explicitly" --------------------------
+
+
+def test_ignore_blockers_proceeds_and_names_what_it_rolled_past(
+    launcher, monkeypatch, target_repo, capsys
+):
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331, ignore=True))
+
+    assert code == 0
+    assert launcher["rolls"] == [331]
+    out = capsys.readouterr().out
+    assert "OVERRIDDEN" in out
+    assert "341" in out, "an override that does not name the blocker is silent"
+
+
+def test_the_override_leaves_a_trace_in_the_launch_record(
+    launcher, monkeypatch, target_repo
+):
+    """An override that leaves no trace is the accident the ruling stops."""
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET, IN_AZ)
+    )
+
+    speedrun_roll.main(_argv(target_repo, 331, ignore=True))
+
+    record = _session_log(target_repo)
+    assert "OVERRIDDEN" in record
+    assert OVERRIDE_FLAG in record
+    assert f"{TARGET}#341" in record and f"{AZ}#2311" in record
+
+
+def test_the_override_rides_the_detached_relaunch():
+    """Otherwise the detached run re-refuses where nothing can answer it."""
+    args = speedrun_roll.build_parser().parse_args(
+        ["--repo", ".", "--issue", "331", "--ignore-blockers"]
+    )
+    argv = speedrun_roll.detached_argv(
+        args, [], Path("/repo"), Path("/az"), Path("/logs")
+    )
+    assert "--ignore-blockers" in argv
+
+    without = speedrun_roll.build_parser().parse_args(["--repo", ".", "--issue", "331"])
+    assert "--ignore-blockers" not in speedrun_roll.detached_argv(
+        without, [], Path("/repo"), Path("/az"), Path("/logs")
+    )
+
+
+# --- "before the first paid model call" ----------------------------------
+
+
+def test_refusal_spends_nothing_and_creates_no_branch(
+    launcher, monkeypatch, target_repo
+):
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331))
+
+    assert code == 91
+    assert launcher["base_calls"] == 0, "ensure_base must not have been reached"
+    assert launcher["rolls"] == []
+
+
+def test_refusal_happens_before_the_detach_handoff(launcher, monkeypatch, target_repo):
+    # Otherwise the refusal lands inside a scheduled task nobody is watching.
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331, detach=True))
+
+    assert code == 91
+    assert launcher["detached"] == 0
+
+
+def test_a_batch_is_refused_as_a_whole(launcher, monkeypatch, target_repo):
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers", lambda *_a, **_k: scan(IN_TARGET)
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331, 332, 2))
+
+    assert code == 91
+    assert launcher["rolls"] == [], "no issue in the batch may roll"
+
+
+# --- "GitHub being unreachable is reported, never fatal" ------------------
+
+
+def test_an_unreachable_board_is_named_and_does_not_brick_the_launch(
+    launcher, monkeypatch, target_repo, capsys
+):
+    monkeypatch.setattr(
+        speedrun_roll, "scan_roll_blockers",
+        lambda *_a, **_k: BlockerScan(
+            (), (AZ,), (f"{TARGET}: could not connect to github.com",)
+        ),
+    )
+
+    code = speedrun_roll.main(_argv(target_repo, 331))
+
+    assert code == 0, "GitHub being unreachable must not brick a local roll"
+    out = capsys.readouterr().out
+    assert "WARNING" in out and TARGET in out
+
+
+# --- the scan itself ------------------------------------------------------
+
+
+def test_the_query_asks_for_open_roll_blocker_issues(tmp_path):
+    gh = FakeGh(
+        remotes={
+            str(tmp_path / "bg"): f"https://github.com/{TARGET}.git",
+            str(tmp_path / "az"): f"https://github.com/{AZ}.git",
+        },
+    )
+    scan_roll_blockers(tmp_path / "bg", tmp_path / "az", runner=gh)
+
+    listings = [c for c in gh.calls if c[0] == "gh"]
+    assert len(listings) == 2
+    for listing in listings:
+        assert listing[listing.index("--label") + 1] == ROLL_BLOCKER_LABEL
+        assert listing[listing.index("--state") + 1] == "open"
+
+
+def test_both_boards_are_read_and_merged(tmp_path):
+    gh = FakeGh(
+        remotes={
+            str(tmp_path / "bg"): f"https://github.com/{TARGET}.git",
+            str(tmp_path / "az"): f"https://github.com/{AZ}.git",
+        },
+        boards={
+            TARGET: [{"number": 341, "title": "target side"}],
+            AZ: [{"number": 2311, "title": "pipeline side"}],
+        },
+    )
+    result = scan_roll_blockers(tmp_path / "bg", tmp_path / "az", runner=gh)
+
+    assert result.refuses
+    assert [(b.repo, b.number) for b in result.blockers] == [
+        (AZ, 2311), (TARGET, 341),
+    ]
+    assert result.consulted == (TARGET, AZ)
+    assert result.errors == ()
+
+
+def test_one_repo_rolling_itself_is_consulted_once(tmp_path):
+    """AssemblyZero rolling its own issues must not list every blocker twice."""
+    gh = FakeGh(
+        remotes={
+            str(tmp_path / "az"): f"https://github.com/{AZ}.git",
+        },
+        boards={AZ: [{"number": 2311, "title": "pipeline side"}]},
+    )
+    result = scan_roll_blockers(tmp_path / "az", tmp_path / "az", runner=gh)
+
+    assert result.consulted == (AZ,)
+    assert len(result.blockers) == 1
+    assert len([c for c in gh.calls if c[0] == "gh"]) == 1
+
+
+def test_an_unreachable_board_is_an_error_not_a_clean_pass(tmp_path):
+    gh = FakeGh(
+        remotes={
+            str(tmp_path / "bg"): f"https://github.com/{TARGET}.git",
+            str(tmp_path / "az"): f"https://github.com/{AZ}.git",
+        },
+        boards={AZ: []},
+        fails=(TARGET,),
+    )
+    result = scan_roll_blockers(tmp_path / "bg", tmp_path / "az", runner=gh)
+
+    assert result.errors and TARGET in result.errors[0]
+    assert result.consulted == (AZ,), "a board that failed was not consulted"
+    assert not result.refuses, "could-not-ask is not knowledge of a blocker"
+
+
+def test_a_checkout_without_a_remote_is_reported_not_skipped_silently(tmp_path):
+    gh = FakeGh(remotes={str(tmp_path / "az"): f"https://github.com/{AZ}.git"})
+    result = scan_roll_blockers(tmp_path / "bg", tmp_path / "az", runner=gh)
+
+    assert result.errors and "no GitHub remote" in result.errors[0]
+    assert result.consulted == (AZ,)
+
+
+def test_the_scan_costs_no_model_call(tmp_path):
+    gh = FakeGh(
+        remotes={
+            str(tmp_path / "bg"): f"https://github.com/{TARGET}.git",
+            str(tmp_path / "az"): f"https://github.com/{AZ}.git",
+        },
+    )
+    scan_roll_blockers(tmp_path / "bg", tmp_path / "az", runner=gh)
+
+    assert gh.calls, "the scan must actually ask something"
+    assert {c[0] for c in gh.calls} <= {"git", "gh"}
+
+
+def test_a_row_without_a_number_is_dropped_rather_than_crashing(tmp_path):
+    gh = FakeGh(
+        remotes={str(tmp_path / "az"): f"https://github.com/{AZ}.git"},
+        boards={AZ: [{"title": "no number"}, {"number": 7, "title": "real"}]},
+    )
+    result = scan_roll_blockers(tmp_path / "az", tmp_path / "az", runner=gh)
+
+    assert [b.number for b in result.blockers] == [7]
+
+
+# --- the messages ---------------------------------------------------------
+
+
+def test_the_refusal_message_is_plain_english():
+    message = blocker_refusal_message(scan(IN_TARGET, IN_AZ))
+
+    # Names them so the operator can act without looking anything up.
+    assert "341" in message and "2311" in message
+    assert "ships blind" in message
+    # Says what to do, and that the override exists.
+    assert "close" in message.lower()
+    assert OVERRIDE_FLAG in message
+
+    titles = {IN_TARGET.title, IN_AZ.title}
+    prose = "\n".join(
+        line for line in message.splitlines()
+        if not any(t in line for t in titles)
+    ).lower()
+    for jargon in ("preflight", "gate", "exit 91", "#2436", "#2381", "scan",
+                   "stage", "argv", "n0c"):
+        assert jargon not in prose, f"{jargon!r} is internal jargon in the prose"
+
+
+def test_the_refusal_message_singular_and_plural_read_correctly():
+    one = blocker_refusal_message(scan(IN_TARGET))
+    many = blocker_refusal_message(scan(IN_TARGET, IN_AZ))
+    assert "1 known problem is open" in one
+    assert "2 known problems are open" in many
+
+
+def test_the_report_names_the_boards_it_checked_in_every_case():
+    clean = "\n".join(blocker_report_lines(scan()))
+    blocked = "\n".join(blocker_report_lines(scan(IN_TARGET)))
+    for text in (clean, blocked):
+        assert TARGET in text and AZ in text
+
+
+def test_the_report_marks_an_override_differently_from_a_refusal():
+    refused = "\n".join(blocker_report_lines(scan(IN_TARGET), overridden=False))
+    overridden = "\n".join(blocker_report_lines(scan(IN_TARGET), overridden=True))
+    assert "OPEN" in refused and "OVERRIDDEN" not in refused
+    assert "OVERRIDDEN" in overridden
+
+
+def test_the_trace_line_distinguishes_all_three_outcomes():
+    clean = blocker_trace_line(scan(), overridden=False)
+    refused = blocker_trace_line(scan(IN_TARGET), overridden=False)
+    overridden = blocker_trace_line(scan(IN_TARGET), overridden=True)
+
+    assert "none open" in clean
+    assert "refused" in refused and "341" in refused
+    assert "OVERRIDDEN" in overridden and OVERRIDE_FLAG in overridden
+    assert len({clean, refused, overridden}) == 3

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -101,6 +101,12 @@ from assemblyzero.speedrun.emergency_stop import (  # noqa: E402  (#2422)
     killed_verdict_lines,
     tree_kill,
 )
+from assemblyzero.speedrun.roll_blockers import (  # noqa: E402  (#2436)
+    blocker_refusal_message,
+    blocker_report_lines,
+    blocker_trace_line,
+    scan_roll_blockers,
+)
 from assemblyzero.speedrun.successes import (  # noqa: E402  (#2191)
     completed_on,
     describe,
@@ -1374,6 +1380,11 @@ def detached_argv(
     # the detached run re-refuses on the very gate the operator waived.
     if getattr(args, "override_prereqs", False):
         argv.append("--override-prereqs")
+    # #2436: same reasoning -- the detached run re-runs every preflight, so an
+    # override left behind here would refuse inside a scheduled task where the
+    # refusal is invisible and the operator is told the roll simply died.
+    if getattr(args, "ignore_blockers", False):
+        argv.append("--ignore-blockers")
     # #2191: a confirmed redraw must ride too, or the detached run re-refuses
     # on the gate the operator just typed a phrase to clear -- and refuses
     # non-interactively, where nothing can answer it.
@@ -2961,6 +2972,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--ignore-blockers", action="store_true",
+        help=(
+            "Launch even though an issue marked `roll-blocker` is open in this "
+            "repo or in AssemblyZero (#2436). The launch names every blocker it "
+            "rolled past and records the override, so rolling into known-broken "
+            "ground stays possible but can never happen by accident."
+        ),
+    )
+    parser.add_argument(
         "--redraw-completed", action="store_true",
         help=(
             "Redraw an issue this arc has already rolled to success (#2191). "
@@ -3135,6 +3155,19 @@ def main(argv: list[str] | None = None) -> int:
         print(refusal_message(blocking))
         return 91
 
+    # #2436: the launcher answers "what will stop this roll" instead of relying
+    # on a human having read the board. An open `roll-blocker` in EITHER repo
+    # refuses, because a roll executes both trees; --ignore-blockers overrides
+    # it deliberately. The result prints on every launch, pass or fail: a check
+    # that is silent when it passes cannot be told apart from one that never
+    # ran, which is #2381's complaint about box health.
+    blockers = scan_roll_blockers(repo_root, az_root)
+    for line in blocker_report_lines(blockers, overridden=args.ignore_blockers):
+        print(line)
+    if blockers.refuses and not args.ignore_blockers:
+        print(blocker_refusal_message(blockers))
+        return 91
+
     # #2227: the ADR 0226 form check, report-only by default. Free and instant
     # -- no model calls -- so it runs before anything is spent, like every
     # refusal above it. It refuses ONLY on a malformed decision table: nearly
@@ -3189,6 +3222,12 @@ def main(argv: list[str] | None = None) -> int:
     # see launch_detached on why that separation is load-bearing.
     session = EventLog(log_dir / "session-events.log")
     install_signal_handlers(session)
+
+    # #2436: the launch record carries what the blocker check found and whether
+    # the operator rolled past it. Written by the process that actually rolls,
+    # so the trace lands in the record a postmortem reads rather than only in a
+    # console that has since scrolled away.
+    session.write(blocker_trace_line(blockers, overridden=args.ignore_blockers))
 
     # How --detach-stop finds the tree to kill (#2016). Written by whichever
     # process does the rolling, detached or not.


### PR DESCRIPTION
Closes #2436

The launcher can now answer "what will stop this roll" without a human having read the board.

## The operator's ruling, implemented as ruled

Recorded on the issue 2026-08-15: **refuse, with an explicit override.**

- An open `roll-blocker` in **either** the target repo or AssemblyZero halts the launch before the first paid model call, naming every blocker by number and title.
- `--ignore-blockers` proceeds anyway, and the launch record states that the override was used and which blockers were rolled past.
- The list prints on **every** launch, pass or fail. The clean case says it checked and found none — the same complaint #2381 makes about box health printing only on refusal.
- No model call, and no dependence on an agent remembering to run it.

## What landed

`assemblyzero/speedrun/roll_blockers.py` — the scan, the report, the refusal message, and the launch-record trace. Both slugs are derived from the two checkouts' own remotes rather than hardcoded, so a fork or a second clone asks its own board. Slug derivation is imported from `must_resolve` rather than re-derived: a second copy of one fact is two parsers that drift.

`tools/speedrun_roll.py` — the gate sits with the other preflights in `main()`, before the detach hand-off, refusing with 91 like every gate beside it. `--ignore-blockers` rides the detached relaunch for the reason `--override-prereqs` does: an override left behind re-refuses inside a scheduled task where nothing can answer it. The trace is stamped into `session-events.log` by the process that actually rolls.

`docs/runbooks/0952-speedrun-operator-solo.md` — the refusal, the override, and the measured cost, beside the #2296 memory-ceiling ruling made the same day.

## Measured, not assumed

Run against both live boards before wiring anything: **1.04s, two boards consulted, zero blockers found**, printing

```
ROLL BLOCKERS: checked martymcenroe/boostgauge and martymcenroe/AssemblyZero -- none open.
```

That matters because four checks written the previous day cried wolf on their first real run. This one was run against the real corpus first and its findings counted.

## Decisions worth reading

**An unreachable board warns and proceeds.** The sibling gate settled this posture and the reasoning holds here: "could not ask" is not knowledge that something is broken, and GitHub being down must never brick a local roll. The launch names the board it could not read, so the gap is stated rather than silent.

**The label's meaning stays narrow.** `roll-blocker` means *this kills a roll*. A feature issue the next roll exists to build is not a blocker — labelling one that way refuses the launch that would have built it.

## Tests

23 tests in `tests/unit/test_roll_blocker_preflight.py`, covering both cases the acceptance names plus the ones the ruling implies: a blocker in AssemblyZero alone still refuses; the clean case says which boards it read; the override names what it rolled past and lands in the launch record; the refusal beats the detach hand-off and creates no branch; one repo rolling itself is consulted once; an unreachable board is an error rather than a clean pass; and the scan invokes nothing but `git` and `gh`.

Full unit suite green locally.
