### PR TITLE
fix: zero collected tests is a named collection failure, and the validator sees what pytest will (Closes #2546, Closes #2547)

### DIFF
--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -196,6 +196,18 @@ def _build_recommendation(
     state: dict[str, Any] | None = None,
 ) -> str:
     """Generate human-readable advice based on error type."""
+    # #2546: a zero-collection halt names its own cause, whatever class the
+    # classifier assigned it — the one wrong reading is the old stagnation
+    # advice pointing at the LLD/spec, which run-issue331-235455 received
+    # while the actual defect was one line in a generated conftest.
+    if "collected 0 tests" in (error_message or ""):
+        return (
+            "Non-transient: pytest collected ZERO tests — the suite fails at "
+            "collection/conftest load, so no coverage or pass count means "
+            "anything. Fix the collection error named in the halt (typically "
+            "an import or a conftest defect in the generated files); the LLD "
+            "and spec are not implicated."
+        )
     if error_type == "capacity_exhausted":
         return (
             "Transient error: Gemini is overloaded (503/529). "

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -181,7 +181,19 @@ def generate_file_with_retry(
         # Build retry prompt if this isn't the first attempt
         if attempt > 0:
             prompt = build_retry_prompt(pruned_prompt or base_prompt, last_error, attempt_num)
-            print(f"        [RETRY {attempt_num}/{max_retries}] {last_error[:80]}...")
+            # #2547: causal wording. The old line printed the PREVIOUS
+            # attempt's error under the NEW attempt's number, so
+            # "[RETRY 2/2] Validation failed: ..." followed by silence read
+            # as an exhausted validator the pipeline ignored — a reading the
+            # #2546/#2547 investigation spent real time refuting. The line
+            # now says whose error it is and what happens next; the outcome
+            # is always printed too ([SUCCESS] on recovery, the
+            # ImplementationError halt on exhaustion — never a silent
+            # proceed).
+            print(
+                f"        [RETRY {attempt_num}/{max_retries}] attempt "
+                f"{attempt_num - 1} failed ({last_error[:80]}...) -- retrying"
+            )
             if attempt_num == 2:
                 emit("retry.strike_one", repo=str(audit_dir.parent.parent.parent.parent) if audit_dir else "", metadata={"filepath": filepath, "error": last_error[:200]})
 
@@ -641,10 +653,20 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
                     batch_failed_specs.append(spec)
                     continue
 
-                # Validate
-                valid, val_error = validate_code_response(code, fp)
+                # Validate. #2547: repo_root travels here too — the batch
+                # path used to omit it, which silently skipped import (and
+                # now conftest-option) validation for every batch-written
+                # file. run-issue331-235455's killing conftest was written
+                # exactly this way, validated for syntax alone.
+                valid, val_error = validate_code_response(
+                    code, fp, repo_root=str(repo_root),
+                )
                 if not valid:
-                    print(f"        [BATCH] Validation failed for {fp}: {val_error}")
+                    print(
+                        f"        [BATCH] Validation failed for {fp}: "
+                        f"{val_error} -- falling back to individual "
+                        f"generation with retries"
+                    )
                     batch_failed_specs.append(spec)
                     continue
 

--- a/assemblyzero/workflows/testing/nodes/implementation/parsers.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/parsers.py
@@ -102,8 +102,8 @@ def validate_code_response(
             return False, f"Python syntax error: {e}"
 
         # Issue #842: Validate imports resolve to real modules.
-        # Only run when repo_root is provided (skip for batch validation
-        # where repo_root isn't passed through).
+        # #2547: repo_root now travels through the batch path too, so this
+        # runs for every generated .py, not just the individual-retry path.
         if repo_root:
             from .import_validator import validate_imports
             from pathlib import Path
@@ -112,6 +112,116 @@ def validate_code_response(
             if not imports_ok:
                 return False, f"Unresolvable imports: {', '.join(bad_imports)}"
 
+            # #2547: a generated conftest must not re-register a pytest
+            # option an ancestor conftest already registers. This is the
+            # defect that killed run-issue331-235455: the generated
+            # tests/visual/conftest.py re-registered --generate-baselines
+            # (already in tests/conftest.py), pytest died at conftest load
+            # with "ValueError: option names ... already added", the green
+            # phase collected zero tests, and the run halted as a coverage
+            # mystery. Cross-file, mechanical, caught at write time.
+            options_ok, options_error = validate_conftest_options(
+                code, filepath, Path(repo_root)
+            )
+            if not options_ok:
+                return False, options_error
+
+    return True, ""
+
+
+def _addoption_flags(code: str) -> set[str]:
+    """String-literal option names registered via ``parser.addoption(...)``."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        # fail-open: syntax is the syntax check's finding, two lines above
+        # this check's call site — judging options in code that does not
+        # parse would double-report one defect. No flags means no verdict.
+        return set()
+    flags: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "addoption"
+        ):
+            for arg in node.args:
+                if (
+                    isinstance(arg, ast.Constant)
+                    and isinstance(arg.value, str)
+                    and arg.value.startswith("-")
+                ):
+                    flags.add(arg.value)
+    return flags
+
+
+def validate_conftest_options(
+    code: str, filepath: str, repo_root
+) -> tuple[bool, str]:
+    """A conftest may not re-register an ancestor conftest's option (#2547).
+
+    pytest loads every conftest on the path from rootdir to the test file and
+    registers their options into ONE parser; a duplicate raises ValueError at
+    load time and collection dies with zero tests. The check walks the
+    ancestor directories the same way pytest will, comparing string-literal
+    ``parser.addoption`` names.
+    """
+    from pathlib import Path
+
+    if Path(filepath).name != "conftest.py":
+        return True, ""
+    new_flags = _addoption_flags(code)
+    if not new_flags:
+        return True, ""
+
+    root = Path(repo_root).resolve()
+    current = ((root / filepath).parent.parent).resolve()
+    # A conftest at the repo root has no in-repo ancestors; never walk
+    # above the repo.
+    if current != root and root not in current.parents:
+        return True, ""
+    conflicts: list[str] = []
+    while True:
+        ancestor = current / "conftest.py"
+        if ancestor.is_file():
+            try:
+                ancestor_flags = _addoption_flags(
+                    ancestor.read_text(encoding="utf-8-sig")
+                )
+            except OSError:
+                # fail-open: an unreadable ancestor conftest cannot be
+                # compared — the check reports what it CAN see rather than
+                # failing the file on a filesystem hiccup, and pytest itself
+                # will name any duplicate this misses at collection time,
+                # which the green gate now surfaces (#2546).
+                ancestor_flags = set()
+            duplicated = sorted(new_flags & ancestor_flags)
+            if duplicated:
+                conflicts.append(
+                    f"{', '.join(duplicated)} already registered in "
+                    f"{ancestor.relative_to(root)}"
+                )
+        try:
+            at_root = current.resolve() == root
+        except OSError:
+            # fail-open: a directory that cannot resolve ends the ancestor
+            # walk early — the check reports what it already compared, and
+            # pytest itself names any duplicate this misses at collection
+            # time, which the green gate now surfaces (#2546).
+            at_root = True
+        if at_root or current.parent == current:
+            break
+        current = current.parent
+
+    if conflicts:
+        return False, (
+            "conftest re-registers pytest option(s) an ancestor conftest "
+            "already registers -- pytest dies at conftest load with "
+            "'ValueError: option names ... already added' and collects zero "
+            "tests: " + "; ".join(conflicts) + ". Drop the duplicate "
+            "registration; the ancestor's option is already available via "
+            "request.config.getoption()."
+        )
     return True, ""
 
 

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -477,6 +477,26 @@ def _pytest_env() -> dict[str, str]:
     return env
 
 
+def _summarize_collection_failure(output: str) -> str:
+    """The last exception line of a zero-collection run, for the halt (#2546).
+
+    A collection death prints a traceback and collects nothing; the final
+    ``SomethingError: ...`` line is the fact a repair needs (the live case:
+    ``ValueError: option names {'--generate-baselines'} already added``).
+    Purely mechanical; an output with no such line returns "" and the caller
+    says so rather than inventing one.
+    """
+    lines = [line.strip() for line in (output or "").splitlines() if line.strip()]
+    exception_lines = [
+        line for line in lines
+        if re.match(r"(?:E\s+)?[\w.]*(?:Error|Exception)\b\s*:", line)
+    ]
+    if exception_lines:
+        return exception_lines[-1][:300]
+    error_lines = [line for line in lines if "error" in line.lower()]
+    return error_lines[-1][:300] if error_lines else ""
+
+
 def run_pytest(
     test_files: list[str],
     coverage_module: str | None = None,
@@ -1672,6 +1692,85 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
     # Issue #501: Extract failed test names for identity-based stagnation
     current_green_failures = _extract_failed_test_names(output)
+
+    # --------------------------------------------------------------------------
+    # #2546: a zero needs a denominator. run-issue331-235455 collected ZERO
+    # tests (a generated conftest re-registered a parent conftest's option;
+    # pytest died at conftest load with exit 1), and this gate read the empty
+    # collection as "all 0 test(s) pass", diagnosed the 0% coverage as a test
+    # GAP, prescribed more tests for a suite that cannot load, and halted as
+    # coverage stagnation blaming the LLD and spec — which had just passed
+    # five rounds of review. Zero collected is a COLLECTION failure, never a
+    # pass and never a coverage problem: the first occurrence hands the
+    # implement-iterate loop a named repair task (#2547 — the defect lives
+    # in the run's own planned files), and a second occurrence halts with
+    # the collection error named, so the resume reads the true cause.
+    # --------------------------------------------------------------------------
+    total_collected = passed_count + failed_count + error_count
+    if total_collected == 0:
+        collection_error = _summarize_collection_failure(output)
+        strikes = int(state.get("zero_collected_strikes", 0) or 0) + 1
+        print(
+            "    [N5] pytest collected 0 tests -- collection is broken; "
+            "this is not a pass and not a coverage gap (#2546)"
+        )
+        if collection_error:
+            print(f"    [N5] collection error: {collection_error[:200]}")
+        log_workflow_execution(
+            target_repo=repo_root,
+            issue_number=state.get("issue_number", 0),
+            workflow_type="testing",
+            event="green_phase_zero_collected",
+            details={"strikes": strikes, "exit_code": exit_code,
+                     "collection_error": collection_error[:300]},
+        )
+        if strikes >= 2:
+            error_msg = (
+                f"Green phase failed: pytest collected 0 tests on "
+                f"{strikes} iterations -- collection is broken, not a "
+                f"coverage problem. Collection error: "
+                f"{collection_error or '(no exception line captured; see green_phase_output)'}. "
+                f"The generated test/conftest files need repair; the LLD and "
+                f"spec are not implicated (#2546)."
+            )
+            return {
+                "green_phase_output": output,
+                "coverage_achieved": 0,
+                "previous_coverage": 0,
+                "previous_passed": 0,
+                "previous_green_failures": [],
+                "test_failure_summary": collection_error,
+                "zero_collected_strikes": strikes,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "iteration_count": iteration_count + 1,
+                "next_node": "end",
+                "error_message": error_msg,
+            }
+        print(
+            "    [N5] routing the collection failure to the implement-iterate "
+            "loop as a named repair task (the defect is in this run's own "
+            "planned files)"
+        )
+        return {
+            "green_phase_output": output,
+            "coverage_achieved": 0,
+            "previous_coverage": 0,
+            "previous_passed": 0,
+            "previous_green_failures": [],
+            "test_failure_summary": (
+                f"pytest collected 0 tests -- collection is broken, and no "
+                f"test can run until it is repaired. Collection error: "
+                f"{collection_error or '(see output)'}. Fix the named defect "
+                f"in the planned files; do not add tests."
+            ),
+            "zero_collected_strikes": strikes,
+            "file_counter": file_num,
+            "pytest_exit_code": exit_code,
+            "iteration_count": iteration_count + 1,
+            "next_node": "N4_implement_code",
+            "error_message": "",
+        }
 
     # Check for failures
     if failed_count > 0 or error_count > 0:

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -207,6 +207,11 @@ class TestingWorkflowState(TypedDict, total=False):
     # when True, N4 must not rewrite test files; they are the frozen contract.
     identity_plateau_strikes: int
     freeze_tests: bool
+    # #2546: green-phase iterations where pytest collected ZERO tests. A zero
+    # needs a denominator: one zero-collection routes to the implement loop
+    # as a named collection-repair task; a second halts naming the collection
+    # error, never "coverage stagnant". MUST stay declared (#2018).
+    zero_collected_strikes: int
     test_failure_summary: str  # Issue #498: Structured test failure feedback for N4
     e2e_failure_summary: str  # Issue #498: Structured E2E failure feedback for N4
     full_suite_validated: bool  # Issue #842: True after full test suite passes regression check

--- a/tests/unit/test_zero_needs_denominator.py
+++ b/tests/unit/test_zero_needs_denominator.py
@@ -1,0 +1,231 @@
+"""A zero needs a denominator, and the validator sees what pytest will (#2546/#2547).
+
+boostgauge run-issue331-235455, the first run ever to reach the green phase:
+a batch-written tests/visual/conftest.py re-registered --generate-baselines
+(already registered by tests/conftest.py), pytest died at conftest load with
+``ValueError: option names {'--generate-baselines'} already added`` and exit
+code 1, the green gate read "0 passed, 0 failed" as ALL PASSING, diagnosed
+the 0% coverage as a test gap, added tests to a suite that cannot load, and
+halted as "Coverage stagnant: 0.0% -> 0.0%" blaming the LLD and spec.
+
+Verified against the preserved post-impl checkpoint (boostgauge e819825,
+reproduced read-only: the duplicate registration kills collection with 13
+collectable tests behind it; removing it collects all 13, so the missing
+skins/__init__.py is benign). Also refuted while verifying: the validator did
+NOT proceed past exhausted retries — attempt 2 validated and the log printed
+[SUCCESS]; the killing conftest was batch-written, and the batch path omitted
+repo_root, silently skipping every validation beyond syntax.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from assemblyzero.core.recovery_plan import _build_recommendation
+from assemblyzero.workflows.testing.nodes.implementation.parsers import (
+    validate_code_response,
+    validate_conftest_options,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _summarize_collection_failure,
+    verify_green_phase,
+)
+
+#: The live collection death, distilled: pytest's stderr tail.
+COLLECTION_OUTPUT = """\
+Traceback (most recent call last):
+  File "conftest.py", line 6, in pytest_addoption
+    parser.addoption(
+  File "argparsing.py", line 429, in addoption
+    raise ValueError(f"option names {conflict} already added")
+ValueError: option names {'--generate-baselines'} already added
+"""
+
+
+def _pytest_result(passed: int, failed: int, output: str = "") -> dict:
+    return {
+        "returncode": 1,
+        "stdout": output,
+        "stderr": "",
+        "parsed": {"passed": passed, "failed": failed, "errors": 0,
+                   "coverage": 0.0},
+    }
+
+
+def _state(tmp_path: Path, **overrides: object) -> dict:
+    state = {
+        "repo_root": str(tmp_path),
+        "issue_number": 331,
+        "audit_dir": "",
+        "test_files": [],
+        "implementation_files": [],
+        "files_to_modify": [],
+        "coverage_target": 95,
+        "iteration_count": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+class TestZeroCollectedIsNeverAPass:
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_first_zero_routes_to_the_loop_as_a_named_repair(
+        self, mock_pytest, tmp_path: Path, capsys,
+    ) -> None:
+        mock_pytest.return_value = _pytest_result(0, 0, COLLECTION_OUTPUT)
+
+        result = verify_green_phase(_state(tmp_path))
+        printed = capsys.readouterr().out
+
+        assert result["next_node"] == "N4_implement_code"
+        assert result["zero_collected_strikes"] == 1
+        assert "collected 0 tests" in result["test_failure_summary"]
+        assert "--generate-baselines" in result["test_failure_summary"], (
+            "the collection error travels as the repair task"
+        )
+        assert "collection is broken" in printed
+        assert "test gap" not in printed, (
+            "zero collected must never read as a coverage/test gap"
+        )
+        assert "all 0 test(s) pass" not in printed
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_second_zero_halts_naming_the_collection_error(
+        self, mock_pytest, tmp_path: Path, capsys,
+    ) -> None:
+        mock_pytest.return_value = _pytest_result(0, 0, COLLECTION_OUTPUT)
+
+        result = verify_green_phase(
+            _state(tmp_path, zero_collected_strikes=1, iteration_count=1)
+        )
+        capsys.readouterr()
+
+        assert result["next_node"] == "end"
+        assert "collected 0 tests" in result["error_message"]
+        assert "ValueError" in result["error_message"]
+        assert "not implicated" in result["error_message"], (
+            "the halt must exonerate the LLD and spec by name"
+        )
+        assert "Coverage stagnant" not in result["error_message"]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_a_nonzero_denominator_keeps_the_ordinary_paths(
+        self, mock_pytest, tmp_path: Path, capsys,
+    ) -> None:
+        mock_pytest.return_value = _pytest_result(8, 5, "8 passed, 5 failed")
+
+        result = verify_green_phase(_state(tmp_path))
+        printed = capsys.readouterr().out
+
+        assert result["next_node"] == "N4_implement_code"
+        assert "collection is broken" not in printed
+
+    def test_the_recovery_advice_names_collection_not_the_lld(self) -> None:
+        advice = _build_recommendation(
+            "stagnation",
+            "Green phase failed: pytest collected 0 tests on 2 iterations -- "
+            "collection is broken ...",
+            "testing",
+        )
+        assert "ZERO tests" in advice
+        assert "not implicated" in advice
+        assert "LLD or spec likely needs manual editing" not in advice
+
+    def test_ordinary_stagnation_advice_is_unchanged(self) -> None:
+        advice = _build_recommendation(
+            "stagnation",
+            "Coverage stagnant: 42.0% -> 42.5% (< 1% improvement).",
+            "testing",
+        )
+        assert "manual editing" in advice or "GENERATED TEST FILE" in advice
+
+
+class TestCollectionFailureSummary:
+    def test_the_live_valueerror_is_extracted(self) -> None:
+        summary = _summarize_collection_failure(COLLECTION_OUTPUT)
+        assert summary.startswith("ValueError:")
+        assert "--generate-baselines" in summary
+
+    def test_no_exception_line_returns_empty_not_invented(self) -> None:
+        assert _summarize_collection_failure("nothing ran\n") == ""
+
+
+PARENT_CONFTEST = """\
+def pytest_addoption(parser):
+    parser.addoption("--generate-baselines", action="store_true")
+"""
+
+CHILD_CONFTEST = """\
+def pytest_addoption(parser):
+    parser.addoption("--generate-baselines", action="store_true",
+                     help="Generate baseline images for visual tests")
+"""
+
+
+class TestConftestOptionValidation:
+    """#2547: the write-time check for the exact defect that killed the run."""
+
+    def _repo(self, tmp_path: Path) -> Path:
+        (tmp_path / "tests" / "visual").mkdir(parents=True)
+        (tmp_path / "tests" / "conftest.py").write_text(
+            PARENT_CONFTEST, encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_the_killing_conftest_is_rejected_with_the_finding_named(
+        self, tmp_path: Path,
+    ) -> None:
+        repo = self._repo(tmp_path)
+        ok, error = validate_conftest_options(
+            CHILD_CONFTEST, "tests/visual/conftest.py", repo
+        )
+        assert ok is False
+        assert "--generate-baselines" in error
+        assert "tests" in error  # names the ancestor carrying it
+        assert "zero tests" in error or "collects zero" in error
+
+    def test_it_reaches_the_shared_validator_when_repo_root_travels(
+        self, tmp_path: Path,
+    ) -> None:
+        """The batch path now passes repo_root (#2547), so the batch-written
+        conftest that killed the run gets exactly this rejection."""
+        repo = self._repo(tmp_path)
+        ok, error = validate_code_response(
+            CHILD_CONFTEST, "tests/visual/conftest.py", "",
+            repo_root=str(repo),
+        )
+        assert ok is False
+        assert "already registers" in error
+
+    def test_a_fresh_flag_passes(self, tmp_path: Path) -> None:
+        repo = self._repo(tmp_path)
+        ok, error = validate_conftest_options(
+            "def pytest_addoption(parser):\n"
+            "    parser.addoption('--fresh-flag', action='store_true')\n",
+            "tests/visual/conftest.py", repo,
+        )
+        assert ok is True, error
+
+    def test_a_non_conftest_file_is_untouched(self, tmp_path: Path) -> None:
+        repo = self._repo(tmp_path)
+        ok, _ = validate_conftest_options(
+            CHILD_CONFTEST, "tests/visual/test_x.py", repo
+        )
+        assert ok is True
+
+    def test_a_root_level_conftest_has_no_in_repo_ancestors(
+        self, tmp_path: Path,
+    ) -> None:
+        ok, _ = validate_conftest_options(
+            PARENT_CONFTEST, "conftest.py", tmp_path
+        )
+        assert ok is True
+
+    def test_unparseable_new_code_abstains_here(self, tmp_path: Path) -> None:
+        """Syntax is the syntax check's finding; this check judges options."""
+        repo = self._repo(tmp_path)
+        ok, _ = validate_conftest_options(
+            "def broken(:", "tests/visual/conftest.py", repo
+        )
+        assert ok is True


### PR DESCRIPTION
Closes #2546, Closes #2547

Two halves of one death, and the seam is genuinely shared: the validator decides what reaches the green gate, the green gate decides what a zero means, and the observed case exercises both. One PR per the work order's allowance.

## Verified against the preserved state — both root-cause candidates settled, one framing refuted

The killing state is preserved as boostgauge's post-impl checkpoint commit `e819825` (23:56:45, the second N5 started). Reproduced read-only from its exact three files:

- **The killer is a cross-file conftest defect, not an import**: the batch-written `tests/visual/conftest.py` re-registers `--generate-baselines`, which the pre-existing `tests/conftest.py` already registers. pytest loads both into one parser and dies at conftest load — `ValueError: option names {'--generate-baselines'} already added` — with **exit code 1** (reproduced), which is exactly why the green gate's describer read it as "coverage below fail-under; all tests passed".
- **The missing `skins/__init__.py` is benign** (candidate settled): with the duplicate-registering conftest removed, all **13 tests collect**, module-level `from boostgauge.skins.stingray import …` included — the namespace subpackage resolves under the regular `boostgauge` parent.
- **#2547's "proceeded past exhausted retries" is refuted**: retries were NOT exhausted. `[RETRY 2/2]` prints the PREVIOUS attempt's error at the next attempt's start; attempt 2 validated, the log printed `[SUCCESS] Retry 2 succeeded`, and the exhausted-retry path already raises `ImplementationError` naming file and finding — no silent proceed exists on that path. The REAL fail-open was one call site over: **the batch path called `validate_code_response(code, fp)` without `repo_root`, silently skipping every validation beyond syntax for batch-written files** — and the killing conftest was batch-written.

## The green gate (#2546)

- **A zero needs a denominator.** `passed + failed + errors == 0` is now a hard, named event before any interpretation: never "all 0 test(s) pass", never a test gap, never a route to N4c test additions. The collection error is extracted from the output (`_summarize_collection_failure` — the last `SomethingError:` line; the live ValueError in the fixture) and surfaced.
- **First zero → the implement-iterate loop as a named repair task** (the #2547 ask: the defect lives in the run's own planned files, and N4 can fix them); **second zero → halt** naming the collection error and stating plainly that the generated files need repair and "the LLD and spec are not implicated". The old path — "Coverage stagnant: 0.0% → 0.0%" — is unreachable for empty collections.
- **The recovery advice matches**: a "collected 0 tests" halt gets collection advice whatever class the classifier assigned; the old "LLD or spec likely needs manual editing" misdirection cannot attach to it. Ordinary stagnation advice unchanged.

## The validator (#2547)

- **`repo_root` travels through the batch path**, so batch-written files get the same import (and now conftest-option) validation as individually-generated ones, with the batch fallback message saying what happens next.
- **New mechanical check, the exact killer at write time**: a generated `conftest.py` may not re-register a pytest option an ancestor conftest already registers (`validate_conftest_options` — AST-extracted `parser.addoption` string literals, ancestor walk bounded to the repo). Rejection names the flag, the ancestor file, and the consequence; the retry loop then makes the drafter fix it, or exhausts into the existing named `ImplementationError` halt.
- **The retry line reads causally**: `[RETRY 2/2] attempt 1 failed (…) -- retrying`, so "Validation failed" followed by silence can no longer read as an ignored exhaustion; the outcome is always printed (`[SUCCESS]` or the halt).
- Declared fall-throughs per the #2475 regime: an unreadable ancestor conftest abstains (pytest itself names any duplicate this misses, and the green gate now surfaces it — the finding-travels-forward correlation the issue asked for), and unparseable new code abstains here because syntax is the syntax check's finding.

## Acceptance

- The observed case as fixture: empty collection with the live ValueError output → first pass routes to N4 with the error as the repair task, second pass halts naming it; both assert the test-gap/stagnation readings are gone (`TestZeroCollectedIsNeverAPass`).
- The killing conftest as fixture: rejected at write time with the flag, the ancestor, and the zero-collection consequence named, through both `validate_conftest_options` and the shared `validate_code_response` with `repo_root` (`TestConftestOptionValidation`).
- A resumed impl stage for #331 now meets the import/conftest defect as an actionable named repair — at write time if regenerating, at the green gate if not — instead of a coverage mystery.

**What only a live roll proves:** the N4 loop actually repairing the conftest from the routed feedback with real LLM revisions, and the two-strike halt in a live detached run. No roll launched; boostgauge PR #367 untouched; the #331 state read, never written (the repro ran from extracted copies in AZ scratch; collect-only, `-p no:cacheprovider`).

## Tests

- New `tests/unit/test_zero_needs_denominator.py` (13): the shapes above plus `_summarize_collection_failure` extraction/abstention, recovery-advice routing, root-level-conftest and non-conftest boundaries.
- 1770 tests across the green/red/implement/parsers/recovery suites pass unmodified; full unit suite reported below and in the merge-gate CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
