### PR TITLE
fix: the arc doc-sync absorbs the arc's remote movement before carrying rulings (Closes #2473)

### DIFF
--- a/tests/unit/test_arc_doc_sync.py
+++ b/tests/unit/test_arc_doc_sync.py
@@ -371,3 +371,97 @@ def _issue_updated_at(stamp: str, real):
             return subprocess.CompletedProcess(cmd, 0, stdout=stamp, stderr="")
         return real(cmd, cwd=cwd) if env is None else real(cmd, cwd=cwd)
     return _run
+
+
+# ---------------------------------------------------------------------------
+# The arc moved on origin while the local ref slept (#2473)
+#
+# Earned 2026-08-16: boostgauge PR #321 moved origin/hardening-run-17; the
+# next launch built its doc merge on the stale local ref, the push was
+# rejected non-fast-forward, the launch died at SYNC BLOCKED in fifteen
+# seconds, and a diverged local branch was left stranded. The operator,
+# launched detached, believed it was rolling for ninety minutes.
+# ---------------------------------------------------------------------------
+
+
+def move_arc_on_origin(tmp_path: Path, origin: Path, text: str) -> None:
+    """Move origin/<ARC> from a second clone, as a pipeline PR merge would.
+
+    The primary clone's local arc ref goes stale -- it learns nothing until
+    something fetches, which is exactly the state the launch dies in.
+    """
+    other = tmp_path / "other-clone"
+    subprocess.run(
+        ["git", "clone", "--quiet", str(origin), str(other)], capture_output=True
+    )
+    git(other, "config", "user.email", "t@example.com")
+    git(other, "config", "user.name", "Test")
+    git(other, "checkout", "-q", ARC)
+    (other / "README.md").write_text(text, encoding="utf-8")
+    git(other, "add", ".")
+    git(other, "commit", "-qm", "arc: a pipeline PR moved the arc")
+    git(other, "push", "-q", "origin", ARC)
+
+
+def test_an_arc_moved_on_origin_is_absorbed_not_fatal(
+    repo, origin, log, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    move_arc_on_origin(tmp_path, origin, "arc moved remotely\n")
+    rule_on_main(repo, "needle: candy-apple #F73923\n", "docs: the palette ruling")
+
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    assert problems == []
+    assert "F73923" in arc_doc(repo), "the ruling reached the moved arc"
+    assert "arc moved remotely" in git(
+        repo, "show", f"origin/{ARC}:README.md"
+    ).stdout, "the remote movement was kept, not clobbered"
+    written = log.path.read_text(encoding="utf-8")
+    assert "absorbing before the doc merge" in written
+
+
+def test_a_previously_stranded_diverged_arc_reconciles(
+    repo, origin, log, monkeypatch, tmp_path
+):
+    """The leftover of the 2026-08-16 incident: local-only commits on the
+    arc AND independent remote movement. The next launch reconciles by
+    ordinary merge -- all three sides land on origin, nothing discarded."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    git(repo, "checkout", "-q", ARC)
+    (repo / "docs" / "design" / "notes.md").write_text(
+        "stranded sync-merge leftovers\n", encoding="utf-8"
+    )
+    git(repo, "add", ".")
+    git(repo, "commit", "-qm", "Merge main into arc - the stranded sync merge")
+    git(repo, "checkout", "-q", "main")
+    move_arc_on_origin(tmp_path, origin, "arc moved remotely\n")
+    rule_on_main(repo, "needle: candy-apple #F73923\n", "docs: the palette ruling")
+
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    assert problems == []
+    assert "F73923" in arc_doc(repo), "the ruling landed"
+    assert "arc moved remotely" in git(
+        repo, "show", f"origin/{ARC}:README.md"
+    ).stdout, "the remote side survived"
+    assert "stranded sync-merge leftovers" in git(
+        repo, "show", f"origin/{ARC}:docs/design/notes.md"
+    ).stdout, "the stranded local side survived"
+
+
+def test_a_blocked_push_names_the_leftover_state(repo, origin, log, monkeypatch):
+    """A push refusal must say what state it left behind and who repairs it,
+    not just relay git's rejection line."""
+    monkeypatch.setattr(speedrun_roll.attempt, "default_branch", lambda _r: "main")
+    rule_on_main(repo, "needle: candy-apple #F73923\n", "docs: the palette ruling")
+    hook = origin / "hooks" / "pre-receive"
+    hook.write_text("#!/bin/sh\necho rejected by test hook >&2\nexit 1\n")
+    hook.chmod(0o755)
+
+    problems = speedrun_roll.sync_binding_docs_to_arc(repo, ARC, log)
+
+    assert len(problems) == 1
+    assert "could not push" in problems[0]
+    assert f"local '{ARC}' now carries the sync merge" in problems[0]
+    assert "the next launch absorbs" in problems[0]

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -859,6 +859,42 @@ def sync_binding_docs_to_arc(
                 f"could not check out '{base}' to sync binding docs: "
                 f"{(add.stderr or '').strip()}"
             ]
+        # Absorb the arc's own remote movement FIRST (#2473). The local arc
+        # ref goes stale the moment a pipeline PR moves origin/<arc>, and
+        # nothing in the clone updates it. Building the doc merge on the
+        # stale ref made the push below non-fast-forward: the launch died at
+        # SYNC BLOCKED and left a diverged local branch stranded. Same
+        # preserve-then-proceed rule as the doc merge: a no-op when current,
+        # a fast-forward when merely behind, an ordinary merge when a prior
+        # stranding left local-only commits -- nothing discarded, a conflict
+        # refuses loudly.
+        local_sha = _run(["git", "rev-parse", base], cwd=repo_root).stdout.strip()
+        remote_sha = _run(
+            ["git", "rev-parse", f"origin/{base}"], cwd=repo_root
+        ).stdout.strip()
+        if local_sha != remote_sha:
+            log.write(
+                f"SYNC arc '{base}' moved on origin (local {local_sha[:8]}, "
+                f"origin {remote_sha[:8]}) -- absorbing before the doc merge"
+            )
+            absorb = _run(
+                ["git", "merge", f"origin/{base}", "-m",
+                 f"Merge origin/{base} into {base} - absorb the arc's remote "
+                 f"movement before carrying rulings (#2473)"],
+                cwd=sync_tree,
+            )
+            if absorb.returncode != 0:
+                conflicted = _run(
+                    ["git", "diff", "--name-only", "--diff-filter=U"],
+                    cwd=sync_tree,
+                ).stdout.split()
+                _run(["git", "merge", "--abort"], cwd=sync_tree)
+                return [
+                    f"the arc '{base}' moved on origin and its movement "
+                    f"conflicts with the local copy in "
+                    f"{', '.join(conflicted) or 'unknown file(s)'} -- "
+                    "resolve by hand, then roll. Nothing was changed."
+                ]
         merge = _run(
             ["git", "merge", f"origin/{default}", "-m",
              f"Merge {default} into {base} - carry binding-doc rulings onto "
@@ -880,7 +916,10 @@ def sync_binding_docs_to_arc(
             if push.returncode != 0:
                 problems.append(
                     f"synced '{base}' locally but could not push it: "
-                    f"{(push.stderr or '').strip()}"
+                    f"{(push.stderr or '').strip()}. The local '{base}' now "
+                    f"carries the sync merge and origin does not -- the next "
+                    f"launch absorbs origin/{base} and retries; no by-hand "
+                    f"repair is needed unless the refusal repeats."
                 )
             else:
                 log.write(


### PR DESCRIPTION
## What

`sync_binding_docs_to_arc` fetched origin but then built its doc merge on the **local** arc ref. A pipeline PR that moved `origin/<arc>` made that push non-fast-forward: the launch died at SYNC BLOCKED in fifteen seconds and left a diverged local branch stranded — observed live on 2026-08-16 killing the first boostgauge #331 launch while the operator believed it was rolling.

The sync now absorbs the arc's own remote movement first, in the same sync worktree, under the same preserve-then-proceed rule as the doc merge itself:

- local == origin → no-op
- local behind → fast-forward
- diverged (a prior stranding) → ordinary merge, both sides kept
- conflict → refuses loudly, names the files, nothing changed

The push-rejection message (now reachable only by a mid-sync race) names the leftover state and who repairs it: the next launch absorbs and retries.

## Tests

Three new tests in `tests/unit/test_arc_doc_sync.py`, on the existing real-git harness, plus a second-clone helper that moves the arc on origin the way a pipeline PR merge does:

- arc moved on origin → absorbed, ruling lands, remote movement kept, absorb announced in the log
- the 2026-08-16 leftover (local-only commits AND independent remote movement) → reconciles by ordinary merge; all three sides verified on origin
- blocked push (pre-receive hook) → the problem string names the local state and the self-healing path, not just git's rejection line

File suite: 18 passed. `ruff check` clean on both changed files.

Closes #2473
