### PR TITLE
fix: retire the spec stage's full-revision fallback -- a failed edit-script re-prompts with its failure, and exhaustion halts naming the blocks (Closes #2569)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/edit_script.py
@@ -40,8 +40,16 @@ def build_edit_script_prompt(
     review_feedback: str,
     completeness_issues: list[str],
     prior_completeness_breakdown: list[dict] | None = None,
+    apply_failure: str = "",
 ) -> str:
-    """Build the revision prompt that requests edit blocks, not a rewrite."""
+    """Build the revision prompt that requests edit blocks, not a rewrite.
+
+    ``apply_failure`` (#2569): the exact failure of the previous attempt's
+    edit blocks, when there was one. There is no full-regeneration fallback
+    any more — a failed script re-prompts with its failure, because the
+    drafter can disambiguate a SEARCH far more reliably than enforcement
+    can un-mangle a rewrite.
+    """
     sections: list[str] = []
 
     sections.append(
@@ -72,6 +80,15 @@ def build_edit_script_prompt(
         "items, put a single line `UNLOCK: <one-line reason>` before your "
         "first edit block; the unlock is logged, never silent."
     )
+
+    if apply_failure:
+        sections.append(
+            "## YOUR PREVIOUS ATTEMPT FAILED TO APPLY (#2569)\n\n"
+            f"{apply_failure}\n\n"
+            "This is a correction round, not a restart: emit a fresh, "
+            "complete set of edit blocks for ALL listed deficiencies, "
+            "with the failure above repaired."
+        )
 
     if completeness_issues:
         issues_text = "## DEFICIENCIES TO FIX (mechanical validation)\n\n"

--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -72,6 +72,31 @@ MAX_SNAPSHOT_CHARS = 10_000
 # Maximum total prompt content chars (to avoid token limits)
 MAX_TOTAL_PROMPT_CHARS = 120_000
 
+#: #2569: total edit-script attempts per revision round — the initial call
+#: plus re-prompts carrying the exact apply failure. Three covers the
+#: observed failure classes: a transport failure (retried on the same
+#: prompt) plus one drafter correction. Counted basis: 192 applied vs 16
+#: fallbacks across every boostgauge run log, seven of the sixteen the
+#: SEARCH-not-found class a single correction recovers.
+EDIT_SCRIPT_MAX_ATTEMPTS = 3
+
+
+def _spec_edit_halt(reason: str) -> str:
+    """Halt message for a revision that could not be applied as edits (#2569).
+
+    Legible on its own in a halt banner (#2197): it names the contract,
+    what broke it, and the fact that nothing was lost. Mirrors the lld
+    stage's #2200 wording — the two stages carry the same law.
+    """
+    return (
+        f"[EDIT-SCRIPT] spec revision rejected after "
+        f"{EDIT_SCRIPT_MAX_ATTEMPTS} attempt(s): {reason}. The prior draft "
+        f"is unchanged and remains the working copy. A revision is applied "
+        f"as SEARCH/REPLACE edit blocks and is never redrawn wholesale "
+        f"(#2569) — the full-regeneration fallback was the vector for every "
+        f"mangled draft on the record. Relaunch to resume from this stage."
+    )
+
 
 # =============================================================================
 # System Prompt
@@ -337,72 +362,160 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
     # #1528: Edit-script revision — the model emits SEARCH/REPLACE blocks
     # which are applied mechanically, so unflagged content cannot drift
     # (measured regenerations oscillated 1,149→341→1,407 lines; see #1529).
-    # Any failure falls through to the classic full-revision call below.
+    #
+    # #2569: the full-revision FALLBACK is retired. Counted across every
+    # boostgauge run log: 192 applied edit-scripts vs 16 fallbacks, and
+    # every text disaster (the 458→1296 chimera, the eliding rewrite that
+    # deleted 18 tests) traveled through the wide channel the fallback
+    # opened, while the edit path only ever failed loudly. A failed script
+    # now RE-PROMPTS with its exact failure — the drafter can disambiguate
+    # a SEARCH far more reliably than enforcement can un-mangle a rewrite —
+    # and on exhaustion the stage halts naming the unappliable blocks,
+    # mirroring the lld stage's #2200 contract. The classic path below
+    # remains for the initial draft and for mock drafters only.
+    #
+    # The old `retry_count < 1` gate is dropped: nothing in this workflow
+    # ever sets retry_count (verified by grep — it is only ever read), so
+    # the gate was dead; a revision is a revision.
     # -------------------------------------------------------------------------
     edit_script_content: str | None = None
     result = None
     #: #2532: pinning refusals, regression-class flags, and unlock grants
     #: from this revision, accumulated across whichever path produced it.
     pinning_events: list[str] = []
-    if is_revision and retry_count < 1 and not drafter_spec.startswith("mock:"):
-        cost_before = get_cumulative_cost()
-        edit_result = drafter.invoke(
-            system_prompt=EDIT_SCRIPT_SYSTEM_PROMPT,
-            content=build_edit_script_prompt(
-                existing_draft=existing_draft,
+    node_cost_usd = 0.0
+    if is_revision and not drafter_spec.startswith("mock:"):
+        halt_reason = ""
+        failure_context = ""
+        for attempt in range(1, EDIT_SCRIPT_MAX_ATTEMPTS + 1):
+            cost_before = get_cumulative_cost()
+            edit_result = drafter.invoke(
+                system_prompt=EDIT_SCRIPT_SYSTEM_PROMPT,
+                content=build_edit_script_prompt(
+                    existing_draft=existing_draft,
+                    review_feedback=review_feedback,
+                    completeness_issues=completeness_issues,
+                    prior_completeness_breakdown=state.get(
+                        "prior_completeness_breakdown", []
+                    ),
+                    apply_failure=failure_context,
+                ),
+                timeout_seconds=600,
+            )
+            node_cost_usd += get_cumulative_cost() - cost_before
+            if not edit_result.success:
+                # A transport failure is the provider's, not the drafter's:
+                # the same prompt goes again (failure_context unchanged).
+                halt_reason = (
+                    f"drafter call failed: {edit_result.error_message}"
+                )
+                print(
+                    f"    [EDIT-SCRIPT] attempt {attempt}/"
+                    f"{EDIT_SCRIPT_MAX_ATTEMPTS} failed ({halt_reason})"
+                    + (" -- retrying" if attempt < EDIT_SCRIPT_MAX_ATTEMPTS
+                       else "")
+                )
+                continue
+            blocks = parse_edit_blocks(edit_result.response or "")
+            if not blocks:
+                halt_reason = (
+                    "no well-formed SEARCH/REPLACE blocks in the response"
+                )
+                failure_context = (
+                    "Your previous response contained no well-formed "
+                    "SEARCH/REPLACE blocks. Emit ONLY edit blocks in the "
+                    "exact format specified — no prose, no rewritten "
+                    "document."
+                )
+                print(
+                    f"    [EDIT-SCRIPT] attempt {attempt}/"
+                    f"{EDIT_SCRIPT_MAX_ATTEMPTS}: {halt_reason} -- "
+                    f"re-prompting with the failure"
+                )
+                continue
+            patched, failures = apply_edit_blocks(existing_draft, blocks)
+            if failures:
+                halt_reason = "; ".join(failures)
+                failure_context = (
+                    f"Your previous edit blocks did not apply: "
+                    f"{halt_reason}. Copy each SEARCH character-for-"
+                    f"character from the CURRENT SPEC below. If a SEARCH "
+                    f"matched more than once, extend it with surrounding "
+                    f"lines until it is unique."
+                )
+                print(
+                    f"    [EDIT-SCRIPT] attempt {attempt}/"
+                    f"{EDIT_SCRIPT_MAX_ATTEMPTS}: {halt_reason} -- "
+                    f"re-prompting with the failure"
+                )
+                continue
+            if patched == existing_draft:
+                halt_reason = (
+                    f"{len(blocks)} edit block(s) applied but changed "
+                    f"nothing"
+                )
+                failure_context = (
+                    "Your previous edit blocks applied but changed "
+                    "nothing. Each REPLACE must differ from its SEARCH, "
+                    "and the edits must address the deficiencies listed "
+                    "below."
+                )
+                print(
+                    f"    [EDIT-SCRIPT] attempt {attempt}/"
+                    f"{EDIT_SCRIPT_MAX_ATTEMPTS}: {halt_reason} -- "
+                    f"re-prompting with the failure"
+                )
+                continue
+            # #2532: pin what passed. Edits touching content the verdict
+            # did not name are refused mechanically; the locked spans
+            # carry forward byte-verbatim.
+            pinned, events = _apply_pinning(
+                state, existing_draft, patched,
+                response=edit_result.response or "",
                 review_feedback=review_feedback,
                 completeness_issues=completeness_issues,
-                prior_completeness_breakdown=state.get(
-                    "prior_completeness_breakdown", []
-                ),
-            ),
-            timeout_seconds=600,
-        )
-        node_cost_usd = get_cumulative_cost() - cost_before
-        if edit_result.success:
-            blocks = parse_edit_blocks(edit_result.response or "")
-            if blocks:
-                patched, failures = apply_edit_blocks(existing_draft, blocks)
-                if not failures and patched != existing_draft:
-                    # #2532: pin what passed. Edits touching content the
-                    # verdict did not name are refused mechanically; the
-                    # locked spans carry forward byte-verbatim.
-                    patched, events = _apply_pinning(
-                        state, existing_draft, patched,
-                        response=edit_result.response or "",
-                        review_feedback=review_feedback,
-                        completeness_issues=completeness_issues,
-                    )
-                    pinning_events.extend(events)
-                if not failures and patched != existing_draft:
-                    ratio = unchanged_ratio(existing_draft, patched)
-                    print(
-                        f"    [EDIT-SCRIPT] Applied {len(blocks)} edit(s); "
-                        f"{ratio:.0%} of prior spec preserved byte-identical "
-                        f"(#1528)"
-                    )
-                    edit_script_content = patched
-                    result = edit_result
-                else:
-                    reason = (
-                        "; ".join(failures)
-                        if failures
-                        else "edits produced no change"
-                    )
-                    print(
-                        f"    [EDIT-SCRIPT] Falling back to full revision: "
-                        f"{reason}"
-                    )
-            else:
-                print(
-                    "    [EDIT-SCRIPT] Falling back to full revision: "
-                    "no well-formed edit blocks in response"
-                )
-        else:
-            print(
-                f"    [EDIT-SCRIPT] Falling back to full revision: "
-                f"{edit_result.error_message}"
             )
+            pinning_events.extend(events)
+            if pinned == existing_draft:
+                refusals = [
+                    e for e in events if "[PINNING] refused:" in e
+                ]
+                halt_reason = (
+                    f"every edit touched locked content and was refused "
+                    f"by pinning ({len(refusals)} refusal(s))"
+                )
+                failure_context = (
+                    "Your previous edits were refused by pinning "
+                    "enforcement as locked content the feedback did not "
+                    "name: "
+                    + "; ".join(refusals[:4])
+                    + ". Edit ONLY the content the deficiencies and "
+                    "feedback below name."
+                )
+                print(
+                    f"    [EDIT-SCRIPT] attempt {attempt}/"
+                    f"{EDIT_SCRIPT_MAX_ATTEMPTS}: {halt_reason} -- "
+                    f"re-prompting with the failure"
+                )
+                continue
+            ratio = unchanged_ratio(existing_draft, pinned)
+            print(
+                f"    [EDIT-SCRIPT] Applied {len(blocks)} edit(s); "
+                f"{ratio:.0%} of prior spec preserved byte-identical "
+                f"(#1528)"
+            )
+            edit_script_content = pinned
+            result = edit_result
+            break
+        if edit_script_content is None:
+            message = _spec_edit_halt(halt_reason)
+            print(f"    {message}")
+            return {
+                "error_message": message,
+                "pinning_events": (
+                    list(state.get("pinning_events", [])) + pinning_events
+                ),
+            }
 
     # -------------------------------------------------------------------------
     # Call drafter LLM (classic full draft/revision path)

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1522,11 +1522,20 @@ class TestGenerateSpec:
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
     def test_revision_increments_iteration(self, mock_template, mock_provider, base_state):
-        """Revision mode increments review_iteration."""
+        """Revision mode increments review_iteration.
+
+        #2569: a revision travels as an edit-script — there is no
+        full-regeneration fallback — so the stub answers in edit blocks.
+        """
         mock_template.return_value = "# Template"
         drafter = Mock()
         drafter.invoke.return_value = Mock(
-            success=True, response="# Revised Spec\n\n## 1. Overview", error_message=None,
+            success=True,
+            response=(
+                "<<<<<<< SEARCH\n# Old Draft\n=======\n"
+                "# Revised Spec\n\n## 1. Overview\n>>>>>>> REPLACE"
+            ),
+            error_message=None,
             input_tokens=0, output_tokens=0,
         )
         mock_provider.return_value = drafter

--- a/tests/unit/test_spec_edit_script.py
+++ b/tests/unit/test_spec_edit_script.py
@@ -207,9 +207,11 @@ class TestGenerateSpecEditScriptIntegration:
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
     @patch("assemblyzero.core.preflight.check_gemini_available")
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
-    def test_prose_response_falls_back_to_full_revision(
+    def test_prose_response_reprompts_and_the_correction_applies(
         self, mock_get_provider, mock_preflight, mock_template, tmp_path
     ):
+        """#2569: no full-revision fallback. A prose response re-prompts
+        with the failure, and the corrected edit-script applies."""
         from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
 
         mock_template.return_value = "# Template"
@@ -218,12 +220,13 @@ class TestGenerateSpecEditScriptIntegration:
         )
         drafter = MagicMock()
         drafter.invoke.side_effect = [
-            Mock(  # edit-script attempt: prose, no blocks
+            Mock(  # attempt 1: prose, no blocks
                 success=True, response="I rewrote the spec:\n# Spec v2\n...",
                 error_message=None, input_tokens=1, output_tokens=1,
             ),
-            Mock(  # classic full-revision call
-                success=True, response="# Spec v2 (classic)\n\ncontent",
+            Mock(  # attempt 2: a real edit block
+                success=True,
+                response=_block("Loads the config.", "Loads the config from disk."),
                 error_message=None, input_tokens=1, output_tokens=1,
             ),
         ]
@@ -232,15 +235,25 @@ class TestGenerateSpecEditScriptIntegration:
         result = generate_spec(self._base_revision_state(tmp_path))
 
         assert result["error_message"] == ""
-        assert result["spec_draft"].startswith("# Spec v2 (classic)")
+        assert "Loads the config from disk." in result["spec_draft"]
         assert drafter.invoke.call_count == 2
+        # Both calls used the edit-script system prompt — no wide channel.
+        for call in drafter.invoke.call_args_list:
+            assert "patch engine" in call.kwargs["system_prompt"]
+        # The re-prompt named the failure.
+        reprompt = drafter.invoke.call_args_list[1].kwargs["content"]
+        assert "PREVIOUS ATTEMPT FAILED" in reprompt
+        assert "no well-formed" in reprompt
 
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
     @patch("assemblyzero.core.preflight.check_gemini_available")
     @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
-    def test_unmatched_search_falls_back(
+    def test_unmatched_search_reprompts_with_the_exact_failure(
         self, mock_get_provider, mock_preflight, mock_template, tmp_path
     ):
+        """#2569: the observed recoverable class — seven of the sixteen
+        counted fallbacks were SEARCH-not-found. The re-prompt carries the
+        exact block failure; the correction applies."""
         from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
 
         mock_template.return_value = "# Template"
@@ -249,13 +262,14 @@ class TestGenerateSpecEditScriptIntegration:
         )
         drafter = MagicMock()
         drafter.invoke.side_effect = [
-            Mock(  # edit-script attempt: block whose SEARCH isn't verbatim
+            Mock(  # attempt 1: block whose SEARCH isn't verbatim
                 success=True,
                 response=_block("text that is not in the spec", "replacement"),
                 error_message=None, input_tokens=1, output_tokens=1,
             ),
-            Mock(
-                success=True, response="# Spec v3 (classic)\n\ncontent",
+            Mock(  # attempt 2: corrected block
+                success=True,
+                response=_block("Validates the config.", "Validates the config strictly."),
                 error_message=None, input_tokens=1, output_tokens=1,
             ),
         ]
@@ -264,5 +278,75 @@ class TestGenerateSpecEditScriptIntegration:
         result = generate_spec(self._base_revision_state(tmp_path))
 
         assert result["error_message"] == ""
-        assert result["spec_draft"].startswith("# Spec v3 (classic)")
+        assert "Validates the config strictly." in result["spec_draft"]
         assert drafter.invoke.call_count == 2
+        reprompt = drafter.invoke.call_args_list[1].kwargs["content"]
+        assert "SEARCH text not found" in reprompt
+        assert "text that is not in the spec" in reprompt
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
+    @patch("assemblyzero.core.preflight.check_gemini_available")
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
+    def test_exhausted_attempts_halt_naming_the_blocks(
+        self, mock_get_provider, mock_preflight, mock_template, tmp_path
+    ):
+        """#2569: on exhaustion the stage halts naming the unappliable
+        blocks — never a regeneration, mirroring the lld stage's #2200."""
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            EDIT_SCRIPT_MAX_ATTEMPTS,
+            generate_spec,
+        )
+
+        mock_template.return_value = "# Template"
+        mock_preflight.return_value = Mock(
+            passed=True, available_credentials=4, total_credentials=4, warnings=[]
+        )
+        drafter = MagicMock()
+        drafter.invoke.return_value = Mock(
+            success=True,
+            response=_block("never in the spec", "replacement"),
+            error_message=None, input_tokens=1, output_tokens=1,
+        )
+        mock_get_provider.return_value = drafter
+
+        result = generate_spec(self._base_revision_state(tmp_path))
+
+        assert "spec revision rejected" in result["error_message"]
+        assert "SEARCH text not found" in result["error_message"]
+        assert "prior draft is unchanged" in result["error_message"]
+        assert drafter.invoke.call_count == EDIT_SCRIPT_MAX_ATTEMPTS
+        assert "spec_draft" not in result, "a halt never overwrites the draft"
+
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.load_template")
+    @patch("assemblyzero.core.preflight.check_gemini_available")
+    @patch("assemblyzero.workflows.implementation_spec.nodes.generate_spec.get_provider")
+    def test_transport_failure_retries_the_same_prompt(
+        self, mock_get_provider, mock_preflight, mock_template, tmp_path
+    ):
+        """#2569: three of the sixteen counted fallbacks were provider
+        failures falling to the wide channel — the wrong remedy. The same
+        edit prompt goes again instead."""
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import generate_spec
+
+        mock_template.return_value = "# Template"
+        mock_preflight.return_value = Mock(
+            passed=True, available_credentials=4, total_credentials=4, warnings=[]
+        )
+        drafter = MagicMock()
+        drafter.invoke.side_effect = [
+            Mock(success=False, response=None,
+                 error_message="All credentials failed",
+                 input_tokens=0, output_tokens=0),
+            Mock(success=True,
+                 response=_block("Loads the config.", "Loads it from disk."),
+                 error_message=None, input_tokens=1, output_tokens=1),
+        ]
+        mock_get_provider.return_value = drafter
+
+        result = generate_spec(self._base_revision_state(tmp_path))
+
+        assert result["error_message"] == ""
+        assert "Loads it from disk." in result["spec_draft"]
+        first = drafter.invoke.call_args_list[0].kwargs["content"]
+        second = drafter.invoke.call_args_list[1].kwargs["content"]
+        assert first == second, "a transport failure is not the drafter's"


### PR DESCRIPTION
Closes #2569

Every text disaster on the record traveled through the wide channel: edit-script fails, full rewrite follows, and the rewrite elides, duplicates, or embeds a second document that enforcement then half-restores. The narrow channel never mangled anything; it only ever failed loudly. This PR retires the spec stage's full-revision fallback and replaces it with bounded re-prompting.

## Verified before cutting code (the issue's own questions)

- **Counted across every boostgauge run log: 192 applied edit-scripts vs 16 fallbacks** (~92% success). The sixteen decompose: five "edits produced no change" (the #2555 pinning deadlock, fixed upstream by PR #2558/#2562), seven SEARCH-not-found (the drafter not copying verbatim — exactly the class a correction round recovers), three provider failures ("All credentials failed") falling to the wide channel — the wrong remedy for a transport error — and one SEARCH-ambiguous (the merge-manufactured duplicates now gated by PR #2562).
- **The lld stage already lives under this law**: #2200's `generate_draft.py` applies edits or halts, explicitly "never redrawn wholesale", with no fallback. The chimera drafts were all the spec stage, the one remaining fallback site.
- **The `retry_count < 1` gate was dead**: nothing in this workflow ever sets `retry_count` (grep-verified; it is only read), so dropping it changes no live behavior.
- **Iteration 1 is untouched**: the classic path remains for the initial draft and for mock drafters.

## The repair

`generate_spec`'s revision path becomes an attempt loop (`EDIT_SCRIPT_MAX_ATTEMPTS = 3`): each failure class re-prompts with its exact failure — no blocks parsed, per-block apply failures verbatim (the `block N: SEARCH text not found: '...'` text the applier already formats), applied-but-changed-nothing, and every-edit-refused-by-pinning (quoting the refusal events so the drafter re-aims at named content). A provider failure retries the same prompt: the failure is the transport's, not the drafter's. On exhaustion the stage halts with `_spec_edit_halt`, mirroring #2200's wording — the prior draft unchanged and named as the working copy, the unappliable blocks named, relaunch resumes the stage. Pinning applies to the accepted patch exactly as before, and the accumulated pinning events travel in state even on the halt path.

`build_edit_script_prompt` gains `apply_failure`: a correction section stating what failed and that this is a correction round, not a restart.

## Acceptance

`tests/unit/test_spec_edit_script.py` (21 tests): a prose response re-prompts and the correction applies, with BOTH calls on the edit-script system prompt — no wide channel; an unmatched SEARCH re-prompts carrying the exact block failure; exhaustion halts naming the blocks with the draft untouched and exactly `EDIT_SCRIPT_MAX_ATTEMPTS` calls spent; a transport failure retries the identical prompt. The one-call success path and all parser/applier behavior pinned as before. Full unit suite green.

**What only a live roll proves:** the real drafter's correction rate under the failure-carrying re-prompt, and the halt frequency in practice (the counted basis predicts it will be rare: seven of sixteen historic fallbacks were the recoverable class, and the other nine had upstream causes since fixed).
