### PR TITLE
feat: an element named in scope prose must reach a row, an alias, or an exclusion (Closes #2645)

### DIFF
--- a/assemblyzero/workflows/requirements/form_gate.py
+++ b/assemblyzero/workflows/requirements/form_gate.py
@@ -59,6 +59,10 @@ from assemblyzero.workflows.requirements.form_check import (
     FormReport,
     check_form,
 )
+from assemblyzero.workflows.requirements.scope_coverage import (  # noqa: E402  (#2645)
+    ScopeReport,
+    check_scope_coverage,
+)
 
 #: Violations of the table's own shape: wrong row count for its condition
 #: count, or a repeated combination. These are what "malformed table" means.
@@ -85,6 +89,10 @@ class IssueForm:
     #: of the non-counting findings -- it reads intent from prose, so a refusal
     #: on it would block a roll over a phrasing choice.
     discrimination: DiscriminationReport | None = None
+    #: #2645: the scope-coverage extension. Report-only for the same reason
+    #: the form check is: no issue in the fleet declares a scope alias yet, so
+    #: a refusal would fire on the ordinary case and be waved through.
+    scope: ScopeReport | None = None
 
     @property
     def has_tables(self) -> bool:
@@ -125,7 +133,7 @@ def check_issue(repo_root, issue: int, fetch) -> IssueForm:
     """Run the form check for one issue. Never raises."""
     result = IssueForm(issue=issue)
     try:
-        _title, body = fetch(repo_root, issue)
+        title, body = fetch(repo_root, issue)
     except Exception as exc:  # noqa: BLE001 - a read failure is not a verdict
         result.error = str(exc)
         return result
@@ -141,6 +149,19 @@ def check_issue(repo_root, issue: int, fetch) -> IssueForm:
         result.discrimination = check_discrimination(body)
     except Exception:  # noqa: BLE001 - an extension is not the gate
         result.discrimination = None
+    # #2645: same containment. The scope check reads the TITLE as well, which
+    # is the witness that survived nineteen ruled conflicts on boostgauge #331
+    # while the table lost a row.
+    try:
+        result.scope = check_scope_coverage(title, body)
+    except Exception:  # noqa: BLE001
+        # fail-open: an extension that crashes must not cost the form check
+        # its verdict, and this one parses free-form prose from every issue in
+        # the fleet. None is NOT a clean bill -- `render` prints nothing at all
+        # for a None scope, so the operator sees the disclosure line missing
+        # rather than a passing one. Report-only either way, so nothing is
+        # gated on it.
+        result.scope = None
     return result
 
 
@@ -199,6 +220,14 @@ def render(results: list[IssueForm]) -> tuple[str, bool]:
         if item.discrimination is not None:
             lines.append(f"      {item.discrimination.disclosure()}")
             for violation in item.discrimination.violations:
+                lines.append(f"        {violation}")
+
+        # #2645: printed on every issue for the same reason. This is the only
+        # check in the stack that can see an element the table never carried,
+        # so its silence has to be distinguishable from it not having run.
+        if item.scope is not None:
+            lines.append(f"      {item.scope.disclosure()}")
+            for violation in item.scope.violations:
                 lines.append(f"        {violation}")
 
         if item.reporting and item.refusing:

--- a/assemblyzero/workflows/requirements/scope_coverage.py
+++ b/assemblyzero/workflows/requirements/scope_coverage.py
@@ -1,0 +1,500 @@
+"""Elements named in an issue's scope prose must reach the table (#2645).
+
+Every gate this campaign built audits rows that EXIST. Row-absence is invisible
+to all of them, and the gap cost boostgauge #331 its dominant visual element:
+the title and the opening scope both name "bezel", nineteen ruled conflicts
+hardened every row that existed, and nothing ever asked whether a row was
+missing. The factory then carried a nine-row table through fourteen gates with
+perfect fidelity and faithfully built an incomplete face (boostgauge #375).
+
+The one place the full element list exists is the issue's own prose, inches
+above the table that dropped one. This module reads it.
+
+## The acceptance case is a near-miss, not a bare absence
+
+The obvious implementation fails its own acceptance, and it took running four
+matchers over the preserved body to see why. #331's table DOES carry a row
+whose Element cell begins with the word bezel -- `S9 | Bezel seat` -- which
+asserts a shadow on the transition annulus at 1.01 R and binds nothing about
+the ring. Measured over the enumeration extracted from #331's title and scope
+sentence, against what a human reader gives:
+
+    matcher        errors
+    substring      bezel FALSE PASS, tick marks false alarm
+    token-subset   bezel FALSE PASS, tick marks false alarm
+    exact          dial, ticks, tick marks false alarms
+    head-noun      dial, tick marks false alarms
+
+No rule does better, because the difference is not in the names:
+
+    'Dial face'    modifier=dial   head=face   -> COVERS 'dial'
+    'Bezel seat'   modifier=bezel  head=seat   -> does NOT cover 'bezel'
+
+Identical shape, opposite answers. A name-matcher here is a proxy-heuristic in
+#2540's exact sense -- a correlate, satisfiable without satisfying the intent
+-- and its failure direction is a FALSE PASS. The two matchers that read as
+most helpful are precisely the two that ship #331 unchanged.
+
+## So the coverage judgement is not mechanical, and this module does not make it
+
+Normalized-EXACT matching, and everything else needs a disposition written
+down. Exact is the least accurate of the four by raw error count; it is the
+only one whose errors all point the safe way. Its misses are false alarms an
+author discharges once with a declared alias, and every alias is a falsifiable
+claim a reader -- and the sibling contract-fidelity review -- can audit.
+
+Three explicit sources dispose of an element. Nothing else does, and nothing is
+guessed:
+
+1. a criteria-table row whose Element cell equals the term (normalized);
+2. a declared alias, ``<!-- scope-alias: tick marks -> S3, S4 -->``;
+3. a declared exclusion in scope prose -- #331's ``NO pivot cap -- ... belongs
+   to #332`` is the existing pattern and parses today.
+
+That is exact bookkeeping over three named sets, which is the
+`manifest_traceability` shape: a fact-verifier, not a proxy. What this module
+can no longer do is decide that S9 covers "bezel". What it does is make
+somebody write that claim down.
+
+## It reads criteria tables, not ADR 0226 decision tables
+
+`check_form` on #331's preserved body reports `Decision tables: 0 found, so 0
+checked` and `RESULT: PASS`. `is_decision_table` requires yes/no condition
+columns per ADR 0226 section 3.2; #331's table is `ID | Element | Binding value
+| Assertion method`, which `is_criteria_table` recognises and that predicate
+does not. A check keyed on the wrong predicate would examine zero tables on the
+exact issue it was built for and report clean -- a vacuous pass wearing a
+gate's clothes. This module keys on `is_criteria_table`, the same predicate
+`table_injection` and the manifest compiler already share, and adds no third
+notion of what a table is.
+
+## What it deliberately does not read
+
+A draw-order list quoted IN the issue body is read like any other scope
+enumeration. One that lives only in the cited design contract is not: loading
+the contract belongs to the sibling contract-fidelity review (#2646), and two
+loaders of one document is the #1698 class.
+
+Report-only, at launcher preflight, beside the form check. No issue in the
+fleet carries an alias yet, so a refusal here would fire on the ordinary case
+-- the #2227 ruling's own reason for report-only, and #2387's. It prints on
+every issue, pass or fail, and discloses a vacuous result separately from a
+clean one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+    is_criteria_table,
+)
+from assemblyzero.workflows.requirements.form_check import (
+    Violation,
+    parse_tables,
+)
+
+LABEL = "Scope coverage (#2645)"
+
+#: The alias an author writes to discharge a name this module cannot match --
+#: `tick marks` against rows `S3` and `S4`. An HTML comment so it is invisible
+#: in every markdown viewer and machine-findable, the same arrangement
+#: `table_injection` uses for its machine-owned fence.
+_ALIAS_RE = re.compile(
+    r"<!--\s*scope-alias:\s*(?P<term>[^>\n]+?)\s*(?:->|-->|→)\s*"
+    r"(?P<rows>[^>\n]*?)\s*-->",
+    re.IGNORECASE,
+)
+
+#: An element the issue says it is NOT doing. #331 writes both forms in its
+#: lede: `No needles and NO pivot cap -- the cap ... belongs to #332`.
+#:
+#: A reason is REQUIRED. "no gradient" with nothing after it is a binding
+#: value's phrasing, not a scope exclusion, and #331's own S1 cell says exactly
+#: that ("NO gradient, glass sweep, or reflection"). Requiring the reason is
+#: what keeps a table cell from silently excusing an element -- and the
+#: exclusion scan is confined to scope prose for the same reason.
+_EXCLUSION_RE = re.compile(
+    r"\bno\s+(?P<term>[a-z][a-z ]{1,28}?)\s*"
+    r"(?=--|—|-\s|,|\.|;|\)|$|\band\b|\bbelongs\b|\bis\b|\bare\b)",
+    re.IGNORECASE,
+)
+
+#: The reason that makes an exclusion a declared one rather than a phrasing.
+_EXCLUSION_REASON = re.compile(
+    r"belongs to|out of scope|excluded|#\d+|\bis\s+#|\bstop\b|scope:",
+    re.IGNORECASE,
+)
+
+#: A `## Boundary terms` style section also declares exclusions, as bolded
+#: lead-ins: `- **Needles** -- main needle is the sibling needle issue's`.
+_BOUNDARY_TERM_RE = re.compile(r"^\s*[-*]\s*\*\*(?P<term>[^*]+)\*\*", re.MULTILINE)
+
+_BOUNDARY_HEADINGS = ("boundary terms", "out of scope", "non-goals", "boundaries")
+
+#: A markdown heading, used to find where the scope prose ends.
+_HEADING = re.compile(r"^(#{1,6})\s+(.*)$", re.MULTILINE)
+
+#: The smallest comma list this module will read as an enumeration.
+#:
+#: #331's title carries two: the seven elements, and the two-item participle
+#: tail `baked once, cached` that describes behaviour rather than naming parts.
+#: Taking the longest separates them on the one real title available, and the
+#: floor is what stops a two-item tail from reading as an enumeration when it
+#: is the only list there. A quiet miss here is not the last line of defence:
+#: the scope sentence is the richer source, and the contract-fidelity review
+#: reaches the same elements from the contract side.
+_MIN_ENUMERATION = 3
+
+
+def _norm(text: str) -> str:
+    """Lowercase, punctuation to spaces, whitespace collapsed.
+
+    Backticks, hyphens and case are formatting; `Chrome housing` and
+    `chrome housing` are the same element name and must compare equal.
+    """
+    return " ".join(re.sub(r"[^a-z0-9 ]", " ", text.lower()).split())
+
+
+@dataclass(frozen=True)
+class ScopeElement:
+    """One element the issue's prose says is in scope.
+
+    `source` is carried so a finding can say WHERE the claim was made -- the
+    title survived nineteen ruled conflicts on #331 and is the strongest
+    witness in the document. `also_named` carries the coarser wording when the
+    same element was named twice at different grains.
+    """
+
+    term: str
+    source: str
+    also_named: tuple[str, ...] = ()
+
+    @property
+    def key(self) -> str:
+        return _norm(self.term)
+
+
+def _stems(text: str) -> frozenset[str]:
+    """Token stems, for reconciling two PROSE names of one element.
+
+    Used only by `_reconcile_grains`, never against a table row -- see its
+    docstring for why that boundary is load-bearing.
+    """
+    return frozenset(
+        tok[:-1] if tok.endswith("s") and len(tok) > 3 else tok
+        for tok in _norm(text).split()
+    )
+
+
+def _reconcile_grains(elements: list[ScopeElement]) -> list[ScopeElement]:
+    """Collapse a prose name that a more specific prose name already contains.
+
+    #331 names the same two elements twice at different grains: the title says
+    `dial` and `ticks`, the scope sentence says `dial face` and `tick marks`.
+    Those are one element each, stated once coarsely and once precisely, and
+    reporting both would put two findings on the board for one thing -- the
+    #2539 disease.
+
+    **This reconciles PROSE against PROSE and never against a table row**, and
+    that boundary is the whole safety argument. Two prose names nesting means
+    the author refined their own statement. A prose name nesting inside a ROW
+    name means nothing of the kind: `bezel` sits inside `Bezel seat`, and S9
+    binds a shadow annulus rather than the ring (boostgauge #375). Letting rows
+    into this rule would reintroduce the token-subset matcher measured in the
+    module docstring as a FALSE PASS on this module's own acceptance case.
+
+    The more specific name wins, because it is the author's own refinement.
+    """
+    kept: list[ScopeElement] = []
+    for element in elements:
+        mine = _stems(element.term)
+        broader = [
+            other for other in elements
+            if other is not element and mine < _stems(other.term)
+        ]
+        if broader:
+            continue  # a more specific prose name carries this one
+        coarser = tuple(
+            other.term for other in elements
+            if other is not element and _stems(other.term) < mine
+        )
+        kept.append(
+            ScopeElement(
+                term=element.term,
+                source=element.source,
+                also_named=coarser,
+            )
+            if coarser
+            else element
+        )
+    return kept
+
+
+@dataclass
+class ScopeReport:
+    """What was judged about one issue's scope coverage."""
+
+    elements: list[ScopeElement] = field(default_factory=list)
+    table_found: bool = False
+    rows_examined: int = 0
+    matched: dict[str, str] = field(default_factory=dict)
+    aliased: dict[str, str] = field(default_factory=dict)
+    excluded: dict[str, str] = field(default_factory=dict)
+    violations: list[Violation] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+    @property
+    def vacuous(self) -> bool:
+        """Nothing was judged, which is NOT the same as nothing was wrong."""
+        return not self.elements or not self.table_found
+
+    def disclosure(self) -> str:
+        """One line stating what the check actually did (#2227).
+
+        A check with nothing to check must say so. Reporting "no findings" for
+        a document it never judged is how a gate reads as thorough validation
+        while verifying nothing.
+        """
+        if not self.elements:
+            return (
+                "scope coverage: NOT CHECKED — no scope enumeration found in "
+                "the title or the opening scope prose, so no element was "
+                "looked for."
+            )
+        if not self.table_found:
+            return (
+                f"scope coverage: NOT CHECKED — {len(self.elements)} element(s) "
+                f"named in scope prose, but the issue carries no criteria "
+                f"table (ID + binding value) to carry them."
+            )
+        return (
+            f"scope coverage: {len(self.elements)} element(s) named in scope "
+            f"prose against {self.rows_examined} table row(s) — "
+            f"{len(self.matched)} matched a row, {len(self.aliased)} declared "
+            f"an alias, {len(self.excluded)} declared an exclusion, "
+            f"{len(self.violations)} undisposed."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reading the document
+# ---------------------------------------------------------------------------
+
+
+def scope_prose(body: str) -> str:
+    """The issue's lede: everything before its first markdown heading.
+
+    The scope claim and the exclusions both live here on #331, and confining
+    the scan to it is what keeps a binding value's `NO gradient` from reading
+    as a scope exclusion.
+    """
+    match = _HEADING.search(body or "")
+    return (body or "")[: match.start()] if match else (body or "")
+
+
+def _comma_lists(text: str) -> list[list[str]]:
+    """Every comma list in one span, longest first.
+
+    Items split on commas and on a trailing ``and``. Empty items and pure
+    citations are dropped rather than becoming elements nothing can match.
+    """
+    lists: list[list[str]] = []
+    for chunk in re.split(r"—|--|–", text):
+        parts = [
+            p.strip().strip(".").strip()
+            for p in re.split(r",|\band\b", chunk)
+        ]
+        items = [p for p in parts if _norm(p)]
+        if len(items) >= _MIN_ENUMERATION:
+            lists.append(items)
+    return sorted(lists, key=len, reverse=True)
+
+
+def title_elements(title: str) -> list[ScopeElement]:
+    """The enumeration in the title, after any conventional-commit prefix.
+
+    #331's title after `feat:` is
+    ``static face renderer — bezel, ..., screws — baked once, cached``: two
+    comma lists, and the longer is the element list.
+    """
+    if not title:
+        return []
+    text = title.split(":", 1)[1] if ":" in title.split("—")[0] else title
+    lists = _comma_lists(text)
+    if not lists:
+        return []
+    return [ScopeElement(term=item, source="title") for item in lists[0]]
+
+
+def scope_sentence_elements(body: str) -> list[ScopeElement]:
+    """Colon-introduced enumerations in the issue's lede.
+
+    #331: ``this is the baked half of the renderer: bezel, chrome housing,
+    dial face, redline band, tick marks, numerals, wordmark, and screws.``
+
+    A span ends at the first period FOLLOWED BY WHITESPACE, so `PIL.Image` and
+    `docs/design/0002-...md` never split a list, while the sentence after the
+    enumeration is never swallowed into it.
+    """
+    found: list[ScopeElement] = []
+    prose = scope_prose(body)
+    for match in re.finditer(r":\s*", prose):
+        tail = prose[match.end():]
+        stop = re.search(r"\.(?=\s|$)", tail)
+        span = tail[: stop.start()] if stop else tail
+        lists = _comma_lists(span)
+        if lists:
+            found.extend(
+                ScopeElement(term=item, source="scope prose")
+                for item in lists[0]
+            )
+    return found
+
+
+def declared_aliases(body: str) -> dict[str, str]:
+    """Author-declared name -> the rows it is claimed to be carried by."""
+    return {
+        _norm(m.group("term")): m.group("rows").strip()
+        for m in _ALIAS_RE.finditer(body or "")
+        if _norm(m.group("term"))
+    }
+
+
+def declared_exclusions(body: str) -> dict[str, str]:
+    """Elements the issue's scope prose says it is NOT doing, with the reason.
+
+    Two forms, both taken from #331: a ``no <term>`` clause carrying a reason,
+    and a bolded lead-in under a boundary-terms heading.
+    """
+    found: dict[str, str] = {}
+    prose = scope_prose(body)
+
+    for match in _EXCLUSION_RE.finditer(prose):
+        term = _norm(match.group("term"))
+        if not term:
+            continue
+        # The reason has to be nearby, in the same sentence-ish span.
+        tail = prose[match.end(): match.end() + 240]
+        if _EXCLUSION_REASON.search(tail):
+            found[term] = tail.strip().split("\n")[0][:120]
+
+    for heading in _find_sections(body or "", _BOUNDARY_HEADINGS):
+        for match in _BOUNDARY_TERM_RE.finditer(heading):
+            term = _norm(match.group("term"))
+            if term:
+                found.setdefault(term, "declared under a boundary-terms section")
+
+    return found
+
+
+def _find_sections(body: str, headings: tuple[str, ...]) -> list[str]:
+    """The text under any heading whose name is one of ``headings``."""
+    sections: list[str] = []
+    matches = list(_HEADING.finditer(body))
+    for i, match in enumerate(matches):
+        if _norm(match.group(2)) not in headings:
+            continue
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections.append(body[match.end(): end])
+    return sections
+
+
+def element_rows(body: str) -> dict[str, str]:
+    """Normalized element name -> row ID, from every criteria table.
+
+    The Element column is the second cell of a criteria table's row by the
+    ruled #332 shape (`ID | Element | Binding value | Assertion method`). A
+    table without one contributes no names rather than contributing wrong ones.
+    """
+    rows: dict[str, str] = {}
+    for table in parse_tables(body or ""):
+        if not is_criteria_table(table):
+            continue
+        for row in table.rows:
+            if len(row) < 2:
+                continue
+            name = _norm(row[1])
+            if name:
+                rows.setdefault(name, row[0].strip())
+    return rows
+
+
+def criteria_row_count(body: str) -> int:
+    return sum(
+        len(t.rows) for t in parse_tables(body or "") if is_criteria_table(t)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The check
+# ---------------------------------------------------------------------------
+
+
+def check_scope_coverage(title: str, body: str) -> ScopeReport:
+    """Every element named in scope prose must reach a row, an alias, or an
+    exclusion (#2645).
+
+    Normalized-exact matching only. The module never decides that a row whose
+    name merely CONTAINS the term carries it -- that judgement is what shipped
+    boostgauge #375, and the measurement behind the ruling is in the module
+    docstring.
+    """
+    report = ScopeReport()
+
+    seen: set[str] = set()
+    named: list[ScopeElement] = []
+    for element in title_elements(title) + scope_sentence_elements(body):
+        if element.key in seen:
+            continue
+        seen.add(element.key)
+        named.append(element)
+    report.elements = _reconcile_grains(named)
+
+    rows = element_rows(body)
+    report.table_found = bool(rows)
+    report.rows_examined = criteria_row_count(body)
+
+    if not report.elements or not report.table_found:
+        return report
+
+    aliases = declared_aliases(body)
+    exclusions = declared_exclusions(body)
+
+    for element in report.elements:
+        key = element.key
+        if key in rows:
+            report.matched[key] = rows[key]
+        elif key in aliases:
+            report.aliased[key] = aliases[key]
+        elif key in exclusions:
+            report.excluded[key] = exclusions[key]
+        else:
+            also = (
+                f" (also named {', '.join(repr(t) for t in element.also_named)})"
+                if element.also_named
+                else ""
+            )
+            report.violations.append(
+                Violation(
+                    kind="scope-uncovered",
+                    where=element.term + also,
+                    detail=(
+                        f"named in the {element.source} but no table row is "
+                        f"called {element.term!r}, no alias declares which row "
+                        f"carries it, and no exclusion declares it out of "
+                        f"scope. Add a row, or declare "
+                        f"`<!-- scope-alias: {element.term} -> <row ids> -->` "
+                        f"if an existing row already binds it, or say why it "
+                        f"is excluded. Matching is exact by design: a row that "
+                        f"merely mentions {element.term!r} is not evidence it "
+                        f"binds it (boostgauge #375)."
+                    ),
+                )
+            )
+
+    return report

--- a/tests/unit/test_scope_coverage.py
+++ b/tests/unit/test_scope_coverage.py
@@ -1,0 +1,421 @@
+"""An element named in scope prose reaches a row, an alias, or an exclusion.
+
+boostgauge #331's title said "bezel" through nineteen ruled conflicts. Its
+decision table carried `S9 | Bezel seat` -- the seat shadow, not the ring --
+and every gate this campaign built audits rows that EXIST, so nothing asked.
+The factory ran the nine-row table through fourteen gates with perfect fidelity
+and built a face with no bezel (boostgauge #375).
+
+`TestNoNameMatcherSeparatesThem` is the finding this module's design rests on,
+kept as a program: the covering case and the near-miss are structurally
+identical strings, so the two matchers that read as most helpful both pass
+#331 unchanged. Everything else here is downstream of it.
+
+The #331 excerpts below are VERBATIM from the preserved issue body. They are
+the evidence, not a paraphrase of it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.assertion_manifest import (
+    is_criteria_table,
+)
+from assemblyzero.workflows.requirements import form_gate
+from assemblyzero.workflows.requirements.form_gate import check_form_at_preflight
+from assemblyzero.workflows.requirements.form_check import (
+    check_form,
+    is_decision_table,
+    parse_tables,
+)
+from assemblyzero.workflows.requirements.scope_coverage import (
+    check_scope_coverage,
+    declared_aliases,
+    declared_exclusions,
+    element_rows,
+    scope_sentence_elements,
+    title_elements,
+)
+
+# ---------------------------------------------------------------------------
+# boostgauge #331, verbatim
+# ---------------------------------------------------------------------------
+
+TITLE_331 = (
+    "feat: static face renderer — bezel, chrome housing, dial, ticks, "
+    "numerals, wordmark, screws — baked once, cached"
+)
+
+LEDE_331 = (
+    "Render the complete static face of the Stingray gauge — everything that "
+    "never moves — as one cached `PIL.Image`. Per the render-architecture "
+    "ruling (#329) this is the baked half of the renderer: bezel, chrome "
+    "housing, dial face, redline band, tick marks, numerals, wordmark, and "
+    "screws. No needles and NO pivot cap -- the cap covers the attachment "
+    "point of all five needles, so it draws on top of them and belongs to "
+    "#332 (ruling on the #333 conflict) — the main needle belongs to #332, "
+    "telltales to #2.\n"
+)
+
+#: The nine-row S-table, element and ID columns verbatim; binding and assertion
+#: cells abbreviated where this module never reads them. S1's cell keeps its
+#: "NO gradient" phrasing, which is the control for the exclusion scan.
+TABLE_331 = """
+## Decision table — static elements and their binding values
+
+| ID | Element | Binding value (quoted from the render contract) | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 × size; NO gradient, glass sweep, or reflection (#325) | classification at 3 interior points |
+| S2 | Redline band | `#AA0F19` crimson, inner 0.88 R to outer 1.00 R | classification at radius 0.94 R |
+| S3 | Major ticks | `#FFFFFF`, 11 total at values 0,10,…,100 | stroke predicate at each tick's midpoint |
+| S4 | Minor ticks | `#FFFFFF`, 40 total, 4 between each major pair | stroke predicate at 4 sampled minors |
+| S5 | Numerals | `#FFFFFF`, values 0–100 step 10, cap height 0.11 R | presence: ≥1 white-classified pixel |
+| S6 | Wordmark | `BOOSTGAUGE`, `#FFFFFF`, cap height 0.09 R | presence: ≥1 white-classified pixel |
+| S7 | Chrome housing | square, chamfer radius 0.13 × size | the #328 predicate: ≥3 achromatic samples |
+| S8 | Screws | 2, centres at pivot + (−0.25 R, 0) and (+0.25 R, 0) | the #326 predicate: centre pixel within ±6 |
+| S9 | Bezel seat | dial sits below the bezel plane — the slight inner shadow on the annulus containing 1.01 R | sample at 1.01 R is darker than chrome at 1.10 R |
+
+## Boundary terms
+
+- **Needles** — main needle is the sibling needle issue's; telltales are #2's.
+- **Caching lifetime and invalidation policy** — this issue caches per (size, skin) per session.
+"""
+
+BODY_331 = LEDE_331 + TABLE_331
+
+
+@pytest.fixture
+def report_331():
+    return check_scope_coverage(TITLE_331, BODY_331)
+
+
+# ---------------------------------------------------------------------------
+# The finding the design rests on
+# ---------------------------------------------------------------------------
+
+
+class TestNoNameMatcherSeparatesThem:
+    """`Dial face` covers `dial`; `Bezel seat` does not cover `bezel`.
+
+    Same shape, opposite answers -- so the coverage judgement cannot be made
+    from names, and the matchers that look most helpful are the ones that ship
+    the defect.
+    """
+
+    def _norm_tokens(self, text: str) -> set[str]:
+        return set(text.lower().replace("-", " ").split())
+
+    def test_the_two_decisive_strings_are_structurally_identical(self) -> None:
+        covering = self._norm_tokens("Dial face")
+        near_miss = self._norm_tokens("Bezel seat")
+        assert len(covering) == len(near_miss) == 2
+        # modifier + head, in both, with the extracted term as the modifier
+        assert "dial" in covering and "bezel" in near_miss
+
+    def test_substring_matching_would_pass_the_acceptance_case(self) -> None:
+        """The measured FALSE PASS. This is why exact matching was chosen."""
+        rows = list(element_rows(BODY_331))
+        assert any("bezel" in row for row in rows), "S9 does contain the word"
+        # ...and yet the ring is bound nowhere: no row NAMES the bezel.
+        assert "bezel" not in rows
+
+    def test_token_subset_matching_would_pass_the_acceptance_case(self) -> None:
+        rows = list(element_rows(BODY_331))
+        subset_hits = [
+            row for row in rows if {"bezel"} <= self._norm_tokens(row)
+        ]
+        assert subset_hits == ["bezel seat"], (
+            "token-subset finds S9 for 'bezel', which is the false pass"
+        )
+
+    def test_exact_matching_does_not(self, report_331) -> None:
+        assert "bezel" not in report_331.matched
+
+
+# ---------------------------------------------------------------------------
+# The acceptance: #331 replayed
+# ---------------------------------------------------------------------------
+
+
+class TestThe331Acceptance:
+    def test_the_gate_fires_naming_bezel(self, report_331) -> None:
+        assert not report_331.ok
+        fired = {v.where.split(" (")[0] for v in report_331.violations}
+        assert "bezel" in fired
+
+    def test_the_bezel_finding_says_a_mention_is_not_a_binding(
+        self, report_331
+    ) -> None:
+        finding = next(
+            v for v in report_331.violations if v.where.startswith("bezel")
+        )
+        assert "merely mentions" in finding.detail
+        assert finding.kind == "scope-uncovered"
+
+    def test_the_pivot_cap_exclusion_passes_as_the_control(self) -> None:
+        """The declared-exclusion control, from #331's own prose."""
+        exclusions = declared_exclusions(BODY_331)
+        assert "pivot cap" in exclusions
+        assert "belongs to" in exclusions["pivot cap"]
+
+    def test_needles_is_excluded_too_by_the_same_clause(self) -> None:
+        assert "needles" in declared_exclusions(BODY_331)
+
+    def test_every_element_with_a_row_passes(self, report_331) -> None:
+        assert report_331.matched == {
+            "chrome housing": "S7",
+            "numerals": "S5",
+            "wordmark": "S6",
+            "screws": "S8",
+            "dial face": "S1",
+            "redline band": "S2",
+        }
+
+    def test_it_fires_on_exactly_two_things(self, report_331) -> None:
+        """One shipped defect, one wording gap discharged by a single alias.
+
+        Stated as an exact set because a gate that names nine elements when one
+        is missing is a gate people wave through.
+        """
+        fired = {v.where.split(" (")[0] for v in report_331.violations}
+        assert fired == {"bezel", "tick marks"}
+
+    def test_the_coarser_title_wording_is_not_a_second_finding(
+        self, report_331
+    ) -> None:
+        """`ticks` (title) and `tick marks` (scope) are one element."""
+        finding = next(
+            v for v in report_331.violations if v.where.startswith("tick marks")
+        )
+        assert "'ticks'" in finding.where
+
+    def test_dial_does_not_fire_because_dial_face_carries_it(
+        self, report_331
+    ) -> None:
+        fired = {v.where.split(" (")[0] for v in report_331.violations}
+        assert "dial" not in fired
+        assert report_331.matched["dial face"] == "S1"
+
+
+# ---------------------------------------------------------------------------
+# Why it reads criteria tables and not ADR 0226 decision tables
+# ---------------------------------------------------------------------------
+
+
+class TestItLooksAtTheTableThatIsActuallyThere:
+    def test_the_331_table_is_not_an_adr_0226_decision_table(self) -> None:
+        tables = parse_tables(BODY_331)
+        assert len(tables) == 1
+        assert not is_decision_table(tables[0])
+        assert is_criteria_table(tables[0])
+
+    def test_the_form_check_therefore_examines_nothing_and_passes(self) -> None:
+        """The vacuous pass this module exists beside, measured not assumed."""
+        report = check_form(BODY_331)
+        assert report.tables == []
+        assert report.ok
+        assert "bezel" not in "\n".join(str(v) for v in report.violations)
+
+    def test_this_module_examines_all_nine_rows(self, report_331) -> None:
+        assert report_331.rows_examined == 9
+        assert report_331.table_found
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtraction:
+    def test_the_title_yields_its_element_list(self) -> None:
+        terms = [e.term for e in title_elements(TITLE_331)]
+        assert terms == [
+            "bezel", "chrome housing", "dial", "ticks",
+            "numerals", "wordmark", "screws",
+        ]
+
+    def test_the_participle_tail_is_not_an_enumeration(self) -> None:
+        """`baked once, cached` describes behaviour; it names no parts."""
+        terms = [e.term for e in title_elements(TITLE_331)]
+        assert "baked once" not in terms
+        assert "cached" not in terms
+
+    def test_the_scope_sentence_yields_its_element_list(self) -> None:
+        terms = [e.term for e in scope_sentence_elements(BODY_331)]
+        assert terms == [
+            "bezel", "chrome housing", "dial face", "redline band",
+            "tick marks", "numerals", "wordmark", "screws",
+        ]
+
+    def test_the_sentence_after_the_enumeration_is_not_swallowed(self) -> None:
+        terms = [e.term for e in scope_sentence_elements(BODY_331)]
+        assert not any("needles" in t for t in terms)
+
+    def test_a_dotted_token_does_not_split_an_enumeration(self) -> None:
+        body = "It draws these: alpha, `PIL.Image` handles, beta, gamma. Then stop.\n"
+        terms = [e.term for e in scope_sentence_elements(body)]
+        assert terms == ["alpha", "`PIL.Image` handles", "beta", "gamma"]
+
+    def test_a_title_with_no_enumeration_yields_nothing(self) -> None:
+        assert title_elements("fix: the parser drops a row") == []
+
+    def test_no_title_yields_nothing(self) -> None:
+        assert title_elements("") == []
+
+
+# ---------------------------------------------------------------------------
+# The three dispositions
+# ---------------------------------------------------------------------------
+
+
+class TestDispositions:
+    def test_an_alias_discharges_a_finding(self) -> None:
+        body = BODY_331 + "\n<!-- scope-alias: tick marks -> S3, S4 -->\n"
+        report = check_scope_coverage(TITLE_331, body)
+        fired = {v.where.split(" (")[0] for v in report.violations}
+        assert fired == {"bezel"}
+        assert report.aliased["tick marks"] == "S3, S4"
+
+    def test_an_alias_can_discharge_the_acceptance_case_too(self) -> None:
+        """Deliberate: the module makes the claim WRITABLE, not unwritable.
+
+        Declaring `bezel -> S9` is wrong on the artifact, and the sibling
+        contract-fidelity review is what audits it. What this module ends is
+        the claim being made by nobody, in silence.
+        """
+        body = BODY_331 + "\n<!-- scope-alias: bezel -> S9 -->\n"
+        report = check_scope_coverage(TITLE_331, body)
+        assert report.aliased["bezel"] == "S9"
+
+    def test_an_exclusion_discharges_a_finding(self) -> None:
+        title = "feat: renderer — bezel, dial face, numerals, screws"
+        body = (
+            "Draws the face. No bezel -- the ring belongs to #999.\n" + TABLE_331
+        )
+        report = check_scope_coverage(title, body)
+        assert "bezel" in report.excluded
+        assert report.ok
+
+    def test_an_exclusion_needs_a_reason(self) -> None:
+        """`NO gradient, glass sweep, or reflection` is a binding value.
+
+        S1's own cell writes it. Reading it as a scope exclusion would let a
+        table cell silently excuse an element the issue promised.
+        """
+        assert "gradient" not in declared_exclusions(BODY_331)
+
+    def test_a_boundary_terms_section_declares_exclusions(self) -> None:
+        exclusions = declared_exclusions(BODY_331)
+        assert "caching lifetime and invalidation policy" in exclusions
+
+    def test_an_alias_is_read_regardless_of_arrow_spelling(self) -> None:
+        for arrow in ("->", "→"):
+            body = f"<!-- scope-alias: tick marks {arrow} S3, S4 -->"
+            assert declared_aliases(body) == {"tick marks": "S3, S4"}
+
+
+# ---------------------------------------------------------------------------
+# Silence is not a pass
+# ---------------------------------------------------------------------------
+
+
+class TestVacuousStatesAreDisclosed:
+    def test_no_enumeration_is_not_checked(self) -> None:
+        report = check_scope_coverage("fix: a typo", TABLE_331)
+        assert report.vacuous
+        assert "NOT CHECKED" in report.disclosure()
+        assert "no scope enumeration" in report.disclosure()
+        assert report.ok  # nothing was found wrong, and nothing was judged
+
+    def test_no_criteria_table_is_not_checked(self) -> None:
+        report = check_scope_coverage(TITLE_331, LEDE_331)
+        assert report.vacuous
+        assert "NOT CHECKED" in report.disclosure()
+        assert "no criteria table" in report.disclosure()
+
+    def test_a_judged_document_says_what_it_judged(self, report_331) -> None:
+        line = report_331.disclosure()
+        assert "NOT CHECKED" not in line
+        assert "8 element(s) named in scope prose against 9 table row(s)" in line
+        assert "2 undisposed" in line
+
+    def test_a_clean_document_reports_zero_undisposed(self) -> None:
+        body = (
+            BODY_331
+            + "\n<!-- scope-alias: tick marks -> S3, S4 -->"
+            + "\n<!-- scope-alias: bezel -> S9 -->\n"
+        )
+        report = check_scope_coverage(TITLE_331, body)
+        assert report.ok
+        assert "0 undisposed" in report.disclosure()
+
+    def test_an_empty_body_never_raises(self) -> None:
+        report = check_scope_coverage("", "")
+        assert report.vacuous
+        assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# At the seam it actually runs at
+# ---------------------------------------------------------------------------
+
+
+def _fetch(title: str, body: str):
+    def fetch(_repo_root, _issue):
+        return (title, body)
+    return fetch
+
+
+class TestItRunsAtLauncherPreflight:
+    """Free, instant, and before anything is spent -- beside the form check.
+
+    The #331 defect was cheapest to catch here: at ratification, before
+    nineteen ruled conflicts hardened a table that was already missing a row.
+    """
+
+    def test_the_331_finding_reaches_the_operators_console(self, tmp_path) -> None:
+        text, refuse = check_form_at_preflight(
+            tmp_path, [331], _fetch(TITLE_331, BODY_331)
+        )
+        assert "scope coverage:" in text
+        assert "bezel" in text
+
+    def test_it_does_not_refuse(self, tmp_path) -> None:
+        """Report-only: no issue in the fleet declares an alias yet."""
+        _text, refuse = check_form_at_preflight(
+            tmp_path, [331], _fetch(TITLE_331, BODY_331)
+        )
+        assert refuse is False
+
+    def test_it_speaks_on_a_clean_issue_too(self, tmp_path) -> None:
+        """A check that is silent when it passes cannot be told from one that
+        never ran -- #2381's complaint about box health."""
+        body = (
+            BODY_331
+            + "\n<!-- scope-alias: tick marks -> S3, S4 -->"
+            + "\n<!-- scope-alias: bezel -> S9 -->\n"
+        )
+        text, _ = check_form_at_preflight(tmp_path, [331], _fetch(TITLE_331, body))
+        assert "scope coverage:" in text
+        assert "0 undisposed" in text
+
+    def test_it_discloses_when_it_checked_nothing(self, tmp_path) -> None:
+        text, _ = check_form_at_preflight(
+            tmp_path, [7], _fetch("fix: a typo", "Some prose with no table.\n")
+        )
+        assert "scope coverage: NOT CHECKED" in text
+
+    def test_a_scope_crash_never_costs_the_form_check_its_verdict(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The declared fail-open, exercised rather than asserted about."""
+        monkeypatch.setattr(
+            form_gate, "check_scope_coverage",
+            lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = form_gate.check_issue(tmp_path, 331, _fetch(TITLE_331, BODY_331))
+        assert result.scope is None
+        assert result.report is not None  # the form check still reached a verdict
+        text, _ = form_gate.render([result])
+        assert "scope coverage" not in text  # absent, never a passing line


### PR DESCRIPTION
Every gate this campaign built audits rows that **exist**. Row-absence is invisible to all of them, and the gap cost boostgauge #331 its dominant visual element: the title and the opening scope both name "bezel", the S-table carried no bezel-ring row, nineteen ruled conflicts hardened every row that existed, and nothing ever asked whether a row was missing. The factory then ran the nine-row table through fourteen gates with perfect fidelity and faithfully built an incomplete face.

## The acceptance case is a near-miss, and that decided the design

#331's table **does** carry a row whose Element cell begins with the word bezel — `S9 | Bezel seat`, which asserts a shadow on the transition annulus at 1.01 R and binds nothing about the ring. Four matchers, measured over the preserved body against what a human reader gives:

| matcher | errors |
|---|---|
| substring | `bezel` **FALSE PASS**, `tick marks` false alarm |
| token-subset | `bezel` **FALSE PASS**, `tick marks` false alarm |
| exact | `dial`, `ticks`, `tick marks` false alarms |
| head-noun | `dial`, `tick marks` false alarms |

The reason no rule does better is structural:

```
'Dial face'    modifier=dial   head=face   -> COVERS 'dial'
'Bezel seat'   modifier=bezel  head=seat   -> does NOT cover 'bezel'
```

Identical shape, opposite answers. A name-matcher here is a proxy-heuristic in #2540's exact sense, and its failure direction is a **false pass** — the one direction a gate must not fail in. The two matchers that read as most helpful are precisely the two that ship #331 unchanged.

So the module matches **normalized-exact** and never judges coverage. Exact is the least accurate of the four by raw error count; it is the only one whose errors all point the safe way. Three explicit sources dispose of an element and nothing else does:

1. a criteria-table row whose Element cell equals the term,
2. a declared alias — `<!-- scope-alias: tick marks -> S3, S4 -->`,
3. a declared exclusion carrying a reason — #331's `NO pivot cap -- ... belongs to #332` is the existing pattern and parses today.

That is exact bookkeeping over three named sets: the `manifest_traceability` shape, a fact-verifier. What it can no longer do is decide that S9 covers "bezel". What it does is make somebody **write that claim down**, where the sibling contract-fidelity review then audits it against the contract.

## Two findings the issue did not name, both measured

**The form check never looked at this table.** `check_form` on #331's preserved body reports `Decision tables: 0 found, so 0 checked` and `RESULT: PASS`. `is_decision_table` requires ADR 0226 yes/no condition columns; #331's table is `ID | Element | Binding value | Assertion method`. A check keyed on that predicate would have examined **zero tables on the exact issue it was built for** and reported clean — a vacuous pass wearing a gate's clothes. This keys on `is_criteria_table`, the predicate `table_injection` and the manifest compiler already share, and adds no third notion of what a table is.

**The title and the scope sentence name two elements at two grains** — `dial`/`dial face`, `ticks`/`tick marks`. Reporting both would put two findings on the board for one thing. They are reconciled **prose against prose only, never against a row**: two prose names nesting means the author refined their own statement, while a prose name nesting inside a row name means nothing of the kind. Letting rows into that rule reintroduces the token-subset matcher measured above as a false pass on this module's own acceptance case.

## Replayed on #331

Fires on exactly two things — `bezel`, the shipped defect, and `tick marks`, discharged by one alias line and never fired again:

```
scope coverage: 8 element(s) named in scope prose against 9 table row(s) —
6 matched a row, 0 declared an alias, 0 declared an exclusion, 2 undisposed.
  [scope-uncovered] bezel: named in the title but no table row is called
      'bezel' ... Matching is exact by design: a row that merely mentions
      'bezel' is not evidence it binds it.
  [scope-uncovered] tick marks (also named 'ticks'): ...
```

The pivot-cap exclusion parses with its reason and passes as the declared-exclusion control.

## Where it runs

Launcher preflight, beside the form check and the discrimination check — free, instant, before anything is spent. **Report-only:** no issue in the fleet declares an alias yet, and a gate that refuses on the ordinary case is one people learn to wave through (the #2227 ruling, and #2387's). It prints on every issue, pass or fail, and discloses a vacuous result separately from a clean one, because a check that is silent when it passes cannot be told from one that never ran.

Its fail-open handler is declared per the #2475 regime and returns `None` rather than a clean report — `render` then prints no line at all, so the operator sees the disclosure missing rather than a passing one.

## Boundary

A draw-order list quoted **in the issue body** is read like any other enumeration. One that lives only in the cited design contract is not: loading the contract belongs to the sibling contract-fidelity review (see #2646), and two loaders of one document is the #1698 class.

## Tests

`tests/unit/test_scope_coverage.py`, 38 cases. The #331 excerpts are verbatim from the preserved issue body — evidence, not paraphrase.

- `TestNoNameMatcherSeparatesThem` — the measurement the design rests on, kept as a program: the false pass is asserted, not argued.
- `TestThe331Acceptance` — fires naming `bezel`; the pivot-cap control passes; fires on **exactly** `{bezel, tick marks}`, stated as an exact set because a gate that names nine elements when one is missing gets waved through.
- `TestItLooksAtTheTableThatIsActuallyThere` — the vacuous-pass trap, measured: `is_decision_table` is False, `is_criteria_table` is True, and `check_form` returns PASS naming nothing.
- `TestDispositions`, `TestVacuousStatesAreDisclosed`, `TestItRunsAtLauncherPreflight` — including the declared fail-open exercised rather than asserted about.

Full unit suite: **9309 passed, 21 skipped, 5 xfailed**. `ruff check` clean.

Closes #2645
