### PR TITLE
feat: the loader rebuilds a missing input from refs before concluding absence (Closes #2571)

### DIFF
--- a/assemblyzero/speedrun/restore.py
+++ b/assemblyzero/speedrun/restore.py
@@ -1,0 +1,156 @@
+"""Rebuild pipeline inputs from refs (#2571; machinery moved from speedrun_roll).
+
+The working copy of a pipeline input is a cache, not a source of record.
+Issue #331's LLD was deleted from the working tree three times in one day
+(see #2551) and survived only on refs — the live `{issue}-lld` branch and
+the janitor's preservation refs. This module is the search-and-materialize
+half: whatever was preserved can be restored, and the LOADER can now do it
+too, not just the speedrun resume planner.
+
+Search order, verified against the measured incidents:
+
+* the live `{issue}-lld` branch and its origin twin — the lld stage pushes
+  the approved LLD there (boostgauge PR #366 was exactly that branch, and
+  the only ref carrying `LLD-331.md` through the 2026-08-27 deletions);
+* `graveyard/{issue}-lld-*` grafts — a HALT's RESTORE renames the branch
+  to an archive name and keeps the commits (#2516);
+* `graveyard/leavings-*` refs, newest first — where the file janitor
+  preserves what it clears (standard 0027; the 2026-08-15 boostgauge #1
+  incident in `restore_artifact`'s history was exactly two artifacts
+  sitting on these, preserved, pushed, and one `git show` away).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assemblyzero.speedrun.leavings import _run
+
+
+def graveyard_leavings_refs(repo_root: Path) -> list[str]:
+    """Every `graveyard/leavings-*` ref, newest first.
+
+    These are where the file janitor PRESERVES what it clears. Nothing is
+    deleted -- preserve-then-clear is structural (standard 0027) -- so a
+    cleared artifact is always on one of these, and the newest is the one
+    the last run wrote.
+    """
+    result = _run(
+        [
+            "git", "for-each-ref", "--format=%(refname:short)",
+            "refs/heads/graveyard/leavings-*",
+            "refs/remotes/origin/graveyard/leavings-*",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    refs = [
+        line.strip()
+        for line in (result.stdout or "").splitlines() if line.strip()
+    ]
+
+    # Sorted on the timestamp in the NAME, not on committerdate. Two
+    # leavings refs cut in the same second tie under `--sort=-committerdate`
+    # and git then falls back to refname ASCENDING -- oldest first, the
+    # wrong way round, which a fixture caught. The name carries
+    # `-YYYYMMDD-HHMMSS` by construction, so it orders these exactly and
+    # cannot be perturbed by a rewrite that changes commit times.
+    def _stamp(ref: str) -> str:
+        _, _, tail = ref.rpartition("leavings-")
+        return tail
+
+    return sorted(refs, key=_stamp, reverse=True)
+
+
+def graveyard_issue_lld_refs(repo_root: Path, issue: int) -> list[str]:
+    """Every grafted copy of this issue's lld branch, newest first (#2516).
+
+    A HALT's RESTORE preserves the attempt branch by renaming it to
+    `graveyard/{issue}-lld-<UTC stamp>` (ADR 0217 keeps the commits; the
+    rename frees the name). The stamp is in the NAME, so name order is
+    time order -- same reasoning as `graveyard_leavings_refs`, same
+    immunity to history rewrites perturbing committer dates.
+    """
+    result = _run(
+        [
+            "git", "for-each-ref", "--format=%(refname:short)",
+            f"refs/heads/graveyard/{issue}-lld-*",
+            f"refs/remotes/origin/graveyard/{issue}-lld-*",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    refs = [
+        line.strip()
+        for line in (result.stdout or "").splitlines() if line.strip()
+    ]
+
+    def _stamp(ref: str) -> str:
+        _, _, tail = ref.rpartition("-lld-")
+        return tail
+
+    return sorted(refs, key=_stamp, reverse=True)
+
+
+def input_refs(repo_root: Path, issue: int) -> list[str]:
+    """The refs a missing input is rebuilt from, in search order."""
+    refs = [f"{issue}-lld", f"origin/{issue}-lld"]
+    # #2516: the grafted copies of the lld branch rank right behind the
+    # live ones -- a HALT's RESTORE renames the branch to
+    # graveyard/{issue}-lld-*, and what it holds IS the lld branch's
+    # content under an archive name.
+    refs += graveyard_issue_lld_refs(repo_root, issue)
+    # Newest leavings first: the last run's copy is the current one, and
+    # an older ref may hold a stale draft from a superseded attempt.
+    refs += graveyard_leavings_refs(repo_root)
+    return refs
+
+
+def restore_artifact(
+    repo_root: Path, issue: int, artifact: str, *, log=None
+) -> bool:
+    """Materialize a file from the refs so a stage can read it.
+
+    The exit janitor clears pipeline-authored untracked files (standard
+    0027). Two places hold what it cleared, and BOTH are searched: the
+    issue's lld branch (when the draft was committed there) and the
+    `graveyard/leavings-*` refs the janitor preserves onto.
+
+    The second was missing once, and it is the difference between a resume
+    and a redraw. Measured on boostgauge #1, 2026-08-15: neither
+    `LLD-001.md` nor `spec-0001-implementation-readiness.md` was on disk,
+    and NEITHER was on `1-lld` -- they were on
+    `graveyard/leavings-20260815-161853` and `...-161847`. The restorer
+    consulted only the lld branch, so it returned False and the resume was
+    abandoned for artifacts that were preserved, pushed, and one
+    `git show` away.
+
+    #2571 moves this here so the LOADER can rebuild too: a working copy is
+    a cache, and `find_lld_path` now rebuilds it from these refs before
+    concluding absence instead of depending on an untracked file surviving.
+    """
+    path = Path(artifact)
+    if path.is_file():
+        return True
+    try:
+        rel = path.relative_to(repo_root)
+    except ValueError:
+        # fail-open: a path outside the repo cannot be on any of the
+        # repo's refs; False is the honest "not restorable", exactly what
+        # this returned when it lived in speedrun_roll (the move into the
+        # audited package is what made the site newly visible).
+        return False
+
+    for ref in input_refs(repo_root, issue):
+        show = _run(
+            ["git", "show", f"{ref}:{rel.as_posix()}"], cwd=repo_root
+        )
+        if show.returncode == 0 and show.stdout:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(show.stdout, encoding="utf-8")
+            if log is not None:
+                log(f"[REBUILT] {rel.as_posix()} restored from '{ref}' (#2571)")
+            return True
+    return False

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -231,20 +231,26 @@ def scenarios_from_spec_functions(
     return scenarios
 
 
-def find_lld_path(issue_number: int, repo_root: Path) -> Path | None:  # pragma: no cover
-    """Find the LLD file for an issue number.
+def find_lld_path(issue_number: int, repo_root: Path) -> Path | None:
+    """Find the LLD file for an issue number, rebuilding from refs on a miss.
+
+    #2571: the working copy is a cache, not a source of record. Issue
+    #331's LLD was deleted from the working tree three times in one day
+    (see #2551) and survived only on refs; this loader used to conclude
+    absence from the cache alone, which is the path the #2552 near-miss
+    would have taken. On a miss it now asks the restore machinery to
+    materialize the canonical copy from the `{issue}-lld` branch, its
+    graveyard grafts, or the janitor's leavings refs — loudly — before
+    concluding the LLD genuinely does not exist anywhere.
 
     Args:
         issue_number: GitHub issue number.
         repo_root: Repository root path.
 
     Returns:
-        Path to LLD file if found, None otherwise.
+        Path to LLD file if found or rebuilt, None otherwise.
     """
     lld_dir = repo_root / LLD_ACTIVE_DIR
-
-    if not lld_dir.exists():
-        return None
 
     # Search patterns in priority order
     patterns = [
@@ -254,13 +260,42 @@ def find_lld_path(issue_number: int, repo_root: Path) -> Path | None:  # pragma:
         f"LLD-{issue_number}-*.md",  # LLD-86-desc.md
     ]
 
-    for pattern in patterns:
-        matches = list(lld_dir.glob(pattern))
-        if matches:
-            # Return most recently modified if multiple
-            if len(matches) > 1:
-                matches.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-            return matches[0]
+    def _glob_once() -> Path | None:
+        if not lld_dir.exists():
+            return None
+        for pattern in patterns:
+            matches = list(lld_dir.glob(pattern))
+            if matches:
+                # Return most recently modified if multiple
+                if len(matches) > 1:
+                    matches.sort(
+                        key=lambda p: p.stat().st_mtime, reverse=True
+                    )
+                return matches[0]
+        return None
+
+    found = _glob_once()
+    if found is not None:
+        return found
+
+    # The cache missed. Rebuild the canonical copy from the refs before
+    # concluding absence — only in a git repo, and never raising: a loader
+    # that cannot rebuild must report the same absence it always did.
+    if (repo_root / ".git").exists():
+        try:
+            from assemblyzero.speedrun.restore import restore_artifact
+
+            canonical = lld_dir / f"LLD-{issue_number:03d}.md"
+            if restore_artifact(
+                repo_root, issue_number, str(canonical),
+                log=lambda m: print(f"    {m}"),
+            ):
+                return _glob_once()
+        except Exception as exc:  # noqa: BLE001
+            # fail-open: the rebuild is a recovery attempt on a path that
+            # previously always reported absence; a rebuild error must not
+            # turn a clean "not found" into a crash.
+            print(f"    [WARN] LLD rebuild from refs failed: {exc}")
 
     return None
 

--- a/tests/unit/test_input_rebuild_from_refs.py
+++ b/tests/unit/test_input_rebuild_from_refs.py
@@ -1,0 +1,160 @@
+"""The loader rebuilds a missing input from refs before concluding absence (#2571).
+
+The working copy is a cache. Issue #331's LLD was deleted from the working
+tree three times on 2026-08-27 (see #2551) and survived only on refs — the
+`{issue}-lld` branch and the janitor's leavings refs. The restore machinery
+already knew how to search those (the speedrun resume planner used it);
+this pins its new shared home and the loader's rebuild-on-miss.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+from assemblyzero.speedrun.leavings import preserve_and_clear  # noqa: E402
+from assemblyzero.speedrun.restore import (  # noqa: E402
+    graveyard_leavings_refs,
+    restore_artifact,
+)
+from assemblyzero.workflows.testing.nodes.load_lld import find_lld_path  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+    return result
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo with a bare origin, as the janitor tests build one."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(origin)],
+        capture_output=True, text=True, check=True,
+    )
+    root = tmp_path / "proj"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    _git(root, "remote", "add", "origin", str(origin))
+    _git(root, "push", "-qu", "origin", "main")
+    return root
+
+
+LLD_REL = "docs/lld/active/LLD-007.md"
+LLD_BODY = "# LLD-007\n\n## 3. Requirements\n\n1. Render the face.\n"
+
+
+def _swept_lld(repo: Path) -> None:
+    """The observed shape: the LLD preserved onto a leavings ref, working
+    copy cleared."""
+    target = repo / LLD_REL
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(LLD_BODY, encoding="utf-8")
+    result = preserve_and_clear(repo, [LLD_REL])
+    assert result.branch, "fixture failed to preserve"
+    assert not target.exists()
+
+
+class TestRestoreArtifact:
+    def test_a_swept_input_is_rebuilt_from_the_leavings_ref(self, repo, capsys):
+        _swept_lld(repo)
+        events: list[str] = []
+        assert restore_artifact(
+            repo, 7, str(repo / LLD_REL), log=events.append
+        ) is True
+        assert (repo / LLD_REL).read_text(encoding="utf-8") == LLD_BODY
+        assert events and "[REBUILT]" in events[0]
+        assert "graveyard/leavings-" in events[0]
+
+    def test_the_live_lld_branch_outranks_the_leavings(self, repo):
+        """The lld stage's branch is the freshest home; a stale leavings
+        copy must not shadow it."""
+        _swept_lld(repo)
+        _git(repo, "checkout", "-qb", "7-lld")
+        fresh = repo / LLD_REL
+        fresh.parent.mkdir(parents=True, exist_ok=True)
+        fresh.write_text(LLD_BODY + "\n(revised on the lld branch)\n",
+                         encoding="utf-8")
+        _git(repo, "add", LLD_REL)
+        _git(repo, "commit", "-qm", "lld")
+        _git(repo, "checkout", "-q", "main")
+        assert not (repo / LLD_REL).exists()
+
+        assert restore_artifact(repo, 7, str(repo / LLD_REL)) is True
+        assert "revised on the lld branch" in (repo / LLD_REL).read_text(
+            encoding="utf-8"
+        )
+
+    def test_nothing_preserved_is_a_clean_false(self, repo):
+        assert restore_artifact(repo, 7, str(repo / LLD_REL)) is False
+        assert not (repo / LLD_REL).exists()
+
+    def test_a_present_file_is_left_alone(self, repo):
+        target = repo / LLD_REL
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("already here\n", encoding="utf-8")
+        assert restore_artifact(repo, 7, str(target)) is True
+        assert target.read_text(encoding="utf-8") == "already here\n"
+
+    def test_leavings_refs_order_newest_first(self, repo):
+        for rel in ("docs/lld/active/LLD-001.md", "docs/lld/active/LLD-002.md"):
+            path = repo / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("x\n", encoding="utf-8")
+            preserve_and_clear(repo, [rel])
+        refs = graveyard_leavings_refs(repo)
+        assert len(refs) >= 2
+        stamps = [ref.rpartition("leavings-")[2] for ref in refs]
+        assert stamps == sorted(stamps, reverse=True)
+
+
+class TestTheLoaderRebuilds:
+    def test_find_lld_path_rebuilds_from_refs_on_a_miss(self, repo, capsys):
+        """#2571's acceptance: delete the working copy, and the loader
+        rebuilds it from the ref and resolves it, logging the rebuild."""
+        _swept_lld(repo)
+        resolved = find_lld_path(7, repo)
+        assert resolved is not None
+        assert resolved.read_text(encoding="utf-8") == LLD_BODY
+        out = capsys.readouterr().out
+        assert "[REBUILT]" in out
+
+    def test_a_present_working_copy_needs_no_refs(self, tmp_path):
+        lld = tmp_path / "docs" / "lld" / "active" / "LLD-007.md"
+        lld.parent.mkdir(parents=True)
+        lld.write_text("cache hit\n", encoding="utf-8")
+        assert find_lld_path(7, tmp_path) == lld
+
+    def test_genuine_absence_stays_a_clean_none(self, repo, capsys):
+        assert find_lld_path(7, repo) is None
+        assert "[WARN]" not in capsys.readouterr().out
+
+    def test_a_plain_directory_is_not_probed_for_refs(self, tmp_path):
+        assert find_lld_path(7, tmp_path) is None
+
+
+class TestTheOldCallSitesStillWork:
+    def test_speedrun_roll_aliases_the_shared_machinery(self):
+        """Moved, not forked: two copies is how the 2026-08-15 gap
+        happened in the first place."""
+        import speedrun_roll as sr
+
+        assert sr._restore_artifact is restore_artifact
+        assert sr._graveyard_leavings_refs is graveyard_leavings_refs

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -133,6 +133,14 @@ from assemblyzero.speedrun.leavings import (  # noqa: E402
     preserve_and_clear,
     untracked_files,
 )
+# #2571: the ref-restore machinery moved to a shared module so the LOADER
+# can rebuild inputs too, not just this resume planner. Aliased to the old
+# private names so every call site reads unchanged.
+from assemblyzero.speedrun.restore import (  # noqa: E402
+    graveyard_issue_lld_refs as _graveyard_issue_lld_refs,
+    graveyard_leavings_refs as _graveyard_leavings_refs,
+    restore_artifact as _restore_artifact,
+)
 from assemblyzero.speedrun.worktrees import (  # noqa: E402
     sweep_pipeline_worktrees,
 )
@@ -708,115 +716,6 @@ def _resolve_stage_artifact(
         if found:
             return str(repo_root / found)
     return ""
-
-
-def _graveyard_leavings_refs(repo_root: Path) -> list[str]:
-    """Every `graveyard/leavings-*` ref, newest first.
-
-    These are where the file janitor PRESERVES what it clears. Nothing is
-    deleted -- preserve-then-clear is structural (standard 0027) -- so a
-    cleared artifact is always on one of these, and the newest is the one the
-    last run wrote.
-    """
-    result = _run(
-        [
-            "git", "for-each-ref", "--format=%(refname:short)",
-            "refs/heads/graveyard/leavings-*",
-            "refs/remotes/origin/graveyard/leavings-*",
-        ],
-        cwd=repo_root,
-    )
-    if result.returncode != 0:
-        return []
-    refs = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
-
-    # Sorted on the timestamp in the NAME, not on committerdate. Two leavings
-    # refs cut in the same second tie under `--sort=-committerdate` and git
-    # then falls back to refname ASCENDING -- oldest first, the wrong way
-    # round, which a fixture caught. The name carries `-YYYYMMDD-HHMMSS` by
-    # construction, so it orders these exactly and cannot be perturbed by a
-    # rewrite that changes commit times.
-    def _stamp(ref: str) -> str:
-        _, _, tail = ref.rpartition("leavings-")
-        return tail
-
-    return sorted(refs, key=_stamp, reverse=True)
-
-
-def _graveyard_issue_lld_refs(repo_root: Path, issue: int) -> list[str]:
-    """Every grafted copy of this issue's lld branch, newest first (#2516).
-
-    A HALT's RESTORE preserves the attempt branch by renaming it to
-    `graveyard/{issue}-lld-<UTC stamp>` (ADR 0217 keeps the commits; the
-    rename frees the name). The stamp is in the NAME, so name order is time
-    order -- same reasoning as `_graveyard_leavings_refs`, same immunity to
-    history rewrites perturbing committer dates.
-    """
-    result = _run(
-        [
-            "git", "for-each-ref", "--format=%(refname:short)",
-            f"refs/heads/graveyard/{issue}-lld-*",
-            f"refs/remotes/origin/graveyard/{issue}-lld-*",
-        ],
-        cwd=repo_root,
-    )
-    if result.returncode != 0:
-        return []
-    refs = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
-
-    def _stamp(ref: str) -> str:
-        _, _, tail = ref.rpartition("-lld-")
-        return tail
-
-    return sorted(refs, key=_stamp, reverse=True)
-
-
-def _restore_artifact(repo_root: Path, issue: int, artifact: str) -> bool:
-    """Materialize a passed stage's file so the next stage can read it.
-
-    The exit janitor clears pipeline-authored untracked files (standard 0027).
-    Two places hold what it cleared, and BOTH are searched:
-
-    * the issue's lld branch, when the draft was committed there;
-    * the `graveyard/leavings-*` refs the janitor preserves onto.
-
-    The second was missing, and it is the difference between a resume and a
-    redraw. Measured on boostgauge #1, 2026-08-15: neither `LLD-001.md` nor
-    `spec-0001-implementation-readiness.md` was on disk, and NEITHER was on
-    `1-lld` -- they were on `graveyard/leavings-20260815-161853` and
-    `...-161847`. `_restore_artifact` consulted only the lld branch, so it
-    returned False and the resume was abandoned for artifacts that were
-    preserved, pushed, and one `git show` away.
-
-    #2311 stopped the SPEC being lost in future runs by writing it somewhere
-    the janitor does not sweep. It could not un-clear what earlier runs had
-    already swept, and it does not cover the LLD, which still lives under
-    `docs/lld/active/` inside the janitor's allowlist. This closes that gap
-    from the other side: whatever was preserved can be restored.
-    """
-    path = Path(artifact)
-    if path.is_file():
-        return True
-    try:
-        rel = path.relative_to(repo_root)
-    except ValueError:
-        return False
-    refs = [f"{issue}-lld", f"origin/{issue}-lld"]
-    # #2516: the grafted copies of the lld branch rank right behind the live
-    # ones -- a HALT's RESTORE renames the branch to graveyard/{issue}-lld-*,
-    # and what it holds IS the lld branch's content under an archive name.
-    refs += _graveyard_issue_lld_refs(repo_root, issue)
-    # Newest leavings first: the last run's copy is the current one, and an
-    # older ref may hold a stale draft from a superseded attempt.
-    refs += _graveyard_leavings_refs(repo_root)
-
-    for ref in refs:
-        show = _run(["git", "show", f"{ref}:{rel.as_posix()}"], cwd=repo_root)
-        if show.returncode == 0 and show.stdout:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(show.stdout, encoding="utf-8")
-            return True
-    return False
 
 
 # Binding-input paths: a commit touching any of them invalidates a draft


### PR DESCRIPTION
Closes #2571

The working copy of a pipeline input is a cache, not a source of record. Issue #331's LLD was deleted from the working tree three times in one day (see #2551) and survived only on refs. The verification comment on the issue narrowed the scope: the ref-store half already exists (the lld stage pushes the approved LLD on the `{issue}-lld` branch, and `speedrun_roll._restore_artifact` already searched it, its graveyard grafts, and the janitor's leavings refs — but ONLY on the speedrun resume-planning path). The hole was the loader concluding absence from the cache alone.

## The repair

**The restore machinery moves to a shared home**, `assemblyzero/speedrun/restore.py` — `restore_artifact`, `graveyard_leavings_refs`, `graveyard_issue_lld_refs`, and the search order (`input_refs`) — with `speedrun_roll` importing it under the old private names so every call site reads unchanged, and a test asserting the alias IS the shared function. Moved, not forked: two copies is how the 2026-08-15 gap (two artifacts preserved, pushed, one `git show` away, and the restorer looking in only one place) happened in the first place.

**`find_lld_path` rebuilds on a miss.** When the glob finds nothing and the repo is a git repo, the loader asks the restore machinery to materialize the canonical `LLD-{issue:03d}.md` from the refs — logging `[REBUILT] ... restored from '<ref>'` — before concluding the LLD genuinely does not exist. The #2552 "requirements unreadable" event now fires only when the refs are gone too, which is the honest meaning of unreadable. Fail-open by design: a rebuild error reports and returns the same absence the loader always reported, never a crash.

**The commit-to-arc half of the issue is deliberately not implemented** (reasons on the issue): the `{issue}-lld` branch already is the canonical ref home, the machinery searches it first, and a second copy on the arc is a sync burden closing no failure mode the rebuild does not. The incident that would earn it — the lld branch itself deleted while the arc survives — is not on the record.

## Acceptance

`tests/unit/test_input_rebuild_from_refs.py` (10 tests, real repos with bare origins, the sweep performed by the real janitor): a swept input rebuilds from the leavings ref with the ref named in the log; the live lld branch outranks a stale leavings copy; the loader's acceptance case — delete the working copy, `find_lld_path` rebuilds and resolves it with content intact, logging the rebuild; a present working copy needs no refs; genuine absence stays a clean None; a plain directory is never probed; newest-first ref ordering; and the speedrun aliases are identity with the shared functions. Full unit suite green.

**What only a live roll proves:** a real boostgauge launch resolving through a rebuild after an out-of-band deletion, alongside the #2551 sweep exemption that should make such deletions rare.
