### PR TITLE
fix(hooks): secret-file-guard reads stdin JSON, not the retired env var (Closes #2489)

### DIFF
--- a/.claude/hooks/secret-file-guard.sh
+++ b/.claude/hooks/secret-file-guard.sh
@@ -7,7 +7,7 @@
 # using Read() to inspect secrets or Write() to render them in the permission
 # prompt (the leak happens at prompt-render time, before user approval).
 #
-# Environment: $CLAUDE_TOOL_INPUT_FILE_PATH contains the target file path
+# Input: hook JSON on stdin; field depends on the tool (see below)
 # Matched tools: Read, Write, Edit (via settings.json PreToolUse matchers)
 #
 # Incident: 2026-03-09 — career agent wrote API key via Write(.dev.vars),
@@ -15,10 +15,15 @@
 
 set -e
 
-# Grep uses $CLAUDE_TOOL_INPUT_PATH, Read/Write/Edit use $CLAUDE_TOOL_INPUT_FILE_PATH
-file_path="$CLAUDE_TOOL_INPUT_FILE_PATH"
+# Grep uses .tool_input.path; Read/Write/Edit use .tool_input.file_path
+# Input arrives as JSON on stdin. It used to arrive in CLAUDE_TOOL_INPUT_*, which
+# the harness no longer sets -- so this hook received an empty string, hit the
+# guard below, and exited 0 while the config still read as protected (#301).
+# Read stdin ONCE: a second `cat` in the same process gets nothing.
+_hook_json=$(cat)
+file_path=$(printf '%s' "$_hook_json" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 if [ -z "$file_path" ]; then
-    file_path="$CLAUDE_TOOL_INPUT_PATH"
+    file_path=$(printf '%s' "$_hook_json" | jq -r '.tool_input.path // empty' 2>/dev/null)
 fi
 
 # Skip empty paths
@@ -100,7 +105,7 @@ fi
 # Pattern 4: Grep glob targeting secret files
 # Issue #714 bypass #14: Grep(path=".dev.vars") or Grep(glob=".env*")
 # ---------------------------------------------------------------------------
-grep_glob="$CLAUDE_TOOL_INPUT_GLOB"
+grep_glob=$(printf '%s' "$_hook_json" | jq -r '.tool_input.glob // empty' 2>/dev/null)
 if [ -n "$grep_glob" ]; then
     grep_glob_lower=$(printf '%s' "$grep_glob" | tr '[:upper:]' '[:lower:]')
     if [[ "$grep_glob_lower" =~ \.env ]] ||


### PR DESCRIPTION
## The defect

`.claude/hooks/secret-file-guard.sh` reads its input from
`$CLAUDE_TOOL_INPUT_FILE_PATH` / `$CLAUDE_TOOL_INPUT_PATH` /
`$CLAUDE_TOOL_INPUT_GLOB`. **The harness no longer sets any of them.**

The hook receives an empty path, hits its own `[ -z "$file_path" ] && exit 0`
guard, and allows everything. It does not error. The registration reads as fully
protected.

This is the guard that exists because of the 2026-03-09 incident where an agent
wrote an API key via `Write(.dev.vars)` — and the leak in that class happens at
permission-prompt render time, before anyone can approve or deny. So the window
it protects is one the operator cannot cover by being careful.

It has been inert for an unknown period.

## The fix here

Read the hook payload as JSON from stdin, once, and pull the three fields from
it:

| tool | field |
|---|---|
| Read / Write / Edit | `.tool_input.file_path` |
| Grep (path form) | `.tool_input.path` |
| Grep (glob form) | `.tool_input.glob` |

Detection logic is untouched. Verified by invoking the hook the way the harness
does, with a `Read` payload targeting a `.dev.vars` path: it now produces its
BLOCKED banner, where before it printed nothing and exited 0.

## What this does NOT fix, and it matters

**The hook exits 1. Claude Code denies on exit 2.** Any other non-zero code is
surfaced to the model as a non-blocking error and the tool call then proceeds.

So after this change the hook evaluates, prints `BLOCKED: Secret File Guard`, and
the read still happens. That is a real improvement over silence — the warning
reaches the model and the transcript — but it is not yet enforcement, and the
banner could be misread as enforcement by someone reading the log later.

Correcting the exit code is deliberately not in this change. Agent edits to hook
scripts are refused by the auto-mode classifier as self-modification, which is
correct: a hook is agent-safety configuration and an agent should not be able to
quietly weaken one. It needs explicit per-file operator authorization.

## Two more, found alongside

**Duplicate copies drift.** This repo also carries `.claude/hooks/bash-gate.sh`
and `.claude/hooks/secret-guard.sh`, which are **not** the copies
`~/.claude/settings.json` registers. The registered ones live under the home
directory and have been repaired; these repo copies have not. Two copies of a
guard, one fixed, and nothing reconciles them.

**Nothing tested any of this.** A self-test that feeds every registered hook a
known-bad payload and asserts exit 2 now exists in the private coordination
repo's tooling. Cases for this hook belong there once its exit code is corrected;
adding a failing case now would leave a red suite, which trains people to ignore
it.

---

Verified by invoking the hook exactly as the harness does, payload as JSON on stdin: a `Read` targeting a `.dev.vars` path now produces the BLOCKED banner, where before the hook printed nothing and exited 0.

Closes #2489
