### PR TITLE
fix: the io-example complaint names the function in a form the draft contains (Closes #2590)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -908,7 +908,24 @@ def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
         missing_examples.append(func_name)
 
     if missing_examples:
-        func_list = ", ".join(f"`{f}()`" for f in missing_examples[:5])
+        # #2590: the backticked span carries the BARE name; the readable
+        # call form sits outside it. `named_tokens` parses what is inside
+        # backticks verbatim, so `compute_needle_angle()` -- parens included
+        # -- occurs in a draft only when the function happens to take no
+        # arguments. Two drafts differing solely in the parameter list drew
+        # a byte-identical complaint, one addressable and one not, and the
+        # broken case is the ordinary one. The bare name appears verbatim in
+        # every `def` line, so the token now lands and the demanded example
+        # survives enforcement instead of being reverted as content no
+        # verdict named (registry class 3, standard 0029).
+        #
+        # Dropping the parens rather than adding a second span: the sentence
+        # already says "Functions", so the call form earned nothing, and a
+        # second `name()` span would parse as a token that matches nothing.
+        # Loosening `named_tokens` to strip trailing parens was the other
+        # candidate and is rejected -- that vocabulary is shared by every
+        # complaint, and a looser token matches more than it should.
+        func_list = ", ".join(f"`{f}`" for f in missing_examples[:5])
         suffix = (
             f" (and {len(missing_examples) - 5} more)"
             if len(missing_examples) > 5

--- a/docs/audits/0905-message-addressability-sweep-2026-08-28.md
+++ b/docs/audits/0905-message-addressability-sweep-2026-08-28.md
@@ -39,9 +39,14 @@ fallback rather than an equal alternative.
 
 Four of eleven checks swept. **All four classified unaddressable**, each filed.
 
+**Update 2026-08-28:** #2590 is **repaired** — the backticked span now carries
+the bare name, so the parameterised case addresses its target. The row below
+records the sweep's finding as measured; the verdict column carries the
+current state.
+
 | check | verdict | finding |
 |---|---|---|
-| `check_functions_have_io_examples` (parameterised fn) | unaddressable | #2590 |
+| `check_functions_have_io_examples` (parameterised fn) | ~~unaddressable~~ → **addressed** | #2590, fixed |
 | `check_functions_have_io_examples` (zero-arg fn) | addressed | — |
 | `check_modify_files_have_excerpts` | unaddressable | #2591 |
 | `check_change_instructions_specific` | unaddressable | #2592 |
@@ -62,6 +67,17 @@ The emitted message is byte-identical in both cases. Whether the complaint can
 be acted on depends on whether the function happens to take arguments — and
 the broken case is the ordinary one. This is #2555's deadlock shape on a check
 that fires on routine specs rather than on an exotic fence condition.
+
+**Repaired 2026-08-28.** The span now carries the bare name, which every `def`
+line contains verbatim. Verifying the fix sharpened the diagnosis: the
+deadlock is **shape-dependent**, because `enforce_pinning` passes insertions
+through by design. Driven against the real enforcement, a fix that inserted a
+line above `pass` always survived; only fixes that **replaced** existing lines
+(`pass` → example + `return`, or a docstring rewrite) were reverted. That is
+still the ordinary case — replacing `pass` is the natural way to give a stub
+an example — but a fixture built on the insertion shape would have passed
+before the repair and proved nothing. `test_completeness_pinning_deadlock.py`
+uses the replacement shape for exactly this reason.
 
 ### The vocabulary gap under #2591
 

--- a/docs/reports/2590/implementation-report.md
+++ b/docs/reports/2590/implementation-report.md
@@ -1,0 +1,52 @@
+# Implementation Report — The IO-Example Complaint Addresses Its Target (#2590)
+
+## Issue Reference
+[#2590: the io-examples complaint backticks name() -- a function with parameters never contains that literal, so it addresses nothing](https://github.com/martymcenroe/AssemblyZero/issues/2590)
+
+Registry class 3 — the demanded change is never refusable (`docs/standards/0029-defect-class-registry.md`).
+
+## Files Changed
+- `assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py`: one line — the backticked span drops the call parens.
+- `tests/unit/test_completeness_pinning_deadlock.py`: the issue's table as fixture, plus the end-to-end class-3 property (6 tests).
+- `tests/unit/test_completeness_message_addressability.py`: the pinned known-gap test moves from `TestUnaddressableToday` to `TestAddressableToday`, fixture unchanged.
+- `docs/audits/0905-message-addressability-sweep-2026-08-28.md`: the sweep's #2590 row corrected, and the sharpened diagnosis recorded.
+
+## The Fix
+
+```python
+# before
+func_list = ", ".join(f"`{f}()`" for f in missing_examples[:5])
+# after
+func_list = ", ".join(f"`{f}`" for f in missing_examples[:5])
+```
+
+`named_tokens` parses what sits inside backticks verbatim, so `compute_needle_angle()` — parens included — occurs in a draft only when the function happens to take no arguments. The bare name appears verbatim in every `def` line.
+
+**Parens dropped rather than a second span added.** The sentence already says "Functions", so the call form earned nothing, and a second `` `name()` `` span would parse as a token matching nothing. **Loosening `named_tokens` to strip trailing parens was rejected** — that vocabulary is shared by every complaint, and a looser token matches more than it should.
+
+## Verification Before The Code
+
+**The table reproduces exactly.** Real check, real `named_tokens`: with parameters → token `compute_needle_angle()`, zero lines addressed, unaddressable. Zero-arg → line 5 addressed. Byte-identical message.
+
+**The diagnosis was sharpened, not refuted.** The issue says "the drafter adds the example, `enforce_pinning` reverts it". That is true for **replacement**-shaped revisions only — enforcement passes insertions through by design ("adding is not un-fixing"). Driven against the real enforcement:
+
+| revision shape | refusals (before fix) | example survived |
+|---|---|---|
+| insert a comment above `pass` | 0 | yes |
+| replace `pass` with example + `return` | 1 | **no** |
+| replace `pass` with docstring + `return` | 1 | **no** |
+| prose example above the `def` | 0 | yes |
+
+Still the ordinary case — replacing `pass` is the natural way to give a stub an example — but a fixture built on the insertion shape would have passed before the repair and proved nothing. The fixture uses the replacement shape for exactly this reason. Posted to the issue before any code changed.
+
+**The `()` suffix is not shared.** Checked before touching anything, per the cross-read instruction: line 911 was the only paren-suffixed backtick span in the package; every other site formats `` `{x}` `` bare. The reword is local, and **#2591–#2594 are unaffected** — nothing to note on a sibling.
+
+**The fix does not over-unlock.** `_blocks` splits per `def` only inside fences, so the fenced shape is where scoping is testable. With the bare name, the named function's block unlocks (lines 6–9) and a sibling function meddled with in the same round is **still reverted**.
+
+## The #2540 Ruling, Honoured
+
+Ratified 2026-08-28: proxies advise, facts gate. `functions_have_io_examples` is a fact-verifier — an example exists or it does not — so it **stays a hard gate**. This change is to its addressability, not its authority. Nothing was demoted.
+
+## Known Limitations
+
+None for this check. The three sibling unaddressable complaints (#2591, #2593) and the proxy ruling that subsumes #2592 remain open and untouched, as instructed.

--- a/docs/reports/2590/test-report.md
+++ b/docs/reports/2590/test-report.md
@@ -1,0 +1,47 @@
+# Test Report — The IO-Example Complaint Addresses Its Target (#2590)
+
+## Issue Reference
+[#2590](https://github.com/martymcenroe/AssemblyZero/issues/2590)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_completeness_pinning_deadlock.py` | **21 passed** (6 new) |
+| `tests/unit/test_completeness_message_addressability.py` | **19 passed** (1 test moved) |
+| combined | 40 passed in 0.5s |
+| `tests/unit` (full) | see below |
+| `ruff` on both touched test files | clean |
+
+## The Fixtures Were Proved To Fail Without The Fix
+
+The essential check: the production line was temporarily reverted and the new tests re-run.
+
+**4 of 6 went red**, including the end-to-end deadlock test:
+
+- `test_the_parameterised_function_is_addressed`
+- `test_both_drafts_draw_the_same_token`
+- `test_the_span_carries_no_call_parens`
+- `test_the_demanded_example_survives_pinning_in_the_same_round`
+
+**2 stayed green, correctly.** `test_the_zero_arg_function_stays_addressed` pins the case that already worked — it is the "must not regress" direction and green in both states is the right answer. `test_an_unnamed_sibling_function_is_still_locked` drives enforcement with explicit tokens rather than the message, so it is a scoping guard independent of the reword.
+
+Without that distribution the suite would be compatible with a tautology.
+
+## What Is Pinned
+
+**The issue's table, both directions (4 tests).** Parameterised and zero-arg drafts each drive the **real** check and the **real** `named_tokens`; no message text is hand-written, so a reword that drops the address fails the suite. `test_both_drafts_draw_the_same_token` asserts both cases yield the identical token — if a future change makes addressability depend on the parameter list again, that is the assertion that says so. `test_the_span_carries_no_call_parens` is the specific regression guard.
+
+**The class-3 end-to-end property (1 test).** Real complaint → real `named_tokens` → real `enforce_pinning`, with the drafter's fix in the **replacement** shape that enforcement actually refused. Asserts zero refusals, zero regressions, and that the example text survives in the merged output.
+
+**The inverse (1 test).** Inside a fence, where `_blocks` splits per `def`: naming one function frees its block, and a sibling function meddled with in the same round is still reverted with a refusal recorded. This is what stops the fix from being an over-unlock.
+
+**The sweep's own pin, flipped.** `test_functions_have_io_examples_loses_the_address_on_parameters` moved out of `TestUnaddressableToday` and into `TestAddressableToday` as `..._addresses_a_parameterised_function`, **with `FUNCTION_WITH_PARAMS` unchanged** — only the expected verdict moved, which is what the issue's acceptance asked for.
+
+## Seam Choice
+
+`test_completeness_pinning_deadlock.py` rather than `test_pinning_conservation.py`: this defect is the deadlock class (a demanded change being refused), not the conservation class (content lost through a merge). The file already replays #2555's deadlock end to end against real producers, and the new section follows its conventions — module-level fixtures, a `_io_complaint()` helper that asserts the fixture still trips the check, and no hand-written message strings.
+
+## Regression Risk
+
+One f-string in one check. The message is consumed by `named_tokens` (now matches, previously did not), by the halt text, and by prompt-failure telemetry, where it changes the recorded fingerprint for this check — a deliberate consequence of a reworded message, and the same thing that happens on any message change under #2074's fingerprint contract. The full unit suite confirms nothing else moved.

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -169,24 +169,30 @@ class TestAddressableToday:
         )
         assert verdict.verdict == ADDRESSED
 
+    def test_functions_have_io_examples_addresses_a_parameterised_function(
+        self,
+    ):
+        """#2590, repaired. The message backticked `name()`, and a function
+        taking parameters never contains that literal -- so the identical
+        complaint addressed the draft only when the arg list happened to be
+        empty, and the common case was the broken one.
+
+        The fixture is unchanged from when this test lived in
+        TestUnaddressableToday; only the expected verdict moved. The bare
+        name is what a `def` line actually contains."""
+        verdict = _classify(
+            vc.check_functions_have_io_examples(FUNCTION_WITH_PARAMS),
+            FUNCTION_WITH_PARAMS,
+        )
+        assert verdict.tokens == ("compute_needle_angle",)
+        assert verdict.matched_lines != ()
+        assert verdict.verdict == ADDRESSED
+
 
 class TestUnaddressableToday:
     """The deadlock class, pinned. Each test asserts the CURRENT broken state
     against its filed issue. Repairing one flips its test, which is the
     signal to move it into TestAddressableToday."""
-
-    def test_functions_have_io_examples_loses_the_address_on_parameters(self):
-        """#2590. The message backticks `name()`; a function taking
-        parameters never contains the literal `name()`, so the identical
-        message addresses the draft only when the arg list happens to be
-        empty. The common case is the broken one."""
-        verdict = _classify(
-            vc.check_functions_have_io_examples(FUNCTION_WITH_PARAMS),
-            FUNCTION_WITH_PARAMS,
-        )
-        assert verdict.tokens == ("compute_needle_angle()",)
-        assert verdict.matched_lines == ()
-        assert verdict.verdict == UNADDRESSABLE
 
     def test_modify_files_have_excerpts_names_a_path_not_in_the_draft(self):
         """#2591. The complaint backticks a file path that is absent from the

--- a/tests/unit/test_completeness_pinning_deadlock.py
+++ b/tests/unit/test_completeness_pinning_deadlock.py
@@ -31,6 +31,7 @@ from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
 )
 from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
     check_api_symbols_exist,
+    check_functions_have_io_examples,
     validate_completeness,
 )
 from assemblyzero.workflows.implementation_spec.revision_pinning import (
@@ -318,3 +319,162 @@ class TestTheHaltNamesEnforcement:
         message = out["error_message"]
         assert "reached the check unchanged" in message
         assert "pinning enforcement reverted" not in message
+
+
+# ---------------------------------------------------------------------------
+# The same class on a check that fires on ordinary specs (#2590)
+# ---------------------------------------------------------------------------
+#
+# The fence complaint above addressed its target in a scheme no token could
+# read. This one addressed it in a scheme that PARSES and matches nothing:
+# `check_functions_have_io_examples` backticked the name with a `()` suffix,
+# and `def compute_needle_angle(value, redline):` never contains the literal
+# `compute_needle_angle()`. Two drafts differing solely in the parameter list
+# drew a byte-identical complaint, one addressable and one not, and the
+# broken case is the ordinary one -- most functions take arguments.
+#
+# Registry class 3, standard 0029: the demanded change is never refusable.
+
+#: The issue's measured table, verbatim. These two differ ONLY in the
+#: parameter list, which is the whole point: the message is byte-identical
+#: and the old token addressed one and not the other.
+IO_DRAFT_WITH_PARAMS = """# Spec
+
+## Section 6
+
+def compute_needle_angle(value, redline):
+    pass
+"""
+
+IO_DRAFT_ZERO_ARG = """# Spec
+
+## Section 6
+
+def compute_needle_angle():
+    pass
+"""
+
+#: Two functions, so the inverse direction has an UNNAMED sibling to protect.
+IO_DRAFT_TWO_FUNCS = """# Spec
+
+## Section 6 Signatures
+
+```python
+def compute_needle_angle(value, redline):
+    pass
+
+
+def render_gauge(surface, values):
+    pass
+```
+"""
+
+
+def _io_complaint(draft: str) -> str:
+    """The real check's real message. Never a hand-written string: a reword
+    that drops the address must fail these tests, and it cannot if the test
+    supplies the text itself."""
+    result = check_functions_have_io_examples(draft)
+    assert result["passed"] is False, "fixture no longer trips the check"
+    return result["details"]
+
+
+def _with_example(draft: str) -> str:
+    """The fix the complaint demands, in the shape that used to be reverted.
+
+    Verified 2026-08-28: `enforce_pinning` passes INSERTIONS through by
+    design, so a fixture that merely adds a line above `pass` would have
+    survived before the repair and proved nothing. Replacing `pass` is both
+    the natural way to give a stub an example and the shape enforcement
+    actually refused.
+    """
+    return draft.replace(
+        "def compute_needle_angle(value, redline):\n    pass\n",
+        "def compute_needle_angle(value, redline):\n"
+        "    # example: compute_needle_angle(75, 60) -> 42.0\n"
+        "    return 42.0\n",
+    )
+
+
+class TestTheIoComplaintAddressesItsTarget:
+    """The issue's table, both directions, against the real producer."""
+
+    def test_the_parameterised_function_is_addressed(self):
+        """#2590's broken case. The token must occur in the draft, not
+        merely parse."""
+        tokens = named_tokens("", [_io_complaint(IO_DRAFT_WITH_PARAMS)])
+        assert "compute_needle_angle" in tokens
+        flags = named_line_flags(IO_DRAFT_WITH_PARAMS, tokens)
+        assert any(flags), (
+            "the complaint names a function the draft defines and still "
+            "addresses no line of it"
+        )
+
+    def test_the_zero_arg_function_stays_addressed(self):
+        """The case that worked by accident must keep working on purpose."""
+        tokens = named_tokens("", [_io_complaint(IO_DRAFT_ZERO_ARG)])
+        assert any(named_line_flags(IO_DRAFT_ZERO_ARG, tokens))
+
+    def test_both_drafts_draw_the_same_token(self):
+        """The messages differ only where the drafts do. If a future reword
+        makes addressability depend on the parameter list again, this is
+        the assertion that says so."""
+        with_params = named_tokens("", [_io_complaint(IO_DRAFT_WITH_PARAMS)])
+        zero_arg = named_tokens("", [_io_complaint(IO_DRAFT_ZERO_ARG)])
+        assert with_params == zero_arg == {"compute_needle_angle"}
+
+    def test_the_span_carries_no_call_parens(self):
+        """The specific regression guard. `name()` parses as a token and
+        occurs only in a zero-arg def, which is how this defect worked."""
+        details = _io_complaint(IO_DRAFT_WITH_PARAMS)
+        assert "`compute_needle_angle`" in details
+        assert "`compute_needle_angle()`" not in details
+
+
+class TestTheIoDeadlockIsBroken:
+    """Acceptance, both directions -- the class-3 end-to-end property."""
+
+    def test_the_demanded_example_survives_pinning_in_the_same_round(self):
+        details = _io_complaint(IO_DRAFT_WITH_PARAMS)
+        tokens = named_tokens("", [details])
+        revised = _with_example(IO_DRAFT_WITH_PARAMS)
+        assert revised != IO_DRAFT_WITH_PARAMS
+
+        result = enforce_pinning(
+            IO_DRAFT_WITH_PARAMS,
+            revised,
+            current_tokens=tokens,
+            ever_tokens=tokens,
+            current_ranges=named_line_ranges([details]),
+        )
+        assert result.refusals == (), (
+            "the change the completeness failure explicitly demands must "
+            "never be revertible by pinning in the same round"
+        )
+        assert result.regressions == ()
+        assert "example:" in result.text, "the demanded example was reverted"
+
+    def test_an_unnamed_sibling_function_is_still_locked(self):
+        """The inverse. Naming a function frees ITS block, not the fence.
+
+        Inside a fence `_blocks` splits per def, so this is where scoping is
+        testable at all -- outside one, the unit is the whole markdown
+        section and both functions share a block by design.
+        """
+        only_one = {"compute_needle_angle"}
+        revised = _with_example(IO_DRAFT_TWO_FUNCS).replace(
+            "def render_gauge(surface, values):\n    pass\n",
+            "def render_gauge(surface, values):\n    return None\n",
+        )
+        result = enforce_pinning(
+            IO_DRAFT_TWO_FUNCS,
+            revised,
+            current_tokens=only_one,
+            ever_tokens=only_one,
+        )
+        assert "example:" in result.text, "the named function's fix was lost"
+        assert "return None" not in result.text, (
+            "meddling with an unnamed function survived -- the bare-name "
+            "token unlocked more than the block it names"
+        )
+        assert result.refusals


### PR DESCRIPTION
`check_functions_have_io_examples` backticked the function name with a `()` suffix. `named_tokens` parses what sits inside backticks **verbatim**, so `compute_needle_angle()` — parens included — occurs in a draft only when the function happens to take no arguments. Two drafts differing solely in the parameter list drew a byte-identical complaint, one addressable and one not, and the broken case is the ordinary one.

Registry class 3 — the demanded change is never refusable (`docs/standards/0029-defect-class-registry.md`).

## The fix

```python
- func_list = ", ".join(f"`{f}()`" for f in missing_examples[:5])
+ func_list = ", ".join(f"`{f}`" for f in missing_examples[:5])
```

The bare name appears verbatim in every `def` line. **Parens dropped rather than a second span added** — the sentence already says "Functions", and a second `` `name()` `` span would parse as a token matching nothing. **Loosening `named_tokens` to strip trailing parens was rejected**: that vocabulary is shared by every complaint, and a looser token matches more than it should.

## Verified before the code, three ways

**The table reproduces exactly** against the real check and real `named_tokens`.

**The diagnosis was sharpened, not refuted** — [posted to the issue](https://github.com/martymcenroe/AssemblyZero/issues/2590#issuecomment-5453523452) before anything changed. "The drafter adds the example and pinning reverts it" holds for **replacement**-shaped revisions only; `enforce_pinning` passes insertions through by design:

| revision shape | refusals (pre-fix) | example survived |
|---|---|---|
| insert a comment above `pass` | 0 | yes |
| replace `pass` with example + `return` | 1 | **no** |
| replace `pass` with docstring + `return` | 1 | **no** |
| prose example above the `def` | 0 | yes |

Still the ordinary case — replacing `pass` is the natural way to give a stub an example — but a fixture built on the insertion shape **would have passed before this repair and proved nothing**. The fixture uses the replacement shape for exactly that reason.

**The `()` suffix was not shared.** Checked before touching anything, per the cross-read instruction: line 911 was the only paren-suffixed backtick span in the package; every other site formats `` `{x}` `` bare. The reword is local, so **#2591–#2594 are unaffected** and there is nothing to note on a sibling.

## It does not over-unlock

`_blocks` splits per `def` only **inside fences**, so the fenced shape is where scoping is testable at all:

| tokens | named lines | demanded fix | sibling meddled in the same round |
|---|---|---|---|
| `compute_needle_angle()` (before) | none | refused, example lost | reverted |
| `compute_needle_angle` (after) | 6–9, that block only | **0 refusals, survives** | **still reverted** |

## The #2540 ruling, honoured

Ratified 2026-08-28: proxies advise, facts gate. `functions_have_io_examples` is a **fact-verifier** — an example exists or it does not — so it stays a hard gate. This changes its addressability, not its authority. Nothing demoted.

## Tests

Six new fixtures beside the #2558/#2562 deadlock tests, following that file's conventions — real producers, no hand-written message strings, so a reword that drops the address fails the suite.

**Proved non-tautological:** with the production line temporarily reverted, **4 of the 6 go red**, including the end-to-end `test_the_demanded_example_survives_pinning_in_the_same_round`. The 2 that stay green are correct — the zero-arg case is the "must not regress" direction, and the scoping guard drives enforcement with explicit tokens rather than the message.

The sweep's own pin moves from `TestUnaddressableToday` into `TestAddressableToday`, **with `FUNCTION_WITH_PARAMS` unchanged** — only the expected verdict moved, which is what the acceptance asked for.

Full unit suite green at **8949 passed**. `ruff` clean on both touched test files. `docs/audits/0905` corrected where this fix falsifies it.

Closes #2590
