### PR TITLE
refactor: criteria coverage joins on IDs or abstains, never on prose (Closes #2619)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/check_classification.py
+++ b/assemblyzero/workflows/implementation_spec/check_classification.py
@@ -203,21 +203,19 @@ CLASSIFICATIONS: dict[str, Classification] = {
         check="criteria_have_tests",
         kind=FACT,
         reads=(
-            "in EXACT mode, the REQ-N tag set in the LLD against the tag set "
-            "in the spec's tests; in the OUTCOME fallback, each criterion's "
-            "normalised outcome text as a substring of a test's name and body"
+            "the REQ-N tag set in the LLD's pass-criteria table against the "
+            "tag set cited by the spec's test functions"
         ),
         reason=(
-            "EXACT mode is an id-set difference and is a plain fact (#2239)."
-        ),
-        flagged=(
-            "The class is MODE-DEPENDENT, which no other check here is. The "
-            "OUTCOME fallback -- used whenever the criteria are not all tagged "
-            "-- matches normalised substrings, which is a correlate: a test "
-            "can contain a criterion's words without covering it. Left GATING "
-            "in both modes rather than demoting the fallback on the sweep's "
-            "own judgement, because a per-run class is a design change and not "
-            "a classification. Filed for a ruling as #2619."
+            "an id-set difference: a criterion ID either has a test citing it "
+            "or it does not (#2239). The sweep flagged this entry as "
+            "mode-dependent, because a substring fallback ran whenever the "
+            "criteria were not all tagged -- and the operator ruled 2026-08-28 "
+            "(#2619) that the fallback be REMOVED rather than classified, "
+            "since injection (#2607/#2611) carries criterion IDs byte-verbatim "
+            "and the mangled-ID case it served is structurally gone. With one "
+            "mode left, the class is no longer arguable: an untagged table now "
+            "abstains and says so instead of guessing."
         ),
     ),
     # -------------------------------------------------------------- proxies

--- a/assemblyzero/workflows/implementation_spec/criteria_coverage.py
+++ b/assemblyzero/workflows/implementation_spec/criteria_coverage.py
@@ -14,22 +14,32 @@ also caught a test feeding malformed JSON to dodge type validation, and an
 exception-handling defect that would crash the app and lose user data; those are
 the catches worth ninety seconds of model time. The twelve-test count was not.
 
-The two join modes
-------------------
+One join mode, and an honest abstention (#2619)
+-----------------------------------------------
 
-**exact** -- the criteria carry ``REQ-N`` tags and the spec's tests cite them, so
-the mapping is a join on identifiers. This is what ADR 0226's exact mode gives
-once boostgauge #284 lands row IDs, and what today's tagged LLDs already permit.
+**exact** -- the criteria carry ``REQ-N`` tags and the spec's tests cite them,
+so the mapping is a join on identifiers. A criterion ID either has a test
+citing it or it does not, which is a fact, so this gates.
 
-**count-and-outcome** -- no usable tags on one side or the other. Criteria are
-matched to tests by outcome text, using the same maximum bipartite matching the
-form checker uses in its no-ID mode (#2219). Greedy assignment is wrong for the
-same reason there: in LLD-007 "unchanged" is a substring of "unchanged; the CLI
-value is not written", so matching in row order can consume the only test a
-later criterion could have used and report a gap that is not there.
+There used to be a **count-and-outcome** fallback: with no usable tags, criteria
+were matched to tests by outcome text under maximum bipartite matching. It
+existed because derived criterion IDs could arrive mangled. **#2607/#2611
+injection now carries the criteria tables byte-verbatim from issue to LLD to
+spec, so the case it served is structurally gone**, and the operator ruled it
+removed rather than classified -- classifying dead code enshrines it.
 
-The report always names which mode ran, because the weaker mode must never be
-mistaken for the stronger one.
+It was also a correlate in both directions, which is why removal rather than
+demotion was right: a test containing a criterion's words is not a test
+covering it, and a test covering a criterion in different words was reported
+missing. A false veto is the #2539 disease.
+
+Where the fallback used to guess, the check now **abstains and says so**: an
+untagged criteria table is reported not-applicable, naming the untagged rows,
+per the #1870 convention that a check which verified nothing must never render
+as a check that passed. Verified before removal against boostgauge's live #331
+state, where exact mode engages on both sides: every row of the LLD's `10.1
+Test Scenarios` table carries a REQ tag, and its spec's thirteen tests cite
+REQ-1 through REQ-13.
 
 What exact mode still cannot see
 --------------------------------
@@ -45,10 +55,14 @@ stays where it already was: with the semantic reviewer.
 Reuse, deliberately
 -------------------
 
-``parse_tables``, ``_max_matching`` and ``_norm`` come from the form checker
-rather than being reimplemented here. One markdown-table parser and one matching
-algorithm, used by both callers: a second copy would drift from the first, which
-is the failure this codebase has already paid for twice (#1586, #1698).
+``parse_tables`` and ``_norm`` come from the form checker rather than being
+reimplemented here. One markdown-table parser, used by both callers: a second
+copy would drift from the first, which is the failure this codebase has already
+paid for twice (#1586, #1698).
+
+``_max_matching`` was imported too, for the outcome fallback's bipartite
+assignment. #2619 removed the fallback, so the import went with it -- an unused
+import is a live reference to a removed mechanism.
 """
 
 from __future__ import annotations
@@ -57,7 +71,6 @@ import re
 from dataclasses import dataclass, field
 
 from assemblyzero.workflows.requirements.form_check import (
-    _max_matching,
     _norm,
     parse_tables,
 )
@@ -81,7 +94,8 @@ _CRITERIA_COLUMN = "pass criteria"
 _ID_COLUMN = "id"
 
 MODE_EXACT = "exact (criterion IDs)"
-MODE_OUTCOME = "count and outcome (no IDs to join on)"
+#: #2619 removed the count-and-outcome fallback. The name is gone with it --
+#: a constant kept "for compatibility" is how a removed mode gets resurrected.
 
 
 @dataclass(frozen=True)
@@ -211,49 +225,51 @@ def criteria_coverage(spec: str, lld: str) -> CoverageReport:
             reason="the LLD states no pass-criteria table to check against",
         )
 
-    tests = spec_tests(spec)
-    if not tests:
+    # #2619: no ID to join on is NOT APPLICABLE, never a weaker join.
+    #
+    # The substring fallback existed because derived criterion IDs could arrive
+    # mangled. #2607/#2611 injection now carries the criteria tables
+    # byte-verbatim from issue to LLD to spec, so the case it served is
+    # structurally gone -- and classifying dead code enshrines it. Removed.
+    #
+    # Reporting not-applicable rather than guessing is the #1870 convention:
+    # a check that verified nothing must never render as a check that passed.
+    if not all(c.tagged for c in criteria):
+        untagged = [c.row_id or "(no id)" for c in criteria if not c.tagged]
         return CoverageReport(
-            ran=True,
-            join_mode=MODE_EXACT if all(c.tagged for c in criteria) else MODE_OUTCOME,
-            criteria=criteria,
-            missing=list(criteria),
-            test_count=0,
+            ran=False,
+            reason=(
+                f"{len(untagged)} of {len(criteria)} pass criteria carry no "
+                f"REQ tag to join on ({', '.join(untagged[:5])}"
+                + (f", and {len(untagged) - 5} more" if len(untagged) > 5 else "")
+                + "), so coverage cannot be established by identity. Tag the "
+                "rows; matching outcome prose was removed in #2619 because a "
+                "test containing a criterion's words is not a test covering it"
+            ),
         )
 
+    tests = spec_tests(spec)
     tagged_in_spec = {
         f"REQ-{n}"
         for _name, body in tests
         for n in REQ_TAG.findall(body)
     }
 
-    if all(c.tagged for c in criteria) and tagged_in_spec:
-        missing = [c for c in criteria if c.key not in tagged_in_spec]
+    if not tests or not tagged_in_spec:
+        # Every criterion is tagged and the spec cites none of them: that is a
+        # real, exact miss -- all of them -- not an absence of information.
         return CoverageReport(
             ran=True,
             join_mode=MODE_EXACT,
             criteria=criteria,
-            missing=missing,
+            missing=list(criteria),
             test_count=len(tests),
         )
 
-    # Fallback: match each criterion's outcome text into a test, one test per
-    # criterion, maximising the number matched.
-    normalised_tests = [_norm(f"{name} {body}") for name, body in tests]
-    candidates = [
-        [
-            index
-            for index, text in enumerate(normalised_tests)
-            if _norm(c.outcome) and _norm(c.outcome) in text
-        ]
-        for c in criteria
-    ]
-    matching = _max_matching(candidates, len(normalised_tests))
-    missing = [c for c, assigned in zip(criteria, matching, strict=False) if assigned is None]
-
+    missing = [c for c in criteria if c.key not in tagged_in_spec]
     return CoverageReport(
         ran=True,
-        join_mode=MODE_OUTCOME,
+        join_mode=MODE_EXACT,
         criteria=criteria,
         missing=missing,
         test_count=len(tests),
@@ -277,8 +293,10 @@ def format_report(report: CoverageReport) -> str:
         f"{len(report.missing)} LLD pass criterion(s) have no test in the spec "
         f"[join {report.join_mode}]. Add a test for each:",
     ]
+    # #2619: a report that RAN has only tagged criteria -- an untagged table
+    # abstains above and never reaches here -- so the untagged label branch
+    # this used to carry was unreachable and went with the fallback.
     for c in report.missing:
-        label = c.key if c.tagged else f"row {c.row_id}"
-        where = f" (row {c.row_id})" if c.tagged and c.row_id else ""
-        lines.append(f"  - {label}{where}: {c.scenario} -- expected: {c.outcome}")
+        where = f" (row {c.row_id})" if c.row_id else ""
+        lines.append(f"  - {c.key}{where}: {c.scenario} -- expected: {c.outcome}")
     return "\n".join(lines)

--- a/tests/unit/test_check_classification.py
+++ b/tests/unit/test_check_classification.py
@@ -126,23 +126,33 @@ class TestTheRuling:
             "function_spec_sections_have_examples"
         ).kind == FACT
 
-    def test_arguable_classifications_are_flagged_not_demoted(self) -> None:
-        """Conservative where it is arguable: keep gating, record the tension.
+    def test_every_flag_the_sweep_raised_has_been_ruled(self) -> None:
+        """The sweep raised two flags and both are now answered.
 
-        `functions_have_io_examples` left this set when #2620 ruled on it --
-        a flag is for an open question, and that one is answered.
+        `functions_have_io_examples` was ruled a proxy and demoted (#2620);
+        `criteria_have_tests` had its substring fallback removed rather than
+        classified (#2619), which retired the mode-dependence the flag was
+        about. A flag marks an OPEN question, so an answered one must not keep
+        advertising itself -- and an empty flag set is the queue being empty.
         """
         flagged = {e.check for e in CLASSIFICATIONS.values() if e.flagged}
-        assert flagged == {"criteria_have_tests"}
-        for name in flagged:
-            assert classification_of(name).gates, (
-                f"{name} is flagged as arguable and must stay GATING -- a "
-                f"sweep does not demote on its own judgement"
-            )
+        assert flagged == set(), (
+            f"still-flagged, and therefore still-unruled: {sorted(flagged)}"
+        )
 
-    def test_a_demoted_check_carries_no_stale_flag(self) -> None:
-        """A ruled question must not keep advertising itself as open."""
-        assert classification_of("functions_have_io_examples").flagged == ""
+    def test_the_ruled_checks_carry_no_stale_flag(self) -> None:
+        for name in ("functions_have_io_examples", "criteria_have_tests"):
+            assert classification_of(name).flagged == ""
+
+    def test_a_flagged_entry_would_still_have_to_gate(self) -> None:
+        """The rule outlives the current empty set: a sweep never demotes on
+        its own judgement, so anything it flags stays gating until ruled."""
+        for entry in CLASSIFICATIONS.values():
+            if entry.flagged:
+                assert entry.gates, (
+                    f"{entry.check} is flagged as arguable and must stay "
+                    f"GATING until an operator rules on it"
+                )
 
     def test_an_unclassified_name_is_never_demoted(self) -> None:
         """Forgetting to classify a check must not remove its gate."""

--- a/tests/unit/test_criteria_coverage.py
+++ b/tests/unit/test_criteria_coverage.py
@@ -28,7 +28,6 @@ import pytest
 
 from assemblyzero.workflows.implementation_spec.criteria_coverage import (
     MODE_EXACT,
-    MODE_OUTCOME,
     criteria_coverage,
     format_report,
     lld_criteria,
@@ -214,13 +213,24 @@ class TestSpecTestExtraction:
 
 
 # ---------------------------------------------------------------------------
-# The fallback mode
+# The fallback mode is REMOVED (#2619)
 # ---------------------------------------------------------------------------
 
 
-class TestCountAndOutcomeFallback:
-    """Used when there are no IDs to join on. #2239 requires the mode be named,
-    and requires matching rather than greedy assignment."""
+class TestTheOutcomeFallbackIsGone:
+    """Operator-ruled 2026-08-28: EXACT stays a hard gate, the substring
+    fallback is removed rather than classified.
+
+    It existed because derived criterion IDs could arrive mangled. #2607/#2611
+    injection carries the criteria tables byte-verbatim from issue to LLD to
+    spec, so the case it served is structurally gone, and classifying dead code
+    enshrines it.
+
+    Verified against boostgauge's live #331 state before removal: every row of
+    that LLD's `10.1 Test Scenarios` table carries a REQ tag, and its spec's
+    thirteen tests cite REQ-1 through REQ-13 -- so exact mode engages on both
+    sides and the issue about to be rolled keeps its gate.
+    """
 
     UNTAGGED_LLD = (
         "### 10.1 Test Scenarios\n\n"
@@ -230,35 +240,97 @@ class TestCountAndOutcomeFallback:
         "| 020 | Size no reset size given | Auto | size unchanged; the CLI value is not written |\n"
     )
 
-    def test_the_mode_is_named(self):
+    SPEC_WITH_MATCHING_PROSE = (
+        "```python\n"
+        "def test_a():\n    \"\"\"size unchanged.\"\"\"\n\n"
+        "def test_b():\n    \"\"\"size unchanged; the CLI value is not written.\"\"\"\n"
+        "```\n"
+    )
+
+    def test_the_constant_is_gone(self):
+        """A constant kept 'for compatibility' is how a removed mode returns."""
+        import assemblyzero.workflows.implementation_spec.criteria_coverage as cc
+
+        assert not hasattr(cc, "MODE_OUTCOME")
+
+    def test_untagged_criteria_abstain_rather_than_guess(self):
+        report = criteria_coverage(self.SPEC_WITH_MATCHING_PROSE, self.UNTAGGED_LLD)
+
+        assert report.ran is False
+        assert report.join_mode == ""
+
+    def test_the_abstention_names_the_untagged_rows(self):
+        """#1870: a check that verified nothing must say so, and say what it
+        would have needed."""
+        report = criteria_coverage(self.SPEC_WITH_MATCHING_PROSE, self.UNTAGGED_LLD)
+
+        assert "010" in report.reason
+        assert "020" in report.reason
+        assert "REQ tag" in report.reason
+        assert "not applicable" in format_report(report).lower()
+
+    def test_substring_prose_no_longer_counts_as_coverage(self):
+        """The removal's point. These test docstrings contain each criterion's
+        outcome text verbatim, which the fallback scored as full coverage. A
+        test containing a criterion's words is not a test covering it."""
+        report = criteria_coverage(self.SPEC_WITH_MATCHING_PROSE, self.UNTAGGED_LLD)
+
+        assert report.ran is False, (
+            "prose matching must no longer produce a coverage verdict"
+        )
+
+    def test_the_matching_helper_is_no_longer_imported(self):
+        """An unused import is a live reference to a removed mechanism."""
+        import assemblyzero.workflows.implementation_spec.criteria_coverage as cc
+
+        assert not hasattr(cc, "_max_matching")
+
+
+class TestExactModeStillGates:
+    """The control. Removing the fallback must not weaken the mode that stays."""
+
+    TAGGED_LLD = (
+        "### 10.1 Test Scenarios\n\n"
+        "| ID | Scenario | Type | Pass Criteria |\n"
+        "|---|---|---|---|\n"
+        "| 010 | Sizes rejected (REQ-1) | Auto | raises ValueError |\n"
+        "| 020 | Face is flat (REQ-2) | Auto | matches #0A0A0C |\n"
+    )
+
+    def test_cited_criteria_pass(self):
         spec = (
             "```python\n"
-            "def test_a():\n    \"\"\"size unchanged.\"\"\"\n\n"
-            "def test_b():\n    \"\"\"size unchanged; the CLI value is not written.\"\"\"\n"
+            "def test_a():\n    \"\"\"REQ-1 covered.\"\"\"\n\n"
+            "def test_b():\n    \"\"\"REQ-2 covered.\"\"\"\n"
             "```\n"
         )
-        report = criteria_coverage(spec, self.UNTAGGED_LLD)
-        assert report.join_mode == MODE_OUTCOME
-        assert "count and outcome" in format_report(report)
+        report = criteria_coverage(spec, self.TAGGED_LLD)
 
-    def test_matching_is_not_greedy(self):
-        """'size unchanged' is a substring of 'size unchanged; the CLI value is
-        not written'. Assigning in row order would consume the only test row 020
-        could use and report a gap that is not there -- the exact hazard
-        _max_matching exists for."""
-        spec = (
-            "```python\n"
-            "def test_b():\n    \"\"\"size unchanged; the CLI value is not written.\"\"\"\n\n"
-            "def test_a():\n    \"\"\"size unchanged.\"\"\"\n"
-            "```\n"
-        )
-        report = criteria_coverage(spec, self.UNTAGGED_LLD)
-        assert report.ok, f"false gap reported: {[c.row_id for c in report.missing]}"
+        assert report.ran is True
+        assert report.join_mode == MODE_EXACT
+        assert report.ok
 
-    def test_a_genuine_gap_is_still_caught(self):
-        spec = "```python\ndef test_a():\n    \"\"\"size unchanged.\"\"\"\n```\n"
-        report = criteria_coverage(spec, self.UNTAGGED_LLD)
-        assert len(report.missing) == 1
+    def test_an_uncited_criterion_is_a_miss(self):
+        spec = "```python\ndef test_a():\n    \"\"\"REQ-1 covered.\"\"\"\n```\n"
+        report = criteria_coverage(spec, self.TAGGED_LLD)
+
+        assert report.ran is True
+        assert [c.key for c in report.missing] == ["REQ-2"]
+
+    def test_a_spec_citing_nothing_misses_everything(self):
+        """Every criterion tagged and the spec citing none is an exact miss --
+        real information, not an absence of it."""
+        spec = "```python\ndef test_a():\n    \"\"\"does something.\"\"\"\n```\n"
+        report = criteria_coverage(spec, self.TAGGED_LLD)
+
+        assert report.ran is True
+        assert len(report.missing) == 2
+
+    def test_a_spec_with_no_tests_misses_everything(self):
+        report = criteria_coverage("# Spec\n\nNo fences.\n", self.TAGGED_LLD)
+
+        assert report.ran is True
+        assert len(report.missing) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2619

Implements the operator ruling of 2026-08-28: **EXACT mode stays a hard gate; the substring fallback is removed, not classified.**

EXACT's failure is a fact — a criterion ID either has a test citing it or it does not. The fallback existed because derived criterion IDs could arrive mangled; #2607/#2611 injection now carries the criteria tables byte-verbatim from issue to LLD to spec, so the case it served is structurally gone. Classifying dead code enshrines it.

## Verified against real state before deleting anything

The ruling asked for that explicitly, and it was the right instruction — EXACT engages only when **every** criterion carries a `REQ-N` tag, so removal would have been a live behaviour change if #331's table were untagged. Measured read-only:

| side | evidence |
|---|---|
| boostgauge `docs/lld/active/LLD-331.md` | every row of the `### 10.1 Test Scenarios` table carries a REQ tag — `REQ-1` … `REQ-5` and beyond, in the Scenario cell |
| its preserved spec, `331-implspec/…/004-spec-draft.md` | 13 test functions citing `REQ-1` through `REQ-13` |

So exact mode engages on **both sides** of the issue that is about to be rolled, and it keeps its gate. Three further real pairs already in the fixture set — boostgauge PRs #285 (LLD-007), #214 (LLD-041) and #220 (LLD-001) — all run in EXACT mode too, and their verdicts are unchanged by this PR, including the deliberately-pinned finding that #220 shipped green with four criteria untested.

## What replaces the guess: an honest abstention

The fallback matched each criterion's normalised outcome text as a substring of a test's name and body. That is a correlate in **both** directions — a test can contain a criterion's words without covering it, and a test covering it in different words was reported missing. A false veto is the #2539 disease.

Where it used to guess, the check now abstains and says so, per the #1870 convention that a check which verified nothing must never render as a check that passed:

```
Criterion coverage not applicable: 2 of 2 pass criteria carry no REQ tag to
join on (010, 020), so coverage cannot be established by identity. Tag the
rows; matching outcome prose was removed in #2619 because a test containing a
criterion's words is not a test covering it.
```

It names the untagged rows and what would fix them, so the abstention is actionable rather than a shrug.

**One case that looks like an abstention is not.** Every criterion tagged and the spec citing none of them is an exact miss of *all* of them — real information, not an absence of it. `test_a_spec_citing_nothing_misses_everything` and `test_a_spec_with_no_tests_misses_everything` pin that the removal did not turn a real failure into a quiet pass.

## Removed, not deprecated

`MODE_OUTCOME`, the `_max_matching` import, and the unreachable untagged-label branch in `format_report` all went with the fallback. A constant kept "for compatibility" is how a removed mode returns, and an unused import is a live reference to a removed mechanism — `test_the_constant_is_gone` and `test_the_matching_helper_is_no_longer_imported` pin both.

## Tests

`TestTheOutcomeFallbackIsGone` drives the fallback's own former fixture — two criteria whose outcome text appears **verbatim** in two test docstrings, which the fallback scored as full coverage — and asserts it now abstains rather than reporting a verdict. `TestExactModeStillGates` is the control set: cited criteria pass, an uncited one is named, and removal did not weaken the mode that stays.

## The sweep's flag queue is now empty

`criteria_have_tests` was the second of the two entries #2540's sweep flagged as arguable. #2620 ruled the first, this rules the second, and `test_every_flag_the_sweep_raised_has_been_ruled` asserts the flagged set is empty — while `test_a_flagged_entry_would_still_have_to_gate` keeps the rule alive for the next flag rather than deleting it along with the last one.

## What only a live roll proves

Exact mode is verified to engage on #331's preserved artifacts as they stand. Whether a freshly drafted spec cites every REQ tag each round is what the gate is for, and that needs the roll. boostgauge stayed read-only: no roll, PR #367 untouched, no writes to #331 state or working tree.

see #2540 for the classification the ruling completes · see #2611 for the injection that made the fallback dead
