### PR TITLE
fix: red runs once per impl-stage entry -- attempt restarts resume the loop (Closes #2542)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -9,9 +9,11 @@ N4_implement_code. Exit codes 2/3 (interrupt/internal error) stop the workflow.
 """
 
 from assemblyzero.utils.shell import run_command
+import json
 import re
 import shutil
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -636,21 +638,92 @@ def _unsatisfiable_test_failures(output: str) -> set[str]:
     return found
 
 
-def _implementation_already_exists(state: TestingWorkflowState) -> bool:
-    """True when a previous attempt's implementation is present (#2337).
+#: #2542: the stage-entry record that red WAS verified, written into the
+#: audit dir (which lives in the worktree, so the marker's scope is exactly
+#: the stage entry's worktree). Red is a property of STAGE ENTRY, not of
+#: every attempt: attempt restarts consult this instead of re-demanding a
+#: precondition their own prior attempt destroyed by design.
+RED_MARKER_NAME = "red-verified.json"
 
-    Two conditions, both required. This is NOT a first attempt -- a retry sets
-    retry_mode, and a resume carries an iteration count -- AND the files the
-    spec says to write are actually on disk. Either alone is too weak: a first
-    attempt against a repo that happens to have the file is the pre-existing
-    implementation the guard was built for, and a retry whose files were
-    cleared genuinely needs the red phase.
+
+def _red_marker_path(state: TestingWorkflowState) -> Path | None:
+    audit_dir = state.get("audit_dir", "")
+    return Path(audit_dir) / RED_MARKER_NAME if audit_dir else None
+
+
+def write_red_marker(
+    state: TestingWorkflowState, *, failing: int, exit_code: int
+) -> None:
+    """Record that THIS stage entry verified red (#2542). Never raises.
+
+    Written on every valid red outcome — the import-error red and the
+    all-tests-failed red — and overwritten by a fresh first attempt, so a
+    stale marker can never suppress a genuine entry's red demand (it is only
+    ever CONSULTED on a later attempt of the same stage entry).
+    """
+    path = _red_marker_path(state)
+    if path is None or not path.parent.is_dir():
+        return
+    try:
+        path.write_text(
+            json.dumps({
+                "issue": state.get("issue_number", 0),
+                "verified_at": datetime.now(tz=timezone.utc).isoformat(),
+                "failing": failing,
+                "exit_code": exit_code,
+            }, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        # fail-open: the marker is loop bookkeeping, not the red verdict —
+        # a marker that cannot persist costs a later attempt its skip (it
+        # falls back to the file-evidence check below), and the failure is
+        # printed here rather than silently swallowed.
+        print(f"    [N3] WARNING: could not persist the red marker ({exc})")
+
+
+def read_red_marker(state: TestingWorkflowState) -> dict | None:
+    path = _red_marker_path(state)
+    if path is None or not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # fail-open: an unreadable marker is treated as no marker — the
+        # later attempt then falls back to the prior-attempt file evidence,
+        # and a genuinely fresh entry still gets its red demand. Losing the
+        # skip is the cheap direction; inventing one is not possible here.
+        return None
+
+
+def _implementation_already_exists(state: TestingWorkflowState) -> bool:
+    """True when THIS RUN's own prior work explains passing tests (#2337, #2542).
+
+    Two signals, either sufficient once this is a later attempt (a retry sets
+    retry_mode, a resume carries an iteration count — a first attempt never
+    consults either signal, so the pre-existing-implementation guard it was
+    built for still fires there):
+
+    * the stage entry's red marker — red was verified against this worktree
+      before anything was written, so passing tests now are the loop's own
+      progress;
+    * ANY planned .py file present on disk. #2542 changed this from ALL:
+      run-issue331-230544's attempt 1 wrote 2 of its 3 planned files and
+      died on the third's LLM call, so attempt 2 found 8 tests passing —
+      explained entirely by the run's own surviving implementation — and the
+      all() predicate refused to recognise it. In the only branch that
+      consults this (tests PASSING), a partial write that leaves tests
+      passing is this run's work; a cleared implementation cannot reach the
+      branch at all, because its tests fail on ImportError.
     """
     is_later_attempt = bool(state.get("retry_mode")) or int(
         state.get("iteration_count", 0) or 0
     ) > 0
     if not is_later_attempt:
         return False
+
+    if read_red_marker(state) is not None:
+        return True
 
     repo_root = Path(state.get("repo_root", "") or ".")
     targets = [
@@ -659,7 +732,7 @@ def _implementation_already_exists(state: TestingWorkflowState) -> bool:
     ]
     if not targets:
         return False
-    return all((repo_root / path).is_file() for path in targets)
+    return any((repo_root / path).is_file() for path in targets)
 
 
 def _describe_hollow_suite(state: TestingWorkflowState) -> str:
@@ -847,6 +920,10 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 f"    [EXIT CODE {exit_code}] ImportError on expected module(s) "
                 f"-> valid red signal, routing to implementation"
             )
+            # #2542: red is a property of STAGE ENTRY. Record it, so an
+            # attempt restart resumes the loop instead of re-demanding a
+            # precondition its own prior attempt destroyed by design.
+            write_red_marker(state, failing=exp_count_red, exit_code=exit_code)
             return {
                 "red_phase_output": output,
                 "file_counter": file_num,
@@ -932,20 +1009,37 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
         # implementation is still present and still works, which is the state
         # N4 is trying to reach.
         if _implementation_already_exists(state):
+            # #2542: say WHICH evidence explains the passing tests — the
+            # loop's own state, never an anomaly. Ask 3's distinction.
+            marker = read_red_marker(state)
+            if marker:
+                print(
+                    f"    [N3] {passed_count} test(s) pass — red was verified "
+                    f"at this stage entry ({marker.get('verified_at', '?')}, "
+                    f"{marker.get('failing', '?')} failing then), so the "
+                    f"passing tests are this run's own progress."
+                )
+            else:
+                print(
+                    f"    [N3] {passed_count} test(s) pass, and files this "
+                    f"run's prior attempt wrote are present in the worktree."
+                )
             print(
-                f"    [N3] {passed_count} test(s) already pass, and the "
-                f"implementation from a previous attempt is present."
-            )
-            print(
-                "    Not a failed red phase: the tests and the implementation "
-                "agree. Verifying against the coverage gate instead."
+                f"    Not a failed red phase: resuming the implement-iterate "
+                f"loop against the {failed_count + error_count} current "
+                f"failure(s) via the green/coverage gate."
             )
             log_workflow_execution(
                 target_repo=repo_root,
                 issue_number=state.get("issue_number", 0),
                 workflow_type="testing",
                 event="red_phase_implementation_present",
-                details={"passed": passed_count, "retry": True},
+                details={
+                    "passed": passed_count,
+                    "failed": failed_count + error_count,
+                    "retry": True,
+                    "red_marker": bool(marker),
+                },
             )
             return {
                 "red_phase_output": output,
@@ -956,7 +1050,10 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
             }
 
         print(f"    [GUARD] WARNING: {passed_count} tests passed unexpectedly!")
-        print("    This may indicate pre-existing implementation.")
+        print(
+            "    No red-entry marker and no prior-attempt writes explain "
+            "them: the implementation existed BEFORE this stage entered."
+        )
 
         log_workflow_execution(
             target_repo=repo_root,
@@ -976,8 +1073,10 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
             # on it in twelve seconds.
             "error_message": (
                 f"{DETERMINISTIC_FAILURE}: Red phase failed: {passed_count} "
-                f"tests passed unexpectedly. Tests should fail before "
-                f"implementation exists."
+                f"tests passed unexpectedly, and neither a red-entry marker "
+                f"nor this run's own prior writes explain them — the "
+                f"implementation existed before this stage entered. Tests "
+                f"should fail before implementation exists (#2542)."
             ),
             "next_node": "END",
         }
@@ -1005,6 +1104,12 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
         workflow_type="testing",
         event="red_phase_complete",
         details={"failed": failed_count, "errors": error_count, "exit_code": exit_code},
+    )
+
+    # #2542: record the stage entry's verified red, so attempt restarts
+    # resume the loop instead of re-demanding it over their own output.
+    write_red_marker(
+        state, failing=failed_count + error_count, exit_code=exit_code
     )
 
     return {

--- a/tests/unit/test_red_once_per_stage_entry.py
+++ b/tests/unit/test_red_once_per_stage_entry.py
@@ -1,0 +1,195 @@
+"""Red is a property of stage entry, not of every attempt (#2542).
+
+run-issue331-230544 — the first #331 run to pass lld, the operator-approved
+visual gate, AND the spec stage — died 3 seconds into the impl stage's second
+attempt: attempt 1 verified red against the clean worktree, implemented 2 of
+its 3 planned files, and died on the third's LLM call; attempt 2 re-demanded
+red against the worktree attempt 1 had just implemented into, found 8 tests
+passing, and killed the run for the crime of its own progress.
+
+The law now: the red verification is recorded at stage entry (the
+``red-verified.json`` marker in the worktree-scoped audit dir); attempt
+restarts consult the marker or the run's own surviving writes and resume the
+implement-iterate loop against the current failure set; and a genuinely
+pre-existing implementation at stage entry — no marker, no prior-attempt
+writes — still halts, with a message that says which case it is.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    DETERMINISTIC_FAILURE,
+    RED_MARKER_NAME,
+    _implementation_already_exists,
+    read_red_marker,
+    verify_red_phase,
+    write_red_marker,
+)
+
+
+@pytest.fixture()
+def worktree(tmp_path: Path) -> Path:
+    """The observed shape: 2 of 3 planned files written, the third missing."""
+    skins = tmp_path / "src" / "boostgauge" / "skins"
+    skins.mkdir(parents=True)
+    (skins / "stingray.py").write_text(
+        "def render_face(size):\n    return None\n", encoding="utf-8"
+    )
+    visual = tmp_path / "tests" / "visual"
+    visual.mkdir(parents=True)
+    (visual / "conftest.py").write_text("import pytest\n", encoding="utf-8")
+    # tests/visual/test_stingray.py deliberately ABSENT — attempt 1's final
+    # LLM call errored before writing it.
+    tests = tmp_path / "tests"
+    (tests / "test_issue_331.py").write_text(
+        "def test_placeholder():\n    assert True\n", encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _state(worktree: Path, **overrides: object) -> dict:
+    state = {
+        "repo_root": str(worktree),
+        "issue_number": 331,
+        "audit_dir": str(worktree),
+        "file_counter": 1,
+        "test_files": [str(worktree / "tests" / "test_issue_331.py")],
+        "files_to_modify": [
+            {"path": "src/boostgauge/skins/stingray.py"},
+            {"path": "tests/visual/conftest.py"},
+            {"path": "tests/visual/test_stingray.py"},
+        ],
+        "retry_mode": "REGENERATED",
+        "iteration_count": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+def _pytest_result(passed: int, failed: int = 0) -> dict:
+    return {
+        "returncode": 1 if failed else 0,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": failed, "errors": 0,
+                   "coverage": 0},
+    }
+
+
+class TestTheObservedCase:
+    """The acceptance's equivalent fixture: attempt 2 against the run's own
+    partial implementation resumes against 5 failing tests — never
+    re-demands red."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_attempt_two_resumes_the_loop_against_the_failure_set(
+        self, mock_pytest, worktree: Path,
+    ) -> None:
+        mock_pytest.return_value = _pytest_result(passed=8, failed=5)
+
+        result = verify_red_phase(_state(worktree))
+
+        assert result["next_node"] == "N5_verify_green"
+        assert result["error_message"] == ""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_message_carries_the_current_failure_count(
+        self, mock_pytest, worktree: Path, capsys,
+    ) -> None:
+        """Ask 4: the 5 named failures are the work; the resume names them
+        rather than discarding them for a ceremony re-check."""
+        mock_pytest.return_value = _pytest_result(passed=8, failed=5)
+
+        verify_red_phase(_state(worktree))
+        printed = capsys.readouterr().out
+        assert "5 current failure(s)" in printed
+        assert "resuming the implement-iterate loop" in printed.lower()
+
+    def test_partial_writes_are_this_runs_own_work(self, worktree: Path) -> None:
+        """2 of 3 planned files present + a later attempt = the run's own
+        surviving implementation, per the run log's file-write record."""
+        assert _implementation_already_exists(_state(worktree)) is True
+
+
+class TestTheMarker:
+    def test_a_valid_red_writes_the_stage_entry_marker(
+        self, worktree: Path,
+    ) -> None:
+        with patch(
+            "assemblyzero.workflows.testing.nodes.verify_phases.run_pytest"
+        ) as mock_pytest:
+            mock_pytest.return_value = _pytest_result(passed=0, failed=13)
+            result = verify_red_phase(
+                _state(worktree, retry_mode="", iteration_count=0)
+            )
+        assert result["next_node"] == "N4_implement_code"
+        marker = json.loads(
+            (worktree / RED_MARKER_NAME).read_text(encoding="utf-8")
+        )
+        assert marker["failing"] == 13
+        assert marker["issue"] == 331
+
+    def test_the_marker_alone_recognises_a_later_attempt(
+        self, tmp_path: Path,
+    ) -> None:
+        """Even with every planned file cleared, the stage entry's verified
+        red says passing tests are the loop's state, not an anomaly."""
+        write_red_marker(
+            _state(tmp_path, files_to_modify=[]), failing=13, exit_code=2,
+        )
+        state = _state(tmp_path, files_to_modify=[])
+        assert _implementation_already_exists(state) is True
+
+    def test_a_first_attempt_never_consults_the_marker(
+        self, worktree: Path,
+    ) -> None:
+        """A stale marker cannot suppress a genuine entry's red demand: the
+        marker is only read on a later attempt."""
+        write_red_marker(_state(worktree), failing=13, exit_code=2)
+        state = _state(worktree, retry_mode="", iteration_count=0)
+        assert _implementation_already_exists(state) is False
+
+    def test_a_corrupt_marker_abstains(self, worktree: Path) -> None:
+        (worktree / RED_MARKER_NAME).write_text("{not json", encoding="utf-8")
+        assert read_red_marker(_state(worktree)) is None
+        # The file evidence still carries the later-attempt case.
+        assert _implementation_already_exists(_state(worktree)) is True
+
+
+class TestGenuinePreExistingStillHalts:
+    """The guard's founding case is preserved: implementation present at
+    STAGE ENTRY, with no marker and no prior-attempt writes, halts."""
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_first_attempt_green_at_red_halts_deterministically(
+        self, mock_pytest, worktree: Path,
+    ) -> None:
+        mock_pytest.return_value = _pytest_result(passed=8)
+
+        result = verify_red_phase(
+            _state(worktree, retry_mode="", iteration_count=0)
+        )
+
+        assert result["next_node"] == "END"
+        assert DETERMINISTIC_FAILURE in result["error_message"]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_halt_message_says_before_this_stage_entered(
+        self, mock_pytest, worktree: Path,
+    ) -> None:
+        """Ask 3: the anomaly halt and the loop-state resume are different
+        sentences."""
+        mock_pytest.return_value = _pytest_result(passed=8)
+
+        result = verify_red_phase(
+            _state(worktree, retry_mode="", iteration_count=0)
+        )
+
+        assert "before this stage entered" in result["error_message"]
+        assert "re-demand" not in result["error_message"]

--- a/tests/unit/test_red_phase_retry_semantics.py
+++ b/tests/unit/test_red_phase_retry_semantics.py
@@ -87,10 +87,17 @@ def test_a_resume_counts_as_a_later_attempt(worktree: Path) -> None:
     assert _implementation_already_exists(state) is True
 
 
-def test_partial_implementation_is_not_enough(worktree: Path) -> None:
-    """One of two files present is not a surviving implementation."""
+def test_partial_implementation_IS_enough_on_a_later_attempt(worktree: Path) -> None:
+    """LAW CHANGED BY #2542, deliberately. This used to assert that one of
+    two files present was "not a surviving implementation" — and
+    run-issue331-230544 refuted it live: attempt 1 wrote 2 of its 3 planned
+    files, died on the third's LLM call, and attempt 2 found 8 tests passing
+    that the all() predicate refused to attribute to the run's own work. In
+    the only branch that consults this (tests PASSING), a partial write that
+    leaves tests passing is this run's work; a cleared implementation cannot
+    reach the branch, because its tests fail on ImportError."""
     (worktree / "src" / "boostgauge" / "app.py").unlink()
-    assert _implementation_already_exists(_state(worktree)) is False
+    assert _implementation_already_exists(_state(worktree)) is True
 
 
 def test_no_declared_targets_is_not_enough(worktree: Path) -> None:


### PR DESCRIPTION
Closes #2542

## Verified against the preserved evidence — and the diagnosis sharpened

The run log settles the mechanism precisely. Attempt 2 DID carry the retry signal (`retry_mode: REGENERATED` threads into the sub-workflow), and the #2337 escape hatch was consulted — it refused because its predicate demands **all** planned files on disk, while attempt 1's final LLM call errored (74s, mid-`test_stingray.py`) after writing only 2 of its 3 planned files:

```
Written (batch): ...\tests\visual\conftest.py            ← written
Written:         ...\src\boostgauge\skins\stingray.py     ← written (the 8 passing tests)
[2/2] tests/visual/test_stingray.py ... Calling Claude... error (74s)   ← never written
```

So the passing tests were explained entirely by the run's own surviving implementation, and `all()` refused to attribute them. One pre-existing test pinned that predicate ("one of two files present is not a surviving implementation") — flipped with the live refutation in its docstring.

## The fix, per the asks

1. **Red is recorded at stage entry.** Every valid red outcome (the import-error red and the all-failed red) writes `red-verified.json` into the audit dir — which lives in the worktree, so the marker's scope is exactly the stage entry's worktree. Attempt restarts and resumes consult it (the marker is only ever READ on a later attempt — `retry_mode` set or `iteration_count > 0` — and a fresh first attempt overwrites it, so a stale marker can never suppress a genuine entry's red demand) and resume the implement-iterate loop against the current failure set via the green/coverage gate, exactly the #2337 route.
2. **The incoherent option is unreachable.** No clean-slate retry design exists today (`REGENERATED` rewrites files; it never pre-clears), and with the marker plus the corrected file-evidence predicate, red is never silently checked over the run's own output. If a future clean-slate mode appears, it must remove its own prior writes before re-checking — stated in the guard's comments.
3. **The messages distinguish the two cases.** The resume prints which evidence explains the passing tests (the marker with its stage-entry timestamp and then-failing count, or the run's own surviving writes) and that the loop resumes against the N current failures. The halt now says "the implementation existed BEFORE this stage entered — no red-entry marker and no prior-attempt writes explain the passing tests", never the old blame-shaped text.
4. **The real signal carries forward.** The resume path names the current failure count in its message, hands the live pytest output onward, and routes to the green gate whose iterate machinery works exactly that failing set — no ceremony re-check discards it.

The corrected predicate: `any()` planned .py present (was `all()`), consulted only on later attempts and only in the branch where tests PASS — a cleared implementation cannot reach that branch at all, because its tests fail on ImportError, so the #2337 docstring's "a retry whose files were cleared genuinely needs the red phase" caution still holds by construction. A corrupt marker abstains to the file evidence; a marker that cannot persist logs and costs only the skip (both fall-throughs carry their `# fail-open:` rulings).

## The related observation, verified read-only

`src/boostgauge/skins/__pycache__/` in the MAIN checkout holds `stingray.cpython-314.pyc` + `__init__.cpython-314.pyc`, both timestamped **2026-07-29 13:19** — a month before this campaign, from the retired July combined-renderer era. **Inert leftover, not a live write path**: the red/green invocations run `poetry run pytest` with cwd = the worktree, and each run provisions the worktree's own poetry environment (`[ENV] poetry install (target worktree)`), so `import boostgauge` resolves to the worktree's editable install — no cross-checkout resolution exists in the current code, and nothing in this campaign's runs touched those files. The directory is gitignored (`__pycache__/`) and invisible to status. Not deleted per the work order: removing `src/boostgauge/skins/__pycache__/` (and the then-empty `skins/`) from the main checkout is safe whenever the operator chooses.

Also noted read-only: the failed run's worktree (`data/worktrees/331`) no longer exists on disk (only an empty `data/worktrees/orphaned/` remains), so the acceptance runs on the equivalent fixture the work order allows — the exact 2-of-3-files, 8-passed/5-failed shape.

## Acceptance

- The equivalent fixture of the observed case: attempt 2 with `retry_mode` set, 8 passed / 5 failed, 2 of 3 planned files present → routes to the green gate with no error, message naming the 5 current failures (`TestTheObservedCase`, 3 tests).
- A genuinely pre-existing implementation at stage entry — no marker, no prior writes — still halts deterministically, with the before-this-stage-entered message (`TestGenuinePreExistingStillHalts`, 2 tests).
- Marker lifecycle: written on valid red with the failing count; alone sufficient on a later attempt; never consulted on a first attempt; corrupt → abstains to file evidence (`TestTheMarker`, 4 tests).

**What only a live roll proves:** the marker surviving a real orchestrator retry cycle end-to-end, the resumed green gate converging on the remaining failures with real LLM revisions, and `--resume-from impl` re-provisioning a worktree for the now-vanished `data/worktrees/331`. No roll was launched; boostgauge PR #367 untouched; the #331 state read, never written.

## Tests

- New `tests/unit/test_red_once_per_stage_entry.py` (9) — the shapes above.
- `test_red_phase_retry_semantics.py`: one #2337 pin flipped with the live refutation documented; its other 13 tests pass unmodified.
- 1188 tests across the red/green/testing-workflow suites pass; full unit suite reported below and in the merge-gate CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
