### PR TITLE
feat(new_repo): add data-dl/ for downloaded material, and a drift audit so existing repos can catch up (Closes #2485, Closes #1618)

### DIFF
--- a/tests/unit/test_audit_gitignore_drift.py
+++ b/tests/unit/test_audit_gitignore_drift.py
@@ -21,6 +21,7 @@ from audit_gitignore_drift import (  # noqa: E402
     audit_repo,
     backfill,
     ignores_data_g,
+    is_repo,
     patterns,
 )
 
@@ -74,6 +75,32 @@ class TestDriftDetection:
         (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
         (repo / "untracked.txt").write_text("x", encoding="utf-8")
         assert audit_repo(repo, ["*.log"])["dirty"] is True
+
+
+class TestRepoDetection:
+    def test_a_real_repo_counts(self, repo):
+        assert is_repo(repo) is True
+
+    def test_a_linked_worktree_does_not_count(self, repo, tmp_path):
+        """A worktree checks out the same tracked .gitignore, so counting it as a
+        separate repo reports the parent's drift twice under a different name.
+        Caught on the first live run, which listed this audit's own worktree."""
+        (repo / "seed.txt").write_text("x", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"],
+            cwd=repo, check=True,
+        )
+        wt = tmp_path.parent / (tmp_path.name + "-wt")
+        subprocess.run(["git", "worktree", "add", "-q", str(wt), "-b", "wt"], cwd=repo, check=True)
+        try:
+            assert (wt / ".git").exists(), "fixture is wrong if this fails"
+            assert is_repo(wt) is False
+        finally:
+            subprocess.run(["git", "worktree", "remove", str(wt)], cwd=repo, capture_output=True)
+
+    def test_a_plain_directory_does_not_count(self, tmp_path):
+        assert is_repo(tmp_path) is False
 
 
 class TestDataGTrap:

--- a/tests/unit/test_audit_gitignore_drift.py
+++ b/tests/unit/test_audit_gitignore_drift.py
@@ -1,0 +1,140 @@
+"""Tests for tools/audit_gitignore_drift.py (#1618).
+
+What is worth testing here is not "does it find missing lines" -- that is a set
+difference. It is the three judgements that decide whether the report is worth
+reading: that cosmetic template edits do not register as drift, that a repo's own
+extra patterns are never reported, and that an ignored `data-g/` is caught no
+matter which layer the rule came from.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+
+from audit_gitignore_drift import (  # noqa: E402
+    audit_repo,
+    backfill,
+    ignores_data_g,
+    patterns,
+)
+
+
+class TestPatternExtraction:
+    def test_drops_comments_and_blanks(self):
+        assert patterns("# a comment\n\n*.log\n\n# another\nbuild\n") == ["*.log", "build"]
+
+    def test_normalises_trailing_slash(self):
+        """`node_modules/` and `node_modules` are one intent, not two. Reporting
+        the slash variant as missing is a false alarm."""
+        assert patterns("node_modules/\n") == patterns("node_modules\n") == ["node_modules"]
+
+    def test_preserves_negations(self):
+        """`!data-dl/README.md` is load-bearing -- dropping it would make the
+        audit tell every repo to add an ignore that swallows its own README."""
+        assert "!data-dl/README.md" in patterns("data-dl/*\n!data-dl/README.md\n")
+
+    def test_comment_rewording_is_not_drift(self):
+        before = "# old wording\n*.log\nbuild/\n"
+        after = "# completely different wording\n#\n*.log\n\nbuild/\n"
+        assert patterns(before) == patterns(after)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+class TestDriftDetection:
+    def test_missing_pattern_is_reported(self, repo):
+        (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        row = audit_repo(repo, ["*.log", "build", "*.bak"])
+        assert row["missing"] == ["build", "*.bak"]
+
+    def test_extra_local_patterns_are_never_reported(self, repo):
+        """A repo carrying rules the template does not know about is normal.
+        Flagging them would cry wolf on every repo and train the reader to
+        ignore the output."""
+        (repo / ".gitignore").write_text("*.log\nsomething-local/\n", encoding="utf-8")
+        row = audit_repo(repo, ["*.log"])
+        assert row["missing"] == []
+
+    def test_absent_gitignore_is_flagged_not_crashed(self, repo):
+        row = audit_repo(repo, ["*.log"])
+        assert row["has_gitignore"] is False
+        assert row["missing"] == ["*.log"]
+
+    def test_dirty_tree_is_recorded(self, repo):
+        (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        (repo / "untracked.txt").write_text("x", encoding="utf-8")
+        assert audit_repo(repo, ["*.log"])["dirty"] is True
+
+
+class TestDataGTrap:
+    def test_clean_repo_does_not_ignore_data_g(self, repo):
+        (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        assert ignores_data_g(repo) is False
+
+    def test_data_star_glob_is_caught(self, repo):
+        """The specific mistake: `data-*/` reads as tidy and silently stops
+        `data-g/` being tracked. Nothing else in the fleet would notice."""
+        (repo / ".gitignore").write_text("data/\ndata-*/\n", encoding="utf-8")
+        assert ignores_data_g(repo) is True
+
+    def test_explicit_data_g_rule_is_caught(self, repo):
+        (repo / ".gitignore").write_text("data-g/\n", encoding="utf-8")
+        assert ignores_data_g(repo) is True
+
+
+class TestBackfill:
+    def test_appends_without_touching_existing_lines(self, repo):
+        original = "# my own header\n*.log\nlocal-thing/\n"
+        (repo / ".gitignore").write_text(original, encoding="utf-8")
+        backfill(repo, ["*.bak", "*.parked-*"], "2026-08-20")
+        text = (repo / ".gitignore").read_text(encoding="utf-8")
+        assert text.startswith(original), "existing content must be untouched"
+        assert "*.bak" in text and "*.parked-*" in text
+        assert "2026-08-20" in text, "the appended block must be dated"
+
+    def test_never_removes_a_pattern(self, repo):
+        (repo / ".gitignore").write_text("keep-me/\n", encoding="utf-8")
+        backfill(repo, ["*.bak"], "2026-08-20")
+        assert "keep-me" in patterns((repo / ".gitignore").read_text(encoding="utf-8"))
+
+    def test_handles_file_with_no_trailing_newline(self, repo):
+        (repo / ".gitignore").write_text("*.log", encoding="utf-8")
+        backfill(repo, ["*.bak"], "2026-08-20")
+        got = patterns((repo / ".gitignore").read_text(encoding="utf-8"))
+        assert got == ["*.log", "*.bak"], "a missing final newline must not fuse two patterns"
+
+    def test_backfilled_file_still_parses_to_the_union(self, repo):
+        (repo / ".gitignore").write_text("*.log\n", encoding="utf-8")
+        backfill(repo, ["*.bak", "build"], "2026-08-20")
+        assert set(patterns((repo / ".gitignore").read_text(encoding="utf-8"))) == {"*.log", "*.bak", "build"}
+
+
+class TestAgainstTheRealTemplate:
+    def test_template_parses_and_carries_the_data_dl_pair(self):
+        from new_repo import GITIGNORE_TEMPLATE
+        pats = patterns(GITIGNORE_TEMPLATE)
+        assert "data-dl/*" in pats
+        assert "!data-dl/README.md" in pats
+
+    def test_template_does_not_ignore_data_g(self, repo):
+        """Guards the trap at its source: if anyone ever 'tidies' the template
+        into a data-*/ glob, this fails before it reaches 100 repos."""
+        from new_repo import create_gitignore
+        create_gitignore(repo)
+        assert ignores_data_g(repo) is False
+
+    def test_a_repo_scaffolded_now_shows_zero_drift(self, repo):
+        from new_repo import GITIGNORE_TEMPLATE, create_gitignore
+        create_gitignore(repo)
+        row = audit_repo(repo, patterns(GITIGNORE_TEMPLATE))
+        assert row["missing"] == [], "the scaffolder's own output must be drift-free"

--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -1642,6 +1642,80 @@ class TestDataGConvention:
         assert "data/" in text and "data-g/" in text
         assert "#1563" in text
 
+    # --- data-dl/ (#2485) ---------------------------------------------------
+    # data-g/ was absorbing downloaded material because there was nowhere else
+    # for it to go. These assert the third directory exists, that it is really
+    # ignored, and -- the part that actually breaks -- that its README survives
+    # the ignore rule.
+
+    def test_create_writes_data_dl_readme(self, tmp_path):
+        from new_repo import create_data_g_readme
+        create_data_g_readme(tmp_path)
+        assert (tmp_path / "data-dl" / "README.md").exists()
+
+    def test_create_removes_data_dl_schema_gitkeep(self, tmp_path):
+        from new_repo import create_data_g_readme
+        data_dl = tmp_path / "data-dl"
+        data_dl.mkdir()
+        (data_dl / ".gitkeep").touch()
+        create_data_g_readme(tmp_path)
+        assert not (data_dl / ".gitkeep").exists()
+
+    def test_both_readmes_carry_the_full_three_way_table(self, tmp_path):
+        """A README that only describes its own directory does not help someone
+        choosing between directories. Both must show all three."""
+        from new_repo import create_data_g_readme
+        create_data_g_readme(tmp_path)
+        for where in ("data-g", "data-dl"):
+            text = (tmp_path / where / "README.md").read_text(encoding="utf-8")
+            assert "`data/`" in text, where
+            assert "`data-dl/`" in text, where
+            assert "`data-g/`" in text, where
+
+    def test_data_dl_readme_cites_issue(self, tmp_path):
+        from new_repo import create_data_g_readme
+        create_data_g_readme(tmp_path)
+        text = (tmp_path / "data-dl" / "README.md").read_text(encoding="utf-8")
+        assert "#2485" in text
+
+    def test_gitignore_template_ignores_data_dl_but_not_its_readme(self, tmp_path):
+        """The bug this guards: a bare `data-dl/` rule would swallow the README,
+        because git cannot re-include a file underneath an ignored directory.
+        Asserted against real git rather than by reading the template."""
+        import subprocess
+        from new_repo import create_gitignore, create_data_g_readme
+
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        create_gitignore(tmp_path)
+        create_data_g_readme(tmp_path)
+        (tmp_path / "data-dl" / "paper.pdf").write_text("x", encoding="utf-8")
+
+        def ignored(rel):
+            return subprocess.run(
+                ["git", "check-ignore", "-q", rel],
+                cwd=tmp_path, capture_output=True,
+            ).returncode == 0
+
+        assert ignored("data-dl/paper.pdf"), "downloaded material must be ignored"
+        assert not ignored("data-dl/README.md"), "the README must stay tracked"
+
+    def test_gitignore_template_does_not_ignore_data_g(self, tmp_path):
+        """A `data-*/` glob would match data-g/ and silently stop tracking the
+        one directory that is meant to be committed."""
+        import subprocess
+        from new_repo import create_gitignore, create_data_g_readme
+
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+        create_gitignore(tmp_path)
+        create_data_g_readme(tmp_path)
+        (tmp_path / "data-g" / "roster.json").write_text("{}", encoding="utf-8")
+
+        for rel in ("data-g/README.md", "data-g/roster.json"):
+            assert subprocess.run(
+                ["git", "check-ignore", "-q", rel],
+                cwd=tmp_path, capture_output=True,
+            ).returncode != 0, f"{rel} must remain tracked"
+
     def test_schema_includes_data_g(self):
         from new_repo import load_structure_schema
         schema = load_structure_schema()

--- a/tools/audit_gitignore_drift.py
+++ b/tools/audit_gitignore_drift.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Which repos' .gitignore have drifted from the scaffolder template, and how (#1618).
+
+    poetry run python tools/audit_gitignore_drift.py
+    poetry run python tools/audit_gitignore_drift.py --apply
+
+WHY THIS EXISTS
+---------------
+`new_repo.py` emits a canonical `.gitignore`. Every repo scaffolded before a
+given pattern was added never receives it, and nothing detects the gap. The
+patterns arrive one incident at a time -- `node_modules/` after build tooling
+littered a repo root, `*.bak` and `*.parked-*` after the mv-to-bak convention
+started polluting `git status`, `data-dl/` after downloaded material spent months
+landing in the one data directory that is committed.
+
+Each of those was found by a human noticing. This makes it a check.
+
+WHAT DRIFT MEANS HERE, AND WHAT IT DOES NOT
+-------------------------------------------
+Drift is **a pattern in the template that the repo lacks**. It is deliberately
+one-directional: a repo having extra patterns of its own is normal and correct,
+not a finding. Repos carry local rules the template will never know about, and an
+audit that flagged them would cry wolf on every repo it inspected.
+
+So this reports what is MISSING and never what is EXTRA.
+
+WHY IT COMPARES PATTERNS AND NOT TEXT
+-------------------------------------
+The template's comments are prose and get rewritten; its blank lines move.
+Diffing raw text reports every repo as drifted the first time a comment is
+reworded, which trains the reader to ignore the output. Only non-comment,
+non-blank lines are compared, and each is normalised for a trailing slash so
+`node_modules/` and `node_modules` are one pattern rather than two.
+
+THE data-g TRAP
+---------------
+Do not "simplify" the template's `data-dl/*` rule into a `data-*/` glob. That
+glob matches `data-g/`, which exists specifically to be tracked, and the failure
+is silent -- nothing stops being committed, new files just quietly never get
+added. This tool therefore reports a repo that ignores `data-g/` as a FINDING in
+its own right, separate from drift.
+
+SAFETY
+------
+Default is read-only: it reports and writes nothing. `--apply` appends missing
+patterns to each repo's `.gitignore` under a dated, labelled section, and does
+nothing else -- it never removes a line, never reorders, never touches a file
+other than `.gitignore`, and never commits. Committing is a per-repo decision
+with a per-repo issue, which is what the umbrella tracks.
+
+Skips any repo whose working tree is dirty, unless --include-dirty. Appending to
+a file in a tree someone is mid-edit in is how an unrelated change gets swept
+into somebody's commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from new_repo import GITIGNORE_TEMPLATE  # noqa: E402
+
+PROJECTS_ROOT = Path(r"C:\Users\mcwiz\Projects")
+
+# Repos whose .gitignore is deliberately its own thing.
+SKIP_REPOS = {"AssemblyZero"}
+
+
+def patterns(text: str) -> list[str]:
+    """Meaningful ignore patterns, in order, comments and blanks dropped.
+
+    Trailing slashes are normalised away: git treats `foo/` as directory-only and
+    `foo` as either, but for drift purposes a repo that has one has the intent of
+    the other, and reporting it as missing would be a false alarm.
+    """
+    out = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line.rstrip("/"))
+    return out
+
+
+def git(args: list[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["git", "--no-optional-locks", *args],
+        cwd=cwd, capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout.strip()
+
+
+def is_repo(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def is_dirty(path: Path) -> bool:
+    code, out = git(["status", "--porcelain"], path)
+    return code != 0 or bool(out)
+
+
+def ignores_data_g(path: Path) -> bool:
+    """Does this repo ignore data-g/ -- the directory meant to be tracked?
+
+    Asked of git rather than by reading .gitignore, because the rule can arrive
+    from a glob, an exclude file, or the machine's global config, and only git
+    knows the answer for all three.
+    """
+    code, _ = git(["check-ignore", "-q", "data-g/probe"], path)
+    return code == 0
+
+
+def audit_repo(path: Path, wanted: list[str]) -> dict:
+    gitignore = path / ".gitignore"
+    row = {
+        "repo": path.name,
+        "has_gitignore": gitignore.exists(),
+        "missing": [],
+        "ignores_data_g": ignores_data_g(path),
+        "dirty": is_dirty(path),
+    }
+    have = set(patterns(gitignore.read_text(encoding="utf-8", errors="replace"))) if gitignore.exists() else set()
+    row["missing"] = [p for p in wanted if p not in have]
+    return row
+
+
+def backfill(path: Path, missing: list[str], today: str) -> None:
+    """Append the missing patterns. Never removes, never reorders."""
+    gitignore = path / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8", errors="replace") if gitignore.exists() else ""
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    block = [
+        "",
+        f"# --- backfilled from new_repo.py template ({today}) ---",
+        "# Patterns this repo predates. Appended by tools/audit_gitignore_drift.py;",
+        "# nothing above this line was changed.",
+    ]
+    block.extend(missing)
+    gitignore.write_text(existing + "\n".join(block) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", type=Path, default=PROJECTS_ROOT)
+    ap.add_argument("--apply", action="store_true", help="append missing patterns (default: report only)")
+    ap.add_argument("--include-dirty", action="store_true", help="do not skip repos with a dirty working tree")
+    args = ap.parse_args()
+
+    wanted = patterns(GITIGNORE_TEMPLATE)
+    today = dt.date.today().isoformat()
+
+    if not args.root.is_dir():
+        print(f"ERROR: {args.root} is not a directory", file=sys.stderr)
+        return 2
+
+    rows = []
+    for child in sorted(args.root.iterdir()):
+        if not child.is_dir() or child.name in SKIP_REPOS or not is_repo(child):
+            continue
+        try:
+            rows.append(audit_repo(child, wanted))
+        except OSError as exc:
+            rows.append({"repo": child.name, "error": str(exc)[:80], "missing": [],
+                         "has_gitignore": False, "ignores_data_g": False, "dirty": True})
+
+    drifted = [r for r in rows if r["missing"] or not r["has_gitignore"]]
+    data_g_broken = [r for r in rows if r["ignores_data_g"]]
+
+    print(f"repos inspected: {len(rows)}   drifted: {len(drifted)}   clean: {len(rows) - len(drifted)}")
+    print()
+
+    if data_g_broken:
+        print("FINDING -- data-g/ is IGNORED in these repos. It is meant to be tracked;")
+        print("anything added there is silently never committed:")
+        for r in data_g_broken:
+            print(f"  {r['repo']}")
+        print()
+
+    if not drifted:
+        print("No drift.")
+    else:
+        print("MISSING PATTERNS (template has them, repo does not):")
+        for r in sorted(drifted, key=lambda r: -len(r["missing"])):
+            if not r["has_gitignore"]:
+                print(f"  {r['repo']}: NO .gitignore AT ALL")
+                continue
+            flag = " [dirty]" if r["dirty"] else ""
+            print(f"  {r['repo']}{flag}: {len(r['missing'])} missing")
+            for p in r["missing"]:
+                print(f"      {p}")
+
+    if args.apply:
+        print()
+        applied = skipped = 0
+        for r in drifted:
+            path = args.root / r["repo"]
+            if r["dirty"] and not args.include_dirty:
+                print(f"  SKIP {r['repo']}: working tree dirty")
+                skipped += 1
+                continue
+            if not r["missing"]:
+                continue
+            backfill(path, r["missing"], today)
+            print(f"  APPLIED {r['repo']}: {len(r['missing'])} patterns appended")
+            applied += 1
+        print(f"\napplied: {applied}   skipped: {skipped}")
+        print("Nothing was committed. Each repo needs its own issue and PR.")
+    elif drifted:
+        print("\nRead-only. Re-run with --apply to append. Nothing was changed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit_gitignore_drift.py
+++ b/tools/audit_gitignore_drift.py
@@ -95,7 +95,20 @@ def git(args: list[str], cwd: Path) -> tuple[int, str]:
 
 
 def is_repo(path: Path) -> bool:
-    return (path / ".git").exists()
+    """True for a real repository, False for a linked worktree of one.
+
+    A worktree has `.git` as a FILE containing a `gitdir:` pointer; a repository
+    has it as a directory. Both "exist", so a naive check counts every worktree
+    as another repo -- and since a worktree checks out the same tracked
+    `.gitignore`, it reports the parent's drift a second time under a different
+    name. On this machine that inflated the first run by a double-digit count and
+    listed the audit's own worktree as a drifted repo.
+
+    Duplicate rows are worse than merely untidy here: the whole output is a
+    to-do list, and a to-do list with phantom entries gets worked twice or
+    distrusted.
+    """
+    return (path / ".git").is_dir()
 
 
 def is_dirty(path: Path) -> bool:

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -728,8 +728,13 @@ You are a team member on the {name} project, not a tool.
 {context_block}
 ## Data Directories
 
-- `data/`: ephemeral session artifacts (transcripts, run logs, pickup state). Ignored by the fleet-wide global gitignore; not committed.
+Three of them, and only one is committed.
+
+- `data/`: ephemeral session artifacts (transcripts, run logs, pickup state). Not committed.
+- `data-dl/`: downloaded material (papers, drafts, exports, recordings). Not committed -- ignored by this repo's own `.gitignore`, not merely by the machine's global one. See `data-dl/README.md`. (AssemblyZero #2485.)
 - `data-g/`: source-of-truth data the runtime treats as authoritative (rosters, corpora, configs). Git-tracked for durability. See `data-g/README.md`. (AssemblyZero #1563.)
+
+The `-g` is for git-tracked. If a file is here because you downloaded it, it belongs in `data-dl/`.
 
 {overrides_footer}"""
     claude_md_path = project_path / "CLAUDE.md"
@@ -1047,14 +1052,12 @@ SOFTWARE.
     license_path.write_text(content, encoding='utf-8')
 
 
-def create_gitignore(project_path: Path) -> None:
-    """
-    Create the .gitignore file.
-
-    Args:
-        project_path: Path to the project root
-    """
-    content = """# Claude Code local settings (machine-specific)
+# The canonical .gitignore every scaffolded repo receives. Module-level rather
+# than inline in create_gitignore() so tools/audit_gitignore_drift.py can diff an
+# existing repo against it without scaffolding anything (#1618). One definition,
+# two consumers -- a second copy would drift from this one the first time either
+# changed, which is the defect that audit exists to find.
+GITIGNORE_TEMPLATE = """# Claude Code local settings (machine-specific)
 .claude/settings.local.json
 
 # Claude Code temporary files
@@ -1116,6 +1119,21 @@ coverage.xml
 # Unleashed session transcripts (auto-generated, untracked)
 data/unleashed/
 
+# Downloaded material (#2485). Papers, drafts, exports, recordings -- bulk that
+# is usually binary and usually re-fetchable, so git is the wrong store and the
+# cost is permanent. Ignored in THIS file rather than left to the machine's
+# global gitignore, so the rule survives a clone onto any other machine.
+#
+# `data-dl/*` plus the negation, NOT a bare `data-dl/`: git cannot re-include a
+# file underneath an ignored directory, so the bare form would swallow the README
+# that explains the convention.
+data-dl/*
+!data-dl/README.md
+
+# NOT ignored, deliberately: data-g/ is source-of-truth the runtime depends on
+# and is meant to be committed. Do not "tidy" this into a `data-*/` glob -- that
+# would match data-g/ and silently stop tracking the one directory that wants it.
+
 # Agent-parked files (mv $file $file.bak / $file.parked-{timestamp})
 # CLAUDE.md "Destroying uncommitted state" principle: the agent uses
 # mv-to-bak instead of rm to preserve recoverability. Ignored here so
@@ -1133,52 +1151,116 @@ data/unleashed/
 ~$*
 .~lock.*#
 """
+
+
+def create_gitignore(project_path: Path) -> None:
+    """
+    Create the .gitignore file.
+
+    Args:
+        project_path: Path to the project root
+    """
     gitignore_path = project_path / ".gitignore"
-    gitignore_path.write_text(content, encoding='utf-8')
+    gitignore_path.write_text(GITIGNORE_TEMPLATE, encoding='utf-8')
+
+
+DATA_SPLIT_TABLE = """\
+| Path      | Tracked? | Use for |
+|-----------|----------|---------|
+| `data/`   | No       | Ephemeral session artifacts: transcripts, run logs, pickup state |
+| `data-dl/`| No       | Downloaded and fetched material: papers, drafts, exports, recordings |
+| `data-g/` | **Yes**  | Source-of-truth the runtime depends on: rosters, corpora, configs |
+"""
 
 
 def create_data_g_readme(project_path: Path) -> None:
-    """Create data-g/ with a README documenting the tracked-data split (#1563).
+    """Create data-g/ and data-dl/ with READMEs documenting the three-way split.
 
-    The fleet-wide global gitignore ignores `data/` so ephemeral session
-    artifacts (transcripts, run logs, pickup state) never land in git -- the
-    right default for throwaway state. But that ignore silently drops
-    authoritative work product too. Source-of-truth data the runtime reads as
-    canonical (rosters, corpora, recipient lists, configs) goes in `data-g/`
-    (the `-g` reads as "git-tracked"), which the global ignore does NOT match.
+    Three data directories, because two were not enough and the gap was filled
+    by guessing (#1563 established data-g/; #2485 added data-dl/).
 
-    Surfaced in IEEE-LRP-SC5 #19 when a roster JSON under data/ was silently
-    dropped from a durability commit and would have been lost on a machine wipe.
+    - `data/`     ephemeral session artifacts. Never committed.
+    - `data-dl/`  downloaded material. Never committed.
+    - `data-g/`   source-of-truth the runtime depends on. Committed.
 
-    Removes the schema-created .gitkeep -- the README makes the directory
-    non-empty and committable on its own.
+    WHY data-dl/ EXISTS
+    -------------------
+    Until #2485 there was nowhere for downloaded material to go, so it went into
+    `data-g/` -- the tracked one. That is backwards: a paper, an export or a
+    meeting recording is bulk that should never be committed, and it was landing
+    in the directory whose entire purpose is durability.
+
+    The cause was the name. `-g` is one letter, and the only place it was
+    explained was a README *inside the directory it explains*, which nobody
+    reads before deciding where to put a download. The convention was documented
+    and still failed, for months, for the person who commissioned it. So both
+    READMEs now carry the full three-way table rather than each describing only
+    itself.
+
+    WHY data-dl/ IS IGNORED IN THE REPO'S OWN .gitignore
+    ----------------------------------------------------
+    Not left to the machine's global gitignore. A global ignore protects only
+    the machine it is configured on; clone anywhere else and the rule is gone.
+    The repo carries its own rule so it protects itself on any clone.
+
+    Removes the schema-created .gitkeep from both -- each README makes its
+    directory non-empty on its own.
+
+    Note the ignore pattern this pairs with is `data-dl/*` plus a negation for
+    the README, NOT a bare `data-dl/`. Git cannot re-include a file underneath an
+    ignored *directory*, so `data-dl/` alone would ignore the README too and the
+    explanation would never reach the repo.
     """
     data_g = project_path / "data-g"
     data_g.mkdir(parents=True, exist_ok=True)
     gitkeep = data_g / ".gitkeep"
     if gitkeep.exists():
         gitkeep.unlink()
-    readme = '''\
+    readme = f'''\
 # data-g/ -- git-tracked data
 
 Source-of-truth data files that must persist in GitHub live here.
 
-The fleet-wide global gitignore ignores `data/` so ephemeral session artifacts
-(transcripts, run logs, pickup state) never land in git. That is the right
-default for throwaway state -- but it silently drops authoritative work product
-too. Anything the runtime reads as canonical input -- roster files, corpora,
-recipient lists, convergence configs -- belongs in `data-g/`, which the global
-ignore does NOT match.
+This repo has three data directories. Only this one is committed.
 
-| Path | Tracked? | Use for |
-|------|----------|---------|
-| `data/`   | No (global gitignore) | Session transcripts, pickup state, throwaway run output |
-| `data-g/` | Yes                   | Source-of-truth: rosters, corpora, configs the runtime depends on |
+{DATA_SPLIT_TABLE}
+The `-g` is for **git-tracked**. That is the whole distinction, and it is the
+one that gets missed: if you are putting a file here because you downloaded it,
+it belongs in `data-dl/` instead.
 
-Rule of thumb: if losing the file on a machine wipe would hurt, it goes in
-`data-g/`. (Convention established in AssemblyZero #1563.)
+Rule of thumb: if losing the file on a machine wipe would hurt **and** it is
+something this project produces or depends on rather than something you fetched,
+it goes in `data-g/`. (Convention established in AssemblyZero #1563; the
+three-way split in #2485.)
 '''
     (data_g / "README.md").write_text(readme, encoding="utf-8", newline="")
+
+    data_dl = project_path / "data-dl"
+    data_dl.mkdir(parents=True, exist_ok=True)
+    dl_gitkeep = data_dl / ".gitkeep"
+    if dl_gitkeep.exists():
+        dl_gitkeep.unlink()
+    dl_readme = f'''\
+# data-dl/ -- downloaded material, never committed
+
+Anything fetched from somewhere else lives here: papers, report drafts,
+spreadsheets, exports, images, meeting recordings.
+
+**This directory is gitignored.** Nothing in it is committed except this README.
+That is deliberate -- downloaded material is usually bulk, usually binary, and
+usually reproducible by downloading it again. Git is a poor store for it and the
+cost is permanent, because every clone pays for it forever.
+
+{DATA_SPLIT_TABLE}
+If something you downloaded genuinely needs to be durable -- it cannot be fetched
+again, or the project depends on it as canonical input -- move it to `data-g/`
+deliberately, rather than committing it from here. That move should be a decision
+someone made, not a side effect of where a file happened to land.
+
+(Convention established in AssemblyZero #2485, after `data-g/` spent months
+absorbing downloads because this directory did not exist.)
+'''
+    (data_dl / "README.md").write_text(dl_readme, encoding="utf-8", newline="")
 
 
 def create_file_inventory(project_path: Path, name: str) -> None:
@@ -1210,7 +1292,8 @@ This document provides a complete inventory of files in the {name} project, orga
 ```
 {name}/
 ├── .claude/                    # Claude Code configuration
-├── data/                       # Ephemeral data (git-ignored fleet-wide)
+├── data/                       # Ephemeral data (not committed)
+├── data-dl/                    # Downloaded material (not committed; see data-dl/README.md)
 ├── data-g/                     # Git-tracked source-of-truth data (see data-g/README.md)
 ├── docs/                       # All documentation
 │   ├── adrs/                   # Architecture Decision Records
@@ -3193,12 +3276,14 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
     create_file_inventory(project_path, args.name)
     print("  Created file inventory")
 
-    # Step 11a: Create data-g/ (git-tracked source-of-truth data) (#1563).
-    # The global gitignore ignores data/; data-g/ is the durable counterpart
-    # the ignore does not match. README explains the split.
-    print("\n11a. Creating data-g/ (git-tracked data convention)...")
+    # Step 11a: Create the two non-ephemeral data directories (#1563, #2485).
+    # data-g/ is the durable, committed one; data-dl/ is where downloaded bulk
+    # goes so it stops landing in data-g/. Each README carries the full
+    # three-way table, because a README that only describes its own directory
+    # does not help someone deciding which directory to use.
+    print("\n11a. Creating data-g/ and data-dl/ (three-way data convention)...")
     create_data_g_readme(project_path)
-    print("  Created data-g/README.md")
+    print("  Created data-g/README.md and data-dl/README.md")
 
     # Step 11b: Create .unleashed.json (wrapper configuration)
     print("\n11b. Creating .unleashed.json...")
@@ -3354,6 +3439,37 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         checks_passed += 1
     else:
         print("  [FAIL] data-g/README.md missing")
+
+    # Verify data-dl/ present AND actually ignored (#2485). Presence alone is not
+    # the property that matters -- a data-dl/ that git would happily commit is the
+    # bug this directory exists to prevent, so the check asserts the ignore rule
+    # bites and that the README survives it.
+    checks_total += 1
+    data_dl_readme = project_path / "data-dl" / "README.md"
+    probe = project_path / "data-dl" / ".ignore-probe"
+    dl_ok = False
+    if data_dl_readme.exists():
+        try:
+            probe.write_text("", encoding="utf-8")
+            ignored = subprocess.run(
+                ["git", "check-ignore", "-q", "data-dl/.ignore-probe"],
+                cwd=project_path, capture_output=True,
+            ).returncode == 0
+            readme_ignored = subprocess.run(
+                ["git", "check-ignore", "-q", "data-dl/README.md"],
+                cwd=project_path, capture_output=True,
+            ).returncode == 0
+            dl_ok = ignored and not readme_ignored
+        finally:
+            if probe.exists():
+                probe.unlink()
+    if dl_ok:
+        print("  [PASS] data-dl/ present, ignored, README still tracked")
+        checks_passed += 1
+    elif not data_dl_readme.exists():
+        print("  [FAIL] data-dl/README.md missing")
+    else:
+        print("  [FAIL] data-dl/ ignore rule wrong (contents must be ignored, README must not)")
 
     # Verify settings.json has hooks configured
     checks_total += 1


### PR DESCRIPTION
Two halves of one problem: the scaffolder's `.gitignore` template gains patterns
one incident at a time, and existing repos never receive them.

## `data-dl/` — martymcenroe/AssemblyZero#2485

There were two data directories and three kinds of data. `data/` for ephemeral
session state, `data-g/` for source-of-truth, and **nowhere at all for downloaded
material** — so downloads went into `data-g/`, the tracked one. A paper, an
export or a meeting recording is bulk that should never be committed, landing in
the directory whose entire purpose is durability.

The cause was the name. `-g` is one letter, and the only place it was explained
was a README *inside the directory it explains*, which nobody reads before
deciding where to put a download. The convention was documented and still failed,
for months, for the person who commissioned it. So both READMEs now carry the
full three-way table rather than each describing only itself.

| Path | Tracked? | Use for |
|---|---|---|
| `data/` | No | Ephemeral session artifacts |
| `data-dl/` | No | Downloaded and fetched material |
| `data-g/` | **Yes** | Source-of-truth the runtime depends on |

Two details are load-bearing:

**The ignore rule is `data-dl/*` plus `!data-dl/README.md`, not a bare
`data-dl/`.** Git cannot re-include a file underneath an ignored *directory*, so
the bare form would swallow the README that explains the convention. There is a
test for exactly this, asserted against real `git check-ignore` rather than by
reading the template back.

**It lives in the repo's own `.gitignore`**, not the machine's global one, so the
rule survives a clone onto any other machine.

The post-scaffold check asserts the property rather than mere presence: that
`data-dl/` contents really are ignored **and** that its README is not.

## `audit_gitignore_drift.py` — martymcenroe/AssemblyZero#1618

`GITIGNORE_TEMPLATE` is lifted to module level so the audit can diff a repo
against it without scaffolding anything. One definition, two consumers — a second
copy would drift the first time either changed, which is the defect being
audited.

Three judgements decide whether the report is worth reading, and each has a test:

- **Drift is one-directional.** Patterns the template has and the repo lacks. A
  repo's own extra rules are normal and are never reported. An audit that flagged
  them would cry wolf on every repo and train the reader to ignore it.
- **Comparison is on patterns, not text.** Trailing slashes normalised, comments
  and blanks dropped. Rewording a comment must not register as fleet-wide drift.
- **An ignored `data-g/` is a separate finding.** That is the silent failure —
  nothing stops being committed, new files just quietly never get added — and a
  `data-*/` glob is the easy way to cause it. Asked of `git check-ignore` rather
  than by reading `.gitignore`, because the rule can arrive from a glob, an
  exclude file, or global config.

A second commit fixes a defect the first live run exposed: `is_repo` accepted a
linked worktree (`.git` as a file) as a separate repository, so each one reported
its parent's drift again under a different name — including this branch's own
worktree. That is what took the count from 102 to 97.

Read-only by default. `--apply` appends under a dated, labelled block, never
removes or reorders, never commits, and skips dirty working trees.

## First run

97 repos. **Every one has drifted.**

| | repos |
|---|---|
| missing 7+ patterns | 62 |
| missing 3–6 | 29 |
| no `.gitignore` at all | 5 (wiki repos) |
| missing only the new `data-dl` pair | 1 |

And one live instance of the `data-g` trap already on the fleet — a repo where
`data-g/` is ignored today, so anything added there is silently never committed.
That is what the check was written to find, found on its first run.

Nothing was applied. The retrofit is per-repo work and belongs to martymcenroe/Secret-Agent-Man#363, which
this makes mechanical: its hand-built 2026-05-30 table can be replaced by this
tool's output.

## Verification

- `tests/unit/test_new_repo.py` — 129 pass
- `tests/unit/test_audit_gitignore_drift.py` — 21 pass, new
- `tests/unit/test_office_owner_file_ignores.py` — 13 pass, the other
  `create_gitignore` consumer, confirming the module-level refactor is invisible
  to callers
- `ruff` clean on all four files
- Both gitignore assertions run against real `git check-ignore`, not against the
  template text

Closes martymcenroe/AssemblyZero#2485, Closes martymcenroe/AssemblyZero#1618
