### PR TITLE
feat: a halt writes a resume contract, and a resume verifies it before spending a token (Closes #2570)

### DIFF
--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -230,6 +230,36 @@ def create_halt_node(workflow_name: str):
         # 5. Save plan to same directory as state
         plan_path = plan.save(state_path.parent)
 
+        # 5b. #2570: the halt writes the resume contract — every input the
+        # resume will need, hashed, plus the counters and the snapshot it
+        # seeds from. The resume verifies this FIRST and refuses by name
+        # on any mismatch. Written beside the plan, and copied into the
+        # run's audit dir when there is one, so the lineage carries the
+        # manifest. Best-effort: a contract that cannot be written must
+        # never mask the halt it describes.
+        try:
+            from assemblyzero.core.resume_contract import (
+                build_resume_contract,
+                save_resume_contract,
+            )
+
+            contract = build_resume_contract(
+                state, workflow_name, state_snapshot=state_path
+            )
+            save_resume_contract(contract)
+            audit_dir_str = str(state.get("audit_dir", "") or "")
+            if audit_dir_str and Path(audit_dir_str).is_dir():
+                save_resume_contract(contract, Path(audit_dir_str))
+            print(
+                f"  resume contract written: "
+                f"{len(contract['inputs'])} input(s) (#2570)"
+            )
+        except Exception as exc:  # noqa: BLE001
+            # fail-open: the contract is the resume's protection, not the
+            # halt's -- a halt that cannot write it still halts, loudly,
+            # and the resume simply has no contract to verify.
+            print(f"  [WARN] resume contract not written: {exc}")
+
         # 6. Print human-readable summary
         plan.print_summary()
 

--- a/assemblyzero/core/resume_contract.py
+++ b/assemblyzero/core/resume_contract.py
@@ -1,0 +1,229 @@
+"""The resume contract: a halt names what its resume needs (#2570).
+
+The 2026-08-27 campaign patched one invariant hole by hole: a resume finds
+what the halted attempt had. The LLD swept as leavings (#2551), the
+zero-requirements fallback that would have certified against nothing
+(#2552), the stale counters that put a resumed round over its own ceiling
+(#2514) — each was the same defect wearing a different artifact. The halt
+knew exactly what it had; the resume had to rediscover it from a world
+that had meanwhile changed.
+
+So the halt writes a manifest: every input the resume will need, with
+content hashes, plus the counters and the state snapshot the resume seeds
+from. The resume verifies the manifest FIRST and refuses by name on any
+mismatch, before a single token is spent. A deliberate override is an
+explicit flag, logged, never a silent proceed.
+
+Lifecycle: verification CONSUMES the contract. A verified resume deletes
+it and proceeds; if that run halts again, the halt writes a fresh one. A
+contract therefore always describes the most recent halt, and a completed
+run leaves none behind.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from assemblyzero.core.state_persistence import STATE_DIR
+
+#: State keys that name input artifacts a resume re-reads. Key-generic on
+#: purpose: in the testing workflow `lld_path` holds the SPEC and
+#: `original_lld_path` the LLD (#2024); in the implementation_spec workflow
+#: `lld_path` holds the LLD. The contract records whatever the halted state
+#: actually pointed at, labeled by its state key.
+_INPUT_KEYS = ("lld_path", "original_lld_path", "spec_path")
+
+#: Counters the resume seeds from. Recorded so the contract is the durable
+#: record of where the cap regime stood at halt (#2514's class).
+_COUNTER_KEYS = ("review_iteration", "iteration_count", "max_iterations")
+
+#: List-valued state whose LENGTH matters to a resume's regime.
+_COUNTED_LIST_KEYS = (
+    "checks_shown_to_drafter", "grace_revisions_used", "pinning_events",
+)
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        # fail-open: None IS the signal -- an unreadable file hashes as
+        # absent, which the verifier reports as a named mismatch rather
+        # than crashing the halt or the resume check.
+        return None
+
+
+def contract_path(workflow: str, issue: int, directory: Path | None = None) -> Path:
+    return (directory or STATE_DIR) / f"resume-contract-{workflow}-{issue}.json"
+
+
+def build_resume_contract(
+    state: dict, workflow: str, state_snapshot: Path | None = None
+) -> dict[str, Any]:
+    """The manifest of what this halt's resume will need. Pure except reads."""
+    inputs: list[dict[str, Any]] = []
+    for key in _INPUT_KEYS:
+        raw = state.get(key)
+        if not raw:
+            continue
+        path = Path(str(raw))
+        digest = _sha256_file(path)
+        inputs.append({
+            "key": key,
+            "path": str(path),
+            "exists": digest is not None,
+            "sha256": digest,
+        })
+
+    counters: dict[str, Any] = {
+        key: state.get(key, 0) for key in _COUNTER_KEYS
+    }
+    for key in _COUNTED_LIST_KEYS:
+        counters[f"{key}_count"] = len(state.get(key) or [])
+
+    snapshot_entry = None
+    if state_snapshot is not None:
+        snapshot_entry = {
+            "path": str(state_snapshot),
+            "sha256": _sha256_file(Path(state_snapshot)),
+        }
+
+    return {
+        "contract_version": 1,
+        "workflow": workflow,
+        "issue": int(state.get("issue_number", 0) or 0),
+        "halted_at": datetime.now(tz=timezone.utc).isoformat(),
+        "audit_dir": str(state.get("audit_dir", "") or ""),
+        "inputs": inputs,
+        "counters": counters,
+        "state_snapshot": snapshot_entry,
+    }
+
+
+def save_resume_contract(
+    contract: dict, directory: Path | None = None
+) -> Path:
+    target = contract_path(
+        contract["workflow"], contract["issue"], directory
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(contract, indent=2), encoding="utf-8")
+    return target
+
+
+def load_resume_contract(
+    workflow: str, issue: int, directory: Path | None = None
+) -> dict | None:
+    path = contract_path(workflow, issue, directory)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        # fail-open: an unreadable or corrupt contract reads as no
+        # contract, which is the pre-#2570 world -- the resume proceeds
+        # unverified rather than being blocked by a broken manifest the
+        # halt half-wrote. The contract protects the resume; it must
+        # never be able to brick it.
+        return None
+
+
+def verify_resume_contract(contract: dict) -> list[str]:
+    """Every way the world differs from the halt, named. Empty means intact.
+
+    An input that did not exist at halt and exists now is not a mismatch —
+    the world gaining an input breaks nothing a resume depends on.
+    """
+    mismatches: list[str] = []
+    for entry in contract.get("inputs", []):
+        key, path = entry.get("key", "?"), Path(entry.get("path", ""))
+        recorded = entry.get("sha256")
+        if not entry.get("exists"):
+            continue
+        current = _sha256_file(path)
+        if current is None:
+            mismatches.append(
+                f"{key}: the file at {path} existed at halt "
+                f"(sha256 {str(recorded)[:12]}) and is now missing"
+            )
+        elif current != recorded:
+            mismatches.append(
+                f"{key}: the file at {path} hashed {str(recorded)[:12]} at "
+                f"halt and hashes {current[:12]} now"
+            )
+    snapshot = contract.get("state_snapshot")
+    if snapshot and snapshot.get("sha256"):
+        current = _sha256_file(Path(snapshot["path"]))
+        if current is None:
+            mismatches.append(
+                f"state_snapshot: the snapshot at {snapshot['path']} the "
+                f"resume seeds from is missing"
+            )
+        elif current != snapshot["sha256"]:
+            mismatches.append(
+                f"state_snapshot: the snapshot at {snapshot['path']} hashed "
+                f"{snapshot['sha256'][:12]} at halt and hashes "
+                f"{current[:12]} now -- the counters a resume seeds from "
+                f"are not the ones the halt wrote"
+            )
+    return mismatches
+
+
+def check_and_consume(
+    workflow: str,
+    issue: int,
+    *,
+    accept_changed: bool = False,
+    directory: Path | None = None,
+    log: Callable[[str], None] = print,
+) -> bool:
+    """Verify the halt's contract, consume it, and say so. False = refuse.
+
+    No contract (a fresh run, or a halt that predates the mechanism) is a
+    silent pass — the contract constrains resumes, never first runs. A
+    verified or explicitly-accepted contract is deleted: it described the
+    halt it came from, and the next halt writes its own.
+    """
+    contract = load_resume_contract(workflow, issue, directory)
+    if contract is None:
+        return True
+    mismatches = verify_resume_contract(contract)
+    path = contract_path(workflow, issue, directory)
+    if mismatches and not accept_changed:
+        log(
+            "RESUME CONTRACT: the world changed since the halt -- refusing "
+            "before any token is spent (#2570)"
+        )
+        for mismatch in mismatches:
+            log(f"  {mismatch}")
+        log(
+            "  Rerun with --accept-changed-inputs to proceed against the "
+            "changed world; the acceptance is printed and logged, never "
+            "silent."
+        )
+        return False
+    if mismatches:
+        log(
+            f"RESUME CONTRACT: {len(mismatches)} changed input(s) ACCEPTED "
+            f"by --accept-changed-inputs (#2570):"
+        )
+        for mismatch in mismatches:
+            log(f"  {mismatch}")
+    else:
+        log(
+            f"resume contract verified: {len(contract.get('inputs', []))} "
+            f"input(s), snapshot intact (#2570)"
+        )
+    try:
+        path.unlink()
+    except OSError:
+        # fail-open: a verified contract that could not be deleted only
+        # costs a redundant re-verification on the next launch, and the
+        # WARN names it; refusing the run over a leftover file would
+        # invert the cost.
+        log(f"  [WARN] verified contract could not be consumed: {path}")
+    return True

--- a/tests/unit/test_resume_contract.py
+++ b/tests/unit/test_resume_contract.py
@@ -1,0 +1,193 @@
+"""A halt writes what its resume needs, and the resume verifies it (#2570).
+
+The observed worlds as fixtures: the swept-LLD world (the input the loader
+resolves deleted between halt and resume — #2551's incident) refuses
+naming the path; the stale-counter world (the snapshot the resume seeds
+from not the one the halt wrote — #2514's class) refuses naming the
+snapshot. A fresh run has no contract and passes silently; verification
+consumes the contract so a completed lifecycle leaves none behind.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assemblyzero.core.resume_contract as rc
+import assemblyzero.core.state_persistence as sp
+from assemblyzero.core.halt_node import create_halt_node
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    """A throwaway contract/snapshot store standing in for STATE_DIR."""
+    directory = tmp_path / "state"
+    directory.mkdir()
+    monkeypatch.setattr(rc, "STATE_DIR", directory)
+    monkeypatch.setattr(sp, "STATE_DIR", directory)
+    return directory
+
+
+def _world(tmp_path) -> dict:
+    lld = tmp_path / "docs" / "lld" / "active" / "LLD-331.md"
+    lld.parent.mkdir(parents=True)
+    lld.write_text("## 3. Requirements\n\n1. Render the face.\n",
+                   encoding="utf-8")
+    spec = tmp_path / "spec.md"
+    spec.write_text("# Spec\n", encoding="utf-8")
+    return {
+        "issue_number": 331,
+        "original_lld_path": str(lld),
+        "lld_path": str(spec),
+        "review_iteration": 3,
+        "max_iterations": 3,
+        "pinning_events": ["[PINNING] refused: x"],
+        "checks_shown_to_drafter": ["criteria_have_tests"],
+        "audit_dir": "",
+    }
+
+
+class TestBuildAndVerify:
+    def test_the_contract_records_inputs_hashed_and_counters(self, tmp_path):
+        contract = rc.build_resume_contract(_world(tmp_path), "testing")
+        keys = {entry["key"] for entry in contract["inputs"]}
+        assert keys == {"original_lld_path", "lld_path"}
+        assert all(entry["sha256"] for entry in contract["inputs"])
+        assert contract["counters"]["review_iteration"] == 3
+        assert contract["counters"]["pinning_events_count"] == 1
+        assert contract["issue"] == 331
+
+    def test_an_unchanged_world_verifies_clean(self, tmp_path):
+        contract = rc.build_resume_contract(_world(tmp_path), "testing")
+        assert rc.verify_resume_contract(contract) == []
+
+    def test_the_swept_lld_world_refuses_naming_the_path(self, tmp_path):
+        state = _world(tmp_path)
+        contract = rc.build_resume_contract(state, "testing")
+        Path(state["original_lld_path"]).unlink()
+        mismatches = rc.verify_resume_contract(contract)
+        assert len(mismatches) == 1
+        assert "original_lld_path" in mismatches[0]
+        assert "LLD-331.md" in mismatches[0]
+        assert "now missing" in mismatches[0]
+
+    def test_a_changed_input_names_both_hashes(self, tmp_path):
+        state = _world(tmp_path)
+        contract = rc.build_resume_contract(state, "testing")
+        Path(state["original_lld_path"]).write_text(
+            "## 3. Requirements\n\n1. Render something else.\n",
+            encoding="utf-8",
+        )
+        mismatches = rc.verify_resume_contract(contract)
+        assert len(mismatches) == 1
+        assert "hashed" in mismatches[0] and "now" in mismatches[0]
+
+    def test_an_input_absent_at_halt_may_appear(self, tmp_path):
+        state = _world(tmp_path)
+        missing = tmp_path / "spec-late.md"
+        state["spec_path"] = str(missing)
+        contract = rc.build_resume_contract(state, "testing")
+        missing.write_text("appeared later\n", encoding="utf-8")
+        assert rc.verify_resume_contract(contract) == []
+
+    def test_the_stale_counter_world_refuses_naming_the_snapshot(
+        self, tmp_path
+    ):
+        state = _world(tmp_path)
+        snapshot = tmp_path / "testing-331.json"
+        snapshot.write_text(json.dumps({"review_iteration": 3}),
+                            encoding="utf-8")
+        contract = rc.build_resume_contract(
+            state, "testing", state_snapshot=snapshot
+        )
+        snapshot.write_text(json.dumps({"review_iteration": 9}),
+                            encoding="utf-8")
+        mismatches = rc.verify_resume_contract(contract)
+        assert len(mismatches) == 1
+        assert "state_snapshot" in mismatches[0]
+        assert "counters a resume seeds from" in mismatches[0]
+
+
+class TestCheckAndConsume:
+    def test_no_contract_is_a_silent_pass(self, store, capsys):
+        assert rc.check_and_consume("testing", 331) is True
+        assert capsys.readouterr().out == ""
+
+    def test_an_intact_contract_verifies_and_is_consumed(
+        self, store, tmp_path, capsys
+    ):
+        contract = rc.build_resume_contract(_world(tmp_path), "testing")
+        path = rc.save_resume_contract(contract)
+        assert rc.check_and_consume("testing", 331) is True
+        out = capsys.readouterr().out
+        assert "resume contract verified: 2 input(s)" in out
+        assert not path.exists(), "verification consumes the contract"
+
+    def test_a_changed_world_refuses_before_any_token(
+        self, store, tmp_path, capsys
+    ):
+        state = _world(tmp_path)
+        path = rc.save_resume_contract(
+            rc.build_resume_contract(state, "testing")
+        )
+        Path(state["original_lld_path"]).unlink()
+        assert rc.check_and_consume("testing", 331) is False
+        out = capsys.readouterr().out
+        assert "refusing before any token is spent" in out
+        assert "LLD-331.md" in out
+        assert "--accept-changed-inputs" in out
+        assert path.exists(), "a refused contract is kept for the next try"
+
+    def test_the_override_is_loud_and_consumes(self, store, tmp_path, capsys):
+        state = _world(tmp_path)
+        path = rc.save_resume_contract(
+            rc.build_resume_contract(state, "testing")
+        )
+        Path(state["original_lld_path"]).unlink()
+        assert rc.check_and_consume(
+            "testing", 331, accept_changed=True
+        ) is True
+        out = capsys.readouterr().out
+        assert "ACCEPTED" in out
+        assert "LLD-331.md" in out
+        assert not path.exists()
+
+
+class TestTheHaltWritesTheContract:
+    def test_halt_writes_the_manifest_beside_the_plan_and_into_lineage(
+        self, store, tmp_path, capsys
+    ):
+        state = _world(tmp_path)
+        audit_dir = tmp_path / "lineage"
+        audit_dir.mkdir()
+        state["audit_dir"] = str(audit_dir)
+        state["error_message"] = "Iteration cap: 3 revision(s) ended"
+
+        halt = create_halt_node("testing")
+        result = halt(state)
+        capsys.readouterr()
+
+        assert result["workflow_status"] == "halted"
+        contract = rc.load_resume_contract("testing", 331)
+        assert contract is not None
+        assert len(contract["inputs"]) == 2
+        assert contract["state_snapshot"]["sha256"]
+        lineage_copy = audit_dir / "resume-contract-testing-331.json"
+        assert lineage_copy.exists(), "the lineage carries the manifest"
+
+    def test_a_contract_write_failure_never_masks_the_halt(
+        self, store, tmp_path, monkeypatch, capsys
+    ):
+        state = _world(tmp_path)
+        state["error_message"] = "some halt"
+        monkeypatch.setattr(
+            rc, "build_resume_contract",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        halt = create_halt_node("testing")
+        result = halt(state)
+        out = capsys.readouterr().out
+        assert result["workflow_status"] == "halted"
+        assert "resume contract not written" in out

--- a/tools/run_implement_from_lld.py
+++ b/tools/run_implement_from_lld.py
@@ -356,6 +356,16 @@ def create_argument_parser() -> argparse.ArgumentParser:
         type=str,
         help="Target repository path (default: current repo)",
     )
+    # #2570: a resume verifies the halt's contract first and refuses by
+    # name when the world changed. Explicit, logged override only.
+    parser.add_argument(
+        "--accept-changed-inputs",
+        action="store_true",
+        help=(
+            "Proceed even when inputs changed since the last halt's resume "
+            "contract (#2570). The acceptance is printed, never silent."
+        ),
+    )
     parser.add_argument(
         "--lld",
         type=str,
@@ -700,6 +710,17 @@ def main():
     # Validate issue number
     if args.issue is None or args.issue <= 0:
         print("Error: --issue must be a positive integer")
+        sys.exit(1)
+
+    # #2570: a resume finds the world the halt described, or refuses by
+    # name -- before the worktree is touched and any token is spent. A
+    # fresh run has no contract and passes silently.
+    from assemblyzero.core.resume_contract import check_and_consume
+
+    if not check_and_consume(
+        "testing", args.issue,
+        accept_changed=args.accept_changed_inputs,
+    ):
         sys.exit(1)
 
     # Track original repo for worktree cleanup later

--- a/tools/run_implementation_spec_workflow.py
+++ b/tools/run_implementation_spec_workflow.py
@@ -231,6 +231,19 @@ Examples:
         help="Allow running in the AssemblyZero root directory (not recommended)",
     )
 
+    # #2570: a resume verifies the halt's contract first and refuses by
+    # name when the world changed. This flag is the explicit, logged
+    # override for a deliberate change (the operator edited the LLD on
+    # purpose); it is never the default.
+    parser.add_argument(
+        "--accept-changed-inputs",
+        action="store_true",
+        help=(
+            "Proceed even when inputs changed since the last halt's resume "
+            "contract (#2570). The acceptance is printed, never silent."
+        ),
+    )
+
     # Issue #517: Global workflow timeout
     from assemblyzero.utils.workflow_timeout import add_timeout_argument
     add_timeout_argument(parser)
@@ -589,6 +602,17 @@ def run_workflow(
     # Handle dry-run
     if args.dry_run:
         return run_dry_run(args, target_repo)
+
+    # #2570: a resume finds the world the halt described, or refuses by
+    # name -- before any state is built and any token is spent. A fresh
+    # run has no contract and passes silently.
+    from assemblyzero.core.resume_contract import check_and_consume
+
+    if not check_and_consume(
+        "implementation_spec", args.issue,
+        accept_changed=args.accept_changed_inputs,
+    ):
+        return 1
 
     # Build initial state
     state = build_initial_state(args, assemblyzero_root, target_repo)


### PR DESCRIPTION
Closes #2570

The campaign patched one invariant hole by hole: a resume finds what the halted attempt had. The swept LLD, the zero-requirements fallback, the stale counters that put a resumed round over its own ceiling — the same defect wearing different artifacts. The halt knew exactly what it had; the resume had to rediscover it from a world that had meanwhile changed. Now the halt says, and the resume checks.

## The mechanism

**`assemblyzero/core/resume_contract.py`.** `build_resume_contract` records every input artifact the halted state points at (`lld_path`, `original_lld_path`, `spec_path` — key-generic, since the testing workflow's `lld_path` holds the SPEC per #2024), each with existence and content hash; the cap-regime counters (`review_iteration`, iteration and max, plus the lengths of the shown/grace/pinning lists); and the state snapshot the resume seeds from, hashed. `verify_resume_contract` names every difference: a missing input names its path and the hash it had; a changed input names both hashes; a mutated snapshot says in words that the counters a resume seeds from are not the ones the halt wrote. An input absent at halt that exists now is not a mismatch — the world gaining an input breaks nothing.

**The halt writes it.** `create_halt_node`'s shared path (all four workflows) writes the contract beside the recovery plan and copies it into the run's audit dir, so the lineage carries the manifest. Best-effort by design: a halt that cannot write the contract still halts loudly — the contract protects the resume, not the halt.

**The resume verifies first and consumes.** Both runners (`run_implementation_spec_workflow.py`, `run_implement_from_lld.py`) check before any state is built or token spent: mismatches print each named difference and refuse with exit 1; `--accept-changed-inputs` is the explicit override, printed loudly with every accepted difference, never silent. A fresh run has no contract and passes silently. Verification consumes the contract — it described the halt it came from, the next halt writes its own, and a completed lifecycle leaves none behind.

## Acceptance

`tests/unit/test_resume_contract.py` (12 tests), with the observed worlds as fixtures: the swept-LLD world (input deleted between halt and resume — the #2551 incident) refuses naming `LLD-331.md` and "now missing"; the stale-counter world (snapshot rewritten — the #2514 class) refuses naming the snapshot; an unchanged world verifies clean in one line and consumes; the override is loud and consumes; no contract passes silently; the halt writes the manifest beside the plan AND into lineage with the snapshot hashed; a contract-write failure never masks the halt. Full unit suite green.

**What only a live roll proves:** the contract flowing through a real halt banner and a real relaunch, and the override ergonomics when the operator has deliberately edited the LLD between attempts.
