### PR TITLE
fix: N0c halts when it cannot run instead of drafting unchecked (Closes #2474)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -57,6 +57,14 @@ def classify_error(error_message: str) -> str:
     # situation. The fix is an operator ruling on the issue text.
     if "requirements conflict" in msg_lower:
         return "requirements_conflict"
+    # #2474: the gate could not RUN. Checked before the capacity and auth
+    # patterns below because the reason text quotes the transport failure
+    # verbatim ("All credentials failed ... 503/529"), and classifying on that
+    # would produce "wait 15 minutes and retry the run" — advice that skips the
+    # part the operator has to know, which is that requirements were never
+    # checked. Transient or not is the second question here, not the first.
+    if "requirements unverified" in msg_lower:
+        return "requirements_unverified"
     # #1939: 'stagnant' is what the live guards actually print
     # ("[STAGNANT] Coverage stagnant: 87.0% -> 86.0%") — the old
     # 'stagnation'-only pattern never matched a real halt message.

--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -257,6 +257,20 @@ def _build_recommendation(
             "Non-transient: Authentication failed. "
             "Check your Gemini credentials in ~/.assemblyzero/gemini-credentials.json."
         )
+    elif error_type == "requirements_unverified":
+        # #2474: deliberately not filed as transient even though the usual
+        # cause is. A transient classification tells the launcher it may retry
+        # on its own, and the point of this halt is that a human learns the
+        # requirements were never checked before anything spends again.
+        return (
+            "Non-transient: the requirements gate never reached a verdict, so "
+            "NOTHING about the issue text was checked -- this is not a clean "
+            "check and not a conflict (#2474). The usual cause is a transient "
+            "capacity storm, and the gate already waited it out across its "
+            "backoff and still got nothing. Re-run the gate on its own with "
+            "tools/check_requirements.py --repo <repo> --issue <N>; relaunch "
+            "the roll only once that returns a verdict."
+        )
     elif error_type == "requirements_conflict":
         return (
             "Non-transient: the ISSUE's requirements contradict each other — "

--- a/assemblyzero/workflows/requirements/atlas.py
+++ b/assemblyzero/workflows/requirements/atlas.py
@@ -62,11 +62,17 @@ ATLAS: dict[str, dict] = {
             "No spec can satisfy two contradictory sentences, so a conflict "
             "halts the run and files a question for the operator instead of "
             "drafting the wrong reading. A halt here is the system working: "
-            "the cheapest possible failure, before generation."
+            "the cheapest possible failure, before generation. The gate also "
+            "halts when it could not RUN — an unreachable governance model "
+            "stops the run rather than letting it draft against requirements "
+            "nobody checked (#2474)."
         ),
         "successors": {
             "N1_generate_draft": "the requirements are consistent",
-            "HALT": "a requirements conflict needs an operator ruling",
+            "HALT": (
+                "a requirements conflict needs an operator ruling, or the "
+                "gate reached no verdict and the run must not draft unchecked"
+            ),
         },
     },
     "N1_generate_draft": {

--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -107,12 +107,26 @@ HALT = "HALT"
 def route_after_analyze_requirements(
     state: RequirementsWorkflowState,
 ) -> Literal["N1_generate_draft", "HALT"]:
-    """Route after the requirements-ambiguity gate (Issue #1899).
+    """Route after the requirements-ambiguity gate (Issue #1899, #2474).
 
     A REQUIREMENTS CONFLICT halts before any generation spends tokens —
     no spec can satisfy contradictory criteria, so the ISSUE needs an
-    operator ruling, not a roll. Anything else proceeds to drafting.
+    operator ruling, not a roll.
+
+    #2474: a gate that could not REACH a verdict halts too. The node used to
+    return the same empty dict for "checked, and clean" and "could not check",
+    so both arrived here as the same event and both proceeded to drafting —
+    the run then spent drafter budget with the pipeline's highest-value gate
+    skipped. ``requirements_unverified`` is the distinction the node now
+    carries, and this is the edge that acts on it.
+
+    The check is explicit rather than leaning on ``error_message`` being set
+    alongside it. The two keys mean different things, and a halt that depends
+    on a second field happening to be populated is the same implicit coupling
+    that produced the defect.
     """
+    if state.get("requirements_unverified"):
+        return "HALT"
     if state.get("error_message"):
         return "HALT"
     return "N1_generate_draft"

--- a/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_requirements.py
@@ -24,24 +24,61 @@ emerge mid-pipeline (#1900), so both classify as ``requirements_conflict``
 (non-transient: no retry fixes an ambiguous requirement, the ISSUE needs
 an operator ruling).
 
-Fail-open by design: this gate is protective, not load-bearing. If the
-analysis call itself fails (provider storm, parse noise), the workflow
-proceeds to drafting with a printed warning rather than dying in a
-pre-flight check.
+Fails CLOSED when it cannot reach a verdict (#2474, operator ruling
+2026-08-16). It was fail-open from #1899 through #2290 on the reasoning
+that a provider storm must not brick a launch. Measured against what that
+bought: on boostgauge #331 the governance model was unreachable, the node
+printed ``proceeding``, and the run went on to spend drafter budget with
+the highest-value-per-dollar gate in the pipeline skipped. A storm that
+bricks a launch is cheaper than a launch that drafts against unverified
+requirements, so an unreachable gate is now a halt condition.
 
-Failing open is not the same as failing silently (#2290). Every path that
-proceeds without a verdict records that fact where the roll's verdict block
-and the operator summary will print it, because "requirements were not
-checked" and "requirements were checked and were clean" are different roll
-outcomes that used to look identical from the outside.
+The halt is preceded by a backoff (``GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS``)
+because the observed outage cleared within minutes -- halting on the first
+storm would be brittle in the other direction.
+
+Three outcomes, three destinations. The graph declares two successors for
+this node, and until #2474 the node returned ``{}`` for BOTH "checked, and
+clean" and "could not check" -- LangGraph routes on the return value, so
+those collapsed onto the same edge and the distinction died inside the node
+before routing ever saw it. Now:
+
+- verified consistent      -> ``{}``                         -> drafting
+- conflict found           -> ``error_message``              -> HALT
+- no verdict reached       -> ``requirements_unverified``    -> HALT
+
+The remaining fail-open path is the one from #2462, where the model answers
+but every conflict it reports lacks a divergence condition. That is a
+deliberate decision on record, not an oversight: halting there would stop
+the roll on a finding the check itself could not state. It still records the
+unverified state, so the end-of-run banner still fires for it.
+
+Failing open is not the same as failing silently (#2290). The fail-open path
+that survives records that fact where the roll's verdict block and the
+operator summary will print it, because "requirements were not checked" and
+"requirements were checked and were clean" are different roll outcomes that
+used to look identical from the outside. The paths that now HALT deliberately
+do NOT write that record: the banner says the run "proceeded anyway", which is
+false of a halted run, and the halt's own message and recovery plan are the
+report.
 """
 
 from __future__ import annotations
 
 import json
+import time
 from typing import Any
 
 REQUIREMENTS_CONFLICT_MARKER = "REQUIREMENTS CONFLICT:"
+
+#: Prefix on the halt message when the gate could not reach a verdict (#2474).
+#:
+#: Deliberately NOT the conflict marker. "The requirements contradict each
+#: other" and "I could not check the requirements" call for opposite operator
+#: responses -- one needs a ruling on the issue text, the other needs a re-run --
+#: and sharing a marker is the same collapse at the reporting layer that #2474
+#: fixed at the routing layer.
+REQUIREMENTS_UNVERIFIED_MARKER = "REQUIREMENTS UNVERIFIED:"
 
 #: Wall-clock budget for the single analysis call.
 #:
@@ -79,6 +116,35 @@ REQUIREMENTS_GATE_TIMEOUT_SECONDS = 600
 GATE_DRAFTER_ESCALATION: dict[str, str] = {
     "claude:sonnet": "claude:opus",
 }
+
+#: How long to wait between attempts before halting an unreachable gate (#2474).
+#:
+#: One entry per retry, in seconds of sleep BEFORE that attempt. Measured
+#: against boostgauge #331, where the node saw ``All credentials failed ...
+#: riding 503/529 capacity storms`` and the same run logged ``[PREFLIGHT]
+#: Gemini: 4/4 credentials`` minutes later. Capacity came back on its own, so a
+#: halt on the first storm would trade one failure mode for another.
+#:
+#: Two retries spanning four minutes of waiting. The bound matters because each
+#: attempt can itself burn the full ``REQUIREMENTS_GATE_TIMEOUT_SECONDS``, and
+#: this schedule COMPOSES with the #2375 timeout retry above rather than
+#: replacing it. Counted, not estimated:
+#:
+#:   no escalation: 3 calls x 600s + 240s sleep = 2040s (34 min)
+#:   after a #2375 escalation: 4 calls x 600s + 240s sleep = 2640s (44 min)
+#:
+#: That ceiling is bought deliberately. It buys back rolls that would otherwise
+#: halt on a transient storm, it is only reached when EVERY attempt burns its
+#: full budget (a total outage, not the observed case), and it is gate time
+#: rather than drafter spend -- which is the trade #2474 rules on. A run that
+#: cannot get a verdict across four minutes of waiting is in a real outage, and
+#: halting resumably beats waiting longer.
+#:
+#: Unlike the #2375 timeout retry above, this schedule deliberately DOES run
+#: during a provider storm. #2086's objection is to re-asking immediately, which
+#: burns a second budget against the same wall; waiting is the remedy for a
+#: storm rather than an instance of the thing #2086 forbids.
+GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS: tuple[int, ...] = (60, 180)
 
 
 def escalated_drafter(spec: str) -> str | None:
@@ -219,10 +285,13 @@ def _provider_storm_active() -> bool:
 def _record_unverified(state: dict, reason: str) -> None:
     """Record a fail-open so the roll can say so. Never raises (#2290).
 
-    Recorded on EVERY path that proceeds without a verdict, not only on the
-    exhausted retry: an unparseable response and an invalid provider leave the
-    requirements exactly as unchecked as a timeout does, and the operator's
-    question is "were they checked", not "which way did the check fail".
+    Recorded on every path that PROCEEDS without a verdict. Since #2474 that is
+    one path — the #2462 case where the model answered but could not articulate
+    any of the conflicts it reported. The unreachable, unparseable and
+    invalid-provider paths no longer proceed at all, so they no longer record:
+    the banner this feeds says the run "proceeded anyway", which is false of a
+    halted run, and a halt reports itself through its own message and recovery
+    plan.
 
     Not recorded for the standalone pre-check, which is not a roll: it reports
     its own failure with a non-zero exit and its own report, and a record
@@ -249,8 +318,76 @@ def _record_unverified(state: dict, reason: str) -> None:
         print(f"  [N0c] WARNING: could not record the unverified state: {exc}")
 
 
+def _sleep(seconds: float) -> None:
+    """The backoff wait (#2474), as a seam the tests replace.
+
+    A suite that really slept this schedule would pay four minutes per case,
+    which is how a suite stops being run. Patching ``time.sleep`` globally from
+    a test would reach every other sleeper in the process; one named function
+    here is the narrower thing to replace.
+    """
+    time.sleep(seconds)
+
+
+def _verdict_of(result: Any) -> dict | None:
+    """The parsed verdict from one attempt, or None if it did not reach one.
+
+    Collapses "the call failed", "the call returned nothing" and "the call
+    returned something unparseable" into the single question the retry loop
+    asks: is there a verdict yet?
+    """
+    if not getattr(result, "success", False) or not getattr(result, "response", ""):
+        return None
+    return _parse_analysis(result.response)
+
+
+def _no_verdict_reason(result: Any) -> str:
+    """Why this attempt produced no verdict, in the operator's words.
+
+    One function so the backoff loop, the halt message and the log line cannot
+    disagree about which of the two failures happened.
+    """
+    if not getattr(result, "success", False) or not getattr(result, "response", ""):
+        return getattr(result, "error_message", "") or "empty response"
+    return "the analysis response was unparseable"
+
+
+def _halt_unverified(state: dict, answered_by: str, reason: str) -> dict[str, Any]:
+    """Stop the run because the gate could not run (#2474).
+
+    Returns BOTH keys deliberately. ``requirements_unverified`` is what the
+    router and the standalone pre-check read, because it is the only thing that
+    separates this halt from a conflict halt; ``error_message`` is what the HALT
+    node classifies, prints and writes into the recovery plan.
+    """
+    repo = state.get("target_repo") or "<repo>"
+    issue = state.get("issue_number") or "<N>"
+    message = (
+        f"{REQUIREMENTS_UNVERIFIED_MARKER} the consistency gate did not run, so "
+        f"nothing about this issue's requirements was checked. This is NOT a "
+        f"clean requirements check and NOT a conflict finding -- the gate never "
+        f"reached a verdict.\n"
+        f"  Gate model: {answered_by}\n"
+        f"  Why: {reason}\n"
+        f"  Attempts: 1 + {len(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS)} retries "
+        f"over {sum(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS)}s of backoff.\n"
+        f"  The run stopped here rather than spend drafter budget against "
+        f"unverified requirements (#2474).\n"
+        f"  Resume: poetry run python tools/check_requirements.py --repo {repo} "
+        f"--issue {issue}\n"
+        f"  Then relaunch the roll once the gate returns a verdict."
+    )
+    print(f"  [N0c] {message}")
+    return {"error_message": message, "requirements_unverified": reason}
+
+
 def analyze_requirements(state: dict) -> dict[str, Any]:
-    """N0c node body. Returns {} to proceed, or error_message to halt."""
+    """N0c node body.
+
+    Returns ``{}`` to proceed, ``error_message`` to halt on a conflict, or
+    ``requirements_unverified`` (plus ``error_message``) to halt because no
+    verdict could be reached (#2474).
+    """
     if state.get("config_mock_mode"):
         return {}
 
@@ -268,9 +405,12 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
     try:
         provider = get_provider(drafter_spec)
     except ValueError as e:
-        print(f"  [N0c] WARNING: analysis skipped (invalid provider: {e})")
-        _record_unverified(state, f"invalid provider '{drafter_spec}': {e}")
-        return {}
+        # #2474: halts immediately, with no backoff. The backoff exists to
+        # outlast a transient outage; a provider spec that does not name a real
+        # provider is not transient and no amount of waiting resolves it.
+        return _halt_unverified(
+            state, drafter_spec, f"invalid provider '{drafter_spec}': {e}"
+        )
 
     content = f"# Issue: {issue_title}\n\n{issue_body}"
 
@@ -325,26 +465,34 @@ def analyze_requirements(state: dict) -> dict[str, Any]:
             )
         result = _invoke(provider)
 
-    # Fail-open: a dead analysis call must not kill the roll (#1899).
-    if not result.success or not result.response:
-        reason = result.error_message or "empty response"
-        # #2375: name the model. "The gate did not answer" and "the gate did
-        # not answer ON SONNET" are different facts, and only the second one
-        # tells the next reader whether escalating is worth trying.
-        print(
-            f"  [N0c] WARNING: analysis unavailable on {answered_by} "
-            f"({reason}); proceeding."
-        )
-        _record_unverified(
-            state, f"analysis unavailable on {answered_by}: {reason}"
-        )
-        return {}
-
-    parsed = _parse_analysis(result.response)
+    # #2474: no verdict is a halt condition, not a warning -- but not before a
+    # backoff, because the outage that prompted this ruling cleared on its own
+    # within minutes. Unreachable and unparseable share this path because they
+    # are the same fact from the graph's side ("no verdict"), and because both
+    # are plausibly transient: one is the transport, the other is a sample. What
+    # they must NOT share is the verified-clean return value, which is the
+    # collapse #2474 is about.
+    parsed = _verdict_of(result)
     if parsed is None:
-        print("  [N0c] WARNING: analysis response unparseable; proceeding.")
-        _record_unverified(state, "analysis response was unparseable")
-        return {}
+        # #2375: every line below names the model. "The gate did not answer" and
+        # "the gate did not answer ON SONNET" are different facts, and only the
+        # second tells the next reader whether escalating is worth trying.
+        reason = _no_verdict_reason(result)
+        for attempt, delay in enumerate(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS, 1):
+            print(
+                f"  [N0c] no verdict on {answered_by} ({reason}); waiting {delay}s "
+                f"before retry {attempt} of "
+                f"{len(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS)} (#2474)."
+            )
+            _sleep(delay)
+            result = _invoke(provider)
+            parsed = _verdict_of(result)
+            if parsed is not None:
+                print(f"  [N0c] the retry reached a verdict on {answered_by}.")
+                break
+            reason = _no_verdict_reason(result)
+        if parsed is None:
+            return _halt_unverified(state, answered_by, reason)
 
     conflicts = parsed.get("conflicts") or []
     if parsed.get("is_consistent", True) or not conflicts:

--- a/assemblyzero/workflows/requirements/precheck.py
+++ b/assemblyzero/workflows/requirements/precheck.py
@@ -282,8 +282,23 @@ def run_gate(
         ) from exc
 
     output = capture.getvalue()
-    conflict = str((update or {}).get("error_message") or "")
+    update = update or {}
 
+    # #2474: checked BEFORE error_message, which the node now sets on this path
+    # too so the HALT node has something to classify. Reading error_message
+    # first would report "the requirements contradict each other" for a run
+    # where the gate never answered -- the exact conflation #2474 removed from
+    # routing, re-introduced at the reporting layer. `error` is the honest
+    # status: no verdict was reached.
+    unverified = str(update.get("requirements_unverified") or "")
+    if unverified:
+        return PrecheckResult(
+            "error",
+            f"the gate reached no verdict: {unverified}",
+            output,
+        )
+
+    conflict = str(update.get("error_message") or "")
     if conflict:
         return PrecheckResult("conflict", conflict, output)
     if CLEAN_MARKER in output:

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -144,6 +144,11 @@ class RequirementsWorkflowState(TypedDict, total=False):
 
         # Error handling (common)
         error_message: Last error message if any.
+        requirements_unverified: Why N0c reached no verdict, when it reached
+            none (#2474). Set only on the halt path, so its presence — not its
+            value — is what routing keys on. Distinct from error_message
+            because "the requirements contradict each other" and "I could not
+            check the requirements" need opposite operator responses.
 
         # Git commit tracking (Issue #162)
         created_files: List of files created by workflow for commit.
@@ -232,6 +237,11 @@ class RequirementsWorkflowState(TypedDict, total=False):
 
     # Error handling
     error_message: str
+
+    # #2474: N0c could not reach a verdict, so the run halts rather than draft
+    # against unverified requirements. Carries the reason; routing keys on
+    # presence.
+    requirements_unverified: str
 
     # Mechanical validation (Issue #277)
     validation_errors: list[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration for test suite."""
 
+import importlib
 import os
 import sys
 from pathlib import Path
@@ -62,6 +63,32 @@ def _restore_review_test_plan_module():
             sys.modules.pop(key, None)
         else:
             sys.modules[key] = mod
+
+
+@pytest.fixture(autouse=True)
+def gate_backoff_waits(monkeypatch):
+    """Record the N0c backoff waits suite-wide instead of serving them (#2474).
+
+    The requirements gate now waits out a transient outage before halting, on a
+    schedule measured in minutes. Any test that drives the gate to a no-verdict
+    outcome would otherwise pay that schedule in real seconds -- four minutes
+    per case, in a suite whose whole point is being run often. Several such
+    tests already exist in files that know nothing about the backoff, so the
+    seam belongs here rather than in the one file that introduced it.
+
+    Yields the list of waits requested, so a test that cares about the schedule
+    can assert on it without enduring it.
+    """
+    waits: list[float] = []
+    try:
+        module = importlib.import_module(
+            "assemblyzero.workflows.requirements.nodes.analyze_requirements"
+        )
+    except Exception:  # noqa: BLE001 - a test run must not need this module
+        yield waits
+        return
+    monkeypatch.setattr(module, "_sleep", waits.append)
+    yield waits
 
 
 @pytest.fixture

--- a/tests/unit/test_requirements_conflict.py
+++ b/tests/unit/test_requirements_conflict.py
@@ -82,17 +82,23 @@ class TestN0cGate:
             result = analyze_requirements(_state())
         assert result == {}
 
-    def test_failed_analysis_call_fails_open(self):
+    def test_failed_analysis_call_fails_closed(self):
+        """#2474 reversed #1899's fail-open ruling. A gate that could not reach
+        the governance model stops the run instead of letting it draft against
+        requirements nobody checked."""
         provider = _provider_returning(None, success=False, error="503 storm")
         with patch(f"{MODULE}.get_provider", return_value=provider):
             result = analyze_requirements(_state())
-        assert result == {}
+        assert result.get("requirements_unverified"), "must not proceed"
+        assert result != {}, (
+            "returning the clean value here is the collapse #2474 fixed"
+        )
 
-    def test_unparseable_response_fails_open(self):
+    def test_unparseable_response_fails_closed(self):
         provider = _provider_returning("I think it looks fine!")
         with patch(f"{MODULE}.get_provider", return_value=provider):
             result = analyze_requirements(_state())
-        assert result == {}
+        assert "unparseable" in result.get("requirements_unverified", "")
 
     def test_mock_mode_skips_entirely(self):
         with patch(f"{MODULE}.get_provider") as gp:
@@ -165,3 +171,58 @@ class TestSharedClassification:
             classify_error("Capacity exhausted after 3 retries (503/529)")
             == "capacity_exhausted"
         )
+
+
+class TestUnverifiedClassification:
+    """#2474: a gate that could not RUN classifies apart from one that ran and
+    found a contradiction. The two need opposite operator responses."""
+
+    def _message(self, why="All credentials failed: 503/529 capacity storms"):
+        provider = _provider_returning(None, success=False, error=why)
+        with patch(f"{MODULE}.get_provider", return_value=provider):
+            return analyze_requirements(_state())["error_message"]
+
+    def test_the_halt_message_classifies_as_unverified(self):
+        assert classify_error(self._message()) == "requirements_unverified"
+
+    def test_it_does_not_classify_as_a_conflict(self):
+        """Sending the operator to rule on a contradiction in requirements
+        nothing ever read is the collapse #2474 removed."""
+        assert classify_error(self._message()) != "requirements_conflict"
+
+    def test_the_quoted_transport_failure_does_not_capture_it(self):
+        """The reason text quotes the provider verbatim, so it is full of
+        capacity markers. Classifying on those would produce 'wait 15 minutes
+        and retry', which skips the part the operator has to know."""
+        assert classify_error(self._message()) != "capacity_exhausted"
+
+    def test_it_is_not_transient(self):
+        """A transient class tells the launcher it may retry unattended, and
+        the point of this halt is that a human learns the requirements were
+        never checked before anything spends again."""
+        assert "requirements_unverified" not in TRANSIENT_ERROR_TYPES
+
+    def test_the_launcher_does_not_read_it_as_a_conflict(self):
+        """`is_requirements_conflict` is a SUBSTRING test on the halt message,
+        and the launcher exits 93 on it -- stop this issue, never redraw,
+        continue the batch. That is right for a conflict and wrong here: an
+        unverified gate is usually a transient outage that a later attempt
+        clears. A reword of the halt message that let the marker appear in it
+        would silently retire every retry this failure should get.
+        """
+        from assemblyzero.core.exit_codes import is_requirements_conflict
+
+        assert not is_requirements_conflict(self._message())
+
+    def test_the_recovery_plan_names_the_gate_rerun(self):
+        plan = generate_recovery_plan(
+            issue_number=331,
+            workflow="requirements",
+            stage="N0c_analyze_requirements",
+            error_type="requirements_unverified",
+            error_message="REQUIREMENTS UNVERIFIED: ...",
+            state={},
+        )
+        assert plan.is_transient is False
+        assert "check_requirements.py" in plan.recommendation
+        assert "not a clean check" in plan.recommendation.lower()

--- a/tests/unit/test_requirements_gate_escalation.py
+++ b/tests/unit/test_requirements_gate_escalation.py
@@ -171,23 +171,29 @@ class TestTheRetryEscalates:
 
 
 class TestWhatEscalationDoesNotChange:
-    """The retry's preconditions are #2290's and stay #2290's."""
+    """The retry's preconditions are #2290's and stay #2290's.
 
-    def test_a_storm_still_suppresses_the_retry(self, tmp_path, specs, storm):
+    These assert on WHICH MODEL was asked, not on how many calls were made:
+    #2474 added waited retries behind the immediate one, and those reuse the
+    provider already selected. Escalation is about model choice, so model
+    choice is what these pin.
+    """
+
+    def test_a_storm_still_suppresses_escalation(self, tmp_path, specs, storm):
         asked, provider = specs(TIMEOUT, OK)
 
         analyze_requirements(_state(tmp_path, "claude:sonnet"))
 
-        assert asked == ["claude:sonnet"]
-        assert len(provider.calls) == 1, "escalating into a storm is still wrong"
+        assert asked == ["claude:sonnet"], "escalating into a storm is still wrong"
 
-    def test_a_non_timeout_failure_is_still_not_retried(self, tmp_path, specs, calm):
+    def test_a_non_timeout_failure_still_does_not_escalate(
+        self, tmp_path, specs, calm
+    ):
         asked, provider = specs(OTHER_FAILURE, OK)
 
         analyze_requirements(_state(tmp_path, "claude:sonnet"))
 
         assert asked == ["claude:sonnet"]
-        assert len(provider.calls) == 1
 
     def test_a_first_attempt_that_succeeds_never_escalates(
         self, tmp_path, specs, calm
@@ -199,14 +205,23 @@ class TestWhatEscalationDoesNotChange:
         assert asked == ["claude:sonnet"]
         assert len(provider.calls) == 1
 
-    def test_the_gate_still_fails_open_when_both_attempts_die(
+    def test_the_gate_now_halts_when_every_attempt_dies(
         self, tmp_path, specs, calm
     ):
-        """Protective, not load-bearing (#1899). Escalation does not make the
-        gate able to kill a roll."""
+        """#2474 reversed #1899's fail-open ruling; escalation is unaffected.
+
+        Escalation was never what decided whether a dead gate kills a roll --
+        it decides which model the retry asks. What changed is the destination
+        when no model answers: the run stops rather than draft against
+        requirements nobody checked.
+        """
         specs(TIMEOUT, TIMEOUT)
 
-        assert analyze_requirements(_state(tmp_path, "claude:sonnet")) == {}
+        update = analyze_requirements(_state(tmp_path, "claude:sonnet"))
+
+        assert update.get("requirements_unverified"), (
+            "every attempt died, so the run must not proceed to the drafter"
+        )
 
 
 class TestTheVerdictNamesItsDrafter:
@@ -242,9 +257,12 @@ class TestTheVerdictNamesItsDrafter:
     def test_an_unavailable_verdict_names_the_model_that_actually_ran(
         self, tmp_path, specs, calm, capsys
     ):
+        """#2474 turned this warning into a halt message. The model name is
+        still the point: it is what tells the next reader whether escalating
+        further is worth trying."""
         specs(TIMEOUT, TIMEOUT)
         analyze_requirements(_state(tmp_path, "claude:sonnet"))
-        assert "analysis unavailable on claude:opus" in capsys.readouterr().out
+        assert "Gate model: claude:opus" in capsys.readouterr().out
 
 
 class TestTheEscalationMap:

--- a/tests/unit/test_requirements_gate_timeout.py
+++ b/tests/unit/test_requirements_gate_timeout.py
@@ -13,6 +13,7 @@ throughout.
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -31,9 +32,15 @@ from assemblyzero.speedrun.requirements_status import (  # noqa: E402
     unverified_path,
 )
 from assemblyzero.workflows.requirements.nodes.analyze_requirements import (  # noqa: E402
+    GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS,
     REQUIREMENTS_GATE_TIMEOUT_SECONDS,
     analyze_requirements,
 )
+
+#: Attempts before the gate gives up: the first call plus one per backoff entry.
+#: Written as an expression rather than a literal so retuning the schedule
+#: retunes the tests with it (#2474).
+ATTEMPTS_BEFORE_HALT = 1 + len(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS)
 
 #: What the gate's own call actually took on boostgauge #7, wall clock.
 MEASURED_ISSUE_7_SECONDS = 294
@@ -88,6 +95,18 @@ def calm(monkeypatch):
 @pytest.fixture
 def storm(monkeypatch):
     monkeypatch.setattr("assemblyzero.core.provider_storm.is_storm", lambda: True)
+
+
+@pytest.fixture
+def slept(gate_backoff_waits):
+    """The backoff waits this case requested, recorded rather than served.
+
+    The seam itself is autouse in tests/conftest.py, because tests in files
+    that know nothing about the backoff drive the gate to a no-verdict outcome
+    too and would otherwise sleep the real schedule. This is the local name for
+    reading it.
+    """
+    return gate_backoff_waits
 
 
 def _state(tmp_path, **over):
@@ -152,7 +171,7 @@ class TestTheBudget:
 
 class TestTheRetry:
     def test_a_timeout_on_a_healthy_transport_retries_once(
-        self, tmp_path, provider, calm
+        self, tmp_path, provider, calm, slept
     ):
         p = provider(TIMEOUT, OK)
 
@@ -160,31 +179,192 @@ class TestTheRetry:
 
         assert len(p.calls) == 2, "a healthy-transport timeout must be retried once"
         assert result == {}, "the retry succeeded, so the gate proceeds normally"
+        assert slept == [], "the immediate #2375 retry does not wait"
 
-    def test_it_retries_only_once(self, tmp_path, provider, calm):
+    def test_the_immediate_retry_is_still_only_once(self, tmp_path, provider, calm):
+        """#2375's retry is one extra call, not a loop.
+
+        Measured as the difference from the no-immediate-retry cases below:
+        a healthy-transport timeout costs exactly one call more than a failure
+        that never earns the immediate retry.
+        """
         p = provider(TIMEOUT)
 
         analyze_requirements(_state(tmp_path))
 
-        assert len(p.calls) == 2, "one retry, not a loop"
+        assert len(p.calls) == ATTEMPTS_BEFORE_HALT + 1, (
+            "one immediate retry on top of the backoff schedule, not a loop"
+        )
 
-    def test_a_storm_is_not_retried_into(self, tmp_path, provider, storm):
-        """The storm is the condition fail-open exists for. Retrying burns
-        another full budget to reach the same wall (#2086)."""
+    def test_a_storm_is_not_retried_into_immediately(self, tmp_path, provider, storm):
+        """#2086: re-asking during a storm burns a second budget against the
+        same wall, so the IMMEDIATE retry stays suppressed.
+
+        #2474's waited retries are a different thing and deliberately DO run
+        here -- waiting is the remedy for a storm, not an instance of what
+        #2086 forbids. So the storm case costs exactly one call fewer than the
+        calm case above, and that one call is the suppressed immediate retry.
+        """
         p = provider(TIMEOUT)
 
         analyze_requirements(_state(tmp_path))
 
-        assert len(p.calls) == 1
+        assert len(p.calls) == ATTEMPTS_BEFORE_HALT
 
-    def test_a_non_timeout_failure_is_not_retried(self, tmp_path, provider, calm):
+    def test_a_non_timeout_failure_gets_no_immediate_retry(
+        self, tmp_path, provider, calm
+    ):
+        """Unchanged from #2290: an identical IMMEDIATE second call will not
+        change why it failed. #2474's waited retries are what follow."""
         p = provider(OTHER_FAILURE)
 
         analyze_requirements(_state(tmp_path))
 
-        assert len(p.calls) == 1, (
-            "it failed for a reason an identical second call will not change"
+        assert len(p.calls) == ATTEMPTS_BEFORE_HALT
+
+
+# ---------------------------------------------------------------------------
+# Failing closed (#2474)
+# ---------------------------------------------------------------------------
+
+
+class TestItHaltsWhenItCannotRun:
+    """The operator ruling of 2026-08-16.
+
+    Before this, a gate that could not reach the governance model returned the
+    same empty dict as a gate that checked and found the requirements clean.
+    LangGraph routes on the return value, so both went to the drafter and the
+    run kept spending with the pipeline's highest-value gate skipped.
+    """
+
+    def test_an_unreachable_gate_halts_instead_of_proceeding(
+        self, tmp_path, provider, calm
+    ):
+        provider(_result(False, None, "All credentials failed: 503/529 storm"))
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert update.get("requirements_unverified"), (
+            "the run must carry WHY it could not check, not an empty dict"
         )
+        assert "503/529" in update["requirements_unverified"]
+
+    def test_the_halt_is_distinguishable_from_a_clean_check(
+        self, tmp_path, provider, calm
+    ):
+        """The whole defect in one assertion.
+
+        'I checked and it is fine' and 'I could not check' must not be the same
+        value, because the graph has nothing else to route on.
+        """
+        provider(OTHER_FAILURE)
+        unreachable = analyze_requirements(_state(tmp_path))
+
+        provider(OK)
+        clean = analyze_requirements(_state(tmp_path))
+
+        assert clean == {}
+        assert unreachable != clean
+
+    def test_the_halt_is_distinguishable_from_a_conflict(
+        self, tmp_path, provider, calm
+    ):
+        """A conflict needs an operator ruling on the issue text; an
+        unreachable gate needs a re-run. Sharing a signal sends the operator
+        to rewrite requirements that were never read."""
+        provider(OTHER_FAILURE)
+        update = analyze_requirements(_state(tmp_path))
+
+        assert "REQUIREMENTS CONFLICT:" not in update["error_message"]
+        assert "REQUIREMENTS UNVERIFIED:" in update["error_message"]
+
+    def test_an_unparseable_response_halts_too(self, tmp_path, provider, calm):
+        provider(_result(True, "not json at all"))
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert "unparseable" in update.get("requirements_unverified", "")
+
+    def test_an_invalid_provider_halts_without_waiting(
+        self, tmp_path, monkeypatch, slept
+    ):
+        """No backoff outlasts a provider spec that names nothing real."""
+        def _raise(spec, *a, **k):
+            raise ValueError(f"unknown provider: {spec}")
+
+        monkeypatch.setattr(
+            "assemblyzero.core.llm_provider.get_provider", _raise
+        )
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert "invalid provider" in update.get("requirements_unverified", "")
+        assert slept == [], "a bad spec is not transient; waiting cannot fix it"
+
+    def test_it_backs_off_on_the_declared_schedule_before_halting(
+        self, tmp_path, provider, calm, slept
+    ):
+        """The observed outage cleared in minutes, so halting on the first
+        storm would be brittle in the other direction."""
+        p = provider(OTHER_FAILURE)
+
+        analyze_requirements(_state(tmp_path))
+
+        assert slept == list(GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS)
+        assert len(p.calls) == ATTEMPTS_BEFORE_HALT
+
+    def test_a_verdict_on_a_backoff_retry_proceeds_normally(
+        self, tmp_path, provider, calm, slept
+    ):
+        """The point of the backoff: a storm that clears must not cost a halt."""
+        p = provider(OTHER_FAILURE, OK)
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert update == {}, "the retry got a verdict, so the run proceeds"
+        assert len(p.calls) == 2, "it stops retrying the moment it has an answer"
+        assert slept == [GATE_UNAVAILABLE_RETRY_BACKOFF_SECONDS[0]], (
+            "it waits once, not through the whole schedule"
+        )
+
+    def test_a_conflict_still_halts_the_old_way(self, tmp_path, provider, calm):
+        """#1899's halt is untouched: it is a verdict, not a failure to reach
+        one, and it must not acquire the unverified marker."""
+        provider(_result(True, json.dumps({
+            "is_consistent": False,
+            "conflicts": [{
+                "criterion_a": "the floor is the highest value in the window",
+                "criterion_b": "the floor drifts toward the most recent value",
+                "diverging_situation": "when the window max is not the latest sample",
+            }],
+        })))
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert "REQUIREMENTS CONFLICT:" in update["error_message"]
+        assert not update.get("requirements_unverified")
+
+    def test_the_halt_message_says_the_gate_did_not_run(
+        self, tmp_path, provider, calm
+    ):
+        provider(OTHER_FAILURE)
+
+        message = analyze_requirements(_state(tmp_path))["error_message"]
+
+        assert "did not run" in message
+        assert "NOT a clean requirements check" in message
+
+    def test_the_halt_message_carries_the_resume_command(
+        self, tmp_path, provider, calm
+    ):
+        """Read at the moment something has already failed, so the next action
+        has to be in the message rather than in a runbook."""
+        provider(OTHER_FAILURE)
+
+        message = analyze_requirements(_state(tmp_path))["error_message"]
+
+        assert "tools/check_requirements.py" in message
+        assert str(tmp_path) in message and "--issue 7" in message
 
 
 # ---------------------------------------------------------------------------
@@ -193,25 +373,56 @@ class TestTheRetry:
 
 
 class TestItSaysSoWhenItDidNotRun:
-    def test_an_exhausted_retry_records_the_unverified_state(
+    """The ledger behind the end-of-run banner (#2290).
+
+    #2474 narrowed what feeds it. The banner's own sentence is "the run
+    proceeded anyway", so it may only carry paths where the run DID proceed.
+    A halted run is reported by its halt message and recovery plan; writing it
+    here as well would put a false sentence in front of the operator.
+    """
+
+    def test_an_exhausted_retry_records_nothing_because_it_halts(
         self, tmp_path, provider, calm
     ):
         provider(TIMEOUT)
 
-        analyze_requirements(_state(tmp_path))
+        update = analyze_requirements(_state(tmp_path))
 
-        records = read_unverified(tmp_path)
-        assert len(records) == 1
-        assert records[0]["issue"] == 7
-        assert "timed out" in records[0]["reason"]
+        assert update.get("requirements_unverified"), "it halted"
+        assert read_unverified(tmp_path) == [], (
+            "the banner says the run proceeded anyway, which this run did not"
+        )
 
-    def test_an_unparseable_response_records_it_too(self, tmp_path, provider, calm):
+    def test_an_unparseable_response_records_nothing_either(
+        self, tmp_path, provider, calm
+    ):
         provider(_result(True, "not json at all"))
 
-        analyze_requirements(_state(tmp_path))
+        update = analyze_requirements(_state(tmp_path))
 
+        assert update.get("requirements_unverified"), "it halted"
+        assert read_unverified(tmp_path) == []
+
+    def test_the_surviving_fail_open_path_still_records(self, tmp_path, provider, calm):
+        """#2462: the model answered, but every conflict it reported lacked a
+        divergence condition. That path still PROCEEDS -- halting there would
+        stop the roll on a finding the check itself could not state -- so it is
+        exactly the case the banner exists for, and it must keep feeding it.
+        """
+        provider(_result(True, json.dumps({
+            "is_consistent": False,
+            "conflicts": [{
+                "criterion_a": "A",
+                "criterion_b": "B",
+                "diverging_situation": "?",
+            }],
+        })))
+
+        update = analyze_requirements(_state(tmp_path))
+
+        assert update == {}, "this one proceeds, by the decision recorded in #2462"
         records = read_unverified(tmp_path)
-        assert len(records) == 1 and "unparseable" in records[0]["reason"]
+        assert len(records) == 1 and records[0]["issue"] == 7
 
     def test_a_verdict_records_nothing(self, tmp_path, provider, calm):
         provider(OK)
@@ -232,6 +443,21 @@ class TestItSaysSoWhenItDidNotRun:
         precheck.run_gate(tmp_path, 7, "t", "The app shall persist state.")
 
         assert read_unverified(tmp_path) == []
+
+    def test_the_precheck_reports_no_verdict_as_error_not_conflict(
+        self, tmp_path, provider, calm
+    ):
+        """#2474: the node now sets error_message on the unreachable path so
+        the HALT node has something to classify. The pre-check reads
+        requirements_unverified first, or it would tell the operator to rule on
+        a contradiction in requirements nothing ever read."""
+        from assemblyzero.workflows.requirements import precheck
+
+        provider(OTHER_FAILURE)
+        result = precheck.run_gate(tmp_path, 7, "t", "The app shall persist state.")
+
+        assert result.status == "error"
+        assert "no verdict" in result.detail
 
     def test_recording_never_raises(self, tmp_path):
         blocker = tmp_path / "data"

--- a/tests/unit/test_requirements_graph.py
+++ b/tests/unit/test_requirements_graph.py
@@ -180,6 +180,48 @@ class TestGraphRouting:
         assert route_from_human_gate_verdict(state) == "N1_generate_draft"
 
 
+class TestRequirementsGateRouting:
+    """The N0c edge, which is where #2474's defect lived.
+
+    The node has three real outcomes and the graph declared two successors.
+    Until #2474 "checked, and clean" and "could not check" both returned an
+    empty dict, so routing could not tell them apart and both went to the
+    drafter -- the run then spent drafter budget with the pipeline's
+    highest-value-per-dollar gate skipped.
+    """
+
+    def _route(self, state):
+        from assemblyzero.workflows.requirements.graph import (
+            route_after_analyze_requirements,
+        )
+
+        return route_after_analyze_requirements(state)
+
+    def test_a_clean_gate_proceeds_to_drafting(self):
+        assert self._route({}) == "N1_generate_draft"
+
+    def test_a_conflict_halts(self):
+        assert self._route({"error_message": "REQUIREMENTS CONFLICT: ..."}) == "HALT"
+
+    def test_an_unverified_gate_halts(self):
+        assert self._route({"requirements_unverified": "503 storm"}) == "HALT"
+
+    def test_unverified_halts_on_its_own_without_an_error_message(self):
+        """The regression guard.
+
+        The node sets both keys today, so a router keyed only on error_message
+        would pass every other test in this class while the actual distinction
+        went unread. Pinning the marker alone is what makes the halt depend on
+        the fact rather than on a second field happening to be populated.
+        """
+        assert self._route({"requirements_unverified": "503 storm",
+                            "error_message": ""}) == "HALT"
+
+    def test_a_clean_gate_and_an_unverified_gate_route_differently(self):
+        """The whole defect in one assertion."""
+        assert self._route({}) != self._route({"requirements_unverified": "x"})
+
+
 class TestGraphExecution:
     """Tests for full graph execution paths."""
 


### PR DESCRIPTION
## The defect

`workflows/requirements/atlas.py` declares two successors for N0c:

```python
"successors": {
    "N1_generate_draft": "the requirements are consistent",
    "HALT": "a requirements conflict needs an operator ruling",
}
```

Two edges. The node had **three** real outcomes, and `nodes/analyze_requirements.py`
returned an identical empty dict for the non-conflict ones. LangGraph routes on the
return value, so "I checked and it is fine" and "I could not check" were the same
event by the time routing happened. The distinction was destroyed inside the node
before the graph ever saw it.

On boostgauge #331 the governance model was unreachable, the node printed
`proceeding`, and the run went on to spend drafter budget with the highest-value-
per-dollar gate in the pipeline skipped.

## What changed

The three outcomes now have three destinations:

| Outcome | Returns | Routes to |
|---|---|---|
| verified consistent | `{}` | drafting |
| conflict found | `error_message` | HALT |
| no verdict reached | `requirements_unverified` | HALT |

This reverses the fail-open ruling from #1899, per the operator ruling of
2026-08-16: a storm that bricks a launch is cheaper than a launch that drafts
against requirements nobody checked.

`route_after_analyze_requirements` checks the new marker explicitly rather than
leaning on `error_message` being populated alongside it. A halt that depends on a
second field happening to be set is the same implicit coupling that produced the
defect, and a test pins the marker halting on its own.

### The halt comes before any drafter spend, after a backoff

The observed outage cleared within minutes -- the same run later logged
`[PREFLIGHT] Gemini: 4/4 credentials` -- so halting on the first storm would be
brittle in the other direction. Two waited retries, 60s and 180s.

The schedule composes with #2375's immediate timeout retry rather than replacing
it, so the worst case is counted in the constant's docstring rather than estimated:

```
no escalation:              3 calls x 600s + 240s sleep = 34 min
after a #2375 escalation:   4 calls x 600s + 240s sleep = 44 min
```

That ceiling is bought deliberately. It is only reached when every attempt burns
its full budget -- a total outage, not the observed case -- and it is gate time
rather than drafter spend, which is the trade the ruling makes.

### Reporting keeps the two apart as carefully as routing does

A conflict needs an operator ruling on the issue text; an unreachable gate needs a
re-run. Sharing a signal sends the operator to rewrite requirements that were never
read. So:

- The halt carries its own `REQUIREMENTS UNVERIFIED:` marker, states plainly that
  the gate did not run, and gives the resume command with the repo and issue
  filled in.
- `classify_error` returns `requirements_unverified`, checked ahead of the capacity
  patterns. The reason text quotes the transport failure verbatim
  (`All credentials failed ... 503/529`), and classifying on that would produce
  "wait 15 minutes and retry" -- advice that skips the part the operator has to
  know.
- It is deliberately **not** transient. A transient class tells the launcher it may
  retry unattended, and the point of this halt is that a human learns the
  requirements were never checked before anything spends again.
- The standalone pre-check reads the new marker **before** `error_message`, or it
  would report a requirements conflict for a run where the gate never answered --
  the same conflation, re-introduced at the reporting layer.
- A test pins that the halt message does not trip `is_requirements_conflict`, which
  is a substring test the launcher exits 93 on. A future reword that let the marker
  appear would silently retire every retry this failure should get.

### The banner is untouched

`format_banner`'s own sentence is "the run proceeded anyway", so the halting paths
no longer feed it -- writing them there would put a false sentence in front of the
operator. The banner code is unchanged and still fires for the one fail-open path
that survives.

### The fail-open path that deliberately survives

#2462's case: the model answers, but every conflict it reports lacks a divergence
condition. Halting there would stop the roll on a finding the check itself could
not state, and filing them would block later launches with questions nobody can
close. That remains a decision on record, it still proceeds, and it still records
the unverified state so the banner fires for it. The systemic sweep for fail-open
sites is tracked in #2475.

## Tests

The backoff seam is neutralized suite-wide in `tests/conftest.py` rather than in
the one file that introduced it. Tests in files that know nothing about the backoff
already drive the gate to a no-verdict outcome, and each would otherwise sleep four
real minutes.

Tests were updated where they encoded the reversed decision, not to make them pass.
`test_failed_analysis_call_fails_open` became `fails_closed`; the escalation tests
now assert on **which model was asked** rather than on a call count that the waited
retries changed, because escalation was always about model choice.

New coverage: the routing edge itself, the halt distinguishable from both a clean
check and a conflict, the declared backoff schedule, a verdict arriving on a retry,
the invalid-provider path halting without waiting, the classification, the recovery
advice, the pre-check status, and the launcher substring guard.

Full unit suite: **8371 passed, 21 skipped, 5 xfailed**.

Closes #2474
