### PR TITLE
fix: an opening fence belongs to the region it opens, not the heading above it (Closes #2681)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -122,11 +122,23 @@ def _blocks(draft: str) -> list[_Block]:
     Outside fences: one block per markdown section (heading to heading).
     Inside fences: one block per top-level ``def``/``class`` — the verdict's
     unit of naming is the test, and a fence routinely holds many.
+
+    An OPENING fence delimiter belongs to the region it opens, not to the
+    heading above it (#2681). It was attributed backward, so on a spec whose
+    §10.1 fence holds the named tests, the tests unlocked while the ```python
+    line stayed locked inside an unnamed heading block — and an insertion
+    inside the fence, which shifts that line, read as modifying locked
+    content. `manifest_traceability` demands a `# manifest:` comment that can
+    only live inside the fence, so the two were jointly unsatisfiable and
+    boostgauge #384 burned two caps with the drafter's fix written and
+    refused. A fence that holds no top-level def keeps its old attribution:
+    there is no region for it to open.
     """
     lines = draft.splitlines()
     blocks: list[_Block] = []
     current = _Block(name="(preamble)", start=0, end=0)
     in_fence = False
+    fence_open_at: int | None = None
 
     def close(at: int) -> None:
         nonlocal current
@@ -138,12 +150,18 @@ def _blocks(draft: str) -> list[_Block]:
     for index, line in enumerate(lines):
         if _FENCE_RE.match(line.strip()):
             in_fence = not in_fence
+            # Remember an opening delimiter so the first def inside can claim
+            # it; forget it on the close, and on an open whose fence turned
+            # out to hold no def (the delimiter then stays where it was).
+            fence_open_at = index if in_fence else None
             continue
         if in_fence:
             match = _DEF_RE.match(line)
             if match and not line[:1].isspace():
-                close(index)
-                current = _Block(name=match.group(1), start=index, end=index)
+                start = fence_open_at if fence_open_at is not None else index
+                close(start)
+                current = _Block(name=match.group(1), start=start, end=start)
+                fence_open_at = None
             continue
         match = _HEADING_RE.match(line)
         if match:

--- a/tests/unit/test_pinning_fence_attribution.py
+++ b/tests/unit/test_pinning_fence_attribution.py
@@ -1,0 +1,108 @@
+"""An opening fence belongs to the region it opens (#2681).
+
+boostgauge #384, runs run-issue384-063258 and run-issue384-095434: the spec
+stage burned two iteration caps on `manifest_traceability` while the
+drafter's fix was already written. Draft 010 carried every `# manifest:`
+citation the check demanded, correctly placed inside the §10.1 test bodies,
+and the halt still reported those same two tests as "tracing to nothing" —
+with six [PINNING] refusals naming ```python in the same log.
+
+The attribution was backward. `_blocks` gave an opening fence delimiter to
+the heading block ABOVE it, while the tests inside became their own blocks.
+A verdict names tests, so the test blocks unlocked and the fence line stayed
+locked in an unnamed heading block — and an insertion inside the fence,
+which shifts that line, read as modifying locked content. The citation the
+check demands can only live inside the fence, so the two requirements were
+jointly unsatisfiable.
+"""
+
+from __future__ import annotations
+
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_flags,
+)
+
+#: The observed shape: a heading, a fence, and two named tests inside it.
+DRAFT = """## 10. Test Plan
+
+### 10.1 Per-criterion test functions
+
+```python
+def test_req_010_verify_horizon_returns_to_bright():
+    img = render_face(1024)
+    assert img is not None
+
+
+def test_req_020_verify_legacy_bindings_survive():
+    img = render_face(1024)
+    assert img.size == (1024, 1024)
+```
+"""
+
+#: The drafter's fix: the citation comment the check demands, inside the
+#: fence, in the body of a test the verdict named.
+REVISED = DRAFT.replace(
+    "def test_req_010_verify_horizon_returns_to_bright():\n",
+    "def test_req_010_verify_horizon_returns_to_bright():\n"
+    "    # manifest: S10r.1\n",
+)
+
+NAMED = {"test_req_010_verify_horizon_returns_to_bright"}
+
+
+class TestTheFenceIsNotLockedAwayFromItsTests:
+    def test_the_opening_delimiter_is_named_with_the_tests_it_opens(self) -> None:
+        flags = named_line_flags(DRAFT, NAMED)
+        fence_line = DRAFT.splitlines().index("```python")
+        assert flags[fence_line], (
+            "the opening fence is still attributed to the heading above it, "
+            "so an insertion inside the fence reads as modifying locked "
+            "content (#2681)"
+        )
+
+    def test_the_citation_insertion_is_accepted(self) -> None:
+        result = enforce_pinning(
+            DRAFT, REVISED,
+            current_tokens=NAMED,
+            ever_tokens=NAMED,
+        )
+        assert "# manifest: S10r.1" in result.text, (
+            f"the drafter's citation was reverted; refusals={result.refusals} "
+            f"regressions={result.regressions}"
+        )
+        assert not result.refusals
+        assert not result.regressions
+
+
+class TestTheLockStillHoldsWhereItShould:
+    def test_an_unnamed_prose_rewrite_is_still_refused(self) -> None:
+        """#2532's direction must not become a hole: content in a block no
+        verdict named is still locked."""
+        draft = DRAFT + "\n## 11. Rollout\n\nShip it on Tuesday.\n"
+        revised = draft.replace("Ship it on Tuesday.", "Ship it on Friday.")
+        result = enforce_pinning(
+            draft, revised,
+            current_tokens=NAMED,
+            ever_tokens=NAMED,
+        )
+        assert "Tuesday" in result.text, (
+            "an unnamed section was rewritten and pinning allowed it"
+        )
+
+    def test_a_fence_holding_no_def_keeps_its_old_attribution(self) -> None:
+        """There is no region for such a delimiter to open, so it stays with
+        the heading — the change is scoped to fences that hold tests."""
+        draft = (
+            "## 7. Patterns\n\n```python\nCONSTANT = 3\n```\n\n"
+            "### 10.1 Tests\n\n```python\n"
+            "def test_req_010_verify_horizon_returns_to_bright():\n"
+            "    assert True\n```\n"
+        )
+        flags = named_line_flags(draft, NAMED)
+        lines = draft.splitlines()
+        first_fence = lines.index("```python")
+        assert not flags[first_fence], (
+            "a fence holding no def should not inherit naming from a test "
+            "in a different section"
+        )


### PR DESCRIPTION
Closes #2681

boostgauge #384 burned two iteration caps at the spec stage on `manifest_traceability` with the drafter's fix already written. Draft `010-spec-draft.md` carried every `# manifest:` citation the check demanded, correctly placed inside the §10.1 test bodies; the halt still reported those two tests as "tracing to nothing", alongside six `[PINNING] refused: 1 line(s) starting '```python'` events in the same log. The halt's own text says to read the PINNING events before treating the drafter as the failing side, which is how this was found.

The attribution was backward. `_blocks` gave an opening fence delimiter to the heading block ABOVE it, while the top-level defs inside the fence became their own blocks. A verdict names tests, so the test blocks unlocked while the ` ```python ` line stayed locked inside an unnamed heading block — and an insertion inside the fence, which shifts that line, read as modifying locked content the verdict never named. Since the citation `manifest_traceability` demands can only live inside the fence, the two requirements were jointly unsatisfiable for any spec whose first draft omits a citation — the ordinary case, because the verdict is what teaches the drafter to add one.

The repair attributes an opening fence to the region it opens: when a top-level `def`/`class` starts inside the fence, its block begins at the delimiter rather than at the `def`. A fence holding no top-level def keeps its old attribution — there is no region for it to open — so the change is scoped to fences that hold tests.

Tests (`tests/unit/test_pinning_fence_attribution.py`): the observed shape — heading, fence, two named tests — has its delimiter named with the tests, and the citation insertion is accepted with no refusals or regressions; and the guard direction is pinned in both ways it could rot, an unnamed prose section still refusing a rewrite and a def-less fence still not inheriting naming from a test in another section. The sibling pinning suites (`test_completeness_pinning_deadlock`, `test_generate_spec_pinning`, `test_pinning_conservation`, `test_lld_edit_script_revision` — 82 tests) pass unchanged.
