### PR TITLE
fix(auto-reviewer): treat any completed conclusion as terminal instead of polling it for 10 minutes (Closes #2627)

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -69,7 +69,12 @@ jobs:
           echo "PR #${PR_NUMBER} — waiting for required checks: ${REQUIRED_CHECKS}"
 
           IFS=',' read -ra CHECKS <<< "$REQUIRED_CHECKS"
-          MAX_ATTEMPTS=30   # 30 × 20s = 10 minutes max wait
+          # #2627: was 30 (10 minutes). With the terminal-state test below, the
+          # only path that still reaches this ceiling is "the check was never
+          # created at all" -- a name mismatch, or the reporting service being
+          # unreachable. Five minutes is far beyond normal reporting latency and
+          # halves what an outage costs in billed minutes.
+          MAX_ATTEMPTS=15   # 15 × 20s = 5 minutes max wait
           ATTEMPT=0
 
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
@@ -84,13 +89,33 @@ jobs:
                 --jq ".check_runs[] | select(.name | contains(\"${check_name}\")) | .conclusion" \
                 2>/dev/null | head -1)
 
+              # #2627: ANY non-empty conclusion is terminal. GitHub populates
+              # `conclusion` only when a check run has COMPLETED -- while one is
+              # genuinely in flight the field is null -- so polling a non-empty
+              # conclusion cannot change the answer, it just spends minutes.
+              #
+              # This was previously an allowlist of `failure` and `cancelled`,
+              # which meant `action_required` (what the sentinel posts when its
+              # issue-reference regex extracts a ref it cannot validate) fell
+              # through to "pending" and was polled for the full ten minutes.
+              # Measured across the fleet in August: 29 runs died this way,
+              # ~300 billed minutes, roughly 10% of the monthly allowance.
+              #
+              # Deliberately a test for "completed and not success" rather than
+              # a longer allowlist. Enumerating states is how action_required
+              # was missed in the first place, and the next unlisted conclusion
+              # would be discovered the same way, in ten-minute increments.
+              #
+              # No outcome changes: every state that used to time out already
+              # ended in step failure. It now gets there in ~20s instead of
+              # ~600s.
               if [ "$STATUS" = "success" ]; then
                 echo "  ✅ ${check_name}: passed"
-              elif [ "$STATUS" = "failure" ] || [ "$STATUS" = "cancelled" ]; then
-                echo "  ❌ ${check_name}: ${STATUS} — will NOT approve"
+              elif [ -n "$STATUS" ]; then
+                echo "  ❌ ${check_name}: ${STATUS} (completed, not success) — will NOT approve"
                 exit 1
               else
-                echo "  ⏳ ${check_name}: pending (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS})"
+                echo "  ⏳ ${check_name}: no conclusion yet (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS})"
                 ALL_PASSED=false
               fi
             done
@@ -105,7 +130,9 @@ jobs:
             sleep 20
           done
 
-          echo "❌ Timed out waiting for checks after $((MAX_ATTEMPTS * 20))s"
+          echo "❌ Timed out after $((MAX_ATTEMPTS * 20))s — required check never reported a conclusion."
+          echo "   Most likely the check was never created: verify the name in"
+          echo "   the required_checks input matches what the reporting service posts."
           exit 1
 
       - name: Approve PR

--- a/tests/test_auto_reviewer_wait_loop.py
+++ b/tests/test_auto_reviewer_wait_loop.py
@@ -1,0 +1,194 @@
+"""The auto-reviewer's check-wait loop, executed rather than eyeballed (#2627).
+
+The loop lives inline in `.github/workflows/auto-reviewer.yml` and cannot move
+to a script file: it is a REUSABLE workflow, so when another repo calls it there
+is no checkout of this repository and a sibling `.sh` would not exist. The bash
+therefore has to stay in the YAML, which is exactly the kind of code that never
+gets tested and quietly grows a ten-minute hole.
+
+So these tests extract the real `run:` block from the real workflow file and run
+it under bash with a stub `gh` on PATH. What is asserted is the shipped text,
+not a paraphrase of it.
+
+The defect: the loop treated every conclusion except `failure` and `cancelled`
+as "still pending" and polled 30 times at 20s. `action_required` -- what the
+sentinel posts when its issue-reference regex extracts a ref it cannot validate
+-- fell into that gap. GitHub sets `conclusion` only when a check has COMPLETED,
+so it was re-asking a finished question for ten minutes. 29 runs died that way
+across the fleet in August, ~300 billed minutes.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-reviewer.yml"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="needs bash to execute the workflow step"
+)
+
+
+def _wait_step_script() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["auto-review"]["steps"]
+    for step in steps:
+        if step.get("name") == "Wait for required checks":
+            return step["run"]
+    raise AssertionError("the 'Wait for required checks' step is gone")
+
+
+def _run(tmp_path: Path, conclusion: str | None, *, checks: str = "issue-reference",
+         timeout: float = 60):
+    """Execute the real step with a stub `gh` that reports `conclusion`.
+
+    None means the check exists but has not completed (empty output), which is
+    also what a check that was never created looks like to this loop.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    # The step calls `gh api ... --jq ...` and reads stdout. Printing nothing is
+    # the "no conclusion yet" case.
+    (bindir / "gh").write_text(
+        "#!/usr/bin/env bash\n" + (f'printf "%s\\n" "{conclusion}"\n' if conclusion else "exit 0\n"),
+        encoding="utf-8",
+        newline="\n",
+    )
+    (bindir / "gh").chmod(0o755)
+
+    script = tmp_path / "step.sh"
+    script.write_text("set -u\n" + _wait_step_script(), encoding="utf-8", newline="\n")
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "GH_TOKEN": "stub",
+        "PR_NUMBER": "1",
+        "REQUIRED_CHECKS": checks,
+        "REPO": "owner/repo",
+        "HEAD_SHA": "deadbeef",
+    }
+    started = time.monotonic()
+    try:
+        # encoding is explicit: the step prints ✅/❌/⏳ and Windows would
+        # otherwise decode stdout as cp1252 and blow up on them.
+        proc = subprocess.run(
+            ["bash", str(script)],
+            env=env,
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as expired:
+        return expired, time.monotonic() - started
+    return proc, time.monotonic() - started
+
+
+class TestTerminalConclusionsFailFast:
+    """Every one of these used to poll for ten minutes."""
+
+    @pytest.mark.parametrize(
+        "conclusion",
+        ["action_required", "timed_out", "stale", "neutral", "skipped", "startup_failure"],
+    )
+    def test_completed_but_not_success_exits_immediately(self, tmp_path, conclusion):
+        proc, elapsed = _run(tmp_path, conclusion)
+        assert proc.returncode == 1, proc.stdout
+        assert "will NOT approve" in proc.stdout
+        assert elapsed < 15, (
+            f"{conclusion} took {elapsed:.0f}s -- it is a COMPLETED state and must "
+            "not be polled"
+        )
+
+    def test_the_fix_is_not_a_longer_allowlist(self):
+        """Enumerating states is how action_required was missed in the first
+        place. The terminal test must be "completed and not success", not a
+        list that the next unlisted conclusion falls straight through.
+
+        Comments are stripped before checking: the code comment explains the
+        history and names the state, and matching on that would pass while the
+        logic underneath was an allowlist again.
+        """
+        code = "\n".join(
+            line.split("#", 1)[0] for line in _wait_step_script().splitlines()
+        )
+        assert '-n "$STATUS"' in code, "the terminal branch must test for any conclusion"
+        for state in ("action_required", "timed_out", "stale", "neutral"):
+            assert f'= "{state}"' not in code, (
+                f"{state} is being compared by name -- that is the allowlist shape "
+                "this fix exists to remove"
+            )
+
+    @pytest.mark.parametrize("conclusion", ["failure", "cancelled"])
+    def test_the_previously_handled_states_still_fail_fast(self, tmp_path, conclusion):
+        proc, elapsed = _run(tmp_path, conclusion)
+        assert proc.returncode == 1
+        assert elapsed < 15
+
+
+class TestSuccessStillApproves:
+    def test_success_exits_zero_without_waiting(self, tmp_path):
+        proc, elapsed = _run(tmp_path, "success")
+        assert proc.returncode == 0, proc.stdout
+        assert "All required checks passed" in proc.stdout
+        assert elapsed < 15
+
+    def test_every_check_in_a_multi_check_list_must_pass(self, tmp_path):
+        proc, _ = _run(tmp_path, "success", checks="issue-reference, pr-sentinel")
+        assert proc.returncode == 0
+        assert proc.stdout.count("passed") >= 2
+
+
+class TestPendingStillPolls:
+    def test_an_empty_conclusion_is_treated_as_in_flight(self, tmp_path):
+        """The one case that must still wait: a check genuinely running.
+
+        Asserted by letting it poll and then killing it, rather than sitting
+        through the full five-minute ceiling in the test suite. What matters is
+        that it does NOT exit on an empty conclusion -- an early exit here would
+        mean the loop refuses to approve anything that has not already finished
+        by the time it first looks.
+        """
+        result, elapsed = _run(tmp_path, None, timeout=45)
+        assert isinstance(result, subprocess.TimeoutExpired), (
+            "an empty conclusion must keep polling, not exit -- otherwise a "
+            "check still in flight is treated as a verdict"
+        )
+        out = (result.stdout or b"").decode("utf-8", "replace") if isinstance(
+            result.stdout, bytes
+        ) else (result.stdout or "")
+        assert "no conclusion yet" in out
+        assert elapsed >= 40
+
+
+class TestTheCeilingIsCapped:
+    def test_max_attempts_is_fifteen(self):
+        script = _wait_step_script()
+        assert "MAX_ATTEMPTS=15" in script, (
+            "the ceiling is the only remaining path to a long run (a check that "
+            "was never created); it must stay capped"
+        )
+
+    def test_the_wait_is_five_minutes_not_ten(self):
+        proc_script = _wait_step_script()
+        assert "MAX_ATTEMPTS=30" not in proc_script
+
+
+class TestTheHarnessIsHonest:
+    def test_the_step_still_exists_and_is_substantial(self):
+        assert len(_wait_step_script()) > 500
+
+    def test_the_stub_gh_is_actually_being_used(self, tmp_path):
+        """If the real gh were on PATH first, these tests would be measuring
+        GitHub rather than the loop."""
+        proc, _ = _run(tmp_path, "success")
+        assert "owner/repo" not in proc.stderr
+        assert proc.returncode == 0

--- a/tools/deploy_auto_reviewer_poll_fix.py
+++ b/tools/deploy_auto_reviewer_poll_fix.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""One-shot: land the auto-reviewer poll-loop fix (Closes #2627).
+
+The change is to `.github/workflows/auto-reviewer.yml`, which needs `workflow`
+scope. The fine-grained PAT behind `gh` and `git push` deliberately does not
+carry it (ADR-0216 section 1), so the file goes in through the Contents API
+using the in-process classic-PAT pattern.
+
+WHAT IT FIXES
+
+The "Wait for required checks" step treated every conclusion except `failure`
+and `cancelled` as still-pending and polled 30 times at 20-second intervals.
+GitHub sets `conclusion` only when a check has COMPLETED, so any non-empty
+conclusion was a finished answer being re-asked for ten minutes. Measured
+across the private fleet in August: 29 runs died that way, about 300 billed
+minutes -- roughly 10% of the monthly Actions allowance -- spent waiting.
+
+Two changes:
+
+  1. Any non-empty conclusion is terminal. Inverted rather than extended: an
+     allowlist is how `action_required` was missed, and the next unlisted
+     conclusion would be found the same way, ten minutes at a time. No outcome
+     changes -- every state that used to time out already ended in failure, it
+     just gets there in ~20s instead of ~600s.
+
+  2. The ceiling drops from 30 attempts to 15 (10 minutes to 5). With (1) in
+     place the only remaining path to the ceiling is a check that was never
+     created at all.
+
+THE WORKFLOW IS EMBEDDED BASE64, and this file was generated from the tested
+file rather than typed. The content carries backticks, quotes and non-ASCII
+glyphs; every hand-transport through a quoted string is a chance to corrupt it
+silently. The script verifies its own payload before sending.
+
+Tested by tests/test_auto_reviewer_wait_loop.py, which extracts this exact step
+from the YAML and executes it under bash against a stub `gh`. Reverting the
+terminal test to the old allowlist fails 7 of those tests.
+
+THE OPERATOR RUNS THIS, NOT AN AGENT (ADR-0216). A script an agent invokes is a
+process the agent parents, and the decrypted PAT lives in that process's heap.
+
+Required classic PAT scopes: repo (full), workflow.
+
+Usage, in bash:
+
+    cd /c/Users/mcwiz/Projects/AssemblyZero
+    poetry run python tools/deploy_auto_reviewer_poll_fix.py
+
+Idempotent: skips whatever already exists. One-shot -- safe to delete after the
+PR merges, at which point the workflow file itself is the only copy that matters.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _pat_session import classic_pat_session  # noqa: E402
+
+GITHUB_USER = "martymcenroe"
+REPO = "AssemblyZero"
+ISSUE_NUMBER = 2627
+BRANCH = f"{ISSUE_NUMBER}-auto-reviewer-poll-fix"
+WORKFLOW_PATH = ".github/workflows/auto-reviewer.yml"
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_S = 30
+
+TITLE = (
+    "fix(auto-reviewer): treat any completed conclusion as terminal instead of "
+    f"polling it for 10 minutes (Closes #{ISSUE_NUMBER})"
+)
+
+# Generated from the tested file. Do not hand-edit -- regenerate instead.
+WORKFLOW_B64 = (
+    "bmFtZTogYXV0by1yZXZpZXdlcgoKIyBSZXVzYWJsZSB3b3JrZmxvdzogYXV0by1hcHByb3ZlcyBQ"
+    "UnMgd2hlbiBhbGwgcmVxdWlyZWQgY2hlY2tzIHBhc3MuCiMKIyBUaGlzIHVzZXMgYSBHaXRIdWIg"
+    "QXBwIGlkZW50aXR5IChub3QgdGhlIHJlcG8gb3duZXIpIHRvIHN1Ym1pdCBhbgojIGFwcHJvdmlu"
+    "ZyByZXZpZXcsIGJyZWFraW5nIHRoZSBzZWxmLWF1dGhvcml6YXRpb24gbG9vcCB3aGVyZSBhZ2Vu"
+    "dHMKIyBjcmVhdGUgaXNzdWVzLCBjcmVhdGUgUFJzLCBhbmQgbWVyZ2UgdGhlaXIgb3duIFBScy4K"
+    "IwojIFByZXJlcXVpc2l0ZXM6CiMgICAxLiBHaXRIdWIgQXBwICJBc3NlbWJseVplcm8gUmV2aWV3"
+    "ZXIiIGNyZWF0ZWQgYW5kIGluc3RhbGxlZCBvbiBhbGwgcmVwb3MKIyAgIDIuIEFwcCBJRCBzdG9y"
+    "ZWQgYXMgb3JnL3JlcG8gdmFyaWFibGU6IFJFVklFV0VSX0FQUF9JRAojICAgMy4gQXBwIHByaXZh"
+    "dGUga2V5IHN0b3JlZCBhcyBvcmcvcmVwbyBzZWNyZXQ6IFJFVklFV0VSX0FQUF9QUklWQVRFX0tF"
+    "WQojICAgNC4gQnJhbmNoIHByb3RlY3Rpb246IHJlcXVpcmUgMSBhcHByb3ZpbmcgcmV2aWV3LCBl"
+    "bmZvcmNlIGFkbWlucwojCiMgQ2FsbGVkIGZyb20gZWFjaCByZXBvIHZpYToKIyAgIHVzZXM6IG1h"
+    "cnR5bWNlbnJvZS9Bc3NlbWJseVplcm8vLmdpdGh1Yi93b3JrZmxvd3MvYXV0by1yZXZpZXdlci55"
+    "bWxAbWFpbgojCiMgSXNzdWU6ICM3MzYgfCBSZWxhdGVkOiAjNzMyCgpvbjoKICB3b3JrZmxvd19j"
+    "YWxsOgogICAgaW5wdXRzOgogICAgICByZXF1aXJlZF9jaGVja3M6CiAgICAgICAgZGVzY3JpcHRp"
+    "b246ID4KICAgICAgICAgIENvbW1hLXNlcGFyYXRlZCBsaXN0IG9mIGNoZWNrIG5hbWVzIHRoYXQg"
+    "bXVzdCBwYXNzIGJlZm9yZSBhcHByb3ZhbC4KICAgICAgICAgIERlZmF1bHQ6IHByLXNlbnRpbmVs"
+    "LiBPdmVycmlkZSBwZXItcmVwbyBpZiBhZGRpdGlvbmFsIGNoZWNrcyBleGlzdC4KICAgICAgICBy"
+    "ZXF1aXJlZDogZmFsc2UKICAgICAgICB0eXBlOiBzdHJpbmcKICAgICAgICBkZWZhdWx0OiAiaXNz"
+    "dWUtcmVmZXJlbmNlIgogICAgc2VjcmV0czoKICAgICAgUkVWSUVXRVJfQVBQX0lEOgogICAgICAg"
+    "IHJlcXVpcmVkOiB0cnVlCiAgICAgIFJFVklFV0VSX0FQUF9QUklWQVRFX0tFWToKICAgICAgICBy"
+    "ZXF1aXJlZDogdHJ1ZQoKcGVybWlzc2lvbnM6CiAgcHVsbC1yZXF1ZXN0czogd3JpdGUKICBjaGVj"
+    "a3M6IHJlYWQKCmpvYnM6CiAgYXV0by1yZXZpZXc6CiAgICBydW5zLW9uOiB1YnVudHUtbGF0ZXN0"
+    "CiAgICAjIE9ubHkgcnVuIG9uIFBScywgbm90IG9uIHRoZSBQUiBjcmVhdGVkIGJ5IHRoZSBBcHAg"
+    "aXRzZWxmIChwcmV2ZW50IGxvb3BzKS4KICAgICMKICAgICMgQ2VyYmVydXMgaXMgdGhlIEFHRU5U"
+    "IGZlbmNlLCBub3QgdGhlIERlcGVuZGFib3QgZW5hYmxlciAoIzEyNTEpLgogICAgIyBPbiBhbiBh"
+    "Z2VudCBQUiB0aGUgYXV0aG9yIGlzIHRoZSByZXBvIG93bmVyLCBzbyBHaXRIdWIncyBuby1zZWxm"
+    "LWFwcHJvdmFsCiAgICAjIHJ1bGUgbGVhdmVzIG5vIGVsaWdpYmxlIHJldmlld2VyIGFuZCBvbmUg"
+    "aGFzIHRvIGJlIG1hbnVmYWN0dXJlZCAtLSB0aGF0IGlzCiAgICAjIHdoYXQgdGhpcyB3b3JrZmxv"
+    "dyBpcyBmb3IuIE9uIGEgRGVwZW5kYWJvdCBQUiB0aGUgYXV0aG9yIGlzIERlcGVuZGFib3QsIHNv"
+    "CiAgICAjIHRoZSBvd25lciBhbHJlYWR5IElTIGFuIGVsaWdpYmxlIHRoaXJkLXBhcnR5IHJldmll"
+    "d2VyIGFuZCB0aGVyZSBpcyBub3RoaW5nCiAgICAjIGF0IHRoYXQgZ2F0ZSB0byBndWFyZC4gRGVw"
+    "ZW5kYWJvdCBnZXRzIGl0cyBvd24gbGFuZTogdG9vbHMvZGVwZW5kYWJvdF9yZXZpZXcucHkKICAg"
+    "ICMgcnVucyB0aGUgc3VpdGUgYW5kIGFwcHJvdmVzIGFzIHRoZSBvd25lci4KICAgIGlmOiAoZ2l0"
+    "aHViLmV2ZW50X25hbWUgPT0gJ3B1bGxfcmVxdWVzdCcgfHwgZ2l0aHViLmV2ZW50X25hbWUgPT0g"
+    "J3dvcmtmbG93X2NhbGwnKSAmJiBnaXRodWIuZXZlbnQucHVsbF9yZXF1ZXN0LnVzZXIubG9naW4g"
+    "IT0gJ2RlcGVuZGFib3RbYm90XScKICAgIHN0ZXBzOgogICAgICAtIG5hbWU6IEdlbmVyYXRlIEFw"
+    "cCB0b2tlbgogICAgICAgIGlkOiBhcHAtdG9rZW4KICAgICAgICB1c2VzOiBhY3Rpb25zL2NyZWF0"
+    "ZS1naXRodWItYXBwLXRva2VuQHYzCiAgICAgICAgd2l0aDoKICAgICAgICAgIGFwcC1pZDogJHt7"
+    "IHNlY3JldHMuUkVWSUVXRVJfQVBQX0lEIH19CiAgICAgICAgICBwcml2YXRlLWtleTogJHt7IHNl"
+    "Y3JldHMuUkVWSUVXRVJfQVBQX1BSSVZBVEVfS0VZIH19CgogICAgICAtIG5hbWU6IFdhaXQgZm9y"
+    "IHJlcXVpcmVkIGNoZWNrcwogICAgICAgIGVudjoKICAgICAgICAgIEdIX1RPS0VOOiAke3sgZ2l0"
+    "aHViLnRva2VuIH19CiAgICAgICAgICBQUl9OVU1CRVI6ICR7eyBnaXRodWIuZXZlbnQucHVsbF9y"
+    "ZXF1ZXN0Lm51bWJlciB9fQogICAgICAgICAgUkVRVUlSRURfQ0hFQ0tTOiAke3sgaW5wdXRzLnJl"
+    "cXVpcmVkX2NoZWNrcyB9fQogICAgICAgICAgUkVQTzogJHt7IGdpdGh1Yi5yZXBvc2l0b3J5IH19"
+    "CiAgICAgICAgICBIRUFEX1NIQTogJHt7IGdpdGh1Yi5ldmVudC5wdWxsX3JlcXVlc3QuaGVhZC5z"
+    "aGEgfX0KICAgICAgICBydW46IHwKICAgICAgICAgIGVjaG8gIlBSICMke1BSX05VTUJFUn0g4oCU"
+    "IHdhaXRpbmcgZm9yIHJlcXVpcmVkIGNoZWNrczogJHtSRVFVSVJFRF9DSEVDS1N9IgoKICAgICAg"
+    "ICAgIElGUz0nLCcgcmVhZCAtcmEgQ0hFQ0tTIDw8PCAiJFJFUVVJUkVEX0NIRUNLUyIKICAgICAg"
+    "ICAgICMgIzI2Mjc6IHdhcyAzMCAoMTAgbWludXRlcykuIFdpdGggdGhlIHRlcm1pbmFsLXN0YXRl"
+    "IHRlc3QgYmVsb3csIHRoZQogICAgICAgICAgIyBvbmx5IHBhdGggdGhhdCBzdGlsbCByZWFjaGVz"
+    "IHRoaXMgY2VpbGluZyBpcyAidGhlIGNoZWNrIHdhcyBuZXZlcgogICAgICAgICAgIyBjcmVhdGVk"
+    "IGF0IGFsbCIgLS0gYSBuYW1lIG1pc21hdGNoLCBvciB0aGUgcmVwb3J0aW5nIHNlcnZpY2UgYmVp"
+    "bmcKICAgICAgICAgICMgdW5yZWFjaGFibGUuIEZpdmUgbWludXRlcyBpcyBmYXIgYmV5b25kIG5v"
+    "cm1hbCByZXBvcnRpbmcgbGF0ZW5jeSBhbmQKICAgICAgICAgICMgaGFsdmVzIHdoYXQgYW4gb3V0"
+    "YWdlIGNvc3RzIGluIGJpbGxlZCBtaW51dGVzLgogICAgICAgICAgTUFYX0FUVEVNUFRTPTE1ICAg"
+    "IyAxNSDDlyAyMHMgPSA1IG1pbnV0ZXMgbWF4IHdhaXQKICAgICAgICAgIEFUVEVNUFQ9MAoKICAg"
+    "ICAgICAgIHdoaWxlIFsgJEFUVEVNUFQgLWx0ICRNQVhfQVRURU1QVFMgXTsgZG8KICAgICAgICAg"
+    "ICAgQUxMX1BBU1NFRD10cnVlCgogICAgICAgICAgICBmb3IgY2hlY2tfbmFtZSBpbiAiJHtDSEVD"
+    "S1NbQF19IjsgZG8KICAgICAgICAgICAgICBjaGVja19uYW1lPSQoZWNobyAiJGNoZWNrX25hbWUi"
+    "IHwgeGFyZ3MpICAjIHRyaW0gd2hpdGVzcGFjZQoKICAgICAgICAgICAgICAjIFF1ZXJ5IGNoZWNr"
+    "IHJ1bnMgZm9yIHRoaXMgU0hBIGFuZCBjaGVjayBuYW1lCiAgICAgICAgICAgICAgU1RBVFVTPSQo"
+    "Z2ggYXBpIFwKICAgICAgICAgICAgICAgICJyZXBvcy8ke1JFUE99L2NvbW1pdHMvJHtIRUFEX1NI"
+    "QX0vY2hlY2stcnVucyIgXAogICAgICAgICAgICAgICAgLS1qcSAiLmNoZWNrX3J1bnNbXSB8IHNl"
+    "bGVjdCgubmFtZSB8IGNvbnRhaW5zKFwiJHtjaGVja19uYW1lfVwiKSkgfCAuY29uY2x1c2lvbiIg"
+    "XAogICAgICAgICAgICAgICAgMj4vZGV2L251bGwgfCBoZWFkIC0xKQoKICAgICAgICAgICAgICAj"
+    "ICMyNjI3OiBBTlkgbm9uLWVtcHR5IGNvbmNsdXNpb24gaXMgdGVybWluYWwuIEdpdEh1YiBwb3B1"
+    "bGF0ZXMKICAgICAgICAgICAgICAjIGBjb25jbHVzaW9uYCBvbmx5IHdoZW4gYSBjaGVjayBydW4g"
+    "aGFzIENPTVBMRVRFRCAtLSB3aGlsZSBvbmUgaXMKICAgICAgICAgICAgICAjIGdlbnVpbmVseSBp"
+    "biBmbGlnaHQgdGhlIGZpZWxkIGlzIG51bGwgLS0gc28gcG9sbGluZyBhIG5vbi1lbXB0eQogICAg"
+    "ICAgICAgICAgICMgY29uY2x1c2lvbiBjYW5ub3QgY2hhbmdlIHRoZSBhbnN3ZXIsIGl0IGp1c3Qg"
+    "c3BlbmRzIG1pbnV0ZXMuCiAgICAgICAgICAgICAgIwogICAgICAgICAgICAgICMgVGhpcyB3YXMg"
+    "cHJldmlvdXNseSBhbiBhbGxvd2xpc3Qgb2YgYGZhaWx1cmVgIGFuZCBgY2FuY2VsbGVkYCwKICAg"
+    "ICAgICAgICAgICAjIHdoaWNoIG1lYW50IGBhY3Rpb25fcmVxdWlyZWRgICh3aGF0IHRoZSBzZW50"
+    "aW5lbCBwb3N0cyB3aGVuIGl0cwogICAgICAgICAgICAgICMgaXNzdWUtcmVmZXJlbmNlIHJlZ2V4"
+    "IGV4dHJhY3RzIGEgcmVmIGl0IGNhbm5vdCB2YWxpZGF0ZSkgZmVsbAogICAgICAgICAgICAgICMg"
+    "dGhyb3VnaCB0byAicGVuZGluZyIgYW5kIHdhcyBwb2xsZWQgZm9yIHRoZSBmdWxsIHRlbiBtaW51"
+    "dGVzLgogICAgICAgICAgICAgICMgTWVhc3VyZWQgYWNyb3NzIHRoZSBmbGVldCBpbiBBdWd1c3Q6"
+    "IDI5IHJ1bnMgZGllZCB0aGlzIHdheSwKICAgICAgICAgICAgICAjIH4zMDAgYmlsbGVkIG1pbnV0"
+    "ZXMsIHJvdWdobHkgMTAlIG9mIHRoZSBtb250aGx5IGFsbG93YW5jZS4KICAgICAgICAgICAgICAj"
+    "CiAgICAgICAgICAgICAgIyBEZWxpYmVyYXRlbHkgYSB0ZXN0IGZvciAiY29tcGxldGVkIGFuZCBu"
+    "b3Qgc3VjY2VzcyIgcmF0aGVyIHRoYW4KICAgICAgICAgICAgICAjIGEgbG9uZ2VyIGFsbG93bGlz"
+    "dC4gRW51bWVyYXRpbmcgc3RhdGVzIGlzIGhvdyBhY3Rpb25fcmVxdWlyZWQKICAgICAgICAgICAg"
+    "ICAjIHdhcyBtaXNzZWQgaW4gdGhlIGZpcnN0IHBsYWNlLCBhbmQgdGhlIG5leHQgdW5saXN0ZWQg"
+    "Y29uY2x1c2lvbgogICAgICAgICAgICAgICMgd291bGQgYmUgZGlzY292ZXJlZCB0aGUgc2FtZSB3"
+    "YXksIGluIHRlbi1taW51dGUgaW5jcmVtZW50cy4KICAgICAgICAgICAgICAjCiAgICAgICAgICAg"
+    "ICAgIyBObyBvdXRjb21lIGNoYW5nZXM6IGV2ZXJ5IHN0YXRlIHRoYXQgdXNlZCB0byB0aW1lIG91"
+    "dCBhbHJlYWR5CiAgICAgICAgICAgICAgIyBlbmRlZCBpbiBzdGVwIGZhaWx1cmUuIEl0IG5vdyBn"
+    "ZXRzIHRoZXJlIGluIH4yMHMgaW5zdGVhZCBvZgogICAgICAgICAgICAgICMgfjYwMHMuCiAgICAg"
+    "ICAgICAgICAgaWYgWyAiJFNUQVRVUyIgPSAic3VjY2VzcyIgXTsgdGhlbgogICAgICAgICAgICAg"
+    "ICAgZWNobyAiICDinIUgJHtjaGVja19uYW1lfTogcGFzc2VkIgogICAgICAgICAgICAgIGVsaWYg"
+    "WyAtbiAiJFNUQVRVUyIgXTsgdGhlbgogICAgICAgICAgICAgICAgZWNobyAiICDinYwgJHtjaGVj"
+    "a19uYW1lfTogJHtTVEFUVVN9IChjb21wbGV0ZWQsIG5vdCBzdWNjZXNzKSDigJQgd2lsbCBOT1Qg"
+    "YXBwcm92ZSIKICAgICAgICAgICAgICAgIGV4aXQgMQogICAgICAgICAgICAgIGVsc2UKICAgICAg"
+    "ICAgICAgICAgIGVjaG8gIiAg4o+zICR7Y2hlY2tfbmFtZX06IG5vIGNvbmNsdXNpb24geWV0IChh"
+    "dHRlbXB0ICQoKEFUVEVNUFQrMSkpLyR7TUFYX0FUVEVNUFRTfSkiCiAgICAgICAgICAgICAgICBB"
+    "TExfUEFTU0VEPWZhbHNlCiAgICAgICAgICAgICAgZmkKICAgICAgICAgICAgZG9uZQoKICAgICAg"
+    "ICAgICAgaWYgWyAiJEFMTF9QQVNTRUQiID0gdHJ1ZSBdOyB0aGVuCiAgICAgICAgICAgICAgZWNo"
+    "byAiIgogICAgICAgICAgICAgIGVjaG8gIkFsbCByZXF1aXJlZCBjaGVja3MgcGFzc2VkLiIKICAg"
+    "ICAgICAgICAgICBleGl0IDAKICAgICAgICAgICAgZmkKCiAgICAgICAgICAgIEFUVEVNUFQ9JCgo"
+    "QVRURU1QVCsxKSkKICAgICAgICAgICAgc2xlZXAgMjAKICAgICAgICAgIGRvbmUKCiAgICAgICAg"
+    "ICBlY2hvICLinYwgVGltZWQgb3V0IGFmdGVyICQoKE1BWF9BVFRFTVBUUyAqIDIwKSlzIOKAlCBy"
+    "ZXF1aXJlZCBjaGVjayBuZXZlciByZXBvcnRlZCBhIGNvbmNsdXNpb24uIgogICAgICAgICAgZWNo"
+    "byAiICAgTW9zdCBsaWtlbHkgdGhlIGNoZWNrIHdhcyBuZXZlciBjcmVhdGVkOiB2ZXJpZnkgdGhl"
+    "IG5hbWUgaW4iCiAgICAgICAgICBlY2hvICIgICB0aGUgcmVxdWlyZWRfY2hlY2tzIGlucHV0IG1h"
+    "dGNoZXMgd2hhdCB0aGUgcmVwb3J0aW5nIHNlcnZpY2UgcG9zdHMuIgogICAgICAgICAgZXhpdCAx"
+    "CgogICAgICAtIG5hbWU6IEFwcHJvdmUgUFIKICAgICAgICBlbnY6CiAgICAgICAgICBHSF9UT0tF"
+    "TjogJHt7IHN0ZXBzLmFwcC10b2tlbi5vdXRwdXRzLnRva2VuIH19CiAgICAgICAgICBQUl9OVU1C"
+    "RVI6ICR7eyBnaXRodWIuZXZlbnQucHVsbF9yZXF1ZXN0Lm51bWJlciB9fQogICAgICAgICAgUkVQ"
+    "TzogJHt7IGdpdGh1Yi5yZXBvc2l0b3J5IH19CiAgICAgICAgcnVuOiB8CiAgICAgICAgICBlY2hv"
+    "ICJTdWJtaXR0aW5nIGFwcHJvdmluZyByZXZpZXcgYXMgR2l0SHViIEFwcC4uLiIKCiAgICAgICAg"
+    "ICBnaCBhcGkgXAogICAgICAgICAgICAicmVwb3MvJHtSRVBPfS9wdWxscy8ke1BSX05VTUJFUn0v"
+    "cmV2aWV3cyIgXAogICAgICAgICAgICAtZiBldmVudD0iQVBQUk9WRSIgXAogICAgICAgICAgICAt"
+    "ZiBib2R5PSJBdXRvLWFwcHJvdmVkOiBhbGwgcmVxdWlyZWQgY2hlY2tzIHBhc3NlZC4g8J+kliIK"
+    "CiAgICAgICAgICBlY2hvICLinIUgUFIgIyR7UFJfTlVNQkVSfSBhcHByb3ZlZCBieSBBc3NlbWJs"
+    "eVplcm8gUmV2aWV3ZXIiCg=="
+)
+
+# Sanity-checked before anything is sent: a corrupted payload must not reach the
+# API looking like a successful deploy.
+EXPECTED_MARKERS = (
+    'elif [ -n "$STATUS" ]; then',
+    "MAX_ATTEMPTS=15",
+    "name: auto-reviewer",
+)
+
+PR_BODY = f"""## The defect
+
+`auto-reviewer.yml`'s "Wait for required checks" step treated every conclusion
+except `failure` and `cancelled` as still-pending, and polled 30 times at
+20-second intervals before giving up.
+
+**GitHub sets `conclusion` only when a check run has completed.** A non-empty
+conclusion is a finished answer, so the loop was re-asking a settled question
+for ten minutes. `action_required` -- what the sentinel posts when its
+issue-reference regex extracts a ref it cannot validate -- landed squarely in
+that gap.
+
+Observed step timing:
+
+```
+- Generate App token         [success]     1s
+- Wait for required checks   [FAILURE]   611s
+- Approve PR                 [skipped]     0s
+```
+
+Measured across the private fleet in August: **29 runs died this way, about 300
+billed minutes** -- roughly 10% of the monthly Actions allowance, spent entirely
+on waiting. 22 of the 29 fell inside one three-day window, which is the shape of
+checks not being reported rather than routine per-PR error. The ten-minute price
+tag is paid identically either way, and that part is ours.
+
+## The change
+
+**Any non-empty conclusion is terminal.** Inverted rather than extended.
+Enumerating states is how `action_required` was missed in the first place; a
+longer allowlist leaves the next unlisted conclusion to be discovered the same
+way, in ten-minute increments.
+
+**No outcome changes.** Every state that previously timed out already ended in
+step failure. It now gets there in ~20 seconds instead of ~600.
+
+**The ceiling drops 30 -> 15 attempts** (10 minutes -> 5). With the above, the
+only remaining path to the ceiling is a check that was never created at all --
+a name mismatch, or the reporting service being unreachable. Five minutes is far
+beyond normal reporting latency.
+
+## Verification
+
+`tests/test_auto_reviewer_wait_loop.py` extracts this exact `run:` block from
+the YAML and executes it under bash against a stub `gh`, so what is asserted is
+the shipped text rather than a paraphrase. The loop cannot move to a script file
+-- this is a reusable workflow, and a caller repo has no checkout of this one.
+
+16 tests: each terminal conclusion exits in under 15s, `success` still approves,
+an empty conclusion still polls (asserted by letting it poll and killing it, not
+by sitting through the ceiling), and the ceiling is pinned at 15.
+
+Proven non-vacuous by reverting the terminal test to the old allowlist, which
+fails 7 of them -- all six terminal states plus the structural check that the
+fix is not simply a longer list.
+
+Landed via the Contents API because `.github/workflows/*` requires `workflow`
+scope (ADR-0216). Script: `tools/deploy_auto_reviewer_poll_fix.py`, generated
+from the tested file with the workflow embedded base64 so the landed bytes are
+the tested bytes.
+
+Closes #{ISSUE_NUMBER}
+"""
+
+
+def _request(pat: str, method: str, url: str, payload: dict | None = None):
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={
+            "Authorization": f"Bearer {pat}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+            "User-Agent": "assemblyzero-deploy-auto-reviewer-poll-fix",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8")
+            return resp.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return 404, {}
+        detail = e.read().decode("utf-8", "replace")[:400]
+        raise SystemExit(f"HTTP {e.code} on {method} {url}\n{detail}") from e
+
+
+def exists(pat: str, url: str) -> bool:
+    status, _ = _request(pat, "GET", url)
+    return status != 404
+
+
+def main() -> int:
+    content = base64.b64decode(WORKFLOW_B64)
+    text = content.decode("utf-8")
+    for marker in EXPECTED_MARKERS:
+        if marker not in text:
+            raise SystemExit(f"ABORT: embedded workflow is missing {marker!r} -- regenerate")
+    if b"\r\n" in content:
+        raise SystemExit("ABORT: embedded workflow has CRLF line endings")
+    print(f"Payload verified: {len(content)} bytes, {len(text.splitlines())} lines")
+
+    base = f"{GH_API}/repos/{GITHUB_USER}/{REPO}"
+    print(f"Target: {GITHUB_USER}/{REPO}  branch: {BRANCH}")
+    print()
+
+    with classic_pat_session() as pat:
+        _, open_prs = _request(
+            pat, "GET", f"{base}/pulls?state=open&head={GITHUB_USER}:{BRANCH}&per_page=10"
+        )
+        if open_prs:
+            pr = open_prs[0]
+            print(f"  Open PR already exists: #{pr['number']} {pr['html_url']}")
+            print("  No-op. Merge through the normal flow.")
+            return 0
+
+        if not exists(pat, f"{base}/git/refs/heads/{BRANCH}"):
+            _, ref = _request(pat, "GET", f"{base}/git/refs/heads/main")
+            sha = ref["object"]["sha"]
+            print(f"  Creating branch {BRANCH} from main@{sha[:7]}...")
+            _request(pat, "POST", f"{base}/git/refs",
+                     {"ref": f"refs/heads/{BRANCH}", "sha": sha})
+        else:
+            print(f"  Branch {BRANCH} already on origin.")
+
+        _, current = _request(pat, "GET", f"{base}/contents/{WORKFLOW_PATH}?ref={BRANCH}")
+        blob_sha = current.get("sha")
+        if blob_sha and base64.b64decode(current.get("content", "")) == content:
+            print("  Workflow already up to date on the branch.")
+        else:
+            print(f"  PUT {WORKFLOW_PATH} on {BRANCH}...")
+            payload = {
+                "message": TITLE,
+                "content": base64.b64encode(content).decode("ascii"),
+                "branch": BRANCH,
+            }
+            if blob_sha:
+                payload["sha"] = blob_sha
+            _request(pat, "PUT", f"{base}/contents/{WORKFLOW_PATH}", payload)
+            print("    succeeded.")
+
+        print("  Opening PR...")
+        _, pr = _request(pat, "POST", f"{base}/pulls", {
+            "title": TITLE, "head": BRANCH, "base": "main", "body": PR_BODY,
+        })
+        print()
+        print(f"PR #{pr['number']} opened: {pr['html_url']}")
+        print()
+        print("This changes the workflow EVERY repo calls, so watch the first")
+        print("agent PR that merges after it: the wait step should now settle in")
+        print("seconds, and a stuck check should fail in ~20s rather than 10 min.")
+        print()
+        print(f"  gh pr merge {pr['number']} --squash --repo {GITHUB_USER}/{REPO}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The defect

`auto-reviewer.yml`'s "Wait for required checks" step treated every conclusion
except `failure` and `cancelled` as still-pending, and polled 30 times at
20-second intervals before giving up.

**GitHub sets `conclusion` only when a check run has completed.** A non-empty
conclusion is a finished answer, so the loop was re-asking a settled question
for ten minutes. `action_required` -- what the sentinel posts when its
issue-reference regex extracts a ref it cannot validate -- landed squarely in
that gap.

Observed step timing:

```
- Generate App token         [success]     1s
- Wait for required checks   [FAILURE]   611s
- Approve PR                 [skipped]     0s
```

Measured across the private fleet in August: **29 runs died this way, about 300
billed minutes** -- roughly 10% of the monthly Actions allowance, spent entirely
on waiting. 22 of the 29 fell inside one three-day window, which is the shape of
checks not being reported rather than routine per-PR error. The ten-minute price
tag is paid identically either way, and that part is ours.

## The change

**Any non-empty conclusion is terminal.** Inverted rather than extended.
Enumerating states is how `action_required` was missed in the first place; a
longer allowlist leaves the next unlisted conclusion to be discovered the same
way, in ten-minute increments.

**No outcome changes.** Every state that previously timed out already ended in
step failure. It now gets there in ~20 seconds instead of ~600.

**The ceiling drops 30 -> 15 attempts** (10 minutes -> 5). With the above, the
only remaining path to the ceiling is a check that was never created at all --
a name mismatch, or the reporting service being unreachable. Five minutes is far
beyond normal reporting latency.

## Verification

`tests/test_auto_reviewer_wait_loop.py` extracts this exact `run:` block from
the YAML and executes it under bash against a stub `gh`, so what is asserted is
the shipped text rather than a paraphrase. The loop cannot move to a script file
-- this is a reusable workflow, and a caller repo has no checkout of this one.

16 tests: each terminal conclusion exits in under 15s, `success` still approves,
an empty conclusion still polls (asserted by letting it poll and killing it, not
by sitting through the ceiling), and the ceiling is pinned at 15.

Proven non-vacuous by reverting the terminal test to the old allowlist, which
fails 7 of them -- all six terminal states plus the structural check that the
fix is not simply a longer list.

Landed via the Contents API because `.github/workflows/*` requires `workflow`
scope (ADR-0216). Script: `tools/deploy_auto_reviewer_poll_fix.py`, generated
from the tested file with the workflow embedded base64 so the landed bytes are
the tested bytes.

Closes #2627
