### PR TITLE
fix: one authority for the spec ceiling decision (Closes #2536)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/graph.py
+++ b/assemblyzero/workflows/implementation_spec/graph.py
@@ -194,6 +194,20 @@ def route_after_validation(
     # stops a grace being claimed twice cannot live here.
     grace_for = state.get("grace_revision_for", [])
     if review_iteration >= max_iterations and grace_for:
+        # #2536: N3 already refuses a grace at the hard ceiling; this is the
+        # backstop for a hand-built state carrying one. A regeneration the
+        # review guard would refuse to review must not be granted from any
+        # path -- one authority for the ceiling decision.
+        from assemblyzero.workflows.implementation_spec.review_progress import (
+            regeneration_allowed,
+        )
+
+        if not regeneration_allowed(review_iteration, max_iterations):
+            print(
+                "    [ROUTING] Grace requested at the hard ceiling -- "
+                "suppressed; the revision could never be reviewed (#2536)"
+            )
+            return "HALT"
         print(
             f"    [ROUTING] Cap reached ({max_iterations}), but "
             f"{', '.join(grace_for)} has never reached a revision prompt - "

--- a/assemblyzero/workflows/implementation_spec/lineage_seed.py
+++ b/assemblyzero/workflows/implementation_spec/lineage_seed.py
@@ -62,6 +62,14 @@ class Seed:
     #: Every verdict the prior run produced, oldest first, so #2382's
     #: convergence check is not blind on the resumed round.
     prior_feedbacks: list[str] = field(default_factory=list)
+    #: #2536: the newest draft POSTDATES the newest verdict — the prior run
+    #: generated it and died before reviewing it (run-issue331-150920: the
+    #: grace draft the over-ceiling guard refused). Its verdict-file items
+    #: were already consumed by the revision that produced it, so seeding
+    #: them as outstanding feedback would spend a regeneration re-applying
+    #: fixes the draft already carries. The resumed grant's first action for
+    #: this shape is REVIEWING the draft, not regenerating it.
+    draft_unreviewed: bool = False
 
     @property
     def rounds_completed(self) -> int:
@@ -131,6 +139,11 @@ def seed_from_lineage(
                 for text in (_read(v) for v in verdicts)
                 if text.strip()
             ],
+            # #2536: lineage files carry zero-padded sequence prefixes
+            # (make_run_id ordering), so name order is generation order —
+            # a draft whose name sorts after the last verdict's was never
+            # reviewed.
+            draft_unreviewed=drafts[-1].name > verdicts[-1].name,
         )
     return None
 
@@ -160,9 +173,17 @@ def resume_payload(seed: Seed) -> dict:
     convergence. History is memory; the counter is budget. They separate
     here deliberately.
     """
+    # #2536: a draft the prior run generated but never reviewed already
+    # CARRIES its last verdict's fixes — that verdict fed the revision that
+    # produced it. Seeding the verdict as outstanding feedback would make the
+    # first resumed round a regeneration re-applying landed fixes (and under
+    # #2532's pinning, one that mostly gets refused). Seed no outstanding
+    # feedback instead: N2 passes the draft through untouched and the grant's
+    # first spend is the REVIEW the draft never got. History still carries
+    # every verdict, so #2382's stagnation check stays sighted either way.
     return {
         "spec_draft": seed.draft,
-        "review_feedback": seed.feedback,
+        "review_feedback": "" if seed.draft_unreviewed else seed.feedback,
         "review_feedback_history": list(seed.prior_feedbacks),
         "review_iteration": 0,
     }
@@ -170,6 +191,15 @@ def resume_payload(seed: Seed) -> dict:
 
 def describe(seed: Seed) -> str:
     """What the operator should see when a resume reuses paid work."""
+    if seed.draft_unreviewed:
+        return (
+            f"    [spec] resuming from lineage: {Path(seed.draft_path).name} "
+            f"({len(seed.draft.splitlines())} lines) was generated but never "
+            f"reviewed — the first action is reviewing it, not regenerating "
+            f"(#2536). {seed.rounds_completed} completed review round(s) in "
+            f"{Path(seed.run_dir).name}; the review cap regime starts fresh "
+            f"for this grant (#2514)."
+        )
     return (
         f"    [spec] resuming from lineage: {Path(seed.draft_path).name} "
         f"({len(seed.draft.splitlines())} lines) with "

--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -219,6 +219,26 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
                             "error_message": "",
                         }
 
+    # #2536: a seeded draft with NO outstanding feedback is one the prior
+    # grant generated but never got reviewed (run-issue331-150920: the guard
+    # refused its final draft, so the run died with paid work unjudged). Its
+    # last verdict's items are already IN it — that verdict fed the revision
+    # that produced it — so redrawing here would overwrite paid work with an
+    # unreviewed re-roll. Pass it through untouched: the grant's first spend
+    # is the review the draft never got, at this grant's iteration counter.
+    if not is_revision and existing_draft:
+        lines = len(existing_draft.splitlines())
+        print(
+            f"\n[N2] Seeded draft ({lines} lines) was never reviewed — "
+            f"passing it to review untouched (#2536)"
+        )
+        return {
+            "spec_draft": existing_draft,
+            "review_iteration": review_iteration,
+            "completeness_issues": [],
+            "error_message": "",
+        }
+
     if is_revision:
         review_iteration += 1
         print(

--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -244,21 +244,37 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
     # do it by synthesizing a verdict no reviewer issued, which is the defect
     # #1775 removed from this same guard.
     from assemblyzero.workflows.implementation_spec.review_progress import (
+        EXIT_CEILING,
         hard_ceiling,
     )
 
     ceiling = hard_ceiling(max_iterations)
     if review_iteration > ceiling:
-        print(f"    [GUARD] Iteration {review_iteration} exceeds ceiling ({ceiling})")
+        # #2536: with every regeneration-granting path consulting
+        # regeneration_allowed — the review loop's decide(), N3's grace
+        # clause, and the validation router's backstop — this state is
+        # unreachable from the graph. It survives as the last line of
+        # defence for a hand-built state, and it speaks the CLEAN ceiling
+        # vocabulary: run-issue331-150920 ended 39m 49s of honest converging
+        # rounds with "the regeneration routing should have halted earlier",
+        # an incoherence that blamed the run for a defect in the grace
+        # clause. A guard's halt must report the ceiling, not assign blame.
+        print(
+            f"    [GUARD] Iteration {review_iteration} is beyond the hard "
+            f"ceiling ({ceiling}) — halting with the ceiling report"
+        )
+        report = (
+            f"Spec review stopped [{EXIT_CEILING}]: iteration "
+            f"{review_iteration} is beyond the grant's hard ceiling "
+            f"({ceiling}), so this draft is preserved in lineage unreviewed "
+            f"and nothing more is spent. An explicit relaunch grants a "
+            f"fresh cap regime (#2514)."
+        )
         return {
             "review_verdict": "BLOCKED",
-            "review_feedback": (
-                f"Review iteration {review_iteration} exceeds the hard ceiling "
-                f"({ceiling}); the regeneration routing should have halted "
-                "earlier — treating as BLOCKED. The last generated spec was "
-                "NOT reviewed."
-            ),
-            "error_message": "",
+            "review_feedback": report,
+            "review_exit": EXIT_CEILING,
+            "error_message": report,
         }
 
     # -------------------------------------------------------------------------

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -284,7 +284,43 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
         max_iterations = state.get("max_iterations", 3)
         if iteration >= max_iterations:
             grace_for = grant_grace(failing_names, shown, grace_used)
-            if grace_for:
+            # #2536: the ceiling decision has ONE authority. The grace clause
+            # checked only the base cap, so a completeness failure at the
+            # hard ceiling (run-issue331-150920: iteration 9, reached by
+            # eight honest converging rounds) was granted a revision carrying
+            # iteration 10 — a state the review guard refuses to review. The
+            # grace draft was pure spend with unreviewable output, and the
+            # halt was the incoherent "routing should have halted earlier"
+            # instead of the clean hard-ceiling report.
+            from assemblyzero.workflows.implementation_spec.review_progress import (
+                CEILING_MULTIPLIER,
+                EXIT_CEILING,
+                hard_ceiling,
+                regeneration_allowed,
+            )
+
+            if not regeneration_allowed(iteration, max_iterations):
+                if grace_for:
+                    print(
+                        f"    [CAP] {', '.join(grace_for)} has never been "
+                        f"shown to the drafter, but the grant is at its hard "
+                        f"ceiling — the revision it would earn could never be "
+                        f"reviewed, so it is not granted (#2536)."
+                    )
+                    grace_for = []
+                ceiling = hard_ceiling(max_iterations)
+                listed = "; ".join(completeness_issues[:3])
+                cap_message = (
+                    f"Spec review stopped [{EXIT_CEILING}]: the grant reached "
+                    f"its hard ceiling of {ceiling} ({CEILING_MULTIPLIER}x "
+                    f"the base cap of {max_iterations}) during a completeness "
+                    f"revision — iteration {iteration}'s draft failed "
+                    f"{len(completeness_issues)} completeness check(s) and no "
+                    f"further regeneration may be granted. Unfixed: {listed}. "
+                    f"The draft and every verdict are in lineage; an explicit "
+                    f"relaunch grants a fresh cap regime (#2514)."
+                )
+            elif grace_for:
                 grace_used.extend(grace_for)
                 print(
                     f"    [CAP] {max_iterations} revision(s) spent, but "

--- a/assemblyzero/workflows/implementation_spec/review_progress.py
+++ b/assemblyzero/workflows/implementation_spec/review_progress.py
@@ -75,6 +75,27 @@ def hard_ceiling(max_iterations: int) -> int:
     return base * CEILING_MULTIPLIER
 
 
+def regeneration_allowed(review_iteration: int, max_iterations: int) -> bool:
+    """May a regeneration be granted at this counter? The ONE authority (#2536).
+
+    The next revision will carry ``review_iteration + 1``, and #1775
+    guarantees the draft generated AT the ceiling still gets its review — so
+    the last grantable regeneration is the one that produces the ceiling
+    itself. Every path that can send the graph back to N2 past the base cap
+    consults this predicate; nothing else compares anything to the ceiling.
+
+    The defect this retires (run-issue331-150920, 2026-08-26): the #2304
+    grace clause checked only the BASE cap, so a completeness failure at
+    iteration 9 — the ceiling, reached by honest converging rounds — was
+    granted a grace revision carrying iteration 10, which the review guard
+    then refused to review. 39m 49s of real work ended in the incoherent
+    "the regeneration routing should have halted earlier" instead of the
+    clean hard-ceiling report, and the grace draft was pure spend with
+    unreviewable output.
+    """
+    return review_iteration < hard_ceiling(max_iterations)
+
+
 @dataclass(frozen=True)
 class Decision:
     """Whether to run another round, and the name of the exit if not."""

--- a/tests/unit/test_ceiling_one_authority.py
+++ b/tests/unit/test_ceiling_one_authority.py
@@ -1,0 +1,255 @@
+"""One authority for the ceiling decision (#2536).
+
+run-issue331-150920: eight honest converging rounds, then iteration 9's draft
+failed completeness, the #2304 grace clause — which checked only the BASE cap
+— granted a revision carrying iteration 10, and the review guard refused to
+review it: 39m 49s ended in "the regeneration routing should have halted
+earlier". The issue's label-vs-counter hypothesis was REFUTED against the run
+log (the seeded counter worked; rounds 1–8 were grant-relative); the real
+defect was a regeneration-granting path that never consulted the ceiling.
+
+The law now: ``regeneration_allowed`` is the one predicate every path that
+can send the graph back to N2 past the base cap consults, a genuine grant
+ceiling always produces the clean ``[hard-ceiling]`` report, and the
+incoherent guard message is retired from every path including the backstop.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec import lineage_seed as ls
+from assemblyzero.workflows.implementation_spec.graph import (
+    route_after_validation,
+)
+from assemblyzero.workflows.implementation_spec.review_progress import (
+    EXIT_CEILING,
+    decide,
+    hard_ceiling,
+    regeneration_allowed,
+)
+
+VERDICTS = [
+    f"REVISE: round {n} raises `test_distinct_{n}` — a new objection.\n"
+    for n in range(12)
+]
+
+
+class TestTheOneAuthority:
+    def test_the_last_grantable_regeneration_produces_the_ceiling(self):
+        """#1775: the draft generated AT the ceiling still gets its review,
+        so iteration 8 may regenerate (producing 9 == ceiling) and 9 may not."""
+        assert hard_ceiling(3) == 9
+        assert regeneration_allowed(8, 3) is True
+        assert regeneration_allowed(9, 3) is False
+        assert regeneration_allowed(10, 3) is False
+
+    def test_cross_grant_labels_never_reach_the_authority(self):
+        """The issue's required fixture: history labels far beyond the
+        ceiling while the grant counter is mid-cap — the loop continues.
+        Whatever the cap regime counts is the variable checked; the history
+        length (the cross-grant 'label') is not it."""
+        assert regeneration_allowed(2, 3) is True  # counter mid-cap
+        decision = decide(
+            review_iteration=2,
+            max_iterations=3,
+            current_feedback="REVISE: `test_fresh_objection` is new.\n",
+            prior_feedbacks=VERDICTS,  # 12 prior rounds across grants
+        )
+        assert decision.should_continue, decision.detail
+
+    def test_a_grant_genuinely_at_its_ceiling_halts_clean(self):
+        decision = decide(
+            review_iteration=9,
+            max_iterations=3,
+            current_feedback="REVISE: `test_yet_another` — still converging.\n",
+            prior_feedbacks=VERDICTS[:9],
+        )
+        assert not decision.should_continue
+        assert decision.exit_name == EXIT_CEILING
+
+
+class TestTheGraceClauseConsultsTheCeiling:
+    """The observed defect path: a completeness failure at the ceiling."""
+
+    def _validate(self, iteration: int, shown=()):
+        from unittest.mock import patch
+
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+
+        state = {
+            "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+            "review_iteration": iteration,
+            "max_iterations": 3,
+            "checks_shown_to_drafter": list(shown),
+        }
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={
+                "check_name": "never_shown_check", "passed": False,
+                "details": "missing excerpt for a.py",
+            },
+        ):
+            return validate_completeness(state)
+
+    def test_below_the_ceiling_the_grace_still_grants(self):
+        out = self._validate(iteration=8)
+        assert "never_shown_check" in out["grace_revision_for"]
+        assert out["error_message"] == ""
+
+    def test_at_the_ceiling_the_grace_is_refused_and_the_halt_is_clean(self):
+        """run-issue331-150920's exact shape: an unshown check failing at
+        iteration 9 must NOT earn a revision the guard would refuse to
+        review — it must halt with the hard-ceiling report."""
+        out = self._validate(iteration=9)
+        assert out["grace_revision_for"] == []
+        assert f"[{EXIT_CEILING}]" in out["error_message"]
+        assert "hard ceiling" in out["error_message"]
+        assert "should have halted earlier" not in out["error_message"]
+
+    def test_the_ceiling_halt_names_the_unfixed_checks(self):
+        out = self._validate(iteration=9)
+        assert "missing excerpt" in out["error_message"]
+
+
+class TestTheRouterBackstop:
+    def test_a_hand_built_grace_at_the_ceiling_routes_to_halt(self):
+        assert route_after_validation({
+            "validation_passed": False,
+            "review_iteration": 9,
+            "max_iterations": 3,
+            "grace_revision_for": ["some_check"],
+        }) == "HALT"
+
+    def test_a_grace_below_the_ceiling_still_routes_to_n2(self):
+        assert route_after_validation({
+            "validation_passed": False,
+            "review_iteration": 5,
+            "max_iterations": 3,
+            "grace_revision_for": ["some_check"],
+        }) == "N2_generate_spec"
+
+
+class TestTheGuardBackstopSpeaksTheCleanVocabulary:
+    def test_beyond_the_ceiling_the_report_is_the_ceiling_report(self):
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            review_spec,
+        )
+
+        out = review_spec({
+            "spec_draft": "# Spec\n\nbody\n",
+            "review_iteration": 10,
+            "max_iterations": 3,
+        })
+        assert out["review_verdict"] == "BLOCKED"
+        assert out["review_exit"] == EXIT_CEILING
+        assert f"[{EXIT_CEILING}]" in out["error_message"]
+        assert "preserved in lineage unreviewed" in out["review_feedback"]
+        # The incoherence is retired from its last home.
+        assert "should have halted earlier" not in out["review_feedback"]
+
+    def test_at_the_ceiling_the_review_still_happens(self):
+        """#1775 stands: iteration == ceiling is reviewable; only beyond it
+        is refused. A mock review at 9 must reach the reviewer, not the
+        guard."""
+        from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+            review_spec,
+        )
+
+        out = review_spec({
+            "spec_draft": "# Spec\n\n" + ("body\n" * 30),
+            "lld_content": "# LLD\n",
+            "review_iteration": 9,
+            "max_iterations": 3,
+            "config_mock_mode": True,
+        })
+        assert "beyond the grant's hard ceiling" not in (
+            out.get("review_feedback") or ""
+        )
+
+
+class TestTheUnreviewedDraftResume:
+    """The acceptance's second observation: 150920's final draft was never
+    reviewed, so the resumed grant's first action is reviewing it."""
+
+    def _run_dir(self, tmp_path, *, last_draft_reviewed: bool):
+        run = tmp_path / "lineage" / "2026-08-26T20-09-22Z"
+        run.mkdir(parents=True)
+        (run / "001-spec-draft.md").write_text(
+            "# Spec\n\nDRAFT ONE\n", encoding="utf-8"
+        )
+        (run / "003-readiness-verdict.md").write_text(
+            "REVISE: `test_x` is wrong.\n", encoding="utf-8"
+        )
+        if not last_draft_reviewed:
+            (run / "005-spec-draft.md").write_text(
+                "# Spec\n\nDRAFT TWO — never reviewed\n", encoding="utf-8"
+            )
+        return run.parent
+
+    def test_an_unreviewed_final_draft_is_detected(self, tmp_path):
+        seed = ls.seed_from_lineage(
+            self._run_dir(tmp_path, last_draft_reviewed=False)
+        )
+        assert seed.draft_unreviewed is True
+        assert "DRAFT TWO" in seed.draft
+
+    def test_its_payload_seeds_no_outstanding_feedback(self, tmp_path):
+        """The verdict's items already fed the revision that produced the
+        draft; seeding them again would spend a regeneration re-applying
+        landed fixes. The first action is the review."""
+        seed = ls.seed_from_lineage(
+            self._run_dir(tmp_path, last_draft_reviewed=False)
+        )
+        payload = ls.resume_payload(seed)
+        assert payload["review_feedback"] == ""
+        assert payload["review_iteration"] == 0
+        assert payload["review_feedback_history"], "history still travels"
+
+    def test_a_reviewed_final_draft_keeps_the_old_behaviour(self, tmp_path):
+        seed = ls.seed_from_lineage(
+            self._run_dir(tmp_path, last_draft_reviewed=True)
+        )
+        assert seed.draft_unreviewed is False
+        assert ls.resume_payload(seed)["review_feedback"].startswith("REVISE")
+
+    def test_the_description_says_review_first(self, tmp_path):
+        seed = ls.seed_from_lineage(
+            self._run_dir(tmp_path, last_draft_reviewed=False)
+        )
+        assert "never reviewed" in ls.describe(seed)
+
+    def test_n2_passes_the_unreviewed_draft_through_untouched(self):
+        """No LLM call, no redraw, counter unchanged: the seeded draft goes
+        to review as-is."""
+        from unittest.mock import patch
+
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            generate_spec,
+        )
+
+        state = {
+            "config_mock_mode": True,
+            "lld_content": "# LLD\n",
+            "current_state_snapshots": {},
+            "pattern_references": [],
+            "assemblyzero_root": "",
+            "repo_root": "",
+            "spec_draft": "# Spec\n\nPAID, UNREVIEWED DRAFT\n",
+            "review_feedback": "",
+            "review_iteration": 0,
+        }
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "generate_spec.get_provider",
+        ) as provider:
+            out = generate_spec(state)
+        provider.assert_not_called()
+        assert out["spec_draft"] == "# Spec\n\nPAID, UNREVIEWED DRAFT\n"
+        assert out["review_iteration"] == 0
+        assert out["error_message"] == ""

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -2133,7 +2133,12 @@ class TestReviewSpec:
 
         result = review_spec(base_state)
         assert result["review_verdict"] == "BLOCKED"
-        assert "NOT reviewed" in result["review_feedback"]
+        # #2536: the guard now speaks the clean ceiling vocabulary — the
+        # draft is preserved unreviewed and the halt names the exit, never
+        # the "routing should have halted earlier" incoherence.
+        assert "unreviewed" in result["review_feedback"]
+        assert "hard ceiling" in result["review_feedback"]
+        assert "should have halted earlier" not in result["review_feedback"]
         mock_provider.assert_not_called()
 
     @patch("assemblyzero.workflows.implementation_spec.nodes.review_spec.get_provider")


### PR DESCRIPTION
Closes #2536

## The hypothesis, verified against the preserved state — and refuted

The issue hypothesized two counters: the grant counting from zero while the guard reads an absolute cross-grant label. The run log (`run-issue331-150920.log`) refutes it: the #2517 seeding worked — rounds 1–8 print grant-relative "round N of this grant", the counter started at 0, and every iteration was real work. The actual defect, read straight off the trace:

```
[N2] ... revision (iteration 9)      ← eight honest converging rounds behind it
    BLOCKED: 1 check(s) failed       ← iteration 9's draft FAILED completeness; never reviewed
    [CAP] ... change_instructions_specific has never been shown ... Granting one revision (#2304)
[N2] ... revision (iteration 10)     ← the grace draft
    [GUARD] Iteration 10 exceeds ceiling (9)   ← refused unreviewed; the incoherent halt
```

**The #2304 grace clause checked only the base cap and never consulted the ceiling.** A completeness failure at iteration 9 (== the ceiling, reached legitimately) earned a grace revision carrying iteration 10 — a state the review guard refuses to review — so the grace draft was pure spend with unreviewable output, and the clean ceiling exit (which lives in N5's `decide()`) never got its chance because iteration 9 never reached N5. The observed facts are fully explained; no label/counter split exists.

## One authority

`review_progress.regeneration_allowed(review_iteration, max_iterations)` — the next revision carries `iteration + 1`, and #1775 guarantees the draft generated AT the ceiling still gets its review, so the last grantable regeneration is the one that produces the ceiling itself. Every path that can send the graph back to N2 past the base cap consults it:

- **N3's grace clause** refuses a grace at the ceiling (logging that the check was never shown AND why the revision cannot be granted) and emits the CLEAN `Spec review stopped [hard-ceiling]: …` report as the cap message — naming the ceiling, the multiplier, the unfixed checks, and the #2514 fresh-regime relaunch.
- **The validation router** backstops a hand-built state carrying a grace at the ceiling → HALT, never N2.
- **N5's over-ceiling guard** is now unreachable from the graph and survives as the last line of defence — speaking the clean ceiling vocabulary (`review_exit: hard-ceiling`, error_message set so the halt banner carries it end-to-end). The "regeneration routing should have halted earlier" incoherence is retired from its last home; iteration == ceiling remains reviewable per #1775.

Cross-grant labels (the feedback history) keep continuing for lineage legibility and are never compared to the ceiling — pinned by the required fixture: 12 prior-round labels with the grant counter mid-cap → CONTINUE.

## The unreviewed-draft resume (the acceptance's second observation)

150920's final draft (027) was never reviewed, and its last verdict's items already fed the revision that produced it — so the old seeding (draft + that verdict as outstanding feedback) would spend the resumed grant's first round re-applying landed fixes. Now: `lineage_seed` detects a draft postdating the last verdict (`draft_unreviewed`), seeds it with NO outstanding feedback (history still travels for #2382's stagnation check), and N2 passes it through untouched — no LLM call, counter unchanged — so **the resumed grant's first spend is the review the draft never got.** A reviewed-final-draft lineage keeps the old behaviour exactly.

## Acceptance against the preserved live state, read-only

`data/scratch-2026-08-26-2536/acceptance_150920.py` against the real boostgauge lineage:

```
seed run dir:      2026-08-26T20-09-22Z     seed draft: 027-spec-draft.md (365 lines)
draft_unreviewed:  True                     rounds completed: 8
payload iteration: 0    payload feedback: '' (first action is the REVIEW)
regeneration_allowed 0..8: all True         at the ceiling (9): False
a fully-converging grant exits: [hard-ceiling] (clean)
lineage byte-identical after proof: True (sha256 83c57b4b129eb03a)
```

So a post-fix resume of this exact state reviews draft 027 at grant iteration 0 and, if it converges all the way, halts with the clean ceiling report at grant round 9. **What only a live roll proves:** the real reviewer's verdict on draft 027, the pass-through flowing through a live orchestrated graph walk, and the #2532 pinning + #2533 manifest interacting with the resumed rounds. The #331 state was read, never written; no roll was launched; boostgauge PR #367 untouched.

## Tests

`tests/unit/test_ceiling_one_authority.py` (15): the authority's boundaries, the required cross-grant fixture (labels past the ceiling, counter mid-cap → continues), the genuine-ceiling clean halt, the grace refusal at the ceiling with the `[hard-ceiling]` message (and grants below it unchanged), the router backstop both sides, the guard backstop's clean vocabulary (+ iteration==ceiling still reviewable per #1775), and the unreviewed-draft resume end-to-end including the no-LLM pass-through. One pinned wording in `test_over_budget_iteration_guard` updated to the clean vocabulary (its intent — BLOCKED without a provider call — unchanged). All other suites pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
