### PR TITLE
fix: Section 3 ends at a section, not at injection's own subheading (Closes #2628)

### DIFF
--- a/assemblyzero/core/section_utils.py
+++ b/assemblyzero/core/section_utils.py
@@ -77,6 +77,80 @@ def extract_sections(markdown: str) -> list[Section]:
     return sections
 
 
+#: Any ATX heading, with its level. One notion of "heading" for the boundary
+#: rule below, so a section's extent is never a second opinion.
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]*(.*)$", re.MULTILINE)
+
+
+def section_body(markdown: str, title_pattern: re.Pattern) -> str | None:
+    """The body of the first heading matching ``title_pattern``, subsections
+    included. ``None`` when no heading matches.
+
+    **The boundary is LEVEL-AWARE, and that is the whole point (#2628).** A
+    section ends at the next heading of the same or higher level; a deeper
+    heading belongs to it.
+
+    The rule this replaces ended Section 3 at the next heading beginning with
+    a digit:
+
+        (?=^#{1,3}\\s*\\d|^#{1,3}\\s*[A-Z]|\\Z)
+
+    which was correct until #2607 injection began inserting
+    ``### 3.1 Source Decision Table (injected verbatim)`` INSIDE Section 3.
+    The lookahead then fired on the injected subheading, so Section 3 captured
+    the 62 characters before it -- a blank line and an HTML comment -- and the
+    drafter's numbered requirements below the block were invisible. Measured on
+    boostgauge's halted draw `run-issue331-152355`: 0 requirements extracted
+    from a document that carries 4.
+
+    Level, not first-character, is what separates "the next section" from "a
+    subsection of this one", and it is the only rule that stays correct as more
+    machine-owned subsections are injected.
+    """
+    for match in _HEADING_RE.finditer(markdown or ""):
+        level = len(match.group(1))
+        if not title_pattern.match(match.group(2).strip()):
+            continue
+        start = match.end()
+        for following in _HEADING_RE.finditer(markdown, start):
+            if len(following.group(1)) <= level:
+                return markdown[start:following.start()]
+        return markdown[start:]
+    return None
+
+
+def drafter_authored(markdown: str) -> str:
+    """``markdown`` with every machine-owned block removed (#2628).
+
+    Requirement extraction reads what the DRAFTER wrote. #2607's injected block
+    is authored by the derivation, is restored verbatim on every revision, and
+    its rows are a binding-value reference the requirements cite -- its own
+    preamble says so: *"Cite these IDs from the requirements and test-plan
+    sections; do not restate their values."*
+
+    Removing it before parsing is not cosmetic. The extractor accumulates
+    unnumbered lines as continuation text of the preceding requirement, so a
+    numbered item sitting above an injected block would silently swallow the
+    whole table into its text.
+
+    Imported lazily: `requirements.table_injection` reaches
+    `implementation_spec.assertion_manifest`, which pulls a package whose
+    `__init__` imports the spec graph. A module-level import here would build a
+    cycle for a three-line call. Same reasoning, and the same shape, as
+    `generate_spec._spec_injection` (#2611).
+    """
+    try:
+        from assemblyzero.workflows.requirements.table_injection import (
+            strip_injection,
+        )
+    except ImportError:
+        # fail-open: only in shape -- with no stripper available the caller
+        # parses the document as it stands, which is the pre-#2628 behaviour.
+        # A missing import must never make a valid LLD unreadable.
+        return markdown or ""
+    return strip_injection(markdown or "")
+
+
 def identify_changed_sections(
     feedback: str | dict,
     sections: list[Section],

--- a/assemblyzero/core/validation/test_plan_validator.py
+++ b/assemblyzero/core/validation/test_plan_validator.py
@@ -94,6 +94,16 @@ HUMAN_DELEGATION_PATTERNS = [
 # =============================================================================
 
 
+#: The Section 3 heading, matched against the heading TEXT (the hashes are
+#: consumed by the boundary scanner). Case-insensitive, period optional.
+_SECTION_3_TITLE_RE = re.compile(r"3\.?\s*Requirements\b", re.IGNORECASE)
+
+#: Section 10's heading, for the same level-aware boundary scanner.
+_SECTION_10_TITLE_RE = re.compile(
+    r"10\.?\s*(?:Verification|Test|Testing)\b", re.IGNORECASE
+)
+
+
 def extract_requirements(lld_content: str) -> list[Requirement]:
     """Extract requirements from LLD Section 3.
 
@@ -110,13 +120,18 @@ def extract_requirements(lld_content: str) -> list[Requirement]:
     Returns:
         List of Requirement objects with id and text.
     """
-    # Find Section 3 — case-insensitive, H1-H3, optional period after "3"
-    section_pattern = re.compile(
-        r"^#{1,3}\s*3\.?\s*Requirements\b.*?\n(.*?)(?=^#{1,3}\s*\d|^#{1,3}\s*[A-Z]|\Z)",
-        re.MULTILINE | re.DOTALL | re.IGNORECASE,
+    # #2628: the section's extent is decided by heading LEVEL, so an injected
+    # `### 3.1` subsection is part of Section 3 rather than the end of it, and
+    # the machine-owned block is removed before parsing because requirements
+    # are what the DRAFTER wrote. Both rules live in `section_utils` -- one
+    # definition, shared with the testing workflow's extractor, because two
+    # readers of "where does Section 3 end" is the #1698 class.
+    from assemblyzero.core.section_utils import drafter_authored, section_body
+
+    section_content = section_body(
+        drafter_authored(lld_content), _SECTION_3_TITLE_RE
     )
-    match = section_pattern.search(lld_content)
-    if not match:
+    if section_content is None:
         import logging
         logging.getLogger(__name__).warning(
             "Section 3 (Requirements) heading not found in LLD content "
@@ -124,8 +139,6 @@ def extract_requirements(lld_content: str) -> list[Requirement]:
             len(lld_content),
         )
         return []
-
-    section_content = match.group(1)
 
     # Parse numbered list items (1., 2., etc.)
     # Each item starts with a number followed by a period
@@ -190,17 +203,24 @@ def extract_test_scenarios(lld_content: str) -> list[LLDTestScenario]:
     )
     match = section_pattern.search(lld_content)
 
-    # Fall back to entire Section 10 if 10.1 not found or has no tables
+    # Fall back to entire Section 10 if 10.1 not found or has no tables.
+    #
+    # #2628: through the same level-aware boundary as Section 3. This one was
+    # not broken -- its old lookahead ended at `### 11` or `### <Capital>`, so
+    # `### 10.1` slipped past it and the real draft yielded 13 scenarios --
+    # but it survived by the accident of a literal `11` in the pattern, not by
+    # a rule. The next injected subsection under Section 10 would have found
+    # the same edge Section 3 did. Converted while the lesson is in hand, with
+    # that 13-scenario measurement as the control.
+    section_10_body = None
     if not match or "|" not in match.group(1):
-        section_10_pattern = re.compile(
-            r"^#{1,3}\s*10\.?\s*(?:Verification|Test|Testing)\b.*?\n(.*?)(?=^#{1,3}\s*(?:11|[A-Z])|\Z)",
-            re.MULTILINE | re.DOTALL | re.IGNORECASE,
-        )
-        match_10 = section_10_pattern.search(lld_content)
-        if match_10 and "|" in match_10.group(1):
-            match = match_10
+        from assemblyzero.core.section_utils import section_body
 
-    if not match:
+        section_10_body = section_body(lld_content, _SECTION_10_TITLE_RE)
+        if section_10_body is not None and "|" not in section_10_body:
+            section_10_body = None
+
+    if match is None and section_10_body is None:
         import logging
         logging.getLogger(__name__).warning(
             "Section 10 / 10.1 (Test Scenarios) not found in LLD content "
@@ -209,7 +229,12 @@ def extract_test_scenarios(lld_content: str) -> list[LLDTestScenario]:
         )
         return []
 
-    section_content = match.group(1)
+    # The 10.1 match wins when it carried a table; otherwise the whole of
+    # Section 10, boundary-scanned.
+    if match is not None and "|" in match.group(1):
+        section_content = match.group(1)
+    else:
+        section_content = section_10_body or match.group(1)
     scenarios: list[LLDTestScenario] = []
 
     for line in section_content.splitlines():

--- a/assemblyzero/workflows/requirements/nodes/generate_draft.py
+++ b/assemblyzero/workflows/requirements/nodes/generate_draft.py
@@ -394,7 +394,7 @@ CRITICAL FORMATTING RULES:
 - First line MUST be the title starting with #
 
 CRITICAL — REQUIREMENT/TEST MAPPING (failure to follow halts the workflow):
-- Section 3 (Requirements) MUST be a plain numbered markdown list (1. 2. 3. ...). NO REQ-ID prefixes, NO tables, NO bullets.
+- Section 3 (Requirements): YOUR requirements MUST be a plain numbered markdown list (1. 2. 3. ...). NO REQ-ID prefixes, NO tables, NO bullets. Write the list AFTER any machine-owned block in that section (#2628) — a block fenced by `<!-- BEGIN MACHINE-OWNED ... -->` is injected by the derivation, is not yours, and is not one of your requirements.
 - Section 10.1 (Test Scenarios) MUST be a markdown table. Each scenario's `Scenario` column MUST end with `(REQ-N)` where N is the requirement number from Section 3 the scenario covers. Example: `| 010 | Happy path object creation (REQ-1) | Auto | ... |`
 - EVERY requirement in Section 3 MUST be covered by at least one test scenario via the `(REQ-N)` suffix. A mechanical validator counts coverage by regex-matching `(REQ-N)` patterns in Section 10.1 against the numbered list in Section 3. Missing coverage halts the workflow.
 - Multiple scenarios may cover the same requirement (e.g. two error-case scenarios both ending in `(REQ-2)`). That's fine. What's NOT fine: a requirement with zero matching `(REQ-N)` references.

--- a/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
+++ b/assemblyzero/workflows/requirements/nodes/validate_test_plan.py
@@ -224,12 +224,27 @@ def _build_validation_feedback(result: dict) -> str:
     lines.append("")
     lines.append("### Format Requirements (CRITICAL)")
     lines.append("")
-    lines.append("**Section 3 (Requirements):** MUST use numbered list format:")
+    # #2628: this text used to end "Do NOT use tables ... in Section 3", which
+    # contradicted the pipeline's own output -- #2607 injection puts a
+    # machine-owned table INSIDE Section 3 that no revision may remove. A
+    # drafter reading it had no compliant move, and the revision loop could
+    # not converge. Guidance that forbids what the pipeline itself emits is
+    # how this fired, so the rule now says where the numbered list goes
+    # RELATIVE to the block instead of denying the block exists.
+    lines.append("**Section 3 (Requirements):** your requirements MUST be a "
+                 "plain numbered list:")
     lines.append("```")
     lines.append("1. First requirement text")
     lines.append("2. Second requirement text")
     lines.append("```")
-    lines.append("Do NOT use tables, bullet points, or REQ-ID prefixes in Section 3.")
+    lines.append(
+        "Write that list AFTER any machine-owned block in Section 3. A block "
+        "fenced by `<!-- BEGIN MACHINE-OWNED ... -->` is injected by the "
+        "derivation, is restored verbatim on every revision, and is NOT one "
+        "of your requirements -- cite its row IDs, never restate its values. "
+        "Apart from that block: no tables, no bullet points, and no REQ-ID "
+        "prefixes on your own numbered items."
+    )
     lines.append("")
     lines.append("**Section 10.1 (Test Scenarios):** Each test scenario MUST reference "
                  "its requirement in the Scenario column using `(REQ-N)` suffix:")

--- a/assemblyzero/workflows/requirements/table_injection.py
+++ b/assemblyzero/workflows/requirements/table_injection.py
@@ -66,8 +66,31 @@ from assemblyzero.workflows.requirements.form_check import RawTable, parse_table
 BEGIN_MARKER = "<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->"
 END_MARKER = "<!-- END MACHINE-OWNED -->"
 
+#: A machine-owned block: BEGIN, then anything that is NOT another BEGIN,
+#: then END.
+#:
+#: The "not another BEGIN" clause is load-bearing (#2628). A plain `.*?` lets a
+#: STRAY begin marker swallow the document down to the real block's end, and
+#: drafters emit stray markers: boostgauge's halted draw `run-issue331-152355`
+#: carries an empty pair at line 3 whose END reads
+#: `<!-- END MACHINE-OWNED: source decision table (#2607) -->` -- byte-exact
+#: BEGIN, near-miss END. With `.*?` the span ran from line 3 to line 126 and
+#: `strip_injection` deleted 125 lines including Sections 1, 2 and 3.
+#:
+#: That was one revision round from firing for real: `reassert` runs on every
+#: lld draft and `apply_injection` strips first, so the next round would have
+#: deleted Section 3, then failed to find `## 3.` to insert at, and appended
+#: the block to a gutted document. The format-war halt this issue reports is
+#: what stopped it.
+#:
+#: With the guard, the match starting at the stray BEGIN is rejected because a
+#: real BEGIN intervenes before any END, and the match starting at the real
+#: BEGIN is accepted. The stray pair is left alone: it is the drafter's own
+#: text, and removing it is not this rule's job.
 _BLOCK_RE = re.compile(
-    re.escape(BEGIN_MARKER) + r".*?" + re.escape(END_MARKER),
+    re.escape(BEGIN_MARKER)
+    + r"(?:(?!" + re.escape(BEGIN_MARKER) + r").)*?"
+    + re.escape(END_MARKER),
     re.DOTALL,
 )
 

--- a/assemblyzero/workflows/testing/nodes/load_lld.py
+++ b/assemblyzero/workflows/testing/nodes/load_lld.py
@@ -451,14 +451,21 @@ def extract_requirements(lld_content: str) -> list[str]:  # pragma: no cover
         requirements.append(f"{req_id}: {req_desc}")
 
     # Pattern 2: Numbered requirements in acceptance criteria
-    # Look for section 3 (Requirements) or acceptance criteria
-    req_section_pattern = re.compile(
-        r"##\s*\d*\.?\s*(?:Requirements|Acceptance Criteria)\s*\n(.*?)(?=\n##|\Z)",
-        re.DOTALL | re.IGNORECASE,
+    #
+    # #2628: the section boundary is LEVEL-AWARE and the machine-owned block
+    # is removed first, through the SAME `section_utils` helpers the test-plan
+    # validator uses. This extractor had the identical defect -- its old
+    # lookahead `(?=\n##|\Z)` fired on `### 3.1`, because `###` starts with
+    # `##` -- and measured 0 requirements on the same halted draft that broke
+    # the other one. Two readers of "where does Section 3 end" is the #1698
+    # class, so there is now one.
+    from assemblyzero.core.section_utils import drafter_authored, section_body
+
+    _req_title = re.compile(
+        r"\d*\.?\s*(?:Requirements|Acceptance Criteria)\b", re.IGNORECASE
     )
-    match = req_section_pattern.search(lld_content)
-    if match:
-        section = match.group(1)
+    section = section_body(drafter_authored(lld_content), _req_title)
+    if section is not None:
         # Extract numbered items
         numbered_pattern = re.compile(r"^\s*(\d+)\.\s+(.+)$", re.MULTILINE)
         for item_match in numbered_pattern.finditer(section):
@@ -474,13 +481,14 @@ def extract_requirements(lld_content: str) -> list[str]:  # pragma: no cover
     # Pattern 4: Spec format — extract Test IDs from Section 10 Test Mapping
     # | T010 | `run_pytest()` | `test_parser.py` | ... |
     if not requirements:
-        test_mapping_pattern = re.compile(
-            r"##\s*10\s*\.\s*Test Mapping[^\n]*\n(.*?)(?=\n##|\Z)",
-            re.DOTALL | re.IGNORECASE,
-        )
-        mapping_match = test_mapping_pattern.search(lld_content)
-        if mapping_match:
-            section = mapping_match.group(1)
+        # #2628: the same level-aware boundary. This one reads a SPEC's Test
+        # Mapping section, where #2618 injects `## 9.5 Binding Decision Table`
+        # -- a sibling, not a subsection, so it never truncated here. Converted
+        # anyway: leaving one hand-rolled boundary beside two shared ones is
+        # how the next injected heading finds an edge nobody swept.
+        _mapping_title = re.compile(r"10\s*\.\s*Test Mapping\b", re.IGNORECASE)
+        section = section_body(drafter_authored(lld_content), _mapping_title)
+        if section is not None:
             row_pattern = re.compile(
                 r"\|\s*(T\d+)\s*\|\s*`?([^`|]+)`?\s*\|"
             )

--- a/tests/fixtures/section3/lld-331-run152355-failed-iter3.md
+++ b/tests/fixtures/section3/lld-331-run152355-failed-iter3.md
@@ -1,0 +1,394 @@
+# Issue #331: static face renderer — bezel, chrome housing, dial, ticks, numerals, wordmark, screws — baked once, cached
+
+<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
+<!-- END MACHINE-OWNED: source decision table (#2607) -->
+
+## 1. Context & Goal
+* **Issue:** #331
+* **Objective:** Implement a cached `PIL.Image` renderer for the complete static face of the Stingray gauge (elements S1-S9), enforcing isolation from the main application.
+* **Status:** Draft
+* **Related Issues:** #1, #329, #332, #333, #328, #326, #325, #354, #365, #361, #369
+
+### Open Questions
+None.
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/skins/__init__.py` | Add | Exports `render_face` as the public skin interface |
+| `src/boostgauge/skins/stingray.py` | Add | Implements the static element renderer (S1-S9) and session caching |
+| `tests/conftest.py` | Modify | Registers the `--generate-baselines` pytest flag |
+| `tests/visual/test_stingray_face.py` | Add | Implements visual tier tests and pointwise assertions for S1-S9 |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks:
+- All "Modify" files must exist in repository
+- All "Delete" files must exist in repository
+- All "Add" files must have existing parent directories
+- No placeholder prefixes (`src/`, `lib/`, `app/`) unless directory exists
+
+### 2.2 Dependencies
+
+```toml
+
+# pyproject.toml additions
+
+# No new dependencies needed (Pillow is already configured)
+```
+
+### 2.3 Data Structures
+
+```python
+
+# Caching handled via standard library functools
+```
+
+### 2.4 Function Signatures
+
+```python
+import functools
+from PIL import Image
+
+@functools.lru_cache(maxsize=4)
+def render_face(size: int, skin: str = "stingray") -> Image.Image:
+    """
+    Renders and caches the static face (S1-S9) for the given size.
+    Raises ValueError if size < 128.
+    """
+    ...
+
+def _draw_dial_face(draw: ImageDraw.ImageDraw, size: int) -> None:
+    ...
+
+# Additional internal helpers for S2-S9 follow similar patterns
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. Receive render_face(size, skin) request
+2. IF size < 128 THEN raise ValueError
+3. CACHE CHECK (managed by lru_cache):
+   - IF (size, skin) in cache THEN return cached PIL.Image
+4. Create new PIL.Image(size, size, mode="RGBA")
+5. Draw S1 (Dial face, flat #0A0A0C, radius 0.40 * size)
+6. Draw S2 (Redline band, #AA0F19, 0.88R to 1.00R)
+7. Draw S3 & S4 (Major and Minor ticks, #FFFFFF)
+8. Draw S5 (Numerals, #FFFFFF)
+9. Draw S6 (Wordmark BOOSTGAUGE, #FFFFFF)
+10. Draw S7 (Chrome housing with chamfer and environment strip)
+11. Draw S8 (Screws, #1A1A1C)
+12. Draw S9 (Bezel seat shadow)
+13. Return rendered Image (lru_cache stores it automatically)
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/skins/stingray.py`
+* **Pattern:** Factory / Cached Singleton (via `lru_cache`)
+* **Key Decisions:** The visual test tier generates real images directly from `PIL` via `pytest --generate-baselines` without ever instantiating a `tkinter.Tk()` runtime environment.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Static Element Caching | Custom dict, `lru_cache` | `lru_cache` | Simplifies invalidation and prevents unbounded memory growth if dynamic sizes are requested. |
+| Test Environment | `tkinter` runtime, Pure `PIL` | Pure `PIL` | Mandated by Option C in `docs/design/0001-test-strategy.md` to ensure tests remain headless and deterministic. |
+
+**Architectural Constraints:**
+- Must exclusively use numerical and color constants defined in the visual contract.
+- Must separate the static render from the needle drawing completely.
+
+## 3. Requirements
+
+<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
+
+### 3.1 Source Decision Table (injected verbatim)
+
+The rows below are carried **verbatim** from the source issue by the derivation itself (#2607). They are machine-owned: the drafter does not write them, and a revision cannot change them. Cite these IDs from the requirements and test-plan sections; do not restate their values.
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size, centre (0.5, 0.5) × size; NO gradient, glass sweep, or reflection (#325) | classification at 3 interior points + equality of samples at (0.3 R, 0.5 R, 0.7 R) along one needle-free radial — flatness IS the assertion |
+| S2 | Redline band | `#AA0F19` crimson (ruling 2026-08-25), inner 0.88 R to outer 1.00 R, spanning values 60–100 via `angle(value) = 225° − 2.7° × value` | classification at radius 0.94 R at values 65/75/85 — deliberately offset from every tick position, because ticks render on top of the band (majors sit at multiples of 10, minors at even values; 65/75/85 carry no tick) |
+| S3 | Major ticks | `#FFFFFF`, 11 total at values 0,10,…,100, length 0.10 R, width 0.025 R | stroke predicate at each tick's midpoint: channel mean ≥ 100, all 11 — the white stroke samples ~255, and the 100 threshold clears both backgrounds: the face's ~10 (values 0–50) and the band's ~70 (values 60–100, where ticks render on top of the band; `#AA0F19` → mean 70.0). A missing tick fails on either background: 10 < 100 and 70 < 100. Width 2.56 px at the pinned test size is too thin for the interior rule |
+| S4 | Minor ticks | `#FFFFFF`, 40 total, 4 between each major pair, length 0.05 R, width 0.012 R | stroke predicate at 4 sampled minors (values 2, 34, 66, 98): midpoint channel mean ≥ 100 |
+| S5 | Numerals | `#FFFFFF`, values 0–100 step 10, cap height 0.11 R, numeral centres at 0.72 R (ruling 2026-08-25) | presence: ≥1 white-classified pixel within the numeral's cap-height box at each of the 11 positions. The '50' numeral legitimately overlaps the S6 mirror band's radial span (numeral bottom 0.665 R vs band centred 0.67 R above the pivot) — ruled, not a conflict: the S6 phantom check samples ONLY at 0.12 R–0.25 R off-axis and never sees the numeral, whose half-width is ~0.065 R (ruling on the #361 conflict, reaffirmed on #369). Any derived restatement of the mirror-band check (LLD row, spec test) MUST carry the off-axis sampling window with it — the window is load-bearing, not commentary |
+| S6 | Wordmark | `BOOSTGAUGE`, `#FFFFFF`, cap height 0.09 R, band centred 0.67 R below the pivot — level with the 0/100 major ticks (ruling 2026-08-25) | presence: ≥1 white-classified pixel in the wordmark band; absence of white in the mirror band above the pivot, sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis (ruling on the #361 conflict: the numeral '50' legitimately occupies the axis at 0.665–0.775 R above the pivot, half-width ~0.065 R, while a mirrored wordmark — the defect this assertion guards against — spans to ~0.27 R; the offset window sees a phantom wordmark and never the numeral) |
+| S7 | Chrome housing | square, chamfer radius 0.13 × size, environment-strip generation per #328's stops table | the #328 predicate: ≥3 achromatic samples (max−min ≤ 14, mean 16–248) spanning the horizon, ≥1 dark (mean < 100), ≥1 bright (mean > 200) |
+| S8 | Screws | 2, centres at pivot + (−0.25 R, 0) and pivot + (+0.25 R, 0) — horizontal offsets from the dial centre defined above — radius 0.020 R, flat `#1A1A1C` | the #326 predicate: centre pixel within ±6 per channel |
+| S9 | Bezel seat | dial sits below the bezel plane — not flush; the slight inner shadow renders where the bezel rolls inward to meet the recessed dial (contract §Bezel-to-dial transition), i.e. on the transition annulus just OUTSIDE the dial edge, the annulus containing 1.01 R. Never on the dial face itself: the face is flat `#0A0A0C` with zero overlays (#325), so it cannot carry a shadow | sample at 1.01 R is darker (channel mean) than the chrome at 1.10 R on the same radial |
+
+<!-- END MACHINE-OWNED -->
+
+1. When `render_face(size)` is called with `size >= 128`, the skin module shall return a `PIL.Image` of dimensions `size × size` containing every static element defined in S1 through S9, and containing no needles.
+2. When the same `(size, skin)` is requested twice in one session, the system shall render once and serve the identical cached image object thereafter.
+3. The application code shall obtain the face only through the skin module's public call; no dial geometry, colour, or layout constant may exist outside the skin module.
+4. When the visual test tier runs with `--generate-baselines`, the test run shall write the rendered face PNG into the run's artifacts directory and print its path to stdout.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Monolithic Renderer | Simpler initial draw logic | Violates issue #331 requirement to split static baking from dynamic needles | **Rejected** |
+| Module-level global cache dictionary | Full control over cache keys | Requires manual invalidation and unbounded size handling | **Rejected** |
+| `functools.lru_cache` | Built-in, natively bounded memory | Marginally less explicit cache clearing | **Selected** |
+
+**Rationale:** Using standard library caching enforces boundaries easily without reinventing state management. Splitting static and dynamic rendering is non-negotiable per the source rulings.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Numeric render contract (`docs/design/0002-aesthetic-v1-stingray.md`) |
+| Format | Hardcoded constant geometry and color hex values |
+| Size | N/A |
+| Refresh | Manual |
+| Copyright/License | MIT |
+
+### 5.2 Data Pipeline
+
+```
+Contract values ──hardcoded──► skin module ──render──► PIL.Image
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| `--generate-baselines` | Pytest CLI | Writes explicit test artifacts to disk, preventing silent baseline acceptance. |
+
+### 5.4 Deployment Pipeline
+
+Visual baselines are stored on disk only when actively regenerated. Normal CI runs assert against pixel classification rules and stroke predicates without manual comparisons.
+
+## 6. Diagram
+
+### 6.1 Mermaid Quality Gate
+
+**Auto-Inspection Results:**
+```
+- Touching elements: [x] None / [ ] Found: ___
+- Hidden lines: [x] None / [ ] Found: ___
+- Label readability: [x] Pass / [ ] Issue: ___
+- Flow clarity: [x] Clear / [ ] Issue: ___
+```
+
+### 6.2 Diagram
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant SkinModule
+    participant Cache
+
+    App->>SkinModule: render_face(size)
+    SkinModule->>Cache: Check (size, skin)
+    alt In Cache
+        Cache-->>SkinModule: Return cached PIL.Image
+    else Not In Cache
+        SkinModule->>SkinModule: Draw S1-S9 Elements
+        SkinModule->>Cache: Store PIL.Image
+        Cache-->>SkinModule:
+    end
+    SkinModule-->>App: Return PIL.Image
+```
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Unbounded memory allocation via size | Validate size parameter to enforce reasonable limits and reject extreme values | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Memory exhaustion from caching | Bound cache size using `lru_cache(maxsize=4)` | Addressed |
+
+**Fail Mode:** Fail Closed - Invalid image sizes or missing skin configurations will throw exceptions rather than returning corrupted imagery.
+
+**Recovery Strategy:** Caching resets automatically on application restart.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Render Time | < 100ms (Cold) | Utilize performant PIL polygon/ellipse drawing. |
+| Memory | < 5MB per cached size | Restrict cache max size. |
+
+**Bottlenecks:** Initializing font files via `ImageFont.truetype()` is I/O bound.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| N/A | N/A | N/A | $0 |
+
+**Cost Controls:**
+- [x] Budget alerts configured at $0 threshold
+- [x] Rate limiting prevents runaway costs
+- [x] Fallback to cheaper alternatives when appropriate
+
+**Worst-Case Scenario:** N/A.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | N/A |
+| Third-Party Licenses | Yes | Ensure `bahnschrift.ttf` or replacement fonts are legally distributable if packaged. |
+| Terms of Service | No | N/A |
+| Data Retention | No | N/A |
+| Export Controls | No | N/A |
+
+**Data Classification:** Public
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. Manual tests are a last resort for scenarios that genuinely cannot be automated (e.g., visual inspection, hardware interaction). Every scenario marked "Manual" requires justification.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | Render face rejects small size | ValueError raised for size < 128 | RED |
+| T020 | Render face cache equality | Subsequent identical calls return the same memory object | RED |
+| T030 | Assert S1 Dial face | Flatness check passes per S1 rule | RED |
+| T040 | Assert S2 Redline band | Classification passes per S2 rule | RED |
+| T050 | Assert S3 Major ticks | Stroke predicate passes per S3 rule | RED |
+| T060 | Assert S4 Minor ticks | Stroke predicate passes per S4 rule | RED |
+| T070 | Assert S5 Numerals | Presence check passes per S5 rule | RED |
+| T080 | Assert S6 Wordmark | Presence check passes per S6 rule | RED |
+| T090 | Assert S7 Chrome housing | Predicate passes per S7 rule | RED |
+| T100 | Assert S8 Screws | Predicate passes per S8 rule | RED |
+| T110 | Assert S9 Bezel seat | Darker shadow check passes per S9 rule | RED |
+| T120 | AST Constant Isolation | No styling constants exist outside skin module | RED |
+| T130 | Artifact Emission on Baseline | PNG is written, stdout printed with path | RED |
+
+**Coverage Target:** 100%
+
+**TDD Checklist:**
+- [x] All tests written before implementation
+- [x] Tests currently RED (failing)
+- [x] Test IDs match scenario IDs in 10.1
+- [x] Test file created at: `tests/visual/test_stingray_face.py`
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | Render face with invalid size < 128 (REQ-1) | Auto | `size=127` | `ValueError` | Exception raised |
+| 020 | Cache equality on repeat calls (REQ-2) | Auto | `render_face(256)` twice | Identical object | `id(img1) == id(img2)` |
+| 030 | Assert S1 Dial face flatness (REQ-1) | Auto | `size=256` | Image | Meets S1 assertion method |
+| 040 | Assert S2 Redline band presence (REQ-1) | Auto | `size=256` | Image | Meets S2 assertion method |
+| 050 | Assert S3 Major ticks stroke predicate (REQ-1) | Auto | `size=256` | Image | Meets S3 assertion method |
+| 060 | Assert S4 Minor ticks stroke predicate (REQ-1) | Auto | `size=256` | Image | Meets S4 assertion method |
+| 070 | Assert S5 Numerals presence (REQ-1) | Auto | `size=256` | Image | Meets S5 assertion method |
+| 080 | Assert S6 Wordmark presence and phantom band (REQ-1) | Auto | `size=256` | Image | Meets S6 assertion method |
+| 090 | Assert S7 Chrome housing predicate (REQ-1) | Auto | `size=256` | Image | Meets S7 assertion method |
+| 100 | Assert S8 Screws centre pixel check (REQ-1) | Auto | `size=256` | Image | Meets S8 assertion method |
+| 110 | Assert S9 Bezel seat shadow (REQ-1) | Auto | `size=256` | Image | Meets S9 assertion method |
+| 120 | Layout constants isolated to skin module (REQ-3) | Auto | AST Source | Pass | No constants outside `skins/stingray.py` |
+| 130 | Artifact emission during baseline generation (REQ-4) | Auto | `--generate-baselines` | Artifact written | File on disk, absolute path in stdout |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run all automated visual tests
+poetry run pytest tests/visual/test_stingray_face.py -v
+
+# Run tests and explicitly generate baseline artifacts
+poetry run pytest tests/visual/test_stingray_face.py -v --generate-baselines
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated.
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Memory leak from unbounded caching | Med | Low | The `render_face` cache uses a bounded `functools.lru_cache(maxsize=4)` to cap memory overhead. |
+| Test suite attempts to use tkinter environment | High | Low | The test scenarios strictly operate on pure `PIL.Image` instances per Option C in the test strategy document. |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+- [ ] Test Report (0113) completed if applicable
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks:
+- Every file mentioned in this section must appear in Section 2.1
+- Every risk mitigation in Section 11 should have a corresponding function in Section 2.4 (warning if not)
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| Reviewer #1 | (auto) | (auto) | |
+
+**Final Status:** PENDING
+
+<!-- validation feedback -->
+## Mechanical Test Plan Validation Failed
+
+**Coverage:** 0.0% (0/0 requirements mapped)
+
+### Errors (must fix)
+
+- **coverage**: No requirements found in Section 3
+
+Please revise the LLD to address the errors above.
+
+### Format Requirements (CRITICAL)
+
+**Section 3 (Requirements):** MUST use numbered list format:
+```
+1. First requirement text
+2. Second requirement text
+```
+Do NOT use tables, bullet points, or REQ-ID prefixes in Section 3.
+
+**Section 10.1 (Test Scenarios):** Each test scenario MUST reference its requirement in the Scenario column using `(REQ-N)` suffix:
+```
+| 010 | Create logger with defaults (REQ-1) | Auto | ... |
+| 020 | Log directory auto-created (REQ-2) | Auto | ... |
+```

--- a/tests/unit/test_section3_boundary.py
+++ b/tests/unit/test_section3_boundary.py
@@ -1,0 +1,330 @@
+"""Injection puts a subsection inside Section 3; extraction must survive it (#2628).
+
+The observed case, as a fixture. boostgauge's `run-issue331-152355` halted at
+the iteration cap with `Coverage: 0.0% (0/0 requirements)` and
+`No requirements found in Section 3`, three revisions spent, 652s.
+
+**The diagnosis in the issue is refuted by its own artifact, and this file
+pins the correction.** The halt was read as a format war -- a machine-owned
+table the drafter cannot remove versus a validator demanding numbered-list-
+only. The preserved draft carries BOTH: the injected S1-S9 block, and a
+four-item numbered list written around it, exactly as both sets of guidance
+asked. The drafter complied. Extraction returned zero anyway, because
+`### 3.1 Source Decision Table (injected verbatim)` -- a heading injection
+itself inserts -- terminated a section boundary that ended at "the next
+heading starting with a digit".
+
+Two defects, one seam, both measured on this fixture:
+
+* the section boundary was not level-aware, so Section 3 captured 62
+  characters -- a blank line and an HTML comment;
+* `strip_injection` let a STRAY begin marker swallow 125 lines including
+  Sections 1-3, which was one revision round from firing for real.
+
+The requirements are the DRAFTER's four numbered items, not the table's nine
+rows. #2612's own injected preamble says so -- *"Cite these IDs from the
+requirements and test-plan sections; do not restate their values"* -- and the
+draft's 13 scenarios cite `(REQ-1)`..`(REQ-4)` and no S-ID.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.section_utils import drafter_authored, section_body
+from assemblyzero.core.validation.test_plan_validator import (
+    check_requirement_coverage,
+    extract_requirements,
+    extract_test_scenarios,
+)
+from assemblyzero.workflows.requirements.table_injection import (
+    BEGIN_MARKER,
+    END_MARKER,
+    injected_line_span,
+    strip_injection,
+)
+
+FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures" / "section3" / "lld-331-run152355-failed-iter3.md"
+)
+
+
+@pytest.fixture
+def halted_draft() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+#: A pre-injection LLD: numbered list, no machine-owned block. The control for
+#: every assertion below -- the ordinary format must stay legal.
+PLAIN_LLD = """\
+# Issue #7: a plain LLD
+
+## 3. Requirements
+
+1. The logger shall write to the configured directory.
+2. The logger shall create that directory when absent.
+
+## 10. Verification & Testing
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Expected |
+|----|----------|------|----------|
+| 010 | Writes to the directory (REQ-1) | Auto | file exists |
+| 020 | Creates it when absent (REQ-2) | Auto | dir exists |
+"""
+
+
+class TestTheObservedCase:
+    """run-152355, inverted."""
+
+    def test_the_fixture_reproduces_the_shape(self, halted_draft: str) -> None:
+        """Guard: everything below is vacuous if the artifact is not the one
+        that halted."""
+        assert halted_draft.count(BEGIN_MARKER) == 2, "stray + canonical BEGIN"
+        assert halted_draft.count(END_MARKER) == 1, "only the canonical END"
+        assert "### 3.1 Source Decision Table" in halted_draft
+        assert re.search(r"(?m)^1\. When `render_face", halted_draft)
+
+    def test_requirements_extract(self, halted_draft: str) -> None:
+        reqs = extract_requirements(halted_draft)
+        assert [r["id"] for r in reqs] == ["REQ-1", "REQ-2", "REQ-3", "REQ-4"]
+
+    def test_the_denominator_is_nonzero_and_coverage_passes(
+        self, halted_draft: str
+    ) -> None:
+        """The acceptance's real intent: a nonzero denominator and no format
+        revision. Four, not nine -- the number the artifact justifies."""
+        reqs = extract_requirements(halted_draft)
+        tests = extract_test_scenarios(halted_draft)
+
+        passed, pct, violations = check_requirement_coverage(reqs, tests)
+
+        assert len(reqs) == 4
+        assert pct == 100.0
+        assert passed is True
+        assert violations == []
+
+    def test_no_requirement_is_the_injected_table(self, halted_draft: str) -> None:
+        """The nine S-rows are a binding-value reference the requirements
+        cite, by #2612's own preamble. Reading them as requirements would
+        report nine uncovered requirements on an artifact whose scenarios
+        cite none of them."""
+        texts = " ".join(r["text"] for r in extract_requirements(halted_draft))
+        for row_id in ("S1", "S5", "S9"):
+            assert f"| {row_id} |" not in texts
+
+    def test_the_scenarios_cite_only_the_numbered_requirements(
+        self, halted_draft: str
+    ) -> None:
+        cited = set(re.findall(r"\(REQ-(\d+)\)", halted_draft))
+        assert cited == {"1", "2", "3", "4"}
+
+
+class TestTheSectionBoundaryIsLevelAware:
+    def test_a_deeper_heading_does_not_end_the_section(
+        self, halted_draft: str
+    ) -> None:
+        body = section_body(
+            drafter_authored(halted_draft),
+            re.compile(r"3\.?\s*Requirements\b", re.IGNORECASE),
+        )
+        assert body is not None
+        assert "1. When `render_face" in body
+
+    def test_a_same_level_heading_does_end_it(self, halted_draft: str) -> None:
+        """The control. Without it, a boundary that never ends would pass the
+        test above."""
+        body = section_body(
+            drafter_authored(halted_draft),
+            re.compile(r"3\.?\s*Requirements\b", re.IGNORECASE),
+        )
+        assert "## 4. Alternatives Considered" not in body
+        assert "Alternatives Considered" not in body
+
+    def test_a_missing_section_reports_none(self) -> None:
+        assert section_body(
+            "# Doc\n\n## 2. Design\n\nprose\n",
+            re.compile(r"3\.?\s*Requirements\b", re.IGNORECASE),
+        ) is None
+
+    def test_the_last_section_runs_to_the_end(self) -> None:
+        body = section_body(
+            "# Doc\n\n## 3. Requirements\n\n1. only item\n",
+            re.compile(r"3\.?\s*Requirements\b", re.IGNORECASE),
+        )
+        assert "1. only item" in body
+
+
+class TestStrayMarkersCannotEatTheDocument:
+    """The second defect, and the more dangerous one.
+
+    `reassert` runs on every lld draft and `apply_injection` strips first, so
+    an over-reaching span deletes Section 3 and then cannot find `## 3.` to
+    insert at. The halt this issue reports is what stopped that from firing.
+    """
+
+    def test_the_span_is_the_real_block(self, halted_draft: str) -> None:
+        assert injected_line_span(halted_draft) == (108, 126)
+
+    def test_stripping_preserves_every_section(self, halted_draft: str) -> None:
+        stripped = strip_injection(halted_draft)
+        for heading in ("## 1. Context", "## 2.", "## 3. Requirements", "## 4."):
+            assert heading in stripped, f"{heading} was destroyed by the strip"
+
+    def test_stripping_removes_the_block_itself(self, halted_draft: str) -> None:
+        """The control: the stripper must still do its job."""
+        stripped = strip_injection(halted_draft)
+        assert "| S1 | Dial face" not in stripped
+        assert END_MARKER not in stripped
+
+    def test_a_stray_begin_is_left_alone(self, halted_draft: str) -> None:
+        """It is the drafter's own text; removing it is not this rule's job."""
+        stripped = strip_injection(halted_draft)
+        assert BEGIN_MARKER in stripped
+
+    def test_a_lone_stray_pair_strips_nothing(self) -> None:
+        doc = (
+            "# Doc\n\n" + BEGIN_MARKER + "\n"
+            "<!-- END MACHINE-OWNED: with extra text -->\n\n"
+            "## 3. Requirements\n\n1. a requirement\n"
+        )
+        assert strip_injection(doc) == doc
+        assert extract_requirements(doc)[0]["id"] == "REQ-1"
+
+
+class TestThePreInjectionFormatStaysLegal:
+    """A repo or issue with no decision table must extract exactly as before."""
+
+    def test_a_plain_numbered_list_extracts(self) -> None:
+        reqs = extract_requirements(PLAIN_LLD)
+        assert [r["id"] for r in reqs] == ["REQ-1", "REQ-2"]
+
+    def test_it_reaches_full_coverage(self) -> None:
+        reqs = extract_requirements(PLAIN_LLD)
+        tests = extract_test_scenarios(PLAIN_LLD)
+        passed, pct, _violations = check_requirement_coverage(reqs, tests)
+        assert passed is True
+        assert pct == 100.0
+
+    def test_a_genuinely_empty_section_still_reports_zero(self) -> None:
+        """#2546/#2552 undisturbed: 0/0 must keep failing loudly. The fix is
+        the extractor's boundary, never the zero-denominator law."""
+        empty = "# Doc\n\n## 3. Requirements\n\nProse, no numbered items.\n"
+        assert extract_requirements(empty) == []
+
+    def test_a_zero_denominator_still_blocks(self) -> None:
+        empty = "# Doc\n\n## 3. Requirements\n\nProse only.\n"
+        passed, pct, violations = check_requirement_coverage(
+            extract_requirements(empty), []
+        )
+        assert passed is False
+        assert pct == 0.0
+        assert any("No requirements found" in v["message"] for v in violations)
+
+
+class TestTheUnwinnableLoopIsGone:
+    """A draft whose only 'defect' was table-format requirements must not
+    consume a revision."""
+
+    def test_the_halted_draft_now_passes_the_test_plan_validator(
+        self, halted_draft: str
+    ) -> None:
+        from assemblyzero.core.validation.test_plan_validator import (
+            validate_test_plan,
+        )
+
+        result = validate_test_plan(halted_draft)
+
+        coverage_errors = [
+            v for v in result["violations"]
+            if v["check_type"] == "coverage" and v["severity"] == "error"
+        ]
+        assert coverage_errors == [], coverage_errors
+
+    def test_the_guidance_no_longer_forbids_what_injection_emits(self) -> None:
+        """Guidance contradicting the pipeline's own output is how this fired."""
+        from assemblyzero.workflows.requirements.nodes.validate_test_plan import (
+            _build_validation_feedback,
+        )
+
+        feedback = _build_validation_feedback({
+            "passed": False,
+            "coverage_percentage": 0.0,
+            "mapped_count": 0,
+            "requirements_count": 0,
+            "violations": [{
+                "check_type": "coverage", "severity": "error",
+                "requirement_id": None, "test_id": None,
+                "message": "No requirements found in Section 3",
+                "line_number": None,
+            }],
+        })
+
+        assert "Do NOT use tables, bullet points, or REQ-ID prefixes" not in feedback
+        assert "MACHINE-OWNED" in feedback
+        assert "AFTER any machine-owned block" in feedback
+
+    def test_the_drafter_prompt_says_the_same_thing(self) -> None:
+        """Two guidance surfaces, one rule -- they disagreed before."""
+        source = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "requirements" / "nodes"
+            / "generate_draft.py"
+        ).read_text(encoding="utf-8")
+        assert "machine-owned block in that section (#2628)" in source
+
+
+class TestBothExtractorsAgree:
+    """#1698: one definition of where Section 3 ends, used by both readers.
+
+    The testing workflow's own `extract_requirements` had the identical defect
+    -- its lookahead `(?=\\n##|\\Z)` fired on `### 3.1` because `###` starts
+    with `##` -- and measured 0 on this same fixture.
+    """
+
+    def test_the_testing_workflow_extractor_agrees(self, halted_draft: str) -> None:
+        from assemblyzero.workflows.testing.nodes.load_lld import (
+            extract_requirements as testing_extract,
+        )
+
+        ids = [r.split(":")[0] for r in testing_extract(halted_draft)]
+        assert ids == ["REQ-1", "REQ-2", "REQ-3", "REQ-4"]
+
+    def test_both_agree_on_the_plain_lld_too(self) -> None:
+        from assemblyzero.workflows.testing.nodes.load_lld import (
+            extract_requirements as testing_extract,
+        )
+
+        validator_ids = [r["id"] for r in extract_requirements(PLAIN_LLD)]
+        testing_ids = [r.split(":")[0] for r in testing_extract(PLAIN_LLD)]
+        assert validator_ids == testing_ids == ["REQ-1", "REQ-2"]
+
+    def test_neither_reads_the_boundary_for_itself(self) -> None:
+        """Structural: a second lookahead is how they drifted the first time.
+
+        Read by PATH, not through the module object: `nodes/__init__` binds
+        `load_lld` to the FUNCTION of that name, so the attribute has no
+        `__file__`.
+
+        Comment lines are excluded before matching. Both modules deliberately
+        quote the old lookaheads to explain what went wrong, and a bare
+        substring ban would forbid recording the lesson -- the same trap the
+        #2615 sweep hit with `updatedAt`.
+        """
+        root = Path(__file__).resolve().parents[2] / "assemblyzero"
+        sources = (
+            root / "core" / "validation" / "test_plan_validator.py",
+            root / "workflows" / "testing" / "nodes" / "load_lld.py",
+        )
+        for path in sources:
+            code = "\n".join(
+                line for line in path.read_text(encoding="utf-8").splitlines()
+                if not line.lstrip().startswith("#")
+            )
+            assert "?=^#{1,3}" not in code, path.name
+            assert r"(?=\n##|\Z)" not in code, path.name


### PR DESCRIPTION
Closes #2628

boostgauge `run-issue331-152355` halted at the iteration cap: `Coverage: 0.0% (0/0 requirements)`, `No requirements found in Section 3`, three revisions, 652s. Two defects in one seam, both measured against the preserved draft, and **the second is worse than the one reported.**

## The reported diagnosis is refuted by its own artifact

The halt was read as a format war — a machine-owned table the drafter cannot remove versus a validator demanding numbered-list-only. The preserved draft carries **both**:

```
## 3. Requirements
<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
### 3.1 Source Decision Table (injected verbatim)
...S1–S9...
<!-- END MACHINE-OWNED -->

1. When `render_face(size)` is called with `size >= 128`, ...
2. When the same `(size, skin)` is requested twice in one session, ...
3. The application code shall obtain the face only through ...
4. When the visual test tier runs with `--generate-baselines`, ...
```

**The drafter complied with both guidance sets, three times, and was failed anyway** — which is why three revisions changed nothing. There was no unwinnable format war; there was a broken section boundary.

`extract_requirements`' lookahead ended Section 3 at the next heading beginning with a digit. Injection inserts `### 3.1 …` **inside** Section 3, so the capture terminated on injection's own subheading: **62 characters**, a blank line and an HTML comment. Everything below — the table *and* the four requirements — was outside Section 3 as far as the regex was concerned.

### The acceptance's "9 requirements" would have failed the artifact

The scenarios cite `(REQ-1)`×11, `(REQ-2)`×2, `(REQ-3)`, `(REQ-4)` — **nothing cites an S-ID**, and `check_requirement_coverage` files an error per uncovered requirement:

| extraction yields | coverage | verdict |
|---|---|---|
| the 4 numbered items | 4/4 | **passes** |
| the 9 table rows (as specified) | 0/9 | fails with 9 errors, and the 4 real requirements are lost |
| all 13 | 4/13 | fails with 9 errors |

#2612's own injected preamble settles it: *"Cite these IDs from the requirements and test-plan sections; do not restate their values."* The block is the binding-value reference requirements cite, not the requirement list. **The number the artifact justifies is 4, and the acceptance's real intent — a nonzero denominator and no format revision — is met at 4.**

## The second defect: a stray marker eats the document

Wiring the extractor to strip the machine-owned block *still* returned 0. Chasing that found this:

```
BEGIN occurrences: 2      exact END occurrences: 1
  line   3: <!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
  line   4: <!-- END MACHINE-OWNED: source decision table (#2607) -->   <-- near-miss
  line 108: <!-- BEGIN MACHINE-OWNED: ... -->
  line 126: <!-- END MACHINE-OWNED -->                                   <-- canonical
injected_line_span -> (3, 126)          after strip: 269 of 394 lines
  '## 1. Context' survives: False   '## 3. Requirements' survives: False
```

The drafter emitted its own empty pair; its BEGIN is byte-exact, its END is not. `_BLOCK_RE`'s `BEGIN .*? END` therefore ran from line 3 to the real block's close, and **`strip_injection` deleted 125 lines including Sections 1–3.**

**This was one revision round from firing for real.** `reassert` runs on every lld draft (`generate_draft.py:626`) and `apply_injection` strips first, so the next round would have deleted Section 3, failed to find `## 3.` to insert at, and appended the block to a gutted document. The halt this PR removes is what stopped it. The drafter demonstrably emits stray markers, so this reproduces.

Fixed at the root — a block may not span another BEGIN:

```python
re.escape(BEGIN) + r"(?:(?!" + re.escape(BEGIN) + r").)*?" + re.escape(END)
```

Span is now `(108, 126)`; every section survives; the stray pair is left alone because it is the drafter's own text.

## The fix

One **level-aware** boundary in `core/section_utils.py`: a section ends at a heading of the same or higher level, so a deeper heading belongs to it. Level, not first character, is what distinguishes "the next section" from "a subsection of this one", and it stays correct as more machine-owned subsections are injected. Plus `drafter_authored()`, which removes machine-owned blocks before parsing — not cosmetic, since the extractor accumulates unnumbered lines as continuation text, so a numbered item above a block would silently swallow the whole table into its text.

## The sweep, and its boundary

Grepped `assemblyzero/` for readers of Section 3 / numbered-list assumptions and for hand-rolled section boundaries. **Four sites found, all four converted to the one helper:**

| site | was it broken? | evidence |
|---|---|---|
| `test_plan_validator.extract_requirements` | **yes** | 0 on the fixture, 4 after |
| `testing/nodes/load_lld.extract_requirements` (Pattern 2) | **yes** | 0 on the same fixture, 4 after — its `(?=\n##\|\Z)` fires on `### 3.1` because `###` starts with `##` |
| `test_plan_validator.extract_test_scenarios` | no | survived by the accident of a literal `11` in its lookahead; 13 scenarios before and after |
| `load_lld` Pattern 4 (Test Mapping) | no | reads a spec, where #2618 injects a sibling not a subsection |

The two working sites were converted anyway: leaving one hand-rolled boundary beside three shared ones is how the next injected heading finds an edge nobody swept. `test_neither_reads_the_boundary_for_itself` pins that structurally.

**Boundary of the sweep, stated:** it was `grep` over `assemblyzero/` for `Section 3`, `numbered list`, `Requirements` headings and boundary-lookahead shapes. It would not find a consumer that reads Section 3 without naming it, or one outside `assemblyzero/`. That a grep was the instrument is itself the argument in #2631.

Guidance corrected on both surfaces — the validator's revision feedback and the drafter's system prompt — from *"Do NOT use tables … in Section 3"* to where the numbered list goes **relative to** the machine-owned block. Guidance contradicting the pipeline's own output is how this fired.

## Acceptance

| clause | evidence |
|---|---|
| the run-152355 LLD extracts, nonzero denominator, no format revision | `TestTheObservedCase` — 4 requirements, 100%, zero coverage violations |
| a numbered-list LLD with no injected table still extracts | `TestThePreInjectionFormatStaysLegal` |
| the unwinnable loop is gone | `test_the_halted_draft_now_passes_the_test_plan_validator` — zero coverage errors, so zero revisions |
| **0/0 still fails loudly** | `test_a_genuinely_empty_section_still_reports_zero`, `test_a_zero_denominator_still_blocks` — #2546/#2552 untouched, as instructed |

24 tests, each guarantee paired with its control: the boundary must still *end* somewhere, the stripper must still *strip*, and an empty section must still report zero.

## Interaction matrix

Answered on the issue and filed as **#2631**, not bolted on. The matrix discovers mechanisms by finding modules that call an artifact's `signatures`; injection and the extractor share `draft-text` but interact through a format contract with **no call between them**, so no call-site scan can see it. That needs a producers/consumers notion the matrix does not have, and inventing it inside a bug fix would give the "looks complete, enforces nothing" outcome #2568 refused.

## What only a live roll proves

All fixtures and preserved state: the halted draft now extracts, and the destructive strip is disarmed before it ever ran. Whether the next draw passes the lld stage end to end — and whether the drafter keeps emitting stray markers now that the guidance names them — needs the roll. boostgauge stayed read-only: no roll, PR #367 untouched, no writes to #331 state or working tree.

follow-up: #2631 · see #2612 for the injection this repairs · see #2602 for the sibling weak-scan hole
