### PR TITLE
fix: the pinning merge is conservation-gated, demanded additions land, and the halt's survival claim requires a clean pinning record (Closes #2559, Closes #2560, Closes #2561)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -536,6 +536,7 @@ def _apply_pinning(
     in is named content, never a lock refusal, never the regression class.
     """
     from assemblyzero.workflows.implementation_spec.revision_pinning import (
+        demands_additions,
         enforce_pinning,
         named_line_ranges,
         named_tokens,
@@ -563,6 +564,7 @@ def _apply_pinning(
         current_tokens=current,
         ever_tokens=ever,
         current_ranges=ranges,
+        additions_demanded=demands_additions(completeness_issues),
         unlock_reason=unlock_requested(response),
     )
 
@@ -581,6 +583,15 @@ def _apply_pinning(
         events.append(
             f"[PINNING] REGRESSION CLASS: revision modified content no "
             f"verdict ever objected to: {regression} (#2532)"
+        )
+    for addition in result.additions:
+        events.append(
+            f"[PINNING] demanded addition passed: {addition} — this round's "
+            f"completeness failures demand new tests (#2560)"
+        )
+    if result.conservation_event:
+        events.append(
+            f"[PINNING] CONSERVATION: {result.conservation_event} (#2559)"
         )
     for event in events:
         print(f"    {event}")

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -391,9 +391,13 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                         for entry in prior_iters
                     )
                 ]
+                # #2561: a conservation override (#2559) is an enforcement
+                # intervention exactly as a refusal is — either way the
+                # drafter's revision did not reach the check intact.
                 reversions = [
                     event for event in state.get("pinning_events", [])
                     if "[PINNING] refused:" in event
+                    or "[PINNING] CONSERVATION:" in event
                 ]
                 declined = [] if reversions else identical
                 reverted = identical if reversions else []
@@ -427,10 +431,31 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
                 ]
                 detail = ""
                 if kept_failing:
-                    detail += (
-                        f" Each unresolved check was shown to the drafter and "
-                        f"survived a revision: {', '.join(kept_failing)}."
-                    )
+                    # #2561: "survived a revision" claims the drafter's
+                    # output reached this check and still failed. With
+                    # enforcement interventions on the record that is
+                    # unprovable — run-issue331-111729's halt asserted
+                    # survival for criteria_have_tests while pinning had
+                    # refused the drafter's demanded addition in the same
+                    # granted revision. The survival claim survives only a
+                    # clean pinning record, because there it is true.
+                    if reversions:
+                        detail += (
+                            f" Each unresolved check was shown to the "
+                            f"drafter, but pinning enforcement refused or "
+                            f"overrode revision content in this run "
+                            f"({len(reversions)} event(s), e.g. "
+                            f"{reversions[0]}) — the drafter's revision may "
+                            f"not have reached the check intact; read the "
+                            f"[PINNING] events before treating these as "
+                            f"drafter failures: {', '.join(kept_failing)}."
+                        )
+                    else:
+                        detail += (
+                            f" Each unresolved check was shown to the drafter "
+                            f"and survived a revision: "
+                            f"{', '.join(kept_failing)}."
+                        )
                 if declined:
                     detail += (
                         f" NOTE: {', '.join(declined)} drew the IDENTICAL "

--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -23,6 +23,13 @@ This module makes that impossible mechanically:
 * **The regression event**: a revision that modified content NO verdict in
   the whole history ever objected to is the S2-regression class, flagged at
   the moment it happens instead of one round later.
+* **The conservation gate** (#2559): the merge never emits a document that
+  lost a test definition the previous draft held and no verdict named —
+  on violation it emits the revision unenforced or the previous draft
+  entire, loudly, never the stitched result.
+* **Demanded additions** (#2560): when the round's completeness failures
+  demand new tests, a locked region introducing one passes — a demand to
+  add has no line to cite, so the named-content exemptions cannot cover it.
 
 Iteration 1 (the initial draft) is untouched — this governs revisions only.
 Every function here is pure (ADR 0224): text in, text and events out.
@@ -194,10 +201,62 @@ class PinningResult:
     #: Changed regions no verdict EVER named — the S2-regression class,
     #: flagged at the moment it happens (computed before restoration).
     regressions: tuple[str, ...] = ()
+    #: Regions passed through as demanded additions (#2560) — a completeness
+    #: failure demanded new tests, and the region introduces one.
+    additions: tuple[str, ...] = ()
+    #: Non-empty when the conservation gate overrode the merge (#2559):
+    #: the walked output lost tests no verdict named, so ``text`` is the
+    #: revision unenforced (differ misalignment) or the previous draft
+    #: entire (the revision itself removed them).
+    conservation_event: str = ""
     unlock_reason: str = ""
 
 
 _UNLOCK_RE = re.compile(r"^\s*UNLOCK:\s*(.+?)\s*$", re.MULTILINE)
+
+#: A test definition line — the conserved quantity of the merge (#2559) and
+#: the artifact class completeness checks demand added (#2560).
+_TEST_DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(")
+
+#: The phrases our own completeness checks use when they demand ADDITIONS
+#: ("3 LLD pass criterion(s) have no test in the spec ... Add a test for
+#: each", "... have no test asserting them. Section 10 owes each a test").
+#: A demand to add has no line to cite and no existing content to name —
+#: the #2555/#2558 vocabulary addresses only content that exists (#2560).
+_ADDITION_DEMAND_RE = re.compile(
+    r"\bhave no test\b|\badd a test\b|\bowes each a test\b", re.IGNORECASE
+)
+
+
+def demands_additions(completeness_issues: list[str] | None) -> bool:
+    """True when any current completeness failure demands new tests (#2560)."""
+    return any(
+        _ADDITION_DEMAND_RE.search(str(issue))
+        for issue in completeness_issues or []
+    )
+
+
+def _test_def_names(text: str) -> set[str]:
+    names: set[str] = set()
+    for line in text.splitlines():
+        match = _TEST_DEF_RE.match(line)
+        if match:
+            names.add(match.group(1))
+    return names
+
+
+def _is_expansion(old_region: list[str], new_region: list[str]) -> bool:
+    """Every old line survives, in order, inside the new region.
+
+    Such a replace is an insertion wearing a replace costume — the differ
+    bundled new content with untouched neighbours (a blank line, an anchor
+    comment). No previous byte is lost, so pinning has nothing to protect:
+    insertions pass, and this IS one (#2560 — run-issue331-111729's
+    demanded error-path test landed only because its region happened to
+    diff as a pure insert, while the REQ-8/9/10 additions died bundled).
+    """
+    iterator = iter(new_region)
+    return all(line in iterator for line in old_region)
 
 
 def unlock_requested(response: str) -> str:
@@ -218,6 +277,7 @@ def enforce_pinning(
     current_tokens: set[str],
     ever_tokens: set[str] | None = None,
     current_ranges: tuple[tuple[int, int], ...] = (),
+    additions_demanded: bool = False,
     unlock_reason: str = "",
 ) -> PinningResult:
     """Carry every unnamed span of ``previous`` forward byte-verbatim.
@@ -247,6 +307,26 @@ def enforce_pinning(
     With ``unlock_reason`` the restoration is skipped entirely — the drafter
     asked to restructure and the caller logs it — but the regression events
     still fire, because an unlock explains a change, it does not un-happen it.
+
+    ``additions_demanded`` (#2560): the round's completeness failures demand
+    NEW tests ("have no test in the spec ... Add a test for each"). A demand
+    to add has no line to cite and no existing content to name, so the
+    named-content exemptions cannot cover it; instead, a locked region whose
+    revised side introduces a test definition the previous draft lacks is
+    the demanded compliance and passes. Off by default — an unprompted
+    addition bundled into a locked modification stays refusable.
+
+    The conservation gate (#2559): the walk's region rule is all-or-nothing
+    — a region touching ANY named line passes wholesale — which is sound for
+    targeted diffs and lossy for restructures. run-issue331-111729's
+    iteration 6 diffed an eliding rewrite into giant regions; each touched
+    some named line, so the elisions passed through and 18 test definitions
+    vanished with no refusal and no regression event. So the way out is
+    gated: if the walked output lost any test definition the previous draft
+    held and no verdict named, the merge has malfunctioned — emit the
+    revision unenforced when it still holds those tests (differ
+    misalignment), or the previous draft entire when it does not (the
+    revision itself removed them). Never the stitched result.
     """
     prev_lines = previous.splitlines()
     rev_lines = revised.splitlines()
@@ -255,9 +335,11 @@ def enforce_pinning(
         named_line_flags(previous, ever_tokens, current_ranges)
         if ever_tokens is not None else current_flags
     )
+    prev_test_names = _test_def_names(previous)
 
     refusals: list[str] = []
     regressions: list[str] = []
+    additions: list[str] = []
     out: list[str] = []
 
     matcher = difflib.SequenceMatcher(None, prev_lines, rev_lines, autojunk=False)
@@ -269,6 +351,13 @@ def enforce_pinning(
             out.extend(rev_lines[j1:j2])
             continue
         old_region = prev_lines[i1:i2]
+        new_region = rev_lines[j1:j2]
+        # An expansion is an insertion wearing a replace costume: every old
+        # line survives in order, so nothing pinning protects is touched.
+        # No refusal, no regression — same law as the insert branch (#2560).
+        if old_region and new_region and _is_expansion(old_region, new_region):
+            out.extend(new_region)
+            continue
         # The S2-regression class: this change touches lines NO verdict ever
         # named. Recorded before any restoration decision.
         if old_region and all(not ever_flags[i] for i in range(i1, i2)):
@@ -277,17 +366,137 @@ def enforce_pinning(
             not current_flags[i] for i in range(i1, i2)
         )
         if locked and not unlock_reason:
-            out.extend(old_region)  # byte-verbatim carry-forward
-            refusals.append(_preview(old_region, i2 - i1))
+            if additions_demanded and any(
+                (match := _TEST_DEF_RE.match(line))
+                and match.group(1) not in prev_test_names
+                for line in new_region
+            ):
+                # The demanded compliance: this round's completeness
+                # failures asked for new tests and this region carries one
+                # the previous draft lacks (#2560). The regression event
+                # above still fires — visibility without destruction.
+                out.extend(new_region)
+                additions.append(_preview(new_region, j2 - j1))
+            else:
+                out.extend(old_region)  # byte-verbatim carry-forward
+                refusals.append(_preview(old_region, i2 - i1))
         else:
             out.extend(rev_lines[j1:j2])
 
     text = "\n".join(out)
     if revised.endswith("\n") or previous.endswith("\n"):
         text += "\n"
+
+    # Conservation gate (#2559). Skipped under an explicit unlock — the
+    # drafter asked to restructure and owns the outcome; the grant is
+    # logged, never silent.
+    if not unlock_reason:
+        override = _conservation_override(
+            previous, revised, text,
+            current_tokens=current_tokens,
+            current_flags=current_flags,
+            regressions=tuple(regressions),
+        )
+        if override is not None:
+            return override
+
     return PinningResult(
         text=text,
         refusals=tuple(refusals),
         regressions=tuple(regressions),
+        additions=tuple(additions),
         unlock_reason=unlock_reason,
+    )
+
+
+def _conservation_override(
+    previous: str,
+    revised: str,
+    walked: str,
+    *,
+    current_tokens: set[str],
+    current_flags: list[bool],
+    regressions: tuple[str, ...] = (),
+) -> PinningResult | None:
+    """The way out of the merge is gated (#2559): None when conservation
+    holds; otherwise the result to emit INSTEAD of the stitched text.
+
+    A test definition the previous draft held is lost when it is absent
+    from the walked output and no current verdict named it — neither as a
+    token nor by flagging any of its definition lines. Tier one: the
+    revision still holds every lost test (differ misalignment — a moved
+    block the walk mispaired), emit the revision unenforced. Tier two: the
+    revision lost them too (an eliding rewrite — run-issue331-111729's
+    iteration 6 carried [UNCHANGED] placeholders where 18 definitions had
+    been), emit the previous draft entire; abstaining to the revision
+    there would lose exactly what the gate exists to keep.
+
+    The merge can also MANUFACTURE duplicates — run-issue331-111729's
+    iteration 2 restored a superseded test listing alongside the
+    revision's moved copy, and the duplicate definitions later broke six
+    edit-script SEARCH blocks as ambiguous. A name occurring more times in
+    the walked output than in EITHER input was minted by the merge, never
+    authored: emit the revision unenforced. (A count the revision itself
+    carries is authored content — the fleet's spec template legitimately
+    lists a test in both its change-instruction and test-mapping sections
+    — and is not the merge's to judge.)
+    """
+    prev_lines = previous.splitlines()
+    walked_names = _test_def_names(walked)
+    lost = sorted(
+        name for name in _test_def_names(previous)
+        if name not in walked_names
+        and name.lower() not in current_tokens
+        and not any(
+            current_flags[i]
+            for i, line in enumerate(prev_lines)
+            if (match := _TEST_DEF_RE.match(line))
+            and match.group(1) == name
+        )
+    )
+    if not lost:
+        def _counts(text: str) -> dict[str, int]:
+            counts: dict[str, int] = {}
+            for line in text.splitlines():
+                match = _TEST_DEF_RE.match(line)
+                if match:
+                    counts[match.group(1)] = counts.get(match.group(1), 0) + 1
+            return counts
+
+        prev_counts = _counts(previous)
+        rev_counts = _counts(revised)
+        multiplied = sorted(
+            name for name, count in _counts(walked).items()
+            if count > max(prev_counts.get(name, 0), rev_counts.get(name, 0))
+        )
+        if multiplied:
+            return PinningResult(
+                text=revised,
+                regressions=regressions,
+                conservation_event=(
+                    f"the walked merge multiplied {len(multiplied)} test "
+                    f"definition(s) beyond both inputs "
+                    f"({', '.join(multiplied)}) -- emitting the revision "
+                    f"unenforced instead of the stitched result"
+                ),
+            )
+        return None
+    if all(name in _test_def_names(revised) for name in lost):
+        return PinningResult(
+            text=revised,
+            regressions=regressions,
+            conservation_event=(
+                f"the walked merge lost {len(lost)} test(s) present in "
+                f"both inputs ({', '.join(lost)}) -- emitting the revision "
+                f"unenforced instead of the stitched result"
+            ),
+        )
+    return PinningResult(
+        text=previous,
+        regressions=regressions,
+        conservation_event=(
+            f"the revision removed {len(lost)} test(s) no verdict named "
+            f"({', '.join(lost)}) -- revision refused entire, previous "
+            f"draft kept"
+        ),
     )

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -259,6 +259,9 @@ class ImplementationSpecState(TypedDict, total=False):
     # event — a mechanically refused edit to locked content, a
     # regression-class flag ("revision modified content no verdict ever
     # objected to" — the S2 class made visible at the moment it happens),
-    # or an explicit UNLOCK grant with the drafter's stated reason.
+    # an explicit UNLOCK grant with the drafter's stated reason, a
+    # demanded-addition pass (#2560), or a conservation override (#2559).
+    # The cap halt consults this record before attributing a recurring
+    # or surviving complaint to the drafter (#2556, #2561).
     # Accumulated across the run; iteration 1 never writes here.
     pinning_events: list[str]

--- a/tests/unit/test_pinning_conservation.py
+++ b/tests/unit/test_pinning_conservation.py
@@ -1,0 +1,400 @@
+"""Three faces of one death, as fixture (#2559, #2560, #2561).
+
+run-issue331-111729: five healthy review rounds, then iteration 6's
+edit-script died on SEARCH-ambiguous duplicates (merge-made at iteration 2
+— restore-alongside-moved-copy), the fallback was an eliding rewrite
+([UNCHANGED] placeholder headings), and enforcement's all-or-nothing region
+rule passed the elisions wholesale: 565 lines / 28 test definitions became
+381 / 10 with no refusal and no regression event for the lost tests
+(#2559). The #2304 grace revision then added the demanded tests back and
+enforcement refused the additions as locked-content replaces — while the
+one addition that happened to diff as a pure insert landed and flipped its
+check back to PASS (#2560). The halt reported "shown to the drafter and
+survived a revision" with the refusal in the same log (#2561).
+
+These tests pin the repairs: the conservation gate never emits a merge that
+lost unnamed tests; a demanded addition is never refusable in the round
+that demands it; the halt's survival claim requires a clean pinning record.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    validate_completeness,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    PinningResult,
+    _conservation_override,
+    _is_expansion,
+    demands_additions,
+    enforce_pinning,
+    named_line_flags,
+    named_tokens,
+)
+
+# ---------------------------------------------------------------------------
+# The observed shapes, miniature
+# ---------------------------------------------------------------------------
+
+#: Draft-015 shape: a passed draft whose test fence holds the criterion
+#: tests. The round-6 verdict names `render_face`, which appears in §5.1
+#: and inside test_req_1_alpha's body — so those blocks are named and the
+#: REQ-8/9/10 test blocks are not, exactly the observed asymmetry.
+PREVIOUS = """# Implementation Spec: Stingray Face
+
+## 5. Function Specifications
+
+### 5.1 `render_face()`
+
+Renders the face. The cache is bounded at sixteen entries.
+
+## 6. Change Instructions
+
+### 6.3 `tests/visual/test_skin.py` (Add)
+
+```python
+def test_req_1_alpha():
+    assert render_face(256).mode == "RGBA"
+
+def test_req_8_chrome_housing():
+    assert housing_gradient_samples() >= 3
+
+def test_req_9_screws():
+    assert screw_count() == 4
+
+def test_req_10_bezel():
+    assert bezel_radius() > 0
+```
+
+## 10. Test Mapping
+
+Each criterion maps to one test above.
+
+## 11. Implementation Notes
+
+Cache eviction uses least-recently-used order.
+"""
+
+VERDICT = "REVISE: `render_face` must bound its cache at thirty-two entries."
+
+#: The iteration-6 shape: an eliding rewrite. Every middle line is reworded
+#: (no verbatim anchor survives between the head and the tail), the REQ-8/9/10
+#: tests are gone, and elided sections carry [UNCHANGED] placeholders — the
+#: markers found verbatim in preserved draft 018.
+ELIDED = """# Implementation Spec: Stingray Face
+
+## 5. Function Specifications (revised)
+
+### 5.1 `render_face()` — cache bound raised
+
+Renders the face; the cache is bounded at thirty-two entries per verdict.
+
+## 6. Change Instructions (consolidated)
+
+### 6.3 `tests/visual/test_skin.py` (Add, trimmed)
+
+```python
+def test_req_1_alpha():
+    assert render_face(256, bound=32).mode == "RGBA"
+```
+
+## [UNCHANGED] 10. Test Mapping
+
+## [UNCHANGED] 11. Implementation Notes
+"""
+
+
+class TestTheConservationGate:
+    def test_the_eliding_rewrite_is_refused_entire(self):
+        """The observed loss: the giant region touches a named line, so the
+        walk would pass the elisions through and delete the unnamed tests.
+        The gate sees the loss, sees the revision lost them too, and emits
+        the previous draft entire — never the stitched result."""
+        result = enforce_pinning(
+            PREVIOUS, ELIDED, current_tokens=named_tokens(VERDICT),
+        )
+        assert result.conservation_event, "the gate must fire"
+        assert "refused entire" in result.conservation_event
+        assert "test_req_8_chrome_housing" in result.conservation_event
+        assert result.text == PREVIOUS
+        for name in ("test_req_8_chrome_housing", "test_req_9_screws",
+                     "test_req_10_bezel"):
+            assert name in result.text
+
+    def test_a_targeted_revision_never_trips_the_gate(self):
+        """The #2532/#2558 protections stand: a small named fix passes, an
+        unnamed tinker is refused per-region, and conservation stays out of
+        the way."""
+        targeted = PREVIOUS.replace(
+            "bounded at sixteen entries", "bounded at thirty-two entries"
+        ).replace(
+            "least-recently-used order", "first-in-first-out order"
+        )
+        result = enforce_pinning(
+            PREVIOUS, targeted, current_tokens=named_tokens(VERDICT),
+        )
+        assert result.conservation_event == ""
+        assert "thirty-two entries" in result.text, "the named fix lands"
+        assert "least-recently-used order" in result.text, (
+            "the unnamed tinker is restored"
+        )
+        assert result.refusals
+
+    def test_a_verdict_named_test_may_be_removed(self):
+        """A deletion the verdict names is not a conservation loss — the
+        gate protects only what nothing asked to touch."""
+        verdict = (
+            "REVISE: `render_face` must bound its cache; remove "
+            "`test_req_10_bezel`, the bezel is out of scope."
+        )
+        removed = PREVIOUS.replace(
+            "\ndef test_req_10_bezel():\n    assert bezel_radius() > 0\n",
+            "\n",
+        )
+        result = enforce_pinning(
+            PREVIOUS, removed, current_tokens=named_tokens(verdict),
+        )
+        assert result.conservation_event == ""
+        assert "test_req_10_bezel" not in result.text
+
+    def test_the_misalignment_tier_emits_the_revision(self):
+        """Tier one, at the gate's own seam: the walked output lost a test
+        the revision still holds — differ misalignment, not drafter
+        deletion — so the revision is emitted unenforced."""
+        walked_missing_one = PREVIOUS.replace(
+            "\ndef test_req_9_screws():\n    assert screw_count() == 4\n",
+            "\n",
+        )
+        flags = named_line_flags(PREVIOUS, named_tokens(VERDICT))
+        override = _conservation_override(
+            PREVIOUS, PREVIOUS, walked_missing_one,
+            current_tokens=named_tokens(VERDICT),
+            current_flags=flags,
+        )
+        assert isinstance(override, PinningResult)
+        assert "emitting the revision unenforced" in override.conservation_event
+        assert override.text == PREVIOUS
+        assert "test_req_9_screws" in override.text
+
+    def test_a_clean_walk_returns_no_override(self):
+        flags = named_line_flags(PREVIOUS, named_tokens(VERDICT))
+        assert _conservation_override(
+            PREVIOUS, PREVIOUS, PREVIOUS,
+            current_tokens=named_tokens(VERDICT),
+            current_flags=flags,
+        ) is None
+
+    def test_a_merge_minted_duplicate_emits_the_revision(self):
+        """The iteration-2 event: the walk restored a superseded copy
+        alongside the revision's moved one. A count beyond BOTH inputs was
+        minted by the merge, never authored."""
+        duplicated_walk = PREVIOUS.replace(
+            "## 10. Test Mapping",
+            "```python\ndef test_req_9_screws():\n"
+            "    assert screw_count() == 4\n```\n\n## 10. Test Mapping",
+        )
+        flags = named_line_flags(PREVIOUS, named_tokens(VERDICT))
+        override = _conservation_override(
+            PREVIOUS, PREVIOUS, duplicated_walk,
+            current_tokens=named_tokens(VERDICT),
+            current_flags=flags,
+        )
+        assert isinstance(override, PinningResult)
+        assert "multiplied" in override.conservation_event
+        assert "test_req_9_screws" in override.conservation_event
+        assert override.text == PREVIOUS
+
+    def test_an_authored_dual_listing_is_not_the_merges_to_judge(self):
+        """The fleet's spec template legitimately lists a test in both its
+        change-instruction and test-mapping sections — a count the revision
+        itself carries never trips the gate."""
+        dual = PREVIOUS.replace(
+            "Each criterion maps to one test above.",
+            "```python\ndef test_req_1_alpha():\n"
+            "    assert render_face(256).mode == \"RGBA\"\n```",
+        )
+        flags = named_line_flags(PREVIOUS, named_tokens(VERDICT))
+        assert _conservation_override(
+            PREVIOUS, dual, dual,
+            current_tokens=named_tokens(VERDICT),
+            current_flags=flags,
+        ) is None
+
+
+class TestDemandedAdditions:
+    #: Draft-018 shape at iteration 7: the previous draft carries an unnamed
+    #: comment block; the demanded test arrives as a replace over it.
+    COMMENT_PREVIOUS = """# Spec
+
+## 6. Change Instructions
+
+```python
+def test_alpha():
+    assert True
+
+# Baseline-independent geometric assertion:
+# - housing horizon samples
+# - one dark sample
+# - one bright sample
+```
+
+## 7. Notes
+
+The notes block stays put.
+"""
+
+    ADDED = COMMENT_PREVIOUS.replace(
+        """# Baseline-independent geometric assertion:
+# - housing horizon samples
+# - one dark sample
+# - one bright sample""",
+        """def test_req_8_chrome_housing():
+    assert housing_gradient_samples() >= 3""",
+    )
+
+    #: Names §7 only — pinning engaged, the comment block unnamed.
+    TOKENS = {"the notes block stays put."}
+
+    def test_the_demanded_addition_lands(self):
+        """The observed refusal, repaired: the differ bundles the new test
+        as a replace over unnamed old lines, and the round's completeness
+        failures demand additions — the compliance passes."""
+        result = enforce_pinning(
+            self.COMMENT_PREVIOUS, self.ADDED,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=True,
+        )
+        assert "def test_req_8_chrome_housing" in result.text
+        assert result.refusals == ()
+        assert result.additions, "the pass is an event, never silent"
+
+    def test_an_unprompted_addition_is_still_refused(self):
+        """The inverse: the same revision in a round demanding no additions
+        is judged exactly as before."""
+        result = enforce_pinning(
+            self.COMMENT_PREVIOUS, self.ADDED,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=False,
+        )
+        assert "def test_req_8_chrome_housing" not in result.text
+        assert "# Baseline-independent geometric assertion:" in result.text
+        assert result.refusals
+
+    def test_a_plain_modification_gains_nothing_from_the_demand(self):
+        """additions_demanded frees additions, not modifications: a locked
+        rewording with no new test in it is refused either way."""
+        reworded = self.COMMENT_PREVIOUS.replace(
+            "# - one dark sample", "# - two dark samples"
+        )
+        result = enforce_pinning(
+            self.COMMENT_PREVIOUS, reworded,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=True,
+        )
+        assert "# - one dark sample" in result.text
+        assert result.refusals
+
+    def test_the_real_check_messages_read_as_demands(self):
+        assert demands_additions([
+            "3 LLD pass criterion(s) have no test in the spec [join exact "
+            "(criterion IDs)]. Add a test for each:\n  - REQ-8 (row 080): "
+            "Chrome housing gradients check"
+        ])
+        assert demands_additions([
+            "1 exception type(s) the spec raises have no test asserting "
+            "them. Section 10 owes each a test:\n  - ValueError: raised 2 "
+            "times"
+        ])
+        assert not demands_additions([
+            "1 code fence(s) tagged as Python do not parse as Python: "
+            "lines 81-83"
+        ])
+        assert not demands_additions([])
+        assert not demands_additions(None)
+
+
+class TestIsExpansion:
+    def test_ordered_containment_is_an_expansion(self):
+        assert _is_expansion(["a", "b"], ["x", "a", "y", "b", "z"])
+
+    def test_reordering_is_not(self):
+        assert not _is_expansion(["a", "b"], ["b", "a"])
+
+    def test_a_dropped_line_is_not(self):
+        assert not _is_expansion(["a", "b"], ["a", "z"])
+
+
+class TestTheHaltsSurvivalClaim:
+    """#2561: 'shown to the drafter and survived a revision' asserts the
+    drafter's output reached the check intact — provable only against a
+    clean pinning record."""
+
+    REFUSAL = (
+        "[PINNING] refused: 7 line(s) starting '# Baseline-independent "
+        "geometric assertion:' — locked content the verdict did not name "
+        "(#2532)"
+    )
+    CONSERVATION = (
+        "[PINNING] CONSERVATION: the revision removed 3 test(s) no verdict "
+        "named (test_req_8_chrome_housing, test_req_9_screws, "
+        "test_req_10_bezel) -- revision refused entire, previous draft "
+        "kept (#2559)"
+    )
+
+    def _state(self, iteration=3, shown=(), breakdown=(), pinning_events=()):
+        return {
+            "spec_draft": "# Spec\n\n" + ("body line\n" * 40),
+            "files_to_modify": [],
+            "pattern_references": [],
+            "repo_root": "",
+            "lld_content": "",
+            "review_iteration": iteration,
+            "max_iterations": 3,
+            "checks_shown_to_drafter": list(shown),
+            "prior_completeness_breakdown": [dict(e) for e in breakdown],
+            "pinning_events": list(pinning_events),
+        }
+
+    def _at_cap(self, pinning_events=()):
+        """The kept_failing shape: the complaint CHANGED across rounds, so
+        neither the identical-complaint nor the complied class claims it."""
+        with patch(
+            "assemblyzero.workflows.implementation_spec.nodes."
+            "validate_completeness.check_modify_files_have_excerpts",
+            return_value={
+                "check_name": "x", "passed": False,
+                "details": "missing excerpt for a.py",
+            },
+        ):
+            first = validate_completeness(self._state())
+            return validate_completeness(self._state(
+                shown=first["checks_shown_to_drafter"],
+                breakdown=[
+                    {"iteration": 0, "failures": ["missing excerpt for b.py"]},
+                    {"iteration": 1, "failures": ["missing excerpt for c.py"]},
+                ],
+                pinning_events=pinning_events,
+            ))
+
+    def test_refusals_on_the_record_suppress_the_survival_claim(self, capsys):
+        out = self._at_cap(pinning_events=[self.REFUSAL])
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "may not have reached the check intact" in message
+        assert "survived a revision" not in message
+
+    def test_a_conservation_override_counts_as_enforcement(self, capsys):
+        out = self._at_cap(pinning_events=[self.CONSERVATION])
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "may not have reached the check intact" in message
+        assert "survived a revision" not in message
+
+    def test_a_clean_record_keeps_the_survival_claim(self, capsys):
+        out = self._at_cap(pinning_events=())
+        capsys.readouterr()
+        message = out["error_message"]
+        assert "survived a revision" in message
+        assert "may not have reached the check intact" not in message


### PR DESCRIPTION
Closes #2559, Closes #2560, Closes #2561

Three faces of one death on the #331 roll of 11:17 (`run-issue331-111729.log`) — the first run carrying the #2558 repair. Five healthy review rounds, then: the enforcement merge deleted 184 lines and 18 test definitions from an eliding fallback revision (#2559), the grace round's demanded additions were refused as locked-content replaces (#2560), and the halt asserted the check "survived a revision" with the refusal in the same log (#2561).

## Verified against the preserved state (sharpenings posted on #2559 before the fix)

- **The duplication hypothesis is CONFIRMED and located at iteration 2**: drafts 001/004 carry no duplicated test names (004's §6.3 holds a pointer line, not bodies); the iteration-2 enforced merge produced draft 007 (458 → 1296 lines) with full listings in BOTH §6.3 and §10.1 plus an embedded second document tail — restore-alongside-moved-copy. That dual listing is what made six edit-script SEARCH blocks ambiguous at iteration 6.
- **The deletion mechanism is sharper than lossy stitching**: the iteration-6 fallback was an ELIDING rewrite (`[UNCHANGED]` placeholder headings sit in preserved draft 018 with bodies gone). The walk's region rule is all-or-nothing — a region touching ANY named line passes wholesale — so the elision's giant regions passed (deletions, invisible: no refusal, no regression event) while unnamed regions were restored (the refusal wall). 565/28 → 381/10.
- **The #2560 mechanism, nailed by the 020 vs 018 diff**: exactly one definition differs — `test_exceptions_value_error`, a pure-insert region that PASSED and flipped `error_paths_have_tests` back to PASS in the same round the REQ-8/9/10 additions died bundled as replaces over a 7-line unnamed comment and blank lines. Inserts pass; bundled inserts didn't. The hole was the bundling.

## The repair

**Conservation gate (#2559).** The way out of the merge is gated: if the walked output lost any test definition the previous draft held and no current verdict named (neither as a token nor by flagging its definition lines), the merge has malfunctioned — emit the revision unenforced when it still holds the lost tests (differ misalignment), or the previous draft entire when it does not (the eliding-rewrite case, where abstaining to the revision would lose exactly what the gate exists to keep). Never the stitched result. Skipped under an explicit `UNLOCK` — the drafter asked to restructure and owns the outcome, logged as ever. Replayed on the real artifacts (previous = draft 015, walked = draft 018, tokens = the real round-6 verdict): the gate fires and keeps 3 of the 4 lost tests — the fourth was named by that verdict, so its removal is verdict-sanctioned, and the completeness check then demands it back into a round the next repair covers.

The confirmed duplication mechanism gets the same gate: a test name occurring more times in the walked output than in EITHER input was minted by the merge, never authored — emit the revision unenforced. A count the revision itself carries is authored content (the spec template legitimately lists a test in both its change-instruction and test-mapping sections) and is not the merge's to judge. This is what stops the iteration-2 event from re-poisoning edit-scripts with SEARCH-ambiguous duplicates.

**Demanded additions land (#2560).** A demand to ADD has no line to cite and no existing content to name — the #2555/#2558 vocabulary addresses only content that exists. Two rules: an expansion (every old line surviving in order inside the revised region) is an insertion wearing a replace costume and passes unconditionally; and when the round's completeness failures demand new tests (`demands_additions` reads our own checks' phrasing — "have no test", "Add a test for each", "owes each a test"), a locked region introducing a test definition the previous draft lacks is the demanded compliance and passes, as a logged `[PINNING] demanded addition passed` event. The inverse stands: an unprompted addition, and any plain modification even in a demanding round, is judged exactly as before.

**The survival claim requires a clean record (#2561).** The kept_failing branch now performs the same consult #2558 gave the identical-complaint branch: with `[PINNING] refused:` or `[PINNING] CONSERVATION:` events on the record, the halt says the drafter's revision may not have reached the check intact, quotes an event, and routes at the enforcement record; "shown to the drafter and survived a revision" survives only a clean pinning record, because there it is true.

## Acceptance

`tests/unit/test_pinning_conservation.py` pins the observed shapes: the eliding rewrite is refused entire with the lost tests named; a targeted revision never trips the gate (named fix lands, unnamed tinker restored); a verdict-named test may still be removed; the misalignment tier emits the revision; the demanded addition lands and its two inverses hold; the real check messages read as demands; and the halt's survival claim flips on exactly the pinning record. Full unit suite green.

**What only a live roll proves:** the gate and addition rules under real Gemini revisions, the edit-script path staying clear of SEARCH ambiguity now that duplicates stop being manufactured, and the resumed #331 roll converging end to end.

Sibling context: the #2558 line-citation vocabulary stands untouched; this PR extends the same enforcement machinery where the 11:17 run found its next three holes.
