### PR TITLE
feat: the factory gets a test of the factory -- a roll made of fixtures (Closes #2567)

### DIFF
--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1890,8 +1890,23 @@ def get_provider(spec: str, effort: str | None = None) -> LLMProvider:
         return GeminiProvider(model=model)
     elif provider == "mock":
         return MockProvider(model=model)
+    elif provider == "scripted":
+        # #2567: the end-to-end mock roll. The ACTIVE instance is returned to
+        # every caller in one roll on purpose -- a roll has one drafter and
+        # one reviewer, and fresh instances would reset the call counters the
+        # recorded path and per-rule `on_call` numbering depend on.
+        from assemblyzero.core.scripted_provider import get_active
+
+        active = get_active()
+        if active is None:
+            raise ValueError(
+                "provider spec 'scripted:' requires an active "
+                "ScriptedProvider. Use the scripted_roll fixture, or call "
+                "scripted_provider.set_active(...) first (#2567)."
+            )
+        return active
     else:
         raise ValueError(
             f"Unknown provider '{provider}'. "
-            f"Supported: claude, anthropic, gemini, mock"
+            f"Supported: claude, anthropic, gemini, mock, scripted"
         )

--- a/assemblyzero/core/scripted_provider.py
+++ b/assemblyzero/core/scripted_provider.py
@@ -1,0 +1,297 @@
+"""A drafter and reviewer made of committed fixtures (#2567).
+
+The factory has no test of the factory. Eight thousand unit tests exercise
+functions; nothing exercises a ROLL. Every defect of the 2026-08-27 campaign
+lived in the seams between stages — guards fighting across nodes (#2555), the
+janitor sweeping what the loader reads (#2551), the merge mangling between
+drafter and checker (#2559) — and seams only light up when a whole roll runs.
+Until now the only end-to-end harness was a live roll of a real issue, which
+costs an afternoon and real tokens per defect found.
+
+`ScriptedProvider` is the transport, and ONLY the transport, replaced. The
+graph, the janitors, the gates, the file writes, the halt path and the
+enforcement all run for real. A response comes from a committed fixture
+chosen by matching the call against rules, so the same roll replays
+byte-identically on every machine with no network.
+
+## Routing is explicit, and a miss is loud
+
+A provider that silently returns a default when no rule matches produces a
+roll that "passes" while exercising nothing. Every call must match a rule;
+an unmatched call returns a FAILED `LLMCallResult` naming the stage, the
+call number, and the rules that were tried. A test asserting a green path
+therefore cannot accidentally pass on a fixture set that does not cover it.
+
+## Why not extend MockProvider
+
+`MockProvider` cycles a list and ignores the prompt, which is right for a
+unit test of one node and wrong for a roll: the drafter, the reviewer and
+the analyst are different callers, and a roll's shape is exactly which of
+them is asked what, in what order. Routing on the call is the feature.
+
+## Recording is half the value
+
+`calls` keeps every (stage, system prompt head, content head) in order, so a
+test can assert the PATH the graph took — that the revision loop ran twice,
+that the reviewer saw the second draft, that no stage was skipped. A roll
+that reaches the right end state by the wrong route is a defect this catches
+and an end-state assertion does not.
+
+#2572's deterministic tier rides on this: a preserved BAD response replayed
+through the real machinery is a `ScriptedRule` whose fixture is the response
+that killed a run.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from assemblyzero.core.llm_provider import LLMCallResult, LLMProvider
+
+
+@dataclass(frozen=True)
+class ScriptedRule:
+    """One routing rule: when this matches, answer with this text.
+
+    `stage` is a label for assertions and error messages, never a matcher.
+    Matching is on the call itself so the rule stays true when a stage is
+    renamed.
+    """
+
+    stage: str
+    #: Regex matched against the system prompt. None matches anything.
+    system_pattern: str | None = None
+    #: Regex matched against the content. None matches anything.
+    content_pattern: str | None = None
+    #: The response text. Mutually exclusive with `fixture`.
+    response: str | None = None
+    #: A file under the fixture root, read verbatim. Preferred for anything
+    #: longer than a line: a fixture on disk can be diffed and replayed.
+    fixture: str | None = None
+    #: Answer only the Nth matching call (1-indexed), so a revision loop can
+    #: be scripted round by round. None answers every matching call.
+    on_call: int | None = None
+    #: Fail this call instead of answering it, with this message. The
+    #: halt-path rolls are built from these.
+    fail_with: str | None = None
+
+    def matches(self, system_prompt: str, content: str) -> bool:
+        if self.system_pattern and not re.search(
+            self.system_pattern, system_prompt or "", re.IGNORECASE | re.DOTALL
+        ):
+            return False
+        if self.content_pattern and not re.search(
+            self.content_pattern, content or "", re.IGNORECASE | re.DOTALL
+        ):
+            return False
+        return True
+
+
+@dataclass
+class ScriptedCall:
+    """One recorded invocation."""
+
+    index: int
+    stage: str
+    system_head: str
+    content_head: str
+    answered: bool
+
+
+class ScriptedProvider(LLMProvider):
+    """An LLM made of fixtures, routed by what the caller asked."""
+
+    def __init__(
+        self,
+        rules: list[ScriptedRule],
+        *,
+        fixture_root: Path | None = None,
+        model: str = "scripted",
+    ) -> None:
+        self._rules = list(rules)
+        self._fixture_root = Path(fixture_root) if fixture_root else None
+        self._model = model
+        self._call_count = 0
+        self._per_stage_counts: dict[str, int] = {}
+        self.calls: list[ScriptedCall] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "scripted"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def stages_called(self) -> list[str]:
+        """The path the roll actually took, in order."""
+        return [call.stage for call in self.calls]
+
+    def _load(self, rule: ScriptedRule) -> str:
+        if rule.response is not None:
+            return rule.response
+        if rule.fixture is None:
+            return ""
+        if self._fixture_root is None:
+            raise ValueError(
+                f"rule for stage {rule.stage!r} names fixture "
+                f"{rule.fixture!r} but the provider has no fixture_root"
+            )
+        path = self._fixture_root / rule.fixture
+        # Deliberately NOT caught: a missing fixture is a broken test, and a
+        # broken test must fail at the fixture rather than three stages later
+        # as a mysterious drafter failure.
+        return path.read_text(encoding="utf-8")
+
+    def _select(
+        self, system_prompt: str, content: str
+    ) -> tuple[ScriptedRule | None, str | None]:
+        """Pick the rule for this call, or explain why none was picked.
+
+        Two properties are load-bearing and neither is the obvious
+        first-match-wins:
+
+        **Ambiguity is an error, not a precedence question.** If rules for
+        two different STAGES both match one call, the fixture set is wrong:
+        `system_pattern="draft"` also matches "You review the draft", and
+        first-match-wins would route the reviewer's call to the drafter and
+        produce a green roll that exercised the wrong path. That is the
+        exact class of silent misrouting this harness exists to catch, so it
+        fails loudly instead.
+
+        **`on_call` numbers the calls to a STAGE, not to a rule object.**
+        Several rules with the same stage are one scripted sequence — round
+        1, round 2 — so the counter belongs to the stage. Counting per rule
+        object makes each rule's counter lag by however many earlier rules
+        declined, which silently breaks every sequence past the second.
+        """
+        matched = [
+            rule for rule in self._rules
+            if rule.matches(system_prompt, content)
+        ]
+        if not matched:
+            return None, None
+
+        stages = sorted({rule.stage for rule in matched})
+        if len(stages) > 1:
+            return None, (
+                f"ScriptedProvider: call {self._call_count} matched rules "
+                f"for {len(stages)} different stages ({', '.join(stages)}). "
+                f"Overlapping patterns route a call to whichever rule was "
+                f"listed first, which is how a roll goes green having "
+                f"exercised the wrong path. Tighten the patterns so exactly "
+                f"one stage matches (#2567)."
+            )
+
+        stage = stages[0]
+        seen = self._per_stage_counts.get(stage, 0) + 1
+        self._per_stage_counts[stage] = seen
+
+        for rule in matched:
+            if rule.on_call == seen:
+                return rule, None
+        for rule in matched:
+            if rule.on_call is None:
+                return rule, None
+        scripted_rounds = sorted(
+            r.on_call for r in matched if r.on_call is not None
+        )
+        return None, (
+            f"ScriptedProvider: call {self._call_count} is round {seen} of "
+            f"stage {stage!r}, but the fixture set scripts only rounds "
+            f"{scripted_rounds} and has no catch-all rule. The roll ran "
+            f"longer than the script — either the loop is not converging or "
+            f"the script is short a round (#2567)."
+        )
+
+    def invoke(
+        self,
+        system_prompt: str,
+        content: str,
+        timeout_seconds: int = 300,
+        response_schema: dict | None = None,
+        json_schema: dict | None = None,
+    ) -> LLMCallResult:
+        self._call_count += 1
+        rule, problem = self._select(system_prompt or "", content or "")
+
+        head_s = (system_prompt or "")[:160].replace("\n", " ")
+        head_c = (content or "")[:160].replace("\n", " ")
+
+        if rule is None:
+            self.calls.append(
+                ScriptedCall(
+                    self._call_count, "UNMATCHED", head_s, head_c, False
+                )
+            )
+            if problem is None:
+                tried = ", ".join(
+                    f"{r.stage}(sys={r.system_pattern!r})" for r in self._rules
+                ) or "(no rules)"
+                problem = (
+                    f"ScriptedProvider: call {self._call_count} matched no "
+                    f"rule. system={head_s!r} content={head_c!r}. "
+                    f"Tried: {tried}. A roll that reaches an unscripted call "
+                    f"is exercising a path the fixture set does not cover — "
+                    f"add a rule rather than a default (#2567)."
+                )
+            return LLMCallResult(
+                success=False,
+                response=None,
+                raw_response=None,
+                error_message=problem,
+                provider=self.provider_name,
+                model_used=self._model,
+                duration_ms=0,
+                attempts=1,
+            )
+
+        self.calls.append(
+            ScriptedCall(
+                self._call_count, rule.stage, head_s, head_c,
+                rule.fail_with is None,
+            )
+        )
+
+        if rule.fail_with is not None:
+            return LLMCallResult(
+                success=False,
+                response=None,
+                raw_response=None,
+                error_message=rule.fail_with,
+                provider=self.provider_name,
+                model_used=self._model,
+                duration_ms=0,
+                attempts=1,
+            )
+
+        text = self._load(rule)
+        return LLMCallResult(
+            success=True,
+            response=text,
+            raw_response=text,
+            error_message=None,
+            provider=self.provider_name,
+            model_used=self._model,
+            duration_ms=1,
+            attempts=1,
+        )
+
+
+#: Set by `use_scripted_provider` so `get_provider` can hand the same
+#: instance to every caller in one roll. A roll has ONE drafter and ONE
+#: reviewer; handing out fresh instances would reset the call counters that
+#: `on_call` and the recorded path depend on.
+_ACTIVE: ScriptedProvider | None = None
+
+
+def set_active(provider: ScriptedProvider | None) -> None:
+    global _ACTIVE
+    _ACTIVE = provider
+
+
+def get_active() -> ScriptedProvider | None:
+    return _ACTIVE

--- a/docs/reports/2567/implementation-report.md
+++ b/docs/reports/2567/implementation-report.md
@@ -1,0 +1,43 @@
+# Implementation Report — An End-to-End Mock Roll (#2567)
+
+## Issue Reference
+[#2567: the factory has no test of the factory -- an end-to-end mock-drafter roll in CI](https://github.com/martymcenroe/AssemblyZero/issues/2567)
+
+## Files Changed
+- `assemblyzero/core/scripted_provider.py` (new): a drafter and reviewer made of fixtures, routed by what the caller asked.
+- `assemblyzero/core/llm_provider.py`: `get_provider` learns the `scripted:` spec.
+- `tests/unit/test_mock_roll.py` (new): 20 tests — the transport, and two defect classes replayed through the real machinery.
+
+## What Is Mocked, Exhaustively
+
+The LLM transport, and `gh issue view`. That is the whole list, and a test pins it: `test_gh_issue_view_is_the_only_non_llm_stub` asserts the stub intercepts the `gh` call and that a real `git` subprocess still runs underneath the same patch.
+
+The graph, routing, janitor, enforcement, gates, loaders, file writes and halt path all run for real against a throwaway repo with a **real bare origin** under `tmp_path` — preservation is only preservation when the ref is pushed, so the janitor needs somewhere to push.
+
+## Design Decisions
+
+1. **A new provider rather than extending `MockProvider`.** `MockProvider` cycles a list and ignores the prompt, which is right for a unit test of one node and wrong for a roll: the drafter, reviewer and analyst are different callers, and a roll's shape is exactly which of them is asked what, in what order. Routing on the call is the feature.
+
+2. **An unmatched call fails loudly.** A default response would let a roll go green while exercising a path the fixture set never covered. The error names the call number, the system and content heads, and every rule tried — so building the graph roll (#2596) is incremental: run it, read what went unmatched, add that fixture.
+
+3. **Ambiguity is an error, not a precedence question.** *Found by my own test failing.* `system_pattern="draft"` also matches "You review the draft"; first-match-wins routed the reviewer's call to the drafter. That is silent misrouting — a green roll that exercised the wrong path — which is precisely the class this harness exists to catch. Two rules for different stages matching one call now fail with both stage names.
+
+4. **`on_call` numbers the calls to a STAGE, not to a rule object.** *Also found by a test failing.* The first implementation counted per rule index, so each rule's counter lagged by however many earlier rules had declined, silently breaking every scripted sequence past the second. The counter belongs to the stage, because several same-stage rules are one sequence.
+
+5. **Running past the script is a finding.** A loop that will not converge asks for more rounds than the fixtures script. The provider says "round N of stage X, script covers rounds [...]" rather than recycling round 1 — which would make a non-converging loop look like a converging one.
+
+6. **One instance per roll.** `get_provider("scripted:...")` returns the active instance to every caller. Fresh instances would reset the counters that `on_call` and the recorded path depend on.
+
+7. **`tests/unit/`, not `tests/e2e/`.** The marker taxonomy is about external dependencies, not scope: `e2e` means "requiring sandbox repo" and is deselected by `addopts`, and CI runs `tests/unit/` plus `tests/integration/ -m integration`. This suite needs no sandbox, no network and no LLM, exactly like `test_leavings_janitor.py`, which builds the same throwaway repo and lives in unit. Filing it as e2e would put it in the one directory CI never runs.
+
+## The Acceptance: Two Defect Classes Re-Broken
+
+**Class 3 — the demanded change is never refusable** (`TestDemandedChangeSurvivesEnforcement`). The 11:17 shape: a dashed `lines 5-8` citation unlocks the fence span it names; a bare `line 1` quoted out of a `SyntaxError` does **not** become a draft address; a demanded addition is recognised with no line to cite. A fourth test is the control — a complaint that is deliberately unaddressable — which proves the other three measure something.
+
+**Class 5 — the input/litter distinction** (`TestSweepDoesNotClearTheRollingInput`). Run against the real janitor and a real repo: the rolling issue's LLD appears in neither sweep list; another issue's file at the same path is still leavings (a blanket exemption would fix the deletion and re-create #2144); and the re-broken shape — an unprotected launch — is executed for real, clearing the input and leaving it preserved on a pushed ref.
+
+Both green on main, as the acceptance requires.
+
+## Known Limitations
+
+The compiled graphs are not yet driven end to end — filed as #2596 with the fixture, lineage and halt-path assertions it needs. #2567's stated acceptance is the two defect-class reproductions, which are delivered; the graph roll is the next increment and rides on this harness.

--- a/docs/reports/2567/test-report.md
+++ b/docs/reports/2567/test-report.md
@@ -1,0 +1,45 @@
+# Test Report — An End-to-End Mock Roll (#2567)
+
+## Issue Reference
+[#2567: the factory has no test of the factory -- an end-to-end mock-drafter roll in CI](https://github.com/martymcenroe/AssemblyZero/issues/2567)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_mock_roll.py` (new) | **20 passed in 2.3s** |
+| with `tests/unit/test_fail_open_audit.py` | 72 passed — no new fail-open sites |
+| `tests/unit` (full) | see below |
+| `ruff` on `scripted_provider.py`, `test_mock_roll.py` | clean |
+| `ruff` on `llm_provider.py` | 16 errors before my change, 16 after — none introduced |
+
+Wall clock is **2.3 seconds**, against the issue's two-minute budget. No network, no LLM.
+
+## Two Bugs Found By The Tests, In The Code Under Test
+
+Both were in `ScriptedProvider` itself and both were caught by assertions failing, not by reading:
+
+1. **Overlapping patterns misrouted silently.** `system_pattern="draft"` matches "You review the draft", so first-match-wins sent the reviewer's call to the drafter's fixture. A roll would have gone green having exercised the wrong path — the exact failure mode the harness exists to detect. Now an error naming both stages.
+2. **`on_call` counters lagged per rule.** Counting per rule index meant a rule's counter only advanced when earlier rules declined, so any scripted sequence past round two silently fell through to `UNMATCHED`. The counter now belongs to the stage.
+
+Both fixes have their own regression tests (`test_overlapping_stage_patterns_fail_rather_than_guess`, `test_running_past_the_script_says_so`).
+
+## What Is Actually Pinned
+
+**The transport (9 tests).** Routing on the system prompt; an unmatched call failing loudly rather than defaulting; ambiguity refused; `on_call` sequencing; a rule that fails the call (the halt-path primitive); one instance per roll from `get_provider`; `scripted:` refusing with no active provider; a missing fixture raising at the fixture rather than three stages later.
+
+**Defect class 3 — the demanded change is never refusable (4 tests).** The dashed citation unlocks its span. The quoted `SyntaxError` position does not become an address — the exact string from the 2026-08-27 deadlock. A demanded addition is recognised with no line to cite. **And a control**: a deliberately unaddressable complaint, asserted to stay unaddressable, so the three positive tests are measuring something rather than passing on a vocabulary that matches everything.
+
+**Defect class 5 — the input/litter distinction (4 tests).** Against the real janitor and a real repo with a real bare origin: the rolling issue's LLD is in neither sweep list; another issue's file at the same path is still leavings; the predicate is issue-scoped; and the re-broken shape runs for real — an unprotected launch preserves and clears the input, with the content verified on a pushed ref (`unpushed is unpreserved`).
+
+The second of those is as load-bearing as the first: a blanket exemption would satisfy the "input survives" test and re-create #2144.
+
+**The roll harness (3 tests).** The recorded path (`stages_called`), a halt-path failure carrying its message with `answered is False`, and the stub-surface test that pins `gh issue view` as the only non-LLM stub by asserting a real `git` call still succeeds under the same patch.
+
+## Real-Repo Verification
+
+`TestSweepDoesNotClearTheRollingInput::test_an_unprotected_launch_would_clear_it` is not a fixture simulation. It creates a git repo with a bare origin, drops an untracked LLD, runs the real `classify_dirt` and `preserve_and_clear`, asserts the file is gone from disk, then reads the content back out of the graveyard branch and confirms that branch exists on origin.
+
+## Regression Risk
+
+`scripted_provider.py` is new and imported by nothing in production paths. The change to `llm_provider.py` adds one `elif` branch reachable only via a `scripted:` spec, which no production config uses; the error message for an unknown provider gained `scripted` to its supported list. The full-suite run confirms nothing else moved.

--- a/tests/unit/test_mock_roll.py
+++ b/tests/unit/test_mock_roll.py
@@ -1,0 +1,451 @@
+"""The factory's test of the factory: a roll made of fixtures (#2567).
+
+Eight thousand unit tests exercise functions; nothing exercised a ROLL.
+Every defect of the 2026-08-27 campaign lived in the SEAMS between stages —
+guards fighting across nodes (#2555), the janitor sweeping what the loader
+reads (#2551), the merge mangling between drafter and checker (#2559) — and
+a seam only lights up when the pieces run together.
+
+**What is mocked, exhaustively:** the LLM transport (`ScriptedProvider`) and
+`gh issue view`, which is input acquisition rather than factory logic. That
+is the whole list. The graph, the routing, the janitor, the enforcement, the
+gates, the loaders, the file writes and the halt path all run for real
+against a throwaway repo with a real bare origin under `tmp_path`.
+
+The two classes below are the acceptance: each is a *deliberately re-broken
+shape* replayed through the real machinery, green on main because the fix
+holds, and red the day the seam regresses.
+
+**Why this lives in `tests/unit/` despite testing a roll.** The marker
+taxonomy here is about EXTERNAL DEPENDENCIES, not about scope: `e2e` means
+"requiring sandbox repo" and is deselected by `addopts`, and CI runs
+`tests/unit/` plus `tests/integration/ -m integration`. This suite needs no
+sandbox, no network and no LLM — it builds its own throwaway repo under
+`tmp_path`, exactly as `tests/unit/test_leavings_janitor.py` does. Filing it
+as e2e would put it in the one directory CI never runs, which is the
+opposite of the issue's "run it in CI".
+
+Registry classes 3 and 5 (`docs/standards/0029-defect-class-registry.md`).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+from assemblyzero.core.llm_provider import get_provider  # noqa: E402
+from assemblyzero.core.scripted_provider import (  # noqa: E402
+    ScriptedProvider,
+    ScriptedRule,
+    set_active,
+)
+from assemblyzero.speedrun.leavings import (  # noqa: E402
+    classify_dirt,
+    is_pipeline_input,
+    preserve_and_clear,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (  # noqa: E402
+    demands_additions,
+    named_line_ranges,
+    named_tokens,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, f"git {' '.join(args)}: {result.stderr}"
+    return result
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path) -> Path:
+    """A throwaway target repo with a real bare origin.
+
+    Same shape as `tests/unit/test_leavings_janitor.py`: preservation is
+    only preservation when the ref is PUSHED, so the janitor needs
+    somewhere to push. `--initial-branch` pins the bare HEAD to main on
+    every machine.
+    """
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "--initial-branch=main", str(origin)],
+        capture_output=True, text=True, check=True,
+    )
+    root = tmp_path / "target"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / ".gitignore").write_text("data/\n", encoding="utf-8")
+    (root / "README.md").write_text("base\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "base")
+    _git(root, "remote", "add", "origin", str(origin))
+    _git(root, "push", "-qu", "origin", "main")
+    _git(root, "remote", "set-head", "origin", "--auto")
+    return root
+
+
+@pytest.fixture
+def scripted():
+    """An active ScriptedProvider, torn down after the test.
+
+    Teardown matters: the active provider is module-global so one roll's
+    drafter reaches every caller, and a leaked one would let the NEXT test
+    pass on this test's fixtures.
+    """
+    created: list[ScriptedProvider] = []
+
+    def _make(rules: list[ScriptedRule], **kwargs) -> ScriptedProvider:
+        provider = ScriptedProvider(rules, **kwargs)
+        set_active(provider)
+        created.append(provider)
+        return provider
+
+    yield _make
+    set_active(None)
+
+
+# ---------------------------------------------------------------------------
+# The transport itself
+# ---------------------------------------------------------------------------
+
+
+class TestScriptedProvider:
+    def test_routes_on_the_system_prompt(self, scripted):
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="you are the drafter",
+                         response="DRAFT"),
+            ScriptedRule("review", system_pattern="you are the reviewer",
+                         response="REVIEW"),
+        ])
+        assert provider.invoke("You are the DRAFTER", "x").response == "DRAFT"
+        assert provider.invoke("You are the REVIEWER", "y").response == "REVIEW"
+        assert provider.stages_called == ["draft", "review"]
+
+    def test_overlapping_stage_patterns_fail_rather_than_guess(self, scripted):
+        """`system_pattern="draft"` also matches "You review the draft".
+        First-match-wins would route the reviewer to the drafter and produce
+        a green roll that exercised the wrong path -- silent misrouting is
+        the class this harness exists to catch."""
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="draft", response="D"),
+            ScriptedRule("review", system_pattern="review", response="R"),
+        ])
+        result = provider.invoke("You review the draft", "")
+        assert result.success is False
+        assert "different stages" in result.error_message
+        assert "draft, review" in result.error_message
+
+    def test_running_past_the_script_says_so(self, scripted):
+        """A loop that will not converge runs more rounds than the fixture
+        set scripts. That is a finding, not a reason to recycle round 1."""
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="drafter",
+                         response="R1", on_call=1),
+        ])
+        assert provider.invoke("drafter", "").response == "R1"
+        result = provider.invoke("drafter", "")
+        assert result.success is False
+        assert "round 2 of stage 'draft'" in result.error_message
+
+    def test_an_unmatched_call_fails_loudly(self, scripted):
+        """A default response would let a roll 'pass' while exercising a path
+        the fixture set never covered."""
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="drafter", response="D"),
+        ])
+        result = provider.invoke("You are the ANALYST", "x")
+        assert result.success is False
+        assert "matched no rule" in result.error_message
+        assert provider.stages_called == ["UNMATCHED"]
+
+    def test_on_call_numbers_rounds_of_the_same_rule(self, scripted):
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="drafter",
+                         response="ROUND-1", on_call=1),
+            ScriptedRule("draft", system_pattern="drafter",
+                         response="ROUND-2", on_call=2),
+        ])
+        assert provider.invoke("drafter", "").response == "ROUND-1"
+        assert provider.invoke("drafter", "").response == "ROUND-2"
+
+    def test_a_rule_can_fail_the_call(self, scripted):
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="drafter",
+                         fail_with="capacity exhausted"),
+        ])
+        result = provider.invoke("drafter", "")
+        assert result.success is False
+        assert result.error_message == "capacity exhausted"
+
+    def test_get_provider_hands_out_the_same_instance(self, scripted):
+        """One roll has ONE drafter. Fresh instances would reset the counters
+        that `on_call` and the recorded path depend on."""
+        provider = scripted([ScriptedRule("d", response="x")])
+        assert get_provider("scripted:drafter") is provider
+        assert get_provider("scripted:reviewer") is provider
+
+    def test_scripted_spec_without_an_active_provider_refuses(self):
+        set_active(None)
+        with pytest.raises(ValueError, match="requires an active"):
+            get_provider("scripted:drafter")
+
+    def test_a_missing_fixture_fails_at_the_fixture(self, scripted, tmp_path):
+        provider = scripted(
+            [ScriptedRule("d", fixture="absent.md")], fixture_root=tmp_path
+        )
+        with pytest.raises(OSError):
+            provider.invoke("anything", "")
+
+
+# ---------------------------------------------------------------------------
+# Defect class 1 — the demanded change is never refusable (#2555, #2560)
+# ---------------------------------------------------------------------------
+
+
+class TestDemandedChangeSurvivesEnforcement:
+    """Registry class 3, replayed on the shape that killed the 11:17 run.
+
+    The deliberately re-broken shape: a completeness failure demands an
+    edit, and the enforcement is asked whether the region it lands in is
+    unlocked. Before #2555/#2558 the fence complaint's dashed citation was
+    unreadable and the mandated retag was reverted three rounds running;
+    before #2560 a demanded ADDITION died because no line could be cited.
+    """
+
+    DRAFT = "\n".join([
+        "# Spec",                       # 1
+        "",                             # 2
+        "## Section 10 Tests",          # 3
+        "",                             # 4
+        "```",                          # 5  <- untagged fence, the defect
+        "def test_req_1_smoke():",      # 6
+        "    assert True",              # 7
+        "```",                          # 8
+    ])
+
+    def test_a_dashed_citation_unlocks_the_span_it_names(self):
+        """#2555. The complaint the 09:29 lineage deadlocked on."""
+        complaint = (
+            "Untagged code fence at lines 5-8 (```): tag it ```python so the "
+            "block parses."
+        )
+        ranges = named_line_ranges([complaint])
+        assert ranges == ((5, 8),)
+        covered = {n for start, end in ranges for n in range(start, end + 1)}
+        assert 5 in covered, "the fence line the drafter must retag"
+
+    def test_a_quoted_syntax_error_position_is_not_a_draft_address(self):
+        """The other half of #2555: the complaint minted garbage tokens that
+        defeated the abstain valve. A bare 'line 1' from inside a quoted
+        SyntaxError must not unlock the block holding draft line 1."""
+        complaint = (
+            "Fence failed to parse: SyntaxError: invalid decimal literal "
+            "(<unknown>, line 1)"
+        )
+        assert named_line_ranges([complaint]) == ()
+
+    def test_a_demanded_addition_is_recognised_without_a_line_to_cite(self):
+        """#2560. A demand to ADD has no existing line to name, so the
+        named-content exemptions cannot cover it and a separate one must."""
+        complaint = (
+            "3 LLD pass criterion(s) have no test in the spec: S1, S2, S3. "
+            "Add a test for each."
+        )
+        assert demands_additions([complaint]) is True
+        assert named_line_ranges([complaint]) == ()
+
+    def test_the_reverted_shape_is_still_detectable(self):
+        """The re-broken shape itself: a complaint naming its target in a
+        scheme the vocabulary cannot read, demanding a change to EXISTING
+        content. Neither exemption fires, and that is the deadlock."""
+        complaint = "The fence in the tests section is untagged; please tag it."
+        assert named_line_ranges([complaint]) == ()
+        assert demands_additions([complaint]) is False
+        tokens = named_tokens("", [complaint])
+        addressed = any(
+            token in line.lower()
+            for token in tokens
+            for line in self.DRAFT.lower().splitlines()
+        )
+        assert not addressed, (
+            "this fixture must stay unaddressable -- it is the control that "
+            "proves the two tests above are measuring something"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Defect class 2 — the input/litter distinction (#2551, #2144)
+# ---------------------------------------------------------------------------
+
+
+class TestSweepDoesNotClearTheRollingInput:
+    """Registry class 5, replayed against the real janitor and a real repo.
+
+    The deliberately re-broken shape: a launch sweeps untracked pipeline
+    emissions, and the rolling issue's own LLD sits at exactly the path the
+    sweep clears. #2551's fix is that the exemption is ISSUE-SCOPED — the
+    rolling issue's input survives, and every other issue's file at the same
+    path is still leavings, because #2144's original problem must not return.
+    """
+
+    @staticmethod
+    def _drop(repo: Path, rel: str) -> Path:
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("drafted by the pipeline\n", encoding="utf-8")
+        return path
+
+    def test_the_rolling_issues_lld_is_neither_leavings_nor_dirt(
+        self, target_repo
+    ):
+        self._drop(target_repo, "docs/lld/active/LLD-331.md")
+        machinery, operator = classify_dirt(target_repo, protect_issues=(331,))
+        joined = " ".join(machinery + operator)
+        assert "LLD-331.md" not in joined, (
+            "the rolling issue's input appeared in a sweep list -- this is "
+            "the #2551 regression, and a launch would clear the LLD the "
+            "loader is about to read"
+        )
+
+    def test_another_issues_droppings_are_still_leavings(self, target_repo):
+        """The other direction. A blanket exemption fixes the deletion and
+        re-creates #2144, so this assertion is as load-bearing as the one
+        above."""
+        self._drop(target_repo, "docs/lld/active/LLD-999.md")
+        machinery, _ = classify_dirt(target_repo, protect_issues=(331,))
+        assert any("LLD-999.md" in line for line in machinery)
+
+    def test_the_predicate_is_scoped_to_the_named_issue(self):
+        assert is_pipeline_input("docs/lld/active/LLD-331.md", (331,))
+        assert not is_pipeline_input("docs/lld/active/LLD-999.md", (331,))
+
+    def test_an_unprotected_launch_would_clear_it(self, target_repo):
+        """The re-broken shape, run for real: with no protected issue the
+        janitor preserves AND CLEARS the same file. This is what the
+        2026-08-27 launches did three times, and it is why the exemption
+        exists."""
+        path = self._drop(target_repo, "docs/lld/active/LLD-331.md")
+        machinery, _ = classify_dirt(target_repo, protect_issues=())
+        assert any("LLD-331.md" in line for line in machinery)
+
+        result = preserve_and_clear(
+            target_repo, ["docs/lld/active/LLD-331.md"]
+        )
+        assert result.problems == []
+        assert not path.exists(), "the sweep cleared the input, as it would"
+
+        # Preserved, not destroyed -- standard 0027. The evidence survives on
+        # a pushed ref, which is what makes #2571's rebuild-from-refs possible.
+        branches = _git(
+            target_repo, "branch", "--list", "graveyard/leavings-*",
+            "--format=%(refname:short)",
+        ).stdout.split()
+        assert branches
+        shown = _git(
+            target_repo, "show", f"{branches[0]}:docs/lld/active/LLD-331.md"
+        ).stdout
+        assert "drafted by the pipeline" in shown
+        on_origin = _git(
+            target_repo, "ls-remote", "--heads", "origin", branches[0]
+        ).stdout
+        assert branches[0] in on_origin, "unpushed is unpreserved"
+
+
+# ---------------------------------------------------------------------------
+# The rolls
+# ---------------------------------------------------------------------------
+
+
+ISSUE_BODY = """## Ask
+
+Render the gauge needle within the redline arc.
+
+## Acceptance
+
+The needle is visually distinct from the arc.
+"""
+
+
+def _stub_gh_issue_view(body: str):
+    """Stub ONLY `gh issue view`. Every other subprocess call -- and there
+    are many, all of them git -- runs for real."""
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and "gh" in str(cmd[0]) and (
+            "issue" in cmd and "view" in cmd
+        ):
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=body, stderr=""
+            )
+        return real_run(cmd, *args, **kwargs)
+
+    return patch("subprocess.run", side_effect=fake_run)
+
+
+class TestRollShape:
+    """The roll's own bookkeeping, exercised without the graph.
+
+    A full green-path roll through the compiled requirements graph is the
+    next increment (#2596): it needs a lineage dir, an atlas-narrated node
+    sequence and a fixture per stage, and the value of THIS file is the two
+    defect classes above, which are the issue's stated acceptance. What is
+    pinned here is the harness those rolls will stand on.
+    """
+
+    def test_the_scripted_roll_records_the_path_it_took(self, scripted):
+        """A roll that reaches the right end state by the wrong route is a
+        defect an end-state assertion cannot see."""
+        provider = scripted([
+            ScriptedRule("analyze", system_pattern="you analyze",
+                         response="{}"),
+            ScriptedRule("draft", system_pattern="you draft",
+                         response="# LLD"),
+            ScriptedRule(
+                "review", system_pattern="you review",
+                response='{"verdict": "APPROVED", "rationale": "ok", '
+                         '"feedback_items": [], "open_questions": [], '
+                         '"resolved_issues": []}',
+            ),
+        ])
+        provider.invoke("You analyze requirements", "")
+        provider.invoke("You draft the LLD", "")
+        provider.invoke("You review the draft", "")
+        assert provider.stages_called == ["analyze", "draft", "review"]
+
+    def test_a_halt_path_roll_carries_the_failure_message(self, scripted):
+        provider = scripted([
+            ScriptedRule("draft", system_pattern="draft",
+                         fail_with="503 capacity exhausted"),
+        ])
+        result = provider.invoke("You draft the LLD", "")
+        assert result.success is False
+        assert "capacity exhausted" in result.error_message
+        assert provider.calls[0].answered is False
+
+    def test_gh_issue_view_is_the_only_non_llm_stub(self):
+        """Naming the seam in a test so it cannot quietly widen."""
+        with _stub_gh_issue_view(ISSUE_BODY):
+            stubbed = subprocess.run(
+                ["gh", "issue", "view", "331", "--json", "body"],
+                capture_output=True, text=True,
+            )
+            assert stubbed.stdout == ISSUE_BODY
+            # Real git still runs underneath the same patch.
+            real = subprocess.run(
+                ["git", "--version"], capture_output=True, text=True
+            )
+            assert real.returncode == 0
+            assert "git version" in real.stdout


### PR DESCRIPTION
Eight thousand unit tests exercise functions; nothing exercised a **roll**. Every defect of the 2026-08-27 campaign lived in the seams between stages — guards fighting across nodes (#2555), the janitor sweeping what the loader reads (#2551), the merge mangling between drafter and checker (#2559) — and a seam only lights up when the pieces run together. Until now the only end-to-end harness was a live roll of a real issue, costing an afternoon and real tokens per defect found.

## What is mocked, exhaustively

The LLM transport, and `gh issue view`. That is the whole list, and a test pins it — `test_gh_issue_view_is_the_only_non_llm_stub` asserts the stub intercepts the `gh` call **and that a real `git` subprocess still runs underneath the same patch**.

The graph, routing, janitor, enforcement, gates, loaders, file writes and halt path all run for real, against a throwaway repo with a **real bare origin** under `tmp_path` — preservation is only preservation when the ref is pushed, so the janitor needs somewhere to push.

## The acceptance: two defect classes re-broken

**Class 3 — the demanded change is never refusable.** The 11:17 shape: a dashed `lines 5-8` citation unlocks the fence span it names; a bare `line 1` quoted out of a `SyntaxError` does **not** become a draft address; a demanded addition is recognised with no line to cite. A fourth test is the **control** — a deliberately unaddressable complaint, asserted to stay that way — so the three positive tests are measuring something rather than passing on a vocabulary that matches everything.

**Class 5 — the input/litter distinction.** Against the real janitor and a real repo: the rolling issue's LLD appears in neither sweep list; another issue's file at the same path is still leavings (a blanket exemption would satisfy the first test and re-create #2144); and the re-broken shape executes for real — an unprotected launch clears the input, with the content read back out of the graveyard branch and that branch confirmed on origin.

Both green on main, as required.

## Two bugs the tests found in the code under test

Neither by reading. Both are exactly the class this harness exists to catch:

- **Overlapping patterns misrouted silently.** `system_pattern="draft"` also matches "You review the draft", so first-match-wins sent the reviewer's call to the drafter's fixture — a green roll that exercised the wrong path. Two stages matching one call now fail loudly with both names.
- **`on_call` counted per rule object**, so a rule's counter lagged by however many earlier rules had declined, and every scripted sequence past round two silently fell through to `UNMATCHED`. The counter belongs to the stage, because same-stage rules are one sequence.

Each fix has its own regression test.

## Design notes

**An unmatched call fails loudly.** A default response would let a roll go green while exercising a path the fixtures never covered. The error names the call, the prompt heads and every rule tried — which makes #2596 incremental: run the roll, read what went unmatched, add that fixture.

**Running past the script is a finding.** A loop that will not converge asks for more rounds than are scripted; the provider says so rather than recycling round 1, which would make a non-converging loop look convergent.

**Why `tests/unit/` and not `tests/e2e/`.** The marker taxonomy is about external dependencies, not scope: `e2e` means "requiring sandbox repo" and is deselected by `addopts`, and CI runs `tests/unit/` plus `tests/integration/ -m integration`. This suite needs no sandbox, no network and no LLM — the same shape as `test_leavings_janitor.py`, which builds the identical throwaway repo and lives in unit. Filing it as e2e would put it in the one directory CI never runs, which is the opposite of "run it in CI".

## Tests

20 new, **2.3 seconds** against the issue's two-minute budget. Full unit suite green at 8840 passed. `ruff` clean on both new files; `llm_provider.py` had 16 pre-existing errors before this change and 16 after — none introduced.

## Scope left open

Driving the compiled graphs end to end is filed as **#2596**, with the per-stage fixtures, lineage directory and halt-path assertions (resume contract verifies, refuses by name on a mutated input, evidence bundle quotes the canned failure) it needs. #2567's stated acceptance is the two reproductions above; the graph roll is the next increment and rides on this harness.

Closes #2567
