### PR TITLE
fix: the lld derivation conserves its source rows' literals -- a shed qualifier is named by row, not silently dropped (Closes #2563)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -708,6 +708,107 @@ def _carries_a_literal(text: str) -> bool:
     return any(ch.isdigit() for ch in text)
 
 
+#: #2563: numeric tokens inside an extracted literal ("0.12 R" -> "0.12").
+_NUMERIC_TOKEN_RE = re.compile(r"\d+(?:\.\d+)?")
+
+
+def _number_survives(token: str, lld_content: str) -> bool:
+    """The numeric token appears in the LLD as its own number.
+
+    Boundary-guarded so "12" never matches inside "0.12" and "0.12" never
+    matches inside "0.125" -- a conservation check that can be satisfied by
+    a coincidental substring is not a check.
+    """
+    return re.search(
+        rf"(?<![\d.]){re.escape(token)}(?!\d)", lld_content
+    ) is not None
+
+
+def validate_assertion_literal_conservation(
+    issue_body: str, lld_content: str
+) -> list[ValidationError]:
+    """Reject a derivation that shed a source row's literals (#2563).
+
+    The #331 issue's S6 row states its mirror-band check with a ruled
+    sampling window ("sampled ONLY at horizontal offsets 0.12 R-0.25 R
+    either side of the vertical axis" -- the #361 ruling), and the generated
+    LLD restated the check twice with no window; 0.12 appeared nowhere in
+    the document. The spec-stage reviewer then correctly proved the
+    requirement set contradictory from the geometry and halted the roll for
+    an operator ruling made six days earlier. In a ruling-dense requirement
+    the subordinate clause IS the ruling; a derivation that sheds it
+    re-opens settled conflicts.
+
+    Mechanics: for each row of each decision table in the SOURCE issue (the
+    ruled #332 shape -- an ID column and a binding-value column), every
+    literal `extract_literals` finds in the row's cells must survive into
+    the LLD -- hex colours verbatim (case-insensitive), numeric literals as
+    boundary-guarded numbers anywhere in the document. Absence-phrase
+    literals ("renders nothing") are phrasing, not values, and are not
+    conserved. A row whose literals were shed is named with exactly what
+    went missing, so the revision loop hands the drafter the clause to
+    carry rather than a style note.
+
+    An issue with no decision table (most repos, every non-visual issue)
+    yields no checks and no errors -- not applicable is not failure.
+    """
+    from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+        _HEX_RE,
+        extract_literals,
+        is_criteria_table,
+    )
+    from assemblyzero.workflows.requirements.form_check import parse_tables
+
+    errors: list[ValidationError] = []
+    if not issue_body or not lld_content:
+        return errors
+
+    lld_lower = lld_content.lower()
+    for table in parse_tables(issue_body):
+        if not is_criteria_table(table):
+            continue
+        for row in table.rows:
+            if not row:
+                continue
+            row_id = row[0] or "?"
+            source_text = " | ".join(row[1:])
+            missing: list[str] = []
+            for literal in extract_literals(source_text):
+                if _HEX_RE.fullmatch(literal):
+                    if literal.lower() not in lld_lower:
+                        missing.append(literal)
+                    continue
+                tokens = _NUMERIC_TOKEN_RE.findall(literal)
+                if not tokens:
+                    # Absence/identity phrasing ("renders nothing") -- a
+                    # legitimate literal for the manifest, but phrasing is
+                    # the drafter's to restate; only values are conserved.
+                    continue
+                if any(
+                    not _number_survives(token, lld_content)
+                    for token in tokens
+                ):
+                    missing.append(literal)
+            if missing:
+                errors.append(
+                    ValidationError(
+                        severity=ValidationSeverity.ERROR,
+                        section="10 Test Plan",
+                        message=(
+                            f"Critical: source decision-table row {row_id}'s "
+                            f"qualifiers were lost in derivation -- "
+                            f"{', '.join(repr(m) for m in missing[:6])} "
+                            f"appear(s) nowhere in the LLD. Carry the "
+                            f"qualifying clause (sampling window, offset, "
+                            f"threshold) into the derived requirement and "
+                            f"test rows verbatim; the qualifier is the "
+                            f"ruling, not commentary (#2563)"
+                        ),
+                    )
+                )
+    return errors
+
+
 def validate_mandatory_sections(lld_content: str) -> list[ValidationError]:
     """Verify that all mandatory LLD sections exist.
 
@@ -1545,6 +1646,17 @@ def _validate_lld_mechanical_inner(state: Dict[str, Any]) -> Dict[str, Any]:
     # stage nothing to assert. Caught here, in the lld stage, rather than
     # after the spec has spent its budget discovering the same thing.
     all_errors.extend(validate_test_plan_pass_criteria(lld_content))
+
+    # Step 6c (#2563): a derivation that sheds a source row's qualifying
+    # literals re-opens ruled conflicts -- the #331 S6 sampling window
+    # vanished and the spec reviewer re-proved a contradiction ruled six
+    # days earlier. Every literal in the issue's decision-table rows must
+    # survive into the LLD, or the row is named lossy.
+    all_errors.extend(
+        validate_assertion_literal_conservation(
+            state.get("issue_body", ""), lld_content
+        )
+    )
 
     # Step 7: Trace risk mitigations (warnings only, with Issue #312 smart filtering)
     mitigations = extract_mitigations_from_risks(lld_content)

--- a/tests/unit/test_assertion_literal_conservation.py
+++ b/tests/unit/test_assertion_literal_conservation.py
@@ -1,0 +1,118 @@
+"""The derivation carries its source row's literals, or says it shed them (#2563).
+
+The observed case: boostgauge #331's S6 row states the mirror-band check
+with a ruled sampling window ("sampled ONLY at horizontal offsets
+0.12 R-0.25 R either side of the vertical axis" -- the #361 ruling); the
+generated LLD (preserved at graveyard/331-lld-20260827T170422Z) restated
+the check twice with no window, 0.12 appeared nowhere in the document, and
+the spec-stage reviewer re-proved from the geometry a contradiction ruled
+six days earlier. Calibrated against the real pair before landing: four
+firings, all genuine losses (S3, S5, S6, S7), zero false alarms on the five
+conserved rows.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    validate_assertion_literal_conservation,
+)
+
+#: The observed S6 row, verbatim shape: ID column, binding value, assertion
+#: method carrying the ruled window inline.
+ISSUE_BODY = """## Decision table — static elements and their binding values
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|----|---------|------------------------------------------------|------------------|
+| S6 | Wordmark | `BOOSTGAUGE`, `#FFFFFF`, cap height 0.09 R, band centred 0.67 R below the pivot | presence: ≥1 white-classified pixel in the wordmark band; absence of white in the mirror band above the pivot, sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis |
+"""
+
+#: The observed derived shape: the check restated with no window — the bare
+#: "0 white pixels in mirrored band" the preserved LLD carried.
+LLD_WITHOUT_WINDOW = """# LLD-331
+
+## 3. Requirements
+
+1. Wordmark presence and phantom check.
+
+## 10. Test Plan
+
+| ID | Scenario | Pass criterion |
+|----|----------|----------------|
+| 070 | Wordmark existential and phantom check | >= 1 white pixel in wordmark band (`#FFFFFF`), cap height 0.09 R, centred 0.67 R below pivot; 0 white pixels in mirrored band |
+"""
+
+LLD_WITH_WINDOW = LLD_WITHOUT_WINDOW.replace(
+    "0 white pixels in mirrored band",
+    "0 white pixels in mirrored band sampled at offsets 0.12 R–0.25 R "
+    "either side of the vertical axis",
+)
+
+
+class TestTheObservedCase:
+    def test_the_shed_window_is_flagged_by_row(self):
+        errors = validate_assertion_literal_conservation(
+            ISSUE_BODY, LLD_WITHOUT_WINDOW
+        )
+        assert len(errors) == 1
+        message = errors[0].message
+        assert "S6" in message
+        assert "0.12" in message
+        assert "#2563" in message
+
+    def test_the_carried_window_is_quiet(self):
+        assert validate_assertion_literal_conservation(
+            ISSUE_BODY, LLD_WITH_WINDOW
+        ) == []
+
+    def test_a_control_row_with_no_numeric_qualifiers_derives_unchanged(self):
+        issue = """| ID | Element | Binding value | Assertion method |
+|----|---------|---------------|------------------|
+| T1 | Peak marker | a `None` peak renders nothing | the rendered face is identical to the bare face |
+"""
+        assert validate_assertion_literal_conservation(
+            issue, "# LLD\n\nAny content at all."
+        ) == []
+
+
+class TestConservationMechanics:
+    def _issue(self, binding: str, assertion: str) -> str:
+        return (
+            "| ID | Element | Binding value | Assertion method |\n"
+            "|----|---------|---------------|------------------|\n"
+            f"| S1 | Element | {binding} | {assertion} |\n"
+        )
+
+    def test_a_hex_colour_is_conserved_case_insensitively(self):
+        issue = self._issue("`#AA0F19` crimson", "classification at 3 points")
+        assert validate_assertion_literal_conservation(
+            issue, "# LLD\n\nband is #aa0f19, sampled at 3 points"
+        ) == []
+        errors = validate_assertion_literal_conservation(
+            issue, "# LLD\n\nband is crimson, sampled at 3 points"
+        )
+        assert len(errors) == 1
+        assert "#AA0F19" in errors[0].message
+
+    def test_a_number_does_not_survive_as_a_substring(self):
+        """0.12 inside 0.125 is not conservation, and 12 inside 0.12 is not
+        either -- a coincidental substring must never satisfy the check."""
+        issue = self._issue("window at 0.12 R", "sampled in the window")
+        errors = validate_assertion_literal_conservation(
+            issue, "# LLD\n\nthreshold 0.125 R applies"
+        )
+        assert len(errors) == 1
+        issue_12 = self._issue("offset 12 px", "sampled at the offset")
+        errors_12 = validate_assertion_literal_conservation(
+            issue_12, "# LLD\n\nwindow at 0.12 R"
+        )
+        assert len(errors_12) == 1
+
+    def test_an_issue_with_no_decision_table_is_not_applicable(self):
+        assert validate_assertion_literal_conservation(
+            "## Requirements\n\nJust prose with 0.12 R in it.",
+            "# LLD\n\nNothing conserved.",
+        ) == []
+
+    def test_empty_inputs_are_quiet(self):
+        assert validate_assertion_literal_conservation("", "x") == []
+        assert validate_assertion_literal_conservation("x", "") == []


### PR DESCRIPTION
Closes #2563

The lld stage's derivation shed a ruled sampling window — boostgauge #331's S6 row states its mirror-band check "sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis" (the #361 ruling), and the generated LLD (preserved at `graveyard/331-lld-20260827T170422Z`) restated the check twice with no window; `0.12` appeared nowhere in the document. The spec-stage reviewer then correctly re-proved the requirement set contradictory from the geometry and halted the roll for a ruling made six days earlier. In a ruling-dense requirement the subordinate clause IS the ruling.

## The repair

`validate_assertion_literal_conservation` (a Step 6c sibling of #2208's pass-criterion check in `validate_mechanical.py`): for each row of each decision table in the SOURCE issue (the ruled #332 shape — ID column plus binding-value column, recognized by the assertion manifest's own `is_criteria_table`), every literal `extract_literals` finds in the row's cells must survive into the LLD — hex colours verbatim case-insensitively, numeric literals as boundary-guarded numbers (`0.12` is never satisfied by `0.125`, `12` never by `0.12`). Absence-phrase literals ("renders nothing") are phrasing, not values, and are not conserved. A shed row fails mechanical validation with the row id and exactly the missing literals, so the revision loop hands the drafter the clause to carry. An issue with no decision table yields no checks — not applicable is not failure.

Direction chosen from the issue's candidates: the conservation check, not verbatim-quoting rows — the check is mechanical, rides the existing revision loop, and reuses the fleet's own literal vocabulary (`extract_literals`, built for exactly this domain: R-fractions, bounds, hex, degrees; deliberately no bare integers, so no issue-number noise).

## Calibrated against the real pair before landing

Run against the live #331 issue body and the preserved LLD: **four firings, all genuine losses, zero false alarms** on the five conserved rows.

- S6: `0.12 R`, `0.775 R`, `0.065 R`, `0.27 R` — the observed defect, caught by row.
- S5: the same window (the post-hardening row carries it; the pre-hardening-derived LLD does not).
- S3: `2.56 px` — the clause explaining why the stroke predicate exists at all.
- S7: `≤ 14` — "achromatic" without its numeric definition is a pointer, not a value.

One honest limitation, stated rather than hidden: matching is document-scoped, not row-scoped (derived rows carry no reliable join key back to source rows), so a literal another row legitimately carries can coincidentally conserve — `0.25` survives via S8's screw offsets. The flag still fires whenever ANY of a row's literals is missing, which is what caught S6; a fully-coincidental cover of every literal in a multi-literal qualifier is the residual gap, and shrinking it needs derived-row join keys that do not exist today.

## Acceptance

`tests/unit/test_assertion_literal_conservation.py`: the observed S6 row against the observed bare restatement fires naming `S6` and `0.12`; the window carried is quiet; a control row with no numeric qualifiers derives unchanged; hex conservation both directions; substring non-conservation both directions; no-decision-table and empty inputs are quiet. Full unit suite green.

**What only a live roll proves:** the drafter actually carrying the clause when the revision loop hands it this feedback, and the derived LLD then passing the spec reviewer's geometry check first try.
