### PR TITLE
feat: classify every completeness check fact-verifier or proxy-heuristic (Closes #2540)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/check_classification.py
+++ b/assemblyzero/workflows/implementation_spec/check_classification.py
@@ -1,0 +1,281 @@
+"""Every completeness check, classified fact-verifier or proxy-heuristic (#2540).
+
+Operator-ratified 2026-08-28: **a proxy metric never outranks an engaged judge
+examining the same dimension with reasons.** Facts stay hard gates; proxies
+demote to advisory whenever the adversarial review stage is engaged.
+
+The week's evidence base is three deep, and each instance cost a full roll to
+discover: `api_symbols_exist` on `str.isupper` (#2526), `change_instructions_
+specific` on a fence-density off-by-one (#2539), and the same check's
+no-target complaint (#2592). Fixing them one funeral at a time is the wrong
+loop, so this is one deliberate pass over every check.
+
+## Why a table and not scattered edits
+
+#2539's demotion was an inline rewrite of one check's result inside the runner:
+compute the check, notice it failed, build a replacement `CompletenessCheck`
+with `passed=True` and an ADVISORY prefix. Correct, and invisible -- nothing
+named the class, nothing stopped the next check from being demoted differently,
+and a reader had to find the hack to know the rule existed. On the #2475 model
+the classification is a reviewable artifact with a lint, so the sweep can be
+re-run rather than re-remembered.
+
+## The rule, and how a classification is decided
+
+A check is a **fact-verifier** only if its failure is a fact about the
+artifact: a cited symbol does not exist, a fence does not parse, a manifest row
+is cited by no test. Those block, because the failure is true.
+
+A check is a **proxy-heuristic** if its failure is a correlate: a count against
+a threshold, a keyword within a window, a fence somewhere near a filename.
+Those advise. The N5 adversarial reviewer judges the same dimension directly,
+with reasons, every round, and a proxy adds no information it lacks.
+
+**Proximity is the tell.** Three checks here pass on finding *something*
+within N characters of *something else*. That answers "are these near each
+other", never "is this an example OF that thing" -- and the drafter can satisfy
+it without satisfying the intent, which is what makes it a correlate rather
+than a fact.
+
+## Conservative where it is arguable
+
+Two entries are marked `flagged`: classified fact and left GATING, with the
+tension recorded rather than resolved. Demoting a check on an agent's own
+reading -- against an operator ruling, or across a mode boundary the operator
+has not seen -- would be exactly the unilateral judgement this registry exists
+to replace. A flag costs nothing and surfaces the question; a wrong demotion
+removes a gate quietly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: A check whose failure is a fact about the artifact. Blocks.
+FACT = "fact-verifier"
+
+#: A check whose failure is a correlate. Advises when review is engaged.
+PROXY = "proxy-heuristic"
+
+
+@dataclass(frozen=True)
+class Classification:
+    """One check's class, with the reading that decided it.
+
+    `reads` is what the code actually looks at, not what the check is named
+    after -- the sweep decides from the former, because several of these are
+    named for the thing they wish they measured.
+    """
+
+    check: str
+    kind: str
+    reads: str
+    reason: str
+    #: Set when the classification is arguable and deliberately left gating.
+    flagged: str = ""
+
+    @property
+    def gates(self) -> bool:
+        return self.kind == FACT
+
+
+CLASSIFICATIONS: dict[str, Classification] = {
+    # ---------------------------------------------------------------- facts
+    "api_symbols_exist": Classification(
+        check="api_symbols_exist",
+        kind=FACT,
+        reads="calls in the spec against the gathered symbol table and the repo",
+        reason=(
+            "a symbol exists or it does not. #2526 was a defect in its symbol "
+            "table -- `str.isupper` is real and the table did not know it -- "
+            "not evidence that the question is a correlate. A wrong fact is "
+            "fixed by fixing the fact."
+        ),
+    ),
+    "python_fences_parse": Classification(
+        check="python_fences_parse",
+        kind=FACT,
+        reads="ast.parse over every python-tagged fence",
+        reason=(
+            "the parser succeeds or raises. Reports under its own name since "
+            "#2556 and is the precondition the symbol check depends on."
+        ),
+    ),
+    "import_targets_exist": Classification(
+        check="import_targets_exist",
+        kind=FACT,
+        reads=(
+            "each imported module path on disk, cross-referenced against the "
+            "spec's own Files Changed table for files it creates"
+        ),
+        reason=(
+            "a module resolves or it does not. The cross-reference against "
+            "the spec's own Files Changed table is what keeps it a fact rather "
+            "than a false alarm on a module the spec is about to create (#842)."
+        ),
+    ),
+    "pattern_references_valid": Classification(
+        check="pattern_references_valid",
+        kind=FACT,
+        reads="each file:line pattern reference against real code in the repo",
+        reason=(
+            "a reference points at real code or it does not; a stale one sends "
+            "the implementation agent to the wrong place."
+        ),
+    ),
+    "manifest_traceability": Classification(
+        check="manifest_traceability",
+        kind=FACT,
+        reads="manifest row ids against the source of each parsed test function",
+        reason=(
+            "an exact bookkeeping diff -- every row cited by exactly one test, "
+            "every test citing a row. It abstains on fences it cannot parse "
+            "(#2526's unknown-is-not-guilty) rather than guessing, which is a "
+            "fact-verifier declining to state a fact it lacks."
+        ),
+    ),
+    "error_paths_have_tests": Classification(
+        check="error_paths_have_tests",
+        kind=FACT,
+        reads=(
+            "`raise X` names in the spec's code fences against the exception "
+            "names asserted in its test fences"
+        ),
+        reason=(
+            "a set difference over names extracted from both halves of the "
+            "same document. 'The spec raises ValueError and no test asserts "
+            "ValueError' is a fact (#2333)."
+        ),
+    ),
+    "visual_baselines_not_self_referential": Classification(
+        check="visual_baselines_not_self_referential",
+        kind=FACT,
+        reads=(
+            "whether the spec adds or regenerates baseline images, and whether "
+            "it carries the literal marker `baseline-independent`"
+        ),
+        reason=(
+            "both halves are exact: a file list, and a literal string. #1902's "
+            "failure -- a systematically wrong first render becoming its own "
+            "reference -- is not a matter of degree."
+        ),
+    ),
+    # ------------------------------------------- facts, flagged as arguable
+    "functions_have_io_examples": Classification(
+        check="functions_have_io_examples",
+        kind=FACT,
+        reads=(
+            "a +/-2000-character window around each function definition, for "
+            "an I/O vocabulary word AND any concrete-looking value"
+        ),
+        reason=(
+            "Operator-ruled a fact-verifier and kept gating: #2590 (PR #2606) "
+            "fixed its addressability, not its authority."
+        ),
+        flagged=(
+            "This reads like a proxy by the rule above: a window plus a "
+            "vocabulary plus any number or quoted string does not verify that "
+            "the example is OF that function, and #2302 shows the verdict has "
+            "moved on how often a name happened to be repeated. Left GATING "
+            "per the ruling; the tension, and the fair counter-argument for "
+            "it, are recorded on #2620 so the next sweep starts from the "
+            "question rather than rediscovering it."
+        ),
+    ),
+    "criteria_have_tests": Classification(
+        check="criteria_have_tests",
+        kind=FACT,
+        reads=(
+            "in EXACT mode, the REQ-N tag set in the LLD against the tag set "
+            "in the spec's tests; in the OUTCOME fallback, each criterion's "
+            "normalised outcome text as a substring of a test's name and body"
+        ),
+        reason=(
+            "EXACT mode is an id-set difference and is a plain fact (#2239)."
+        ),
+        flagged=(
+            "The class is MODE-DEPENDENT, which no other check here is. The "
+            "OUTCOME fallback -- used whenever the criteria are not all tagged "
+            "-- matches normalised substrings, which is a correlate: a test "
+            "can contain a criterion's words without covering it. Left GATING "
+            "in both modes rather than demoting the fallback on the sweep's "
+            "own judgement, because a per-run class is a design change and not "
+            "a classification. Filed for a ruling as #2619."
+        ),
+    ),
+    # -------------------------------------------------------------- proxies
+    "change_instructions_specific": Classification(
+        check="change_instructions_specific",
+        kind=PROXY,
+        reads=(
+            "fence count against `max(3, lines//50)` and indicator count "
+            "against `max(5, lines//30)`"
+        ),
+        reason=(
+            "a density ratio, and a self-defeating one: both thresholds derive "
+            "from line count, so complying grows the spec and moves the demand "
+            "with it -- observed live as 7-of-8 at 441 lines becoming 8-of-9 "
+            "at 454, one or two rounds from approval on a spec the reviewer "
+            "had certified for five consecutive rounds (#2539). It also parses "
+            "nothing from its own message, so it cannot address its own "
+            "complaint (#2592)."
+        ),
+    ),
+    "modify_files_have_excerpts": Classification(
+        check="modify_files_have_excerpts",
+        kind=PROXY,
+        reads=(
+            "3000 characters after each Modify file's name, passing if the "
+            "substring ``` appears anywhere in them"
+        ),
+        reason=(
+            "any fence at all, about anything, within a fixed window. It "
+            "measures proximity, never whether an excerpt of THAT file's "
+            "current state is present -- and it passes on a fence that shows "
+            "something else entirely."
+        ),
+    ),
+    "data_structures_have_examples": Classification(
+        check="data_structures_have_examples",
+        kind=PROXY,
+        reads=(
+            "5000 characters after each structure name, for any of five loose "
+            "patterns -- including any fenced block of 20 or more characters"
+        ),
+        reason=(
+            "same proximity shape as the excerpts check and looser: a code "
+            "fence anywhere in a 5000-character window satisfies it regardless "
+            "of what it contains. Whether an example is OF the structure is "
+            "the question, and this never asks it."
+        ),
+    ),
+}
+
+
+def classification_of(check_name: str) -> Classification | None:
+    return CLASSIFICATIONS.get(check_name)
+
+
+def is_proxy(check_name: str) -> bool:
+    """True only for a check DECLARED a proxy.
+
+    An unclassified check is never demoted. A name this table does not know is
+    either new or renamed, and the honest response is to keep its authority and
+    let the exhaustiveness lint fail -- silently demoting an unknown check
+    would remove a gate as a side effect of forgetting to classify it.
+    """
+    entry = CLASSIFICATIONS.get(check_name)
+    return entry is not None and entry.kind == PROXY
+
+
+def advisory_details(details: str) -> str:
+    """The demoted check's details, carrying its category with it.
+
+    #2540 asks that a borderline check state its classification in its own
+    output, so the next false alarm arrives already labelled instead of costing
+    another investigation.
+    """
+    return (
+        "ADVISORY (proxy-heuristic, not blocking -- #2540; the N5 adversarial "
+        "reviewer judges this dimension directly, with reasons): " + details
+    )

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -33,6 +33,10 @@ from assemblyzero.workflows.implementation_spec.state import (
     ImplementationSpecState,
     PatternRef,
 )
+from assemblyzero.workflows.implementation_spec.check_classification import (
+    advisory_details,
+    is_proxy,
+)
 from assemblyzero.workflows.implementation_spec.criteria_coverage import (
     criteria_coverage,
     format_report as format_coverage_report,
@@ -145,32 +149,14 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_functions)
     _log_check(check_functions)
 
-    # Check 4: Change instructions should be specific — ADVISORY (#2539).
-    # A fence-count density ratio is a proxy, not a verification: it killed
-    # run-issue331-200815 one or two rounds from approval, at "found 8,
-    # expected 9" on a 454-line spec the adversarial reviewer had certified
-    # concrete and executable for five consecutive rounds — and because the
-    # threshold is derived from line count, the drafter's compliance (adding
-    # a fenced snippet, 7→8) grew the spec and moved the demand with it
-    # (8→9). This graph ALWAYS runs the N5 adversarial review, which judges
-    # concreteness and executability directly, with reasons, every round; a
-    # density heuristic adds no information the reviewer lacks and must not
-    # hold a veto the reviewer cannot override. A mechanical check
-    # hard-blocks only on what it can verify — a symbol exists, a row is
-    # cited — and a ratio is not that. Second instance of the class after
-    # #2526's str.isupper.
+    # Check 4: Change instructions should be specific.
+    #
+    # #2539 demoted this one check inline, here, by rewriting its result. That
+    # hack is gone: #2540 classified every check fact-verifier or
+    # proxy-heuristic in one pass, and the demotion below applies the table to
+    # all of them uniformly. See `check_classification.py` for this check's
+    # entry and the reading that decided it.
     check_instructions = check_change_instructions_specific(spec_draft)
-    if not check_instructions["passed"]:
-        print(f"    [ADVISORY] {check_instructions['details']}")
-        check_instructions = CompletenessCheck(
-            check_name="change_instructions_specific",
-            passed=True,
-            details=(
-                "ADVISORY (density heuristic — not blocking, #2539; the N5 "
-                "reviewer judges concreteness directly): "
-                + check_instructions["details"]
-            ),
-        )
     checks.append(check_instructions)
     _log_check(check_instructions)
 
@@ -230,6 +216,13 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
         _record_hallucination_telemetry(state, spec_draft, gathered_symbols)
     except Exception as e:  # noqa: BLE001 — record-only contract
         print(f"    [telemetry] WARNING: hallucination telemetry failed: {e}")
+
+    # #2540: a proxy-heuristic never outranks an engaged judge examining the
+    # same dimension. Applied here, once, over every check -- so the rule is
+    # the table's, not each check's call site's, and a check added tomorrow
+    # obeys it without anyone remembering to write the demotion again.
+    review_engaged = review_is_engaged(state)
+    checks = [_demote_proxies(check, review_engaged) for check in checks]
 
     # Collect issues from failed checks
     completeness_issues = [
@@ -2865,6 +2858,53 @@ _KNOWN_STDLIB_TOPS: frozenset[str] = frozenset({
 # =============================================================================
 # Utility
 # =============================================================================
+
+
+def review_is_engaged(state: ImplementationSpecState) -> bool:
+    """Is the adversarial reviewer going to judge this draft? (#2540)
+
+    True for this graph, and that is a fact about its routing rather than an
+    assumption: `route_after_validation` sends a passing draft to N5 directly,
+    or to N4's human gate, which routes onward to N5 when the human approves.
+    `test_check_classification.py::TestReviewIsReallyEngaged` reads both
+    routers and pins those paths, so this cannot quietly become a lie.
+
+    The one exit that reaches no reviewer is the human REJECTING the draft at
+    N4, which ends the run. A demoted proxy goes unjudged there and nothing
+    ships either, so the demotion costs nothing on that path.
+
+    A state may say `review_engaged: False` explicitly, for a future graph that
+    runs these checks WITHOUT a reviewer. There, proxies re-arm and gate again,
+    because the demotion's whole justification is that a better judge is about
+    to look at the same dimension. Absent that judge, a weak check is better
+    than none.
+    """
+    declared = state.get("review_engaged")
+    if declared is None:
+        return True
+    return bool(declared)
+
+
+def _demote_proxies(
+    check: CompletenessCheck, review_engaged: bool
+) -> CompletenessCheck:
+    """A failed proxy-heuristic reports instead of blocking (#2540).
+
+    Only a FAILED check is touched, and only a declared proxy. A passing check
+    is returned unchanged so the pass/na accounting downstream is unaffected,
+    and an unclassified check keeps its authority -- the exhaustiveness lint,
+    not a silent demotion, is what catches a check nobody classified.
+    """
+    if check["passed"] or not review_engaged:
+        return check
+    if not is_proxy(check["check_name"]):
+        return check
+    print(f"    [ADVISORY] {check['details']}")
+    return CompletenessCheck(
+        check_name=check["check_name"],
+        passed=True,
+        details=advisory_details(check["details"]),
+    )
 
 
 def _log_check(check: CompletenessCheck) -> None:

--- a/assemblyzero/workflows/implementation_spec/state.py
+++ b/assemblyzero/workflows/implementation_spec/state.py
@@ -181,6 +181,12 @@ class ImplementationSpecState(TypedDict, total=False):
     error_message: str
     next_node: str
 
+    # #2540: whether the adversarial reviewer will judge this draft. Absent
+    # means True, which is this graph's routing. A future graph that runs the
+    # completeness checks WITHOUT a reviewer sets this False, and proxy-class
+    # checks gate again -- absent a better judge, a weak check beats none.
+    review_engaged: bool
+
     # Issue #476: API cost budget
     cost_budget_usd: float
 

--- a/tests/unit/test_check_classification.py
+++ b/tests/unit/test_check_classification.py
@@ -1,0 +1,248 @@
+"""The completeness-check classification sweep (#2540).
+
+Operator-ratified 2026-08-28: facts stay hard gates, proxies demote to advisory
+whenever the adversarial review stage is engaged. This is the sweep as a
+program -- it re-runs, it fails when a check joins the suite unclassified, and
+it pins the guarantee the ruling is actually about: **no proxy-class check can
+produce a cap halt while review is engaged.**
+
+The evidence base is three deep and each instance cost a full roll:
+`api_symbols_exist` on `str.isupper` (#2526), `change_instructions_specific` on
+a fence-density off-by-one (#2539), and the same check's no-target complaint
+(#2592).
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.check_classification import (
+    CLASSIFICATIONS,
+    FACT,
+    PROXY,
+    advisory_details,
+    classification_of,
+    is_proxy,
+)
+# The MODULE, not the node function of the same name. `nodes/__init__` binds
+# the attribute `validate_completeness` to the FUNCTION, and both `from ...
+# import validate_completeness` and `import ....validate_completeness as vc`
+# resolve through that attribute -- so both hand back the function. Only
+# `import_module` reaches the module object itself.
+vc = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
+)
+
+SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "assemblyzero" / "workflows" / "implementation_spec"
+    / "nodes" / "validate_completeness.py"
+)
+
+
+def emitted_check_names() -> set[str]:
+    """Every `check_name=` the node can emit, read from its source.
+
+    Read from source rather than listed here, so a check added tomorrow joins
+    this set without anyone remembering to update a literal -- which is the
+    only way the exhaustiveness test below can actually fail on a new check.
+    """
+    return set(
+        re.findall(r'check_name="([a-z_]+)"', SOURCE.read_text(encoding="utf-8"))
+    )
+
+
+class TestTheSweepIsExhaustive:
+    """The lint. Neither list may drift from the other."""
+
+    def test_every_emitted_check_is_classified(self) -> None:
+        unclassified = emitted_check_names() - set(CLASSIFICATIONS)
+        assert not unclassified, (
+            f"checks the sweep has never classified: {sorted(unclassified)}. "
+            f"Add an entry to CLASSIFICATIONS with what it READS and why that "
+            f"makes it a fact or a proxy."
+        )
+
+    def test_every_classification_names_a_real_check(self) -> None:
+        """A phantom entry is worse than a missing one: it reads as coverage."""
+        phantom = set(CLASSIFICATIONS) - emitted_check_names()
+        assert not phantom, f"classified checks nothing emits: {sorted(phantom)}"
+
+    def test_the_sweep_found_the_check_the_issue_did_not_list(self) -> None:
+        """#2540 named eleven checks and said the code is authoritative. The
+        twelfth is `python_fences_parse`, which reports under its own name
+        since #2556 and appears in no issue list."""
+        assert "python_fences_parse" in CLASSIFICATIONS
+        assert len(CLASSIFICATIONS) == 12
+
+    @pytest.mark.parametrize("name", sorted(CLASSIFICATIONS))
+    def test_each_entry_states_what_it_reads_and_why(self, name: str) -> None:
+        entry = CLASSIFICATIONS[name]
+        assert entry.kind in (FACT, PROXY)
+        assert len(entry.reads) > 20, f"{name}: `reads` must be specific"
+        assert len(entry.reason) > 40, f"{name}: `reason` must be specific"
+        assert entry.check == name
+
+
+class TestTheRuling:
+    def test_facts_gate(self) -> None:
+        for entry in CLASSIFICATIONS.values():
+            if entry.kind == FACT:
+                assert entry.gates
+                assert not is_proxy(entry.check)
+
+    def test_proxies_do_not_gate(self) -> None:
+        proxies = {e.check for e in CLASSIFICATIONS.values() if e.kind == PROXY}
+        assert proxies == {
+            "change_instructions_specific",
+            "modify_files_have_excerpts",
+            "data_structures_have_examples",
+        }
+        for name in proxies:
+            assert is_proxy(name)
+            assert not classification_of(name).gates
+
+    def test_the_boundaries_the_operator_ruled(self) -> None:
+        """#2590/PR #2606 fixed io-examples' addressability, not its authority;
+        #2592 rides on this sweep and is a proxy."""
+        assert classification_of("functions_have_io_examples").kind == FACT
+        assert classification_of("change_instructions_specific").kind == PROXY
+
+    def test_arguable_classifications_are_flagged_not_demoted(self) -> None:
+        """Conservative where it is arguable: keep gating, record the tension."""
+        flagged = {e.check for e in CLASSIFICATIONS.values() if e.flagged}
+        assert flagged == {"functions_have_io_examples", "criteria_have_tests"}
+        for name in flagged:
+            assert classification_of(name).gates, (
+                f"{name} is flagged as arguable and must stay GATING -- a "
+                f"sweep does not demote on its own judgement"
+            )
+
+    def test_an_unclassified_name_is_never_demoted(self) -> None:
+        """Forgetting to classify a check must not remove its gate."""
+        assert is_proxy("a_check_nobody_classified") is False
+
+
+class TestNoProxyCanCapHalt:
+    """The guarantee #2540 asks to be pinned.
+
+    A failing check enters `completeness_issues`, which makes
+    `validation_passed` False, which routes back to N2 -- and at
+    `max_iterations` routes to HALT. So "cannot produce a cap halt" is exactly
+    "cannot enter `completeness_issues` while review is engaged".
+    """
+
+    def _failed(self, name: str) -> vc.CompletenessCheck:
+        return vc.CompletenessCheck(
+            check_name=name, passed=False, details=f"{name} failed"
+        )
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(e.check for e in CLASSIFICATIONS.values() if e.kind == PROXY),
+    )
+    def test_a_failing_proxy_stops_blocking(self, name: str) -> None:
+        demoted = vc._demote_proxies(self._failed(name), review_engaged=True)
+        assert demoted["passed"] is True
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(e.check for e in CLASSIFICATIONS.values() if e.kind == FACT),
+    )
+    def test_a_failing_fact_still_blocks(self, name: str) -> None:
+        """The control. Without it, a demoter that demoted everything would
+        pass the test above."""
+        kept = vc._demote_proxies(self._failed(name), review_engaged=True)
+        assert kept["passed"] is False
+
+    def test_the_demoted_check_carries_its_category(self) -> None:
+        demoted = vc._demote_proxies(
+            self._failed("change_instructions_specific"), review_engaged=True
+        )
+        assert "ADVISORY" in demoted["details"]
+        assert "proxy-heuristic" in demoted["details"]
+        assert "#2540" in demoted["details"]
+        assert "change_instructions_specific failed" in demoted["details"]
+
+    def test_a_passing_proxy_is_untouched(self) -> None:
+        """Demotion must not disturb the pass/not-applicable accounting."""
+        passing = vc.CompletenessCheck(
+            check_name="change_instructions_specific",
+            passed=True,
+            details="not applicable",
+        )
+        assert vc._demote_proxies(passing, review_engaged=True) is passing
+
+    def test_proxies_re_arm_when_no_reviewer_is_engaged(self) -> None:
+        """The demotion's justification is that a better judge is about to
+        look. Without one, a weak check beats no check."""
+        armed = vc._demote_proxies(
+            self._failed("change_instructions_specific"), review_engaged=False
+        )
+        assert armed["passed"] is False
+
+
+class TestReviewIsReallyEngaged:
+    """`review_is_engaged` returning True is a fact about this graph's routing.
+
+    Read from the router rather than asserted, so the constant cannot quietly
+    become a lie if a future branch skips N5.
+    """
+
+    def test_a_passing_draft_always_reaches_the_reviewer(self) -> None:
+        from assemblyzero.workflows.implementation_spec.graph import (
+            route_after_validation,
+        )
+
+        without_gate = route_after_validation(
+            {"validation_passed": True, "human_gate_enabled": False}
+        )
+        with_gate = route_after_validation(
+            {"validation_passed": True, "human_gate_enabled": True}
+        )
+
+        assert without_gate == "N5_review_spec"
+        assert with_gate == "N4_human_gate"
+
+    def test_the_human_gate_routes_onward_to_the_reviewer(self) -> None:
+        """The other half: N4 is a checkpoint before N5, not instead of it.
+
+        The gate's third exit is END, when the human rejects the draft. That is
+        the one path where a demoted proxy is never re-judged -- and nothing
+        ships either, because the run stops. The demotion's justification holds
+        on every path that CONTINUES, which is the claim that matters.
+        """
+        from assemblyzero.workflows.implementation_spec.graph import (
+            route_after_human_gate,
+        )
+
+        assert route_after_human_gate(
+            {"next_node": "N5_review_spec"}
+        ) == "N5_review_spec"
+        assert route_after_human_gate(
+            {"next_node": "N2_generate_spec"}
+        ) == "N2_generate_spec"
+        assert route_after_human_gate({}) == "END"
+
+    def test_the_default_is_engaged(self) -> None:
+        assert vc.review_is_engaged({}) is True
+
+    def test_a_graph_can_declare_no_reviewer(self) -> None:
+        assert vc.review_is_engaged({"review_engaged": False}) is False
+
+
+class TestTheInlineHackIsGone:
+    """#2539's demotion was an inline result rewrite in the runner. The sweep
+    replaces it with the table; leaving both would let them disagree."""
+
+    def test_the_runner_no_longer_hardcodes_one_checks_demotion(self) -> None:
+        source = SOURCE.read_text(encoding="utf-8")
+        assert "density heuristic — not blocking" not in source
+        assert "_demote_proxies(check, review_engaged)" in source
+
+    def test_the_advisory_prefix_has_one_definition(self) -> None:
+        assert advisory_details("x").startswith("ADVISORY (proxy-heuristic")

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1054,9 +1054,25 @@ class TestFindPatternReferences:
 class TestValidateCompleteness:
     """Tests for N3: validate_completeness node."""
 
-    def test_t050_catches_missing_excerpts(self, base_state):
-        """T050: Incomplete spec fails validation."""
+    def test_t050_missing_excerpts_now_advises_instead_of_blocking(
+        self, base_state
+    ):
+        """T050, restated for #2540: a spec whose only failures are PROXY-class
+        no longer blocks — it advises, and the N5 reviewer decides.
+
+        This spec has no code fences at all, so it fails
+        `modify_files_have_excerpts` and `change_instructions_specific`. Both
+        are classified proxy-heuristics: the first passes on any fence within
+        3000 characters of a filename, the second on a fence count against a
+        line-count threshold. Neither states a fact about the artifact, and a
+        proxy never outranks an engaged judge examining the same dimension.
+
+        The check still FAILS; what changed is that its failure no longer caps
+        a run. `test_check_classification.py::TestNoProxyCanCapHalt` pins the
+        rule per-check; this pins it through the real node.
+        """
         from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            check_modify_files_have_excerpts,
             validate_completeness,
         )
 
@@ -1064,15 +1080,61 @@ class TestValidateCompleteness:
             "# Implementation Spec\n\n## Overview\n\nChanges.\n\n"
             + ("filler content\n" * 20)
         )
-        base_state["files_to_modify"] = [{
+        files = [{
             "path": "assemblyzero/workflows/test/graph.py",
             "change_type": "Modify", "description": "Update graph",
             "current_content": "existing code",
         }]
+        base_state["files_to_modify"] = files
+
+        # The check itself is unchanged and still finds the gap.
+        assert check_modify_files_have_excerpts(
+            base_state["spec_draft"], files
+        )["passed"] is False
 
         result = validate_completeness(base_state)
+
+        assert result["validation_passed"] is True
+        assert result["completeness_issues"] == []
+
+    def test_t050b_a_fact_class_failure_still_blocks(self, base_state):
+        """The control. Without it, the test above passes against a node that
+        had stopped gating on anything at all.
+
+        Which fact-class check catches this spec is not the point and is not
+        asserted -- the point is that whatever still blocks is a FACT, never a
+        proxy. Naming one check here would pin an incidental detail of the
+        fixture rather than the rule.
+        """
+        from assemblyzero.workflows.implementation_spec.check_classification import (
+            CLASSIFICATIONS,
+            PROXY,
+        )
+        from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+            validate_completeness,
+        )
+
+        base_state["spec_draft"] = (
+            "# Implementation Spec\n\n## Overview\n\nChanges.\n\n"
+            "```python\ndef broken(:\n    pass\n```\n"
+            + ("filler content\n" * 20)
+        )
+        base_state["files_to_modify"] = []
+
+        result = validate_completeness(base_state)
+
         assert result["validation_passed"] is False
-        assert len(result["completeness_issues"]) > 0
+        assert result["completeness_issues"]
+
+        proxy_details = {
+            entry.check for entry in CLASSIFICATIONS.values()
+            if entry.kind == PROXY
+        }
+        for issue in result["completeness_issues"]:
+            assert "ADVISORY" not in issue, (
+                f"a demoted proxy reached completeness_issues: {issue}"
+            )
+        assert proxy_details, "the classification table must know some proxies"
 
     def test_t060_passes_complete_spec(self, base_state, sample_spec_complete):
         """T060: Complete spec passes validation."""


### PR DESCRIPTION
Closes #2540

Every completeness check classified fact-verifier or proxy-heuristic in one deliberate pass. Facts stay hard gates; proxies demote to advisory whenever the adversarial review stage is engaged.

## The classification

Twelve checks, decided from what each one **reads** rather than what it is named after — several are named for the thing they wish they measured.

### Fact-verifiers — stay hard gates

| check | reads | why it is a fact |
|---|---|---|
| `api_symbols_exist` | calls against the gathered symbol table and the repo | a symbol exists or it does not. #2526 was a defect in its symbol *table* — `str.isupper` is real and the table did not know it — not evidence the question is a correlate. A wrong fact is fixed by fixing the fact. |
| `python_fences_parse` | `ast.parse` over every python-tagged fence | the parser succeeds or raises. Reports under its own name since #2556. |
| `import_targets_exist` | each module path on disk, cross-referenced against the spec's own Files Changed table | a module resolves or it does not; the cross-reference is what keeps it from false-alarming on a module the spec creates (#842). |
| `pattern_references_valid` | each `file:line` reference against real code | a reference points at real code or it does not. |
| `manifest_traceability` | row ids against each parsed test's source | an exact bookkeeping diff. It abstains on unparseable fences (#2526's unknown-is-not-guilty) — a fact-verifier declining to state a fact it lacks. |
| `error_paths_have_tests` | `raise X` names in code fences vs asserted names in test fences | a set difference over names from both halves of the same document (#2333). |
| `visual_baselines_not_self_referential` | baseline-file touches vs the literal marker `baseline-independent` | both halves exact: a file list and a literal string. #1902's failure is not a matter of degree. |

### Proxy-heuristics — advisory when review is engaged

| check | reads | why it is a correlate |
|---|---|---|
| `change_instructions_specific` | fence count vs `max(3, lines//50)`, indicators vs `max(5, lines//30)` | a density ratio, and self-defeating: both thresholds derive from line count, so complying grows the spec and moves the demand — 7-of-8 at 441 lines becoming 8-of-9 at 454, on a spec the reviewer had certified for five consecutive rounds (#2539). It parses nothing from its own message (#2592). |
| `modify_files_have_excerpts` | 3000 chars after each Modify filename, passing if ``` ``` ``` appears | any fence at all, about anything. Passes on a fence showing something else entirely. |
| `data_structures_have_examples` | 5000 chars after each structure name, five loose patterns incl. any fence ≥20 chars | same proximity shape, looser. Whether an example is *of* the structure is the question, and it never asks it. |

**Proximity is the tell.** Three checks pass on finding *something* within N characters of *something else*. That answers "are these near each other", never "is this an example OF that thing".

### Classified fact, flagged as arguable — left GATING

| check | flag |
|---|---|
| `functions_have_io_examples` | Operator-ruled a fact-verifier and kept gating: #2590/PR #2606 fixed its addressability, not its authority. Verifying it found the tension anyway — a ±2000-char window plus a vocabulary word plus any concrete-looking value is the same shape as the three checks above, differing only in window size. Recorded with its fair counter-argument on **#2620**; nothing changed. |
| `criteria_have_tests` | **The only mode-dependent class in the suite.** `MODE_EXACT` is a `REQ-N` id-set difference and a plain fact. The `MODE_OUTCOME` fallback matches normalised substrings, which is a correlate in both directions. Left gating in both modes — a per-run class is a design change, not a classification. Filed as **#2619**. |

Conservative where it is arguable, per the issue's own instruction. Demoting on the sweep's judgement — against an operator ruling, or across a mode boundary the operator has not seen — would be exactly the unilateral call this registry replaces. A flag costs nothing; a wrong demotion removes a gate quietly.

## What landed

`check_classification.py` is the reviewable artifact, on the #2475 model. #2539's demotion was an inline rewrite of one check's result inside the runner — correct, and invisible: nothing named the class, nothing stopped the next check from being demoted differently, and a reader had to find the hack to know the rule existed. That hack is **gone**, replaced by one pass over every check:

```python
review_engaged = review_is_engaged(state)
checks = [_demote_proxies(check, review_engaged) for check in checks]
```

The rule is the table's now, not each call site's, so a check added tomorrow obeys it without anyone remembering to write the demotion again.

**`review_is_engaged` is a fact about routing, not an assumption.** `TestReviewIsReallyEngaged` reads both routers: `route_after_validation` sends a passing draft to N5 or to N4, and `route_after_human_gate` sends N4 onward to N5. The one exit reaching no reviewer is the human *rejecting* the draft, which ends the run — a demoted proxy goes unjudged there and nothing ships either. A future graph without a reviewer sets `review_engaged: False` and proxies re-arm: absent a better judge, a weak check beats none.

## The guarantee, pinned

#2540 asks for a re-runnable test that no proxy-class check can produce a cap halt while review is engaged. A failing check enters `completeness_issues` → `validation_passed` False → route back to N2, and at `max_iterations` → HALT. So the guarantee is exactly "cannot enter `completeness_issues`", and `TestNoProxyCanCapHalt` asserts it per-check, parametrised over the table — **with the control**: every fact-class check, also parametrised, still blocks. Without that control a demoter that demoted everything would pass.

The exhaustiveness lint reads `check_name="..."` out of the node's source rather than from a literal list, so a check added tomorrow joins the swept set automatically and fails the lint until classified. It found the twelfth check the issue did not list: `python_fences_parse`, which reports under its own name since #2556 and appears in no issue's enumeration.

41 tests.

## Boundaries honoured

- `functions_have_io_examples` stays a hard gate (#2590 fixed addressability, not authority).
- `change_instructions_specific` is classified proxy, so **#2592 rides on this**: once demoted, its unaddressable complaint cannot deadlock a revision loop. Its reword is now optional cleanup rather than a blocker, and is not done here.
- `#2541`'s advisory mechanics are the prior art this generalises.

## Not done

The three demoted checks keep their current message text. Rewording them is cleanup that only matters while they gate, and they no longer do.

follow-up: #2619, #2620 · see #2592 · see #2475
