### PR TITLE
fix: the pipeline child's IO is UTF-8, so no stage dies printing what it processes (Closes #2662)

### DIFF
--- a/tests/unit/test_child_process_encoding.py
+++ b/tests/unit/test_child_process_encoding.py
@@ -92,6 +92,37 @@ INSTALL_PREAMBLE = (
     "install()\n"
 )
 
+#: Reports which encoding governs stdio and which governs `open()`, before and
+#: after the reconfigure. Two different knobs, and conflating them is what the
+#: first cut of this file got wrong.
+ENCODINGS_PROBE = (
+    "import locale, sys\n"
+    f"sys.path.insert(0, {str(ROOT)!r})\n"
+    "before = locale.getpreferredencoding(False)\n"
+    "from assemblyzero.core.utf8_console import install\n"
+    "install()\n"
+    "after = locale.getpreferredencoding(False)\n"
+    "print(f'preferred_before={before}')\n"
+    "print(f'preferred_after={after}')\n"
+    "print(f'stdout={sys.stdout.encoding}')\n"
+)
+
+
+def _default_encoding_handles_u2265() -> bool:
+    """Can a default-encoding `open()` on THIS host carry U+2265?
+
+    True on a UTF-8 locale (every CI runner), False on the cp1252 locale where
+    the defect lives. Used to skip rather than to weaken: the crash test is a
+    witness only where the crash is possible.
+    """
+    import locale
+
+    try:
+        "≥".encode(locale.getpreferredencoding(False))
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
 
 class TestTheKillReproduces:
     """The defect, before anything is claimed about the fix."""
@@ -197,9 +228,55 @@ class TestTheEnvironmentHalf:
         assert b"WROTE" in raw
         assert GE_UTF8 in (tmp_path / "written.txt").read_bytes()
 
-    def test_the_reconfigure_alone_does_not_reach_them(self, tmp_path):
-        """Stated as a test so the two halves are never collapsed into one."""
-        script = INSTALL_PREAMBLE + (
+    def test_utf8_mode_moves_the_encoding_that_governs_open(self, tmp_path):
+        raw = _run_child(tmp_path, ENCODINGS_PROBE, {"PYTHONUTF8": "1"})
+
+        assert b"preferred_after=utf-8" in raw
+
+    def test_the_reconfigure_leaves_that_encoding_alone(self, tmp_path):
+        """Stated as a test so the two halves are never collapsed into one.
+
+        Asserted on the ENCODINGS rather than on a crash. The first cut drove
+        a `Path.write_text` under `PYTHONIOENCODING=cp1252` and expected it to
+        raise -- true on Windows, false on CI, and the difference is the point:
+        `PYTHONIOENCODING` governs stdio only, while `open()` follows
+        `locale.getpreferredencoding(False)`. Simulating a cp1252 LOCALE with a
+        stdio variable is not the same thing, and a green Windows run was not
+        evidence of portability.
+
+        What is true everywhere: `install()` moves stdout and moves nothing
+        else, so it cannot be the file half no matter what the locale is.
+        """
+        raw = _run_child(
+            tmp_path, ENCODINGS_PROBE, {"PYTHONIOENCODING": "cp1252"},
+        )
+        reported = dict(
+            line.split(b"=", 1)
+            for line in raw.splitlines()
+            if b"=" in line
+        )
+
+        assert reported[b"stdout"] == b"utf-8", "stdio IS widened"
+        assert reported[b"preferred_before"] == reported[b"preferred_after"], (
+            "the encoding open() uses is untouched by the reconfigure"
+        )
+
+    @pytest.mark.skipif(
+        _default_encoding_handles_u2265(),
+        reason=(
+            "the ambient default encoding already carries U+2265, so a "
+            "default-encoding write cannot fail here -- this is the "
+            "cp1252-locale case, which is where the defect lives"
+        ),
+    )
+    def test_a_default_encoding_write_fails_without_it(self, tmp_path):
+        """The real crash on a real cp1252 locale, kept as evidence.
+
+        Skipped where the locale is UTF-8 rather than asserted around, because
+        a test that passes by construction on the platform CI runs is not a
+        witness to anything.
+        """
+        script = (
             "from pathlib import Path\n"
             "import sys\n"
             "try:\n"
@@ -209,9 +286,12 @@ class TestTheEnvironmentHalf:
             "except UnicodeEncodeError:\n"
             "    print('FAILED')\n"
         )
-        raw = _run_child(tmp_path, script, {"PYTHONIOENCODING": "cp1252"})
+        raw = _run_child(tmp_path, INSTALL_PREAMBLE + script, {})
 
-        assert b"FAILED" in raw
+        assert b"FAILED" in raw, (
+            "the reconfigure is installed and the write still fails -- this is "
+            "the half PYTHONUTF8 exists for"
+        )
 
 
 class TestBothHalvesAreWired:

--- a/tests/unit/test_child_process_encoding.py
+++ b/tests/unit/test_child_process_encoding.py
@@ -1,0 +1,265 @@
+"""A stage print never dies on the text the stage exists to process (#2662).
+
+boostgauge #379's first roll halted in the LLD stage three attempts out of
+three, non-transient:
+
+    LLD stage error: 'charmap' codec can't encode character '\\u2265' in
+    position 239: character maps to <undefined>
+
+N0c's model call completed (108.7s on the third attempt) and found conflicts.
+The print of the finding killed the gate before the verdict rendered, so the
+conflicts themselves are unknown -- the crash consumed the evidence it was
+about to state. The sink is `analyze_requirements.py`'s
+
+    print(f"          A: {c.get('criterion_a') or '(not stated)'}")
+
+which emits the model's quoted criterion text verbatim, and #379's decision
+table carries U+2265 in every assertion cell.
+
+Sixth kill in one class -- #161, #1163, #1493, #1876, #2367 -- each repaired at
+the sink, each outlived by the class, because any NEW print of issue text,
+contract text or model output re-creates it. Moving exactly that text is the
+pipeline's whole job.
+
+## Why these tests spawn real processes
+
+The defect lives in the boundary between two processes: the launcher redirects
+the child's stdout straight to a file handle, and the child owns the encoding
+of what lands there. Nothing in-process reproduces that -- `capsys` hands back
+`str`, and a `StringIO` has no encoding at all. So every test here runs a real
+interpreter with a real redirect and reads the resulting BYTES.
+
+`PYTHONIOENCODING=cp1252` stands in for the Windows locale, which makes the
+reproduction deterministic on any host: CI runs Linux, where the ambient
+locale is UTF-8 and the defect cannot occur by accident.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+#: U+2265 as it lands in a UTF-8 file. The assertion is on bytes, not on a
+#: decoded str: `errors="replace"` anywhere in the chain would still decode to
+#: SOMETHING, and a replaced character inside a quoted conflict criterion
+#: silently corrupts the evidence an operator rules on.
+GE_UTF8 = b"\xe2\x89\xa5"
+
+#: A stage print in the shape N0c uses for a conflict it found.
+STAGE_PRINT = (
+    'print("          A: the strip step is \\u2265 200 across the horizon")\n'
+    'print("OK")\n'
+)
+
+
+def _run_child(tmp_path: Path, script: str, env_extra: dict[str, str]) -> bytes:
+    """Run a child exactly as the launcher does: stdout straight to a file.
+
+    `subprocess.Popen(..., stdout=fh)` hands the child a file descriptor, so
+    the parent's `encoding=` on that handle governs nothing about what the
+    child writes -- which is why boostgauge #379's log carries a raw cp1252
+    em-dash (0x97) inside a file the launcher opened as UTF-8.
+    """
+    child = tmp_path / "child.py"
+    child.write_text(script, encoding="utf-8")
+    log = tmp_path / "out.log"
+
+    env = dict(os.environ)
+    env.pop("PYTHONUTF8", None)
+    env.pop("PYTHONIOENCODING", None)
+    env.update(env_extra)
+
+    with log.open("wb") as fh:
+        proc = subprocess.Popen(
+            [sys.executable, str(child)], stdout=fh,
+            stderr=subprocess.STDOUT, env=env, cwd=str(tmp_path),
+        )
+        proc.wait()
+    return log.read_bytes()
+
+
+INSTALL_PREAMBLE = (
+    "import sys\n"
+    f"sys.path.insert(0, {str(ROOT)!r})\n"
+    "from assemblyzero.core.utf8_console import install\n"
+    "install()\n"
+)
+
+
+class TestTheKillReproduces:
+    """The defect, before anything is claimed about the fix."""
+
+    def test_a_cp1252_child_dies_printing_u2265(self, tmp_path):
+        raw = _run_child(tmp_path, STAGE_PRINT, {"PYTHONIOENCODING": "cp1252"})
+
+        assert b"UnicodeEncodeError" in raw
+        assert b"charmap" in raw
+        assert b"can't encode character" in raw
+        assert b"OK" not in raw, "the print after it never ran"
+
+    def test_cp1252_can_encode_the_characters_331_was_dense_in(self, tmp_path):
+        """Why twenty-four rolls of #331 never hit this.
+
+        cp1252 HAS the degree sign, the multiplication sign and the section
+        sign -- the symbols dominating #331's geometry rows. It does not have
+        U+2265, and #379's table is unusually dense in it. The latent defect
+        predates #379; #379's character mix is the first to fire it.
+        """
+        script = 'print("\\u00b0 \\u00d7 \\u00a7")\nprint("OK")\n'
+        raw = _run_child(tmp_path, script, {"PYTHONIOENCODING": "cp1252"})
+
+        assert b"UnicodeEncodeError" not in raw
+        assert b"OK" in raw
+
+
+class TestTheReconfigureHalf:
+    """`utf8_console.install()` at the orchestrator entry point."""
+
+    def test_it_survives_the_print(self, tmp_path):
+        raw = _run_child(
+            tmp_path, INSTALL_PREAMBLE + STAGE_PRINT,
+            {"PYTHONIOENCODING": "cp1252"},
+        )
+
+        assert b"UnicodeEncodeError" not in raw
+        assert b"OK" in raw
+
+    def test_the_character_lands_as_real_utf8(self, tmp_path):
+        """Not `errors="replace"`. The log is UTF-8-capable and a replaced
+        character in a quoted criterion corrupts what the operator rules on."""
+        raw = _run_child(
+            tmp_path, INSTALL_PREAMBLE + STAGE_PRINT,
+            {"PYTHONIOENCODING": "cp1252"},
+        )
+
+        assert GE_UTF8 in raw
+        assert b"?" not in raw
+        assert "\ufffd".encode() not in raw
+
+    def test_it_beats_pythonioencoding(self, tmp_path):
+        """The reason this half is load-bearing rather than redundant.
+
+        A stream reconfigure is the last word; the env var is not.
+        """
+        raw = _run_child(
+            tmp_path, INSTALL_PREAMBLE + STAGE_PRINT,
+            {"PYTHONIOENCODING": "cp1252", "PYTHONUTF8": "1"},
+        )
+
+        assert GE_UTF8 in raw
+
+
+class TestTheEnvironmentHalf:
+    """`PYTHONUTF8=1` in the launcher's child environment."""
+
+    def test_it_survives_the_print(self, tmp_path):
+        raw = _run_child(tmp_path, STAGE_PRINT, {"PYTHONUTF8": "1"})
+
+        assert b"UnicodeEncodeError" not in raw
+        assert GE_UTF8 in raw
+
+    def test_pythonioencoding_defeats_it(self, tmp_path):
+        """Measured, and the reason both halves ship.
+
+        UTF-8 mode loses to PYTHONIOENCODING for stdio -- identical crash,
+        identical position. `_child_env` builds on `dict(os.environ)`, so
+        whatever the launcher inherits travels down, and a wrapper in this
+        fleet is documented to set exactly this variable (dependabot_review's
+        note on #2156).
+        """
+        raw = _run_child(
+            tmp_path, STAGE_PRINT,
+            {"PYTHONIOENCODING": "cp1252", "PYTHONUTF8": "1"},
+        )
+
+        assert b"UnicodeEncodeError" in raw
+
+    def test_it_reaches_default_encoding_file_writes(self, tmp_path):
+        """The half the reconfigure cannot cover, and the half every prior
+        per-sink print repair never touched. The pipeline writes LLD and spec
+        artifacts through exactly this path."""
+        script = (
+            "from pathlib import Path\n"
+            "import sys\n"
+            "Path(sys.argv[0]).with_name('written.txt')"
+            ".write_text('step is \\u2265 200\\n')\n"
+            "print('WROTE')\n"
+        )
+        raw = _run_child(tmp_path, script, {"PYTHONUTF8": "1"})
+
+        assert b"WROTE" in raw
+        assert GE_UTF8 in (tmp_path / "written.txt").read_bytes()
+
+    def test_the_reconfigure_alone_does_not_reach_them(self, tmp_path):
+        """Stated as a test so the two halves are never collapsed into one."""
+        script = INSTALL_PREAMBLE + (
+            "from pathlib import Path\n"
+            "import sys\n"
+            "try:\n"
+            "    Path(sys.argv[0]).with_name('written.txt')"
+            ".write_text('step is \\u2265 200\\n')\n"
+            "    print('WROTE')\n"
+            "except UnicodeEncodeError:\n"
+            "    print('FAILED')\n"
+        )
+        raw = _run_child(tmp_path, script, {"PYTHONIOENCODING": "cp1252"})
+
+        assert b"FAILED" in raw
+
+
+class TestBothHalvesAreWired:
+    """The entry points themselves, so a later edit cannot quietly drop one."""
+
+    def test_the_launcher_sets_utf8_mode_for_the_child(self):
+        import speedrun_roll
+
+        assert speedrun_roll._child_env()["PYTHONUTF8"] == "1"
+
+    def test_the_launcher_still_sets_what_it_set_before(self):
+        env = __import__("speedrun_roll")._child_env()
+
+        assert env["PYTHONUNBUFFERED"] == "1"
+        assert env["CLAUDECODE"] == ""
+
+    def test_the_orchestrator_entry_point_installs_the_reconfigure(self):
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+
+        assert "utf8_console" in source
+        assert "_install_utf8_console()" in source
+
+    def test_it_installs_before_the_workflow_imports(self):
+        """Before anything can print, the way no_console lands before anything
+        can spawn."""
+        source = (ROOT / "tools" / "orchestrate.py").read_text(encoding="utf-8")
+
+        assert source.index("_install_utf8_console()") < source.index(
+            "from assemblyzero.workflows.orchestrator.graph import"
+        )
+
+
+class TestTheStageThatDied:
+    """The real print, driven with the real text shape."""
+
+    @pytest.mark.parametrize("criterion", [
+        "channel mean \u2265 100 at each tick midpoint",
+        "samples at t=0.485 and t=0.500 differ by \u2265 200",
+        "a 1-px transect contains \u2265 1 intermediate luminance",
+    ])
+    def test_a_quoted_criterion_survives_and_stays_intact(
+        self, tmp_path, criterion
+    ):
+        script = INSTALL_PREAMBLE + (
+            f'print("          A: {criterion}")\n'
+            'print("OK")\n'
+        )
+        raw = _run_child(tmp_path, script, {"PYTHONIOENCODING": "cp1252"})
+
+        assert b"UnicodeEncodeError" not in raw
+        assert criterion.encode("utf-8") in raw

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -24,6 +24,25 @@ from assemblyzero.core.no_console import install as _install_no_console  # noqa:
 
 _install_no_console()
 
+# #2662: installed before anything can PRINT, for the same reason and in the
+# same place. #2367 built this installer and wired it into ten report tools;
+# the pipeline entry point -- the one process whose whole job is moving issue,
+# contract and model text -- never called it. boostgauge #379 died three
+# attempts out of three when N0c printed the conflict it had just found:
+# 'charmap' codec can't encode character U+2265, the gate killed by the text it
+# exists to process, sixth in the cp1252 class.
+#
+# Load-bearing over the PYTHONUTF8 the launcher also sets, and not redundant
+# with it. Measured both ways: an inherited PYTHONIOENCODING=cp1252 defeats
+# PYTHONUTF8=1 completely -- same crash, same position -- while a stream
+# reconfigure beats PYTHONIOENCODING because it is the last word. This also
+# covers every invocation that bypasses the launcher, and orchestrate.py is a
+# documented CLI that halt banners hand the operator directly. What it does NOT
+# cover is default-encoding `open()`, which is the env var's half.
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
 from assemblyzero.workflows.orchestrator.graph import (  # noqa: E402
     ConcurrentOrchestrationError,
     OrchestrationResult,

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1490,6 +1490,27 @@ def _child_env(tag: str = "", start: str = "") -> dict[str, str]:
     env = dict(os.environ)
     env["CLAUDECODE"] = ""         # nested Claude sessions fail without this
     env["PYTHONUNBUFFERED"] = "1"  # Python buffers stdout when not on a TTY
+    # #2662: the child's IO is UTF-8, so no stage can be killed by printing the
+    # text it exists to process. boostgauge #379 halted three attempts out of
+    # three when N0c printed the conflict it had just found -- the sixth kill in
+    # the cp1252 class, and the verdict never rendered, so the conflicts
+    # themselves were consumed by the crash.
+    #
+    # This is the half `utf8_console.install()` at orchestrate.py's entry cannot
+    # reach: UTF-8 mode also makes every default-encoding `open()` UTF-8, and
+    # the pipeline writes LLD and spec artifacts. Measured -- with a stream
+    # reconfigure in force, `Path.write_text` still raised on U+2265; with this,
+    # it wrote b'\xe2\x89\xa5'.
+    #
+    # It is NOT sufficient alone, which is why both ship. PYTHONIOENCODING takes
+    # precedence over UTF-8 mode for stdio, so an inherited
+    # PYTHONIOENCODING=cp1252 -- and a wrapper in this fleet is documented to
+    # set one, see dependabot_review's note on #2156 -- defeats this entirely,
+    # with the identical crash at the identical position, while the reconfigure
+    # holds. Set here rather than only relied upon from the ambient environment
+    # for the reason that docstring records: correctness that depends on the
+    # launcher leaves every other invocation unprotected.
+    env["PYTHONUTF8"] = "1"
     # #2423: --fail-fast rides the environment rather than argv. The pipeline
     # is three processes deep and has several independent retry gates; a flag
     # would have to be threaded through every one of them, which is exactly how


### PR DESCRIPTION
boostgauge #379's first roll halted in the LLD stage three attempts out of three, non-transient:

```
LLD stage error: 'charmap' codec can't encode character '≥' in position 239:
character maps to <undefined>
```

N0c's model call completed and found conflicts. The print of the finding killed the gate before the verdict rendered, so **the conflicts themselves are unknown** — the crash consumed the evidence it was about to state. Sixth kill in the cp1252 class (#161, #1163, #1493, #1876, #2367), every prior one repaired at the individual sink and every one outlived by the class, because any new print of issue, contract or model text re-creates it. Moving exactly that text is the pipeline's whole job.

## Mechanism, reproduced before anything was touched

Driving the launcher's real shape — `Popen(..., stdout=<file handle>)`, a child owning its own encoding — with a stand-in criterion print:

```
A. locale cp1252 (the #379 shape)
    rc=1  crashed=True
    UnicodeEncodeError: 'charmap' codec can't encode character '≥'
```

Same codec, same character, same shape as the halt. The sink is `analyze_requirements.py:532-533`, which prints the model's quoted criterion verbatim. `tools/orchestrate.py` calls `_install_no_console()` and **never** `utf8_console.install()` — every report tool in `tools/` calls it, and the one process whose whole job is moving arbitrary text did not. That is the gap #2367 left.

## Both halves ship, because neither subsumes the other

The issue asks which. Five cases, measured:

| case | crashed | U+2265 as real UTF-8 |
|---|---|---|
| A. locale cp1252 | **yes** | no |
| B. cp1252 + `PYTHONUTF8=1` | **yes** | no |
| C. `PYTHONUTF8=1` alone | no | **yes** |
| D. cp1252 + `utf8_console.install()` | no | **yes** |
| E. both | no | **yes** |

**Case B is why the env var alone is not a boundary.** `PYTHONIOENCODING` takes precedence over UTF-8 mode for stdio, so an inherited `PYTHONIOENCODING=cp1252` defeats `PYTHONUTF8=1` entirely — identical crash, identical position — and `_child_env` builds on `dict(os.environ)`. Not hypothetical: `dependabot_review.py`'s own docstring records a wrapper in this fleet that sets it, and the lesson it drew — *"correctness depended on the launcher, leaving every manual run unprotected."*

It is unset on this machine, so #379 would have been fixed by the env var alone. A fix whose correctness depends on no wrapper ever setting a standard Python variable is not the boundary this issue asks for.

**And the reconfigure does not subsume the env var.** On a default-encoding `Path.write_text` of the same character:

```
locale cp1252                    FAILED 'charmap' codec can't encode '≥'
cp1252 + utf8_console.install()  FAILED   <- the reconfigure cannot reach open()
PYTHONUTF8=1                     WROTE    b'step is \xe2\x89\xa5 200\r\n'
```

UTF-8 mode also makes every default-encoding `open()` UTF-8 — the half no per-sink print repair ever touched, and the pipeline writes LLD and spec artifacts through it.

So: `utf8_console.install()` at `orchestrate.py`'s entry, load-bearing because it beats `PYTHONIOENCODING` and covers invocations that bypass the launcher; and `PYTHONUTF8=1` in `_child_env`, for the file half.

## Real UTF-8, not `errors="replace"`

Already satisfied, and worth stating because it reads otherwise. `reconfigure(encoding="utf-8", errors="replace")` **is** real UTF-8 on the encode path: UTF-8 represents every string Python can hold, so the error handler never fires. End-to-end through the real `_child_env`:

```
=== child rc=0 ===
  crashed: False
  U+2265 present as real UTF-8: 2 time(s)
  replacement chars: 0
  verdict line printed: True

  [N0c] REQUIREMENTS CONFLICT: two criteria diverge.
          A: channel mean ≥ 100 at each tick midpoint
          B: the strip step is ≥ 200 across the horizon
  [N0c] Verdict from gemini:3.1-pro-high.
```

## The log reporting the loud failure already carried a silent one

```
$ grep -a "HALT" run-issue379-140008.log | od -c
        H   A   L   T     227       W   o   r   k   f   l   o   w
```

Octal `227` is `0x97` — the **cp1252 em-dash**, written raw into a file the launcher opened with `encoding="utf-8"`. The parent's encoding governs the parent's writes; the child gets the descriptor and encodes for itself. It did not crash because cp1252 *can* encode an em-dash, exactly as it can encode the `°`, `×` and `§` that dominate #331's geometry rows and let twenty-four rolls pass.

The class has two faces — the crash, and mojibake nobody notices. A per-sink print repair addresses neither reliably.

## Tests

`tests/unit/test_child_process_encoding.py`, 16 cases. Every one spawns a **real** interpreter with a **real** redirect and asserts on **bytes** — nothing in-process reproduces a two-process encoding boundary, `capsys` hands back `str`, and a `StringIO` has no encoding at all. `PYTHONIOENCODING=cp1252` stands in for the Windows locale so the reproduction is deterministic on CI's Linux, where the ambient locale is UTF-8 and the defect cannot occur by accident.

- `TestTheKillReproduces` — the crash, asserted before anything is claimed about the fix, plus why `°`/`×`/`§` never fired it.
- `TestTheReconfigureHalf` — survives, lands as real UTF-8 (`b"?"` and U+FFFD both asserted absent), and beats `PYTHONIOENCODING`.
- `TestTheEnvironmentHalf` — survives; **`PYTHONIOENCODING` defeats it**, pinned as a test so the two halves are never collapsed; reaches default-encoding file writes, which the reconfigure alone does not.
- `TestBothHalvesAreWired` — `_child_env()` sets it, `orchestrate.py` installs it, and installs it *before* the workflow imports, so a later edit cannot quietly drop either.
- `TestTheStageThatDied` — three real `≥`-bearing criteria in N0c's own print shape.

Full unit suite: **9390 passed, 21 skipped, 5 xfailed**. `ruff check` clean on `speedrun_roll.py` and the new test; `orchestrate.py`'s one E402 is pre-existing on `origin/main` (line 32, `provider_storm`, which this PR does not touch) — verified against `git show origin/main:tools/orchestrate.py`.

## Scope

N0c's logic, the gates, the manifest and pinning are untouched. The five prior repairs stay — none is made wrong by this, and #2367's installer is the thing being reused rather than replaced. Redundancy noted, not removed, per the ask.

Filed rather than left implicit: **#2663** — every orchestrator halt prints `Resume: poetry run python tools/run_orchestrator.py`, a file present in neither repo, and a second contradictory resume line below it.

The #379 replay is the operator's to fire after merge.

Closes #2662
