### PR TITLE
fix: a parenthetical-suffixed requirements heading is the marked section (Closes #2465)

### DIFF
--- a/assemblyzero/workflows/requirements/form_check.py
+++ b/assemblyzero/workflows/requirements/form_check.py
@@ -173,8 +173,26 @@ class FormReport:
 # ---------------------------------------------------------------------------
 
 
+def _heading_matches(text: str, heading: str) -> bool:
+    """Exact heading, or the exact heading plus one parenthetical suffix.
+
+    ``Requirements (EARS)`` names its own notation and is a strictly more
+    informative form of ``Requirements`` -- treating it as a different section
+    made the EARS check examine nothing on the real issues that carried it
+    (#2465). A non-parenthetical divergence (``Requirements Analysis``) is a
+    genuinely different section and still does not match.
+    """
+    if text == heading:
+        return True
+    return re.fullmatch(re.escape(heading) + r"\s*\([^)]*\)", text) is not None
+
+
 def section_lines(body: str, heading: str) -> list[str] | None:
-    """Lines under an exact ``## <heading>``, up to the next heading.
+    """Lines under ``## <heading>``, up to the next heading.
+
+    The heading matches exactly, or with a single trailing parenthetical
+    (``Requirements (EARS)`` is the ``Requirements`` section; ``Requirements
+    Analysis`` is not -- see ``_heading_matches``).
 
     Returns None when the section is absent, which is a different fact from
     the section being empty and must not be flattened into one.
@@ -187,7 +205,7 @@ def section_lines(body: str, heading: str) -> list[str] | None:
         if not match:
             continue
         if start is None:
-            if match.group(2).strip() == heading:
+            if _heading_matches(match.group(2).strip(), heading):
                 start = i + 1
                 level = len(match.group(1))
             continue

--- a/tests/unit/test_check_requirements_form.py
+++ b/tests/unit/test_check_requirements_form.py
@@ -271,9 +271,49 @@ class TestEars:
         assert report.nested_bullets_skipped == 1
         assert "1 nested bullet(s)" in fc.render_report(report, "x")
 
-    def test_the_section_heading_must_be_exact(self):
-        """'## Requirements (draft)' is not the marked section."""
-        body = "## Requirements (draft)\n\n- Config is saved on exit.\n"
+    def test_a_parenthetical_suffix_is_the_marked_section(self):
+        """'## Requirements (EARS)' is the Requirements section (#2465).
+
+        boostgauge #331 and #332 carried exactly this heading and were
+        reported form-checker PASS with zero sentences examined. The
+        parenthetical names the notation -- a strictly more informative
+        heading must not silently downgrade the check to nothing. (This
+        flips the earlier exact-equality pin, which treated
+        '## Requirements (draft)' as unmarked; examining a draft section
+        is strictly safer than examining nothing.)
+        """
+        body = (
+            "## Requirements (EARS)\n\n"
+            "- The system shall render the bezel.\n"
+            "- The dial is offset from the tick.\n"
+        )
+
+        report = fc.check_form(body)
+
+        assert report.ears_ran is True
+        assert report.requirements_examined == 2
+
+    def test_the_bare_heading_still_matches(self):
+        """boostgauge #2's form: the control that always worked."""
+        body = "## Requirements\n\n- The system shall start.\n"
+
+        report = fc.check_form(body)
+
+        assert report.ears_ran is True
+        assert report.requirements_examined == 1
+
+    def test_a_non_parenthetical_divergence_is_not_the_section(self):
+        """'## Requirements Analysis' is a genuinely different section."""
+        body = "## Requirements Analysis\n\n- Config is saved on exit.\n"
+
+        report = fc.check_form(body)
+
+        assert report.ears_ran is False
+        assert report.ok
+
+    def test_the_parenthetical_must_be_a_suffix_of_the_exact_heading(self):
+        """'## Requirement (EARS)' (singular) is not a match either."""
+        body = "## Requirement (EARS)\n\n- Config is saved on exit.\n"
 
         report = fc.check_form(body)
 


### PR DESCRIPTION
## What

`section_lines` matched section headings by exact string equality, so `## Requirements (EARS)` — the heading boostgauge #331 and #332 carried — was invisible to the ADR 0226 form check. `ears_ran` stayed False and both issues were reported form-checker PASS with **zero sentences examined**.

The matcher now accepts the exact heading or the exact heading plus one parenthetical suffix (`_heading_matches`): `Requirements (EARS)` is the Requirements section; `Requirements Analysis` and `Requirement (EARS)` are not.

## Why checker-side

A heading that names its own notation is strictly more informative than the bare word, and issue authors will keep writing it. A gate that silently downgrades to a vacuous pass on a better heading keeps meeting that heading. (The two live issues were separately repaired issue-side on 2026-08-24 — their headings are bare `## Requirements` now — so this lands for the next issue written the same way, exactly the case the source issue argues.)

## Deliberate behavior flip

The prior test `test_the_section_heading_must_be_exact` pinned `## Requirements (draft)` as unmarked. Under this change a parenthetical-suffixed heading IS the marked section, so that pin is replaced by four tests covering the new boundary: parenthetical matches (examined count nonzero), bare heading matches, `Requirements Analysis` does not, `Requirement (EARS)` (singular) does not. Examining a draft section is strictly safer than examining nothing.

`section_lines` is shared with the acceptance-criteria lookup, so `## Acceptance Criteria (v2)` would now match too — same rule, same reasoning.

## Verification

- `tests/unit/test_check_requirements_form.py` + `tests/unit/test_form_gate.py`: 98 passed
- Full unit suite: run before push (result in PR checks)
- `ruff check` clean on both changed files

Closes #2465
