### PR TITLE
fix: the launcher widens its own stdout before the first print (Closes #2673)

### DIFF
--- a/tests/unit/test_headless_tools_widen_stdout.py
+++ b/tests/unit/test_headless_tools_widen_stdout.py
@@ -1,0 +1,43 @@
+"""Every headless-print tool widens its stdout (#2673).
+
+The cp1252 class was repaired sink-by-sink six times before #2662 made the
+boundary systemic — and the launcher itself was the seventh kill: it installs
+`no_console` (it spawns git/gh detached) but never installed `utf8_console`,
+and its requirements-form echo prints raw issue text. boostgauge #384's `→`
+killed the launch before the run log existed.
+
+The invariant is mechanical: a tool that needs `no_console` runs headless and
+prints reports, which is exactly the class that needs the widened stream. The
+sweep matches the IMPORT, not the word — `speedrun_roll.py` carried the word
+`utf8_console` in a comment for a month while its stdout stayed cp1252.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+
+NO_CONSOLE = "no_console import install"
+UTF8_CONSOLE = "utf8_console import install"
+
+
+def test_every_no_console_tool_also_widens_stdout() -> None:
+    offenders: list[str] = []
+    for tool in sorted(TOOLS.glob("*.py")):
+        source = tool.read_text(encoding="utf-8", errors="replace")
+        if NO_CONSOLE in source and UTF8_CONSOLE not in source:
+            offenders.append(tool.name)
+    assert not offenders, (
+        f"tool(s) install no_console without utf8_console — headless print "
+        f"tools crash on the first non-cp1252 character in the text they "
+        f"echo (#2673): {offenders}"
+    )
+
+
+def test_the_sweep_sees_the_launcher() -> None:
+    """The sweep's subject list must actually include the tool that motivated
+    it — an empty glob or a moved directory would pass vacuously."""
+    swept = {t.name for t in TOOLS.glob("*.py")}
+    assert "speedrun_roll.py" in swept
+    assert "orchestrate.py" in swept

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -72,6 +72,20 @@ try:
 except ImportError:  # pragma: no cover - tool copied outside the package
     pass
 
+# #2673: installed before anything can PRINT, same reasoning and position as
+# orchestrate.py's #2662 block. This tool echoes the requirements-form check —
+# raw issue text — before any child process exists, and launching boostgauge
+# #384 it died at its own print() on U+2192 under a cp1252 stdout: the seventh
+# kill in the class, in the one process that prints first. The child-env
+# PYTHONUTF8 half of #2662 (line ~1499) never covered the launcher's own
+# streams.
+try:
+    from assemblyzero.core.utf8_console import install as _install_utf8_console
+
+    _install_utf8_console()
+except ImportError:  # pragma: no cover - tool copied outside the package
+    pass
+
 # Imported after the sys.path insert above -- the package root is not on the
 # path when this tool is run as a script from tools/ (#2077).
 from assemblyzero.core import retry_gate  # noqa: E402  (#2423)


### PR DESCRIPTION
Closes #2673

Launching boostgauge #384, the launcher died at its own `print(form_text)` on U+2192 under a cp1252 stdout — before the run log existed. The #2662 repair set `PYTHONUTF8=1` in the launcher's child environment and installed `utf8_console` at `orchestrate.py`'s entry; `speedrun_roll.py` — which echoes the requirements-form check, raw issue text, before any child exists — installs `no_console` and never installed the widening. Seventh kill in the class, in the one process that prints first.

Two changes: the `utf8_console` install at the launcher's entry, same position and reasoning as `orchestrate.py`'s #2662 block; and the sweep test that was missing — every `tools/*.py` importing `no_console`'s installer must also import `utf8_console`'s, matched on the import rather than the word, because the launcher carried the word in a comment while its stdout stayed cp1252. The sweep also asserts its own subject list is non-vacuous (the launcher and orchestrate are actually swept).

Tests: `tests/unit/test_headless_tools_widen_stdout.py` new; the #2662 suites (`test_utf8_console.py`, `test_child_process_encoding.py`) pass unchanged.
