### PR TITLE
fix: the scaffold routing decision is computed once, in the node, and carried (Closes #2676)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -443,10 +443,21 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
     # #2331: name the halt BEFORE the hash is overwritten. `exhausted_reason`
     # compares this attempt against the previous one, and the line below
     # replaces the previous with this one.
+    #
+    # #2676: the decision is computed HERE, once, and carried in
+    # `scaffold_route` — the router must not recompute it, because after this
+    # node returns, `previous_scaffold_hash` holds THIS attempt's hash and a
+    # recompute compares the attempt against itself: always byte-identical,
+    # spuriously exhausted, and the run ended silently as success
+    # (run-issue384-044442 merged a PR with an assertion-free stub and no
+    # code).
     if not is_valid:
-        _halt_if_exhausted(
+        reason = _halt_if_exhausted(
             state, result_dict, generated_tests, new_attempts, all_errors
         )
+        result_dict["scaffold_route"] = "escalate" if reason else "regenerate"
+    else:
+        result_dict["scaffold_route"] = "continue"
 
     # Issue #502: Store hash for stagnation detection
     if generated_tests:
@@ -489,6 +500,7 @@ def _validate_non_pytest(
                 "real_test_count": 0,
             },
             "scaffold_attempts": scaffold_attempts,
+            "scaffold_route": "continue",  # #2676
         }
 
     # Validate each test file using the runner
@@ -526,8 +538,14 @@ def _validate_non_pytest(
     # #2331: the non-pytest path escalates through the same routing, so it
     # owes the same named halt. Leaving it out would make the defect a
     # property of the framework the run happens to use.
+    # #2676: and it owes the same carried route, for the same reason.
     if not is_valid:
-        _halt_if_exhausted(state, result, generated_tests, new_attempts, all_errors)
+        reason = _halt_if_exhausted(
+            state, result, generated_tests, new_attempts, all_errors
+        )
+        result["scaffold_route"] = "escalate" if reason else "regenerate"
+    else:
+        result["scaffold_route"] = "continue"
     return result
 
 
@@ -571,7 +589,7 @@ def _halt_if_exhausted(
     generated_tests: str,
     attempts: int,
     errors: list[str],
-) -> None:
+) -> str:
     """Name the halt in state when regeneration cannot help, per #2331.
 
     Before this, an unusable suite routed to N4_implement_code and skipped the
@@ -579,10 +597,15 @@ def _halt_if_exhausted(
     reached implementation with one fewer check than a suite that passed. The
     run then burned its implementation budget against tests no code could
     satisfy. Now it stops, and says which side is wrong.
+
+    #2676: returns the reason ("" when not exhausted) so the node can carry
+    the routing decision it implies — the caller sets `scaffold_route` from
+    it, and the router reads the carried route instead of recomputing against
+    the by-then-overwritten hash.
     """
     reason = exhausted_reason(state, generated_tests, attempts)
     if not reason:
-        return
+        return ""
 
     shown = "; ".join(errors[:3]) if errors else "no specific error was recorded"
     result["error_message"] = (
@@ -593,6 +616,7 @@ def _halt_if_exhausted(
     )
     result["next_node"] = "end"
     print(f"    [HALT] {result['error_message']}")
+    return reason
 
 
 def should_regenerate(state: dict[str, Any]) -> Literal["regenerate", "continue", "escalate"]:
@@ -618,6 +642,27 @@ def should_regenerate(state: dict[str, Any]) -> Literal["regenerate", "continue"
     Returns:
         Routing decision string.
     """
+    # #2676: the node computed the decision BEFORE it overwrote
+    # `previous_scaffold_hash` with this attempt's own hash; recomputing here
+    # compares the attempt against itself — always byte-identical — and a
+    # first-attempt failure spuriously escalated to a silent end that read as
+    # success downstream (run-issue384-044442 merged a PR with an
+    # assertion-free stub and no code). Read the carried route.
+    carried = state.get("scaffold_route", "")
+    if carried in ("continue", "regenerate", "escalate"):
+        if carried == "escalate":
+            print("    [EXHAUSTED] per the validation node's carried route; "
+                  "the halt is named in error_message")
+        elif carried == "regenerate":
+            attempts = state.get("scaffold_attempts", 0)
+            print(f"    [REGENERATE] Attempt {attempts}/{MAX_SCAFFOLD_ATTEMPTS}, "
+                  f"returning to scaffold")
+        return carried  # type: ignore[return-value]
+
+    # Fallback for resumed state that predates the carried key. This path
+    # keeps the pre-#2676 behaviour, hash-timing wart included — it exists
+    # only so an in-flight resume does not crash, and the first fresh pass
+    # through the node replaces it.
     validation_result = state.get("validation_result", {})
     is_valid = validation_result.get("is_valid", False)
 

--- a/tests/unit/test_scaffold_route_carried.py
+++ b/tests/unit/test_scaffold_route_carried.py
@@ -1,0 +1,125 @@
+"""#2676: the scaffold routing decision is computed once, in the node.
+
+run-issue384-044442: a FIRST-attempt validation failure printed [EXHAUSTED]
+and silently ended the testing workflow as success — no halt, no red phase,
+no implementation — and the pipeline merged a PR containing an assertion-free
+stub and no code. The node had correctly decided "regenerate" (no previous
+hash, attempts under the cap), then stored this attempt's hash; the router
+recomputed `exhausted_reason` from the updated state and compared the attempt
+against its own hash — always byte-identical, spuriously exhausted, and the
+escalate edge ends the graph without an error_message.
+
+The node now carries `scaffold_route` in its result and the router reads it.
+Escalate therefore structurally implies the node wrote the DETERMINISTIC
+FAILURE halt.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    MAX_SCAFFOLD_ATTEMPTS,
+    should_regenerate,
+    validate_tests_mechanical_node,
+)
+
+#: One real test, one assertion-free stub — the run's exact validation error
+#: class ("has no assertions - only pass/docstring").
+INVALID_SUITE = '''
+def test_req_010_real():
+    value = 1 + 1
+    assert value == 2
+
+def test_req_020_stub():
+    """Only a docstring lives here."""
+    pass
+'''
+
+VALID_SUITE = '''
+from myproj.config import write_config
+
+def test_req_010_real(tmp_path):
+    path = tmp_path / "c.json"
+    write_config(path)
+    assert path.exists()
+
+def test_req_020_also_real(tmp_path):
+    path = tmp_path / "d.json"
+    write_config(path)
+    assert path.read_text() != ""
+'''
+
+
+def _state(**overrides: object) -> dict:
+    state = {
+        "generated_tests": INVALID_SUITE,
+        "parsed_scenarios": {"scenarios": []},
+        "scaffold_attempts": 0,
+        "previous_scaffold_hash": "",
+    }
+    state.update(overrides)
+    return state
+
+
+def _after_node(state: dict) -> tuple[dict, dict]:
+    result = validate_tests_mechanical_node(state)
+    merged = {**state, **result}
+    return result, merged
+
+
+class TestFirstAttemptFailureRegenerates:
+    """The run-issue384-044442 regression pin."""
+
+    def test_the_node_carries_regenerate(self) -> None:
+        result, _ = _after_node(_state())
+        assert result["validation_result"]["is_valid"] is False
+        assert result["scaffold_route"] == "regenerate"
+        assert "error_message" not in result
+
+    def test_the_router_reads_the_carried_route(self) -> None:
+        """Pre-#2676 this returned 'escalate': the router recomputed against
+        the node's own just-stored hash and found the attempt byte-identical
+        to itself."""
+        _, merged = _after_node(_state())
+        assert should_regenerate(merged) == "regenerate"
+
+
+class TestTrueExhaustionStillEscalatesWithTheHalt:
+    def test_byte_identical_second_attempt(self) -> None:
+        prior = hashlib.sha256(INVALID_SUITE.encode()).hexdigest()
+        result, merged = _after_node(
+            _state(previous_scaffold_hash=prior, scaffold_attempts=1)
+        )
+        assert result["scaffold_route"] == "escalate"
+        assert "byte for byte" in result["error_message"]
+        assert should_regenerate(merged) == "escalate"
+
+    def test_attempts_cap(self) -> None:
+        result, merged = _after_node(
+            _state(
+                previous_scaffold_hash="something-else",
+                scaffold_attempts=MAX_SCAFFOLD_ATTEMPTS - 1,
+            )
+        )
+        assert result["scaffold_route"] == "escalate"
+        assert "limit of" in result["error_message"]
+        assert should_regenerate(merged) == "escalate"
+
+
+class TestValidSuiteContinues:
+    def test_continue_is_carried_and_read(self) -> None:
+        result, merged = _after_node(_state(generated_tests=VALID_SUITE))
+        assert result["validation_result"]["is_valid"] is True, (
+            result["validation_result"]["errors"]
+        )
+        assert result["scaffold_route"] == "continue"
+        assert should_regenerate(merged) == "continue"
+
+
+class TestFallbackWithoutTheCarriedKey:
+    def test_a_valid_legacy_state_continues(self) -> None:
+        """Resumed state that predates the key still routes."""
+        assert should_regenerate(
+            {"validation_result": {"is_valid": True}}
+        ) == "continue"


### PR DESCRIPTION
Closes #2676

run-issue384-044442 (boostgauge): a first-attempt scaffold validation failure silently ended the testing workflow as success. The node had correctly decided the route was "regenerate" — no previous hash, attempts under the cap, so `_halt_if_exhausted` wrote nothing — and then stored this attempt's hash into `previous_scaffold_hash`. The router (`should_regenerate`) recomputed `exhausted_reason` from the post-node state, comparing the attempt against its own just-stored hash: always byte-identical, spuriously "exhausted", escalate. The escalate edge routes to `end`, and with no `error_message` the ended workflow read as success downstream — the run skipped red, implementation, and green, and merged boostgauge#395 containing an assertion-free stub and zero code. #2331 unified the condition into one function so the two callers "cannot disagree"; they disagree through state timing — same function, two snapshots.

The repair computes the decision once, in the node: `scaffold_route` ("continue" / "regenerate" / "escalate") is carried in the node's result, set from the same call that writes the halt for a true exhaustion — so escalate structurally implies the DETERMINISTIC FAILURE message exists. `should_regenerate` reads the carried route; the recompute survives only as a documented fallback for resumed state that predates the key. Both validator paths (pytest and non-pytest, including the runner-unavailable early return) carry the route.

Tests (`tests/unit/test_scaffold_route_carried.py`, driving the real node and router in sequence): the first-attempt failure routes to regenerate — the regression pin that returned "escalate" before this change; byte-identical and attempts-cap exhaustion escalate WITH the halt message present; a valid suite continues; a legacy state without the key still routes.

The backstop half — the impl stage wrapper reading the incomplete workflow as `passed` — is tracked in #2677, not touched here.
