### PR TITLE
feat: demote the io-example window scan, build the structural gate (Closes #2620)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/check_classification.py
+++ b/assemblyzero/workflows/implementation_spec/check_classification.py
@@ -163,23 +163,40 @@ CLASSIFICATIONS: dict[str, Classification] = {
     # ------------------------------------------- facts, flagged as arguable
     "functions_have_io_examples": Classification(
         check="functions_have_io_examples",
-        kind=FACT,
+        kind=PROXY,
         reads=(
             "a +/-2000-character window around each function definition, for "
             "an I/O vocabulary word AND any concrete-looking value"
         ),
         reason=(
-            "Operator-ruled a fact-verifier and kept gating: #2590 (PR #2606) "
-            "fixed its addressability, not its authority."
+            "Operator-ruled a PROXY 2026-08-28 (#2620), superseding the "
+            "earlier fact-verifier ruling on the #2590 work order. That "
+            "ruling classified the check's INTENTION; this one classifies the "
+            "implementation that actually runs, and the two disagree. A "
+            "window plus a vocabulary plus any number or quoted string does "
+            "not verify that the example is OF that function -- neighbouring "
+            "definitions share the window, and #2302 documents the verdict "
+            "moving on how often a name happened to be repeated. A false veto "
+            "from a well-intentioned check is still the #2539 disease."
         ),
-        flagged=(
-            "This reads like a proxy by the rule above: a window plus a "
-            "vocabulary plus any number or quoted string does not verify that "
-            "the example is OF that function, and #2302 shows the verdict has "
-            "moved on how often a name happened to be repeated. Left GATING "
-            "per the ruling; the tension, and the fair counter-argument for "
-            "it, are recorded on #2620 so the next sweep starts from the "
-            "question rather than rediscovering it."
+    ),
+    "function_spec_sections_have_examples": Classification(
+        check="function_spec_sections_have_examples",
+        kind=FACT,
+        reads=(
+            "each `### 5.N `name()`` subsection of the spec's Function "
+            "Specifications section, for an Input Example and an Output "
+            "Example block INSIDE that subsection's own bounds"
+        ),
+        reason=(
+            "the path back to a hard gate, named by #2620's ruling and built "
+            "with it. Presence within a bounded region is a fact: the section "
+            "either carries the block or it does not, no window is scanned, "
+            "and no neighbour can satisfy it. Template 0701 defines the "
+            "structure, and both preserved boostgauge specs follow it exactly "
+            "-- #331's seven subsections carry seven Input Examples, #1's two "
+            "carry two -- so the gate passes on real work rather than "
+            "blocking it."
         ),
     ),
     "criteria_have_tests": Classification(

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -144,10 +144,19 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_data)
     _log_check(check_data)
 
-    # Check 3: Functions should have I/O examples
+    # Check 3: Functions should have I/O examples — PROXY since #2620, so the
+    # demotion pass below turns its failure into an advisory. Kept because it
+    # grades functions the template's section-5 structure may not cover.
     check_functions = check_functions_have_io_examples(spec_draft)
     checks.append(check_functions)
     _log_check(check_functions)
+
+    # Check 3b (#2620): the structural fact-verifier that carries the gate
+    # check 3 used to hold. Bounded by each subsection's own heading, so a
+    # neighbouring function's example cannot satisfy it.
+    check_func_sections = check_function_spec_sections_have_examples(spec_draft)
+    checks.append(check_func_sections)
+    _log_check(check_func_sections)
 
     # Check 4: Change instructions should be specific.
     #
@@ -823,8 +832,119 @@ def grant_grace(
     ]
 
 
+#: A Function Specifications subsection: `### 5.2 `compute_needle_angle()``.
+#: Template 0701 defines this shape, and both preserved boostgauge specs
+#: follow it exactly -- #331's spec carries seven subsections and seven Input
+#: Examples, #1's carries two and two.
+_FUNC_SPEC_HEADING_RE = re.compile(
+    r"^###\s+5\.\d+\s+(.+?)\s*$", re.MULTILINE
+)
+
+#: The blocks template 0701 requires inside each such subsection.
+_REQUIRED_EXAMPLE_BLOCKS = ("**Input Example:**", "**Output Example:**")
+
+
+def function_spec_sections(spec: str) -> list[tuple[str, str, int]]:
+    """Every `### 5.N` subsection as (heading, body, 1-based heading line).
+
+    Bounded by the NEXT heading of any level, so a subsection's body is its
+    own -- which is the whole difference between this and a window scan.
+    """
+    text = spec or ""
+    matches = list(_FUNC_SPEC_HEADING_RE.finditer(text))
+    if not matches:
+        return []
+    next_heading = re.compile(r"^#{1,6}\s", re.MULTILINE)
+    out: list[tuple[str, str, int]] = []
+    for index, match in enumerate(matches):
+        start = match.end()
+        limit = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        )
+        following = next_heading.search(text, start, limit)
+        body_end = following.start() if following else limit
+        line_no = text.count("\n", 0, match.start()) + 1
+        out.append((match.group(0).strip(), text[start:body_end], line_no))
+    return out
+
+
+def check_function_spec_sections_have_examples(spec: str) -> CompletenessCheck:
+    """Every Function Specifications subsection carries its example blocks.
+
+    #2620's path back to a hard gate. `functions_have_io_examples` searches a
+    +/-2000-character window for vocabulary and any concrete-looking value,
+    which cannot tell whether the example belongs to the function it is
+    grading -- neighbouring definitions share the window. That is a correlate,
+    and the operator demoted it to advisory.
+
+    This asks a bounded, structural question instead: does the subsection that
+    documents this function, between its own heading and the next one, contain
+    the `**Input Example:**` and `**Output Example:**` blocks template 0701
+    requires? Presence within a region is a fact. No neighbour can satisfy it,
+    and no repetition of a name can move the verdict.
+
+    Not applicable is not failure: a spec with no `### 5.N` subsections -- a
+    spec that adds no functions, or one written before the template -- yields
+    no checks and passes, per the #1870 convention.
+
+    The complaint names the subsection HEADING, which occurs verbatim in the
+    draft, so revision pinning can read the address (#2555's lesson, swept by
+    `test_completeness_message_addressability.py`).
+    """
+    sections = function_spec_sections(spec)
+    if not sections:
+        return CompletenessCheck(
+            check_name="function_spec_sections_have_examples",
+            passed=True,
+            details=(
+                "No `### 5.N` function-specification subsections found — "
+                "check not applicable."
+            ),
+        )
+
+    missing: list[str] = []
+    for heading, body, line_no in sections:
+        absent = [b for b in _REQUIRED_EXAMPLE_BLOCKS if b not in body]
+        if absent:
+            missing.append(
+                f"{heading} (line {line_no}-{line_no}) lacks "
+                f"{' and '.join(absent)}"
+            )
+
+    if missing:
+        listed = "; ".join(missing[:5])
+        suffix = f" (and {len(missing) - 5} more)" if len(missing) > 5 else ""
+        return CompletenessCheck(
+            check_name="function_spec_sections_have_examples",
+            passed=False,
+            details=(
+                f"{len(missing)} of {len(sections)} function-specification "
+                f"subsection(s) are missing a required example block: "
+                f"{listed}{suffix}. Add the block inside that subsection; "
+                f"template 0701 section 5 requires both."
+            ),
+        )
+
+    return CompletenessCheck(
+        check_name="function_spec_sections_have_examples",
+        passed=True,
+        details=(
+            f"All {len(sections)} function-specification subsection(s) carry "
+            f"an Input Example and an Output Example."
+        ),
+    )
+
+
 def check_functions_have_io_examples(spec: str) -> CompletenessCheck:
     """Every non-test function must have input/output examples.
+
+    **Classified a PROXY-heuristic and demoted to advisory (#2620.)** The
+    window scan below cannot tell whether the example it finds belongs to the
+    function it is grading, so its failure is a correlate rather than a fact.
+    `check_function_spec_sections_have_examples` above is the fact-verifier
+    that replaces its authority; this stays as an advisory second opinion,
+    because it grades functions the template's section-5 structure may not
+    cover.
 
     Judged at each function's DEFINITION SITE, once per function. The previous
     implementation scanned a forward-only window from every textual occurrence

--- a/tests/unit/test_check_classification.py
+++ b/tests/unit/test_check_classification.py
@@ -75,9 +75,12 @@ class TestTheSweepIsExhaustive:
     def test_the_sweep_found_the_check_the_issue_did_not_list(self) -> None:
         """#2540 named eleven checks and said the code is authoritative. The
         twelfth is `python_fences_parse`, which reports under its own name
-        since #2556 and appears in no issue list."""
+        since #2556 and appears in no issue list. The thirteenth is
+        `function_spec_sections_have_examples`, built by #2620 as the path
+        back to a hard gate."""
         assert "python_fences_parse" in CLASSIFICATIONS
-        assert len(CLASSIFICATIONS) == 12
+        assert "function_spec_sections_have_examples" in CLASSIFICATIONS
+        assert len(CLASSIFICATIONS) == 13
 
     @pytest.mark.parametrize("name", sorted(CLASSIFICATIONS))
     def test_each_entry_states_what_it_reads_and_why(self, name: str) -> None:
@@ -101,26 +104,45 @@ class TestTheRuling:
             "change_instructions_specific",
             "modify_files_have_excerpts",
             "data_structures_have_examples",
+            "functions_have_io_examples",
         }
         for name in proxies:
             assert is_proxy(name)
             assert not classification_of(name).gates
 
     def test_the_boundaries_the_operator_ruled(self) -> None:
-        """#2590/PR #2606 fixed io-examples' addressability, not its authority;
-        #2592 rides on this sweep and is a proxy."""
-        assert classification_of("functions_have_io_examples").kind == FACT
+        """#2620, 2026-08-28: **classification follows the implementation.**
+
+        The earlier ruling on the #2590 work order classified this check's
+        INTENTION and kept it gating; this one classifies the implementation
+        that actually runs, and demotes it. The two disagree, and the
+        implementation is what gates, so the implementation is what gets
+        classified. The gate it held moves to the structural check built with
+        the ruling.
+        """
+        assert classification_of("functions_have_io_examples").kind == PROXY
         assert classification_of("change_instructions_specific").kind == PROXY
+        assert classification_of(
+            "function_spec_sections_have_examples"
+        ).kind == FACT
 
     def test_arguable_classifications_are_flagged_not_demoted(self) -> None:
-        """Conservative where it is arguable: keep gating, record the tension."""
+        """Conservative where it is arguable: keep gating, record the tension.
+
+        `functions_have_io_examples` left this set when #2620 ruled on it --
+        a flag is for an open question, and that one is answered.
+        """
         flagged = {e.check for e in CLASSIFICATIONS.values() if e.flagged}
-        assert flagged == {"functions_have_io_examples", "criteria_have_tests"}
+        assert flagged == {"criteria_have_tests"}
         for name in flagged:
             assert classification_of(name).gates, (
                 f"{name} is flagged as arguable and must stay GATING -- a "
                 f"sweep does not demote on its own judgement"
             )
+
+    def test_a_demoted_check_carries_no_stale_flag(self) -> None:
+        """A ruled question must not keep advertising itself as open."""
+        assert classification_of("functions_have_io_examples").flagged == ""
 
     def test_an_unclassified_name_is_never_demoted(self) -> None:
         """Forgetting to classify a check must not remove its gate."""

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -162,6 +162,25 @@ class TestAddressableToday:
     is a rewording guard: change the message so it drops its address and this
     fails."""
 
+    def test_function_spec_sections_addresses_its_subsection(self):
+        """#2620's new hard gate, swept BEFORE it ships rather than discovered
+        to deadlock on a live roll (#2617's discipline).
+
+        The complaint names the subsection heading, which occurs verbatim in
+        the draft, and cites its line as a dashed range -- both halves of the
+        enforcement vocabulary, so pinning can read the address either way.
+        """
+        draft = (
+            "# Spec\n\n## 5. Function Specifications\n\n"
+            "### 5.1 `compute_needle_angle()`\n\n"
+            "**Signature:**\n\n```python\ndef compute_needle_angle(v):\n"
+            "    ...\n```\n\nNo examples here.\n"
+        )
+        verdict = _classify(
+            vc.check_function_spec_sections_have_examples(draft), draft
+        )
+        assert verdict.verdict == ADDRESSED
+
     def test_functions_have_io_examples_addresses_a_zero_arg_function(self):
         verdict = _classify(
             vc.check_functions_have_io_examples(FUNCTION_ZERO_ARG),
@@ -245,6 +264,7 @@ class TestTheSweepIsExhaustive:
         }
         swept = {
             "check_functions_have_io_examples",
+            "check_function_spec_sections_have_examples",
             "check_modify_files_have_excerpts",
             "check_change_instructions_specific",
             "check_manifest_traceability",

--- a/tests/unit/test_function_spec_sections.py
+++ b/tests/unit/test_function_spec_sections.py
@@ -1,0 +1,219 @@
+"""The structural fact-verifier that replaces a window scan (#2620).
+
+`functions_have_io_examples` searches +/-2000 characters around each `def` for
+an I/O vocabulary word and any concrete-looking value. That cannot tell whether
+the example belongs to the function it is grading -- neighbouring definitions
+share the window -- so the operator ruled it a proxy and demoted it.
+
+This check asks a bounded question instead: does the `### 5.N` subsection that
+documents a function, between its own heading and the next one, carry the
+`**Input Example:**` and `**Output Example:**` blocks template 0701 requires?
+Presence within a region is a fact.
+
+**The difference is provable, and `TestTheWindowScanCannotDoThis` proves it**:
+one fixture where a neighbour's example satisfies the window scan and this
+check still fails. Without that test, "structural" is a claim about intent
+rather than a property of the code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_function_spec_sections_have_examples,
+    check_functions_have_io_examples,
+    function_spec_sections,
+)
+
+DOCUMENTED = """\
+### 5.1 `render_face()`
+
+**Signature:**
+
+```python
+def render_face(width: int) -> bytes:
+    ...
+```
+
+**Input Example:**
+
+```python
+width = 1024
+```
+
+**Output Example:**
+
+```python
+b"\\x89PNG..."
+```
+"""
+
+UNDOCUMENTED = """\
+### 5.2 `_draw_ticks()`
+
+**Signature:**
+
+```python
+def _draw_ticks(surface) -> None:
+    ...
+```
+"""
+
+
+def spec(*sections: str) -> str:
+    return (
+        "# Implementation Spec\n\n## 1. Overview\n\nRender.\n\n"
+        "## 5. Function Specifications\n\n" + "\n".join(sections)
+        + "\n## 10. Test Mapping\n\n- covered\n"
+    )
+
+
+class TestPresenceIsAFact:
+    def test_a_fully_documented_section_passes(self) -> None:
+        result = check_function_spec_sections_have_examples(spec(DOCUMENTED))
+        assert result["passed"] is True
+        assert "All 1 function-specification" in result["details"]
+
+    def test_a_section_missing_both_blocks_fails(self) -> None:
+        result = check_function_spec_sections_have_examples(spec(UNDOCUMENTED))
+        assert result["passed"] is False
+        assert "_draw_ticks()" in result["details"]
+
+    def test_a_section_missing_only_the_output_block_fails(self) -> None:
+        half = DOCUMENTED.replace("**Output Example:**", "**Edge Cases:**")
+        result = check_function_spec_sections_have_examples(spec(half))
+        assert result["passed"] is False
+        assert "**Output Example:**" in result["details"]
+        assert "**Input Example:**" not in result["details"]
+
+    def test_it_names_every_missing_section(self) -> None:
+        result = check_function_spec_sections_have_examples(
+            spec(UNDOCUMENTED, UNDOCUMENTED.replace("5.2", "5.3"))
+        )
+        assert result["passed"] is False
+        assert "2 of 2" in result["details"]
+
+    def test_a_mixed_spec_names_only_the_gap(self) -> None:
+        result = check_function_spec_sections_have_examples(
+            spec(DOCUMENTED, UNDOCUMENTED)
+        )
+        assert result["passed"] is False
+        assert "1 of 2" in result["details"]
+        assert "_draw_ticks()" in result["details"]
+        assert "render_face()" not in result["details"]
+
+
+class TestNotApplicableIsNotFailure:
+    def test_a_spec_with_no_function_sections_passes(self) -> None:
+        result = check_function_spec_sections_have_examples(
+            "# Spec\n\n## 1. Overview\n\nNo functions.\n"
+        )
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_an_empty_spec_passes(self) -> None:
+        assert check_function_spec_sections_have_examples("")["passed"] is True
+
+    def test_other_numbered_sections_are_not_graded(self) -> None:
+        """The control: only section 5 subsections. A `### 6.1` is a change
+        instruction and owes no example block."""
+        other = "### 6.1 `path/to/file.py` (Add)\n\nNo examples here.\n"
+        assert check_function_spec_sections_have_examples(
+            spec(DOCUMENTED) + other
+        )["passed"] is True
+
+
+class TestTheWindowScanCannotDoThis:
+    """The reason this check exists, as a measurement rather than a claim."""
+
+    def test_a_neighbours_example_satisfies_the_window_but_not_the_section(
+        self,
+    ) -> None:
+        """`_draw_ticks` carries no example of its own; `render_face`'s sits a
+        few hundred characters away. The window scan is satisfied by proximity.
+        The structural check is not, because the example is in another
+        subsection's bounds."""
+        draft = spec(DOCUMENTED, UNDOCUMENTED)
+
+        window = check_functions_have_io_examples(draft)
+        structural = check_function_spec_sections_have_examples(draft)
+
+        assert window["passed"] is True, (
+            "the fixture must reproduce the window scan's blind spot, or the "
+            "comparison below proves nothing"
+        )
+        assert structural["passed"] is False
+        assert "_draw_ticks()" in structural["details"]
+
+    def test_both_agree_when_everything_is_documented(self) -> None:
+        """The control: the structural check is stricter, never merely
+        different -- it must not fail what the window scan passes for good
+        reason."""
+        draft = spec(DOCUMENTED)
+
+        assert check_functions_have_io_examples(draft)["passed"] is True
+        assert check_function_spec_sections_have_examples(draft)["passed"] is True
+
+
+class TestSectionBounds:
+    def test_a_section_ends_at_the_next_heading(self) -> None:
+        sections = function_spec_sections(spec(UNDOCUMENTED, DOCUMENTED))
+        assert len(sections) == 2
+        first_body = sections[0][1]
+        assert "_draw_ticks" in first_body
+        assert "render_face" not in first_body, (
+            "a subsection's body must not run into the next one"
+        )
+
+    def test_the_heading_line_is_reported(self) -> None:
+        draft = spec(DOCUMENTED)
+        _heading, _body, line_no = function_spec_sections(draft)[0]
+        assert draft.splitlines()[line_no - 1].startswith("### 5.1")
+
+
+class TestItPassesOnRealSpecs:
+    """Verified against boostgauge's preserved specs, read-only.
+
+    Both follow template 0701 exactly -- #331's spec carries seven `### 5.N`
+    subsections and seven Input Examples, #1's carries two and two -- so this
+    gate passes on real work rather than blocking the roll it was built for.
+    The fixture below is the shape those specs actually have.
+    """
+
+    @pytest.mark.parametrize("count", [2, 7])
+    def test_a_spec_shaped_like_the_preserved_ones_passes(self, count: int) -> None:
+        sections = [
+            DOCUMENTED.replace("5.1", f"5.{n}").replace(
+                "render_face", f"fn_{n}"
+            )
+            for n in range(1, count + 1)
+        ]
+        result = check_function_spec_sections_have_examples(spec(*sections))
+
+        assert result["passed"] is True
+        assert f"All {count} function-specification" in result["details"]
+
+
+class TestTheComplaintIsAddressable:
+    """#2617's discipline: a new gate's message must name a draft line before
+    it ships, or it is the #2555 deadlock class wearing a new artifact."""
+
+    def test_the_message_names_the_subsection_heading_verbatim(self) -> None:
+        draft = spec(UNDOCUMENTED)
+        details = check_function_spec_sections_have_examples(draft)["details"]
+
+        heading = "### 5.2 `_draw_ticks()`"
+        assert heading in details
+        assert heading in draft, "the cited heading must occur in the draft"
+
+    def test_the_message_carries_a_dashed_line_citation(self) -> None:
+        """`named_line_ranges` requires the dash (#2555), so a bare line
+        number would address nothing."""
+        import re
+
+        details = check_function_spec_sections_have_examples(
+            spec(UNDOCUMENTED)
+        )["details"]
+
+        assert re.search(r"line \d+-\d+", details), details

--- a/tests/unit/test_implementation_spec_workflow.py
+++ b/tests/unit/test_implementation_spec_workflow.py
@@ -1114,9 +1114,16 @@ class TestValidateCompleteness:
             validate_completeness,
         )
 
+        # #2620: this fixture used to block via `functions_have_io_examples`,
+        # which is now a demoted proxy. It blocks on the structural check that
+        # inherited that gate instead: a `### 5.N` subsection carrying neither
+        # example block is a presence FACT about a bounded region.
         base_state["spec_draft"] = (
-            "# Implementation Spec\n\n## Overview\n\nChanges.\n\n"
-            "```python\ndef broken(:\n    pass\n```\n"
+            "# Implementation Spec\n\n## 1. Overview\n\nChanges.\n\n"
+            "## 5. Function Specifications\n\n"
+            "### 5.1 `render_face()`\n\n"
+            "**Signature:**\n\n```python\ndef render_face(w):\n    ...\n```\n\n"
+            "No example blocks here.\n\n"
             + ("filler content\n" * 20)
         )
         base_state["files_to_modify"] = []


### PR DESCRIPTION
Closes #2620

Implements the operator ruling of 2026-08-28: **classification follows the implementation.** The fact/proxy line is drawn by how reliably a check's failure is true, not by what the check intends to measure — so when intention and implementation disagree, the implementation is what gates, and the implementation is what gets classified.

## The demotion

`functions_have_io_examples` searches a ±2000-character window around each `def` for an I/O vocabulary word and any concrete-looking value. That cannot tell whether the example it finds belongs to the function it is grading: neighbouring definitions share the window, and #2302 documents the verdict moving on how often a name happened to be repeated. It is now classified **proxy-heuristic** and demotes to advisory while the adversarial reviewer is engaged, joining the sweep's three via #2621's mechanics.

The earlier fact-verifier ruling on the #2590 work order classified the check's *intention*; this supersedes it for the code that actually runs. The `flagged` note the sweep recorded is removed — a flag marks an open question, and this one is answered. `test_a_demoted_check_carries_no_stale_flag` pins that.

## The path back, built with the ruling

The ruling named the way back to a hard gate, and it was small enough to land here: **`function_spec_sections_have_examples`**.

Template 0701 section 5 defines the structure — `### 5.N \`name()\`` subsections, each carrying `**Input Example:**` and `**Output Example:**`. The new check asks whether the subsection that documents a function, **between its own heading and the next one**, carries those blocks. Presence within a bounded region is a fact: no window is scanned, no neighbour can satisfy it, and no repetition of a name can move the verdict.

**The difference is measured, not asserted.** `test_a_neighbours_example_satisfies_the_window_but_not_the_section` builds one draft where `render_face` is documented and `_draw_ticks` is not, and asserts the window scan **passes** while the structural check **fails**. The window scan's blind spot is reproduced in the fixture, so the comparison proves something; its companion asserts both agree when everything is documented, so the new check is stricter rather than merely different.

## Verified against real state before it ships

Both preserved boostgauge specs follow the template exactly, counted read-only:

| spec | `### 5.N` subsections | `Input Example` blocks |
|---|---|---|
| #331, `004-spec-draft.md` | 7 | 7 |
| #1, `010-spec-draft.md` | 2 | 2 |

So the new gate **passes on real work rather than blocking the roll it was built for.** `TestItPassesOnRealSpecs` drives the same shape at both counts.

Its blast radius is narrow by construction: a spec with no `### 5.N` subsections yields no checks and passes (#1870's not-applicable convention), so a spec written to a different structure cannot be blocked by it.

## Swept before it ships, not after it deadlocks

#2617's discipline, applied here: a new hard gate joins the #2557 addressability sweep **before** shipping, so its message is known to address a draft line rather than discovered to deadlock on a live roll. `check_function_spec_sections_have_examples` is in the swept set, classified `ADDRESSED`, and both halves of the enforcement vocabulary are exercised:

- the complaint names the subsection heading (`### 5.2 \`_draw_ticks()\``), which occurs **verbatim** in the draft — `named_tokens` reads it;
- it carries a **dashed** line citation (`line 42-42`), because `named_line_ranges` requires the dash (#2555) and a bare number would address nothing.

`TestTheComplaintIsAddressable` asserts the cited heading actually occurs in the draft, not merely that a heading-shaped string was emitted — the second half of class 3's detection question, which is what caught #2590 and #2591.

## The sweep's own tests moved with the ruling

The classification table is now 13 entries. `test_the_boundaries_the_operator_ruled` records the supersession explicitly rather than silently flipping an assertion, and the #2540 node-level control (`test_t050b_a_fact_class_failure_still_blocks`) now blocks on the structural check — its old fixture blocked via the check this PR demoted, which is precisely what a control is for.

`functions_have_io_examples` is kept, not deleted: it grades functions the template's section-5 structure may not cover, and as an advisory it costs nothing and can only inform the reviewer.

## What only a live roll proves

The gate passes on two preserved specs and on fixtures shaped like them. Whether a freshly drafted spec satisfies it every round, and what the advisory's firing rate looks like beside it, needs a roll. boostgauge stayed read-only: no roll, PR #367 untouched, no writes to #331 state.

see #2621 for the demotion mechanics · see #2617 for the addressability discipline
