### PR TITLE
fix: visual-gate live-hour repairs -- resume consumes feedback, infra halts resumably, provider-layer transport, URLs on every surface (Closes #2521, Closes #2520)

### DIFF
--- a/assemblyzero/visual_gate/gate.py
+++ b/assemblyzero/visual_gate/gate.py
@@ -407,11 +407,40 @@ def run_gate(
             return GateOutcome(status="halted", error=reason, rounds=rounds_run)
 
         # modify
-        items = decompose(words, manifest, transport)
-        plan: ModifyPlan = plan_from_items(
-            items, manifest,
-            separation_floor=config.separation_floor, ruled=config.ruled,
-        )
+        try:
+            # #2521: the declaration's ruled values are contract vocabulary
+            # even when a stale round's manifest predates them -- the live
+            # round-001 was rendered before needle_tip joined the contract,
+            # and without this merge the model would file the operator's
+            # tip-extension ask as a contract gap instead of routing it to
+            # the ruling surface the design demands.
+            prompt_manifest = _with_declared_ruled(manifest, config.ruled)
+            items = decompose(words, prompt_manifest, transport)
+            plan: ModifyPlan = plan_from_items(
+                items, prompt_manifest,
+                separation_floor=config.separation_floor, ruled=config.ruled,
+            )
+        except Exception as exc:  # noqa: BLE001 -- see the ruling below
+            # fail-open: in shape only -- the handler substitutes a HALTED,
+            # resumable outcome, this stage's halt idiom. An infra error in
+            # the model pass is not an operator verdict and not a render
+            # failure (#2521): the bundle and the submitted feedback are
+            # intact, feedback.json is deliberately NOT consumed, and the
+            # resume re-enters this exact dispatch without re-serving the
+            # page or asking the operator to click again. The first live
+            # Modify let this exception kill the whole run and trigger
+            # RESTORE, turning a wiring typo into a dead roll.
+            return GateOutcome(
+                status="halted",
+                error=(
+                    f"the Modify model pass failed before any verdict was "
+                    f"reached: {exc}. This is an infra error, not an operator "
+                    f"verdict -- the submitted feedback in {current} is "
+                    f"preserved unconsumed, and a resume of the visual stage "
+                    f"dispatches it without re-serving the page."
+                ),
+                rounds=rounds_run, deltas=accumulated,
+            )
         _record_round_plan(current, plan)
         _mark_consumed(current)
         if plan.halted_on_ruling:
@@ -430,6 +459,27 @@ def run_gate(
         pending_candidates = plan.candidate_sets
         # Loop: the next iteration renders the accumulated deltas (plus any
         # candidate variants, side by side) and serves the new round.
+
+
+def _with_declared_ruled(manifest: dict, ruled: dict) -> dict:
+    """The manifest, plus any declaration-ruled key it does not carry (#2521).
+
+    A round rendered before a key joined the contract has no entry for it,
+    but the declaration's pinned value is still binding law -- the model
+    pass must see the key (or it invents a gap), and the guardrail must see
+    the pin (or a delta on it slips past the ruling surface).
+    """
+    merged = dict(manifest)
+    values = dict(merged.get("values", {}))
+    for key, value in (ruled or {}).items():
+        if key not in values:
+            values[key] = {
+                "value": value,
+                "source": "visual-gate.json ruled declaration",
+                "ruled": True,
+            }
+    merged["values"] = values
+    return merged
 
 
 def _record_round_plan(round_dir: Path, plan: ModifyPlan) -> None:

--- a/assemblyzero/visual_gate/modify.py
+++ b/assemblyzero/visual_gate/modify.py
@@ -124,18 +124,30 @@ def decompose(text: str, manifest: dict, transport) -> list[FeedbackItem]:
     return parse_items(transport(system, content))
 
 
-def default_transport(system: str, content: str) -> str:
-    """The fleet's governance transport (ADR 0220). Imported lazily so the
-    gate's non-Modify paths never touch credentials."""
-    from assemblyzero.core.gemini_client import GeminiClient
+#: Provider spec for the translation pass: top-tier Gemini through the
+#: provider LAYER, which pairs the model id with its transport. The first
+#: live Modify (#2521, run-issue331-172000) constructed GeminiClient bare,
+#: whose default model is core.config.REVIEWER_MODEL -- a Claude id -- and
+#: the Gemini validator rejected it before any call was made. get_provider
+#: is the house pattern every workflow node routes through; the spec is the
+#: reviewer default the spec stage already uses (AZ #1434).
+TRANSLATION_PROVIDER = "gemini:3.1-pro"
 
-    result = GeminiClient().invoke(system, content)
-    if not getattr(result, "success", False):
+
+def default_transport(system: str, content: str) -> str:
+    """The fleet's provider layer (ADR 0220 / #2521). Imported lazily so the
+    gate's non-Modify paths never touch credentials."""
+    from assemblyzero.core.llm_provider import get_provider
+
+    result = get_provider(TRANSLATION_PROVIDER).invoke(system, content)
+    response = (getattr(result, "response", None) or "").strip()
+    if not getattr(result, "success", False) or not response:
         raise RuntimeError(
-            f"visual-gate Modify pass failed via agy: "
-            f"{getattr(result, 'error', 'no detail')}"
+            f"visual-gate Modify translation failed via "
+            f"{TRANSLATION_PROVIDER}: "
+            f"{getattr(result, 'error_message', '') or 'empty response'}"
         )
-    return result.text
+    return response
 
 
 def plan_from_items(

--- a/assemblyzero/visual_gate/server.py
+++ b/assemblyzero/visual_gate/server.py
@@ -159,10 +159,34 @@ def wait_for_feedback(
         if deadline is not None and now - start > deadline:
             raise TimeoutError(f"no feedback.json in {round_dir} after {deadline}s")
         if now - last_reminder >= reminder_every:
-            pending = round_dir / "feedback-pending.json"
+            # #2520: say the URL, every time. The first live serve printed a
+            # path to the JSON holding the URL, and the operator spent 26
+            # minutes staring at the indirection. In a detached run these
+            # lines are the only surface -- each one must be actionable on
+            # sight, with the file kept as the machine-readable copy.
             log(
-                f"    [visual] still waiting on operator feedback "
-                f"({round_dir.name}; see {pending})"
+                f"    [visual] still waiting on operator feedback -- open "
+                f"{pending_url(round_dir) or 'the review page'} "
+                f"({round_dir.name})"
             )
             last_reminder = now
         time.sleep(poll_seconds)
+
+
+def pending_url(round_dir: Path) -> str:
+    """The served page's URL, from the round's own sentinel; "" if unknowable.
+
+    The sentinel stays the machine-readable home of the URL (#2520) -- this
+    is the one reader, shared by the waiting line and the launcher-side
+    announcement, so the two surfaces can never disagree.
+    """
+    import json
+
+    path = round_dir / "feedback-pending.json"
+    try:
+        return str(json.loads(path.read_text(encoding="utf-8")).get("url", ""))
+    except (OSError, ValueError):
+        # fail-open: "" is this function's documented "unknowable" answer --
+        # the waiting line falls back to naming the review page generically,
+        # and a reminder must never crash the wait it decorates (#2520).
+        return ""

--- a/tests/fixtures/fail_open_baseline.json
+++ b/tests/fixtures/fail_open_baseline.json
@@ -2,8 +2,8 @@
   "_comment": "Undeclared fail-open sites known at the time this was written (#2475). CI fails on any key not listed here. To clear one, either make the site fail closed or write '# fail-open: <reason>' on it, then regenerate with tools/audit_fail_open.py --write-baseline. Do not add keys by hand: the point is that each removal is a decision somebody made in the code.",
   "measured_against": {
     "files_scanned": 282,
-    "sites_examined": 7385,
-    "findings_total": 469
+    "sites_examined": 7392,
+    "findings_total": 471
   },
   "undeclared": [
     "assemblyzero/core/audit.py::ReviewAuditLog._read_jsonl_safe::except_handler::0",

--- a/tests/unit/test_visual_gate_live_resume.py
+++ b/tests/unit/test_visual_gate_live_resume.py
@@ -1,0 +1,386 @@
+"""The first live hour's defects, pinned (#2521, #2520).
+
+The acceptance scenario is real: boostgauge round-001's preserved
+feedback.json carries verb modify and the operator's words verbatim --
+"extend the need to the exact radius of the start of the minor tick mark" --
+translated tip 0.86 R -> 0.95 R, which radially re-enters the band (inner
+0.88 R) and amends the 2026-08-25 tip-short-of-band restatement. These tests
+build that exact shape: an OLD manifest that predates needle_tip, the
+declaration's ruled pin, and the words unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.visual_gate import bundle as bundle_mod
+from assemblyzero.visual_gate import modify as modify_mod
+from assemblyzero.visual_gate.config import GateConfig
+from assemblyzero.visual_gate.gate import _with_declared_ruled, run_gate
+from assemblyzero.visual_gate.server import pending_url, wait_for_feedback
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll  # noqa: E402
+
+ISSUE = 331
+
+#: The operator's preserved words, verbatim per the issue's requirement.
+OPERATOR_WORDS = (
+    "extend the need to the exact radius of the start of the minor tick mark"
+)
+
+#: The round-001 manifest shape: rendered BEFORE needle_tip joined the
+#: contract, so the key is absent -- the live resume's exact starting state.
+STALE_MANIFEST = {
+    "values": {
+        "band_inner": {"value": 0.88,
+                       "source": "operator ruling 2026-08-25", "ruled": True},
+        "band_rgb": {"value": [170, 15, 25],
+                     "source": "operator ruling 2026-08-25", "ruled": True},
+        "needle_rgb": {"value": [247, 57, 35],
+                       "source": "ruling #228", "ruled": True},
+        "wordmark_y": {"value": 0.67,
+                       "source": "operator ruling 2026-08-25", "ruled": True},
+    },
+    "palette": {"needle": [247, 57, 35], "band": [170, 15, 25],
+                "white": [255, 255, 255], "face": [10, 10, 12]},
+}
+
+TRANSLATION = json.dumps([{
+    "kind": "modify-geometry", "key": "needle_tip", "value": 0.95,
+    "note": "extend the needle tip to 0.95 R, the minor tick start -- this "
+            "re-enters the band (inner 0.88 R) and amends the tip-short-of-"
+            "band restatement",
+}])
+
+PNG_1PX = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\xcf\xc0"
+    b"\x00\x00\x00\x03\x00\x01\x9d\xc0\x0e\xf5\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    """A target repo holding the live shape: round-001 with images, the stale
+    manifest, and the operator's UNCONSUMED feedback."""
+    r = tmp_path / "boostgauge"
+    round_dir = r / "data" / "visual-gate" / str(ISSUE) / "round-001"
+    round_dir.mkdir(parents=True)
+    (round_dir / "face-1024.png").write_bytes(PNG_1PX)
+    (round_dir / "manifest.json").write_text(
+        json.dumps(STALE_MANIFEST), encoding="utf-8",
+    )
+    (round_dir / "overrides.json").write_text("{}", encoding="utf-8")
+    (round_dir / "feedback-pending.json").write_text(
+        '{"served_at": "2026-08-25T22:30:00+00:00", '
+        '"url": "http://127.0.0.1:56772/"}',
+        encoding="utf-8",
+    )
+    bundle_mod.write_feedback(round_dir, "modify", OPERATOR_WORDS)
+    return r
+
+
+@pytest.fixture
+def config() -> GateConfig:
+    return GateConfig(
+        issues=(ISSUE,),
+        renderer_cmd=("python", "tools/never_invoked_here.py"),
+        contract="docs/design/0002-aesthetic-v1-stingray.md",
+        separation_floor=85.0,
+        ruled={
+            "needle_rgb": [247, 57, 35], "band_rgb": [170, 15, 25],
+            "band_inner": 0.88, "wordmark_y": 0.67, "needle_tip": 0.86,
+        },
+    )
+
+
+class TestResumeHonoursSubmittedFeedback:
+    """#2521 requirement 1: a submitted verdict is state, not a prompt to
+    repeat -- the resume consumes it and never re-serves the round."""
+
+    def test_the_preserved_modify_dispatches_without_reserving(
+        self, repo, config
+    ):
+        pending_before = (
+            repo / "data" / "visual-gate" / str(ISSUE) / "round-001"
+            / "feedback-pending.json"
+        ).read_text(encoding="utf-8")
+
+        outcome = run_gate(
+            repo, ISSUE, config, mock=True,
+            transport=lambda *_: TRANSLATION,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        # It dispatched (reaching the ruling surface below) rather than
+        # timing out waiting on a click the operator already gave.
+        assert outcome.status == "halted"
+        assert "landed ruling" in outcome.error
+        pending_after = (
+            repo / "data" / "visual-gate" / str(ISSUE) / "round-001"
+            / "feedback-pending.json"
+        ).read_text(encoding="utf-8")
+        assert pending_after == pending_before, (
+            "re-serving would rewrite the pending sentinel -- it must not"
+        )
+
+
+class TestTheLiveFeedbackReachesTheRulingSurface:
+    """#2521's acceptance scenario, words verbatim: the tip delta amends the
+    tip-short-of-band restatement and is SURFACED, never silently applied."""
+
+    def test_the_verbatim_words_travel_to_the_model_pass(self, repo, config):
+        captured = {}
+
+        def transport(system, content):
+            captured["content"] = content
+            return TRANSLATION
+
+        run_gate(
+            repo, ISSUE, config, mock=True, transport=transport,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        assert OPERATOR_WORDS in captured["content"]
+
+    def test_the_stale_manifest_still_offers_the_ruled_key(self, repo, config):
+        """The declaration's ruled values are contract vocabulary even when
+        the round predates them -- without this the ask files as a vague
+        contract gap instead of reaching the ruling surface."""
+        captured = {}
+
+        def transport(system, content):
+            captured["content"] = content
+            return TRANSLATION
+
+        run_gate(
+            repo, ISSUE, config, mock=True, transport=transport,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        assert "needle_tip" in captured["content"]
+        assert "[RULED" in captured["content"]
+
+    def test_the_delta_halts_with_the_interaction_stated(self, repo, config):
+        outcome = run_gate(
+            repo, ISSUE, config, mock=True,
+            transport=lambda *_: TRANSLATION,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        assert outcome.status == "halted"
+        assert "contradicts a landed ruling" in outcome.error
+        assert "'needle_tip'" in outcome.error
+        assert "0.86" in outcome.error and "0.95" in outcome.error
+        assert "re-enters the band" in outcome.error, (
+            "the interaction is stated, not just the key"
+        )
+
+    def test_merging_declared_ruled_keys_never_clobbers_the_manifest(self):
+        merged = _with_declared_ruled(
+            STALE_MANIFEST, {"needle_tip": 0.86, "band_inner": 0.99},
+        )
+
+        assert merged["values"]["needle_tip"]["value"] == 0.86
+        assert merged["values"]["needle_tip"]["ruled"] is True
+        assert merged["values"]["band_inner"]["value"] == 0.88, (
+            "a key the manifest carries keeps the manifest's own record"
+        )
+        assert "needle_tip" not in STALE_MANIFEST["values"], (
+            "the merge returns a copy; the round's manifest is history"
+        )
+
+
+class TestAModelPassFailureHaltsResumably:
+    """#2521 requirement 2: an infra error is not a verdict -- the stage
+    halts resumably with the feedback preserved, and the resumed stage
+    consumes it. The first live Modify let this kill the whole run."""
+
+    def test_the_crash_becomes_a_halt_and_the_feedback_survives(
+        self, repo, config
+    ):
+        def broken_transport(*_):
+            raise RuntimeError(
+                "Model 'claude-opus-4-6' is not a valid Gemini model"
+            )
+
+        outcome = run_gate(
+            repo, ISSUE, config, mock=True, transport=broken_transport,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        assert outcome.status == "halted"
+        assert "not an operator verdict" in outcome.error
+        assert "preserved unconsumed" in outcome.error
+        round_dir = repo / "data" / "visual-gate" / str(ISSUE) / "round-001"
+        assert (round_dir / "feedback.json").is_file(), (
+            "the operator's submitted verdict survives the infra error"
+        )
+        assert not (round_dir / "feedback-consumed.json").exists()
+
+    def test_the_resume_after_the_crash_dispatches_the_same_feedback(
+        self, repo, config
+    ):
+        """The full live cycle: crash on the broken transport, resume with a
+        working one, the SAME preserved feedback reaches the ruling surface
+        without the operator clicking again."""
+        run_gate(
+            repo, ISSUE, config, mock=True,
+            transport=lambda *_: (_ for _ in ()).throw(RuntimeError("wiring")),
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        outcome = run_gate(
+            repo, ISSUE, config, mock=True,
+            transport=lambda *_: TRANSLATION,
+            wait_kwargs={"poll_seconds": 0.05, "deadline": 2},
+        )
+
+        assert outcome.status == "halted"
+        assert "contradicts a landed ruling" in outcome.error
+
+
+class TestTheTransportWiring:
+    """#2521 requirement 3: the translation call routes through the provider
+    layer, which pairs model id with transport."""
+
+    def test_default_transport_uses_the_provider_layer(self, monkeypatch):
+        calls = {}
+
+        class _Result:
+            success = True
+            response = TRANSLATION
+            error_message = ""
+
+        def fake_get_provider(spec, effort=None):
+            calls["spec"] = spec
+
+            class _P:
+                def invoke(self, system, content, **_kw):
+                    calls["system"] = system
+                    return _Result()
+
+            return _P()
+
+        import assemblyzero.core.llm_provider as llm_provider
+        monkeypatch.setattr(llm_provider, "get_provider", fake_get_provider)
+
+        out = modify_mod.default_transport("sys prompt", "content")
+
+        assert calls["spec"] == modify_mod.TRANSLATION_PROVIDER
+        assert calls["spec"].startswith("gemini:"), (
+            "the spec routes a Gemini model to the Gemini transport"
+        )
+        assert out == TRANSLATION
+
+    def test_a_provider_failure_raises_naming_the_spec(self, monkeypatch):
+        class _Result:
+            success = False
+            response = None
+            error_message = "quota exhausted"
+
+        import assemblyzero.core.llm_provider as llm_provider
+        monkeypatch.setattr(
+            llm_provider, "get_provider",
+            lambda spec, effort=None: type(
+                "P", (), {"invoke": lambda self, s, c, **_kw: _Result()}
+            )(),
+        )
+
+        with pytest.raises(RuntimeError) as err:
+            modify_mod.default_transport("s", "c")
+
+        assert modify_mod.TRANSLATION_PROVIDER in str(err.value)
+        assert "quota exhausted" in str(err.value)
+
+
+class TestTheWaitingLineSaysTheURL:
+    """#2520: every repeat of the waiting line is actionable on sight."""
+
+    def test_the_reminder_prints_the_url_from_the_sentinel(self, tmp_path):
+        round_dir = tmp_path / "round-001"
+        round_dir.mkdir()
+        (round_dir / "feedback-pending.json").write_text(
+            '{"url": "http://127.0.0.1:56772/"}', encoding="utf-8",
+        )
+        lines = []
+
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.02, reminder_every=0.01,
+                deadline=0.2, log=lines.append,
+            )
+
+        assert lines, "at least one reminder fired in the window"
+        assert all("open http://127.0.0.1:56772/" in line for line in lines)
+        assert all("round-001" in line for line in lines)
+
+    def test_a_missing_or_broken_sentinel_never_breaks_the_wait(self, tmp_path):
+        round_dir = tmp_path / "round-001"
+        round_dir.mkdir()
+        assert pending_url(round_dir) == ""
+        (round_dir / "feedback-pending.json").write_text("{not json",
+                                                         encoding="utf-8")
+        assert pending_url(round_dir) == ""
+
+
+class TestTheLauncherAnnouncesTheURL:
+    """#2520: the launcher's own surface (detached-launcher.log is its
+    stdout) says the URL once per served round."""
+
+    def _run_watch(self, repo_root, announce, cycles=0.4):
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=speedrun_roll._watch_visual_gate_urls,
+            args=(repo_root, stop),
+            kwargs={"announce": announce, "poll_seconds": 0.05},
+            daemon=True,
+        )
+        thread.start()
+        time.sleep(cycles)
+        stop.set()
+        thread.join(timeout=5)
+
+    def test_a_served_round_is_announced_once_with_the_url(self, tmp_path):
+        round_dir = tmp_path / "data" / "visual-gate" / "331" / "round-001"
+        round_dir.mkdir(parents=True)
+        (round_dir / "feedback-pending.json").write_text(
+            '{"url": "http://127.0.0.1:56772/"}', encoding="utf-8",
+        )
+        announced = []
+
+        self._run_watch(tmp_path, lambda line, **_kw: announced.append(line))
+
+        assert len(announced) == 1, "once per round, not once per poll"
+        assert "http://127.0.0.1:56772/" in announced[0]
+        assert "331" in announced[0] and "round-001" in announced[0]
+
+    def test_an_answered_round_is_not_announced(self, tmp_path):
+        round_dir = tmp_path / "data" / "visual-gate" / "331" / "round-001"
+        round_dir.mkdir(parents=True)
+        (round_dir / "feedback-pending.json").write_text(
+            '{"url": "http://127.0.0.1:56772/"}', encoding="utf-8",
+        )
+        (round_dir / "feedback.json").write_text(
+            '{"verb": "modify", "text": "words"}', encoding="utf-8",
+        )
+        announced = []
+
+        self._run_watch(tmp_path, lambda line, **_kw: announced.append(line))
+
+        assert announced == []
+
+    def test_a_repo_with_no_gate_is_silent_and_harmless(self, tmp_path):
+        announced = []
+        self._run_watch(tmp_path, lambda line, **_kw: announced.append(line))
+        assert announced == []

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1292,6 +1292,58 @@ def ensure_base_for_resume(
 # =============================================================================
 
 
+def _watch_visual_gate_urls(
+    repo_root: Path, stop: "threading.Event", log: "EventLog | None" = None,
+    announce=print, poll_seconds: float = 5.0,
+) -> None:
+    """Announce the visual gate's review URL on the LAUNCHER's surfaces (#2520).
+
+    The gate serves inside the orchestrate child, whose stdout is the run
+    log; the operator's standing habit is the launcher narration -- this
+    process's stdout, which --detached-stdout binds to detached-launcher.log.
+    The first live serve cost 26 operator-minutes because no watched surface
+    said the URL. Each newly served, still-unanswered round is announced
+    exactly once, read from the round's own sentinel so this surface and the
+    child's waiting line can never disagree.
+
+    Never raises: a broken sentinel or a scan error skips a beat, and the
+    next poll tries again -- announcing is a courtesy that must not touch
+    the roll.
+    """
+    seen: set[str] = set()
+    gate_dir = repo_root / "data" / "visual-gate"
+    while not stop.wait(poll_seconds):
+        try:
+            for pending in sorted(gate_dir.glob("*/round-*/feedback-pending.json")):
+                key = str(pending)
+                if key in seen:
+                    continue
+                round_dir = pending.parent
+                if (round_dir / "feedback.json").is_file() or (
+                    round_dir / "feedback-consumed.json"
+                ).is_file():
+                    seen.add(key)
+                    continue
+                try:
+                    url = str(json.loads(
+                        pending.read_text(encoding="utf-8")
+                    ).get("url", ""))
+                except (OSError, ValueError):
+                    continue  # mid-write; the next poll reads it whole
+                if not url:
+                    continue
+                seen.add(key)
+                line = (
+                    f"VISUAL GATE waiting for the operator -- open {url} "
+                    f"(issue {round_dir.parent.name}, {round_dir.name})"
+                )
+                announce(line, flush=True)
+                if log is not None:
+                    log.write(line)
+        except OSError:
+            continue
+
+
 def roll_issue(
     repo_root: Path, issue: int, log_dir: Path, az_root: Path, extra: list[str],
     resume_from: str | None = None, *, fresh: bool = False,
@@ -1366,8 +1418,22 @@ def roll_issue(
                     subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
                 ),
             )
-            with watch.watch(proc):
-                returncode = proc.wait()
+            # #2520: announce the visual gate's URL on the launcher's own
+            # surfaces while the child runs -- concurrent, like the kill
+            # watch, because the gate serves mid-stage and the operator is
+            # watching THIS log.
+            gate_stop = threading.Event()
+            gate_watch = threading.Thread(
+                target=_watch_visual_gate_urls,
+                args=(repo_root, gate_stop, log),
+                daemon=True,
+            )
+            gate_watch.start()
+            try:
+                with watch.watch(proc):
+                    returncode = proc.wait()
+            finally:
+                gate_stop.set()
         log.write(f"CHILD EXITED rc={returncode}")
 
         if watch.fired:


### PR DESCRIPTION
## What

The visual gate's first live hour found three defects and one indirection; this PR fixes all of them, in the issue's priority order, with the live operator's preserved feedback as the acceptance scenario.

## #2521 — the three requirements

**1. Resume honours submitted feedback.** The dispatch loop already consumed an unconsumed answered round without re-serving; it is now pinned against the live shape — a round-001 with the operator's words verbatim ("extend the need to the exact radius of the start of the minor tick mark"), an unrewritten pending sentinel as the no-re-serve witness, and the crash-then-resume cycle dispatching the same file without another click.

**2. A model-pass failure halts resumably.** The translation call is wrapped: an exception becomes a HALTED outcome stating it is an infra error and not a verdict, `feedback.json` is deliberately NOT consumed, and the resume re-enters the same dispatch. The first live Modify let this exception kill the run and trigger RESTORE — a wiring typo became a dead roll. The handler carries its in-code fail-open ruling (it substitutes the stage's halt idiom).

**3. The transport wiring.** `default_transport` routed through a bare `GeminiClient()`, whose default model is `core.config.REVIEWER_MODEL` — a Claude id — which the Gemini validator rejected before any call. It now routes through the provider layer (`get_provider("gemini:3.1-pro")`, the reviewer default the spec stage already uses), which pairs model id with transport. Failure raises naming the spec and the provider's error.

**The ruling-interaction path, live.** The preserved delta (tip 0.86 R → 0.95 R) re-enters the band and amends the 2026-08-25 tip-short-of-band restatement. Two pieces route it to the surface the design demands: boostgauge #363 (PR #364, merged) makes `needle_tip` a ruled contract key; and `_with_declared_ruled` merges the declaration's ruled values into stale round manifests — round-001 predates the key, and without the merge the model would file the ask as a vague contract gap. The halt names the pin, the ask, and the interaction, verbatim from the translation's note.

## #2520 — say the URL

- The waiting line now prints the URL every repeat — `still waiting on operator feedback -- open http://127.0.0.1:PORT/ (round-NNN)` — read from the round's own sentinel via one shared reader, so surfaces cannot disagree. The sentinel keeps the URL for machine consumers.
- The launcher announces each newly served, unanswered round once on its OWN surfaces (`_watch_visual_gate_urls`, a concurrent daemon thread beside the kill watch): stdout — which `--detached-stdout` binds to `detached-launcher.log` — and the events log. Never raises; a mid-write sentinel skips a beat and the next poll reads it whole.

## Tests (14 new, all real)

`tests/unit/test_visual_gate_live_resume.py`: the verbatim-words scenario end to end (dispatch without re-serving, the stale-manifest ruled-key merge, the ruling halt with the interaction stated), the crash-preserves-feedback and crash-then-resume cycle, provider-layer wiring both ways, the reminder line carrying the URL, sentinel robustness, and the launcher watch (announced once with the URL; answered rounds and gateless repos silent). Existing gate family: 65 passing alongside.

## Read-only proof against the live state (definition of done)

A replica of the REAL round-001 (original byte-verified untouched) plus the REAL merged declaration, driven through the real `run_gate` with a stand-in translation: **7/7** — the operator's actual words reached the model pass, the stale manifest offered the ruled key, the dispatch never re-served, and the halt surfaced the ruling interaction naming 0.86, 0.95, and the band re-entry. **What only a live roll proves**: the real Gemini translation of those words, and `resume_plan` walking the orchestrator back into the stage.

Closes #2521, Closes #2520
