### PR TITLE
feat: the halt emits its own evidence bundle -- events quoted, artifacts hashed, identical groups named, a draft issue body included (Closes #2574)

### DIFF
--- a/assemblyzero/core/halt_evidence.py
+++ b/assemblyzero/core/halt_evidence.py
@@ -1,0 +1,257 @@
+"""Auto-forensics at halt: the evidence bundle, emitted, not excavated (#2574).
+
+The same forensic dig was performed by hand eight times on 2026-08-27:
+locate the lineage dir, count and hash the drafts (four byte-identical,
+md5-confirmed, was the load-bearing fact of #2555), collect the [PINNING]
+events, name the preserved refs, and assemble an issue body from it all.
+Every input to that dig is in scope at the moment of the halt; the halt
+path used to discard it.
+
+The bundle is state-side evidence: the events the run recorded, the
+lineage artifacts with their hashes and identical groups, the refs the
+machinery preserved, and a DRAFT issue body — saved, never auto-filed, so
+the operator's filing step starts at "verify and sharpen" instead of
+"excavate". Log-line excerpts are deliberately NOT here: the halt node is
+the process writing the log and cannot portably read its own transcript;
+the wrapper-side death detection (#2510) owns that half, and this module's
+formats are what it will share.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+#: How many trailing preserved-branch records travel in the bundle. The
+#: record has no reliable run-id linkage (leavings refs carry run="" by
+#: construction), so the tail is the honest cut, said in the bundle.
+PRESERVED_TAIL = 8
+
+#: Event caps keep the markdown a bundle, not a transcript. The JSON always
+#: carries everything.
+MD_EVENT_CAP = 20
+
+
+def _sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        # fail-open: an unreadable artifact is reported as unreadable in
+        # the bundle rather than crashing the halt that is trying to
+        # describe it.
+        return None
+
+
+def _artifact_inventory(audit_dir: Path) -> dict[str, Any]:
+    """Every top-level lineage file: name, size, hash — and the identical
+    groups, because four byte-identical drafts was the fact a manual dig
+    took an md5 loop to establish."""
+    files: list[dict[str, Any]] = []
+    by_hash: dict[str, list[str]] = {}
+    for path in sorted(audit_dir.iterdir()):
+        if not path.is_file():
+            continue
+        digest = _sha256(path)
+        files.append({
+            "name": path.name,
+            "bytes": path.stat().st_size if digest is not None else None,
+            "sha256": digest[:12] if digest else None,
+        })
+        if digest:
+            by_hash.setdefault(digest, []).append(path.name)
+    identical = sorted(
+        names for names in by_hash.values() if len(names) >= 2
+    )
+    return {"files": files, "identical_groups": identical}
+
+
+def _preserved_tail(repo_root: Path) -> list[dict[str, Any]]:
+    record = repo_root / "data" / "speedrun" / "runs" / "preserved-branches.jsonl"
+    if not record.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in record.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                # fail-open: one corrupt record in the preservation log
+                # drops that record from the bundle's tail, never the
+                # bundle -- the evidence is a best-effort slice of a file
+                # this process does not own.
+                continue
+    except OSError:
+        # fail-open: the preservation record is evidence ABOUT the run,
+        # not of it -- a bundle without it still carries the events and
+        # artifacts, and says nothing false.
+        return []
+    return entries[-PRESERVED_TAIL:]
+
+
+def build_halt_evidence(
+    state: dict, workflow: str, *, stage: str, error_message: str
+) -> dict[str, Any]:
+    """The state-side evidence a forensic reader needs, as one document."""
+    audit_dir_str = str(state.get("audit_dir", "") or "")
+    audit_dir = Path(audit_dir_str) if audit_dir_str else None
+    repo_root_str = str(
+        state.get("repo_root", "") or state.get("target_repo", "") or ""
+    )
+
+    events: dict[str, list[str]] = {
+        "pinning_events": [str(e) for e in state.get("pinning_events") or []],
+        "completeness_issues": [
+            str(i) for i in state.get("completeness_issues") or []
+        ],
+        "validation_errors": [
+            str(e) for e in state.get("validation_errors") or []
+        ],
+    }
+
+    artifacts: dict[str, Any] = {"files": [], "identical_groups": []}
+    if audit_dir is not None and audit_dir.is_dir():
+        artifacts = _artifact_inventory(audit_dir)
+
+    preserved: list[dict[str, Any]] = []
+    if repo_root_str:
+        preserved = _preserved_tail(Path(repo_root_str))
+
+    return {
+        "bundle_version": 1,
+        "workflow": workflow,
+        "issue": int(state.get("issue_number", 0) or 0),
+        "stage": stage,
+        "halted_at": datetime.now(tz=timezone.utc).isoformat(),
+        "error_message": error_message,
+        "counters": {
+            "review_iteration": state.get("review_iteration", 0),
+            "iteration_count": state.get("iteration_count", 0),
+            "max_iterations": state.get("max_iterations", 0),
+        },
+        "events": events,
+        "audit_dir": audit_dir_str,
+        "artifacts": artifacts,
+        "preserved_refs_tail": preserved,
+    }
+
+
+def _md_events(title: str, lines: list[str]) -> list[str]:
+    if not lines:
+        return []
+    out = [f"## {title}", ""]
+    for line in lines[:MD_EVENT_CAP]:
+        out.append(f"> {line}")
+    if len(lines) > MD_EVENT_CAP:
+        out.append(
+            f"> (and {len(lines) - MD_EVENT_CAP} more; the JSON bundle "
+            f"carries all of them)"
+        )
+    out.append("")
+    return out
+
+
+def render_halt_evidence_md(evidence: dict[str, Any]) -> str:
+    """The bundle as a document, ending in the draft issue body."""
+    lines: list[str] = [
+        f"# Halt evidence — {evidence['workflow']} #{evidence['issue']}, "
+        f"{evidence['stage']}",
+        "",
+        f"Halted at {evidence['halted_at']}. Assembled by the halt path "
+        f"(#2574) from state-side evidence; the run log carries the full "
+        f"transcript.",
+        "",
+        "## What halted",
+        "",
+        f"> {evidence['error_message']}",
+        "",
+        f"Counters: iteration {evidence['counters']['review_iteration']}"
+        f"/{evidence['counters']['max_iterations']} (review), "
+        f"{evidence['counters']['iteration_count']} (loop).",
+        "",
+    ]
+    events = evidence["events"]
+    lines += _md_events("Pinning events", events["pinning_events"])
+    lines += _md_events("Completeness issues", events["completeness_issues"])
+    lines += _md_events("Validation errors", events["validation_errors"])
+
+    artifacts = evidence["artifacts"]
+    if artifacts["files"]:
+        lines += ["## Lineage artifacts", ""]
+        lines += ["| file | bytes | sha256 |", "|---|---|---|"]
+        for entry in artifacts["files"]:
+            size = entry["bytes"] if entry["bytes"] is not None else "?"
+            lines.append(
+                f"| {entry['name']} | {size} | {entry['sha256'] or 'unreadable'} |"
+            )
+        lines.append("")
+        for group in artifacts["identical_groups"]:
+            lines.append(
+                f"**Byte-identical group:** {', '.join(group)} — "
+                f"{len(group)} file(s), one content."
+            )
+        if artifacts["identical_groups"]:
+            lines.append("")
+
+    if evidence["preserved_refs_tail"]:
+        lines += [
+            "## Preserved refs (tail of the preservation record; no "
+            "run-id linkage exists, so this is the recent slice)",
+            "",
+        ]
+        for entry in evidence["preserved_refs_tail"]:
+            lines.append(
+                f"- {entry.get('at', '?')} `{entry.get('branch', '?')}` "
+                f"({entry.get('source', '?')}: {entry.get('detail', '')})"
+            )
+        lines.append("")
+
+    head = (evidence["error_message"] or "halt with no message").splitlines()[0]
+    lines += [
+        "## Draft issue body (verify and sharpen before filing — never "
+        "auto-filed)",
+        "",
+        f"**Suggested title:** {head[:120]}",
+        "",
+        "```markdown",
+        f"Observed on the {evidence['workflow']} workflow for issue "
+        f"#{evidence['issue']}, stage {evidence['stage']}, "
+        f"{evidence['halted_at']}.",
+        "",
+        "## What the halt said",
+        "",
+        f"> {evidence['error_message']}",
+        "",
+        "## Evidence",
+        "",
+        f"- Lineage: `{evidence['audit_dir'] or '(no audit dir)'}`",
+        f"- {len(events['pinning_events'])} pinning event(s), "
+        f"{len(events['completeness_issues'])} completeness issue(s) — "
+        f"quoted in halt-evidence.md beside this draft",
+        f"- {len(artifacts['identical_groups'])} byte-identical artifact "
+        f"group(s)",
+        "",
+        "## Repro state",
+        "",
+        "Preserved, read-only: the lineage dir above and the refs listed "
+        "in halt-evidence.md.",
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_halt_evidence(
+    evidence: dict[str, Any], directory: Path
+) -> tuple[Path, Path]:
+    directory.mkdir(parents=True, exist_ok=True)
+    json_path = directory / "halt-evidence.json"
+    md_path = directory / "halt-evidence.md"
+    json_path.write_text(json.dumps(evidence, indent=2), encoding="utf-8")
+    md_path.write_text(render_halt_evidence_md(evidence), encoding="utf-8")
+    return json_path, md_path

--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -260,6 +260,38 @@ def create_halt_node(workflow_name: str):
             # and the resume simply has no contract to verify.
             print(f"  [WARN] resume contract not written: {exc}")
 
+        # 5c. #2574: the halt emits its own evidence bundle — the events
+        # the run recorded, the lineage artifacts hashed with their
+        # byte-identical groups named, the preserved refs, and a DRAFT
+        # issue body, saved beside the plan and into the audit dir. The
+        # same dig was done by hand eight times on 2026-08-27; every input
+        # was in scope right here.
+        try:
+            from assemblyzero.core.halt_evidence import (
+                build_halt_evidence,
+                write_halt_evidence,
+            )
+
+            evidence = build_halt_evidence(
+                state, workflow_name,
+                stage=stage, error_message=error_message,
+            )
+            write_halt_evidence(evidence, state_path.parent)
+            audit_dir_str = str(state.get("audit_dir", "") or "")
+            if audit_dir_str and Path(audit_dir_str).is_dir():
+                write_halt_evidence(evidence, Path(audit_dir_str))
+            groups = len(evidence["artifacts"]["identical_groups"])
+            print(
+                f"  halt evidence written: "
+                f"{len(evidence['artifacts']['files'])} artifact(s), "
+                f"{groups} byte-identical group(s), draft issue body "
+                f"included (#2574)"
+            )
+        except Exception as exc:  # noqa: BLE001
+            # fail-open: the bundle describes the halt; failing to write
+            # it must never mask the halt it describes.
+            print(f"  [WARN] halt evidence not written: {exc}")
+
         # 6. Print human-readable summary
         plan.print_summary()
 

--- a/tests/unit/test_halt_evidence.py
+++ b/tests/unit/test_halt_evidence.py
@@ -1,0 +1,150 @@
+"""The halt emits its own evidence bundle (#2574).
+
+The acceptance is fidelity to the manual digs: the bundle's facts for the
+observed run shapes must match what the hand-derived forensics found —
+the refusal events quoted, the byte-identical draft group named, the
+preserved refs listed — and a bundle failure must never mask the halt.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assemblyzero.core.halt_evidence as he
+import assemblyzero.core.resume_contract as rc
+import assemblyzero.core.state_persistence as sp
+from assemblyzero.core.halt_evidence import (
+    build_halt_evidence,
+    render_halt_evidence_md,
+    write_halt_evidence,
+)
+from assemblyzero.core.halt_node import create_halt_node
+
+REFUSAL = (
+    "[PINNING] refused: 1 line(s) starting '```python' — locked content "
+    "the verdict did not name (#2532)"
+)
+
+
+def _lineage(tmp_path: Path) -> Path:
+    """The observed shape: four drafts, three byte-identical (#2555's
+    load-bearing fact), one different."""
+    audit = tmp_path / "lineage"
+    audit.mkdir()
+    for name in ("001-spec-draft.md", "004-spec-draft.md", "006-spec-draft.md"):
+        (audit / name).write_text("# Spec\n\nsame bytes\n", encoding="utf-8")
+    (audit / "002-check.json").write_text('{"passed": true}', encoding="utf-8")
+    return audit
+
+
+def _state(tmp_path: Path) -> dict:
+    audit = _lineage(tmp_path)
+    repo = tmp_path / "repo"
+    runs = repo / "data" / "speedrun" / "runs"
+    runs.mkdir(parents=True)
+    (runs / "preserved-branches.jsonl").write_text(
+        '{"at": "2026-08-27 13:01:22", "branch": '
+        '"graveyard/leavings-20260827-130120", "detail": "1 file(s)", '
+        '"run": "", "source": "leavings"}\n',
+        encoding="utf-8",
+    )
+    return {
+        "issue_number": 331,
+        "audit_dir": str(audit),
+        "repo_root": str(repo),
+        "pinning_events": [REFUSAL] * 6,
+        "completeness_issues": ["3 LLD pass criterion(s) have no test"],
+        "review_iteration": 3,
+        "max_iterations": 3,
+    }
+
+
+class TestTheBundle:
+    def test_the_facts_match_the_manual_dig(self, tmp_path):
+        evidence = build_halt_evidence(
+            _state(tmp_path), "implementation_spec",
+            stage="N5_review_iter3", error_message="Iteration cap: ...",
+        )
+        assert len(evidence["events"]["pinning_events"]) == 6
+        assert len(evidence["artifacts"]["files"]) == 4
+        groups = evidence["artifacts"]["identical_groups"]
+        assert groups == [[
+            "001-spec-draft.md", "004-spec-draft.md", "006-spec-draft.md",
+        ]]
+        preserved = evidence["preserved_refs_tail"]
+        assert preserved[0]["branch"] == "graveyard/leavings-20260827-130120"
+
+    def test_the_markdown_quotes_events_and_names_the_group(self, tmp_path):
+        evidence = build_halt_evidence(
+            _state(tmp_path), "implementation_spec",
+            stage="N5_review_iter3", error_message="Iteration cap: ...",
+        )
+        md = render_halt_evidence_md(evidence)
+        assert REFUSAL in md
+        assert "Byte-identical group:" in md
+        assert "3 file(s), one content" in md
+        assert "Draft issue body" in md
+        assert "never auto-filed" in md
+        assert "graveyard/leavings-20260827-130120" in md
+
+    def test_a_bare_state_still_builds_a_bundle(self, tmp_path):
+        evidence = build_halt_evidence(
+            {"issue_number": 1}, "testing", stage="N0", error_message="x",
+        )
+        assert evidence["artifacts"]["files"] == []
+        assert evidence["preserved_refs_tail"] == []
+        assert "What halted" in render_halt_evidence_md(evidence)
+
+    def test_write_emits_both_formats(self, tmp_path):
+        evidence = build_halt_evidence(
+            _state(tmp_path), "implementation_spec",
+            stage="N5", error_message="cap",
+        )
+        json_path, md_path = write_halt_evidence(evidence, tmp_path / "out")
+        assert json.loads(json_path.read_text(encoding="utf-8"))["issue"] == 331
+        assert md_path.read_text(encoding="utf-8").startswith("# Halt evidence")
+
+
+class TestTheHaltEmitsIt:
+    @pytest.fixture
+    def store(self, tmp_path, monkeypatch):
+        directory = tmp_path / "state"
+        directory.mkdir()
+        monkeypatch.setattr(rc, "STATE_DIR", directory)
+        monkeypatch.setattr(sp, "STATE_DIR", directory)
+        return directory
+
+    def test_the_bundle_lands_beside_the_plan_and_in_lineage(
+        self, store, tmp_path, capsys
+    ):
+        state = _state(tmp_path)
+        state["error_message"] = "Iteration cap: 3 revision(s) ended"
+        halt = create_halt_node("implementation_spec")
+        result = halt(state)
+        out = capsys.readouterr().out
+
+        assert result["workflow_status"] == "halted"
+        assert "halt evidence written" in out
+        assert (store / "halt-evidence.md").exists()
+        assert (store / "halt-evidence.json").exists()
+        lineage_md = Path(state["audit_dir"]) / "halt-evidence.md"
+        assert lineage_md.exists(), "the lineage carries the bundle"
+        assert REFUSAL in lineage_md.read_text(encoding="utf-8")
+
+    def test_a_bundle_failure_never_masks_the_halt(
+        self, store, tmp_path, monkeypatch, capsys
+    ):
+        state = _state(tmp_path)
+        state["error_message"] = "some halt"
+        monkeypatch.setattr(
+            he, "build_halt_evidence",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        halt = create_halt_node("implementation_spec")
+        result = halt(state)
+        out = capsys.readouterr().out
+        assert result["workflow_status"] == "halted"
+        assert "halt evidence not written" in out


### PR DESCRIPTION
Closes #2574

The same forensic dig was performed by hand eight times on 2026-08-27: locate the lineage dir, count and hash the drafts, collect the [PINNING] events, name the preserved refs, assemble an issue body. Every input to that dig is in scope at the moment of the halt; the halt path used to discard it. Now it emits the bundle.

## The mechanism

`assemblyzero/core/halt_evidence.py` builds the state-side evidence as one document, written as `halt-evidence.json` and `halt-evidence.md` beside the recovery plan AND into the run's audit dir, from the shared halt node (all four workflows), directly after the resume contract:

- **The events the run recorded**: pinning events, completeness issues, validation errors — quoted in the markdown (capped at twenty per class with the JSON carrying everything).
- **The lineage artifacts, hashed, with byte-identical groups named** — the fact that took a manual md5 loop to establish on #2555 ("drafts 001, 004, 006, 008 are byte-identical") is now one line in every bundle.
- **The preserved refs**: the tail of `preserved-branches.jsonl`, with the honest caveat stated in the bundle itself (the record has no run-id linkage, so the tail is the recent slice).
- **A draft issue body** — suggested title from the error head, the halt quoted, the evidence pointers listed — saved, never auto-filed: the filing step starts at "verify and sharpen" instead of "excavate".

**Deliberately not in scope, stated rather than hidden**: log-line excerpts. The halt node is the process writing the log and cannot portably read its own transcript; the wrapper-side death detection (#2510, filed) owns that half, and this module's formats are what it will share. Best-effort throughout: a bundle failure prints a WARN and never masks the halt it describes, and the #2475 gate confirmed every fall-through carries its declared ruling.

## Acceptance

`tests/unit/test_halt_evidence.py`: the observed run shape (six refusal events, four lineage files of which three are byte-identical, a real preservation record line) produces a bundle whose facts match the manual digs — the group named with its members, the events quoted verbatim, the leavings branch listed; a bare state still builds a bundle; both formats written; the halt node lands the bundle beside the plan and in lineage; a bundle failure never masks the halt. Full unit suite green.

**What only a live roll proves:** the bundle's usefulness on the next real kill — whether the draft issue body starts the filing at verify-and-sharpen in practice.
