### PR TITLE
fix: the leavings sweep knows a pipeline input from litter -- the rolling issue's LLD survives launch and teardown (Closes #2551)

### DIFF
--- a/assemblyzero/speedrun/leavings.py
+++ b/assemblyzero/speedrun/leavings.py
@@ -43,6 +43,54 @@ EMISSION_ALLOWLIST = (
     "docs/lld/drafts/",
 )
 
+#: #2551: the CURRENT roll's canonical inputs are not leavings. The LLD
+#: working copy at docs/lld/active/LLD-{issue}.md is untracked on the main
+#:  checkout (main does not carry it; the arc branch does), so the sweep
+#: classified it as leavings and preserved-and-cleared it three times on
+#: 2026-08-27 -- including once at LAUNCH, before the run had done
+#: anything -- and every later stage (and every resume) then read its own
+#: input's canonical path and found it gone. The patterns mirror the
+#: loader's exactly (`find_lld_path` / `find_spec_path` in
+#: workflows/testing/nodes/load_lld.py): what the loader would resolve for
+#: the rolling issue is an input; every OTHER issue's file at these paths
+#: stays genuine leavings -- the run-16 droppings that this janitor was
+#: built to clear (#2144) are still cleared.
+_INPUT_GLOB_TEMPLATES = (
+    "docs/lld/active/LLD-{padded3}.md",
+    "docs/lld/active/LLD-{padded3}-*.md",
+    "docs/lld/active/LLD-{issue}.md",
+    "docs/lld/active/LLD-{issue}-*.md",
+    "docs/lld/drafts/spec-{padded4}.md",
+    "docs/lld/drafts/spec-{padded4}-*.md",
+    "docs/lld/drafts/spec-{padded3}.md",
+    "docs/lld/drafts/spec-{padded3}-*.md",
+    "docs/lld/drafts/spec-{issue}.md",
+    "docs/lld/drafts/spec-{issue}-*.md",
+)
+
+
+def pipeline_input_globs(issue: int) -> tuple[str, ...]:
+    """The canonical input paths the loader resolves for ``issue``."""
+    return tuple(
+        template.format(
+            issue=issue, padded3=f"{issue:03d}", padded4=f"{issue:04d}"
+        )
+        for template in _INPUT_GLOB_TEMPLATES
+    )
+
+
+def is_pipeline_input(rel_path: str, issues) -> bool:
+    """True when ``rel_path`` is a canonical input for any rolling issue."""
+    from fnmatch import fnmatch
+
+    normalized = rel_path.replace("\\", "/")
+    return any(
+        fnmatch(normalized, glob)
+        for issue in (issues or ())
+        for glob in pipeline_input_globs(int(issue))
+    )
+
+
 GRAVEYARD_LEAVINGS_PREFIX = "graveyard/leavings"
 
 _TS_FMT = "%Y%m%d-%H%M%S"
@@ -144,13 +192,22 @@ def is_machinery_owned(rel_path: str) -> bool:
     return any(normalized.startswith(prefix) for prefix in EMISSION_ALLOWLIST)
 
 
-def classify_dirt(repo: Path | str) -> tuple[list[str], list[str]]:
+def classify_dirt(
+    repo: Path | str, *, protect_issues=()
+) -> tuple[list[str], list[str]]:
     """(machinery-owned untracked, operator-owned dirt) as porcelain lines.
 
     Machinery-owned: untracked AND under the emission allowlist -- ours to
     preserve and clear. Operator-owned: every other dirty entry (tracked
     modifications of any kind, untracked outside the allowlist) -- named,
     never touched.
+
+    ``protect_issues`` (#2551): the issues currently rolling. Their
+    canonical input files (the LLD the loader resolves, the spec-draft
+    fallback) are neither machinery leavings nor operator dirt -- they are
+    the pipeline's own input at the path every stage and every resume
+    reads, and appear in neither list. Every other issue's file at those
+    paths is still leavings.
     """
     result = _run(["git", "-C", str(repo), "status", "--porcelain", "-uall"])
     if result.returncode != 0:
@@ -166,6 +223,9 @@ def classify_dirt(repo: Path | str) -> tuple[list[str], list[str]]:
             # The machinery's own record is never dirt (#2164).
             continue
         if line.startswith("?? ") and is_machinery_owned(path):
+            if is_pipeline_input(path, protect_issues):
+                # The current roll's input is not litter (#2551).
+                continue
             machinery.append(path)
         else:
             operator.append(line.strip())

--- a/tests/unit/test_leavings_janitor.py
+++ b/tests/unit/test_leavings_janitor.py
@@ -31,6 +31,7 @@ import speedrun_roll as sr  # noqa: E402
 
 from assemblyzero.speedrun.leavings import (  # noqa: E402
     classify_dirt,
+    is_pipeline_input,
     preserve_and_clear,
     untracked_files,
 )
@@ -315,3 +316,99 @@ class TestNewAttemptPosture:
         assert leaving.exists()
         assert _leavings_branches(repo) == []
         assert "pipeline-authored leaving" in capsys.readouterr().out
+
+
+# --- the roll's own inputs are not litter (#2551) ---------------------------
+
+
+class TestPipelineInputClassification:
+    """The classifier gains the concept it lacked: a canonical INPUT path
+    for the issues currently rolling. Patterns mirror the loader's
+    (`find_lld_path` / `find_spec_path`) exactly."""
+
+    def test_the_loaders_patterns_are_inputs(self):
+        assert is_pipeline_input("docs/lld/active/LLD-331.md", [331])
+        assert is_pipeline_input("docs/lld/active/LLD-007.md", [7])
+        assert is_pipeline_input("docs/lld/active/LLD-7.md", [7])
+        assert is_pipeline_input("docs/lld/active/LLD-007-cache.md", [7])
+        assert is_pipeline_input("docs/lld/drafts/spec-0007.md", [7])
+
+    def test_another_issues_file_is_not_an_input(self):
+        """The run-16 droppings this janitor was built to clear (#2144)
+        are still leavings when a different issue rolls."""
+        assert not is_pipeline_input("docs/lld/active/LLD-002.md", [7])
+        assert not is_pipeline_input("docs/lld/active/LLD-016.md", [331])
+
+    def test_no_rolling_issues_protect_nothing(self):
+        assert not is_pipeline_input("docs/lld/active/LLD-007.md", [])
+        assert not is_pipeline_input("docs/lld/active/LLD-007.md", None)
+
+    def test_classify_dirt_keeps_the_input_out_of_both_lists(self, repo):
+        _drop_leaving(repo, "docs/lld/active/LLD-007.md")
+        machinery, operator = classify_dirt(repo, protect_issues=[7])
+        assert machinery == []
+        assert operator == []
+        unprotected, _ = classify_dirt(repo)
+        assert "docs/lld/active/LLD-007.md" in unprotected
+
+
+class TestCanonicalInputsSurviveTheRoll:
+    """#2551's acceptance: a launch-then-teardown cycle leaves the rolling
+    issue's LLD readable at the loader's resolved path, while genuine
+    leavings are still swept and preserved. The observed failure: the
+    13:01:22 launch sweep of run-issue331-130125 cleared the very LLD the
+    run was about to read, and the 13:25:57 teardown sweep cleared the
+    regenerated copy the resume would have needed."""
+
+    def test_the_rolling_issues_lld_survives_launch_and_teardown(self, repo):
+        _drop_leaving(repo, "docs/lld/active/LLD-007.md")
+        seen = {}
+
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            seen["at_roll"] = (
+                Path(repo_root) / "docs" / "lld" / "active" / "LLD-007.md"
+            ).exists()
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert seen["at_roll"] is True, "the launch janitor swept the input"
+        from assemblyzero.workflows.testing.nodes.load_lld import find_lld_path
+
+        resolved = find_lld_path(7, repo)
+        assert resolved is not None, "the loader must find the input after teardown"
+        assert resolved.read_text(encoding="utf-8") == "drafted by the pipeline\n"
+
+    def test_an_input_written_during_the_run_survives_the_exit_reconcile(
+        self, repo
+    ):
+        """The teardown half: the lld stage saves the approved LLD during
+        the run; a resume reads it there. The reconcile leaves it."""
+
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            _drop_leaving(Path(repo_root), "docs/lld/active/LLD-007.md")
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert (repo / "docs" / "lld" / "active" / "LLD-007.md").exists()
+
+    def test_genuine_leavings_are_still_swept_beside_the_kept_input(
+        self, repo
+    ):
+        """Do not weaken the sweep: another issue's dropping on the same
+        path prefix is preserved-and-cleared exactly as before."""
+        _drop_leaving(repo, "docs/lld/active/LLD-002.md")
+        _drop_leaving(repo, "docs/lld/active/LLD-007.md")
+
+        def _roll(repo_root, issue, log_dir, az_root, extra):
+            return 0
+
+        code = _launch(repo, _roll)
+
+        assert code == 0
+        assert not (repo / "docs" / "lld" / "active" / "LLD-002.md").exists()
+        assert (repo / "docs" / "lld" / "active" / "LLD-007.md").exists()
+        assert _leavings_branches(repo), "the genuine leaving was preserved"

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -129,6 +129,7 @@ from assemblyzero.speedrun.healing import record_heal  # noqa: E402
 from assemblyzero.speedrun.leavings import (  # noqa: E402
     classify_dirt,
     is_machinery_owned,
+    is_pipeline_input,
     preserve_and_clear,
     untracked_files,
 )
@@ -2566,10 +2567,26 @@ def restore_repo(
     if tracked:
         failures.append(f"{len(tracked)} tracked modification(s) left behind")
 
+    inputs_kept: list[str] = []
     if baseline_untracked is not None:
         new = sorted(set(untracked_files(repo_root)) - baseline_untracked)
-        machinery_new = [f for f in new if is_machinery_owned(f)]
-        operator_new = [f for f in new if not is_machinery_owned(f)]
+        # #2551: the roll's own canonical inputs are not leavings even when
+        # the run itself wrote them -- the lld stage saves the approved LLD
+        # to docs/lld/active/, the impl stage reads it there on every entry
+        # including a resume, and the 13:25 teardown sweep of
+        # run-issue331-130125 cleared it between the two. What the loader
+        # resolves for a rolling issue stays in place, named in the log.
+        inputs_kept = [f for f in new if is_pipeline_input(f, issues)]
+        for kept in inputs_kept:
+            log.write(f"RESTORE input kept (not litter): {kept}")
+        machinery_new = [
+            f for f in new
+            if is_machinery_owned(f) and f not in inputs_kept
+        ]
+        operator_new = [
+            f for f in new
+            if not is_machinery_owned(f) and f not in inputs_kept
+        ]
 
         if machinery_new:
             janitor = preserve_and_clear(
@@ -2594,9 +2611,13 @@ def restore_repo(
             failures.append(f"new untracked file not made by the pipeline: {f}")
 
     if not failures:
+        kept_note = (
+            f" beyond {len(inputs_kept)} canonical input(s) kept in place"
+            if inputs_kept else ""
+        )
         log.write(
             f"RESTORE verified: on '{base}', no pipeline worktrees, clean, "
-            "no new untracked files"
+            f"no new untracked files{kept_note}"
         )
     return failures
 
@@ -3469,7 +3490,18 @@ def main(argv: list[str] | None = None) -> int:
     # janitor problem is reported and never costs the roll.
     session.write("JANITOR pipeline file leavings")
     try:
-        machinery, _operator = classify_dirt(repo_root)
+        # #2551: the rolling issues' canonical inputs (the LLD the loader
+        # resolves, the spec-draft fallback) are not leavings -- the 13:01
+        # launch sweep of run-issue331-130125 cleared the very LLD the run
+        # was about to read. Named so the log shows the input survived.
+        machinery, _operator = classify_dirt(
+            repo_root, protect_issues=args.issue or []
+        )
+        for kept in [
+            f for f in untracked_files(repo_root)
+            if is_pipeline_input(f, args.issue or [])
+        ]:
+            session.write(f"  file janitor: input kept (not litter): {kept}")
         if machinery:
             janitor = preserve_and_clear(
                 repo_root, machinery, log=lambda m: session.write(m.strip())


### PR DESCRIPTION
Closes #2551

The run swept its own input as litter. The standard-0027 leavings sweep classifies every untracked file under the emission allowlist as leavings, and the LLD working copy at `docs/lld/active/LLD-331.md` is untracked on the main checkout — so the sweep preserved it to `graveyard/leavings-20260827-130120` (commit `8ce93be`, verified: the file is in the tree) and cleared it, three times on 2026-08-27, including once at LAUNCH before the run had done anything. The sweep works as specified; its classifier had no concept of a canonical pipeline-input path.

## The repair — issue-scoped, not a blanket exemption

The direction chosen from the issue's two candidates is the path exemption, with one sharpening the sweep's own history forces: this janitor was BUILT (#2144) to clear stale LLD droppings from `docs/lld/active/` — the run-16 files that blocked two launches — so exempting `LLD-*.md` wholesale would resurrect the defect the sweep exists to prevent. The exemption is therefore scoped to the issues currently rolling:

- `is_pipeline_input(path, issues)` / `pipeline_input_globs(issue)` in the leavings module, with patterns mirroring the loader's exactly (`find_lld_path`'s four LLD patterns, `find_spec_path`'s drafts fallback). What the loader would resolve for a rolling issue is an input; every OTHER issue's file at those paths stays genuine leavings.
- `classify_dirt(repo, protect_issues=...)`: a protected input appears in neither the machinery nor the operator list — it is the pipeline's own input at the path every stage and every resume reads.
- Both `speedrun_roll` sweep sites thread the rolling issues through: the launch janitor (the 13:01:22 sweep that cleared the input before the run began) and the exit reconcile (the 13:25:57 teardown sweep that cleared the regenerated copy the resume would have needed — the lld stage saves the approved LLD mid-run, making it new-since-baseline and previously sweepable). Kept inputs are named in the log (`input kept (not litter)`), and the RESTORE-verified line says when inputs were kept rather than claiming "no new untracked files".

`speedrun_new_attempt`'s sweeps are deliberately untouched: settling a repo for a fresh attempt is a different intent with no observed harm, and clearing there is plausibly correct.

## Invariant, proven in a real launch-teardown cycle

`tests/unit/test_leavings_janitor.py` gains two classes riding the existing full-launch harness (real repo, real bare origin, real `speedrun_roll.main`):

- The rolling issue's LLD present at launch survives the launch janitor, is present when the roll runs, and after teardown `find_lld_path` — the loader itself — resolves it with content intact. A resume finds the same input the halted attempt found, at the path the loader resolves.
- An input written DURING the run survives the exit reconcile.
- Do-not-weaken, both directions: another issue's dropping beside the kept input is still preserved-and-cleared, and classification unit tests pin the loader-pattern matching, the other-issue negative, and the no-rolling-issues negative.

Full unit suite green.

**What only a live roll proves:** the real boostgauge checkout keeping `LLD-331.md` across an actual `speedrun_roll` launch, and the resumed impl stage reading it.
