### PR TITLE
fix: stop sending the operator to a file the agy migration retired (Closes #2441)

### DIFF
--- a/assemblyzero/core/config.py
+++ b/assemblyzero/core/config.py
@@ -40,12 +40,24 @@ CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-6")
 # =============================================================================
 
 CREDENTIALS_FILE = Path.home() / ".assemblyzero" / "gemini-credentials.json"
+
+#: State for the API-key credential rotation that the agy migration retired
+#: (#1595/#1605). Nothing in the pipeline's transport writes it any more, so on
+#: a current machine it is stale or absent. It survives because `GeminiClient`
+#: and `preflight` still read it, and a file that is absent reads as "nothing
+#: exhausted", which is the harmless answer.
+#:
+#: Do NOT reintroduce it into operator-facing text (#2441). Two messages used to
+#: send a human here for quota reset times at the moment something had already
+#: failed; under the subscription transport there are no credentials to rotate
+#: and no per-key reset to look up.
 ROTATION_STATE_FILE = Path.home() / ".assemblyzero" / "gemini-rotation-state.json"
 GEMINI_API_LOG_FILE = Path.home() / ".assemblyzero" / "gemini-api.jsonl"
 
-# Issue #1883: cross-provider capacity state. Gemini's exhaustion already
-# lives in ROTATION_STATE_FILE; Claude's was detected and then forgotten, so
-# a run could start with Claude dry and burn Gemini quota finding out.
+# Issue #1883: cross-provider capacity state. Gemini's exhaustion state lives in
+# ROTATION_STATE_FILE (above, and retired with the API-key path); Claude's was
+# detected and then forgotten, so a run could start with Claude dry and burn
+# Gemini quota finding out.
 CAPACITY_STATE_FILE = Path.home() / ".assemblyzero" / "provider-capacity.json"
 
 # =============================================================================

--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -1,12 +1,20 @@
-"""Custom Gemini client with credential rotation and model enforcement.
+"""The governance model's transport, plus the retired rotation client (#2441).
 
-This module encapsulates ALL Gemini API interaction for LLD reviews,
-ensuring:
-1. Model hierarchy enforcement - Never downgrades from Pro
-2. Credential rotation - Automatic failover on quota exhaustion
-3. Differentiated error handling - 529 vs 429 vs other errors
+What this module does TODAY: it invokes the governance model through the
+Antigravity CLI (`agy`), the subscription transport that replaced the retired
+Gemini CLI (#1335, ADR 0220). `_invoke_via_stdin` is that path -- prompt on
+stdin, plain pipes, output stripped of the pseudo-console's control sequences.
+Model hierarchy is still enforced: a model on `FORBIDDEN_MODELS` is refused
+rather than silently downgraded.
 
-Ported from tools/gemini-rotate.py for programmatic use.
+What is still here but no longer drives anything: `GeminiClient`, the API-key
+rotation client ported from `tools/gemini-rotate.py`. It rotates credentials on
+quota exhaustion and reads a rotation-state file, both of which belong to the
+paid-API path the agy migration retired (#1595/#1605). It is left in place
+rather than deleted here because #2441 is scoped to the operator-facing residue
+it left behind -- messages that sent a human to a file that no longer exists.
+Read anything about "credential rotation" below as describing that client, not
+the transport the pipeline uses.
 """
 
 import json
@@ -151,7 +159,14 @@ class CredentialPoolExhaustedException(Exception):
         """Generate a user-friendly message about when to resume."""
         if self.earliest_reset:
             return f"Earliest quota reset: {self.earliest_reset}"
-        return "Check ~/.assemblyzero/gemini-rotation-state.json for reset times"
+        # #2441: the fallback used to name the rotation-state file, which the
+        # agy migration retired along with the credentials it tracked. With no
+        # reset timestamp to report, say so rather than send the reader to a
+        # file that is stale or absent.
+        return (
+            "No reset time was reported; wait for the subscription limit to "
+            "reset, or review on the other provider"
+        )
 
 
 @dataclass

--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -202,9 +202,19 @@ def _build_recommendation(
             "Wait 15 minutes and retry, or try --reviewer claude:opus."
         )
     elif error_type == "quota_exhausted":
+        # #2441: this used to send the operator to
+        # ~/.assemblyzero/gemini-rotation-state.json for reset times. That file
+        # belonged to the API-key rotation retired in the agy migration
+        # (#1595/#1605), so it is stale or absent -- and this sentence is read
+        # at the moment something has already failed, which is the worst
+        # moment to be sent somewhere useless. The governance model now runs on
+        # the subscription CLI, where there are no credentials to rotate and no
+        # per-key reset to look up: the limit is the subscription's own, and
+        # the two things that actually help are waiting for it or reviewing on
+        # the other provider.
         return (
-            "Transient error: All Gemini credentials are quota-exhausted. "
-            "Check ~/.assemblyzero/gemini-rotation-state.json for reset times."
+            "Transient error: the Gemini subscription is out of quota. "
+            "Wait for its limit to reset, or rerun with --reviewer claude:opus."
         )
     elif error_type == "stagnation":
         # #2321: this is the pipeline's last word before a human picks the run

--- a/tests/unit/test_no_retired_rotation_advice.py
+++ b/tests/unit/test_no_retired_rotation_advice.py
@@ -1,0 +1,70 @@
+"""No operator-facing message sends a human to the retired rotation file (#2441).
+
+The rotation-state file belonged to the API-key credential rotation that the
+agy migration retired (#1595/#1605), so on a current machine it is stale or
+absent. Two messages still named it, and both are read at the moment something
+has already failed -- the worst moment to be sent somewhere useless.
+
+These tests cover the MESSAGES, not the constant. `ROTATION_STATE_FILE` itself
+survives because `GeminiClient` and `preflight` still read it, and a file that
+is absent reads as "nothing exhausted", which is the harmless answer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.core.gemini_client import CredentialPoolExhaustedException
+from assemblyzero.core.recovery_plan import _build_recommendation
+
+#: Every branch of the recommendation, plus an unknown type for the else.
+ERROR_TYPES = [
+    "capacity_exhausted",
+    "quota_exhausted",
+    "stagnation",
+    "budget",
+    "auth",
+    "requirements_conflict",
+    "something_nobody_has_classified_yet",
+]
+
+#: The dead file, in the spellings a message could plausibly use.
+DEAD_REFERENCES = ("rotation-state", "rotation_state", "gemini-rotation")
+
+
+@pytest.mark.parametrize("error_type", ERROR_TYPES)
+def test_no_recommendation_names_the_retired_rotation_file(error_type):
+    advice = _build_recommendation(error_type, "some error", "requirements")
+    lowered = advice.lower()
+    for dead in DEAD_REFERENCES:
+        assert dead not in lowered, (
+            f"{error_type} advice sends the operator to a file the agy "
+            f"migration retired: {advice!r}"
+        )
+
+
+def test_the_quota_advice_names_something_the_operator_can_do():
+    """Naming no file is necessary but not sufficient -- the replacement has to
+    be actionable under the transport that actually runs."""
+    advice = _build_recommendation("quota_exhausted", "429", "requirements")
+    assert "--reviewer claude:opus" in advice, (
+        "the reviewer swap is the one action that works while the "
+        "subscription is out of quota"
+    )
+    assert "credentials are quota-exhausted" not in advice, (
+        "there are no credentials to rotate under the subscription transport"
+    )
+
+
+def test_the_resume_message_reports_a_reset_when_one_is_known():
+    exc = CredentialPoolExhaustedException("dry", earliest_reset="2026-08-16T18:00:00Z")
+    assert "2026-08-16T18:00:00Z" in exc.get_resume_message()
+
+
+def test_the_resume_message_fallback_names_no_retired_file():
+    exc = CredentialPoolExhaustedException("dry")
+    message = exc.get_resume_message().lower()
+    for dead in DEAD_REFERENCES:
+        assert dead not in message, (
+            f"the no-reset-known fallback still names the retired file: {message!r}"
+        )
+    assert message.strip(), "saying nothing is not an improvement on saying the wrong thing"


### PR DESCRIPTION
Closes #2441

Two operator-facing messages sent a human to `~/.assemblyzero/gemini-rotation-state.json` for quota reset times. That file belonged to the API-key credential rotation retired in the agy migration (#1595/#1605), so on a current machine it is stale or absent.

Both messages are read at the moment something has already failed, which is the worst possible moment to be sent somewhere useless — and the roll's drafter IS the governance model, so this fires precisely during roll diagnosis.

## What changed

**`recovery_plan.py` — the one that is not cosmetic.** The quota advice now names what actually helps under the subscription transport: wait for the limit to reset, or rerun with `--reviewer claude:opus`. It no longer says "all Gemini credentials are quota-exhausted" either, because there are no credentials to rotate.

**`gemini_client.py` resume-message fallback.** With no reset timestamp to report it now says so, instead of pointing at the file.

**`gemini_client.py` module docstring.** It described only credential rotation and model enforcement — the half that no longer runs. It now leads with what the module does today: invoke the governance model through the Antigravity CLI (`agy`), the subscription transport per ADR 0220, with `FORBIDDEN_MODELS` still enforced. `GeminiClient` is named as the retired half so the next reader is not misled by the rotation vocabulary further down.

**`config.py` — `ROTATION_STATE_FILE` stays, with its purpose stated where it is defined.** The issue's acceptance allows either. Removing it is not the smaller change: `GeminiClient` and `preflight` both still read it, in four places. An absent file reads as "nothing exhausted", which is the harmless answer, so the constant is inert rather than wrong. The comment says that, and says not to reintroduce it into operator-facing text.

## Scope, held deliberately

This does not delete `GeminiClient`. That is a larger question about an orphaned paid-API path and it has a neighbour on the board already; folding it in here would bury a one-line operator-facing repair inside a subsystem removal.

## Tests

Ten in `tests/unit/test_no_retired_rotation_advice.py`, pinning the **messages** rather than the constant — every branch of `_build_recommendation` plus an unclassified type, and both paths of the resume message. The quota case additionally asserts the replacement is actionable, because naming no file is necessary and not sufficient. The empty-string case is asserted too: saying nothing is not an improvement on saying the wrong thing.

115 tests pass across the adjacent suites (`gemini_client`, `gemini_client_capacity`, `preflight`, `halt_node`, `orchestrator_stages`, `recovery_plan`).

## Lint

`ruff` reports two errors in these files — `os` imported but unused in `gemini_client.py`, and an f-string without placeholders in `recovery_plan.py`. Both are on `origin/main` untouched by this branch; verified by linting the two files as they exist on main. They are #2433 and get their own change.
