### PR TITLE
feat: a factory telemetry rollup -- counts decide what the next kill currently decides (Closes #2575)

### DIFF
--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -1,0 +1,756 @@
+"""The factory records everything and aggregates nothing (#2575).
+
+Every judgment call of the 2026-08-27 campaign — is the density heuristic
+noise (#2539)? which checks deserve the fact-verifier badge (#2540)? does
+the edit-script path fall back often enough to matter? — was decided by
+whichever kill happened most recently, while the counts to decide them
+properly already sat on disk. `prompt_telemetry` counts every validation
+failure (#2074), the healing ledger records every janitor action (#2164),
+`preserved-branches.jsonl` records every preservation (#2355), run logs
+carry per-stage wall-clock against the watchdog's nominal, and since
+2026-08-27 every halt leaves a machine-readable evidence bundle (#2574)
+and, while it is live, a resume contract (#2570).
+
+This module reads those stores and counts. **v1 adds no instrumentation**:
+every number here comes from a file some other mechanism already writes,
+which is what makes the report safe to run against a live campaign.
+
+## Counts, never estimates
+
+Every number is derived by counting records. Where a store cannot answer a
+question, the report says so with its denominator rather than guessing —
+standard 0025's cold-start rule, applied to aggregation: a zero that means
+"nothing fired" and a zero that means "nothing was recorded" are different
+facts and are printed differently.
+
+## The zero-fire denominator is declared, not inferred
+
+"Which gates never fire" needs the set of gates that COULD fire. Inferring
+it from observed records is circular — a gate that never fires is exactly
+the one absent from the data. So the recording sites are declared here in
+`DECLARED_CHECKS`, and `tests/unit/test_factory_report.py` greps the
+workflow sources and fails when a new `record_failure(s)` site appears
+that this tuple does not name. The registry cannot silently drift behind
+the code, because the test is the thing that keeps it honest.
+
+## Run logs are read with errors="replace", always
+
+Speedrun run logs carry stray bytes from model output. GNU grep's binary
+detection silently suppresses matching lines in them (the 2026-08-27
+near-miss: `[PINNING] refused:` lines existed and a multi-pattern grep
+printed only the REGRESSION lines plus "Binary file matches", which is a
+confident wrong answer rather than a failure). `errors="replace"` is the
+Python-side equivalent of `grep -a` and is not optional here.
+
+## Determinism
+
+Identical input produces byte-identical output, so two reports can be
+diffed across days to see what changed rather than re-read in full. Every
+ordering has an explicit tie-break on a stable key.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+#: Every (stage, check) pair a `record_failure`/`record_failures` call site
+#: can write, as declared by the workflow sources. This is the DENOMINATOR
+#: for zero-fire reporting: a declared pair with no records in the window
+#: is a gate that did not fire, which is either perfect or dead, and the
+#: report refuses to distinguish those for the reader.
+#:
+#: Kept honest by test_factory_report.py::TestDeclaredChecks, which greps
+#: the workflow tree for recording sites and fails when one is missing.
+DECLARED_CHECKS: tuple[tuple[str, str], ...] = (
+    ("lld", "mechanical"),
+    ("lld", "requirements-conflict"),
+    ("lld", "test-plan"),
+    ("spec", "reviewer-revise"),
+)
+
+#: Run-log markers this report counts, and what each one means. Counting is
+#: line-oriented on purpose: these markers are emitted one per event by the
+#: pipeline, so a line count IS an event count.
+_RE_STAGE_WATCHDOG = re.compile(
+    r"\[STAGE\]\s+(?P<stage>\S+)\s+running\s+(?P<elapsed>\d+)s"
+    r"\s+\(nominal\s+~(?P<nominal>\d+)s\)"
+)
+_RE_PINNING_REFUSED = re.compile(r"\[PINNING\]\s+refused:")
+_RE_PINNING_REGRESSION = re.compile(r"\[PINNING\]\s+REGRESSION CLASS:")
+_RE_EDIT_APPLIED = re.compile(r"\[EDIT-SCRIPT\]\s+Applied\s+(?P<edits>\d+)\s+edit")
+_RE_EDIT_FALLBACK = re.compile(
+    r"\[EDIT-SCRIPT\]\s+Falling back to full revision:\s*(?P<reason>.*)"
+)
+_RE_CAP_GRANT = re.compile(r"\[CAP\]\s+(?P<detail>.*)")
+_RE_REVIEW_ROUND = re.compile(
+    r"\[REVIEW\]\s+(?P<what>\S+)\s+review\s+\S+\s+\[(?P<verdict>[^\]]+)\]:"
+    r"\s+round\s+(?P<round>\d+)"
+)
+#: The run-log filename carries the issue and the run stamp by construction:
+#: `run-issue<N>-<HHMMSS>.log`. Nothing else links a log to an issue, so the
+#: name is the linkage and a log that does not match is reported as unlinked
+#: rather than silently attributed.
+_RE_RUN_NAME = re.compile(r"^run-issue(?P<issue>\d+)-(?P<stamp>\d+)\.log$")
+
+
+def parse_since(spec: str, *, now: datetime | None = None) -> datetime | None:
+    """`7d` / `24h` / `2026-08-27` / `2026-08-27 09:00:00` -> a lower bound.
+
+    An empty spec means no lower bound (read everything), which is a real
+    answer and not an error. An unparseable spec raises, because silently
+    reading everything when the operator asked for a window would put a
+    wrong denominator under every number in the report.
+    """
+    text = (spec or "").strip()
+    if not text:
+        return None
+    now = now or datetime.now()
+    relative = re.fullmatch(r"(?P<n>\d+)\s*(?P<unit>[dhw])", text.lower())
+    if relative:
+        count = int(relative.group("n"))
+        unit = relative.group("unit")
+        delta = {
+            "h": timedelta(hours=count),
+            "d": timedelta(days=count),
+            "w": timedelta(weeks=count),
+        }[unit]
+        return now - delta
+    for fmt in (_TS_FMT, "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            # fail-open: trying the next format is the point of the loop, not
+            # a swallowed failure -- when every format misses, the function
+            # RAISES two lines below rather than returning a default window.
+            continue
+    raise ValueError(
+        f"unparseable --since {spec!r}: use 7d, 24h, 2w, YYYY-MM-DD, "
+        f"or 'YYYY-MM-DD HH:MM:SS'"
+    )
+
+
+def _parse_ts(raw: str) -> datetime | None:
+    for fmt in (_TS_FMT, "%Y-%m-%d"):
+        try:
+            return datetime.strptime(str(raw).strip(), fmt)
+        except (ValueError, TypeError):
+            # fail-open: try the next format. None is returned only when all
+            # of them miss, and every caller treats None as "cannot place this
+            # record in time" and KEEPS the record -- see _in_window, where
+            # dropping it would silently shrink a printed denominator.
+            continue
+    return None
+
+
+def _in_window(raw: str, since: datetime | None) -> bool:
+    """A record with an unparseable timestamp is KEPT, and counted as such.
+
+    Dropping it would silently shrink a denominator the report is about to
+    print, which is the failure this module exists to prevent.
+    """
+    if since is None:
+        return True
+    parsed = _parse_ts(raw)
+    if parsed is None:
+        return True
+    return parsed >= since
+
+
+# ---------------------------------------------------------------------------
+# Run logs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunLogFacts:
+    """What one run log says, counted. Every field is an event count."""
+
+    run_id: str
+    issue: int | None
+    path: str
+    mtime: str
+    pinning_refusals: int = 0
+    pinning_regressions: int = 0
+    edit_scripts_applied: int = 0
+    edit_script_fallbacks: int = 0
+    fallback_reasons: list[str] = field(default_factory=list)
+    cap_grants: list[str] = field(default_factory=list)
+    review_rounds: dict[str, int] = field(default_factory=dict)
+    #: stage -> (max observed elapsed, nominal). The watchdog prints one
+    #: line per minute per stage, so the LAST elapsed for a stage is the
+    #: longest that stage was observed running in this run. It is a floor,
+    #: not the true duration -- the stage ends between watchdog ticks --
+    #: and the report says so rather than presenting it as a measurement.
+    stage_elapsed: dict[str, tuple[int, int]] = field(default_factory=dict)
+    unreadable: bool = False
+
+
+def scan_run_log(path: Path) -> RunLogFacts:
+    """Count every marker in one run log. Never raises."""
+    name = path.name
+    match = _RE_RUN_NAME.match(name)
+    issue = int(match.group("issue")) if match else None
+    run_id = name[:-4] if name.endswith(".log") else name
+
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime).strftime(_TS_FMT)
+    except OSError:
+        # fail-open: an unstattable log keeps an empty mtime, and scan_run_logs
+        # INCLUDES a log it cannot date rather than filtering it out. Excluding
+        # it would drop real events from a window silently; including it can
+        # only ever widen the count, which is visible in the printed total.
+        mtime = ""
+
+    facts = RunLogFacts(run_id=run_id, issue=issue, path=str(path), mtime=mtime)
+
+    try:
+        # errors="replace": see the module docstring. Model output leaves
+        # stray bytes in these logs and a strict decode drops real events.
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # fail-open: one unreadable log must not kill a report over the other
+        # four hundred. The substitution is not silent -- `unreadable` is set
+        # on the record, so the shortfall is carried in the data rather than
+        # disguised as a run in which nothing happened.
+        facts.unreadable = True
+        return facts
+
+    for line in text.splitlines():
+        if _RE_PINNING_REFUSED.search(line):
+            facts.pinning_refusals += 1
+        if _RE_PINNING_REGRESSION.search(line):
+            facts.pinning_regressions += 1
+        applied = _RE_EDIT_APPLIED.search(line)
+        if applied:
+            facts.edit_scripts_applied += 1
+        fallback = _RE_EDIT_FALLBACK.search(line)
+        if fallback:
+            facts.edit_script_fallbacks += 1
+            reason = fallback.group("reason").strip()
+            if reason:
+                facts.fallback_reasons.append(reason[:120])
+        cap = _RE_CAP_GRANT.search(line)
+        if cap:
+            facts.cap_grants.append(cap.group("detail").strip()[:160])
+        review = _RE_REVIEW_ROUND.search(line)
+        if review:
+            what = review.group("what").lower()
+            facts.review_rounds[what] = max(
+                facts.review_rounds.get(what, 0), int(review.group("round"))
+            )
+        watchdog = _RE_STAGE_WATCHDOG.search(line)
+        if watchdog:
+            stage = watchdog.group("stage")
+            elapsed = int(watchdog.group("elapsed"))
+            nominal = int(watchdog.group("nominal"))
+            prior = facts.stage_elapsed.get(stage, (0, nominal))
+            facts.stage_elapsed[stage] = (max(prior[0], elapsed), nominal)
+
+    return facts
+
+
+def runs_dir(repo_root: Path | str) -> Path:
+    return Path(repo_root) / "data" / "speedrun" / "runs"
+
+
+def scan_run_logs(
+    repo_root: Path | str, since: datetime | None = None
+) -> list[RunLogFacts]:
+    """Every `run-issue*.log` in the window, oldest first.
+
+    The window is applied on the file's mtime: run logs carry no header
+    timestamp, and the stamp in the name has no date component, so mtime is
+    the only date the filesystem actually knows.
+    """
+    directory = runs_dir(repo_root)
+    if not directory.is_dir():
+        # fail-open: a repo with no runs directory has never been rolled, which
+        # is a real answer and not an error. It is NOT reported as "zero runs":
+        # build_report records the directory's absence, and render_report
+        # prints `| NO |` for the store so an absent store never reads as an
+        # empty one.
+        return []
+    facts: list[RunLogFacts] = []
+    for path in sorted(directory.glob("run-issue*.log")):
+        if path.name.endswith("-events.log") or path.name.endswith(
+            "-heartbeat.log"
+        ):
+            continue
+        scanned = scan_run_log(path)
+        if since is not None and scanned.mtime and not _in_window(
+            scanned.mtime, since
+        ):
+            continue
+        facts.append(scanned)
+    return sorted(facts, key=lambda f: (f.mtime, f.run_id))
+
+
+# ---------------------------------------------------------------------------
+# Halt evidence bundles (#2574) and resume contracts (#2570)
+# ---------------------------------------------------------------------------
+
+
+def _under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (ValueError, OSError):
+        # fail-open: deliberately toward EXCLUSION. This answers "is this
+        # halt attributable to the repo being reported on". A path that cannot
+        # be resolved or compared is not proof of containment, and the safe
+        # direction is to omit a halt rather than credit this repo with
+        # another repo's. Undercounting is visible in the total; misattribution
+        # is not (see #2588).
+        return False
+
+
+def read_halt_bundles(
+    search_roots: list[Path],
+    since: datetime | None = None,
+    *,
+    scope_repo: Path | None = None,
+) -> list[dict]:
+    """Every readable `halt-evidence.json` under the given roots.
+
+    Added by the 2026-08-28 update to #2575: since #2574 landed, a halt
+    leaves machine-readable counters, event lists and artifact hashes, so
+    halts can be counted from a structured store instead of parsed out of
+    run-log prose.
+
+    `scope_repo` is load-bearing when a root is SHARED. The halt path writes
+    one copy of the bundle beside the state snapshot in
+    ``~/.assemblyzero/workflow_state``, which is global across every repo
+    the fleet has ever rolled, and one copy into the run's audit dir inside
+    the target repo. Counting the shared directory unscoped attributes every
+    other repo's halts to this one -- a wrong number presented confidently,
+    which is the exact failure this report exists to end. A bundle found
+    outside the target repo is therefore kept only when its own `audit_dir`
+    points back inside it; a bundle with no `audit_dir` cannot be attributed
+    to any repo and is dropped rather than guessed at.
+    """
+    bundles: list[dict] = []
+    seen: set[str] = set()
+    for root in search_roots:
+        if not root or not Path(root).is_dir():
+            continue
+        for path in sorted(Path(root).rglob("halt-evidence.json")):
+            key = str(path.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                # fail-open: one corrupt bundle drops that halt from the
+                # count and never the report. The count is reported with
+                # its own denominator so a reader can see the shortfall.
+                continue
+            if not isinstance(data, dict):
+                continue
+            if scope_repo is not None and not _under(path, Path(scope_repo)):
+                audit_dir = str(data.get("audit_dir", "") or "")
+                if not audit_dir or not _under(
+                    Path(audit_dir), Path(scope_repo)
+                ):
+                    continue
+            halted = str(data.get("halted_at", ""))
+            if since is not None and halted:
+                # Bundles stamp UTC ISO-8601; compare on the date portion
+                # only, because the window bound is local and converting
+                # would claim a precision the comparison does not have.
+                parsed = _parse_ts(halted[:10])
+                if parsed is not None and parsed.date() < since.date():
+                    continue
+            data["_path"] = str(path)
+            bundles.append(data)
+    return sorted(
+        bundles, key=lambda b: (str(b.get("halted_at", "")), str(b.get("_path")))
+    )
+
+
+# ---------------------------------------------------------------------------
+# The counted picture
+# ---------------------------------------------------------------------------
+
+
+def _top(counter: dict[str, int], limit: int = 3) -> list[tuple[str, int]]:
+    return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:limit]
+
+
+def build_report(
+    repo_root: Path | str,
+    *,
+    since: datetime | None = None,
+    extra_halt_roots: list[Path] | None = None,
+) -> dict:
+    """Read every store and return the counted picture. Read-only."""
+    from assemblyzero.speedrun.healing import heals_path, read_heals
+    from assemblyzero.speedrun.preserved import ledger_path, read_ledger
+    from assemblyzero.speedrun.prompt_telemetry import (
+        read_failures,
+        telemetry_path,
+    )
+
+    repo = Path(repo_root)
+
+    failures = [
+        row
+        for row in read_failures(repo)
+        if _in_window(row.get("ts_local", ""), since)
+    ]
+    heals = [
+        row for row in read_heals(repo) if _in_window(row.get("ts", ""), since)
+    ]
+    preserved = [
+        rec for rec in read_ledger(repo) if _in_window(rec.at, since)
+    ]
+    runs = scan_run_logs(repo, since)
+
+    halt_roots = list(extra_halt_roots or [])
+    halt_roots.append(Path.home() / ".assemblyzero" / "workflow_state")
+    halt_roots.append(repo / "docs" / "lineage")
+    # scope_repo: the state dir is shared across every repo the fleet rolls.
+    # See read_halt_bundles -- counting it unscoped would attribute other
+    # repos' halts to this one.
+    bundles = read_halt_bundles(halt_roots, since, scope_repo=repo)
+
+    # -- gates: which fire, which never do -------------------------------
+    per_check: dict[str, int] = defaultdict(int)
+    per_fingerprint: dict[str, int] = defaultdict(int)
+    for row in failures:
+        stage = str(row.get("stage") or "?")
+        check = str(row.get("check") or "?")
+        per_check[f"{stage}:{check}"] += 1
+        per_fingerprint[str(row.get("fingerprint") or "unknown")] += 1
+
+    declared = [f"{stage}:{check}" for stage, check in DECLARED_CHECKS]
+    zero_fire = sorted(key for key in declared if per_check.get(key, 0) == 0)
+    undeclared = sorted(key for key in per_check if key not in declared)
+
+    # -- loops: revision rounds, cap grants, edit-script health -----------
+    rounds_per_issue: dict[str, int] = defaultdict(int)
+    cap_grants: list[tuple[str, str]] = []
+    fallback_reasons: dict[str, int] = defaultdict(int)
+    applied_total = 0
+    fallback_total = 0
+    for run in runs:
+        applied_total += run.edit_scripts_applied
+        fallback_total += run.edit_script_fallbacks
+        for reason in run.fallback_reasons:
+            fallback_reasons[reason] += 1
+        for detail in run.cap_grants:
+            cap_grants.append((run.run_id, detail))
+        for what, highest in run.review_rounds.items():
+            key = f"#{run.issue}:{what}" if run.issue else f"?:{what}"
+            rounds_per_issue[key] = max(rounds_per_issue[key], highest)
+
+    # -- pinning ---------------------------------------------------------
+    pinning_refusals = sum(run.pinning_refusals for run in runs)
+    pinning_regressions = sum(run.pinning_regressions for run in runs)
+
+    # -- janitor and preservation ----------------------------------------
+    heals_by_category: dict[str, int] = defaultdict(int)
+    heals_by_outcome: dict[str, int] = defaultdict(int)
+    heal_targets: dict[str, int] = defaultdict(int)
+    for row in heals:
+        heals_by_category[str(row.get("category") or "?")] += 1
+        heals_by_outcome[str(row.get("outcome") or "?")] += 1
+        heal_targets[
+            f"{row.get('category', '?')}:{row.get('target', '?')}"
+        ] += 1
+
+    preserved_by_source: dict[str, int] = defaultdict(int)
+    for rec in preserved:
+        preserved_by_source[rec.source or "(unnamed)"] += 1
+
+    # -- halts -----------------------------------------------------------
+    halts_by_stage: dict[str, int] = defaultdict(int)
+    for bundle in bundles:
+        halts_by_stage[
+            f"{bundle.get('workflow', '?')}:{bundle.get('stage', '?')}"
+        ] += 1
+
+    return {
+        "repo": str(repo),
+        "since": since.strftime(_TS_FMT) if since else "",
+        "generated_at": datetime.now().strftime(_TS_FMT),
+        "stores": {
+            "prompt_failures": {
+                "path": str(telemetry_path(repo)),
+                "exists": telemetry_path(repo).exists(),
+                "in_window": len(failures),
+            },
+            "heals": {
+                "path": str(heals_path(repo)),
+                "exists": heals_path(repo).exists(),
+                "in_window": len(heals),
+            },
+            "preserved": {
+                "path": str(ledger_path(repo)),
+                "exists": ledger_path(repo).is_file(),
+                "in_window": len(preserved),
+            },
+            "run_logs": {
+                "path": str(runs_dir(repo)),
+                "exists": runs_dir(repo).is_dir(),
+                "in_window": len(runs),
+            },
+            "halt_bundles": {
+                "path": "; ".join(str(r) for r in halt_roots),
+                "exists": any(Path(r).is_dir() for r in halt_roots),
+                "in_window": len(bundles),
+            },
+        },
+        "gates": {
+            "per_check": dict(per_check),
+            "declared": declared,
+            "zero_fire": zero_fire,
+            "undeclared": undeclared,
+            "top_fingerprints": _top(per_fingerprint),
+        },
+        "loops": {
+            "rounds_per_issue": dict(rounds_per_issue),
+            "cap_grants": cap_grants,
+            "edit_scripts_applied": applied_total,
+            "edit_script_fallbacks": fallback_total,
+            "fallback_reasons": _top(fallback_reasons, 5),
+        },
+        "pinning": {
+            "refusals": pinning_refusals,
+            "regressions": pinning_regressions,
+        },
+        "runs": runs,
+        "heals": {
+            "by_category": dict(heals_by_category),
+            "by_outcome": dict(heals_by_outcome),
+            "recurring_targets": [
+                (target, count)
+                for target, count in sorted(
+                    heal_targets.items(), key=lambda kv: (-kv[1], kv[0])
+                )
+                if count >= 2
+            ],
+        },
+        "preserved": {
+            "by_source": dict(preserved_by_source),
+            "total": len(preserved),
+        },
+        "halts": {
+            "by_stage": dict(halts_by_stage),
+            "total": len(bundles),
+        },
+    }
+
+
+def _bar(label: str, count: int, width: int) -> str:
+    return f"  {label.ljust(width)}  {count}"
+
+
+def render_report(data: dict) -> str:
+    """The counted picture as deterministic text."""
+    lines: list[str] = []
+    window = data["since"] or "(all time)"
+    lines.append(f"# Factory report — {data['repo']}")
+    lines.append("")
+    lines.append(f"Window: since {window}. Generated {data['generated_at']}.")
+    lines.append("")
+
+    # Stores read, with their denominators. A store that does not exist is
+    # a different fact from a store that exists and is empty, and the two
+    # are never collapsed.
+    lines.append("## Stores read")
+    lines.append("")
+    lines.append("| store | present | records in window |")
+    lines.append("|---|---|---|")
+    for name, info in sorted(data["stores"].items()):
+        present = "yes" if info["exists"] else "NO"
+        lines.append(f"| {name} | {present} | {info['in_window']} |")
+    lines.append("")
+
+    gates = data["gates"]
+    lines.append("## Gates: which fire, which never do")
+    lines.append("")
+    if gates["per_check"]:
+        width = max(len(k) for k in gates["per_check"])
+        lines.append("Failures per stage:check:")
+        for key, count in sorted(
+            gates["per_check"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(_bar(key, count, width))
+    else:
+        lines.append(
+            f"No validation failures recorded in this window "
+            f"(of {len(gates['declared'])} declared recording sites)."
+        )
+    lines.append("")
+    if gates["zero_fire"]:
+        lines.append(
+            f"Zero-fire gates ({len(gates['zero_fire'])} of "
+            f"{len(gates['declared'])} declared) — each is either perfect "
+            f"or dead, and this report does not distinguish those:"
+        )
+        for key in gates["zero_fire"]:
+            lines.append(f"  {key}")
+    else:
+        lines.append("Zero-fire gates: none — every declared gate fired.")
+    lines.append("")
+    if gates["undeclared"]:
+        lines.append(
+            "Recorded but NOT declared in DECLARED_CHECKS — the registry is "
+            "behind the code, which test_factory_report.py should have "
+            "caught:"
+        )
+        for key in gates["undeclared"]:
+            lines.append(f"  {key}")
+        lines.append("")
+    if gates["top_fingerprints"]:
+        lines.append("Top fingerprints by volume:")
+        for key, count in gates["top_fingerprints"]:
+            lines.append(f"  {count:>4}  {key}")
+        lines.append("")
+
+    loops = data["loops"]
+    lines.append("## Loops: revision rounds, caps, edit-script health")
+    lines.append("")
+    applied = loops["edit_scripts_applied"]
+    fell_back = loops["edit_script_fallbacks"]
+    total = applied + fell_back
+    if total:
+        pct = (fell_back * 100.0) / total
+        lines.append(
+            f"Edit scripts: {applied} applied, {fell_back} fell back to full "
+            f"revision ({pct:.1f}% of {total} attempts)."
+        )
+    else:
+        lines.append("Edit scripts: no attempts recorded in this window.")
+    if loops["fallback_reasons"]:
+        lines.append("")
+        lines.append("Fallback reasons by volume:")
+        for reason, count in loops["fallback_reasons"]:
+            lines.append(f"  {count:>4}  {reason}")
+    lines.append("")
+    if loops["rounds_per_issue"]:
+        lines.append("Highest review round reached, per issue and loop:")
+        width = max(len(k) for k in loops["rounds_per_issue"])
+        for key, highest in sorted(
+            loops["rounds_per_issue"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(_bar(key, highest, width))
+        lines.append("")
+    if loops["cap_grants"]:
+        lines.append(f"Cap grants ({len(loops['cap_grants'])}):")
+        for run_id, detail in loops["cap_grants"]:
+            lines.append(f"  {run_id}: {detail}")
+        lines.append("")
+
+    pinning = data["pinning"]
+    lines.append("## Pinning enforcement")
+    lines.append("")
+    lines.append(
+        f"{pinning['refusals']} refusal(s), {pinning['regressions']} "
+        f"regression-class event(s) across "
+        f"{data['stores']['run_logs']['in_window']} run log(s)."
+    )
+    lines.append("")
+
+    heals = data["heals"]
+    lines.append("## Janitor and preservation activity")
+    lines.append("")
+    if heals["by_category"]:
+        lines.append("Heals by category:")
+        width = max(len(k) for k in heals["by_category"])
+        for key, count in sorted(
+            heals["by_category"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(_bar(key, count, width))
+        lines.append("")
+        lines.append(
+            "Outcomes: "
+            + ", ".join(
+                f"{k} {v}" for k, v in sorted(heals["by_outcome"].items())
+            )
+        )
+        lines.append("")
+    else:
+        lines.append("No heals recorded in this window.")
+        lines.append("")
+    if heals["recurring_targets"]:
+        lines.append(
+            "Targets healed more than once (a spike here is the signal — "
+            "three sweeps of one file in one day should be visible, not "
+            "discovered by forensics):"
+        )
+        for target, count in heals["recurring_targets"]:
+            lines.append(f"  {count:>4}  {target}")
+        lines.append("")
+
+    preserved = data["preserved"]
+    lines.append(
+        f"Preservations: {preserved['total']} in window"
+        + (
+            " ("
+            + ", ".join(
+                f"{k} {v}" for k, v in sorted(preserved["by_source"].items())
+            )
+            + ")."
+            if preserved["by_source"]
+            else "."
+        )
+    )
+    lines.append("")
+
+    halts = data["halts"]
+    lines.append("## Halts (from #2574 evidence bundles)")
+    lines.append("")
+    if halts["by_stage"]:
+        lines.append(f"{halts['total']} bundle(s):")
+        for key, count in sorted(
+            halts["by_stage"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(f"  {count:>4}  {key}")
+    else:
+        lines.append(
+            "No halt-evidence bundles found. #2574 landed 2026-08-28, so "
+            "halts before it left no bundle; their count is not zero, it "
+            "is unrecorded."
+        )
+    lines.append("")
+
+    # The shortlist the report COMPUTES, not the reader.
+    lines.append("## Shortlist (computed)")
+    lines.append("")
+    shortlist: list[str] = []
+    # A report where every store was empty still ranks the declared gates as
+    # zero-fire, which is true but reads as a finding about the gates when it
+    # is actually a finding about the window. Say which it is, first.
+    if not any(info["in_window"] for info in data["stores"].values()):
+        shortlist.append(
+            "No store carried records in this window -- every zero below is "
+            "an absence of data, not an absence of events."
+        )
+    for key, count in _top(gates["per_check"]):
+        shortlist.append(f"Top check by failure volume: {key} ({count})")
+    if fell_back and total:
+        shortlist.append(
+            f"Edit-script fallback rate: {fell_back}/{total} "
+            f"({(fell_back * 100.0) / total:.1f}%)"
+        )
+    for key in gates["zero_fire"]:
+        shortlist.append(f"Zero-fire gate (perfect or dead): {key}")
+    if heals["recurring_targets"]:
+        target, count = heals["recurring_targets"][0]
+        shortlist.append(f"Most-repeated heal target: {target} ({count})")
+    if not shortlist:
+        shortlist.append("Nothing ranked: no store carried records in window.")
+    for item in shortlist:
+        lines.append(f"- {item}")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"

--- a/docs/audits/0904-factory-report-boostgauge-2026-08-28.md
+++ b/docs/audits/0904-factory-report-boostgauge-2026-08-28.md
@@ -1,0 +1,146 @@
+# Factory report — C:\Users\mcwiz\Projects\boostgauge
+
+Window: since 2026-08-27 00:00:00. Generated 2026-08-28 00:32:12.
+
+## Stores read
+
+| store | present | records in window |
+|---|---|---|
+| halt_bundles | yes | 0 |
+| heals | yes | 9 |
+| preserved | yes | 6 |
+| prompt_failures | yes | 5 |
+| run_logs | yes | 4 |
+
+## Gates: which fire, which never do
+
+Failures per stage:check:
+  lld:mechanical        3
+  spec:reviewer-revise  2
+
+Zero-fire gates (2 of 4 declared) — each is either perfect or dead, and this report does not distinguish those:
+  lld:requirements-conflict
+  lld:test-plan
+
+Top fingerprints by volume:
+     1  lld:mechanical:critical-source-decision-table-row-s3-s-qualifiers-were-lost-in-derivation-2-56-px-appear-s-nowhere-in-the-lld-carry-the-qualifying-clause-sampling-window-offset-threshold-into-the-derived-requirement-and-test-rows-verbatim-the-qualifier-is-the-ruling-not-commentary-2563
+     1  lld:mechanical:critical-source-decision-table-row-s5-s-qualifiers-were-lost-in-derivation-0-665-r-0-065-r-appear-s-nowhere-in-the-lld-carry-the-qualifying-clause-sampling-window-offset-threshold-into-the-derived-requirement-and-test-rows-verbatim-the-qualifier-is-the-ruling-not-commentary-2563
+     1  lld:mechanical:critical-source-decision-table-row-s6-s-qualifiers-were-lost-in-derivation-0-775-r-0-065-r-0-27-r-appear-s-nowhere-in-the-lld-carry-the-qualifying-clause-sampling-window-offset-threshold-into-the-derived-requirement-and-test-rows-verbatim-the-qualifier-is-the-ruling-not-commentary-2563
+
+## Loops: revision rounds, caps, edit-script health
+
+Edit scripts: 24 applied, 6 fell back to full revision (20.0% of 30 attempts).
+
+Fallback reasons by volume:
+     5  edits produced no change
+     1  block 3: SEARCH text ambiguous (2 occurrences): 'def test_req_8_chrome_housing():\n    # Chrome housing gradients (REQ-8
+
+Highest review round reached, per issue and loop:
+  #331:spec  9
+
+Cap grants (1):
+  run-issue331-111729: 3 revision(s) spent, but criteria_have_tests has never been shown to the drafter. Granting one revision for it (#2304).
+
+## Pinning enforcement
+
+52 refusal(s), 45 regression-class event(s) across 4 run log(s).
+
+## Janitor and preservation activity
+
+Heals by category:
+  janitor            3
+  restore-reconcile  3
+  base-replace       1
+  reset              1
+  reset-refused      1
+
+Outcomes: healed 8, refused 1
+
+Targets healed more than once (a spike here is the signal — three sweeps of one file in one day should be visible, not discovered by forensics):
+     3  janitor:docs/lld/active/LLD-331.md
+     3  restore-reconcile:docs/lld/active/LLD-331.md
+
+Preservations: 6 in window (leavings 6).
+
+## Halts (from #2574 evidence bundles)
+
+No halt-evidence bundles found. #2574 landed 2026-08-28, so halts before it left no bundle; their count is not zero, it is unrecorded.
+
+## Shortlist (computed)
+
+- Top check by failure volume: lld:mechanical (3)
+- Top check by failure volume: spec:reviewer-revise (2)
+- Edit-script fallback rate: 6/30 (20.0%)
+- Zero-fire gate (perfect or dead): lld:requirements-conflict
+- Zero-fire gate (perfect or dead): lld:test-plan
+- Most-repeated heal target: janitor:docs/lld/active/LLD-331.md (3)
+
+
+---
+
+## Reconciliation against the hand-derived record (#2575 acceptance)
+
+The acceptance names three facts derived by hand during the 2026-08-27
+campaign and requires this report's counts to reconcile with them.
+**None of the three reconciles**, and each discrepancy is a finding about
+the record or the stores rather than a defect in this tool. Every number
+below was counted, not estimated; the counting script is preserved at
+`data/scratch-2026-08-28-factory-sequence/reconcile.py`.
+
+### 1. "six pinning refusals in run-issue331-111729" — right number, wrong run
+
+| run log | `[PINNING] refused:` | `REGRESSION CLASS:` |
+|---|---|---|
+| run-issue331-092913 | **6** | 6 |
+| run-issue331-111729 | **43** | 36 |
+| run-issue331-170916 | 3 | 3 |
+| the other 13 `#331` logs | 0 | 0 |
+
+Six is a real count and it belongs to `run-issue331-092913` — the 09:29
+lineage the campaign replayed #2555 against. `run-issue331-111729` is the
+11:17 death, and it carries 43. The hand-derived note attached the right
+number to the wrong run id. Filed as a record correction.
+
+### 2. "four leavings sweeps" — the stores say six and three, and neither is four
+
+Six leavings preservations are recorded on 2026-08-27, at 09:29, 10:08,
+11:17, 12:04, 13:01 and 13:25, each `1 file(s)`. Separately the healing
+ledger records **three** `janitor` heals of `docs/lld/active/LLD-331.md`.
+Both are correct and they count different things: a sweep preserves
+whatever it cleared, and only three of the six sweeps cleared the LLD.
+Four matches neither, and is most likely a count taken mid-campaign,
+before the 13:01 and 13:25 sweeps existed. Filed.
+
+### 3. "three spec-stage cap halts" — unverifiable from any store
+
+This report finds **zero** halt-evidence bundles for boostgauge in the
+window and one `[CAP]` grant line. The claim cannot be checked, for two
+separate reasons, both filed:
+
+- **#2574 landed 2026-08-28**, so every halt of the 2026-08-27 campaign
+  predates the bundle and left none. The report says this in place of
+  printing zero, because the count is unrecorded rather than nil.
+- **The state snapshot is one file per (workflow, issue), overwritten.**
+  `implementation_spec-331.json` holds only the LAST halt — 11 pinning
+  events, `review_iteration` 9 against `max_iterations` 3, error message
+  `Iteration cap: 3 review rounds ended REVISE`. The two earlier spec-stage
+  cap halts of that day are not recoverable from it at any effort.
+
+### 4. Incidental finding: an unattributable halt bundle
+
+`~/.assemblyzero/workflow_state/halt-evidence.json` carries
+`issue: 999`, `stage: N2_generate` and `audit_dir: ""`. With no audit dir
+it cannot be attributed to any repository, so this report's repo-scoping
+drops it rather than crediting boostgauge with another repo's halt. A real
+halt that writes an empty `audit_dir` therefore goes uncounted. Filed.
+
+### What reconciles
+
+Everything the stores are actually authoritative for. The 52 pinning
+refusals reported across the window are exactly 6 + 43 + 3 from the three
+`#331` logs whose mtime falls on 2026-08-27; the other twelve `#331` logs
+were last written on 08-16, 08-25 and 08-26 and are correctly outside the
+window. The 20.0% edit-script fallback rate is 6 of 30 counted attempts.
+The three-sweep spike on `LLD-331.md` — the recurrence #2551 was filed for
+— surfaces at the top of the recurring-targets table without a forensic
+dig, which is the outcome this report was built for.

--- a/docs/reports/2575/implementation-report.md
+++ b/docs/reports/2575/implementation-report.md
@@ -1,0 +1,46 @@
+# Implementation Report — A Factory Telemetry Rollup (#2575)
+
+## Issue Reference
+[#2575: a factory telemetry rollup -- counts decide what the next kill currently decides](https://github.com/martymcenroe/AssemblyZero/issues/2575)
+
+## Files Changed
+- `assemblyzero/speedrun/factory_report.py` (new): reads every factory store and returns the counted picture; renders it deterministically.
+- `tools/factory_report.py` (new): the CLI — `--repo`, `--since`, `--save`, `--save-path`.
+- `tests/unit/test_factory_report.py` (new): 31 tests.
+- `docs/audits/0904-factory-report-boostgauge-2026-08-28.md` (new): the report run over the 2026-08-27 campaign window, with the reconciliation section the acceptance requires.
+
+## What It Reads
+
+All read-only. v1 adds no instrumentation — every number comes from a file another mechanism already writes, which is what makes the tool safe to run against a live campaign.
+
+| store | written by | used for |
+|---|---|---|
+| `data/speedrun/telemetry/prompt-failures.jsonl` | `prompt_telemetry` (#2074) | failures per `stage:check`, fingerprint ranking |
+| `data/speedrun/telemetry/heals.jsonl` | healing ledger (#2164) | heals by category/outcome, recurring targets |
+| `data/speedrun/runs/preserved-branches.jsonl` | preservation record (#2355) | preservations by source |
+| `data/speedrun/runs/run-issue*.log` | the pipeline | pinning, edit-script health, cap grants, review rounds, watchdog drift |
+| `halt-evidence.json` | halt path (#2574) | halts per workflow:stage |
+
+## Design Decisions
+
+1. **The zero-fire denominator is declared, not inferred.** "Which gates never fire" needs the set of gates that *could* fire, and deriving it from observed records is circular — a gate that never fires is exactly the one absent from the data. `DECLARED_CHECKS` names the four `record_failure(s)` sites. `TestDeclaredChecks` greps the workflow tree in **both** directions: an undeclared recording site fails, and a declared pair with no site fails as a phantom (which would otherwise report as a permanently perfect gate that does not exist).
+
+2. **Halt bundles are scoped to the target repo.** The halt path writes one copy of the bundle beside the state snapshot in `~/.assemblyzero/workflow_state` — shared across every repo the fleet has ever rolled — and one into the run's audit dir. Counting the shared directory unscoped attributes other repos' halts to this one. A bundle outside the target repo is kept only when its own `audit_dir` points back inside it. This was found by a test failing, not by reading the code.
+
+3. **Run logs are read with `errors="replace"`.** The Python-side equivalent of `grep -a`. These logs carry stray bytes from model output, and GNU grep's binary detection silently suppresses matching lines in them — the 2026-08-27 near-miss, where real `[PINNING] refused:` lines were dropped while others printed. A fixture writes genuinely bad bytes and asserts events still count.
+
+4. **Absence and zero are never collapsed.** A store that does not exist prints `| NO |`; a store that exists and is empty prints `0`. When *every* store is empty the shortlist says so first, so the zero-fire list below it reads as a finding about the window rather than about the gates.
+
+5. **An unparseable `--since` raises.** Silently reading everything when the operator asked for a window would put a wrong denominator under every number that follows. This is the one condition the CLI refuses on.
+
+6. **The watchdog elapsed is a floor, not a duration.** `[STAGE]` prints once a minute, so the last elapsed for a stage is the longest it was *observed* running; the stage ends between ticks. The module says so rather than presenting it as a measurement.
+
+## Fail-Open Rulings (#2475 regime)
+
+Six sites, each ruled in place. Five fail open toward inclusion (a record that cannot be dated is kept, because dropping it would silently shrink a printed denominator); `_under` fails open toward **exclusion**, because undercounting a halt is visible in the total while misattributing one is not.
+
+## Known Limitations
+
+- Halts before #2574 left no bundle, so their count is unrecorded rather than zero. The report states this instead of printing zero (#2587).
+- A bundle with an empty `audit_dir` names no repo and is dropped (#2588).
+- Run logs carry no header timestamp and no date in the filename, so windowing uses mtime. Verified correct for the campaign window: 4 of the 16 `#331` logs fall on 2026-08-27, and their refusals sum to exactly the reported 52.

--- a/docs/reports/2575/test-report.md
+++ b/docs/reports/2575/test-report.md
@@ -1,0 +1,42 @@
+# Test Report — A Factory Telemetry Rollup (#2575)
+
+## Issue Reference
+[#2575: a factory telemetry rollup -- counts decide what the next kill currently decides](https://github.com/martymcenroe/AssemblyZero/issues/2575)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_factory_report.py` | **31 passed** |
+| `tests/unit/test_fail_open_audit.py` (the #2475 gate) | **passed** after six rulings |
+| `tests/unit/test_healing_ledger.py`, `test_prompt_telemetry.py` (adjacent stores) | **passed** |
+| `tests/unit` (full) | **8830 passed**, 21 skipped, 5 xfailed |
+| `ruff check` on all three new files | clean |
+
+The full-suite run that first exposed the fail-open gate was re-run after the rulings landed: a suite verdict binds only to the tree it read, and the tree changed.
+
+## What Is Actually Pinned
+
+**The registry cannot drift (2 tests).** `test_every_recording_site_is_declared` greps `assemblyzero/workflows/` for `record_failure(s)` call sites and fails when one is not in `DECLARED_CHECKS`. `test_no_declared_check_is_a_phantom` fails in the opposite direction — a declared pair with no recording site would report as permanently zero-fire, which reads as a perfect gate that does not exist. Both directions matter because the registry is the denominator for the zero-fire claim.
+
+**Stray bytes do not suppress events (1 test).** `test_stray_bytes_do_not_suppress_events` writes a log containing `\x97` and `\xff\xfe` and asserts all three pinning events still count. This is the 2026-08-27 near-miss pinned: grep's binary fallback dropped real lines while printing others, which is a confident wrong answer rather than a visible failure.
+
+**Repo scoping (2 tests).** `test_a_shared_root_is_scoped_to_the_target_repo` builds a shared state directory holding three bundles — one whose `audit_dir` points into the target, one pointing at another repo, one with no `audit_dir` — and asserts only the first is counted. `test_a_bundle_inside_the_repo_needs_no_audit_dir` asserts a bundle found inside the repo needs no containment proof. Together these are the guard against crediting one repo with another's halts.
+
+**The window refuses to widen silently (1 test).** `test_unparseable_raises_rather_than_silently_widening` asserts `parse_since("last tuesday")` raises rather than returning `None`, because `None` means "all time" and would put a wrong denominator under the whole report.
+
+**Absence is not zero (2 tests).** An empty repo renders `| NO |` for each store and leads the shortlist with "an absence of data, not an absence of events".
+
+**Determinism (1 test).** Identical input renders byte-identically, so two reports can be diffed rather than re-read.
+
+**Counting (7 tests).** Per-marker counts in one log, per-store counts in a seeded repo, the edit-script fallback split, pinning summed across runs, recurring heal targets surfacing while a single heal does not, preservations by source, and window exclusion.
+
+## Real-Data Verification
+
+Beyond fixtures, the tool was run against the live boostgauge stores for the campaign window and its output reconciled by hand against the three facts in the acceptance. Full working in `docs/audits/0904-factory-report-boostgauge-2026-08-28.md`; the counting script is preserved at `data/scratch-2026-08-28-factory-sequence/reconcile.py`.
+
+Result: **none of the three hand-derived facts reconciles**, and each is a finding about the record or the stores rather than a defect in the tool — filed as #2585, #2586, #2587, with #2588 falling out incidentally. What does reconcile is everything the stores are authoritative for: the 52 reported pinning refusals are exactly 6 + 43 + 3 from the three `#331` logs dated 2026-08-27, and the 20.0% edit-script fallback rate is 6 of 30 counted attempts.
+
+## Regression Risk
+
+The module is additive and read-only; nothing existing imports it. The only shared surface touched is the fail-open baseline, which the gate itself verifies.

--- a/tests/unit/test_factory_report.py
+++ b/tests/unit/test_factory_report.py
@@ -1,0 +1,439 @@
+"""The factory telemetry rollup (#2575).
+
+Counts, never estimates; honest denominators; a declared gate registry that
+cannot silently drift behind the recording sites in the workflow sources.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import factory_report as cli  # noqa: E402
+
+from assemblyzero.speedrun.factory_report import (  # noqa: E402
+    DECLARED_CHECKS,
+    build_report,
+    parse_since,
+    read_halt_bundles,
+    render_report,
+    scan_run_log,
+    scan_run_logs,
+)
+from assemblyzero.speedrun.healing import record_heal  # noqa: E402
+from assemblyzero.speedrun.preserved import record_preserved  # noqa: E402
+from assemblyzero.speedrun.prompt_telemetry import record_failure  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# The registry is kept honest by the source, not by convention
+# ---------------------------------------------------------------------------
+
+
+class TestDeclaredChecks:
+    """DECLARED_CHECKS is the denominator for zero-fire reporting.
+
+    Inferring it from observed records would be circular -- a gate that
+    never fires is exactly the one absent from the data -- so it is
+    declared, and this test is what stops it drifting behind the code.
+    """
+
+    def _recording_sites(self) -> set[tuple[str, str]]:
+        """Every (stage, check) literal pair at a record_failure(s) site."""
+        found: set[tuple[str, str]] = set()
+        workflows = REPO_ROOT / "assemblyzero" / "workflows"
+        call = re.compile(r"record_failures?\(")
+        for path in sorted(workflows.rglob("*.py")):
+            text = path.read_text(encoding="utf-8", errors="replace")
+            lines = text.splitlines()
+            for index, line in enumerate(lines):
+                if not call.search(line):
+                    continue
+                # The call's keyword arguments sit within a short window
+                # after the opening paren in every current site; widen the
+                # window rather than parse Python, and let a miss fail loud.
+                window = "\n".join(lines[index : index + 15])
+                stage = re.search(r'stage=["\']([^"\']+)["\']', window)
+                check = re.search(r'check=["\']([^"\']+)["\']', window)
+                if stage and check:
+                    found.add((stage.group(1), check.group(1)))
+        return found
+
+    def test_every_recording_site_is_declared(self):
+        sites = self._recording_sites()
+        assert sites, "found no record_failure sites -- the grep is wrong"
+        missing = sites - set(DECLARED_CHECKS)
+        assert not missing, (
+            f"recording sites not in DECLARED_CHECKS: {sorted(missing)}. "
+            f"A new gate must be declared or zero-fire reporting silently "
+            f"loses its denominator."
+        )
+
+    def test_no_declared_check_is_a_phantom(self):
+        sites = self._recording_sites()
+        phantom = set(DECLARED_CHECKS) - sites
+        assert not phantom, (
+            f"declared but no recording site emits them: {sorted(phantom)}. "
+            f"A phantom entry reports as permanently zero-fire, which reads "
+            f"as a perfect gate that does not exist."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Window parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseSince:
+    def test_relative_days(self):
+        now = datetime(2026, 8, 28, 12, 0, 0)
+        assert parse_since("7d", now=now) == now - timedelta(days=7)
+
+    def test_relative_hours_and_weeks(self):
+        now = datetime(2026, 8, 28, 12, 0, 0)
+        assert parse_since("24h", now=now) == now - timedelta(hours=24)
+        assert parse_since("2w", now=now) == now - timedelta(weeks=2)
+
+    def test_absolute_date_and_timestamp(self):
+        assert parse_since("2026-08-27") == datetime(2026, 8, 27, 0, 0, 0)
+        assert parse_since("2026-08-27 09:30:00") == datetime(
+            2026, 8, 27, 9, 30, 0
+        )
+
+    def test_empty_means_no_bound(self):
+        assert parse_since("") is None
+        assert parse_since("   ") is None
+
+    def test_unparseable_raises_rather_than_silently_widening(self):
+        """Silently reading everything would put a wrong denominator under
+        every number in the report."""
+        with pytest.raises(ValueError, match="unparseable"):
+            parse_since("last tuesday")
+
+
+# ---------------------------------------------------------------------------
+# Run-log scanning
+# ---------------------------------------------------------------------------
+
+
+def _write_run_log(directory: Path, name: str, body: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestScanRunLog:
+    def test_counts_each_marker_once_per_line(self, tmp_path):
+        log = _write_run_log(
+            tmp_path,
+            "run-issue331-111729.log",
+            "\n".join(
+                [
+                    "    [PINNING] refused: 1 line(s) starting 'A'",
+                    "    [PINNING] refused: 2 line(s) starting 'B'",
+                    "    [PINNING] REGRESSION CLASS: revision modified 'A'",
+                    "    [EDIT-SCRIPT] Applied 9 edit(s); 91% preserved",
+                    "    [EDIT-SCRIPT] Falling back to full revision: no change",
+                    "    [CAP] 3 revision(s) spent, granting one (#2304).",
+                    "    [REVIEW] Spec review continues [continue]: round 4 of",
+                    "    [STAGE] lld running 60s (nominal ~409s)",
+                    "    [STAGE] lld running 120s (nominal ~409s)",
+                ]
+            ),
+        )
+        facts = scan_run_log(log)
+        assert facts.issue == 331
+        assert facts.run_id == "run-issue331-111729"
+        assert facts.pinning_refusals == 2
+        assert facts.pinning_regressions == 1
+        assert facts.edit_scripts_applied == 1
+        assert facts.edit_script_fallbacks == 1
+        assert facts.fallback_reasons == ["no change"]
+        assert len(facts.cap_grants) == 1
+        assert facts.review_rounds == {"spec": 4}
+        # The watchdog prints once a minute; the LAST elapsed is the floor.
+        assert facts.stage_elapsed == {"lld": (120, 409)}
+
+    def test_stray_bytes_do_not_suppress_events(self, tmp_path):
+        """The 2026-08-27 near-miss: GNU grep's binary detection silently
+        dropped matching lines from a run log carrying stray bytes, which is
+        a confident wrong answer. errors="replace" is the Python-side grep -a.
+        """
+        directory = tmp_path / "data" / "speedrun" / "runs"
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "run-issue331-090000.log"
+        path.write_bytes(
+            b"    [PINNING] refused: 1 line(s) \x97 locked content\n"
+            b"    [PINNING] refused: 2 line(s) \xff\xfe bad bytes\n"
+            b"    [PINNING] REGRESSION CLASS: revision modified\n"
+        )
+        facts = scan_run_log(path)
+        assert facts.pinning_refusals == 2
+        assert facts.pinning_regressions == 1
+        assert not facts.unreadable
+
+    def test_unmatched_filename_is_unlinked_not_misattributed(self, tmp_path):
+        log = _write_run_log(tmp_path, "run-issueXYZ.log", "[CAP] x")
+        facts = scan_run_log(log)
+        assert facts.issue is None
+
+    def test_events_and_heartbeat_logs_are_not_scanned_as_runs(self, tmp_path):
+        directory = tmp_path / "data" / "speedrun" / "runs"
+        _write_run_log(directory, "run-issue1-010101.log", "[CAP] a")
+        _write_run_log(directory, "run-issue1-010101-events.log", "[CAP] b")
+        _write_run_log(directory, "run-issue1-010101-heartbeat.log", "[CAP] c")
+        scanned = scan_run_logs(tmp_path)
+        assert [f.run_id for f in scanned] == ["run-issue1-010101"]
+
+
+# ---------------------------------------------------------------------------
+# Halt bundles
+# ---------------------------------------------------------------------------
+
+
+class TestHaltBundles:
+    def test_reads_bundles_and_skips_corrupt_ones(self, tmp_path):
+        good = tmp_path / "lineage" / "a"
+        good.mkdir(parents=True)
+        (good / "halt-evidence.json").write_text(
+            json.dumps(
+                {
+                    "workflow": "implementation_spec",
+                    "stage": "spec",
+                    "halted_at": "2026-08-27T11:17:00+00:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+        bad = tmp_path / "lineage" / "b"
+        bad.mkdir(parents=True)
+        (bad / "halt-evidence.json").write_text("{not json", encoding="utf-8")
+
+        bundles = read_halt_bundles([tmp_path])
+        assert len(bundles) == 1
+        assert bundles[0]["stage"] == "spec"
+
+    def test_a_shared_root_is_scoped_to_the_target_repo(self, tmp_path):
+        """The halt path writes one copy beside the state snapshot in the
+        SHARED ~/.assemblyzero/workflow_state, which holds every repo the
+        fleet has ever rolled. Counting it unscoped attributes other repos'
+        halts to this one."""
+        shared = tmp_path / "shared_state"
+        repo = tmp_path / "target"
+        other = tmp_path / "other"
+        for directory in (shared / "a", shared / "b", shared / "c", repo, other):
+            directory.mkdir(parents=True)
+
+        (shared / "a" / "halt-evidence.json").write_text(
+            json.dumps({"stage": "spec", "audit_dir": str(repo / "lineage")}),
+            encoding="utf-8",
+        )
+        (shared / "b" / "halt-evidence.json").write_text(
+            json.dumps({"stage": "lld", "audit_dir": str(other / "lineage")}),
+            encoding="utf-8",
+        )
+        (shared / "c" / "halt-evidence.json").write_text(
+            json.dumps({"stage": "lld"}), encoding="utf-8"
+        )
+
+        bundles = read_halt_bundles([shared], scope_repo=repo)
+        assert [b["stage"] for b in bundles] == ["spec"]
+
+    def test_a_bundle_inside_the_repo_needs_no_audit_dir(self, tmp_path):
+        repo = tmp_path / "target"
+        lineage = repo / "docs" / "lineage" / "run-1"
+        lineage.mkdir(parents=True)
+        (lineage / "halt-evidence.json").write_text(
+            json.dumps({"stage": "spec"}), encoding="utf-8"
+        )
+        assert len(read_halt_bundles([repo], scope_repo=repo)) == 1
+
+    def test_window_filters_on_the_bundle_date(self, tmp_path):
+        root = tmp_path / "l"
+        root.mkdir(parents=True)
+        (root / "halt-evidence.json").write_text(
+            json.dumps({"stage": "lld", "halted_at": "2026-08-01T00:00:00+00:00"}),
+            encoding="utf-8",
+        )
+        assert read_halt_bundles([tmp_path], datetime(2026, 8, 27)) == []
+        assert len(read_halt_bundles([tmp_path], datetime(2026, 7, 1))) == 1
+
+
+# ---------------------------------------------------------------------------
+# The counted picture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def seeded_repo(tmp_path):
+    """A target repo with one record in every store."""
+    repo = tmp_path / "target"
+    repo.mkdir()
+
+    record_failure(
+        repo, stage="lld", check="mechanical",
+        detail="Section 2.1 table malformed",
+        issue=331, drafter_model="gemini:3.1-pro", run_id="run-issue331-111729",
+    )
+    record_failure(
+        repo, stage="lld", check="mechanical",
+        detail="Section 2.1 table malformed",
+        issue=331, drafter_model="gemini:3.1-pro", run_id="run-issue331-111729",
+    )
+    record_failure(
+        repo, stage="spec", check="reviewer-revise", detail="missing window",
+        issue=331, run_id="run-issue331-111729",
+    )
+
+    record_heal(repo, "janitor", "docs/lld/active/LLD-331.md", "healed",
+                run_tag="run-issue331-111729")
+    record_heal(repo, "janitor", "docs/lld/active/LLD-331.md", "healed",
+                run_tag="run-issue331-123221")
+    record_heal(repo, "reset", "#331", "partial", run_tag="run-issue331-111729")
+
+    record_preserved(repo, branch="graveyard/leavings-20260827-111730",
+                     source="leavings", detail="1 file(s)")
+    record_preserved(repo, branch="graveyard/331-lld-20260827-111731",
+                     source="halt-restore", detail="attempt branch")
+
+    _write_run_log(
+        repo / "data" / "speedrun" / "runs",
+        "run-issue331-111729.log",
+        "\n".join(
+            [
+                "    [PINNING] refused: 1 line(s) starting 'A'",
+                "    [PINNING] refused: 2 line(s) starting 'B'",
+                "    [EDIT-SCRIPT] Applied 3 edit(s); 100% preserved",
+                "    [EDIT-SCRIPT] Falling back to full revision: no change",
+                "    [EDIT-SCRIPT] Falling back to full revision: no change",
+                "    [REVIEW] Spec review continues [continue]: round 6 of",
+                "    [STAGE] spec running 300s (nominal ~409s)",
+            ]
+        ),
+    )
+    return repo
+
+
+class TestBuildReport:
+    def test_counts_every_store(self, seeded_repo):
+        data = build_report(seeded_repo)
+        assert data["stores"]["prompt_failures"]["in_window"] == 3
+        assert data["stores"]["heals"]["in_window"] == 3
+        assert data["stores"]["preserved"]["in_window"] == 2
+        assert data["stores"]["run_logs"]["in_window"] == 1
+
+    def test_gates_split_fired_from_zero_fire(self, seeded_repo):
+        data = build_report(seeded_repo)
+        gates = data["gates"]
+        assert gates["per_check"]["lld:mechanical"] == 2
+        assert gates["per_check"]["spec:reviewer-revise"] == 1
+        # Declared but unfired in this window -- the honest denominator.
+        assert "lld:test-plan" in gates["zero_fire"]
+        assert "lld:requirements-conflict" in gates["zero_fire"]
+        assert gates["undeclared"] == []
+
+    def test_edit_script_fallback_rate_is_counted_not_estimated(
+        self, seeded_repo
+    ):
+        data = build_report(seeded_repo)
+        assert data["loops"]["edit_scripts_applied"] == 1
+        assert data["loops"]["edit_script_fallbacks"] == 2
+
+    def test_pinning_events_are_summed_across_runs(self, seeded_repo):
+        assert build_report(seeded_repo)["pinning"]["refusals"] == 2
+
+    def test_recurring_heal_target_surfaces_as_a_spike(self, seeded_repo):
+        data = build_report(seeded_repo)
+        targets = dict(data["heals"]["recurring_targets"])
+        assert targets["janitor:docs/lld/active/LLD-331.md"] == 2
+        # The single reset is not a "recurrence" and must not be listed.
+        assert "reset:#331" not in targets
+
+    def test_preservation_counted_by_source(self, seeded_repo):
+        by_source = build_report(seeded_repo)["preserved"]["by_source"]
+        assert by_source["leavings"] == 1
+        assert by_source["halt-restore"] == 1
+
+    def test_window_excludes_older_records(self, seeded_repo):
+        future = datetime.now() + timedelta(days=1)
+        data = build_report(seeded_repo, since=future)
+        assert data["stores"]["prompt_failures"]["in_window"] == 0
+        assert data["stores"]["heals"]["in_window"] == 0
+
+    def test_empty_repo_reports_absence_not_zero(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        data = build_report(empty)
+        assert data["stores"]["prompt_failures"]["exists"] is False
+        assert data["stores"]["run_logs"]["exists"] is False
+        assert data["gates"]["zero_fire"] == sorted(
+            f"{s}:{c}" for s, c in DECLARED_CHECKS
+        )
+
+
+class TestRenderReport:
+    def test_is_deterministic(self, seeded_repo):
+        data = build_report(seeded_repo)
+        first = render_report(data)
+        second = render_report(data)
+        assert first == second
+
+    def test_names_a_missing_store_rather_than_printing_zero(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        text = render_report(build_report(empty))
+        assert "| NO |" in text
+        # The zeros below must read as absence of DATA, not absence of events.
+        assert "an absence of data, not an absence of events" in text
+
+    def test_zero_fire_gates_are_not_called_healthy(self, seeded_repo):
+        text = render_report(build_report(seeded_repo))
+        assert "either perfect \nor dead" in text or "perfect" in text
+        assert "lld:test-plan" in text
+
+    def test_shortlist_is_computed_for_the_reader(self, seeded_repo):
+        text = render_report(build_report(seeded_repo))
+        assert "## Shortlist (computed)" in text
+        assert "Top check by failure volume: lld:mechanical (2)" in text
+        assert "Edit-script fallback rate: 2/3" in text
+
+
+class TestCli:
+    def test_missing_repo_is_not_an_error(self, tmp_path, capsys):
+        assert cli.main(["--repo", str(tmp_path / "nope")]) == 0
+        assert "No such repository" in capsys.readouterr().out
+
+    def test_runs_and_prints(self, seeded_repo, capsys):
+        assert cli.main(["--repo", str(seeded_repo)]) == 0
+        out = capsys.readouterr().out
+        assert "# Factory report" in out
+        assert "## Shortlist (computed)" in out
+
+    def test_save_path_writes_the_same_text_that_printed(
+        self, seeded_repo, tmp_path, capsys
+    ):
+        target = tmp_path / "out" / "report.md"
+        assert cli.main(
+            ["--repo", str(seeded_repo), "--save-path", str(target)]
+        ) == 0
+        out = capsys.readouterr().out
+        assert target.is_file()
+        assert target.read_text(encoding="utf-8") in out
+
+    def test_default_save_path_names_target_and_date(self, tmp_path):
+        path = cli.default_save_path(
+            Path("/c/Users/mcwiz/Projects/boostgauge"),
+            when=datetime(2026, 8, 28),
+        )
+        assert path.name == "0904-factory-report-boostgauge-2026-08-28.md"
+        assert path.parent.name == "audits"

--- a/tools/factory_report.py
+++ b/tools/factory_report.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Roll up every factory store into one counted picture (#2575).
+
+The factory records everything and aggregates nothing: prompt-failure
+telemetry (#2074), the healing ledger (#2164), the preservation record
+(#2355), run logs, and since 2026-08-28 the halt evidence bundles (#2574).
+Each judgment call of the 2026-08-27 campaign was decided by whichever kill
+happened most recently, while the counts to decide them properly already
+sat on disk.
+
+    poetry run python tools/factory_report.py --repo /c/.../boostgauge
+    poetry run python tools/factory_report.py --repo <path> --since 7d
+    poetry run python tools/factory_report.py --repo <path> --since 2026-08-27 --save
+
+Read-only by construction: v1 adds no instrumentation and writes nothing
+except the optional saved copy under `docs/audits/`.
+
+Exit codes: 0 always, including "nothing recorded" -- an empty store is a
+fact about the pipeline, not an error in this tool.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# #2367: before anything prints. Fingerprints and heal details quote model
+# and checker prose verbatim.
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+from assemblyzero.speedrun.factory_report import (  # noqa: E402
+    build_report,
+    parse_since,
+    render_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def default_save_path(repo: Path, when: datetime | None = None) -> Path:
+    """`docs/audits/0904-factory-report-<repo>-<date>.md` in AssemblyZero.
+
+    The report is about a TARGET repo but is an AssemblyZero audit artifact,
+    so it lands in this repo's audits directory with the target named in the
+    filename -- one file per target per day, overwritten on re-run so a
+    second run the same day corrects rather than accumulates.
+    """
+    stamp = (when or datetime.now()).strftime("%Y-%m-%d")
+    return (
+        REPO_ROOT
+        / "docs"
+        / "audits"
+        / f"0904-factory-report-{repo.name.lower()}-{stamp}.md"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Roll up the factory's telemetry stores into one counted picture."
+    )
+    parser.add_argument(
+        "--repo", required=True, help="target repository whose stores to read"
+    )
+    parser.add_argument(
+        "--since",
+        default="",
+        help="window lower bound: 7d, 24h, 2w, YYYY-MM-DD, or 'YYYY-MM-DD HH:MM:SS'",
+    )
+    parser.add_argument(
+        "--save",
+        action="store_true",
+        help="also write the report under docs/audits/ in AssemblyZero",
+    )
+    parser.add_argument(
+        "--save-path",
+        default="",
+        help="explicit destination for --save (default: docs/audits/0904-...)",
+    )
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo)
+    if not repo.is_dir():
+        print(f"No such repository: {repo}", flush=True)
+        return 0
+
+    try:
+        since = parse_since(args.since)
+    except ValueError as exc:
+        # A window the operator asked for and this tool could not parse is
+        # the one error worth refusing on: reading everything instead would
+        # put a wrong denominator under every number that follows.
+        parser.error(str(exc))
+        return 2  # unreachable; parser.error exits 2
+
+    data = build_report(repo, since=since)
+    text = render_report(data)
+    print(text, end="", flush=True)
+
+    if args.save or args.save_path:
+        target = (
+            Path(args.save_path) if args.save_path else default_save_path(repo)
+        )
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+            print(f"Saved to {target}", flush=True)
+        except OSError as exc:
+            # The report already printed; failing to ALSO save it is not a
+            # reason to report failure for work that succeeded.
+            print(f"[WARN] could not save report: {exc}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The factory records everything and aggregates nothing. `prompt_telemetry` counts every validation failure (#2074), the healing ledger records every janitor action (#2164), `preserved-branches.jsonl` records every preservation (#2355), run logs carry per-stage wall-clock against the watchdog's nominal, and since 2026-08-28 every halt leaves an evidence bundle (#2574). Nobody read any of it in aggregate, so the campaign's judgment calls were each decided by whichever kill happened most recently.

This adds `tools/factory_report.py` over `assemblyzero/speedrun/factory_report.py`. It is **read-only and adds no instrumentation**: every number comes from a file another mechanism already writes, which is what makes it safe to run against a live campaign.

```
poetry run python tools/factory_report.py --repo /c/.../boostgauge --since 7d --save
```

## What it counts

- **Gates**: failures per `stage:check`, top fingerprints, and zero-fire gates against a declared denominator.
- **Loops**: highest review round per issue, cap grants quoted, and the edit-script fallback rate with reasons ranked.
- **Pinning**: refusals and regression-class events summed across the window's run logs.
- **Janitor and preservation**: heals by category and outcome, preservations by source, and targets healed more than once — the spike surfaces without a forensic dig.
- **Halts**: counted from #2574 bundles, scoped to the target repo.
- **A shortlist the report computes**, not the reader.

## Three decisions worth review

**The zero-fire denominator is declared, not inferred.** "Which gates never fire" needs the set that could fire, and inferring it from observed records is circular — a gate that never fires is exactly the one absent from the data. So `DECLARED_CHECKS` names the four recording sites, and `TestDeclaredChecks` greps the workflow sources in both directions: a new `record_failure` site that is not declared fails, and a declared pair with no recording site fails as a phantom that would report as permanently zero-fire.

**Halt bundles are scoped to the target repo.** The halt path writes one copy beside the state snapshot in `~/.assemblyzero/workflow_state`, which is shared across every repo the fleet has ever rolled. Counting it unscoped credits this repo with other repos' halts. A bundle outside the target is kept only when its own `audit_dir` points back inside it; one that names no repo is dropped rather than guessed at. This was found by a test, not by reading — see #2588 for the hole it leaves.

**Run logs are read with `errors="replace"`.** The Python-side equivalent of `grep -a`, and not optional: these logs carry stray bytes from model output, and the 2026-08-27 near-miss was grep's binary detection silently dropping real `[PINNING] refused:` lines while printing others. A fixture writes genuinely bad bytes and asserts the events still count.

## Reconciliation — the acceptance criterion

The acceptance requires the counts to reconcile with three hand-derived facts. **None of the three does**, and each is a finding rather than a defect in the tool. Full working in `docs/audits/0904-factory-report-boostgauge-2026-08-28.md`, counting script preserved in the scratch dir.

| claimed | counted | finding |
|---|---|---|
| six pinning refusals in `run-issue331-111729` | six in `run-issue331-**092913**`; 111729 carries 43 | #2585 |
| four leavings sweeps | six preservations; three janitor heals of the LLD | #2586 |
| three spec-stage cap halts | unverifiable — no bundle predates #2574, and the snapshot is overwritten per (workflow, issue) | #2587 |

A fourth finding fell out: a bundle with an empty `audit_dir` names no repo and is structurally invisible to per-repo counting (#2588).

What does reconcile is everything the stores are authoritative for: the 52 reported refusals are exactly 6 + 43 + 3 from the three `#331` logs whose mtime falls on 2026-08-27, and the 20.0% fallback rate is 6 of 30 counted attempts.

## Tests

31 new tests in `tests/unit/test_factory_report.py` — registry drift in both directions, window parsing including the refusal to silently widen on an unparseable bound, marker counting, the bad-bytes fixture, repo scoping across a shared root, determinism, and the absence-versus-zero distinction in rendering.

Closes #2575
