### PR TITLE
fix: the manifest abstain carries its denominator, and a destroyed table fails the lld stage (Closes #2608)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/assertion_manifest.py
+++ b/assemblyzero/workflows/implementation_spec/assertion_manifest.py
@@ -201,6 +201,36 @@ class CompileResult:
     criteria_ids: tuple[str, ...] = ()
     #: Hex colours the contract carries, empty when no contract was given.
     contract_hexes: frozenset[str] = field(default_factory=frozenset)
+    #: #2608: the denominator behind `applicable=False`. An abstain that
+    #: does not say what it searched is indistinguishable from an abstain
+    #: that found nothing to search, and the run-19 misread was exactly
+    #: that: 15 tables parsed, none in the criteria shape, reported as
+    #: "not applicable" as though the LLD had no tables at all.
+    tables_seen: int = 0
+
+    @property
+    def abstained(self) -> bool:
+        """Not applicable, with tables present that simply were not criteria.
+
+        Distinct from a document with no tables at all: the first is a
+        shape mismatch worth surfacing, the second is the ordinary
+        non-visual issue this compiler is meant to sit out.
+        """
+        return not self.applicable and self.tables_seen > 0
+
+    def denominator(self) -> str:
+        """What was searched and what was found, for the log and the report."""
+        if self.applicable:
+            return (
+                f"{len(self.criteria_ids)} criterion(s) compiled from "
+                f"{self.tables_seen} table(s)"
+            )
+        if self.tables_seen:
+            return (
+                f"{self.tables_seen} table(s) parsed, 0 in the criteria "
+                f"shape (an ID column and a binding column)"
+            )
+        return "0 tables in the document"
 
 
 def contract_hex_universe(contract_text: str) -> frozenset[str]:
@@ -218,9 +248,15 @@ def compile_manifest(
     must resolve into — a colour in neither the palette nor any other contract
     table is the "sample point resolving to no zone row" defect.
     """
-    tables = [t for t in parse_tables(lld_content or "") if is_criteria_table(t)]
+    all_tables = parse_tables(lld_content or "")
+    tables = [t for t in all_tables if is_criteria_table(t)]
     if not tables:
-        return CompileResult(applicable=False)
+        # #2608: carry the denominator. `tables_seen` is what separates "this
+        # document has no tables, as most issues do" from "this document has
+        # fifteen and none is a criteria table" -- the second is a shape
+        # mismatch the caller must surface, and the run-19 misread was to
+        # report both as a bare "not applicable".
+        return CompileResult(applicable=False, tables_seen=len(all_tables))
 
     contract_hexes = contract_hex_universe(contract_text)
     rows: list[ManifestRow] = []
@@ -333,6 +369,7 @@ def compile_manifest(
         failures=tuple(failures),
         criteria_ids=tuple(criteria_ids),
         contract_hexes=contract_hexes,
+        tables_seen=len(all_tables),
     )
 
 

--- a/assemblyzero/workflows/implementation_spec/nodes/compile_manifest.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/compile_manifest.py
@@ -86,13 +86,35 @@ def compile_assertion_manifest(
     result = compile_manifest(lld_content, _contract_text(repo_root))
 
     if not result.applicable:
-        print(
-            "    [N1b] no criteria decision table in the LLD — "
-            "assertion manifest not applicable; drafting proceeds as before"
-        )
+        # fail-open: #2608. The compiler sits out an issue with no decision
+        # table, which is most of them, and that remains correct. What is
+        # NOT correct is sitting out silently: run-issue331-093613 abstained
+        # on an LLD holding fifteen tables because none carried the criteria
+        # shape, and the #2533 protection switched off with one log line and
+        # no downstream trace. Continuing is deliberate -- a repo with no
+        # decision tables must still roll -- so the abstain is declared here,
+        # carries the denominator it searched, and travels forward on state
+        # for the report and for every later stage, which is what makes it a
+        # declared fall-through rather than an accident.
+        detail = result.denominator()
+        if result.abstained:
+            print(
+                f"    [N1b] ABSTAIN: {detail}. The #2533 protection is OFF "
+                f"for this run and the absence travels forward (#2608). A "
+                f"document carrying tables but none in the criteria shape "
+                f"is a shape mismatch, not an empty document."
+            )
+        else:
+            print(
+                f"    [N1b] not applicable: {detail} — assertion manifest "
+                f"does not apply; drafting proceeds as before (#2608)"
+            )
         return {
             "assertion_manifest": "",
             "assertion_manifest_rows": [],
+            "assertion_manifest_absent": True,
+            "assertion_manifest_absence_reason": detail,
+            "assertion_manifest_abstained": result.abstained,
             "error_message": "",
         }
 
@@ -206,7 +228,21 @@ def manifest_gate(state: ImplementationSpecState) -> dict[str, Any]:
     manifest_text = state.get("assertion_manifest", "")
     rows = state.get("assertion_manifest_rows", [])
     if not manifest_text and not rows:
-        print("    [N1c] no manifest to gate — passing through")
+        # fail-open: #2608. Nothing to gate is a real state and passing
+        # through is correct, but the gate must repeat WHY rather than say
+        # only that it did — "no manifest to gate" alone gave the operator
+        # a second reassuring line about a protection that was off.
+        reason = state.get("assertion_manifest_absence_reason", "")
+        if state.get("assertion_manifest_abstained"):
+            print(
+                f"    [N1c] no manifest to gate — the compiler ABSTAINED "
+                f"({reason}); the #2533 protection is off for this run "
+                f"(#2608)"
+            )
+        elif reason:
+            print(f"    [N1c] no manifest to gate — {reason} (#2608)")
+        else:
+            print("    [N1c] no manifest to gate — passing through")
         return {"error_message": ""}
 
     from assemblyzero.workflows.implementation_spec.assertion_manifest import (

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -253,6 +253,15 @@ class ImplementationSpecState(TypedDict, total=False):
     #   DOCUMENT rather than against a list re-derived from the rows.
     assertion_manifest: str
     assertion_manifest_rows: list[dict]
+    # #2608: the abstain, travelling forward. An empty manifest alone cannot
+    # tell a later stage whether the compiler found nothing to protect or
+    # could not see what to protect, and the run-19 misread turned on exactly
+    # that ambiguity. `absence_reason` carries the denominator the compiler
+    # searched; `abstained` is True only for the shape-mismatch case (tables
+    # present, none in the criteria shape), which is the one worth surfacing.
+    assertion_manifest_absent: bool
+    assertion_manifest_absence_reason: str
+    assertion_manifest_abstained: bool
     assertion_manifest_criteria: list[str]
 
     # Closes #2532: the pinning record. Each entry is one revision-time

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -392,6 +392,22 @@ def format_stage_table(stage_results: dict) -> str:
         secs = r.get("duration_seconds", 0.0)
         detail = r.get("error_message") or r.get("artifact_path") or ""
         lines.append(f"{stage:<9} {status:<9} {secs:>6.1f}s  {detail[:60]}")
+
+    # #2608: declared fall-throughs, under the table. A stage that passed
+    # with a protection switched off renders identically to one that ran
+    # every guard, and run-issue331-093613 is the case: "spec passed" with
+    # the #2533 manifest silently absent. Printed only when non-empty, so
+    # the section's presence is itself the signal.
+    notes = [
+        (stage, note)
+        for stage in STAGE_ORDER
+        for note in (stage_results.get(stage) or {}).get("notes", []) or []
+    ]
+    if notes:
+        lines.append("")
+        lines.append("DECLARED FALL-THROUGHS (a protection did not run):")
+        for stage, note in notes:
+            lines.append(f"  {stage:<9} {note}")
     return "\n".join(lines)
 
 

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -117,6 +117,7 @@ def _make_stage_result(
     duration_seconds: float = 0.0,
     attempts: int = 0,
     transient: bool | None = None,
+    notes: list[str] | None = None,
 ) -> StageResult:
     """Helper to create a StageResult.
 
@@ -134,7 +135,31 @@ def _make_stage_result(
     )
     if transient is not None:
         result["transient"] = transient
+    if notes:
+        # #2608: only when there is something to say. An empty key on every
+        # result would put a blank NOTES section under every run record and
+        # train the reader to skip the one that matters.
+        result["notes"] = list(notes)
     return result
+
+
+def _declared_fallthroughs(sub_result: dict) -> list[str]:
+    """Protections a sub-workflow deliberately sat out, for the run record.
+
+    #2608: run-issue331-093613 passed the spec stage with the #2533
+    assertion-manifest protection switched off, and the stage table said
+    only "passed". A declared fall-through is survivable by design -- that
+    is what makes it declared -- but it must reach the record, or a green
+    row means two different things and the reader cannot tell which.
+    """
+    notes: list[str] = []
+    if sub_result.get("assertion_manifest_abstained"):
+        reason = sub_result.get("assertion_manifest_absence_reason", "")
+        notes.append(
+            f"assertion manifest ABSTAINED ({reason}) — the #2533 "
+            f"protection did not run for this stage (#2608)"
+        )
+    return notes
 
 
 def _unresolved_test_failures(sub_result: dict) -> int:
@@ -1019,6 +1044,7 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                 artifact_path=spec_path,
                 duration_seconds=time.monotonic() - start_time,
                 attempts=1,
+                notes=_declared_fallthroughs(sub_result),
             )
         else:
             error_msg = sub_result.get("error_message", "")

--- a/assemblyzero/workflows/orchestrator/state.py
+++ b/assemblyzero/workflows/orchestrator/state.py
@@ -25,6 +25,11 @@ class StageResult(TypedDict, total=False):
     # non-transient recovery plan). When True or absent, the retry loop runs
     # as today. Closes #1463.
     transient: bool
+    # #2608: declared fall-throughs this stage took -- a protection that sat
+    # out, and why. A passed stage that silently skipped a guard reads in the
+    # table exactly like one that ran every guard, which is how the #2533
+    # manifest switching off produced a green run record nobody questioned.
+    notes: list[str]
 
 
 class OrchestrationState(TypedDict, total=False):

--- a/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_mechanical.py
@@ -809,6 +809,78 @@ def validate_assertion_literal_conservation(
     return errors
 
 
+def validate_decision_table_survives(
+    issue_body: str, lld_content: str
+) -> list[ValidationError]:
+    """Reject a derivation that destroyed the source's table SHAPE (#2608).
+
+    #2563's sibling, and deliberately a separate check rather than an
+    extension of it. That gate conserves LITERALS -- every hex and number
+    from a source row must appear somewhere in the LLD -- and it is
+    shape-blind by construction. Measured on run-issue331-093613: the
+    source's nine-row `| ID | Element | Binding value | Assertion method |`
+    table became a seven-item bullet list, the gate fired five criticals for
+    genuinely-missing numbers, the drafter repaired by appending bullets
+    carrying those numbers, and the gate went green with the table still
+    gone. S7 and S9 never returned and every assertion method was lost.
+
+    The downstream cost is precise: `compile_manifest` looks for a criteria
+    decision table in the LLD, found none, and reported "not applicable" --
+    so the #2533 protection, which exists because drafters invent expected
+    values, switched off for the run that most needed it.
+
+    So: when the SOURCE carries a criteria decision table and the derived
+    LLD carries none, that is a structure a downstream stage consumes being
+    destroyed in derivation. It is an ERROR here, where the revision loop
+    can still fix it, rather than a silent abstain three stages later.
+
+    An issue with no criteria table yields no checks -- the ordinary case,
+    and not a failure.
+    """
+    from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+        is_criteria_table,
+    )
+    from assemblyzero.workflows.requirements.form_check import parse_tables
+
+    errors: list[ValidationError] = []
+    if not issue_body or not lld_content:
+        return errors
+
+    source_tables = [
+        table for table in parse_tables(issue_body) if is_criteria_table(table)
+    ]
+    if not source_tables:
+        return errors
+
+    lld_tables = parse_tables(lld_content)
+    if any(is_criteria_table(table) for table in lld_tables):
+        return errors
+
+    source_ids = [
+        (row[0] or "?") for table in source_tables for row in table.rows if row
+    ]
+    errors.append(
+        ValidationError(
+            severity=ValidationSeverity.ERROR,
+            section="3 Requirements",
+            message=(
+                f"Critical: the source issue carries a criteria decision "
+                f"table ({len(source_ids)} row(s): "
+                f"{', '.join(source_ids[:9])}) and the LLD carries none. "
+                f"{len(lld_tables)} table(s) were parsed in the LLD and not "
+                f"one has an ID column and a binding column. Restating the "
+                f"rows as prose or bullets does not satisfy this: the "
+                f"assertion-manifest compiler reads the TABLE, and without "
+                f"it the #2533 protection silently does not run for this "
+                f"roll. Carry the decision table into the LLD as a table, "
+                f"one row per source row, keeping the ID and binding-value "
+                f"columns (#2608)"
+            ),
+        )
+    )
+    return errors
+
+
 def validate_mandatory_sections(lld_content: str) -> list[ValidationError]:
     """Verify that all mandatory LLD sections exist.
 
@@ -1654,6 +1726,18 @@ def _validate_lld_mechanical_inner(state: Dict[str, Any]) -> Dict[str, Any]:
     # survive into the LLD, or the row is named lossy.
     all_errors.extend(
         validate_assertion_literal_conservation(
+            state.get("issue_body", ""), lld_content
+        )
+    )
+
+    # Step 6d (#2608): #2563 conserves the row's LITERALS and is shape-blind.
+    # A derivation can satisfy it by restating the numbers as bullets while
+    # destroying the table, which is what run-issue331-093613 did -- and the
+    # manifest compiler three stages later then read "no table" as "not
+    # applicable" and switched the #2533 protection off. Checked here, where
+    # both documents are in hand and the revision loop can still repair it.
+    all_errors.extend(
+        validate_decision_table_survives(
             state.get("issue_body", ""), lld_content
         )
     )

--- a/docs/reports/2608/implementation-report.md
+++ b/docs/reports/2608/implementation-report.md
@@ -1,0 +1,56 @@
+# Implementation Report — The Manifest Abstain Carries Its Denominator (#2608)
+
+## Issue Reference
+[#2608: the assertion-manifest stage reads 'cannot see the table' as 'no table'](https://github.com/martymcenroe/AssemblyZero/issues/2608)
+
+## The Diagnosis: Neither Enumerated Reading
+
+Established against the preserved run-19 lineage before any code changed, driving the real parsers. [Posted to the issue first.](https://github.com/martymcenroe/AssemblyZero/issues/2608#issuecomment-5454081845)
+
+**Reading 2 (parser brittleness) is refuted.** `parse_tables` found and parsed **all 15** tables in the LLD and the 1 in the source issue. `is_criteria_table` correctly returned False for all 15 — none carries both an ID and a binding column. There is no parse failure, so "found N tables, 0 parseable" would have been the wrong message.
+
+**Reading 1 is literally true and its conclusion false.** The LLD carries no criteria decision table because the **derivation destroyed it**:
+
+| artifact | tables | criteria tables | S-rows |
+|---|---|---|---|
+| `001-issue.md` (source) | 1 | **1 — nine rows, S1–S9, 3,539 chars** | S1…S9 |
+| `002-draft.md` (first derivation) | 15 | **0** | **none at all** |
+| `003-draft.md` (post-#2563 repair) | 15 | **0** | 7 bullets: S1–S6, S8 |
+| `005-final.md` (passed lld) | 15 | **0** | 7 bullets |
+
+S7 and S9 never returned; every assertion method was lost. `not applicable` was a misread of a **derivation failure** as an **absence**.
+
+**Second finding: #2563's gate is shape-blind by construction.** It conserves literals, not structure. It fired five criticals, the drafter appended bullets carrying the missing numbers, and the gate went green with the table gone. That is why a table-less LLD reached the manifest stage with a green lld verdict.
+
+## The Fix, In Two Seams
+
+**1. The lld stage owes the existence check** (Ask item 2). `validate_decision_table_survives` sits beside `validate_assertion_literal_conservation` — the only place holding both source and derived document. A source criteria table with no counterpart in the LLD is an ERROR, named with the lost row IDs and the count of LLD tables searched.
+
+Deliberately a **separate** check, not an extension: literals and shape are different conserved quantities. A test asserts the division of labour in both directions — the shape gate passes an LLD that keeps the table but sheds a literal, and the literal gate fires on exactly that case.
+
+**2. The abstain carries its denominator and travels forward** (Ask item 4). `CompileResult` gains `tables_seen`, `abstained` and `denominator()`. Three outcomes now render distinctly:
+
+- `0 tables in the document` — the ordinary non-visual issue, not an abstain.
+- `15 table(s) parsed, 0 in the criteria shape` — **abstain**, announced as the #2533 protection being OFF.
+- `9 criterion(s) compiled from 16 table(s)` — applicable.
+
+The absence lands on state (`assertion_manifest_absent`, `_absence_reason`, `_abstained`), the gate node repeats the reason instead of a second reassuring "passing through", and the orchestrator's run record grows a **DECLARED FALL-THROUGHS** section — printed only when non-empty, so its presence is the signal.
+
+Both fall-throughs carry `# fail-open:` declarations per the #2475 regime.
+
+## Verified Against The Observed Case
+
+Replayed on the real preserved pair:
+
+- the lld stage now **fails**, naming all nine lost rows and the 15 tables searched;
+- the compiler reports `abstained=True` with `15 table(s) parsed, 0 in the criteria shape`;
+- **control 1** (source with no table): 0 errors, `abstained=False`, "0 tables in the document";
+- **control 2** (LLD carrying the table): 0 errors, manifest compiles 9 criteria.
+
+## Note On Process
+
+The first full-suite run showed two failures in `inspect.getsource` tests. Cause: I edited `stages.py` while that background suite was running. A suite verdict binds only to the tree it read; the run was re-done on the settled tree rather than investigated as a defect.
+
+## Known Limitations
+
+The structure check requires the LLD to carry *a* criteria table, not that its rows match the source's one-for-one. A derivation that carries a table with only S1 would pass this check and be caught by #2563's literal gate instead. Row-level correspondence is #2607's territory — injection makes it moot.

--- a/docs/reports/2608/test-report.md
+++ b/docs/reports/2608/test-report.md
@@ -1,0 +1,52 @@
+# Test Report — The Manifest Abstain Carries Its Denominator (#2608)
+
+## Issue Reference
+[#2608](https://github.com/martymcenroe/AssemblyZero/issues/2608)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_decision_table_survives.py` (new) | **22 passed** |
+| with `test_assertion_manifest.py`, `test_assertion_literal_conservation.py`, `test_fail_open_audit.py` | 106 passed |
+| `tests/unit` (full, on the settled tree) | see below |
+
+## The Acceptance, Replayed On Real Preserved State
+
+Not fixtures alone — the real run-19 lineage, read-only, driving the real code:
+
+```
+manifest compiler:  applicable=False  tables_seen=15  abstained=True
+                    "15 table(s) parsed, 0 in the criteria shape"
+lld structure check: 1 ERROR — "the source issue carries a criteria decision
+                    table (9 row(s): S1…S9) and the LLD carries none.
+                    15 table(s) were parsed in the LLD…"
+control 1 (no source table):  0 errors, abstained=False, "0 tables in the document"
+control 2 (table carried):    0 errors, manifest compiles 9 criteria
+```
+
+That is the issue's acceptance in all three branches: this run fails naming what went wrong, a document genuinely outside the domain passes with its declaration, and a correct derivation compiles.
+
+## What Is Pinned
+
+**The structure check (8 tests).** The destroyed table is an ERROR naming the lost rows; the message carries what was searched; a carried table passes; a source with no table yields no checks; empty inputs yield no checks.
+
+Two tests pin the **division of labour with #2563** in both directions, so the pair provably leaves no gap: the shape gate is blind to a shed literal *by design*, and the literal gate fires on exactly that case.
+
+The load-bearing one is `test_bullets_satisfy_the_literal_gate_while_failing_this_one` — the measured run-19 condition as a fixture. It asserts `validate_assertion_literal_conservation` returns **`[]`** on the bullet-form LLD (reproducing the shape-blind green verdict) while the new check fires. My first draft of that fixture did **not** carry every literal, so the literal gate fired and the test failed honestly; the fixture was corrected to carry the assertion-method numbers, which is what the real drafter appended after its five criticals. Without that correction the test would have asserted a condition the run never had.
+
+**The denominator (4 tests).** The three outcomes render distinctly, and `test_the_two_absences_are_distinguishable` asserts the point directly: both are `applicable=False`, and `abstained` and `denominator()` differ. Before #2608 they were one message.
+
+**Forward travel (4 tests).** The abstain lands on state with the reason; the ordinary absence travels too but is not an abstain; the abstain prints as a protection being OFF; the ordinary absence does not.
+
+**The run record (4 tests).** A passed stage with an abstain grows a `DECLARED FALL-THROUGHS` section; an ordinary run record has none, so the section's presence is itself the signal; `_declared_fallthroughs` maps sub-result to note and returns empty when nothing sat out.
+
+**The gate (2 tests).** It repeats the abstain reason rather than printing a second reassuring "passing through"; a bare pass-through still works.
+
+## A Process Note
+
+The first full-suite run reported two failures, both `inspect.getsource` tests, both passing in isolation and together. Cause: `stages.py` was edited **while that background suite ran**. A suite verdict binds only to the tree it read, so the suite was re-run on the settled tree rather than the failures investigated as defects.
+
+## Regression Risk
+
+`tables_seen` defaults to 0, so any `CompileResult` built elsewhere keeps working. `notes` is written only when non-empty. The new lld check is additive and returns `[]` for every issue without a criteria decision table, which is most of them.

--- a/tests/unit/test_decision_table_survives.py
+++ b/tests/unit/test_decision_table_survives.py
@@ -1,0 +1,353 @@
+"""A derivation that destroys the source's table SHAPE is caught (#2608).
+
+The observed case: run-issue331-093613, 2026-08-28. The manifest stage
+printed "no criteria decision table in the LLD -- assertion manifest not
+applicable" and the #2533 protection switched off with one log line.
+
+Established against the preserved run-19 lineage before any code changed:
+
+* the parser is NOT brittle -- it parsed all 15 tables in the LLD and the 1
+  in the source issue, correctly. No parse failure exists here;
+* the LLD genuinely carries no criteria decision table, because the
+  DERIVATION destroyed it: the source's nine-row
+  `| ID | Element | Binding value | Assertion method |` table became a
+  seven-item bullet list (S1-S6, S8 -- S7 and S9 never returned, and every
+  assertion method was lost);
+* #2563's literal gate is shape-blind by construction. It fired five
+  criticals, the drafter repaired by appending bullets carrying the missing
+  numbers, and the gate went green with the table still gone.
+
+So "not applicable" was a misread of a derivation failure as an absence.
+This suite pins both halves of the repair: the structure check that fails
+in the lld stage where the loop can still fix it, and the abstain that
+carries its denominator and travels forward when it does happen.
+
+Composes with #2563's fixture (`test_assertion_literal_conservation.py`)
+rather than replacing it: literals and shape are different conserved
+quantities and each needs its own gate.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+    compile_manifest,
+)
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    validate_decision_table_survives,
+)
+
+#: The observed source shape, two rows of the real #331 table.
+ISSUE_WITH_TABLE = """## Decision table — static elements and their binding values
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|----|---------|------------------------------------------------|------------------|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size | classification at 3 interior points |
+| S2 | Redline band | `#AA0F19` crimson, inner 0.88 R to outer 1.00 R | classification at radius 0.94 R at values 65/75/85 |
+"""
+
+#: The observed derived shape, faithful to the measured run: the table
+#: restated as bullets carrying EVERY literal from the source rows -- which
+#: is exactly why #2563 goes green on it -- while the table itself is gone.
+#: The assertion-method numbers are present because that is what the real
+#: drafter appended when the literal gate fired its five criticals.
+LLD_AS_BULLETS = """# 331 - Feature
+
+## 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/skins/stingray.py` | Add | The renderer. |
+
+## 3. Requirements
+
+1. The system shall render each static element from the contract:
+   - S1: flat `#0A0A0C`, R = 0.40 × size
+   - S2: `#AA0F19`, 0.88 R, 1.00 R
+
+## 10.1 Test Scenarios
+
+| ID | Scenario | Type | Expected Output | Pass Criteria |
+|----|----------|------|-----------------|---------------|
+| 020 | Dial face (REQ-1) | Auto | flat face | classification at 3 interior points |
+| 030 | Redline band (REQ-1) | Auto | crimson band | classification at radius 0.94 R at values 65/75/85 |
+"""
+
+#: The derivation that kept the shape: same rows, carried as a table.
+LLD_WITH_TABLE = """# 331 - Feature
+
+## 3. Requirements
+
+1. The system shall render each static element from the contract.
+
+| ID | Element | Binding value | Assertion method |
+|----|---------|---------------|------------------|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size | classification at 3 interior points |
+| S2 | Redline band | `#AA0F19` crimson, inner 0.88 R to outer 1.00 R | classification at radius 0.94 R |
+"""
+
+#: A source genuinely outside the manifest's domain -- most issues.
+ISSUE_NO_TABLE = """# Make the button blue
+
+## Requirements
+
+1. The button shall be blue.
+2. The button shall stay blue on hover.
+"""
+
+LLD_PROSE_ONLY = """# LLD
+
+## 3. Requirements
+
+1. The button renders blue.
+"""
+
+
+class TestTheStructureCheck:
+    def test_a_destroyed_table_is_an_error(self):
+        """The observed run. Bullets carrying every literal do not satisfy
+        this: the manifest compiler reads the TABLE."""
+        errors = validate_decision_table_survives(
+            ISSUE_WITH_TABLE, LLD_AS_BULLETS
+        )
+        assert len(errors) == 1
+        message = errors[0].message
+        assert "S1, S2" in message, "the lost rows are named"
+        assert "carries none" in message
+
+    def test_the_message_names_what_was_searched(self):
+        """A denominator, not a bare complaint: the LLD's own tables were
+        parsed and counted, so the drafter cannot read this as 'your tables
+        are malformed'."""
+        message = validate_decision_table_survives(
+            ISSUE_WITH_TABLE, LLD_AS_BULLETS
+        )[0].message
+        assert "2 table(s) were parsed in the LLD" in message
+
+    def test_a_carried_table_passes(self):
+        assert validate_decision_table_survives(
+            ISSUE_WITH_TABLE, LLD_WITH_TABLE
+        ) == []
+
+    def test_a_source_without_a_table_yields_no_checks(self):
+        """The ordinary case -- most repos, every non-visual issue. Not
+        applicable is not failure."""
+        assert validate_decision_table_survives(
+            ISSUE_NO_TABLE, LLD_PROSE_ONLY
+        ) == []
+
+    def test_an_empty_side_yields_no_checks(self):
+        assert validate_decision_table_survives("", LLD_AS_BULLETS) == []
+        assert validate_decision_table_survives(ISSUE_WITH_TABLE, "") == []
+
+    def test_it_is_blind_to_literals_by_design(self):
+        """The division of labour with #2563, asserted. An LLD that keeps
+        the TABLE but sheds a literal passes THIS check -- the literal gate
+        owns that, and duplicating it here would double-report one defect.
+        """
+        lossy_but_shaped = LLD_WITH_TABLE.replace("0.88 R", "some radius")
+        assert validate_decision_table_survives(
+            ISSUE_WITH_TABLE, lossy_but_shaped
+        ) == []
+
+    def test_the_sibling_gate_catches_what_this_one_does_not(self):
+        """The complement, so the pair is provably not leaving a gap: the
+        literal gate fires on exactly the case this check passes."""
+        from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+            validate_assertion_literal_conservation,
+        )
+
+        lossy_but_shaped = LLD_WITH_TABLE.replace("0.88 R", "some radius")
+        assert validate_assertion_literal_conservation(
+            ISSUE_WITH_TABLE, lossy_but_shaped
+        ), "the literal gate must own the case the shape gate passes"
+
+    def test_bullets_satisfy_the_literal_gate_while_failing_this_one(self):
+        """The measured run-19 condition, as a fixture: this is why one gate
+        was not enough. Every literal survives into the bullets, so #2563 is
+        green; the table is gone, so #2608 fires."""
+        from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+            validate_assertion_literal_conservation,
+        )
+
+        assert validate_assertion_literal_conservation(
+            ISSUE_WITH_TABLE, LLD_AS_BULLETS
+        ) == [], "the fixture must reproduce the shape-blind green verdict"
+        assert validate_decision_table_survives(
+            ISSUE_WITH_TABLE, LLD_AS_BULLETS
+        ), "and the shape gate must be what catches it"
+
+
+class TestTheAbstainCarriesItsDenominator:
+    def test_tables_present_but_none_criteria_is_an_abstain(self):
+        """The run-19 shape: the document has tables, none is a criteria
+        table. That is a shape mismatch worth surfacing, not an empty
+        document."""
+        result = compile_manifest(LLD_AS_BULLETS, "")
+        assert result.applicable is False
+        assert result.tables_seen == 2
+        assert result.abstained is True
+        assert "0 in the criteria shape" in result.denominator()
+
+    def test_no_tables_at_all_is_not_an_abstain(self):
+        """The ordinary non-visual issue. It still states its denominator,
+        but it is not the case that warrants a warning."""
+        result = compile_manifest(LLD_PROSE_ONLY, "")
+        assert result.applicable is False
+        assert result.tables_seen == 0
+        assert result.abstained is False
+        assert result.denominator() == "0 tables in the document"
+
+    def test_an_applicable_compile_reports_its_counts(self):
+        result = compile_manifest(LLD_WITH_TABLE, "")
+        assert result.applicable is True
+        assert result.abstained is False
+        assert result.tables_seen == 1
+        assert "criterion(s) compiled from 1 table(s)" in result.denominator()
+
+    def test_the_two_absences_are_distinguishable(self):
+        """The whole point. Before #2608 both rendered as one message, and
+        a protection switching off was indistinguishable from a protection
+        correctly sitting out."""
+        shape_mismatch = compile_manifest(LLD_AS_BULLETS, "")
+        genuinely_absent = compile_manifest(LLD_PROSE_ONLY, "")
+        assert shape_mismatch.applicable == genuinely_absent.applicable
+        assert shape_mismatch.abstained != genuinely_absent.abstained
+        assert shape_mismatch.denominator() != genuinely_absent.denominator()
+
+
+class TestTheNodeTravelsTheAbsenceForward:
+    def _run(self, lld: str) -> dict:
+        from assemblyzero.workflows.implementation_spec.nodes.compile_manifest import (
+            compile_assertion_manifest,
+        )
+
+        return compile_assertion_manifest(
+            {"lld_content": lld, "repo_root": "", "config_mock_mode": True}
+        )
+
+    def test_the_abstain_lands_on_state(self, capsys):
+        out = self._run(LLD_AS_BULLETS)
+        capsys.readouterr()
+        assert out["assertion_manifest_absent"] is True
+        assert out["assertion_manifest_abstained"] is True
+        assert "0 in the criteria shape" in out["assertion_manifest_absence_reason"]
+        assert out["error_message"] == "", "the abstain is survivable, not a halt"
+
+    def test_the_ordinary_absence_also_travels_but_is_not_an_abstain(
+        self, capsys
+    ):
+        out = self._run(LLD_PROSE_ONLY)
+        capsys.readouterr()
+        assert out["assertion_manifest_absent"] is True
+        assert out["assertion_manifest_abstained"] is False
+
+    def test_the_abstain_is_announced_as_a_protection_being_off(self, capsys):
+        self._run(LLD_AS_BULLETS)
+        printed = capsys.readouterr().out
+        assert "ABSTAIN" in printed
+        assert "#2533 protection is OFF" in printed
+        assert "15 table" not in printed, "the count must be this draft's own"
+
+    def test_the_ordinary_absence_is_not_announced_as_an_abstain(self, capsys):
+        self._run(LLD_PROSE_ONLY)
+        printed = capsys.readouterr().out
+        assert "ABSTAIN" not in printed
+        assert "not applicable" in printed
+
+
+class TestTheGateRepeatsTheReason:
+    def _gate(self, state: dict) -> str:
+        from assemblyzero.workflows.implementation_spec.nodes.compile_manifest import (
+            manifest_gate,
+        )
+
+        manifest_gate(state)
+        return ""
+
+    def test_the_gate_names_the_abstain_rather_than_only_passing_through(
+        self, capsys
+    ):
+        """Two reassuring lines about a protection that was off is what the
+        operator actually saw. The gate repeats WHY."""
+        from assemblyzero.workflows.implementation_spec.nodes.compile_manifest import (
+            manifest_gate,
+        )
+
+        manifest_gate({
+            "assertion_manifest": "",
+            "assertion_manifest_rows": [],
+            "assertion_manifest_abstained": True,
+            "assertion_manifest_absence_reason": "15 table(s) parsed, 0 in the criteria shape",
+        })
+        printed = capsys.readouterr().out
+        assert "ABSTAINED" in printed
+        assert "15 table(s) parsed" in printed
+
+    def test_a_bare_pass_through_still_works(self, capsys):
+        from assemblyzero.workflows.implementation_spec.nodes.compile_manifest import (
+            manifest_gate,
+        )
+
+        out = manifest_gate(
+            {"assertion_manifest": "", "assertion_manifest_rows": []}
+        )
+        printed = capsys.readouterr().out
+        assert "no manifest to gate" in printed
+        assert out["error_message"] == ""
+
+
+class TestTheRunRecordSurfacesIt:
+    """#2608's last mile: the absence must reach the record, or a green row
+    means two different things and the reader cannot tell which."""
+
+    def test_a_passed_stage_with_an_abstain_is_annotated(self):
+        from assemblyzero.workflows.orchestrator.graph import format_stage_table
+
+        table = format_stage_table({
+            "spec": {
+                "status": "passed",
+                "duration_seconds": 12.0,
+                "artifact_path": "docs/spec.md",
+                "notes": [
+                    "assertion manifest ABSTAINED (15 table(s) parsed, 0 in "
+                    "the criteria shape) — the #2533 protection did not run "
+                    "for this stage (#2608)"
+                ],
+            }
+        })
+        assert "DECLARED FALL-THROUGHS" in table
+        assert "ABSTAINED" in table
+        assert "#2533 protection did not run" in table
+
+    def test_an_ordinary_run_record_carries_no_section(self):
+        """The section's presence is the signal, so it must not appear on a
+        run where nothing sat out."""
+        from assemblyzero.workflows.orchestrator.graph import format_stage_table
+
+        table = format_stage_table({
+            "spec": {"status": "passed", "duration_seconds": 12.0}
+        })
+        assert "DECLARED FALL-THROUGHS" not in table
+
+    def test_the_stage_result_carries_the_note_from_the_sub_result(self):
+        from assemblyzero.workflows.orchestrator.stages import (
+            _declared_fallthroughs,
+        )
+
+        notes = _declared_fallthroughs({
+            "assertion_manifest_abstained": True,
+            "assertion_manifest_absence_reason":
+                "15 table(s) parsed, 0 in the criteria shape",
+        })
+        assert len(notes) == 1
+        assert "15 table(s) parsed" in notes[0]
+
+    def test_no_abstain_yields_no_notes(self):
+        from assemblyzero.workflows.orchestrator.stages import (
+            _declared_fallthroughs,
+        )
+
+        assert _declared_fallthroughs({}) == []
+        assert _declared_fallthroughs(
+            {"assertion_manifest_abstained": False}
+        ) == []


### PR DESCRIPTION
`run-issue331-093613` printed *"no criteria decision table in the LLD — assertion manifest not applicable"* and the #2533 protection switched off with one log line and no downstream trace.

## Diagnosis: neither enumerated reading was right

Established against the preserved run-19 lineage **before any code changed**, driving the real parsers. [Posted to the issue first.](https://github.com/martymcenroe/AssemblyZero/issues/2608#issuecomment-5454081845)

**The parser is not brittle — reading 2 refuted.** `parse_tables` found and parsed **all 15** tables in the LLD and the 1 in the source issue; `is_criteria_table` correctly rejected all 15, since none carries both an ID and a binding column. There is no parse failure here, so "found N tables, 0 parseable" would have been the wrong message.

**Reading 1 is literally true and its conclusion false.** The LLD carries no criteria table because the *derivation destroyed it*:

| artifact | tables | criteria tables | S-rows |
|---|---|---|---|
| `001-issue.md` (source) | 1 | **1 — nine rows, S1–S9, 3,539 chars** | S1…S9 |
| `002-draft.md` (first derivation) | 15 | **0** | **none at all** |
| `003-draft.md` (post-#2563 repair) | 15 | **0** | 7 bullets: S1–S6, S8 |
| `005-final.md` (passed lld) | 15 | **0** | 7 bullets |

S7 and S9 never returned; every assertion method was lost. `not applicable` was a misread of a **derivation failure** as an **absence**.

**Second finding: #2563's gate is shape-blind by construction.** It conserves literals, not structure — so bullets carrying the missing numbers satisfy it exactly. That is *why* a table-less LLD reached the manifest stage with a green lld verdict.

## The fix, in two seams

**1. The lld stage owes the existence check.** `validate_decision_table_survives` sits beside the literal gate — the only place holding both source and derived document. A source criteria table with no counterpart in the LLD is an ERROR naming the lost row IDs and the count of LLD tables searched.

Deliberately a **separate** check rather than an extension: literals and shape are different conserved quantities. Two tests pin the division of labour in **both** directions, so the pair provably leaves no gap.

**2. The abstain carries its denominator and travels forward.** Three outcomes now render distinctly:

| condition | rendering |
|---|---|
| no tables at all | `0 tables in the document` — not an abstain |
| tables, none criteria-shaped | **`15 table(s) parsed, 0 in the criteria shape`** — ABSTAIN, announced as the #2533 protection being OFF |
| applicable | `9 criterion(s) compiled from 16 table(s)` |

The absence lands on state, the gate node repeats the reason instead of a second reassuring "passing through", and the run record grows a **DECLARED FALL-THROUGHS** section — printed only when non-empty, so its presence is the signal. Both fall-throughs carry `# fail-open:` declarations per the #2475 regime.

## Acceptance, replayed on real preserved state

```
manifest compiler:   applicable=False  tables_seen=15  abstained=True
lld structure check: 1 ERROR — "source issue carries a criteria decision table
                     (9 row(s): S1…S9) and the LLD carries none. 15 table(s)
                     were parsed in the LLD…"
control 1 (no source table):  0 errors, abstained=False, "0 tables in the document"
control 2 (table carried):    0 errors, manifest compiles 9 criteria
```

All three branches of the issue's acceptance.

## Tests

22 new. The load-bearing one is `test_bullets_satisfy_the_literal_gate_while_failing_this_one` — the measured run-19 condition as a fixture, asserting #2563 returns `[]` on the bullet-form LLD while the new check fires. My first draft of that fixture didn't carry every literal, so the literal gate fired and the test failed honestly; the fixture was corrected to carry the assertion-method numbers, which is what the real drafter appended.

Full unit suite green at **8971 passed**. Lint delta zero (2 pre-existing unused imports before and after, verified against `origin/main`).

**Process note:** an earlier suite run showed two `inspect.getsource` failures because I edited `stages.py` while it was running. A suite verdict binds only to the tree it read; the run was redone on the settled tree rather than the failures chased as defects.

Closes #2608
