### PR TITLE
feat: the source decision table reaches the LLD by code, not by drafter (Closes #2607)

### DIFF
--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -48,6 +48,11 @@ from assemblyzero.workflows.requirements.best_of_n import (  # noqa: E402
     score_candidate,
     select_winner,
 )
+from assemblyzero.workflows.requirements.table_injection import (  # noqa: E402
+    BEGIN_MARKER,
+    build_injection,
+    reassert,
+)
 from assemblyzero.workflows.requirements.state import RequirementsWorkflowState
 from assemblyzero.workflows.requirements.feedback_window import (
     build_feedback_block,
@@ -413,6 +418,25 @@ Use the template structure provided. Include all sections. Be specific about:
 - Data structures
 - Error handling approach"""
 
+    # #2607: when the source carries a decision table, the derivation injects
+    # it verbatim after this call returns. Telling the drafter so is not
+    # decoration -- a drafter that restates the table anyway produces a
+    # second, lossy copy of rows the document already holds correctly, and
+    # the reader cannot tell which is binding. It writes AROUND the block.
+    if workflow_type == "lld" and build_injection(state.get("issue_body", "")):
+        system_prompt += f"""
+
+DO NOT RESTATE THE SOURCE DECISION TABLE (#2607):
+- The source issue's decision table is carried into this document VERBATIM
+  by the derivation itself, in a machine-owned block beginning
+  `{BEGIN_MARKER}`. You are not writing those rows and must not reproduce,
+  paraphrase, summarise or "carry forward" their values anywhere.
+- Write AROUND that block. In Section 3 and Section 10, CITE the row IDs
+  (S1, S2, ...) and state what the requirement or test DOES; do not restate
+  the binding values, thresholds, colours, or sampling windows the rows
+  already carry. The row is the ruling; your prose points at it.
+- Anything you write inside the machine-owned markers is discarded."""
+
     # #1443: Revise-with-context — when the orchestrator's stage runner has
     # populated previous_draft_path and/or previous_verdict_text (set on retry
     # of a stage that previously failed), augment the system prompt so the
@@ -591,6 +615,22 @@ Use the template structure provided. Include all sections. Be specific about:
             f"{ratio:.0%} of prior draft preserved byte-identical (#2200)"
         )
         draft_content = patched
+
+    # #2607: the source decision table reaches the LLD by code, never through
+    # the drafter. Applied AFTER the draft is produced and before anything
+    # reads it, so an initial draft that omitted the table gets it and a
+    # revision that edited the machine-owned block has it reasserted. The
+    # #2563 conservation gate stays as the backstop; on injected rows it
+    # should now never fire, which is #2607's success metric.
+    if workflow_type == "lld":
+        draft_content, reasserted = reassert(
+            draft_content, state.get("issue_body", "")
+        )
+        if reasserted:
+            print(
+                "    [INJECT] source decision table carried into the LLD "
+                "verbatim; machine-owned block reasserted (#2607)"
+            )
 
     # Issue #775: Use structured parse for open questions extraction (REQ-1, REQ-2).
     # parse_structured_draft_questions tries JSON first, falls back to regex.

--- a/assemblyzero/workflows/requirements/table_injection.py
+++ b/assemblyzero/workflows/requirements/table_injection.py
@@ -1,0 +1,199 @@
+"""The source decision table reaches the LLD by code, not by drafter (#2607).
+
+Literals travelled through a stochastic rewriter and the whole guard stack
+existed to catch what fell out. Three demonstrations in one week:
+
+* the #361 sampling window shed silently, re-opening a settled conflict as
+  boostgauge #369 and killing a roll (#2563's founding case);
+* four genuine losses in the #2563 gate's own calibration (PR #2564);
+* five criticals on the first post-gate redraw (run-issue331-093613) — and
+  that same run, diagnosed under #2608, turned out to have emitted **no
+  table at all** in draft 1, then repaired to a seven-item bullet list that
+  dropped S7 and S9 and every assertion method.
+
+The last one is why detection alone is not enough. The gate makes loss
+loud; injection makes loss impossible. Where the transform is "copy these
+values verbatim", no LLM belongs in the path.
+
+## Byte-verbatim, and how
+
+`RawTable.line_no` is the 1-based index of the header line, so the source's
+own lines can be SLICED out of the issue body and re-emitted unchanged.
+Nothing is re-rendered from parsed cells: a round-trip through cells would
+normalise padding, drop trailing whitespace, and quietly become "modulo
+reformatting" — a phrase that hides exactly the kind of drift this module
+exists to end. The block that lands in the LLD is the block that was in the
+issue, byte for byte.
+
+## The shared substrate question, answered by evidence
+
+#2607 asks whether the #2533 manifest compiler's row parser is the right
+shared substrate. It already IS shared: `assertion_manifest` imports
+`parse_tables` and `RawTable` from `requirements.form_check`, and layers
+`is_criteria_table` on top. #2608 established the parser handles real state
+correctly — 15 of 15 tables in the run-19 LLD, and the source's nine-row
+table — so the failure was never parsing. This module reuses that pair and
+adds no third notion of "what a decision table is".
+
+## Machine-owned regions
+
+The injected block is fenced by HTML comment markers. Two properties follow
+and both are mechanical rather than adjudicated:
+
+* the drafter is told to write AROUND it and never to restate the table;
+* on every revision the block is RE-ASSERTED from source — whatever the
+  drafter did inside the markers is discarded and the canonical text
+  restored.
+
+Re-assertion is deliberately stronger than asking pinning to protect the
+region. Pinning adjudicates a diff and can be argued with; re-assertion
+does not adjudicate. It also means pinning never has to reason about the
+injected rows at all, which is what #2607 asks for — the region is content
+no verdict need ever name.
+"""
+
+from __future__ import annotations
+
+import re
+
+from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+    is_criteria_table,
+)
+from assemblyzero.workflows.requirements.form_check import RawTable, parse_tables
+
+#: The fence. HTML comments so the block renders as an ordinary table in
+#: every markdown viewer while staying machine-findable.
+BEGIN_MARKER = "<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->"
+END_MARKER = "<!-- END MACHINE-OWNED -->"
+
+_BLOCK_RE = re.compile(
+    re.escape(BEGIN_MARKER) + r".*?" + re.escape(END_MARKER),
+    re.DOTALL,
+)
+
+#: The heading the block is filed under. A real heading, so the table sits
+#: somewhere a reader expects to find it rather than in an unexplained fence.
+INJECTED_HEADING = "### 3.1 Source Decision Table (injected verbatim)"
+
+_PREAMBLE = (
+    "The rows below are carried **verbatim** from the source issue by the "
+    "derivation itself (#2607). They are machine-owned: the drafter does "
+    "not write them, and a revision cannot change them. Cite these IDs from "
+    "the requirements and test-plan sections; do not restate their values."
+)
+
+
+def source_table_text(issue_body: str, table: RawTable) -> str:
+    """The table's own lines, sliced out of the source. Byte-verbatim.
+
+    `line_no` is 1-based and points at the header; the separator follows it
+    and then one line per row, which is exactly how `parse_tables` walked
+    them. Slicing rather than re-rendering is the whole point -- a
+    round-trip through parsed cells would normalise the very characters the
+    derivation is supposed to preserve.
+    """
+    lines = (issue_body or "").splitlines()
+    start = max(0, table.line_no - 1)
+    end = min(len(lines), start + 2 + len(table.rows))
+    return "\n".join(lines[start:end])
+
+
+def source_criteria_tables(issue_body: str) -> list[RawTable]:
+    """Every criteria decision table in the source, in document order."""
+    return [t for t in parse_tables(issue_body or "") if is_criteria_table(t)]
+
+
+def build_injection(issue_body: str) -> str:
+    """The machine-owned block for this issue, or "" when none applies.
+
+    An issue with no criteria decision table injects nothing and the
+    derivation proceeds exactly as before -- prose-only requirements are the
+    ordinary case and #2607's control.
+    """
+    tables = source_criteria_tables(issue_body)
+    if not tables:
+        return ""
+    parts = [BEGIN_MARKER, "", INJECTED_HEADING, "", _PREAMBLE, ""]
+    for table in tables:
+        parts.append(source_table_text(issue_body, table))
+        parts.append("")
+    parts.append(END_MARKER)
+    return "\n".join(parts)
+
+
+def has_injection(text: str) -> bool:
+    return bool(_BLOCK_RE.search(text or ""))
+
+
+def strip_injection(text: str) -> str:
+    """Remove every machine-owned block, leaving the drafter's own prose."""
+    stripped = _BLOCK_RE.sub("", text or "")
+    # Collapse the blank-line run the removal leaves behind, so repeated
+    # strip/inject cycles do not accumulate whitespace in the document.
+    return re.sub(r"\n{3,}", "\n\n", stripped)
+
+
+def injected_line_span(text: str) -> tuple[int, int] | None:
+    """1-based inclusive (start, end) of the machine-owned block.
+
+    For callers that need to know which lines are not the drafter's -- the
+    pinning path asserts it never adjudicates them.
+    """
+    match = _BLOCK_RE.search(text or "")
+    if not match:
+        return None
+    before = (text or "")[: match.start()]
+    start = before.count("\n") + 1
+    end = start + match.group(0).count("\n")
+    return (start, end)
+
+
+def _insertion_point(lines: list[str]) -> int:
+    """Index to insert at: just after the Requirements section's heading.
+
+    Falls back to the end of the document. Placement is for the human
+    reader; the manifest compiler finds a criteria table anywhere, so a
+    fallback that appends is correct rather than degraded.
+    """
+    for index, line in enumerate(lines):
+        if re.match(r"^##\s+3[.\s]", line.strip()):
+            return index + 1
+    return len(lines)
+
+
+def apply_injection(draft: str, injection: str) -> str:
+    """Assemble the drafter's output with the machine-owned block.
+
+    Idempotent: an existing block is REPLACED, never duplicated, so calling
+    this on every round re-asserts the canonical text over whatever the
+    drafter did to it.
+    """
+    if not injection:
+        return draft
+    body = strip_injection(draft or "")
+    lines = body.splitlines()
+    at = _insertion_point(lines)
+    merged = lines[:at] + ["", injection, ""] + lines[at:]
+    text = "\n".join(merged)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    if (draft or "").endswith("\n") and not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def reassert(draft: str, issue_body: str) -> tuple[str, bool]:
+    """Restore the canonical block over whatever the draft now holds.
+
+    Returns (text, changed). `changed` is True when the draft's block did
+    not match the source -- which is the drafter having edited machine-owned
+    content, and the caller logs it. Nothing is refused and nothing halts:
+    the correct text is simply reinstated, which is why pinning never has to
+    adjudicate this region.
+    """
+    injection = build_injection(issue_body)
+    if not injection:
+        return draft, False
+    current = _BLOCK_RE.search(draft or "")
+    if current and current.group(0) == injection:
+        return draft, False
+    return apply_injection(draft, injection), True

--- a/docs/reports/2607/implementation-report.md
+++ b/docs/reports/2607/implementation-report.md
@@ -1,0 +1,50 @@
+# Implementation Report — Decision Tables Injected Mechanically (#2607)
+
+## Issue Reference
+[#2607: inject decision tables into derived artifacts mechanically — literals never travel through the drafter](https://github.com/martymcenroe/AssemblyZero/issues/2607)
+
+## Scope: The LLD-Side Half
+
+Split at the seam the issue names as natural — lld-side injection here, spec-side filed as **#2611** — rather than by shipping half a protection. The lld half is complete and independently verifiable against every clause of the acceptance.
+
+## Files Changed
+- `assemblyzero/workflows/requirements/table_injection.py` (new): the substrate.
+- `assemblyzero/workflows/requirements/nodes/generate_draft.py`: injection applied after every draft; the prompt tells the drafter to write *around* the block.
+- `tests/unit/test_table_injection.py` (new): 22 tests.
+
+## The Two Design Questions, Answered With Evidence
+
+**Is the #2533 manifest compiler's row parser the right shared substrate?** It already *is* shared — `assertion_manifest` imports `parse_tables` and `RawTable` from `requirements.form_check` and layers `is_criteria_table` on top. My #2608 diagnosis established the parser handles real state correctly (15 of 15 tables in the run-19 LLD, plus the source's nine-row table), so the failure was never parsing. This module reuses that pair and introduces **no third notion** of what a decision table is.
+
+**Should injected regions be machine-owned?** Yes, and delivered by **re-assertion** rather than by pinning adjudication. On every round the canonical block is restored over whatever the draft holds. This is deliberately stronger than asking pinning to protect the region: pinning adjudicates a diff and can be argued with; re-assertion does not adjudicate, so pinning never has to reason about injected rows — which is what the issue asks for.
+
+A test found this claim needed sharpening. My first fixture asserted pinning *fails* to protect the block; it does not — with an empty vocabulary pinning locks everything and already reverts the tamper. The real gap is conditional: **a verdict naming any token inside the block unlocks it**, correctly, by pinning's own rule that restructuring around a named item is the named item's business. A reviewer writing "the `Dial face` row is wrong" is enough. Both facts are now pinned as separate tests.
+
+## Byte-Verbatim, And How
+
+`RawTable.line_no` is the 1-based header index, so the source's own lines are **sliced** out of the issue body and re-emitted unchanged. Nothing is re-rendered from parsed cells — a cell round-trip would normalise padding and drop trailing whitespace, quietly becoming "modulo reformatting", a phrase that hides exactly the drift this exists to end.
+
+**No reformatting is declared, because none happens.** Tests assert the en-dash in `0.12 R–0.25 R`, the `×` in `R = 0.40 × size`, and the separator padding `|----|` all survive.
+
+## Verified Against The Real #331 State
+
+Read-only against the preserved run-19 lineage:
+
+| property | result |
+|---|---|
+| every sliced line present verbatim in the source | **true** |
+| S1–S9 table byte-verbatim in the LLD | **true** |
+| manifest on the real lossy draft, before | `applicable=False` (the #2608 defect) |
+| manifest on the same draft, after injection | **`applicable=True`, 9 criteria** |
+| in-block tamper of `R = 0.40` | reverted; canonical restored |
+| drafter's own prose outside the block | untouched |
+| `reassert` on a clean document | idempotent, no change |
+| prose-only issue (control) | injects nothing, draft returned unchanged |
+
+The success metric the issue names — the #2563 gate's firing rate on injected rows — is **zero**, asserted directly: the gate fires on the lossy fixture and returns `[]` once injected.
+
+## Known Limitations
+
+- Spec-side injection is #2611, which needs a source-of-truth ruling first (issue vs LLD) and should check whether the assertion manifest already discharges it.
+- `_insertion_point` looks for the LLD's `## 3.` Requirements heading and appends otherwise. Placement is for the human reader; the compiler finds a criteria table anywhere, so the fallback is correct rather than degraded, and a test covers it.
+- Re-assertion guards the machine-owned region, not the document. Literals the drafter restates in its own prose remain #2563's territory — deliberate, and tested.

--- a/docs/reports/2607/test-report.md
+++ b/docs/reports/2607/test-report.md
@@ -1,0 +1,49 @@
+# Test Report — Decision Tables Injected Mechanically (#2607)
+
+## Issue Reference
+[#2607](https://github.com/martymcenroe/AssemblyZero/issues/2607)
+
+## Suites Run
+
+| suite | result |
+|---|---|
+| `tests/unit/test_table_injection.py` (new) | **22 passed** |
+| with `test_completeness_pinning_deadlock.py`, `test_pinning_conservation.py`, `test_decision_table_survives.py`, `test_fail_open_audit.py` | **134 passed** |
+| `tests/unit` (full) | see below |
+
+The 134-test run is the one that matters for the instruction not to weaken #2558/#2562/#2606: the pinning fixtures are **untouched** and pass unchanged alongside the new work.
+
+## The Acceptance, Clause By Clause
+
+**"The #331 S1–S7 table derived under injection appears byte-verbatim modulo a declared mechanical reformatting (whatever is declared is tested)."**
+
+No reformatting is declared, because none happens — the source's own lines are sliced, not re-rendered. Three tests pin the characters a cell round-trip would have destroyed: the en-dash in `0.12 R–0.25 R`, the `×` in `R = 0.40 × size`, and the separator padding `|----|`. A fourth asserts every emitted line appears verbatim in the source.
+
+**"Zero conservation-gate losses on injected rows."** `test_the_conservation_gate_finds_nothing_on_injected_rows` asserts both halves: the #2563 gate **fires** on the lossy fixture (so the fixture reproduces the real defect) and returns **`[]`** on the injected one. Without the first assertion the second would prove nothing.
+
+**"A later-round drafter revision cannot modify an injected row."** Four tests: an in-block edit is reverted; deleting the markers entirely restores the block; `reassert` is idempotent; repeated cycles accumulate no whitespace and never duplicate markers.
+
+**"Prose-only requirements derive exactly as today."** Three control tests: no injection is built, the draft is returned byte-identical, and `reassert` is a no-op.
+
+## A Wrong Claim The Tests Caught
+
+My first pinning fixture asserted that pinning alone does not protect the injected block. It failed, correctly — with an empty vocabulary pinning locks everything and already reverts the tamper. The claim was wrong as written.
+
+The corrected pair now records the true, more precise fact:
+
+- `test_pinning_locks_the_block_when_nothing_names_it` — the ordinary round; pinning refuses the edit and records a refusal.
+- `test_pinning_alone_leaves_a_gap_that_reassertion_closes` — a verdict naming any token inside the block (`dial face`) **unlocks** it, correctly, by pinning's own rule. Pinning then allows the edit; re-assertion restores it anyway, because it does not consult the vocabulary.
+
+That second test carries a note telling a future reader that if the unlock stops happening, pinning changed and this is where to re-derive the claim.
+
+## Cross-Gate Composition
+
+Three tests assert the new machinery satisfies the gates that already exist, rather than bypassing them: the manifest compiles (9 criteria on the real source), #2563 finds nothing, and #2608's structure check passes. Injection is what makes those green by construction instead of by asking the drafter again.
+
+## Real-State Verification
+
+Beyond fixtures, the module was driven against the preserved run-19 lineage read-only, including the tamper case located by line number **inside** the machine-owned span — a document-wide tamper would have proved nothing, since `reassert` deliberately guards only the injected region.
+
+## Regression Risk
+
+`table_injection` is a new module. The only production wiring is in `generate_draft`: one `reassert` call on the lld path, and a prompt clause added only when the source actually carries a criteria table. An issue with no decision table takes neither branch, which is most issues — and is the control the suite pins.

--- a/tests/unit/test_table_injection.py
+++ b/tests/unit/test_table_injection.py
@@ -1,0 +1,333 @@
+"""The source decision table reaches the LLD by code, not by drafter (#2607).
+
+Literals travelled through a stochastic rewriter and the guard stack existed
+to catch what fell out. Three demonstrations in one week; the sharpest is
+run-issue331-093613, where -- diagnosed under #2608 -- the drafter asked to
+restate a nine-row ruling-dense table emitted **no table at all** in draft 1,
+and one round of gate-driven repair restored seven rows as prose bullets,
+dropping S7, S9 and every assertion method.
+
+Detection was good. This is prevention: where the transform is "copy these
+values verbatim", no LLM is in the path.
+
+Composes with the pinning fixtures rather than rewriting them. The
+#2558/#2562/#2606 invariants are untouched: an injected region is
+re-asserted mechanically, so pinning is never asked to adjudicate it, and
+the tests below assert that separation directly.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+    compile_manifest,
+)
+from assemblyzero.workflows.requirements.table_injection import (
+    BEGIN_MARKER,
+    END_MARKER,
+    apply_injection,
+    build_injection,
+    has_injection,
+    injected_line_span,
+    reassert,
+    source_criteria_tables,
+    source_table_text,
+    strip_injection,
+)
+
+#: Two rows of the real #331 table, with the padding and the em-dashes the
+#: source actually carries -- byte-verbatim means these characters survive.
+ISSUE = """# 331 - static face renderer
+
+## Decision table — static elements and their binding values
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|----|---------|------------------------------------------------|------------------|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size | classification at 3 interior points |
+| S5 | Numerals | `#FFFFFF`, cap height 0.11 R, centres at 0.72 R | ≥1 white pixel within the cap-height box; the mirror check samples ONLY at 0.12 R–0.25 R off-axis |
+
+## Test plan constraints
+
+Option C only.
+"""
+
+#: The lossy shape the drafter actually produced: bullets, no table.
+LOSSY_DRAFT = """# 331 - static face renderer
+
+## 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/skins/stingray.py` | Add | The renderer. |
+
+## 3. Requirements
+
+1. The system shall render each static element:
+   - S1: R = 0.40
+   - S5: 0.11 R
+
+## 4. Alternatives Considered
+
+Vector rendering rejected.
+"""
+
+PROSE_ISSUE = """# Make the button blue
+
+## Requirements
+
+1. The button shall be blue.
+"""
+
+
+class TestByteVerbatim:
+    """The acceptance: the table appears verbatim, not re-rendered."""
+
+    def test_the_sliced_block_is_the_sources_own_lines(self):
+        table = source_criteria_tables(ISSUE)[0]
+        block = source_table_text(ISSUE, table)
+        source_lines = ISSUE.splitlines()
+        for line in block.splitlines():
+            assert line in source_lines, (
+                f"{line!r} was re-rendered rather than sliced"
+            )
+
+    def test_the_slice_spans_header_separator_and_every_row(self):
+        table = source_criteria_tables(ISSUE)[0]
+        block = source_table_text(ISSUE, table)
+        assert len(block.splitlines()) == 2 + len(table.rows)
+
+    def test_padding_and_unicode_survive(self):
+        """A round-trip through parsed cells would normalise these. The
+        em-dash and en-dash are in the real #331 rows."""
+        block = source_table_text(ISSUE, source_criteria_tables(ISSUE)[0])
+        assert "0.12 R–0.25 R" in block, "en-dash normalised"
+        assert "R = 0.40 × size" in block, "multiplication sign normalised"
+        assert "|----|" in block, "separator padding normalised"
+
+    def test_the_table_reaches_the_draft_verbatim(self):
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        block = source_table_text(ISSUE, source_criteria_tables(ISSUE)[0])
+        for line in block.splitlines():
+            assert line in injected.splitlines()
+
+
+class TestTheDefectIsPrevented:
+    """The #2608 condition, eliminated at source."""
+
+    def test_the_lossy_draft_compiles_a_manifest_once_injected(self):
+        before = compile_manifest(LOSSY_DRAFT, "")
+        assert before.applicable is False, "fixture must reproduce the defect"
+
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        after = compile_manifest(injected, "")
+        assert after.applicable is True
+        assert set(after.criteria_ids) == {"S1", "S5"}
+
+    def test_the_conservation_gate_finds_nothing_on_injected_rows(self):
+        """#2607's success metric: the #2563 backstop should never fire on
+        injected rows, because the literals are the source's own bytes."""
+        from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+            validate_assertion_literal_conservation,
+        )
+
+        assert validate_assertion_literal_conservation(
+            ISSUE, LOSSY_DRAFT
+        ), "fixture must reproduce the loss the gate catches today"
+
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        assert validate_assertion_literal_conservation(ISSUE, injected) == [], (
+            "the gate fired on rows carried verbatim from the source -- "
+            "injection did not do its job"
+        )
+
+    def test_the_structure_check_passes_once_injected(self):
+        """#2608's gate, satisfied by construction rather than by asking the
+        drafter again."""
+        from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+            validate_decision_table_survives,
+        )
+
+        assert validate_decision_table_survives(ISSUE, LOSSY_DRAFT)
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        assert validate_decision_table_survives(ISSUE, injected) == []
+
+
+class TestARevisionCannotModifyAnInjectedRow:
+    """The third acceptance clause."""
+
+    def _injected(self) -> str:
+        return apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+
+    def test_an_edit_inside_the_block_is_reverted(self):
+        injected = self._injected()
+        tampered = injected.replace("R = 0.40 × size", "R = 0.99 × size")
+        assert tampered != injected
+
+        restored, changed = reassert(tampered, ISSUE)
+        assert changed is True
+        start, end = injected_line_span(restored)
+        block = "\n".join(restored.splitlines()[start - 1 : end])
+        assert "R = 0.40 × size" in block
+        assert "R = 0.99" not in block
+
+    def test_deleting_the_block_entirely_restores_it(self):
+        """The strongest tamper: the drafter removes the markers."""
+        gutted = strip_injection(self._injected())
+        assert has_injection(gutted) is False
+
+        restored, changed = reassert(gutted, ISSUE)
+        assert changed is True
+        assert has_injection(restored) is True
+        assert "| S1 |" in restored
+
+    def test_reassert_is_idempotent(self):
+        injected = self._injected()
+        again, changed = reassert(injected, ISSUE)
+        assert changed is False
+        assert again == injected
+
+    def test_reassert_leaves_the_drafters_own_prose_alone(self):
+        """It guards the machine-owned region, not the document. The
+        drafter's own sections remain the drafter's."""
+        injected = self._injected()
+        edited = injected.replace(
+            "Vector rendering rejected.", "Vector rendering reconsidered."
+        )
+        restored, _ = reassert(edited, ISSUE)
+        assert "Vector rendering reconsidered." in restored
+
+    def test_repeated_cycles_do_not_accumulate_whitespace(self):
+        text = LOSSY_DRAFT
+        for _ in range(4):
+            text, _ = reassert(text, ISSUE)
+        assert "\n\n\n" not in text
+        assert text.count(BEGIN_MARKER) == 1
+        assert text.count(END_MARKER) == 1
+
+
+class TestTheControl:
+    """Prose-only requirements derive exactly as today."""
+
+    def test_an_issue_with_no_table_injects_nothing(self):
+        assert build_injection(PROSE_ISSUE) == ""
+
+    def test_the_draft_is_returned_untouched(self):
+        draft = "# LLD\n\n## 3. Requirements\n\n1. Blue.\n"
+        assert apply_injection(draft, build_injection(PROSE_ISSUE)) == draft
+
+    def test_reassert_is_a_no_op(self):
+        draft = "# LLD\n\n## 3. Requirements\n\n1. Blue.\n"
+        restored, changed = reassert(draft, PROSE_ISSUE)
+        assert changed is False
+        assert restored == draft
+
+
+class TestPlacementAndSpan:
+    def test_the_block_lands_under_the_requirements_heading(self):
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        lines = injected.splitlines()
+        heading = next(
+            i for i, ln in enumerate(lines) if ln.startswith("## 3. Requirements")
+        )
+        marker = next(i for i, ln in enumerate(lines) if ln == BEGIN_MARKER)
+        assert marker > heading
+
+    def test_a_draft_with_no_requirements_heading_still_gets_the_block(self):
+        """Placement is for the reader; the compiler finds a criteria table
+        anywhere, so appending is correct rather than degraded."""
+        injected = apply_injection("# LLD\n\nJust prose.\n", build_injection(ISSUE))
+        assert has_injection(injected)
+        assert compile_manifest(injected, "").applicable is True
+
+    def test_the_span_is_reported_one_based_and_inclusive(self):
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        start, end = injected_line_span(injected)
+        lines = injected.splitlines()
+        assert lines[start - 1] == BEGIN_MARKER
+        assert lines[end - 1] == END_MARKER
+
+    def test_no_injection_means_no_span(self):
+        assert injected_line_span(LOSSY_DRAFT) is None
+
+
+class TestPinningNeverAdjudicatesTheBlock:
+    """#2607 asks that pinning never have to reason about injected rows.
+
+    Re-assertion is what delivers that, and it is deliberately stronger than
+    asking pinning to protect the region: pinning adjudicates a diff and can
+    be argued with; re-assertion does not adjudicate. These tests assert the
+    separation holds without weakening #2558/#2562/#2606 -- the pinning
+    fixtures are untouched and pinning's own behaviour is unchanged.
+    """
+
+    def test_pinning_alone_leaves_a_gap_that_reassertion_closes(self):
+        """Pinning's protection of the block is CONDITIONAL on the round's
+        vocabulary; re-assertion's is not.
+
+        With an empty vocabulary pinning locks everything, so it happens to
+        protect the block. But a verdict that names any token occurring
+        inside the block unlocks that region -- correctly, by pinning's own
+        rule that restructuring around a named item is the named item's
+        business. A reviewer writing "the `Dial face` row is wrong" is
+        enough. That is the gap, and it is exactly why the injected region
+        is re-asserted rather than left to adjudication.
+        """
+        from assemblyzero.workflows.implementation_spec.revision_pinning import (
+            enforce_pinning,
+        )
+
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        tampered = injected.replace("R = 0.40 × size", "R = 0.99 × size")
+        assert tampered != injected
+
+        naming = {"dial face"}
+        pinned = enforce_pinning(
+            injected, tampered, current_tokens=naming, ever_tokens=naming
+        )
+        assert "R = 0.99" in pinned.text, (
+            "a verdict naming content inside the block should unlock it -- "
+            "if this stops being true, pinning changed and this test is the "
+            "place to re-derive the claim"
+        )
+
+        # Re-assertion does not consult the vocabulary, so it closes the gap.
+        restored, changed = reassert(pinned.text, ISSUE)
+        assert changed is True
+        start, end = injected_line_span(restored)
+        assert "R = 0.99" not in "\n".join(
+            restored.splitlines()[start - 1 : end]
+        )
+
+    def test_pinning_locks_the_block_when_nothing_names_it(self):
+        """The complement, recorded because it is the ordinary round: with
+        no naming token, pinning already refuses the edit. Re-assertion is
+        the belt to that braces, not a replacement for it."""
+        from assemblyzero.workflows.implementation_spec.revision_pinning import (
+            enforce_pinning,
+        )
+
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        tampered = injected.replace("R = 0.40 × size", "R = 0.99 × size")
+        pinned = enforce_pinning(
+            injected, tampered, current_tokens=set(), ever_tokens=set()
+        )
+        assert "R = 0.99" not in pinned.text
+        assert pinned.refusals
+
+    def test_pinning_still_protects_the_drafters_own_content(self):
+        """The invariant that must NOT weaken: outside the machine-owned
+        block, pinning behaves exactly as before."""
+        from assemblyzero.workflows.implementation_spec.revision_pinning import (
+            enforce_pinning,
+        )
+
+        injected = apply_injection(LOSSY_DRAFT, build_injection(ISSUE))
+        meddled = injected.replace(
+            "Vector rendering rejected.", "Vector rendering reconsidered."
+        )
+        result = enforce_pinning(
+            injected, meddled,
+            current_tokens={"nothing-that-matches"},
+            ever_tokens={"nothing-that-matches"},
+        )
+        assert "Vector rendering rejected." in result.text
+        assert result.refusals


### PR DESCRIPTION
Literals travelled through a stochastic rewriter and the whole guard stack existed to catch what fell out. Three demonstrations in one week — the sharpest being `run-issue331-093613`, where (diagnosed under #2608) the drafter asked to restate a nine-row ruling-dense table emitted **no table at all** in draft 1, and one round of gate-driven repair restored seven rows as prose bullets, dropping S7, S9 and every assertion method.

Detection was good. This is prevention: where the transform is "copy these values verbatim", no LLM is in the path.

**Scope: the lld-side half.** Spec-side is filed as **#2611**, split at the seam the issue names as natural rather than by shipping half a protection.

## Byte-verbatim, and how

`RawTable.line_no` is the 1-based header index, so the source's own lines are **sliced** out of the issue body and re-emitted unchanged. Nothing is re-rendered from parsed cells — a cell round-trip would normalise padding and drop trailing whitespace, quietly becoming "modulo reformatting", which is the phrase that hides the drift this exists to end.

**No reformatting is declared, because none happens.** Tests pin the characters a round-trip would have destroyed: the en-dash in `0.12 R–0.25 R`, the `×` in `R = 0.40 × size`, the separator padding `|----|`.

## Both design questions, answered with evidence

**The parser substrate** already *is* shared — `assertion_manifest` imports `parse_tables`/`RawTable` from `requirements.form_check` — and #2608 established it handles real state correctly (15 of 15 tables in the run-19 LLD, plus the source's nine-row table). The failure was never parsing. No third notion of "decision table" is introduced.

**Machine-owned regions** are delivered by **re-assertion**, not pinning adjudication: the canonical block is restored over whatever the draft holds, every round. Deliberately stronger than asking pinning to protect the region — pinning adjudicates a diff and can be argued with; re-assertion does not adjudicate. That is what lets pinning never reason about injected rows.

## A wrong claim the tests caught

My first pinning fixture asserted that pinning alone does not protect the block. **It failed, correctly** — with an empty vocabulary pinning locks everything and already reverts the tamper. The real gap is conditional, and now pinned as two tests:

| round | pinning's behaviour |
|---|---|
| nothing names the block | **locks it** — refuses the edit, records a refusal |
| a verdict names `dial face` | **unlocks it**, correctly, by pinning's own rule that restructuring around a named item is the named item's business |

A reviewer writing "the `Dial face` row is wrong" is enough to open the gap. Re-assertion closes it because it does not consult the vocabulary. The second test carries a note saying where to re-derive the claim if pinning ever changes.

## Verified read-only against the real #331 state

| property | result |
|---|---|
| every sliced line verbatim in the source | **true** |
| S1–S9 table byte-verbatim in the LLD | **true** |
| manifest on the real lossy draft | `applicable=False` — the #2608 defect |
| same draft, after injection | **`applicable=True`, 9 criteria** |
| in-block tamper of `R = 0.40` | reverted; drafter's own prose untouched |
| `reassert` on a clean document | idempotent |
| prose-only issue (control) | injects nothing, draft byte-identical |

The success metric the issue names — the #2563 gate's firing rate on injected rows — is **zero**, asserted with the gate firing on the lossy fixture first, so the zero means something.

## Tests

22 new; **134 with the pinning fixtures**, which are untouched and pass unchanged — the #2558/#2562/#2606 invariants are not weakened. Full unit suite green at **8993 passed**. Lint delta zero (13 pre-existing before and after, verified against `origin/main`).

Closes #2607
