### PR TITLE
fix: zero requirements is a named event with its cause, and no gate certifies against the empty set (Closes #2552)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/completeness_gate.py
+++ b/assemblyzero/workflows/testing/nodes/completeness_gate.py
@@ -103,6 +103,42 @@ def completeness_gate(state: TestingWorkflowState) -> dict[str, Any]:
     # Combine implementation and test files for analysis
     all_files = implementation_files + test_files
 
+    # =========================================================================
+    # #2552: a zero needs a denominator here too. This gate's verdict comes
+    # entirely from Layer 1's AST analysis of the implementation files; the
+    # requirement set only ever fed Layer 2's PREPARATION — so with zero
+    # requirements the gate reviewed the implementation against nothing and
+    # returned the same PASS five requirements would earn (#2024 repaired
+    # the path resolution that caused one such run; the requirement-
+    # blindness itself survived it). Certifying completeness against an
+    # empty set is not a verdict, it is the absence of one: refuse, naming
+    # load_lld's recorded reason so the halt says whether the set was
+    # declared empty or unreadable and where it looked.
+    # =========================================================================
+    requirements = state.get("requirements", [])
+    if not requirements:
+        reason = state.get("requirements_empty_reason", "") or (
+            "no requirement set in state and no recorded reason -- "
+            "load_lld did not run, or ran before this field existed"
+        )
+        message = (
+            f"Completeness gate: cannot certify an implementation against "
+            f"zero requirements -- {reason} (#2552)"
+        )
+        print(f"    [N4b] {message}")
+        log_workflow_execution(
+            target_repo=repo_root,
+            issue_number=issue_number,
+            workflow_type="testing",
+            event="completeness_zero_requirements",
+            details={"reason": reason},
+        )
+        return {
+            "completeness_verdict": "BLOCK",
+            "completeness_issues": [],
+            "error_message": message,
+        }
+
     if not all_files:
         print("    [WARN] No implementation files to analyze — passing through")
         return {

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -457,6 +457,54 @@ def extract_requirements(lld_content: str) -> list[str]:  # pragma: no cover
     return requirements
 
 
+#: #2552: the patterns extract_requirements actually searches, named so a
+#: zero-requirements event can say what was looked for without the reader
+#: opening this file. Update alongside the extractor.
+_REQUIREMENTS_SEARCHED = (
+    "'### REQ-x.y:' headers, a '## Requirements'/'## Acceptance Criteria' "
+    "numbered list, and a '## 10. Test Mapping' table"
+)
+
+
+def describe_zero_requirements(
+    issue_number: int,
+    repo_root: Path,
+    spec_path: str,
+    original_lld_path: Path | None,
+    original_lld_readable: bool,
+) -> str:
+    """The empty requirement set as a named fact (#2552).
+
+    A zero needs a denominator here as much as it did for collected tests
+    (#2546): "no requirements declared" and "requirements unreadable" are
+    different events, the second names the path it searched, and neither is
+    a WARN that scrolls past. The 2026-08-27 near-miss: the leavings sweep
+    had cleared the LLD working copy, and a resumed impl stage would have
+    fallen back to the spec — whose Section 3 is "Current State", so every
+    extraction pattern returns empty — and certified against nothing.
+    """
+    if original_lld_path is None:
+        lld_dir = repo_root / LLD_ACTIVE_DIR
+        return (
+            f"requirements unreadable: no LLD found for issue "
+            f"#{issue_number} under {lld_dir} (searched "
+            f"LLD-{issue_number:03d}.md and its dash/unpadded variants), "
+            f"and the spec at {spec_path} declares none "
+            f"(searched: {_REQUIREMENTS_SEARCHED})"
+        )
+    if not original_lld_readable:
+        return (
+            f"requirements unreadable: the LLD at {original_lld_path} "
+            f"exists but could not be read, and the spec at {spec_path} "
+            f"declares none (searched: {_REQUIREMENTS_SEARCHED})"
+        )
+    return (
+        f"no requirements declared: neither the LLD at "
+        f"{original_lld_path} nor the spec at {spec_path} yields any "
+        f"(searched: {_REQUIREMENTS_SEARCHED})"
+    )
+
+
 def parse_test_scenarios(test_plan: str) -> list[TestScenario]:  # pragma: no cover
     """Parse test scenarios from test plan section.
 
@@ -1030,12 +1078,14 @@ def load_lld(state: TestingWorkflowState) -> dict[str, Any]:  # pragma: no cover
     # and its Section 10 may use a different format. The original LLD
     # has the canonical Section 3 (Requirements) and Section 10.1 (Test Scenarios).
     original_lld_content = lld_content  # default: use spec content
+    original_lld_readable = False  # #2552: tracked for the zero-req event
     original_lld_path = find_lld_path(issue_number, repo_root)
     if not original_lld_path and state.get("original_repo_root"):
         original_lld_path = find_lld_path(issue_number, Path(state["original_repo_root"]))
     if original_lld_path and original_lld_path.exists():
         try:
             original_lld_content = original_lld_path.read_text(encoding="utf-8")
+            original_lld_readable = True
             print(f"    Original LLD: {original_lld_path}")
         except OSError:
             print("    [WARN] Could not read original LLD, using spec content")
@@ -1096,13 +1146,23 @@ def load_lld(state: TestingWorkflowState) -> dict[str, Any]:  # pragma: no cover
 
     # Extract requirements — use original LLD (has Section 3: Requirements)
     requirements = extract_requirements(original_lld_content)
+    requirements_empty_reason = ""
     if not requirements:
         # Diagnostic: try spec content as fallback
         requirements = extract_requirements(lld_content)
         if requirements:
             print(f"    Found {len(requirements)} requirements (from spec)")
         else:
-            print("    [WARN] No requirements found in LLD or spec content")
+            # #2552: a named event, never a WARN that scrolls past. The
+            # reason travels in state so N1's guard and the N4b gate can
+            # say WHY the denominator is zero — declared-none and
+            # unreadable are different repairs, and the second names the
+            # path it searched.
+            requirements_empty_reason = describe_zero_requirements(
+                issue_number, repo_root, str(lld_path_obj),
+                original_lld_path, original_lld_readable,
+            )
+            print(f"    [ZERO-REQUIREMENTS] {requirements_empty_reason}")
     else:
         print(f"    Found {len(requirements)} requirements (from LLD)")
 
@@ -1170,6 +1230,8 @@ def load_lld(state: TestingWorkflowState) -> dict[str, Any]:  # pragma: no cover
         "detected_test_types": detected_types,
         "coverage_target": coverage_target,
         "requirements": requirements,
+        # #2552: why the denominator is zero, when it is. "" otherwise.
+        "requirements_empty_reason": requirements_empty_reason,
         "files_to_modify": files_to_modify,
         "audit_dir": str(audit_dir),
         "file_counter": file_num,

--- a/assemblyzero/workflows/testing/nodes/review_test_plan.py
+++ b/assemblyzero/workflows/testing/nodes/review_test_plan.py
@@ -299,8 +299,14 @@ def _run_mechanical_gates(state: TestingWorkflowState) -> list[str]:
     # Gate 2: Requirements exist
     requirements = state.get("requirements", [])
     if not requirements:
+        # #2552: the block names WHY the denominator is zero — load_lld's
+        # named event distinguishes "no requirements declared" from
+        # "requirements unreadable" and carries the searched path, so the
+        # operator repairs the right thing instead of hunting.
+        reason = state.get("requirements_empty_reason", "")
         errors.append(
             "No requirements extracted from LLD — cannot verify coverage"
+            + (f" ({reason})" if reason else "")
         )
 
     # Gate 3: Scenario-to-requirement coverage ratio

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -165,6 +165,12 @@ class TestingWorkflowState(TypedDict, total=False):
     detected_test_types: list[str]
     coverage_target: int
     requirements: list[str]
+    # #2552: why `requirements` is empty, when it is — "no requirements
+    # declared" vs "requirements unreadable" naming the searched path. ""
+    # when requirements were found. N1's guard and the N4b gate quote it,
+    # so a zero denominator halts with its cause named instead of
+    # certifying vacuously.
+    requirements_empty_reason: str
     files_to_modify: list[dict]  # Files from LLD Section 2.1
 
     # Workflow tracking

--- a/tests/unit/test_wave2_reliability.py
+++ b/tests/unit/test_wave2_reliability.py
@@ -338,6 +338,9 @@ class TestCompletenessGateStoresIssueIds:
                 "test_files": [],
                 "audit_dir": "",
                 "iteration_count": 0,
+                # #2552: the gate refuses an empty requirement set before
+                # any analysis; this test exercises the ordinary path.
+                "requirements": ["REQ-1: foo exists"],
             }
             # Create a dummy file so analysis has something
             (tmp_path / "foo.py").write_text("pass")

--- a/tests/unit/test_zero_requirements_denominator.py
+++ b/tests/unit/test_zero_requirements_denominator.py
@@ -1,0 +1,145 @@
+"""Zero requirements is a named event, and no gate goes vacuously green (#2552).
+
+The near-miss of 2026-08-27: the leavings sweep had cleared the LLD working
+copy, and a resumed impl stage would have fallen back to the spec — whose
+Section 3 is "Current State", so every extraction pattern returns empty —
+with only a WARN line saying so. Verification against the code sharpened
+the filed diagnosis: the N1 fast path has refused a zero denominator since
+2026-02-01 (`728f0116`) and #496's Gate 2 blocks empty requirements before
+the fast path is consulted — both now PINNED here, since nothing tested
+them — while the N4b completeness gate's verdict was genuinely
+requirement-blind (its own #2024 comment records a prior zero-requirements
+verdict) and load_lld's WARN scrolled past unnamed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes.completeness_gate import (
+    completeness_gate,
+)
+from assemblyzero.workflows.testing.nodes.load_lld import (
+    describe_zero_requirements,
+)
+from assemblyzero.workflows.testing.nodes.review_test_plan import (
+    _run_mechanical_gates,
+    check_requirement_coverage,
+)
+
+
+class TestTheEmptySetIsNamed:
+    def test_a_missing_lld_reads_as_unreadable_and_names_the_search(self):
+        reason = describe_zero_requirements(
+            331, Path("C:/repo"), "C:/repo/spec.md", None, False
+        )
+        assert reason.startswith("requirements unreadable")
+        assert "LLD-331.md" in reason
+        assert "docs" in reason and "lld" in reason
+        assert "searched:" in reason
+
+    def test_an_unreadable_lld_names_its_path(self):
+        reason = describe_zero_requirements(
+            331, Path("C:/repo"), "C:/repo/spec.md",
+            Path("C:/repo/docs/lld/active/LLD-331.md"), False,
+        )
+        assert reason.startswith("requirements unreadable")
+        assert "LLD-331.md" in reason
+        assert "could not be read" in reason
+
+    def test_a_readable_pair_with_nothing_to_extract_reads_as_declared_none(self):
+        reason = describe_zero_requirements(
+            331, Path("C:/repo"), "C:/repo/spec.md",
+            Path("C:/repo/docs/lld/active/LLD-331.md"), True,
+        )
+        assert reason.startswith("no requirements declared")
+        assert "LLD-331.md" in reason
+        assert "spec.md" in reason
+
+
+class TestN1RefusesTheZeroDenominator:
+    """The two guards the filed diagnosis missed, pinned so a refactor
+    cannot silently drop them."""
+
+    def test_zero_zero_is_never_full_coverage(self):
+        """The 2026-02-01 guard: 0/0 reads as passed=False, so the
+        fast path can never skip the reviewer on an empty set."""
+        result = check_requirement_coverage([], [])
+        assert result["passed"] is False
+        assert result["total"] == 0
+
+    def test_gate_two_blocks_empty_requirements(self):
+        errors = _run_mechanical_gates({
+            "test_scenarios": [{"name": "test_x", "type": "unit"}],
+            "requirements": [],
+            "lld_content": "word " * 60,
+        })
+        assert any("No requirements" in e for e in errors)
+
+    def test_gate_two_quotes_the_recorded_reason(self):
+        """#2552: the block names WHY — declared-none vs unreadable, with
+        the searched path — instead of leaving the operator to hunt."""
+        errors = _run_mechanical_gates({
+            "test_scenarios": [{"name": "test_x", "type": "unit"}],
+            "requirements": [],
+            "requirements_empty_reason": (
+                "requirements unreadable: no LLD found for issue #331 "
+                "under C:/repo/docs/lld/active"
+            ),
+            "lld_content": "word " * 60,
+        })
+        gate_two = next(e for e in errors if "No requirements" in e)
+        assert "requirements unreadable" in gate_two
+        assert "LLD" in gate_two
+
+
+class TestN4bRefusesTheEmptySet:
+    def _state(self, tmp_path: Path, requirements, reason=""):
+        return {
+            "repo_root": str(tmp_path),
+            "issue_number": 331,
+            "implementation_files": [str(tmp_path / "impl.py")],
+            "test_files": [],
+            "requirements": requirements,
+            "requirements_empty_reason": reason,
+            "iteration_count": 0,
+        }
+
+    def test_zero_requirements_is_never_a_pass(self, tmp_path, capsys):
+        out = completeness_gate(self._state(
+            tmp_path, [],
+            reason="requirements unreadable: no LLD found for issue #331",
+        ))
+        capsys.readouterr()
+        assert out["completeness_verdict"] == "BLOCK"
+        assert "zero requirements" in out["error_message"]
+        assert "requirements unreadable" in out["error_message"]
+        assert "#2552" in out["error_message"]
+
+    def test_a_zero_with_no_recorded_reason_still_refuses_and_says_so(
+        self, tmp_path, capsys
+    ):
+        out = completeness_gate(self._state(tmp_path, []))
+        capsys.readouterr()
+        assert out["completeness_verdict"] == "BLOCK"
+        assert "no recorded reason" in out["error_message"]
+
+    def test_a_populated_set_still_passes_layer_one(self, tmp_path, capsys):
+        """The inverse: the gate's ordinary verdict is untouched when a
+        real requirement set is present."""
+        (tmp_path / "impl.py").write_text("x = 1\n", encoding="utf-8")
+        with patch(
+            "assemblyzero.workflows.testing.nodes.completeness_gate."
+            "run_ast_analysis",
+            return_value={
+                "verdict": "PASS",
+                "issues": [],
+                "ast_analysis_ms": 1,
+                "gemini_review_ms": None,
+            },
+        ):
+            out = completeness_gate(self._state(tmp_path, ["REQ-1: exists"]))
+        capsys.readouterr()
+        assert out["completeness_verdict"] == "PASS"
+        assert out["error_message"] == ""


### PR DESCRIPTION
Closes #2552

Zero requirements passed quietly, and one gate certified against the empty set. Verification against the code sharpened the filed diagnosis before fixing (comment on the issue): the N1 fast path has refused a zero denominator since 2026-02-01 (`728f0116`: `total == 0` → `passed: False`), and #496's Gate 2 blocks empty requirements before the fast path is even consulted — while `load_lld`'s WARN-and-proceed and N4b's requirement-blind verdict stood exactly as filed (N4b's own #2024 comment records a prior zero-requirements verdict; #2024 repaired the path resolution, not the blindness).

## The repair

**The empty set becomes a named event at load (`load_lld`).** `describe_zero_requirements` distinguishes three facts and names the paths: "requirements unreadable: no LLD found for issue #N under docs/lld/active (searched LLD-NNN.md and variants)…", "requirements unreadable: the LLD at <path> exists but could not be read…", and "no requirements declared: neither the LLD at <path> nor the spec at <path> yields any…" — each naming what the extractor searches (`### REQ-x.y:` headers, the Requirements/Acceptance-Criteria numbered list, the Test Mapping table). Printed as `[ZERO-REQUIREMENTS]`, never a WARN that scrolls, and carried in state as `requirements_empty_reason`.

**N1's Gate 2 quotes the reason.** The existing block ("No requirements extracted from LLD — cannot verify coverage") now carries load_lld's recorded reason, so the halt names the path it searched instead of leaving the operator to hunt.

**N4b refuses the empty set.** Before any analysis: zero requirements → verdict `BLOCK` with an error message quoting the reason and a `completeness_zero_requirements` telemetry event — certifying completeness against nothing is not a verdict, it is the absence of one. The inverse is pinned: a populated set takes the ordinary Layer-1 path unchanged.

**The two guards the diagnosis missed are pinned by regression test** — `check_requirement_coverage([], [])` is never a pass, and Gate 2 blocks — so a refactor cannot silently drop the defenses that turned out to already exist.

No proceed-on-zero fall-through was added anywhere, so no `# fail-open:` declaration is owed under the #2475 regime — every consumer of the empty set now refuses loudly.

## Acceptance

`tests/unit/test_zero_requirements_denominator.py`: the three named shapes of the empty set; 0/0 never reads as coverage; Gate 2 blocks and quotes the recorded reason; N4b returns BLOCK (never PASS) on zero with the reason in the error, refuses even with no recorded reason, and passes normally on a populated set. Full unit suite green.

**What only a live roll proves:** the named events flowing through a real halted run's banner, and the resume behavior on a repo whose LLD survives thanks to the sibling sweep fix.

Sibling context: the sweep repair makes this trigger rare; this PR makes it loud when it fires anyway.
