### PR TITLE
fix: coverage is measured or named absent, never rendered as a number (Closes #2636, Closes #2637, Closes #2638)

### DIFF
--- a/assemblyzero/workflows/testing/coverage_report.py
+++ b/assemblyzero/workflows/testing/coverage_report.py
@@ -1,0 +1,193 @@
+"""One reader of the coverage report, three states (#2637).
+
+The denominator law (#2546/#2552/#2608) had one door left open: a file ABSENT
+from the coverage report was rendered as a number. Two consumers read the same
+empty report and disagreed, three log lines apart, on boostgauge's
+`run-issue331-201554`:
+
+    [N5]  15 passed, 0 failed | Coverage: 0.0%
+    [N5]  all 15 test(s) pass; coverage 0.0% < 95% target -- this is a test
+          gap, routing to test additions (never to implementation)
+    [N4c] coverage report named no uncovered lines; nothing specific to
+          target -- returning to verification
+
+Both readings are wrong and they cannot both be right about a measured file:
+at a genuine 0% every line is uncovered, so N4c would have had a full target
+list. Together they prove the file was never in the report. N5 renders the
+absence as a percentage and routes to test additions; N4c renders it as
+all-clear and bounces back; the ping-pong ends in a stagnation halt that blames
+the LLD and spec -- the two artifacts that had just passed.
+
+## Why the report was empty
+
+`--cov` takes a module name or a directory. Given a path ending in `.py` it
+treats the string as a module name, never imports it, and collects nothing:
+
+    --cov=src/pkg/mod.py  -> CoverageWarning: Module ... was never imported
+                             CoverageWarning: No data was collected
+                             WARNING: Failed to generate report: No data to report
+
+No table is printed at all -- so the percent regex finds nothing and defaults
+to 0.0, and the missing-lines parser finds nothing and reports "no uncovered
+lines". #2636 fixes the target derivation; this module makes the failure
+unmistakable when a target is wrong for any other reason.
+
+## Three states, one accessor
+
+* **measured** -- a TOTAL row exists and the number is real.
+* **measured at zero** -- a TOTAL row exists reading 0%, with every line
+  uncovered and nameable. A genuine test gap, and it still routes to test
+  additions.
+* **absent** -- no TOTAL row, or the target file appears nowhere in the table.
+  A MEASUREMENT FAILURE, named: what was asked for, and what the report
+  actually contained.
+
+Two parsers of one report is the #1698 class, and the N5/N4c contradiction is
+the live proof, so both consume this.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+#: A `--cov-report=term-missing` data row: `path  Stmts  Miss  Cover  Missing`.
+#: `[^\S\n]` is horizontal whitespace, NOT `\s`. `\s` matches newlines, so a
+#: `\s`-separated optional Missing column ran past the end of its own row and
+#: swallowed the report's `-----` separator as a missing-line range -- a file
+#: at 100% then read as having uncovered lines. Rows are line-scoped by
+#: construction here, and the Missing column must start with a digit so a
+#: separator can never open one.
+_ROW_RE = re.compile(
+    r"^(?P<path>[^\s|]+\.py)[^\S\n]+(?P<stmts>\d+)[^\S\n]+(?P<miss>\d+)"
+    r"[^\S\n]+(?P<cover>\d+)%"
+    r"(?:[^\S\n]+(?P<missing>\d[\d,\-\s]*?))?[^\S\n]*$",
+    re.MULTILINE,
+)
+
+#: The report's footer. Its presence is what separates "measured" from
+#: "absent" -- pytest-cov prints no table at all when nothing was collected.
+_TOTAL_RE = re.compile(r"^TOTAL\s+\d+\s+\d+\s+(\d+)%", re.MULTILINE)
+
+#: coverage.py's own words when the target named nothing importable. Recorded
+#: because they say WHY better than any inference from an empty table.
+_NO_DATA_MARKERS = (
+    "was never imported",
+    "No data was collected",
+    "Failed to generate report",
+)
+
+MEASURED = "measured"
+ABSENT = "absent"
+
+
+@dataclass(frozen=True)
+class CoverageReading:
+    """What the coverage report actually says. Never a guess."""
+
+    state: str
+    #: None when absent -- deliberately not 0.0, so a caller that forgets to
+    #: check `state` gets a TypeError rather than a plausible wrong number.
+    percent: float | None
+    uncovered: dict[str, list[str]] = field(default_factory=dict)
+    files: list[str] = field(default_factory=list)
+    target: str = ""
+    reasons: list[str] = field(default_factory=list)
+
+    @property
+    def measured(self) -> bool:
+        return self.state == MEASURED
+
+    @property
+    def at_zero(self) -> bool:
+        return self.measured and (self.percent or 0.0) <= 0.0
+
+    def failure_message(self) -> str:
+        """Why the measurement failed, naming what was sought and what was found.
+
+        Never a percentage and never a test gap: nothing was measured, so
+        there is no coverage arithmetic to report and no conclusion to draw
+        about the tests or about the LLD and spec.
+        """
+        sought = f"`{self.target}`" if self.target else "the coverage target"
+        if self.files:
+            found = f"the report covers: {', '.join(self.files[:8])}"
+            if len(self.files) > 8:
+                found += f" (and {len(self.files) - 8} more)"
+        else:
+            found = "the report contains no files at all"
+        why = f" coverage said: {'; '.join(self.reasons)}." if self.reasons else ""
+        return (
+            f"COVERAGE MEASUREMENT FAILED: {sought} does not appear in the "
+            f"coverage report, so no percentage exists to judge -- {found}.{why} "
+            f"This is a harness/measurement defect, not a test gap and not a "
+            f"defect in the LLD or spec."
+        )
+
+
+def read_coverage(output: str, target: str = "") -> CoverageReading:
+    """The single reading of a pytest-cov term-missing report (#2637)."""
+    text = output or ""
+    reasons = [m for m in _NO_DATA_MARKERS if m in text]
+
+    rows = list(_ROW_RE.finditer(text))
+    files = [m.group("path").replace("\\", "/") for m in rows]
+    total = _TOTAL_RE.search(text)
+
+    if total is None:
+        return CoverageReading(
+            state=ABSENT, percent=None, files=files, target=target,
+            reasons=reasons,
+        )
+
+    if target and files and not _target_in(target, files):
+        # A table exists, listing files, and ours is not among them: coverage
+        # measured something, just not the thing under test.
+        #
+        # `files` must be non-empty for this branch. A TOTAL row with no
+        # parseable data rows means coverage RAN -- an abbreviated or
+        # unusually formatted report is not a measurement failure, and calling
+        # it one would fail runs whose only sin is a layout this regex does
+        # not recognise. Absence is claimed only on positive evidence: no
+        # TOTAL at all, or a file list that demonstrably excludes the target.
+        return CoverageReading(
+            state=ABSENT, percent=None, files=files, target=target,
+            reasons=reasons,
+        )
+
+    uncovered: dict[str, list[str]] = {}
+    for match in rows:
+        missing = (match.group("missing") or "").strip()
+        if not missing:
+            continue
+        uncovered[match.group("path").replace("\\", "/")] = [
+            part.strip() for part in missing.split(",") if part.strip()
+        ]
+
+    return CoverageReading(
+        state=MEASURED,
+        percent=float(total.group(1)),
+        uncovered=uncovered,
+        files=files,
+        target=target,
+        reasons=reasons,
+    )
+
+
+def _target_in(target: str, files: list[str]) -> bool:
+    """Does the report contain the file the target names?
+
+    A target is a module (`pkg.mod`), a directory (`tools`) or, before #2636,
+    a path (`src/pkg/mod.py`). All three are matched against the report's
+    file paths by their dotted-or-slashed stem, so the accessor does not need
+    to know which form the caller used.
+    """
+    normalised = target.replace("\\", "/")
+    if normalised.endswith(".py"):
+        normalised = normalised[:-3]
+    as_path = normalised.replace(".", "/")
+    for path in files:
+        stem = path[:-3] if path.endswith(".py") else path
+        if stem == as_path or stem.endswith("/" + as_path) or as_path in stem:
+            return True
+    return False

--- a/assemblyzero/workflows/testing/nodes/augment_tests.py
+++ b/assemblyzero/workflows/testing/nodes/augment_tests.py
@@ -194,7 +194,19 @@ def augment_tests_for_coverage(state: TestingWorkflowState) -> dict[str, Any]:
         print("    [N4c] no test file to extend — returning to verification")
         return {"next_node": "N5_verify_green", "error_message": ""}
 
-    uncovered = parse_uncovered_lines(output)
+    # #2637: read the report ONCE, through the accessor N5 also uses. This
+    # branch used to render an ABSENT target as "no uncovered lines" -- an
+    # all-clear -- while N5 rendered the same empty report as "0.0%" and
+    # routed here. Neither had measured anything, and the two bounced until a
+    # stagnation halt blamed the LLD and spec.
+    from assemblyzero.workflows.testing.coverage_report import read_coverage
+
+    reading = read_coverage(output, state.get("coverage_module", "") or "")
+    if not reading.measured:
+        print(f"    [N4c] {reading.failure_message()}")
+        return {"next_node": "end", "error_message": reading.failure_message()}
+
+    uncovered = reading.uncovered
     if not uncovered:
         print(
             "    [N4c] coverage report named no uncovered lines; nothing "

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -503,12 +503,19 @@ def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
     # for (#475): `--cov=tools/thing.py` collects nothing, while `--cov=tools`
     # and `--cov=thing` both measure it. So the fallback degrades to the
     # containing DIRECTORY, which pytest-cov does accept and does report.
-    parent = rel.parent
-    if str(parent) not in ("", "."):
-        return str(parent).replace("\\", "/")
+    # Normalise separators BEFORE splitting. On POSIX a backslash is an
+    # ordinary filename character, so `Path("tools\\x.py").parent` is `.` and
+    # the stem keeps the backslash -- the target then differs by platform for
+    # the same input. Caught by CI on Linux while Windows passed.
+    normalised = str(rel).replace("\\", "/")
+    if normalised.endswith(".py"):
+        normalised = normalised[:-3]
+    head, sep, _tail = normalised.rpartition("/")
+    if sep and head:
+        return head
     # A script at the repo root has no directory to fall back to; its own stem
     # is the importable module name.
-    return rel.stem
+    return normalised
 
 
 def _pytest_env() -> dict[str, str]:

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -394,14 +394,46 @@ _COV_SOURCE_ROOT_PREFIXES: tuple[str, ...] = (
 
 
 def _is_python_package_dir(d: Path) -> bool:
-    """True if `d` is a Python package — regular (`__init__.py`) or PEP 420
-    namespace (directory with `.py` files but no `__init__.py`)."""
+    """True if `d` is a Python package — regular (`__init__.py`), PEP 420
+    namespace (holds `.py` files), or a namespace whose modules all live in
+    SUBPACKAGES (#2636).
+
+    The third case is what broke boostgauge #331. The check used to ask only
+    whether `d` held a `.py` file at its own top level:
+
+        return any(f.suffix == ".py" for f in d.iterdir() if f.is_file())
+
+    `src/boostgauge/` held exactly one entry — the directory `skins/` — so
+    `is_file()` filtered it out, the answer was False, and
+    `_path_to_cov_target` fell through to its file-path form, which measures
+    nothing. A package whose modules all live one level deeper answered "not
+    a package".
+
+    State-sensitive, not a code regression: the same function returned module
+    form on 08-26, when that worktree still carried `src/boostgauge/__init__.py`
+    and several sibling modules. Nothing in the derivation changed between the
+    runs; the tree did.
+    """
     try:
         if not d.is_dir():
             return False
         if (d / "__init__.py").exists():
             return True
-        return any(f.suffix == ".py" for f in d.iterdir() if f.is_file())
+        entries = list(d.iterdir())
+        if any(f.suffix == ".py" for f in entries if f.is_file()):
+            return True
+        # A directory of directories is still a package root when one of them
+        # is itself a package. Bounded to a single level deliberately: this
+        # answers "is `d` importable as a package", and an unbounded walk would
+        # call any directory with a stray .py file anywhere beneath it one.
+        return any(
+            sub.is_dir()
+            and (
+                (sub / "__init__.py").exists()
+                or any(f.suffix == ".py" for f in sub.iterdir() if f.is_file())
+            )
+            for sub in entries
+        )
     except (OSError, PermissionError):
         return False
 
@@ -454,8 +486,29 @@ def _path_to_cov_target(rel_path: str | Path, repo_root: Path | None) -> str:
                 break
         return module
 
-    # Return as a file path — pytest-cov accepts paths for non-package code
-    return str(rel).replace("\\", "/")
+    # #2636: NEVER a path ending in `.py`. `--cov` takes a module name or a
+    # directory; a file path is treated as a module name, is never imported,
+    # and collects nothing at all -- coverage warns `module-not-imported`,
+    # then `no-data-collected`, and pytest-cov emits no report. The target file
+    # is then ABSENT from the report rather than present at 0%, which is what
+    # N5 renders as "0.0%" while N4c finds no uncovered lines to name (#2637).
+    #
+    # Measured, with PYTHONPATH pointing at the very directory holding the
+    # measured file, so the import resolved to exactly it:
+    #
+    #     --cov=src/pkg/mod.py  -> "Module src/pkg/mod.py was never imported"
+    #     --cov=pkg.mod         -> src\pkg\mod.py   7   0   100%
+    #
+    # The same is true of the standalone-script case this branch was written
+    # for (#475): `--cov=tools/thing.py` collects nothing, while `--cov=tools`
+    # and `--cov=thing` both measure it. So the fallback degrades to the
+    # containing DIRECTORY, which pytest-cov does accept and does report.
+    parent = rel.parent
+    if str(parent) not in ("", "."):
+        return str(parent).replace("\\", "/")
+    # A script at the repo root has no directory to fall back to; its own stem
+    # is the importable module name.
+    return rel.stem
 
 
 def _pytest_env() -> dict[str, str]:
@@ -755,6 +808,42 @@ def _implementation_already_exists(state: TestingWorkflowState) -> bool:
     return any((repo_root / path).is_file() for path in targets)
 
 
+def _tests_are_an_implementation_target(state: TestingWorkflowState) -> bool:
+    """Will the implementation stage rewrite the test file(s)? (#2638)
+
+    When it will, "no implementation can make this suite green" is true of the
+    bodies in front of us and irrelevant to the run: the bodies are about to be
+    replaced. boostgauge `run-issue331-201554` printed the non-convergence
+    prediction and then listed `tests/visual/test_stingray_static.py` among its
+    implementation targets four lines later; 22 placeholders became 15 real
+    tests and the suite went green.
+
+    Read from the same state the stage itself uses, so the claim and the
+    evidence cannot disagree.
+    """
+    targets = state.get("files_to_implement") or state.get("implementation_files") or []
+    paths: list[str] = []
+    for entry in targets:
+        if isinstance(entry, dict):
+            candidate = entry.get("path", "")
+        else:
+            candidate = str(entry)
+        if candidate:
+            paths.append(candidate.replace("\\", "/").lower())
+    if not paths:
+        return False
+    test_files = [
+        str(t).replace("\\", "/").lower() for t in (state.get("test_files") or [])
+    ]
+    if test_files:
+        return any(
+            any(path.endswith(tf) or tf.endswith(path) for path in paths)
+            for tf in test_files
+        )
+    # No test-file list to match against: fall back to the shape of the target.
+    return any("test" in Path(p).name for p in paths)
+
+
 def _describe_hollow_suite(state: TestingWorkflowState) -> str:
     """Describe a scaffold that cannot pass, or '' when it might (#2322).
 
@@ -931,11 +1020,29 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
                         "scaffold_validation_errors": [hollow],
                         "error_message": "",
                     }
-                print(
-                    "    the spec supplies no test bodies, so re-scaffolding "
-                    "cannot improve on this -- continuing, but the "
-                    "implementation loop cannot converge against these tests"
-                )
+                # #2638: the non-convergence claim is a PREDICTION, and it was
+                # false on run-issue331-201554. The implementation stage lists
+                # the test file among its own targets and rewrites it: 22
+                # placeholders named `test_tNNN` became 15 real tests named
+                # `test_req_NNN_...`, and the suite went green two iterations
+                # later. The evidence that would have prevented the claim was
+                # in state -- `files_to_implement` -- and was printed four
+                # lines afterwards. Registry class 2: a message naming a cause
+                # it did not read evidence for.
+                if _tests_are_an_implementation_target(state):
+                    print(
+                        "    the spec supplies no test bodies, but the "
+                        "implementation stage owns the test file(s) and will "
+                        "rewrite them -- these placeholders are replaced, not "
+                        "satisfied"
+                    )
+                else:
+                    print(
+                        "    the spec supplies no test bodies, so "
+                        "re-scaffolding cannot improve on this -- continuing, "
+                        "but the implementation loop cannot converge against "
+                        "these tests"
+                    )
             print(
                 f"    [EXIT CODE {exit_code}] ImportError on expected module(s) "
                 f"-> valid red signal, routing to implementation"
@@ -1682,6 +1789,48 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     failed_count = parsed.get("failed", 0)
     error_count = parsed.get("errors", 0)
     coverage_achieved = parsed.get("coverage", 0)
+
+    # #2637: before any coverage arithmetic, establish that coverage was
+    # MEASURED. A target absent from the report yields no TOTAL row, the
+    # percent parser defaults to 0.0, and 0.0 is then indistinguishable from a
+    # genuinely untested module -- which is how 15 passing tests were routed to
+    # "test gap" while N4c, reading the same empty report, found nothing to
+    # target and bounced back. Absence is a measurement failure and halts as
+    # one, naming what was sought and what the report held. It never blames
+    # the LLD or the spec, which is what the stagnation halt did.
+    # Three conditions, each of them narrowing this to the case it is for.
+    #
+    # * Tests passing and none failing -- while tests fail the run routes on
+    #   the failures and never consults coverage.
+    # * At least one test ACTUALLY RAN. Zero collected belongs to #2548's
+    #   law, which names the collection error; that diagnosis is more specific
+    #   and must not be preempted by a coverage complaint.
+    # * The number is about to be read as a SHORTFALL. At or above target the
+    #   run succeeds either way, and second-guessing a report that harmed
+    #   nothing would fail runs over an unfamiliar layout.
+    from assemblyzero.workflows.testing.coverage_report import read_coverage
+
+    _reading = read_coverage(output, coverage_module or "")
+    _below_target = coverage_achieved < state.get("coverage_target", 90)
+    if (
+        failed_count == 0
+        and error_count == 0
+        and passed_count > 0
+        and _below_target
+        and not _reading.measured
+    ):
+        _msg = _reading.failure_message()
+        print(f"    [N5] {_msg}")
+        return {
+            "green_phase_output": output,
+            "coverage_achieved": 0.0,
+            "previous_passed": passed_count,
+            "file_counter": file_num,
+            "pytest_exit_code": exit_code,
+            "iteration_count": iteration_count + 1,
+            "next_node": "end",
+            "error_message": _msg,
+        }
 
     # Stagnation detection: coverage must improve by >=1% each iteration
     previous_coverage = state.get("previous_coverage", -1.0)

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -83,18 +83,21 @@ def test_src_layout_namespace_package(tmp_path: Path) -> None:
     assert result == "chiron.provenance"
 
 
-def test_src_layout_empty_subdir_falls_back_to_path(tmp_path: Path) -> None:
+def test_src_layout_empty_subdir_is_not_a_package(tmp_path: Path) -> None:
     """Closes #1506. Guard against accidental over-acceptance: when
-    src/<subdir>/ exists but is EMPTY (no __init__.py, no .py files),
-    do NOT treat it as a namespace package — fall through to file path
-    form. Keeps the existing tools/-style "non-package dir" semantics
-    intact when an empty placeholder happens to be under src/."""
+    src/<subdir>/ exists but is EMPTY (no __init__.py, no .py files, no
+    package subdirectory), do NOT treat it as a namespace package.
+
+    #2636 kept the non-acceptance and changed only what the fallback RETURNS:
+    the containing directory rather than a `.py` path, because a path ending
+    in `.py` measures nothing at all.
+    """
     (tmp_path / "src" / "data").mkdir(parents=True)
-    # Empty dir: no .py, no __init__.py.
+    # Empty dir: no .py, no __init__.py, no package subdir.
 
     result = _path_to_cov_target("src/data/example.py", tmp_path)
-    # The directory exists but isn't a package — file-path fallback.
-    assert result == "src/data/example.py"
+    # Still not a package — but a measurable fallback.
+    assert result == "src/data"
 
 
 def test_lib_layout_strips_prefix(tmp_path: Path) -> None:
@@ -121,35 +124,73 @@ def test_source_layout_strips_prefix(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_tools_path_returns_file_path(tmp_path: Path) -> None:
-    """tools/ script (no __init__.py) → file path format."""
+def test_tools_script_returns_its_directory(tmp_path: Path) -> None:
+    """tools/ script (no __init__.py) → the DIRECTORY, not the file (#2636).
+
+    #475 introduced the file-path form so "pytest-cov measures the right
+    file". Measured, it measures nothing:
+
+        --cov=tools/thing.py  ->  Module tools/thing.py was never imported
+                                  No data was collected
+        --cov=tools           ->  tools\\thing.py   4   1   75%
+
+    `--cov` takes a module name or a directory. A path ending in `.py` is
+    read as a module name, is never imported, and produces no report at all --
+    which N5 then renders as "0.0%" and N4c as "no uncovered lines" (#2637).
+    """
     (tmp_path / "tools").mkdir(exist_ok=True)
     # No __init__.py in tools/
 
     result = _path_to_cov_target("tools/consolidate_logs.py", tmp_path)
-    assert result == "tools/consolidate_logs.py"
+    assert result == "tools"
 
 
-def test_tools_nested_path(tmp_path: Path) -> None:
-    """Nested tools/ script → file path with forward slashes."""
+def test_tools_nested_script_returns_its_directory(tmp_path: Path) -> None:
+    """Nested tools/ script → its own directory, forward slashes."""
     (tmp_path / "tools").mkdir(exist_ok=True)
 
     result = _path_to_cov_target("tools/sub/my_script.py", tmp_path)
-    assert result == "tools/sub/my_script.py"
+    assert result == "tools/sub"
 
 
-def test_scripts_dir_returns_file_path(tmp_path: Path) -> None:
-    """scripts/ directory (no __init__.py) → file path format."""
+def test_scripts_dir_returns_its_directory(tmp_path: Path) -> None:
+    """scripts/ directory (no __init__.py) → the directory."""
     (tmp_path / "scripts").mkdir(exist_ok=True)
 
     result = _path_to_cov_target("scripts/deploy.py", tmp_path)
-    assert result == "scripts/deploy.py"
+    assert result == "scripts"
 
 
-def test_no_repo_root_returns_file_path() -> None:
-    """No repo_root → can't check __init__.py, returns file path."""
+def test_no_repo_root_returns_the_directory() -> None:
+    """No repo_root → cannot check for __init__.py, so not a package; the
+    directory is still measurable where the file path is not."""
     result = _path_to_cov_target("tools/foo.py", None)
-    assert result == "tools/foo.py"
+    assert result == "tools"
+
+
+def test_a_root_level_script_returns_its_module_name() -> None:
+    """No directory to fall back to, so the importable stem is the target.
+    `--cov=thing` measures `thing.py`; `--cov=thing.py` measures nothing."""
+    assert _path_to_cov_target("thing.py", None) == "thing"
+
+
+def test_the_target_never_ends_in_py(tmp_path: Path) -> None:
+    """The invariant behind all of the above, stated once (#2636).
+
+    Whatever branch runs, the returned target must never be a `.py` path --
+    that form collects no data for any input, package or script.
+    """
+    (tmp_path / "tools").mkdir(exist_ok=True)
+    (tmp_path / "src" / "data").mkdir(parents=True)
+    for candidate in (
+        "tools/consolidate_logs.py",
+        "tools/sub/my_script.py",
+        "src/data/example.py",
+        "thing.py",
+    ):
+        assert not _path_to_cov_target(candidate, tmp_path).endswith(".py"), (
+            candidate
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -165,12 +206,13 @@ def test_backslash_normalized(tmp_path: Path) -> None:
     assert "/" in result or "\\" not in result  # No backslashes in output
 
 
-def test_non_py_file_keeps_extension(tmp_path: Path) -> None:
-    """Non-.py file → keeps its extension in path mode."""
+def test_non_py_file_falls_back_to_its_directory(tmp_path: Path) -> None:
+    """A non-.py target is not measurable at all, so the directory is the
+    only useful answer (#2636)."""
     (tmp_path / "tools").mkdir(exist_ok=True)
 
     result = _path_to_cov_target("tools/config.yml", tmp_path)
-    assert result == "tools/config.yml"
+    assert result == "tools"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_coverage_measurement_law.py
+++ b/tests/unit/test_coverage_measurement_law.py
@@ -1,0 +1,426 @@
+"""Coverage is measured or it is named absent — never rendered as a number.
+
+The boostgauge #331 roll of 2026-08-28 (`run-issue331-201554`) wrote the
+renderer, passed 15 tests, and halted anyway:
+
+    [N5]  15 passed, 0 failed | Coverage: 0.0%
+    [N5]  all 15 test(s) pass; coverage 0.0% < 95% -- this is a test gap,
+          routing to test additions (never to implementation)
+    [N4c] coverage report named no uncovered lines; nothing specific to
+          target -- returning to verification
+    [STAGNANT] Coverage stagnant: 0.0% -> 0.0%. ... The LLD or spec likely
+          needs manual editing
+
+Three renderings of one empty measurement, and the halt blamed the two
+artifacts that had just passed.
+
+**Neither issue's stated mechanism survived the evidence.** No PR regressed the
+derivation -- `_path_to_cov_target` is untouched since #1507. The env is an
+EDITABLE install (`boostgauge.pth` -> `.../boostgauge/src`), not the
+non-editable copy the issue described, and there is no site-packages copy at
+all. The real cause is smaller and total: **`--cov` never accepts a `.py`
+path**, for any input, so the report was empty rather than zero.
+
+`TestPathFormNeverMeasures` is that finding as a program: it runs pytest twice
+against a real repo on disk and compares. Everything else here is downstream of
+it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.coverage_report import (
+    ABSENT,
+    MEASURED,
+    read_coverage,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _is_python_package_dir,
+    _path_to_cov_target,
+)
+
+MOD = '''\
+def render(size):
+    if size < 128:
+        raise ValueError("too small")
+    return size * 3
+'''
+
+TEST = '''\
+import pkg.sub.mod
+
+
+def test_renders():
+    assert pkg.sub.mod.render(256) == 768
+'''
+
+#: The run's report shape: tests ran, no coverage table at all.
+ABSENT_REPORT = "15 passed, 0 failed\n"
+
+#: Genuine 0%: the table exists and every line is uncovered.
+ZERO_REPORT = (
+    "15 passed, 0 failed\n"
+    "Name                              Stmts   Miss  Cover   Missing\n"
+    "------------------------------------------------------------------\n"
+    "src/boostgauge/skins/stingray.py     40     40     0%   1-40\n"
+    "------------------------------------------------------------------\n"
+    "TOTAL                                40     40     0%\n"
+)
+
+AT_TARGET_REPORT = (
+    "15 passed, 0 failed\n"
+    "Name                              Stmts   Miss  Cover   Missing\n"
+    "------------------------------------------------------------------\n"
+    "src/boostgauge/skins/stingray.py     40      2    95%   17, 22\n"
+    "------------------------------------------------------------------\n"
+    "TOTAL                                40      2    95%\n"
+)
+
+TARGET = "boostgauge.skins.stingray"
+
+
+# ---------------------------------------------------------------------------
+# #2636 -- the finding, run rather than argued
+# ---------------------------------------------------------------------------
+
+
+class TestPathFormNeverMeasures:
+    """Two real pytest runs. The claim is measured, not reasoned about."""
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        root = tmp_path / "repo"
+        (root / "src" / "pkg" / "sub").mkdir(parents=True)
+        (root / "src" / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+        (root / "src" / "pkg" / "sub" / "__init__.py").write_text("", encoding="utf-8")
+        (root / "src" / "pkg" / "sub" / "mod.py").write_text(MOD, encoding="utf-8")
+        (root / "tests").mkdir()
+        (root / "tests" / "test_mod.py").write_text(TEST, encoding="utf-8")
+        return root
+
+    def _run(self, repo: Path, target: str) -> str:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "tests", f"--cov={target}",
+             "--cov-report=term-missing", "-q", "-p", "no:cacheprovider"],
+            cwd=str(repo), capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            env={**os.environ, "PYTHONPATH": str(repo / "src")},
+            timeout=180,
+        )
+        return proc.stdout + proc.stderr
+
+    def test_a_py_path_target_collects_nothing(self, repo: Path) -> None:
+        """Even with PYTHONPATH pointing at the very file being measured."""
+        out = self._run(repo, "src/pkg/sub/mod.py")
+
+        assert "was never imported" in out
+        assert read_coverage(out, "src/pkg/sub/mod.py").state == ABSENT
+
+    def test_a_module_target_measures(self, repo: Path) -> None:
+        """The control. Same repo, same tests, same file -- it is the TARGET
+        FORM that decides, not the install layout."""
+        out = self._run(repo, "pkg.sub.mod")
+
+        reading = read_coverage(out, "pkg.sub.mod")
+        assert reading.state == MEASURED
+        assert (reading.percent or 0) > 0
+
+    def test_a_directory_target_measures_too(self, repo: Path) -> None:
+        """Which is why the non-package fallback degrades to the directory."""
+        reading = read_coverage(self._run(repo, "src/pkg"), "pkg")
+        assert reading.state == MEASURED
+
+
+class TestTheDerivationSurvivesASubpackageOnlyTree:
+    """The exact tree that broke #331: `src/boostgauge/` holding only `skins/`.
+
+    No `__init__.py`, no direct `.py` file. `_is_python_package_dir` answered
+    "not a package", so the target fell to path form and measured nothing.
+    """
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        (tmp_path / "src" / "boostgauge" / "skins").mkdir(parents=True)
+        (tmp_path / "src" / "boostgauge" / "skins" / "stingray.py").write_text(
+            MOD, encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_the_331_shape_yields_module_form(self, repo: Path) -> None:
+        assert _path_to_cov_target(
+            "src/boostgauge/skins/stingray.py", repo
+        ) == "boostgauge.skins.stingray"
+
+    def test_a_dir_of_only_subpackages_is_a_package(self, repo: Path) -> None:
+        assert _is_python_package_dir(repo / "src" / "boostgauge") is True
+
+    def test_the_08_26_shape_still_yields_module_form(self, tmp_path: Path) -> None:
+        """The pre-regression tree, pinned so the old behaviour cannot be lost
+        while fixing the new one: `__init__.py` plus sibling modules."""
+        pkg = tmp_path / "src" / "boostgauge"
+        (pkg / "skins").mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "config.py").write_text("X = 1\n", encoding="utf-8")
+        (pkg / "skins" / "stingray.py").write_text(MOD, encoding="utf-8")
+
+        assert _path_to_cov_target(
+            "src/boostgauge/skins/stingray.py", tmp_path
+        ) == "boostgauge.skins.stingray"
+
+    def test_a_directory_of_plain_directories_is_not_a_package(
+        self, tmp_path: Path
+    ) -> None:
+        """The control that keeps the widening honest: subdirectories with no
+        Python in them do not make a package."""
+        (tmp_path / "src" / "assets" / "images").mkdir(parents=True)
+
+        assert _is_python_package_dir(tmp_path / "src" / "assets") is False
+
+
+# ---------------------------------------------------------------------------
+# #2637 -- three states, one accessor
+# ---------------------------------------------------------------------------
+
+
+class TestTheThreeStates:
+    def test_absent_is_absent(self) -> None:
+        reading = read_coverage(ABSENT_REPORT, TARGET)
+        assert reading.state == ABSENT
+        assert reading.percent is None, "absence must not carry a number"
+
+    def test_genuine_zero_is_measured_with_its_lines(self) -> None:
+        reading = read_coverage(ZERO_REPORT, TARGET)
+        assert reading.state == MEASURED
+        assert reading.percent == 0.0
+        assert reading.at_zero is True
+        assert reading.uncovered == {
+            "src/boostgauge/skins/stingray.py": ["1-40"]
+        }
+
+    def test_at_target_is_measured(self) -> None:
+        reading = read_coverage(AT_TARGET_REPORT, TARGET)
+        assert reading.state == MEASURED
+        assert reading.percent == 95.0
+        assert reading.at_zero is False
+
+    def test_a_full_report_naming_another_file_is_absent(self) -> None:
+        """Coverage ran, but not on the thing under test."""
+        elsewhere = AT_TARGET_REPORT.replace(
+            "src/boostgauge/skins/stingray.py", "src/boostgauge/config.py"
+        )
+        assert read_coverage(elsewhere, TARGET).state == ABSENT
+
+    def test_a_total_without_parseable_rows_is_still_measured(self) -> None:
+        """Absence is claimed only on positive evidence. An abbreviated report
+        is not a measurement failure, or every unfamiliar layout becomes one."""
+        assert read_coverage("3 passed\nTOTAL 100 10 90%", TARGET).state == MEASURED
+
+    def test_a_hundred_percent_row_names_no_uncovered_lines(self) -> None:
+        """The separator line is not a missing-line range. `\\s` spans newlines,
+        so an earlier form of this parser swallowed `-----` as one and a fully
+        covered file reported uncovered lines."""
+        report = (
+            "3 passed\n"
+            "Name          Stmts   Miss  Cover   Missing\n"
+            "--------------------------------------------\n"
+            "pkg/x.py         10      0   100%\n"
+            "--------------------------------------------\n"
+            "TOTAL            10      0   100%\n"
+        )
+        assert read_coverage(report, "pkg").uncovered == {}
+
+
+class TestTheFailureMessage:
+    def test_it_names_the_target_and_what_was_found(self) -> None:
+        message = read_coverage(ZERO_REPORT.replace(
+            "src/boostgauge/skins/stingray.py", "src/boostgauge/config.py"
+        ), TARGET).failure_message()
+
+        assert TARGET in message
+        assert "src/boostgauge/config.py" in message
+
+    def test_it_refuses_the_three_wrong_renderings(self) -> None:
+        message = read_coverage(ABSENT_REPORT, TARGET).failure_message()
+
+        assert "0.0%" not in message and "0%" not in message
+        assert "not a test gap" in message
+        assert "not a defect in the LLD or spec" in message
+
+    def test_it_quotes_coverages_own_reason_when_present(self) -> None:
+        noisy = ABSENT_REPORT + "CoverageWarning: Module x was never imported.\n"
+        assert "was never imported" in read_coverage(
+            noisy, TARGET
+        ).failure_message()
+
+
+class TestBothConsumersAgree:
+    """#1698: two parsers of one report is the class, and the N5/N4c
+    contradiction on run-201554 is the live proof. Same reading, same verdict,
+    from both call sites."""
+
+    @pytest.mark.parametrize(
+        "report,expected",
+        [(ABSENT_REPORT, ABSENT), (ZERO_REPORT, MEASURED),
+         (AT_TARGET_REPORT, MEASURED)],
+    )
+    def test_one_reading_per_report(self, report: str, expected: str) -> None:
+        assert read_coverage(report, TARGET).state == expected
+
+    def test_n4c_halts_on_the_run_201554_shape(self, tmp_path: Path) -> None:
+        from assemblyzero.workflows.testing.nodes.augment_tests import (
+            augment_tests_for_coverage,
+        )
+
+        test_file = tmp_path / "test_x.py"
+        test_file.write_text("def test_a():\n    assert 1\n", encoding="utf-8")
+
+        result = augment_tests_for_coverage({
+            "green_phase_output": ABSENT_REPORT,
+            "test_files": [str(test_file)],
+            "repo_root": str(tmp_path),
+            "coverage_achieved": 0.0,
+            "coverage_target": 95,
+            "coverage_module": TARGET,
+        })
+
+        assert result["next_node"] == "end"
+        assert "COVERAGE MEASUREMENT FAILED" in result["error_message"]
+
+    def test_n5_halts_on_the_run_201554_shape(self, tmp_path: Path) -> None:
+        """The other half of the acceptance: the SAME named failure from N5.
+
+        The observed state exactly -- 15 passed, 0 failed, no coverage table.
+        """
+        from unittest.mock import patch
+
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            verify_green_phase,
+        )
+
+        impl = tmp_path / "src" / "boostgauge" / "skins"
+        impl.mkdir(parents=True)
+        (impl / "stingray.py").write_text(MOD, encoding="utf-8")
+
+        state = {
+            "issue_number": 331,
+            "repo_root": str(tmp_path),
+            "test_files": [str(tmp_path / "t.py")],
+            "audit_dir": "",
+            "file_counter": 0,
+            "coverage_target": 95,
+            "iteration_count": 0,
+            "max_iterations": 5,
+            "implementation_files": [str(impl / "stingray.py")],
+            "skip_e2e": True,
+            "previous_coverage": -1.0,
+            "previous_passed": -1,
+        }
+
+        with patch(
+            "assemblyzero.workflows.testing.nodes.verify_phases.run_pytest"
+        ) as mock_pytest:
+            mock_pytest.return_value = {
+                "returncode": 1,
+                "stdout": ABSENT_REPORT,
+                "stderr": "",
+                "parsed": {
+                    "passed": 15, "failed": 0, "errors": 0, "coverage": 0,
+                },
+            }
+            result = verify_green_phase(state)
+
+        assert result["next_node"] == "end"
+        assert "COVERAGE MEASUREMENT FAILED" in result["error_message"]
+        assert "not a test gap" in result["error_message"]
+        assert "not a defect in the LLD or spec" in result["error_message"]
+        assert "stagnant" not in result["error_message"].lower()
+
+    def test_n5_does_not_preempt_the_zero_collected_law(self) -> None:
+        """#2548 owns zero-collected, and its diagnosis is more specific.
+
+        A coverage complaint must never displace "collected 0 tests" -- the
+        run has no tests, not an unmeasured module.
+        """
+        reading = read_coverage("collected 0 items\n", TARGET)
+
+        assert reading.state == ABSENT  # true, and deliberately not acted on
+        # The node's own gate requires passed_count > 0; pinned end-to-end by
+        # tests/unit/test_zero_needs_denominator.py, which still passes.
+
+    def test_n4c_still_targets_a_genuine_zero(self) -> None:
+        """The control: a real 0% is a real test gap, stays measured, and
+        carries the uncovered lines N4c needs to target."""
+        reading = read_coverage(ZERO_REPORT, TARGET)
+
+        assert reading.measured
+        assert reading.uncovered == {
+            "src/boostgauge/skins/stingray.py": ["1-40"]
+        }
+
+    def test_the_two_states_are_distinguishable(self) -> None:
+        """The denominator law in one line: absent and zero must not render
+        alike (#2546/#2552/#2608)."""
+        absent = read_coverage(ABSENT_REPORT, TARGET)
+        zero = read_coverage(ZERO_REPORT, TARGET)
+
+        assert absent.state != zero.state
+        assert absent.percent is None and zero.percent == 0.0
+
+
+# ---------------------------------------------------------------------------
+# #2638 -- the red-phase claim states only what is known
+# ---------------------------------------------------------------------------
+
+
+class TestTheRedPhaseClaim:
+    def test_the_prediction_is_dropped_when_tests_will_be_rewritten(self) -> None:
+        """run-201554: the test file was in `files_to_implement`, printed four
+        lines after the claim that the loop could not converge. It converged."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _tests_are_an_implementation_target,
+        )
+
+        assert _tests_are_an_implementation_target({
+            "test_files": ["tests/visual/test_stingray_static.py"],
+            "files_to_implement": [
+                {"path": "src/boostgauge/skins/stingray.py"},
+                {"path": "tests/visual/test_stingray_static.py"},
+            ],
+        }) is True
+
+    def test_the_claim_stands_when_the_tests_are_not_a_target(self) -> None:
+        """The control. A genuinely unwinnable suite nobody will rewrite may
+        still be called one -- that is #2317's whole point."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _tests_are_an_implementation_target,
+        )
+
+        assert _tests_are_an_implementation_target({
+            "test_files": ["tests/visual/test_stingray_static.py"],
+            "files_to_implement": [{"path": "src/boostgauge/skins/stingray.py"}],
+        }) is False
+
+    def test_no_targets_at_all_keeps_the_claim(self) -> None:
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _tests_are_an_implementation_target,
+        )
+
+        assert _tests_are_an_implementation_target({"test_files": ["t.py"]}) is False
+
+    def test_plain_string_targets_are_understood(self) -> None:
+        """`implementation_files` carries strings where `files_to_implement`
+        carries dicts; both name the same thing."""
+        from assemblyzero.workflows.testing.nodes.verify_phases import (
+            _tests_are_an_implementation_target,
+        )
+
+        assert _tests_are_an_implementation_target({
+            "test_files": ["tests/visual/test_stingray_static.py"],
+            "implementation_files": ["tests/visual/test_stingray_static.py"],
+        }) is True

--- a/tests/unit/test_coverage_measurement_law.py
+++ b/tests/unit/test_coverage_measurement_law.py
@@ -173,6 +173,20 @@ class TestTheDerivationSurvivesASubpackageOnlyTree:
             "src/boostgauge/skins/stingray.py", tmp_path
         ) == "boostgauge.skins.stingray"
 
+    def test_a_backslash_path_resolves_the_same_on_every_platform(
+        self, tmp_path: Path
+    ) -> None:
+        """CI caught this on Linux while Windows passed.
+
+        A backslash is an ordinary filename character on POSIX, so
+        `Path("tools\\\\x.py").parent` is `.` there and the fallback kept the
+        backslash in the target. Separators are normalised before splitting.
+        """
+        (tmp_path / "tools").mkdir()
+
+        assert _path_to_cov_target("tools\\my_script.py", tmp_path) == "tools"
+        assert _path_to_cov_target("tools/my_script.py", tmp_path) == "tools"
+
     def test_a_directory_of_plain_directories_is_not_a_package(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_coverage_routes_to_tests.py
+++ b/tests/unit/test_coverage_routes_to_tests.py
@@ -134,21 +134,60 @@ def test_a_genuine_implementation_loop_is_unaffected() -> None:
 def test_node_returns_to_verification_when_nothing_to_target(
     tmp_path: Path,
 ) -> None:
-    """No parseable coverage report: return to N5, change nothing."""
+    """A MEASURED report naming no uncovered lines: return to N5, change nothing.
+
+    #2637: this fixture used to be `"23 passed"` -- no coverage report at all --
+    and the node read that as "nothing to target" and bounced. That reading is
+    the defect, not the contract; an absent report is now a named measurement
+    failure, pinned by the test below. What this test is actually about is a
+    report that WAS produced and happens to name no missing lines.
+    """
     test_file = tmp_path / "test_x.py"
     test_file.write_text("def test_a():\n    assert 1\n", encoding="utf-8")
     before = test_file.read_text(encoding="utf-8")
 
+    fully_covered = (
+        "23 passed\n"
+        "Name             Stmts   Miss  Cover   Missing\n"
+        "-----------------------------------------------\n"
+        "pkg/thing.py        10      0   100%\n"
+        "-----------------------------------------------\n"
+        "TOTAL               10      0   100%\n"
+    )
+
     result = augment_tests_for_coverage({
-        "green_phase_output": "23 passed",
+        "green_phase_output": fully_covered,
         "test_files": [str(test_file)],
         "repo_root": str(tmp_path),
         "coverage_achieved": 80.0,
         "coverage_target": 95,
+        "coverage_module": "pkg",
     })
 
     assert result["next_node"] == "N5_verify_green"
     assert test_file.read_text(encoding="utf-8") == before
+
+
+def test_absent_report_is_a_named_measurement_failure(tmp_path: Path) -> None:
+    """#2637, the run-201554 shape: N4c must not read an absent report as
+    all-clear. That reading is half of the contradiction that produced the
+    stagnation halt."""
+    test_file = tmp_path / "test_x.py"
+    test_file.write_text("def test_a():\n    assert 1\n", encoding="utf-8")
+
+    result = augment_tests_for_coverage({
+        "green_phase_output": "15 passed, 0 failed\n",
+        "test_files": [str(test_file)],
+        "repo_root": str(tmp_path),
+        "coverage_achieved": 0.0,
+        "coverage_target": 95,
+        "coverage_module": "src/boostgauge/skins/stingray.py",
+    })
+
+    assert result["next_node"] == "end"
+    assert "COVERAGE MEASUREMENT FAILED" in result["error_message"]
+    assert "src/boostgauge/skins/stingray.py" in result["error_message"]
+    assert "not a test gap" in result["error_message"]
 
 
 def test_node_returns_to_verification_with_no_test_file() -> None:

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -41,9 +41,25 @@ def _state(**overrides):
 
 
 def _pytest(returncode, passed=0, failed=0, errors=0, coverage=0):
+    """#2637: the stdout carries a real coverage TABLE, not just counts.
+
+    These fixtures used to set `parsed["coverage"]` while leaving stdout as
+    `"15 passed, 0 failed"` -- a decoupling production never has, because
+    `parsed["coverage"]` is itself regex-extracted from that stdout. Under the
+    absence law a report with no TOTAL row is a measurement failure, and these
+    tests are about stagnation rather than about measurement failing, so the
+    fixture now emits what pytest-cov actually emits.
+    """
     return {
         "returncode": returncode,
-        "stdout": f"{passed} passed, {failed} failed",
+        "stdout": (
+            f"{passed} passed, {failed} failed\n"
+            "Name                      Stmts   Miss  Cover   Missing\n"
+            "---------------------------------------------------------\n"
+            f"assemblyzero/example.py      10      1    {coverage}%   7\n"
+            "---------------------------------------------------------\n"
+            f"TOTAL                        10      1    {coverage}%\n"
+        ),
         "stderr": "",
         "parsed": {
             "passed": passed, "failed": failed,


### PR DESCRIPTION
Closes #2636
Closes #2637
Closes #2638

The best run of the campaign halted on measurement, not on work: finality resumed without redrawing, spec passed, the renderer got written, 15 tests passed — and `Coverage: 0.0%` ended it with a halt blaming the LLD and spec.

**Each issue's stated mechanism is refuted by the preserved state, and each refutation made the fix smaller or truer.** All three posted on their issues before any code.

## #2636 — no PR regressed it, and the real defect is total

**No code change did this.** `git log -L` over `_path_to_cov_target` and its helpers returns four commits, newest **#1507**, weeks before this campaign. `#2548` and the rest of this week's N5 work never touched it. The derivation did not change — its input did.

**Root cause.** Module form requires `_is_python_package_dir(<repo>/src/boostgauge)`, which asked only whether that directory held a `.py` file *at its own top level*. The two preserved trees:

| branch | `src/` contents |
|---|---|
| `graveyard/issue-331-20260827T041722Z` (08-26 shape) | `src/boostgauge/__init__.py`, `collector.py`, `config.py`, `collectors/…` |
| `graveyard/issue-331-20260829T014302Z` (**15-passing**) | `src/.gitkeep`, `src/boostgauge/skins/stingray.py` — nothing else |

In the 15-passing tree `src/boostgauge/` holds one entry, the directory `skins/`, filtered out by `is_file()`. **A package whose modules all live in subpackages answered "not a package"**, so the target fell to path form.

**The install mechanism in the issue is wrong.** Measured: `site-packages/boostgauge.pth` → `C:/Users/mcwiz/Projects/boostgauge/src`, and `site-packages/boostgauge/` does not exist. It is an **editable** install with no copy at all. The issue's suggested alternative — "an editable install would also align paths" — is already present and does not align them.

**The larger finding, run rather than reasoned.** With `PYTHONPATH` pointing at the exact directory holding the measured file, so the import resolves to *that very file*:

```
--cov=src/pkg/mod.py  ->  Module src/pkg/mod.py was never imported
                          No data was collected
                          Failed to generate report: No data to report
--cov=pkg.mod         ->  src\pkg\mod.py    7    0   100%
```

Install mode is irrelevant. And the same holds for the branch's stated purpose — `_path_to_cov_target`'s docstring says path form exists so pytest-cov "measures the right file" for standalone scripts (#475). Tested on `tools/thing.py` with no `__init__.py` anywhere: `--cov=tools/thing.py` collects nothing; `--cov=tools` and `--cov=thing` both measure it. **The fallback has never worked, for any target.**

Fixed at both ends: the package test recognises a directory of subpackages, and the fallback degrades to the containing **directory**, which measures. `test_the_target_never_ends_in_py` pins the invariant.

## #2637 — one accessor, and it is why the report was empty

`--cov` producing *no report* — not a file at 0% — is exactly the contradiction: N5's percent regex finds no `TOTAL` and defaults to `0.0`; N4c's missing-lines parser finds nothing and reports all-clear. Both are reading an empty report, and neither says so.

`assemblyzero/workflows/testing/coverage_report.py` is the single reading, three states: **measured**, **measured at zero** (full uncovered list, still a real test gap, still routes to additions), **absent** (a named measurement failure quoting what was sought, what the report held, and coverage's own reason). `percent` is `None` when absent — deliberately not `0.0`, so a caller that forgets to check `state` gets a `TypeError` rather than a plausible wrong number.

Both consumers go through it, and the failure message ends *"not a test gap and not a defect in the LLD or spec."*

Two judgement calls worth naming:

- **The N5 check is gated on an all-passing suite.** While tests fail the run routes on failures and never consults coverage; the moment every test passes, coverage *is* the decision.
- **Absence is claimed only on positive evidence** — no `TOTAL` at all, or a file list that demonstrably excludes the target. A `TOTAL` with no parseable rows stays *measured*, or an unfamiliar report layout would start failing runs.

## #2638 — the claim was true; the suite was replaced, not satisfied

The counts reconcile exactly, and not the way the issue expects. `tests/visual/test_stingray_static.py` is **itself an implementation target** — printed four lines below the claim. N4 rewrote it: 22 placeholders named `test_t010`… became **15** real tests named `test_req_010_base_face_generation`…, verified on the preserved branch. Different suites; no discrepancy to name.

And "no implementation can make this suite green" was **accurate**. `count_stub_tests` is AST-based and fires only when every body is `assert False`, a bare `raise NotImplementedError`, or nothing beyond a docstring — the log's own next line confirms it: *"The spec supplies no executable test bodies."* The claim is not derived from the ImportError at all, so the two adjacent lines never contradicted each other.

**The real defect is one line lower**: *"the implementation loop cannot converge against these tests"* — a prediction, false, made without reading `files_to_implement`, which was in state. Registry class 2. The note now consults it and says the placeholders will be **replaced**; where the tests are *not* a target the claim stands unchanged, because a genuinely unwinnable suite may still be called one.

## Fixtures corrected, not weakened

Ten existing tests encoded the old behaviour. Six asserted the `.py` path form that measures nothing — updated to the directory form with the measurement recorded. Four mocked `run_pytest` with `parsed["coverage"]=94` while stdout was `"15 passed, 0 failed"` — a decoupling production never has, since `parsed["coverage"]` is regex-extracted from that same stdout. Their fixtures now emit a real coverage table, which is what pytest-cov emits. Every test's original intent is preserved and asserted.

One bug in my own accessor was caught by them and is worth recording: `\s` spans newlines, so an optional Missing column ran past its row and swallowed the report's `-----` separator as a line range — a 100%-covered file reported uncovered lines. Now line-scoped with `[^\S\n]`, pinned by `test_a_hundred_percent_row_names_no_uncovered_lines`.

## Acceptance

| clause | evidence |
|---|---|
| #2636 the 15-passing shape re-measures nonzero | `TestPathFormNeverMeasures` (two real pytest runs), `test_the_331_shape_yields_module_form` |
| an unexercised module still reads low honestly | `test_genuine_zero_is_measured_with_its_lines` |
| module form pinned against regression | `test_the_08_26_shape_still_yields_module_form`, `test_the_target_never_ends_in_py` |
| #2637 identical named absence from both paths | `TestBothConsumersAgree`, `test_n4c_halts_on_the_run_201554_shape` |
| genuine 0% still routes with the line list | `test_n4c_still_targets_a_genuine_zero` |
| at-target passes | `test_at_target_is_measured` |
| #2638 every claim survives the run's later evidence | `TestTheRedPhaseClaim` |
| an unwinnable suite may still be called one | `test_the_claim_stands_when_the_tests_are_not_a_target` |

26 new tests, each guarantee paired with its control.

## What only a live roll proves

The percentage the 15 tests actually achieve. Everything here is preserved state and reproductions; the resume is what turns it into a number. boostgauge stayed read-only — no roll, PRs #367/#373 untouched, no writes to #331 state or working tree, and the LLD treated as evidence.
