### PR TITLE
fix: never file a conflict the gate could not articulate (Closes #2462)

### DIFF
--- a/assemblyzero/speedrun/must_resolve.py
+++ b/assemblyzero/speedrun/must_resolve.py
@@ -84,6 +84,69 @@ def conflict_fingerprint(criterion_a: str, criterion_b: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Is this filing something an operator can actually rule on? (#2462)
+# ---------------------------------------------------------------------------
+#
+# boostgauge #344 was filed with this conflict block, verbatim:
+#
+#     - A: alpha at distance 2 reads fully opaque; at 2.5 midway within +/-10; at 3 baseline
+#     - B: additive bloom on the body
+#     - Diverge when: ?
+#
+# The `?` is this module's own renderer default showing through: the model
+# returned no `diverging_situation`, `build_body` substituted `?`, and the
+# result was a launch-blocking question with nothing to rule ON.
+#
+# The must-resolve contract is "edit the source issue so only one reading
+# survives", which presupposes the filing names where the two readings part.
+# A filing that does not delegates the gate's own job -- articulating the
+# conflict -- to the operator, at launch-blocking priority. By the fleet's
+# no-false-alarms rule, a check that files what it cannot articulate trains the
+# operator to skim its filings.
+#
+# Deliberately narrow: the DIVERGENCE only. `conflict_from_rationale` emits an
+# empty `criterion_b` on purpose when the reviewer's prose cannot be split in
+# two (#2192, "a slightly coarse issue is worth having; a missing one is the
+# defect"), and rejecting that would re-open the blocked-roll-with-no-question
+# defect this module exists to close.
+
+#: One letter or digit anywhere is enough to be saying something. A condition
+#: made only of punctuation -- `?`, `-`, `...` -- is not.
+_HAS_MEANING = re.compile(r"[^\W_]", re.UNICODE)
+
+#: Words that fill the slot without answering it. Punctuation-only strings are
+#: not listed here -- the check above owns those, and a second list of `?`,
+#: `??`, `???` would be dead the day it was written.
+_PLACEHOLDER_WORDS = frozenset({
+    "n/a", "na", "none", "null", "nil", "unknown", "unclear", "unspecified",
+    "tbd", "todo",
+})
+
+
+def unanswerable_reason(conflict: dict) -> str | None:
+    """Why this conflict cannot be ruled on, or None if it can be (#2462).
+
+    Returns a phrase naming the defect, so a rejection is surfaced by name
+    rather than dropped -- the pairing may sit near a real conflict even when
+    the model could not articulate it, which is exactly what happened on #344.
+    """
+    stated = str(conflict.get("diverging_situation") or "").strip()
+    if not stated:
+        return "the model stated no situation where the two readings diverge"
+    if not _HAS_MEANING.search(stated):
+        return (
+            "the divergence condition is punctuation only "
+            f"({stated!r}), so there is nothing to rule on"
+        )
+    if stated.casefold() in _PLACEHOLDER_WORDS:
+        return (
+            f"the divergence condition is the placeholder {stated!r}, "
+            "so there is nothing to rule on"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
 # gh plumbing
 # ---------------------------------------------------------------------------
 
@@ -91,7 +154,7 @@ def conflict_fingerprint(criterion_a: str, criterion_b: str) -> str:
 @dataclass
 class FilingResult:
     ok: bool
-    action: str  # filed | commented | skipped | failed
+    action: str  # filed | commented | skipped | rejected | failed
     issue_number: int | None = None
     fingerprint: str | None = None
     detail: str = ""
@@ -251,9 +314,13 @@ def build_body(
         f"**Source issue:** #{source_issue}",
         "",
         "**Conflict (verbatim):**",
-        f"- A: {conflict.get('criterion_a', '?')}",
-        f"- B: {conflict.get('criterion_b', '?')}",
-        f"- Diverge when: {conflict.get('diverging_situation', '?')}",
+        # `(not stated)` rather than `?`: the bare question mark is what made
+        # #344 unreadable as a question at all. An empty divergence can no
+        # longer reach here (unanswerable_reason rejects it before filing), and
+        # an empty criterion says so in words (#2462).
+        f"- A: {conflict.get('criterion_a') or '(not stated)'}",
+        f"- B: {conflict.get('criterion_b') or '(not stated)'}",
+        f"- Diverge when: {conflict.get('diverging_situation') or '(not stated)'}",
         "",
         "**Ruling needed:** edit the source issue's text so only one reading "
         "survives, then close this issue. The roll will refuse to launch while "
@@ -327,6 +394,21 @@ def file_must_resolve(
         # Brief and idea entry paths carry file input, not an issue number.
         # There is nothing to file against.
         return FilingResult(True, "skipped", detail="entry path has no issue number")
+
+    # #2462: never file a question nothing can answer. Enforced HERE, at the
+    # filing boundary, so both gates that file -- N0c and the spec reviewer --
+    # get the invariant from one predicate rather than each carrying a copy.
+    unanswerable = unanswerable_reason(conflict)
+    if unanswerable:
+        log(
+            f"  [{origin.tag}] NOT FILED: {unanswerable}. The pairing is "
+            "reported here rather than raised as a question, because a "
+            "must-resolve with nothing to rule on blocks every later launch "
+            "and cannot be closed by ruling:"
+        )
+        log(f"      A: {conflict.get('criterion_a', '') or '(not stated)'}")
+        log(f"      B: {conflict.get('criterion_b', '') or '(not stated)'}")
+        return FilingResult(False, "rejected", detail=unanswerable)
 
     env_run_id, env_run_start = run_context()
     run_id = run_id or env_run_id

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -136,8 +136,16 @@ ANALYSIS_SCHEMA = {
 }
 
 
-def _format_conflict_message(conflicts: list[dict]) -> str:
-    """Build the halt message: marker + each conflict named verbatim."""
+def _format_conflict_message(
+    conflicts: list[dict], unarticulated: list[tuple[dict, str]] | None = None
+) -> str:
+    """Build the halt message: marker + each conflict named verbatim.
+
+    `unarticulated` are pairings the model reported without saying where the
+    two readings diverge (#2462). They are named here rather than dropped: one
+    of them sat beside a real latent tension on boostgauge #332, and a human
+    found it by reading around the empty filing.
+    """
     lines = [
         f"{REQUIREMENTS_CONFLICT_MARKER} the issue's requirements are "
         f"internally inconsistent — no spec can satisfy both readings. "
@@ -146,9 +154,17 @@ def _format_conflict_message(conflicts: list[dict]) -> str:
     for i, c in enumerate(conflicts, 1):
         lines.append(
             f"\nConflict {i}:\n"
-            f"  A: {c.get('criterion_a', '?')}\n"
-            f"  B: {c.get('criterion_b', '?')}\n"
-            f"  Diverge when: {c.get('diverging_situation', '?')}"
+            f"  A: {c.get('criterion_a') or '(not stated)'}\n"
+            f"  B: {c.get('criterion_b') or '(not stated)'}\n"
+            f"  Diverge when: {c.get('diverging_situation') or '(not stated)'}"
+        )
+    for c, reason in unarticulated or []:
+        lines.append(
+            f"\nAlso reported, NOT raised as a question ({reason}):\n"
+            f"  A: {c.get('criterion_a') or '(not stated)'}\n"
+            f"  B: {c.get('criterion_b') or '(not stated)'}\n"
+            "  Worth a look by eye — the pairing may sit near something real "
+            "even though the check could not say what."
         )
     return "\n".join(lines)
 
@@ -338,7 +354,55 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
         print(f"  [N0c] Verdict from {answered_by}.")
         return {}
 
-    message = _format_conflict_message(conflicts)
+    # #2462: a conflict whose divergence condition is empty or a placeholder is
+    # a malformed response, not a finding. Standard 0028 applied to this gate's
+    # own output: what came back does not satisfy the contract, so it is
+    # rejected by name rather than passed on as if it were a verdict. Observed
+    # on boostgauge #344, whose entire divergence condition was `?` -- a
+    # launch-blocking question no ruling could address.
+    from assemblyzero.speedrun.must_resolve import unanswerable_reason
+
+    articulated: list[dict] = []
+    unarticulated: list[tuple[dict, str]] = []
+    for c in conflicts:
+        reason = unanswerable_reason(c)
+        if reason:
+            unarticulated.append((c, reason))
+        else:
+            articulated.append(c)
+    conflicts = articulated
+
+    for c, reason in unarticulated:
+        print(
+            f"  [N0c] REJECTED a reported conflict: {reason}. "
+            "Not filed as a question."
+        )
+        print(f"          A: {c.get('criterion_a') or '(not stated)'}")
+        print(f"          B: {c.get('criterion_b') or '(not stated)'}")
+
+    if not conflicts:
+        # Every pairing it reported was one it could not articulate, so this
+        # call produced no usable verdict. That is the fail-open case the node
+        # is built around -- and #2290's rule applies: failing open is recorded,
+        # never silent, because "not checked" and "checked and clean" are
+        # different roll outcomes. Filing these would block every later launch
+        # with a question nobody can close; halting on them would stop the roll
+        # on a finding the check itself could not state.
+        count = len(unarticulated)
+        noun = "conflict" if count == 1 else "conflicts"
+        print(
+            f"  [N0c] WARNING: the analysis on {answered_by} reported {count} "
+            f"{noun} it could not articulate and nothing else; requirements "
+            "are unverified. Proceeding."
+        )
+        _record_unverified(
+            state,
+            f"analysis on {answered_by} reported {count} {noun} with no "
+            "divergence condition, so nothing was verifiable",
+        )
+        return {}
+
+    message = _format_conflict_message(conflicts, unarticulated)
     print(f"  [N0c] {message}")
 
     # #2072: the finding used to go to a run log and nowhere else, and N0c is

--- a/tests/unit/test_filed_questions_ledger.py
+++ b/tests/unit/test_filed_questions_ledger.py
@@ -57,6 +57,18 @@ RUN_083155 = [
 ]
 
 
+#: A well-formed conflict. The divergence condition is load-bearing input, not
+#: decoration: #2462 made a filing with an empty one impossible, because a
+#: question with nothing to rule ON blocks every later launch and cannot be
+#: closed by ruling. These tests are about the ledger, so they hand the filer
+#: something it would really file.
+CONFLICT = {
+    "criterion_a": "A",
+    "criterion_b": "B",
+    "diverging_situation": "when the reading is at its stop",
+}
+
+
 class TestTheLedgerRecordsWhatWasFiled:
     def test_a_filed_number_is_recorded_at_filing_time(self, repo):
         def runner(args):
@@ -74,8 +86,7 @@ class TestTheLedgerRecordsWhatWasFiled:
             return subprocess.CompletedProcess(args, 0, stdout="")
 
         result = file_must_resolve(
-            repo, 7, {"criterion_a": "A", "criterion_b": "B"},
-            runner=runner, log=lambda *a: None,
+            repo, 7, CONFLICT, runner=runner, log=lambda *a: None,
         )
 
         assert result.issue_number == 273
@@ -106,8 +117,7 @@ class TestTheLedgerRecordsWhatWasFiled:
             lambda a, b: "deadbeef",
         ):
             result = file_must_resolve(
-                repo, 7, {"criterion_a": "A", "criterion_b": "B"},
-                runner=runner, log=lambda *a: None,
+                repo, 7, CONFLICT, runner=runner, log=lambda *a: None,
             )
 
         assert result.action == "commented"

--- a/tests/unit/test_n0c_unarticulated_conflict.py
+++ b/tests/unit/test_n0c_unarticulated_conflict.py
@@ -1,0 +1,332 @@
+"""A conflict the gate could not articulate is never filed as a question (#2462).
+
+boostgauge #344 was filed with a divergence condition of `?` -- a
+launch-blocking must-resolve that no ruling could address, because the
+must-resolve contract ("edit the issue so only one reading survives")
+presupposes the filing names where the two readings part.
+
+The `?` was this pipeline's own renderer default showing through a missing
+field, so the reconstruction below is tested BOTH ways: with the key absent
+(what the model most likely returned) and with a literal `?` (what the issue
+body shows). Neither may be filed, and neither may be dropped silently.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from assemblyzero.core.llm_provider import LLMCallResult  # noqa: E402
+from assemblyzero.speedrun.must_resolve import (  # noqa: E402
+    build_body,
+    conflict_from_rationale,
+    file_must_resolve,
+    unanswerable_reason,
+)
+from assemblyzero.workflows.requirements.nodes.analyze_requirements import (  # noqa: E402
+    REQUIREMENTS_CONFLICT_MARKER,
+    analyze_requirements,
+)
+
+# The #344 conflict block, verbatim from the issue body.
+A_344 = (
+    "alpha at distance 2 reads fully opaque; at 2.5 midway within +/-10; "
+    "at 3 baseline"
+)
+B_344 = "additive bloom on the body"
+
+#: What the issue body renders -- the placeholder made it into the text.
+ISSUE_344_AS_RENDERED = {
+    "criterion_a": A_344,
+    "criterion_b": B_344,
+    "diverging_situation": "?",
+}
+
+#: What the model most likely returned -- the field simply absent, with the
+#: `?` supplied by the renderer's own default.
+ISSUE_344_AS_RETURNED = {"criterion_a": A_344, "criterion_b": B_344}
+
+GOOD = {
+    "criterion_a": "floor = highest value still in the window",
+    "criterion_b": "floor drifts toward the most recent value",
+    "diverging_situation": "when the window maximum is not the latest sample",
+}
+
+
+class FakeGh:
+    """Records every command instead of running it."""
+
+    def __init__(self, listing: str = "[]") -> None:
+        self.calls: list[list[str]] = []
+        self.listing = listing
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+        if args[0] == "git":
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/martymcenroe/boostgauge.git", ""
+            )
+        if "list" in args:
+            return subprocess.CompletedProcess(args, 0, self.listing, "")
+        if "create" in args:
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/martymcenroe/boostgauge/issues/999", ""
+            )
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    @property
+    def created(self) -> list[list[str]]:
+        return [c for c in self.calls if "issue" in c and "create" in c]
+
+
+# ---------------------------------------------------------------------------
+# The predicate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [ISSUE_344_AS_RENDERED, ISSUE_344_AS_RETURNED],
+    ids=["as-rendered", "as-returned"],
+)
+def test_the_344_payload_is_rejected(conflict):
+    reason = unanswerable_reason(conflict)
+    assert reason, "the #344 conflict must not be treated as answerable"
+    assert "rule on" in reason or "diverge" in reason
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "   ", "?", "??", "-", "--", "...", "N/A", "n/a", "TBD", "unknown",
+     "None", "unclear", "\t\n", "!!", "???"],
+)
+def test_placeholder_divergences_are_rejected(value):
+    assert unanswerable_reason({**GOOD, "diverging_situation": value})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "when the window maximum is not the latest sample",
+        "at distance 2.5",
+        "0 rpm",
+        "if the needle is at its stop",
+        "when both fire in the same frame",
+    ],
+)
+def test_real_divergences_are_not_rejected(value):
+    """The narrow half. A check that cries wolf gets skimmed, and this one
+    files launch-blocking issues -- over-rejecting would silence a real gate."""
+    assert unanswerable_reason({**GOOD, "diverging_situation": value}) is None
+
+
+def test_the_reason_names_the_defect_rather_than_saying_invalid():
+    """'Invalid response' tells the next reader nothing. The reason quotes what
+    came back and says why it cannot be ruled on."""
+    rendered = unanswerable_reason(ISSUE_344_AS_RENDERED)
+    assert "'?'" in rendered and "nothing to rule on" in rendered
+
+    returned = unanswerable_reason(ISSUE_344_AS_RETURNED)
+    assert "no situation" in returned and "diverge" in returned
+
+    word = unanswerable_reason({**GOOD, "diverging_situation": "TBD"})
+    assert "placeholder" in word and "'TBD'" in word
+
+
+# ---------------------------------------------------------------------------
+# The filing boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [ISSUE_344_AS_RENDERED, ISSUE_344_AS_RETURNED],
+    ids=["as-rendered", "as-returned"],
+)
+def test_an_unanswerable_conflict_is_never_filed(tmp_path, conflict):
+    gh = FakeGh()
+    result = file_must_resolve(tmp_path, 332, conflict, runner=gh, log=lambda _m: None)
+
+    assert result.action == "rejected"
+    assert not result.ok
+    assert gh.created == [], "no must-resolve issue may be created"
+
+
+def test_the_rejection_is_surfaced_by_name_not_dropped(tmp_path):
+    """It may sit near something real -- on #332 it did, and a human found it
+    by reading around the empty filing."""
+    said: list[str] = []
+    file_must_resolve(
+        tmp_path, 332, ISSUE_344_AS_RENDERED, runner=FakeGh(), log=said.append
+    )
+
+    text = "\n".join(said)
+    assert "NOT FILED" in text
+    assert A_344 in text and B_344 in text, "both readings must still be shown"
+
+
+def test_a_well_formed_conflict_still_files(tmp_path):
+    gh = FakeGh()
+    result = file_must_resolve(tmp_path, 332, GOOD, runner=gh, log=lambda _m: None)
+
+    assert result.action == "filed"
+    assert gh.created, "the guard must not stop real findings from being filed"
+
+
+def test_the_spec_reviewers_coarse_conflict_still_files(tmp_path):
+    """#2192 emits an empty criterion_b ON PURPOSE when the reviewer's prose
+    cannot be split in two: a coarse issue is worth having, a missing one is
+    the defect. This guard is scoped to the divergence and must not undo it."""
+    coarse = conflict_from_rationale(
+        "REQUIREMENTS CONFLICT: the two acceptance criteria disagree about "
+        "what happens at the stop."
+    )
+    assert coarse["criterion_b"] == "", "the fixture must exercise the coarse shape"
+
+    gh = FakeGh()
+    result = file_must_resolve(tmp_path, 332, coarse, runner=gh, log=lambda _m: None)
+
+    assert result.action == "filed"
+    assert gh.created
+
+
+def test_a_rendered_body_never_shows_a_bare_question_mark():
+    body = build_body(
+        332,
+        {"criterion_a": "only A was stated"},
+        run_id="r", run_start="s", conflict_ts="t", fingerprint="f",
+    )
+    assert "- B: ?" not in body and "Diverge when: ?" not in body
+    assert "(not stated)" in body
+
+
+# ---------------------------------------------------------------------------
+# The node
+# ---------------------------------------------------------------------------
+
+
+class _FakeProvider:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[dict] = []
+
+    def invoke(self, **kwargs) -> LLMCallResult:
+        self.calls.append(kwargs)
+        return LLMCallResult(
+            success=True,
+            response=self.response,
+            raw_response=self.response,
+            error_message=None,
+            provider="fake",
+            model_used="fake-model",
+            duration_ms=1,
+            attempts=1,
+        )
+
+
+@pytest.fixture
+def node(monkeypatch, tmp_path):
+    """Drive the live node, capturing filings and unverified records."""
+    captured = {"filed": [], "unverified": []}
+
+    monkeypatch.setattr(
+        "assemblyzero.speedrun.must_resolve.file_all_conflicts",
+        lambda repo, issue, conflicts, **k: captured["filed"].extend(conflicts),
+    )
+    monkeypatch.setattr(
+        "assemblyzero.speedrun.prompt_telemetry.record_failures",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "assemblyzero.speedrun.requirements_status.record_unverified",
+        lambda repo, **k: captured["unverified"].append(k),
+    )
+
+    def run(response: str) -> dict:
+        provider = _FakeProvider(response)
+        monkeypatch.setattr(
+            "assemblyzero.core.llm_provider.get_provider",
+            lambda spec, *a, **k: provider,
+        )
+        return analyze_requirements({
+            "issue_title": "t",
+            "issue_body": "some requirement text",
+            "issue_number": 332,
+            "target_repo": str(tmp_path),
+            "config_drafter": "fake:model",
+        })
+
+    captured["run"] = run
+    return captured
+
+
+ALL_UNARTICULATED = (
+    '{"is_consistent": false, "conflicts": [{"criterion_a": "%s", '
+    '"criterion_b": "%s", "diverging_situation": "?"}]}' % (A_344, B_344)
+)
+
+MIXED = (
+    '{"is_consistent": false, "conflicts": ['
+    '{"criterion_a": "%s", "criterion_b": "%s", "diverging_situation": "?"}, '
+    '{"criterion_a": "%s", "criterion_b": "%s", "diverging_situation": "%s"}]}'
+    % (A_344, B_344, GOOD["criterion_a"], GOOD["criterion_b"],
+       GOOD["diverging_situation"])
+)
+
+ONLY_GOOD = (
+    '{"is_consistent": false, "conflicts": [{"criterion_a": "%s", '
+    '"criterion_b": "%s", "diverging_situation": "%s"}]}'
+    % (GOOD["criterion_a"], GOOD["criterion_b"], GOOD["diverging_situation"])
+)
+
+
+def test_an_all_unarticulated_verdict_files_nothing_and_does_not_halt(node, capsys):
+    result = node["run"](ALL_UNARTICULATED)
+
+    assert result == {}, "a finding the check could not state must not halt the roll"
+    assert node["filed"] == [], "and must not become a launch-blocking question"
+    out = capsys.readouterr().out
+    assert "REJECTED" in out and A_344 in out
+
+
+def test_an_all_unarticulated_verdict_is_recorded_as_unverified(node):
+    """Failing open is recorded, never silent (#2290): 'not checked' and
+    'checked and clean' are different roll outcomes."""
+    node["run"](ALL_UNARTICULATED)
+
+    assert len(node["unverified"]) == 1
+    assert "divergence" in node["unverified"][0]["reason"]
+
+
+def test_a_clean_verdict_is_not_recorded_as_unverified(node):
+    node["run"]('{"is_consistent": true, "conflicts": []}')
+    assert node["unverified"] == []
+
+
+def test_a_mixed_verdict_halts_on_the_real_one_and_files_only_that(node):
+    result = node["run"](MIXED)
+
+    assert REQUIREMENTS_CONFLICT_MARKER in result["error_message"]
+    assert [c["criterion_a"] for c in node["filed"]] == [GOOD["criterion_a"]]
+    assert node["unverified"] == [], "it did produce a verdict"
+
+
+def test_a_mixed_verdict_still_names_the_pairing_it_dropped(node):
+    result = node["run"](MIXED)
+
+    message = result["error_message"]
+    assert A_344 in message, "the dropped pairing must be surfaced, not silently lost"
+    assert "NOT raised as a question" in message
+
+
+def test_a_well_formed_verdict_is_unchanged(node):
+    result = node["run"](ONLY_GOOD)
+
+    assert REQUIREMENTS_CONFLICT_MARKER in result["error_message"]
+    assert len(node["filed"]) == 1
+    assert node["unverified"] == []


### PR DESCRIPTION
Closes #2462

The N0c gate filed a launch-blocking question whose divergence condition was a literal `?`. There was nothing to rule on, so no ruling could ever clear it.

## Where the `?` came from

It is this pipeline's own renderer default showing through. The model returned no `diverging_situation`; `build_body` substituted `?`; the result was filed as boostgauge issue #344 and blocked every later launch.

The contract is "edit the source issue so only one reading survives", which presupposes the filing names where the two readings part. A filing that does not names nothing — it delegates the gate's own job, articulating the conflict, to the operator at launch-blocking priority. By the no-false-alarms rule, a check that files what it cannot articulate trains the operator to skim its filings.

## The fix — standard 0028 applied to the gate's own output

`unanswerable_reason(conflict)` in `assemblyzero/speedrun/must_resolve.py` returns a phrase naming the defect, or None. Enforced at the **filing boundary**, so both gates that file — N0c and the spec reviewer — get the invariant from one predicate instead of each carrying a copy.

**Deliberately scoped to the divergence.** `conflict_from_rationale` emits an empty `criterion_b` on purpose when the reviewer's prose cannot be split in two (#2192: a slightly coarse issue is worth having, a missing one is the defect). Rejecting that would re-open the blocked-roll-with-no-question defect that code exists to prevent. A test pins it.

**Rejection is surfaced, never dropped.** The pairing may sit near something real — on boostgauge #332 it did, and a human found it by reading around the empty filing. So:

- N0c prints `REJECTED a reported conflict: <reason>` with both readings.
- If some conflicts are articulate and some are not, the roll halts on the real ones and the halt message still names the dropped pairing under "Also reported, NOT raised as a question".
- If *every* pairing it reported was one it could not articulate, the call produced no usable verdict. That is the fail-open case this node is built around, and #2290's rule applies: the fail-open is recorded in the requirements-status ledger, because "not checked" and "checked and clean" are different roll outcomes. Filing them would block every later launch with a question nobody can close; halting on them would stop a roll on a finding the check itself could not state.

`?` is also gone as a rendering default. An unstated field now renders `(not stated)`, which cannot be misread as content.

## Why this matters to the next roll

boostgauge #331 and #332 were pre-checked by this same gate standalone, but the roll re-runs it with authority. A `?`-filing during the roll bricks the launch for nothing.

## Tests

36 tests in `tests/unit/test_n0c_unarticulated_conflict.py`. The #344 payload is reconstructed **both ways** — with the key absent (what the model most likely returned) and with the literal `?` the issue body shows — because the renderer default means the artifact cannot tell us which it was. Neither is filed.

The narrow half is tested too: `at distance 2.5`, `0 rpm`, `if the needle is at its stop` all pass. Over-rejecting would silence a gate that catches real conflicts, which is the more expensive direction.

Two fixtures in `tests/unit/test_filed_questions_ledger.py` passed a conflict with no divergence condition at all. They are about ledger recording, not conflict content, and now hand the filer something it would really file.

Full unit suite green locally.
