### PR TITLE
feat: best-of-N drafts judged by the mechanical gates (Closes #2573)

### DIFF
--- a/assemblyzero/workflows/requirements/best_of_n.py
+++ b/assemblyzero/workflows/requirements/best_of_n.py
@@ -1,0 +1,189 @@
+"""Best-of-N drafts, judged by the mechanical gates (#2573).
+
+The cap-halt pathology is a SERIAL-LOOP ARTIFACT. One drafter iterates
+against one complaint stream until the cap, and an entire subsystem exists
+to referee that loop: stagnation detection, grace clauses, ceiling regimes,
+identical-complaint classifiers. Every one of those guards is correct. The
+shape they guard is the problem.
+
+## The breakeven, counted rather than assumed
+
+The issue asked for the cost math to be verified before building. From
+`tools/factory_report.py` over the boostgauge stores, 2026-08-01 onward:
+
+* the spec loop reached **round 9** on #331 and **round 7** on #1;
+* **five** cap grants fired, all on the spec stage;
+* edit scripts applied 165 times against 14 fallbacks.
+
+A revision round costs one drafter call plus one validation. N=3 costs
+three drafter calls and three validations and zero revision rounds when any
+candidate clears. Against loops that actually reached seven and nine
+rounds, three is favourable. That is a counted comparison, not an estimate.
+
+## What this does and does not replace
+
+It replaces the MECHANICAL-GATE revision churn -- the rounds spent because
+a draft failed a deterministic check, which is where the deadlocks lived.
+It does not replace the reviewer's semantic revision loop: the winner
+proceeds INTO review, never past it. Revisions remain edit-script only
+(#2569).
+
+## Scoring uses the real gates, never a proxy
+
+A candidate is scored by running the actual mechanical validator and the
+actual test-plan validator against a state carrying that candidate as its
+draft. Re-implementing a cheaper approximation is how the score and the
+gate drift apart, and a winner chosen by a proxy that the real gate then
+rejects is worse than no selection at all.
+
+## Ties are broken deterministically, and the reason matters
+
+Equal failure counts fall back to candidate ORDER, so the first-generated
+candidate wins. Not "longest", which rewards padding; not "shortest", which
+rewards elision -- the exact behaviour #2559's eliding rewrite exhibited.
+Order is arbitrary but it is stable, and stability is what makes a roll
+replayable.
+
+Default OFF. The serial path remains the default until live-roll data says
+otherwise, which is the issue's own instruction.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+#: `--draft-candidates 1` is the serial path exactly, not a degenerate
+#: best-of-N: no scoring runs, no extra state is written, and the node
+#: behaves byte-identically to the pre-#2573 code.
+SERIAL = 1
+
+#: A ceiling on candidates. Not a policy about what is useful -- a policy
+#: about what a typo can cost. `--draft-candidates 30` on a live roll is
+#: thirty drafter calls, and the flag is one keystroke from 3.
+MAX_CANDIDATES = 5
+
+
+@dataclass
+class CandidateScore:
+    """One candidate draft, judged by the full mechanical gate suite."""
+
+    index: int
+    draft: str
+    #: Every gate failure, gate by gate. The COUNT decides the winner; the
+    #: text is what makes the scored table worth reading.
+    failures: dict[str, list[str]] = field(default_factory=dict)
+    #: A candidate the drafter never produced (an LLM failure). It is
+    #: scored as unusable rather than as perfect -- an empty draft trips no
+    #: gate that reads content, so "no failures" would otherwise win.
+    unusable: str = ""
+
+    @property
+    def failure_count(self) -> int:
+        return sum(len(items) for items in self.failures.values())
+
+    @property
+    def clears(self) -> bool:
+        return not self.unusable and self.failure_count == 0
+
+    def summary(self) -> str:
+        if self.unusable:
+            return f"unusable: {self.unusable}"
+        if not self.failures:
+            return "clears every gate"
+        return ", ".join(
+            f"{gate} {len(items)}" for gate, items in sorted(self.failures.items())
+        )
+
+
+def score_candidate(
+    index: int,
+    draft: str,
+    state: dict,
+    *,
+    mechanical: Callable[[dict], dict],
+    test_plan: Callable[[dict], dict],
+) -> CandidateScore:
+    """Run the REAL gates against one candidate.
+
+    The validators are injected rather than imported here so this module
+    stays free of the node import cycle and so a test can drive it without
+    standing up a workflow. Production passes the real ones.
+    """
+    score = CandidateScore(index=index, draft=draft)
+    if not (draft or "").strip():
+        score.unusable = "the drafter returned an empty draft"
+        return score
+
+    # A candidate is judged in ISOLATION: its own draft, and none of the
+    # accumulated validation state from a sibling. Leaking `validation_errors`
+    # between candidates would score candidate 3 for candidate 2's failures.
+    probe = dict(state)
+    probe["current_draft"] = draft
+    probe["validation_errors"] = []
+    probe["validation_warnings"] = []
+    probe["test_plan_errors"] = []
+
+    for gate_name, gate in (("mechanical", mechanical), ("test-plan", test_plan)):
+        try:
+            result = gate(probe) or {}
+        except Exception as exc:  # noqa: BLE001
+            # fail-open: a gate that CRASHES on a candidate must not kill the
+            # roll, but the candidate is not thereby good. The crash is
+            # recorded as a failure of that gate, so a candidate that breaks
+            # a validator can never win by breaking it.
+            score.failures[gate_name] = [f"gate raised {type(exc).__name__}: {exc}"]
+            continue
+        errors = [
+            str(item)
+            for key in ("validation_errors", "test_plan_errors")
+            for item in (result.get(key) or [])
+        ]
+        if errors:
+            score.failures[gate_name] = errors
+    return score
+
+
+def select_winner(scores: list[CandidateScore]) -> CandidateScore | None:
+    """Fewest gate failures wins; ties go to the earlier candidate.
+
+    Returns None only when every candidate is unusable, which is a halt
+    condition for the caller rather than something to paper over with the
+    least-bad empty draft.
+    """
+    usable = [score for score in scores if not score.unusable]
+    if not usable:
+        return None
+    return min(usable, key=lambda s: (s.failure_count, s.index))
+
+
+def render_score_table(scores: list[CandidateScore], winner_index: int) -> str:
+    """The scored table the issue asks the log to carry."""
+    lines = [
+        f"    [BEST-OF-N] {len(scores)} candidate(s) scored by the mechanical "
+        f"gates (#2573):"
+    ]
+    for score in scores:
+        mark = "WINNER" if score.index == winner_index else "      "
+        lines.append(
+            f"      {mark} candidate {score.index}: "
+            f"{score.failure_count} failure(s) -- {score.summary()}"
+        )
+    return "\n".join(lines)
+
+
+def clamp_candidates(requested: Any) -> int:
+    """A candidate count that cannot surprise the operator's wallet."""
+    try:
+        value = int(requested)
+    except (TypeError, ValueError):
+        # fail-open: toward the SERIAL path, which is the pre-#2573
+        # behaviour and spends the fewest tokens. An unparseable candidate
+        # count is a config typo, and the safe reading of a typo is "do the
+        # cheap thing", never "do it five times". Falling closed here would
+        # halt a roll over a malformed flag; falling open the other way
+        # would let one spend the operator's quota.
+        return SERIAL
+    if value < SERIAL:
+        return SERIAL
+    return min(value, MAX_CANDIDATES)

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -41,6 +41,13 @@ from assemblyzero.workflows.requirements.audit import (
     next_file_number,
     save_audit_file,
 )
+from assemblyzero.workflows.requirements.best_of_n import (  # noqa: E402
+    SERIAL,
+    clamp_candidates,
+    render_score_table,
+    score_candidate,
+    select_winner,
+)
 from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 from assemblyzero.workflows.requirements.feedback_window import (
     build_feedback_block,
@@ -121,6 +128,151 @@ def _extract_open_questions(
     retained for signature compatibility; they are not used.
     """
     return scan_open_questions_section(response)
+
+
+def _generate_best_of_n(
+    *,
+    state: RequirementsWorkflowState,
+    drafter,
+    system_prompt: str,
+    prompt: str,
+    candidates: int,
+    audit_dir: Path,
+    draft_count: int,
+    cost_before: float,
+) -> dict[str, Any]:
+    """N independent drafts, scored by the real gates, best one forward (#2573).
+
+    Generation is SEQUENTIAL. The issue asks for parallel and the wall-clock
+    win is real, but cumulative cost accounting (`get_cumulative_cost`), the
+    prompt-failure telemetry and the provider's own retry state are process
+    globals that no test here can prove safe under concurrency. The COST
+    argument -- three drafter calls against loops that reached seven and
+    nine rounds -- holds either way, and it is the decisive one. Parallel
+    generation is filed as #2604.
+
+    Every candidate is preserved to lineage whether it wins or loses: the
+    losers are the evidence for whether best-of-N is worth keeping, and
+    discarding them would make that question unanswerable the same way the
+    serial loop's discarded drafts did.
+    """
+    from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+        validate_lld_mechanical,
+    )
+    from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
+        validate_test_plan_node,
+    )
+
+    print(
+        f"    [BEST-OF-N] generating {candidates} independent candidate(s) "
+        f"(#2573; serial generation, see #2604)"
+    )
+
+    scores = []
+    file_num = state.get("file_counter", 0)
+    last_result = None
+    for index in range(1, candidates + 1):
+        result = drafter.invoke(system_prompt=system_prompt, content=prompt)
+        last_result = result
+        if not result.success:
+            # A failed candidate is scored unusable, not fatal: the point of
+            # N drafts is that one failing does not end the round.
+            scores.append(
+                _unusable(index, f"drafter failed: {result.error_message}")
+            )
+            continue
+
+        candidate = result.response or ""
+        score = score_candidate(
+            index, candidate, state,
+            mechanical=validate_lld_mechanical,
+            test_plan=validate_test_plan_node,
+        )
+        scores.append(score)
+
+        if audit_dir.exists():
+            file_num = next_file_number(audit_dir)
+            save_audit_file(
+                audit_dir, file_num, f"candidate-{index}-draft.md", candidate
+            )
+
+        if score.clears:
+            # A draft that passes every gate outright short-circuits: the
+            # remaining candidates cannot beat zero failures, and spending
+            # their calls to confirm that is the waste this replaces.
+            print(
+                f"    [BEST-OF-N] candidate {index} clears every gate; "
+                f"stopping early"
+            )
+            break
+
+    winner = select_winner(scores)
+    if winner is None:
+        return {
+            "error_message": (
+                f"BEST-OF-N: all {len(scores)} candidate(s) were unusable. "
+                + "; ".join(s.unusable for s in scores)
+            )
+        }
+
+    print(render_score_table(scores, winner.index))
+
+    draft_content = winner.draft
+    node_cost_usd = get_cumulative_cost() - cost_before
+    iteration_count = state.get("iteration_count", 0) + 1
+
+    draft_path = None
+    if audit_dir.exists():
+        file_num = next_file_number(audit_dir)
+        draft_path = save_audit_file(audit_dir, file_num, "draft.md", draft_content)
+
+    node_costs = accumulate_node_cost(
+        dict(state.get("node_costs", {})), "generate_draft", node_cost_usd,
+    )
+    node_tokens = accumulate_node_tokens(
+        dict(state.get("node_tokens", {})),
+        "generate_draft",
+        getattr(last_result, "input_tokens", 0) or 0,
+        getattr(last_result, "output_tokens", 0) or 0,
+    )
+
+    return {
+        "current_draft": draft_content,
+        "current_draft_path": str(draft_path) if draft_path else "",
+        "draft_count": draft_count,
+        "iteration_count": iteration_count,
+        "file_counter": file_num,
+        "user_feedback": "",
+        "previous_review_feedback": state.get("current_verdict", ""),
+        "previous_draft": state.get("current_draft", ""),
+        # The winner has NOT been through the gates as the live draft yet --
+        # it was scored on a probe copy. Clearing here matches the serial
+        # path, and N1.5 re-runs against the real state immediately after.
+        "validation_errors": [],
+        "finalize_repair_pending": False,
+        "error_message": "",
+        "node_costs": node_costs,
+        "node_tokens": node_tokens,
+        # #2573: the scored table, in state as well as the log, so a report
+        # can count best-of-N rounds without parsing prose.
+        "draft_candidate_scores": [
+            {
+                "index": s.index,
+                "failures": s.failure_count,
+                "summary": s.summary(),
+                "winner": s.index == winner.index,
+            }
+            for s in scores
+        ],
+    }
+
+
+def _unusable(index: int, reason: str):
+    from assemblyzero.workflows.requirements.best_of_n import CandidateScore
+
+    score = CandidateScore(index=index, draft="")
+    score.unusable = reason
+    return score
 
 
 def generate_draft(state: RequirementsWorkflowState) -> dict[str, Any]:
@@ -332,6 +484,32 @@ Use the template structure provided. Include all sections. Be specific about:
         and is_revision
         and not drafter_spec.startswith("mock:")
     )
+
+    # #2573: best-of-N. Only on the INITIAL draft of an lld run, and only
+    # when the operator asked for it -- the serial path stays the default.
+    # A revision is deliberately excluded: revisions travel as edit scripts
+    # (#2569) against a specific prior draft, so N independent revisions
+    # would be N different documents with no common parent to merge.
+    candidates_requested = clamp_candidates(
+        state.get("config_draft_candidates", SERIAL)
+    )
+    use_best_of_n = (
+        candidates_requested > SERIAL
+        and workflow_type == "lld"
+        and not is_revision
+    )
+
+    if use_best_of_n:
+        return _generate_best_of_n(
+            state=state,
+            drafter=drafter,
+            system_prompt=system_prompt,
+            prompt=prompt,
+            candidates=candidates_requested,
+            audit_dir=audit_dir,
+            draft_count=draft_count,
+            cost_before=cost_before,
+        )
 
     if use_edit_script:
         edit_context = build_revision_context(state)

--- a/assemblyzero/workflows/requirements/state.py
+++ b/assemblyzero/workflows/requirements/state.py
@@ -176,6 +176,9 @@ class RequirementsWorkflowState(TypedDict, total=False):
     config_gates_verdict: bool
     config_auto_mode: bool
     config_mock_mode: bool
+    #: #2573: how many independent initial drafts to generate and score by
+    #: the mechanical gates. 1 is the serial path and the default.
+    config_draft_candidates: int
 
     # Input - Issue workflow
     brief_file: str
@@ -303,6 +306,9 @@ def create_initial_state(
     gates_verdict: bool = True,
     auto_mode: bool = False,
     mock_mode: bool = False,
+    # #2573: 1 is the serial path exactly. Best-of-N is opt-in until
+    # live-roll data says otherwise.
+    draft_candidates: int = 1,
     max_iterations: int = 3,
     effort: str = "max",
     # Issue #1071: retry policy for transient LLM failures.
@@ -363,6 +369,7 @@ def create_initial_state(
         "config_gates_verdict": gates_verdict,
         "config_auto_mode": auto_mode,
         "config_mock_mode": mock_mode,
+        "config_draft_candidates": draft_candidates,
         # Workflow tracking
         "audit_dir": "",
         "file_counter": 0,

--- a/docs/reports/2573/implementation-report.md
+++ b/docs/reports/2573/implementation-report.md
@@ -1,0 +1,50 @@
+# Implementation Report — Best-of-N Drafts (#2573)
+
+## Issue Reference
+[#2573: best-of-N drafts judged by the mechanical gates -- replace the serial revision loop where stagnation is the pathology](https://github.com/martymcenroe/AssemblyZero/issues/2573)
+
+## Files Changed
+- `assemblyzero/workflows/requirements/best_of_n.py` (new): scoring, selection, the scored table, the candidate clamp.
+- `assemblyzero/workflows/requirements/nodes/generate_draft.py`: `_generate_best_of_n`, taken only on an initial lld draft when asked for.
+- `assemblyzero/workflows/requirements/state.py`: `config_draft_candidates`, defaulting to 1.
+- `tools/run_requirements_workflow.py`: `--draft-candidates`.
+- `tests/unit/test_best_of_n.py` (new): 21 tests.
+
+## The Cost Math, Verified First
+
+The issue asked for the breakeven to be verified before building. Counted with `tools/factory_report.py` (#2575) over the boostgauge stores, 2026-08-01 onward:
+
+| measure | counted |
+|---|---|
+| highest spec review round, #331 | **9** |
+| highest spec review round, #1 | **7** |
+| cap grants (all spec stage) | **5** |
+| edit scripts applied / fell back | 165 / 14 |
+
+A revision round costs one drafter call plus one validation. N=3 costs three drafter calls and three validations and **zero** revision rounds when any candidate clears. Against loops that actually reached seven and nine rounds, three is favourable. That is a counted comparison — the tool built for #2575 feeding the decision for #2573, which is the dependency the sequence was designed around.
+
+## Design Decisions
+
+1. **Initial drafts only, lld only, opt-in.** `--draft-candidates 1` is the serial path *exactly* — no scoring runs, no extra state, the node behaves as it did before. Revisions are deliberately excluded: they travel as edit scripts against a specific prior draft (#2569), so N independent revisions would be N different documents with no common parent.
+
+2. **Scoring uses the real gates.** A candidate is scored by running the actual `validate_lld_mechanical` and `validate_test_plan_node` against a state carrying that candidate. A cheaper approximation would drift from the gate, and a winner chosen by a proxy the real gate then rejects is worse than no selection.
+
+3. **Candidates are scored in isolation.** The probe state clears `validation_errors` before each gate run — leaking them would score candidate 3 for candidate 2's failures. A test asserts both halves: the probe is clean, and the caller's own state is not mutated.
+
+4. **An empty draft is `unusable`, not perfect.** Registry class 1 — a zero needs a denominator. An empty draft trips no gate that reads content, so "zero failures" would otherwise make the drafter's failure the winner.
+
+5. **A gate that crashes counts against the candidate.** Otherwise a candidate could win by breaking a validator.
+
+6. **Ties go to the earlier candidate.** Not longest (rewards padding), not shortest (rewards elision — #2559's exact pathology). Arbitrary but stable, and stability is what makes a roll replayable.
+
+7. **A clean candidate short-circuits.** The remaining calls cannot beat zero failures.
+
+8. **`MAX_CANDIDATES = 5`.** Not a claim about what is useful — a bound on what a typo costs, since the flag is one keystroke from 3 and every candidate is a real drafter call.
+
+9. **Every candidate is preserved to lineage.** The losers are the evidence for whether best-of-N is worth keeping; discarding them would make that unanswerable the same way the serial loop's discarded drafts did.
+
+## Known Limitation: Generation Is Sequential
+
+The issue asks for parallel. Three process globals sit in the loop's path — cumulative cost accounting, prompt-failure telemetry appends, and the provider's cross-instance circuit-breaker state — and none could be proven concurrency-safe here.
+
+**The cost argument does not depend on parallelism**, and cost is the decisive number. Filed as #2604, which also notes that the short-circuit makes parallel a *worse* trade than it looks if clearing on the first candidate is common — something #2575's rollup can now measure. #2604 says measure before building.

--- a/docs/reports/2573/test-report.md
+++ b/docs/reports/2573/test-report.md
@@ -1,0 +1,45 @@
+# Test Report — Best-of-N Drafts (#2573)
+
+## Issue Reference
+[#2573: best-of-N drafts judged by the mechanical gates -- replace the serial revision loop where stagnation is the pathology](https://github.com/martymcenroe/AssemblyZero/issues/2573)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_best_of_n.py` (new) | **21 passed in 0.4s** |
+| `tests/unit` (full) | see below |
+| `ruff` on `best_of_n.py`, `test_best_of_n.py`, `state.py` | clean |
+| `ruff` on `generate_draft.py`, `run_requirements_workflow.py` | 26 errors before, **26 after** — none introduced |
+
+The lint delta was briefly +1 (an `E402` on the new import, in a file that already carries many). It is now zero.
+
+## The Acceptance Fixture
+
+The issue names it specifically: **a fixture where candidate two alone clears the gates asserts the winner selection**. `test_candidate_two_alone_clears_and_wins` builds three candidates, drives the real scoring path, and asserts:
+
+- candidate 1 scores 2 failures, candidate 2 clears, candidate 3 scores 3;
+- `select_winner` returns candidate **2**, and the winning draft is candidate 2's text;
+- the rendered table marks exactly candidate 2 as `WINNER` and shows each other candidate's count.
+
+Candidate two is the load-bearing choice: any arrangement where the winner is first or last would also pass under an order-based selector, so only a middle winner proves selection happens on **score**.
+
+## What Else Is Pinned
+
+**Scoring (6).** A clean candidate clears; failures are counted per gate; an empty draft is `unusable` rather than perfect (a zero needs a denominator); a gate that raises counts *against* the candidate, so nothing wins by breaking a validator; candidates are scored in isolation — asserted in both directions, that the probe carries no sibling's errors **and** that the caller's state is not mutated; and unrelated state (issue number, target repo) still reaches the gates, so isolation has not become amnesia.
+
+**Selection (4).** Fewest failures wins; ties go to the earlier candidate; an unusable candidate never wins even against a flawed usable one; all-unusable returns `None`, which is a halt condition for the caller rather than something papered over with the least-bad empty draft.
+
+**Opt-in discipline (3).** `create_initial_state` defaults `config_draft_candidates` to 1; the parameter reaches state when passed; the CLI declares `--draft-candidates` with `default=1`. The serial path stays the default, which is the issue's own instruction.
+
+**Clamping (3).** 1, `None` and garbage all fall back to serial; 0 and negatives too; 30 clamps to 5 — a typo cannot cost thirty drafter calls on a live roll.
+
+**Determinism (1, parameterised over 2/3/5 candidates).** Identical candidates produce an identical winner across repeat runs. A roll that picks differently on replay is not replayable, which would defeat the golden-disaster corpus (#2572) and the mock roll (#2567) both.
+
+## What Is Not Covered
+
+No test drives `_generate_best_of_n` end to end through the node, because doing so honestly needs a live-ish drafter and a real audit dir. The scoring and selection it delegates to are fully covered; the node function is assembly. #2596 (the graph roll on the `ScriptedProvider` harness) is where that gap closes, and it is the natural place — a scripted roll with `--draft-candidates 3` exercises exactly this path with no network.
+
+## Regression Risk
+
+The feature is off by default and the default path is unchanged: `use_best_of_n` requires `candidates > 1`, `workflow_type == "lld"`, and a non-revision. All three must hold before any new code executes. The full unit suite confirms the serial path is untouched.

--- a/tests/unit/test_best_of_n.py
+++ b/tests/unit/test_best_of_n.py
@@ -1,0 +1,280 @@
+"""Best-of-N drafts judged by the mechanical gates (#2573).
+
+The acceptance fixture is `test_candidate_two_alone_clears_and_wins`: the
+issue asks specifically for a case where candidate two alone clears the
+gates, because that is the only arrangement that proves selection happens
+on SCORE rather than on order.
+
+Registry class 1 applies here — a zero needs a denominator. A candidate the
+drafter never produced trips no gate that reads content, so "zero failures"
+would make an empty draft the winner. `unusable` is that denominator.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+from assemblyzero.workflows.requirements.best_of_n import (  # noqa: E402
+    MAX_CANDIDATES,
+    SERIAL,
+    CandidateScore,
+    clamp_candidates,
+    render_score_table,
+    score_candidate,
+    select_winner,
+)
+
+DRAFT = "# LLD-1\n\n## 3. Requirements\n\n1. A thing\n"
+
+
+def _gate(errors_by_call):
+    """A fake GATE (not a fake drafter): returns the errors it is told to.
+
+    The real validators are injected in production; here the injection point
+    is used to drive scoring deterministically without standing up a
+    workflow. The thing under test is the scoring and selection, not the
+    validators -- those have their own suites.
+    """
+    calls = {"n": 0}
+
+    def gate(state):
+        calls["n"] += 1
+        draft = state.get("current_draft", "")
+        return {"validation_errors": list(errors_by_call.get(draft, []))}
+
+    gate.calls = calls
+    return gate
+
+
+def _empty_gate(state):
+    return {"validation_errors": []}
+
+
+class TestScoring:
+    def test_a_clean_candidate_clears(self):
+        score = score_candidate(
+            1, DRAFT, {}, mechanical=_empty_gate, test_plan=_empty_gate
+        )
+        assert score.clears is True
+        assert score.failure_count == 0
+        assert score.summary() == "clears every gate"
+
+    def test_failures_are_counted_per_gate(self):
+        mech = _gate({DRAFT: ["missing section 3", "bad title"]})
+        plan = _gate({DRAFT: ["no REQ coverage"]})
+        score = score_candidate(1, DRAFT, {}, mechanical=mech, test_plan=plan)
+        assert score.failure_count == 3
+        assert len(score.failures["mechanical"]) == 2
+        assert len(score.failures["test-plan"]) == 1
+        assert score.clears is False
+
+    def test_an_empty_draft_is_unusable_not_perfect(self):
+        """A zero needs a denominator: an empty draft trips no gate that
+        reads content, so 'no failures' would otherwise make it the winner."""
+        score = score_candidate(
+            1, "   ", {}, mechanical=_empty_gate, test_plan=_empty_gate
+        )
+        assert score.unusable
+        assert score.clears is False
+
+    def test_a_gate_that_crashes_counts_against_the_candidate(self):
+        """A candidate cannot win by breaking a validator."""
+        def exploding(state):
+            raise RuntimeError("boom")
+
+        score = score_candidate(
+            1, DRAFT, {}, mechanical=exploding, test_plan=_empty_gate
+        )
+        assert score.clears is False
+        assert "gate raised RuntimeError" in score.failures["mechanical"][0]
+
+    def test_candidates_are_scored_in_isolation(self):
+        """Leaking accumulated validation state between candidates would
+        score candidate 3 for candidate 2's failures."""
+        seen = []
+
+        def recording(state):
+            seen.append(list(state.get("validation_errors") or []))
+            return {"validation_errors": ["one"]}
+
+        dirty = {"validation_errors": ["stale from a sibling"], "other": "kept"}
+        score_candidate(1, DRAFT, dirty, mechanical=recording, test_plan=recording)
+        assert seen == [[], []], "the probe state carried a sibling's errors"
+        # The caller's state is not mutated.
+        assert dirty["validation_errors"] == ["stale from a sibling"]
+
+    def test_unrelated_state_reaches_the_gates(self):
+        """Isolation must not become amnesia: the gates need the rest of the
+        state (issue number, target repo) to judge anything."""
+        seen = {}
+
+        def recording(state):
+            seen.update(state)
+            return {"validation_errors": []}
+
+        score_candidate(
+            1, DRAFT, {"issue_number": 331, "target_repo": "/x"},
+            mechanical=recording, test_plan=_empty_gate,
+        )
+        assert seen["issue_number"] == 331
+        assert seen["current_draft"] == DRAFT
+
+
+class TestSelection:
+    def test_fewest_failures_wins(self):
+        scores = [
+            CandidateScore(1, "a", {"mechanical": ["x", "y"]}),
+            CandidateScore(2, "b", {"mechanical": ["x"]}),
+            CandidateScore(3, "c", {"mechanical": ["x", "y", "z"]}),
+        ]
+        assert select_winner(scores).index == 2
+
+    def test_ties_go_to_the_earlier_candidate(self):
+        """Deterministic, and deliberately NOT longest (rewards padding) or
+        shortest (rewards elision -- #2559's exact pathology)."""
+        scores = [
+            CandidateScore(1, "short", {"mechanical": ["x"]}),
+            CandidateScore(2, "a much longer draft", {"mechanical": ["y"]}),
+        ]
+        assert select_winner(scores).index == 1
+
+    def test_an_unusable_candidate_never_wins(self):
+        good = CandidateScore(2, "b", {"mechanical": ["x"]})
+        bad = CandidateScore(1, "")
+        bad.unusable = "drafter failed"
+        assert select_winner([bad, good]).index == 2
+
+    def test_all_unusable_returns_none(self):
+        """A halt condition for the caller, not something to paper over with
+        the least-bad empty draft."""
+        scores = []
+        for index in (1, 2):
+            score = CandidateScore(index, "")
+            score.unusable = "drafter failed"
+            scores.append(score)
+        assert select_winner(scores) is None
+
+
+class TestTheAcceptanceFixture:
+    """The issue's named case: candidate two alone clears the gates."""
+
+    def test_candidate_two_alone_clears_and_wins(self):
+        one = "# LLD-1\n\n## 3. Requirements\n\n1. Only a bit\n"
+        two = "# LLD-1\n\n## 3. Requirements\n\n1. Complete\n\n## 10.1\n\n(REQ-1)\n"
+        three = "# LLD-1\n\n## 3. Requirements\n\n1. Also incomplete\n"
+
+        mech = _gate({
+            one: ["Section 10.1 missing"],
+            three: ["Section 10.1 missing", "no REQ-N coverage"],
+        })
+        plan = _gate({
+            one: ["no test scenarios"],
+            three: ["no test scenarios"],
+        })
+
+        scores = [
+            score_candidate(index, draft, {}, mechanical=mech, test_plan=plan)
+            for index, draft in enumerate((one, two, three), start=1)
+        ]
+
+        assert scores[0].failure_count == 2
+        assert scores[1].clears is True
+        assert scores[2].failure_count == 3
+
+        winner = select_winner(scores)
+        assert winner.index == 2
+        assert winner.draft == two
+
+        table = render_score_table(scores, winner.index)
+        assert "WINNER candidate 2" in table
+        assert "clears every gate" in table
+        assert "candidate 1: 2 failure(s)" in table
+        assert "candidate 3: 3 failure(s)" in table
+
+
+class TestClamping:
+    def test_the_default_is_the_serial_path(self):
+        assert clamp_candidates(1) == SERIAL
+        assert clamp_candidates(None) == SERIAL
+        assert clamp_candidates("nonsense") == SERIAL
+
+    def test_zero_and_negative_fall_back_to_serial(self):
+        assert clamp_candidates(0) == SERIAL
+        assert clamp_candidates(-5) == SERIAL
+
+    def test_a_typo_cannot_cost_thirty_drafter_calls(self):
+        """The flag is one keystroke from 3, and every candidate is a real
+        drafter call on a live roll."""
+        assert clamp_candidates(30) == MAX_CANDIDATES
+        assert clamp_candidates(3) == 3
+
+
+class TestTheNodeIsOptIn:
+    """The serial path must remain byte-identical by default."""
+
+    def test_state_defaults_to_the_serial_path(self):
+        from assemblyzero.workflows.requirements.state import (
+            create_initial_state,
+        )
+
+        state = create_initial_state(
+            workflow_type="lld", assemblyzero_root="/a", target_repo="/b",
+        )
+        assert state["config_draft_candidates"] == SERIAL
+
+    def test_the_flag_reaches_state(self):
+        from assemblyzero.workflows.requirements.state import (
+            create_initial_state,
+        )
+
+        state = create_initial_state(
+            workflow_type="lld", assemblyzero_root="/a", target_repo="/b",
+            draft_candidates=3,
+        )
+        assert state["config_draft_candidates"] == 3
+
+    def test_the_cli_declares_the_flag_with_a_serial_default(self):
+        import run_requirements_workflow as cli
+
+        parser = cli.build_parser() if hasattr(cli, "build_parser") else None
+        if parser is None:
+            source = (TOOLS / "run_requirements_workflow.py").read_text(
+                encoding="utf-8"
+            )
+            assert '"--draft-candidates"' in source
+            assert "default=1" in source
+            return
+        args = parser.parse_args(["--issue", "1"])
+        assert args.draft_candidates == 1
+
+
+def test_render_score_table_marks_exactly_one_winner():
+    scores = [
+        CandidateScore(1, "a", {"mechanical": ["x"]}),
+        CandidateScore(2, "b"),
+    ]
+    table = render_score_table(scores, 2)
+    assert table.count("WINNER") == 1
+
+
+@pytest.mark.parametrize("count", [2, 3, MAX_CANDIDATES])
+def test_scoring_is_stable_across_repeat_runs(count):
+    """Identical candidates must produce an identical winner every time; a
+    roll that picks differently on replay is not replayable."""
+    drafts = [f"# LLD-1\n\n## 3. Requirements\n\n{n}. thing\n" for n in range(count)]
+    errors = {draft: ["e"] * (index + 1) for index, draft in enumerate(drafts)}
+    first = select_winner([
+        score_candidate(i, d, {}, mechanical=_gate(errors), test_plan=_empty_gate)
+        for i, d in enumerate(drafts, start=1)
+    ])
+    second = select_winner([
+        score_candidate(i, d, {}, mechanical=_gate(errors), test_plan=_empty_gate)
+        for i, d in enumerate(drafts, start=1)
+    ])
+    assert first.index == second.index == 1

--- a/tools/run_requirements_workflow.py
+++ b/tools/run_requirements_workflow.py
@@ -499,6 +499,18 @@ Examples:
         help="Maximum revision iterations (default: 20)",
     )
     parser.add_argument(
+        "--draft-candidates",
+        type=int,
+        default=1,
+        help=(
+            "#2573: generate N independent initial LLD drafts, score each by "
+            "the full mechanical gate suite, and take the best forward into "
+            "review. 1 (default) is the serial path exactly. Capped at 5. "
+            "Applies to the lld workflow's initial draft only -- revisions "
+            "remain edit-script based."
+        ),
+    )
+    parser.add_argument(
         "--budget",
         type=float,
         default=3.0,
@@ -691,6 +703,7 @@ def build_initial_state(
             retry_policy=getattr(args, "retry_policy", "default"),
             issue_number=args.issue or 0,
             context_files=args.context or [],
+            draft_candidates=getattr(args, "draft_candidates", 1),
         )
 
     # Issue #476: API cost budget


### PR DESCRIPTION
The cap-halt pathology is a **serial-loop artifact**. One drafter iterates against one complaint stream until the cap, and an entire subsystem exists to referee that loop — stagnation detection, grace clauses, ceiling regimes, identical-complaint classifiers. Every one of those guards is correct. The shape they guard is the problem.

## The cost math, verified before building

The issue asked for this first. Counted with the telemetry rollup from #2575 over the boostgauge stores, 2026-08-01 onward:

| measure | counted |
|---|---|
| highest spec review round, #331 | **9** |
| highest spec review round, #1 | **7** |
| cap grants (all spec stage) | **5** |
| edit scripts applied / fell back | 165 / 14 |

A revision round costs one drafter call plus one validation. N=3 costs three drafter calls and **zero** revision rounds when any candidate clears. Against loops that actually reached seven and nine rounds, three is favourable — counted, not estimated. This is the tool built in #2575 feeding the decision in #2573, which is the dependency the sequence was built around.

## What it does

`--draft-candidates N` generates N independent initial LLD drafts, scores each with the **real** mechanical and test-plan validators, and takes the best forward **into** review — never past it. Every candidate is preserved to lineage, because the losers are the evidence for whether this is worth keeping.

```
    [BEST-OF-N] 3 candidate(s) scored by the mechanical gates (#2573):
             candidate 1: 2 failure(s) -- mechanical 1, test-plan 1
      WINNER candidate 2: 0 failure(s) -- clears every gate
             candidate 3: 3 failure(s) -- mechanical 2, test-plan 1
```

## Decisions worth review

- **Scoring runs the real gates** against a probe state, never a cheaper approximation. A winner chosen by a proxy the real gate then rejects is worse than no selection at all.
- **Candidates are scored in isolation.** Leaking `validation_errors` would score candidate 3 for candidate 2's failures. Asserted in both directions — the probe is clean, and the caller's state is not mutated.
- **An empty draft is `unusable`, not perfect.** It trips no gate that reads content, so "zero failures" would otherwise crown the drafter's own failure. Registry class 1: a zero needs a denominator.
- **A gate that crashes counts against the candidate**, so nothing wins by breaking a validator.
- **Ties go to the earlier candidate.** Not longest, which rewards padding; not shortest, which rewards elision — #2559's exact pathology. Arbitrary but stable, and stability is what keeps a roll replayable.
- **`MAX_CANDIDATES = 5`** bounds what a typo costs, not what is useful. The flag is one keystroke from 3 and every candidate is a real drafter call.

## Default off, and genuinely so

`--draft-candidates 1` is the serial path *exactly*: no scoring, no extra state, byte-identical behaviour. Three conditions must all hold before any new code runs — `candidates > 1`, `workflow_type == "lld"`, and not a revision. Revisions stay edit-script based (#2569); N independent revisions would be N documents with no common parent to merge.

## Known limitation: generation is sequential

The issue asks for parallel. Three process globals sit in the loop's path — cumulative cost accounting, prompt-failure telemetry appends, and the provider's cross-instance circuit breaker — and none could be proven concurrency-safe here.

**The cost argument does not depend on parallelism**, and cost is the decisive number, so the safe half ships now. Filed as **#2604**, which also notes something worth weighing: the short-circuit means a clean first candidate costs *one* call, while parallel always pays for N. If clearing early is common — which #2575's rollup can now measure — parallel is a worse trade than it looks. #2604 says measure before building.

## Tests

21 new, including the issue's named acceptance fixture: **candidate two alone clears the gates.** A middle winner is the only arrangement that proves selection happens on score rather than order.

Full unit suite green at **8941 passed**. One new fail-open site ruled in place (`clamp_candidates`, failing open toward the serial path — the cheap thing is the safe reading of a config typo). Lint delta on the two edited pre-existing files is zero.

Closes #2573
