### PR TITLE
chore: land the one-shot landing scripts that can live here (Closes #2442)

### DIFF
--- a/tools/land_aletheia_775.py
+++ b/tools/land_aletheia_775.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Land Aletheia #775 (remove deploy-infra + post-deploy-smoke from ci.yml).
+
+Issue: martymcenroe/Aletheia#775 (follow-up to #773).
+
+Removes the last static-credential path from CI: the manual-only `deploy-infra`
+job (and its `post-deploy-smoke` companion) were the only remaining consumers of
+the admin `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` repo secrets. Deploys are
+done locally via provision.sh, so the jobs are redundant. After this merges, the
+two repo secrets are unreferenced and can be deleted in Settings.
+
+Same mechanism + threat model as land_aletheia_ci_oidc.py: the fine-grained PAT
+can't push workflow files (ADR-0216 §1), so this lands the already-committed fix
+(local branch `775-retire-deploy-infra-static-keys`) via the gpg-decrypted classic
+PAT + Contents API + PR + squash-merge. THE OPERATOR RUNS THIS in their own Git
+Bash; an agent must never invoke it.
+
+Usage (operator, one run):
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/land_aletheia_775.py --apply
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+REPO = "Aletheia"
+GH_API = "https://api.github.com"
+WORKFLOW_PATH = ".github/workflows/ci.yml"
+BRANCH = "775-retire-deploy-infra-static-keys"
+LOCAL_BRANCH = "775-retire-deploy-infra-static-keys"
+ISSUE_NUMBER = 775
+ALETHEIA_REPO = Path("C:/Users/mcwiz/Projects/Aletheia")
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 900
+
+PR_TITLE = "ci: remove deploy-infra + post-deploy-smoke; drop static AWS keys (Closes #775)"
+PR_BODY = """## Summary
+
+Removes the `deploy-infra` and `post-deploy-smoke` jobs from `ci.yml`. `deploy-infra`
+ran `provision.sh` on manual dispatch using the admin static keys
+(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) — it was the last consumer of those
+secrets and is redundant with local `provision.sh` deploys. Also drops the now-unused
+`workflow_dispatch` trigger.
+
+After this merges, the two repo secrets are unreferenced and should be deleted
+(Settings → Secrets and variables → Actions). Completes the OIDC hardening from #773 —
+CI now holds no long-lived AWS credentials.
+
+Closes #775
+"""
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def read_fixed_ci_yml() -> bytes:
+    """Return the fixed ci.yml bytes from the local branch blob (LF, not CRLF)."""
+    proc = subprocess.run(
+        ["git", "-C", str(ALETHEIA_REPO), "show", f"{LOCAL_BRANCH}:{WORKFLOW_PATH}"],
+        capture_output=True, check=True,
+    )
+    return proc.stdout.replace(b"\r\n", b"\n")
+
+
+def get_branch_head(pat: str, branch: str = "main") -> str:
+    r = requests.get(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{branch}",
+                     headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def ensure_branch(pat: str, source_sha: str) -> None:
+    r = requests.post(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs",
+                      headers=_headers(pat),
+                      json={"ref": f"refs/heads/{BRANCH}", "sha": source_sha},
+                      timeout=HTTP_TIMEOUT_S)
+    if r.status_code == 422:
+        print(f"  branch {BRANCH} already exists — reusing it")
+        return
+    r.raise_for_status()
+
+
+def get_file_sha(pat: str, ref: str) -> str:
+    r = requests.get(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{WORKFLOW_PATH}",
+                     params={"ref": ref}, headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+    r.raise_for_status()
+    return r.json()["sha"]
+
+
+def put_file(pat: str, content: bytes, file_sha: str) -> None:
+    r = requests.put(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{WORKFLOW_PATH}",
+                     headers=_headers(pat),
+                     json={"message": f"ci: remove deploy-infra + post-deploy-smoke; drop static AWS keys (Closes #{ISSUE_NUMBER})",
+                           "content": base64.b64encode(content).decode(),
+                           "sha": file_sha, "branch": BRANCH},
+                     timeout=HTTP_TIMEOUT_S)
+    r.raise_for_status()
+
+
+def create_pr(pat: str) -> int:
+    r = requests.post(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+                      headers=_headers(pat),
+                      json={"title": PR_TITLE, "head": BRANCH, "base": "main", "body": PR_BODY},
+                      timeout=HTTP_TIMEOUT_S)
+    if r.status_code == 422 and "already exist" in r.text.lower():
+        existing = requests.get(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+                                params={"state": "open", "head": f"{GITHUB_USER}:{BRANCH}"},
+                                headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+        existing.raise_for_status()
+        num = existing.json()[0]["number"]
+        print(f"  PR for {BRANCH} already open (#{num}) — reusing")
+        return num
+    r.raise_for_status()
+    return r.json()["number"]
+
+
+def mergeable_state(pat: str, pr: int) -> str | None:
+    r = requests.get(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr}",
+                     headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+    r.raise_for_status()
+    return r.json().get("mergeable_state")
+
+
+def wait_for_mergeable(pat: str, pr: int, timeout_s: int = MERGEABLE_TIMEOUT_S) -> str:
+    deadline = time.time() + timeout_s
+    last, polled = "unknown", False
+    while time.time() < deadline:
+        state = mergeable_state(pat, pr) or "unknown"
+        last = state
+        print(f"  mergeable_state = {state}")
+        if state in ("clean", "unstable"):
+            return state
+        if state == "dirty":
+            return state
+        if state == "blocked" and polled:
+            return state
+        polled = True
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+def merge_pr(pat: str, pr: int) -> str:
+    r = requests.put(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr}/merge",
+                     headers=_headers(pat), json={"merge_method": "squash"},
+                     timeout=HTTP_TIMEOUT_S)
+    r.raise_for_status()
+    return r.json().get("sha", "")
+
+
+def delete_remote_branch(pat: str) -> None:
+    try:
+        requests.delete(f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{BRANCH}",
+                        headers=_headers(pat), timeout=HTTP_TIMEOUT_S)
+    except requests.RequestException:
+        pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--apply", action="store_true",
+                    help="Perform branch + commit + PR + squash-merge. Default: dry-run.")
+    args = ap.parse_args()
+
+    content = read_fixed_ci_yml()
+    print(f"Loaded fixed {WORKFLOW_PATH} from local branch {LOCAL_BRANCH}: {len(content)} bytes")
+    if b"secrets.AWS" in content:
+        print("ERROR: fixed ci.yml STILL references secrets.AWS_* — wrong branch/content. Aborting.")
+        return 1
+    if b"AletheiaCIAuditRole" not in content:
+        print("ERROR: fixed ci.yml missing the OIDC role (would undo #773) — wrong content. Aborting.")
+        return 1
+    print("  guard OK: static AWS keys removed, OIDC role preserved")
+
+    with classic_pat_session() as pat:
+        main_sha = get_branch_head(pat, "main")
+        print(f"main HEAD: {main_sha[:8]}")
+
+        if not args.apply:
+            cur = get_file_sha(pat, "main")
+            print("\n=== DRY-RUN (no changes) ===")
+            print(f"Would branch {BRANCH} from {main_sha[:8]}")
+            print(f"Would update {WORKFLOW_PATH} (current blob {cur[:8]}) via Contents API")
+            print(f"Would open PR: {PR_TITLE!r}")
+            print(f"Would wait for mergeable, then squash-merge (Closes #{ISSUE_NUMBER})")
+            print("\nRe-run with --apply to execute.")
+            return 0
+
+        print("\n=== APPLY ===")
+        ensure_branch(pat, main_sha)
+        file_sha = get_file_sha(pat, BRANCH)
+        print(f"current {WORKFLOW_PATH} blob on branch: {file_sha[:8]}")
+        put_file(pat, content, file_sha)
+        print(f"committed fixed {WORKFLOW_PATH} on {BRANCH}")
+        pr = create_pr(pat)
+        print(f"PR #{pr} opened — waiting for checks + Cerberus-AZ approval...")
+        state = wait_for_mergeable(pat, pr)
+        if state not in ("clean", "unstable"):
+            print(f"\nPR #{pr} did not become mergeable (final state: {state}). "
+                  f"Branch + PR retained for review. NOT merged.")
+            return 1
+        sha = merge_pr(pat, pr)
+        delete_remote_branch(pat)
+        print(f"\n✓ PR #{pr} squash-merged at {sha[:8]} — Closes #{ISSUE_NUMBER}")
+        print("Next: delete the AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY repo secrets in "
+              "Settings → Secrets and variables → Actions. Then CI holds no static AWS creds.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/land_aletheia_ci_oidc.py
+++ b/tools/land_aletheia_ci_oidc.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Land the Aletheia CI OIDC migration (ci.yml) via the classic-PAT Contents API.
+
+Issue: martymcenroe/Aletheia#773.
+
+The Aletheia fine-grained PAT deliberately lacks `workflow` scope (ADR-0216 §1),
+so `git push` of a `.github/workflows/*` change is rejected. This tool lands the
+already-committed ci.yml fix (local branch `773-ci-oidc-migration`) using the
+gpg-decrypted classic PAT via the GitHub Contents API + PR + squash-merge.
+
+The fix migrates the `compliance-audit` job from admin static keys to the
+read-only OIDC role `AletheiaCIAuditRole` (already created + verified in AWS),
+and gates `deploy-infra`/`post-deploy-smoke` to manual (`workflow_dispatch`) so
+merges to main no longer auto-run provision.sh. This greens the nightly red
+badge and removes long-lived CI credentials.
+
+Auth: _pat_session.classic_pat_session() — the classic PAT is gpg-decrypted in
+this process's heap only, never written to env or passed via argv. THE OPERATOR
+RUNS THIS, in their own Git Bash. An agent must never invoke it (the PAT would
+be readable from the agent's child-process heap for the seconds it's in scope).
+
+Required classic-PAT scopes: repo (full) + workflow.
+
+Usage (operator, one run):
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/land_aletheia_ci_oidc.py --apply
+
+Default is dry-run (prints the plan, read-only). --apply performs the branch +
+Contents-API commit + PR + squash-merge. Everything upstream (AWS role, ci.yml
+edit) is already done and verified, so --apply directly is fine.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+REPO = "Aletheia"
+GH_API = "https://api.github.com"
+WORKFLOW_PATH = ".github/workflows/ci.yml"
+BRANCH = "773-ci-oidc-migration"
+LOCAL_BRANCH = "773-ci-oidc-migration"
+ISSUE_NUMBER = 773
+ALETHEIA_REPO = Path("C:/Users/mcwiz/Projects/Aletheia")
+SENTINEL = b"AletheiaCIAuditRole"  # must be present in the fixed ci.yml
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGEABLE_TIMEOUT_S = 900
+
+PR_TITLE = (
+    "ci: migrate compliance-audit to GitHub OIDC read-only role; "
+    "gate deploy to manual (Closes #773)"
+)
+PR_BODY = """## Summary
+
+Migrates the `compliance-audit` CI job from admin static access keys to the
+least-privilege OIDC role `AletheiaCIAuditRole` (assumed via GitHub Actions
+`id-token`; trust scoped to `repo:martymcenroe/Aletheia:*`; only the three
+read-only bedrock actions the audit tests call). Gates `deploy-infra` and
+`post-deploy-smoke` to `workflow_dispatch` so merges to main no longer
+auto-run `provision.sh`.
+
+Fixes the nightly red badge (the `Configure AWS Credentials` step was failing
+on missing/expired static secrets) and removes long-lived CI credentials. The
+AWS OIDC provider + role were provisioned out-of-band and verified.
+
+Closes #773
+"""
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def read_fixed_ci_yml() -> bytes:
+    """Return the fixed ci.yml bytes from the local branch blob (LF, not CRLF).
+
+    Reads the git blob directly (git stores LF), so no working-tree CRLF leaks
+    into the Contents API and flips the whole file's line endings on origin.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(ALETHEIA_REPO), "show", f"{LOCAL_BRANCH}:{WORKFLOW_PATH}"],
+        capture_output=True,
+        check=True,
+    )
+    return proc.stdout.replace(b"\r\n", b"\n")
+
+
+def get_branch_head(pat: str, branch: str = "main") -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{branch}",
+        headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def ensure_branch(pat: str, source_sha: str) -> None:
+    r = requests.post(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs",
+        headers=_headers(pat),
+        json={"ref": f"refs/heads/{BRANCH}", "sha": source_sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 422:  # ref already exists — reuse (idempotent re-run)
+        print(f"  branch {BRANCH} already exists — reusing it")
+        return
+    r.raise_for_status()
+
+
+def get_file_sha(pat: str, ref: str) -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{WORKFLOW_PATH}",
+        params={"ref": ref}, headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["sha"]
+
+
+def put_file(pat: str, content: bytes, file_sha: str) -> None:
+    r = requests.put(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{WORKFLOW_PATH}",
+        headers=_headers(pat),
+        json={
+            "message": f"ci: migrate compliance-audit to OIDC; gate deploy to manual (Closes #{ISSUE_NUMBER})",
+            "content": base64.b64encode(content).decode(),
+            "sha": file_sha,
+            "branch": BRANCH,
+        },
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+
+
+def create_pr(pat: str) -> int:
+    r = requests.post(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+        headers=_headers(pat),
+        json={"title": PR_TITLE, "head": BRANCH, "base": "main", "body": PR_BODY},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    if r.status_code == 422 and "already exist" in r.text.lower():
+        existing = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+            params={"state": "open", "head": f"{GITHUB_USER}:{BRANCH}"},
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+        existing.raise_for_status()
+        num = existing.json()[0]["number"]
+        print(f"  PR for {BRANCH} already open (#{num}) — reusing")
+        return num
+    r.raise_for_status()
+    return r.json()["number"]
+
+
+def mergeable_state(pat: str, pr: int) -> str | None:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr}",
+        headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json().get("mergeable_state")
+
+
+def wait_for_mergeable(pat: str, pr: int, timeout_s: int = MERGEABLE_TIMEOUT_S) -> str:
+    """Poll until clean/unstable (both squash-mergeable). Cerberus-AZ approves
+    after pr-sentinel-mm passes, which can take up to a few minutes."""
+    deadline = time.time() + timeout_s
+    last, polled = "unknown", False
+    while time.time() < deadline:
+        state = mergeable_state(pat, pr) or "unknown"
+        last = state
+        print(f"  mergeable_state = {state}")
+        if state in ("clean", "unstable"):
+            return state
+        if state == "dirty":
+            return state
+        if state == "blocked" and polled:
+            return state
+        polled = True
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+def merge_pr(pat: str, pr: int) -> str:
+    r = requests.put(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr}/merge",
+        headers=_headers(pat), json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json().get("sha", "")
+
+
+def delete_remote_branch(pat: str) -> None:
+    """Best-effort cleanup of the remote branch after merge."""
+    try:
+        requests.delete(
+            f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{BRANCH}",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+    except requests.RequestException:
+        pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--apply", action="store_true",
+                    help="Perform branch + commit + PR + squash-merge. Default: dry-run.")
+    args = ap.parse_args()
+
+    content = read_fixed_ci_yml()
+    print(f"Loaded fixed {WORKFLOW_PATH} from local branch {LOCAL_BRANCH}: {len(content)} bytes")
+    if SENTINEL not in content:
+        print(f"ERROR: fixed ci.yml does not contain {SENTINEL!r} — wrong branch or content. Aborting.")
+        return 1
+
+    with classic_pat_session() as pat:
+        main_sha = get_branch_head(pat, "main")
+        print(f"main HEAD: {main_sha[:8]}")
+
+        if not args.apply:
+            cur = get_file_sha(pat, "main")
+            print("\n=== DRY-RUN (no changes) ===")
+            print(f"Would branch {BRANCH} from {main_sha[:8]}")
+            print(f"Would update {WORKFLOW_PATH} (current blob {cur[:8]}) via Contents API")
+            print(f"Would open PR: {PR_TITLE!r}")
+            print(f"Would wait for mergeable, then squash-merge (Closes #{ISSUE_NUMBER})")
+            print("\nRe-run with --apply to execute.")
+            return 0
+
+        print("\n=== APPLY ===")
+        ensure_branch(pat, main_sha)
+        file_sha = get_file_sha(pat, BRANCH)
+        print(f"current {WORKFLOW_PATH} blob on branch: {file_sha[:8]}")
+        put_file(pat, content, file_sha)
+        print(f"committed fixed {WORKFLOW_PATH} on {BRANCH}")
+        pr = create_pr(pat)
+        print(f"PR #{pr} opened — waiting for checks + Cerberus-AZ approval...")
+        state = wait_for_mergeable(pat, pr)
+        if state not in ("clean", "unstable"):
+            print(f"\nPR #{pr} did not become mergeable (final state: {state}). "
+                  f"Branch + PR retained for review. NOT merged.")
+            return 1
+        sha = merge_pr(pat, pr)
+        delete_remote_branch(pat)
+        print(f"\n✓ PR #{pr} squash-merged at {sha[:8]} — Closes #{ISSUE_NUMBER}")
+        print("The merge triggers CI on main; compliance-audit now runs via OIDC. Watch it go green.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/land_aletheia_ci_pipestatus.py
+++ b/tools/land_aletheia_ci_pipestatus.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Land the CI pytest exit-code fix in the Aletheia repository.
+
+Aletheia issue #831.
+
+The `test` job pipes pytest into `tee`, so the step exits with tee's status.
+GitHub Actions runs `bash -e` but not `pipefail`, and nothing afterwards
+inspects the real code — the follow-up logic only verifies that tests were
+*collected*, never that they *passed*. The check therefore reported success
+over a red suite.
+
+This lands a two-line fix (`EXIT_CODE=${PIPESTATUS[0]}` and a trailing
+`exit $EXIT_CODE`), matching the `integration-tests` step in the same file,
+which already handles it correctly.
+
+Why this script exists at all
+-----------------------------
+The change touches `.github/workflows/`, and the fine-grained agent PAT
+deliberately lacks `workflow` scope (ADR-0216 §1), so a direct push is refused
+by the remote. The change lands via the GitHub Contents API using the in-process
+classic-PAT context manager.
+
+OPERATOR RUNS THIS. NOT AN AGENT.
+    Per `_pat_session` module contract: a script importing that module must be
+    run by the operator in their own shell. Invoked from an agent's Bash tool,
+    the Python process becomes the agent's child and its heap is theoretically
+    readable while the PAT is in scope.
+
+Usage
+-----
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/land_aletheia_ci_pipestatus.py            # dry run
+    poetry run python tools/land_aletheia_ci_pipestatus.py --apply    # land it
+
+Dry run performs every read-only step (fetches the remote file, diffs it
+against the local replacement) and stops before any write.
+
+Required PAT scopes: `repo`, `workflow`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import difflib
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+REPO = "Aletheia"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+
+WORKFLOW_PATH = ".github/workflows/ci.yml"
+BRANCH = "831-ci-pytest-exit-code"
+ISSUE = 831
+
+# The corrected workflow, produced and validated alongside the diagnosis.
+LOCAL_FILE = (
+    Path("C:/Users/mcwiz/Projects/Aletheia/data/scratch-20260809-backlog/ci.yml.fixed")
+)
+
+PR_TITLE = (
+    "fix(ci): propagate pytest's real exit code so a failing suite fails "
+    f"the check (Closes #{ISSUE})"
+)
+
+PR_BODY = f"""Closes #{ISSUE}
+
+## The defect
+
+`.github/workflows/ci.yml` pipes pytest into `tee`, so the step exits with
+**`tee`'s** status rather than pytest's. GitHub Actions runs `bash -e` but not
+`pipefail`, and nothing afterwards inspects the real code — the follow-up logic
+verifies only that tests were *collected*, never that they *passed*.
+
+The `test` job therefore reported success whenever pytest collected at least one
+test, including when tests failed.
+
+## Proof
+
+PR #805, CI run `31337211982`:
+
+```
+tests/compliance/test_index_consistency.py::TestIndexConsistency::test_audit_index_complete FAILED
+```
+
+`gh pr checks 805` for that same run reported `test  pass`. A failing test and a
+passing check, from one run.
+
+The pipe was introduced in `5789741` (2026-01-10), so this check has been able
+to certify a red suite for roughly seven months. It is also why the fleet
+dependabot tool and CI disagreed: the tool calls pytest directly, saw exit 1,
+and was correct.
+
+## The change
+
+Capture and propagate the real status, matching the `integration-tests` step in
+the same file which already does this:
+
+```yaml
+EXIT_CODE=${{PIPESTATUS[0]}}
+...
+exit $EXIT_CODE
+```
+
+The collection check is kept — it guards a genuinely different failure (a green
+run that silently collected nothing).
+
+## Blast radius
+
+**Expect red.** This surfaces whatever the check has been hiding. That is the
+intent and should not be suppressed. The known audit-index failure is already
+repaired on main, so the tree may be clean, but that is unverified until this
+runs.
+
+Risk of not landing it: the `test` check keeps certifying suites it has not
+verified.
+
+## Rollback
+
+`git revert` on the workflow file.
+
+## Landing note
+
+Landed via the GitHub Contents API using the in-process classic-PAT pattern
+(AssemblyZero ADR-0216) — the agent PAT deliberately lacks `workflow` scope, so
+this path is a human checkpoint by design.
+"""
+
+
+def _gh_headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_file(path: str, pat: str, ref: str = "main") -> dict[str, Any]:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{path}",
+        params={"ref": ref},
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def get_branch_head(branch: str, pat: str) -> str:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{branch}",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["object"]["sha"]
+
+
+def branch_exists(branch: str, pat: str) -> bool:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs/heads/{branch}",
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    return r.status_code == 200
+
+
+def create_branch(branch: str, source_sha: str, pat: str) -> None:
+    r = requests.post(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/git/refs",
+        headers=_gh_headers(pat),
+        json={"ref": f"refs/heads/{branch}", "sha": source_sha},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+
+
+def put_file(
+    path: str, content: bytes, file_sha: str, message: str, branch: str, pat: str
+) -> None:
+    r = requests.put(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/contents/{path}",
+        headers=_gh_headers(pat),
+        json={
+            "message": message,
+            "content": base64.b64encode(content).decode("ascii"),
+            "sha": file_sha,
+            "branch": branch,
+        },
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+
+
+def find_open_pr(branch: str, pat: str) -> int | None:
+    r = requests.get(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+        params={"head": f"{GITHUB_USER}:{branch}", "state": "open"},
+        headers=_gh_headers(pat),
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    prs = r.json()
+    return prs[0]["number"] if prs else None
+
+
+def create_pr(head: str, base: str, title: str, body: str, pat: str) -> int:
+    r = requests.post(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls",
+        headers=_gh_headers(pat),
+        json={"title": title, "head": head, "base": base, "body": body},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["number"]
+
+
+def wait_for_mergeable(pr_number: int, pat: str, timeout_s: int = 900) -> str:
+    """Poll until the PR is mergeable.
+
+    Accepts `unstable` as well as `clean`. This change makes a previously
+    always-green check capable of failing, so the very PR that introduces it can
+    legitimately sit at `unstable` — strict-clean polling would wait forever on
+    the check it is fixing. `gh pr merge --squash` succeeds in both states.
+
+    `dirty` means a merge conflict and is returned immediately.
+    """
+    deadline = time.time() + timeout_s
+    state = "unknown"
+    while time.time() < deadline:
+        r = requests.get(
+            f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr_number}",
+            headers=_gh_headers(pat),
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        state = r.json().get("mergeable_state") or "unknown"
+        print(f"  mergeable_state: {state}")
+        if state in ("clean", "unstable", "dirty"):
+            return state
+        time.sleep(15)
+    return state
+
+
+def merge_pr(pr_number: int, pat: str) -> str:
+    r = requests.put(
+        f"{GH_API}/repos/{GITHUB_USER}/{REPO}/pulls/{pr_number}/merge",
+        headers=_gh_headers(pat),
+        json={"merge_method": "squash"},
+        timeout=HTTP_TIMEOUT_S,
+    )
+    r.raise_for_status()
+    return r.json()["sha"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the write. Without it, the run is read-only.",
+    )
+    args = parser.parse_args()
+
+    if not LOCAL_FILE.exists():
+        print(f"ERROR: replacement file not found: {LOCAL_FILE}")
+        return 1
+
+    # CRLF normalize. The working tree is Windows-checked-out, and the Contents
+    # API stores bytes verbatim — without this the whole file's line endings
+    # flip on origin and the diff becomes unreadable.
+    content = LOCAL_FILE.read_bytes().replace(b"\r\n", b"\n")
+
+    reason = f"land the CI workflow exit-code fix in {GITHUB_USER}/{REPO}"
+
+    with classic_pat_session(reason=reason) as pat:
+        remote = get_file(WORKFLOW_PATH, pat)
+        remote_bytes = base64.b64decode(remote["content"])
+
+        if remote_bytes == content:
+            print("Remote already matches the replacement. Nothing to do.")
+            return 0
+
+        print(f"=== diff: origin/main {WORKFLOW_PATH} -> replacement ===")
+        diff = difflib.unified_diff(
+            remote_bytes.decode("utf-8").splitlines(),
+            content.decode("utf-8").splitlines(),
+            fromfile="origin/main",
+            tofile="replacement",
+            lineterm="",
+        )
+        for line in diff:
+            print(line)
+
+        if not args.apply:
+            print("\nDRY RUN — no write performed. Re-run with --apply to land.")
+            return 0
+
+        if branch_exists(BRANCH, pat):
+            print(f"Branch {BRANCH} already exists; reusing it.")
+        else:
+            head = get_branch_head("main", pat)
+            create_branch(BRANCH, head, pat)
+            print(f"Created branch {BRANCH} from main@{head[:7]}")
+
+        # Re-read the file's sha ON THE BRANCH; on a reused branch it differs
+        # from main's and a stale sha is rejected.
+        branch_file = get_file(WORKFLOW_PATH, pat, ref=BRANCH)
+        put_file(
+            WORKFLOW_PATH,
+            content,
+            branch_file["sha"],
+            f"fix(ci): propagate pytest's real exit code (Closes #{ISSUE})",
+            BRANCH,
+            pat,
+        )
+        print("Committed the workflow change to the branch.")
+
+        pr_number = find_open_pr(BRANCH, pat)
+        if pr_number:
+            print(f"Reusing existing PR #{pr_number}")
+        else:
+            pr_number = create_pr(BRANCH, "main", PR_TITLE, PR_BODY, pat)
+            print(f"Opened PR #{pr_number}")
+
+        print("Waiting for the PR to become mergeable...")
+        state = wait_for_mergeable(pr_number, pat)
+
+        if state == "dirty":
+            print("PR has a merge conflict. Resolve it, then re-run.")
+            return 1
+        if state not in ("clean", "unstable"):
+            print(f"PR did not become mergeable (state={state}). Not merging.")
+            return 1
+
+        sha = merge_pr(pr_number, pat)
+        print(f"Merged PR #{pr_number} as {sha[:7]}")
+
+    print(
+        "\nDone. Next CI run will report pytest's real status.\n"
+        "Expect red if anything was failing behind the old check — that is the point."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/widen_boostgauge_auto_reviewer_trigger.py
+++ b/tools/widen_boostgauge_auto_reviewer_trigger.py
@@ -1,0 +1,187 @@
+"""One-shot: make boostgauge's Auto Review run on speedrun branches.
+
+Closes boostgauge#90.
+
+The problem: .github/workflows/auto-reviewer.yml only triggers on pull
+requests that target main. Every speedrun PR targets a speedrun-attempt-*
+branch, so the automated review never runs during a recorded take.
+
+The fix: widen the trigger to include speedrun-attempt-* and
+hardening-run-* branches.
+
+Why this script exists: the everyday fine-grained token is not allowed to
+edit workflow files. This script uses the gpg-encrypted classic token via
+_pat_session (ADR-0216) — decrypted only inside this process — and lands
+the change the normal way: branch -> pull request -> automatic review ->
+squash merge. No branch protection is touched, nothing is forced.
+
+Run it yourself (the agent must not):
+
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/widen_boostgauge_auto_reviewer_trigger.py            # dry run
+    poetry run python tools/widen_boostgauge_auto_reviewer_trigger.py --apply    # do it
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GH_API = "https://api.github.com"
+OWNER = "martymcenroe"
+REPO = "boostgauge"
+FILE_PATH = ".github/workflows/auto-reviewer.yml"
+OLD_LINE = "    branches: [main]"
+NEW_LINE = "    branches: [main, 'speedrun-attempt-*', 'hardening-run-*']"
+WORK_BRANCH = "90-widen-auto-reviewer-trigger"
+PR_TITLE = "ci: run Auto Review on speedrun branches too (Closes #90)"
+PR_BODY = (
+    "Closes #90\n\n"
+    "Auto Review only fired on PRs targeting main. Speedrun PRs target "
+    "speedrun-attempt-* branches, so the automated review never ran during "
+    "a recorded take. This widens the trigger to those branches (plus "
+    "hardening-run-* for off-camera hardening runs).\n\n"
+    "Landed via the classic-token one-shot pattern (ADR-0216) because the "
+    "everyday token cannot edit workflow files.\n\n"
+    "\U0001F916 Generated with Claude Code"
+)
+HTTP_TIMEOUT_S = 30
+POLL_INTERVAL_S = 10
+MERGE_TIMEOUT_S = 300
+
+
+def _headers(pat: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {pat}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually land the change (default: dry run, no writes)",
+    )
+    args = parser.parse_args()
+
+    with classic_pat_session() as pat:
+        # 1. Fetch the current workflow file from main.
+        r = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+            params={"ref": "main"},
+            headers=_headers(pat),
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        info = r.json()
+        raw = base64.b64decode(info["content"])
+        # Contents API stores bytes verbatim — normalize Windows line
+        # endings so the diff is one line, not the whole file.
+        text = raw.replace(b"\r\n", b"\n").decode("utf-8")
+
+        if NEW_LINE in text:
+            print("Already widened — nothing to do.")
+            return 0
+        if text.count(OLD_LINE) != 1:
+            print(f"ERROR: expected exactly one '{OLD_LINE.strip()}' line; "
+                  f"found {text.count(OLD_LINE)}. Refusing to guess.")
+            return 1
+
+        new_text = text.replace(OLD_LINE, NEW_LINE, 1)
+
+        print(f"File:   {FILE_PATH} @ main (sha {info['sha'][:9]})")
+        print(f"Change: {OLD_LINE.strip()}")
+        print(f"     -> {NEW_LINE.strip()}")
+
+        if not args.apply:
+            print("\nDry run. Re-run with --apply to land it.")
+            return 0
+
+        # 2. Branch from main.
+        r = requests.get(
+            f"{GH_API}/repos/{OWNER}/{REPO}/git/refs/heads/main",
+            headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        main_sha = r.json()["object"]["sha"]
+        r = requests.post(
+            f"{GH_API}/repos/{OWNER}/{REPO}/git/refs",
+            headers=_headers(pat),
+            json={"ref": f"refs/heads/{WORK_BRANCH}", "sha": main_sha},
+            timeout=HTTP_TIMEOUT_S,
+        )
+        if r.status_code == 422 and "already exists" in r.text:
+            print(f"Branch {WORK_BRANCH} already exists — reusing.")
+        else:
+            r.raise_for_status()
+
+        # 3. Put the updated file on the branch.
+        r = requests.put(
+            f"{GH_API}/repos/{OWNER}/{REPO}/contents/{FILE_PATH}",
+            headers=_headers(pat),
+            json={
+                "message": PR_TITLE,
+                "content": base64.b64encode(new_text.encode("utf-8")).decode("ascii"),
+                "sha": info["sha"],
+                "branch": WORK_BRANCH,
+            },
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        print(f"Committed to {WORK_BRANCH}.")
+
+        # 4. Open the pull request.
+        r = requests.post(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls",
+            headers=_headers(pat),
+            json={"title": PR_TITLE, "head": WORK_BRANCH,
+                  "base": "main", "body": PR_BODY},
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        pr_number = r.json()["number"]
+        print(f"PR #{pr_number} opened. Waiting for checks + automatic review...")
+
+        # 5. Wait until mergeable, then squash-merge.
+        deadline = time.time() + MERGE_TIMEOUT_S
+        state = "unknown"
+        while time.time() < deadline:
+            r = requests.get(
+                f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{pr_number}",
+                headers=_headers(pat), timeout=HTTP_TIMEOUT_S,
+            )
+            r.raise_for_status()
+            state = r.json().get("mergeable_state", "unknown")
+            print(f"  state: {state}")
+            if state in ("clean", "unstable"):
+                break
+            time.sleep(POLL_INTERVAL_S)
+        else:
+            print(f"Timed out waiting (last state: {state}). "
+                  f"PR #{pr_number} is open — finish it manually.")
+            return 1
+
+        r = requests.put(
+            f"{GH_API}/repos/{OWNER}/{REPO}/pulls/{pr_number}/merge",
+            headers=_headers(pat),
+            json={"merge_method": "squash"},
+            timeout=HTTP_TIMEOUT_S,
+        )
+        r.raise_for_status()
+        print(f"Merged: {r.json().get('sha', '')[:9]}  (PR #{pr_number}, closes #90)")
+        print("Done. Next: re-point the speedrun start tag (see boostgauge #88).")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2442

Eight untracked scripts had been sitting loose in `tools/` — the state a `stash -u` nearly destroyed once. The files being loose is the cause; the stash rules are the bandage.

## Commit, not delete

They are the ADR-0216 pattern: the agent writes the script, the operator runs it, because a fine-grained PAT cannot push a workflow file. The same class is already tracked here — `land_windows_ci_job.py` sits in `tools/` for exactly this reason — so these belong in the repo rather than in the bin. Each is also the record of *how* a change was landed when `git push` could not do it, which is the part worth keeping after the change itself is history.

## Four land here; four cannot

Four of the eight target **private** repositories. AssemblyZero is public, so committing them would write a private repo's name onto a public surface — and their filenames alone carry the names, so there is no version of the commit that avoids it. They are parked in a gitignored directory and tracked in **#2467**, not deleted: they are the same class of work product and equally worth keeping, they just need a home in the repo each targets.

Membrane checked by query rather than by memory, before anything was staged:

```
AssemblyZero: PUBLIC   Aletheia: PUBLIC   boostgauge: PUBLIC
```

and the two private ones, which this body does not name. The four committed files were then grepped for private repo names; the only hits were `workflow_dispatch`, a GitHub Actions trigger.

## The four, and where their work stands

| Script | Target | State |
|---|---|---|
| `land_aletheia_775.py` | Aletheia#775 | landed, issue closed |
| `land_aletheia_ci_oidc.py` | Aletheia#773 | landed, issue closed |
| `land_aletheia_ci_pipestatus.py` | Aletheia#831 | **still open** — not yet run, so still needed |
| `widen_boostgauge_auto_reviewer_trigger.py` | boostgauge#90 | landed, issue closed |

The pipestatus one is the argument against deleting on sight: it looks like spent scaffolding and is actually pending work.

`ruff` clean on all four. No behaviour change in this repo — nothing imports them.
