### PR TITLE
fix: a resume after a hard-ceiling halt re-enters a fresh cap regime (Closes #2516, Closes #2514)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/lineage_seed.py
+++ b/assemblyzero/workflows/implementation_spec/lineage_seed.py
@@ -135,6 +135,39 @@ def seed_from_lineage(
     return None
 
 
+def resume_payload(seed: Seed) -> dict:
+    """The graph-state seed for a resumed spec grant (#2516).
+
+    ``spec_draft`` + ``review_feedback`` are the pair that makes the first
+    resumed round a REVISION of the paid draft -- the halted run's final
+    readiness verdict reaches the first regeneration verbatim, so no round
+    is respent rediscovering the reviewer's last word.
+
+    ``review_iteration`` is **0**, not ``seed.rounds_completed``. The #2514
+    ruling: the cap regime is per LAUNCH, not per issue lifetime -- the
+    operator's explicit relaunch is the spend grant, worth exactly one more
+    normal regime (base cap 3, the still-converging continuation rules
+    unchanged, ceiling 3x). Restoring the prior grant's counter made the
+    first resumed round iteration 10 against a ceiling of 9: BLOCKED before
+    any model call, three instant outer attempts, 56.8 seconds
+    (run-issue331-102255) -- and the review guard's "exceeds the hard
+    ceiling" state is unreachable from a resume precisely because nothing
+    seeds an exhausted counter any more.
+
+    ``review_feedback_history`` still carries EVERY prior grant's verdict:
+    #2382's stagnation check stays sighted across grants, so an objection
+    from the old grant coming back halts as a repeat rather than reading as
+    convergence. History is memory; the counter is budget. They separate
+    here deliberately.
+    """
+    return {
+        "spec_draft": seed.draft,
+        "review_feedback": seed.feedback,
+        "review_feedback_history": list(seed.prior_feedbacks),
+        "review_iteration": 0,
+    }
+
+
 def describe(seed: Seed) -> str:
     """What the operator should see when a resume reuses paid work."""
     return (
@@ -142,5 +175,6 @@ def describe(seed: Seed) -> str:
         f"({len(seed.draft.splitlines())} lines) with "
         f"{Path(seed.feedback_path).name}'s items as feedback, after "
         f"{seed.rounds_completed} completed review round(s) in "
-        f"{Path(seed.run_dir).name}."
+        f"{Path(seed.run_dir).name}; the review cap regime starts fresh for "
+        f"this grant (#2514)."
     )

--- a/assemblyzero/workflows/implementation_spec/review_progress.py
+++ b/assemblyzero/workflows/implementation_spec/review_progress.py
@@ -120,6 +120,15 @@ def decide(
     ceiling = hard_ceiling(max_iterations)
     progress = classify(current_feedback, prior_feedbacks)
     rounds_seen = len(prior_feedbacks or []) + 1
+    # #2516: on a resumed grant the counter restarts at zero while the
+    # feedback history carries every prior grant's verdict (#2514 -- history
+    # is memory, the counter is budget). The cap clauses must therefore count
+    # in GRANT rounds, or the first resumed round prints "round 10 is within
+    # the base cap of 3". In a single-grant run the two counts are equal, so
+    # nothing changes for the ordinary case. `rounds_seen` stays the total
+    # across grants and keeps naming the stagnation and ceiling rounds, where
+    # the true total is the honest number.
+    round_this_grant = review_iteration + 1
 
     if progress == EMPTY:
         return Decision(
@@ -143,7 +152,8 @@ def decide(
         return Decision(
             True,
             CONTINUE,
-            f"round {rounds_seen} is within the base cap of {max_iterations}.",
+            f"round {round_this_grant} of this grant is within the base cap "
+            f"of {max_iterations}.",
         )
 
     if review_iteration >= ceiling:
@@ -160,9 +170,9 @@ def decide(
     return Decision(
         True,
         CONTINUE,
-        f"round {rounds_seen} resolved the previous round's items and raised "
-        f"distinct ones, so the loop continues past the base cap of "
-        f"{max_iterations} toward the ceiling of {ceiling}.",
+        f"round {round_this_grant} of this grant resolved the previous "
+        f"round's items and raised distinct ones, so the loop continues past "
+        f"the base cap of {max_iterations} toward the ceiling of {ceiling}.",
     )
 
 

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -870,16 +870,18 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                     "in lineage; drawing fresh."
                 )
 
-        resumed_payload = (
-            {
-                "spec_draft": seed.draft,
-                "review_feedback": seed.feedback,
-                "review_feedback_history": list(seed.prior_feedbacks),
-                "review_iteration": seed.rounds_completed,
-            }
-            if seed
-            else {}
+        # #2516: the payload seeds the paid draft, the final verdict's items
+        # (so the first regeneration starts from the reviewer's last word),
+        # the full cross-grant feedback history for #2382's stagnation check
+        # -- and a review counter at ZERO, per the #2514 ruling that each
+        # explicit relaunch grants one fresh cap regime. Seeding the prior
+        # grant's counter made the first resumed round illegal by
+        # construction (iteration 10 > ceiling 9, run-issue331-102255).
+        from assemblyzero.workflows.implementation_spec.lineage_seed import (
+            resume_payload,
         )
+
+        resumed_payload = resume_payload(seed) if seed else {}
 
         app = create_spec_graph()
         sub_result = app.invoke({

--- a/tests/unit/test_resume_after_ceiling_halt.py
+++ b/tests/unit/test_resume_after_ceiling_halt.py
@@ -1,0 +1,284 @@
+"""A resume after a hard-ceiling HALT engages, fresh-capped and preloaded (#2516).
+
+The measured failure, boostgauge 2026-08-25: the spec stage halted at the
+ceiling (round 9, still converging), its RESTORE grafted the attempt branch to
+`graveyard/331-lld-<stamp>` and removed the worktree, and the advertised
+resume died in 56.8 seconds -- the restored counter made the first resumed
+round iteration 10 against a ceiling of 9, BLOCKED before any model call.
+
+The #2514 ruling this implements: the cap regime is per launch. An explicit
+relaunch grants one fresh regime (counter from zero, base cap 3, continuation
+rules unchanged), the first regeneration is fed the halted run's final verdict
+items, and the machinery's own archive (graveyard grafts, leavings refs,
+lineage) is part of where a resume looks -- or, failing everything, part of
+what the refusal names.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLS = ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll  # noqa: E402
+
+from assemblyzero.workflows.implementation_spec import lineage_seed as ls  # noqa: E402
+
+ARC = "hardening-run-17"
+ISSUE = 331
+LLD_REL = "docs/lld/active/LLD-331.md"
+GRAFT = f"graveyard/{ISSUE}-lld-20260825T152354Z"
+
+#: The live case's final verdict shape: one objection, two explicit items.
+FINAL_VERDICT = (
+    "# Readiness Verdict\n\nREVISE\n\n"
+    "## Outstanding\n\n"
+    "- FEEDBACK ITEM ALPHA: the assertion for tick 60 must trace to R4.\n"
+    "- FEEDBACK ITEM BETA: name the baseline flag in the test plan.\n"
+)
+
+CEILING_ROUNDS = 9  # the counter state of a real hard-ceiling halt (3 * 3)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def az_root(tmp_path) -> Path:
+    root = tmp_path / "az"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    """The post-HALT+RESTORE shape: the lld branch exists ONLY as its
+    graveyard graft, the working tree carries neither the LLD nor a worktree,
+    and the spec lineage survives with the halted run's drafts and verdicts.
+    """
+    r = tmp_path / "boostgauge"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    (r / "README.md").write_text("base\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "base")
+
+    # The attempt branch's one kept commit, grafted under the graveyard name.
+    _git(r, "checkout", "-q", "-b", GRAFT)
+    lld = r / LLD_REL
+    lld.parent.mkdir(parents=True)
+    lld.write_text("# LLD-331\n\nSTATUS: APPROVED\n", encoding="utf-8")
+    _git(r, "add", ".")
+    _git(r, "commit", "-qm", "docs: add LLD-331 via requirements workflow")
+    _git(r, "checkout", "-q", "main")
+    assert not lld.exists(), "fixture: RESTORE cleared the working tree"
+
+    # The halted run's lineage: drafts and a ceiling's worth of verdicts.
+    run_dir = r / "docs" / "lineage" / "active" / f"{ISSUE}-implspec" / "2026-08-25T04-46-02Z"
+    run_dir.mkdir(parents=True)
+    for i in range(1, CEILING_ROUNDS + 1):
+        (run_dir / f"{i:03d}-spec-draft.md").write_text(
+            f"# Implementation Spec\n\nDRAFT {i}\n", encoding="utf-8"
+        )
+        text = FINAL_VERDICT if i == CEILING_ROUNDS else (
+            f"# Readiness Verdict\n\nREVISE\n\n- distinct objection {i}\n"
+        )
+        (run_dir / f"{i + 20:03d}-readiness-verdict.md").write_text(
+            text, encoding="utf-8"
+        )
+    # The failed resume's own dir: a draft, no verdict (guard blocked before
+    # reviewing). seed_from_lineage must skip it, not seed half a round.
+    barren = run_dir.parent / "2026-08-25T15-22-56Z"
+    barren.mkdir()
+    (barren / "001-spec-draft.md").write_text("# unreviewed\n", encoding="utf-8")
+    return r
+
+
+@pytest.fixture
+def log(tmp_path) -> "speedrun_roll.EventLog":
+    return speedrun_roll.EventLog(tmp_path / "session-events.log")
+
+
+def write_state(az_root: Path, repo: Path) -> Path:
+    """331.json as the ceiling halt left it: lld passed, spec failed."""
+    state_dir = az_root / ".assemblyzero" / "orchestrator" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "issue_number": ISSUE,
+        "current_stage": "spec",
+        "target_repo": str(repo),
+        "base_branch": ARC,
+        "lld_path": str(repo / LLD_REL),
+        "spec_path": "",
+        "resumed_from": "spec",
+        "stage_results": {
+            "triage": {"status": "skipped"},
+            "lld": {"status": "passed"},
+            "spec": {
+                "status": "failed",
+                "error_message": (
+                    "Iteration cap: 3 review rounds ended BLOCKED, so the run "
+                    "stopped rather than spend another round on the same "
+                    "objection."
+                ),
+            },
+        },
+    }
+    path = state_dir / f"{ISSUE}.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestTheAcceptanceScenario:
+    """State at the ceiling + graveyard-preserved branch: the resume runs,
+    the counter starts fresh, the first regeneration sees the verdict items
+    verbatim."""
+
+    def test_resume_plan_engages_against_the_preserved_state(
+        self, az_root, repo, log, monkeypatch
+    ):
+        monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+        monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+        monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: False)
+        write_state(az_root, repo)
+
+        assert speedrun_roll.resume_plan(az_root, repo, ISSUE, log) == "spec"
+
+    def test_the_plan_restored_the_lld_from_the_graveyard_graft(
+        self, az_root, repo, log, monkeypatch
+    ):
+        monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: ARC)
+        monkeypatch.setattr(speedrun_roll, "_open_lld_pr_exists", lambda *_a: True)
+        monkeypatch.setattr(speedrun_roll, "draft_is_stale", lambda *_a: False)
+        write_state(az_root, repo)
+
+        speedrun_roll.resume_plan(az_root, repo, ISSUE, log)
+
+        restored = repo / LLD_REL
+        assert restored.is_file(), "the graft was the only holder of the LLD"
+        assert "LLD-331" in restored.read_text(encoding="utf-8")
+
+    def test_the_counter_starts_fresh(self, repo):
+        lineage = repo / "docs" / "lineage" / "active" / f"{ISSUE}-implspec"
+        seed = ls.seed_from_lineage(lineage)
+
+        assert seed is not None
+        assert seed.rounds_completed == CEILING_ROUNDS, (
+            "precondition: the seed sees the full halted grant"
+        )
+        assert ls.resume_payload(seed)["review_iteration"] == 0
+
+    def test_the_first_regeneration_input_carries_the_verdict_items_verbatim(
+        self, repo
+    ):
+        lineage = repo / "docs" / "lineage" / "active" / f"{ISSUE}-implspec"
+        seed = ls.seed_from_lineage(lineage)
+        payload = ls.resume_payload(seed)
+
+        assert "FEEDBACK ITEM ALPHA: the assertion for tick 60 must trace to R4." in (
+            payload["review_feedback"]
+        )
+        assert "FEEDBACK ITEM BETA: name the baseline flag in the test plan." in (
+            payload["review_feedback"]
+        )
+
+    def test_the_barren_resume_dir_is_not_the_seed(self, repo):
+        """The failed resume's own dir holds a draft the guard never reviewed;
+        seeding it would pair a draft with the WRONG grant's feedback."""
+        lineage = repo / "docs" / "lineage" / "active" / f"{ISSUE}-implspec"
+        seed = ls.seed_from_lineage(lineage)
+
+        assert "2026-08-25T04-46-02Z" in seed.run_dir
+
+
+class TestGraveyardGraftsAreASearchedPlace:
+    def test_resolve_stage_artifact_finds_the_lld_on_the_graft(self, repo):
+        found = speedrun_roll._resolve_stage_artifact(repo, ISSUE, {}, "lld")
+
+        assert found, "no recorded path anywhere -- the graft is the only source"
+        assert found.replace("\\", "/").endswith(LLD_REL)
+
+    def test_the_newest_graft_wins(self, repo):
+        newer = f"graveyard/{ISSUE}-lld-20260826T000000Z"
+        _git(repo, "checkout", "-q", "-b", newer, GRAFT)
+        lld = repo / LLD_REL
+        lld.write_text("# LLD-331\n\nNEWER GRAFT\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "later graft")
+        _git(repo, "checkout", "-q", "main")
+        lld.unlink(missing_ok=True)
+
+        assert speedrun_roll._restore_artifact(repo, ISSUE, str(lld)) is True
+        assert "NEWER GRAFT" in lld.read_text(encoding="utf-8")
+
+    def test_a_live_lld_branch_still_outranks_the_graft(self, repo):
+        _git(repo, "checkout", "-q", "-b", f"{ISSUE}-lld", "main")
+        lld = repo / LLD_REL
+        lld.parent.mkdir(parents=True, exist_ok=True)
+        lld.write_text("# LLD-331\n\nLIVE BRANCH\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-qm", "live lld branch")
+        _git(repo, "checkout", "-q", "main")
+        lld.unlink(missing_ok=True)
+
+        speedrun_roll._restore_artifact(repo, ISSUE, str(lld))
+        assert "LIVE BRANCH" in lld.read_text(encoding="utf-8")
+
+    def test_the_graft_refs_are_discovered_newest_first(self, repo):
+        newer = f"graveyard/{ISSUE}-lld-20260826T000000Z"
+        _git(repo, "branch", newer, GRAFT)
+
+        refs = speedrun_roll._graveyard_issue_lld_refs(repo, ISSUE)
+
+        assert refs[0] == newer
+        assert GRAFT in refs
+
+    def test_another_issues_grafts_are_not_this_issues(self, repo):
+        _git(repo, "branch", "graveyard/7-lld-20260826T000000Z", GRAFT)
+
+        refs = speedrun_roll._graveyard_issue_lld_refs(repo, ISSUE)
+
+        assert all(f"/{ISSUE}-lld-" in r for r in refs)
+
+
+class TestTheRefusalNamesWhatWasPreserved:
+    """When no attempt branch exists on origin, the machinery itself archived
+    it -- a bare 'no attempt branch exists' reads as loss when everything is
+    one rename away."""
+
+    def test_the_refusal_inventories_the_graveyard_and_lineage(
+        self, repo, log, monkeypatch
+    ):
+        monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: "")
+
+        assert speedrun_roll.ensure_base_for_resume(repo, ISSUE, log) is None
+
+        written = log.path.read_text(encoding="utf-8")
+        assert "no attempt branch exists on origin" in written
+        assert GRAFT in written, "the grafted lld branch must be named"
+        assert f"{ISSUE}-implspec" in written, "the surviving lineage must be named"
+
+    def test_a_repo_with_nothing_preserved_still_refuses_cleanly(
+        self, tmp_path, log, monkeypatch
+    ):
+        bare = tmp_path / "plain"
+        bare.mkdir()
+        _git(bare, "init", "-q", "-b", "main")
+        monkeypatch.setattr(speedrun_roll, "resolve_attempt_branch", lambda _r: "")
+
+        assert speedrun_roll.ensure_base_for_resume(bare, ISSUE, log) is None
+        assert "no attempt branch exists on origin" in log.path.read_text(
+            encoding="utf-8"
+        )

--- a/tests/unit/test_spec_resume_seed.py
+++ b/tests/unit/test_spec_resume_seed.py
@@ -192,18 +192,23 @@ class TestSeedingIsKeyedOnAnActualResume:
         spec_stage = source.split("def run_spec_stage", 1)[1].split("\ndef ", 1)[0]
         assert 'state.get("resumed_from") == "spec"' in spec_stage
 
-    def test_the_stage_seeds_the_four_fields_the_loop_needs(self):
+    def test_the_stage_seeds_through_the_shared_payload(self):
+        """#2516 moved the payload into lineage_seed.resume_payload so the
+        counter ruling (#2514) has one home; the stage must use it rather
+        than rebuilding the dict inline, where the two could drift."""
         source = (
             ROOT / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
         ).read_text(encoding="utf-8")
         spec_stage = source.split("def run_spec_stage", 1)[1].split("\ndef ", 1)[0]
-        for field in (
-            '"spec_draft": seed.draft',
-            '"review_feedback": seed.feedback',
-            '"review_feedback_history": list(seed.prior_feedbacks)',
-            '"review_iteration": seed.rounds_completed',
-        ):
-            assert field in spec_stage
+        assert "resumed_payload = resume_payload(seed) if seed else {}" in spec_stage
+
+    def test_the_payload_carries_the_four_fields_the_loop_needs(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        payload = ls.resume_payload(seed)
+        assert payload["spec_draft"] == seed.draft
+        assert payload["review_feedback"] == seed.feedback
+        assert payload["review_feedback_history"] == seed.prior_feedbacks
+        assert "review_iteration" in payload
 
     def test_the_stage_excludes_its_own_run_directory(self):
         source = (
@@ -221,3 +226,65 @@ class TestItSaysWhatItReused:
         assert "010-spec-draft.md" in text
         assert "012-readiness-verdict.md" in text
         assert "3 completed review round" in text
+
+    def test_the_description_says_the_cap_regime_is_fresh(self, lineage):
+        """#2515's operator followed a resume hint with no way to know what it
+        carried. The narration now states the grant terms."""
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert "cap regime starts fresh" in ls.describe(seed)
+
+
+class TestTheResumedGrantStartsFresh:
+    """#2516, implementing the #2514 ruling: per-launch cap regime.
+
+    Restoring the prior grant's counter made the first resumed round
+    iteration 10 against a ceiling of 9 -- BLOCKED before any model call,
+    56.8 seconds, no work (run-issue331-102255).
+    """
+
+    def test_the_counter_is_zero_not_the_prior_grants_count(self, lineage):
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        assert seed.rounds_completed == 3, "precondition: prior rounds exist"
+
+        assert ls.resume_payload(seed)["review_iteration"] == 0
+
+    def test_the_seeded_counter_cannot_trip_the_ceiling_guard(self, lineage):
+        """The 'exceeds the hard ceiling' state must be unreachable from a
+        resume: the guard fires on iteration > ceiling, and the grant's
+        first review arrives at iteration 1 after the revision increment."""
+        from assemblyzero.workflows.implementation_spec.review_progress import (
+            hard_ceiling,
+        )
+
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        first_review_iteration = ls.resume_payload(seed)["review_iteration"] + 1
+
+        assert first_review_iteration <= hard_ceiling(3)
+
+    def test_history_still_carries_every_prior_grant_round(self, lineage):
+        """History is memory, the counter is budget: #2382's stagnation check
+        must stay sighted across grants, so an objection from the old grant
+        coming back halts as a repeat instead of reading as convergence."""
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        payload = ls.resume_payload(seed)
+
+        assert len(payload["review_feedback_history"]) == 3
+        assert payload["review_feedback_history"] == seed.prior_feedbacks
+
+    def test_a_prior_grant_objection_returning_still_stagnates(self, lineage):
+        from assemblyzero.workflows.implementation_spec.review_progress import (
+            EXIT_STAGNATION,
+            decide,
+        )
+
+        seed = ls.seed_from_lineage(lineage, exclude=lineage / "2026-08-14T22-00-00Z")
+        payload = ls.resume_payload(seed)
+
+        decision = decide(
+            review_iteration=payload["review_iteration"] + 1,
+            max_iterations=3,
+            current_feedback=seed.prior_feedbacks[0],
+            prior_feedbacks=payload["review_feedback_history"],
+        )
+        assert decision.should_continue is False
+        assert decision.exit_name == EXIT_STAGNATION

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -638,8 +638,15 @@ def _find_on_lld_branch(repo_root: Path, issue: int, pattern: str) -> str:
     The last match in sort order wins, so a repo carrying spec-0001 and
     spec-0002 resolves to the newer one rather than to whichever git listed
     first.
+
+    #2516: the grafted copies of the lld branch are consulted after the live
+    refs. A HALT's own RESTORE renames `{issue}-lld` to
+    `graveyard/{issue}-lld-<stamp>` -- the machinery archived the branch the
+    next resume needs, so the archive is part of where the resume looks.
     """
-    for ref in (f"{issue}-lld", f"origin/{issue}-lld"):
+    refs = [f"{issue}-lld", f"origin/{issue}-lld"]
+    refs += _graveyard_issue_lld_refs(repo_root, issue)
+    for ref in refs:
         result = _run(["git", "ls-tree", "-r", "--name-only", ref], cwd=repo_root)
         if result.returncode != 0:
             continue
@@ -725,6 +732,34 @@ def _graveyard_leavings_refs(repo_root: Path) -> list[str]:
     return sorted(refs, key=_stamp, reverse=True)
 
 
+def _graveyard_issue_lld_refs(repo_root: Path, issue: int) -> list[str]:
+    """Every grafted copy of this issue's lld branch, newest first (#2516).
+
+    A HALT's RESTORE preserves the attempt branch by renaming it to
+    `graveyard/{issue}-lld-<UTC stamp>` (ADR 0217 keeps the commits; the
+    rename frees the name). The stamp is in the NAME, so name order is time
+    order -- same reasoning as `_graveyard_leavings_refs`, same immunity to
+    history rewrites perturbing committer dates.
+    """
+    result = _run(
+        [
+            "git", "for-each-ref", "--format=%(refname:short)",
+            f"refs/heads/graveyard/{issue}-lld-*",
+            f"refs/remotes/origin/graveyard/{issue}-lld-*",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    refs = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+
+    def _stamp(ref: str) -> str:
+        _, _, tail = ref.rpartition("-lld-")
+        return tail
+
+    return sorted(refs, key=_stamp, reverse=True)
+
+
 def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
     """Materialize a passed stage's file so the next stage can read it.
 
@@ -756,6 +791,10 @@ def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
     except ValueError:
         return False
     refs = [f"{issue}-lld", f"origin/{issue}-lld"]
+    # #2516: the grafted copies of the lld branch rank right behind the live
+    # ones -- a HALT's RESTORE renames the branch to graveyard/{issue}-lld-*,
+    # and what it holds IS the lld branch's content under an archive name.
+    refs += _graveyard_issue_lld_refs(repo_root, issue)
     # Newest leavings first: the last run's copy is the current one, and an
     # older ref may hold a stale draft from a superseded attempt.
     refs += _graveyard_leavings_refs(repo_root)
@@ -1139,13 +1178,16 @@ def resume_plan(
         if not artifact:
             log.write(
                 f"RESUME abandoned for #{issue}: no {stage} artifact recorded, "
-                f"and none found on the {issue}-lld branch"
+                f"and none found on the {issue}-lld branch, its "
+                f"graveyard/{issue}-lld-* grafts, or the leavings refs"
             )
             return None
         if not _restore_artifact(repo_root, issue, artifact):
             log.write(
                 f"RESUME abandoned for #{issue}: {stage} artifact missing and "
-                f"not restorable: {artifact}"
+                f"not restorable from the {issue}-lld branch, its "
+                f"graveyard/{issue}-lld-* grafts, or the leavings refs: "
+                f"{artifact}"
             )
             return None
 
@@ -1155,6 +1197,38 @@ def resume_plan(
         f"state {state_path.name})"
     )
     return failed
+
+
+def _preserved_inventory(repo_root: Path, issue: int) -> list[str]:
+    """What the machinery preserved for #issue, and where, for a refusal to
+    name (#2516). Empty means genuinely nothing was found -- which is itself
+    the honest report.
+    """
+    lines: list[str] = []
+    prefix = attempt_prefix(repo_root)
+    arc_refs = _run(
+        [
+            "git", "for-each-ref", "--format=%(refname:short)",
+            f"refs/heads/graveyard/{prefix}-*",
+            f"refs/remotes/origin/graveyard/{prefix}-*",
+        ],
+        cwd=repo_root,
+    )
+    for ref in (arc_refs.stdout or "").splitlines()[:3]:
+        if ref.strip():
+            lines.append(f"arc branch grafted as '{ref.strip()}'")
+    for ref in _graveyard_issue_lld_refs(repo_root, issue)[:3]:
+        lines.append(f"lld branch grafted as '{ref}' (content restorable from it)")
+    for ref in _graveyard_leavings_refs(repo_root)[:2]:
+        lines.append(f"cleared files preserved on '{ref}'")
+    lineage = repo_root / "docs" / "lineage" / "active" / f"{issue}-implspec"
+    if lineage.is_dir():
+        runs = sum(1 for p in lineage.iterdir() if p.is_dir())
+        lines.append(
+            f"spec lineage intact at '{lineage}' ({runs} run director"
+            f"{'y' if runs == 1 else 'ies'})"
+        )
+    return lines
 
 
 def ensure_base_for_resume(
@@ -1169,7 +1243,18 @@ def ensure_base_for_resume(
     """
     base = resolve_attempt_branch(repo_root)
     if not base:
-        log.write("RESUME abandoned: no attempt branch exists")
+        # #2516: the machinery's own RESTORE archives the surfaces a resume
+        # needs -- branches grafted under graveyard names, files preserved on
+        # leavings refs, lineage left in place. A bare "no attempt branch
+        # exists" after the machinery itself archived that branch reads as
+        # loss when everything is preserved and one rename away. Refuse WITH
+        # the inventory, so the operator's next move needs no excavation.
+        log.write(
+            "RESUME abandoned: no attempt branch exists on origin. "
+            "Preserved state, if any, is listed below; a fresh draw follows."
+        )
+        for line in _preserved_inventory(repo_root, issue):
+            log.write(f"RESUME preserved: {line}")
         return None
     problems = base_is_structurally_sound(repo_root, base)
     if problems:


### PR DESCRIPTION
## What

Implements the #2514 operator ruling — **the cap regime is per launch, not per issue lifetime** — and repairs the three resume surfaces #2516 names. One PR for both because the implementation embodies the ruling.

## The counter

`lineage_seed.resume_payload` (new, extracted from the inline dict in `run_spec_stage`) seeds the resumed grant with `review_iteration: 0`. The prior seeding restored the halted grant's counter, so the first resumed round was iteration 10 against a ceiling of 9 — BLOCKED before any model call, three instant outer attempts, 56.8s (`run-issue331-102255`). The "exceeds the hard ceiling" guard state is unreachable from a resume because nothing seeds an exhausted counter any more; the guard itself stays, protecting hand-built states.

History and counter deliberately separate: `review_feedback_history` still carries every prior grant's verdict, so #2382's stagnation check stays sighted across grants — an old objection coming back halts as a repeat, and a test pins that. `review_progress.decide`'s cap-clause prose now counts in grant rounds (identical output for single-grant runs; without this the first resumed round prints "round 10 is within the base cap of 3").

## The preload

Already carried by the #2383 seed — `resume_payload` keeps it and the acceptance test pins it: the first regeneration's `review_feedback` contains the halted run's final verdict items verbatim. The resume narration now also states the grant terms ("the review cap regime starts fresh for this grant"), since the operator who followed the 10:22 banner had no way to know what the resume carried.

## The RESTORE complication

A HALT's own RESTORE grafts the lld branch to `graveyard/{issue}-lld-<stamp>` and removes the worktree. Both reconstruct-and-refuse halves land:

- **Reconstruct:** `_find_on_lld_branch` and `_restore_artifact` now consult the `graveyard/{issue}-lld-*` grafts (newest first, name-stamp ordered, local + origin) right behind the live refs — the machinery's own archive is part of where a resume looks. Live branch still outranks the graft; leavings refs remain the final fallback.
- **Refuse with the inventory:** when no attempt branch exists on origin, `ensure_base_for_resume` now lists what was preserved and where — grafted arc refs, grafted lld refs, leavings refs, and the surviving spec lineage with its run count — instead of the bare "no attempt branch exists". `resume_plan`'s artifact-abandon messages name every searched place.

## Tests

- `tests/unit/test_resume_after_ceiling_halt.py` (new, 12 tests): the acceptance scenario as a real-git fixture — state file at the ceiling, lld branch existing only as its graveyard graft, lineage with nine verdicts plus the failed resume's barren run dir. Asserts resume_plan engages, the LLD restores from the graft, the counter starts fresh, the first regeneration input carries both verdict items verbatim, the barren dir is never the seed, graft discovery/ordering/isolation, and both refusal paths (inventory named; nothing-preserved still refuses cleanly).
- `tests/unit/test_spec_resume_seed.py`: the source pin that froze the defective seeding (`"review_iteration": seed.rounds_completed`) is deliberately flipped to pin the shared payload; new class covers counter-zero, ceiling-guard unreachability, cross-grant history, and prior-grant-objection stagnation.
- Suites: resume-family 82 passed; convergence + spec workflow 234 passed; fail-open gate 52 passed (no new undeclared sites — the new helpers carry no exception handlers). Full unit suite before merge; `ruff check` clean on all six changed files.

## Live verification (read-only, per the definition of done)

A probe script walked every `resume_plan` gate against the live repos with the changed code, replacing the one writing step with a `git show` restorability check: **12/12 passed** — state/arc/stages/PR/staleness gates green, `docs/lld/active/LLD-331.md` restorable from `origin/331-lld` with `graveyard/331-lld-20260825T152354Z` visible as fallback, seed drawn from the halted grant's run dir (9 rounds), counter 0, `030-readiness-verdict.md` preloaded. A resume plan for boostgauge #331 engages against the preserved state; the roll itself is the operator's to launch.

Closes #2516, Closes #2514
