### PR TITLE
fix(hooks): secret-file-guard must exit 2 to actually deny (Closes #2491)

### DIFF
--- a/.claude/hooks/secret-file-guard.sh
+++ b/.claude/hooks/secret-file-guard.sh
@@ -60,7 +60,7 @@ if [[ "$filename" == ".env" ]] ||
     echo "To update secrets: tell the user to run the command in their" >&2
     echo "own terminal, or use a deployment script that reads from env." >&2
     echo "" >&2
-    exit 1
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -77,7 +77,7 @@ if [[ "$file_path_lower" =~ \.aws/(credentials|config) ]]; then
     echo "AWS credential files must never be accessed by Claude." >&2
     echo "Use boto3 or os.environ.get() in Python instead." >&2
     echo "" >&2
-    exit 1
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -98,7 +98,7 @@ if [[ "$filename_lower" =~ secret ]] ||
     echo "Files with 'secret', 'credential', or 'private.key' in the name" >&2
     echo "are presumed to contain sensitive material." >&2
     echo "" >&2
-    exit 1
+    exit 2
 fi
 
 # ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ if [ -n "$grep_glob" ]; then
         echo "" >&2
         echo "Grep glob pattern targets secret files." >&2
         echo "" >&2
-        exit 1
+        exit 2
     fi
 fi
 


### PR DESCRIPTION
## What

`.claude/hooks/secret-file-guard.sh` exits **1** on a denial. Claude Code denies
on **exit 2**; any other non-zero code is surfaced to the model as a non-blocking
error and the tool call then proceeds.

So since its input plumbing was repaired, the hook has been *evaluating*
correctly and *printing* its full `BLOCKED: Secret File Guard` banner — and the
read has gone ahead anyway.

That is worse than the silence it replaced. An inert guard protects nothing; a
guard that announces denials it did not perform gets budgeted against by anyone
reading the transcript, including a future audit of whether this class of leak is
covered.

## Why this hook specifically

It exists because of the 2026-03-09 incident where an agent wrote an API key via
`Write(.dev.vars)`. In that class the leak happens **when the permission prompt
renders** — before anyone can approve or deny. So the window it protects is one
the operator cannot cover by being careful, and a guard that does not actually
stop the call leaves that window fully open.

## Fix

All four denial sites move from `exit 1` to `exit 2`. No detection logic is
touched.

## Verification

Covered by a self-test in the private coordination repo's tooling, which invokes
the hook exactly as the harness does — payload as JSON on stdin — and asserts the
exit code:

```
reading .dev.vars                -> 2
reading .env                     -> 2
an ordinary source file is fine  -> 0
```

The negative case is not filler. A guard that blocks ordinary source edits gets
switched off, and takes the real protection with it.

## Note on the sibling copies

This repo also carries `.claude/hooks/bash-gate.sh` and
`.claude/hooks/secret-guard.sh`, which are **not** the copies `settings.json`
registers — the registered ones live under the home directory and have been
repaired. Two copies of a guard, one fixed, and nothing reconciles them. Not
addressed here; worth its own decision about whether the repo copies should exist
at all.
n---

Verified by invoking the hook exactly as the harness does. 40 hook self-test cases pass overall, zero failures.

Closes #2491
