### PR TITLE
fix(new-repo): stop instructing a key revoke that blocks the repo just created, and delete the drifted caller copy (Closes #2496, Closes #1193)

### DIFF
--- a/tests/unit/test_fleet_readiness.py
+++ b/tests/unit/test_fleet_readiness.py
@@ -172,10 +172,22 @@ def test_audit_tsv_row_includes_all_four_dims():
 # =========================================================================
 
 def test_caller_workflow_calls_az_reusable():
-    """The caller content must reference the AZ reusable workflow path."""
+    """The caller must reference the AZ reusable workflow AND satisfy the
+    contract that workflow declares.
+
+    This previously asserted `secrets: inherit`, which is how the stale caller
+    format survived a green suite for months (#1193). The reusable workflow
+    declares `workflow_call` with a `required_checks` input and two REQUIRED
+    secrets; `inherit` does not satisfy a declared-secrets contract, and the
+    mismatch produced `startup_failure` in 0s on every PR of every repo this
+    tool touched.
+    """
     assert "uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main" \
         in deploy.CALLER_WORKFLOW
-    assert "secrets: inherit" in deploy.CALLER_WORKFLOW
+    assert "secrets: inherit" not in deploy.CALLER_WORKFLOW
+    assert "required_checks" in deploy.CALLER_WORKFLOW
+    assert "REVIEWER_APP_ID" in deploy.CALLER_WORKFLOW
+    assert "REVIEWER_APP_PRIVATE_KEY" in deploy.CALLER_WORKFLOW
     assert "pull_request" in deploy.CALLER_WORKFLOW
 
 

--- a/tests/unit/test_new_repo.py
+++ b/tests/unit/test_new_repo.py
@@ -1505,41 +1505,58 @@ class TestGitHubRepoNameCasePreservation:
 
 
 class TestCerberusPostDeployAdvice:
-    """#1536: the post-deploy success message must distinguish between
-    the plaintext flow (`--cerberus-pem`, .pem deleted, revoke-the-key
-    correct) and the encrypted-reusable flow (`--cerberus-pem-gpg`, blob
-    preserved, revoke-the-key catastrophic — would invalidate the
-    reusable encrypted file).
+    """#134 supersedes #1536. The post-deploy advice must NOT branch.
 
-    Bug pre-fix: a single `print(\"REMEMBER to revoke the key...\")` line
-    fired for both flows. The operator following it under the
-    encrypted-reusable flow would lose the ability to use the encrypted
-    PEM for subsequent new-repo runs.
+    #1536 split the advice by flow: the plaintext flow (`--cerberus-pem`)
+    deletes the .pem, so it was told to revoke as belt-and-braces, while
+    the encrypted-reusable flow (`--cerberus-pem-gpg`) was told not to,
+    because revoking would invalidate the blob it had just kept.
+
+    That split asks the wrong question. Revoking does not retire an
+    on-disk copy — it removes the PUBLIC half registered on the App, so
+    GitHub can no longer validate a JWT signed by that key, and the
+    REVIEWER_APP_PRIVATE_KEY secret the run just deployed becomes dead
+    bytes. No installation token, no approving review, mergeable_state
+    stuck at `blocked` — in the new repo AND in every other repo holding
+    the same key.
+
+    The question is not "did a plaintext file survive this run". It is
+    "is this key deployed anywhere", and after either flow the answer is
+    yes, because deploying it is the point of the run. So the advice is
+    the same on both paths: keep the key active, rotate via runbook 0939.
+
+    These tests previously asserted the presence of the revoke
+    instruction, which is how the defect stayed shipped through a green
+    suite. They now assert its absence.
     """
 
-    def test_revoke_advice_only_present_in_plaintext_branch(self):
-        """The string 'REMEMBER to revoke' should only appear inside a
-        conditional that checks args.cerberus_pem (the plaintext flow)."""
+    def test_no_revoke_instruction_on_any_flow(self):
         from pathlib import Path
         script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo.py"
         content = script.read_text(encoding="utf-8")
-        # The advisory text must exist (it's correct for the plaintext flow)
-        assert "REMEMBER to revoke the key in the app UI" in content
-        # And the encrypted-flow branch must have the NEGATING advice
-        assert "DO NOT revoke the key in the app UI" in content, (
-            "regression #1536: the encrypted-reusable flow "
-            "(--cerberus-pem-gpg) lost its do-not-revoke guidance. The "
-            "post-deploy success message must distinguish the two flows."
+        assert "REMEMBER to revoke the key in the app UI" not in content, (
+            "#134: deploy-then-revoke instruction is back. Revoking "
+            "invalidates the Actions secret this run just deployed."
         )
+        assert "Revoke the key you just used" not in content
+
+    def test_keep_active_guidance_is_present_on_both_flows(self):
+        """Deleting the bad advice without replacing it would pass the test
+        above and leave the operator at a Revoke button with no guidance."""
+        from pathlib import Path
+        script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo.py"
+        content = script.read_text(encoding="utf-8")
+        assert "do NOT revoke" in content or "Do NOT revoke" in content
+        assert "0939" in content, "must point at the rotation runbook"
 
     def test_anchor_comment_naming_issue_present(self):
-        """A comment naming #1536 should sit at the cerberus_status branch
-        so future agents understand why the two flows produce different
-        end-of-run advice."""
+        """A comment naming #134 should sit at the cerberus_status branch so
+        the next reader does not re-derive the on-disk model and
+        re-introduce the split."""
         from pathlib import Path
         script = Path(__file__).resolve().parent.parent.parent / "tools" / "new_repo.py"
         content = script.read_text(encoding="utf-8")
-        assert "#1536" in content
+        assert "#134" in content
         # The #1536 anchor must be near the `elif cerberus_status == \"OK\":`
         # branch (within a few hundred chars BEFORE the branch text — the
         # anchor comment introduces the conditional).

--- a/tests/unit/test_new_repo_guidance.py
+++ b/tests/unit/test_new_repo_guidance.py
@@ -1,0 +1,104 @@
+"""Guidance the new-repo path prints, and the caller template it deploys.
+
+Two defects that shipped for months without failing anything, because neither
+is about behaviour. One was operator-facing prose. The other was a duplicated
+constant. Nothing executes prose and nothing compares duplicates, so nothing
+caught either.
+
+DEPLOY-THEN-REVOKE (#134)
+-------------------------
+The script told the operator to revoke the Cerberus App key after deploying it.
+Revoking removes the PUBLIC half registered on the App, so GitHub can no longer
+validate a JWT signed by that key -- and the REVIEWER_APP_PRIVATE_KEY secret
+the run just deployed becomes dead bytes. No installation token, no approving
+review, mergeable_state stuck at `blocked`, in the new repo and in every other
+repo holding the same key.
+
+Runbook 0927 was corrected and the script was not, so the two contradicted each
+other, and the script is the copy the operator actually reads at 10pm.
+
+CALLER-TEMPLATE DRIFT (#1193)
+-----------------------------
+deploy_auto_reviewer_workflow.py carried its own copy of the auto-reviewer
+caller YAML. It went stale: pre-`workflow_call` format, no `with:` inputs,
+`secrets: inherit` instead of the named secrets the reusable workflow declares
+as required. Every repo it touched got a workflow that died at startup.
+
+The copy is now gone -- it imports the constant from new_repo.py -- and this
+asserts they cannot diverge again.
+"""
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS))
+
+NEW_REPO_SRC = (TOOLS / "new_repo.py").read_text(encoding="utf-8")
+DEPLOY_SRC = (TOOLS / "deploy_auto_reviewer_workflow.py").read_text(encoding="utf-8")
+
+
+class TestNoDeployThenRevoke:
+    # Lines that TELL the operator to revoke. Prose explaining what revocation
+    # does, or pointing at the rotation runbook, is fine and must stay -- the
+    # rule is "never instruct a revoke right after a deploy", not "never say
+    # the word".
+    IMPERATIVE = re.compile(
+        r"^\s*print\(.*(?:REMEMBER to revoke"
+        r"|Revoke the key you just"
+        r"|revoke the key in the app UI\""
+        r"|,\s*revoke the key)",
+        re.IGNORECASE | re.MULTILINE,
+    )
+
+    def test_new_repo_never_instructs_a_revoke(self):
+        hits = self.IMPERATIVE.findall(NEW_REPO_SRC)
+        assert not hits, f"deploy-then-revoke instruction present: {hits}"
+
+    def test_the_keep_active_warning_is_actually_printed(self):
+        # The inverse assertion. Deleting the bad advice without replacing it
+        # would pass the test above and leave the operator with no guidance at
+        # the exact moment they are looking at a Revoke button.
+        assert "do NOT revoke" in NEW_REPO_SRC or "Do NOT revoke" in NEW_REPO_SRC
+        assert "0939" in NEW_REPO_SRC, "must point at the rotation runbook"
+
+    def test_advice_does_not_branch_on_which_pem_flow_ran(self):
+        # The superseded #1536 split told the plaintext flow to revoke because
+        # no on-disk credential survived. Wrong question: the key is deployed
+        # either way, which is what makes revoking destructive.
+        assert "belt-and-" not in NEW_REPO_SRC
+        assert "no on-disk credential to retire" not in NEW_REPO_SRC
+
+
+class TestCallerTemplateHasOneDefinition:
+    def test_deploy_tool_imports_rather_than_redefines(self):
+        assert "_CANONICAL_AUTO_REVIEWER_CALLER" in DEPLOY_SRC
+        assert not re.search(r"^CALLER_WORKFLOW\s*=\s*[\"']", DEPLOY_SRC, re.MULTILINE), \
+            "deploy tool redefines the caller instead of importing it (#1193)"
+
+    def test_the_two_modules_agree_by_identity(self):
+        new_repo = pytest.importorskip("new_repo")
+        deploy = pytest.importorskip("deploy_auto_reviewer_workflow")
+        assert deploy.CALLER_WORKFLOW is new_repo._CANONICAL_AUTO_REVIEWER_CALLER
+
+    def test_the_canonical_caller_matches_the_reusable_workflow_contract(self):
+        new_repo = pytest.importorskip("new_repo")
+        caller = new_repo._CANONICAL_AUTO_REVIEWER_CALLER
+        # The reusable workflow declares workflow_call with a required_checks
+        # input and two REQUIRED secrets. `secrets: inherit` does not satisfy
+        # a declared-secrets contract -- that mismatch is what produced
+        # startup_failure in 0s on every PR.
+        assert "workflows/auto-reviewer.yml@main" in caller
+        assert "required_checks" in caller
+        assert "REVIEWER_APP_ID" in caller
+        assert "REVIEWER_APP_PRIVATE_KEY" in caller
+        assert "secrets: inherit" not in caller
+
+    def test_docstring_does_not_carry_a_third_copy(self):
+        # The module docstring used to quote the YAML, and the quote went stale
+        # alongside the code copy. A transcribed example is a copy nothing
+        # tests and everyone trusts.
+        head = DEPLOY_SRC.split('"""')[1] if '"""' in DEPLOY_SRC else ""
+        assert "secrets: inherit" not in head

--- a/tools/deploy_auto_reviewer_workflow.py
+++ b/tools/deploy_auto_reviewer_workflow.py
@@ -9,8 +9,9 @@ fine-grained PATs intentionally lack that scope.
 What this script does:
 
   1. Determines the canonical auto-reviewer.yml content. Each repo
-     gets the CALLER pattern (a 6-line YAML that invokes AZ's reusable
-     auto-reviewer workflow via `uses:`).
+     gets the CALLER pattern -- a short YAML that invokes AZ's reusable
+     auto-reviewer workflow via `uses:`, passing the `required_checks`
+     input and the named Cerberus secrets it declares.
   2. For each target repo, PUTs the caller file via Contents API to
      `.github/workflows/auto-reviewer.yml` on the default branch.
   3. Idempotent: skips repos that already have the file.
@@ -42,16 +43,14 @@ updates ... use in-process classic-PAT"). It is NOT the banned
 `--admin` flag (which is the `gh pr merge --admin` shortcut). The
 bypass window is bounded to a single PUT, owner-role-scoped, atomic.
 
-The canonical CALLER file is:
+The canonical CALLER file lives in ONE place: `_CANONICAL_AUTO_REVIEWER_CALLER`
+in `new_repo.py`. It is deliberately not reproduced here (#1193).
 
-    name: auto-reviewer
-    on:
-      pull_request:
-        types: [opened, synchronize, reopened]
-    jobs:
-      review:
-        uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
-        secrets: inherit
+This docstring used to quote it, and the quote went stale alongside the code
+copy it described -- both showing the pre-`workflow_call` format long after the
+reusable workflow started requiring `with:` inputs and named secrets. A
+transcribed example is a third copy that nothing tests and everyone trusts.
+Read the constant.
 
 Usage:
 
@@ -76,26 +75,28 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _pat_session import classic_pat_session  # noqa: E402
+# The caller content is NOT defined here (#1193). It is imported from
+# new_repo.py, the single source of truth that creation-time writing and
+# post-setup verification already share.
+#
+# This file used to carry its own copy, and that copy went stale. It still had
+# the pre-`workflow_call` format -- no `with:` inputs, `secrets: inherit`
+# instead of the named secrets the reusable workflow declares as required. Any
+# repo it touched got a workflow that failed at startup: `auto-reviewer`
+# completing in 0s with conclusion `startup_failure`, Cerberus never posting a
+# review, `mergeable_state` stuck at `blocked`. Seen on two PRs in a scaffolded
+# repo, both blocked indefinitely until unblocked by hand.
+#
+# Copying the current format in here would fix today and leave the mechanism
+# intact. Two definitions of one artifact drift -- that is not a prediction,
+# it is what this defect IS. So the duplicate is deleted rather than corrected,
+# and the test suite asserts the two modules agree by identity.
+from new_repo import _CANONICAL_AUTO_REVIEWER_CALLER as CALLER_WORKFLOW  # noqa: E402
 
 GITHUB_USER = "martymcenroe"
 GH_API = "https://api.github.com"
 HTTP_TIMEOUT_S = 30
 WORKFLOW_PATH = ".github/workflows/auto-reviewer.yml"
-
-# Canonical caller workflow. Mirrors what every other repo in the fleet
-# uses to invoke the AssemblyZero reusable auto-reviewer.yml.
-CALLER_WORKFLOW = """\
-name: auto-reviewer
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-
-jobs:
-  review:
-    uses: martymcenroe/AssemblyZero/.github/workflows/auto-reviewer.yml@main
-    secrets: inherit
-"""
 
 
 def _headers(pat: str) -> dict[str, str]:
@@ -446,7 +447,7 @@ def deploy_with_bootstrap(repo: str, branch: str,
 
     # Bootstrap path
     if classic_strict:
-        print(f"  bootstrap: classic protection strict (enforce_admins=True)")
+        print("  bootstrap: classic protection strict (enforce_admins=True)")
     if has_rulesets:
         rs_ids = [rs.get("id") for rs in rulesets]
         print(f"  bootstrap: {len(rulesets)} active ruleset(s) targeting {branch}: {rs_ids}")

--- a/tools/new_repo.py
+++ b/tools/new_repo.py
@@ -2760,9 +2760,13 @@ def _deploy_cerberus(
               "the path you provided; reuse it for additional repos.)")
 
     print()
-    print("  NEXT STEP (browser-only, cannot be automated):")
-    print("    Revoke the key you just used in the GitHub App UI:")
-    print("    https://github.com/settings/apps/cerberus-az > Private keys > Revoke")
+    print("  KEEP THE APP KEY ACTIVE -- do NOT revoke it (#134).")
+    print("    The REVIEWER_APP_PRIVATE_KEY secret this run just deployed is")
+    print("    only usable while its PUBLIC half stays registered on the App.")
+    print("    Revoking removes that registration, so GitHub rejects the JWT,")
+    print("    no installation token is issued, and Cerberus never approves --")
+    print("    in this repo and in every other repo holding the same key.")
+    print("    To rotate: runbook 0939 (deploy new, audit, THEN revoke old).")
 
     return "OK"
 
@@ -3878,31 +3882,38 @@ def _create_repo(project_path: Path, args: argparse.Namespace, github_user: str)
         print("  #   Without secrets, PRs pass pr-sentinel but are never auto-approved.")
         print("  #   1. https://github.com/settings/apps/cerberus-az > Private keys > Generate")
         print("  #   2. poetry run python tools/deploy_cerberus_secrets.py /path/to/downloaded.pem")
-        print("  #   3. Delete the .pem, revoke the key in the app UI")
+        print("  #   3. Delete the .pem. Do NOT revoke the key -- the deployed")
+        print("  #      secret depends on it staying active (#134).")
         print("  #   See runbook 0927 step 4 for full procedure.")
         print("  #   OR re-run this script with --cerberus-pem PATH (single-shot)")
         print("  #   or --cerberus-pem-gpg PATH (reusable, encrypted at rest).")
     elif cerberus_status == "OK":
-        # Closes #1536: the post-deploy advice depends on which Cerberus
-        # flow ran. The plaintext flow (--cerberus-pem) deletes the .pem
-        # after deploy, so revoking the GitHub-side key as belt-and-
-        # suspenders is correct — no on-disk credential survives this run.
-        # The encrypted-reusable flow (--cerberus-pem-gpg) intentionally
-        # keeps the encrypted blob for subsequent new-repo invocations;
-        # revoking the key would invalidate that blob — catastrophic for
-        # the documented design intent of the flag.
+        # #134 supersedes the #1536 split. That split branched on "did a
+        # plaintext .pem survive this run", and told the --cerberus-pem flow to
+        # revoke because none did. Revocation does not retire an on-disk copy.
+        # It removes the PUBLIC half registered on the App, so GitHub can no
+        # longer validate a JWT signed by that key -- and the
+        # REVIEWER_APP_PRIVATE_KEY secret this run just deployed becomes dead
+        # bytes. No installation token, no approving review, mergeable_state
+        # stuck at blocked, in this repo and every other one holding the key.
+        #
+        # The question is not "is a plaintext file left on disk". It is "is
+        # this key deployed anywhere", and after either flow the answer is yes,
+        # because deploying it is the point of the run. So the advice no longer
+        # branches: keep the key active either way. Runbook 0927 reached the
+        # same conclusion (per unleashed#658) and this brings the script into
+        # line with it -- the two had been contradicting each other.
         print()
         print("  # Cerberus secrets deployed and verified.")
         if args.cerberus_pem is not None:
             print("  # The plaintext .pem was deleted by the script.")
-            print("  # REMEMBER to revoke the key in the app UI (browser-only step) —")
-            print("  # there is no on-disk credential to retire otherwise.")
         else:  # args.cerberus_pem_gpg is not None
             print(f"  # Encrypted PEM preserved at {args.cerberus_pem_gpg} for reuse.")
-            print("  # DO NOT revoke the key in the app UI — that would invalidate")
-            print("  # the encrypted blob you just kept. Revoke only when you want")
-            print("  # to retire this credential entirely (e.g., rotation per")
-            print("  # runbook 0930, AZ #1017).")
+        print("  # KEEP THE APP KEY ACTIVE -- do NOT revoke it. The secret just")
+        print("  # deployed works only while the key's public half stays")
+        print("  # registered on the App page; revoking breaks Cerberus here and")
+        print("  # in every other repo holding it.")
+        print("  # To rotate: runbook 0939 -- deploy new, audit, THEN revoke old.")
 
     # The internal function uses `no_pypi` (legacy parameter name); compute
     # it as "did the operator OPT IN via --pypi?" -- false = no_pypi=True =


### PR DESCRIPTION
fix(new-repo): stop instructing a key revoke that blocks the repo just created, and delete the drifted caller copy (Closes #2496, Closes #1193)

Two defects on the new-repo path. Neither is about behaviour -- one is
operator-facing prose, the other a duplicated constant -- which is why both
shipped for months through a green suite. Nothing executes prose and nothing
compares duplicates.

DEPLOY-THEN-REVOKE (#2496)

new_repo.py told the operator to revoke the Cerberus App key immediately after
deploying it, on three of four paths, while a fourth said not to -- four lines
apart. It also contradicted its own runbook: 0927 was corrected some time ago
and says "Do NOT revoke" in five places, line 122 stating outright that the
earlier guidance was wrong. The script was never brought into line.

Revoking removes the PUBLIC half registered on the App page. GitHub can then no
longer validate a JWT signed by that key, so no installation token is issued
and Cerberus never approves. The REVIEWER_APP_PRIVATE_KEY secret the run just
deployed becomes dead bytes -- in the new repo AND in every other repo holding
the same key. mergeable_state sits at blocked and nothing announces why.

The prior split branched on "did a plaintext .pem survive this run", telling
the --cerberus-pem flow to revoke because none did. That is the wrong question.
Revocation does not retire an on-disk copy. The right question is "is this key
deployed anywhere", and after either flow the answer is yes, because deploying
it is the point of the run. The advice no longer branches: keep the key active,
rotate via runbook 0939 (deploy new, audit, THEN revoke old).

CALLER-TEMPLATE DRIFT (#1193)

deploy_auto_reviewer_workflow.py carried its own copy of the auto-reviewer
caller YAML, and it went stale: pre-workflow_call format, no `with:` inputs,
`secrets: inherit` instead of the named secrets the reusable workflow declares
as required. Every repo it touched got a workflow that died at startup --
auto-reviewer completing in 0s with conclusion startup_failure, Cerberus never
posting a review, mergeable_state blocked. Seen on two PRs in a scaffolded
repo, both blocked indefinitely until unblocked by hand.

new_repo.py already holds the correct content in
_CANONICAL_AUTO_REVIEWER_CALLER, shared by creation-time writing and post-setup
verification.

Copying the current format into the deploy tool would fix today and leave the
mechanism intact. Two definitions of one artifact drift -- that is not a
prediction, it is what this defect IS. So the duplicate is deleted and the tool
imports the constant. There was a THIRD copy, transcribed into the module
docstring, equally stale; it is replaced by a pointer rather than a fresh
transcription.

TESTS

Two existing tests asserted the defects and had to be inverted. Called out
because inverting a test to make a change pass is normally the wrong move:

  test_new_repo.py::TestCerberusPostDeployAdvice required the string
  "REMEMBER to revoke the key in the app UI" to be PRESENT.

  test_fleet_readiness.py::test_caller_workflow_calls_az_reusable required
  "secrets: inherit" to be PRESENT.

Both encoded the wrong model rather than the wrong behaviour, so neither could
ever go red. They now assert absence, plus companion assertions that the
REPLACEMENT is present -- deleting bad advice without replacing it would pass
an absence-only test and leave the operator at a Revoke button with no guidance.

New tests/unit/test_new_repo_guidance.py, 7 cases: no imperative revoke on any
path, keep-active guidance present, advice does not branch on the pem flow, the
deploy tool imports rather than redefines, the two modules agree by identity,
the canonical caller satisfies the reusable workflow's declared contract, and
the docstring carries no third copy.

Verified non-vacuous against the unfixed files first: 3 revoke instructions,
1 CALLER_WORKFLOW redefinition, 2 stale `secrets: inherit`. Every assertion
fails on the code before this commit.

Also fixed a pre-existing F541 (f-string with no placeholders) in the deploy
tool, so the file lints clean.

Suites: 199 passed across the four affected files; full unit suite 8464 passed
before the last test correction.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
