### PR TITLE
feat: the guard-vs-guard interaction matrix, linted (Closes #2568)

### DIFF
--- a/assemblyzero/core/interaction_matrix.py
+++ b/assemblyzero/core/interaction_matrix.py
@@ -1,0 +1,332 @@
+"""Guard-vs-guard: the interaction matrix, as data (#2568).
+
+Guard-vs-guard is the factory's emergent defect class, and nothing owned the
+interaction matrix. The 2026-08-27 campaign was almost entirely PAIRWISE
+failures between mechanisms that are each locally correct:
+
+* the completeness check demanded the edit pinning refused (#2555);
+* pinning's merge destroyed what the drafter and no verdict asked to remove
+  (#2559);
+* the cap halt blamed the drafter for what enforcement did (#2556, #2561);
+* the leavings janitor swept what the loader reads (#2551).
+
+Every one was found by a killed run. **None could have been found by any
+single guard's own tests, because each guard passed its own tests.**
+
+## The matrix is data so it can be linted
+
+A matrix that lives only in prose goes stale the first time someone adds a
+mechanism. Here the artifacts, their mechanisms and the cells between them
+are Python, and `tests/unit/test_interaction_matrix.py` enforces three
+things a document cannot:
+
+1. **No undeclared mechanism.** A module that calls one of an artifact's
+   signature symbols and is not declared for it fails the lint by name.
+   This is the "new mechanism fails a checklist lint" the issue asks for.
+2. **No unruled cell.** Every mechanism pair is either fixture-backed or
+   marked non-interacting WITH A REASON. A blank cell is not allowed,
+   because a blank cell is indistinguishable from an unconsidered one.
+3. **No phantom.** Declared modules and named fixtures must exist, so the
+   matrix cannot rot into a description of code that has moved.
+
+## Cells assert invariants, not implementations
+
+`test_completeness_pinning_deadlock.py` does not assert that pinning has a
+particular branch; it asserts that a change one gate demands is never
+refusable by another in the same round. Implementations change and the
+invariant survives, which is what makes a cell worth writing down.
+
+Registry class 3 (`docs/standards/0029-defect-class-registry.md`) is the
+single-mechanism form of this; the matrix is the pairwise form.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One mechanism pair, ruled.
+
+    Exactly one of `fixture` or `non_interacting` must be set. A cell with
+    neither is an unconsidered pair wearing the costume of a considered one.
+    """
+
+    invariant: str
+    #: Repo-relative test file pinning this pair.
+    fixture: str = ""
+    #: Why this pair cannot interact. Required when there is no fixture.
+    non_interacting: str = ""
+
+    def ruled(self) -> bool:
+        return bool(self.fixture) != bool(self.non_interacting)
+
+
+@dataclass(frozen=True)
+class Artifact:
+    """A shared thing, and every mechanism that touches it."""
+
+    slug: str
+    title: str
+    #: Function names whose CALL marks a module as touching this artifact.
+    #: The lint scans for these; a symbol that is never called anywhere is a
+    #: phantom and fails its own check.
+    signatures: tuple[str, ...]
+    #: mechanism name -> the repo-relative modules that implement it.
+    mechanisms: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    #: (mechanism_a, mechanism_b) -> Cell. Order-insensitive by convention:
+    #: the lint canonicalises to sorted order before looking a pair up.
+    cells: dict[tuple[str, str], Cell] = field(default_factory=dict)
+
+    def declared_modules(self) -> set[str]:
+        return {mod for mods in self.mechanisms.values() for mod in mods}
+
+    def pairs(self) -> list[tuple[str, str]]:
+        names = sorted(self.mechanisms)
+        return [
+            (a, b)
+            for index, a in enumerate(names)
+            for b in names[index + 1:]
+        ]
+
+
+def key(a: str, b: str) -> tuple[str, str]:
+    """Canonical, order-insensitive cell key."""
+    return (a, b) if a <= b else (b, a)
+
+
+DRAFT_TEXT = Artifact(
+    slug="draft-text",
+    title="The draft the drafter emits and every gate reads",
+    signatures=(
+        "enforce_pinning", "named_tokens", "named_line_ranges",
+        "demands_additions",
+    ),
+    mechanisms={
+        "pinning-enforcement": (
+            "assemblyzero/workflows/implementation_spec/revision_pinning.py",
+        ),
+        "completeness-checks": (
+            "assemblyzero/workflows/implementation_spec/nodes/"
+            "validate_completeness.py",
+        ),
+        "message-addressability": (
+            "assemblyzero/workflows/implementation_spec/"
+            "message_addressability.py",
+        ),
+        "spec-generation": (
+            "assemblyzero/workflows/implementation_spec/nodes/"
+            "generate_spec.py",
+        ),
+    },
+    cells={
+        key("pinning-enforcement", "completeness-checks"): Cell(
+            invariant=(
+                "A change a completeness failure explicitly demands is never "
+                "revertible by pinning in the same round."
+            ),
+            fixture="tests/unit/test_completeness_pinning_deadlock.py",
+        ),
+        key("pinning-enforcement", "message-addressability"): Cell(
+            invariant=(
+                "Enforcement can READ every complaint that demands an edit: "
+                "the message addresses a draft line, or demands an addition "
+                "and is exempt."
+            ),
+            fixture="tests/unit/test_completeness_message_addressability.py",
+        ),
+        key("pinning-enforcement", "spec-generation"): Cell(
+            invariant=(
+                "The merge never emits a document that lost or multiplied an "
+                "unnamed test definition -- revision unenforced or previous "
+                "entire, never the stitch."
+            ),
+            fixture="tests/unit/test_pinning_conservation.py",
+        ),
+        key("completeness-checks", "message-addressability"): Cell(
+            invariant=(
+                "Every check's real emitted message is classified, and a "
+                "rewording that drops its address fails the suite."
+            ),
+            fixture="tests/unit/test_completeness_message_addressability.py",
+        ),
+        key("completeness-checks", "spec-generation"): Cell(
+            invariant=(
+                "A demanded addition lands: an expansion-replace passes "
+                "unconditionally and a locked region introducing a new test "
+                "is freed."
+            ),
+            fixture="tests/unit/test_generate_spec_pinning.py",
+        ),
+        key("message-addressability", "spec-generation"): Cell(
+            invariant=(
+                "Classification is a pure read of a message against a draft."
+            ),
+            non_interacting=(
+                "message_addressability holds no draft state and is never "
+                "called from the generation path -- it reads a message and a "
+                "draft that generation has already produced. Neither can "
+                "change what the other sees within a round."
+            ),
+        ),
+    },
+)
+
+
+WORKING_TREE = Artifact(
+    slug="working-tree-files",
+    title="Untracked pipeline emissions on disk, and who may remove them",
+    signatures=(
+        "preserve_and_clear", "classify_dirt", "is_pipeline_input",
+        "restore_artifact",
+    ),
+    mechanisms={
+        "leavings-janitor": ("assemblyzero/speedrun/leavings.py",),
+        "restore-machinery": ("assemblyzero/speedrun/restore.py",),
+        "loaders": (
+            "assemblyzero/workflows/testing/nodes/load_lld.py",
+            "assemblyzero/workflows/implementation_spec/nodes/load_lld.py",
+        ),
+        # Found by the lint, not by reading: these are the SWEEP SITES, and
+        # they are where #2551 actually happened. A matrix built only from
+        # the package would have missed the mechanism that caused the kill.
+        "launch-sweep": (
+            "tools/speedrun_roll.py",
+            "tools/speedrun_new_attempt.py",
+        ),
+    },
+    cells={
+        key("leavings-janitor", "loaders"): Cell(
+            invariant=(
+                "A file a later stage reads on entry is never removable by "
+                "the sweep -- and the exemption is scoped to the ROLLING "
+                "issue, because a blanket one re-creates #2144."
+            ),
+            fixture="tests/unit/test_leavings_janitor.py",
+        ),
+        key("leavings-janitor", "restore-machinery"): Cell(
+            invariant=(
+                "Preserve-then-clear is structural: whatever the sweep "
+                "clears is recoverable from the refs the restorer searches."
+            ),
+            fixture="tests/unit/test_restore_from_graveyard.py",
+        ),
+        key("loaders", "restore-machinery"): Cell(
+            invariant=(
+                "A working copy is a cache: the loader rebuilds a missing "
+                "input from refs before concluding absence."
+            ),
+            fixture="tests/unit/test_restore_best_on_failure.py",
+        ),
+        key("launch-sweep", "leavings-janitor"): Cell(
+            invariant=(
+                "The exemption is applied at BOTH sweep sites, and it is "
+                "issue-scoped at each -- the janitor keeps clearing other "
+                "issues' droppings."
+            ),
+            fixture="tests/unit/test_leavings_janitor.py",
+        ),
+        key("launch-sweep", "loaders"): Cell(
+            invariant=(
+                "A launch never clears the input the loader is about to "
+                "read on entry. This is #2551's kill, replayed end to end "
+                "against a real repo."
+            ),
+            fixture="tests/unit/test_mock_roll.py",
+        ),
+        key("launch-sweep", "restore-machinery"): Cell(
+            invariant=(
+                "Whatever a launch sweeps is recoverable: preserve-then-"
+                "clear is structural, and the ref is pushed before the "
+                "file is removed."
+            ),
+            fixture="tests/unit/test_restore_from_graveyard.py",
+        ),
+    },
+)
+
+
+HALT_RESUME = Artifact(
+    slug="halt-resume-state",
+    title="What a halt records and a resume reads",
+    signatures=(
+        "build_resume_contract", "check_and_consume", "build_halt_evidence",
+        "write_halt_evidence", "save_state_snapshot",
+    ),
+    mechanisms={
+        "resume-contract": ("assemblyzero/core/resume_contract.py",),
+        "halt-evidence": ("assemblyzero/core/halt_evidence.py",),
+        "halt-node": ("assemblyzero/core/halt_node.py",),
+        # Also found by the lint: the runners are where a resume actually
+        # verifies, so they are a participant in this artifact, not callers
+        # of one.
+        "workflow-runners": (
+            "tools/run_implement_from_lld.py",
+            "tools/run_implementation_spec_workflow.py",
+        ),
+    },
+    cells={
+        key("resume-contract", "halt-node"): Cell(
+            invariant=(
+                "Every halt writes a contract, and verification CONSUMES it "
+                "-- a completed lifecycle leaves none behind."
+            ),
+            fixture="tests/unit/test_resume_after_ceiling_halt.py",
+        ),
+        key("halt-evidence", "halt-node"): Cell(
+            invariant=(
+                "Every halt emits its bundle, and a bundle that cannot be "
+                "written never masks the halt it describes."
+            ),
+            fixture="tests/unit/test_halt_evidence.py",
+        ),
+        key("halt-evidence", "resume-contract"): Cell(
+            invariant=(
+                "Both are written at the same halt from the same state, and "
+                "neither's failure suppresses the other."
+            ),
+            non_interacting=(
+                "Both are write-only at halt and read by different readers "
+                "-- the contract by the next launch, the bundle by a human "
+                "or a report. Neither reads the other's output, and the halt "
+                "node wraps each in its own fail-open so one cannot suppress "
+                "the other. Their shared risk is the janitor, which is the "
+                "working-tree artifact's concern, not this pair's."
+            ),
+        ),
+        key("workflow-runners", "resume-contract"): Cell(
+            invariant=(
+                "The runner verifies the contract FIRST and refuses by name "
+                "on any mismatch, before a single token is spent; "
+                "--accept-changed-inputs is the loud, logged override."
+            ),
+            fixture="tests/unit/test_resume_after_ceiling_halt.py",
+        ),
+        key("workflow-runners", "halt-node"): Cell(
+            invariant=(
+                "A resume seeds from the snapshot the halt wrote, and "
+                "inherits its counters rather than rediscovering them."
+            ),
+            fixture="tests/unit/test_resume_after_failure.py",
+        ),
+        key("workflow-runners", "halt-evidence"): Cell(
+            invariant=(
+                "A resume's behaviour never depends on the evidence bundle."
+            ),
+            non_interacting=(
+                "The bundle is forensic output addressed to a human or a "
+                "report; no runner reads it, and none should -- a resume "
+                "that consulted the bundle would be reading a summary when "
+                "the contract carries the authoritative hashes. Deliberate "
+                "asymmetry, not an oversight."
+            ),
+        ),
+    },
+)
+
+
+ARTIFACTS: dict[str, Artifact] = {
+    artifact.slug: artifact
+    for artifact in (DRAFT_TEXT, WORKING_TREE, HALT_RESUME)
+}

--- a/docs/reports/2568/implementation-report.md
+++ b/docs/reports/2568/implementation-report.md
@@ -1,0 +1,43 @@
+# Implementation Report — The Guard Interaction Matrix (#2568)
+
+## Issue Reference
+[#2568: guard-vs-guard is the emergent defect class -- an interaction invariant suite for mechanisms sharing an artifact](https://github.com/martymcenroe/AssemblyZero/issues/2568)
+
+## Files Changed
+- `assemblyzero/core/interaction_matrix.py` (new): the matrix as data — artifacts, mechanisms, ruled cells.
+- `docs/standards/0030-guard-interaction-matrix.md` (new): the written matrix.
+- `tests/unit/test_interaction_matrix.py` (new): the checklist lint — 30 tests.
+
+## The Central Decision: The Matrix Is Data
+
+A matrix living only in prose goes stale the first time someone adds a mechanism. Here the artifacts, mechanisms and cells are Python, and the lint enforces three things a document cannot:
+
+1. **No undeclared mechanism.** A module calling one of an artifact's signature symbols and appearing in no mechanism fails **by name**. This is the "new mechanism fails a checklist lint until it appears in the matrix" the issue asks for.
+2. **No unruled cell.** Every mechanism pair is fixture-backed or marked non-interacting **with a reason**. `Cell.ruled()` rejects both-and-neither, so a cell cannot carry a fixture *and* a hand-wave.
+3. **No phantom.** Declared modules and named fixtures must exist, and a signature symbol nothing calls fails as **dead** — a scan looking for a symbol that is never called is weaker than it looks, and that weakness would be invisible.
+
+## What The Lint Found That Reading Did Not
+
+Building the matrix from `assemblyzero/` alone produced a matrix that **missed the mechanism responsible for #2551**. Scanning `tools/` as well, the lint reported four undeclared modules:
+
+- `tools/speedrun_roll.py`, `tools/speedrun_new_attempt.py` — calling `classify_dirt`, `preserve_and_clear`, `is_pipeline_input`. These are the **sweep sites**: where a launch decides what to clear, and where the 2026-08-27 kill happened.
+- `tools/run_implement_from_lld.py`, `tools/run_implementation_spec_workflow.py` — calling `check_and_consume`. Where a resume actually verifies its contract.
+
+Neither pair appears in the issue's proposed enumeration. That is the argument for a lint over a written list, and it is why `SCAN_ROOTS` includes `tools/`.
+
+## Coverage
+
+Three artifacts, 11 mechanisms, **15 ruled cells** — 12 fixture-backed, 3 reasoned non-interacting. All four of the campaign's named pairwise kills have cells, asserted directly by `test_the_campaigns_four_pairwise_failures_are_all_covered`.
+
+A `test_most_cells_are_fixture_backed_not_reasoned_away` floor asserts at least half of all cells carry a fixture, because a matrix of non-interaction reasons is a matrix that gave up.
+
+## Deliberately Incomplete
+
+The issue names a fourth artifact — requirement/verdict state. It is **absent, and the standard says so with the reason**: its mechanisms are graph nodes reached through LangGraph routing rather than direct calls to a shared symbol, so the call-site scan that makes this lint honest cannot see them. Adding it with a weaker scan would produce a matrix that looks complete and enforces nothing, which is worse than an absent one because the green cells read as coverage.
+
+Filed as #2602 with two candidate detection mechanisms and a recommendation to rule before building.
+
+## Known Limitations
+
+- Detection is call-site based, so a mechanism reaching an artifact purely through graph state is invisible to it (#2602).
+- `SCAN_EXEMPT` carries two entries — the module that defines `is_pipeline_input`, and the golden-disaster corpus, which replays artifacts but never runs inside a roll. Each is listed with its reason and asserted to exist.

--- a/docs/reports/2568/test-report.md
+++ b/docs/reports/2568/test-report.md
@@ -1,0 +1,43 @@
+# Test Report — The Guard Interaction Matrix (#2568)
+
+## Issue Reference
+[#2568: guard-vs-guard is the emergent defect class -- an interaction invariant suite for mechanisms sharing an artifact](https://github.com/martymcenroe/AssemblyZero/issues/2568)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_interaction_matrix.py` (new) | **30 passed in 4.3s** |
+| `tests/unit` (full) | see below |
+| `ruff` on both new Python files | clean |
+
+## The Lint Earned Its Place On First Run
+
+It failed, correctly, four times before the matrix was complete:
+
+1. **Two undeclared sweep sites** — `tools/speedrun_roll.py` and `tools/speedrun_new_attempt.py` call `classify_dirt`, `preserve_and_clear` and `is_pipeline_input`. These are where #2551 actually happened, and a matrix built by reading `assemblyzero/` alone had missed them.
+2. **Two undeclared resume verifiers** — `tools/run_implement_from_lld.py` and `tools/run_implementation_spec_workflow.py` call `check_and_consume`.
+3. **A dead signature** — `input_refs` was declared as a scan symbol and is called nowhere, so it contributed nothing. Removed.
+4. **A missing standard** — `test_the_standard_documents_every_artifact` failed until `0030` existed and named every artifact and mechanism.
+
+Every one of those is a hole a written-only matrix would have carried indefinitely.
+
+## What Is Actually Pinned
+
+**The checklist lint (4 parameterised groups).** Per artifact: no undeclared module touches it; every declared module exists; every signature is called somewhere; plus a global check that every `SCAN_EXEMPT` entry names a real file. The undeclared-module failure message names the module, the symbols it called, and both remedies (declare it, or exempt it with a reason).
+
+**Cell completeness (5 parameterised groups).** Every mechanism pair has a cell; no cell has both a fixture and a non-interaction reason, or neither; every cell states an invariant of at least twenty characters; every named fixture file exists; no cell references a mechanism that does not exist.
+
+The "both or neither" check is the load-bearing one — without it a cell could carry a fixture *and* a hand-waving reason, and read as ruled twice over.
+
+**Substance (3).** All four of the campaign's named pairwise kills have cells, asserted individually by artifact and pair rather than by counting. At least half of all cells are fixture-backed, because a matrix of non-interaction reasons is a matrix that gave up. And the standard document must name every artifact and every mechanism — so the prose and the data cannot drift apart, which is the failure mode that made a written matrix worthless in the first place.
+
+**Primitives (2).** `Cell.ruled()` rejects both-and-neither; `key()` is order-insensitive, so a cell written `(b, a)` is found when looked up as `(a, b)`.
+
+## Coverage
+
+3 artifacts, 11 mechanisms, 15 cells — 12 fixture-backed, 3 reasoned. The fourth artifact from the issue is absent by decision, named as absent in the standard with its reason, and filed as #2602.
+
+## Regression Risk
+
+Additive and inert at runtime: `interaction_matrix.py` is pure data plus two small helpers, imported only by its own test. No production path touches it. The standard is documentation. The only way this change can break anything is by failing its own lint, which is its purpose.

--- a/docs/standards/0030-guard-interaction-matrix.md
+++ b/docs/standards/0030-guard-interaction-matrix.md
@@ -1,0 +1,125 @@
+# 0030 — The guard-vs-guard interaction matrix
+
+**Status:** Active
+**Issue:** #2568
+**Data:** `assemblyzero/core/interaction_matrix.py`
+**Lint:** `tests/unit/test_interaction_matrix.py`
+**Sibling:** standard 0029, the defect-class registry — class 3 is the single-mechanism form of this; the matrix is the pairwise form.
+
+Guard-vs-guard is the factory's emergent defect class. The 2026-08-27
+campaign was almost entirely **pairwise failures between mechanisms that
+are each locally correct**:
+
+- the completeness check demanded the edit pinning refused (#2555);
+- pinning's merge destroyed what the drafter and no verdict asked to
+  remove (#2559);
+- the cap halt blamed the drafter for what enforcement did (#2556, #2561);
+- the leavings janitor swept what the loader reads (#2551).
+
+Every one was found by a killed run. **None could have been found by any
+single guard's own tests, because each guard passed its own tests.**
+
+## The matrix is data, and the data is linted
+
+The tables below are generated from `interaction_matrix.py`, and the lint
+enforces three things prose cannot:
+
+1. **No undeclared mechanism.** A module calling one of an artifact's
+   signature symbols and appearing in no mechanism fails by name. This is
+   the checklist lint: a new mechanism cannot silently join an artifact.
+2. **No unruled cell.** Every mechanism pair is either fixture-backed or
+   marked non-interacting **with a reason**. A blank cell is
+   indistinguishable from an unconsidered one.
+3. **No phantom.** Declared modules and named fixtures must exist, and a
+   signature symbol nothing calls fails as dead — a scan looking for a
+   symbol that is never called is weaker than it looks.
+
+**Cells assert invariants, not implementations.** Implementations change;
+the invariant is what makes the cell worth writing down.
+
+## The lint found two mechanisms reading could not
+
+Building this matrix from the package alone produced a matrix that missed
+the mechanism responsible for #2551. The scan covers `tools/` as well, and
+reported:
+
+- **`tools/speedrun_roll.py`** and **`tools/speedrun_new_attempt.py`** call
+  `classify_dirt`, `preserve_and_clear` and `is_pipeline_input`. These are
+  the **sweep sites** — where a launch decides what to clear, and where the
+  2026-08-27 kill happened.
+- **`tools/run_implement_from_lld.py`** and
+  **`tools/run_implementation_spec_workflow.py`** call `check_and_consume`.
+  These are where a resume actually verifies its contract.
+
+Both are now first-class mechanisms. Neither was in the issue's proposed
+enumeration, which is the argument for the lint over a written list.
+
+---
+
+## Artifact: `draft-text`
+
+The draft the drafter emits and every gate reads.
+
+**Mechanisms:** `pinning-enforcement`, `completeness-checks`,
+`message-addressability`, `spec-generation`.
+
+| pair | ruling | invariant |
+|---|---|---|
+| pinning-enforcement × completeness-checks | `test_completeness_pinning_deadlock.py` | A change a completeness failure explicitly demands is never revertible by pinning in the same round. |
+| pinning-enforcement × message-addressability | `test_completeness_message_addressability.py` | Enforcement can READ every complaint that demands an edit: the message addresses a draft line, or demands an addition and is exempt. |
+| pinning-enforcement × spec-generation | `test_pinning_conservation.py` | The merge never emits a document that lost or multiplied an unnamed test definition — revision unenforced or previous entire, never the stitch. |
+| completeness-checks × message-addressability | `test_completeness_message_addressability.py` | Every check's real emitted message is classified, and a rewording that drops its address fails the suite. |
+| completeness-checks × spec-generation | `test_generate_spec_pinning.py` | A demanded addition lands: an expansion-replace passes unconditionally and a locked region introducing a new test is freed. |
+| message-addressability × spec-generation | **non-interacting** | `message_addressability` holds no draft state and is never called from the generation path — it reads a message and a draft generation has already produced. Neither can change what the other sees within a round. |
+
+## Artifact: `working-tree-files`
+
+Untracked pipeline emissions on disk, and who may remove them.
+
+**Mechanisms:** `leavings-janitor`, `restore-machinery`, `loaders`,
+`launch-sweep`.
+
+| pair | ruling | invariant |
+|---|---|---|
+| leavings-janitor × loaders | `test_leavings_janitor.py` | A file a later stage reads on entry is never removable by the sweep — and the exemption is scoped to the ROLLING issue, because a blanket one re-creates #2144. |
+| leavings-janitor × restore-machinery | `test_restore_from_graveyard.py` | Preserve-then-clear is structural: whatever the sweep clears is recoverable from the refs the restorer searches. |
+| loaders × restore-machinery | `test_restore_best_on_failure.py` | A working copy is a cache: the loader rebuilds a missing input from refs before concluding absence. |
+| launch-sweep × leavings-janitor | `test_leavings_janitor.py` | The exemption is applied at BOTH sweep sites, and it is issue-scoped at each. |
+| launch-sweep × loaders | `test_mock_roll.py` | A launch never clears the input the loader is about to read on entry. #2551's kill, replayed end to end against a real repo. |
+| launch-sweep × restore-machinery | `test_restore_from_graveyard.py` | Whatever a launch sweeps is recoverable: the ref is pushed before the file is removed. |
+
+## Artifact: `halt-resume-state`
+
+What a halt records and a resume reads.
+
+**Mechanisms:** `resume-contract`, `halt-evidence`, `halt-node`,
+`workflow-runners`.
+
+| pair | ruling | invariant |
+|---|---|---|
+| halt-node × resume-contract | `test_resume_after_ceiling_halt.py` | Every halt writes a contract, and verification CONSUMES it — a completed lifecycle leaves none behind. |
+| halt-evidence × halt-node | `test_halt_evidence.py` | Every halt emits its bundle, and a bundle that cannot be written never masks the halt it describes. |
+| halt-evidence × resume-contract | **non-interacting** | Both are write-only at halt and read by different readers — the contract by the next launch, the bundle by a human or a report. Neither reads the other's output, and the halt node wraps each in its own fail-open so one cannot suppress the other. |
+| workflow-runners × resume-contract | `test_resume_after_ceiling_halt.py` | The runner verifies the contract FIRST and refuses by name on any mismatch, before a single token is spent; `--accept-changed-inputs` is the loud, logged override. |
+| workflow-runners × halt-node | `test_resume_after_failure.py` | A resume seeds from the snapshot the halt wrote, and inherits its counters rather than rediscovering them. |
+| workflow-runners × halt-evidence | **non-interacting** | The bundle is forensic output addressed to a human or a report; no runner reads it, and none should — a resume consulting the bundle would be reading a summary when the contract carries the authoritative hashes. Deliberate asymmetry. |
+
+---
+
+## Adding a mechanism
+
+1. Add it to the artifact's `mechanisms` in `interaction_matrix.py`.
+2. Rule **every** new pair it creates — fixture or reasoned non-interaction.
+3. Add its row here.
+
+The lint fails until all three are done, which is the point.
+
+## The requirement/verdict-state artifact is not yet in the matrix
+
+#2568 names a fourth artifact — requirement and verdict state, touched by
+extraction, the N1 gates, N4b, the cap-halt classifier and resume seeding.
+It is **deliberately absent**: its mechanisms are spread across nodes whose
+signature symbols are called through the graph rather than directly, so the
+call-site scan that makes this lint honest does not yet reach them. Adding
+it with a weaker scan would give a matrix that looks complete and enforces
+nothing. Tracked in #2602.

--- a/tests/unit/test_interaction_matrix.py
+++ b/tests/unit/test_interaction_matrix.py
@@ -1,0 +1,243 @@
+"""The guard-vs-guard interaction matrix, linted (#2568).
+
+The matrix is only worth writing once if a new mechanism cannot silently
+join an artifact without appearing in it. That is what these tests are: the
+"checklist lint" the issue asks for, plus the phantom checks that stop the
+matrix rotting into a description of code that has moved.
+
+Registry class 3 is the single-mechanism form of this; the matrix is the
+pairwise form (`docs/standards/0029-defect-class-registry.md`).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.interaction_matrix import ARTIFACTS, Cell, key
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Where a mechanism can live. `tools/` is included deliberately: several
+#: janitor and report entry points are scripts, and a sweep that scanned
+#: only the package would miss exactly the mechanisms that caused #2551.
+SCAN_ROOTS = ("assemblyzero", "tools")
+
+#: Modules that reference a signature symbol without being a mechanism:
+#: the module that DEFINES it, and the test-facing corpus/replay code.
+#: Each is listed with the reason it is not a participant.
+SCAN_EXEMPT = {
+    # Defines the vocabulary rather than participating in a round.
+    "assemblyzero/speedrun/leavings.py": "defines is_pipeline_input",
+    # Replays preserved artifacts; never runs inside a roll.
+    "assemblyzero/speedrun/golden_disasters.py": "corpus replay, not a roll",
+}
+
+
+def _modules_calling(symbols: tuple[str, ...]) -> dict[str, set[str]]:
+    """Repo-relative module -> the signature symbols it CALLS.
+
+    A definition is not a call: `def enforce_pinning(` must not mark
+    revision_pinning.py as a caller of itself, or every artifact's owner
+    would be reported as an undeclared mechanism.
+    """
+    found: dict[str, set[str]] = {}
+    for root in SCAN_ROOTS:
+        for path in sorted((REPO_ROOT / root).rglob("*.py")):
+            if "__pycache__" in str(path):
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for symbol in symbols:
+                defines = re.search(
+                    rf"^\s*(?:async\s+)?def\s+{re.escape(symbol)}\s*\(",
+                    text, re.MULTILINE,
+                )
+                calls = re.search(
+                    rf"(?<!def )\b{re.escape(symbol)}\s*\(", text
+                )
+                if calls and not defines:
+                    found.setdefault(rel, set()).add(symbol)
+    return found
+
+
+class TestTheLint:
+    """A new mechanism touching a listed artifact fails until it appears."""
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_no_undeclared_mechanism_touches_the_artifact(self, slug):
+        artifact = ARTIFACTS[slug]
+        callers = _modules_calling(artifact.signatures)
+        declared = artifact.declared_modules()
+
+        undeclared = {
+            module: sorted(symbols)
+            for module, symbols in callers.items()
+            if module not in declared and module not in SCAN_EXEMPT
+        }
+        assert not undeclared, (
+            f"module(s) touch the {slug!r} artifact but appear in no "
+            f"mechanism: {undeclared}. Add each to a mechanism in "
+            f"assemblyzero/core/interaction_matrix.py and rule its cells, "
+            f"or add it to SCAN_EXEMPT with the reason it does not "
+            f"participate in a round (#2568)."
+        )
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_every_declared_module_exists(self, slug):
+        """A matrix naming code that has moved describes nothing."""
+        missing = [
+            module
+            for module in sorted(ARTIFACTS[slug].declared_modules())
+            if not (REPO_ROOT / module).is_file()
+        ]
+        assert not missing, f"{slug}: declared modules that do not exist: {missing}"
+
+    def test_every_exemption_names_a_real_module(self):
+        missing = [
+            module for module in sorted(SCAN_EXEMPT)
+            if not (REPO_ROOT / module).is_file()
+        ]
+        assert not missing, f"exemptions for modules that do not exist: {missing}"
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_every_signature_is_called_somewhere(self, slug):
+        """A signature nothing calls scans for nothing, so the lint for that
+        artifact is weaker than it looks."""
+        artifact = ARTIFACTS[slug]
+        callers = _modules_calling(artifact.signatures)
+        seen = {symbol for symbols in callers.values() for symbol in symbols}
+        dead = sorted(set(artifact.signatures) - seen)
+        assert not dead, (
+            f"{slug}: signature symbol(s) {dead} are called nowhere, so they "
+            f"contribute nothing to the scan. Remove them or fix the name."
+        )
+
+
+class TestEveryCellIsRuled:
+    """No blank cells. A blank cell is indistinguishable from an
+    unconsidered one, which is the state this matrix replaces."""
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_every_mechanism_pair_has_a_cell(self, slug):
+        artifact = ARTIFACTS[slug]
+        missing = [
+            pair for pair in artifact.pairs()
+            if key(*pair) not in artifact.cells
+        ]
+        assert not missing, (
+            f"{slug}: mechanism pair(s) with no cell: {missing}. Every pair "
+            f"is either fixture-backed or marked non-interacting with a "
+            f"reason."
+        )
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_no_cell_is_both_or_neither(self, slug):
+        artifact = ARTIFACTS[slug]
+        bad = [
+            pair for pair, cell in artifact.cells.items() if not cell.ruled()
+        ]
+        assert not bad, (
+            f"{slug}: cell(s) with both a fixture and a non-interacting "
+            f"reason, or with neither: {bad}"
+        )
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_every_cell_states_an_invariant(self, slug):
+        """Cells assert invariants, not implementations. An empty one is a
+        pair somebody pointed at without saying what must hold."""
+        thin = [
+            pair for pair, cell in ARTIFACTS[slug].cells.items()
+            if len(cell.invariant.strip()) < 20
+        ]
+        assert not thin, f"{slug}: cell(s) with no stated invariant: {thin}"
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_every_named_fixture_exists(self, slug):
+        """A cell citing a test file that does not exist is a green cell
+        protecting nothing."""
+        missing = sorted(
+            {
+                cell.fixture
+                for cell in ARTIFACTS[slug].cells.values()
+                if cell.fixture and not (REPO_ROOT / cell.fixture).is_file()
+            }
+        )
+        assert not missing, f"{slug}: cells naming absent fixtures: {missing}"
+
+    @pytest.mark.parametrize("slug", sorted(ARTIFACTS))
+    def test_no_cell_references_an_unknown_mechanism(self, slug):
+        artifact = ARTIFACTS[slug]
+        known = set(artifact.mechanisms)
+        unknown = sorted(
+            {
+                name
+                for pair in artifact.cells
+                for name in pair
+                if name not in known
+            }
+        )
+        assert not unknown, (
+            f"{slug}: cell(s) reference mechanism(s) that do not exist: "
+            f"{unknown}"
+        )
+
+
+class TestTheMatrixIsSubstantive:
+    def test_the_campaigns_four_pairwise_failures_are_all_covered(self):
+        """The four kills that motivated this issue, each with a cell."""
+        draft = ARTIFACTS["draft-text"]
+        tree = ARTIFACTS["working-tree-files"]
+        # #2555: completeness demanded what pinning refused.
+        assert draft.cells[
+            key("pinning-enforcement", "completeness-checks")
+        ].fixture
+        # #2559: the merge destroyed what no verdict named.
+        assert draft.cells[
+            key("pinning-enforcement", "spec-generation")
+        ].fixture
+        # #2551: the janitor swept what the loader reads.
+        assert tree.cells[key("leavings-janitor", "loaders")].fixture
+        # #2571: the loader rebuilds from what preservation kept.
+        assert tree.cells[key("loaders", "restore-machinery")].fixture
+
+    def test_most_cells_are_fixture_backed_not_reasoned_away(self):
+        """A matrix of non-interacting reasons is a matrix that gave up.
+        This is a floor, not a target."""
+        cells = [
+            cell
+            for artifact in ARTIFACTS.values()
+            for cell in artifact.cells.values()
+        ]
+        backed = [cell for cell in cells if cell.fixture]
+        assert len(backed) * 2 >= len(cells), (
+            f"only {len(backed)} of {len(cells)} cells carry a fixture; the "
+            f"rest are reasoned non-interacting, which is how a matrix "
+            f"becomes decorative"
+        )
+
+    def test_the_standard_documents_every_artifact(self):
+        """The written matrix and the data must not drift apart."""
+        doc = (
+            REPO_ROOT / "docs" / "standards"
+            / "0030-guard-interaction-matrix.md"
+        ).read_text(encoding="utf-8", errors="replace")
+        for slug, artifact in ARTIFACTS.items():
+            assert slug in doc, f"artifact {slug} is absent from the standard"
+            for mechanism in artifact.mechanisms:
+                assert mechanism in doc, (
+                    f"mechanism {mechanism!r} of {slug} is absent from the "
+                    f"standard"
+                )
+
+
+def test_cell_ruled_rejects_both_and_neither():
+    assert Cell("inv", fixture="a.py").ruled() is True
+    assert Cell("inv", non_interacting="because").ruled() is True
+    assert Cell("inv").ruled() is False
+    assert Cell("inv", fixture="a.py", non_interacting="because").ruled() is False
+
+
+def test_key_is_order_insensitive():
+    assert key("b", "a") == key("a", "b") == ("a", "b")


### PR DESCRIPTION
Guard-vs-guard is the factory's emergent defect class. The 2026-08-27 campaign was almost entirely **pairwise failures between mechanisms that are each locally correct** — the completeness check demanded the edit pinning refused (#2555), pinning's merge destroyed what no verdict named (#2559), the cap halt blamed the drafter for what enforcement did (#2556, #2561), the janitor swept what the loader reads (#2551).

Every one was found by a killed run. **None could have been found by any single guard's own tests, because each guard passed its own tests.**

## The matrix is data, and the data is linted

A prose matrix goes stale the first time someone adds a mechanism. `assemblyzero/core/interaction_matrix.py` carries three artifacts, eleven mechanisms and fifteen ruled cells, and the lint enforces three things a document cannot:

1. **No undeclared mechanism.** A module calling one of an artifact's signature symbols and appearing in no mechanism fails **by name**, with both remedies in the message. This is the checklist lint the issue asks for.
2. **No unruled cell.** Every pair is fixture-backed or non-interacting **with a reason**, and `Cell.ruled()` rejects both-and-neither — a blank cell is indistinguishable from an unconsidered one, and a cell carrying a fixture *and* a hand-wave reads as ruled twice over.
3. **No phantom.** Declared modules and named fixtures must exist, and a signature symbol nothing calls fails as **dead** — a scan for a symbol that is never called is weaker than it looks, and invisibly so.

## The lint found two mechanisms that reading did not

Built from `assemblyzero/` alone, the matrix **missed the mechanism responsible for #2551**. Scanning `tools/` as well, it failed on first run with:

- `tools/speedrun_roll.py`, `tools/speedrun_new_attempt.py` — calling `classify_dirt`, `preserve_and_clear`, `is_pipeline_input`. **The sweep sites**, where the 2026-08-27 kill happened.
- `tools/run_implement_from_lld.py`, `tools/run_implementation_spec_workflow.py` — calling `check_and_consume`. Where a resume actually verifies.

Neither pair appears in the issue's own enumeration. That is the argument for a lint over a written list.

It also failed on a dead signature (`input_refs`, called nowhere) and on the standard not yet existing. Four real holes, caught before the matrix was ever trusted.

## Coverage

**15 cells — 12 fixture-backed, 3 reasoned non-interacting.** All four of the campaign's named pairwise kills have cells, asserted individually by artifact and pair rather than by counting. A floor test requires at least half of all cells to carry a fixture, because a matrix of non-interaction reasons is a matrix that gave up. Another asserts standard 0030 names every artifact and mechanism, so prose and data cannot drift — the failure that makes a written matrix worthless.

## Deliberately incomplete, and it says so

The issue names a fourth artifact — requirement/verdict state. It is **absent**, and the standard states the reason: its mechanisms are graph nodes reached through LangGraph routing rather than direct calls to a shared symbol, so the call-site scan that makes this lint honest cannot see them.

Adding it with a weaker scan would produce a matrix that looks complete and enforces nothing — worse than an absent one, because the green cells read as coverage. Filed as **#2602** with two candidate detectors and a recommendation to rule before building.

Two of the campaign's four kills live in that artifact, so this is a real gap, named rather than papered over.

## Tests

30 new, 4.3s. Full unit suite green at **8922 passed**. `ruff` clean on both new files.

Closes #2568
