### PR TITLE
fix: name the transport in every failure the governance client reports (Closes #2476)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -89,6 +89,38 @@ AGY_CALL_TIMEOUT_SECONDS = 300.0
 MAX_TOTAL_INVOKE_SECONDS = 600.0
 MIN_ATTEMPT_SECONDS = 20.0
 
+#: Named in every failure this module hands back to a caller (#2476).
+#:
+#: Three surfaces here all say "gemini" and none of them mean the CLI retired on
+#: 2026-06-18: the module name, ``provider="gemini"`` in capacity.py and
+#: errors.py, and the ``gemini:3.1-pro`` provider spec, which is genuinely
+#: ``provider:model`` format. Each is defensible alone -- the MODEL is Gemini --
+#: and together, inside an error message, they read as the tool the fleet rules
+#: say never to invoke. A real `gemini` binary is still on PATH on the
+#: workstation, so the misreading is plausible rather than paranoid.
+#:
+#: On 2026-08-16 that cost a real diagnosis: ``analysis unavailable on
+#: gemini:3.1-pro (All credentials failed: ...)`` was read as "we regressed to
+#: the banned client", and disproving it took reading `_find_agy_cli`, the
+#: provider-spec format and the model-id table. "The vendor's capacity is
+#: overloaded" and "we regressed to a retired client" call for completely
+#: different next actions.
+#:
+#: Naming the transport in the failure text is the cheap fix, and it lands
+#: exactly where the harm happens -- at failure time, when something else has
+#: already gone wrong and attention is short. The module and provider names are
+#: left alone: renaming them is a wider change for no extra safety, since
+#: `gemini-3.1-pro-high` really is the model's name.
+TRANSPORT_LABEL = "agy (Antigravity CLI)"
+
+#: The same fact in log-line form, for the ``[LLM] ...`` diagnostics this module
+#: prints while a call is going wrong. One constant rather than seven literals,
+#: so the transport cannot fall off one line and leave that line ambiguous
+#: again. ``transport=`` is a separate key from ``provider=`` on purpose: the
+#: provider really is Gemini, and the pair says so without either word standing
+#: alone long enough to be misread.
+PROVIDER_LOG_ID = "provider=gemini transport=agy"
+
 # #1872: Windows process-creation failures. A child that dies with one of
 # these never got to run — desktop-heap / DLL-init pressure on a busy
 # machine, not a credential problem. Twice in 30 minutes on 2026-07-28 these
@@ -768,7 +800,10 @@ class GeminiClient:
                 response=None,
                 raw_response=None,
                 error_type=GeminiErrorType.QUOTA_EXHAUSTED,
-                error_message=f"All credentials exhausted: {', '.join(exhausted_names)}. Wait for quota reset.",
+                error_message=(
+                    f"All credentials exhausted via {TRANSPORT_LABEL}: "
+                    f"{', '.join(exhausted_names)}. Wait for quota reset."
+                ),
                 credential_used="",
                 rotation_occurred=False,
                 attempts=0,
@@ -821,7 +856,7 @@ class GeminiClient:
                         f"{MAX_TOTAL_INVOKE_SECONDS:.0f}s exhausted{flavor}"
                     )
                     print(
-                        f"    [LLM] provider=gemini model={self.model}: "
+                        f"    [LLM] {PROVIDER_LOG_ID} model={self.model}: "
                         f"call budget of {MAX_TOTAL_INVOKE_SECONDS:.0f}s "
                         f"exhausted — halting instead of retrying"
                     )
@@ -888,7 +923,7 @@ class GeminiClient:
                     ):
                         msg = f"{type(e).__name__}: {error_str}"
                         print(
-                            f"    [LLM] provider=gemini: programming error, "
+                            f"    [LLM] {PROVIDER_LOG_ID}: programming error, "
                             f"not retryable — {msg[:160]}"
                         )
                         log_gemini_event(
@@ -939,7 +974,7 @@ class GeminiClient:
                         )
                         # Issue #537: Log retries to stdout so babysitters see progress
                         print(
-                            f"    [LLM] provider=gemini model={self.model} "
+                            f"    [LLM] {PROVIDER_LOG_ID} model={self.model} "
                             f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
                             f"{status_code or 503} capacity exhausted (retrying in {delay:.0f}s)"
                         )
@@ -962,7 +997,7 @@ class GeminiClient:
                         )
                         # Issue #537: Log rotation to stdout
                         print(
-                            f"    [LLM] provider=gemini credential={cred.name}: "
+                            f"    [LLM] {PROVIDER_LOG_ID} credential={cred.name}: "
                             f"429 quota exhausted — rotating to next credential"
                         )
                         errors.append(f"{cred.name}: Quota exhausted")
@@ -979,7 +1014,7 @@ class GeminiClient:
                         )
                         # Issue #537: Log auth errors to stdout
                         print(
-                            f"    [LLM] provider=gemini credential={cred.name}: "
+                            f"    [LLM] {PROVIDER_LOG_ID} credential={cred.name}: "
                             f"auth error (status={status_code}) — skipping credential"
                         )
                         errors.append(f"{cred.name}: Authentication failed")
@@ -997,7 +1032,7 @@ class GeminiClient:
                                 details={"status_code": status_code, "retryable": True, "backoff_seconds": delay},
                             )
                             print(
-                                f"    [LLM] provider=gemini model={self.model} "
+                                f"    [LLM] {PROVIDER_LOG_ID} model={self.model} "
                                 f"attempt={attempt}/{MAX_RETRIES_PER_CREDENTIAL}: "
                                 f"transient error (status={status_code}), retrying in {delay:.0f}s"
                             )
@@ -1022,7 +1057,7 @@ class GeminiClient:
                 # failed with capacity errors. Previously this was silently dropped.
                 # Issue #537: Log exhaustion to stdout
                 print(
-                    f"    [LLM] provider=gemini credential={cred.name}: "
+                    f"    [LLM] {PROVIDER_LOG_ID} credential={cred.name}: "
                     f"capacity exhausted after {MAX_RETRIES_PER_CREDENTIAL} retries"
                 )
                 errors.append(
@@ -1073,7 +1108,10 @@ class GeminiClient:
             response=None,
             raw_response=None,
             error_type=final_error_type,
-            error_message="All credentials failed:\n  - " + "\n  - ".join(errors),
+            error_message=(
+                f"All credentials failed via {TRANSPORT_LABEL}:\n  - "
+                + "\n  - ".join(errors)
+            ),
             credential_used="",
             rotation_occurred=len(available) > 1,
             attempts=total_attempts,

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1689,7 +1689,16 @@ class GeminiProvider(LLMProvider):
             classified = classify_gemini_error(e)
             is_rate_limit = isinstance(classified, RateLimitError)
             if is_rate_limit:
-                print(f"    [LLM] RATE LIMITED: provider=gemini model={self._model} error={str(e)[:100]}")
+                # #2476: name the transport. This prints when something has
+                # already failed, and "provider=gemini" beside a gemini-* model
+                # id reads as the CLI retired on 2026-06-18 -- which is a
+                # different problem with a different next action.
+                from assemblyzero.core.gemini_client import PROVIDER_LOG_ID
+
+                print(
+                    f"    [LLM] RATE LIMITED: {PROVIDER_LOG_ID} "
+                    f"model={self._model} error={str(e)[:100]}"
+                )
 
             call_result = LLMCallResult(
                 success=False,

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -619,6 +619,113 @@ def test_invoke_via_cli_strips_ansi_and_returns_text():
     assert resp == '{"verdict":"APPROVE"}'
 
 
+class TestTheFailureTextNamesTheTransport:
+    """#2476: no error message may be readable as naming the retired CLI.
+
+    Three surfaces here say "gemini" and none of them mean the CLI retired on
+    2026-06-18 -- the module name, `provider="gemini"`, and the `gemini:3.1-pro`
+    provider spec, which is genuinely provider:model format. Each is defensible
+    alone; together, inside a failure, they read as the tool the fleet rules say
+    never to invoke. On 2026-08-16 that cost a real diagnosis.
+
+    These pin the transport into the text at failure time, which is the moment
+    the harm happens and the moment attention is shortest.
+    """
+
+    def _failing_client(self, creds, state):
+        client = GeminiClient(
+            model="gemini-3.1-pro-preview",
+            credentials_file=creds,
+            state_file=state,
+        )
+        return client
+
+    def test_all_credentials_failed_names_agy(
+        self, temp_credentials_file, temp_state_file
+    ):
+        """The exact message from the boostgauge #331 diagnosis."""
+        client = self._failing_client(temp_credentials_file, temp_state_file)
+
+        with patch.object(
+            client,
+            "_invoke_via_cli",
+            side_effect=lambda *a, **k: (False, "", "429 TerminalQuotaError"),
+        ):
+            result = client.invoke("system", "content")
+
+        assert result.success is False
+        assert "agy" in result.error_message
+        assert "Antigravity" in result.error_message
+
+    def test_the_message_still_says_what_failed(
+        self, temp_credentials_file, temp_state_file
+    ):
+        """Naming the transport must not push out the reason. The operator
+        needs both: which client ran, and why it did not answer."""
+        client = self._failing_client(temp_credentials_file, temp_state_file)
+
+        with patch.object(
+            client,
+            "_invoke_via_cli",
+            side_effect=lambda *a, **k: (False, "", "429 TerminalQuotaError"),
+        ):
+            result = client.invoke("system", "content")
+
+        assert "All credentials failed" in result.error_message
+        assert "Quota exhausted" in result.error_message
+        assert "key-1" in result.error_message
+
+    def test_the_live_log_lines_name_it_too(
+        self, temp_credentials_file, temp_state_file, capsys
+    ):
+        """The failure text is not the only thing read at failure time.
+
+        The rotation diagnostics printed while a call is dying carried a bare
+        `provider=gemini` beside a `gemini-*` model id, which is the same
+        ambiguity in the place an operator actually looks first.
+        """
+        client = self._failing_client(temp_credentials_file, temp_state_file)
+
+        with patch.object(
+            client,
+            "_invoke_via_cli",
+            side_effect=lambda *a, **k: (False, "", "429 TerminalQuotaError"),
+        ):
+            client.invoke("system", "content")
+
+        out = capsys.readouterr().out
+        assert "[LLM]" in out, "the fixture must actually print a diagnostic"
+        for line in out.splitlines():
+            if "provider=gemini" in line:
+                assert "transport=agy" in line, (
+                    f"a failure line names the provider but not the "
+                    f"transport, so it reads as the retired CLI: {line!r}"
+                )
+
+    def test_the_transport_label_names_a_cli_that_is_not_retired(self):
+        """The label is the whole point, so it may not drift back.
+
+        `gemini` as a bare word is what the retired CLI was invoked as, and the
+        fleet rules ban invoking it. A label containing it would reintroduce
+        the ambiguity this issue closed.
+        """
+        from assemblyzero.core.gemini_client import TRANSPORT_LABEL
+
+        assert "agy" in TRANSPORT_LABEL
+        assert "gemini" not in TRANSPORT_LABEL.lower()
+
+    def test_the_missing_cli_message_already_named_it(self):
+        """Untouched, and asserted so a future edit cannot quietly widen the
+        gap this issue narrowed."""
+        client = GeminiClient(model="gemini-3.1-pro-preview")
+        client._agy_cli = None
+
+        ok, _, err = client._invoke_via_cli("sys", "content")
+
+        assert ok is False
+        assert "agy" in err
+
+
 def test_invoke_via_cli_empty_output_is_failure():
     client = GeminiClient(model="gemini-3.1-pro-preview")
     client._agy_cli = "agy"


### PR DESCRIPTION
## The misreading

On 2026-08-16 a pipeline warning read:

```
[N0c] WARNING: analysis unavailable on gemini:3.1-pro (All credentials failed:
- oauth-primary: call budget of 600s exhausted riding 503/529 capacity storms); proceeding.
```

Read at speed, that says *"we are still running the retired Gemini CLI"*. It was
not. `_find_agy_cli` resolves `shutil.which("agy")` and `gemini:3.1-pro` maps to
`gemini-3.1-pro-high` — everything was correct, only the labels misled.
Disproving it took reading the CLI resolver, the provider-spec format and the
model-id table.

Three surfaces say `gemini` and none of them mean the binary retired on
2026-06-18: the module name, `provider="gemini"` in `capacity.py` and
`errors.py`, and the `gemini:3.1-pro` spec, which is genuinely `provider:model`
format. Each is defensible alone — the *model* is Gemini. Together, inside an
error message, they read as the tool the fleet rules say never to invoke. A real
`gemini` binary is still on PATH on the workstation, which is what makes the
misreading plausible rather than paranoid.

The cost is real: at failure time an operator cannot tell *"the vendor's
capacity is overloaded"* from *"we regressed to a banned client"*, and those have
completely different next actions.

## The fix

The issue offers two options; this takes the cheaper one — **name the transport
in the failure text**, rather than rename modules. The harm happens at failure
time, so that is where the fix lands. `gemini-3.1-pro-high` really is the
model's name, so renaming the provider surface would be a wider change for no
extra safety.

Two forms, one constant each, so the transport cannot fall off a line and leave
it ambiguous again:

| Constant | Value | Used in |
|---|---|---|
| `TRANSPORT_LABEL` | `agy (Antigravity CLI)` | prose, inside `error_message` |
| `PROVIDER_LOG_ID` | `provider=gemini transport=agy` | the `[LLM]` diagnostics |

`transport=` is a separate key from `provider=` deliberately. The provider
really *is* Gemini, and the pair says so without either word standing alone long
enough to be misread.

After:

```
All credentials failed via agy (Antigravity CLI):
  - oauth-primary: call budget of 600s exhausted riding 503/529 capacity storms
```

## Both surfaces, not just the one in the issue

- **The two terminal failure messages** handed back to callers — what a warning
  or a halt quotes verbatim.
- **All seven live `[LLM] provider=gemini ...` rotation diagnostics.** These
  carried a bare `provider=gemini` beside a `gemini-*` model id, which is the
  same ambiguity in the place an operator actually looks *first*. They surfaced
  while testing the message fix: the captured stdout of the new test still read
  `[LLM] provider=gemini credential=key-1: 429 quota exhausted`.

The already-correct `"Antigravity CLI (agy) not found"` path is untouched, and
is now asserted so a later edit cannot quietly widen the gap this narrowed.

## Tests

Four assertions, each pinning a different way the ambiguity could come back:

- the failure text names the transport
- the reason survives alongside it — naming the transport must not push out
  *why* it failed
- **every** printed line containing `provider=gemini` also contains
  `transport=agy`, checked by iterating the captured output rather than by
  spot-checking one line
- `TRANSPORT_LABEL` does not contain the word `gemini` — a drift back is the
  whole failure mode, so the label itself is pinned

Full unit suite: **8377 passed, 21 skipped, 5 xfailed** (rebased onto #2475; the
new fail-open gate passes with these changes: `275 files, 7236 sites examined,
no new fail-open`).

`ruff` on both touched files: 17 errors before, 17 after — all pre-existing,
none introduced.

Closes #2476
