### PR TITLE
fix: a completeness failure's line citation is pinning vocabulary, and the cap halt consults the pinning record before blaming the drafter (Closes #2555, Closes #2556)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -529,15 +529,22 @@ def _apply_pinning(
     When the current verdict names nothing extractable, pinning abstains
     entirely — locking the whole document on an unparseable naming would
     refuse every legitimate fix, and unknown is not guilty (#2526).
+
+    Line-range citations from the current completeness failures count as
+    naming (#2555): "lines 81-83" addresses ``previous`` exactly — the
+    checks measured that document — so the span a failure demands a change
+    in is named content, never a lock refusal, never the regression class.
     """
     from assemblyzero.workflows.implementation_spec.revision_pinning import (
         enforce_pinning,
+        named_line_ranges,
         named_tokens,
         unlock_requested,
     )
 
     current = named_tokens(review_feedback, completeness_issues)
-    if not current:
+    ranges = named_line_ranges(completeness_issues)
+    if not current and not ranges:
         note = (
             "[PINNING] the verdict names nothing extractable — pinning not "
             "applied this round (#2532)"
@@ -555,6 +562,7 @@ def _apply_pinning(
         previous, revised,
         current_tokens=current,
         ever_tokens=ever,
+        current_ranges=ranges,
         unlock_reason=unlock_requested(response),
     )
 

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -358,25 +358,45 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                 # every failing check HAS been tried, that is the true reading.
                 tried = sorted(set(failing_names) & set(shown + grace_used))
                 # #2526: within "tried", the drafter FAILING to fix a check and
-                # the drafter DECLINING to change the code are different facts,
+                # the drafter leaving the code untouched are different facts,
                 # and the halt says which. When a check's complaint is
-                # byte-identical across every prior revision, the flagged code
-                # survived every round unchanged — the drafter was shown it
-                # repeatedly and repeatedly chose not to break working code,
-                # which is itself evidence of a false positive in the check.
-                # str.isupper died exactly this way: three identical
-                # complaints, three identical declines, one dead run.
+                # byte-identical across every prior revision, the flagged
+                # content reached the check unchanged every round — evidence
+                # of a false positive in the check. str.isupper died exactly
+                # this way: three identical complaints, one dead run.
+                #
+                # #2556: that inference is only sound when the drafter's
+                # output actually SURVIVED to the next check. Pinning
+                # enforcement (#2532) broke the assumption the day after the
+                # wording landed: a reverted revision re-presents the
+                # previous bytes, indistinguishable — from the complaint
+                # stream alone — from a drafter that changed nothing.
+                # run-issue331-092913 halted claiming "the drafter ... left
+                # the flagged code unchanged each time" with six [PINNING]
+                # refusal lines in the same log; the drafter had made the
+                # mandated fix every round and enforcement restored it. So:
+                # an identical complaint reads as drafter-left-unchanged
+                # ONLY when no pinning reversion happened in this run's
+                # revisions; with reversions on the record, enforcement is
+                # named and the drafter is not accused. Never attribute an
+                # artifact to an actor without proof.
                 prior_iters = prior_breakdown[:-1]
                 details_by_name = {
                     c["check_name"]: c["details"] for c in checks if not c["passed"]
                 }
-                declined = [
+                identical = [
                     name for name in tried
                     if prior_iters and all(
                         details_by_name[name] in entry["failures"]
                         for entry in prior_iters
                     )
                 ]
+                reversions = [
+                    event for event in state.get("pinning_events", [])
+                    if "[PINNING] refused:" in event
+                ]
+                declined = [] if reversions else identical
+                reverted = identical if reversions else []
                 # #2539: the third class. A complaint whose NUMBERS moved
                 # under revision while its verdict never did means the
                 # drafter complied with the instruction and the check's
@@ -393,7 +413,7 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
 
                 complied = [
                     name for name in tried
-                    if name not in declined and prior_iters and all(
+                    if name not in identical and prior_iters and all(
                         any(
                             _shape(details_by_name[name]) == _shape(failure)
                             for failure in entry["failures"]
@@ -403,7 +423,7 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                 ]
                 kept_failing = [
                     name for name in tried
-                    if name not in declined and name not in complied
+                    if name not in identical and name not in complied
                 ]
                 detail = ""
                 if kept_failing:
@@ -414,11 +434,27 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                 if declined:
                     detail += (
                         f" NOTE: {', '.join(declined)} drew the IDENTICAL "
-                        f"complaint on every revision — the drafter saw it "
-                        f"{len(prior_iters)} time(s) and left the flagged code "
-                        f"unchanged each time. A drafter declining to change "
-                        f"code it believes correct is evidence of a false "
-                        f"positive in the check, not of an unfixable spec."
+                        f"complaint on every revision — the drafter was shown "
+                        f"it {len(prior_iters)} time(s), no pinning reversion "
+                        f"intervened, and the flagged content reached the "
+                        f"check unchanged each time. Flagged content "
+                        f"surviving every revision untouched is evidence of "
+                        f"a false positive in the check, not of an unfixable "
+                        f"spec."
+                    )
+                if reverted:
+                    detail += (
+                        f" NOTE: {', '.join(reverted)} drew the IDENTICAL "
+                        f"complaint on every revision while pinning "
+                        f"enforcement reverted revision content in this "
+                        f"run ({len(reversions)} refusal(s), e.g. "
+                        f"{reversions[0]}). A reverted revision re-presents "
+                        f"the previous bytes to the check, so the recurrence "
+                        f"cannot be read as the drafter leaving the flagged "
+                        f"content unchanged — the complaint and the pinning "
+                        f"vocabulary are deadlocked (#2555): the check's "
+                        f"complaint must name its target in terms pinning "
+                        f"reads, or the named span must be unlocked."
                     )
                 if complied:
                     detail += (
@@ -2326,6 +2362,22 @@ def check_api_symbols_exist(
     # first-class defect in an implementation spec, and it is reported before
     # anything else. It used to be scraped with regex and mentioned in a
     # footnote, which fed this very check a confident, wrong call list.
+    #
+    # #2556: it reports under its OWN name. When this precondition failure
+    # shared check_name with the symbol check, the run-issue331-092913 cap
+    # halt sent the operator cross-checking api_symbols_exist against
+    # per-iteration hallucination-check artifacts that all said passed —
+    # the artifacts belong to the symbol half, which never ran.
+    #
+    # #2555: the "lines N-M" citation is load-bearing beyond legibility —
+    # it is the address revision pinning reads (named_line_ranges), so the
+    # span this failure demands a change in is named content a revision may
+    # edit. The advice clause deliberately writes its tag examples WITHOUT
+    # backticks: "(```text, ```json, ```bash)" fed named_tokens the garbage
+    # spans between the fence runs ("text,", "json,"), which defeated
+    # pinning's names-nothing-extractable abstention while naming zero
+    # draft lines — the exact deadlock that produced four byte-identical
+    # drafts on run-issue331-092913.
     if scan.failures:
         listed = "; ".join(
             f"lines {f.start_line}-{f.end_line} (```{f.tag}) — {f.error}"
@@ -2337,13 +2389,13 @@ def check_api_symbols_exist(
             else ""
         )
         return CompletenessCheck(
-            check_name="api_symbols_exist",
+            check_name="python_fences_parse",
             passed=False,
             details=(
                 f"{len(scan.failures)} code fence(s) tagged as Python do not "
-                f"parse as Python: {listed}{suffix}. Fix the snippet, or tag "
-                f"the fence with the language it actually contains (```text, "
-                f"```json, ```bash) if it was never meant to be Python."
+                f"parse as Python: {listed}{suffix}. Fix the snippet, or "
+                f"retag the fence with the language it actually contains "
+                f"(text, json, bash) if it was never meant to be Python."
             ),
         )
 

--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -11,8 +11,9 @@ This module makes that impossible mechanically:
 
 * **Named** content is what the current verdict (and the current completeness
   failures) actually point at — test names, backticked spans, quoted phrases,
-  manifest row ids — attributed to the draft's natural blocks (a test
-  function, a markdown section).
+  manifest row ids, and line-range citations (``lines 81-83``, #2555) —
+  attributed to the draft's natural blocks (a test function, a markdown
+  section).
 * **Locked** content is everything else in the reviewed draft: a completed
   round passed it without objection. A revision that touches locked text is
   refused mechanically — the locked span carries forward byte-verbatim from
@@ -55,6 +56,40 @@ def named_tokens(feedback: str, completeness_issues: list[str] | None = None) ->
     for pattern in (_TEST_NAME_RE, _ROW_ID_RE, _SECTION_RE):
         tokens.update(m.group(0).strip() for m in pattern.finditer(text))
     return {t.lower() for t in tokens if len(t.strip()) >= 3}
+
+
+#: Line-range citations like "lines 81-83" (#2555). The DASH IS REQUIRED:
+#: a completeness check cites a span deliberately, while bare "line 1"
+#: occurs inside quoted error text constantly — the observed fence complaint
+#: itself carries "SyntaxError: invalid decimal literal (<unknown>, line 1)",
+#: where the 1 is a position inside the snippet, not a draft address.
+#: Parsing that would unlock the block holding draft line 1 on every fence
+#: complaint. A dashed range in a mechanical check's message is a draft
+#: address by construction; a bare line number is anybody's.
+_LINE_RANGE_RE = re.compile(r"\blines?\s+(\d+)\s*[-–]\s*(\d+)\b", re.IGNORECASE)
+
+
+def named_line_ranges(completeness_issues: list[str] | None) -> tuple[tuple[int, int], ...]:
+    """1-based inclusive (start, end) ranges the completeness failures cite.
+
+    Completeness checks measure the draft the revision is diffed against, so
+    their line numbers address that exact document (#2555 — the fence-parse
+    complaint "lines 81-83 (```python)" named the one span the drafter had
+    to change, in an addressing scheme no token pattern could read, and
+    pinning reverted the mandated retag three rounds running).
+
+    Deliberately NOT parsed from free-form reviewer feedback: a reviewer
+    citing "lines 40-60" may mean a repo file or the LLD, and a wrong match
+    would silently unlock an unrelated draft block. Mechanical checks own
+    their citation convention; prose does not.
+    """
+    ranges: list[tuple[int, int]] = []
+    for issue in completeness_issues or []:
+        for match in _LINE_RANGE_RE.finditer(str(issue)):
+            start, end = int(match.group(1)), int(match.group(2))
+            if 1 <= start <= end:
+                ranges.append((start, end))
+    return tuple(ranges)
 
 
 # ---------------------------------------------------------------------------
@@ -111,23 +146,34 @@ def _blocks(draft: str) -> list[_Block]:
     return blocks
 
 
-def named_line_flags(draft: str, tokens: set[str]) -> list[bool]:
-    """Per-line: is this line inside a block the tokens name?
+def named_line_flags(
+    draft: str,
+    tokens: set[str],
+    ranges: tuple[tuple[int, int], ...] = (),
+) -> list[bool]:
+    """Per-line: is this line inside a block the tokens or ranges name?
 
-    A block is named when its own name matches a token, or when any token
-    appears anywhere in its text — the generous direction, because a
-    wrongly-locked legitimate fix costs a round while a wrongly-freed line
-    costs only what the old behaviour always risked.
+    A block is named when its own name matches a token, when any token
+    appears anywhere in its text, or when any cited 1-based line range
+    overlaps it (#2555) — the generous direction, because a wrongly-locked
+    legitimate fix costs a round while a wrongly-freed line costs only what
+    the old behaviour always risked. A range names its whole enclosing
+    block for the same reason a token does: restructuring AROUND a named
+    item is the named item's business.
     """
     lines = draft.splitlines()
     flags = [False] * len(lines)
-    if not tokens:
+    if not tokens and not ranges:
         return flags
     for block in _blocks(draft):
         block_lower = block.text.lower()
         name_lower = block.name.lower()
         named = any(
             token in name_lower or token in block_lower for token in tokens
+        ) or any(
+            # 1-based inclusive (start, end) vs 0-based [block.start, block.end)
+            start - 1 < block.end and block.start < end
+            for start, end in ranges
         )
         if named:
             for index in range(block.start, block.end):
@@ -171,6 +217,7 @@ def enforce_pinning(
     *,
     current_tokens: set[str],
     ever_tokens: set[str] | None = None,
+    current_ranges: tuple[tuple[int, int], ...] = (),
     unlock_reason: str = "",
 ) -> PinningResult:
     """Carry every unnamed span of ``previous`` forward byte-verbatim.
@@ -181,9 +228,21 @@ def enforce_pinning(
     through — restructuring AROUND a named item is the named item's business.
     Insertions pass through: adding is not un-fixing.
 
+    ``current_ranges`` (#2555) are the 1-based line spans the CURRENT
+    completeness failures cite against ``previous``; they name lines exactly
+    as tokens do, and they feed BOTH flag sets — a change a completeness
+    failure explicitly demands is never a lock refusal and never the
+    regression class. That is the invariant this parameter exists for: the
+    fence-parse gate demanded a one-line retag by line number, no token
+    pattern could read the address, and pinning reverted the mandated fix
+    into byte-identical drafts three rounds running (run-issue331-092913).
+
     ``ever_tokens`` (the union across the whole verdict history) drives the
     regression events; they are computed from the REVISION AS SUBMITTED, so
-    the flag fires even when enforcement then restores the text.
+    the flag fires even when enforcement then restores the text. Prior
+    rounds' line ranges are deliberately NOT carried into it: line numbers
+    address the one document the check measured, and drafts shift under
+    revision.
 
     With ``unlock_reason`` the restoration is skipped entirely — the drafter
     asked to restructure and the caller logs it — but the regression events
@@ -191,9 +250,9 @@ def enforce_pinning(
     """
     prev_lines = previous.splitlines()
     rev_lines = revised.splitlines()
-    current_flags = named_line_flags(previous, current_tokens)
+    current_flags = named_line_flags(previous, current_tokens, current_ranges)
     ever_flags = (
-        named_line_flags(previous, ever_tokens)
+        named_line_flags(previous, ever_tokens, current_ranges)
         if ever_tokens is not None else current_flags
     )
 

--- a/tests/unit/test_builtin_methods_and_opaque_receivers.py
+++ b/tests/unit/test_builtin_methods_and_opaque_receivers.py
@@ -178,8 +178,11 @@ class TestTheDeliberateBoundaryHolds:
 
 
 class TestTheHaltSaysWhoDeclined:
-    """Ask 3: 'kept failing to fix X' and 'declined to change X' are
-    different facts, and the halt message states which one happened."""
+    """Ask 3: 'kept failing to fix X' and 'the flagged content reached the
+    check unchanged' are different facts, and the halt message states which
+    one happened. (#2556 sharpened the claim: it holds only when no pinning
+    reversion intervened — those cases live in
+    test_completeness_pinning_deadlock.py.)"""
 
     def _state(self, iteration=3, shown=(), breakdown=()):
         return {
@@ -209,7 +212,7 @@ class TestTheHaltSaysWhoDeclined:
                 breakdown=make_breakdown(first["completeness_issues"]),
             ))
 
-    def test_an_identical_complaint_every_round_reads_as_a_decline(self, capsys):
+    def test_an_identical_complaint_with_no_reversions_reads_as_unchanged(self, capsys):
         out = self._at_cap(
             "Spec calls methods not found: `isupper`",
             # Every failing check drew this exact complaint on every prior
@@ -220,8 +223,14 @@ class TestTheHaltSaysWhoDeclined:
         )
         capsys.readouterr()
         assert "IDENTICAL complaint" in out["error_message"]
-        assert "left the flagged code unchanged" in out["error_message"]
+        # #2556: observable facts only — no intent attribution ("declining",
+        # "believes correct"), and the claim is conditioned on enforcement
+        # having stayed out of the loop.
+        assert "reached the check unchanged" in out["error_message"]
+        assert "no pinning reversion intervened" in out["error_message"]
         assert "false positive" in out["error_message"]
+        assert "declining" not in out["error_message"]
+        assert "believes correct" not in out["error_message"]
         assert "survived a revision" not in out["error_message"]
 
     def test_a_changing_complaint_reads_as_kept_failing(self, capsys):

--- a/tests/unit/test_completeness_pinning_deadlock.py
+++ b/tests/unit/test_completeness_pinning_deadlock.py
@@ -1,0 +1,320 @@
+"""The observed completeness/pinning deadlock, as fixture (#2555, #2556).
+
+run-issue331-092913: the fence-parse gate demanded a one-line retag —
+"lines 81-83 (```python)", an output-example repr in a Python-tagged fence —
+the drafter made that exact change in all six attempts across three rounds,
+and pinning reverted it every time as content no verdict ever objected to:
+four byte-identical drafts (md5 379d0859a6750175a48f42934fe31c03) and a
+deterministic kill for every resume. The cap halt then asserted the drafter
+"left the flagged code unchanged each time" with six [PINNING] refusal lines
+in the same log.
+
+Root cause, verified against the preserved lineage: the complaint addresses
+its target by line numbers and a triple-backtick fence tag, which no token
+pattern could read — while the message's own advice clause ("```text,
+```json, ```bash") fed named_tokens the garbage spans between the fence runs
+("text,", "json,"), defeating the names-nothing-extractable abstention. The
+guards enforced with a vocabulary that named zero draft lines.
+
+These tests replay that shape end to end against the real producers: the
+complaint comes from check_api_symbols_exist itself, the address from
+named_line_ranges, the enforcement verdict from enforce_pinning, and the
+halt text from validate_completeness.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+    _apply_pinning,
+)
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_api_symbols_exist,
+    validate_completeness,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_flags,
+    named_line_ranges,
+    named_tokens,
+)
+
+#: The observed draft's shape: a function-spec section whose Output Example
+#: is a repr inside a ```python fence — 256x256 is the invalid decimal
+#: literal — and unrelated sections a completed round passed unobjected.
+DRAFT = """# Implementation Spec: Stingray Skin
+
+## 1. Overview
+
+The stingray skin renders the gauge face.
+
+## 5. Function Specifications
+
+### 5.1 `render(size, skin)`
+
+**Input Example:**
+
+```python
+size = 256
+skin = "stingray"
+```
+
+**Output Example:**
+
+```python
+<PIL.Image.Image image mode=RGBA size=256x256 at 0x1A2B3C4D>
+```
+
+**Edge Cases:**
+- `size < 128` -> raises an error
+
+### 5.2 `clear_cache()`
+
+Clears the render cache. Returns None.
+
+## 6. Conventions
+
+Baselines are self-generated only.
+"""
+
+SYMBOLS = ["render", "clear_cache"]
+
+
+def _complaint() -> str:
+    """The REAL producer's complaint about DRAFT — never a hand-copy."""
+    result = check_api_symbols_exist(DRAFT, SYMBOLS)
+    assert result["passed"] is False
+    return result["details"]
+
+
+def _failing_fence_open_index() -> int:
+    """0-based index of the unparseable fence's opening ```python line."""
+    lines = DRAFT.splitlines()
+    return next(i for i, line in enumerate(lines) if "<PIL" in line) - 1
+
+
+def _retagged() -> str:
+    """The exact fix the drafter attempted every round: retag one line."""
+    lines = DRAFT.splitlines()
+    lines[_failing_fence_open_index()] = "```text"
+    return "\n".join(lines) + "\n"
+
+
+class TestTheComplaintSpeaksPinningsLanguage:
+    def test_the_fence_failure_reports_under_its_own_name(self):
+        """#2556: the fence-parse precondition is not the symbol check — the
+        run's hallucination-check artifacts (all passed) belong to the
+        symbol half, and the halt must not send the operator there."""
+        result = check_api_symbols_exist(DRAFT, SYMBOLS)
+        assert result["check_name"] == "python_fences_parse"
+
+    def test_the_line_citation_parses_into_the_fence_address(self):
+        details = _complaint()
+        open_line = _failing_fence_open_index() + 1  # 1-based
+        assert (open_line, open_line + 2) in named_line_ranges([details])
+
+    def test_the_advice_clause_yields_no_spurious_tokens(self):
+        """The old "(```text, ```json, ```bash)" advice minted tokens from
+        the spans BETWEEN the fence runs, defeating pinning's
+        names-nothing-extractable abstention while naming zero draft
+        lines."""
+        assert named_tokens("", [_complaint()]) == set()
+
+    def test_the_cited_range_names_the_fence_block(self):
+        details = _complaint()
+        flags = named_line_flags(
+            DRAFT, set(), named_line_ranges([details])
+        )
+        open_index = _failing_fence_open_index()
+        assert flags[open_index] is True
+        assert flags[open_index + 1] is True
+
+
+class TestTheDeadlockIsBroken:
+    """Acceptance, both directions."""
+
+    def test_the_mandated_retag_survives_pinning_and_the_check_passes(self):
+        details = _complaint()
+        result = enforce_pinning(
+            DRAFT,
+            _retagged(),
+            current_tokens=named_tokens("", [details]),
+            ever_tokens=named_tokens("", [details]),
+            current_ranges=named_line_ranges([details]),
+        )
+        assert result.text == _retagged(), (
+            "the change the completeness failure explicitly demands must "
+            "never be revertible by pinning in the same round"
+        )
+        assert result.refusals == ()
+        assert result.regressions == ()
+        after = check_api_symbols_exist(result.text, SYMBOLS)
+        assert after["passed"] is True, "one round, converged"
+
+    def test_an_unobjected_line_is_still_reverted(self):
+        """The inverse stays true: line addressing frees the cited block,
+        not the document."""
+        details = _complaint()
+        tinkered = DRAFT.replace(
+            "Baselines are self-generated only.",
+            "Baselines regenerate freely.",
+        )
+        result = enforce_pinning(
+            DRAFT,
+            tinkered,
+            current_tokens=named_tokens("", [details]),
+            ever_tokens=named_tokens("", [details]),
+            current_ranges=named_line_ranges([details]),
+        )
+        assert "Baselines are self-generated only." in result.text
+        assert "regenerate freely" not in result.text
+        assert result.refusals
+        assert result.regressions
+
+    def test_apply_pinning_does_not_abstain_on_a_line_cited_complaint(self, capsys):
+        """With the advice clause minting no tokens, only the line citation
+        keeps pinning engaged — the abstain valve must read it."""
+        tinkered = DRAFT.replace(
+            "Baselines are self-generated only.",
+            "Baselines regenerate freely.",
+        )
+        text, events = _apply_pinning(
+            {}, DRAFT, tinkered,
+            response="",
+            review_feedback="",
+            completeness_issues=[_complaint()],
+        )
+        capsys.readouterr()
+        assert text == DRAFT
+        assert any("refused" in event for event in events)
+        assert not any("names nothing extractable" in event for event in events)
+
+
+class TestNamedLineRanges:
+    def test_a_dashed_range_extracts(self):
+        assert named_line_ranges(
+            ["lines 81-83 (```python) — SyntaxError: invalid decimal literal"]
+        ) == ((81, 83),)
+
+    def test_a_bare_line_number_is_not_an_address(self):
+        """The observed complaint's own error text carries "line 1" — a
+        position inside the snippet, not a draft address. Parsing it would
+        unlock the block holding draft line 1 on every fence complaint."""
+        assert named_line_ranges(
+            ["SyntaxError: invalid decimal literal (<unknown>, line 1)"]
+        ) == ()
+
+    def test_a_reversed_range_is_ignored(self):
+        assert named_line_ranges(["lines 9-3 nonsense"]) == ()
+
+    def test_none_and_empty(self):
+        assert named_line_ranges(None) == ()
+        assert named_line_ranges([]) == ()
+
+    def test_an_out_of_bounds_range_names_nothing(self):
+        assert named_line_flags("a\nb\nc", set(), ((10, 12),)) == [
+            False, False, False,
+        ]
+
+
+class TestTheHaltNamesEnforcement:
+    """#2556: the cap halt consults the pinning record before reading an
+    identical complaint as the-drafter-left-it-unchanged. A reverted
+    revision re-presents the previous bytes, indistinguishable from drafter
+    inaction from the complaint stream alone."""
+
+    REFUSAL = (
+        "[PINNING] refused: 1 line(s) starting '```python' — locked "
+        "content the verdict did not name (#2532)"
+    )
+    COMPLAINT = (
+        "1 code fence(s) tagged as Python do not parse as Python: "
+        "lines 81-83 (```python) — SyntaxError: invalid decimal literal"
+    )
+
+    def _state(self, iteration=3, shown=(), breakdown=(), pinning_events=()):
+        return {
+            "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+            "review_iteration": iteration,
+            "max_iterations": 3,
+            "checks_shown_to_drafter": list(shown),
+            "prior_completeness_breakdown": [dict(e) for e in breakdown],
+            "pinning_events": list(pinning_events),
+        }
+
+    def _at_cap(self, details, make_breakdown, pinning_events=()):
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={"check_name": "x", "passed": False, "details": details},
+        ):
+            first = validate_completeness(self._state())
+            return validate_completeness(self._state(
+                shown=first["checks_shown_to_drafter"],
+                breakdown=make_breakdown(first["completeness_issues"]),
+                pinning_events=pinning_events,
+            ))
+
+    def _identical_history(self, failures):
+        return [
+            {"iteration": i, "failures": list(failures)} for i in range(3)
+        ]
+
+    def test_reversions_on_the_record_name_enforcement_not_the_drafter(
+        self, capsys
+    ):
+        """The #331 replay: identical complaint every round PLUS refusal
+        events in state — the halt names the guard and routes at the
+        deadlock, not at a hypothesized false positive."""
+        out = self._at_cap(
+            self.COMPLAINT,
+            self._identical_history,
+            pinning_events=[self.REFUSAL] * 6,
+        )
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "IDENTICAL complaint" in message
+        assert "pinning enforcement reverted" in message
+        assert "#2555" in message
+        assert "left the flagged code unchanged" not in message
+        assert "reached the check unchanged" not in message
+        assert "declining" not in message
+        assert "believes correct" not in message
+        assert "false positive" not in message
+
+    def test_no_reversions_keeps_the_unchanged_reading(self, capsys):
+        """The classification survives where it is true: no enforcement in
+        the loop means the drafter's output is what the check saw."""
+        out = self._at_cap(
+            self.COMPLAINT,
+            self._identical_history,
+            pinning_events=(),
+        )
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "reached the check unchanged" in message
+        assert "false positive" in message
+        assert "pinning enforcement reverted" not in message
+
+    def test_non_refusal_events_do_not_suppress_the_unchanged_reading(
+        self, capsys
+    ):
+        """Only reversions break the inference — an abstention note is not
+        enforcement."""
+        out = self._at_cap(
+            self.COMPLAINT,
+            self._identical_history,
+            pinning_events=[
+                "[PINNING] the verdict names nothing extractable — pinning "
+                "not applied this round (#2532)"
+            ],
+        )
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "reached the check unchanged" in message
+        assert "pinning enforcement reverted" not in message


### PR DESCRIPTION
Closes #2555, Closes #2556

Two guards were fighting each other and the spec loop could not converge, observed live on the boostgauge #331 roll (run-issue331-092913): the fence-parse gate demanded a one-line retag ("lines 81-83 (```python)" — an output-example repr in a Python-tagged fence), the drafter made that exact change in all six attempts across three rounds, pinning reverted it every time, and the cap halt then asserted the drafter "left the flagged code unchanged" with six `[PINNING] refused:` lines in the same log.

## Root cause, verified against the preserved state

Replayed read-only against the preserved lineage (`331-implspec/2026-08-27T15-02-19Z`, four drafts md5 `379d0859a6750175a48f42934fe31c03`) before cutting code:

- The complaint addresses its target by line numbers and a fence tag — a scheme `named_tokens` cannot read. Sharpening beyond the filed diagnosis: the message did not yield *nothing* — its own advice clause `(```text, ```json, ```bash)` minted two garbage tokens (`text,`, `json,`) from the spans *between* the fence runs, which defeated the names-nothing-extractable abstention in `_apply_pinning` while naming zero draft lines. Both halves were required for the deadlock.
- The issue's log excerpt omitted the `[PINNING] refused:` lines; they are present (six), directly evidencing restoration. The filed root cause stands.
- `UNLOCK` is taught in both revision prompts, but framed for "restructuring beyond the named items" — a drafter making the exact demanded change has no reason to invoke it. The hatch exists and is unreachable for this failure mode.

## The repair

**Pinning learns line addressing (#2555).** `named_line_ranges` parses dashed `lines N-M` citations from the current completeness failures — the checks measured the exact document the revision is diffed against, so the citation is a draft address by construction. The dash is required: the complaint's own `SyntaxError: ... line 1` is a position inside a snippet, and parsing bare line numbers would unlock the block holding draft line 1 on every fence complaint. Cited ranges feed both flag sets in `enforce_pinning`: a change a completeness failure explicitly demands is never a lock refusal and never the regression class. Ranges parse from completeness issues only, never free-form reviewer prose (a reviewer citing lines of some other file must not unlock draft lines). Prior rounds' ranges are not carried into the ever-set — line numbers do not survive document drift.

**The fence message stops minting garbage (#2555).** The advice clause drops its backticks (`(text, json, bash)`); the single-failure message now yields zero tokens and one range, and the abstain valve reads ranges.

**The fence-parse failure reports under its own name (#2556).** `check_name="python_fences_parse"` — the run's per-iteration hallucination-check artifacts (all `passed: true`) belong to the symbol half, which never ran; the halt no longer sends the operator cross-checking a clean record. Consumers verified: the old name appears only in `validate_completeness.py` and tests; the shown/grace bookkeeping is name-agnostic. A run resumed across the rename carries the old name in `checks_shown_to_drafter`, so the renamed check earns one grace revision — harmless, and it converges under the pinning fix.

**The cap halt consults the pinning record before blaming the drafter (#2556).** An identical complaint reads as the-drafter-left-it-unchanged only when no `[PINNING] refused:` event exists in the run's revisions; with reversions on the record the halt names enforcement, quotes a refusal event, and routes at the deadlock. The intent language ("declining", "believes correct") is gone from both branches — the surviving classification states observables only. The drafter-unchanged reading survives for runs with no reversions, because there it is true.

## Acceptance, proven read-only

`tests/unit/test_completeness_pinning_deadlock.py` replays the observed case against the real producers (the complaint comes from `check_api_symbols_exist` itself), both directions:

- A draft whose only unresolved failure is the fence complaint, revised by a drafter that retags the fence, converges in one round — the retag survives pinning with no refusal and no regression event, and the check then passes.
- A revision touching an unnamed, unobjected line is still reverted and still flagged.
- The #331 state (identical complaint x3 + six refusal events) produces a halt naming pinning enforcement, with no drafter-declined claim; the no-reversions control keeps the unchanged reading.

Also replayed against the actual preserved draft (not the fixture): ranges `((81, 83),)`, zero tokens, retag survives, check passes, and the halt message names the deadlock. Full unit suite green; targeted files 85/85.

**What only a live roll proves:** the drafter actually emitting the retag under the reworded message, the edit-script and full-revision paths behaving under real model output, and the resumed #331 roll converging end to end.

Follow-up filed: #2557 — audit every completeness failure message for pinning addressability, so the invariant holds for messages not yet written.
