### PR TITLE
fix: declare scaffold_route in the state schema the graph merges through (Closes #2679)

### DIFF
--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -282,6 +282,11 @@ class TestingWorkflowState(TypedDict, total=False):
     scaffold_attempts: int  # Number of scaffold regeneration attempts
     scaffold_validation_errors: list[str]  # Issue #500: errors from last validation
     previous_scaffold_hash: str  # Issue #502: SHA-256 of last scaffold output
+    # #2679: the routing decision the node computed and carried (#2676). Not
+    # declaring it here is why the #2678 repair shipped inert: the TypedDict
+    # is the graph's merge schema, and an undeclared key is dropped between
+    # the node's return and the router's read.
+    scaffold_route: str  # "continue" | "regenerate" | "escalate"
 
     # Issue #147: Completeness gate (N4b) - Anti-stub detection
     completeness_verdict: Literal["PASS", "WARN", "BLOCK", ""]

--- a/tests/unit/test_scaffold_route_carried.py
+++ b/tests/unit/test_scaffold_route_carried.py
@@ -123,3 +123,38 @@ class TestFallbackWithoutTheCarriedKey:
         assert should_regenerate(
             {"validation_result": {"is_valid": True}}
         ) == "continue"
+
+
+class TestTheCarriedKeySurvivesTheGraphMerge:
+    """#2679: the #2678 repair shipped inert because these tests merged node
+    result into state by hand (`{**state, **result}`), bypassing the graph's
+    TypedDict schema filter — which dropped the undeclared `scaffold_route`
+    between the node's return and the router's read. run-issue384-054226
+    replayed the silent fail-open with the fixed code present and ran the
+    fallback anyway, and the pipeline merged a second junk PR.
+
+    The schema IS the merge contract: every key the node carries for the
+    router must be declared in it."""
+
+    def test_scaffold_route_is_declared_in_the_state_schema(self) -> None:
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        annotations = TestingWorkflowState.__annotations__
+        assert "scaffold_route" in annotations, (
+            "scaffold_route is not declared in TestingWorkflowState — the "
+            "graph merge drops undeclared keys, the router falls back to the "
+            "hash recompute, and the #2676 fail-open returns (#2679)"
+        )
+
+    def test_every_key_the_node_carries_is_declared(self) -> None:
+        """The general form: the node's result keys on the live failure shape
+        must all survive the schema, so a future carried key cannot repeat
+        this defect by omission."""
+        from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+        result, _ = _after_node(_state())
+        undeclared = set(result) - set(TestingWorkflowState.__annotations__)
+        assert not undeclared, (
+            f"node result key(s) not declared in TestingWorkflowState — the "
+            f"graph merge will drop them silently: {sorted(undeclared)}"
+        )


### PR DESCRIPTION
Closes #2679

The #2678 repair shipped inert: the node carried `scaffold_route`, but `TestingWorkflowState` — the TypedDict the graph merges through — never declared it, so the merge dropped the key between the node's return and the router's read. The router took its documented fallback (the pre-#2676 hash recompute) and run-issue384-054226 replayed the silent scaffold fail-open with the fixed code verified present at `8e695eab`: `Validation FAILED` → old-format `[EXHAUSTED]` → no halt → `impl passed 3.0s` → a second junk PR (boostgauge#397) merged. The #2678 unit tests passed because they merged node result into state by hand, bypassing exactly the filter that eats the key live.

Two changes: `scaffold_route: str` declared in the schema beside its siblings; and the tests that would have caught this — the key is asserted present in `TestingWorkflowState.__annotations__` with the failure naming the consequence, and the general form: every key the node's result carries on the live failure shape must be declared, so a future carried key cannot repeat the defect by omission.

The #2678 regression suite passes unchanged.
