### PR TITLE
feat: an artifact that passed its gate is settled until its inputs change (Closes #2609)

### DIFF
--- a/assemblyzero/core/interaction_matrix.py
+++ b/assemblyzero/core/interaction_matrix.py
@@ -195,6 +195,12 @@ WORKING_TREE = Artifact(
             "tools/speedrun_roll.py",
             "tools/speedrun_new_attempt.py",
         ),
+        # #2609. Declared by reading, not by the lint: settlement calls none
+        # of this artifact's signature symbols -- it decides what the reset
+        # may remove by NAMING files, which is the weak-scan hole #2602
+        # tracks. A mechanism that can veto a removal belongs here whether or
+        # not the scan can see it.
+        "settlement": ("assemblyzero/core/settlement.py",),
     },
     cells={
         key("leavings-janitor", "loaders"): Cell(
@@ -242,6 +248,46 @@ WORKING_TREE = Artifact(
                 "file is removed."
             ),
             fixture="tests/unit/test_restore_from_graveyard.py",
+        ),
+        key("settlement", "launch-sweep"): Cell(
+            invariant=(
+                "A settled artifact survives --fresh and is stated as "
+                "preserved; an unsettled one is archived and the mismatch "
+                "that unsettled it is stated too. Settledness decides, never "
+                "branch contents."
+            ),
+            fixture="tests/unit/test_stage_finality_launcher.py",
+        ),
+        key("settlement", "leavings-janitor"): Cell(
+            invariant=(
+                "Preservation is a named-file veto on the reset's archiving "
+                "step, never a widening of the janitor's input exemption -- "
+                "#2551's issue-scoping is untouched, and a preserved file is "
+                "still re-verified against its inputs at the next stage entry."
+            ),
+            fixture="tests/unit/test_stage_finality_launcher.py",
+        ),
+        key("settlement", "loaders"): Cell(
+            invariant=(
+                "A loader reads what settlement preserved: reuse requires the "
+                "artifact on disk to hash as the one that settled, so a file "
+                "edited after settling is redrawn rather than loaded."
+            ),
+            fixture="tests/unit/test_stage_finality_skip.py",
+        ),
+        key("settlement", "restore-machinery"): Cell(
+            invariant=(
+                "Non-interacting. Settlement never removes a file, so it "
+                "creates nothing for the restorer to recover; and the "
+                "restorer rebuilds working copies from refs without "
+                "consulting settledness, because a rebuilt file is checked "
+                "against its recorded artifact hash at stage entry like any "
+                "other. Neither reads the other's output."
+            ),
+            non_interacting=(
+                "settlement only ever declines a removal, and restore only "
+                "ever re-materialises content -- no shared write, no ordering"
+            ),
         ),
     },
 )

--- a/assemblyzero/core/settlement.py
+++ b/assemblyzero/core/settlement.py
@@ -1,0 +1,320 @@
+"""Stage finality: an artifact that passed its gate is settled until its
+inputs change (#2609).
+
+Approvals did not bind. An LLD that survived the conservation gate, mechanical
+validation and adversarial review was torn up by the next fresh attempt as if
+none of that had happened: boostgauge #331 took 20 launches in 12 days and had
+its LLD drawn from scratch seven times, shedding the same settled #361 sampling
+window twice, to two different redraws.
+
+## The mechanism was already there, minus a reader
+
+The diagnosis on #2609 found the record already exists. `lld-status.json`
+(`requirements.audit`) is repo-keyed, issue-keyed, lives under `data/` outside
+the branch lifecycle, and says `"status": "approved"`. Every call site in the
+tree writes it; **nothing read it**. Meanwhile `_delete_landed_working_copies`
+removes the LLD working copy exactly when its PR merges -- and stage entry
+resolves settledness by the presence of that file -- so landing an artifact
+durably is what caused it to be redrawn.
+
+The visual gate is immune for one reason: its stamp is READ at stage entry
+(`visual_gate/gate.py`, the resume shortcut). It is not a different idea. It is
+the same idea with a reader.
+
+So this module does not invent a store. It gives the existing record the input
+hashes it lacked, and gives it its first reader.
+
+## Content, never timestamps
+
+`draft_is_stale` (#2206) already unsettles a resumed draft on input change, by
+comparing the issue's `updatedAt` against the draft time. **GitHub bumps
+`updatedAt` when a comment is posted**, so that probe fires on events which
+changed nothing about the derivation -- measured across three issues with a
+control and filed as #2615. The campaign's own standing method, *post the
+sharpened diagnosis on the issue before fixing*, invalidates every persisted
+draft for that issue under a timestamp check.
+
+Settlement therefore fingerprints CONTENT. Timestamps are recorded as
+provenance for a human reader and are never an authority.
+
+## Line endings are normalised before hashing
+
+The issue body arrives from `gh` with LF; the same text checked out on Windows
+is CRLF (`core.autocrlf=true`). Hashing raw bytes would make every artifact
+unsettle on a platform difference and settle nothing, so every input is
+normalised to LF first. This is the sibling of the CRLF trap that makes a raw
+`diff` of git content against a working-tree file report every line as changed.
+
+## Which direction the failures go
+
+A false UNSETTLE costs one redraw -- the status quo before this module. A false
+SETTLE reuses an artifact derived from inputs that have since changed, which is
+the expensive error and the one the guard stack exists to catch. So every
+ambiguity resolves toward unsettled:
+
+* an unreadable or corrupt record is no record;
+* an input that cannot be read is a mismatch, not a match;
+* an input set that gained or lost a member is a mismatch, even if every
+  common member still hashes the same -- a new binding design doc changes what
+  the artifact should say.
+
+Settlement is durable and is never consumed, which is what separates it from
+the resume contract (#2570): a contract describes one halt and is deleted by
+the resume that verifies it, while a settlement describes a ruling and outlives
+every run until an input moves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: Bumped only when a reader must reject records written by an older writer.
+SETTLEMENT_VERSION = 1
+
+#: Stages that can settle. `impl` and `pr` are excluded deliberately: they are
+#: never skipped (`should_skip_stage`), and an implementation's inputs include
+#: the whole worktree, which this fingerprint does not model.
+SETTLEABLE_STAGES = ("lld", "spec")
+
+#: The docs whose content binds a derivation. Canonical here so the settlement
+#: check and `speedrun_roll.draft_is_stale` cannot drift apart -- they answer
+#: the same question and disagreeing would make one of them wrong (#2206).
+BINDING_DOC_PATHS = ("docs/design", "docs/adrs", "CLAUDE.md")
+
+#: The stage each settleable stage derives FROM. #2611's ruling in structural
+#: form: each stage derives from its immediate upstream settled artifact and
+#: never reaches around it to the source.
+UPSTREAM_OF = {"lld": None, "spec": "lld"}
+
+
+def _normalise(raw: bytes) -> bytes:
+    """CRLF and lone CR to LF, so a hash means content and not a checkout."""
+    return raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(_normalise(text.encode("utf-8"))).hexdigest()
+
+
+def sha256_path(path: Path | str) -> str | None:
+    """The file's content hash, or None when it cannot be read.
+
+    None is the signal, never an exception: an unreadable input has to reach
+    the verifier as a named mismatch rather than crashing a stage that was
+    only asking whether it could skip work.
+    """
+    try:
+        return hashlib.sha256(_normalise(Path(path).read_bytes())).hexdigest()
+    except OSError:
+        # fail-open: only in shape -- None is reported by `verify` as a named
+        # mismatch, which unsettles. The run continues by DRAFTING, which is
+        # the safe direction and the pre-#2609 behaviour.
+        return None
+
+
+@dataclass(frozen=True)
+class SettledInput:
+    """One input an artifact was derived from, by content.
+
+    `key` is the stable identity used to pair a recorded input with a current
+    one -- `issue_body`, `upstream:lld`, `binding:docs/design/dial.md`. `path`
+    is carried for the mismatch message only; the issue body has none.
+    """
+
+    key: str
+    sha256: str | None
+    path: str = ""
+
+    def as_dict(self) -> dict:
+        return {"key": self.key, "sha256": self.sha256, "path": self.path}
+
+    @staticmethod
+    def from_dict(raw: dict) -> "SettledInput":
+        return SettledInput(
+            key=str(raw.get("key", "?")),
+            sha256=raw.get("sha256"),
+            path=str(raw.get("path", "") or ""),
+        )
+
+
+def input_from_text(key: str, text: str) -> SettledInput:
+    return SettledInput(key=key, sha256=sha256_text(text))
+
+
+def input_from_file(key: str, path: Path | str) -> SettledInput:
+    return SettledInput(key=key, sha256=sha256_path(path), path=str(path))
+
+
+def binding_inputs(repo_root: Path, doc_paths: tuple[str, ...]) -> list[SettledInput]:
+    """Every binding design doc under ``doc_paths``, hashed, in a stable order.
+
+    Directories are walked; a plain file is taken as itself. Sorted by relative
+    POSIX path so the recorded order does not depend on the filesystem's, which
+    would make an unchanged input set look changed.
+    """
+    found: list[SettledInput] = []
+    root = Path(repo_root)
+    for entry in doc_paths:
+        target = root / entry
+        if target.is_file():
+            found.append(target)
+        elif target.is_dir():
+            found.extend(p for p in target.rglob("*") if p.is_file())
+    unique = sorted({p.resolve(): p for p in found}.values(),
+                    key=lambda p: _rel_posix(p, root))
+    return [
+        input_from_file(f"binding:{_rel_posix(p, root)}", p) for p in unique
+    ]
+
+
+def _rel_posix(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(Path(root).resolve()).as_posix()
+    except ValueError:
+        # fail-open: a path outside the repo (a symlinked doc tree) keeps its
+        # absolute form as its key. The key only has to be STABLE, not
+        # relative -- an absolute key hashes and compares exactly as well, and
+        # refusing here would fail a settlement check over a layout choice.
+        return path.as_posix()
+
+
+def stage_of_artifact_path(path: str, issue: int) -> str | None:
+    """Which settleable stage a pipeline artifact path belongs to.
+
+    Mirrors `speedrun_clean_check._artifact_needles`, which is what produces
+    the paths this reads. Kept as an explicit mapping rather than a guess: a
+    path that matches nothing returns None and is treated as unsettled, so an
+    unrecognised artifact never wins a reprieve by accident.
+    """
+    lower = path.lower().replace("\\", "/")
+    if f"spec-{issue:04d}" in lower or f"spec-{issue}" in lower:
+        return "spec"
+    if f"lld-{issue:03d}" in lower or f"lld-{issue}" in lower:
+        return "lld"
+    return None
+
+
+def collect_inputs(
+    repo_root: Path | str,
+    *,
+    issue_body: str | None,
+    upstream_artifact: Path | str | None = None,
+    doc_paths: tuple[str, ...] = BINDING_DOC_PATHS,
+) -> list[SettledInput]:
+    """The inputs a derivation at this stage depends on, hashed.
+
+    Pure apart from filesystem reads -- the issue body arrives already fetched,
+    so this stays testable without a network and without `gh`. A None body is
+    recorded as an unreadable input rather than omitted: an input that could
+    not be read must reach `verify` as a mismatch, and omitting it would let a
+    failed fetch read as "nothing to check" and settle everything.
+    """
+    inputs = [SettledInput(key="issue_body", sha256=None)] if issue_body is None \
+        else [input_from_text("issue_body", issue_body)]
+    if upstream_artifact is not None:
+        inputs.append(input_from_file("upstream:artifact", upstream_artifact))
+    inputs.extend(binding_inputs(Path(repo_root), doc_paths))
+    return inputs
+
+
+def build_settlement(
+    stage: str,
+    artifact_path: Path | str,
+    inputs: list[SettledInput],
+    *,
+    verdict: str = "",
+) -> dict:
+    """The durable record of one artifact having passed its gate."""
+    return {
+        "settlement_version": SETTLEMENT_VERSION,
+        "stage": stage,
+        "artifact_path": str(artifact_path),
+        "artifact_sha256": sha256_path(artifact_path),
+        "verdict": verdict,
+        "settled_at": datetime.now(tz=timezone.utc).isoformat(),
+        "inputs": [i.as_dict() for i in inputs],
+    }
+
+
+def verify(record: dict | None, current: list[SettledInput]) -> list[str]:
+    """Every way the world differs from what was settled. Empty means settled.
+
+    Reported in the reader's terms, not the hasher's: which input, by name,
+    and what it hashed then versus now.
+    """
+    if not isinstance(record, dict) or not record:
+        return ["no settlement record exists for this stage"]
+    if record.get("settlement_version") != SETTLEMENT_VERSION:
+        return [
+            f"settlement record is version {record.get('settlement_version')!r}; "
+            f"this reader understands {SETTLEMENT_VERSION}"
+        ]
+
+    recorded = {
+        entry.get("key"): SettledInput.from_dict(entry)
+        for entry in record.get("inputs", [])
+        if isinstance(entry, dict)
+    }
+    now = {i.key: i for i in current}
+
+    mismatches: list[str] = []
+    for key in sorted(set(recorded) | set(now)):
+        was, is_ = recorded.get(key), now.get(key)
+        if was is None:
+            mismatches.append(
+                f"{key}: a new input the settled artifact was not derived from"
+            )
+        elif is_ is None:
+            mismatches.append(
+                f"{key}: an input the settled artifact was derived from is gone"
+            )
+        elif is_.sha256 is None:
+            mismatches.append(
+                f"{key}: recorded as {_short(was.sha256)} and cannot be read now"
+            )
+        elif was.sha256 != is_.sha256:
+            mismatches.append(
+                f"{key}: hashed {_short(was.sha256)} when the artifact settled "
+                f"and hashes {_short(is_.sha256)} now"
+            )
+    return mismatches
+
+
+def artifact_matches(record: dict | None, artifact_path: Path | str) -> bool:
+    """True when the artifact on disk is the one that settled.
+
+    A settled record naming content that has since been hand-edited describes
+    an artifact that no longer exists. Reusing the edited file would present an
+    operator's unreviewed edit as gate-passed.
+    """
+    if not isinstance(record, dict) or not record:
+        return False
+    recorded = record.get("artifact_sha256")
+    if not recorded:
+        return False
+    return sha256_path(artifact_path) == recorded
+
+
+def evidence_lines(record: dict, current: list[SettledInput]) -> list[str]:
+    """The hash evidence a reused stage prints. Short, and per input."""
+    lines = [
+        f"settled {record.get('settled_at', '?')} "
+        f"(verdict {record.get('verdict') or 'n/a'}), "
+        f"artifact {_short(record.get('artifact_sha256'))}"
+    ]
+    by_key = {i.key: i for i in current}
+    for entry in record.get("inputs", []):
+        key = entry.get("key", "?")
+        matched = by_key.get(key)
+        lines.append(
+            f"  {key}: {_short(entry.get('sha256'))} "
+            f"== {_short(matched.sha256 if matched else None)}"
+        )
+    return lines
+
+
+def _short(digest: str | None) -> str:
+    return str(digest)[:12] if digest else "absent"

--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -32,6 +32,7 @@ from assemblyzero.workflows.orchestrator.state import (
     update_stage_result,
 )
 from assemblyzero.core.llm_provider import get_provider
+from assemblyzero.core import settlement as settlement_mod
 
 import logging
 
@@ -56,6 +57,74 @@ def mock_mode(state: OrchestrationState) -> bool:
     return bool((state.get("config", {}) or {}).get("mock_mode", False))
 
 
+def fetch_issue_body(target_repo: str, issue_number: int) -> str | None:
+    """The rolling issue's body text, or None when it cannot be read.
+
+    Indirected through a module-level function so a test can drive settlement
+    without `gh` and without a network. None is a real answer -- it reaches
+    `collect_inputs` as an unreadable input and unsettles, which drafts.
+    """
+    try:
+        from assemblyzero.workflows.requirements.precheck import fetch_issue
+
+        _title, body = fetch_issue(Path(target_repo), issue_number)
+        return body
+    except Exception:
+        # fail-open: only in shape -- None unsettles, and unsettled means the
+        # stage DRAFTS, which is the pre-#2609 behaviour and the safe
+        # direction. A settlement check must never be able to brick a roll.
+        return None
+
+
+def current_inputs(
+    state: OrchestrationState, stage: str, existing_artifacts: dict[str, str | None]
+) -> list[settlement_mod.SettledInput]:
+    """What this stage's derivation currently depends on, hashed (#2609)."""
+    target_repo = state.get("target_repo", "") or "."
+    issue_number = state["issue_number"]
+    upstream_stage = settlement_mod.UPSTREAM_OF.get(stage)
+    upstream = existing_artifacts.get(upstream_stage) if upstream_stage else None
+    return settlement_mod.collect_inputs(
+        target_repo,
+        issue_body=fetch_issue_body(target_repo, issue_number),
+        upstream_artifact=upstream,
+    )
+
+
+def settlement_status(
+    state: OrchestrationState,
+    stage: str,
+    artifact_path: str,
+    existing_artifacts: dict[str, str | None],
+) -> tuple[bool, list[str]]:
+    """(is_settled, lines). Lines are evidence when settled, mismatches when not.
+
+    A stage with no settlement record is NOT settled, and the caller falls back
+    to the pre-#2609 presence check rather than drafting -- an artifact written
+    before this feature existed has no record through no fault of its own, and
+    treating that as a reason to redraw would regress the very tax #2609 exists
+    to remove.
+    """
+    from assemblyzero.workflows.requirements.audit import load_settlement
+
+    target_repo = Path(state.get("target_repo", "") or ".")
+    record = load_settlement(state["issue_number"], stage, target_repo)
+    if record is None:
+        return (False, ["no settlement record"])
+
+    if not settlement_mod.artifact_matches(record, artifact_path):
+        return (False, [
+            f"the artifact at {artifact_path} is not the one that settled "
+            f"(recorded {str(record.get('artifact_sha256'))[:12]})"
+        ])
+
+    inputs = current_inputs(state, stage, existing_artifacts)
+    mismatches = settlement_mod.verify(record, inputs)
+    if mismatches:
+        return (False, mismatches)
+    return (True, settlement_mod.evidence_lines(record, inputs))
+
+
 def should_skip_stage(
     state: OrchestrationState,
     stage: str,
@@ -66,6 +135,13 @@ def should_skip_stage(
     Returns (should_skip, artifact_path).
 
     impl and pr stages are never skipped.
+
+    #2609: presence alone used to be the whole test, which failed in both
+    directions. An artifact whose source issue had since been edited was reused
+    silently, and an artifact whose file cleanup had deleted after its PR merged
+    was redrawn even though the ruling it embodied had not changed. Settlement
+    decides both: a settled artifact is reused with its hash evidence printed,
+    and an input change unsettles it by name.
     """
     if stage in ("impl", "pr"):
         return (False, None)
@@ -84,10 +160,63 @@ def should_skip_stage(
 
     # Validate the artifact actually exists and is valid
     path = Path(artifact_path)
-    if validate_artifact(path, stage):
-        return (True, artifact_path)
+    if not validate_artifact(path, stage):
+        return (False, None)
 
-    return (False, None)
+    if stage in settlement_mod.SETTLEABLE_STAGES:
+        settled, lines = settlement_status(
+            state, stage, artifact_path, existing_artifacts
+        )
+        if settled:
+            print(f"    [{stage}] settled and reused -- no drafter spend")
+            for line in lines:
+                print(f"    [{stage}] {line}")
+            return (True, artifact_path)
+        if lines != ["no settlement record"]:
+            print(f"    [{stage}] unsettled -- redrawing:")
+            for line in lines:
+                print(f"    [{stage}]   {line}")
+            return (False, None)
+
+    return (True, artifact_path)
+
+
+def settle_stage(
+    state: OrchestrationState, stage: str, artifact_path: str, verdict: str = ""
+) -> None:
+    """Record ``stage``'s artifact as settled, having just passed its gate.
+
+    Called only on a passed result. Best-effort by design: a settlement that
+    cannot be written costs the next launch a redraw, which is the pre-#2609
+    behaviour, and must never turn a stage that genuinely passed into a
+    failure.
+    """
+    if stage not in settlement_mod.SETTLEABLE_STAGES or not artifact_path:
+        return
+    try:
+        from assemblyzero.workflows.requirements.audit import save_settlement
+
+        target_repo = Path(state.get("target_repo", "") or ".")
+        existing = detect_existing_artifacts(
+            state["issue_number"], state.get("target_repo", "")
+        )
+        record = settlement_mod.build_settlement(
+            stage,
+            artifact_path,
+            current_inputs(state, stage, existing),
+            verdict=verdict,
+        )
+        save_settlement(state["issue_number"], stage, record, target_repo)
+        print(
+            f"    [{stage}] settled: artifact "
+            f"{str(record['artifact_sha256'])[:12]}, "
+            f"{len(record['inputs'])} input(s) fingerprinted"
+        )
+    except Exception as exc:
+        # fail-open: a stage that passed its gate stays passed. Losing the
+        # record costs one redraw next launch; failing the stage would discard
+        # work that was already certified.
+        print(f"    [{stage}] settlement not recorded ({exc})")
 
 
 def check_human_gate(
@@ -580,6 +709,9 @@ def run_lld_stage(state: OrchestrationState) -> OrchestrationState:
                     duration_seconds=time.monotonic() - start_time,
                     attempts=1,
                 )
+                # #2609: the artifact passed its gate. Settle it, so the next
+                # launch reuses this ruling instead of re-deriving it.
+                settle_stage(state, stage, lld_path, review_verdict)
             else:
                 result = _make_stage_result(
                     status="blocked",
@@ -1046,6 +1178,9 @@ def run_spec_stage(state: OrchestrationState) -> OrchestrationState:
                 attempts=1,
                 notes=_declared_fallthroughs(sub_result),
             )
+            # #2609: the spec passed its gate. Its inputs include the upstream
+            # settled LLD, so editing the LLD unsettles the spec derived from it.
+            settle_stage(state, stage, spec_path)
         else:
             error_msg = sub_result.get("error_message", "")
             if not error_msg:

--- a/assemblyzero/workflows/requirements/audit.py
+++ b/assemblyzero/workflows/requirements/audit.py
@@ -870,6 +870,90 @@ def _reset_lld_status_entry(issue_number: int, target_repo: Path) -> None:
 
 
 # =============================================================================
+# Stage finality (#2609)
+# =============================================================================
+#
+# The settlement record rides INSIDE this cache's per-issue entry rather than
+# in a store of its own, because this file already has every property stage
+# finality needs and had been missing only a reader: it is repo-scoped (#1160),
+# lives in the repo's gitignored `data/` (#1970), survives arc rotation and
+# `--fresh` because no branch carries it, and cleanup is documented never to
+# delete it (`stages.py::_delete_landed_working_copies`).
+#
+# One consequence falls out for free and is correct: `_reset_lld_status_entry`
+# (#279) rewrites the entry from scratch, so an explicit LLD regeneration drops
+# the settlement for BOTH stages. Regenerating the LLD unsettles the spec
+# derived from it, which is the downstream-chain rule #2609 asks for.
+
+
+def load_settlement(
+    issue_number: int, stage: str, target_repo: Path
+) -> dict | None:
+    """This issue's settlement record for ``stage``, or None."""
+    tracking = load_lld_tracking(target_repo)
+    entry = tracking["issues"].get(str(issue_number))
+    if not isinstance(entry, dict):
+        return None
+    settlement = entry.get("settlement")
+    if not isinstance(settlement, dict):
+        return None
+    record = settlement.get(stage)
+    return record if isinstance(record, dict) else None
+
+
+def save_settlement(
+    issue_number: int, stage: str, record: dict, target_repo: Path
+) -> None:
+    """Record ``stage`` as settled, preserving every other field of the entry.
+
+    Read-modify-write of the issue's entry, not a replacement: the approval
+    fields this cache already carried are what a human reads, and a settlement
+    write must not quietly drop them.
+    """
+    tracking = load_lld_tracking(target_repo)
+    key = str(issue_number)
+    entry = tracking["issues"].get(key)
+    if not isinstance(entry, dict):
+        entry = {}
+    settlement = entry.get("settlement")
+    if not isinstance(settlement, dict):
+        settlement = {}
+    settlement[stage] = record
+    entry["settlement"] = settlement
+    tracking["issues"][key] = entry
+    save_lld_tracking(tracking, target_repo)
+
+
+def unsettle(issue_number: int, stage: str, target_repo: Path) -> bool:
+    """Drop ``stage``'s settlement. True when one was actually removed."""
+    tracking = load_lld_tracking(target_repo)
+    key = str(issue_number)
+    entry = tracking["issues"].get(key)
+    if not isinstance(entry, dict):
+        return False
+    settlement = entry.get("settlement")
+    if not isinstance(settlement, dict) or stage not in settlement:
+        return False
+    del settlement[stage]
+    entry["settlement"] = settlement
+    tracking["issues"][key] = entry
+    save_lld_tracking(tracking, target_repo)
+    return True
+
+
+def settled_stages(issue_number: int, target_repo: Path) -> list[str]:
+    """Stages this issue has a settlement record for, in a stable order."""
+    tracking = load_lld_tracking(target_repo)
+    entry = tracking["issues"].get(str(issue_number))
+    if not isinstance(entry, dict):
+        return []
+    settlement = entry.get("settlement")
+    if not isinstance(settlement, dict):
+        return []
+    return sorted(k for k, v in settlement.items() if isinstance(v, dict))
+
+
+# =============================================================================
 # LLD Finalization
 # =============================================================================
 

--- a/docs/standards/0030-guard-interaction-matrix.md
+++ b/docs/standards/0030-guard-interaction-matrix.md
@@ -77,7 +77,7 @@ The draft the drafter emits and every gate reads.
 Untracked pipeline emissions on disk, and who may remove them.
 
 **Mechanisms:** `leavings-janitor`, `restore-machinery`, `loaders`,
-`launch-sweep`.
+`launch-sweep`, `settlement`.
 
 | pair | ruling | invariant |
 |---|---|---|
@@ -87,6 +87,10 @@ Untracked pipeline emissions on disk, and who may remove them.
 | launch-sweep × leavings-janitor | `test_leavings_janitor.py` | The exemption is applied at BOTH sweep sites, and it is issue-scoped at each. |
 | launch-sweep × loaders | `test_mock_roll.py` | A launch never clears the input the loader is about to read on entry. #2551's kill, replayed end to end against a real repo. |
 | launch-sweep × restore-machinery | `test_restore_from_graveyard.py` | Whatever a launch sweeps is recoverable: the ref is pushed before the file is removed. |
+| settlement × launch-sweep | `test_stage_finality_launcher.py` | A settled artifact survives `--fresh` and is stated as preserved; an unsettled one is archived and the mismatch that unsettled it is stated too. Settledness decides, never branch contents. |
+| settlement × leavings-janitor | `test_stage_finality_launcher.py` | Preservation is a named-file veto on the reset's archiving step, never a widening of the janitor's input exemption — #2551's issue-scoping is untouched, and a preserved file is still re-verified against its inputs at the next stage entry. |
+| settlement × loaders | `test_stage_finality_skip.py` | A loader reads what settlement preserved: reuse requires the artifact on disk to hash as the one that settled, so a file edited after settling is redrawn rather than loaded. |
+| settlement × restore-machinery | **non-interacting** | Settlement only ever declines a removal and restore only ever re-materialises content — no shared write and no ordering between them. A rebuilt working copy is checked against its recorded artifact hash at stage entry like any other file, so the restorer never needs to consult settledness. |
 
 ## Artifact: `halt-resume-state`
 

--- a/tests/unit/test_speedrun_roll.py
+++ b/tests/unit/test_speedrun_roll.py
@@ -169,8 +169,9 @@ class TestEnsureBaseDecides:
         _git(repo, "branch", "issue-4")
         healed = {}
 
-        def fake_reset(repo_root, slug, issue):
+        def fake_reset(repo_root, slug, issue, preserve=None):
             healed["called"] = issue
+            healed["preserve"] = preserve
             _git(repo_root, "branch", "-d", "issue-4")
 
         with _no_network(), \
@@ -180,6 +181,9 @@ class TestEnsureBaseDecides:
 
         assert healed["called"] == 4
         assert base == "hardening-run-11"
+        # #2609: nothing is settled in this fixture, so the reset is told to
+        # preserve nothing and behaves exactly as it did before.
+        assert healed["preserve"] == set()
 
     def test_recoverable_debris_without_fresh_refuses(self, repo, log):
         """#2409: the same debris, no flag. Nothing is reset and the roll stops.

--- a/tests/unit/test_stage_finality.py
+++ b/tests/unit/test_stage_finality.py
@@ -1,0 +1,391 @@
+"""Stage finality: settled until the inputs change (#2609).
+
+The observed history as fixture, inverted. boostgauge #331 took 20 launches in
+12 days and had its LLD drawn from scratch seven times while `lld-status.json`
+said `"status": "approved"` the whole while -- because that record had no
+reader and no input hashes. These tests pin both halves: a settled artifact is
+reused with zero drafter spend, and a one-character edit to the source's
+decision table unsettles it by name.
+
+Every reuse test has a control asserting the inverse, because a settledness
+check that never unsettles and one that always settles are indistinguishable
+from a test that only ever asserts reuse.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core import settlement as s
+from assemblyzero.workflows.requirements.audit import (
+    load_settlement,
+    save_settlement,
+    settled_stages,
+    unsettle,
+)
+
+ISSUE = 331
+
+SOURCE_TABLE = """\
+| ID | Decision | Binding value |
+|----|----------|---------------|
+| S1 | sampling window | 250 ms |
+| S7 | redline colour | #AA0F19 |
+| S9 | needle tip | 0.82 r |
+"""
+
+ISSUE_BODY = f"""\
+# The dial must sample on a fixed window
+
+## Pass criteria
+
+{SOURCE_TABLE}
+"""
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A target repo shaped like a real one: docs tree, binding docs, data/."""
+    (tmp_path / "docs" / "lld" / "active").mkdir(parents=True)
+    (tmp_path / "docs" / "lld" / "drafts").mkdir(parents=True)
+    (tmp_path / "docs" / "design").mkdir(parents=True)
+    (tmp_path / "docs" / "design" / "dial.md").write_text(
+        "The dial's law.\n", encoding="utf-8"
+    )
+    (tmp_path / "CLAUDE.md").write_text("Repo rules.\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def lld(repo: Path) -> Path:
+    path = repo / "docs" / "lld" / "active" / f"LLD-{ISSUE:03d}.md"
+    path.write_text(f"## 3. Requirements\n\n{SOURCE_TABLE}", encoding="utf-8")
+    return path
+
+
+def _inputs(repo: Path, body: str = ISSUE_BODY, upstream: Path | None = None):
+    return s.collect_inputs(repo, issue_body=body, upstream_artifact=upstream)
+
+
+def _settle(repo: Path, lld: Path, body: str = ISSUE_BODY) -> dict:
+    record = s.build_settlement("lld", lld, _inputs(repo, body), verdict="APPROVED")
+    save_settlement(ISSUE, "lld", record, repo)
+    return record
+
+
+# ---------------------------------------------------------------------------
+# The invariant: settled until the inputs change
+# ---------------------------------------------------------------------------
+
+
+class TestSettledUntilInputsChange:
+    def test_unchanged_inputs_stay_settled(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        assert s.verify(record, _inputs(repo)) == []
+
+    def test_one_character_edit_to_the_table_unsettles(
+        self, repo: Path, lld: Path
+    ) -> None:
+        """The acceptance case: 250 ms -> 251 ms, and the redraw cites it."""
+        record = _settle(repo, lld)
+        edited = ISSUE_BODY.replace("250 ms", "251 ms")
+        assert edited != ISSUE_BODY  # the fixture really did change
+
+        mismatches = s.verify(record, _inputs(repo, edited))
+
+        assert len(mismatches) == 1
+        assert mismatches[0].startswith("issue_body:")
+        assert "when the artifact settled" in mismatches[0]
+
+    def test_a_binding_doc_edit_unsettles(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        (repo / "docs" / "design" / "dial.md").write_text(
+            "The dial's law, amended.\n", encoding="utf-8"
+        )
+        mismatches = s.verify(record, _inputs(repo))
+        assert [m for m in mismatches if m.startswith("binding:docs/design/dial.md")]
+
+    def test_a_new_binding_doc_unsettles(self, repo: Path, lld: Path) -> None:
+        """A gained input changes the derivation even though nothing was edited."""
+        record = _settle(repo, lld)
+        (repo / "docs" / "design" / "colour.md").write_text("New law.\n", encoding="utf-8")
+        mismatches = s.verify(record, _inputs(repo))
+        assert any("a new input" in m for m in mismatches), mismatches
+
+    def test_a_removed_binding_doc_unsettles(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        (repo / "docs" / "design" / "dial.md").unlink()
+        mismatches = s.verify(record, _inputs(repo))
+        assert any("is gone" in m for m in mismatches), mismatches
+
+    def test_an_unreadable_issue_body_unsettles(self, repo: Path, lld: Path) -> None:
+        """A failed `gh` read must never read as 'nothing changed'."""
+        record = _settle(repo, lld)
+        mismatches = s.verify(record, _inputs(repo, body=None))
+        assert any(m.startswith("issue_body:") for m in mismatches), mismatches
+
+    def test_no_record_is_not_settled(self, repo: Path) -> None:
+        assert s.verify(None, _inputs(repo)) == [
+            "no settlement record exists for this stage"
+        ]
+
+    def test_a_future_version_is_not_settled(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        record["settlement_version"] = s.SETTLEMENT_VERSION + 1
+        assert s.verify(record, _inputs(repo)) != []
+
+
+class TestTheArtifactItselfMustMatch:
+    def test_the_settled_artifact_matches(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        assert s.artifact_matches(record, lld)
+
+    def test_a_hand_edited_artifact_does_not_match(
+        self, repo: Path, lld: Path
+    ) -> None:
+        """Reusing an edited file would present an unreviewed edit as gated."""
+        record = _settle(repo, lld)
+        lld.write_text(lld.read_text(encoding="utf-8") + "\nhand edit\n",
+                       encoding="utf-8")
+        assert not s.artifact_matches(record, lld)
+
+    def test_a_missing_artifact_does_not_match(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        lld.unlink()
+        assert not s.artifact_matches(record, lld)
+
+
+# ---------------------------------------------------------------------------
+# #2615: content, not timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestContentNotTimestamps:
+    """A comment bumps an issue's `updatedAt` and changes no binding text.
+
+    The measured evidence is on #2615: #2540's `updatedAt` equalled its last
+    comment's `createdAt` to the second, and #2611 with zero comments had
+    `updatedAt == createdAt`. A timestamp check unsettles on the campaign's own
+    method of posting a diagnosis before fixing. Hashing the body cannot.
+    """
+
+    def test_a_body_that_did_not_change_stays_settled(
+        self, repo: Path, lld: Path
+    ) -> None:
+        record = _settle(repo, lld)
+        # Same text, re-fetched later. A timestamp check would call this stale.
+        assert s.verify(record, _inputs(repo, ISSUE_BODY)) == []
+
+    def test_whitespace_only_line_ending_change_stays_settled(
+        self, repo: Path, lld: Path
+    ) -> None:
+        """LF from `gh`, CRLF from a Windows checkout -- the same document."""
+        record = _settle(repo, lld)
+        crlf = ISSUE_BODY.replace("\n", "\r\n")
+        assert crlf != ISSUE_BODY
+        assert s.verify(record, _inputs(repo, crlf)) == []
+
+
+# ---------------------------------------------------------------------------
+# The store: durable, and it keeps what it already carried
+# ---------------------------------------------------------------------------
+
+
+class TestTheStore:
+    def test_settlement_round_trips(self, repo: Path, lld: Path) -> None:
+        written = _settle(repo, lld)
+        assert load_settlement(ISSUE, "lld", repo) == written
+
+    def test_no_settlement_reads_as_none(self, repo: Path) -> None:
+        assert load_settlement(ISSUE, "lld", repo) is None
+
+    def test_settling_preserves_the_approval_fields(
+        self, repo: Path, lld: Path
+    ) -> None:
+        """The cache's existing content is what a human reads; a settlement
+        write is a read-modify-write, never a replacement."""
+        from assemblyzero.workflows.requirements.audit import update_lld_status
+
+        update_lld_status(
+            ISSUE, str(lld),
+            {"has_gemini_review": True, "final_verdict": "APPROVED",
+             "last_review_date": "2026-08-28T14:42:38Z", "review_count": 1},
+            repo,
+        )
+        _settle(repo, lld)
+
+        from assemblyzero.workflows.requirements.audit import load_lld_tracking
+
+        entry = load_lld_tracking(repo)["issues"][str(ISSUE)]
+        assert entry["status"] == "approved"
+        assert entry["final_verdict"] == "APPROVED"
+        assert entry["review_count"] == 1
+        assert "settlement" in entry
+
+    def test_two_stages_settle_independently(self, repo: Path, lld: Path) -> None:
+        spec = repo / "docs" / "lld" / "drafts" / f"spec-{ISSUE:04d}-x.md"
+        spec.write_text("spec\n", encoding="utf-8")
+        _settle(repo, lld)
+        save_settlement(
+            ISSUE, "spec",
+            s.build_settlement("spec", spec, _inputs(repo, upstream=lld)),
+            repo,
+        )
+        assert settled_stages(ISSUE, repo) == ["lld", "spec"]
+
+    def test_unsettle_removes_only_its_stage(self, repo: Path, lld: Path) -> None:
+        spec = repo / "docs" / "lld" / "drafts" / f"spec-{ISSUE:04d}-x.md"
+        spec.write_text("spec\n", encoding="utf-8")
+        _settle(repo, lld)
+        save_settlement(
+            ISSUE, "spec", s.build_settlement("spec", spec, _inputs(repo)), repo
+        )
+        assert unsettle(ISSUE, "spec", repo) is True
+        assert settled_stages(ISSUE, repo) == ["lld"]
+
+    def test_unsettle_reports_when_nothing_was_there(self, repo: Path) -> None:
+        assert unsettle(ISSUE, "lld", repo) is False
+
+    def test_regenerating_the_lld_unsettles_the_whole_chain(
+        self, repo: Path, lld: Path
+    ) -> None:
+        """#279's reset rewrites the entry, which drops both stages.
+
+        Regenerating an LLD must unsettle the spec derived from it -- the
+        downstream-chain rule. This asserts the behaviour rather than the
+        mechanism, so a future rewrite of the reset cannot silently lose it.
+        """
+        from assemblyzero.workflows.requirements.audit import (
+            _reset_lld_status_entry,
+        )
+
+        _settle(repo, lld)
+        save_settlement(
+            ISSUE, "spec", s.build_settlement("spec", lld, _inputs(repo)), repo
+        )
+        assert settled_stages(ISSUE, repo) == ["lld", "spec"]
+
+        _reset_lld_status_entry(ISSUE, repo)
+
+        assert settled_stages(ISSUE, repo) == []
+
+
+# ---------------------------------------------------------------------------
+# The upstream chain (#2611's ruling, structurally)
+# ---------------------------------------------------------------------------
+
+
+class TestUpstreamChain:
+    def test_spec_derives_from_the_lld_not_the_issue(self) -> None:
+        assert s.UPSTREAM_OF["spec"] == "lld"
+
+    def test_lld_derives_from_the_source(self) -> None:
+        assert s.UPSTREAM_OF["lld"] is None
+
+    def test_editing_the_lld_unsettles_the_spec(self, repo: Path, lld: Path) -> None:
+        spec = repo / "docs" / "lld" / "drafts" / f"spec-{ISSUE:04d}-x.md"
+        spec.write_text("spec\n", encoding="utf-8")
+        record = s.build_settlement("spec", spec, _inputs(repo, upstream=lld))
+
+        lld.write_text("## 3. Requirements\n\n(gutted)\n", encoding="utf-8")
+
+        mismatches = s.verify(record, _inputs(repo, upstream=lld))
+        assert any(m.startswith("upstream:artifact") for m in mismatches), mismatches
+
+    def test_an_untouched_lld_leaves_the_spec_settled(
+        self, repo: Path, lld: Path
+    ) -> None:
+        spec = repo / "docs" / "lld" / "drafts" / f"spec-{ISSUE:04d}-x.md"
+        spec.write_text("spec\n", encoding="utf-8")
+        record = s.build_settlement("spec", spec, _inputs(repo, upstream=lld))
+        assert s.verify(record, _inputs(repo, upstream=lld)) == []
+
+
+# ---------------------------------------------------------------------------
+# Artifact path -> stage, the launcher's half
+# ---------------------------------------------------------------------------
+
+
+class TestStageOfArtifactPath:
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("docs/lld/active/LLD-331.md", "lld"),
+            ("docs/lld/active/LLD-007.md", None),  # a different issue
+            ("docs/lld/drafts/spec-0331-implementation-readiness.md", "spec"),
+            ("docs\\lld\\active\\LLD-331.md", "lld"),  # windows separators
+            ("docs/lld/active/README.md", None),
+        ],
+    )
+    def test_maps_paths_the_clean_check_emits(
+        self, path: str, expected: str | None
+    ) -> None:
+        assert s.stage_of_artifact_path(path, ISSUE) == expected
+
+    def test_padded_and_unpadded_lld_both_map(self) -> None:
+        assert s.stage_of_artifact_path("docs/lld/active/LLD-007.md", 7) == "lld"
+        assert s.stage_of_artifact_path("docs/lld/active/LLD-7.md", 7) == "lld"
+
+
+# ---------------------------------------------------------------------------
+# Line-ending normalisation, stated as its own guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestNormalisation:
+    def test_crlf_and_lf_hash_the_same(self) -> None:
+        assert s.sha256_text("a\r\nb\r\n") == s.sha256_text("a\nb\n")
+
+    def test_lone_cr_normalises_too(self) -> None:
+        assert s.sha256_text("a\rb") == s.sha256_text("a\nb")
+
+    def test_different_content_still_differs(self) -> None:
+        """The control: normalisation must not flatten real differences."""
+        assert s.sha256_text("a\nb\n") != s.sha256_text("a\nc\n")
+
+    def test_a_file_and_its_text_agree(self, tmp_path: Path) -> None:
+        path = tmp_path / "x.md"
+        path.write_bytes(b"line one\r\nline two\r\n")
+        assert s.sha256_path(path) == s.sha256_text("line one\nline two\n")
+
+    def test_an_unreadable_file_hashes_as_none(self, tmp_path: Path) -> None:
+        assert s.sha256_path(tmp_path / "does-not-exist.md") is None
+
+
+# ---------------------------------------------------------------------------
+# Evidence the reused stage prints
+# ---------------------------------------------------------------------------
+
+
+class TestEvidence:
+    def test_evidence_names_every_input(self, repo: Path, lld: Path) -> None:
+        record = _settle(repo, lld)
+        lines = s.evidence_lines(record, _inputs(repo))
+        body = "\n".join(lines)
+        assert "issue_body" in body
+        assert "binding:docs/design/dial.md" in body
+        assert "binding:CLAUDE.md" in body
+
+    def test_evidence_leads_with_the_settlement_and_artifact(
+        self, repo: Path, lld: Path
+    ) -> None:
+        record = _settle(repo, lld)
+        first = s.evidence_lines(record, _inputs(repo))[0]
+        assert "settled" in first
+        assert "APPROVED" in first
+        assert str(record["artifact_sha256"])[:12] in first
+
+
+class TestBindingInputsAreStable:
+    def test_order_does_not_depend_on_the_filesystem(self, repo: Path) -> None:
+        first = [i.key for i in s.binding_inputs(repo, s.BINDING_DOC_PATHS)]
+        for name in ("z.md", "a.md", "m.md"):
+            (repo / "docs" / "design" / name).write_text("x\n", encoding="utf-8")
+        second = [i.key for i in s.binding_inputs(repo, s.BINDING_DOC_PATHS)]
+        assert second == sorted(second)
+        assert set(first).issubset(set(second))
+
+    def test_a_missing_doc_root_is_not_an_error(self, tmp_path: Path) -> None:
+        assert s.binding_inputs(tmp_path, ("docs/design",)) == []

--- a/tests/unit/test_stage_finality_launcher.py
+++ b/tests/unit/test_stage_finality_launcher.py
@@ -1,0 +1,257 @@
+"""The launcher consults settledness, not branch contents (#2609).
+
+The 09:36 line, inverted:
+
+    BASE 'hardening-run-18' already contains #331's work (1 artifact(s))
+    -- establishing a fresh attempt
+
+That is settling work being read as contamination. A committed LLD on the arc
+branch is where an approved artifact is SUPPOSED to live, so landing it there
+was what triggered redrawing it -- and the redraw shed the settled #361
+sampling window twice.
+
+The committed-artifact scan reads `docs/lld` only, so every finding it can
+produce is an LLD or a spec. #1959's founding case -- a base whose
+implementations were already merged and green -- is invisible to this scan and
+stays that way; the control below pins it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_reset as reset  # noqa: E402
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.core import settlement as s  # noqa: E402
+from assemblyzero.workflows.requirements.audit import save_settlement  # noqa: E402
+
+ISSUE = 331
+BODY = "# Dial\n\n| ID | value |\n|----|-------|\n| S1 | 250 ms |\n"
+FINDING = "committed artifact: docs/lld/active/LLD-331.md"
+
+
+class _Log:
+    """The launcher's EventLog surface, captured."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.lines.append(line)
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "docs" / "lld" / "active").mkdir(parents=True)
+    (tmp_path / "docs" / "lld" / "drafts").mkdir(parents=True)
+    (tmp_path / "docs" / "design").mkdir(parents=True)
+    (tmp_path / "docs" / "design" / "dial.md").write_text("law\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def lld(repo: Path) -> Path:
+    path = repo / "docs" / "lld" / "active" / f"LLD-{ISSUE}.md"
+    path.write_text("## 1. Context\n\n| S1 | 250 ms |\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def body_is(monkeypatch):
+    def _set(text: str | None):
+        monkeypatch.setattr(
+            sr, "fetch_issue",
+            lambda _repo, _issue: ("title", text) if text is not None
+            else (_ for _ in ()).throw(RuntimeError("gh down")),
+        )
+
+    return _set
+
+
+def _settle(repo: Path, lld: Path, body: str = BODY, stage: str = "lld") -> None:
+    save_settlement(
+        ISSUE, stage,
+        s.build_settlement(
+            stage, lld, s.collect_inputs(repo, issue_body=body), verdict="APPROVED"
+        ),
+        repo,
+    )
+
+
+class TestSettledWorkIsNotContamination:
+    def test_a_settled_committed_lld_is_preserved(
+        self, repo, lld, body_is
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY)
+
+        settled, unsettled = sr.partition_by_settledness(repo, ISSUE, [FINDING])
+
+        assert settled == [FINDING]
+        assert unsettled == []
+
+    def test_an_unsettled_committed_lld_is_still_contamination(
+        self, repo, lld, body_is
+    ) -> None:
+        """The control. Without it a function that returns everything as
+        settled would pass the test above."""
+        _settle(repo, lld)
+        body_is(BODY.replace("250 ms", "251 ms"))
+
+        settled, unsettled = sr.partition_by_settledness(repo, ISSUE, [FINDING])
+
+        assert settled == []
+        assert len(unsettled) == 1
+        assert unsettled[0][0] == FINDING
+        assert any("when the artifact settled" in r for r in unsettled[0][1])
+
+    def test_no_settlement_record_is_contamination(
+        self, repo, lld, body_is
+    ) -> None:
+        body_is(BODY)
+        settled, unsettled = sr.partition_by_settledness(repo, ISSUE, [FINDING])
+        assert settled == []
+        assert unsettled[0][1] == ["no settlement record"]
+
+    def test_an_unrecognised_artifact_is_never_reprieved(
+        self, repo, lld, body_is
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY)
+        odd = "committed artifact: docs/lld/active/NOTES.md"
+
+        settled, unsettled = sr.partition_by_settledness(repo, ISSUE, [odd])
+
+        assert settled == []
+        assert "not a recognised settleable artifact" in unsettled[0][1]
+
+    def test_another_issues_artifact_is_never_reprieved(
+        self, repo, lld, body_is
+    ) -> None:
+        """#1959's shape: a base carrying a DIFFERENT issue's work."""
+        _settle(repo, lld)
+        body_is(BODY)
+        other = "committed artifact: docs/lld/active/LLD-007.md"
+
+        settled, unsettled = sr.partition_by_settledness(repo, ISSUE, [other])
+
+        assert settled == []
+
+    def test_a_failed_issue_read_is_contamination(
+        self, repo, lld, body_is
+    ) -> None:
+        """`gh` down must not settle anything."""
+        _settle(repo, lld)
+        body_is(None)
+
+        settled, _unsettled = sr.partition_by_settledness(repo, ISSUE, [FINDING])
+
+        assert settled == []
+
+    def test_mixed_findings_split(self, repo, lld, body_is) -> None:
+        _settle(repo, lld)
+        body_is(BODY)
+        odd = "committed artifact: docs/lld/drafts/spec-0331-x.md"
+
+        settled, unsettled = sr.partition_by_settledness(
+            repo, ISSUE, [FINDING, odd]
+        )
+
+        assert settled == [FINDING]
+        assert len(unsettled) == 1
+
+
+class TestFreshPreservesSettledArtifacts:
+    def test_a_settled_artifact_is_named_for_preservation(
+        self, repo, lld, body_is
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY)
+        log = _Log()
+
+        names = sr.settled_artifact_names(repo, ISSUE, log)
+
+        assert names == {f"LLD-{ISSUE}.md"}
+        assert "FRESH preserving settled lld" in log.text
+
+    def test_an_unsettled_artifact_is_archived_and_said_so(
+        self, repo, lld, body_is
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY.replace("250 ms", "251 ms"))
+        log = _Log()
+
+        names = sr.settled_artifact_names(repo, ISSUE, log)
+
+        assert names == set()
+        assert "FRESH archiving unsettled lld" in log.text
+        assert "when the artifact settled" in log.text
+
+    def test_a_hand_edited_artifact_is_archived(self, repo, lld, body_is) -> None:
+        _settle(repo, lld)
+        lld.write_text("## 1. Context\n\nedited\n", encoding="utf-8")
+        body_is(BODY)
+        log = _Log()
+
+        assert sr.settled_artifact_names(repo, ISSUE, log) == set()
+        assert "is not the file that settled" in log.text
+
+    def test_nothing_settled_names_nothing(self, repo, lld, body_is) -> None:
+        body_is(BODY)
+        assert sr.settled_artifact_names(repo, ISSUE, _Log()) == set()
+
+
+class TestResetHonoursPreservation:
+    """`relocate_lld_artifacts` is `--fresh`'s archiving step."""
+
+    def test_a_preserved_artifact_survives_the_reset(
+        self, repo, lld, capsys
+    ) -> None:
+        moved = reset.relocate_lld_artifacts(repo, ISSUE, {lld.name})
+
+        assert lld.is_file()
+        assert moved == 0
+        assert "Preserved (settled)" in capsys.readouterr().out
+
+    def test_an_unpreserved_artifact_is_relocated(self, repo, lld) -> None:
+        """The control: preservation must be the exception, not the default."""
+        reset.relocate_lld_artifacts(repo, ISSUE, set())
+
+        assert not lld.is_file()
+        assert (
+            repo / "data" / "speedrun" / "reset-artifacts" / f"issue-{ISSUE}"
+            / lld.name
+        ).is_file()
+
+    def test_the_default_is_unchanged(self, repo, lld) -> None:
+        """No `preserve` argument means exactly the pre-#2609 behaviour."""
+        reset.relocate_lld_artifacts(repo, ISSUE)
+        assert not lld.is_file()
+
+    def test_preserving_one_does_not_preserve_another(self, repo, lld) -> None:
+        spec = repo / "docs" / "lld" / "drafts" / f"spec-{ISSUE:04d}-x.md"
+        spec.write_text("spec\n", encoding="utf-8")
+
+        reset.relocate_lld_artifacts(repo, ISSUE, {lld.name})
+
+        assert lld.is_file()
+        assert not spec.is_file()
+
+
+class TestBindingDocPathsAreOneDefinition:
+    def test_the_launcher_imports_the_canonical_tuple(self) -> None:
+        """Two literals would let `draft_is_stale` and settlement disagree
+        about which documents bind, at which point one of them is wrong."""
+        assert sr.BINDING_DOC_PATHS is s.BINDING_DOC_PATHS

--- a/tests/unit/test_stage_finality_skip.py
+++ b/tests/unit/test_stage_finality_skip.py
@@ -1,0 +1,273 @@
+"""Stage entry reuses a settled artifact and redraws an unsettled one (#2609).
+
+The acceptance, driven through the real `should_skip_stage`: a settled LLD with
+matching hashes is reused with the hash evidence printed and zero drafter spend,
+and a one-character edit to the source's decision table unsettles it with the
+redraw citing the mismatch.
+
+`should_skip_stage` returning True IS the zero-spend guarantee -- the drafter
+lives behind it, and `run_lld_stage` returns a `skipped` result without ever
+building the requirements graph. The control below pins the inverse so a check
+that always skips cannot pass this file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core import settlement as s
+from assemblyzero.workflows.orchestrator import stages
+from assemblyzero.workflows.orchestrator.state import OrchestrationState
+from assemblyzero.workflows.requirements.audit import save_settlement
+
+ISSUE = 331
+
+TABLE = """\
+| ID | Decision | Binding value |
+|----|----------|---------------|
+| S1 | sampling window | 250 ms |
+"""
+
+BODY = f"# Dial\n\n## Pass criteria\n\n{TABLE}"
+
+LLD_TEXT = f"""\
+## 1. Context
+
+The dial samples on a fixed window.
+
+## 3. Requirements
+
+{TABLE}
+"""
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "docs" / "lld" / "active").mkdir(parents=True)
+    (tmp_path / "docs" / "design").mkdir(parents=True)
+    (tmp_path / "docs" / "design" / "dial.md").write_text("law\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def lld(repo: Path) -> Path:
+    path = repo / "docs" / "lld" / "active" / f"LLD-{ISSUE}.md"
+    path.write_text(LLD_TEXT, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def state(repo: Path) -> OrchestrationState:
+    return OrchestrationState(
+        issue_number=ISSUE, target_repo=str(repo), config={}
+    )
+
+
+@pytest.fixture
+def body_is(monkeypatch):
+    """Drive the issue body without `gh` and without a network."""
+
+    def _set(text: str | None):
+        monkeypatch.setattr(
+            stages, "fetch_issue_body", lambda _repo, _issue: text
+        )
+
+    return _set
+
+
+def _existing(repo: Path, lld: Path) -> dict[str, str | None]:
+    return {"triage": None, "lld": str(lld), "spec": None, "impl": None, "pr": None}
+
+
+def _settle(repo: Path, lld: Path, body: str = BODY) -> None:
+    record = s.build_settlement(
+        "lld", lld,
+        s.collect_inputs(repo, issue_body=body),
+        verdict="APPROVED",
+    )
+    save_settlement(ISSUE, "lld", record, repo)
+
+
+class TestSettledIsReused:
+    def test_a_settled_lld_is_reused(
+        self, repo, lld, state, body_is, capsys
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY)
+
+        skip, path = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is True
+        assert path == str(lld)
+
+    def test_the_reuse_prints_hash_evidence(
+        self, repo, lld, state, body_is, capsys
+    ) -> None:
+        """'settled-and-reused with the hash evidence' is the acceptance's
+        wording; an operator must be able to see WHY it was reused."""
+        _settle(repo, lld)
+        body_is(BODY)
+
+        stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        out = capsys.readouterr().out
+        assert "settled and reused -- no drafter spend" in out
+        assert "issue_body" in out
+        assert "binding:docs/design/dial.md" in out
+
+
+class TestAnInputChangeRedraws:
+    def test_a_one_character_edit_unsettles(
+        self, repo, lld, state, body_is, capsys
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY.replace("250 ms", "251 ms"))
+
+        skip, path = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is False
+        assert path is None
+
+    def test_the_redraw_cites_the_mismatch(
+        self, repo, lld, state, body_is, capsys
+    ) -> None:
+        _settle(repo, lld)
+        body_is(BODY.replace("250 ms", "251 ms"))
+
+        stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        out = capsys.readouterr().out
+        assert "unsettled -- redrawing" in out
+        assert "issue_body" in out
+        assert "when the artifact settled" in out
+
+    def test_a_binding_doc_edit_unsettles(self, repo, lld, state, body_is) -> None:
+        _settle(repo, lld)
+        (repo / "docs" / "design" / "dial.md").write_text("amended\n", encoding="utf-8")
+        body_is(BODY)
+
+        skip, _ = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is False
+
+    def test_a_hand_edited_lld_unsettles(self, repo, lld, state, body_is) -> None:
+        _settle(repo, lld)
+        lld.write_text(LLD_TEXT + "\nhand edit\n", encoding="utf-8")
+        body_is(BODY)
+
+        skip, _ = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is False
+
+    def test_a_failed_issue_read_unsettles(self, repo, lld, state, body_is) -> None:
+        """`gh` down must draft, never settle on an unread input."""
+        _settle(repo, lld)
+        body_is(None)
+
+        skip, _ = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is False
+
+
+class TestNonRegression:
+    """An artifact with no settlement record keeps the pre-#2609 behaviour.
+
+    Records are written from the first passed stage onward. Treating their
+    absence as a reason to redraw would impose the exact tax #2609 removes on
+    every artifact that predates it.
+    """
+
+    def test_no_record_still_skips_on_presence(
+        self, repo, lld, state, body_is
+    ) -> None:
+        body_is(BODY)
+        skip, path = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+        assert skip is True
+        assert path == str(lld)
+
+    def test_no_record_does_not_claim_to_be_settled(
+        self, repo, lld, state, body_is, capsys
+    ) -> None:
+        body_is(BODY)
+        stages.should_skip_stage(state, "lld", _existing(repo, lld))
+        assert "settled and reused" not in capsys.readouterr().out
+
+    def test_an_invalid_artifact_is_never_skipped(
+        self, repo, lld, state, body_is
+    ) -> None:
+        """The control: a file missing '## 1. Context' fails validation, and
+        settlement must not be able to wave it through."""
+        _settle(repo, lld)
+        lld.write_text("not an LLD\n", encoding="utf-8")
+        _settle(repo, lld)  # settle the broken file, so only validation objects
+        body_is(BODY)
+
+        skip, _ = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is False
+
+    def test_a_missing_artifact_is_never_skipped(self, repo, state, body_is) -> None:
+        body_is(BODY)
+        empty = {"triage": None, "lld": None, "spec": None, "impl": None, "pr": None}
+        assert stages.should_skip_stage(state, "lld", empty) == (False, None)
+
+    def test_impl_and_pr_are_never_skipped(self, repo, lld, state) -> None:
+        for stage in ("impl", "pr"):
+            assert stages.should_skip_stage(
+                state, stage, _existing(repo, lld)
+            ) == (False, None)
+
+    def test_skip_existing_lld_false_still_wins(self, repo, lld, body_is) -> None:
+        """A settled artifact does not override an explicit config refusal."""
+        _settle(repo, lld)
+        body_is(BODY)
+        state = OrchestrationState(
+            issue_number=ISSUE, target_repo=str(repo),
+            config={"skip_existing_lld": False},
+        )
+        assert stages.should_skip_stage(
+            state, "lld", _existing(repo, lld)
+        ) == (False, None)
+
+
+class TestSettleStage:
+    def test_a_passed_stage_settles(self, repo, lld, state, body_is, capsys) -> None:
+        body_is(BODY)
+
+        stages.settle_stage(state, "lld", str(lld), "APPROVED")
+
+        from assemblyzero.workflows.requirements.audit import load_settlement
+
+        record = load_settlement(ISSUE, "lld", repo)
+        assert record is not None
+        assert record["verdict"] == "APPROVED"
+        assert record["artifact_sha256"] == s.sha256_path(lld)
+
+    def test_settling_then_checking_reuses(
+        self, repo, lld, state, body_is
+    ) -> None:
+        """End to end: settle on pass, reuse on the next launch."""
+        body_is(BODY)
+        stages.settle_stage(state, "lld", str(lld), "APPROVED")
+
+        skip, _ = stages.should_skip_stage(state, "lld", _existing(repo, lld))
+
+        assert skip is True
+
+    def test_a_stage_that_cannot_settle_is_a_no_op(self, repo, state) -> None:
+        stages.settle_stage(state, "impl", "", "")  # must not raise
+
+    def test_settlement_failure_never_fails_the_stage(
+        self, repo, lld, state, monkeypatch, capsys
+    ) -> None:
+        """A stage that passed its gate stays passed."""
+        def boom(*_a, **_k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "assemblyzero.workflows.requirements.audit.save_settlement", boom
+        )
+        stages.settle_stage(state, "lld", str(lld), "APPROVED")  # must not raise
+        assert "settlement not recorded" in capsys.readouterr().out

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -573,7 +573,9 @@ def _is_git_tracked(repo_root: Path, file_path: Path) -> bool:
     return result.returncode == 0
 
 
-def relocate_lld_artifacts(repo_root: Path, issue: int) -> int:
+def relocate_lld_artifacts(
+    repo_root: Path, issue: int, preserve: set[str] | None = None
+) -> int:
     """
     Move untracked LLD/spec artifacts out of the target repo's docs tree.
 
@@ -585,7 +587,18 @@ def relocate_lld_artifacts(repo_root: Path, issue: int) -> int:
     commits, so working copies are relocated (never deleted) to
     `data/speedrun/reset-artifacts/issue-{N}/` for inspection. Tracked
     files are deliberate repo content and are left alone.
+
+    #2609: ``preserve`` names files (by basename) that are SETTLED and must
+    survive the reset. A settled artifact embodies a ruling that was not made
+    by the run being reset, so resetting the run must not discard it. The
+    settledness decision is made by the caller, which is where the inputs can
+    be hashed; this function only honours it, and says so per file.
+
+    ``preserve`` deliberately does not weaken #1849: an artifact left in place
+    is only skipped by the next run if it is still settled THEN, which the
+    stage-entry check re-verifies against the inputs at that moment.
     """
+    preserve = preserve or set()
     active = repo_root / "docs" / "lld" / "active"
     drafts = repo_root / "docs" / "lld" / "drafts"
     candidates: list[Path] = []
@@ -601,6 +614,11 @@ def relocate_lld_artifacts(repo_root: Path, issue: int) -> int:
         if artifact in seen or not artifact.is_file():
             continue
         seen.add(artifact)
+        if artifact.name in preserve:
+            print(
+                f"  Preserved (settled): {artifact.relative_to(repo_root)}"
+            )
+            continue
         if _is_git_tracked(repo_root, artifact):
             continue
         dest_dir.mkdir(parents=True, exist_ok=True)
@@ -654,12 +672,16 @@ def reopen_issue(repo: str, issue: int) -> bool:
     return False
 
 
-def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
+def reset_one_issue(
+    repo_root: Path, repo: str, issue: int, preserve: set[str] | None = None
+) -> None:
     """Run all reset steps for one issue.
 
     #2409: the checkpoint is pinned FIRST, before anything that could orphan
     it. Branch deletion is what unreferences a checkpoint commit, so the pin
     has to precede it or the ordering is the bug.
+
+    #2609: ``preserve`` names settled artifacts the reset must leave in place.
     """
     print(f"\nResetting issue #{issue}:")
     pin_checkpoint(repo_root, issue)
@@ -668,7 +690,7 @@ def reset_one_issue(repo_root: Path, repo: str, issue: int) -> None:
     delete_local_branches(repo_root, issue)
     delete_remote_branches(repo_root, issue)
     archive_lineage_dirs(repo_root, issue)
-    relocate_lld_artifacts(repo_root, issue)
+    relocate_lld_artifacts(repo_root, issue, preserve)
     reopen_issue(repo, issue)
 
 

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -126,6 +126,11 @@ from assemblyzero.speedrun.must_resolve import (  # noqa: E402
     refusal_message,
 )
 from assemblyzero.speedrun.healing import record_heal  # noqa: E402
+from assemblyzero.core import settlement as settlement_mod  # noqa: E402  (#2609)
+from assemblyzero.workflows.requirements.audit import (  # noqa: E402  (#2609)
+    load_settlement,
+    settled_stages,
+)
 from assemblyzero.speedrun.leavings import (  # noqa: E402
     classify_dirt,
     is_machinery_owned,
@@ -388,6 +393,108 @@ def refuse_with_exits(
     )
 
 
+def settlement_inputs(repo_root: Path, issue: int, stage: str) -> list:
+    """Current inputs for ``stage``, as the launcher can see them (#2609).
+
+    The launcher hashes the same things the stage does, so the two agree on
+    whether an artifact is settled. A `gh` read that fails yields a None body,
+    which unsettles -- the launcher then behaves exactly as it did before.
+    """
+    try:
+        _title, body = fetch_issue(repo_root, issue)
+    except Exception:
+        # fail-open: only in shape -- a None body unsettles, which restores
+        # the pre-#2609 path. A settlement probe must not be able to stop a
+        # launch it was only advising.
+        body = None
+    upstream_stage = settlement_mod.UPSTREAM_OF.get(stage)
+    upstream = None
+    if upstream_stage:
+        record = load_settlement(issue, upstream_stage, repo_root)
+        if isinstance(record, dict):
+            upstream = record.get("artifact_path") or None
+    return settlement_mod.collect_inputs(
+        repo_root, issue_body=body, upstream_artifact=upstream
+    )
+
+
+def settled_artifact_names(repo_root: Path, issue: int, log: EventLog) -> set[str]:
+    """Basenames of this issue's SETTLED artifacts, for `--fresh` to preserve.
+
+    #2609: `--fresh` resets the RUN. A settled artifact embodies a ruling the
+    run being reset did not make, so it survives, and each decision is stated
+    -- preserved with its evidence, or archived with the mismatch that
+    unsettled it. Silence about either half is what made a reset feel
+    arbitrary.
+    """
+    names: set[str] = set()
+    for stage in settled_stages(issue, repo_root):
+        record = load_settlement(issue, stage, repo_root)
+        if not isinstance(record, dict):
+            continue
+        artifact = record.get("artifact_path") or ""
+        if not artifact:
+            continue
+        mismatches = settlement_mod.verify(
+            record, settlement_inputs(repo_root, issue, stage)
+        )
+        if mismatches:
+            log.write(f"FRESH archiving unsettled {stage}: {Path(artifact).name}")
+            for reason in mismatches:
+                log.write(f"  {reason}")
+            continue
+        if not settlement_mod.artifact_matches(record, artifact):
+            log.write(
+                f"FRESH archiving {stage}: {Path(artifact).name} is not the "
+                f"file that settled (edited since)"
+            )
+            continue
+        names.add(Path(artifact).name)
+        log.write(
+            f"FRESH preserving settled {stage}: {Path(artifact).name} "
+            f"(settled {record.get('settled_at', '?')})"
+        )
+    return names
+
+
+def partition_by_settledness(
+    repo_root: Path, issue: int, committed: list[str]
+) -> tuple[list[str], list[tuple[str, list[str]]]]:
+    """Split committed-artifact findings into (settled, [(finding, why-not)]).
+
+    #2609: the committed-artifact scan reads `docs/lld` only, so every finding
+    it can produce is an LLD or a spec -- never implementation code. When those
+    artifacts are settled, a base carrying them is the DESIRED state and not
+    contamination: it is the arc holding the ruling the pipeline just landed
+    there. Reading it as staleness is what made landing an approved artifact
+    the trigger for redrawing it.
+
+    #1959's founding case is untouched. That case was a base whose
+    implementations were already merged and green; this scan never saw those,
+    and does not see them now.
+    """
+    settled: list[str] = []
+    unsettled: list[tuple[str, list[str]]] = []
+    for finding in committed:
+        path = finding.split(":", 1)[1].strip() if ":" in finding else finding
+        stage = settlement_mod.stage_of_artifact_path(path, issue)
+        if stage is None:
+            unsettled.append((finding, ["not a recognised settleable artifact"]))
+            continue
+        record = load_settlement(issue, stage, repo_root)
+        if record is None:
+            unsettled.append((finding, ["no settlement record"]))
+            continue
+        mismatches = settlement_mod.verify(
+            record, settlement_inputs(repo_root, issue, stage)
+        )
+        if mismatches:
+            unsettled.append((finding, mismatches))
+        else:
+            settled.append(finding)
+    return settled, unsettled
+
+
 def ensure_base(
     repo_root: Path, issue: int, log: EventLog, fresh: bool = False
 ) -> str | None:
@@ -419,6 +526,46 @@ def ensure_base(
         return base
 
     committed = [d for d in debris if d.startswith("committed artifact:")]
+    if committed:
+        # #2609: settledness decides this, not branch contents. A committed
+        # artifact whose inputs still hash as they did when it passed its gate
+        # is the ruling this arc exists to carry -- replacing the base would
+        # redraw it, which is how landing an approved LLD became the thing
+        # that destroyed it.
+        settled, unsettled = partition_by_settledness(repo_root, issue, committed)
+        for finding in settled:
+            log.write(f"BASE settled, preserved: {finding}")
+        for finding, why in unsettled:
+            log.write(f"BASE unsettled: {finding}")
+            for reason in why:
+                log.write(f"  {reason}")
+        if settled and not unsettled:
+            log.write(
+                f"BASE '{base}' carries #{issue}'s SETTLED work "
+                f"({len(settled)} artifact(s)) -- keeping the base; the roll "
+                f"resumes from the settled frontier"
+            )
+            record_heal(
+                repo_root, "base-settled", base, "healed",
+                detail=f"{len(settled)} settled artifact(s) preserved on the base",
+            )
+            debris = [d for d in debris if d not in settled]
+            if not debris:
+                return base
+            committed = []
+        elif settled:
+            # Mixed: something on this base is settled and something is not.
+            # The base is replaced, which redraws the settled ones too. That is
+            # the conservative direction and it is chosen, not overlooked -- a
+            # partial reprieve would leave an unsettled artifact committed on a
+            # base the roll then treats as verified, which is #1959's shape.
+            # Both lists are logged above, so the cost is visible rather than
+            # silent.
+            log.write(
+                f"BASE mixed settledness for #{issue}: {len(settled)} settled, "
+                f"{len(unsettled)} not -- replacing the base redraws both"
+            )
+
     if committed:
         # The base already contains this issue's merged work. No amount of
         # debris cleanup fixes that -- it needs a base that predates it.
@@ -488,7 +635,8 @@ def ensure_base(
     except RuntimeError as err:
         log.write(f"RESET could not determine owner/repo: {err}")
         return None
-    reset.reset_one_issue(repo_root, repo_slug, issue)
+    preserve = settled_artifact_names(repo_root, issue, log)
+    reset.reset_one_issue(repo_root, repo_slug, issue, preserve)
 
     findings = gate.check_repo(repo_root, [issue], base)
     debris = [f for f in findings if not f.startswith("ERROR:")]
@@ -730,7 +878,10 @@ def _resolve_stage_artifact(
 # runs each paid a revision iteration for drafts that marked the phantom files
 # as Modify. Without this the fix would land on main and every future draw on
 # that arc would keep paying the iteration the fix was meant to end.
-BINDING_DOC_PATHS = ("docs/design", "docs/adrs", "CLAUDE.md")
+#: #2609: one definition, imported. `draft_is_stale` and the settlement check
+#: answer the same question about the same documents, and two literals would
+#: let them disagree -- at which point one of them is silently wrong.
+BINDING_DOC_PATHS = settlement_mod.BINDING_DOC_PATHS
 
 
 def _iso_to_epoch(value: str) -> float | None:


### PR DESCRIPTION
Closes #2609

An artifact that passed its gate is settled until its inputs change. boostgauge #331 took **20 launches** in 12 days and had its LLD drawn from scratch **seven times** (counted: seven `graveyard/331-lld-*` branches, latest `20260828T144614Z`), shedding the same settled #361 sampling window twice to two different redraws.

## The diagnosis sharpened before any code

The issue's framing — *"the system accumulates rulings but not settled artifacts"* — was one step off, and the correction made the build smaller. **The system does accumulate them, in a durable store with zero readers.** Posted on the issue in full; the three verified paths:

1. **The approval record already exists and nothing reads it.** `data/assemblyzero/lld-status.json` is repo-keyed, issue-keyed, lives under `data/` outside the branch lifecycle, and carries `"status": "approved"`. boostgauge #331's entry says so right now, `last_review_date` 2026-08-28T14:42:38Z — written after the seventh redraw. All three call sites (`finalize.py:545`, `audit.py:821`, `audit.py:856`) are writers. No production reader existed.

2. **Landing the LLD deletes the evidence stage entry actually used.** `stages.py:1881` calls `_delete_landed_working_copies` under `if lld_merged`, removing `docs/lld/active/LLD-331.md` exactly when its PR merges. Stage entry resolved settledness by that file's presence. The function's docstring promises it never touches `lld-status.json` — so the merge removed the only thing consulted and preserved the only thing that knew.

3. **The launcher's contamination check** (`speedrun_roll.py:421`), the line the issue quotes from `run-issue331-093613-events.log:2`.

**Why the visual gate is immune:** same three tests, opposite answers. Its stamp is READ at stage entry (`gate.py:366`), is never deleted by cleanup, and is invisible to the committed-artifact scan. Not a different idea — this idea with a reader. So this PR extends the existing record rather than inventing a second store.

## Content, never timestamps — and this refuted a shortcut

`draft_is_stale` (#2206) already unsettles a resumed draft on input change, by comparing the issue's `updatedAt` against the draft time. **GitHub bumps `updatedAt` when a comment is posted.** Measured, with a control, and filed as #2615:

| issue | last comment | `updatedAt` | body edited |
|---|---|---|---|
| #2540 | 2026-08-28T14:02:04Z | 2026-08-28T14:02:04Z | no |
| #2609 | 2026-08-28T16:21:57Z | 2026-08-28T16:21:58Z | no |
| #2611 (control, 0 comments) | — | `== createdAt` | no |

The #2609 row is this PR's own diagnosis comment. Following the campaign's standing method — post the sharpened diagnosis before fixing — invalidates every persisted draft for that issue under a timestamp check. Settlement therefore fingerprints content; timestamps are provenance only, never authority.

## What landed

`assemblyzero/core/settlement.py` — input fingerprints, `verify` returning named mismatches, `artifact_matches`, `evidence_lines`. Sibling of `resume_contract.py` in shape, opposite in lifecycle: a contract describes one halt and is consumed by the resume that verifies it; a settlement describes a ruling and outlives every run until an input moves.

| site | before | after |
|---|---|---|
| `should_skip_stage` | skipped on file presence alone | reuses a settled artifact with hash evidence printed; an input change redraws citing the mismatch by name |
| `run_lld_stage` / `run_spec_stage` | — | settle on a passed gate |
| `ensure_base` | a committed artifact meant a fresh attempt branch | settled artifacts are preserved and stated; unsettled ones still replace the base |
| `relocate_lld_artifacts` (`--fresh`) | archived everything | preserves settled artifacts, archives unsettled ones, states each with its reason |

`BINDING_DOC_PATHS` now has one definition, imported by the launcher: two literals would let `draft_is_stale` and settlement disagree about which documents bind, at which point one of them is silently wrong.

## Every ambiguity resolves toward unsettled

A false unsettle costs one redraw — the status quo. A false settle reuses an artifact derived from inputs that have moved, which is what the guard stack exists to catch. So an unreadable record, an unreadable input, a gained or lost binding doc, a hand-edited artifact, and a failed `gh` read all unsettle.

## Acceptance

| clause | evidence |
|---|---|
| settled LLD reused on relaunch, zero drafter spend | `test_stage_finality_skip.py::TestSettledIsReused` — `should_skip_stage` returns True, which is where the drafter lives |
| the hash evidence is printed | `test_the_reuse_prints_hash_evidence` |
| one-character edit to the decision table unsettles, redraw cites the mismatch | `test_a_one_character_edit_unsettles`, `test_the_redraw_cites_the_mismatch` (`250 ms` → `251 ms`) |
| visual stage unchanged | 54 visual/orchestrator tests pass untouched; no visual-gate file is in this diff |
| `--fresh` states what it archived and what it preserved | `TestFreshPreservesSettledArtifacts`, `TestResetHonoursPreservation` |

**72 new tests**, each reuse assertion paired with a control pinning the inverse — a settledness check that never unsettles and one that always settles are indistinguishable from a test that only asserts reuse. Full unit suite: **9064 passed**, one stale test fake updated (`fake_reset` gained the new parameter and now asserts it receives an empty set).

Registry/lint gate pass, per the standing budget: the fail-open audit caught one new undeclared site in `settlement.py::_rel_posix` (now ruled), and the interaction matrix required `settlement` to be declared as a fifth mechanism on `working-tree-files` with all four new pairs ruled — three fixture-backed, one non-interacting with a reason — plus the matching rows in standard 0030. Declared by reading rather than by the lint, because settlement calls none of that artifact's signature symbols; that is the weak-scan hole #2602 tracks.

## Deliberately not done

**Mixed settledness replaces the base.** When some of an issue's committed artifacts are settled and some are not, the base is replaced and the settled ones are redrawn too. A partial reprieve would leave an unsettled artifact committed on a base the roll then treats as verified, which is #1959's shape. Both lists are logged, so the cost is visible rather than silent.

**Artifacts with no settlement record keep the pre-#2609 presence check.** Records are written from the first passed stage onward; treating their absence as grounds to redraw would impose the exact tax this removes on every artifact that predates it. Pinned by `TestNonRegression`.

**#1959 is untouched.** The committed-artifact scan reads `docs/lld` only, so every finding it can produce is an LLD or a spec — it never saw the merged-and-green implementations of #1959's founding case, and does not see them now. Controls: `test_another_issues_artifact_is_never_reprieved`, `test_an_unrecognised_artifact_is_never_reprieved`.

## What only a live roll proves

Everything above is proved read-only against fixtures and preserved state. The firing rate of settled-and-reused on a real relaunch, and the drafter tokens it actually saves, need a live roll. boostgauge was strictly read-only for this work: no roll, no PR #367 merge, no writes to #331 state or working tree.

follow-up: #2615 (the `updatedAt` proxy in `draft_is_stale`), see #2602 (the node-aware detector the matrix's fourth artifact needs)
