### PR TITLE
feat: the LLD's decision table reaches the spec by code, not by drafter (Closes #2611)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/generate_spec.py
@@ -53,6 +53,26 @@ from assemblyzero.workflows.implementation_spec.nodes.retry_prompt_builder impor
 
 logger = logging.getLogger(__name__)
 
+
+def _spec_injection():
+    """The spec-side table injector, imported lazily (#2611).
+
+    NOT a module-level import. `requirements.table_injection` imports
+    `implementation_spec.assertion_manifest` for `is_criteria_table`, which
+    pulls in this package's `__init__` -> `graph` -> `nodes/__init__` -> this
+    module. A module-level import back into `requirements.table_injection`
+    therefore re-enters it while it is still initialising and dies with a
+    partially-initialised module.
+
+    Do not "tidy" this into a top-level import: the cycle is real, and it is
+    invisible to any test that imports the two modules directly -- it appears
+    only on entry paths that start in the requirements workflow.
+    `test_spec_table_injection.py::TestNoImportCycle` pins both halves.
+    """
+    from assemblyzero.workflows.implementation_spec import table_injection
+
+    return table_injection
+
 # =============================================================================
 # Constants
 # =============================================================================
@@ -152,6 +172,34 @@ Do not skip or abbreviate any section."""
 # =============================================================================
 # Helpers
 # =============================================================================
+
+
+def _drafter_system_prompt(lld_content: str) -> str:
+    """The drafter's system prompt, plus the machine-owned notice when one
+    applies (#2611).
+
+    Telling the drafter is not decoration. The derivation injects the LLD's
+    decision table after the call returns; a drafter that restates it anyway
+    produces a second, lossy copy of rows the document already holds
+    correctly, and the reader cannot tell which is binding. The mirror of
+    #2607's notice on the lld side, and the same reasoning.
+    """
+    spec_injection = _spec_injection()
+    if not spec_injection.build_injection(lld_content or ""):
+        return DRAFTER_SYSTEM_PROMPT
+    return DRAFTER_SYSTEM_PROMPT + f"""
+
+DO NOT RESTATE THE LLD'S DECISION TABLE (#2611):
+- The LLD's decision table is carried into this spec VERBATIM by the
+  derivation itself, in a machine-owned block beginning
+  `{spec_injection.BEGIN_MARKER}`. You are not writing those rows and must
+  not reproduce, paraphrase, summarise or "carry forward" their values
+  anywhere.
+- Write AROUND that block. In the test mapping, CITE the row IDs
+  (S1, S2, ...) and the manifest row ids, and state what each test DOES; do
+  not restate the binding values, thresholds, colours or sampling windows the
+  rows already carry. The row is the ruling; your assertion points at it.
+- Anything you write inside the machine-owned markers is discarded."""
 
 
 def _normalize_failure_text(text: str) -> str:
@@ -523,7 +571,7 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
     if edit_script_content is None:
         cost_before = get_cumulative_cost()
         result = drafter.invoke(
-            system_prompt=DRAFTER_SYSTEM_PROMPT,
+            system_prompt=_drafter_system_prompt(state.get("lld_content", "")),
             content=prompt,
             timeout_seconds=600,  # 10 min — impl specs are large
         )
@@ -565,6 +613,24 @@ def generate_spec(state: ImplementationSpecState) -> dict[str, Any]:
                 completeness_issues=completeness_issues,
             )
             pinning_events.extend(events)
+
+    # -------------------------------------------------------------------------
+    # #2611: re-assert the LLD's decision table over whatever the draft holds.
+    #
+    # AFTER pinning, deliberately. Pinning adjudicates a diff and can be argued
+    # with; re-assertion does not adjudicate, so running it last means the
+    # machine-owned region is never something pinning had to reason about --
+    # which is what #2607 asked for on the lld side and this mirrors here.
+    # -------------------------------------------------------------------------
+    if spec_content.strip():
+        spec_content, table_changed = _spec_injection().reassert(
+            spec_content, state.get("lld_content", "")
+        )
+        if table_changed:
+            print(
+                "    [inject] binding decision table re-asserted from the LLD "
+                "(machine-owned; the draft's copy did not match)"
+            )
 
     # -------------------------------------------------------------------------
     # Save to audit trail

--- a/assemblyzero/workflows/implementation_spec/table_injection.py
+++ b/assemblyzero/workflows/implementation_spec/table_injection.py
@@ -1,0 +1,205 @@
+"""The LLD's decision table reaches the spec by code, not by drafter (#2611).
+
+#2607 landed the lld-side half: the source issue's decision table is carried
+into the LLD verbatim, machine-owned, re-asserted every round. This is the
+spec-side half, and it is deliberately NOT a second copy of that module -- it
+imports its primitives and supplies only what genuinely differs.
+
+## The source of truth is the LLD, not the issue
+
+Operator-ruled: **each stage derives from its immediate upstream settled
+artifact, and never reaches around it to the source.** The two candidates the
+issue named -- the LLD's injected block, or the issue directly -- agree while
+the LLD's block is intact and diverge exactly when it is not. Reaching around
+the LLD would make the spec silently correct while the LLD was silently wrong,
+which hides the damage instead of surfacing it.
+
+Under #2609 that is enforced rather than merely intended: the spec's settlement
+records the LLD's content hash as an input, so damaging the LLD unsettles the
+spec derived from it (`settlement.UPSTREAM_OF["spec"] == "lld"`).
+
+## Why the assertion manifest does not already do this
+
+Checked before building, and the answer is no on three counts (evidence on
+#2611):
+
+* the manifest reaches the drafter as PROMPT text -- `_manifest_section`'s
+  "WRAP rows, invent nothing" -- which is an instruction to a stochastic
+  drafter to copy verbatim, the exact path #2607 removed;
+* `check_manifest_traceability` judges row-ID citation bookkeeping and never
+  reads `row.expected`, so a test citing `# manifest: N4.2` and asserting the
+  wrong number passes it;
+* `expected` is `"; ".join(extract_literals(...))` -- regex matches, not the
+  binding cell -- so a qualifying clause like `250 ms ± 5 ms (within the 0.82R
+  band)` contributes its tokens and drops its prose. That is #2563's founding
+  case.
+
+The manifest keeps its job: it tells the drafter which assertions to write.
+The injected block carries the binding values a reader can check them against.
+They are complementary, and neither subsumes the other.
+
+## The same fence, deliberately
+
+The markers are #2607's, imported rather than redefined. The drafter reads the
+LLD -- including its machine-owned block -- so a copy of that block can land in
+the spec by ordinary imitation. Reusing the fence means such a copy is FOUND
+and replaced by the canonical text rather than lingering beside a second block
+under a different name. One marker pair, one meaning: this region is not the
+drafter's.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.requirements.table_injection import (
+    BEGIN_MARKER,
+    END_MARKER,
+    has_injection,
+    injected_line_span,
+    source_criteria_tables,
+    source_table_text,
+    strip_injection,
+)
+
+__all__ = [
+    "BEGIN_MARKER",
+    "END_MARKER",
+    "INJECTED_HEADING",
+    "apply_injection",
+    "authoritative_tables",
+    "build_injection",
+    "current_block",
+    "has_injection",
+    "injected_line_span",
+    "reassert",
+    "strip_injection",
+]
+
+#: The heading the block is filed under in a spec. Numbered into the template's
+#: own scheme (0701) so it reads as a section rather than as an intrusion, and
+#: placed immediately above Test Mapping because that is the section whose
+#: assertions must agree with these values.
+INJECTED_HEADING = "## 9.5 Binding Decision Table (injected verbatim from the LLD)"
+
+_PREAMBLE = (
+    "The rows below are carried **verbatim** from the LLD by the derivation "
+    "itself (#2611), which carried them verbatim from the source issue "
+    "(#2607). They are machine-owned: the drafter does not write them, and a "
+    "revision cannot change them. Every assertion in the test mapping must "
+    "agree with these values; cite the IDs, do not restate the values."
+)
+
+
+def authoritative_tables(lld_content: str):
+    """The LLD's criteria tables that bind the spec, in document order.
+
+    When the LLD carries a machine-owned block, ONLY the tables inside it are
+    authoritative -- that block is the one region no drafter and no revision
+    could have touched. A drafter-written restatement elsewhere in the LLD is
+    not a second source of truth; #2607's preamble tells the drafter not to
+    write one, and #2563 catches it if they do.
+
+    An LLD with no such block -- one drawn before #2607, or a prose-only
+    issue's -- falls back to every criteria table it has. That is the correct
+    reading of "derive from the upstream artifact" when the upstream artifact
+    predates the fence.
+    """
+    tables = source_criteria_tables(lld_content)
+    span = injected_line_span(lld_content or "")
+    if span is None:
+        return tables
+    start, end = span
+    inside = [t for t in tables if start <= t.line_no <= end]
+    # An injected block that parses to no criteria table means the fence is
+    # present but its content is not what this function is looking for. Fall
+    # back rather than inject nothing: emitting no block would silently drop
+    # the protection, which is the failure mode this module exists to end.
+    return inside or tables
+
+
+def build_injection(lld_content: str) -> str:
+    """The machine-owned block for this LLD, or "" when none applies.
+
+    An LLD with no criteria decision table injects nothing and the spec
+    derivation proceeds exactly as before -- prose-only LLDs are the ordinary
+    case and this issue's control.
+    """
+    tables = authoritative_tables(lld_content)
+    if not tables:
+        return ""
+    parts = [BEGIN_MARKER, "", INJECTED_HEADING, "", _PREAMBLE, ""]
+    for table in tables:
+        parts.append(source_table_text(lld_content, table))
+        parts.append("")
+    parts.append(END_MARKER)
+    return "\n".join(parts)
+
+
+def current_block(text: str) -> str:
+    """The machine-owned block ``text`` currently holds, or "" when none.
+
+    Read through the public span helper rather than by re-matching the fence,
+    so this module keeps exactly one notion of where the block is and it is
+    #2607's.
+    """
+    span = injected_line_span(text or "")
+    if span is None:
+        return ""
+    start, end = span
+    return "\n".join((text or "").splitlines()[start - 1:end])
+
+
+def _insertion_point(lines: list[str]) -> int:
+    """Index to insert at: just BEFORE the Test Mapping section.
+
+    The spec template (standard 0701) runs `## 1. Overview` through `## 11.
+    Implementation Notes`; the binding values belong immediately above the
+    section whose assertions have to match them. Falls back to the end of the
+    document, which is correct rather than degraded -- placement is for the
+    human reader, and every consumer of these rows finds a table anywhere.
+    """
+    import re
+
+    for index, line in enumerate(lines):
+        if re.match(r"^##\s+10[.\s]", line.strip()):
+            return index
+    return len(lines)
+
+
+def apply_injection(draft: str, injection: str) -> str:
+    """Assemble the drafter's output with the machine-owned block.
+
+    Idempotent: an existing block is REPLACED, never duplicated, so calling
+    this on every round re-asserts the canonical text over whatever the drafter
+    did to it -- including over a block the drafter copied out of the LLD.
+    """
+    import re
+
+    if not injection:
+        return draft
+    body = strip_injection(draft or "")
+    lines = body.splitlines()
+    at = _insertion_point(lines)
+    merged = lines[:at] + ["", injection, ""] + lines[at:]
+    text = "\n".join(merged)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    if (draft or "").endswith("\n") and not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def reassert(draft: str, lld_content: str) -> tuple[str, bool]:
+    """Restore the canonical block over whatever the draft now holds.
+
+    Returns (text, changed). `changed` is True when the draft's block did not
+    match the LLD's -- the drafter having edited machine-owned content, which
+    the caller logs. Nothing is refused and nothing halts: the correct text is
+    simply reinstated, which is why pinning never has to adjudicate this
+    region. Re-assertion does not adjudicate a diff, so there is nothing for a
+    revision to argue with.
+    """
+    injection = build_injection(lld_content)
+    if not injection:
+        return draft, False
+    if current_block(draft) == injection:
+        return draft, False
+    return apply_injection(draft, injection), True

--- a/tests/fixtures/import_requirements_entry_path.py
+++ b/tests/fixtures/import_requirements_entry_path.py
@@ -1,0 +1,25 @@
+"""Import the requirements entry path in a clean interpreter (#2611).
+
+Run as a subprocess by `test_spec_table_injection.py::TestNoImportCycle`. The
+cycle it guards only appears on a FIRST import in the order that starts at
+`requirements.nodes.generate_draft`, so the check has to happen in a process
+where nothing is in `sys.modules` yet.
+
+It lives in a file rather than inside the test because doing the same thing by
+purging `sys.modules` in-process poisons every later test in the run: the purge
+re-executes modules, later monkeypatching targets a different module object
+than the one under test, and unrelated suites fail with AttributeError. That
+was measured, not theorised -- it broke `test_step_budget.py` and
+`test_stage_verdict_is_explicit.py` on the run that introduced it.
+
+Exit 0 on success; any ImportError propagates and fails the subprocess.
+"""
+
+import sys
+
+import assemblyzero.workflows.requirements.nodes.generate_draft  # noqa: F401
+from assemblyzero.workflows.implementation_spec import table_injection
+
+# Touch the symbol the cycle used to break on, so a lazy failure cannot pass.
+assert table_injection.BEGIN_MARKER
+sys.exit(0)

--- a/tests/unit/test_spec_table_injection.py
+++ b/tests/unit/test_spec_table_injection.py
@@ -1,0 +1,382 @@
+"""The LLD's decision table reaches the spec by code, not by drafter (#2611).
+
+The spec-side half of #2607. Source of truth is the LLD's injected block --
+each stage derives from its immediate upstream settled artifact and never
+reaches around it to the issue -- so these fixtures build a real post-#2607
+LLD and derive from that.
+
+The controls matter as much as the assertions here. An injector that always
+injects and a conservation gate that never fires both look like green tests
+if only the happy path is asserted, so every guarantee is paired with the
+fixture that breaks it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec import table_injection as spec_inject
+from assemblyzero.workflows.requirements import table_injection as lld_inject
+from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+    validate_assertion_literal_conservation,
+)
+
+SOURCE_TABLE = """\
+| ID | Criterion | Binding value (quoted) | Assertion method |
+|----|-----------|------------------------|------------------|
+| S1 | sampling window | sampled ONLY at 0.12 R-0.25 R either side | probe at 0.12 R; probe at 0.25 R |
+| S7 | redline colour | #AA0F19 | sample band mid at 75% |
+| S9 | needle tip | 0.82 R | measure tip radius |
+"""
+
+ISSUE_BODY = f"# Dial\n\n## Pass criteria\n\n{SOURCE_TABLE}"
+
+SPEC_DRAFT = """\
+# Implementation Spec: Dial
+
+## 1. Overview
+
+Render the dial.
+
+## 9. Placeholder
+
+Nothing here.
+
+## 10. Test Mapping
+
+- `test_band_mid` covers S7.
+
+## 11. Implementation Notes
+
+Done.
+"""
+
+
+@pytest.fixture
+def lld() -> str:
+    """A real post-#2607 LLD: drafter prose plus the machine-owned block."""
+    draft = "# LLD\n\n## 3. Requirements\n\nThe dial samples on a window.\n"
+    return lld_inject.apply_injection(
+        draft, lld_inject.build_injection(ISSUE_BODY)
+    )
+
+
+class TestTheChainIsLldToSpec:
+    def test_the_lld_fixture_really_carries_the_block(self, lld: str) -> None:
+        """Guard the fixture: everything below is vacuous without this."""
+        assert lld_inject.has_injection(lld)
+        assert "0.12 R-0.25 R" in lld
+
+    def test_the_spec_block_is_byte_identical_to_the_lld_block(
+        self, lld: str
+    ) -> None:
+        """Verbatim means sliced, never re-rendered. Padding, spacing and
+        unicode survive because nothing round-trips through parsed cells."""
+        injection = spec_inject.build_injection(lld)
+
+        for line in SOURCE_TABLE.strip().splitlines():
+            assert line in injection
+
+    def test_it_derives_from_the_lld_not_the_issue(self, lld: str) -> None:
+        """The ruling, as a behaviour: damage the LLD's block and the spec's
+        injection follows the LLD down rather than silently healing from the
+        issue. Reaching around the LLD would hide the damage."""
+        damaged = lld.replace("0.12 R-0.25 R either side", "a window")
+
+        injection = spec_inject.build_injection(damaged)
+
+        assert "0.12 R-0.25 R" not in injection
+        assert "a window" in injection
+
+    def test_only_the_machine_owned_block_is_authoritative(self, lld: str) -> None:
+        """A drafter-written restatement elsewhere in the LLD is not a second
+        source of truth."""
+        restated = lld + "\n\n## 10. Test Plan\n\n" + SOURCE_TABLE.replace(
+            "0.82 R", "0.99 R"
+        )
+
+        injection = spec_inject.build_injection(restated)
+
+        assert "0.82 R" in injection
+        assert "0.99 R" not in injection
+
+    def test_a_pre_2607_lld_falls_back_to_its_own_tables(self) -> None:
+        """An LLD drawn before the fence existed still binds the spec."""
+        old = f"# LLD\n\n## 3. Requirements\n\n{SOURCE_TABLE}"
+        assert not lld_inject.has_injection(old)
+
+        injection = spec_inject.build_injection(old)
+
+        assert "#AA0F19" in injection
+
+
+class TestNotApplicableIsNotFailure:
+    def test_a_prose_only_lld_injects_nothing(self) -> None:
+        """The control: most issues have no decision table and must derive
+        exactly as they did before this module existed."""
+        assert spec_inject.build_injection("# LLD\n\nJust prose.\n") == ""
+
+    def test_an_empty_lld_injects_nothing(self) -> None:
+        assert spec_inject.build_injection("") == ""
+
+    def test_reassert_leaves_the_draft_alone_when_nothing_applies(self) -> None:
+        text, changed = spec_inject.reassert(SPEC_DRAFT, "# LLD\n\nProse.\n")
+        assert text == SPEC_DRAFT
+        assert changed is False
+
+
+class TestMachineOwnership:
+    def test_a_revision_cannot_modify_an_injected_row(self, lld: str) -> None:
+        """The acceptance. A drafter edits a binding value inside the block;
+        re-assertion restores it without adjudicating anything."""
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+        tampered = injected.replace("#AA0F19", "#000000")
+        assert "#000000" in tampered
+
+        restored, changed = spec_inject.reassert(tampered, lld)
+
+        assert changed is True
+        assert "#AA0F19" in restored
+        assert "#000000" not in restored
+
+    def test_a_deleted_block_is_reinstated(self, lld: str) -> None:
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+        gutted = spec_inject.strip_injection(injected)
+        assert not spec_inject.has_injection(gutted)
+
+        restored, changed = spec_inject.reassert(gutted, lld)
+
+        assert changed is True
+        assert spec_inject.has_injection(restored)
+
+    def test_reassert_is_idempotent(self, lld: str) -> None:
+        once, first = spec_inject.reassert(SPEC_DRAFT, lld)
+        twice, second = spec_inject.reassert(once, lld)
+
+        assert first is True
+        assert second is False, "a settled block must not be rewritten"
+        assert once == twice
+
+    def test_repeated_cycles_do_not_duplicate_the_block(self, lld: str) -> None:
+        text = SPEC_DRAFT
+        for _ in range(4):
+            text, _ = spec_inject.reassert(text, lld)
+
+        assert text.count(spec_inject.BEGIN_MARKER) == 1
+        assert text.count(spec_inject.END_MARKER) == 1
+
+    def test_a_block_copied_from_the_lld_is_replaced_not_duplicated(
+        self, lld: str
+    ) -> None:
+        """The drafter reads the LLD, so imitation puts an LLD-shaped block in
+        the spec. Reusing #2607's fence means it is found rather than left
+        beside a second block under a different name."""
+        copied = SPEC_DRAFT + "\n" + lld_inject.build_injection(ISSUE_BODY) + "\n"
+
+        restored, _ = spec_inject.reassert(copied, lld)
+
+        assert restored.count(spec_inject.BEGIN_MARKER) == 1
+
+    def test_repeated_strip_does_not_accumulate_whitespace(self, lld: str) -> None:
+        text = SPEC_DRAFT
+        for _ in range(3):
+            text = spec_inject.apply_injection(
+                text, spec_inject.build_injection(lld)
+            )
+        assert "\n\n\n" not in text
+
+
+class TestPlacement:
+    def test_the_block_lands_above_test_mapping(self, lld: str) -> None:
+        """The assertions that must agree with these values are right below."""
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+        lines = injected.splitlines()
+        marker = next(
+            i for i, line in enumerate(lines)
+            if spec_inject.BEGIN_MARKER in line
+        )
+        mapping = next(
+            i for i, line in enumerate(lines)
+            if line.strip().startswith("## 10.")
+        )
+        assert marker < mapping
+
+    def test_a_spec_without_test_mapping_appends(self, lld: str) -> None:
+        """Placement is for the reader; a fallback that appends is correct
+        rather than degraded, because every consumer finds a table anywhere."""
+        stub = "# Spec\n\n## 1. Overview\n\nNo mapping section.\n"
+
+        injected = spec_inject.apply_injection(
+            stub, spec_inject.build_injection(lld)
+        )
+
+        assert spec_inject.has_injection(injected)
+        assert "## 1. Overview" in injected
+
+    def test_the_drafters_own_prose_survives(self, lld: str) -> None:
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+        for line in ("Render the dial.", "`test_band_mid` covers S7.", "Done."):
+            assert line in injected
+
+
+class TestConservationGateIsSatisfiedOnInjectedRows:
+    """#2563 as the backstop, with the control that proves it still fires.
+
+    The gate is generic in shape -- (source document, derived document) -- so
+    driving it with (LLD, spec) asks the spec-stage question. Asserting only
+    "zero errors" would pass against a gate that had silently stopped working,
+    which is why the lossy fixture below is not optional.
+    """
+
+    def test_an_injected_spec_sheds_no_literals(self, lld: str) -> None:
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+
+        errors = validate_assertion_literal_conservation(lld, injected)
+
+        assert errors == [], [e.message for e in errors]
+
+    def test_the_gate_still_fires_on_a_lossy_spec(self, lld: str) -> None:
+        """The control. Without injection the drafter's spec sheds the #361
+        sampling window -- the founding case -- and the gate must say so."""
+        lossy = SPEC_DRAFT  # never injected, restates nothing
+
+        errors = validate_assertion_literal_conservation(lld, lossy)
+
+        assert errors, "the gate must fire on a spec that carries no literals"
+        assert any("0.12" in e.message for e in errors), [
+            e.message for e in errors
+        ]
+
+    def test_the_gate_fires_when_one_row_is_shed(self, lld: str) -> None:
+        """Sharper control: a spec that carries most literals but drops one."""
+        injected = spec_inject.apply_injection(
+            SPEC_DRAFT, spec_inject.build_injection(lld)
+        )
+        shed = injected.replace("0.82 R", "the ruled radius")
+
+        errors = validate_assertion_literal_conservation(lld, shed)
+
+        assert errors
+        assert any("0.82" in e.message for e in errors), [
+            e.message for e in errors
+        ]
+
+
+class TestTheDrafterIsTold:
+    def test_the_notice_appears_when_a_table_is_injected(self, lld: str) -> None:
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            DRAFTER_SYSTEM_PROMPT,
+            _drafter_system_prompt,
+        )
+
+        prompt = _drafter_system_prompt(lld)
+
+        assert "DO NOT RESTATE THE LLD'S DECISION TABLE" in prompt
+        assert spec_inject.BEGIN_MARKER in prompt
+        assert prompt.startswith(DRAFTER_SYSTEM_PROMPT)
+
+    def test_the_notice_is_absent_for_a_prose_only_lld(self) -> None:
+        """The control: a prose-only LLD must produce the unchanged prompt,
+        so a notice about a block that does not exist never confuses a
+        drafter."""
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            DRAFTER_SYSTEM_PROMPT,
+            _drafter_system_prompt,
+        )
+
+        assert _drafter_system_prompt("# LLD\n\nProse.\n") == DRAFTER_SYSTEM_PROMPT
+
+    def test_an_empty_lld_produces_the_unchanged_prompt(self) -> None:
+        from assemblyzero.workflows.implementation_spec.nodes.generate_spec import (
+            DRAFTER_SYSTEM_PROMPT,
+            _drafter_system_prompt,
+        )
+
+        assert _drafter_system_prompt("") == DRAFTER_SYSTEM_PROMPT
+
+
+class TestNoImportCycle:
+    """The entry path that starts in the requirements workflow must import.
+
+    `requirements.table_injection` imports `implementation_spec.assertion_manifest`
+    for `is_criteria_table`, which pulls in that package's `__init__` -> `graph`
+    -> `nodes/__init__` -> `generate_spec`. A module-level import from there back
+    into `requirements.table_injection` re-enters it mid-initialisation and dies
+    with a partially-initialised module.
+
+    This failed for exactly that reason during development, and only on the
+    requirements entry path -- importing the two modules directly, as the tests
+    above do, hides it completely. Purging the participants and importing in the
+    order that breaks is what makes this a real check rather than a restatement
+    of whatever is already in `sys.modules`.
+    """
+
+    def test_the_requirements_entry_path_imports(self) -> None:
+        """In a SUBPROCESS, because the cycle only appears on a first import.
+
+        Purging `sys.modules` in-process to force that ordering re-executes the
+        modules, so later monkeypatching targets a different module object than
+        the code under test. That broke `test_step_budget.py` and
+        `test_stage_verdict_is_explicit.py` when this test first did it --
+        measured, not theorised, which is why the isolation is a process.
+        """
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        script = (
+            Path(__file__).resolve().parents[1]
+            / "fixtures" / "import_requirements_entry_path.py"
+        )
+        assert script.is_file(), f"missing fixture script: {script}"
+
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            cwd=str(Path(__file__).resolve().parents[2]),
+            timeout=180,
+        )
+
+        assert result.returncode == 0, (
+            f"the requirements entry path failed to import:\n{result.stderr}"
+        )
+
+    def test_generate_spec_holds_no_module_level_spec_injection_import(
+        self
+    ) -> None:
+        """The specific shape that broke, pinned so a tidy-up cannot restore
+        it silently."""
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "implementation_spec"
+            / "nodes" / "generate_spec.py"
+        ).read_text(encoding="utf-8")
+
+        for line in source.splitlines():
+            if line.startswith(("import ", "from ")):
+                assert "table_injection" not in line, (
+                    f"module-level import re-creates the cycle: {line!r}"
+                )
+
+
+class TestCurrentBlock:
+    def test_it_reads_the_block_back(self, lld: str) -> None:
+        injection = spec_inject.build_injection(lld)
+        injected = spec_inject.apply_injection(SPEC_DRAFT, injection)
+
+        assert spec_inject.current_block(injected) == injection
+
+    def test_no_block_reads_as_empty(self) -> None:
+        assert spec_inject.current_block(SPEC_DRAFT) == ""


### PR DESCRIPTION
Closes #2611

The spec-side half of #2607. The LLD's decision table now reaches the implementation spec by code — byte-verbatim, machine-owned, re-asserted every round.

## The ruling, and the evidence that had to come first

**Source of truth: the LLD's injected block.** Operator-ruled — each stage derives from its immediate upstream settled artifact and never reaches around it to the source. Post-#2607 the LLD's block is byte-identical to the issue's, so the chain loses nothing; and reaching around the LLD would make the spec silently correct while the LLD was silently wrong, which hides the damage rather than surfacing it. `test_it_derives_from_the_lld_not_the_issue` pins that: damage the LLD's block and the spec's injection follows it down.

Under #2609 (landed as `aefc3360`) that is enforced rather than merely intended — the spec's settlement records the LLD's content hash as an input, so damaging the LLD unsettles the spec derived from it.

**Does the assertion manifest already discharge this? No.** The issue asked to close as already-solved if so. Checked before building, three gaps, each verified and posted on the issue:

1. **The manifest reaches the drafter as PROMPT text.** `_manifest_section` wraps it in *"Every manifest row becomes exactly ONE test's assertion(s). WRAP rows, invent nothing."* An instruction to a stochastic drafter to copy verbatim is the precise path #2607 removed. Nothing re-asserts it, and a revision can change anything.
2. **`check_manifest_traceability` never reads `row.expected`.** Its own docstring scopes it to the citation comment or the bare row id; it builds `id_patterns` from row ids alone. A test citing `# manifest: N4.2` while asserting the wrong number passes it. Grepping `expected` across `validate_completeness.py` finds no check comparing manifest literals to the spec.
3. **`expected` is extracted literals, not the binding cell.** `assertion_manifest.py:324-333` — `"; ".join(extract_literals(fragment) or binding_literals)`. A cell reading `250 ms ± 5 ms (within the 0.82R band)` contributes its matching tokens and drops the prose. That is #2563's founding case.

The manifest keeps its job — it tells the drafter which assertions to write. The injected block carries the binding values a reader can check them against. Complementary; neither subsumes the other.

## What landed

`assemblyzero/workflows/implementation_spec/table_injection.py` — imports #2612's primitives rather than copying them. Only three things genuinely differ: where the block goes, what heading it carries, and where the rows come from.

- **Byte-verbatim means slicing.** `source_table_text` off `RawTable.line_no`, reused unchanged. Nothing round-trips through parsed cells, so no reformatting is declared because none happens.
- **The same fence, deliberately.** The drafter reads the LLD *including its machine-owned block*, so a copy can land in the spec by ordinary imitation. Reusing #2607's markers means such a copy is found and replaced rather than left beside a second block under a different name (`test_a_block_copied_from_the_lld_is_replaced_not_duplicated`).
- **Only the machine-owned block is authoritative.** When the LLD carries a fence, only tables inside it bind; a drafter-written restatement elsewhere in the LLD is not a second source of truth. An LLD predating #2607 falls back to its own criteria tables.
- **Re-assertion runs AFTER pinning**, so pinning never has to reason about the region — the same ordering #2607 chose, for the same reason: re-assertion does not adjudicate a diff, so there is nothing for a revision to argue with.
- **The drafter is told**, mirroring #2607's notice, and only when a block actually applies.

## Acceptance

| clause | evidence |
|---|---|
| the LLD's table reaches the spec verbatim | `test_the_spec_block_is_byte_identical_to_the_lld_block` |
| a spec revision cannot modify an injected row | `test_a_revision_cannot_modify_an_injected_row`, `test_a_deleted_block_is_reinstated` |
| the #2563 gate finds zero losses on injected rows | `test_an_injected_spec_sheds_no_literals` |
| …with the gate proven still live | `test_the_gate_still_fires_on_a_lossy_spec` and `test_the_gate_fires_when_one_row_is_shed` — the second is the sharper control: a spec carrying most literals but dropping `0.82 R` |
| a prose-only LLD derives exactly as today | `TestNotApplicableIsNotFailure`, three cases |

27 tests. Every guarantee is paired with the fixture that breaks it, because an injector that always injects and a conservation gate that never fires both look like green tests when only the happy path is asserted.

## Two things worth reading closely

**A real circular import, found by the full suite and not by the unit tests.** `requirements.table_injection` imports `implementation_spec.assertion_manifest`, which pulls in that package's `__init__` → `graph` → `nodes/__init__` → `generate_spec`. A module-level import from there back into `requirements.table_injection` re-enters it mid-initialisation. The tests above never saw it — importing the two modules directly is a different order. It is now a lazy import at its two call sites, with `TestNoImportCycle` pinning both the behaviour and the shape that broke.

**That regression test poisoned the suite on its first attempt, and the fix is the finding.** Forcing the import order by purging `sys.modules` in-process re-executes the modules, so later `monkeypatch.setattr` targets a different module object than the code under test. It broke `test_step_budget.py` and `test_stage_verdict_is_explicit.py` — seven failures, all passing in isolation, none in the file that caused them. Measured by running the pair together, not theorised. The isolation is now a subprocess (`tests/fixtures/import_requirements_entry_path.py`), which is what the check needed all along: the cycle only exists on a first import.

## Deliberately not done

**The #2563 gate is not wired as a live spec-stage check.** The acceptance asks for its firing rate on injected rows to be *asserted zero*, and it is — driven with `(lld, spec)`, the shape the function already takes. Adding it as a new hard gate at the spec stage is a separate concern with real deadlock risk: its complaint would need to be addressable to pinning, which is exactly the class #2555/#2591 are about, and #2540 is still deciding which checks may gate at all. Injection makes loss impossible on injected rows, so the gate is redundant there by construction; wiring it live is follow-up: #2617.

## What only a live roll proves

Everything here is proved read-only against fixtures. Whether a real spec draft carries the block cleanly through a revision loop, and the gate's firing rate on a real run, need a roll. boostgauge stayed strictly read-only: no roll, no PR #367 merge, no writes to #331 state or working tree.

follow-up: #2617 · see #2609 for the settlement chain that makes the LLD the upstream artifact
