### PR TITLE
fix: api_symbols_exist knows the builtin surface and abstains where it cannot know (Closes #2526)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -287,12 +287,43 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                 # The two halts read differently on purpose. "N revisions ended
                 # with 1 unresolved check" reads as a stubborn drafter; when
                 # every failing check HAS been tried, that is the true reading.
-                tried = ", ".join(sorted(set(failing_names) & set(shown + grace_used)))
-                detail = (
-                    f" Each unresolved check was shown to the drafter and "
-                    f"survived a revision: {tried}."
-                    if tried else ""
-                )
+                tried = sorted(set(failing_names) & set(shown + grace_used))
+                # #2526: within "tried", the drafter FAILING to fix a check and
+                # the drafter DECLINING to change the code are different facts,
+                # and the halt says which. When a check's complaint is
+                # byte-identical across every prior revision, the flagged code
+                # survived every round unchanged — the drafter was shown it
+                # repeatedly and repeatedly chose not to break working code,
+                # which is itself evidence of a false positive in the check.
+                # str.isupper died exactly this way: three identical
+                # complaints, three identical declines, one dead run.
+                prior_iters = prior_breakdown[:-1]
+                details_by_name = {
+                    c["check_name"]: c["details"] for c in checks if not c["passed"]
+                }
+                declined = [
+                    name for name in tried
+                    if prior_iters and all(
+                        details_by_name[name] in entry["failures"]
+                        for entry in prior_iters
+                    )
+                ]
+                kept_failing = [name for name in tried if name not in declined]
+                detail = ""
+                if kept_failing:
+                    detail += (
+                        f" Each unresolved check was shown to the drafter and "
+                        f"survived a revision: {', '.join(kept_failing)}."
+                    )
+                if declined:
+                    detail += (
+                        f" NOTE: {', '.join(declined)} drew the IDENTICAL "
+                        f"complaint on every revision — the drafter saw it "
+                        f"{len(prior_iters)} time(s) and left the flagged code "
+                        f"unchanged each time. A drafter declining to change "
+                        f"code it believes correct is evidence of a false "
+                        f"positive in the check, not of an unfixable spec."
+                    )
                 cap_message = (
                     f"Iteration cap: {max_iterations} revision(s) ended with "
                     f"{len(completeness_issues)} unresolved completeness "
@@ -1304,6 +1335,11 @@ class _FenceFacts(NamedTuple):
     # Classes the spec defines (#2399). A class is the one callee whose return
     # type is known without an annotation: `Gauge()` is a Gauge.
     classes: frozenset[str]
+    # Names bound in forms whose type is unknowable by construction (#2526):
+    # lambda parameters, and `except:` targets with no exception class. These
+    # seed the unresolved set directly — a method on one is a method on an
+    # unknown type, and unknown is not guilty.
+    opaque: frozenset[str] = frozenset()
 
 
 class _FenceParseFailure(NamedTuple):
@@ -1445,6 +1481,7 @@ class _FenceVisitor(ast.NodeVisitor):
         self.framework_params: set[str] = set()
         self.returns: dict[str, str] = {}
         self.classes: set[str] = set()
+        self.opaque: set[str] = set()
 
     # ---- imports: receivers the target repo has no authority over (#1948) ----
 
@@ -1556,6 +1593,59 @@ class _FenceVisitor(ast.NodeVisitor):
     def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
         self._record_with(node)
 
+    # #2526: comprehension targets are bindings exactly as `for` targets are —
+    # `[node.id for node in ast.walk(tree)]` binds `node` from `ast.walk`, so
+    # provenance places it in stdlib territory. The live kill was this binding
+    # form going unrecorded: `node` had no provenance at all, fell into no
+    # category, and its builtin-method call was judged against the target
+    # repo's symbols.
+
+    def visit_ListComp(self, node: ast.ListComp) -> None:
+        self._record_comprehension(node)
+
+    def visit_SetComp(self, node: ast.SetComp) -> None:
+        self._record_comprehension(node)
+
+    def visit_DictComp(self, node: ast.DictComp) -> None:
+        self._record_comprehension(node)
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._record_comprehension(node)
+
+    def _record_comprehension(self, node) -> None:
+        # Chained generators resolve through the same fixed point an ordinary
+        # binding chain does: `for row in grid for x in row` records row←grid
+        # and x←row, and whoever owns grid owns both.
+        for gen in node.generators:
+            self._record_binding([gen.target], gen.iter)
+        self.generic_visit(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        # #2526: a lambda parameter's type is unknowable by construction — no
+        # annotation syntax even exists for it. `key=lambda g: g.rank()` says
+        # nothing about what `g` holds, so a method on it abstains.
+        args = node.args
+        collected = [*args.posonlyargs, *args.args, *args.kwonlyargs]
+        if args.vararg is not None:
+            collected.append(args.vararg)
+        if args.kwarg is not None:
+            collected.append(args.kwarg)
+        self.opaque |= {a.arg for a in collected}
+        self.generic_visit(node)
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        # #2526: `except ValueError as e` binds `e` from the exception class,
+        # so provenance answers what it holds; a bare `except ... as e` binds a
+        # value of no stated type at all, which is opaque.
+        if node.name:
+            if node.type is not None:
+                self.assignments.append(
+                    (frozenset({node.name}), _value_provenance(node.type))
+                )
+            else:
+                self.opaque.add(node.name)
+        self.generic_visit(node)
+
     def _record_with(self, node: ast.With | ast.AsyncWith) -> None:
         for item in node.items:
             if item.optional_vars is not None:
@@ -1614,6 +1704,7 @@ def _fence_facts_ast(block: str) -> _FenceFacts:
         framework_params=frozenset(visitor.framework_params),
         returns=tuple(sorted(visitor.returns.items())),
         classes=frozenset(visitor.classes),
+        opaque=frozenset(visitor.opaque),
     )
 
 
@@ -1800,6 +1891,12 @@ def _flag_calls(
     constructor_like = spec_classes | {s for s in symbol_set if s[:1].isupper()}
 
     unresolved: set[str] = set()
+    # #2526: names bound in type-unknowable forms (lambda parameters, bare
+    # `except ... as e`) are unresolved by construction — no fixed point can
+    # place them, so they seed the set directly rather than falling through
+    # to judgment as if the checker knew what they hold.
+    for fence in facts:
+        unresolved |= fence.opaque - exempt
     changed = True
     while changed:
         changed = False
@@ -1852,7 +1949,15 @@ def _flag_calls(
                 continue
             if call.method in symbol_set or call.method in spec_defined:
                 continue
-            if call.method in _API_SYMBOL_ALLOWLIST:
+            # #2526: a method every Python object of a builtin type carries is
+            # never a hallucinated PROJECT API, whoever the receiver is.
+            # `str.isupper` on an AST walk killed a run that had passed the
+            # visual gate because the hand-curated allowlist held `upper` but
+            # not `isupper` — so the builtin surface is now derived, not typed.
+            if (
+                call.method in _API_SYMBOL_ALLOWLIST
+                or call.method in _BUILTIN_TYPE_METHODS
+            ):
                 continue
             flagged.setdefault(call.method, []).append(call.site)
     return flagged
@@ -2102,6 +2207,23 @@ _API_SYMBOL_ALLOWLIST: frozenset[str] = frozenset({
     "assert_called", "assert_called_once", "assert_called_with",
     "assert_any_call", "call_count", "called",
 })
+
+
+#: Every method of every Python builtin type, derived by introspection (#2526).
+#: The hand-curated list above held `upper` but not `isupper`, and the gap
+#: killed run-issue331-083839 at the completeness cap on correct, idiomatic
+#: code (`node.id.isupper()` in an AST walk). A typed list lags the language
+#: forever; `dir()` cannot. The curated list stays for the stdlib idioms and
+#: third-party conventions that are not builtin-type methods.
+_BUILTIN_TYPE_METHODS: frozenset[str] = frozenset(
+    name
+    for builtin_type in (
+        object, type, str, bytes, bytearray, memoryview, list, tuple,
+        dict, set, frozenset, int, float, complex, bool, range, slice,
+        BaseException, BaseExceptionGroup,
+    )
+    for name in dir(builtin_type)
+)
 
 
 _SOURCE_ROOT_PREFIXES: tuple[str, ...] = (

--- a/tests/unit/test_builtin_methods_and_opaque_receivers.py
+++ b/tests/unit/test_builtin_methods_and_opaque_receivers.py
@@ -1,0 +1,245 @@
+"""str.isupper is not a hallucinated API, and unknown is not guilty (#2526).
+
+Roll run-issue331-083839 died at the spec completeness cap — after passing the
+lld stage AND the visual gate's first full operator loop — because
+``api_symbols_exist`` flagged ``node.id.isupper()`` as a method "not found in
+the target project's gathered symbols." ``isupper`` is a method on every
+Python ``str``; the code was correct and idiomatic; the drafter was shown the
+identical complaint three times and correctly declined to break working code;
+the cap killed the run.
+
+Three defects, three fixes, pinned here:
+
+1.  The hand-curated allowlist held ``upper`` but not ``isupper``. The builtin
+    surface is now DERIVED (``dir()`` over every builtin type), so it can
+    never again lag the language by one method.
+2.  A comprehension target was no binding at all — ``node`` in
+    ``[... for node in ast.walk(tree)]`` had no provenance, fell into no
+    category, and was judged against the target repo's symbols. Comprehension
+    generators now record bindings exactly as ``for`` statements do, and
+    type-unknowable binding forms (lambda parameters, bare ``except ... as``)
+    are unresolved by construction: unknown is not guilty.
+3.  The cap's halt message now distinguishes "the drafter kept failing to fix
+    X" from "the drafter declined to change X" — an identical complaint
+    surviving every revision is evidence of a false positive in the check,
+    and the halt says so instead of blaming the spec.
+
+What deliberately did NOT change: bare function parameters and free names
+stay judged (#2391/#2399's carve-out — #1527's founding true positive,
+``question.model_dump()`` on a plain dataclass, arrives exactly that way).
+The guard tests at the bottom pin that boundary.
+"""
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    _BUILTIN_TYPE_METHODS,
+    check_api_symbols_exist,
+    detect_unknown_method_calls,
+    validate_completeness,
+)
+
+#: A plausible small gathered surface; none of the methods below are in it.
+SYMBOLS = ["AppConfig", "SessionState", "WindowsCollector", "load_config"]
+
+#: The live run's killing fence, verbatim from the preserved draft
+#: (boostgauge docs/lineage/active/331-implspec/.../018-spec-draft.md:483).
+OBSERVED_SPEC = """# S
+
+```python
+import ast
+
+def find_constants(tree):
+    constants = [node.id for node in ast.walk(tree) if isinstance(node, ast.Name) and node.id.isupper()]
+    return constants
+```
+"""
+
+
+def _flag(body: str) -> dict:
+    return detect_unknown_method_calls(body, set(SYMBOLS))
+
+
+def _spec(body: str) -> str:
+    return "# S\n\n```python\n" + body + "```\n"
+
+
+class TestTheObservedKill:
+    """The exact case the issue names: node.id.isupper() in an AST walk."""
+
+    def test_the_observed_fence_flags_nothing(self):
+        assert _flag(OBSERVED_SPEC) == {}
+
+    def test_the_observed_fence_passes_the_check(self):
+        result = check_api_symbols_exist(OBSERVED_SPEC, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_isupper_never_flags_on_any_receiver(self):
+        """The allowlist half alone closes it: even a bare-parameter receiver
+        — which stays judged — cannot flag a builtin-type method."""
+        assert "isupper" not in _flag(
+            _spec("def f(name):\n    return name.isupper()\n")
+        )
+
+
+class TestTheBuiltinSurfaceIsDerived:
+    def test_the_str_is_family_is_covered(self):
+        for method in ("isupper", "islower", "isdigit", "isalpha",
+                       "isidentifier", "casefold", "removeprefix"):
+            assert method in _BUILTIN_TYPE_METHODS, method
+
+    def test_the_other_builtin_types_are_covered(self):
+        # int, bytes, set, BaseException — one method each, none in the
+        # hand-curated list, all real Python.
+        for method in ("bit_length", "to_bytes", "isdisjoint",
+                       "with_traceback", "as_integer_ratio"):
+            assert method in _BUILTIN_TYPE_METHODS, method
+
+    def test_builtin_methods_clear_in_a_fence(self):
+        flagged = _flag(_spec(
+            "def f(name, n, chunk):\n"
+            "    a = name.islower()\n"
+            "    b = n.bit_length()\n"
+            "    c = chunk.removeprefix('x')\n"
+        ))
+        assert flagged == {}
+
+    def test_a_project_hallucination_is_not_a_builtin(self):
+        """The derived surface must not swallow the check's whole purpose."""
+        assert "model_dump" not in _BUILTIN_TYPE_METHODS
+        assert "model_validate" not in _BUILTIN_TYPE_METHODS
+
+
+class TestComprehensionTargetsAreBindings:
+    def test_a_comprehension_target_inherits_its_iterables_owner(self):
+        """`node` from `ast.walk(tree)` is stdlib's, so even a NON-builtin
+        method on it is not the target repo's business."""
+        assert _flag(_spec(
+            "import ast\n"
+            "names = [n.walk_away() for n in ast.walk(t)]\n"
+        )) == {}
+
+    def test_chained_generators_resolve_through_the_chain(self):
+        assert _flag(_spec(
+            "import ast\n"
+            "out = [f.arg_names() for n in ast.walk(t) for f in n.fields()]\n"
+        )) == {}
+
+    def test_all_four_comprehension_forms_bind(self):
+        assert _flag(_spec(
+            "import ast\n"
+            "a = {n.invent_a() for n in ast.walk(t)}\n"
+            "b = {n.invent_b(): 1 for n in ast.walk(t)}\n"
+            "c = list(n.invent_c() for n in ast.walk(t))\n"
+        )) == {}
+
+
+class TestOpaqueBindingsAbstain:
+    """Unknown is not guilty: a receiver whose type is unknowable by
+    construction cannot be called absent from anything."""
+
+    def test_a_lambda_parameter_abstains(self):
+        assert _flag(_spec(
+            "result = sorted(xs, key=lambda g: g.rank_weight())\n"
+        )) == {}
+
+    def test_an_except_target_abstains(self):
+        assert _flag(_spec(
+            "try:\n"
+            "    pass\n"
+            "except ValueError as err:\n"
+            "    err.render_hint()\n"
+        )) == {}
+
+
+class TestTheDeliberateBoundaryHolds:
+    """What #2526 did NOT change: affirmatively-placeable receivers, bare
+    parameters, and free names stay judged — #1527's founding true positive
+    arrives as a bare parameter, and abstaining there would retire the check."""
+
+    def test_the_founding_bare_parameter_case_still_flags(self):
+        assert "model_dump" in _flag(_spec(
+            "def apply(question):\n    return question.model_dump()\n"
+        ))
+
+    def test_a_constructor_bound_receiver_still_flags(self):
+        assert "model_dump" in _flag(_spec(
+            "g = SessionState()\ng.model_dump()\n"
+        ))
+
+    def test_a_comprehension_over_a_repo_rooted_source_stays_judged(self):
+        """The comprehension fix routes ownership; it is not an exemption.
+        A target bound from a chain rooted in a gathered symbol is the
+        repo's business, and an invented method on it still flags."""
+        flagged = _flag(_spec(
+            "names = [c.invented_lookup() for c in AppConfig.instances()]\n"
+        ))
+        assert "invented_lookup" in flagged
+
+
+class TestTheHaltSaysWhoDeclined:
+    """Ask 3: 'kept failing to fix X' and 'declined to change X' are
+    different facts, and the halt message states which one happened."""
+
+    def _state(self, iteration=3, shown=(), breakdown=()):
+        return {
+            "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+            "review_iteration": iteration,
+            "max_iterations": 3,
+            "checks_shown_to_drafter": list(shown),
+            "prior_completeness_breakdown": [dict(e) for e in breakdown],
+        }
+
+    def _at_cap(self, details: str, make_breakdown):
+        """Run once to DISCOVER what this minimal spec fails (mirroring
+        test_halt_legibility), then again with everything marked tried and a
+        history built by ``make_breakdown`` from the discovered failures."""
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False, "details": details},
+        ):
+            first = validate_completeness(self._state())
+            return validate_completeness(self._state(
+                shown=first["checks_shown_to_drafter"],
+                breakdown=make_breakdown(first["completeness_issues"]),
+            ))
+
+    def test_an_identical_complaint_every_round_reads_as_a_decline(self, capsys):
+        out = self._at_cap(
+            "Spec calls methods not found: `isupper`",
+            # Every failing check drew this exact complaint on every prior
+            # round — the live run's shape: identical code, identical flag.
+            lambda failures: [
+                {"iteration": i, "failures": list(failures)} for i in range(3)
+            ],
+        )
+        capsys.readouterr()
+        assert "IDENTICAL complaint" in out["error_message"]
+        assert "left the flagged code unchanged" in out["error_message"]
+        assert "false positive" in out["error_message"]
+        assert "survived a revision" not in out["error_message"]
+
+    def test_a_changing_complaint_reads_as_kept_failing(self, capsys):
+        out = self._at_cap(
+            "missing excerpt for a.py",
+            lambda failures: [
+                {"iteration": 0, "failures": ["missing excerpt for b.py"]},
+                {"iteration": 1, "failures": ["missing excerpt for c.py"]},
+            ],
+        )
+        capsys.readouterr()
+        assert "shown to the drafter and survived a revision" in out["error_message"]
+        assert "IDENTICAL complaint" not in out["error_message"]
+
+    def test_no_history_still_reads_as_tried(self, capsys):
+        """The pre-#2526 shape — no breakdown in state — keeps the old
+        sentence, so a first-failure-at-cap is not accused of declining."""
+        out = self._at_cap("missing excerpt for a.py", lambda failures: [])
+        capsys.readouterr()
+        assert "shown to the drafter and survived a revision" in out["error_message"]
+        assert "IDENTICAL complaint" not in out["error_message"]


### PR DESCRIPTION
Closes #2526

Roll run-issue331-083839 — lld passed, visual gate passed its first full operator loop — died at the spec completeness cap because `api_symbols_exist` flagged `node.id.isupper()` as a hallucinated API. Three repairs, per the issue's three asks:

## 1. The check knows the builtin surface, derived rather than typed

The hand-curated allowlist held `upper` but not `isupper`. A typed list lags the language forever, so `_BUILTIN_TYPE_METHODS` is now built by `dir()` over every builtin type (str, bytes, list, dict, set, int, float, BaseException, …). `str.isupper` can never flag again, and neither can any sibling the curator never thought of (`islower`, `bit_length`, `to_bytes`, `casefold`, `removeprefix`, `isdisjoint`, `with_traceback`, …). The curated list stays for stdlib idioms that are not builtin-type methods.

## 2. Unknown is not guilty — the checker abstains where it cannot know

- **Comprehension targets are now bindings.** `[node.id for node in ast.walk(tree)]` binds `node` from `ast.walk`, so provenance places it in stdlib territory — the live kill was this binding form going entirely unrecorded, leaving `node` in no category at all and judged against the target repo's 37 symbols. All four comprehension forms record, and chained generators resolve through the same fixed point ordinary bindings use.
- **Type-unknowable binding forms are unresolved by construction.** Lambda parameters (no annotation syntax exists for them) and bare `except ... as e` targets seed the unresolved set directly; `except ValueError as e` resolves through the exception class like any other binding.

**The deliberate boundary, stated plainly:** bare function parameters and free names STAY judged. That carve-out is prior law (per #2391 and #2399's own test files) because #1527's founding true positive — `question.model_dump()` on a plain dataclass — arrives exactly as a bare parameter, and abstaining there retires the check. Every pinned test of that boundary passes unmodified. If the abstention should widen to parameters too, that is a one-line follow-up ruling.

## 3. The halt says who declined

The cap message now distinguishes "the drafter kept failing to fix X" (complaint text changed across revisions) from "the drafter declined to change X" (byte-identical complaint every round — the flagged code survived every revision unchanged, which is evidence of a false positive in the check, and the halt now says so). The pre-existing "shown to the drafter and survived a revision" sentence is preserved for the kept-failing class.

## DoD: the preserved #331 resume state passes, proven read-only

Replayed the exact judgment against the preserved final draft (`018-spec-draft.md`, 19,651 bytes) with the exact universe the run used — 37 symbols reconstructed via the pipeline's own extractor from `origin/hardening-run-17` (count matches run log line 117):

```
universe: 37 symbols from origin/hardening-run-17 (run log said 37)
api_symbols_exist passed: True
details: All method calls in spec code fences are present in the target repo's
gathered symbols (37 symbols checked). 5 fence(s) skipped by language tag (not Python).
draft byte-identical after proof: True
```

The scan note ("5 fence(s) skipped by language tag") matches the live halt verbatim, and the live run's cap named `isupper` as the only unresolved item — so the resume now passes completeness with zero drafter revisions. The draft was read, never written.

## Tests

- New: `tests/unit/test_builtin_methods_and_opaque_receivers.py` (18 tests) — the exact observed fence verbatim, the derived-surface contents, comprehension/lambda/except abstention, the deliberate judged boundary, and the declined-vs-kept-failing halt in all three history shapes.
- Full unit suite: **8579 passed, 21 skipped, 5 xfailed, 0 failed** (10m47s).
- All 220 pre-existing tests across the nine symbol-checker suites pass **unmodified** — no prior ruling was reversed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
