### PR TITLE
feat: every contract law is tracked, not only the ones a row happened to cite (Closes #2651)

### DIFF
--- a/assemblyzero/workflows/requirements/contract_fidelity.py
+++ b/assemblyzero/workflows/requirements/contract_fidelity.py
@@ -89,6 +89,38 @@ row reaches a scoped section at all is a fact, and that is
 rendering, Width and Highlights with no row naming them, against S9 for
 Bezel-to-dial transition: exactly boostgauge #375's list.
 
+## Every law is tracked, not only the ones a row happened to cite (#2651)
+
+`ContractSection.laws` was built for shape 2 and read in one place -- and only
+for a section a row's binding cell cites by ruling number or `§Name`. S7's cell
+happens to say `per #328's stops table`, so the chrome step law surfaces.
+Rewrite it as `chrome per the contract` -- same meaning, no citation token --
+and the sharpest evidence in the audit goes silent while the law stays exactly
+as binding. Shape 2 also cannot see a section that states a law and carries no
+table: it returns early when `table_values` is empty.
+
+So `law_ledger` tracks every law of every in-play section against the rows that
+reach its section, and a law no row reaches is UNDISCHARGED -- a fact. Whether
+a reaching row's assertion could actually fail under a violating render stays
+the reviewer's, exactly where the binding ledger leaves its own judgement.
+
+Three repairs the ledger's own acceptance required, each measured:
+
+* **`No overlays, ever` is a law and `MUST|NEVER|shall` could not see it.** The
+  vocabulary gained `X, ever` and nothing else -- on the real contract that is
+  one additional line, §Face's flat-fill rule, which #331's S1 discharges.
+  Lowercase widening would have taken the extractor from 3 lines to 21, most of
+  them the document narrating its own history.
+* **Two of three laws were quoted as fragments.** Sentence splitting fires on
+  the `.` of an ordered-list marker, so a law introducing a list came out as
+  its header plus a bare `1.`. Blocks are read before sentences now.
+* **`rows_referencing` matched on provenance.** A dated heading carries its own
+  citation, and rows citing a different ruling shared `ruling`, `2026`, `08` --
+  so a chrome section matched five of #331's nine rows on a date. That was the
+  false-coverage direction for `binding_ledger`, which scopes its row text by
+  the same function, and it was latent only because the sections carrying
+  sub-bindings have single-word names.
+
 The review half then adjudicates with the contract in hand -- the thing no
 current stage does. Report-only, for the reasons #2227 and #2387 give, and only
 for repos that declare a binding contract for the issue being rolled; every
@@ -145,7 +177,29 @@ _NAMED_RULE = re.compile(
 )
 
 #: A law the contract states as binding rather than describing.
-_MUST_LAW = re.compile(r"\b(?:MUST|NEVER|shall)\b")
+#:
+#: `X, ever` was added by #2651 and the addition is deliberately that narrow.
+#: Measured over the whole 301-line contract:
+#:
+#:     MUST|NEVER|shall                 3 lines
+#:     + lowercase must/never          21 lines
+#:     + `X, ever`                     22 lines  <- one more, and it is §Face
+#:     + is rejected/retired/forbidden 23 lines
+#:
+#: The one line `X, ever` adds is 198, §Face's `No overlays, ever` -- the
+#: flat-fill law from ruling #325, which #331's S1 discharges and which the
+#: uppercase-only vocabulary could not see at all. Lowercase widening takes
+#: the extractor from 3 lines to 21 and most of the additions are the document
+#: narrating its own history ("regen-dependency retired", "the operator
+#: approved the render", "Twelve spec review rounds tripped"). Deciding what
+#: counts as law in prose is a judgement, and this module's standing line is
+#: that judgements go to the reviewer rather than into a widened regex.
+_MUST_LAW = re.compile(r"\b(?:MUST|NEVER|shall)\b|\b\w+,\s*ever\b")
+
+#: A blank-line block boundary, and a sentence boundary within one block.
+#: Laws are found per block first -- see `ContractSection.laws` for why.
+_BLOCK = re.compile(r"\n\s*\n")
+_SENTENCE = re.compile(r"(?<=[.;])\s+")
 
 #: Provenance, not specification: a ruling reference, an ISO date, or a
 #: `(ruling ...)` parenthetical. Stripped BEFORE values are read.
@@ -233,12 +287,36 @@ class ContractSection:
 
     @property
     def laws(self) -> list[str]:
-        """Sentences the contract states as binding, quoted for the reviewer."""
-        return [
-            sentence.strip()
-            for sentence in re.split(r"(?<=[.;])\s+", self.body)
-            if _MUST_LAW.search(sentence)
-        ]
+        """What the contract states as binding, quoted whole for the reviewer.
+
+        Blocks first, sentences second (#2651). Splitting the body straight
+        into sentences fires on the `.` of an ordered-list marker, and two of
+        this contract's three laws came out as
+        `Code implementing #1 (core gauge renderer) MUST:` followed by a bare
+        `1.` -- a header with its three numbered obligations dropped, quoted
+        into the reviewer's brief as if it were the law.
+
+        So a block carrying the marker and ending in a colon absorbs the block
+        after it, which is where the obligations live. Everything else is
+        quoted at sentence granularity, unchanged: §Chrome environment strip's
+        block does not end in a colon, so the step law is still the single
+        sentence `signal_assertions_that_cannot_falsify` has always quoted.
+        """
+        found: list[str] = []
+        blocks = [b for b in _BLOCK.split(self.body) if b.strip()]
+        for i, block in enumerate(blocks):
+            if not _MUST_LAW.search(block):
+                continue
+            text = block.strip()
+            if text.endswith(":") and i + 1 < len(blocks):
+                found.append(f"{text}\n{blocks[i + 1].strip()}")
+                continue
+            found.extend(
+                sentence.strip()
+                for sentence in _SENTENCE.split(text)
+                if _MUST_LAW.search(sentence)
+            )
+        return found
 
     @property
     def table_values(self) -> set[str]:
@@ -401,8 +479,19 @@ def rows_referencing(section: ContractSection, rows: list[list[str]]) -> list[st
     coverage -- §Bezel is referenced by S9 ("Bezel seat"), §Redline arc by S2
     ("Redline band"). Whether S9 *discharges* §Bezel is exactly the judgement
     this module refuses to make.
+
+    **Provenance is stripped from the name first (#2651).** A dated heading
+    carries its own citation -- `Chrome environment strip (ruling 2026-08-15,
+    #328)` -- and rows citing `(ruling 2026-08-25)` share the tokens `ruling`,
+    `2026` and `08`, so a chrome section matched five of #331's nine rows on a
+    date. That was latent rather than harmless: `binding_ledger` scopes its
+    row text by this function, and a too-broad set marks MORE sub-bindings as
+    named by a row, which is the false-coverage direction. It did not bite on
+    #331 only because the sections carrying sub-bindings have single-word
+    names. `_PROVENANCE` already exists here for the sibling reason -- it is
+    what stops a ruling number reading as a bound value.
     """
-    wanted = _tokens(section.name) - {"the", "a", "and", "of"}
+    wanted = _tokens(_PROVENANCE.sub(" ", section.name)) - {"the", "a", "and", "of"}
     found: list[str] = []
     for row in rows:
         if not row:
@@ -450,6 +539,43 @@ def binding_ledger(
                 row_id for row_id in referencing if name and name in scoped
             ]
             ledger.append((section.name, binding.name, named_by))
+    return ledger
+
+
+def law_ledger(
+    sections: list[ContractSection], rows: list[list[str]]
+) -> list[tuple[str, str, list[str]]]:
+    """(section, law, row IDs that reference the section) (#2651).
+
+    `laws` was built for one signal and read in one place -- inside
+    `signal_assertions_that_cannot_falsify`, and only for a section a row's
+    binding cell cites by ruling number or `§Name`. S7's cell happens to say
+    `per #328's stops table`, so the chrome step law surfaces. Rewrite that
+    cell as `chrome per the contract` -- same meaning, no citation token --
+    and the sharpest evidence in the audit goes silent while the law stays
+    exactly as binding. Shape 2 also cannot see a section that states a law
+    and carries no table: it returns early when `table_values` is empty.
+
+    A law is binding because the contract states it, not because a table cell
+    referenced its section by number. So every law of every in-play section is
+    tracked here, with the rows that reach its section, and a law no row
+    reaches is undischarged.
+
+    **This tracks and surfaces; it does not judge.** Whether a referencing
+    row's assertion can actually falsify its law is the falsifiability
+    judgement, and #2646 put that with the reviewer. §Face's flat-fill law is
+    the worked case: #331's S1 tests equality of samples along one radial,
+    which a gradient fails, so it does discharge it -- and an S1 that asserted
+    only `#0A0A0C` at three points would not, while looking identical here.
+    """
+    ledger: list[tuple[str, str, list[str]]] = []
+    for section in sections:
+        laws = section.laws
+        if not laws:
+            continue
+        referencing = rows_referencing(section, rows)
+        for law in laws:
+            ledger.append((section.name, law, referencing))
     return ledger
 
 
@@ -616,6 +742,9 @@ class FidelityBrief:
     table: RawTable | None = None
     signals: list[Signal] = field(default_factory=list)
     ledger: list[tuple[str, str, list[str]]] = field(default_factory=list)
+    #: #2651: (section, law, rows referencing the section). A law with no
+    #: referencing row is undischarged and says so in the prompt.
+    laws: list[tuple[str, str, list[str]]] = field(default_factory=list)
     error: str = ""
 
     @property
@@ -635,10 +764,17 @@ class FidelityBrief:
                 f"contract fidelity: NOT CHECKED — no section of "
                 f"`{self.contract_path}` is put in play by this issue's scope."
             )
+        undischarged = [law for law in self.laws if not law[2]]
         return (
             f"contract fidelity: {len(self.sections)} contract section(s) from "
             f"`{self.contract_path}` against {len(self.table.rows)} table "
-            f"row(s) — {len(self.signals)} candidate(s) for review."
+            f"row(s) — {len(self.signals)} candidate(s) for review, "
+            f"{len(self.laws)} contract law(s) tracked"
+            + (
+                f", {len(undischarged)} reached by no row."
+                if undischarged
+                else ", all reached by at least one row."
+            )
         )
 
     def as_prompt(self) -> str:
@@ -673,6 +809,28 @@ class FidelityBrief:
             parts.append(f"- §{section_name} / {binding_name}: {mark}")
         if not self.ledger:
             parts.append("(no section in play carries bolded sub-bindings)")
+
+        parts += ["", "# Every law the in-play sections state, and who reaches it", ""]
+        parts.append(
+            "A law is binding because the contract states it, not because a "
+            "row cited its section. UNDISCHARGED below means no row of the "
+            "table reaches that law's section at all -- which is a fact. That "
+            "a row DOES reach it is not a verdict: the question you answer is "
+            "whether that row's assertion could fail under a render violating "
+            "the law. Name a wrong implementation that passes it; if you can, "
+            "it is a finding."
+        )
+        parts.append("")
+        for section_name, law, referencing in self.laws:
+            mark = (
+                f"rows reaching this section: {', '.join(referencing)}"
+                if referencing
+                else "UNDISCHARGED -- no row reaches this section"
+            )
+            parts.append(f"- §{section_name}: {mark}")
+            parts.append(f"    {law}")
+        if not self.laws:
+            parts.append("(no section in play states a MUST/NEVER/shall law)")
 
         parts += ["", "# Mechanical signals already computed", ""]
         if not self.signals:
@@ -722,6 +880,7 @@ def build_brief(repo_root: Path | str, issue: int, title: str, body: str) -> Fid
         + signal_sections_without_rows(brief.sections, rows)
     )
     brief.ledger = binding_ledger(brief.sections, rows)
+    brief.laws = law_ledger(brief.sections, rows)
     return brief
 
 

--- a/tests/unit/test_contract_fidelity.py
+++ b/tests/unit/test_contract_fidelity.py
@@ -32,6 +32,7 @@ from assemblyzero.core.llm_provider import LLMCallResult
 from assemblyzero.workflows.requirements import contract_fidelity as cf
 from assemblyzero.workflows.requirements.contract_fidelity import (
     FIDELITY_MARKER,
+    ContractSection,
     build_brief,
     check_contract_fidelity_at_preflight,
     parse_contract,
@@ -112,6 +113,8 @@ result.
 - **Color:** One flat fill of the palette's matte black `#0A0A0C`, uniform
   across the entire dial face. Black as night (operator ruling 2026-08-15,
   #325).
+- **No overlays, ever:** no gradients, no glass sweep, no specular highlight,
+  no environmental or viewer reflection on the face.
 - **Texture:** Smooth. No grain, no print pattern, no fake weave.
 
 ### Tick marks
@@ -123,6 +126,15 @@ result.
 
 - **Color:** Luminescent candy-apple red.
 - **Position at rest:** Pointing to 0.
+
+## What this doc binds
+
+Code implementing #1 (core gauge renderer) MUST:
+
+1. Produce output satisfying the numeric render contract above — the palette
+   RGBs and the layout fractions — at any `size`.
+2. Structure the renderer so swapping skins requires changing only the skin
+   module.
 
 ## Out of scope
 
@@ -329,6 +341,185 @@ class TestTheBindingWithNoRow:
     def test_a_referenced_section_is_not_a_hard_finding(self, brief):
         """S9 reaches §Bezel, so whether it DISCHARGES it is a judgement."""
         assert [s for s in brief.signals if s.shape == "section-no-row"] == []
+
+
+# ---------------------------------------------------------------------------
+# Every law is tracked, not only the ones a row happened to cite (#2651)
+# ---------------------------------------------------------------------------
+
+
+def _law_for(brief, needle):
+    return next(
+        (entry for entry in brief.laws if needle in entry[1]), None
+    )
+
+
+class TestTheLawLedger:
+    """`laws` was read in one place, gated on a row citing the section by
+    ruling number or `§Name`. A citation-style edit silenced the sharpest
+    evidence in the audit while the law stayed exactly as binding.
+    """
+
+    def test_the_step_law_is_tracked_with_the_row_that_reaches_it(self, brief):
+        entry = _law_for(brief, "MUST remain a step, never a ramp")
+        assert entry is not None
+        section, _law, referencing = entry
+        assert "Chrome environment strip" in section
+        assert "S7" in referencing
+
+    def test_it_survives_a_binding_cell_that_cites_nothing(self, contract_repo):
+        """The whole point. `per #328's stops table` -> `chrome per the
+        contract`: same meaning, no citation token, and shape 2 goes silent."""
+        body = BODY_331.replace(
+            "environment-strip generation per #328's stops table",
+            "chrome per the contract",
+        ).replace("the #328 predicate: ", "the predicate: ")
+        assert "#328" not in body
+
+        quiet = build_brief(contract_repo, 331, TITLE_331, body)
+        assert [
+            s for s in quiet.signals if s.shape == "assertion-cannot-falsify"
+        ] == [], "shape 2 is expected to go silent -- that is the defect"
+
+        entry = _law_for(quiet, "MUST remain a step, never a ramp")
+        assert entry is not None
+        assert "S7" in entry[2]
+
+    def test_the_flat_fill_law_is_tracked_with_s1(self, brief):
+        """§Face states it as `No overlays, ever` -- no MUST, no NEVER.
+
+        The uppercase-only vocabulary found zero laws in §Face, so the ledger
+        would have listed nothing for the section boostgauge #325 rules.
+        """
+        entry = _law_for(brief, "No overlays, ever")
+        assert entry is not None
+        section, _law, referencing = entry
+        assert section == "Face"
+        assert "S1" in referencing
+
+    def test_a_law_no_row_reaches_is_undischarged(self, contract_repo):
+        """Both chrome-touching rows removed: S7 outright, and S9's assertion,
+        which compares against `chrome at 1.10 R` and so reaches the section
+        too."""
+        stripped_body = "\n".join(
+            line for line in BODY_331.splitlines()
+            if not line.startswith("| S7 ")
+        ).replace("chrome at 1.10 R", "housing at 1.10 R")
+        # Only the ROWS matter here; the scope prose still says "chrome
+        # housing", which is what keeps the section in play so its law can be
+        # reported undischarged rather than disappearing.
+        table_lines = [
+            ln for ln in stripped_body.splitlines() if ln.startswith("| S")
+        ]
+        assert not any("chrome" in ln.lower() for ln in table_lines)
+
+        stripped = build_brief(contract_repo, 331, TITLE_331, stripped_body)
+        entry = _law_for(stripped, "MUST remain a step, never a ramp")
+        assert entry is not None
+        assert entry[2] == [], "no row reaches §Chrome environment strip now"
+
+    def test_the_prompt_marks_it_undischarged_in_those_words(
+        self, contract_repo
+    ):
+        stripped_body = "\n".join(
+            line for line in BODY_331.splitlines()
+            if not line.startswith("| S7 ")
+        ).replace("chrome at 1.10 R", "housing at 1.10 R")
+        prompt = build_brief(
+            contract_repo, 331, TITLE_331, stripped_body
+        ).as_prompt()
+
+        assert "UNDISCHARGED -- no row reaches this section" in prompt
+        assert "MUST remain a step, never a ramp" in prompt
+
+    def test_a_law_introducing_a_list_carries_the_list(self):
+        """`re.split(r"(?<=[.;])\\s+")` fires on the `.` of `1.`, so this law
+        was quoted as its header plus a bare list number, its numbered
+        obligations dropped.
+
+        Asserted on the section rather than the brief: §What this doc binds is
+        not put in play by #331's scope, and the fragment is a property of the
+        extractor either way.
+        """
+        section = next(
+            s for s in parse_contract(CONTRACT) if s.name == "What this doc binds"
+        )
+        assert len(section.laws) == 1
+        law = section.laws[0]
+
+        assert law.startswith("Code implementing #1 (core gauge renderer) MUST:")
+        assert "Produce output satisfying the numeric render contract" in law
+        assert "Structure the renderer so swapping skins" in law
+        assert not law.strip().endswith("1.")
+
+    def test_no_law_is_a_bare_list_number(self, brief):
+        assert [law for _s, law, _r in brief.laws if law.strip().endswith("1.")] == []
+
+    def test_a_block_not_ending_in_a_colon_is_still_quoted_by_sentence(self):
+        """The step law is one sentence of a longer paragraph, and stays so --
+        `signal_assertions_that_cannot_falsify` has always quoted it that way.
+        """
+        section = next(
+            s for s in parse_contract(CONTRACT)
+            if s.name.startswith("Chrome environment strip")
+        )
+        assert len(section.laws) == 1
+        assert section.laws[0].startswith("The 0.485")
+        assert "Chrome is a mirror" not in section.laws[0]
+
+    def test_the_ledger_tracks_and_does_not_judge(self, brief):
+        """S1 reaches the flat-fill law. Whether its assertion could FAIL under
+        a gradient is the reviewer's call, and the prompt says so."""
+        prompt = brief.as_prompt()
+
+        assert "A law is binding because the contract states it" in prompt
+        assert "Name a wrong implementation that passes it" in prompt
+
+    def test_the_disclosure_counts_the_laws(self, brief):
+        assert "contract law(s) tracked" in brief.disclosure()
+
+
+class TestRowsReferencingIgnoresProvenance:
+    """A dated heading matched rows on its own citation (#2651).
+
+    `Chrome environment strip (ruling 2026-08-15, #328)` shares the tokens
+    `ruling`, `2026` and `08` with any row citing `(ruling 2026-08-25)`, so a
+    chrome section matched five of #331's nine rows on a date.
+    """
+
+    def test_the_chrome_section_matches_only_rows_about_chrome(self, brief):
+        section = next(
+            s for s in parse_contract(CONTRACT)
+            if s.name.startswith("Chrome environment strip")
+        )
+        referencing = rows_referencing(section, brief.table.rows)
+
+        assert "S7" in referencing
+        assert "S5" not in referencing
+        assert "S6" not in referencing
+
+    def test_a_dated_heading_no_longer_matches_a_dated_row(self):
+        section = ContractSection(
+            name="Widget housing (ruling 2026-08-15, #328)", body="", line_no=1
+        )
+        rows = [["S5", "Numerals", "cap height 0.11 R (ruling 2026-08-25)", "x"]]
+
+        assert rows_referencing(section, rows) == []
+
+    def test_the_binding_ledger_is_unaffected_on_331(self, brief):
+        """The sections carrying sub-bindings have single-word names, which is
+        the only reason this was latent rather than hiding a missing binding."""
+        bezel = {
+            binding: named
+            for section, binding, named in brief.ledger
+            if section == "Bezel"
+        }
+        assert bezel == {
+            "Material rendering": [],
+            "Width": [],
+            "Highlights": [],
+            "Bezel-to-dial transition": ["S9"],
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`ContractSection.laws` was built for one signal and read in one place — inside `signal_assertions_that_cannot_falsify`, and only for a section a row's binding cell cites by ruling number or `§Name`. S7's cell happens to say `per #328's stops table`, so the chrome step law surfaces. Rewrite it as `chrome per the contract` — same meaning, no citation token — and the sharpest evidence in the audit goes silent while the law stays exactly as binding. Shape 2 also cannot see a section that states a law and carries no table: it returns early when `table_values` is empty.

`law_ledger` tracks every law of every in-play section against the rows that reach its section. A law no row reaches is **UNDISCHARGED**, which is a fact. Whether a reaching row's assertion could actually fail under a violating render stays the reviewer's — exactly where the binding ledger leaves its own judgement, and the prompt says so.

## The acceptance as filed could not pass, and finding out why changed the fix three times

**§Face states no law under the old vocabulary.** The acceptance names the flat-fill law, and §Face writes it `No overlays, ever` — no MUST, no NEVER, no shall. Measured over the whole 301-line contract:

| pattern | lines | what the additions are |
|---|---|---|
| `MUST\|NEVER\|shall` | **3** | the step law, plus two list headers |
| `+` lowercase `must\|never` | 21 | real laws *and* the document narrating its own history — "regen-dependency retired", "the operator approved the render", "Twelve spec review rounds tripped" |
| `+` `X, ever` | **22** | exactly one more line: §Face's flat-fill rule |
| `+` `is rejected\|retired\|forbidden` | 23 | narration about drafters and adjectives |

So `X, ever` and nothing else — a surgical +1 whose single hit is precisely the law the acceptance names. Lowercase widening triples the extractor for a mostly-prose harvest, and deciding what counts as law in prose is a judgement; this module's standing line is that judgements go to the reviewer rather than into a widened regex.

**Two of the three laws were mangled fragments.** `re.split(r"(?<=[.;])\s+")` fires on the `.` of an ordered-list marker:

```
extracted -> 'Code implementing #1 (core gauge renderer) MUST:\n\n1.'
extracted -> 'Code implementing #1 MUST NOT:\n\n1.'
```

A header and a bare list number, the numbered obligations dropped — quoted into the reviewer's brief as if it were the law. Blocks are read before sentences now; a block carrying the marker and ending in a colon absorbs the block after it. The step law is unaffected: its block does not end in a colon, so it is still the single sentence shape 2 has always quoted, and a test pins that.

**`rows_referencing` matched on provenance.** The acceptance says the step law's referencing row is S7. Measured before the fix:

```
§Chrome environment strip (ruling 2026-08-15, #328)  ->  ['S2', 'S5', 'S6', 'S7', 'S9']
```

The heading carries its own citation, and rows citing `(ruling 2026-08-25)` share the tokens `ruling`, `2026` and `08` — so a chrome section matched five of nine rows on a date. This is the **false-coverage direction** for `binding_ledger`, which scopes its row text by the same function: more rows scoped in means more sub-bindings marked as named by a row. It was latent only because the sections carrying sub-bindings have single-word names; a dated heading on §Bezel would have hidden a missing binding. `_PROVENANCE` already existed here for the sibling reason and now applies to the section name.

## On #331, measured against the preserved contract

```
contract fidelity: 13 contract section(s) ... 4 contract law(s) tracked,
all reached by at least one row.

§Chrome environment strip   rows: S7, S9     (was S2, S5, S6, S7, S9)
    The 0.485 → 0.500 transition is the horizon and MUST remain a step, never a ramp — ...
§Face                        rows: S1, S3, S9  (was: no law found at all)
    - **No overlays, ever:** no gradients, no glass sweep, no specular highlight, ...
§What this doc binds         rows: S6
    Code implementing #1 (core gauge renderer) MUST:
    1. Produce output satisfying the numeric render contract above — ...

mangled list-header fragments: 0
§Bezel binding ledger: unchanged
```

## Tests

`TestTheLawLedger` and `TestRowsReferencingIgnoresProvenance`, 13 new cases. The contract excerpts are verbatim; §Face's flat-fill bullet and a MUST-introducing list section were added to the fixture from the real document, since the trimmed #2646 fixture carried neither.

- the step law tracked with S7, and **still tracked when S7's cell drops every `#328` token** — the defect this issue exists for, with shape 2 asserted to go silent in the same test so the two are not confused;
- the flat-fill law tracked with S1, which needs the vocabulary addition to exist at all;
- a law no row reaches marked undischarged, in the prompt's own words — the variant removes S7 *and* neutralises S9's `chrome at 1.10 R`, because S9 reaches the section too;
- the list law carrying its numbered obligations, and no law ending in a bare `1.`;
- the chrome section no longer matching S5 or S6, plus a synthetic dated heading against a dated row;
- §Bezel's binding ledger unchanged, pinning that the provenance fix did not move the #2646 result.

Full unit suite: **9359 passed, 21 skipped, 5 xfailed**. `ruff check` clean on both changed files.

Nothing here decides whether a referencing row's assertion actually discharges its law. That is the falsifiability judgement, it is the reviewer's, and #2646 drew that line deliberately.

Closes #2651
