### PR TITLE
fix: staleness fingerprints content, through one shared function (Closes #2615)

### DIFF
--- a/tests/unit/test_arc_doc_sync.py
+++ b/tests/unit/test_arc_doc_sync.py
@@ -292,75 +292,94 @@ def _drafted_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def test_a_claude_md_edit_makes_a_persisted_draft_stale(repo, log, monkeypatch):
-    """Acceptance 2. A draft older than the correction must redraw, not resume
-    onto a document the ruling has already invalidated."""
-    monkeypatch.setattr(
-        speedrun_roll, "_run",
-        _issue_updated_at("2020-01-01T00:00:00Z", real=speedrun_roll._run),
-    )
-    drafted = _drafted_now()
+#: #2615: staleness is decided by CONTENT, so these fixtures edit the arc's
+#: working tree rather than moving commit dates. The arc IS the tree the roll
+#: reads -- `repo` is checked out on it below -- so a doc ruling landing on the
+#: arc is a doc changing under the draft, which is #2205's whole subject.
+BODY = "# Issue seven\n\nProse only.\n"
 
+
+def _settle_against_the_arc(repo: Path, issue: int = 7) -> None:
+    from assemblyzero.core import settlement as s
+    from assemblyzero.workflows.requirements.audit import save_settlement
+
+    lld = repo / "docs" / "lld" / "active" / f"LLD-{issue}.md"
+    lld.parent.mkdir(parents=True, exist_ok=True)
+    lld.write_text("## 1. Context\n\nDerived.\n", encoding="utf-8")
+    save_settlement(
+        issue, "lld",
+        s.build_settlement(
+            "lld", lld, s.collect_inputs(repo, issue_body=BODY),
+            verdict="APPROVED",
+        ),
+        repo,
+    )
+
+
+@pytest.fixture
+def body_unchanged(monkeypatch):
+    monkeypatch.setattr(
+        speedrun_roll, "fetch_issue", lambda _r, _i: ("title", BODY)
+    )
+
+
+def test_a_claude_md_edit_makes_a_persisted_draft_stale(
+    repo, log, body_unchanged
+):
+    """Acceptance 2. A draft made before the correction must redraw, not
+    resume onto a document the ruling has already invalidated."""
     git(repo, "checkout", "-q", ARC)
+    _settle_against_the_arc(repo)
+
     _commit_dated(
         repo, "CLAUDE.md", "Key modules: corrected\n",
         "docs: correct Key modules", "2099-01-01T00:00:00+0000",
     )
-    git(repo, "push", "-q", "origin", ARC)
-    git(repo, "fetch", "-q", "origin")
 
-    assert speedrun_roll.draft_is_stale(repo, 7, drafted, ARC, log), (
-        "the draft predates the CLAUDE.md correction, so resuming spends the "
-        "stage on a document already known to be wrong"
+    assert speedrun_roll.draft_is_stale(repo, 7, log), (
+        "the draft was derived before the CLAUDE.md correction, so resuming "
+        "spends the stage on a document already known to be wrong"
     )
-    assert "binding doc" in log.path.read_text(encoding="utf-8")
 
 
-def test_a_non_binding_edit_leaves_the_draft_current(repo, log, monkeypatch):
+def test_a_non_binding_edit_leaves_the_draft_current(repo, log, body_unchanged):
     """The control that makes the test above mean something: the SAME shape
     with a file outside the tuple must NOT invalidate the draft. Without this,
-    a staleness assertion proves only that some commit exists."""
-    monkeypatch.setattr(
-        speedrun_roll, "_run",
-        _issue_updated_at("2020-01-01T00:00:00Z", real=speedrun_roll._run),
-    )
-    drafted = _drafted_now()
-
+    a staleness assertion proves only that some file changed."""
     git(repo, "checkout", "-q", ARC)
+    _settle_against_the_arc(repo)
+
     _commit_dated(
         repo, "README.md", "changed\n", "chore: readme",
         "2099-01-01T00:00:00+0000",
     )
-    git(repo, "push", "-q", "origin", ARC)
-    git(repo, "fetch", "-q", "origin")
 
-    assert not speedrun_roll.draft_is_stale(repo, 7, drafted, ARC, log), (
+    assert not speedrun_roll.draft_is_stale(repo, 7, log), (
         "code on the arc is not law; only the binding-doc paths invalidate a "
         "draft"
     )
 
 
-def test_the_staleness_message_reads_as_a_list_not_a_path(repo, log, monkeypatch):
-    """Three entries joined by '/' rendered 'docs/design/docs/adrs/CLAUDE.md',
-    which reads as one nonexistent path."""
-    monkeypatch.setattr(
-        speedrun_roll, "_run",
-        _issue_updated_at("2020-01-01T00:00:00Z", real=speedrun_roll._run),
-    )
-    drafted = _drafted_now()
-
+def test_the_staleness_message_names_the_document_that_moved(
+    repo, log, body_unchanged
+):
+    """The old message joined the whole BINDING_DOC_PATHS tuple with '/',
+    rendering `docs/design/docs/adrs/CLAUDE.md` -- one nonexistent path. The
+    content check names the single input that actually moved, which is both
+    unambiguous and more useful, and the run-together hazard is structurally
+    gone because no tuple is joined into prose any more."""
     git(repo, "checkout", "-q", ARC)
+    _settle_against_the_arc(repo)
+
     _commit_dated(
         repo, "CLAUDE.md", "changed\n", "docs: change",
         "2099-01-01T00:00:00+0000",
     )
-    git(repo, "push", "-q", "origin", ARC)
-    git(repo, "fetch", "-q", "origin")
 
-    speedrun_roll.draft_is_stale(repo, 7, drafted, ARC, log)
+    speedrun_roll.draft_is_stale(repo, 7, log)
 
     written = log.path.read_text(encoding="utf-8")
-    assert "docs/design, docs/adrs, CLAUDE.md" in written
+    assert "binding:CLAUDE.md" in written
     assert "docs/adrs/CLAUDE.md" not in written
 
 

--- a/tests/unit/test_no_retries.py
+++ b/tests/unit/test_no_retries.py
@@ -188,54 +188,119 @@ def test_a_storm_does_not_wait_or_redraw(monkeypatch, repo):
 # ---------------------------------------------------------------------------
 
 
-def test_doc_ruling_after_the_draft_is_stale(monkeypatch, repo, log):
-    """The live case: docs moved after the draft, issue text did not."""
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, AFTER_DRAFT),
+#: The issue body the draft was derived from. Content, not a timestamp
+#: (#2615) -- so the fixtures below edit text rather than moving clocks.
+BODY = "# Dial\n\n| ID | Binding value |\n|----|---------------|\n| S1 | 250 ms |\n"
+
+
+def settled(repo: Path, issue: int = 1, body: str = BODY) -> None:
+    """Record the lld stage as settled against ``body`` and the repo's docs."""
+    from assemblyzero.core import settlement as s
+    from assemblyzero.workflows.requirements.audit import save_settlement
+
+    lld = repo / "docs" / "lld" / "active" / f"LLD-{issue}.md"
+    lld.parent.mkdir(parents=True, exist_ok=True)
+    lld.write_text("## 1. Context\n\n| S1 | 250 ms |\n", encoding="utf-8")
+    save_settlement(
+        issue, "lld",
+        s.build_settlement(
+            "lld", lld, s.collect_inputs(repo, issue_body=body),
+            verdict="APPROVED",
+        ),
+        repo,
     )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
 
 
-def test_issue_edit_after_the_draft_is_stale(monkeypatch, repo, log):
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner(AFTER_DRAFT, BEFORE_DRAFT),
-    )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+@pytest.fixture
+def body_is(monkeypatch):
+    """Drive the issue body without `gh` and without a network."""
+
+    def _set(text: str | None):
+        def _fetch(_repo, _issue):
+            if text is None:
+                raise RuntimeError("gh unavailable")
+            return ("title", text)
+
+        monkeypatch.setattr(speedrun_roll, "fetch_issue", _fetch)
+
+    return _set
 
 
-def test_current_draft_is_not_stale(monkeypatch, repo, log):
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT),
-    )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is False
+def test_doc_ruling_after_the_draft_is_stale(repo, log, body_is):
+    """#2206's live case, measured by content: the binding doc moved and the
+    issue text did not."""
+    (repo / "docs" / "design").mkdir(parents=True)
+    (repo / "docs" / "design" / "dial.md").write_text("law\n", encoding="utf-8")
+    settled(repo)
+    body_is(BODY)
+
+    (repo / "docs" / "design" / "dial.md").write_text("law, amended\n", encoding="utf-8")
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is True
 
 
-def test_repo_with_no_doc_history_is_not_stale(monkeypatch, repo, log):
-    """An empty probe result means no binding doc has ever changed."""
-    monkeypatch.setattr(speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, ""))
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is False
+def test_issue_body_edit_after_the_draft_is_stale(repo, log, body_is):
+    """A one-character edit to the binding value still unsettles."""
+    settled(repo)
+    body_is(BODY.replace("250 ms", "251 ms"))
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is True
 
 
-def test_unknowable_answers_are_stale(monkeypatch, repo, log):
-    """Every probe failure draws fresh, which is always safe."""
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT, issue_rc=1),
-    )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+def test_current_draft_is_not_stale(repo, log, body_is):
+    settled(repo)
+    body_is(BODY)
 
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner(BEFORE_DRAFT, BEFORE_DRAFT, doc_rc=1),
-    )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
-
-    monkeypatch.setattr(
-        speedrun_roll, "_run", fake_runner("not-a-time", BEFORE_DRAFT),
-    )
-    assert speedrun_roll.draft_is_stale(repo, 1, DRAFTED, ARC, log) is True
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is False
 
 
-def test_missing_draft_time_is_stale(repo, log):
-    assert speedrun_roll.draft_is_stale(repo, 1, "", ARC, log) is True
+def test_a_comment_on_the_issue_does_not_unsettle(repo, log, body_is):
+    """#2615, the acceptance. GitHub bumps `updatedAt` when a comment is
+    posted, so the old timestamp probe fired on an event that changed no
+    input -- and the campaign's own method is to post a diagnosis to the
+    issue before fixing. The body is byte-identical here, which is exactly
+    what a comment leaves behind."""
+    settled(repo)
+    body_is(BODY)  # same bytes; only the timeline moved
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is False
+
+
+def test_a_label_or_reaction_does_not_unsettle(repo, log, body_is):
+    """Same shape as a comment: every timeline event that is not a body edit."""
+    settled(repo)
+    body_is(BODY)
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is False
+
+
+def test_no_settlement_record_is_stale(repo, log, body_is):
+    """Unknowable answers stay stale: with nothing to compare against, the
+    caller draws fresh, which is safe."""
+    body_is(BODY)
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is True
+
+
+def test_an_unreadable_issue_is_stale(repo, log, body_is):
+    """`gh` down must never read as 'nothing changed'."""
+    settled(repo)
+    body_is(None)
+
+    assert speedrun_roll.draft_is_stale(repo, 1, log) is True
+
+
+def test_the_mismatch_is_named_in_the_log(repo, log, body_is, tmp_path):
+    """A redraw states which input moved, so the operator is not left
+    guessing why a resume was declined."""
+    settled(repo)
+    body_is(BODY.replace("250 ms", "251 ms"))
+
+    speedrun_roll.draft_is_stale(repo, 1, log)
+
+    written = (tmp_path / "session-events.log").read_text(encoding="utf-8")
+    assert "a binding input changed" in written
+    assert "issue_body" in written
 
 
 def test_resume_plan_refuses_a_stale_draft(monkeypatch, repo, log, tmp_path):

--- a/tests/unit/test_staleness_is_content.py
+++ b/tests/unit/test_staleness_is_content.py
@@ -1,0 +1,311 @@
+"""Staleness is decided by content, and by ONE fingerprint (#2615).
+
+`draft_is_stale` (#2206) used to compare the issue's `updatedAt` against the
+draft time. **GitHub bumps `updatedAt` when a comment is posted**, so the probe
+fired on events that changed nothing about the derivation -- and the campaign's
+standing method is to post a sharpened diagnosis to the issue before fixing.
+Following the method invalidated every persisted draft it touched.
+
+Two things are pinned here, and the second matters as much as the first:
+
+1. **Content decides.** A comment does not unsettle; a one-character body edit
+   does. Each with the control that makes it mean something.
+2. **One fingerprint.** `draft_is_stale` and `should_skip_stage` ask the same
+   question, so they must ask it of the same function over the same inputs.
+   Two parsers of one question is the #1698 failure class, and it is precisely
+   how these two would have drifted -- the settlement path hashing content
+   while the resume path read clocks was that drift, already realised.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_roll as sr  # noqa: E402
+
+from assemblyzero.core import settlement as s  # noqa: E402
+from assemblyzero.workflows.orchestrator import stages  # noqa: E402
+from assemblyzero.workflows.orchestrator.state import OrchestrationState  # noqa: E402
+from assemblyzero.workflows.requirements.audit import save_settlement  # noqa: E402
+
+ISSUE = 331
+
+TABLE = "| ID | Binding value |\n|----|---------------|\n| S1 | 250 ms |\n"
+BODY = f"# Dial\n\n## Pass criteria\n\n{TABLE}"
+
+
+class _Log:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def write(self, line: str) -> None:
+        self.lines.append(line)
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "docs" / "lld" / "active").mkdir(parents=True)
+    (tmp_path / "docs" / "design").mkdir(parents=True)
+    (tmp_path / "docs" / "design" / "dial.md").write_text("law\n", encoding="utf-8")
+    (tmp_path / "CLAUDE.md").write_text("rules\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def lld(repo: Path) -> Path:
+    path = repo / "docs" / "lld" / "active" / f"LLD-{ISSUE}.md"
+    path.write_text(f"## 1. Context\n\n## 3. Requirements\n\n{TABLE}", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def settled(repo: Path, lld: Path):
+    def _settle(body: str = BODY) -> dict:
+        record = s.build_settlement(
+            "lld", lld, s.collect_inputs(repo, issue_body=body), verdict="APPROVED"
+        )
+        save_settlement(ISSUE, "lld", record, repo)
+        return record
+
+    return _settle
+
+
+@pytest.fixture
+def resume_sees(monkeypatch):
+    """What `gh` returns to the RESUME path."""
+
+    def _set(body: str | None):
+        def _fetch(_repo, _issue):
+            if body is None:
+                raise RuntimeError("gh unavailable")
+            return ("title", body)
+
+        monkeypatch.setattr(sr, "fetch_issue", _fetch)
+
+    return _set
+
+
+@pytest.fixture
+def stage_sees(monkeypatch):
+    """What `gh` returns to the STAGE-ENTRY path."""
+
+    def _set(body: str | None):
+        monkeypatch.setattr(stages, "fetch_issue_body", lambda _r, _i: body)
+
+    return _set
+
+
+# ---------------------------------------------------------------------------
+# Content decides
+# ---------------------------------------------------------------------------
+
+
+class TestContentDecides:
+    def test_a_comment_does_not_unsettle(self, repo, settled, resume_sees) -> None:
+        """The acceptance. A comment leaves the body byte-identical -- which
+        is exactly the state this fixture reproduces -- while bumping
+        `updatedAt`, the field the old check read."""
+        settled()
+        resume_sees(BODY)
+
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is False
+
+    def test_a_one_character_body_edit_unsettles(
+        self, repo, settled, resume_sees
+    ) -> None:
+        """The control. Without it, a check that never unsettles would pass
+        the test above."""
+        settled()
+        resume_sees(BODY.replace("250 ms", "251 ms"))
+
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is True
+
+    def test_a_binding_doc_edit_unsettles(self, repo, settled, resume_sees) -> None:
+        settled()
+        resume_sees(BODY)
+        (repo / "docs" / "design" / "dial.md").write_text("amended\n", encoding="utf-8")
+
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is True
+
+    def test_an_unrelated_file_does_not_unsettle(
+        self, repo, settled, resume_sees
+    ) -> None:
+        """Only the binding paths are law."""
+        settled()
+        resume_sees(BODY)
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is False
+
+    def test_whitespace_only_line_endings_do_not_unsettle(
+        self, repo, settled, resume_sees
+    ) -> None:
+        """LF from `gh`, CRLF from a Windows checkout: the same document."""
+        settled()
+        resume_sees(BODY.replace("\n", "\r\n"))
+
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is False
+
+
+class TestUnknowableIsStale:
+    def test_no_settlement_record_is_stale(self, repo, resume_sees) -> None:
+        resume_sees(BODY)
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is True
+
+    def test_an_unreadable_issue_is_stale(self, repo, settled, resume_sees) -> None:
+        settled()
+        resume_sees(None)
+        assert sr.draft_is_stale(repo, ISSUE, _Log()) is True
+
+    def test_the_decline_says_why(self, repo, settled, resume_sees) -> None:
+        settled()
+        resume_sees(BODY.replace("250 ms", "251 ms"))
+        log = _Log()
+
+        sr.draft_is_stale(repo, ISSUE, log)
+
+        assert "a binding input changed" in log.text
+        assert "issue_body" in log.text
+
+    def test_the_missing_record_decline_says_why(self, repo, resume_sees) -> None:
+        resume_sees(BODY)
+        log = _Log()
+
+        sr.draft_is_stale(repo, ISSUE, log)
+
+        assert "no settlement record" in log.text
+
+
+# ---------------------------------------------------------------------------
+# One fingerprint -- the #1698 guard
+# ---------------------------------------------------------------------------
+
+
+class TestOneFingerprint:
+    """The two paths must not be able to disagree.
+
+    They already did: settlement hashed content while the resume path read
+    `updatedAt`, so the same question got two answers on the same state. These
+    tests fail if a future edit reintroduces a second notion of "did the inputs
+    change".
+    """
+
+    def test_both_paths_agree_a_comment_changes_nothing(
+        self, repo, lld, settled, resume_sees, stage_sees
+    ) -> None:
+        settled()
+        resume_sees(BODY)
+        stage_sees(BODY)
+
+        resume_stale = sr.draft_is_stale(repo, ISSUE, _Log())
+        skip, _ = stages.should_skip_stage(
+            OrchestrationState(
+                issue_number=ISSUE, target_repo=str(repo), config={}
+            ),
+            "lld",
+            {"triage": None, "lld": str(lld), "spec": None,
+             "impl": None, "pr": None},
+        )
+
+        assert resume_stale is False
+        assert skip is True, "settled for one path and not the other is drift"
+
+    def test_both_paths_agree_a_body_edit_changes_everything(
+        self, repo, lld, settled, resume_sees, stage_sees
+    ) -> None:
+        """The control, on the same pair: agreement on 'no' is worth nothing
+        without agreement on 'yes'."""
+        settled()
+        edited = BODY.replace("250 ms", "251 ms")
+        resume_sees(edited)
+        stage_sees(edited)
+
+        resume_stale = sr.draft_is_stale(repo, ISSUE, _Log())
+        skip, _ = stages.should_skip_stage(
+            OrchestrationState(
+                issue_number=ISSUE, target_repo=str(repo), config={}
+            ),
+            "lld",
+            {"triage": None, "lld": str(lld), "spec": None,
+             "impl": None, "pr": None},
+        )
+
+        assert resume_stale is True
+        assert skip is False
+
+    def test_the_resume_path_builds_inputs_with_the_shared_collector(
+        self, repo, settled, resume_sees, monkeypatch
+    ) -> None:
+        """Structural: the resume path must go through `collect_inputs`, not
+        assemble its own list. A second assembler is how the fingerprints
+        drift even when both sides hash."""
+        settled()
+        resume_sees(BODY)
+        seen: list[str] = []
+        real = s.collect_inputs
+
+        def _spy(*args, **kwargs):
+            seen.append("called")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(s, "collect_inputs", _spy)
+
+        sr.draft_is_stale(repo, ISSUE, _Log())
+
+        assert seen, "draft_is_stale did not use settlement.collect_inputs"
+
+    def test_the_resume_path_verdicts_through_settlement_verify(
+        self, repo, settled, resume_sees, monkeypatch
+    ) -> None:
+        settled()
+        resume_sees(BODY)
+        seen: list[str] = []
+        real = s.verify
+
+        def _spy(*args, **kwargs):
+            seen.append("called")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(s, "verify", _spy)
+
+        sr.draft_is_stale(repo, ISSUE, _Log())
+
+        assert seen, "draft_is_stale did not use settlement.verify"
+
+    def test_one_definition_of_the_binding_paths(self) -> None:
+        assert sr.BINDING_DOC_PATHS is s.BINDING_DOC_PATHS
+
+
+class TestTheTimestampProbeIsGone:
+    """Dead mechanisms get removed, not left beside the live one."""
+
+    def test_the_source_no_longer_reads_updated_at(self) -> None:
+        """The CODE forms, not the word.
+
+        The docstrings deliberately explain what `updatedAt` did and why it
+        was wrong, so a bare substring search would forbid recording the
+        lesson. What must not come back is the argv that asks GitHub for the
+        field.
+        """
+        source = (TOOLS / "speedrun_roll.py").read_text(encoding="utf-8")
+        for code_form in ('"updatedAt"', "'updatedAt'", ".updatedAt"):
+            assert code_form not in source, (
+                f"{code_form} is the #2615 defect's code form; reading that "
+                f"field again reintroduces unsettling on comments"
+            )
+
+    def test_the_iso_parser_went_with_it(self) -> None:
+        """`_iso_to_epoch` existed only for the timestamp comparisons."""
+        source = (TOOLS / "speedrun_roll.py").read_text(encoding="utf-8")
+        assert "_iso_to_epoch" not in source

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -884,16 +884,6 @@ def _resolve_stage_artifact(
 BINDING_DOC_PATHS = settlement_mod.BINDING_DOC_PATHS
 
 
-def _iso_to_epoch(value: str) -> float | None:
-    """Parse an ISO-8601 timestamp (with Z or offset) to epoch seconds."""
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
-    except ValueError:
-        return None
-
-
 def sync_binding_docs_to_arc(
     repo_root: Path, base: str, log: EventLog
 ) -> list[str]:
@@ -1032,82 +1022,72 @@ def sync_binding_docs_to_arc(
     return problems
 
 
-def draft_is_stale(
-    repo_root: Path, issue: int, drafted_at: str, base: str, log: EventLog
-) -> bool:
-    """True when a binding input moved after the draft was made (#2206).
+def draft_is_stale(repo_root: Path, issue: int, log: EventLog) -> bool:
+    """True when a binding input's CONTENT changed since the draft (#2206, #2615).
 
-    A resumed spec is built on a persisted LLD. If the law that LLD was
-    derived from has since changed, resuming spends the stage on a draft that
-    is already wrong -- and worse, produces a failure that reads as evidence
-    against whatever the ruling just fixed.
+    A resumed spec is built on a persisted LLD. If the law that LLD was derived
+    from has since changed, resuming spends the stage on a draft that is
+    already wrong -- and worse, produces a failure that reads as evidence
+    against whatever the ruling just fixed. #2206's live case: an LLD drafted
+    at 01:27Z was invalidated by design-doc rulings merged at 05:13Z and 06:18Z
+    while the issue's own text had last changed BEFORE the draft, so an
+    issue-only check would have resumed onto it.
 
-    Two inputs can invalidate a draft, and BOTH are checked because the live
-    case proved one is not enough. On 2026-08-11 an LLD drafted at 01:27Z was
-    invalidated by design-doc rulings merged at 05:13Z and 06:18Z while the
-    issue's own text had last changed at 01:10Z -- BEFORE the draft. An
-    issue-only staleness check would have called that draft current and
-    resumed onto it.
+    ## Why this no longer reads timestamps (#2615)
 
-    Unknowable answers are stale: if the draft time cannot be read or a probe
-    fails, this returns True and the caller draws fresh, which is always safe.
+    The old form compared the issue's `updatedAt` against the draft time.
+    **GitHub bumps `updatedAt` when a comment is posted**, so the probe fired
+    on events that changed nothing about the derivation -- measured across
+    three issues with a control, on #2615. The campaign's own standing method,
+    *post the sharpened diagnosis on the issue before fixing*, therefore
+    invalidated every persisted draft it touched, at full drafter cost, against
+    text byte-identical to what the draft already had.
+
+    The question is "did the derivation's INPUTS change", and the inputs are
+    the issue BODY and the binding docs. A comment, a label and a reaction
+    change none of them.
+
+    ## One fingerprint, not two
+
+    This asks `settlement.verify` the same question `should_skip_stage` asks,
+    over inputs built by the same `collect_inputs`. Two parsers of one question
+    is the #1698 failure class, and it is exactly how this check and settlement
+    would have drifted -- `test_staleness_is_content.py::TestOneFingerprint`
+    pins that they cannot.
+
+    It also changes WHAT is measured, deliberately. The old binding-doc probe
+    read `git log` over the base BRANCH, which answers "has a doc landed on the
+    arc since" -- a proxy that is wrong in both directions (a doc merged but
+    not pulled; a working-tree edit never committed). Settlement hashes the
+    working tree the stage actually read, so both sides of the comparison are
+    now the same thing.
+
+    Unknowable answers stay stale: with no settlement record there is nothing
+    to compare content against, and the caller draws fresh, which is safe. A
+    run whose lld stage passed has a record by construction (#2616 settles on
+    the passed branch), so this costs a one-time redraw only for state
+    persisted before settlement existed.
     """
-    drafted = _iso_to_epoch(drafted_at)
-    if drafted is None:
+    record = load_settlement(issue, "lld", repo_root)
+    if record is None:
         log.write(
-            f"RESUME abandoned for #{issue}: draft time unreadable "
-            f"({drafted_at!r})"
+            f"RESUME abandoned for #{issue}: no settlement record for the lld "
+            "stage, so the draft's inputs cannot be compared by content -- "
+            "drawing fresh"
         )
         return True
 
-    # 1. Issue text.
-    result = _run(
-        ["gh", "issue", "view", str(issue), "--json", "updatedAt",
-         "--jq", ".updatedAt"],
-        cwd=repo_root,
+    mismatches = settlement_mod.verify(
+        record, settlement_inputs(repo_root, issue, "lld")
     )
-    if result.returncode != 0:
+    if mismatches:
         log.write(
-            f"RESUME abandoned for #{issue}: cannot read the issue's last-edit "
-            "time to check staleness"
+            f"RESUME abandoned for #{issue}: a binding input changed since the "
+            "draft was made -- drawing fresh against the current law"
         )
+        for reason in mismatches:
+            log.write(f"  {reason}")
         return True
-    edited = _iso_to_epoch(result.stdout.strip())
-    if edited is None:
-        log.write(f"RESUME abandoned for #{issue}: unparseable issue timestamp")
-        return True
-    if edited > drafted:
-        log.write(
-            f"RESUME abandoned for #{issue}: the issue was edited after the "
-            "draft was made -- drawing fresh against the current text"
-        )
-        return True
-
-    # 2. Binding docs on the base branch -- the input that fired live.
-    docs = _run(
-        ["git", "log", "-1", "--format=%cI", f"origin/{base}", "--",
-         *BINDING_DOC_PATHS],
-        cwd=repo_root,
-    )
-    if docs.returncode != 0:
-        log.write(
-            f"RESUME abandoned for #{issue}: cannot read binding-doc history "
-            f"on '{base}' to check staleness"
-        )
-        return True
-    latest_doc = docs.stdout.strip()
-    if latest_doc:
-        doc_ts = _iso_to_epoch(latest_doc)
-        if doc_ts is None:
-            log.write(f"RESUME abandoned for #{issue}: unparseable doc timestamp")
-            return True
-        if doc_ts > drafted:
-            log.write(
-                f"RESUME abandoned for #{issue}: a binding doc "
-                f"({', '.join(BINDING_DOC_PATHS)}) changed on '{base}' after "
-                "the draft was made -- drawing fresh against the current law"
-            )
-            return True
     return False
 
 
@@ -1212,10 +1192,11 @@ def resume_plan(
     if not _open_lld_pr_exists(repo_root, issue):
         return None
 
-    # #2206: the draft must still be derived from current law. `started_at` is
-    # when the run that produced it began, so anything binding that moved
-    # since is a change the draft cannot know about.
-    if draft_is_stale(repo_root, issue, data.get("started_at", ""), base, log):
+    # #2206: the draft must still be derived from current law. #2615: by
+    # CONTENT -- the settled fingerprint of the issue body and the binding
+    # docs -- never by timestamps, which a comment moves without changing a
+    # single input.
+    if draft_is_stale(repo_root, issue, log):
         return None
 
     # #2414: an artifact lookup, not a path-string lookup. The old form read


### PR DESCRIPTION
Closes #2615

`draft_is_stale` compared the issue's `updatedAt` against the draft time. **GitHub bumps `updatedAt` when a comment is posted** — measured across three issues with a control on #2615 — so the probe fired on events that changed nothing about the derivation. The campaign's standing method is *post the sharpened diagnosis on the issue before fixing*, so **the method invalidated every persisted draft it touched**, at full drafter cost, against text byte-identical to what the draft already had.

The staleness question is "did the derivation's INPUTS change", and the inputs are the issue **body** and the binding docs. A comment, a label and a reaction change none of them.

## One fingerprint, not two

The check now asks `settlement.verify` the same question `should_skip_stage` asks, over inputs built by the same `collect_inputs`. That is the acceptance's real demand: two parsers of one question is the #1698 failure class, and **this check versus settlement was that drift already realised** — one side hashing content while the other read clocks, giving two answers for the same state.

`TestOneFingerprint` pins it four ways, because agreement on "nothing changed" is worth nothing without agreement on "everything changed":

| test | what it pins |
|---|---|
| `test_both_paths_agree_a_comment_changes_nothing` | resume says fresh **and** stage entry reuses |
| `test_both_paths_agree_a_body_edit_changes_everything` | the control — resume says stale **and** stage entry redraws |
| `test_the_resume_path_builds_inputs_with_the_shared_collector` | structural: a second input assembler is how fingerprints drift even when both sides hash |
| `test_the_resume_path_verdicts_through_settlement_verify` | structural, the other half |

## What is measured now

| | before (#2206) | after |
|---|---|---|
| issue text | `--json updatedAt` vs draft time | sha256 of the issue **body** |
| binding docs | `git log -1 origin/<arc>` vs draft time | sha256 of each binding doc in the working tree |

The issue-text half is a pure repair. **The binding-doc half is a deliberate substitution and I want it read as one:** settlement hashes the working tree because that is the tree the stage actually read, and a resume check hashing a branch ref instead would be the second fingerprint the acceptance forbids. One fingerprint was the requirement, so both sides now hash the same thing.

That substitution opens a gap — a binding doc merged to origin but not present in the working tree no longer unsettles — and it is **filed as #2622** with what I could and could not establish about its reachability, rather than left implicit. Every other ambiguity still resolves toward unsettled: no record, an unreadable input, a gained or lost doc, a failed `gh` read.

## Acceptance

| clause | evidence |
|---|---|
| a comment does not unsettle | `TestContentDecides::test_a_comment_does_not_unsettle`, and `test_a_label_or_reaction_does_not_unsettle` in the rewritten #2206 suite |
| a one-character body edit still does | `test_a_one_character_body_edit_unsettles` (`250 ms` → `251 ms`) |
| the two paths cannot drift | `TestOneFingerprint`, above |

`#2206`'s own invariant is preserved and re-proved in the new model: `test_doc_ruling_after_the_draft_is_stale` still fires on a binding-doc change with the issue text untouched, and `test_a_non_binding_edit_leaves_the_draft_current` is still its control.

## Dead machinery removed, not left beside the live path

`_iso_to_epoch` existed only for these comparisons. `TestTheTimestampProbeIsGone` asserts the `updatedAt` **code forms** never come back — deliberately not the bare word, because the docstrings explain what the field did and why it was wrong, and a substring ban would forbid recording the lesson.

The old staleness message joined `BINDING_DOC_PATHS` with `/` and rendered `docs/design/docs/adrs/CLAUDE.md`, one nonexistent path. That hazard is structurally gone — no tuple is joined into prose any more — and the replacement names the single input that moved (`binding:CLAUDE.md`), which is both unambiguous and more useful. The test that guarded the run-together now asserts the better message.

## What only a live roll proves

Everything here is proved read-only against fixtures. Whether a real resume reuses a settled draft after a comment — the exact event this repairs — needs a roll. boostgauge stayed read-only: no roll, PR #367 untouched, no writes to #331 state.

follow-up: #2622 · see #2616 for the settlement mechanism this aligns with
