### PR TITLE
feat: the visual gate summons the operator (Closes #2527, Closes #2528, Closes #2529)

### DIFF
--- a/assemblyzero/core/operator_notify.py
+++ b/assemblyzero/core/operator_notify.py
@@ -1,0 +1,254 @@
+"""Escalating notification while a gate waits on the operator (#2529).
+
+The gate's infinite patience is correct — human priority always, no timeout
+that overrides the human (fleet hard rule). What was missing is that the
+patience was SILENT: the run holds, the operator forgets, and the machine has
+no sanctioned way to re-request attention. The operator's own projection:
+"if i get distracted the program could sit there for days waiting for me."
+
+So the wait asks louder over time, and never decides:
+
+* **Toast, on a slow backoff.** After a configurable idle interval (default
+  10 minutes) a Windows toast names the repo, issue, round and URL; clicking
+  it opens the review page. It repeats — 30 minutes later, then hourly —
+  because the first toast lands while the operator is precisely the thing
+  they said: busy. Toasts are the OS's sanctioned attention channel, not a
+  window flash (the spawn is CREATE_NO_WINDOW; nothing steals focus).
+* **One email, ever, as the backstop.** After a long threshold (default 4
+  hours) one message goes to the operator's contact address via the fleet's
+  canonical outbound stack (AWS SES v2, us-east-1, boto3 default credential
+  chain). The sender identity must be an SES-verified address and is supplied
+  by config or environment — it is deliberately not hardcoded here.
+* **Never a timeout.** Nothing in this module ends a wait. Escalation is
+  louder asking, not deciding.
+
+Every failure in this module is non-fatal by construction: each entry point
+returns "" on success or a one-line reason string the caller logs and moves
+past. A notification must never damage the wait it decorates.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+from xml.sax.saxutils import escape as _xml_escape
+
+#: The operator's contact inbox (fleet identity). NEVER an account-login
+#: address — the CloudFlare/AWS account emails are not contact addresses.
+OPERATOR_CONTACT = "martymcenroe@gmail.com"
+
+#: Environment override for the SES-verified sender identity, so it never
+#: has to be written into a repo's tracked declaration.
+EMAIL_FROM_ENV = "AZ_OPERATOR_EMAIL_FROM"
+
+DEFAULT_TOAST_BACKOFF: tuple[float, ...] = (600.0, 1800.0, 3600.0)
+DEFAULT_EMAIL_AFTER: float = 4 * 3600.0
+
+
+@dataclass(frozen=True)
+class NotifyConfig:
+    """The escalation declaration; every interval configurable, all of it
+    disableable, none of it a timeout."""
+
+    enabled: bool = True
+    #: Seconds of idle before the FIRST toast, then between subsequent
+    #: toasts; the last entry repeats forever (default: 10m, then 30m
+    #: later, then hourly).
+    toast_backoff_seconds: tuple[float, ...] = DEFAULT_TOAST_BACKOFF
+    #: Seconds of idle before the single backstop email.
+    email_after_seconds: float = DEFAULT_EMAIL_AFTER
+    email_to: str = OPERATOR_CONTACT
+    #: SES-verified sender identity. Empty means the email backstop is
+    #: disabled (and says so, once); the environment override wins.
+    email_from: str = ""
+
+    @classmethod
+    def from_mapping(cls, data: dict | None) -> "NotifyConfig":
+        data = data or {}
+        backoff = tuple(
+            float(v) for v in data.get("toast_backoff_seconds", [])
+        ) or DEFAULT_TOAST_BACKOFF
+        return cls(
+            enabled=bool(data.get("enabled", True)),
+            toast_backoff_seconds=backoff,
+            email_after_seconds=float(
+                data.get("email_after_seconds", DEFAULT_EMAIL_AFTER)
+            ),
+            email_to=str(data.get("email_to", OPERATOR_CONTACT)),
+            email_from=(
+                os.environ.get(EMAIL_FROM_ENV, "").strip()
+                or str(data.get("email_from", ""))
+            ),
+        )
+
+
+class EscalationSchedule:
+    """Which escalations are due at a given elapsed idle time.
+
+    Pure bookkeeping over a monotonic elapsed-seconds value the caller
+    supplies, so tests drive it with plain numbers and no clock mocking.
+    Each action is returned exactly once; the toast cursor then advances by
+    the next backoff entry (last entry repeating). The email is offered once
+    per schedule — the caller enforces once-per-ROUND across resumes with an
+    on-disk sentinel, because this object dies with the process and the wait
+    does not.
+    """
+
+    def __init__(self, config: NotifyConfig) -> None:
+        self._config = config
+        self._backoff = config.toast_backoff_seconds
+        self._index = 0
+        self._next_toast_at = self._backoff[0] if self._backoff else None
+        self._email_offered = False
+
+    def due(self, elapsed_seconds: float) -> list[str]:
+        if not self._config.enabled:
+            return []
+        actions: list[str] = []
+        if (
+            self._next_toast_at is not None
+            and elapsed_seconds >= self._next_toast_at
+        ):
+            actions.append("toast")
+            self._index += 1
+            step = self._backoff[min(self._index, len(self._backoff) - 1)]
+            self._next_toast_at += step
+        if (
+            not self._email_offered
+            and elapsed_seconds >= self._config.email_after_seconds
+        ):
+            actions.append("email")
+            self._email_offered = True
+        return actions
+
+
+# ---------------------------------------------------------------------------
+# Toast
+# ---------------------------------------------------------------------------
+
+#: PowerShell's registered AppUserModelID — the one AppId every Windows box
+#: already has, so the toast needs no registration step of its own.
+_POWERSHELL_APP_ID = (
+    "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}"
+    "\\WindowsPowerShell\\v1.0\\powershell.exe"
+)
+
+_TOAST_PS_TEMPLATE = """$ErrorActionPreference = 'Stop'
+$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]
+$null = [Windows.UI.Notifications.ToastNotification, Windows.UI.Notifications, ContentType = WindowsRuntime]
+$null = [Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom, ContentType = WindowsRuntime]
+$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
+$xml.LoadXml('{payload}')
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('{app_id}').Show([Windows.UI.Notifications.ToastNotification]::new($xml))
+"""
+
+
+def toast_script(title: str, body: str, url: str = "") -> str:
+    """The PowerShell that shows one toast; pure, so tests read it.
+
+    Clicking the toast opens ``url`` (protocol activation) — the review page
+    is one click away even when the terminal is buried. All three fields are
+    XML-escaped, and the finished payload has its single quotes doubled for
+    PowerShell's single-quoted string, in that order, so neither layer can
+    reinterpret the other's characters.
+    """
+    launch = (
+        f' activationType="protocol" launch="{_xml_escape(url, {'"': "&quot;"})}"'
+        if url else ""
+    )
+    payload = (
+        f"<toast{launch}><visual><binding template=\"ToastGeneric\">"
+        f"<text>{_xml_escape(title)}</text>"
+        f"<text>{_xml_escape(body)}</text>"
+        f"</binding></visual></toast>"
+    )
+    return _TOAST_PS_TEMPLATE.format(
+        payload=payload.replace("'", "''"), app_id=_POWERSHELL_APP_ID
+    )
+
+
+def show_toast(
+    title: str, body: str, url: str = "", *, runner=subprocess.run
+) -> str:
+    """Show a Windows toast. Returns "" on success, a reason string otherwise."""
+    if sys.platform != "win32":
+        return "toast skipped: not a Windows host"
+    try:
+        result = runner(
+            [
+                "powershell",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                toast_script(title, body, url),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        )
+    except Exception as exc:  # noqa: BLE001
+        # fail-open: #2529 — a notification must never damage the wait it
+        # decorates. The failure is returned as a reason string the caller
+        # logs, so it is visible, and the wait (the thing that matters)
+        # continues.
+        return f"toast failed: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return f"toast failed (exit {result.returncode}): {detail[:200]}"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Email (the fleet's canonical outbound stack: SES v2, us-east-1)
+# ---------------------------------------------------------------------------
+
+
+def send_email(
+    *,
+    sender: str,
+    to: str,
+    subject: str,
+    text_body: str,
+    region: str = "us-east-1",
+    client: Any = None,
+) -> str:
+    """One plain-text email via SES v2. Returns "" on success, else a reason.
+
+    ``sender`` must be an SES-verified identity; empty disables with a reason
+    the caller logs once. ``client`` is the test seam — production builds a
+    real boto3 client from the default credential chain.
+    """
+    if not sender:
+        return (
+            f"email backstop disabled: no sender identity configured "
+            f"(set {EMAIL_FROM_ENV} or the gate declaration's "
+            f"notify.email_from to an SES-verified address)"
+        )
+    try:
+        if client is None:
+            import boto3
+
+            client = boto3.client("sesv2", region_name=region)
+        client.send_email(
+            FromEmailAddress=sender,
+            Destination={"ToAddresses": [to]},
+            Content={
+                "Simple": {
+                    "Subject": {"Data": subject, "Charset": "UTF-8"},
+                    "Body": {
+                        "Text": {"Data": text_body, "Charset": "UTF-8"}
+                    },
+                }
+            },
+        )
+        return ""
+    except Exception as exc:  # noqa: BLE001
+        # fail-open: #2529 — same ruling as the toast: the backstop email is
+        # a courtesy, the wait is the contract. The reason string is logged
+        # by the caller, and a failed send does not claim the once-ever
+        # sentinel, so a resumed wait can still deliver the backstop.
+        return f"email send failed: {exc}"

--- a/assemblyzero/core/operator_notify.py
+++ b/assemblyzero/core/operator_notify.py
@@ -171,10 +171,16 @@ def toast_script(title: str, body: str, url: str = "") -> str:
 
 
 def show_toast(
-    title: str, body: str, url: str = "", *, runner=subprocess.run
+    title: str, body: str, url: str = "", *,
+    runner=subprocess.run, platform: str | None = None,
 ) -> str:
-    """Show a Windows toast. Returns "" on success, a reason string otherwise."""
-    if sys.platform != "win32":
+    """Show a Windows toast. Returns "" on success, a reason string otherwise.
+
+    ``platform`` is a test seam (defaults to the real ``sys.platform``) so the
+    composition and spawn wiring stay testable on the Linux CI runner, where
+    the real guard below would otherwise short-circuit them.
+    """
+    if (platform or sys.platform) != "win32":
         return "toast skipped: not a Windows host"
     try:
         result = runner(

--- a/assemblyzero/core/operator_wait.py
+++ b/assemblyzero/core/operator_wait.py
@@ -1,0 +1,70 @@
+"""The operator-wait class of output (#2527): the one state that shouts.
+
+Every other state in the pipeline is the human waiting on the machine, and
+white ticks at a steady cadence are the right voice for it. The one inversion
+— the MACHINE waiting on the HUMAN — looked exactly the same, and the
+operator's own words name the cost: "it wasn't clear to me from the terminal
+output that my judgment was requested... it looks kinda like the counting it
+is doing when an LLM is slow."
+
+So the operator-wait class gets the strongest signal the terminal has:
+
+* :func:`paint` renders a line in amber when stdout is a TTY, and returns it
+  untouched when it is not — log files must not accumulate escape codes;
+* :func:`begin` / :func:`end` mark the process-wide "a human is being waited
+  on" window, so OTHER printers (the stage watchdog's tick line) can say so
+  too instead of impersonating a slow model.
+
+This module belongs to the operator-wait class generally, not to the visual
+gate: any future gate that blocks on a human calls the same three functions
+and inherits the whole treatment.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+
+_AMBER = "\x1b[33;1m"
+_RESET = "\x1b[0m"
+
+_lock = threading.Lock()
+_active: dict | None = None
+
+
+def wants_color(stream=None) -> bool:
+    """True when ``stream`` (default stdout) is a live terminal."""
+    stream = sys.stdout if stream is None else stream
+    isatty = getattr(stream, "isatty", None)
+    try:
+        return bool(isatty and isatty())
+    except (ValueError, OSError):
+        # fail-open: a closed or detached stream is not a terminal, and "no
+        # colour" is the correct, indistinguishable-from-real answer for it —
+        # a paint decision must never crash the line it decorates.
+        return False
+
+
+def paint(text: str, stream=None) -> str:
+    """``text`` in amber for a TTY, verbatim for anything else."""
+    return f"{_AMBER}{text}{_RESET}" if wants_color(stream) else text
+
+
+def begin(url: str = "", note: str = "") -> None:
+    """Declare that the process is now waiting on the operator."""
+    global _active
+    with _lock:
+        _active = {"url": url, "note": note}
+
+
+def end() -> None:
+    """Declare the wait over. Idempotent."""
+    global _active
+    with _lock:
+        _active = None
+
+
+def active() -> dict | None:
+    """The current wait ({"url", "note"}) or None. For other printers."""
+    with _lock:
+        return dict(_active) if _active is not None else None

--- a/assemblyzero/core/stage_watchdog.py
+++ b/assemblyzero/core/stage_watchdog.py
@@ -23,6 +23,8 @@ import threading
 import time
 from typing import Optional
 
+from assemblyzero.core import operator_wait
+
 # Derived, not typed. Each value is the p90 duration of PASSED runs of that
 # stage across the boostgauge speedrun corpus, produced by
 # `tools/derive_stage_nominals.py` and re-derivable with one command:
@@ -107,8 +109,16 @@ class StageWatchdog:
         self._thread: Optional[threading.Thread] = None
 
     def status_line(self, elapsed: float) -> str:
-        """The line printed at `elapsed` seconds — pure, so tests can read it."""
+        """The line printed at `elapsed` seconds — reads only declared state,
+        so tests can drive it with begin()/end() and a number."""
         line = f"    [STAGE] {self.stage} running {int(elapsed)}s"
+        # #2527: the one state where the MACHINE waits on the HUMAN must not
+        # impersonate a slow model. While a gate has declared an operator
+        # wait, the tick says whose turn it is — and no SLOW/STALLED verdict
+        # is issued, because elapsed time here measures the operator's
+        # attention, not the stage's health.
+        if operator_wait.active() is not None:
+            return line + " - awaiting OPERATOR (this wait is yours)"
         if not self.nominal:
             return line
         line += f" (nominal ~{int(self.nominal)}s)"
@@ -121,7 +131,12 @@ class StageWatchdog:
 
     def _run(self) -> None:
         while not self._stop.wait(self.interval):
-            print(self.status_line(time.monotonic() - self._start), flush=True)
+            line = self.status_line(time.monotonic() - self._start)
+            # #2527: amber on a TTY while awaiting the operator; paint() is a
+            # no-op into files, so logs stay free of escape codes.
+            if operator_wait.active() is not None:
+                line = operator_wait.paint(line)
+            print(line, flush=True)
 
     def __enter__(self) -> "StageWatchdog":
         self._start = time.monotonic()

--- a/assemblyzero/visual_gate/config.py
+++ b/assemblyzero/visual_gate/config.py
@@ -13,13 +13,25 @@ Shape::
       "renderer_cmd": ["poetry", "run", "python", "tools/visual_contract_render.py"],
       "contract": "docs/design/0002-aesthetic-v1-stingray.md",
       "separation_floor": 85,
-      "ruled": {"needle_rgb": [247, 57, 35]}
+      "ruled": {"needle_rgb": [247, 57, 35]},
+      "open_browser": true,
+      "notify": {
+        "enabled": true,
+        "toast_backoff_seconds": [600, 1800, 3600],
+        "email_after_seconds": 14400,
+        "email_from": ""
+      }
     }
 
 ``renderer_cmd`` runs with the target repo as cwd, so the repo's own
 environment convention (poetry, house rules) resolves the interpreter and its
 imaging deps. ``ruled`` maps contract keys to the value a landed ruling pinned;
 a Modify delta that would change one halts for the operator (#2518 guardrail).
+``open_browser`` (#2528) and ``notify`` (#2529) are optional; their absence
+means the defaults shown (auto-open on a round's first serve; toast at 10
+minutes, 30 more, then hourly; one backstop email at 4 hours to the operator
+contact — the email needs ``email_from`` set to an SES-verified identity, via
+this file or the ``AZ_OPERATOR_EMAIL_FROM`` environment variable).
 """
 
 from __future__ import annotations
@@ -38,6 +50,15 @@ class GateConfig:
     contract: str
     separation_floor: float
     ruled: dict = field(default_factory=dict)
+    #: #2528: on a round's FIRST serve the gate opens the review page in the
+    #: operator's default browser itself. Default ON by the operator's own
+    #: request; a repo can declare it off, and the environment can too (see
+    #: gate.py) for operators who hate focus-stealing.
+    open_browser: bool = True
+    #: #2529: the escalating-notification declaration (toast backoff, email
+    #: backstop). Raw mapping; the wait parses it via NotifyConfig so the
+    #: intervals and the kill switch live with the repo's other gate law.
+    notify: dict = field(default_factory=dict)
 
 
 def load_gate_config(target_repo: Path | str) -> GateConfig | None:
@@ -57,6 +78,8 @@ def load_gate_config(target_repo: Path | str) -> GateConfig | None:
         contract=str(data.get("contract", "")),
         separation_floor=float(data.get("separation_floor", 0)),
         ruled=dict(data.get("ruled", {})),
+        open_browser=bool(data.get("open_browser", True)),
+        notify=dict(data.get("notify", {})),
     )
 
 

--- a/assemblyzero/visual_gate/gate.py
+++ b/assemblyzero/visual_gate/gate.py
@@ -29,12 +29,15 @@ Round lifecycle on disk (what makes the halt resumable):
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from assemblyzero.core import operator_wait
+from assemblyzero.core.operator_notify import NotifyConfig
 from assemblyzero.visual_gate import bundle as bundle_mod
 from assemblyzero.visual_gate.config import GateConfig
 from assemblyzero.visual_gate.modify import (
@@ -48,6 +51,45 @@ from assemblyzero.visual_gate.server import serve_bundle, wait_for_feedback
 #: Renderer exit code that means "the contract cannot be drawn from" -- the
 #: adjectival-contract finding, distinct from an ordinary crash.
 TOO_ADJECTIVAL_EXIT = 3
+
+#: #2528: machine-level kill switch for the browser auto-open, for operators
+#: who hate focus-stealing on a box whose repos all default it on. Any of
+#: 0/false/no/off disables; the repo's declaration (`open_browser`) is the
+#: per-repo switch.
+OPEN_BROWSER_ENV = "AZ_VISUAL_GATE_OPEN_BROWSER"
+
+
+def _open_review_page(url: str, config: GateConfig, *, log=print, opener=None) -> None:
+    """Open the review page in the operator's default browser (#2528).
+
+    "the url was clickable thank god but can't the program actually pull the
+    url up?" It can. Default ON by that request; the repo declaration and the
+    environment can each turn it off; failure is one logged line and the
+    printed URL remains the fallback — a browser problem must never become a
+    gate problem. The gate exists to summon the operator, so this tab is an
+    operator-REQUESTED interruption — the opposite of the window-flash class.
+    """
+    if not config.open_browser:
+        return
+    if os.environ.get(OPEN_BROWSER_ENV, "").strip().lower() in (
+        "0", "false", "no", "off",
+    ):
+        log(f"    [visual] browser auto-open disabled by {OPEN_BROWSER_ENV}")
+        return
+    try:
+        if opener is None:
+            import webbrowser
+
+            opener = webbrowser.open
+        if opener(url):
+            log("    [visual] opened the review page in your browser")
+        else:
+            log("    [visual] no browser would open -- use the URL above")
+    except Exception as exc:  # noqa: BLE001
+        # fail-open: #2528 — a browser problem must never become a gate
+        # problem. The failure is logged in one line and the printed URL
+        # remains the operator's fallback; the wait proceeds either way.
+        log(f"    [visual] browser auto-open failed ({exc}) -- use the URL above")
 
 
 @dataclass
@@ -349,12 +391,29 @@ def run_gate(
 
         answer = bundle_mod.read_feedback(current)
         if answer is None:
+            # #2528: a round's FIRST serve is a fresh request for eyes; a
+            # re-serve (a resume of a round the operator already saw) is not.
+            # The pending sentinel is the on-disk fact that says which.
+            first_serve = not (current / "feedback-pending.json").is_file()
             server, url = serve_bundle(current, issue)
             bundle_mod.write_pending(current, url)
-            log(f"    [visual] review page: {url}")
+            log(operator_wait.paint(
+                f"    [visual] YOUR JUDGMENT IS REQUESTED -- review page: {url}"
+            ))
             log(f"    [visual] bundle: {current}")
+            if first_serve and not mock:
+                _open_review_page(url, config, log=log)
+            # #2529: mock runs get no live escalation; explicit wait_kwargs
+            # (the test seam) always win over the built defaults.
+            waiting: dict = dict(
+                notify_config=(
+                    None if mock else NotifyConfig.from_mapping(config.notify)
+                ),
+                context={"repo": target_repo.name, "issue": issue},
+            )
+            waiting.update(wait_kwargs)
             try:
-                answer = wait_for_feedback(current, log=log, **wait_kwargs)
+                answer = wait_for_feedback(current, log=log, **waiting)
             finally:
                 server.shutdown()
         rounds_run += 1

--- a/assemblyzero/visual_gate/server.py
+++ b/assemblyzero/visual_gate/server.py
@@ -13,13 +13,18 @@ disk regardless of who was listening when it was given.
 from __future__ import annotations
 
 import html
+import json
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs
 
 from assemblyzero.visual_gate import bundle as bundle_mod
+
+if TYPE_CHECKING:
+    from assemblyzero.core.operator_notify import NotifyConfig
 
 _PAGE = """<!doctype html>
 <html><head><meta charset="utf-8"><title>Visual gate — issue #{issue}</title>
@@ -140,37 +145,130 @@ def serve_bundle(round_dir: Path, issue: int) -> tuple[ThreadingHTTPServer, str]
     return server, f"http://127.0.0.1:{server.server_address[1]}/"
 
 
+#: The on-disk once-ever sentinel for the email backstop (#2529). Beside the
+#: round like every other piece of wait state, so a killed-and-resumed gate
+#: never emails twice about the same round.
+EMAIL_SENT_NAME = "notify-email-sent.json"
+
+
 def wait_for_feedback(
     round_dir: Path, *, poll_seconds: float = 2.0,
     reminder_every: float = 300.0, log=print, deadline: float | None = None,
+    notify_config: "NotifyConfig | None" = None,
+    context: dict | None = None,
+    toaster=None, emailer=None,
 ) -> dict:
     """Block until feedback.json appears, then return it.
 
     No timeout that overrides the human (house rule): the default waits
     forever, reminding every five minutes. ``deadline`` exists for tests.
+
+    #2527: the wait declares itself through ``operator_wait`` — the reminder
+    line renders amber on a TTY (plain in files), and the stage watchdog's
+    tick says "awaiting OPERATOR" instead of impersonating a slow model.
+
+    #2529: the wait asks louder over time — toasts on ``notify_config``'s
+    backoff, then at most ONE backstop email per round, ever, enforced by an
+    on-disk sentinel so a resume cannot re-send it. Escalation never ends the
+    wait; every notification failure is one logged line and the wait goes on.
+    ``toaster`` / ``emailer`` are test seams.
     """
+    from assemblyzero.core import operator_notify, operator_wait
+
+    toaster = toaster or operator_notify.show_toast
+    emailer = emailer or operator_notify.send_email
+    context = context or {}
+    schedule = (
+        operator_notify.EscalationSchedule(notify_config)
+        if notify_config is not None else None
+    )
+
     start = time.monotonic()
     last_reminder = start
-    while True:
-        answer = bundle_mod.read_feedback(round_dir)
-        if answer is not None:
-            return answer
-        now = time.monotonic()
-        if deadline is not None and now - start > deadline:
-            raise TimeoutError(f"no feedback.json in {round_dir} after {deadline}s")
-        if now - last_reminder >= reminder_every:
-            # #2520: say the URL, every time. The first live serve printed a
-            # path to the JSON holding the URL, and the operator spent 26
-            # minutes staring at the indirection. In a detached run these
-            # lines are the only surface -- each one must be actionable on
-            # sight, with the file kept as the machine-readable copy.
-            log(
-                f"    [visual] still waiting on operator feedback -- open "
-                f"{pending_url(round_dir) or 'the review page'} "
-                f"({round_dir.name})"
-            )
-            last_reminder = now
-        time.sleep(poll_seconds)
+    operator_wait.begin(url=pending_url(round_dir), note=round_dir.name)
+    try:
+        while True:
+            answer = bundle_mod.read_feedback(round_dir)
+            if answer is not None:
+                return answer
+            now = time.monotonic()
+            if deadline is not None and now - start > deadline:
+                raise TimeoutError(
+                    f"no feedback.json in {round_dir} after {deadline}s"
+                )
+            if now - last_reminder >= reminder_every:
+                # #2520: say the URL, every time. The first live serve printed
+                # a path to the JSON holding the URL, and the operator spent 26
+                # minutes staring at the indirection. In a detached run these
+                # lines are the only surface -- each one must be actionable on
+                # sight, with the file kept as the machine-readable copy.
+                log(operator_wait.paint(
+                    f"    [visual] AWAITING OPERATOR -- your judgment is "
+                    f"requested: open "
+                    f"{pending_url(round_dir) or 'the review page'} "
+                    f"({round_dir.name})"
+                ))
+                last_reminder = now
+            if schedule is not None:
+                for action in schedule.due(now - start):
+                    _escalate(
+                        action, round_dir, notify_config, context,
+                        elapsed=now - start, log=log,
+                        toaster=toaster, emailer=emailer,
+                    )
+            time.sleep(poll_seconds)
+    finally:
+        operator_wait.end()
+
+
+def _escalate(
+    action: str, round_dir: Path, config, context: dict, *,
+    elapsed: float, log, toaster, emailer,
+) -> None:
+    """One due escalation, delivered non-fatally. Louder asking, never deciding."""
+    url = pending_url(round_dir)
+    repo = context.get("repo", "")
+    issue = context.get("issue", "")
+    where = f"{repo} #{issue}" if repo or issue else round_dir.name
+    minutes = int(elapsed // 60)
+
+    if action == "toast":
+        error = toaster(
+            "Visual gate awaiting your review",
+            f"{where}, {round_dir.name} — waiting {minutes}m. "
+            f"Click to open the review page.",
+            url,
+        )
+        if error:
+            log(f"    [visual] {error}")
+        return
+
+    if action == "email":
+        sentinel = round_dir / EMAIL_SENT_NAME
+        if sentinel.is_file():
+            return  # a prior grant of this wait already sent the one email
+        error = emailer(
+            sender=config.email_from,
+            to=config.email_to,
+            subject=f"[visual gate] {where} awaits your review",
+            text_body=(
+                f"The visual gate has been waiting on your judgment for "
+                f"{minutes} minutes.\n\n"
+                f"Repo:   {repo}\nIssue:  #{issue}\n"
+                f"Round:  {round_dir.name}\nPage:   {url or '(serve URL unknown)'}\n"
+                f"Bundle: {round_dir}\n\n"
+                f"The run holds until you answer or kill it; this is the one "
+                f"email it will ever send about this round.\n"
+            ),
+        )
+        if error:
+            log(f"    [visual] {error}")
+            return
+        sentinel.write_text(
+            json.dumps({"to": config.email_to, "after_seconds": int(elapsed)}),
+            encoding="utf-8",
+        )
+        log(f"    [visual] backstop email sent to {config.email_to}")
 
 
 def pending_url(round_dir: Path) -> str:
@@ -180,8 +278,6 @@ def pending_url(round_dir: Path) -> str:
     is the one reader, shared by the waiting line and the launcher-side
     announcement, so the two surfaces can never disagree.
     """
-    import json
-
     path = round_dir / "feedback-pending.json"
     try:
         return str(json.loads(path.read_text(encoding="utf-8")).get("url", ""))

--- a/tests/unit/test_gate_escalation.py
+++ b/tests/unit/test_gate_escalation.py
@@ -111,7 +111,9 @@ class TestTheToast:
 
             return _Done()
 
-        assert show_toast("t", "b", "http://x/", runner=runner) == ""
+        assert show_toast(
+            "t", "b", "http://x/", runner=runner, platform="win32"
+        ) == ""
         assert calls["cmd"][0] == "powershell"
         assert "-NonInteractive" in calls["cmd"]
         import subprocess
@@ -123,8 +125,15 @@ class TestTheToast:
         def runner(cmd, **kwargs):
             raise OSError("powershell missing")
 
-        reason = show_toast("t", "b", runner=runner)
+        reason = show_toast("t", "b", runner=runner, platform="win32")
         assert "toast failed" in reason
+
+    def test_a_non_windows_host_skips_with_a_reason(self):
+        def forbidden(cmd, **kwargs):
+            raise AssertionError("nothing must spawn off Windows")
+
+        reason = show_toast("t", "b", runner=forbidden, platform="linux")
+        assert "not a Windows host" in reason
 
 
 class TestTheEmail:

--- a/tests/unit/test_gate_escalation.py
+++ b/tests/unit/test_gate_escalation.py
@@ -1,0 +1,259 @@
+"""Escalating notification while the gate waits — never a timeout (#2529).
+
+"i always have a lot going on so if i get distracted the program could sit
+there for days waiting for me." The wait stays infinite — human priority,
+fleet hard rule — but it asks louder over time: toasts on a slow backoff,
+then ONE backstop email per round, ever, enforced on disk so a resume cannot
+re-send it. Every notification failure is a logged line the wait survives.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core import operator_notify
+from assemblyzero.core.operator_notify import (
+    EMAIL_FROM_ENV,
+    EscalationSchedule,
+    NotifyConfig,
+    send_email,
+    show_toast,
+    toast_script,
+)
+from assemblyzero.visual_gate import bundle as bundle_mod
+from assemblyzero.visual_gate.server import EMAIL_SENT_NAME, wait_for_feedback
+
+
+class TestTheSchedule:
+    """Pure timing bookkeeping, driven by plain numbers."""
+
+    def _config(self, **kw) -> NotifyConfig:
+        return NotifyConfig(
+            toast_backoff_seconds=kw.pop("backoff", (10.0, 30.0, 60.0)),
+            email_after_seconds=kw.pop("email_after", 100.0),
+            **kw,
+        )
+
+    def test_nothing_is_due_before_the_first_interval(self):
+        schedule = EscalationSchedule(self._config())
+        assert schedule.due(9.9) == []
+
+    def test_the_first_toast_lands_at_the_first_interval(self):
+        schedule = EscalationSchedule(self._config())
+        assert schedule.due(10.0) == ["toast"]
+        assert schedule.due(10.1) == [], "the same toast must not repeat"
+
+    def test_the_backoff_slows_and_the_last_step_repeats_forever(self):
+        schedule = EscalationSchedule(self._config())
+        assert schedule.due(10.0) == ["toast"]     # first: at 10
+        assert schedule.due(39.9) == []
+        assert schedule.due(40.0) == ["toast"]     # +30
+        assert schedule.due(99.9) == []
+        due_100 = schedule.due(100.0)              # +60, and the email is due
+        assert "toast" in due_100
+        assert schedule.due(160.0) == ["toast"]    # +60 again: last step repeats
+        assert schedule.due(220.0) == ["toast"]    # ... forever
+
+    def test_the_email_is_offered_exactly_once(self):
+        schedule = EscalationSchedule(self._config(backoff=(1000.0,)))
+        assert schedule.due(100.0) == ["email"]
+        assert schedule.due(200.0) == []
+
+    def test_disabled_means_silent(self):
+        schedule = EscalationSchedule(self._config(enabled=False))
+        assert schedule.due(10_000.0) == []
+
+    def test_from_mapping_defaults(self, monkeypatch):
+        monkeypatch.delenv(EMAIL_FROM_ENV, raising=False)
+        config = NotifyConfig.from_mapping(None)
+        assert config.enabled is True
+        assert config.toast_backoff_seconds == (600.0, 1800.0, 3600.0)
+        assert config.email_after_seconds == 4 * 3600.0
+        assert config.email_to == operator_notify.OPERATOR_CONTACT
+        assert config.email_from == ""
+
+    def test_from_mapping_env_overrides_the_sender(self, monkeypatch):
+        monkeypatch.setenv(EMAIL_FROM_ENV, "gate@verified.example")
+        config = NotifyConfig.from_mapping({"email_from": "other@x"})
+        assert config.email_from == "gate@verified.example"
+
+
+class TestTheToast:
+    def test_the_script_carries_the_facts_and_the_click_through(self):
+        script = toast_script(
+            "Visual gate awaiting your review",
+            "boostgauge #331, round-001 — waiting 10m",
+            "http://127.0.0.1:9999/",
+        )
+        assert "Visual gate awaiting your review" in script
+        assert "boostgauge #331, round-001" in script
+        assert 'launch="http://127.0.0.1:9999/"' in script
+        assert 'activationType="protocol"' in script
+        assert "WindowsPowerShell" in script  # the registered AppId
+
+    def test_the_script_escapes_both_layers(self):
+        script = toast_script("a <b> & 'c'", "d", "http://x/?a=1&b=2")
+        assert "a &lt;b&gt; &amp; ''c''" in script  # XML then PS single-quote
+        assert "a=1&amp;b=2" in script
+
+    def test_show_toast_runs_powershell_windowless(self):
+        calls = {}
+
+        def runner(cmd, **kwargs):
+            calls["cmd"] = cmd
+            calls["kwargs"] = kwargs
+
+            class _Done:
+                returncode = 0
+                stdout = stderr = ""
+
+            return _Done()
+
+        assert show_toast("t", "b", "http://x/", runner=runner) == ""
+        assert calls["cmd"][0] == "powershell"
+        assert "-NonInteractive" in calls["cmd"]
+        import subprocess
+        assert calls["kwargs"]["creationflags"] == getattr(
+            subprocess, "CREATE_NO_WINDOW", 0
+        ), "a toast must never flash a console window"
+
+    def test_a_failing_toast_is_a_reason_not_a_raise(self):
+        def runner(cmd, **kwargs):
+            raise OSError("powershell missing")
+
+        reason = show_toast("t", "b", runner=runner)
+        assert "toast failed" in reason
+
+
+class TestTheEmail:
+    class _Client:
+        def __init__(self, fail=False):
+            self.fail = fail
+            self.sent: list[dict] = []
+
+        def send_email(self, **kwargs):
+            if self.fail:
+                raise RuntimeError("SES says no")
+            self.sent.append(kwargs)
+            return {"MessageId": "m-1"}
+
+    def test_a_send_carries_the_facts(self):
+        client = self._Client()
+        error = send_email(
+            sender="gate@verified.example", to="operator@example.com",
+            subject="s", text_body="b", client=client,
+        )
+        assert error == ""
+        [call] = client.sent
+        assert call["FromEmailAddress"] == "gate@verified.example"
+        assert call["Destination"] == {"ToAddresses": ["operator@example.com"]}
+
+    def test_no_sender_identity_is_a_named_reason(self):
+        reason = send_email(sender="", to="x@y", subject="s", text_body="b")
+        assert "no sender identity configured" in reason
+        assert EMAIL_FROM_ENV in reason
+
+    def test_a_failing_send_is_a_reason_not_a_raise(self):
+        reason = send_email(
+            sender="gate@verified.example", to="x@y", subject="s",
+            text_body="b", client=self._Client(fail=True),
+        )
+        assert "email send failed" in reason
+
+
+class TestTheWaitEscalates:
+    """The loop wiring, with a real wait over real files and fake deliverers."""
+
+    def _round(self, tmp_path) -> Path:
+        d = tmp_path / "round-001"
+        d.mkdir()
+        bundle_mod.write_pending(d, "http://127.0.0.1:9999/")
+        return d
+
+    def _config(self, email_after=0.15) -> NotifyConfig:
+        return NotifyConfig(
+            toast_backoff_seconds=(0.05,),
+            email_after_seconds=email_after,
+            email_from="gate@verified.example",
+            email_to="operator@example.com",
+        )
+
+    def _wait(self, round_dir, config, toasts, emails, deadline=0.4):
+        def toaster(title, body, url=""):
+            toasts.append({"title": title, "body": body, "url": url})
+            return ""
+
+        def emailer(**kwargs):
+            emails.append(kwargs)
+            return ""
+
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.01, reminder_every=999,
+                deadline=deadline, log=lambda _l: None,
+                notify_config=config,
+                context={"repo": "boostgauge", "issue": 331},
+                toaster=toaster, emailer=emailer,
+            )
+
+    def test_toasts_repeat_and_carry_the_facts(self, tmp_path):
+        round_dir = self._round(tmp_path)
+        toasts: list[dict] = []
+        self._wait(round_dir, self._config(email_after=999), toasts, [])
+        assert len(toasts) >= 2, "the backoff must re-ask, not ask once"
+        assert toasts[0]["url"] == "http://127.0.0.1:9999/"
+        assert "boostgauge #331" in toasts[0]["body"]
+
+    def test_the_email_goes_once_and_the_sentinel_survives_a_resume(self, tmp_path):
+        round_dir = self._round(tmp_path)
+        emails: list[dict] = []
+        self._wait(round_dir, self._config(), [], emails)
+        assert len(emails) == 1, "one backstop email per round, ever"
+        [sent] = emails
+        assert sent["sender"] == "gate@verified.example"
+        assert sent["to"] == "operator@example.com"
+        assert "round-001" in sent["text_body"]
+        assert "http://127.0.0.1:9999/" in sent["text_body"]
+        sentinel = round_dir / EMAIL_SENT_NAME
+        assert sentinel.is_file()
+
+        # The resume: a fresh wait on the same round must NOT email again.
+        self._wait(round_dir, self._config(), [], emails)
+        assert len(emails) == 1, "a resumed wait re-sent the one-ever email"
+
+    def test_a_failing_deliverer_never_breaks_the_wait(self, tmp_path):
+        round_dir = self._round(tmp_path)
+        lines: list[str] = []
+
+        def broken_toaster(title, body, url=""):
+            return "toast failed: no shell"
+
+        def broken_emailer(**kwargs):
+            return "email send failed: SES says no"
+
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.01, reminder_every=999,
+                deadline=0.3, log=lines.append,
+                notify_config=self._config(email_after=0.1),
+                toaster=broken_toaster, emailer=broken_emailer,
+            )
+        assert any("toast failed" in line for line in lines)
+        assert any("email send failed" in line for line in lines)
+        assert not (round_dir / EMAIL_SENT_NAME).is_file(), (
+            "a failed email must not claim its once-ever slot"
+        )
+
+    def test_an_answer_ends_the_wait_not_the_schedule(self, tmp_path):
+        """Escalation never decides: feedback arriving returns the answer,
+        however deep the backoff was."""
+        round_dir = self._round(tmp_path)
+        bundle_mod.write_feedback(round_dir, "approve", "ship it")
+        answer = wait_for_feedback(
+            round_dir, poll_seconds=0.01,
+            notify_config=self._config(),
+            toaster=lambda *a, **k: "", emailer=lambda **k: "",
+        )
+        assert answer["verb"] == "approve"

--- a/tests/unit/test_gate_opens_browser.py
+++ b/tests/unit/test_gate_opens_browser.py
@@ -1,0 +1,212 @@
+"""The gate pulls the review page up itself (#2528).
+
+"the url was clickable thank god but can't the program actually pull the url
+up?" — each ROUND's first serve opens the operator's default browser, once; a
+re-served round (a resume finding the pending sentinel already on disk) does
+not re-open; a repo declaration or the environment turns it off; failure is
+one logged line and never touches the wait. Real renderer subprocess, real
+server, real files — the only fake is the browser itself.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.visual_gate import bundle as bundle_mod
+from assemblyzero.visual_gate.config import GateConfig, load_gate_config
+from assemblyzero.visual_gate.gate import (
+    OPEN_BROWSER_ENV,
+    _open_review_page,
+    run_gate,
+)
+
+ISSUE = 331
+
+FAKE_RENDERER = '''
+import json, sys
+from pathlib import Path
+args = sys.argv[1:]
+out = Path(args[args.index("--out-dir") + 1])
+from PIL import Image
+Image.new("RGB", (8, 8), (155, 48, 32)).save(out / "render-face.png")
+(out / "manifest.json").write_text(json.dumps({
+    "values": {"band_inner": {"value": 0.80, "source": "contract"}},
+    "palette": {"face": [10, 10, 12]},
+}), encoding="utf-8")
+'''
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv(OPEN_BROWSER_ENV, raising=False)
+
+
+@pytest.fixture
+def repo(tmp_path) -> Path:
+    r = tmp_path / "target"
+    (r / "tools").mkdir(parents=True)
+    (r / "tools" / "fake_render.py").write_text(FAKE_RENDERER, encoding="utf-8")
+    return r
+
+
+@pytest.fixture
+def config(repo) -> GateConfig:
+    return GateConfig(
+        issues=(ISSUE,),
+        renderer_cmd=(sys.executable, str(repo / "tools" / "fake_render.py")),
+        contract="docs/design/contract.md",
+        separation_floor=85.0,
+        ruled={},
+    )
+
+
+@pytest.fixture
+def opened(monkeypatch) -> list[str]:
+    """A recording stand-in for the operator's browser."""
+    calls: list[str] = []
+
+    def fake_open(url: str) -> bool:
+        calls.append(url)
+        return True
+
+    monkeypatch.setattr(webbrowser, "open", fake_open)
+    return calls
+
+
+def _run(repo, config, deadline=3.0, mock=False):
+    return run_gate(
+        repo, ISSUE, config, mock=mock,
+        transport=lambda *_: "[]",
+        wait_kwargs={
+            "poll_seconds": 0.05, "deadline": deadline,
+            "notify_config": None,
+        },
+    )
+
+
+class TestFirstServeOpens:
+    def test_the_first_serve_opens_the_page_once(self, repo, config, opened):
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=1.0)
+        assert len(opened) == 1
+        rounds = bundle_mod.round_dirs(bundle_mod.gate_root(repo, ISSUE))
+        pending = json.loads(
+            (rounds[0] / "feedback-pending.json").read_text(encoding="utf-8")
+        )
+        assert opened[0] == pending["url"], (
+            "the tab and the sentinel must name the same page"
+        )
+
+    def test_a_resumed_round_does_not_reopen(self, repo, config, opened):
+        """The pending sentinel on disk is the fact 'the operator already got
+        a tab for this picture' — a resume re-serves without re-opening."""
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=0.5)
+        assert len(opened) == 1
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=0.5)  # the resume: same round, re-served
+        assert len(opened) == 1, "the resume re-opened an already-seen round"
+
+    def test_a_new_round_after_modify_opens_again(self, repo, config, opened):
+        """A new picture is a new request for eyes."""
+        root = bundle_mod.gate_root(repo, ISSUE)
+
+        def submit_modify():
+            for _ in range(200):
+                for round_dir in bundle_mod.round_dirs(root):
+                    pending = round_dir / "feedback-pending.json"
+                    if pending.is_file() and not (
+                        round_dir / "feedback-consumed.json"
+                    ).is_file() and not (round_dir / "feedback.json").is_file():
+                        url = json.loads(
+                            pending.read_text(encoding="utf-8")
+                        )["url"]
+                        data = urllib.parse.urlencode(
+                            {"verb": "modify", "text": "nudge the band"}
+                        ).encode()
+                        req = urllib.request.Request(
+                            url + "feedback", data=data, method="POST"
+                        )
+                        with urllib.request.urlopen(req, timeout=10) as resp:
+                            assert resp.status == 200
+                        return
+                time.sleep(0.05)
+
+        thread = threading.Thread(target=submit_modify, daemon=True)
+        thread.start()
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=8.0)  # round-002 serves, nobody answers
+        thread.join(timeout=10)
+        assert len(opened) == 2, opened
+
+    def test_mock_mode_never_opens(self, repo, config, opened):
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=0.5, mock=True)
+        assert opened == []
+
+
+class TestTheSwitches:
+    def test_the_repo_declaration_turns_it_off(self, repo, config, opened):
+        quiet = GateConfig(
+            issues=config.issues, renderer_cmd=config.renderer_cmd,
+            contract=config.contract, separation_floor=config.separation_floor,
+            ruled={}, open_browser=False,
+        )
+        with pytest.raises(TimeoutError):
+            _run(repo, quiet, deadline=0.5)
+        assert opened == []
+
+    def test_the_environment_turns_it_off(self, repo, config, opened, monkeypatch):
+        monkeypatch.setenv(OPEN_BROWSER_ENV, "0")
+        with pytest.raises(TimeoutError):
+            _run(repo, config, deadline=0.5)
+        assert opened == []
+
+    def test_the_declaration_parses_from_json(self, tmp_path):
+        gate_json = tmp_path / "docs" / "design" / "visual-gate.json"
+        gate_json.parent.mkdir(parents=True)
+        gate_json.write_text(json.dumps({
+            "issues": [1], "renderer_cmd": ["x"], "contract": "c",
+            "separation_floor": 1, "open_browser": False,
+        }), encoding="utf-8")
+        assert load_gate_config(tmp_path).open_browser is False
+
+    def test_the_declaration_defaults_on(self, tmp_path):
+        """Default ON is the operator's explicit request."""
+        gate_json = tmp_path / "docs" / "design" / "visual-gate.json"
+        gate_json.parent.mkdir(parents=True)
+        gate_json.write_text(json.dumps({
+            "issues": [1], "renderer_cmd": ["x"], "contract": "c",
+            "separation_floor": 1,
+        }), encoding="utf-8")
+        assert load_gate_config(tmp_path).open_browser is True
+
+
+class TestFailureIsNonFatal:
+    def test_a_raising_browser_is_one_logged_line(self, config):
+        lines: list[str] = []
+
+        def broken(_url: str) -> bool:
+            raise RuntimeError("no DISPLAY")
+
+        _open_review_page(
+            "http://127.0.0.1:1/", config, log=lines.append, opener=broken
+        )
+        assert any("browser auto-open failed" in line for line in lines)
+
+    def test_a_declining_browser_is_one_logged_line(self, config):
+        lines: list[str] = []
+        _open_review_page(
+            "http://127.0.0.1:1/", config, log=lines.append,
+            opener=lambda _url: False,
+        )
+        assert any("no browser would open" in line for line in lines)

--- a/tests/unit/test_operator_wait_output.py
+++ b/tests/unit/test_operator_wait_output.py
@@ -1,0 +1,143 @@
+"""The operator-wait state shouts, and only at a terminal (#2527).
+
+The operator's words after the gate's first live loop: "it wasn't clear to me
+from the terminal output that my judgment was requested... it looks kinda
+like the counting it is doing when an LLM is slow." Both states printed white
+ticks at one cadence. These tests pin the repair: the waiting surfaces render
+amber on a TTY and verbatim into files, the stage tick says whose turn it is
+while a gate has declared an operator wait, and the treatment lives in
+``operator_wait`` — the class — not in the visual gate alone.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core import operator_wait
+from assemblyzero.core.stage_watchdog import StageWatchdog
+from assemblyzero.visual_gate import bundle as bundle_mod
+from assemblyzero.visual_gate.server import wait_for_feedback
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_wait():
+    """Every test starts and ends outside an operator wait."""
+    operator_wait.end()
+    yield
+    operator_wait.end()
+
+
+class _Tty(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class TestPaint:
+    def test_a_tty_gets_amber(self):
+        painted = operator_wait.paint("hello", stream=_Tty())
+        assert painted.startswith("\x1b[33;1m")
+        assert painted.endswith("\x1b[0m")
+        assert "hello" in painted
+
+    def test_a_file_gets_the_text_verbatim(self):
+        # A log file must not accumulate escape codes.
+        assert operator_wait.paint("hello", stream=io.StringIO()) == "hello"
+
+    def test_a_stream_without_isatty_gets_the_text_verbatim(self):
+        assert operator_wait.paint("hello", stream=object()) == "hello"
+
+
+class TestTheDeclaredWait:
+    def test_begin_and_end_bracket_the_state(self):
+        assert operator_wait.active() is None
+        operator_wait.begin(url="http://127.0.0.1:1/", note="round-001")
+        assert operator_wait.active() == {
+            "url": "http://127.0.0.1:1/", "note": "round-001",
+        }
+        operator_wait.end()
+        assert operator_wait.active() is None
+
+    def test_end_is_idempotent(self):
+        operator_wait.end()
+        operator_wait.end()
+        assert operator_wait.active() is None
+
+
+class TestTheStageTickSaysWhoseTurn:
+    def test_outside_a_wait_the_tick_is_unchanged(self):
+        line = StageWatchdog("visual", nominal_seconds=None).status_line(120)
+        assert line == "    [STAGE] visual running 120s"
+
+    def test_inside_a_wait_the_tick_names_the_operator(self):
+        operator_wait.begin(url="http://127.0.0.1:1/")
+        line = StageWatchdog("visual", nominal_seconds=None).status_line(120)
+        assert "awaiting OPERATOR" in line
+
+    def test_inside_a_wait_no_slow_or_stalled_verdict_is_issued(self):
+        """Elapsed time during an operator wait measures the operator's
+        attention, not the stage's health — a 40-minute think must not print
+        STALLED as if the machine were sick."""
+        operator_wait.begin(url="http://127.0.0.1:1/")
+        line = StageWatchdog("spec", nominal_seconds=10.0).status_line(600)
+        assert "awaiting OPERATOR" in line
+        assert "SLOW" not in line
+        assert "STALLED" not in line
+
+    def test_the_verdicts_return_when_the_wait_ends(self):
+        operator_wait.begin()
+        operator_wait.end()
+        line = StageWatchdog("spec", nominal_seconds=10.0).status_line(600)
+        assert "STALLED" in line
+
+
+class TestTheWaitingLine:
+    def _round(self, tmp_path) -> Path:
+        d = tmp_path / "round-001"
+        d.mkdir()
+        return d
+
+    def test_the_reminder_says_the_judgment_is_requested_with_the_url(self, tmp_path):
+        round_dir = self._round(tmp_path)
+        bundle_mod.write_pending(round_dir, "http://127.0.0.1:9999/")
+        lines: list[str] = []
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.01, reminder_every=0.02,
+                deadline=0.2, log=lines.append,
+            )
+        reminders = [line for line in lines if "AWAITING OPERATOR" in line]
+        assert reminders, lines
+        assert "http://127.0.0.1:9999/" in reminders[0]
+        assert "judgment is requested" in reminders[0]
+
+    def test_the_wait_declares_itself_and_clears_on_exit(self, tmp_path):
+        """wait_for_feedback brackets the process-wide state even when it
+        leaves by exception — the finally is the contract."""
+        round_dir = self._round(tmp_path)
+        seen: list[dict | None] = []
+
+        def probe(_line: str) -> None:
+            seen.append(operator_wait.active())
+
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.01, reminder_every=0.02,
+                deadline=0.1, log=probe,
+            )
+        assert any(s is not None for s in seen), "the wait never declared itself"
+        assert operator_wait.active() is None, "the wait leaked past its exit"
+
+    def test_no_escape_codes_reach_a_non_tty_log(self, tmp_path):
+        round_dir = self._round(tmp_path)
+        lines: list[str] = []
+        with pytest.raises(TimeoutError):
+            wait_for_feedback(
+                round_dir, poll_seconds=0.01, reminder_every=0.02,
+                deadline=0.1, log=lines.append,
+            )
+        # log=lines.append writes through no TTY; paint() consulted stdout,
+        # which pytest captures (not a TTY), so the lines carry no ANSI.
+        assert all("\x1b[" not in line for line in lines), lines


### PR DESCRIPTION
Closes #2527, Closes #2528, Closes #2529

One UX package from the operator's feedback after the visual gate's first full live loop. The three compose, in the operator's own framing: open the page (catch them now), colour the log (catch them watching), toast then email (catch them gone). One PR because they share `gate.py`, `server.py`, and `config.py` end to end.

## #2527 — the operator-wait state shouts, and only at a terminal

New `assemblyzero/core/operator_wait.py` owns the operator-wait CLASS, not just the visual gate: `paint()` renders amber on a TTY and verbatim into files (log files accumulate no escape codes), and `begin()`/`end()` declare the process-wide "a human is being waited on" window. `wait_for_feedback` brackets its whole wait in that state (`finally`-guaranteed), and its reminder now reads `AWAITING OPERATOR -- your judgment is requested: open <url>`; the serve announcement leads with `YOUR JUDGMENT IS REQUESTED`. The stage watchdog's tick consults the same state: while a gate waits, `[STAGE] visual running 300s - awaiting OPERATOR (this wait is yours)` — painted amber on a TTY, and with SLOW/STALLED verdicts suppressed, because elapsed time during an operator wait measures the operator's attention, not the stage's health. Any future human-blocking gate calls the same three functions and inherits everything.

## #2528 — the gate opens the review page itself

On each round's FIRST serve, `run_gate` opens the URL in the default browser (`webbrowser.open`, which is `os.startfile` on Windows — works from the detached, console-less context). The on-disk pending sentinel is the "first serve" fact, so a resume that re-serves an already-seen round does not re-open, while round-002 after a Modify — a new picture, a new request for eyes — opens again. Default ON per the operator's explicit request; a repo can declare `"open_browser": false`, and `AZ_VISUAL_GATE_OPEN_BROWSER=0` is the machine-level kill switch. Failure to open is one logged line; the printed URL remains the fallback. Mock runs never open. This tab is an operator-REQUESTED interruption — the gate exists to summon the operator — the opposite of the window-flash class.

## #2529 — escalation asks louder, and never decides

New `assemblyzero/core/operator_notify.py`:

- **Toast on a slow backoff** — default first at 10 minutes idle, again 30 minutes later, then hourly forever. Native Windows toast via PowerShell/WinRT, spawned `CREATE_NO_WINDOW` (no console flash — a notification is the OS's sanctioned attention channel), naming repo, issue, round and elapsed; clicking it opens the review page (protocol activation). **Proven live on this box**: one real toast delivered during this session's smoke test (`data/scratch-2026-08-26-2527/toast_smoke.py`, returned success).
- **One backstop email, ever, per round** — default at 4 hours, to the operator contact address, via the fleet's canonical outbound stack (SES v2, us-east-1, boto3 default credential chain). Once-ever is enforced by an on-disk sentinel beside the round (`notify-email-sent.json`), so a killed-and-resumed gate cannot re-send; a FAILED send does not claim the slot. The sender identity must be an SES-verified address supplied via the repo declaration (`notify.email_from`) or `AZ_OPERATOR_EMAIL_FROM` — deliberately not hardcoded in this public repo; until it is set, the backstop reports itself disabled in one logged line and the toasts remain the workhorse.
- **Never a timeout.** Nothing in the module or the wait loop ends a wait; escalation failures are one logged line each and the wait continues. All intervals configurable, the whole feature disableable (`notify.enabled: false`), mock runs get no live escalation.

The declaration shape (all new keys optional) is documented in `visual_gate/config.py`.

## Tests

- New: `test_operator_wait_output.py` (12), `test_gate_opens_browser.py` (10), `test_gate_escalation.py` (18) — real renderer subprocesses, real localhost serves, real files; fakes only for the browser, the toast runner, and the SES client (the design's own seams).
- All 44 pre-existing visual-gate + watchdog tests pass unmodified.
- Full unit suite (local): 8599 passed, 2 failed — both the #2475 fail-open gate correctly catching this PR's four new deliberate fall-throughs (paint's isatty probe, toast, email, browser-open) before they were declared. Each now carries its `# fail-open: <why>` ruling on the site, the baseline is untouched, and `test_fail_open_audit.py` passes 52/52. The required `test` check on this PR is the full-suite run of the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
