### PR TITLE
feat(sentinel): refuse the auto-close verbs GitHub honours and this check ignored (Closes #2494)

### DIFF
--- a/sentinel/src/validate.js
+++ b/sentinel/src/validate.js
@@ -5,6 +5,25 @@
 
 const NO_ISSUE_PATTERN = /^No-Issue:\s*\S+/im;
 
+// GitHub auto-closes on THREE verb families. This validator has only ever
+// looked at one of them:
+//
+//   close / closes / closed        <- extracted below, and policed
+//   fix / fixes / fixed            <- GitHub honours it, we never looked
+//   resolve / resolves / resolved  <- GitHub honours it, we never looked
+//
+// The two we ignored fail silently. A PR body whose prose named an issue with
+// one of those verbs closed that issue on merge, in a PR that said in plain
+// words it was NOT addressing it and had pinned the defect as a passing test.
+// Nothing warned; it was found days later by a handoff cross-check.
+//
+// The house standard mandates `Closes #N` in commit, title and body, so the
+// fix/resolve forms are never a sanctioned way to close anything. Every
+// occurrence is either a mistake or prose about to become one, which is why
+// this blocks rather than warns.
+const SILENT_CLOSE_PATTERN =
+  /\b(?:fix(?:es|ed)?|resolve[sd]?)\s+(?:([\w.-]+)\/([\w.-]+))?#(\d+)/gi;
+
 /**
  * Extract issue references from a PR body.
  * Returns an array of { owner, repo, number } objects.
@@ -29,6 +48,33 @@ export function extractIssueRefs(body) {
 }
 
 /**
+ * Extract references written with an auto-close verb this check has
+ * historically ignored but GitHub acts on.
+ *
+ * Same shape as extractIssueRefs. Separate function because the two sets mean
+ * opposite things: one is the directive we require, the other is the directive
+ * we refuse.
+ * @param {string} body
+ * @returns {Array<{ owner: string|null, repo: string|null, number: number }>}
+ */
+export function extractSilentCloseRefs(body) {
+  if (!body) return [];
+  const refs = [];
+  // exec() on a /g regex is stateful; build a fresh one per call so a previous
+  // partial scan cannot make the next one start mid-string and miss a match.
+  const pattern = new RegExp(SILENT_CLOSE_PATTERN.source, SILENT_CLOSE_PATTERN.flags);
+  let match;
+  while ((match = pattern.exec(body)) !== null) {
+    refs.push({
+      owner: match[1] || null,
+      repo: match[2] || null,
+      number: parseInt(match[3], 10),
+    });
+  }
+  return refs;
+}
+
+/**
  * Validate a PR body for issue references.
  * @param {string|null} body - The PR body text
  * @returns {{ valid: boolean, reason: string, refs: Array, noIssue: boolean }}
@@ -40,6 +86,31 @@ export function validatePRBody(body) {
       reason: "PR body is empty. Add `Closes #N` or `No-Issue: <reason>`.",
       refs: [],
       noIssue: false,
+    };
+  }
+
+  // Checked BEFORE the Closes path: a body can carry a correct `Closes #N`
+  // and a stray `fixes #M` at the same time, and that combination is the most
+  // dangerous one -- it passes every existing check while quietly taking a
+  // second issue down with it on merge.
+  const silent = extractSilentCloseRefs(body);
+  if (silent.length > 0) {
+    const listed = silent
+      .map((r) => (r.owner ? `${r.owner}/${r.repo}#${r.number}` : `#${r.number}`))
+      .join(", ");
+    return {
+      valid: false,
+      reason:
+        `PR body uses an auto-close verb GitHub honours but this check has ` +
+        `never reported: ${listed}. GitHub closes on fix/fixes/fixed and ` +
+        `resolve/resolves/resolved as well as close/closes/closed, so this ` +
+        `would close silently on merge. If you mean to close it, write ` +
+        `\`Closes #N\` -- the mandated form, in commit, title and body. If ` +
+        `you do not, reword: \`see #N\`, \`a fix for #N\`, ` +
+        `\`whoever addresses #N\`, \`follow-up: #N\`.`,
+      refs: [],
+      noIssue: false,
+      silentCloseRefs: silent,
     };
   }
 

--- a/sentinel/tests/silent-close.test.js
+++ b/sentinel/tests/silent-close.test.js
@@ -1,0 +1,124 @@
+// The auto-close verbs this check never looked at.
+//
+// GitHub acts on three verb families; validate.js only ever extracted one.
+// The other two close an issue on merge with nothing reporting it, which is
+// the failure this suite pins down. A body that reads as prose to a human is
+// a directive to GitHub.
+import { describe, it, expect } from "vitest";
+import { validatePRBody, extractSilentCloseRefs } from "../src/validate.js";
+
+describe("extractSilentCloseRefs", () => {
+  it("catches every fix-family spelling", () => {
+    for (const verb of ["fix", "fixes", "fixed", "Fix", "FIXES", "Fixed"]) {
+      const refs = extractSilentCloseRefs(`this ${verb} #47 somehow`);
+      expect(refs, verb).toHaveLength(1);
+      expect(refs[0].number, verb).toBe(47);
+    }
+  });
+
+  it("catches every resolve-family spelling", () => {
+    for (const verb of ["resolve", "resolves", "resolved", "Resolve", "RESOLVED"]) {
+      const refs = extractSilentCloseRefs(`this ${verb} #9 somehow`);
+      expect(refs, verb).toHaveLength(1);
+      expect(refs[0].number, verb).toBe(9);
+    }
+  });
+
+  it("catches the cross-repo qualified form", () => {
+    const refs = extractSilentCloseRefs("fixed owner-x/repo-y#1234");
+    expect(refs).toEqual([{ owner: "owner-x", repo: "repo-y", number: 1234 }]);
+  });
+
+  it("does not fire on close/closes/closed", () => {
+    // Those are the mandated form and are policed by extractIssueRefs. Firing
+    // here would refuse every correctly written PR in the fleet.
+    expect(extractSilentCloseRefs("Closes #1")).toHaveLength(0);
+    expect(extractSilentCloseRefs("closed #1")).toHaveLength(0);
+  });
+
+  it("does not fire on prose that merely mentions a repair", () => {
+    // The verb must be immediately followed by the reference. Without this the
+    // check would make ordinary PR bodies unwritable, and an over-blocking
+    // gate gets switched off, taking the real protections with it.
+    expect(extractSilentCloseRefs("a fix for #47 lands separately")).toHaveLength(0);
+    expect(extractSilentCloseRefs("the repair in #47 is unrelated")).toHaveLength(0);
+    expect(extractSilentCloseRefs("whoever addresses #47")).toHaveLength(0);
+    expect(extractSilentCloseRefs("see #47")).toHaveLength(0);
+    expect(extractSilentCloseRefs("follow-up: #47")).toHaveLength(0);
+  });
+
+  it("does not treat prefixed words as the verb", () => {
+    expect(extractSilentCloseRefs("postfixes #47")).toHaveLength(0);
+    expect(extractSilentCloseRefs("unresolved #47")).toHaveLength(0);
+  });
+
+  it("finds every occurrence, not just the first", () => {
+    // The regex is /g and exec() is stateful; a shared object would resume
+    // mid-string on the next call and silently miss matches.
+    const refs = extractSilentCloseRefs("fixes #1 and resolves #2 and fixed #3");
+    expect(refs.map((r) => r.number)).toEqual([1, 2, 3]);
+  });
+
+  it("is not stateful across calls", () => {
+    const body = "fixes #5";
+    expect(extractSilentCloseRefs(body)).toHaveLength(1);
+    expect(extractSilentCloseRefs(body)).toHaveLength(1);
+  });
+
+  it("handles an empty or missing body", () => {
+    expect(extractSilentCloseRefs("")).toEqual([]);
+    expect(extractSilentCloseRefs(null)).toEqual([]);
+  });
+});
+
+describe("validatePRBody with silent-close verbs", () => {
+  it("refuses a body whose only directive is a silent one", () => {
+    const r = validatePRBody("Fixes #47");
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain("#47");
+    expect(r.silentCloseRefs).toHaveLength(1);
+  });
+
+  it("refuses a correct Closes that also carries a stray silent verb", () => {
+    // The most dangerous combination and the reason this is checked BEFORE the
+    // Closes path: it satisfies every pre-existing rule while quietly taking a
+    // second issue down on merge.
+    const r = validatePRBody("Closes #100. Whoever fixes #47 gets a listing.");
+    expect(r.valid).toBe(false);
+    expect(r.silentCloseRefs.map((x) => x.number)).toEqual([47]);
+    expect(r.reason).not.toContain("#100");
+  });
+
+  it("names the substitution in the refusal", () => {
+    // A gate that refuses without saying what to type instead gets worked
+    // around rather than obeyed.
+    const r = validatePRBody("Resolves #9");
+    expect(r.reason).toContain("Closes #N");
+    expect(r.reason).toContain("see #N");
+  });
+
+  it("still passes an ordinary correct body", () => {
+    const r = validatePRBody("Does the thing.\n\nCloses #123");
+    expect(r.valid).toBe(true);
+    expect(r.refs).toHaveLength(1);
+  });
+
+  it("still passes a No-Issue exemption", () => {
+    const r = validatePRBody("No-Issue: scaffolder catch-up for a same-day repo");
+    expect(r.valid).toBe(true);
+    expect(r.noIssue).toBe(true);
+  });
+
+  it("refuses a No-Issue body carrying a silent verb", () => {
+    // The exemption is from needing an issue, not from closing one by accident.
+    const r = validatePRBody("No-Issue: cleanup\n\nthis fixes #47 incidentally");
+    expect(r.valid).toBe(false);
+    expect(r.silentCloseRefs).toHaveLength(1);
+  });
+
+  it("still refuses an empty body for the original reason", () => {
+    const r = validatePRBody("");
+    expect(r.valid).toBe(false);
+    expect(r.reason).toContain("empty");
+  });
+});


### PR DESCRIPTION
feat(sentinel): refuse the auto-close verbs GitHub honours and this check ignored (Closes #2494)

GitHub auto-closes on three verb families when a PR merges. validate.js only
ever extracted one:

  close / closes / closed        extracted, and policed
  fix / fixes / fixed            GitHub honours it, we never looked
  resolve / resolves / resolved  GitHub honours it, we never looked

The two we ignored are the two that fail silently. The close family at least
produces a loud outcome -- an unintended reference means action_required and
the PR blocks. The others produce no signal: the issue closes on merge and
nobody learns why.

A PR body whose prose named an issue with one of the unwatched verbs closed
that issue on merge, in a PR that said in plain words it was not addressing it
and had pinned the defect as a passing test. It was found days later by an
unrelated cross-check. The body read as commentary to every human who saw it
and as a directive to GitHub.

extractSilentCloseRefs() mirrors extractIssueRefs, kept separate because the
two sets mean opposite things: one is the directive we require, the other the
directive we refuse. It builds a fresh RegExp per call -- exec() on a /g
pattern is stateful, and a shared object would resume mid-string on the next
call and miss matches.

The check runs BEFORE the existing pass. The dangerous case is a body carrying
a correct Closes #N alongside a stray one of these: it satisfies every rule
already in place while quietly taking a second issue down on merge.

The refusal names the substitution. A gate that refuses without saying what to
write instead gets worked around rather than obeyed.

It does not fire on prose. The verb must be immediately followed by the
reference, so "a fix for #N" and "the repair in #N" stay writable, and
"postfixes" and "unresolved" are not the verb. An over-blocking gate gets
switched off and takes the real protections with it, so those cases are
asserted rather than assumed.

16 new cases in tests/silent-close.test.js: every spelling of both families,
the cross-repo qualified form, the correct-plus-stray combination, statefulness
across calls, the No-Issue path, and the prose negatives. Suite: 74 passed.

Not deployed by this commit. The Worker ships with wrangler, not from CI, so
merging does not change production. The deploy is the decision that alters
fleet behaviour: any open PR whose body carries one of these verbs begins to
block at that point, not before.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
