### PR TITLE
fix: traceability spans the document's namespaces, not just the manifest's (Closes #2633)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -210,10 +210,16 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     _log_check(check_error_paths)
 
     # Check 11: Manifest traceability — every manifest row in exactly one
-    # test, every test citing a row id (Issue #2533). A diff, not an LLM
-    # judgment; abstains where it cannot parse (#2526).
+    # test, every test tracing to a real identifier (Issue #2533). A diff, not
+    # an LLM judgment; abstains where it cannot parse (#2526).
+    #
+    # #2633: the LLD is passed because a test may legitimately trace to a
+    # requirement or a test-scenario id when the manifest holds no row for it
+    # -- the manifest's domain is the injected criteria table alone.
     check_manifest = check_manifest_traceability(
-        spec_draft, state.get("assertion_manifest_rows", [])
+        spec_draft,
+        state.get("assertion_manifest_rows", []),
+        state.get("lld_content", ""),
     )
     checks.append(check_manifest)
     _log_check(check_manifest)
@@ -1522,15 +1528,95 @@ def check_error_paths_have_tests(spec: str) -> CompletenessCheck:
     )
 
 
+#: An explicit traceability citation: ``# manifest: S1.1``, ``# manifest:
+#: REQ-3``, ``# manifest: row 010``. The trailing text is captured whole so an
+#: unrecognised citation can be QUOTED BACK (#2633) rather than reported as
+#: absent.
+_CITATION_RE = re.compile(r"#\s*manifest:\s*(.+)")
+
+
+def _citation_namespaces(lld_content: str) -> tuple[set[str], set[str]]:
+    """(requirement ids, LLD test-scenario ids) a citation may name (#2633).
+
+    Both come from readers this module already depends on -- a second parser
+    of either would be the #1698 class -- and both are checked against the
+    upstream LLD rather than accepted on faith.
+    """
+    if not lld_content:
+        return (set(), set())
+
+    from assemblyzero.core.validation.test_plan_validator import (
+        extract_requirements,
+    )
+    from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+        lld_criteria,
+    )
+
+    reqs = {r["id"] for r in extract_requirements(lld_content) if r.get("id")}
+    scenarios = {c.row_id for c in lld_criteria(lld_content) if c.row_id}
+    return (reqs, scenarios)
+
+
+def _classify_citation(
+    cited: str, row_ids: set[str], reqs: set[str], scenarios: set[str]
+) -> str | None:
+    """Which namespace ``cited`` belongs to, or None when it belongs to none."""
+    text = cited.strip().rstrip(".,;")
+    # `row 010` and a bare `010` are the same citation.
+    bare = re.sub(r"^row\s+", "", text, flags=re.IGNORECASE).strip()
+    for candidate in (text, bare):
+        if candidate in row_ids:
+            return "manifest"
+        if candidate in reqs:
+            return "requirement"
+        if candidate in scenarios:
+            return "scenario"
+    return None
+
+
 def check_manifest_traceability(
-    spec: str, manifest_rows: list[dict]
+    spec: str, manifest_rows: list[dict], lld_content: str = ""
 ) -> CompletenessCheck:
-    """Every manifest row in exactly one test; every test cites a row (#2533).
+    """Every manifest row in a test; every test traced to a real identifier.
 
     Rows-to-tests bookkeeping as a mechanical diff — the two minutes of
-    per-round LLM traceability adjudication this check retires. Its whole
-    jurisdiction is the citation comment (``# manifest: N4.2``) or the bare
-    row id appearing inside a test function's source.
+    per-round LLM traceability adjudication this check retires.
+
+    ## Two domains, because the document has two (#2633)
+
+    The manifest compiles the injected criteria table only: visual assertions
+    with sample points and expected literals. A spec's test suite rightly
+    covers more — base generation, a size floor, cache persistence, constant
+    isolation, artifact emission — and no manifest row can ever exist for
+    "cache persistence", which has no sample point and never will. Demanding a
+    manifest citation from those tests demanded the impossible, and on
+    boostgauge's `run-issue331-182658` it cost three revisions and a cap.
+
+    The drafter's response was not sloppiness. It cited LLD **test-scenario**
+    ids -- `row 010`, `row 020`, `row 030`, `row 100`, `row 110`, every one a
+    real row of LLD-331's Test Scenarios table and exactly the five non-visual
+    scenarios -- plus a valid `REQ-N` on every test. It partitioned the LLD's
+    eleven scenarios perfectly: a manifest row where one existed, a scenario
+    id where none could. The check knew one namespace of three and reported
+    the other two as nothing, so the halt read *"test(s) citing no manifest
+    row"* about five tests that visibly cited two identifiers each.
+
+    Three namespaces are therefore legal, and all three are checkable against
+    artifacts already in hand: manifest row ids, the LLD's requirement ids,
+    the LLD's test-scenario ids.
+
+    ## Which way each direction fails
+
+    * **Row to test is unchanged** -- every manifest row must be cited, and a
+      row cited by more than one test still fails. That half catches real gaps
+      and nothing here loosens it.
+    * **Test to identifier** passes on at least ONE valid citation. An
+      unrecognised extra is REPORTED, never fatal on its own: failing a test
+      that has traced itself correctly because it also carries a redundant
+      annotation is the false-alarm disease #2540 removed.
+    * A test whose citations are **all** unrecognised fails, with each invalid
+      citation quoted and the namespaces enumerated, so the complaint names
+      something the draft actually contains (#2555).
 
     Abstention (#2526: unknown is not guilty): a fence that will not parse is
     not judged here — it is already a hard failure of the api-symbols check
@@ -1598,13 +1684,36 @@ def check_manifest_traceability(
             ),
         )
 
+    reqs, scenarios = _citation_namespaces(lld_content)
+    row_id_set = set(row_ids)
+
     cited_by: dict[str, list[str]] = {rid: [] for rid in row_ids}
     uncited_tests: list[str] = []
+    #: (test name, the citations it made that match no namespace)
+    invalid_only: list[tuple[str, list[str]]] = []
+    unrecognised_extras: list[str] = []
+
     for name, segment in tests:
         hits = [rid for rid, pat in id_patterns.items() if pat.search(segment)]
         for rid in hits:
             cited_by[rid].append(name)
-        if not hits:
+
+        # #2633: an explicit citation may name any of the three namespaces.
+        cited = [c.strip() for c in _CITATION_RE.findall(segment)]
+        good: list[str] = []
+        bad: list[str] = []
+        for citation in cited:
+            if _classify_citation(citation, row_id_set, reqs, scenarios):
+                good.append(citation)
+            else:
+                bad.append(citation)
+
+        if hits or good:
+            # Traced. An unrecognised extra is visible but not fatal.
+            unrecognised_extras.extend(f"{name}: `{b}`" for b in bad)
+        elif bad:
+            invalid_only.append((name, bad))
+        else:
             uncited_tests.append(name)
 
     problems: list[str] = []
@@ -1625,22 +1734,47 @@ def check_manifest_traceability(
         problems.append(f"manifest row(s) cited by MORE than one test: {listed}")
     if uncited_tests:
         problems.append(
-            f"test(s) citing no manifest row: "
+            f"test(s) tracing to nothing: "
             f"{', '.join(uncited_tests[:8])}"
             + (
                 f" (and {len(uncited_tests) - 8} more)"
                 if len(uncited_tests) > 8 else ""
             )
         )
+    if invalid_only:
+        # #2633: quote the citation back. Reporting "cites nothing" at a test
+        # that visibly cites something is the complaint that cost three
+        # revisions -- the drafter cannot act on a demand that contradicts the
+        # draft in front of it.
+        listed = "; ".join(
+            f"{name} cites {', '.join(repr(b) for b in bad)}"
+            for name, bad in invalid_only[:4]
+        )
+        problems.append(
+            f"test(s) whose every citation matches no known identifier: "
+            f"{listed}"
+            + (f" (and {len(invalid_only) - 4} more)"
+               if len(invalid_only) > 4 else "")
+        )
 
     if problems:
+        namespaces = [f"manifest rows are {', '.join(row_ids[:12])}"]
+        if reqs:
+            namespaces.append(
+                f"LLD requirements are {', '.join(sorted(reqs)[:12])}"
+            )
+        if scenarios:
+            namespaces.append(
+                f"LLD test-scenario ids are {', '.join(sorted(scenarios)[:12])}"
+            )
         return CompletenessCheck(
             check_name="manifest_traceability",
             passed=False,
             details=(
                 "Manifest traceability is a mechanical diff (#2533) and it "
                 "does not balance: " + " | ".join(problems)
-                + ". Cite rows with a `# manifest: <row-id>` comment."
+                + ". Cite with a `# manifest: <id>` comment; valid ids: "
+                + "; ".join(namespaces) + "."
                 + abstain_note
             ),
         )
@@ -1650,7 +1784,13 @@ def check_manifest_traceability(
         passed=True,
         details=(
             f"All {len(row_ids)} manifest row(s) are each cited by exactly "
-            f"one of {len(tests)} test(s), and every test cites a row."
+            f"one of {len(tests)} test(s), and every test traces to a "
+            f"manifest row, an LLD requirement, or an LLD test-scenario id."
+            + (
+                f" Unrecognised extra citation(s), not fatal: "
+                f"{'; '.join(unrecognised_extras[:6])}."
+                if unrecognised_extras else ""
+            )
             + abstain_note
         ),
     )

--- a/docs/standards/0029-defect-class-registry.md
+++ b/docs/standards/0029-defect-class-registry.md
@@ -102,13 +102,41 @@ first entry.
 **Instances.** #2555 (the fence complaint that deadlocked; dashed `lines N-M`
 citations added to the vocabulary), #2560 (demanded ADDITIONS land — a demand
 to add has no line to cite by construction), #2557 (the sweep that found three
-more unaddressable messages and the `()`-suffix hazard).
+more unaddressable messages and the `()`-suffix hazard), #2628 (the section
+boundary that ended at injection's own subheading, so a compliant draft read as
+empty), #2633 (the variant below).
 
 **The taxonomy is three-way, not two.** A complaint is *addressed* (it cites a
 line), *demands an addition* (there is no line to cite, and the #2560 exemption
 carries it), or *unaddressable* (it targets existing content in a scheme the
 enforcement cannot read). Only the third is a defect. Collapsing the middle case
 into the third produces false alarms on correct code.
+
+**Variant: the check's domain is narrower than the document's (#2633).** The
+sharpest form of this class is not a badly worded message — it is a check that
+sees only one of the identifier namespaces the document actually uses, and so
+reports correct work as absent while blaming the author.
+
+`check_manifest_traceability` demanded a manifest-row citation from every test.
+The manifest's domain is the injected criteria table alone, so five behavioural
+tests had no row to cite. The drafter traced them to LLD **test-scenario** ids
+instead — `row 010`, `row 020`, `row 030`, `row 100`, `row 110`, every one a
+real row of the LLD's own Test Scenarios table, and exactly the five non-visual
+scenarios — plus a valid `REQ-N` on every test. The halt then read *"test(s)
+citing no manifest row"* about five tests that visibly cited two identifiers
+each. Three revisions, cap.
+
+**Detection question for the variant.** *Does this check enumerate every
+namespace the upstream document defines, or only its own?* When the artifact
+carries identifiers the check cannot resolve, a "missing" verdict is a domain
+error rather than a finding.
+
+**Read the artifact before believing the halt.** #2633 was first diagnosed as
+counterfeit compliance — a drafter manufacturing plausible-looking near-misses
+under an impossible demand. That would have been a new and alarming claim about
+drafter behaviour, and it was wrong: every citation resolved against the LLD.
+A halt that blames the author is precisely when the author's output deserves
+checking first.
 
 ---
 

--- a/tests/fixtures/manifest_traceability/lld-331-passed.md
+++ b/tests/fixtures/manifest_traceability/lld-331-passed.md
@@ -1,0 +1,371 @@
+# Issue #331: static face renderer — bezel, chrome housing, dial, ticks, numerals, wordmark, screws — baked once, cached
+
+<!-- Template Metadata
+Last Updated: 2026-02-02
+Updated By: Issue #117 fix
+Update Reason: Moved Verification & Testing to Section 10 (was Section 11) to match 0702c review prompt and testing workflow expectations
+Previous: Added sections based on 80 blocking issues from 164 governance verdicts (2026-02-01)
+-->
+
+## 1. Context & Goal
+* **Issue:** #331
+* **Objective:** Implement a cached, static background rendering module for the Stingray gauge face that outputs a complete, needle-free `PIL.Image` strictly adhering to the S1-S9 geometric and color contract assertions.
+* **Status:** Approved (claude-opus-4-6, 2026-08-28)
+* **Related Issues:** #329, #332, #2, #1, #354, #328, #326, #325, #365, #361, #369, #334
+
+### Open Questions
+None.
+
+## 2. Proposed Changes
+
+### 2.1 Files Changed
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/boostgauge/skins/stingray.py` | Add | Exposes `render_face` and caches the static gauge rendering. |
+| `tests/visual/test_stingray_static.py` | Add | Implements the visual validation assertions (S1-S9) for the static face. |
+
+### 2.1.1 Path Validation (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks:
+- All "Modify" files must exist in repository
+- All "Delete" files must exist in repository
+- All "Add" files must have existing parent directories
+- No placeholder prefixes (`src/`, `lib/`, `app/`) unless directory exists
+
+### 2.2 Dependencies
+
+```toml
+
+# pyproject.toml additions (if any)
+
+# None. pillow is already declared in dependencies.
+```
+
+### 2.3 Data Structures
+
+```python
+FaceCacheKey = tuple[int, str]
+```
+
+### 2.4 Function Signatures
+
+```python
+
+# src/boostgauge/skins/stingray.py
+
+_FACE_CACHE: dict[tuple[int, str], "Image.Image"] = {}
+
+def render_face(size: int, skin: str = "stingray") -> "Image.Image":
+    """
+    Renders or retrieves the cached static face for the Stingray gauge.
+    Raises ValueError if size is less than 128.
+    """
+    ...
+```
+
+### 2.5 Logic Flow (Pseudocode)
+
+```
+1. Receive input (size, skin)
+2. Validate size >= 128
+   - IF size < 128 THEN raise ValueError
+3. Check cache
+   - IF (size, skin) in _FACE_CACHE THEN
+     - Return _FACE_CACHE[(size, skin)]
+4. Instantiate PIL.Image of size x size
+5. Sequentially draw static components:
+   - Chrome housing (S7)
+   - Bezel seat (S9)
+   - Dial face (S1)
+   - Redline band (S2)
+   - Screws (S8)
+   - Major and minor ticks (S3, S4)
+   - Numerals and wordmark (S5, S6)
+6. Store resulting image in _FACE_CACHE[(size, skin)]
+7. Return image
+```
+
+### 2.6 Technical Approach
+
+* **Module:** `src/boostgauge/skins/stingray.py`
+* **Pattern:** Caching / Singleton Factory
+* **Key Decisions:** We render everything without relying on `tkinter` in order to strictly decouple the graphics pipeline from the UI toolkit, returning a canonical `PIL.Image.Image` that can be effortlessly tested per Option C of the visual testing strategy.
+
+### 2.7 Architecture Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| State management | Class instance, Module-level dict | Module-level dict | Simplifies caller access via a pure function `render_face(size)` while safely persisting the cache across calls in the same session. |
+| Test artifact verification | Visual assertions against baselines, Mathematical predicates only | Mathematical predicates (S1-S9) with `--generate-baselines` artifact dumps | Per the project test strategy, automatic tests must use explicit literal assertions, but visual dumps are mandatory for humans to verify layout correctness. |
+
+**Architectural Constraints:**
+- Must satisfy the strict single-pass render and cache mandate (#329).
+- Constants must be physically contained inside the skin module; no external file may hold dial geometries.
+
+## 3. Requirements
+
+<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
+
+### 3.1 Source Decision Table (injected verbatim)
+
+The rows below are carried **verbatim** from the source issue by the derivation itself (#2607). They are machine-owned: the drafter does not write them, and a revision cannot change them. Cite these IDs from the requirements and test-plan sections; do not restate their values.
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size, centre (0.5, 0.5) × size; NO gradient, glass sweep, or reflection (#325) | classification at 3 interior points + equality of samples at (0.3 R, 0.5 R, 0.7 R) along one needle-free radial — flatness IS the assertion |
+| S2 | Redline band | `#AA0F19` crimson (ruling 2026-08-25), inner 0.88 R to outer 1.00 R, spanning values 60–100 via `angle(value) = 225° − 2.7° × value` | classification at radius 0.94 R at values 65/75/85 — deliberately offset from every tick position, because ticks render on top of the band (majors sit at multiples of 10, minors at even values; 65/75/85 carry no tick) |
+| S3 | Major ticks | `#FFFFFF`, 11 total at values 0,10,…,100, length 0.10 R, width 0.025 R | stroke predicate at each tick's midpoint: channel mean ≥ 100, all 11 — the white stroke samples ~255, and the 100 threshold clears both backgrounds: the face's ~10 (values 0–50) and the band's ~70 (values 60–100, where ticks render on top of the band; `#AA0F19` → mean 70.0). A missing tick fails on either background: 10 < 100 and 70 < 100. Width 2.56 px at the pinned test size is too thin for the interior rule |
+| S4 | Minor ticks | `#FFFFFF`, 40 total, 4 between each major pair, length 0.05 R, width 0.012 R | stroke predicate at 4 sampled minors (values 2, 34, 66, 98): midpoint channel mean ≥ 100 |
+| S5 | Numerals | `#FFFFFF`, values 0–100 step 10, cap height 0.11 R, numeral centres at 0.72 R (ruling 2026-08-25) | presence: ≥1 white-classified pixel within the numeral's cap-height box at each of the 11 positions. The '50' numeral legitimately overlaps the S6 mirror band's radial span (numeral bottom 0.665 R vs band centred 0.67 R above the pivot) — ruled, not a conflict: the S6 phantom check samples ONLY at 0.12 R–0.25 R off-axis and never sees the numeral, whose half-width is ~0.065 R (ruling on the #361 conflict, reaffirmed on #369). Any derived restatement of the mirror-band check (LLD row, spec test) MUST carry the off-axis sampling window with it — the window is load-bearing, not commentary |
+| S6 | Wordmark | `BOOSTGAUGE`, `#FFFFFF`, cap height 0.09 R, band centred 0.67 R below the pivot — level with the 0/100 major ticks (ruling 2026-08-25) | presence: ≥1 white-classified pixel in the wordmark band; absence of white in the mirror band above the pivot, sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis (ruling on the #361 conflict: the numeral '50' legitimately occupies the axis at 0.665–0.775 R above the pivot, half-width ~0.065 R, while a mirrored wordmark — the defect this assertion guards against — spans to ~0.27 R; the offset window sees a phantom wordmark and never the numeral) |
+| S7 | Chrome housing | square, chamfer radius 0.13 × size, environment-strip generation per #328's stops table | the #328 predicate: ≥3 achromatic samples (max−min ≤ 14, mean 16–248) spanning the horizon, ≥1 dark (mean < 100), ≥1 bright (mean > 200) |
+| S8 | Screws | 2, centres at pivot + (−0.25 R, 0) and pivot + (+0.25 R, 0) — horizontal offsets from the dial centre defined above — radius 0.020 R, flat `#1A1A1C` | the #326 predicate: centre pixel within ±6 per channel |
+| S9 | Bezel seat | dial sits below the bezel plane — not flush; the slight inner shadow renders where the bezel rolls inward to meet the recessed dial (contract §Bezel-to-dial transition), i.e. on the transition annulus just OUTSIDE the dial edge, the annulus containing 1.01 R. Never on the dial face itself: the face is flat `#0A0A0C` with zero overlays (#325), so it cannot carry a shadow | sample at 1.01 R is darker (channel mean) than the chrome at 1.10 R on the same radial |
+
+<!-- END MACHINE-OWNED -->
+
+1. When `render_face(size)` is called with a size equal to or greater than 128, it shall return a `PIL.Image.Image` containing the static elements and absolutely no needles.
+2. The application shall cache the output so that calling `render_face(size)` again with the same parameters during the same session serves the image from cache without re-rendering.
+3. The rendered dial face shall satisfy the S1 flatness and bounds assertions.
+4. The rendered redline band shall satisfy the S2 classification assertion.
+5. The major and minor ticks shall satisfy the S3 and S4 stroke predicates exactly at their designated values.
+6. The numerals and wordmark shall satisfy the S5 presence assertion and the S6 presence and off-axis sampling mirror-absence assertion.
+7. The chrome housing, screws, and bezel seat shall satisfy the S7, S8, and S9 classification and relative darkness assertions.
+8. Application code shall obtain the face only via the public function; no dial geometry, color, or layout constant may exist outside the skin module.
+9. When the visual test suite is executed with `--generate-baselines`, it shall write the rendered face PNG into the artifacts directory and print the path to stdout to meet artifact emission rule A1.
+
+## 4. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Dynamic Tkinter Canvas Drawing | No extra imaging dependency | Impossible to fulfill artifact generation requirements; tight UI coupling | **Rejected** |
+| Render every frame | Simplifies state architecture | Misses < 1% CPU budget | **Rejected** |
+| Cache static image layer | Meets CPU budget, isolated pure functional render | Requires memory management for image object | **Selected** |
+
+**Rationale:** Caching a single unified `PIL.Image` of the static components (per the Option C visual testing paradigm and #329 operator ruling) is the only mathematically proven way to meet the aggressive CPU budgets while preserving exactly testable aesthetics.
+
+## 5. Data & Fixtures
+
+### 5.1 Data Sources
+
+| Attribute | Value |
+|-----------|-------|
+| Source | Hardcoded constants bounded within `src/boostgauge/skins/stingray.py` |
+| Format | N/A |
+| Size | N/A |
+| Refresh | N/A |
+| Copyright/License | N/A |
+
+### 5.2 Data Pipeline
+
+```
+N/A
+```
+
+### 5.3 Test Fixtures
+
+| Fixture | Source | Notes |
+|---------|--------|-------|
+| Rendered Base Image | Output of `render_face` | Tested using analytical mathematical predicates, output saved on `--generate-baselines` |
+
+### 5.4 Deployment Pipeline
+
+N/A - Image rendered locally by the target application at runtime.
+
+## 6. Diagram
+
+### 6.1 Mermaid Quality Gate
+
+**Auto-Inspection Results:**
+```
+- Touching elements: [x] None / [ ] Found: ___
+- Hidden lines: [x] None / [ ] Found: ___
+- Label readability: [x] Pass / [ ] Issue: ___
+- Flow clarity: [x] Clear / [ ] Issue: ___
+```
+
+### 6.2 Diagram
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant SkinModule
+    participant Cache
+    participant Renderer
+
+    Caller->>SkinModule: render_face(size)
+    SkinModule->>SkinModule: validate size >= 128
+    SkinModule->>Cache: check (size, skin)
+    alt Cache Hit
+        Cache-->>SkinModule: return PIL.Image
+    else Cache Miss
+        SkinModule->>Renderer: execute S1-S9 drawing logic
+        Renderer-->>SkinModule: return PIL.Image
+        SkinModule->>Cache: store (size, skin) -> PIL.Image
+    end
+    SkinModule-->>Caller: return PIL.Image
+```
+
+## 7. Security & Safety Considerations
+
+### 7.1 Security
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Asset inclusion injection | Restrict font usage and internal dependencies to known local disk locations only | Addressed |
+
+### 7.2 Safety
+
+| Concern | Mitigation | Status |
+|---------|------------|--------|
+| Resource exhaustion via memory leak | Cache dictionary strictly bound by a fixed key definition (`size, skin`), limiting explosion vectors from dynamic parameters. | Addressed |
+
+**Fail Mode:** Fail Closed - A failure during rendering will raise an exception rather than returning an invisible or partially-rendered face to the UI.
+
+**Recovery Strategy:** Catching logic inside the UI layer handles transient renderer errors gracefully by skipping a frame.
+
+## 8. Performance & Cost Considerations
+
+### 8.1 Performance
+
+| Metric | Budget | Approach |
+|--------|--------|----------|
+| Latency | < 50ms | `render_face` executes once per size at application startup, < 1ms for subsequent hits |
+| Memory | < 5MB | A single 256x256 RGBA image requires roughly 256KB |
+| API Calls | 0 | Rendered dynamically via Pillow |
+
+**Bottlenecks:** Vector anti-aliasing operations inside `ImageDraw` may be CPU heavy on initial draw, justifying the strict caching mandate.
+
+### 8.2 Cost Analysis
+
+| Resource | Unit Cost | Estimated Usage | Monthly Cost |
+|----------|-----------|-----------------|--------------|
+| Local Compute | $0 | 1 cache miss / size | $0 |
+
+**Cost Controls:**
+- [x] Rate limiting prevents runaway costs (Caching mechanism eliminates repeated renders)
+
+**Worst-Case Scenario:** Negligible; the caching layer caps performance overhead strictly.
+
+## 9. Legal & Compliance
+
+| Concern | Applies? | Mitigation |
+|---------|----------|------------|
+| PII/Personal Data | No | N/A |
+| Third-Party Licenses | Yes | PIL (Pillow) is HPND distributed. Windows fonts are restricted to OS-level UI rendering |
+| Terms of Service | No | N/A |
+| Data Retention | No | N/A |
+| Export Controls | No | N/A |
+
+**Data Classification:** Public
+
+**Compliance Checklist:**
+- [x] No PII stored without consent
+- [x] All third-party licenses compatible with project license
+- [x] External API usage compliant with provider ToS
+- [x] Data retention policy documented
+
+## 10. Verification & Testing
+
+**Testing Philosophy:** Strive for 100% automated test coverage. Manual tests are a last resort for scenarios that genuinely cannot be automated (e.g., visual inspection, hardware interaction). Every scenario marked "Manual" requires justification.
+
+### 10.0 Test Plan (TDD - Complete Before Implementation)
+
+**TDD Requirement:** Tests MUST be written and failing BEFORE implementation begins.
+
+| Test ID | Test Description | Expected Behavior | Status |
+|---------|------------------|-------------------|--------|
+| T010 | Base face generation guard | Emits correctly sized image | RED |
+| T020 | Minimum size threshold verification | Rejects sizing below bounds | RED |
+| T030 | Cache persistence | Subsequent renders return matching pointers | RED |
+| T040 | Dial face adherence | Satisfies S1 flatness requirements | RED |
+| T050 | Redline band inclusion | Satisfies S2 positional requirements | RED |
+| T060 | Major and Minor tick positioning | Satisfies S3 and S4 stroke requirements | RED |
+| T070 | Numeral bounds and placement | Satisfies S5 presence checks | RED |
+| T080 | Wordmark placement and phantom guards | Satisfies S6 offset logic | RED |
+| T090 | Chrome, screw, and bezel bounds | Satisfies S7, S8, S9 assertions | RED |
+| T100 | Enforce constant isolation | Source scan checks constant bounds | RED |
+| T110 | Artifact emission triggers | Verifies A1 artifact saving logic | RED |
+
+**Coverage Target:** ≥95% for all new code (Planned coverage of `stingray.py` is 100% since cache miss/hit branches and size guards are fully exercised).
+
+**TDD Checklist:**
+- [x] All tests written before implementation
+- [ ] Tests currently RED (failing)
+- [x] Test IDs match scenario IDs in 10.1
+- [x] Test file created at: `tests/visual/test_stingray_static.py`
+
+### 10.1 Test Scenarios
+
+| ID | Scenario | Type | Input | Expected Output | Pass Criteria |
+|----|----------|------|-------|-----------------|---------------|
+| 010 | Generate base static image without needles (REQ-1) | Auto | `size=256` | Image size 256x256 | Output is a `PIL.Image.Image` instance |
+| 020 | Reject size < 128 (REQ-1) | Auto | `size=127` | `ValueError` raised | Exception specifies size must be >= 128 |
+| 030 | Return cached object for identical size and skin (REQ-2) | Auto | `size=256`, twice | Identical object returned | `id(first) == id(second)` |
+| 040 | Assert Dial face geometry and flatness per S1 (REQ-3) | Auto | `size=256` | Face passes S1 assertions | Classification and flatness pass per S1 |
+| 050 | Assert Redline band placement and color per S2 (REQ-4) | Auto | `size=256` | Band passes S2 assertions | Classification pass per S2 |
+| 060 | Assert Major and Minor ticks per S3 and S4 (REQ-5) | Auto | `size=256` | Ticks pass S3 and S4 assertions | Stroke predicate pass per S3 and S4 |
+| 070 | Assert Numerals per S5 (REQ-6) | Auto | `size=256` | Numerals pass S5 assertions | Presence pass per S5 |
+| 080 | Assert Wordmark presence and mirror absence per S6 (REQ-6) | Auto | `size=256` | Wordmark passes S6 assertions | Presence and phantom check pass per S6 |
+| 090 | Assert Chrome housing, screws, and bezel seat per S7, S8, S9 (REQ-7) | Auto | `size=256` | Elements pass S7, S8, S9 assertions | Predicates and darkness checks pass per S7, S8, S9 |
+| 100 | Assert constant isolation via AST (REQ-8) | Auto | Source code | No geometry/color constants found | Application code outside skin module imports no constants |
+| 110 | Execute artifact emission per A1 (REQ-9) | Auto | `--generate-baselines` | PNG written and path printed | Artifact exists in target directory and stdout matched |
+
+### 10.2 Test Commands
+
+```bash
+
+# Run visual test assertions against the contract and generate artifacts
+poetry run pytest tests/visual/test_stingray_static.py -v --generate-baselines
+```
+
+### 10.3 Manual Tests (Only If Unavoidable)
+
+N/A - All scenarios automated. Human inspection is triggered by artifact generation (Test 110).
+
+## 11. Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Sub-128 size requests distort the static proportions | High | Low | Size validation guard enforced at the top of `render_face`. |
+| Memory leak from unbound caching | Medium | Low | Dictionary caching is strictly indexed by `(size, skin)` in `render_face`, isolating permutations. |
+| Missing system fonts cause rendering crashes | High | Medium | Font execution wraps system defaults securely within `render_face`. |
+
+## 12. Definition of Done
+
+### Code
+- [ ] Implementation complete and linted
+- [ ] Code comments reference this LLD
+
+### Tests
+- [ ] All test scenarios pass
+- [ ] Test coverage meets threshold
+
+### Documentation
+- [ ] LLD updated with any deviations
+- [ ] Implementation Report (0103) completed
+- [ ] Test Report (0113) completed if applicable
+
+### Review
+- [ ] Code review completed
+- [ ] User approval before closing issue
+
+### 12.1 Traceability (Mechanical - Auto-Checked)
+
+Mechanical validation automatically checks:
+- Every file mentioned in this section must appear in Section 2.1
+- Every risk mitigation in Section 11 should have a corresponding function in Section 2.4 (warning if not)
+
+---
+
+## Appendix: Review Log
+
+### Review Summary
+
+| Review | Date | Verdict | Key Issue |
+|--------|------|---------|-----------|
+| 1 | 2026-08-28 | APPROVED | `claude-opus-4-6` |
+| Orchestrator #1 | (auto) | PENDING | Initial Draft Submission |
+
+**Final Status:** APPROVED

--- a/tests/fixtures/manifest_traceability/manifest-331.md
+++ b/tests/fixtures/manifest_traceability/manifest-331.md
@@ -1,0 +1,14 @@
+# Assertion manifest (compiled — regenerable, never hand-edited)
+
+| Row | Criterion | Sample point (verbatim) | Expected (literal) |
+|---|---|---|---|
+| S1.1 |  | classification at 3 interior points + equality of samples at (0.3 R, 0.5 R, 0.7 R) along one needle-free radial — flatness IS the assertion | 0.3 R; 0.5 R; 0.7 R |
+| S2.1 |  | classification at radius 0.94 R at values 65/75/85 — deliberately offset from every tick position, because ticks render on top of the band (majors sit at multiples of 10, minors at even values; 65/75/85 carry no tick) | 0.94 R |
+| S3.1 |  | stroke predicate at each tick's midpoint: channel mean ≥ 100, all 11 — the white stroke samples ~255, and the 100 threshold clears both backgrounds: the face's ~10 (values 0–50) and the band's ~70 (values 60–100, where ticks render on top of the band; #AA0F19 → mean 70.0). A missing tick fails on either background: 10 < 100 and 70 < 100. Width 2.56 px at the pinned test size is too thin for the interior rule | ≥ 100; #AA0F19; < 100; 2.56 px |
+| S4.1 |  | stroke predicate at 4 sampled minors (values 2, 34, 66, 98): midpoint channel mean ≥ 100 | ≥ 100 |
+| S5.1 |  | presence: ≥1 white-classified pixel within the numeral's cap-height box at each of the 11 positions. The '50' numeral legitimately overlaps the S6 mirror band's radial span (numeral bottom 0.665 R vs band centred 0.67 R above the pivot) — ruled, not a conflict: the S6 phantom check samples ONLY at 0.12 R–0.25 R off-axis and never sees the numeral, whose half-width is ~0.065 R (ruling on the #361 conflict, reaffirmed on #369). Any derived restatement of the mirror-band check (LLD row, spec test) MUST carry the off-axis sampling window with it — the window is load-bearing, not commentary | ≥1; 0.665 R; 0.67 R; 0.12 R; 0.25 R; 0.065 R |
+| S6.1 |  | presence: ≥1 white-classified pixel in the wordmark band | ≥1 |
+| S6.2 |  | absence of white in the mirror band above the pivot, sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis (ruling on the #361 conflict: the numeral '50' legitimately occupies the axis at 0.665–0.775 R above the pivot, half-width ~0.065 R, while a mirrored wordmark — the defect this assertion guards against — spans to ~0.27 R; the offset window sees a phantom wordmark and never the numeral) | 0.12 R; 0.25 R; 0.775 R; 0.065 R; 0.27 R |
+| S7.1 |  | the #328 predicate: ≥3 achromatic samples (max−min ≤ 14, mean 16–248) spanning the horizon, ≥1 dark (mean < 100), ≥1 bright (mean > 200) | ≥3; ≤ 14; ≥1; < 100; > 200 |
+| S8.1 |  | the #326 predicate: centre pixel within ±6 per channel | 0.25 R; 0.020 R; #1A1A1C |
+| S9.1 |  | sample at 1.01 R is darker (channel mean) than the chrome at 1.10 R on the same radial | 1.01 R; 1.10 R |

--- a/tests/fixtures/manifest_traceability/spec-331-009-draft.md
+++ b/tests/fixtures/manifest_traceability/spec-331-009-draft.md
@@ -1,0 +1,490 @@
+# Implementation Spec: Issue #331: static face renderer — bezel, chrome housing, dial, ticks, numerals, wordmark, screws — baked once, cached
+
+<!-- Metadata -->
+| Field | Value |
+|-------|-------|
+| Issue | #331 |
+| LLD | `docs/lld/active/331-static-face-renderer.md` |
+| Generated | 2026-08-28 |
+| Status | DRAFT |
+
+## 1. Overview
+
+**Objective:** Implement a cached, static background rendering module for the Stingray gauge face that outputs a complete, needle-free `PIL.Image` strictly adhering to the S1-S9 geometric and color contract assertions.
+
+**Success Criteria:** When `render_face(size)` is called with a size equal to or greater than 128, it shall return a `PIL.Image.Image` containing the static elements (satisfying S1-S9), and subsequent calls with identical arguments in the same session shall return the cached image pointer.
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/skins/stingray.py` | Add | Exposes `render_face` and caches the static gauge rendering. |
+| 2 | `tests/visual/test_stingray_static.py` | Add | Implements the visual validation assertions (S1-S9) for the static face. |
+
+**Implementation Order Rationale:** The application code (`stingray.py`) must be created first to provide the `render_face` function interface, so the test suite can import and assert against it following the TDD workflow required by the project.
+
+## 3. Current State (for Modify/Delete files)
+
+*No files are being modified or deleted in this Implementation Spec.*
+
+## 4. Data Structures
+
+### 4.1 FaceCacheKey
+
+**Definition:**
+
+```python
+FaceCacheKey = tuple[int, str]
+```
+
+**Concrete Example:**
+
+```json
+[256, "stingray"]
+```
+
+## 5. Function Specifications
+
+### 5.1 `render_face()`
+
+**File:** `src/boostgauge/skins/stingray.py`
+
+**Signature:**
+
+```python
+def render_face(size: int, skin: str = "stingray") -> "Image.Image":
+    """
+    Renders or retrieves the cached static face for the Stingray gauge.
+    Raises ValueError if size is less than 128.
+    """
+    ...
+```
+
+**Input Example:**
+
+```python
+size = 256
+skin = "stingray"
+```
+
+**Output Example:**
+
+```text
+<PIL.Image.Image image mode=RGBA size=256x256 at 0x1A2B3C4D5E0>
+```
+
+**Edge Cases:**
+- `size < 128` -> raises `ValueError("size must be >= 128")`
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/skins/stingray.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Stingray skin static face renderer.
+
+Issue #331: static face renderer — bezel, chrome housing, dial, ticks, numerals, wordmark, screws — baked once, cached
+"""
+import math
+from typing import Dict, Tuple
+
+from PIL import Image, ImageDraw, ImageFont
+
+_FACE_CACHE: Dict[Tuple[int, str], Image.Image] = {}
+
+def _polar(cx: float, cy: float, r: float, deg: float) -> Tuple[float, float]:
+    rad = math.radians(deg)
+    return cx + r * math.cos(rad), cy - r * math.sin(rad)
+
+def _angle(v: float) -> float:
+    return 225.0 - 2.7 * v
+
+def render_face(size: int, skin: str = "stingray") -> Image.Image:
+    """
+    Renders or retrieves the cached static face for the Stingray gauge.
+    Raises ValueError if size is less than 128.
+    """
+    if size < 128:
+        raise ValueError(f"size must be >= 128, got {size}")
+        
+    cache_key = (size, skin)
+    if cache_key in _FACE_CACHE:
+        return _FACE_CACHE[cache_key]
+        
+    # Supersampling for anti-aliasing
+    ss = 3
+    ss_size = size * ss
+    img = Image.new("RGBA", (ss_size, ss_size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    
+    cx = cy = ss_size / 2.0
+    R = 0.40 * ss_size
+    
+    # S7: Chrome housing
+    chamfer = 0.13 * ss_size
+    draw.rounded_rectangle([0, 0, ss_size, ss_size], radius=chamfer, fill=(20, 20, 20, 255))
+    
+    # S9: Bezel seat (transition annulus)
+    seat_r = 1.01 * R
+    draw.ellipse([cx - seat_r, cy - seat_r, cx + seat_r, cy + seat_r], fill=(5, 5, 5, 255))
+    
+    # S1: Dial face
+    draw.ellipse([cx - R, cy - R, cx + R, cy + R], fill="#0A0A0C")
+    
+    # S2: Redline band
+    inner_r = 0.88 * R
+    outer_r = 1.00 * R
+    redline_start_ang = _angle(100)
+    redline_end_ang = _angle(60)
+    
+    draw.arc(
+        [cx - outer_r, cy - outer_r, cx + outer_r, cy + outer_r],
+        start=360 - redline_end_ang, end=360 - redline_start_ang,
+        fill="#AA0F19", width=int(outer_r - inner_r)
+    )
+
+    # S8: Screws
+    screw_r = 0.020 * R
+    for offset_x in [-0.25 * R, 0.25 * R]:
+        draw.ellipse([cx + offset_x - screw_r, cy - screw_r, cx + offset_x + screw_r, cy + screw_r], fill="#1A1A1C")
+
+    # S3 & S4: Ticks
+    for v in range(0, 101, 2):
+        is_major = (v % 10 == 0)
+        tick_len = 0.10 * R if is_major else 0.05 * R
+        tick_wid = 0.025 * R if is_major else 0.012 * R
+        ang = _angle(v)
+        p1 = _polar(cx, cy, R - tick_len, ang)
+        p2 = _polar(cx, cy, R, ang)
+        draw.line([p1, p2], fill="#FFFFFF", width=int(tick_wid))
+
+    try:
+        font_numeral = ImageFont.truetype(r"C:\Windows\Fonts\bahnschrift.ttf", int(0.11 * R))
+        font_wordmark = ImageFont.truetype(r"C:\Windows\Fonts\bahnschrift.ttf", int(0.09 * R))
+    except OSError:
+        font_numeral = ImageFont.load_default()
+        font_wordmark = ImageFont.load_default()
+
+    # S5: Numerals
+    num_r = 0.72 * R
+    for v in range(0, 101, 10):
+        ang = _angle(v)
+        nx, ny = _polar(cx, cy, num_r, ang)
+        draw.text((nx, ny), str(v), fill="#FFFFFF", font=font_numeral, anchor="mm")
+
+    # S6: Wordmark
+    wordmark_y = cy + 0.67 * R
+    draw.text((cx, wordmark_y), "BOOSTGAUGE", fill="#FFFFFF", font=font_wordmark, anchor="mm")
+    
+    # Downsample
+    final_img = img.resize((size, size), Image.Resampling.LANCZOS)
+    _FACE_CACHE[cache_key] = final_img
+    
+    return final_img
+```
+
+### 6.2 `tests/visual/test_stingray_static.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Visual validation assertions (S1-S9) for the Stingray static face.
+
+Issue #331: static face renderer — bezel, chrome housing, dial, ticks, numerals, wordmark, screws — baked once, cached
+"""
+import ast
+import math
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from boostgauge.skins.stingray import render_face
+
+# Section 10.1 test function bodies map exactly here.
+```
+*(The specific test functions are detailed in Section 10.1 and should be placed directly inside this file).*
+
+## 7. Pattern References
+
+### 7.1 Visual Contract Math Protocol
+
+**File:** `tools/visual_contract_render.py` (lines 35-45)
+
+```python
+def polar(cx, cy, r, deg):
+    # math implementation
+    pass
+
+def angle(v):
+    """ruling #255: angle(value) = 225 - 2.7 x value, math convention."""
+    pass
+```
+
+**Relevance:** Demonstrates the canonical math for mapping a gauge value (0-100) to an angle, and converting polar coordinates to cartesian using `cx, cy, r, deg`. The `stingray.py` skin module adopts this exact angle and polar logic internally.
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import math` | stdlib | `src/boostgauge/skins/stingray.py` |
+| `from typing import Dict, Tuple` | stdlib | `src/boostgauge/skins/stingray.py` |
+| `from PIL import Image, ImageDraw, ImageFont` | `pillow` | `src/boostgauge/skins/stingray.py` |
+| `import pytest` | `pytest` | `tests/visual/test_stingray_static.py` |
+| `import ast` | stdlib | `tests/visual/test_stingray_static.py` |
+| `from pathlib import Path` | stdlib | `tests/visual/test_stingray_static.py` |
+
+**New Dependencies:** None (`pillow` is already installed).
+
+## 9. Placeholder
+
+*Reserved for future use to maintain alignment with LLD section numbering.*
+
+<!-- BEGIN MACHINE-OWNED: source decision table (#2607) -->
+
+## 9.5 Binding Decision Table (injected verbatim from the LLD)
+
+The rows below are carried **verbatim** from the LLD by the derivation itself (#2611), which carried them verbatim from the source issue (#2607). They are machine-owned: the drafter does not write them, and a revision cannot change them. Every assertion in the test mapping must agree with these values; cite the IDs, do not restate the values.
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size, centre (0.5, 0.5) × size; NO gradient, glass sweep, or reflection (#325) | classification at 3 interior points + equality of samples at (0.3 R, 0.5 R, 0.7 R) along one needle-free radial — flatness IS the assertion |
+| S2 | Redline band | `#AA0F19` crimson (ruling 2026-08-25), inner 0.88 R to outer 1.00 R, spanning values 60–100 via `angle(value) = 225° − 2.7° × value` | classification at radius 0.94 R at values 65/75/85 — deliberately offset from every tick position, because ticks render on top of the band (majors sit at multiples of 10, minors at even values; 65/75/85 carry no tick) |
+| S3 | Major ticks | `#FFFFFF`, 11 total at values 0,10,…,100, length 0.10 R, width 0.025 R | stroke predicate at each tick's midpoint: channel mean ≥ 100, all 11 — the white stroke samples ~255, and the 100 threshold clears both backgrounds: the face's ~10 (values 0–50) and the band's ~70 (values 60–100, where ticks render on top of the band; `#AA0F19` → mean 70.0). A missing tick fails on either background: 10 < 100 and 70 < 100. Width 2.56 px at the pinned test size is too thin for the interior rule |
+| S4 | Minor ticks | `#FFFFFF`, 40 total, 4 between each major pair, length 0.05 R, width 0.012 R | stroke predicate at 4 sampled minors (values 2, 34, 66, 98): midpoint channel mean ≥ 100 |
+| S5 | Numerals | `#FFFFFF`, values 0–100 step 10, cap height 0.11 R, numeral centres at 0.72 R (ruling 2026-08-25) | presence: ≥1 white-classified pixel within the numeral's cap-height box at each of the 11 positions. The '50' numeral legitimately overlaps the S6 mirror band's radial span (numeral bottom 0.665 R vs band centred 0.67 R above the pivot) — ruled, not a conflict: the S6 phantom check samples ONLY at 0.12 R–0.25 R off-axis and never sees the numeral, whose half-width is ~0.065 R (ruling on the #361 conflict, reaffirmed on #369). Any derived restatement of the mirror-band check (LLD row, spec test) MUST carry the off-axis sampling window with it — the window is load-bearing, not commentary |
+| S6 | Wordmark | `BOOSTGAUGE`, `#FFFFFF`, cap height 0.09 R, band centred 0.67 R below the pivot — level with the 0/100 major ticks (ruling 2026-08-25) | presence: ≥1 white-classified pixel in the wordmark band; absence of white in the mirror band above the pivot, sampled ONLY at horizontal offsets 0.12 R–0.25 R either side of the vertical axis (ruling on the #361 conflict: the numeral '50' legitimately occupies the axis at 0.665–0.775 R above the pivot, half-width ~0.065 R, while a mirrored wordmark — the defect this assertion guards against — spans to ~0.27 R; the offset window sees a phantom wordmark and never the numeral) |
+| S7 | Chrome housing | square, chamfer radius 0.13 × size, environment-strip generation per #328's stops table | the #328 predicate: ≥3 achromatic samples (max−min ≤ 14, mean 16–248) spanning the horizon, ≥1 dark (mean < 100), ≥1 bright (mean > 200) |
+| S8 | Screws | 2, centres at pivot + (−0.25 R, 0) and pivot + (+0.25 R, 0) — horizontal offsets from the dial centre defined above — radius 0.020 R, flat `#1A1A1C` | the #326 predicate: centre pixel within ±6 per channel |
+| S9 | Bezel seat | dial sits below the bezel plane — not flush; the slight inner shadow renders where the bezel rolls inward to meet the recessed dial (contract §Bezel-to-dial transition), i.e. on the transition annulus just OUTSIDE the dial edge, the annulus containing 1.01 R. Never on the dial face itself: the face is flat `#0A0A0C` with zero overlays (#325), so it cannot carry a shadow | sample at 1.01 R is darker (channel mean) than the chrome at 1.10 R on the same radial |
+
+<!-- END MACHINE-OWNED -->
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| T010 | `render_face()` | `size=256` | Returns a valid `PIL.Image.Image` instance |
+| T020 | `render_face()` | `size=127` | Raises `ValueError` |
+| T030 | `render_face()` | `size=256` (twice) | Returns identical object reference (`id(first) == id(second)`) |
+| T040 | `render_face()` | `size=256` | Face color equality at 0.3 R, 0.5 R, 0.7 R (S1) |
+| T050 | `render_face()` | `size=256` | Red band at 0.94 R for values 65, 75, 85 (S2) |
+| T060 | `render_face()` | `size=256` | Tick mean ≥ 100 at tick midpoints (S3, S4) |
+| T070 | `render_face()` | `size=256` | ≥1 white pixel at numeral centres (S5) |
+| T080 | `render_face()` | `size=256` | ≥1 white pixel at wordmark, 0 white at phantom zone (S6) |
+| T090 | `render_face()` | `size=256` | Chrome dark/bright samples (S7), screws (S8), bezel shadow (S9) |
+| T100 | Source AST | `stingray.py` source | No constants exist outside `stingray.py` imports |
+| T110 | Test run | `--generate-baselines` | Emits PNG to artifacts directory |
+
+### 10.1 Per-criterion test functions
+
+```python
+def test_T010_base_face_generation():
+    # Base face generation guard (T010) -- expected: image size 256x256
+    # manifest: row 010
+    # manifest: REQ-1
+    img = render_face(256)
+    assert isinstance(img, Image.Image)
+    assert img.size == (256, 256)
+
+def test_T020_minimum_size_threshold():
+    # Minimum size threshold verification (T020) -- expected: ValueError
+    # manifest: row 020
+    # manifest: REQ-1
+    with pytest.raises(ValueError, match=">= 128"):
+        render_face(127)
+
+def test_T030_cache_persistence():
+    # Cache persistence (T030) -- expected: identical pointers
+    # manifest: row 030
+    # manifest: REQ-2
+    img1 = render_face(256)
+    img2 = render_face(256)
+    assert id(img1) == id(img2)
+
+def test_T040_dial_face_adherence():
+    # Dial face adherence (T040) -- expected: equality of samples at (0.3 R, 0.5 R, 0.7 R)
+    # manifest: S1.1
+    # manifest: REQ-3
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    radials = [0.3 * R, 0.5 * R, 0.7 * R]
+    samples = []
+    for r in radials:
+        y = cy - r
+        samples.append(rgb.getpixel((cx, int(y))))
+        
+    assert samples[0] == samples[1] == samples[2]
+
+def test_T050_redline_band_inclusion():
+    # Redline band inclusion (T050) -- expected: classification at radius 0.94 R at values 65/75/85
+    # manifest: S2.1
+    # manifest: REQ-4
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    for val in [65, 75, 85]:
+        ang = math.radians(225.0 - 2.7 * val)
+        px = cx + 0.94 * R * math.cos(ang)
+        py = cy - 0.94 * R * math.sin(ang)
+        r, g, b = rgb.getpixel((int(px), int(py)))
+        assert r > 150 and g < 50 and b < 50
+
+def test_T060_ticks():
+    # Major and Minor tick positioning (T060) -- expected: channel mean >= 100
+    # manifest: S3.1
+    # manifest: S4.1
+    # manifest: REQ-5
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    for v in range(0, 101, 10):
+        ang = math.radians(225.0 - 2.7 * v)
+        px = cx + (R - 0.05 * R) * math.cos(ang)
+        py = cy - (R - 0.05 * R) * math.sin(ang)
+        r, g, b = rgb.getpixel((int(px), int(py)))
+        assert (r + g + b) / 3 >= 100
+        
+    for v in [2, 34, 66, 98]:
+        ang = math.radians(225.0 - 2.7 * v)
+        px = cx + (R - 0.025 * R) * math.cos(ang)
+        py = cy - (R - 0.025 * R) * math.sin(ang)
+        r, g, b = rgb.getpixel((int(px), int(py)))
+        assert (r + g + b) / 3 >= 100
+
+def test_T070_numeral_bounds():
+    # Numeral bounds and placement (T070) -- expected: >=1 white pixel at numerals
+    # manifest: S5.1
+    # manifest: REQ-6
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    for v in range(0, 101, 10):
+        ang = math.radians(225.0 - 2.7 * v)
+        nx = int(cx + 0.72 * R * math.cos(ang))
+        ny = int(cy - 0.72 * R * math.sin(ang))
+        
+        white_count = 0
+        for dx in range(-5, 6):
+            for dy in range(-5, 6):
+                r, g, b = rgb.getpixel((nx + dx, ny + dy))
+                if r > 200 and g > 200 and b > 200:
+                    white_count += 1
+        assert white_count >= 1
+
+def test_T080_wordmark():
+    # Wordmark placement and phantom guards (T080) -- expected: presence below, absence above
+    # manifest: S6.1
+    # manifest: S6.2
+    # manifest: REQ-6
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    wordmark_y = int(cy + 0.67 * R)
+    white_count = 0
+    for dx in range(-10, 10):
+        r, g, b = rgb.getpixel((int(cx + dx), wordmark_y))
+        if r > 200 and g > 200 and b > 200:
+            white_count += 1
+    assert white_count >= 1
+    
+    mirror_y = int(cy - 0.67 * R)
+    phantom_white = 0
+    start_x, end_x = int(0.12 * R), int(0.25 * R)
+    
+    for offset_x in range(start_x, end_x + 1):
+        for sign in [-1, 1]:
+            r, g, b = rgb.getpixel((int(cx + sign * offset_x), mirror_y))
+            if r > 200 and g > 200 and b > 200:
+                phantom_white += 1
+    assert phantom_white == 0
+
+def test_T090_chrome_screw_bezel():
+    # Chrome, screw, and bezel bounds (T090) -- expected: S7, S8, S9 assertions
+    # manifest: S7.1
+    # manifest: S8.1
+    # manifest: S9.1
+    # manifest: REQ-7
+    img = render_face(256)
+    rgb = img.convert("RGB")
+    cx, cy, R = 128, 128, 102.4
+    
+    screw_r = 0.020 * R
+    for offset in [-0.25 * R, 0.25 * R]:
+        r, g, b = rgb.getpixel((int(cx + offset), int(cy)))
+        assert abs(r - 26) <= 6 and abs(g - 26) <= 6 and abs(b - 28) <= 6
+        
+    r1, g1, b1 = rgb.getpixel((int(cx + 1.01 * R), int(cy)))
+    r2, g2, b2 = rgb.getpixel((int(cx + 1.10 * R), int(cy)))
+    assert (r1 + g1 + b1) / 3 < (r2 + g2 + b2) / 3
+
+def test_T100_constant_isolation():
+    # Enforce constant isolation (T100) -- expected: ast finds no constants outside stingray
+    # manifest: row 100
+    # manifest: REQ-8
+    source = Path("src/boostgauge/skins/stingray.py").read_text()
+    tree = ast.parse(source)
+    assert len(tree.body) > 0
+
+def test_T110_artifact_emission(tmp_path):
+    # Artifact emission triggers (T110) -- expected: PNG written
+    # Property tests above act independently of visual baselines.
+    # manifest: row 110
+    # manifest: REQ-9
+    target = tmp_path / "artifacts" / "face-256.png"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    img = render_face(256)
+    img.save(target)
+    
+    assert target.exists()
+    assert target.suffix == ".png"
+```
+
+## 11. Implementation Notes
+
+### 11.1 Baseline-Independent Rendering Verification
+The test suite strictly implements pure mathematical validations against the returned `PIL.Image.Image` array data. We intentionally avoid direct visual baseline assertions (e.g., `ImageChops.difference`) to prevent rendering variations across OS typography and PIL sub-versions from creating flaky tests, explicitly complying with the baseline-independence requirement (Issue #1902). 
+
+### 11.2 Platform Independent Testing
+Per Issue #1841, path assertions in `test_T110_artifact_emission` strictly use `pathlib.Path` comparative logic instead of string separators.
+
+### 11.3 Constants
+
+Constants are hardcoded strictly inside `src/boostgauge/skins/stingray.py` because the visual contract restricts them to this exact skin file.
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `MIN_SIZE` | `128` | Smallest valid static face resolution allowed. |
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3)
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every **non-test** function has input/output examples with realistic values (Section 5)
+- [x] Every LLD pass criterion has a test function (Section 10.1) — these are exempt from the rule above
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #331 |
+| Verdict | APPROVED |
+| Date | 2026-08-28 |
+| Iterations | 1 |
+| Finalized | 2026-08-28T18:33:56-05:00 |

--- a/tests/unit/test_manifest_traceability_domains.py
+++ b/tests/unit/test_manifest_traceability_domains.py
@@ -1,0 +1,340 @@
+"""Traceability spans the document's namespaces, not just the manifest's (#2633).
+
+The observed case, as fixtures. boostgauge's `run-issue331-182658` spec stage
+spent three revisions and hit the cap on:
+
+    test(s) citing no manifest row: test_T010_base_face_generation,
+    test_T020_minimum_size_threshold, test_T030_cache_persistence,
+    test_T100_constant_isolation, test_T110_artifact_emission
+
+**Those five tests each cited two identifiers.** The issue read them as
+counterfeit near-misses invented under an impossible demand; the artifact says
+otherwise, and `TestTheCitationsWereReal` proves it. `row 010`, `row 020`,
+`row 030`, `row 100`, `row 110` are real rows of LLD-331's Test Scenarios
+table -- exactly the five NON-visual scenarios, the ones for which no manifest
+row can exist, because "cache persistence" has no sample point and never will.
+Scenarios 040-090, the visual ones, the drafter cited by manifest row instead.
+
+So the drafter partitioned the LLD's eleven scenarios perfectly and the check
+knew one namespace of three. The class-3 lesson here is not that drafters
+counterfeit under pressure; it is that **a check whose domain is narrower than
+the document's own identifier namespace reports correct work as absent, and
+its message blames the author.**
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_manifest_traceability,
+)
+
+FIXTURES = (
+    Path(__file__).resolve().parents[1] / "fixtures" / "manifest_traceability"
+)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def spec() -> str:
+    return _fixture("spec-331-009-draft.md")
+
+
+@pytest.fixture
+def lld() -> str:
+    return _fixture("lld-331-passed.md")
+
+
+@pytest.fixture
+def rows() -> list[dict]:
+    """The manifest as the node receives it: compiled row ids."""
+    text = _fixture("manifest-331.md")
+    return [
+        {"row_id": m.group(1)}
+        for line in text.splitlines()
+        if (m := re.match(r"^\|\s*(S[\d.]+)\s*\|", line))
+    ]
+
+
+#: An LLD with a criteria table but no numbered requirements and no scenario
+#: table -- the control for "the namespaces come from the LLD, not from thin
+#: air".
+BARE_LLD = "# LLD\n\n## 3. Requirements\n\nProse only, no numbered items.\n"
+
+
+def _spec_with(*tests: str) -> str:
+    body = "\n\n".join(tests)
+    return f"# Spec\n\n## 10. Test Mapping\n\n```python\n{body}\n```\n"
+
+
+class TestTheCitationsWereReal:
+    """The refutation, as a measurement rather than a claim."""
+
+    def test_every_numeric_citation_is_a_real_lld_scenario(
+        self, spec: str, lld: str
+    ) -> None:
+        cited = [
+            m.group(1)
+            for m in re.finditer(r"#\s*manifest:\s*row\s+(\d{3})", spec)
+        ]
+        scenarios = set(re.findall(r"(?m)^\|\s*(\d{3})\s*\|", lld))
+
+        assert cited == ["010", "020", "030", "100", "110"]
+        assert set(cited).issubset(scenarios), (
+            "these were read as fabrications; they are LLD scenario ids"
+        )
+
+    def test_they_are_exactly_the_non_visual_scenarios(
+        self, spec: str, lld: str
+    ) -> None:
+        """The five with no manifest row, and only those."""
+        cited = set(re.findall(r"#\s*manifest:\s*row\s+(\d{3})", spec))
+        scenarios = set(re.findall(r"(?m)^\|\s*(\d{3})\s*\|", lld))
+
+        assert scenarios - cited == {"040", "050", "060", "070", "080", "090"}
+
+    def test_every_req_citation_is_a_real_lld_requirement(
+        self, spec: str, lld: str
+    ) -> None:
+        from assemblyzero.core.validation.test_plan_validator import (
+            extract_requirements,
+        )
+
+        cited = set(re.findall(r"#\s*manifest:\s*(REQ-\d+)", spec))
+        real = {r["id"] for r in extract_requirements(lld)}
+
+        assert cited == {f"REQ-{n}" for n in range(1, 10)}
+        assert cited.issubset(real)
+
+    def test_every_manifest_row_was_already_cited(
+        self, spec: str, rows: list[dict]
+    ) -> None:
+        """The row-to-test direction never failed here -- only test-to-row."""
+        for row in rows:
+            assert row["row_id"] in spec
+
+
+class TestTheObservedCaseBalances:
+    def test_the_009_draft_passes_unmodified(
+        self, spec: str, rows: list[dict], lld: str
+    ) -> None:
+        """The acceptance, and better than it asked.
+
+        It allowed for the fabricated citations to be replaced first. They are
+        not fabrications, so nothing is replaced: the draft as it actually
+        halted now balances.
+        """
+        result = check_manifest_traceability(spec, rows, lld)
+
+        assert result["passed"] is True, result["details"]
+
+    def test_the_fixture_is_the_artifact_that_halted(
+        self, spec: str, rows: list[dict]
+    ) -> None:
+        """Guard: without the LLD this must still fail, or the test above is
+        passing for the wrong reason."""
+        result = check_manifest_traceability(spec, rows, "")
+
+        assert result["passed"] is False
+        assert "test_T010_base_face_generation" in result["details"]
+
+    def test_it_reports_what_it_verified(
+        self, spec: str, rows: list[dict], lld: str
+    ) -> None:
+        details = check_manifest_traceability(spec, rows, lld)["details"]
+        assert "10 manifest row(s)" in details
+        assert "11 test(s)" in details
+
+
+class TestAnInvalidCitationIsNamed:
+    """#2555: a complaint must name something the draft contains."""
+
+    def test_a_test_citing_only_a_fabricated_id_fails(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: row 999\n    pass",
+        )
+        result = check_manifest_traceability(spec, [{"row_id": "S1.1"}], lld)
+
+        assert result["passed"] is False
+        assert "test_beta" in result["details"]
+
+    def test_the_invalid_citation_is_quoted_back(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: row 999\n    pass",
+        )
+        details = check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], lld
+        )["details"]
+
+        assert "'row 999'" in details, details
+
+    def test_all_three_namespaces_are_enumerated(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: row 999\n    pass",
+        )
+        details = check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], lld
+        )["details"]
+
+        assert "manifest rows are" in details
+        assert "LLD requirements are" in details
+        assert "LLD test-scenario ids are" in details
+
+    def test_a_test_citing_nothing_at_all_still_fails(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    pass",
+        )
+        result = check_manifest_traceability(spec, [{"row_id": "S1.1"}], lld)
+
+        assert result["passed"] is False
+        assert "tracing to nothing" in result["details"]
+        assert "test_beta" in result["details"]
+
+
+class TestAValidCitationWins:
+    def test_a_requirement_citation_traces(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: REQ-2\n    pass",
+        )
+        assert check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], lld
+        )["passed"] is True
+
+    def test_a_scenario_citation_traces(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: row 030\n    pass",
+        )
+        assert check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], lld
+        )["passed"] is True
+
+    def test_a_bare_scenario_id_traces(self, lld: str) -> None:
+        """`row 010` and `010` are the same citation."""
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: 030\n    pass",
+        )
+        assert check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], lld
+        )["passed"] is True
+
+    def test_an_unrecognised_extra_is_reported_but_not_fatal(
+        self, lld: str
+    ) -> None:
+        """Failing a correctly-traced test over a redundant annotation is the
+        false-alarm disease #2540 removed."""
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: REQ-2\n    # manifest: row 999\n"
+            "    pass",
+        )
+        result = check_manifest_traceability(spec, [{"row_id": "S1.1"}], lld)
+
+        assert result["passed"] is True
+        assert "row 999" in result["details"]
+        assert "not fatal" in result["details"]
+
+
+class TestTheRowDirectionIsUntouched:
+    """The half that catches real gaps. Nothing here loosens it."""
+
+    def test_an_uncited_manifest_row_still_fails(self, lld: str) -> None:
+        spec = _spec_with("def test_alpha():\n    # manifest: REQ-1\n    pass")
+        result = check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}, {"row_id": "S2.1"}], lld
+        )
+
+        assert result["passed"] is False
+        assert "cited by NO test" in result["details"]
+        assert "S1.1" in result["details"]
+
+    def test_a_row_cited_twice_still_fails(self, lld: str) -> None:
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: S1.1\n    pass",
+        )
+        result = check_manifest_traceability(spec, [{"row_id": "S1.1"}], lld)
+
+        assert result["passed"] is False
+        assert "MORE than one test" in result["details"]
+
+    def test_a_requirement_citation_cannot_substitute_for_a_row(
+        self, lld: str
+    ) -> None:
+        """The sharpest control: widening the TEST side must not let a
+        manifest row go untested."""
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: REQ-1\n    pass",
+            "def test_beta():\n    # manifest: REQ-2\n    pass",
+        )
+        result = check_manifest_traceability(spec, [{"row_id": "S1.1"}], lld)
+
+        assert result["passed"] is False
+        assert "S1.1" in result["details"]
+
+
+class TestNotApplicableIsUnchanged:
+    """#2608's declared-abstain regime, undisturbed."""
+
+    def test_no_manifest_is_not_applicable(self, lld: str) -> None:
+        result = check_manifest_traceability("# Spec\n", [], lld)
+
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_no_manifest_is_not_applicable_without_an_lld_either(self) -> None:
+        result = check_manifest_traceability("# Spec\n", [], "")
+
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_a_binding_manifest_with_no_tests_is_a_real_gap(
+        self, lld: str
+    ) -> None:
+        """Not applicable is not the same as nothing to check."""
+        result = check_manifest_traceability(
+            "# Spec\n\nNo fences.\n", [{"row_id": "S1.1"}], lld
+        )
+
+        assert result["passed"] is False
+        assert "no parseable test functions" in result["details"]
+
+
+class TestTheNamespacesComeFromTheLld:
+    def test_a_bare_lld_supplies_no_extra_namespace(self) -> None:
+        """The control for the whole fix: the widening is sourced from the
+        LLD, never invented, so an LLD carrying neither requirements nor
+        scenarios rejects exactly as before."""
+        spec = _spec_with(
+            "def test_alpha():\n    # manifest: S1.1\n    pass",
+            "def test_beta():\n    # manifest: REQ-2\n    pass",
+        )
+        result = check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], BARE_LLD
+        )
+
+        assert result["passed"] is False
+        assert "test_beta" in result["details"]
+
+    def test_the_namespace_list_omits_what_the_lld_lacks(self) -> None:
+        spec = _spec_with("def test_beta():\n    # manifest: nonsense\n    pass")
+        details = check_manifest_traceability(
+            spec, [{"row_id": "S1.1"}], BARE_LLD
+        )["details"]
+
+        assert "manifest rows are" in details
+        assert "LLD requirements are" not in details
+        assert "LLD test-scenario ids are" not in details


### PR DESCRIPTION
Closes #2633

boostgauge `run-issue331-182658` spent three revisions and hit the cap on `test(s) citing no manifest row: test_T010_base_face_generation, test_T020_minimum_size_threshold, test_T030_cache_persistence, test_T100_constant_isolation, test_T110_artifact_emission`.

**Those five tests each cited two identifiers.** The domain error the issue describes is real. The counterfeiting is not.

## The refutation, counted

All 26 `# manifest:` citations in `009-spec-draft.md`, classified mechanically — zero unclassified — and checked against the upstream LLD:

```
numeric 'row NNN':  row 010, row 020, row 030, row 100, row 110
manifest S-rows:    S1.1 S2.1 S3.1 S4.1 S5.1 S6.1 S6.2 S7.1 S8.1 S9.1   (all 10)
REQ-N:              REQ-1 … REQ-9                                        (all 9)

LLD scenario ids:   010 020 030 040 050 060 070 080 090 100 110
EVERY cited numeric id is a real LLD scenario:     True
EVERY cited REQ is a real LLD requirement (1..9):  True
scenarios cited via manifest rows instead:         040 050 060 070 080 090
```

`row 010` is LLD-331's Test Scenarios row 010, *"Generate base static image without needles (REQ-1)"*. So are 020, 030, 100 and 110 — **exactly the five non-visual scenarios**, the ones for which no manifest row can exist. The drafter partitioned the LLD's eleven scenarios perfectly: manifest row where one existed, scenario id where none could, plus a valid `REQ-N` on every test. That is complete three-namespace traceability. The check knew one namespace of three and reported the other two as nothing.

**Consequence for the fix.** The issue's rule — *a citation matching neither the manifest nor the requirements list still fails* — leaves `row 010` invalid, so the 009 draft would still halt, and the acceptance allowed for the citations to be replaced first. They are not fabrications, so nothing is replaced: **the draft as it actually halted now balances, unmodified.**

## What landed

Three legal namespaces, all checked against artifacts already in hand — manifest row ids, the LLD's requirement ids, the LLD's test-scenario ids. No new parser: `extract_requirements` (level-aware since #2632) and `criteria_coverage.lld_criteria` already read both, and a second reader is the #1698 class.

| direction | behaviour |
|---|---|
| row → test | **unchanged** — every row cited, a row cited twice still fails |
| test → identifier | passes on at least one valid citation |
| unrecognised extra alongside a valid one | reported in the details, **not fatal** |
| every citation unrecognised | fails, each quoted back, namespaces enumerated |
| no citation at all | fails as before |

An unrecognised extra is reported rather than fatal because failing a test that has traced itself correctly, over a redundant annotation, is the false-alarm disease #2540 just finished removing.

Scenario ids are recognised **only** from an explicit `# manifest:` comment, never by scanning a test body for a bare token: `010` is three digits and would match arithmetic, indices and timestamps, where `S1.1` is distinctive enough to survive a body scan.

## The manifest-expansion question: rejected, and the compiler settles it

The issue asked whether the manifest should instead compile numbered requirements as rows, and to reject it if it dilutes. It does — and this needed no judgement call, because `assertion_manifest.py:324` already refuses:

```python
literals = extract_literals(fragment) or binding_literals
if not literals:
    continue
```

A criterion with no literal anywhere produces **no row at all**. "Return cached object for identical size and skin" has no sample point and no literal, so widening the manifest's input would not yield a row for it — it would yield nothing, leaving exactly the gap we started with, and `gate_findings` would then report a criterion with no manifest row and halt *earlier*. The observed manifest already shows the shape: every row's `Criterion` cell is empty and the value lives in the sample-point and expected columns. A behavioural requirement has neither, and a row with empty assertion cells is the vacuity pattern arriving through the back door.

## Acceptance

| clause | evidence |
|---|---|
| the 009 draft balances | `test_the_009_draft_passes_unmodified` — and unmodified, better than asked |
| a test citing only a fabricated id fails with the citation named | `TestAnInvalidCitationIsNamed` — `'row 999'` quoted, all three namespaces listed |
| an uncited manifest row still fails the other direction | `TestTheRowDirectionIsUntouched`, including the sharpest control: a `REQ-N` citation cannot substitute for a row |
| a not-applicable manifest abstains per #2608 | `TestNotApplicableIsUnchanged`, with the control that a binding manifest and no tests is still a real gap |

23 tests. `TestTheCitationsWereReal` pins the refutation itself, so the correction survives as evidence rather than as a claim in a PR body; `test_the_fixture_is_the_artifact_that_halted` guards that the fixture still fails without the LLD, or the headline test would be passing for the wrong reason.

## Registry

Class 3 gains the variant, corrected: **a check whose domain is narrower than the document's own identifier namespace reports correct work as absent and blames the author.** Detection question: *does this check enumerate every namespace the upstream document defines, or only its own?* The entry also records that the first diagnosis was counterfeit compliance and that it was wrong — a halt that blames the author is precisely when the author's output deserves checking first. #2628 is added as an instance of the same shape.

## What only a live roll proves

All fixtures and preserved lineage: the halted draft now balances, and the row direction still catches gaps. Whether the next spec draw balances first time — and whether the drafter keeps using scenario ids now that they are legal — needs the roll. boostgauge stayed read-only: no roll, PR #367 untouched, no writes to #331 state or working tree. The LLD is treated as evidence and was neither regenerated nor cleaned.
