### PR TITLE
fix: base-satisfied tests at a Modify issue's red entry are regression guards, not an anomaly (Closes #2670)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -815,6 +815,37 @@ def _implementation_already_exists(state: TestingWorkflowState) -> bool:
     return any((repo_root / path).is_file() for path in targets)
 
 
+def _base_ships_the_implementation(state: TestingWorkflowState) -> bool:
+    """True when the PLAN says the implementation predates this run (#2670).
+
+    A Modify issue's base legitimately satisfies conjunction-partner and
+    regression-guard tests at a first-attempt red entry: boostgauge #379
+    plans `stingray.py` as Modify against an arc that ships it, and three of
+    eight tests passed on the pristine worktree — which IS the base, since a
+    first attempt has written nothing. That is the declared state of the
+    plan, not an anomaly.
+
+    Every planned .py must be change_type Modify AND present on disk. A
+    single Add among them means the tests import something this run is
+    supposed to create, so passing tests stay unexplained (fatal); a missing
+    change_type is treated the same way, never forgiven. An empty plan
+    explains nothing.
+    """
+    repo_root = Path(state.get("repo_root", "") or ".")
+    planned = [
+        f for f in (state.get("files_to_modify") or [])
+        if f.get("path", "").endswith(".py")
+    ]
+    if not planned:
+        return False
+    for f in planned:
+        if str(f.get("change_type", "")).lower() != "modify":
+            return False
+        if not (repo_root / f.get("path", "")).is_file():
+            return False
+    return True
+
+
 def _tests_are_an_implementation_target(state: TestingWorkflowState) -> bool:
     """Will the implementation stage rewrite the test file(s)? (#2638)
 
@@ -1181,6 +1212,42 @@ def verify_red_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "pytest_exit_code": exit_code,
                 "error_message": "",
                 "next_node": "N5_verify_green",
+            }
+
+        if _base_ships_the_implementation(state) and total_red > 0:
+            # #2670: on a Modify issue the base predates the run BY PLAN —
+            # every planned file is change_type Modify and present in the
+            # pristine worktree. The passing tests are base-satisfied
+            # regression guards; the failing set is the red signal that
+            # drives the implementation, and the green phase's all-green
+            # requirement already guarantees the guards survive the change.
+            print(
+                f"    [N3] {passed_count} test(s) pass at entry on a Modify "
+                f"issue — the base ships every planned file, so they are "
+                f"base-satisfied regression guards, not an anomaly (#2670)."
+            )
+            print(
+                f"    Red signal: the {total_red} failing test(s) drive the "
+                f"implementation; the green phase holds all "
+                f"{passed_count + total_red} green."
+            )
+            log_workflow_execution(
+                target_repo=repo_root,
+                issue_number=state.get("issue_number", 0),
+                workflow_type="testing",
+                event="red_phase_base_satisfied",
+                details={
+                    "passed": passed_count,
+                    "failed": failed_count,
+                    "errors": error_count,
+                },
+            )
+            return {
+                "red_phase_output": output,
+                "file_counter": file_num,
+                "pytest_exit_code": exit_code,
+                "error_message": "",
+                "next_node": "N4_implement_code",
             }
 
         print(f"    [GUARD] WARNING: {passed_count} tests passed unexpectedly!")

--- a/tests/unit/test_red_phase_modify_awareness.py
+++ b/tests/unit/test_red_phase_modify_awareness.py
@@ -1,0 +1,152 @@
+"""#2670: the red-phase guard gains Modify-awareness.
+
+run-issue379-015229 halted in six seconds: 8 real tests, 3 passing at a
+first-attempt red entry, and the #2542 guard read "the implementation existed
+before this stage entered" as fatal. On a Modify issue that is the plan's own
+declared state — boostgauge #379 modifies `stingray.py` on an arc that ships
+it, and the passing three are conjunction partners and regression guards the
+green phase already holds to staying green.
+
+The sanctioned reading is narrow: every planned .py is change_type Modify AND
+present on disk, and at least one test still fails (the red signal). An Add in
+the plan, a missing change_type, or all-green at entry each keep the fatal
+halt — the #2337/#2542 later-attempt paths are untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _base_ships_the_implementation,
+    verify_red_phase,
+)
+
+
+@pytest.fixture()
+def worktree(tmp_path: Path) -> Path:
+    """A pristine Modify-issue worktree: the base ships the module."""
+    src = tmp_path / "src" / "boostgauge" / "skins"
+    src.mkdir(parents=True)
+    (src / "stingray.py").write_text(
+        "def render_face(size):\n    return None\n", encoding="utf-8"
+    )
+    tests = tmp_path / "tests"
+    tests.mkdir()
+    (tests / "test_issue_379.py").write_text(
+        "def test_placeholder():\n    assert True\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _state(worktree: Path, **overrides: object) -> dict:
+    state = {
+        "repo_root": str(worktree),
+        "issue_number": 379,
+        "audit_dir": str(worktree),
+        "file_counter": 1,
+        "test_files": [str(worktree / "tests" / "test_issue_379.py")],
+        "files_to_modify": [
+            {"path": "src/boostgauge/skins/stingray.py", "change_type": "Modify"},
+        ],
+        # first attempt: the paths #2337/#2542 sanction must all decline
+        "retry_mode": "",
+        "iteration_count": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+def _pytest_result(passed: int, failed: int) -> dict:
+    return {
+        "returncode": 0 if failed == 0 else 1,
+        "stdout": f"{passed} passed, {failed} failed",
+        "stderr": "",
+        "parsed": {
+            "passed": passed, "failed": failed, "errors": 0, "coverage": 0,
+        },
+    }
+
+
+# ------------------------------------------------- the helper's truth table
+
+
+def test_all_modify_and_present_is_base_shipped(worktree: Path) -> None:
+    assert _base_ships_the_implementation(_state(worktree)) is True
+
+
+def test_an_add_in_the_plan_is_not(worktree: Path) -> None:
+    state = _state(worktree, files_to_modify=[
+        {"path": "src/boostgauge/skins/stingray.py", "change_type": "Modify"},
+        {"path": "src/boostgauge/skins/telltale.py", "change_type": "Add"},
+    ])
+    assert _base_ships_the_implementation(state) is False
+
+
+def test_a_missing_change_type_is_never_forgiven(worktree: Path) -> None:
+    """The #2337 fixture shape — path only — must not be read as Modify."""
+    state = _state(worktree, files_to_modify=[
+        {"path": "src/boostgauge/skins/stingray.py"},
+    ])
+    assert _base_ships_the_implementation(state) is False
+
+
+def test_a_planned_file_absent_from_disk_is_not(worktree: Path) -> None:
+    state = _state(worktree, files_to_modify=[
+        {"path": "src/boostgauge/skins/missing.py", "change_type": "Modify"},
+    ])
+    assert _base_ships_the_implementation(state) is False
+
+
+def test_an_empty_plan_explains_nothing(worktree: Path) -> None:
+    assert _base_ships_the_implementation(
+        _state(worktree, files_to_modify=[])
+    ) is False
+
+
+# ------------------------------------------------- the node's behaviour
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_the_379_shape_proceeds_to_implement(
+    mock_pytest, worktree: Path,
+) -> None:
+    """3 base-satisfied guards pass, 5 failures drive the implementation."""
+    mock_pytest.return_value = _pytest_result(passed=3, failed=5)
+
+    result = verify_red_phase(_state(worktree))
+
+    assert result["next_node"] == "N4_implement_code"
+    assert result["error_message"] == ""
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_an_add_in_the_plan_keeps_the_fatal_halt(
+    mock_pytest, worktree: Path,
+) -> None:
+    mock_pytest.return_value = _pytest_result(passed=3, failed=5)
+
+    state = _state(worktree, files_to_modify=[
+        {"path": "src/boostgauge/skins/stingray.py", "change_type": "Add"},
+    ])
+    result = verify_red_phase(state)
+
+    assert result["next_node"] == "END"
+    assert "passed unexpectedly" in result["error_message"]
+
+
+@patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+def test_all_green_at_entry_stays_fatal_even_on_modify(
+    mock_pytest, worktree: Path,
+) -> None:
+    """No failing test means nothing drives the change — vacuous tests or
+    nothing to implement, and proceeding would ship the former."""
+    mock_pytest.return_value = _pytest_result(passed=8, failed=0)
+
+    result = verify_red_phase(_state(worktree))
+
+    assert result["next_node"] == "END"
+    assert "passed unexpectedly" in result["error_message"]


### PR DESCRIPTION
Closes #2670

The red-phase guard sanctioned passing tests only when THIS RUN's prior work explained them (#2337/#2542: retry, resume, red marker). run-issue379-015229 hit the branch those repairs never covered: a first-attempt red entry on a **Modify** issue, where the pristine worktree IS the base and the base legitimately satisfies the conjunction-partner and regression-guard tests. Three of eight passed, the guard read it as "implementation existed before this stage entered" — true, and the plan's own declared state — and halted fatal in six seconds, deterministically, unfixable by relaunch.

The repair adds one narrow sanctioned reading, consulted only after `_implementation_already_exists` declines: when every planned `.py` in `files_to_modify` is `change_type: Modify` AND present on disk, and at least one test still fails, the passing tests are base-satisfied regression guards and the failing set is the red signal — print that reading, log `red_phase_base_satisfied`, proceed to `N4_implement_code`. The green phase's all-green requirement already holds the guards to surviving the change, so no extra bookkeeping.

Everything else stays fatal: an Add anywhere in the plan (the tests import something this run must create), a missing `change_type` (the #2337 fixture shape, never forgiven), an empty plan, and all-green at entry even on Modify (nothing drives the change — vacuous tests or nothing to implement).

Tests: `tests/unit/test_red_phase_modify_awareness.py` — the helper's truth table plus the node behaviour for the #379 shape (3 pass / 5 fail → implement), the Add case, and the all-green case; the #2337/#2542 suites (`test_red_phase_retry_semantics.py`, `test_red_once_per_stage_entry.py`, `test_exit_code_verify_phases.py`) pass unchanged.
