### PR TITLE
docs: add global agy handoff runbook

### DIFF
--- a/docs/runbooks/0953-global-agy-handoff-pickup.md
+++ b/docs/runbooks/0953-global-agy-handoff-pickup.md
@@ -1,0 +1,34 @@
+# Runbook: Global AGY Handoff & Pickup
+
+## Purpose
+This runbook documents the global machine-local skill pattern used across the fleet of 89 repositories to standardize session wrap-up and resumption in Antigravity (AGY).
+
+By implementing these two skills in `~/.gemini/config/skills/`, every single repository on the machine instantly inherits the ability to close out state gracefully, and catch up seamlessly. This replaces the complex and brittle `/cleanup` template command and ensures that Claude Code can still read the repository state if the operator switches agent clients.
+
+## The Skills
+
+### 1. The Global Handoff Skill
+**Location:** `~/.gemini/config/skills/handoff/SKILL.md`
+
+**Trigger:** The operator says "handoff", "wrap up", "cleanup", or "close out".
+
+**Execution Steps:**
+1. Append to `data/handoff-log.md` with an `<!-- handoff-start -->` block detailing accomplishments, current state, and next steps.
+2. Append a session summary to `docs/session-logs/YYYY-MM-DD.md`.
+3. Capture new rules or patterns to `docs/lessons-learned.md`.
+4. Stage only these specific tracking files.
+5. Commit with `chore: session cleanup (logs)` and branch/push the cleanup artifacts.
+
+### 2. The Global Pickup Skill
+**Location:** `~/.gemini/config/skills/pickup/SKILL.md`
+
+**Trigger:** The operator says "pickup", "catch up", "what did I miss", or "reorient".
+
+**Execution Steps:**
+1. Read the most recent entry in `data/handoff-log.md` to see the intended next steps.
+2. Run `git status`, `git log -n 5`, and `gh pr list` to determine what actually occurred while the agent was inactive.
+3. Reconcile the discrepancy between the handoff state and the current git reality.
+4. Output a summary to the operator and propose the next logical action.
+
+## Deployment
+These skills do not need to be duplicated per-repository. Simply ensure they are present in the global config directory on the operator's machine.


### PR DESCRIPTION
Adds a runbook describing a global handoff procedure for Antigravity (agy)
sessions.

No-Issue: membrane remediation, 2026-08-20. This PR's title, body and commit
message each named a private repository by full `owner/name` path on a PUBLIC
repo, and had done so since 2026-08-19. The tracking reference has been removed
from the rendered PR; it is recorded in the private coordination repo instead.

The commit message on this branch still carries the name and cannot be corrected
without a history rewrite, so this edit stops the rendered surface only. Whether
this PR proceeds, and how the commit is dealt with, is pending an operator
decision.
