### PR TITLE
fix: a table present and unexamined never reads as a table checked (Closes #2650)

### DIFF
--- a/assemblyzero/workflows/requirements/form_check.py
+++ b/assemblyzero/workflows/requirements/form_check.py
@@ -167,6 +167,21 @@ class FormReport:
     def ok(self) -> bool:
         return not self.violations
 
+    @property
+    def vacuous_tables(self) -> bool:
+        """A table is present and NONE of them was examined (#2650).
+
+        Distinct from `not tables`, which is also true when the issue carries
+        no table at all. Those are different facts and the report renders them
+        differently -- the same distinction #2227 drew for vacuous EARS and
+        #2387 for discrimination coverage.
+
+        The measured case is boostgauge #331: a nine-row criteria table at
+        line 14, `is_decision_table` False for it per ADR 0226 section 3.2,
+        and a bare `RESULT: PASS` above a body line reading `0 found`.
+        """
+        return not self.tables and self.non_decision_tables > 0
+
 
 # ---------------------------------------------------------------------------
 # Document structure
@@ -722,7 +737,21 @@ def render_report(report: FormReport, label: str) -> str:
             )
 
     out.append("")
-    if not report.tables:
+    if not report.tables and report.non_decision_tables:
+        # #2650: "0 found" states a count of found tables that is not the
+        # number of tables found. On boostgauge #331 a nine-row table sits at
+        # line 14 and this line said 0, while the `Not verified` bullet below
+        # said 1 -- two lines of one report contradicting each other, and the
+        # operator reads the first. The vacuous sentence is `render_ownership`'s
+        # own, unchanged, because this is the same fact about a sibling branch.
+        out += [
+            f"Decision tables: {report.non_decision_tables} table(s) present, "
+            f"0 of them decision tables, so 0 checked.",
+            "  ADR 0226 section 3.2 requires plain yes/no in every non-outcome",
+            "  column. That is an honest vacuous result, not a pass: the",
+            "  table(s) this issue carries were not examined.",
+        ]
+    elif not report.tables:
         out.append("Decision tables: 0 found, so 0 checked.")
     else:
         out.append(f"Decision tables: {len(report.tables)}")
@@ -778,13 +807,38 @@ def render_report(report: FormReport, label: str) -> str:
         ]
 
     out += [""]
+    # #2650: the qualification rides ON the verdict line, because the verdict
+    # line is what an operator reads. A body disclosure eleven lines above a
+    # bare PASS is what this issue measured and is not enough.
+    #
+    # Scoped to the TABLE branch deliberately. Vacuous EARS and vacuous
+    # ownership state themselves in the body and do not qualify the verdict;
+    # making them do so would extend the fleet-wide vacuity invariant by
+    # implementation, and that invariant is a standing proposal for the
+    # operator to ratify rather than something to decree from a print
+    # statement.
     if report.ok:
-        out.append("RESULT: PASS -- 0 violations of the ADR 0226 form.")
+        out.append("RESULT: PASS -- 0 violations of the ADR 0226 form." + (
+            f" VACUOUS on tables: {report.non_decision_tables} present, "
+            f"0 examined."
+            if report.vacuous_tables else ""
+        ))
     else:
-        out.append(f"RESULT: FAIL -- {len(report.violations)} violation(s).")
+        out.append(f"RESULT: FAIL -- {len(report.violations)} violation(s)." + (
+            f" VACUOUS on tables: {report.non_decision_tables} present, "
+            f"0 examined."
+            if report.vacuous_tables else ""
+        ))
         out.append("")
         for violation in report.violations:
             out.append(f"  {violation}")
+
+    if report.vacuous_tables:
+        out += [
+            "",
+            "  This verdict reports what was CHECKED. No table was checked, so",
+            "  it says nothing about the table(s) this issue carries.",
+        ]
 
     out += ["", rule]
     return "\n".join(out) + "\n"

--- a/assemblyzero/workflows/requirements/form_gate.py
+++ b/assemblyzero/workflows/requirements/form_gate.py
@@ -102,6 +102,18 @@ class IssueForm:
     def vacuous_ears(self) -> bool:
         return bool(self.report and not self.report.ears_ran)
 
+    @property
+    def vacuous_tables(self) -> bool:
+        """A table is present and none of them was examined (#2650).
+
+        `has_tables` cannot answer this: it is False both for an issue with no
+        table and for one carrying a table this check does not examine, and
+        the note it drove said "no decision table, so none was checked" for
+        both. On boostgauge #331 that ran at every launch, over a nine-row
+        table the rest of the pipeline treats as normative.
+        """
+        return bool(self.report and self.report.vacuous_tables)
+
 
 def classify(report: FormReport) -> tuple[list, list]:
     """(refusing, reporting) violations, per the ruling.
@@ -192,8 +204,19 @@ def render(results: list[IssueForm]) -> tuple[str, bool]:
                 "no '## Requirements' section, so NO sentence in it was checked "
                 "-- this is a vacuous pass, not a clean bill"
             )
-        if not item.has_tables:
-            notes.append("no decision table, so none was checked")
+        if item.vacuous_tables:
+            # #2650: the launch path said "no decision table" about an issue
+            # carrying one. Load-bearing for the same reason the EARS note
+            # above is: this is the surface an operator reads before spending
+            # a roll, and it was reporting the checked-nothing case in the
+            # words of the nothing-to-check case.
+            notes.append(
+                f"{item.report.non_decision_tables} table(s) present and NOT "
+                f"of the checked kind (ADR 0226 3.2 wants plain yes/no "
+                f"columns), so NO table was checked -- vacuous, not a clean bill"
+            )
+        elif not item.has_tables:
+            notes.append("no table in this issue, so none was checked")
 
         if item.refusing:
             refuse = True

--- a/assemblyzero/workflows/requirements/scope_coverage.py
+++ b/assemblyzero/workflows/requirements/scope_coverage.py
@@ -58,15 +58,19 @@ somebody write that claim down.
 
 ## It reads criteria tables, not ADR 0226 decision tables
 
-`check_form` on #331's preserved body reports `Decision tables: 0 found, so 0
-checked` and `RESULT: PASS`. `is_decision_table` requires yes/no condition
-columns per ADR 0226 section 3.2; #331's table is `ID | Element | Binding value
-| Assertion method`, which `is_criteria_table` recognises and that predicate
-does not. A check keyed on the wrong predicate would examine zero tables on the
-exact issue it was built for and report clean -- a vacuous pass wearing a
-gate's clothes. This module keys on `is_criteria_table`, the same predicate
-`table_injection` and the manifest compiler already share, and adds no third
-notion of what a table is.
+`check_form` examines no table on #331's preserved body. `is_decision_table`
+requires yes/no condition columns per ADR 0226 section 3.2; #331's table is
+`ID | Element | Binding value | Assertion method`, which `is_criteria_table`
+recognises and that predicate does not. A check keyed on the wrong predicate
+would examine zero tables on the exact issue it was built for and report clean
+-- a vacuous pass wearing a gate's clothes. This module keys on
+`is_criteria_table`, the same predicate `table_injection` and the manifest
+compiler already share, and adds no third notion of what a table is.
+
+(When this module landed, `check_form` rendered that as `Decision tables: 0
+found` under a bare `RESULT: PASS` -- the reporting defect filed as #2650 and
+since fixed. The predicate split it describes is unchanged; only the wording
+this paragraph used to quote is.)
 
 ## What it deliberately does not read
 

--- a/tests/unit/test_check_requirements_form.py
+++ b/tests/unit/test_check_requirements_form.py
@@ -541,6 +541,150 @@ class TestReportHonesty:
 
 
 # ---------------------------------------------------------------------------
+# A table present and unexamined never reads as a table checked (#2650)
+# ---------------------------------------------------------------------------
+
+
+#: boostgauge #331's shape, and the shape this campaign actually rolls: an ID,
+#: an element, a binding value and an assertion method. ADR 0226 section 3.2
+#: defines a decision table by plain yes/no in every non-outcome column, so
+#: `is_decision_table` is False for this and `is_criteria_table` is True --
+#: the predicate `table_injection` and the manifest compiler already share.
+CRITERIA_TABLE_BODY = """\
+Render the complete static face.
+
+## Requirements
+
+- WHEN `render_face(size)` is called with `size >= 128`, the skin module shall return a `PIL.Image` of dimensions `size x size`.
+
+## Decision table — static elements and their binding values
+
+| ID | Element | Binding value | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C`, radius R = 0.40 x size | classification at 3 interior points |
+| S7 | Chrome housing | square, chamfer radius 0.13 x size | the #328 predicate: >=3 achromatic samples |
+| S9 | Bezel seat | dial sits below the bezel plane | sample at 1.01 R is darker than chrome at 1.10 R |
+"""
+
+
+class TestAVacuousTableCheckDoesNotReadAsAPass:
+    """#2650. Measured on boostgauge #331: a nine-row table at line 14, and a
+    bare `RESULT: PASS` above a body line reading `Decision tables: 0 found`.
+
+    The two lines of one report contradicted each other -- the `Not verified`
+    bullet said 1 -- and the operator reads the first.
+    """
+
+    @pytest.fixture
+    def report(self):
+        return fc.check_form(CRITERIA_TABLE_BODY)
+
+    def test_the_table_is_present_and_is_not_a_decision_table(self, report):
+        tables = fc.parse_tables(CRITERIA_TABLE_BODY)
+        assert len(tables) == 1
+        assert not fc.is_decision_table(tables[0])
+        assert report.non_decision_tables == 1
+        assert report.tables == []
+
+    def test_the_state_has_a_name_of_its_own(self, report):
+        """`not tables` is true for two different facts. This separates them."""
+        assert report.vacuous_tables
+        assert not fc.check_form("# just a title\n").vacuous_tables
+
+    def test_the_count_of_found_tables_is_the_number_found(self, report):
+        rendered = fc.render_report(report, "boostgauge #331")
+
+        assert "1 table(s) present, 0 of them decision tables" in rendered
+        assert "Decision tables: 0 found" not in rendered
+
+    def test_it_says_the_vacuous_sentence_the_ownership_branch_says(
+        self, report
+    ):
+        """Same fact about a sibling branch, so the same words -- not new ones.
+
+        Compared on normalised whitespace: the two branches wrap the sentence
+        at different columns, and the claim is about the words.
+        """
+        flat = " ".join(fc.render_report(report, "x").split())
+
+        assert flat.count("That is an honest vacuous result, not a pass") == 2
+
+    def test_the_verdict_line_itself_carries_the_qualification(self, report):
+        """The acceptance: at the same prominence as the verdict.
+
+        A disclosure eleven lines above a bare PASS is what this issue
+        measured, so the qualification rides ON the verdict line.
+        """
+        verdict = next(
+            line for line in fc.render_report(report, "x").splitlines()
+            if line.startswith("RESULT:")
+        )
+        assert verdict == (
+            "RESULT: PASS -- 0 violations of the ADR 0226 form. "
+            "VACUOUS on tables: 1 present, 0 examined."
+        )
+
+    def test_it_says_what_the_verdict_does_not_cover(self, report):
+        rendered = fc.render_report(report, "x")
+
+        assert "This verdict reports what was CHECKED" in rendered
+        assert "says nothing about the table(s) this issue carries" in rendered
+
+    def test_a_failing_verdict_is_qualified_too(self):
+        """A FAIL that examined no table overstates in the same direction."""
+        body = CRITERIA_TABLE_BODY.replace(
+            "- WHEN `render_face(size)` is called with `size >= 128`, the skin "
+            "module shall return a `PIL.Image` of dimensions `size x size`.",
+            "- Config is saved on exit.",
+        )
+        report = fc.check_form(body)
+        assert not report.ok
+        assert report.vacuous_tables
+
+        verdict = next(
+            line for line in fc.render_report(report, "x").splitlines()
+            if line.startswith("RESULT:")
+        )
+        assert "RESULT: FAIL" in verdict
+        assert "VACUOUS on tables: 1 present, 0 examined." in verdict
+
+    def test_a_real_decision_table_is_never_called_vacuous(self, ids_body):
+        report = fc.check_form(ids_body)
+
+        assert report.tables
+        assert not report.vacuous_tables
+        rendered = fc.render_report(report, "cache")
+        assert "VACUOUS on tables" not in rendered
+        assert "This verdict reports what was CHECKED" not in rendered
+
+    def test_an_issue_with_no_table_at_all_is_unchanged(self):
+        """Nothing-to-check and checked-nothing stay different facts."""
+        report = fc.check_form("# just a title\n")
+        rendered = fc.render_report(report, "empty")
+
+        assert not report.vacuous_tables
+        assert "Decision tables: 0 found, so 0 checked." in rendered
+        assert "VACUOUS on tables" not in rendered
+
+    def test_the_ears_and_ownership_branches_are_left_alone(self, report):
+        """Scoped to tables deliberately.
+
+        Extending the qualification to every vacuous branch would decree the
+        fleet-wide vacuity invariant by implementation, and that invariant is
+        a standing proposal for the operator to ratify.
+        """
+        no_requirements = fc.check_form("# t\n\nsome prose\n")
+        rendered = fc.render_report(no_requirements, "x")
+
+        assert not no_requirements.ears_ran
+        assert not no_requirements.ownership.ran
+        verdict = next(
+            line for line in rendered.splitlines() if line.startswith("RESULT:")
+        )
+        assert verdict == "RESULT: PASS -- 0 violations of the ADR 0226 form."
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_form_gate.py
+++ b/tests/unit/test_form_gate.py
@@ -136,7 +136,10 @@ class TestTheRefusalCondition:
             tmp_path, [7], _fetch({7: PROSE_ISSUE})
         )
         assert not refuse
-        assert "no decision table" in text
+        # #2650: was "no decision table", which said the same thing about an
+        # issue carrying no table and an issue carrying one this check does
+        # not examine. This issue is the former, and now says so.
+        assert "no table in this issue, so none was checked" in text
 
     def test_a_well_formed_table_does_not_refuse(self, tmp_path):
         text, refuse = check_form_at_preflight(
@@ -267,6 +270,70 @@ class TestSilenceIsNotAPass:
     def test_the_report_says_it_cannot_report_correctness(self, tmp_path):
         text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
         assert "CORRECTNESS" in text
+
+
+#: A criteria table -- `ID | Element | Binding value | Assertion method`, the
+#: shape boostgauge #331 carries and this campaign actually rolls. Not an
+#: ADR 0226 decision table, so the form check does not examine it.
+CRITERIA_TABLE_ISSUE = """\
+Render the static face.
+
+## Requirements
+
+- WHEN `render_face(size)` is called, the skin module shall return a `PIL.Image`.
+
+## Decision table
+
+| ID | Element | Binding value | Assertion method |
+|---|---|---|---|
+| S1 | Dial face | flat `#0A0A0C` | classification at 3 interior points |
+| S9 | Bezel seat | dial sits below the bezel plane | sample at 1.01 R is darker |
+"""
+
+
+class TestATablePresentButUnexaminedSaysSoAtLaunch:
+    """#2650. The launch path is the surface an operator reads before spending
+    a roll, and it said `no decision table, so none was checked` about an issue
+    carrying a nine-row table the rest of the pipeline treats as normative.
+
+    `has_tables` cannot tell those two states apart -- it is False for both --
+    so the note it drove reported the checked-nothing case in the words of the
+    nothing-to-check case.
+    """
+
+    def test_the_note_says_a_table_was_present(self, tmp_path):
+        text, refuse = check_form_at_preflight(
+            tmp_path, [331], _fetch({331: CRITERIA_TABLE_ISSUE})
+        )
+        assert not refuse
+        assert "1 table(s) present and NOT of the checked kind" in text
+        assert "NO table was checked" in text
+        assert "vacuous, not a clean bill" in text
+
+    def test_it_no_longer_claims_there_is_no_table(self, tmp_path):
+        text, _ = check_form_at_preflight(
+            tmp_path, [331], _fetch({331: CRITERIA_TABLE_ISSUE})
+        )
+        assert "no decision table, so none was checked" not in text
+        assert "no table in this issue" not in text
+
+    def test_an_issue_with_no_table_at_all_reads_differently(self, tmp_path):
+        """Nothing-to-check and checked-nothing stay different facts."""
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: PROSE_ISSUE}))
+        assert "no table in this issue, so none was checked" in text
+        assert "NOT of the checked kind" not in text
+
+    def test_a_real_decision_table_carries_no_such_note(self, tmp_path):
+        text, _ = check_form_at_preflight(tmp_path, [7], _fetch({7: GOOD_ISSUE}))
+        assert "NOT of the checked kind" not in text
+        assert "no table in this issue" not in text
+
+    def test_it_still_does_not_refuse(self, tmp_path):
+        """Report-only. A criteria table is the ordinary case, not a defect."""
+        _text, refuse = check_form_at_preflight(
+            tmp_path, [331], _fetch({331: CRITERIA_TABLE_ISSUE})
+        )
+        assert refuse is False
 
 
 class TestPresentation:

--- a/tests/unit/test_scope_coverage.py
+++ b/tests/unit/test_scope_coverage.py
@@ -28,6 +28,7 @@ from assemblyzero.workflows.requirements.form_check import (
     check_form,
     is_decision_table,
     parse_tables,
+    render_report,
 )
 from assemblyzero.workflows.requirements.scope_coverage import (
     check_scope_coverage,
@@ -210,11 +211,26 @@ class TestItLooksAtTheTableThatIsActuallyThere:
         assert not is_decision_table(tables[0])
         assert is_criteria_table(tables[0])
 
-    def test_the_form_check_therefore_examines_nothing_and_passes(self) -> None:
-        """The vacuous pass this module exists beside, measured not assumed."""
+    def test_the_form_check_therefore_examines_nothing(self) -> None:
+        """The vacuous result this module exists beside, measured not assumed.
+
+        #2650 changed what this witnesses. The form check still examines no
+        table here and still finds no violation -- #2645's reason for keying
+        on `is_criteria_table` is unchanged and still pinned above. What it no
+        longer does is render that as a bare PASS, so the assertion moved from
+        "and passes silently" to "and says so".
+        """
         report = check_form(BODY_331)
         assert report.tables == []
         assert report.ok
+        assert report.vacuous_tables
+
+        rendered = render_report(report, "boostgauge #331")
+        verdict = next(
+            line for line in rendered.splitlines() if line.startswith("RESULT:")
+        )
+        assert "VACUOUS on tables" in verdict
+        assert "Decision tables: 0 found" not in rendered
         assert "bezel" not in "\n".join(str(v) for v in report.violations)
 
     def test_this_module_examines_all_nine_rows(self, report_331) -> None:


### PR DESCRIPTION
`check_form` on boostgauge #331's preserved body examined **zero** tables and printed `RESULT: PASS`. The nine-row criteria table sits at line 14; `is_decision_table` is False for it because ADR 0226 §3.2 wants plain yes/no in every non-outcome column, and #331's are `ID | Element | Binding value | Assertion method` — the shape `table_injection` injects byte-verbatim, the manifest compiler reads, and the contract-fidelity reviewer audits.

Two things were worse than the filing said, and the second changed what the fix had to touch.

## `Decision tables: 0 found` states a count that is not the number of tables found

```
=== every markdown table in the body, and its classification ===
  line 14: 9 rows, header=['ID', 'Element']... is_decision_table=False

FormReport fields
  tables (checked):      0
  non_decision_tables:   1
```

A table **was** found. The `Not verified` bullet three paragraphs below said 1, so two lines of one report contradicted each other — and the operator reads the first. This was not a missing disclosure; it was a wrong one.

## There are two operator-facing surfaces and only one was named

| surface | consumer | what it printed on #331 |
|---|---|---|
| `render_report` | `tools/check_requirements_form.py`, run by hand | `RESULT: PASS -- 0 violations of the ADR 0226 form.` |
| `form_gate.render` | **launcher preflight, every roll** | `note: no decision table, so none was checked` |

The acceptance binds `render_report`. But the launch path is `form_gate.render`, and its note said `no decision table` about an issue carrying one — the same conflation, on the surface that actually stands between an operator and a roll. It reached that wording through `IssueForm.has_tables`, which is `bool(report.tables)` and so cannot tell an issue with no table from one carrying a table this check does not examine.

Fixing only the first would have satisfied the written acceptance and left the launch path saying the same wrong thing. Both are fixed.

## What changed

The state has a name — `FormReport.vacuous_tables` — because `not tables` was true for two different facts. The vacuous sentence is `render_ownership`'s own, unchanged: this is the same fact about a sibling branch of the same report, so it gets the same words rather than new ones.

```
Decision tables: 1 table(s) present, 0 of them decision tables, so 0 checked.
  ADR 0226 section 3.2 requires plain yes/no in every non-outcome
  column. That is an honest vacuous result, not a pass: the
  table(s) this issue carries were not examined.
...
RESULT: PASS -- 0 violations of the ADR 0226 form. VACUOUS on tables: 1 present, 0 examined.

  This verdict reports what was CHECKED. No table was checked, so
  it says nothing about the table(s) this issue carries.
```

and at launch:

```
note: 1 table(s) present and NOT of the checked kind (ADR 0226 3.2 wants plain
      yes/no columns), so NO table was checked -- vacuous, not a clean bill
```

The qualification rides **on** the verdict line, because a disclosure eleven lines above a bare PASS is what this issue measured.

## What is deliberately left alone

**Scoped to the table branch.** Vacuous EARS and vacuous ownership already state themselves in the body and still do not qualify the verdict line. Making them do so would extend the fleet-wide vacuity invariant by implementation, and that invariant is a standing proposal for the operator to ratify. A test pins that they are untouched.

**`check_requirements_form.py`'s exit code.** It returns `EXIT_PASS` when `report.ok`, so the exit code still says "the form holds" for a run that examined no table. Same class, same reason: changing an exit-code contract is deciding that policy.

**Extending the checking to criteria tables** is filed as #2653 rather than decided here, with the measurement of what taking it naively would cost. Fed to `check_tables` as a decision table, #331 produces:

```
[table-rows]    2 binary conditions require 2^2 = 4 rows; it carries 9
[row-criterion] no '## Acceptance Criteria' section, so none of its 9 rows has a criterion
```

Both false — the first read `Element` and `Binding value` as condition columns, the second demanded a criteria list the ruled shape replaces with column 4. And **`table-rows` is in `REFUSING_KINDS`**, so the naive extension does not add a noisy line: it refuses the roll, on the exact table shape this campaign rolls.

## The regression witness

`test_the_form_check_therefore_examines_nothing_and_passes` is renamed to `test_the_form_check_therefore_examines_nothing`. It still pins that the form check examines no table here and finds no violation — #2645's reason for keying on `is_criteria_table` is unchanged and the `is_decision_table`/`is_criteria_table` split is still asserted above it. What it stops asserting is that the render passes silently; what it starts asserting is the disclosure.

`scope_coverage.py`'s module docstring quoted the old output verbatim and would have become a doc that lies; it now describes the split without quoting wording that moved, and notes why.

## Tests

23 new cases across `test_check_requirements_form.py` (the report) and `test_form_gate.py` (the launch path), plus the updated witness. Both directions are pinned: a criteria table says so, a real decision table is never called vacuous, and an issue with no table at all still reads `Decision tables: 0 found, so 0 checked` — nothing-to-check and checked-nothing stay different facts.

Full unit suite: **9361 passed, 21 skipped, 5 xfailed**. `ruff check` clean on all six changed files.

Closes #2650
