### PR TITLE
fix: the fence-density heuristic advises, it never vetoes (Closes #2539)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -145,8 +145,32 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_functions)
     _log_check(check_functions)
 
-    # Check 4: Change instructions should be specific
+    # Check 4: Change instructions should be specific — ADVISORY (#2539).
+    # A fence-count density ratio is a proxy, not a verification: it killed
+    # run-issue331-200815 one or two rounds from approval, at "found 8,
+    # expected 9" on a 454-line spec the adversarial reviewer had certified
+    # concrete and executable for five consecutive rounds — and because the
+    # threshold is derived from line count, the drafter's compliance (adding
+    # a fenced snippet, 7→8) grew the spec and moved the demand with it
+    # (8→9). This graph ALWAYS runs the N5 adversarial review, which judges
+    # concreteness and executability directly, with reasons, every round; a
+    # density heuristic adds no information the reviewer lacks and must not
+    # hold a veto the reviewer cannot override. A mechanical check
+    # hard-blocks only on what it can verify — a symbol exists, a row is
+    # cited — and a ratio is not that. Second instance of the class after
+    # #2526's str.isupper.
     check_instructions = check_change_instructions_specific(spec_draft)
+    if not check_instructions["passed"]:
+        print(f"    [ADVISORY] {check_instructions['details']}")
+        check_instructions = CompletenessCheck(
+            check_name="change_instructions_specific",
+            passed=True,
+            details=(
+                "ADVISORY (density heuristic — not blocking, #2539; the N5 "
+                "reviewer judges concreteness directly): "
+                + check_instructions["details"]
+            ),
+        )
     checks.append(check_instructions)
     _log_check(check_instructions)
 
@@ -353,7 +377,34 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                         for entry in prior_iters
                     )
                 ]
-                kept_failing = [name for name in tried if name not in declined]
+                # #2539: the third class. A complaint whose NUMBERS moved
+                # under revision while its verdict never did means the
+                # drafter complied with the instruction and the check's
+                # counter absorbed the compliance — observed live as "found
+                # 7, expected 8, 441 lines" becoming "found 8, expected 9,
+                # 454 lines": the snippet was added, the spec grew, and the
+                # line-derived threshold moved with it. Three revisions that
+                # cannot move a blind counter are evidence against the
+                # check, not the draft. Detected by digit-normalized
+                # identity: same complaint shape every round, only the
+                # counts changed.
+                def _shape(text: str) -> str:
+                    return re.sub(r"\d+", "N", text)
+
+                complied = [
+                    name for name in tried
+                    if name not in declined and prior_iters and all(
+                        any(
+                            _shape(details_by_name[name]) == _shape(failure)
+                            for failure in entry["failures"]
+                        )
+                        for entry in prior_iters
+                    )
+                ]
+                kept_failing = [
+                    name for name in tried
+                    if name not in declined and name not in complied
+                ]
                 detail = ""
                 if kept_failing:
                     detail += (
@@ -368,6 +419,16 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                         f"unchanged each time. A drafter declining to change "
                         f"code it believes correct is evidence of a false "
                         f"positive in the check, not of an unfixable spec."
+                    )
+                if complied:
+                    detail += (
+                        f" NOTE: {', '.join(complied)} COMPLIED WITHOUT "
+                        f"EFFECT — the complaint kept its exact shape across "
+                        f"every revision with only its counts moving, so the "
+                        f"drafter did what the check asked and the check's "
+                        f"own threshold absorbed it. That is evidence of a "
+                        f"false positive in the check, not of an unfixable "
+                        f"spec (#2539)."
                     )
                 cap_message = (
                     f"Iteration cap: {max_iterations} revision(s) ended with "
@@ -814,12 +875,22 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
 
 
 def check_change_instructions_specific(spec: str) -> CompletenessCheck:
-    """Change instructions must be diff-level specific.
+    """Change instructions should be diff-level specific — a DENSITY HEURISTIC.
 
-    Verifies that the spec contains specific change instructions rather
-    than vague directives. Looks for indicators of specificity such as
-    code blocks, line references, before/after snippets, and precise
-    modification instructions.
+    #2539: this check is ADVISORY at the node — its failure is printed, never
+    gated on. The measurement is a proxy (fence count per ~50 lines, indicator
+    count per ~30), and because both thresholds derive from line count, a
+    drafter's compliance grows the spec and can move the demand with it —
+    observed live as 7-of-8 at 441 lines becoming 8-of-9 at 454. The N5
+    adversarial reviewer judges concreteness and executability directly; this
+    heuristic only surfaces a hint the operator can read in the log.
+
+    The fence counter counts EVERY fence pair regardless of language tag —
+    python, diff, text — so guidance in any fence form registers (verified
+    against the run-issue331-200815 draft while refuting the hypothesis that
+    non-Python fences were skipped: that scan note belonged to the
+    api-symbols checker). Per-tag counts are included in the details so the
+    composition is visible at a glance.
 
     Args:
         spec: Implementation Spec markdown content.
@@ -838,9 +909,23 @@ def check_change_instructions_specific(spec: str) -> CompletenessCheck:
             indicator_counts[pattern] = count
             total_indicators += count
 
-    # Count code blocks specifically (strong indicator)
+    # Count code blocks specifically (strong indicator). EVERY fence pair
+    # counts, whatever its tag — the check's own advice says "diff-level
+    # guidance", so a diff or text fence satisfying that advice must move
+    # this number (#2539 ask 2).
     code_blocks = re.findall(r"```[\s\S]*?```", spec)
     code_block_count = len(code_blocks)
+
+    # Per-tag composition, so a reader can see at a glance what kinds of
+    # fences the count is made of (#2539: a skip must be visible).
+    tag_counts: dict[str, int] = {}
+    for block in code_blocks:
+        first_line = block.splitlines()[0] if block.splitlines() else "```"
+        tag = first_line[3:].strip() or "(untagged)"
+        tag_counts[tag] = tag_counts.get(tag, 0) + 1
+    by_tag = ", ".join(
+        f"{tag}={count}" for tag, count in sorted(tag_counts.items())
+    ) or "none"
 
     # The spec should have substantial code blocks for specificity
     # Minimum thresholds based on spec size
@@ -855,10 +940,11 @@ def check_change_instructions_specific(spec: str) -> CompletenessCheck:
             passed=False,
             details=(
                 f"Insufficient code blocks for specificity: found "
-                f"{code_block_count}, expected at least {min_code_blocks} "
-                f"for a {spec_lines}-line spec. Change instructions MUST "
-                f"include before/after code snippets, line references, or "
-                f"diff-level guidance."
+                f"{code_block_count} (by tag: {by_tag}), expected at least "
+                f"{min_code_blocks} for a {spec_lines}-line spec. Change "
+                f"instructions benefit from before/after code snippets, line "
+                f"references, or diff-level guidance — every fence tag "
+                f"counts."
             ),
         )
 

--- a/tests/unit/test_density_heuristic_advisory.py
+++ b/tests/unit/test_density_heuristic_advisory.py
@@ -1,0 +1,175 @@
+"""The fence-density heuristic advises; it never vetoes (#2539).
+
+run-issue331-200815: five review rounds converging under a certifying
+adversarial reviewer, then `change_instructions_specific` failed at "found 8,
+expected at least 9" on a 454-line spec — and the threshold is derived from
+line count, so the drafter's compliance (adding a snippet, 7→8) grew the spec
+and moved the demand with it (8→9). Second instance of the class after
+#2526's str.isupper: a cheap proxy vetoing content the judgment layer was
+certifying.
+
+Verified while fixing: the fence counter counts EVERY pair regardless of tag
+(the "skips non-Python fences" hypothesis belonged to the api-symbols
+checker's scan note; the killed draft's 8 blocks were all ```python). Pinned
+below anyway, so the property can never silently become false.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_change_instructions_specific,
+    validate_completeness,
+)
+
+
+def _spec_of(lines: int, fenced_blocks: list[str]) -> str:
+    """A spec of ~`lines` lines carrying exactly the given fenced blocks."""
+    body = list(fenced_blocks)
+    prose_needed = max(0, lines - sum(b.count("\n") + 1 for b in body) - 2)
+    body.append("\n".join(f"prose line {i}" for i in range(prose_needed)))
+    return "# Spec\n\n" + "\n\n".join(body)
+
+
+def _block(tag: str, i: int = 0) -> str:
+    return f"```{tag}\ncontent {i}\n```"
+
+
+class TestTheObservedCase:
+    """454 lines, 8 blocks — the killed draft's exact shape."""
+
+    OBSERVED = _spec_of(454, [_block("python", i) for i in range(8)])
+
+    def test_the_measurement_still_reports_honestly(self):
+        result = check_change_instructions_specific(self.OBSERVED)
+        assert result["passed"] is False
+        assert "found 8" in result["details"]
+        assert "by tag: python=8" in result["details"]
+
+    def test_the_node_advisory_flags_and_never_hard_blocks(self):
+        """The acceptance: this shape passes-or-advisory-flags, never gates.
+        The N5 reviewer judges concreteness directly; the heuristic's veto
+        is revoked at the node."""
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "modify_files_have_excerpts",
+                          "passed": True, "details": "ok"},
+        ):
+            out = validate_completeness({
+                "spec_draft": self.OBSERVED,
+                "files_to_modify": [],
+                "pattern_references": [],
+                "repo_root": "",
+                "lld_content": "",
+                "review_iteration": 0,
+                "max_iterations": 3,
+            })
+        assert "change_instructions_specific" not in " ".join(
+            out["completeness_issues"]
+        ), "the density heuristic must never enter the blocking issue list"
+        assert not any(
+            "Insufficient code blocks" in issue
+            for issue in out["completeness_issues"]
+        )
+
+    def test_the_advisory_is_visible_not_silent(self, capsys):
+        validate_completeness({
+            "spec_draft": self.OBSERVED,
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+        })
+        printed = capsys.readouterr().out
+        assert "[ADVISORY]" in printed
+        assert "found 8" in printed
+
+
+class TestEveryFenceTagCounts:
+    """Ask 2, pinned: guidance in diff or text fences satisfies the counter,
+    so complying with the check's own advice moves its number."""
+
+    def test_diff_and_text_fences_count_toward_the_threshold(self):
+        blocks = (
+            [_block("python", i) for i in range(3)]
+            + [_block("diff", i) for i in range(3)]
+            + [_block("text", i) for i in range(3)]
+        )
+        spec = _spec_of(440, blocks)  # threshold: 440 // 50 = 8; found 9
+        result = check_change_instructions_specific(spec)
+        assert "found 8" not in result["details"]
+        # The fence count itself is satisfied — if the check reports at all,
+        # it is not about block count.
+        assert "Insufficient code blocks" not in result["details"]
+
+    def test_the_failure_names_the_per_tag_composition(self):
+        spec = _spec_of(454, [_block("python"), _block("diff"), _block("text")])
+        result = check_change_instructions_specific(spec)
+        assert result["passed"] is False
+        assert "diff=1" in result["details"]
+        assert "text=1" in result["details"]
+        assert "python=1" in result["details"]
+
+
+class TestCompliedWithoutEffect:
+    """Ask 3: a complaint whose shape survives every revision with only its
+    counts moving is the drafter complying and the check absorbing it —
+    marked at the cap halt as evidence against the check."""
+
+    def _at_cap(self, details_now: str, prior_failures: list[str]):
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False,
+                          "details": details_now},
+        ):
+            state = {
+                "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+                "files_to_modify": [],
+                "pattern_references": [],
+                "repo_root": "",
+                "lld_content": "",
+                "review_iteration": 3,
+                "max_iterations": 3,
+                "checks_shown_to_drafter": [],
+                "prior_completeness_breakdown": [],
+            }
+            first = validate_completeness(state)
+            state["checks_shown_to_drafter"] = first["checks_shown_to_drafter"]
+            state["prior_completeness_breakdown"] = [
+                {"iteration": i, "failures": [
+                    f if f != "__NOW__" else details_now
+                    for f in prior_failures
+                ] + [
+                    x for x in first["completeness_issues"] if x != details_now
+                ]}
+                for i in range(2)
+            ]
+            return validate_completeness(state)
+
+    def test_counts_moving_under_a_fixed_shape_is_marked(self, capsys):
+        out = self._at_cap(
+            "Insufficient code blocks: found 8, expected 9 for a 454-line spec.",
+            ["Insufficient code blocks: found 7, expected 8 for a 441-line spec."],
+        )
+        capsys.readouterr()
+        assert "COMPLIED WITHOUT EFFECT" in out["error_message"]
+        assert "false positive" in out["error_message"]
+
+    def test_byte_identical_is_still_the_declined_class(self, capsys):
+        same = "Spec calls methods not found: `isupper`"
+        out = self._at_cap(same, [same])
+        capsys.readouterr()
+        assert "IDENTICAL complaint" in out["error_message"]
+        assert "COMPLIED WITHOUT EFFECT" not in out["error_message"]
+
+    def test_a_shape_change_is_still_kept_failing(self, capsys):
+        out = self._at_cap(
+            "missing excerpt for a.py",
+            ["a completely different complaint about b.py"],
+        )
+        capsys.readouterr()
+        assert "shown to the drafter and survived a revision" in out["error_message"]
+        assert "COMPLIED WITHOUT EFFECT" not in out["error_message"]

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1789,7 +1789,15 @@ class TestValidateCompletenessAccumulatesPriorBreakdown:
             "review_iteration": 0,
             "prior_completeness_breakdown": [],
         }
-        result = validate_completeness(state)
+        # #2539 demoted the density heuristic this fixture used to trip, so
+        # the failure this test needs is now supplied deterministically.
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False,
+                          "details": "missing excerpt for a.py"},
+        ):
+            result = validate_completeness(state)
         breakdown = result.get("prior_completeness_breakdown", [])
         assert result["validation_passed"] is False
         assert len(breakdown) == 1
@@ -1813,7 +1821,14 @@ class TestValidateCompletenessAccumulatesPriorBreakdown:
             "review_iteration": 1,
             "prior_completeness_breakdown": prior,
         }
-        result = validate_completeness(state)
+        # #2539: deterministic failure, as above.
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False,
+                          "details": "missing excerpt for a.py"},
+        ):
+            result = validate_completeness(state)
         breakdown = result.get("prior_completeness_breakdown", [])
         assert len(breakdown) == 2
         assert breakdown[0] == {"iteration": 0, "failures": ["old failure"]}


### PR DESCRIPTION
Closes #2539

## Verified against the preserved state first — one sub-claim refuted, and the defect is worse than filed

- **Part 1 confirmed, with a sharper edge.** The killed draft is exactly 454 lines with 8 fence pairs; `max(3, lines // 50)` demanded 9. And because BOTH thresholds derive from line count, the run log shows the drafter's compliance moving the goalposts it was chasing: `found 7, expected 8, 441 lines` → the grace revision added a snippet → `found 8, expected 9, 454 lines`. Complying with the check's advice grows the spec and raises its own demand.
- **Part 2 refuted for this counter.** The fence counter (`` ```[\s\S]*?``` ``) counts EVERY pair regardless of tag, and the killed draft's 8 blocks are all ```` ```python ````. The "5 fence(s) skipped by language tag" note in the evidence belongs to the api-symbols checker's scan, a different counter. Pinned as tests anyway so the property can never silently become false.
- **Part 3 refined.** The halt DID carry #2526's kept-failing marking ("shown to the drafter and survived a revision"). What it could not say is the class this run actually exhibited: the complaint kept its exact shape across revisions with only its counts moving — text-identity can't see compliance when the check's own numbers wobble.

## The fix, per the asks in order

1. **The density heuristic advises; it never vetoes.** In this graph the N5 adversarial review is unconditional — it judges concreteness and executability directly, with reasons, every round (five consecutive certifications in the killed run). The node now converts a `change_instructions_specific` failure into a loud `[ADVISORY]` log line plus a non-blocking check entry prefixed `ADVISORY (density heuristic — not blocking)`. It can no longer enter `completeness_issues`, consume a revision, or cap a run. The measurement itself stays honest (the pure function still reports `passed=False` with real numbers) so the signal survives for the operator and for tests.
2. **Every fence tag counts, visibly.** Already true of the counter — now pinned by test (a spec whose guidance sits in `diff` and `text` fences satisfies the count), and the details carry per-tag composition (`by tag: python=8`) so any future skip is visible at a glance. The failure text no longer commands ("MUST include") what it cannot verify.
3. **The cap halt gains the third class: COMPLIED WITHOUT EFFECT.** Alongside #2526's declined (byte-identical complaint) and kept-failing: a complaint whose digit-normalized shape is identical across every prior revision while its raw text differs means the drafter did what the check asked and the check's threshold absorbed it — marked at the halt as evidence of a false positive in the check, not an unfixable spec. This applies to every completeness check's cap halt, not just this one.

## Acceptance against the preserved live state, read-only

`data/scratch-2026-08-26-2539/acceptance_200815.py` on the real final draft (sha256 `49443ffc38faf4f0`):

```
measurement (honest, unchanged): passed=False
  Insufficient code blocks for specificity: found 8 (by tag: python=8), expected at least 9 ...
[ADVISORY] ... found 8 (by tag: python=8) ...
density check in the BLOCKING issue list: False
other failing checks on this minimal-state probe: 0     PASSED: 7 verified, 4 n/a
draft byte-identical after proof: True
```

The exact draft that died now clears N3 with the density measurement surfaced as an advisory. With the #2536/#2537 unreviewed-draft seeding, a plain relaunch resumes from spec, carries this draft straight through N3, and delivers it to the review it is owed. **What only a live roll proves:** the real reviewer's verdict on that draft and the advisory line rendering in a live detached run. The state was read, never written; no roll launched; boostgauge PR #367 untouched.

## Tests

- New `tests/unit/test_density_heuristic_advisory.py` (8): the observed 454-line/8-block shape measured honestly, advisory-flagged at the node, never blocking, and visible; diff/text fences counting toward the threshold; per-tag composition in the details; and the three-way cap-halt partition (complied-without-effect on the observed count-moving shape, declined still byte-identical, kept-failing still shape-changed).
- Two #1465 breakdown-mechanics tests updated: their fixture relied on the density check being the thing that failed; they now inject a deterministic failure (the established halt-legibility pattern). Intent unchanged.
- Full unit suite: reported below and in the merge-gate CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
