### PR TITLE
feat: spec revisions patch the named items and pin what passed (Closes #2532)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
@@ -64,7 +64,13 @@ def build_edit_script_prompt(
         "Touch NOTHING else — content you do not name in a SEARCH block "
         "cannot and must not change.\n"
         "4. No preamble, no explanation, no markdown fences around the "
-        "blocks — edit blocks only."
+        "blocks — edit blocks only.\n"
+        "5. PINNING (#2532): content a completed review round passed "
+        "without objection is LOCKED — an edit touching text the feedback "
+        "below does not name will be refused mechanically and the old text "
+        "kept. If a fix genuinely requires restructuring beyond the named "
+        "items, put a single line `UNLOCK: <one-line reason>` before your "
+        "first edit block; the unlock is logged, never silent."
     )
 
     if completeness_issues:

--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -321,6 +321,9 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
     # -------------------------------------------------------------------------
     edit_script_content: str | None = None
     result = None
+    #: #2532: pinning refusals, regression-class flags, and unlock grants
+    #: from this revision, accumulated across whichever path produced it.
+    pinning_events: list[str] = []
     if is_revision and retry_count < 1 and not drafter_spec.startswith("mock:"):
         cost_before = get_cumulative_cost()
         edit_result = drafter.invoke(
@@ -340,6 +343,17 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
             blocks = parse_edit_blocks(edit_result.response or "")
             if blocks:
                 patched, failures = apply_edit_blocks(existing_draft, blocks)
+                if not failures and patched != existing_draft:
+                    # #2532: pin what passed. Edits touching content the
+                    # verdict did not name are refused mechanically; the
+                    # locked spans carry forward byte-verbatim.
+                    patched, events = _apply_pinning(
+                        state, existing_draft, patched,
+                        response=edit_result.response or "",
+                        review_feedback=review_feedback,
+                        completeness_issues=completeness_issues,
+                    )
+                    pinning_events.extend(events)
                 if not failures and patched != existing_draft:
                     ratio = unchanged_ratio(existing_draft, patched)
                     print(
@@ -404,6 +418,21 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
         # ---------------------------------------------------------------------
         spec_content = _strip_preamble(spec_content)
 
+        # #2532: the full-regeneration path is the observed regression vector
+        # — run-issue331-233939's resumed grant reintroduced the S2 fix by
+        # regenerating everything. Pinning applies to the diff exactly as on
+        # the edit path: unnamed content carries forward byte-verbatim.
+        # The UNLOCK line is read from the RAW response, because the
+        # preamble strip above would eat it.
+        if is_revision and existing_draft and spec_content.strip():
+            spec_content, events = _apply_pinning(
+                state, existing_draft, spec_content,
+                response=result.response or "",
+                review_feedback=review_feedback,
+                completeness_issues=completeness_issues,
+            )
+            pinning_events.extend(events)
+
     # -------------------------------------------------------------------------
     # Save to audit trail
     # -------------------------------------------------------------------------
@@ -437,6 +466,10 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
     )
 
     return {
+        # #2532: the pinning record travels with the run — refusals,
+        # regression-class flags, unlock grants — so the loop's history
+        # carries who tried to change what no verdict named.
+        "pinning_events": list(state.get("pinning_events", [])) + pinning_events,
         "spec_draft": spec_content,
         # #2297: the audit-trail DRAFT, not the finalized spec. Writing this to
         # `spec_path` made a cap-halted run indistinguishable from a successful
@@ -455,6 +488,75 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
         "node_costs": node_costs,  # Issue #511
         "node_tokens": node_tokens,  # Issue #511
     }
+
+
+def _apply_pinning(
+    state: ImplementationSpecState,
+    previous: str,
+    revised: str,
+    *,
+    response: str,
+    review_feedback: str,
+    completeness_issues: list[str],
+) -> tuple[str, list[str]]:
+    """Enforce #2532's pinning on one revision; returns (text, events).
+
+    Named = the current verdict plus the current completeness failures.
+    Ever-named = those plus every prior round's feedback and every prior
+    completeness breakdown — the union the regression flag is judged
+    against ("content no verdict EVER objected to").
+
+    When the current verdict names nothing extractable, pinning abstains
+    entirely — locking the whole document on an unparseable naming would
+    refuse every legitimate fix, and unknown is not guilty (#2526).
+    """
+    from assemblyzero.workflows.implementation_spec.revision_pinning import (
+        enforce_pinning,
+        named_tokens,
+        unlock_requested,
+    )
+
+    current = named_tokens(review_feedback, completeness_issues)
+    if not current:
+        note = (
+            "[PINNING] the verdict names nothing extractable — pinning not "
+            "applied this round (#2532)"
+        )
+        print(f"    {note}")
+        return revised, [note]
+
+    ever = set(current)
+    for prior in state.get("review_feedback_history", []):
+        ever |= named_tokens(prior)
+    for entry in state.get("prior_completeness_breakdown", []):
+        ever |= named_tokens("", [str(f) for f in entry.get("failures", [])])
+
+    result = enforce_pinning(
+        previous, revised,
+        current_tokens=current,
+        ever_tokens=ever,
+        unlock_reason=unlock_requested(response),
+    )
+
+    events: list[str] = []
+    if result.unlock_reason:
+        events.append(
+            f"[PINNING] UNLOCK granted — drafter's reason: "
+            f"{result.unlock_reason} (#2532)"
+        )
+    for refusal in result.refusals:
+        events.append(
+            f"[PINNING] refused: {refusal} — locked content the verdict "
+            f"did not name (#2532)"
+        )
+    for regression in result.regressions:
+        events.append(
+            f"[PINNING] REGRESSION CLASS: revision modified content no "
+            f"verdict ever objected to: {regression} (#2532)"
+        )
+    for event in events:
+        print(f"    {event}")
+    return result.text, events
 
 
 # =============================================================================
@@ -876,6 +978,14 @@ def _build_revision_prompt(
         "error elsewhere by drifting on unflagged content. If you find "
         "yourself 'tidying up' or 'fixing' something not named in the "
         "feedback above, STOP — that edit is a regression, not a fix.\n\n"
+        "## Pinning is ENFORCED mechanically (#2532)\n"
+        "Content a completed review round passed without objection is "
+        "LOCKED: any change you make to text the feedback does not name "
+        "will be refused and the previous text restored byte-verbatim. If "
+        "a fix genuinely requires restructuring beyond the named items, "
+        "put a single line `UNLOCK: <one-line reason>` as the VERY FIRST "
+        "line of your response (before the # heading); the unlock is "
+        "logged, never silent.\n\n"
         "START YOUR RESPONSE WITH THE # HEADING. NO PREAMBLE."
     )
 

--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -1,0 +1,234 @@
+"""Pin what passed: revisions edit the named items and nothing else (#2532).
+
+The spec review loop's unit of revision was the whole document while its unit
+of error is the individual assertion. Every REVISE re-rolled the dice on every
+assertion that was already right — measured on run-issue331-233939: nine
+rounds to the hard ceiling, and S2's band-background trap FIXED by round 9,
+then REINTRODUCED by the resumed grant's regeneration. The loop un-fixes its
+own progress.
+
+This module makes that impossible mechanically:
+
+* **Named** content is what the current verdict (and the current completeness
+  failures) actually point at — test names, backticked spans, quoted phrases,
+  manifest row ids — attributed to the draft's natural blocks (a test
+  function, a markdown section).
+* **Locked** content is everything else in the reviewed draft: a completed
+  round passed it without objection. A revision that touches locked text is
+  refused mechanically — the locked span carries forward byte-verbatim from
+  the previous draft — unless the drafter requested an unlock explicitly
+  (an ``UNLOCK: <reason>`` line in its response), which is logged, never
+  silent.
+* **The regression event**: a revision that modified content NO verdict in
+  the whole history ever objected to is the S2-regression class, flagged at
+  the moment it happens instead of one round later.
+
+Iteration 1 (the initial draft) is untouched — this governs revisions only.
+Every function here is pure (ADR 0224): text in, text and events out.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# What the verdict names
+# ---------------------------------------------------------------------------
+
+_BACKTICK_RE = re.compile(r"`([^`\n]{2,120})`")
+_TEST_NAME_RE = re.compile(r"\btest_[A-Za-z0-9_]+\b")
+_QUOTED_RE = re.compile(r"\"([^\"\n]{4,120})\"")
+#: Manifest row ids (#2533) — a verdict citing N4.2 names that row's test.
+_ROW_ID_RE = re.compile(r"\b[A-Z]\d{0,3}[a-z]?\.\d+\b")
+#: Section references like "Section 10.2" / "section 5".
+_SECTION_RE = re.compile(r"\bSection\s+[\w.]+", re.IGNORECASE)
+
+
+def named_tokens(feedback: str, completeness_issues: list[str] | None = None) -> set[str]:
+    """The identifiers a verdict actually points at, lowercased."""
+    text = (feedback or "") + "\n" + "\n".join(completeness_issues or [])
+    tokens: set[str] = set()
+    for pattern in (_BACKTICK_RE, _QUOTED_RE):
+        tokens.update(m.group(1).strip() for m in pattern.finditer(text))
+    for pattern in (_TEST_NAME_RE, _ROW_ID_RE, _SECTION_RE):
+        tokens.update(m.group(0).strip() for m in pattern.finditer(text))
+    return {t.lower() for t in tokens if len(t.strip()) >= 3}
+
+
+# ---------------------------------------------------------------------------
+# The draft's natural blocks
+# ---------------------------------------------------------------------------
+
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$")
+_FENCE_RE = re.compile(r"^```")
+_DEF_RE = re.compile(r"^(?:async\s+)?(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+@dataclass
+class _Block:
+    name: str
+    start: int  # inclusive line index
+    end: int    # exclusive
+    text: str = ""
+
+
+def _blocks(draft: str) -> list[_Block]:
+    """Split a draft into attribution blocks.
+
+    Outside fences: one block per markdown section (heading to heading).
+    Inside fences: one block per top-level ``def``/``class`` — the verdict's
+    unit of naming is the test, and a fence routinely holds many.
+    """
+    lines = draft.splitlines()
+    blocks: list[_Block] = []
+    current = _Block(name="(preamble)", start=0, end=0)
+    in_fence = False
+
+    def close(at: int) -> None:
+        nonlocal current
+        current.end = at
+        if current.end > current.start:
+            current.text = "\n".join(lines[current.start:current.end])
+            blocks.append(current)
+
+    for index, line in enumerate(lines):
+        if _FENCE_RE.match(line.strip()):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            match = _DEF_RE.match(line)
+            if match and not line[:1].isspace():
+                close(index)
+                current = _Block(name=match.group(1), start=index, end=index)
+            continue
+        match = _HEADING_RE.match(line)
+        if match:
+            close(index)
+            current = _Block(name=match.group(1), start=index, end=index)
+    close(len(lines))
+    return blocks
+
+
+def named_line_flags(draft: str, tokens: set[str]) -> list[bool]:
+    """Per-line: is this line inside a block the tokens name?
+
+    A block is named when its own name matches a token, or when any token
+    appears anywhere in its text — the generous direction, because a
+    wrongly-locked legitimate fix costs a round while a wrongly-freed line
+    costs only what the old behaviour always risked.
+    """
+    lines = draft.splitlines()
+    flags = [False] * len(lines)
+    if not tokens:
+        return flags
+    for block in _blocks(draft):
+        block_lower = block.text.lower()
+        name_lower = block.name.lower()
+        named = any(
+            token in name_lower or token in block_lower for token in tokens
+        )
+        if named:
+            for index in range(block.start, block.end):
+                flags[index] = True
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# Enforcement
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PinningResult:
+    text: str
+    #: Locked regions the revision tried to change, restored byte-verbatim.
+    refusals: tuple[str, ...] = ()
+    #: Changed regions no verdict EVER named — the S2-regression class,
+    #: flagged at the moment it happens (computed before restoration).
+    regressions: tuple[str, ...] = ()
+    unlock_reason: str = ""
+
+
+_UNLOCK_RE = re.compile(r"^\s*UNLOCK:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def unlock_requested(response: str) -> str:
+    """The drafter's explicit unlock request, or "". Logged, never silent."""
+    match = _UNLOCK_RE.search(response or "")
+    return match.group(1) if match else ""
+
+
+def _preview(lines: list[str], count: int) -> str:
+    first = next((line.strip() for line in lines if line.strip()), "")
+    return f"{count} line(s) starting {first[:70]!r}"
+
+
+def enforce_pinning(
+    previous: str,
+    revised: str,
+    *,
+    current_tokens: set[str],
+    ever_tokens: set[str] | None = None,
+    unlock_reason: str = "",
+) -> PinningResult:
+    """Carry every unnamed span of ``previous`` forward byte-verbatim.
+
+    Walks the line diff. A changed region whose OLD lines are all outside the
+    verdict's named blocks is locked: the old lines are restored and the
+    attempt recorded as a refusal. Regions that touch any named line pass
+    through — restructuring AROUND a named item is the named item's business.
+    Insertions pass through: adding is not un-fixing.
+
+    ``ever_tokens`` (the union across the whole verdict history) drives the
+    regression events; they are computed from the REVISION AS SUBMITTED, so
+    the flag fires even when enforcement then restores the text.
+
+    With ``unlock_reason`` the restoration is skipped entirely — the drafter
+    asked to restructure and the caller logs it — but the regression events
+    still fire, because an unlock explains a change, it does not un-happen it.
+    """
+    prev_lines = previous.splitlines()
+    rev_lines = revised.splitlines()
+    current_flags = named_line_flags(previous, current_tokens)
+    ever_flags = (
+        named_line_flags(previous, ever_tokens)
+        if ever_tokens is not None else current_flags
+    )
+
+    refusals: list[str] = []
+    regressions: list[str] = []
+    out: list[str] = []
+
+    matcher = difflib.SequenceMatcher(None, prev_lines, rev_lines, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            out.extend(prev_lines[i1:i2])
+            continue
+        if tag == "insert":
+            out.extend(rev_lines[j1:j2])
+            continue
+        old_region = prev_lines[i1:i2]
+        # The S2-regression class: this change touches lines NO verdict ever
+        # named. Recorded before any restoration decision.
+        if old_region and all(not ever_flags[i] for i in range(i1, i2)):
+            regressions.append(_preview(old_region, i2 - i1))
+        locked = old_region and all(
+            not current_flags[i] for i in range(i1, i2)
+        )
+        if locked and not unlock_reason:
+            out.extend(old_region)  # byte-verbatim carry-forward
+            refusals.append(_preview(old_region, i2 - i1))
+        else:
+            out.extend(rev_lines[j1:j2])
+
+    text = "\n".join(out)
+    if revised.endswith("\n") or previous.endswith("\n"):
+        text += "\n"
+    return PinningResult(
+        text=text,
+        refusals=tuple(refusals),
+        regressions=tuple(regressions),
+        unlock_reason=unlock_reason,
+    )

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -254,3 +254,11 @@ class ImplementationSpecState(TypedDict, total=False):
     assertion_manifest: str
     assertion_manifest_rows: list[dict]
     assertion_manifest_criteria: list[str]
+
+    # Closes #2532: the pinning record. Each entry is one revision-time
+    # event — a mechanically refused edit to locked content, a
+    # regression-class flag ("revision modified content no verdict ever
+    # objected to" — the S2 class made visible at the moment it happens),
+    # or an explicit UNLOCK grant with the drafter's stated reason.
+    # Accumulated across the run; iteration 1 never writes here.
+    pinning_events: list[str]

--- a/tests/unit/test_generate_spec_pinning.py
+++ b/tests/unit/test_generate_spec_pinning.py
@@ -1,0 +1,205 @@
+"""The drafter node enforces pinning on every revision path (#2532).
+
+Node-level wiring: the full-regeneration path is the observed regression
+vector (run-issue331-233939's resumed grant un-fixed S2 by regenerating), so
+these tests drive `generate_spec` itself with a mocked provider and assert
+the returned draft — not just the pure module — carries the fix forward.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+    generate_spec,
+)
+
+PREVIOUS = """# Spec
+
+## Section 10: Tests
+
+```python
+def test_req_2_s2_redline_band():
+    # S2: between-tick pixel at 0.95 R in the 60-100 arc is BAND, not face
+    sample = face.getpixel(polar(0.95, value=75))
+    assert classify(sample) == "crimson"
+
+def test_req_7_wordmark():
+    band = face.crop(wordmark_box())
+    assert cap_height(band) == 0.09
+```
+"""
+
+REGENERATED = """# Spec
+
+## Section 10: Tests
+
+```python
+def test_req_2_s2_redline_band():
+    # between ticks the face shows through
+    sample = face.getpixel(polar(0.95, value=75))
+    assert classify(sample) == "face"
+
+def test_req_7_wordmark():
+    band = face.crop(wordmark_box(centre=0.67))
+    assert cap_height(band) == 0.09
+```
+"""
+
+VERDICT = (
+    "REVISE: `test_req_7_wordmark` measures cap height against the wrong "
+    "box; compute wordmark_box() from the 0.67 R band centre."
+)
+
+
+def _run(response: str, *, feedback: str = VERDICT, state_extra: dict | None = None):
+    drafter = Mock()
+    drafter.invoke.return_value = Mock(
+        success=True, response=response, error_message=None,
+        input_tokens=0, output_tokens=0,
+    )
+    state = {
+        "config_mock_mode": True,  # mock: skips preflight and the edit path
+        "lld_content": "# LLD\n\ncontent\n",
+        "current_state_snapshots": {},
+        "pattern_references": [],
+        "assemblyzero_root": "",
+        "repo_root": "",
+        "issue_number": 331,
+        "spec_draft": PREVIOUS,
+        "review_feedback": feedback,
+        "review_iteration": 0,
+        **(state_extra or {}),
+    }
+    with patch(
+        "assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider",
+        return_value=drafter,
+    ), patch(
+        "assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template",
+        return_value="# Template",
+    ):
+        return generate_spec(state)
+
+
+class TestTheFullRevisionPathIsPinned:
+    def test_the_s2_unfix_is_restored_and_the_named_fix_lands(self):
+        out = _run(REGENERATED)
+        assert out["error_message"] == ""
+        assert 'assert classify(sample) == "crimson"' in out["spec_draft"], (
+            "the regeneration vector must not un-fix S2"
+        )
+        assert "wordmark_box(centre=0.67)" in out["spec_draft"]
+        assert any("refused" in e for e in out["pinning_events"])
+
+    def test_the_regression_class_is_flagged_at_the_moment_it_happens(self):
+        out = _run(REGENERATED, state_extra={
+            "review_feedback_history": [VERDICT],
+        })
+        assert any("REGRESSION CLASS" in e for e in out["pinning_events"])
+
+    def test_an_unlock_line_lifts_the_pin_and_is_logged(self):
+        out = _run("UNLOCK: retiring the shared sampler helper\n" + REGENERATED)
+        assert '== "face"' in out["spec_draft"], "the unlock lets it land"
+        assert any(
+            "UNLOCK granted" in e and "retiring the shared sampler" in e
+            for e in out["pinning_events"]
+        )
+
+    def test_an_unextractable_verdict_abstains(self):
+        """Locking the whole document on a naming the extractor cannot read
+        would refuse every legitimate fix — unknown is not guilty (#2526)."""
+        out = _run(REGENERATED, feedback="Please make it better overall.")
+        assert '== "face"' in out["spec_draft"], "abstention passes it through"
+        assert any("names nothing extractable" in e for e in out["pinning_events"])
+
+    def test_events_accumulate_across_revisions(self):
+        out = _run(REGENERATED, state_extra={
+            "pinning_events": ["[PINNING] earlier event"],
+        })
+        assert out["pinning_events"][0] == "[PINNING] earlier event"
+        assert len(out["pinning_events"]) > 1
+
+
+class TestTheEditScriptPathIsPinned:
+    """#1528's edit path gets the same law: a well-formed edit block aimed
+    at locked content is refused, while the named fix lands."""
+
+    EDITS = (
+        "<<<<<<< SEARCH\n"
+        '    assert classify(sample) == "crimson"\n'
+        "=======\n"
+        '    assert classify(sample) == "face"\n'
+        ">>>>>>> REPLACE\n\n"
+        "<<<<<<< SEARCH\n"
+        "    band = face.crop(wordmark_box())\n"
+        "=======\n"
+        "    band = face.crop(wordmark_box(centre=0.67))\n"
+        ">>>>>>> REPLACE\n"
+    )
+
+    def test_a_locked_edit_block_is_refused_and_the_named_one_lands(self):
+        drafter = Mock()
+        drafter.invoke.return_value = Mock(
+            success=True, response=self.EDITS, error_message=None,
+            input_tokens=0, output_tokens=0,
+        )
+        state = {
+            "config_mock_mode": False,
+            "config_drafter": "claude:whatever",
+            "lld_content": "# LLD\n",
+            "current_state_snapshots": {},
+            "pattern_references": [],
+            "assemblyzero_root": "",
+            "repo_root": "",
+            "issue_number": 331,
+            "spec_draft": PREVIOUS,
+            "review_feedback": VERDICT,
+            "review_iteration": 0,
+        }
+        preflight = Mock(passed=True, available_credentials=1,
+                         total_credentials=1, warnings=[])
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider",
+            return_value=drafter,
+        ), patch(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template",
+            return_value="# Template",
+        ), patch(
+            "assemblyzero.core.preflight.check_gemini_available",
+            return_value=preflight,
+        ):
+            out = generate_spec(state)
+        assert out["error_message"] == ""
+        assert 'assert classify(sample) == "crimson"' in out["spec_draft"]
+        assert "wordmark_box(centre=0.67)" in out["spec_draft"]
+        assert any("refused" in e for e in out["pinning_events"])
+        # One model call: the edit path succeeded post-pinning, so the
+        # classic full-revision call never ran.
+        assert drafter.invoke.call_count == 1
+
+
+class TestIterationOneIsUntouched:
+    def test_an_initial_draft_writes_no_pinning_events(self):
+        drafter = Mock()
+        drafter.invoke.return_value = Mock(
+            success=True, response="# Spec\n\nfresh draft\n",
+            error_message=None, input_tokens=0, output_tokens=0,
+        )
+        state = {
+            "config_mock_mode": True,
+            "lld_content": "# LLD\n",
+            "current_state_snapshots": {},
+            "pattern_references": [],
+            "assemblyzero_root": "",
+            "repo_root": "",
+        }
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider",
+            return_value=drafter,
+        ), patch(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template",
+            return_value="# Template",
+        ):
+            out = generate_spec(state)
+        assert out["pinning_events"] == []
+        assert out["spec_draft"].startswith("# Spec")

--- a/tests/unit/test_revision_pinning.py
+++ b/tests/unit/test_revision_pinning.py
@@ -1,0 +1,222 @@
+"""Revisions edit the named items; what passed stays passed (#2532).
+
+The fixture is the observed S2 regression from boostgauge #331,
+run-issue331-233939: the band-background trap (`test_req_2_s2_redline_band`
+— a between-tick pixel at 0.95 R in the 60-100 arc is band crimson, not face
+black) was flagged early, FIXED by round 9, then REINTRODUCED by the resumed
+grant's regeneration while the verdict was naming a different test entirely.
+These tests pin that exact shape: the fix survives mechanically, and the
+attempt to un-fix it is flagged at the moment it happens.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_flags,
+    named_tokens,
+    unlock_requested,
+)
+
+#: The reviewed draft: S2 carries its round-9 fix; the wordmark test is the
+#: one the CURRENT verdict names.
+PREVIOUS = """# Spec
+
+## Section 10: Tests
+
+```python
+def test_req_2_s2_redline_band():
+    # S2: between-tick pixel at 0.95 R in the 60-100 arc is BAND, not face
+    sample = face.getpixel(polar(0.95, value=75))
+    assert classify(sample) == "crimson"
+
+def test_req_7_wordmark():
+    band = face.crop(wordmark_box())
+    assert cap_height(band) == 0.09
+```
+
+## Section 11: Conventions
+
+Baselines are self-generated only.
+"""
+
+#: The verdict names ONLY the wordmark test.
+VERDICT = (
+    "REVISE: `test_req_7_wordmark` measures cap height against the wrong "
+    "box; compute wordmark_box() from the 0.67 R band centre."
+)
+
+#: The regeneration: fixes the named test AND silently reverts S2's fix —
+#: the observed un-fixing class.
+REGENERATED = """# Spec
+
+## Section 10: Tests
+
+```python
+def test_req_2_s2_redline_band():
+    # between ticks the face shows through
+    sample = face.getpixel(polar(0.95, value=75))
+    assert classify(sample) == "face"
+
+def test_req_7_wordmark():
+    band = face.crop(wordmark_box(centre=0.67))
+    assert cap_height(band) == 0.09
+```
+
+## Section 11: Conventions
+
+Baselines are self-generated only.
+"""
+
+
+class TestNamedTokens:
+    def test_backticked_and_test_names_extract(self):
+        tokens = named_tokens(VERDICT)
+        assert "test_req_7_wordmark" in tokens
+
+    def test_completeness_issues_name_too(self):
+        tokens = named_tokens("", ["missing excerpt for `stingray.py`"])
+        assert "stingray.py" in tokens
+
+    def test_manifest_row_ids_extract(self):
+        assert "n4.2" in named_tokens("row N4.2 is asserted twice")
+
+
+class TestNamedLineFlags:
+    def test_the_named_test_block_is_named_and_s2_is_not(self):
+        flags = named_line_flags(PREVIOUS, named_tokens(VERDICT))
+        lines = PREVIOUS.splitlines()
+        s2_line = next(
+            i for i, line in enumerate(lines) if "crimson" in line
+        )
+        wordmark_line = next(
+            i for i, line in enumerate(lines) if "wordmark_box" in line
+        )
+        assert flags[wordmark_line] is True
+        assert flags[s2_line] is False
+
+    def test_no_tokens_means_nothing_named(self):
+        assert not any(named_line_flags(PREVIOUS, set()))
+
+
+class TestTheS2Regression:
+    """The issue's own case, end to end."""
+
+    def test_the_unfix_is_refused_and_the_fix_survives(self):
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED, current_tokens=named_tokens(VERDICT),
+        )
+        assert 'assert classify(sample) == "crimson"' in result.text, (
+            "round 9's fix must carry forward byte-verbatim"
+        )
+        assert '== "face"' not in result.text
+        assert result.refusals, "the locked-content change must be refused"
+
+    def test_the_named_fix_still_lands(self):
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED, current_tokens=named_tokens(VERDICT),
+        )
+        assert "wordmark_box(centre=0.67)" in result.text, (
+            "pinning must never block the change the verdict asked for"
+        )
+
+    def test_the_regression_event_fires_at_the_moment_it_happens(self):
+        """Ask 3: 'revision modified content no verdict ever objected to'
+        is a flagged event — visible now, not one round later."""
+        history = [VERDICT, "REVISE: `test_req_9_bezel` samples inside the seat."]
+        ever = set()
+        for feedback in history:
+            ever |= named_tokens(feedback)
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED,
+            current_tokens=named_tokens(VERDICT), ever_tokens=ever,
+        )
+        assert result.regressions, "the S2-class event must be flagged"
+        assert any("s2" in r.lower() or "crimson" in r.lower() or "between" in r.lower()
+                   for r in result.regressions), result.regressions
+
+    def test_a_change_a_prior_round_named_is_not_a_regression(self):
+        """Content SOME verdict once objected to is not the never-objected
+        class, even when the current verdict does not name it."""
+        history_naming_s2 = named_tokens(
+            "REVISE: `test_req_2_s2_redline_band` asserts face where the "
+            "band shows."
+        ) | named_tokens(VERDICT)
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED,
+            current_tokens=named_tokens(VERDICT),
+            ever_tokens=history_naming_s2,
+        )
+        assert result.regressions == ()
+
+
+class TestUnlock:
+    def test_unlock_is_parsed_from_the_response(self):
+        assert unlock_requested(
+            "UNLOCK: the sampling helper both named tests share moves\n# Spec"
+        ) == "the sampling helper both named tests share moves"
+        assert unlock_requested("# Spec\n\nno unlock here") == ""
+
+    def test_an_unlock_lets_the_restructure_land_and_is_carried(self):
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED,
+            current_tokens=named_tokens(VERDICT),
+            unlock_reason="restructuring the sampling helpers",
+        )
+        assert '== "face"' in result.text, "the unlock lifts the refusal"
+        assert result.refusals == ()
+        assert result.unlock_reason == "restructuring the sampling helpers"
+
+    def test_an_unlock_does_not_silence_the_regression_flag(self):
+        """An unlock explains a change; it does not un-happen it."""
+        result = enforce_pinning(
+            PREVIOUS, REGENERATED,
+            current_tokens=named_tokens(VERDICT),
+            ever_tokens=named_tokens(VERDICT),
+            unlock_reason="restructure",
+        )
+        assert result.regressions
+
+
+class TestTheBoundary:
+    def test_identical_revision_changes_nothing(self):
+        result = enforce_pinning(
+            PREVIOUS, PREVIOUS, current_tokens=named_tokens(VERDICT),
+        )
+        assert result.text == PREVIOUS
+        assert result.refusals == ()
+        assert result.regressions == ()
+
+    def test_pure_insertion_passes(self):
+        """Adding is not un-fixing: a new test appended in unnamed territory
+        lands untouched."""
+        added = PREVIOUS.replace(
+            "## Section 11",
+            "```python\ndef test_new_coverage():\n    assert True\n```\n\n"
+            "## Section 11",
+        )
+        result = enforce_pinning(
+            PREVIOUS, added, current_tokens=named_tokens(VERDICT),
+        )
+        assert "test_new_coverage" in result.text
+
+    def test_separate_regions_are_judged_separately(self):
+        """Two changes in one revision get independent verdicts: the named
+        one lands, the locked one is refused. (A single region genuinely
+        SPANNING named and unnamed lines passes — restructuring around the
+        named item is the named item's business.)"""
+        mixed = PREVIOUS.replace(
+            'assert classify(sample) == "crimson"',
+            'assert classify(sample) == "crimson"  # still the band',
+        ).replace(
+            "band = face.crop(wordmark_box())",
+            "band = face.crop(wordmark_box(centre=0.67))",
+        )
+        result = enforce_pinning(
+            PREVIOUS, mixed, current_tokens=named_tokens(VERDICT),
+        )
+        # The S2 comment tweak and the named fix are separate diff regions;
+        # the S2 one is refused, the named one lands.
+        assert "wordmark_box(centre=0.67)" in result.text
+        assert "# still the band" not in result.text
+        assert result.refusals


### PR DESCRIPTION
Closes #2532

The review loop's unit of revision was the whole document while its unit of error is the individual assertion. This PR makes the objection list monotonically shrinking by construction, per the issue's three asks.

## 1. Patch revision, not regeneration

The #1528 edit-script path was already the patch mechanism; what remained was the fallback — full regeneration — which is the observed regression vector (run-issue331-233939's resumed grant reintroduced the S2 fix it had paid nine rounds to get). Both paths now end in the same mechanical enforcement: `revision_pinning.enforce_pinning` walks the line diff against the reviewed draft and carries every unnamed span forward **byte-verbatim** — the drafter never successfully re-types what the verdict did not name.

## 2. Pinning

- **Named** = what the current verdict and the current completeness failures actually point at — test names, backticked spans, quoted phrases, `Section N` references, manifest row ids (#2533's vocabulary, composed) — attributed to the draft's natural blocks (a test function inside a fence, a markdown section).
- **Locked** = everything else in the reviewed draft: a completed round passed it without objection. A changed diff region whose old lines are all locked is refused mechanically — old text restored, refusal logged and recorded in the new `pinning_events` state field. Regions touching any named line pass (restructuring around the named item is the named item's business), and pure insertions pass (adding is not un-fixing).
- **Abstention**: a verdict from which nothing extractable can be named applies no pinning (logged) — locking the whole document on an unparseable naming would refuse every legitimate fix, and unknown is not guilty (#2526).
- **Explicit unlock, never silent**: a single `UNLOCK: <reason>` line at the top of the response (either path; both prompts state the convention) lifts the refusal for that revision, and the reason is logged and recorded.

## 3. The stagnation guard's new eye

"Revision modified content no verdict ever objected to" — judged against the union of the whole `review_feedback_history` (which carries prior grants, per #2514/#2516) plus every prior completeness breakdown — is now a **flagged event at the moment it happens**: `[PINNING] REGRESSION CLASS: …` in the run log and in `pinning_events`, computed from the revision AS SUBMITTED, so the flag fires even when enforcement then restores the text, and an unlock explains a change without silencing the flag.

## Boundary, as ruled

Iteration 1 is unchanged — no previous draft, no pinning, no events. Mock-mode drafts flow through the same wiring (the mock provider path exercises it in tests).

## The S2 case, pinned as the fixture

`test_revision_pinning.py` and `test_generate_spec_pinning.py` both carry the issue's own case: the reviewed draft holds S2's round-9 fix (`between-tick pixel at 0.95 R in the 60–100 arc is BAND, not face`), the verdict names only the wordmark test, and the regeneration flips S2 back to face-black. Asserted end-to-end through `generate_spec` with a mocked provider: the fix carries forward byte-verbatim, the named wordmark fix lands, the refusal is recorded, and the regression-class event fires.

**What only a live roll proves:** how often a real drafter requests unlocks, and whether the naming extractor's vocabulary covers real verdict prose at the observed rate — first consumer boostgauge #332, after the in-flight #331 thread completes. The #331 roll and its resume state are untouched by this PR.

## Tests

- `tests/unit/test_revision_pinning.py` (15): tokens, block attribution, the pinning refusal, the explicit-unlock path (landing + logged + not silencing the regression flag), the regression-flag event, prior-round-named content not flagged, insertions, separate-region judgments.
- `tests/unit/test_generate_spec_pinning.py` (7): the full-regeneration path restored end-to-end, the edit-script path refusing a locked block while the named one lands in one model call, unlock through the node, abstention, event accumulation, iteration 1 untouched.
- All 247 neighboring suite tests (edit-script, spec workflow, diff-aware review, cap grace) pass unmodified.
- Full unit suite (local): **8671 passed, 0 failed** (11m 13s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
