### PR TITLE
feat: a defect-class registry, and the first backlog audit executed as a class sweep (Closes #2576)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/message_addressability.py
+++ b/assemblyzero/workflows/implementation_spec/message_addressability.py
@@ -1,0 +1,168 @@
+"""Can pinning read this complaint? (#2557, swept as a class under #2576.)
+
+The 2026-08-27 deadlock had two required halves: a completeness failure
+whose message addressed its target in a scheme pinning could not read, and
+pinning enforcing anyway because the message happened to mint garbage
+tokens. The repaired invariant — *a change a completeness failure demands
+is never revertible by pinning in the same round* — holds mechanically only
+for complaints pinning can actually READ.
+
+So the property is not "is this message well written" but a mechanical
+question with a yes or no answer:
+
+    Does ``named_tokens(message) | named_line_ranges(message)`` address at
+    least one line of the draft the message is complaining about?
+
+If yes, the drafter's mandated edit lands in a region the enforcement will
+unlock. If no, the drafter makes the demanded change and pinning reverts
+it as touching unnamed content — the loop then burns its cap producing
+byte-identical drafts, which is exactly what #2555 measured.
+
+This module is the classifier. It owns no policy: it reports what the
+pinning vocabulary sees, and the caller decides. `tests/unit/
+test_completeness_message_addressability.py` drives every real check with a
+fixture that fails it and asserts on the REAL emitted message, so a future
+rewording that drops the address fails the suite the day it is written.
+
+Registry class: **the demanded change is never refusable** — see
+`docs/standards/0029-defect-class-registry.md`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    demands_additions,
+    named_line_ranges,
+    named_tokens,
+)
+
+#: The three ways a complaint can stand with respect to enforcement. The
+#: taxonomy is three-way, not two, and the middle one is why: a complaint
+#: that demands NEW content has no line to cite by construction, so failing
+#: to address the draft is correct for it rather than a defect. #2560 added
+#: the exemption that carries those.
+ADDRESSED = "addressed"
+DEMANDS_ADDITION = "demands-addition"
+UNADDRESSABLE = "unaddressable"
+
+#: A token this short matches half the draft by accident. `named_tokens`
+#: already drops anything under three characters; this is the second bound,
+#: applied to the MATCH rather than the token, because a one-word token like
+#: "the" would otherwise "address" every line and report a false pass.
+MIN_MATCH_CHARS = 4
+
+
+@dataclass
+class Addressability:
+    """What the pinning vocabulary sees in one message."""
+
+    addressed: bool
+    tokens: tuple[str, ...] = ()
+    ranges: tuple[tuple[int, int], ...] = ()
+    #: 1-based draft lines the message reaches, in order.
+    matched_lines: tuple[int, ...] = ()
+    #: Ranges the message cites that fall outside the draft entirely. These
+    #: are worse than no citation: they read as an address and unlock
+    #: nothing, so they are reported separately rather than folded into
+    #: `addressed`.
+    out_of_bounds: tuple[tuple[int, int], ...] = ()
+    via: tuple[str, ...] = field(default_factory=tuple)
+    #: True when the message trips `demands_additions` -- the #2560 exemption
+    #: that frees a locked region introducing new content.
+    demands_addition: bool = False
+
+    @property
+    def verdict(self) -> str:
+        """ADDRESSED, DEMANDS_ADDITION, or UNADDRESSABLE.
+
+        Order matters. A complaint that both addresses the draft and demands
+        an addition is ADDRESSED: it has a citable line, which is the
+        stronger guarantee, and the addition exemption is a fallback rather
+        than an equal alternative.
+        """
+        if self.addressed:
+            return ADDRESSED
+        if self.demands_addition:
+            return DEMANDS_ADDITION
+        return UNADDRESSABLE
+
+    def summary(self) -> str:
+        if self.addressed:
+            return (
+                f"addressed via {', '.join(self.via)}; reaches "
+                f"{len(self.matched_lines)} draft line(s)"
+            )
+        if self.demands_addition:
+            return (
+                "demands an addition: no line to cite by construction, and "
+                "the #2560 exemption carries it"
+            )
+        if self.out_of_bounds:
+            return (
+                f"NOT addressed: cites {self.out_of_bounds} which falls "
+                f"outside the draft"
+            )
+        if self.tokens:
+            return (
+                f"NOT addressed: {len(self.tokens)} token(s) parsed but none "
+                f"appears in the draft"
+            )
+        return "NOT addressed: the pinning vocabulary parses nothing at all"
+
+
+def addresses_draft(message: str, draft: str) -> Addressability:
+    """Does this complaint name at least one line of the draft it describes?
+
+    Both halves of the vocabulary are consulted, because they fail in
+    different directions. A token addresses the draft when it actually
+    OCCURS in it -- a backticked span naming something the draft does not
+    contain parses fine and unlocks nothing. A line range addresses the
+    draft when it falls inside it -- #2555's fence complaint carried
+    ``line 1`` from a quoted SyntaxError, a position inside a snippet
+    rather than a draft address, which is why `named_line_ranges` requires
+    the dash and why an out-of-bounds range is reported, not counted.
+    """
+    lines = (draft or "").splitlines()
+    total = len(lines)
+
+    tokens = tuple(sorted(named_tokens("", [message or ""])))
+    ranges = named_line_ranges([message or ""])
+
+    matched: set[int] = set()
+    via: list[str] = []
+
+    lowered = [line.lower() for line in lines]
+    token_hit = False
+    for token in tokens:
+        if len(token) < MIN_MATCH_CHARS:
+            continue
+        for index, line in enumerate(lowered, start=1):
+            if token in line:
+                matched.add(index)
+                token_hit = True
+    if token_hit:
+        via.append("named_tokens")
+
+    out_of_bounds: list[tuple[int, int]] = []
+    range_hit = False
+    for start, end in ranges:
+        if start > total:
+            out_of_bounds.append((start, end))
+            continue
+        for line_no in range(start, min(end, total) + 1):
+            matched.add(line_no)
+            range_hit = True
+    if range_hit:
+        via.append("named_line_ranges")
+
+    return Addressability(
+        addressed=bool(matched),
+        tokens=tokens,
+        ranges=ranges,
+        matched_lines=tuple(sorted(matched)),
+        out_of_bounds=tuple(out_of_bounds),
+        via=tuple(via),
+        demands_addition=demands_additions([message or ""]),
+    )

--- a/docs/audits/0905-message-addressability-sweep-2026-08-28.md
+++ b/docs/audits/0905-message-addressability-sweep-2026-08-28.md
@@ -1,0 +1,109 @@
+# 0905 — Completeness message addressability sweep (2026-08-28)
+
+**Audit:** #2557, executed as a class sweep under #2576
+**Registry class:** 3 — the demanded change is never refusable (`docs/standards/0029-defect-class-registry.md`)
+**Program:** `tests/unit/test_completeness_message_addressability.py` (19 tests)
+**Classifier:** `assemblyzero/workflows/implementation_spec/message_addressability.py`
+
+This audit is a program. It re-runs on every suite, drives each check with a
+fixture that genuinely fails it, and classifies the **real emitted message** —
+no message text is hardcoded, so a rewording that drops an address changes the
+verdict and fails the suite the day it is written.
+
+## The question
+
+The invariant repaired by #2555 and #2558 — *a change a completeness failure
+demands is never revertible by pinning in the same round* — holds mechanically
+only for complaints the enforcement can READ. So, per check:
+
+> Does `named_tokens(message) | named_line_ranges(message)` address at least
+> one line of the draft the message is complaining about?
+
+## The taxonomy is three-way
+
+The sweep's first finding is about the question itself. Classifying messages as
+addressable-or-not produces false alarms, because a third case is correct:
+
+| verdict | meaning | is it a defect |
+|---|---|---|
+| **addressed** | the message cites a line of the draft | no |
+| **demands-addition** | it demands NEW content; there is no line to cite by construction, and #2560's exemption carries it | no |
+| **unaddressable** | it targets EXISTING content in a scheme the vocabulary cannot read | **yes — the deadlock class** |
+
+Collapsing the middle case into the third would have reported #2560's correctly
+exempted messages as defects. The classifier resolves `addressed` first: a
+citable line is the stronger guarantee, and the addition exemption is a
+fallback rather than an equal alternative.
+
+## Results
+
+Four of eleven checks swept. **All four classified unaddressable**, each filed.
+
+| check | verdict | finding |
+|---|---|---|
+| `check_functions_have_io_examples` (parameterised fn) | unaddressable | #2590 |
+| `check_functions_have_io_examples` (zero-arg fn) | addressed | — |
+| `check_modify_files_have_excerpts` | unaddressable | #2591 |
+| `check_change_instructions_specific` | unaddressable | #2592 |
+| `check_manifest_traceability` | unaddressable | #2593 |
+| seven checks not swept | declared uncovered | #2594 |
+
+### The sharpest finding (#2590)
+
+`check_functions_have_io_examples` backticks the name with a `()` suffix. Two
+drafts differing **only** in the parameter list:
+
+| draft | token parsed | draft lines addressed | verdict |
+|---|---|---|---|
+| `def compute_needle_angle(value, redline):` | `compute_needle_angle()` | none | **unaddressable** |
+| `def compute_needle_angle():` | `compute_needle_angle()` | line 5 | addressed |
+
+The emitted message is byte-identical in both cases. Whether the complaint can
+be acted on depends on whether the function happens to take arguments — and
+the broken case is the ordinary one. This is #2555's deadlock shape on a check
+that fires on routine specs rather than on an exotic fence condition.
+
+### The vocabulary gap under #2591
+
+`_ADDITION_DEMAND_RE` recognises exactly three phrases — `have no test`,
+`add a test`, `owes each a test` — all about tests. The regex encodes "an
+addition means a test", which was true when #2560 was written and is not true
+generally: an excerpt, a code block and a data-structure example are all
+additions with no line to cite. Every non-test addition demand therefore falls
+into the unaddressable bucket by default. This is a family, not one message,
+which is why #2591 proposes widening the vocabulary as the honest fix.
+
+### One finding is a ruling, not a repair (#2592)
+
+`check_change_instructions_specific` is a **density heuristic** — it counts
+fences against a line-count threshold — and it parses nothing at all from its
+own message. #2540 asks whether such proxies should veto. A proxy that cannot
+address its own complaint can only ever deadlock, so this finding is evidence
+for that discussion, and #2592 says explicitly it should not be fixed in
+isolation before #2540 is ruled.
+
+## Coverage, stated honestly
+
+Seven of eleven checks are **declared uncovered**, not silently skipped: they
+need a real repo tree, a populated symbol table, or a pass-criteria table that
+parses. `TestTheSweepIsExhaustive` fails if a new check is neither swept nor
+declared, and fails again if a declared name does not exist — so the gap cannot
+widen silently and the list cannot rot. #2594 carries the extension.
+
+With a base rate of four unaddressable messages in four classified, the
+remaining seven should not be assumed healthy.
+
+## What this proves about the registry shape
+
+The acceptance for #2576 asks that one backlog audit be executed AS a class
+sweep, to prove the shape works. It does, and specifically:
+
+- **The detection question did the work.** "Does this complaint name its edit
+  target in a vocabulary the enforcement can read, and does that name actually
+  occur in the draft?" is answerable mechanically, and the second half is what
+  caught #2590 and #2591 — both parse tokens fine and address nothing.
+- **The fixture shape transferred unchanged** from the class's first entry
+  (`test_completeness_pinning_deadlock.py`) to eleven new sites.
+- **The sweep corrected the class entry.** The three-way taxonomy was
+  discovered by running it, and is now written into standard 0029 so the next
+  sweep starts with it rather than rediscovering it.

--- a/docs/reports/2576/implementation-report.md
+++ b/docs/reports/2576/implementation-report.md
@@ -1,0 +1,52 @@
+# Implementation Report — A Defect-Class Registry (#2576)
+
+## Issue Reference
+[#2576: a defect-class registry -- name the classes, give each its fixture, make the audit backlog mechanical](https://github.com/martymcenroe/AssemblyZero/issues/2576)
+
+## Files Changed
+- `docs/standards/0029-defect-class-registry.md` (new): the registry — eight classes.
+- `assemblyzero/workflows/implementation_spec/message_addressability.py` (new): the classifier the #2557 sweep runs on.
+- `tests/unit/test_completeness_message_addressability.py` (new): the sweep, as a program — 19 tests.
+- `docs/audits/0905-message-addressability-sweep-2026-08-28.md` (new): the sweep's findings.
+
+## The Registry
+
+Eight classes, each with: the invariant it protects, a detection question answerable against a diff or a halt without knowing the history, the canonical fixture shape, and every known instance.
+
+1. A zero needs a denominator (#2546, #2552, #2575)
+2. Attribution requires the enforcement record (#2556, #2561, #2574)
+3. The demanded change is never refusable (#2555, #2560, #2557)
+4. Conservation through transformation (#2559, #2563)
+5. The input/litter distinction (#2551, #2144, #2571)
+6. Fail-open must be declared (#2475, #2508, #2575)
+7. The once-under-load flake (#2522, #2538)
+8. A resume inherits, never rediscovers (#2551, #2552, #2514, #2570)
+
+Seven were named in the issue. **The eighth was added by the 2026-08-28 update** after #2570 landed: three defects the campaign fixed separately were one class wearing different artifacts, and the resume contract is the machinery that closes it.
+
+The bar for a new class is **two independent instances**. One is a bug; a class claims the shape recurs, and that claim needs evidence.
+
+## The Sweep (#2557, the acceptance proof)
+
+The issue requires one backlog audit executed AS a class sweep. #2557 was chosen as the smallest.
+
+**Design decision — the taxonomy is three-way, not two.** Classifying messages as addressable-or-not would report #2560's correctly-exempted messages as defects. A complaint is *addressed* (cites a line), *demands an addition* (no line to cite by construction; #2560's exemption carries it), or *unaddressable* (targets existing content in an unreadable scheme). Only the third is a defect. This was discovered by running the sweep and is now written back into the class entry, so the next sweep starts with it.
+
+**Design decision — parsing is not addressing.** A backticked span the draft does not contain parses fine and unlocks nothing. `addresses_draft` requires the token to actually OCCUR in the draft. This second half is what caught #2590 and #2591; a classifier checking only "does the vocabulary parse something" would have passed both.
+
+**Design decision — out-of-bounds ranges are reported, not counted.** A cited range past the end of the draft is worse than no citation: it reads as an address and unlocks nothing. It is surfaced separately rather than folded into the verdict.
+
+**Design decision — the sweep declares what it does not cover.** Seven of eleven checks need a real repo tree, a populated symbol table, or a parseable pass-criteria table. They are named in an explicit `uncovered` set, and `TestTheSweepIsExhaustive` fails both when a new check is neither swept nor declared AND when a declared name does not exist — so the gap cannot widen silently and the list cannot rot.
+
+## Findings
+
+Four of four classified checks are unaddressable — filed as #2590, #2591, #2592, #2593, with coverage tracked in #2594. Each cites registry class 3.
+
+The sharpest is #2590: `check_functions_have_io_examples` backticks `name()`, and a function taking parameters never contains that literal. Two drafts differing only in the parameter list produce a byte-identical message, one addressable and one not — and the broken case is the ordinary one.
+
+#2592 is deliberately filed as a **ruling**, not a repair: the check is a density heuristic, and #2540 asks whether proxies should veto at all. A proxy that cannot address its own complaint can only deadlock, so the two should be ruled together.
+
+## Known Limitations
+
+- Seven of eleven checks unswept (#2594). With four unaddressable in four classified, the rest should not be assumed healthy.
+- The registry's backlog table lists #2508 and #2540 as unconverted; only #2557 was executed here.

--- a/docs/reports/2576/test-report.md
+++ b/docs/reports/2576/test-report.md
@@ -1,0 +1,43 @@
+# Test Report — A Defect-Class Registry (#2576)
+
+## Issue Reference
+[#2576: a defect-class registry -- name the classes, give each its fixture, make the audit backlog mechanical](https://github.com/martymcenroe/AssemblyZero/issues/2576)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_completeness_message_addressability.py` (new) | **19 passed** |
+| `tests/unit/test_completeness_pinning_deadlock.py` (class 3's first entry) | passed |
+| `tests/unit/test_revision_pinning.py` (the enforcement being classified) | passed |
+| `tests/unit/test_fail_open_audit.py` (the #2475 gate) | passed — no new fail-open sites |
+| combined run | **101 passed** |
+| `ruff check` on both new Python files | clean |
+
+## What Is Actually Pinned
+
+**The classifier itself (7 tests).** Each pins one property the sweep's conclusions rest on:
+
+- A backticked span present in the draft addresses it — the happy path.
+- **A token absent from the draft addresses nothing.** Parsing is not addressing; this is what makes #2590 and #2591 findings rather than passes.
+- A dashed range inside the draft addresses it (#2555's repair).
+- **A bare line number is not an address** — the exact `SyntaxError: ... line 1` string from the original deadlock, asserted to parse as no range at all.
+- An out-of-bounds range is reported, not counted.
+- An addition demand is its own verdict.
+- **Addressed beats demands-addition** — a message that both cites a line and demands an addition resolves as addressed, because a citable line is the stronger guarantee.
+
+**The sweep proper (5 tests).** Each drives a REAL check with a fixture that genuinely fails it. The shared `_classify` helper asserts `passed is False` first, so a fixture that stops failing produces a loud error rather than silently classifying a success message — which would prove nothing.
+
+The five assert current truth, four of them the broken state, each against its filed issue. **Repairing any one flips its test**, which is the signal to move it into `TestAddressableToday`. The `()`-suffix pair is the strongest: two fixtures differing only in the parameter list, asserting opposite verdicts from a byte-identical message.
+
+**Exhaustiveness (2 tests).** `TestTheSweepIsExhaustive` fails when a new `check_*` is neither swept nor declared uncovered, and fails in the other direction when a declared name does not exist. Without the second, the uncovered list would rot into a lie as checks are renamed.
+
+**Vocabulary coverage (5 parameterised tests).** Standard 0029's class-3 entry claims five readable schemes — Section references, backticked spans, quoted phrases, row ids, test names. Each is pinned, so a vocabulary change that drops one makes the standard's claim false and this says so.
+
+## Honest Coverage Statement
+
+Four of eleven completeness checks are swept. Seven are declared uncovered with a per-check reason, tracked in #2594. This is stated in the audit, in the standard's backlog table, and enforced by a test — not left implicit.
+
+## Regression Risk
+
+Additive. `message_addressability.py` is a new module nothing else imports; it reads `revision_pinning`'s public functions without modifying them. The registry and audit are documentation. No existing behaviour changed, which the 101-test combined run confirms.

--- a/docs/standards/0029-defect-class-registry.md
+++ b/docs/standards/0029-defect-class-registry.md
@@ -1,0 +1,236 @@
+# 0029 — The defect-class registry
+
+**Status:** Active
+**Issue:** #2576
+**Sibling standards:** 0025 (prompt revision from telemetry), 0027 (idempotent rolls), 0028 (structured or reject)
+
+The fleet already thinks in defect classes. It just had nowhere to keep them.
+
+"A zero needs a denominator" was born on #2546 and applied twice more within a
+day. "Consult the enforcement record before attributing" was born on #2556 and
+applied again on #2561 the same afternoon. The S2-regression class, the flake
+class, and the fail-open regime were each named, each real, and each living in
+scattered comments, closed issues, and one lessons file.
+
+**When a new instance appears, the class match is what makes the fix fast and
+its fixture shape obvious.** Before this registry, that match happened in an
+agent's memory of the campaign — which does not survive the campaign.
+
+## How to use this
+
+**Finding a defect:** read the detection questions. They are written to be
+answerable against a diff or a halt without knowing the history. A yes means you
+have an instance of a known class, and the fixture shape tells you what test to
+write before you touch anything.
+
+**Filing:** name the class in the issue. An instance filed without its class is
+a fact; filed with it, it is evidence about a pattern, and the pattern is what
+gets fixed.
+
+**Auditing:** a standing audit becomes "sweep the codebase for instances of a
+registered class", which is mechanical in exactly the way the Six Rules demand.
+Audits are programs, not inspections. §Backlog below names the three that
+convert.
+
+**Adding a class:** two independent instances, minimum. One instance is a bug;
+a class is a claim that the shape recurs, and that claim needs evidence. Give
+it a name someone would say out loud, the invariant it protects, the detection
+question, the canonical fixture shape, and every known instance.
+
+---
+
+## The classes
+
+### 1. A zero needs a denominator
+
+**Invariant.** A count of zero is meaningless without the population it was
+counted against. "No failures" and "nothing was measured" are different facts
+and must never render identically.
+
+**Detection question.** *If this number were zero because the measurement never
+ran, would the output look any different?*
+
+**Fixture shape.** Drive the code with an empty input AND with a
+never-populated input; assert the two produce distinguishable output.
+
+**Instances.** #2546 (the founding case), #2552 (zero requirements named —
+declared-none vs unreadable, with the searched path), #2575 (a store that does
+not exist renders `| NO |`; one that exists and is empty renders `0`).
+
+---
+
+### 2. Attribution requires the enforcement record
+
+**Invariant.** A halt, a log line, or a report never attributes a change to an
+actor without consulting the record of what the machinery itself did. Blaming
+the drafter for what enforcement did is the specific failure.
+
+**Detection question.** *Does this message name a cause it did not read
+evidence for?*
+
+**Fixture shape.** A state where the mechanism (not the actor) produced the
+observed condition; assert the message names enforcement, not the actor.
+
+**Instances.** #2556 (the cap halt consults `pinning_events` before any
+drafter-unchanged claim), #2561 (the same consult on the `kept_failing`
+branch), #2574 (the halt bundle quotes the events rather than summarising
+them).
+
+**Note.** This is the special case of the general rule *never attribute an
+artifact without proof*. The general form governs operator attribution too.
+
+---
+
+### 3. The demanded change is never refusable
+
+**Invariant.** A change one gate explicitly demands is never revertible by
+another gate in the same round. A loop that can demand and refuse the same edit
+cannot converge, and burns its cap producing byte-identical drafts.
+
+**Detection question.** *Does this complaint name its edit target in a
+vocabulary the enforcement can read — and does that name actually occur in the
+draft?* Both halves are required. A token that parses but matches nothing
+unlocks nothing.
+
+**Fixture shape.** A producer-consumer test: a fixture that genuinely fails the
+check, the REAL emitted message, and an assertion that the enforcement
+vocabulary reaches at least one line of the draft. See
+`tests/unit/test_completeness_message_addressability.py`, which is this class's
+reference sweep, and `tests/unit/test_completeness_pinning_deadlock.py`, its
+first entry.
+
+**Instances.** #2555 (the fence complaint that deadlocked; dashed `lines N-M`
+citations added to the vocabulary), #2560 (demanded ADDITIONS land — a demand
+to add has no line to cite by construction), #2557 (the sweep that found three
+more unaddressable messages and the `()`-suffix hazard).
+
+**The taxonomy is three-way, not two.** A complaint is *addressed* (it cites a
+line), *demands an addition* (there is no line to cite, and the #2560 exemption
+carries it), or *unaddressable* (it targets existing content in a scheme the
+enforcement cannot read). Only the third is a defect. Collapsing the middle case
+into the third produces false alarms on correct code.
+
+---
+
+### 4. Conservation through transformation
+
+**Invariant.** A transformation that merges, stitches, or rewrites a document
+never silently loses or multiplies a conserved quantity. When conservation
+cannot be maintained, emit an unmerged whole — never the stitch.
+
+**Detection question.** *Can this transformation emit a result holding fewer,
+or more, of the conserved thing than either input justified?*
+
+**Fixture shape.** Two inputs whose merge would violate conservation; assert
+the gate fires and that the fallback is one entire input, not a repair.
+
+**Instances.** #2559 (the merge conservation gate — revision unenforced or
+previous entire, never the stitch), #2563 (literal conservation in the LLD
+derivation: qualifying clauses carried verbatim into derived rows).
+
+---
+
+### 5. The input/litter distinction
+
+**Invariant.** A cleanup mechanism never removes what another stage reads as
+input. The distinction is by OWNERSHIP, not by appearance: the rolling issue's
+inputs are protected; other issues' droppings remain litter.
+
+**Detection question.** *Does anything this sweep can delete get read on entry
+by a later stage — and is the exemption scoped to the rolling issue, or
+blanket?*
+
+**Fixture shape.** A tree holding both the rolling issue's input and another
+issue's leftovers; assert the first survives and the second is cleared.
+
+**Instances.** #2551 (issue-scoped leavings exemption at both sweep sites),
+#2144 (the founding opposite — the janitor exists because litter accumulated),
+#2571 (a working copy is a cache; the loader rebuilds from refs rather than
+depending on an untracked file surviving).
+
+**Why the scoping is load-bearing.** A blanket exemption solves the deletion and
+re-creates #2144. Both failures are real and they pull in opposite directions,
+which is why this class is stated as ownership rather than as "do not delete".
+
+---
+
+### 6. Fail-open must be declared
+
+**Invariant.** Every site that continues past a failure is a decision on
+record, not an accident. Declared sites remain fail-open and remain counted;
+what the gate acts on is *undeclared*.
+
+**Detection question.** *If this handler fires, is the run's output
+distinguishable from a successful one?* A silent fall-through is the class.
+
+**Fixture shape.** Not a fixture — a repo-wide gate.
+`tests/unit/test_fail_open_audit.py` compares every site against a baseline and
+fails on a new undeclared one. The ruling is `# fail-open: <why>` inside the
+handler body (or directly above a warn-and-return).
+
+**Instances.** #2475 (the regime), #2508 (68 sites in the standing backlog),
+#2575 (six sites ruled in place; five toward inclusion, one deliberately toward
+exclusion because misattribution is invisible while undercounting is not).
+
+**Placement is part of the class.** Handler-class rulings go INSIDE the handler
+body; warn-and-return rulings directly above the return. The marker is the
+literal string `# fail-open:` — a comma instead of the colon does not register,
+which has already cost one round trip.
+
+---
+
+### 7. The once-under-load flake
+
+**Invariant.** A test that fails once under load and passes on retry is not
+noise. It is a real defect whose trigger is timing, and re-running is not
+triage.
+
+**Detection question.** *Did this pass on retry with no code change — and has
+anyone identified the shared resource?*
+
+**Fixture shape.** Reproduce under contention (parallel workers, a filled
+cache, a held lock) rather than in isolation.
+
+**Instances.** #2522, #2538.
+
+---
+
+### 8. A resume inherits, never rediscovers
+
+**Invariant.** A resume uses what the halt recorded. It never rediscovers state
+from a world that has meanwhile changed, because the halt knew exactly what it
+had and the world no longer does.
+
+**Detection question.** *Does this resume path read anything the halt could
+have recorded instead?*
+
+**Fixture shape.** Halt with recorded state, mutate the world, assert the
+resume refuses BY NAME rather than proceeding on the changed input.
+
+**Instances.** #2551 (the LLD swept as leavings), #2552 (the
+zero-requirements fallback that would have certified against nothing), #2514
+(stale counters putting a resumed round over its own ceiling), #2570 (the
+resume contract — the machinery that closes the class).
+
+**Each was the same defect wearing a different artifact.** That is what earns
+it a class entry rather than three bug fixes.
+
+---
+
+## Backlog conversion
+
+Three standing audits become class sweeps. A sweep is a program: it re-runs,
+and its findings cite registry entries.
+
+| audit | class | status |
+|---|---|---|
+| #2557 — completeness message addressability | 3, the demanded change is never refusable | **Executed.** `tests/unit/test_completeness_message_addressability.py`; findings in `docs/audits/0905-message-addressability-sweep-2026-08-28.md` |
+| #2508 — 68 fail-open sites | 6, fail-open must be declared | Gate exists; the backlog is the ruling pass |
+| #2540 — fact-verifier vs proxy-heuristic | 3 and 1 (a proxy that vetoes is a zero without a denominator) | Not started |
+
+## Lessons discipline
+
+A new entry in `docs/lessons-learned.md` either cites a class here or founds
+one. A lesson that fits no class and does not found one is a fact about one
+day, and will be gone by the next campaign — which is the condition this
+registry exists to end.

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -1,0 +1,301 @@
+"""Can pinning read each completeness complaint? (#2557, swept under #2576.)
+
+Registry class 3 — **the demanded change is never refusable**
+(`docs/standards/0029-defect-class-registry.md`).
+
+The repaired invariant from #2555 holds mechanically only for complaints the
+enforcement can READ. This suite drives every real check with a fixture that
+genuinely fails it, takes the REAL emitted message, and classifies it. No
+message text is hardcoded: a rewording that drops an address changes the
+verdict and fails the suite the day it is written, which is the whole point.
+
+The taxonomy is three-way and the middle case matters:
+
+* **addressed** — the message cites a line of the draft. Enforcement unlocks
+  it; the drafter's mandated edit lands.
+* **demands-addition** — the message demands NEW content. There is no line to
+  cite by construction and #2560's exemption carries it. Correct, not a defect.
+* **unaddressable** — the message targets EXISTING content in a scheme the
+  vocabulary cannot read. **This is the deadlock class**: the drafter makes the
+  change, pinning reverts it, the loop burns its cap on byte-identical drafts.
+
+Four checks are currently unaddressable. Each is pinned below against its filed
+issue, so the gap is a failing-in-waiting rather than a comment. When one is
+repaired, its test here flips and must be moved to the addressable set.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.message_addressability import (
+    ADDRESSED,
+    DEMANDS_ADDITION,
+    UNADDRESSABLE,
+    addresses_draft,
+)
+
+#: `nodes/__init__.py` re-exports the FUNCTION `validate_completeness`, which
+#: shadows the module of the same name. Importing the module by path is the
+#: only way to reach the individual checks.
+vc = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+)
+
+
+# ---------------------------------------------------------------------------
+# The classifier itself
+# ---------------------------------------------------------------------------
+
+
+class TestClassifier:
+    def test_a_backticked_span_present_in_the_draft_addresses_it(self):
+        draft = "line one\nclass RenderValues:\n    pass\n"
+        verdict = addresses_draft("Missing example for `RenderValues`", draft)
+        assert verdict.verdict == ADDRESSED
+        assert verdict.matched_lines == (2,)
+
+    def test_a_token_absent_from_the_draft_addresses_nothing(self):
+        """Parsing is not addressing. A backticked name the draft does not
+        contain reads like an address and unlocks nothing."""
+        draft = "line one\nclass RenderValues:\n    pass\n"
+        verdict = addresses_draft("Missing file `src/absent.py`", draft)
+        assert verdict.tokens == ("src/absent.py",)
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_a_dashed_line_range_inside_the_draft_addresses_it(self):
+        draft = "\n".join(f"line {n}" for n in range(1, 21))
+        verdict = addresses_draft("Retag the fence at lines 3-5", draft)
+        assert verdict.verdict == ADDRESSED
+        assert verdict.matched_lines == (3, 4, 5)
+
+    def test_an_out_of_bounds_range_is_reported_not_counted(self):
+        """Worse than no citation: it reads as an address and unlocks
+        nothing."""
+        draft = "one\ntwo\n"
+        verdict = addresses_draft("see lines 80-90", draft)
+        assert verdict.out_of_bounds == ((80, 90),)
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_a_bare_line_number_is_not_an_address(self):
+        """#2555: the fence complaint carried 'line 1' from a quoted
+        SyntaxError -- a position inside a snippet, not a draft address."""
+        draft = "one\ntwo\nthree\n"
+        verdict = addresses_draft(
+            "SyntaxError: invalid decimal literal (<unknown>, line 1)", draft
+        )
+        assert verdict.ranges == ()
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_an_addition_demand_is_its_own_verdict(self):
+        draft = "## Section 10 Tests\n"
+        verdict = addresses_draft(
+            "2 LLD pass criterion(s) have no test in the spec. Add a test "
+            "for each.",
+            draft,
+        )
+        assert verdict.verdict == DEMANDS_ADDITION
+
+    def test_addressed_beats_demands_addition(self):
+        """A citable line is the stronger guarantee; the exemption is a
+        fallback, not an equal alternative."""
+        draft = "one\ntwo\nthree\nfour\nfive\n"
+        verdict = addresses_draft(
+            "lines 2-3 have no test in the spec", draft
+        )
+        assert verdict.demands_addition is True
+        assert verdict.verdict == ADDRESSED
+
+
+# ---------------------------------------------------------------------------
+# Fixtures that genuinely fail a real check
+# ---------------------------------------------------------------------------
+
+FUNCTION_WITH_PARAMS = """# Implementation Spec
+
+## Section 6 Signatures
+
+def compute_needle_angle(value, redline):
+    pass
+"""
+
+FUNCTION_ZERO_ARG = """# Implementation Spec
+
+## Section 6 Signatures
+
+def compute_needle_angle():
+    pass
+"""
+
+SPARSE_SPEC = """# Implementation Spec
+
+## Section 8 Change Instructions
+
+Update the module to handle the new case appropriately and carefully.
+"""
+
+NO_CITING_TESTS = """# Implementation Spec
+
+## Section 10 Tests
+
+def test_req_1_smoke():
+    assert True
+"""
+
+MODIFY_FILES = [
+    {"path": "src/render.py", "change_type": "Modify", "reason": "x"},
+    {"path": "src/absent_module.py", "change_type": "Modify", "reason": "y"},
+]
+
+
+def _classify(check_result, draft):
+    assert check_result["passed"] is False, (
+        f"fixture no longer fails {check_result['check_name']} -- the sweep "
+        f"is classifying a PASS message, which proves nothing"
+    )
+    return addresses_draft(check_result["details"], draft)
+
+
+class TestAddressableToday:
+    """Checks whose failure message the enforcement can read. Each assertion
+    is a rewording guard: change the message so it drops its address and this
+    fails."""
+
+    def test_functions_have_io_examples_addresses_a_zero_arg_function(self):
+        verdict = _classify(
+            vc.check_functions_have_io_examples(FUNCTION_ZERO_ARG),
+            FUNCTION_ZERO_ARG,
+        )
+        assert verdict.verdict == ADDRESSED
+
+
+class TestUnaddressableToday:
+    """The deadlock class, pinned. Each test asserts the CURRENT broken state
+    against its filed issue. Repairing one flips its test, which is the
+    signal to move it into TestAddressableToday."""
+
+    def test_functions_have_io_examples_loses_the_address_on_parameters(self):
+        """#2590. The message backticks `name()`; a function taking
+        parameters never contains the literal `name()`, so the identical
+        message addresses the draft only when the arg list happens to be
+        empty. The common case is the broken one."""
+        verdict = _classify(
+            vc.check_functions_have_io_examples(FUNCTION_WITH_PARAMS),
+            FUNCTION_WITH_PARAMS,
+        )
+        assert verdict.tokens == ("compute_needle_angle()",)
+        assert verdict.matched_lines == ()
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_modify_files_have_excerpts_names_a_path_not_in_the_draft(self):
+        """#2591. The complaint backticks a file path that is absent from the
+        draft BY DEFINITION -- absence is what it is complaining about -- and
+        its 'MUST include a code block' phrasing does not trip the addition
+        vocabulary, which only knows three test-specific phrases."""
+        verdict = _classify(
+            vc.check_modify_files_have_excerpts(NO_CITING_TESTS, MODIFY_FILES),
+            NO_CITING_TESTS,
+        )
+        assert "src/render.py" in verdict.tokens
+        assert verdict.demands_addition is False
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_change_instructions_specific_parses_nothing_at_all(self):
+        """#2592. A density heuristic about EXISTING content that names no
+        target whatsoever -- the purest form of the class."""
+        verdict = _classify(
+            vc.check_change_instructions_specific(SPARSE_SPEC), SPARSE_SPEC
+        )
+        assert verdict.tokens == ()
+        assert verdict.ranges == ()
+        assert verdict.verdict == UNADDRESSABLE
+
+    def test_manifest_traceability_omits_the_row_ids_it_holds(self):
+        """#2593. Row ids are exactly what the vocabulary parses (`_ROW_ID_RE`
+        reads N4.1), and the check is holding them -- it just does not put
+        them in the message on this branch."""
+        rows = [
+            {"id": "N4.1", "criterion": "needle within arc"},
+            {"id": "N4.2", "criterion": "band background"},
+        ]
+        verdict = _classify(
+            vc.check_manifest_traceability(NO_CITING_TESTS, rows),
+            NO_CITING_TESTS,
+        )
+        assert verdict.tokens == ()
+        assert verdict.verdict == UNADDRESSABLE
+
+
+class TestTheSweepIsExhaustive:
+    """The registry's claim is about EVERY check, so the set of checks this
+    file drives must not drift behind the module."""
+
+    def test_every_check_function_is_either_swept_or_declared_uncovered(self):
+        exported = {
+            name
+            for name in dir(vc)
+            if name.startswith("check_") and callable(getattr(vc, name))
+        }
+        swept = {
+            "check_functions_have_io_examples",
+            "check_modify_files_have_excerpts",
+            "check_change_instructions_specific",
+            "check_manifest_traceability",
+        }
+        #: Checks this sweep does NOT drive, each with the reason. They need
+        #: a real repo tree, a populated symbol table, or an LLD whose
+        #: pass-criteria table parses -- context a unit fixture cannot supply
+        #: honestly. Naming them here is the difference between a known gap
+        #: and a silent one; #2594 carries the work.
+        uncovered = {
+            "check_data_structures_have_examples",
+            "check_pattern_references_valid",
+            "check_import_targets_exist",
+            "check_visual_baselines_not_self_referential",
+            "check_criteria_have_tests",
+            "check_error_paths_have_tests",
+            "check_api_symbols_exist",
+        }
+        unaccounted = exported - swept - uncovered
+        assert not unaccounted, (
+            f"new completeness check(s) {sorted(unaccounted)} are neither "
+            f"swept nor declared uncovered. Add a failing fixture and "
+            f"classify the message, or list it as uncovered with a reason."
+        )
+
+    def test_the_uncovered_list_holds_no_phantoms(self):
+        exported = {name for name in dir(vc) if name.startswith("check_")}
+        uncovered = {
+            "check_data_structures_have_examples",
+            "check_pattern_references_valid",
+            "check_import_targets_exist",
+            "check_visual_baselines_not_self_referential",
+            "check_criteria_have_tests",
+            "check_error_paths_have_tests",
+            "check_api_symbols_exist",
+        }
+        phantom = uncovered - exported
+        assert not phantom, (
+            f"declared uncovered but no such check exists: {sorted(phantom)}"
+        )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Section 10.2 omits the error path",
+        "`compute_angle` returns the wrong type",
+        'the phrase "band background" is missing',
+        "row N4.2 has no citing test",
+        "test_req_8_chrome_housing asserts nothing",
+    ],
+)
+def test_the_vocabulary_parses_each_documented_scheme(message):
+    """The five schemes the registry claims are readable, each pinned. If a
+    vocabulary change drops one, standard 0029's class-3 entry is wrong and
+    this says so."""
+    verdict = addresses_draft(message, "")
+    assert verdict.tokens or verdict.ranges, (
+        f"the vocabulary parsed nothing from {message!r}"
+    )


### PR DESCRIPTION
The fleet already thinks in defect classes. It just had nowhere to keep them — "a zero needs a denominator" was born on #2546 and applied twice more within a day; "consult the enforcement record before attributing" was born on #2556 and applied again on #2561 the same afternoon. The class match is what makes a fix fast and its fixture shape obvious, and it was happening in an agent's memory of the campaign, which does not survive the campaign.

## The registry

`docs/standards/0029-defect-class-registry.md` — eight classes, each with the invariant it protects, a **detection question answerable against a diff or a halt without knowing the history**, the canonical fixture shape, and its instances.

1. A zero needs a denominator · 2. Attribution requires the enforcement record · 3. The demanded change is never refusable · 4. Conservation through transformation · 5. The input/litter distinction · 6. Fail-open must be declared · 7. The once-under-load flake · 8. A resume inherits, never rediscovers

Seven were named in the issue. **The eighth was added after #2570 landed**: #2551, #2552 and #2514 turned out to be one class wearing three different artifacts, which is exactly what earns a class entry rather than three bug fixes.

The bar for a new class is two independent instances. One is a bug; a class claims the shape recurs, and that claim needs evidence.

## The sweep — the acceptance proof

The acceptance asks that one backlog audit be executed AS a class sweep. #2557 was the smallest, and it is now a program: `tests/unit/test_completeness_message_addressability.py` drives real checks with fixtures that genuinely fail them and classifies the **real emitted message**. No message text is hardcoded, so a rewording that drops an address fails the suite the day it is written.

**The sweep changed the class entry it was testing.** The taxonomy is three-way, not two:

| verdict | meaning | defect |
|---|---|---|
| addressed | cites a line of the draft | no |
| demands-addition | demands NEW content; no line to cite by construction, #2560's exemption carries it | no |
| unaddressable | targets EXISTING content in a scheme the vocabulary cannot read | **yes** |

Collapsing the middle case into the third would report #2560's correctly-exempted messages as defects. That is now written into standard 0029 so the next sweep starts with it rather than rediscovering it.

**Parsing is not addressing.** A backticked span the draft does not contain parses fine and unlocks nothing, so `addresses_draft` requires the token to actually occur. That second half is what turned two "looks fine" messages into findings.

## Findings — four of four classified checks are unaddressable

| check | finding |
|---|---|
| `check_functions_have_io_examples` | #2590 |
| `check_modify_files_have_excerpts` | #2591 |
| `check_change_instructions_specific` | #2592 |
| `check_manifest_traceability` | #2593 |
| seven checks not swept | #2594 |

The sharpest is **#2590**. The complaint backticks `name()`, and a function taking parameters never contains that literal:

| draft | draft lines addressed | verdict |
|---|---|---|
| `def compute_needle_angle(value, redline):` | none | **unaddressable** |
| `def compute_needle_angle():` | line 5 | addressed |

The message is byte-identical in both. Whether it can be acted on depends on whether the function happens to take arguments — and the broken case is the ordinary one. This is #2555's deadlock shape on a check that fires on routine specs.

**#2591** exposes a family, not a message: `_ADDITION_DEMAND_RE` knows exactly three phrases, all about tests, so every non-test addition demand (an excerpt, a code block, an example) falls into the unaddressable bucket by default.

**#2592 is filed as a ruling, not a repair.** The check is a density heuristic, and #2540 asks whether proxies should veto at all. A proxy that cannot address its own complaint can only deadlock, so the issue says explicitly it should not be fixed before #2540 is decided.

## Coverage, stated honestly

Seven of eleven checks are **declared uncovered**, not silently skipped — each with the reason it cannot be failed by a unit fixture. `TestTheSweepIsExhaustive` fails when a new check is neither swept nor declared, **and** when a declared name no longer exists, so the gap cannot widen silently and the list cannot rot into a lie. With four unaddressable in four classified, the remaining seven are explicitly not assumed healthy.

## Tests

19 new; 101 with the adjacent pinning suites. The `()`-suffix pair is the load-bearing one: two fixtures differing only in the parameter list, asserting opposite verdicts from one message.

Closes #2576
