### PR TITLE
fix: the LLD stage reads and cuts from the arc, never from the checkout's HEAD; fail closed if the arc cannot be cut (Closes #2684)

### DIFF
--- a/assemblyzero/workflows/requirements/git_operations.py
+++ b/assemblyzero/workflows/requirements/git_operations.py
@@ -66,22 +66,55 @@ def lld_worktree_path_for(target_repo: Path | str, issue_number: int) -> Path:
     return pipeline_worktree_path(target_repo, issue_number, lld=True)
 
 
-def setup_lld_worktree(target_repo: Path | str, issue_number: int) -> tuple[Path, str]:
+def lld_start_point(target_repo: Path | str, base_branch: str) -> str:
+    """The ref the LLD worktree is cut from: ``origin/<base>`` when origin has it,
+    else the local ``<base>`` (#2684). Fetches the branch first so the cut is
+    the arc as it is now, not as the checkout last saw it.
+
+    Raises:
+        GitOperationError: If neither ref resolves.
+    """
+    target_repo = Path(target_repo)
+    run_command(
+        ["git", "-C", str(target_repo), "fetch", "origin", base_branch],
+        capture_output=True, text=True,
+    )
+    for candidate in (f"origin/{base_branch}", base_branch):
+        probe = run_command(
+            ["git", "-C", str(target_repo), "rev-parse", "--verify", "--quiet",
+             f"{candidate}^{{commit}}"],
+            capture_output=True, text=True,
+        )
+        if probe.returncode == 0:
+            return candidate
+    raise GitOperationError(
+        f"base branch '{base_branch}' resolves neither as origin/{base_branch} nor "
+        f"locally in {target_repo}; the LLD worktree cannot be cut from the arc"
+    )
+
+
+def setup_lld_worktree(
+    target_repo: Path | str, issue_number: int, base_branch: str = "",
+) -> tuple[Path, str]:
     """Carve (or reuse) a worktree for the LLD workflow.
 
     Branch name is ``{issue_number}-lld``. If the worktree path already
     exists (e.g. a prior LLD run for the same issue), it is reused; we do
     not re-create. Closes #1459.
 
+    With ``base_branch`` the branch is cut from the arc (``origin/<base>``,
+    fetched first — #2684); without it, from the checkout's HEAD as before.
+
     Args:
         target_repo: Path to the target repository.
         issue_number: GitHub issue number.
+        base_branch: The attempt/integration branch the run declared, or "".
 
     Returns:
         (worktree_path, branch_name)
 
     Raises:
-        GitOperationError: If worktree creation fails.
+        GitOperationError: If worktree creation fails, or the base does not resolve.
     """
     target_repo = Path(target_repo)
     worktree_path = lld_worktree_path_for(target_repo, issue_number)
@@ -91,9 +124,18 @@ def setup_lld_worktree(target_repo: Path | str, issue_number: int) -> tuple[Path
         # Reuse existing worktree from a prior LLD run for the same issue.
         return worktree_path, branch_name
 
+    # #2684: cut from the ARC, never from the checkout's HEAD. The checkout stands
+    # on the default branch (#2012); mid-arc that tree can be ahead of the base in
+    # code the arc does not have, and a worktree cut from HEAD carries all of it
+    # onto the attempt branch through the LLD PR. Empty base_branch keeps the old
+    # behaviour exactly (callers that predate the attempt-branch model).
+    start_point: list[str] = []
+    if base_branch:
+        start_point = [lld_start_point(target_repo, base_branch)]
+
     result = run_command(
         ["git", "-C", str(target_repo), "worktree", "add",
-         str(worktree_path), "-b", branch_name],
+         str(worktree_path), "-b", branch_name, *start_point],
         capture_output=True,
         text=True,
     )

--- a/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
+++ b/assemblyzero/workflows/requirements/nodes/analyze_codebase.py
@@ -119,6 +119,41 @@ def analyze_codebase(state: dict) -> dict:
     # Resolve to absolute to ensure consistent path handling
     repo_path = repo_path.resolve()
 
+    # ------------------------------------------------------------------
+    # #2684: the tree the LLD is designed against is the ARC's, not the
+    # checkout's. The checkout stands on the default branch (#2012); mid-arc
+    # that tree can carry code the arc does not have, and a drafter that reads
+    # it designs from the answer. Cut (or reuse) the LLD worktree from
+    # origin/<base_branch> now and read from it; finalize finds it present and
+    # rides it, so the LLD PR carries the base's tree rather than HEAD's.
+    # Fail closed: if the arc cannot be cut, halt — reading the checkout
+    # instead would be the leak this exists to stop, made silent.
+    # ------------------------------------------------------------------
+    base_branch = str(state.get("base_branch", "") or "")
+    issue_number = state.get("issue_number")
+    if base_branch and issue_number:
+        from assemblyzero.workflows.requirements.git_operations import (
+            GitOperationError,
+            setup_lld_worktree,
+        )
+
+        try:
+            worktree_path, _branch = setup_lld_worktree(
+                repo_path, int(issue_number), base_branch=base_branch,
+            )
+        except GitOperationError as exc:
+            logger.error("LLD analysis cannot read the arc: %s", exc)
+            return {
+                "codebase_context": _empty_codebase_context(),
+                "interface_map": {},
+                "error_message": (
+                    f"LLD analysis cannot read the arc: {exc}. Refusing to read "
+                    f"the checkout ({repo_path}) in its place (#2684)."
+                ),
+            }
+        print(f"    [BASE] LLD analysis reads origin/{base_branch} via {worktree_path}")
+        repo_path = Path(worktree_path).resolve()
+
     # Extract issue text – try several state keys
     issue_text: str = (
         state.get("issue_text", "")

--- a/assemblyzero/workflows/requirements/nodes/finalize.py
+++ b/assemblyzero/workflows/requirements/nodes/finalize.py
@@ -196,8 +196,11 @@ def _commit_and_push_files(state: Dict[str, Any]) -> Dict[str, Any]:
             base_branch = state.get("base_branch", "") or current_branch(
                 target_repo
             )
+            # #2684: cut from the arc, not HEAD. analyze_codebase normally cut it
+            # already (and is reused here); this is the cut when it did not.
             worktree_path, branch_name = setup_lld_worktree(
                 target_repo=target_repo, issue_number=issue_number,
+                base_branch=base_branch,
             )
             # Mirror each created_file from the target_repo working tree into
             # the worktree at its same relative path so the commit captures

--- a/tests/unit/test_issue_2684.py
+++ b/tests/unit/test_issue_2684.py
@@ -1,0 +1,154 @@
+"""#2684: the LLD stage reads and cuts from the ARC, never from the checkout's HEAD.
+
+A temp repo whose default branch is AHEAD of the arc in code — the shape a
+filmed speedrun has the moment v1 ships — discriminates every case: the file
+and README text that exist only on the default branch must be absent from
+what the LLD stage reads and from the branch its PR rides.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from assemblyzero.workflows.requirements.git_operations import (
+    GitOperationError,
+    lld_start_point,
+    setup_lld_worktree,
+)
+from assemblyzero.workflows.requirements.nodes.analyze_codebase import analyze_codebase
+
+MAIN_ONLY_MARKER = "MAIN-ONLY-CONTENT-2684"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def divergent_repo(tmp_path: Path) -> Path:
+    """Default branch `main` ahead of arc `arc`: main carries extra.py and a README the arc lacks."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("# demo\n\nThe arc's README.\n", encoding="utf-8")
+    (repo / "src").mkdir()
+    (repo / "src" / "base.py").write_text("def on_the_arc():\n    return 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "seed")
+    _git(repo, "branch", "arc")
+    (repo / "src" / "extra.py").write_text("def only_on_main():\n    return 2\n", encoding="utf-8")
+    (repo / "README.md").write_text(f"# demo\n\n{MAIN_ONLY_MARKER}\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "main is ahead of the arc")
+    (repo / "data").mkdir()
+    return repo
+
+
+def _is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", ancestor, descendant],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+# ---- setup_lld_worktree -----------------------------------------------------
+
+
+def test_worktree_with_base_is_cut_from_the_arc_not_head(divergent_repo: Path):
+    worktree, branch = setup_lld_worktree(divergent_repo, 41, base_branch="arc")
+    assert branch == "41-lld"
+    assert worktree.is_dir()
+    assert not (worktree / "src" / "extra.py").exists()          # main-only code is absent
+    assert (worktree / "src" / "base.py").exists()
+    assert MAIN_ONLY_MARKER not in (worktree / "README.md").read_text(encoding="utf-8")
+    assert _is_ancestor(divergent_repo, "arc", "41-lld")
+    assert not _is_ancestor(divergent_repo, "main", "41-lld")     # HEAD was never in the lineage
+
+
+def test_worktree_without_base_keeps_the_old_behaviour(divergent_repo: Path):
+    worktree, _ = setup_lld_worktree(divergent_repo, 42)
+    assert (worktree / "src" / "extra.py").exists()               # cut from HEAD, as before #2684
+    assert _is_ancestor(divergent_repo, "main", "42-lld")
+
+
+def test_worktree_is_reused_when_present(divergent_repo: Path):
+    first, _ = setup_lld_worktree(divergent_repo, 43, base_branch="arc")
+    second, _ = setup_lld_worktree(divergent_repo, 43, base_branch="arc")
+    assert first == second
+
+
+def test_start_point_prefers_origin_then_local_then_refuses(divergent_repo: Path):
+    assert lld_start_point(divergent_repo, "arc") == "arc"        # no remote in the temp repo
+    with pytest.raises(GitOperationError, match="resolves neither"):
+        lld_start_point(divergent_repo, "no-such-branch")
+
+
+def test_worktree_with_unresolvable_base_refuses(divergent_repo: Path):
+    with pytest.raises(GitOperationError):
+        setup_lld_worktree(divergent_repo, 44, base_branch="no-such-branch")
+    assert not (divergent_repo / "data" / "worktrees" / "44-lld").exists()
+
+
+# ---- analyze_codebase -------------------------------------------------------
+
+
+def test_analysis_with_base_reads_the_arc(divergent_repo: Path, capsys):
+    result = analyze_codebase({
+        "repo_path": str(divergent_repo), "issue_number": 41, "base_branch": "arc",
+        "issue_text": "add a thing to base.py",
+    })
+    assert not result.get("error_message")
+    context = result["codebase_context"]
+    blob = str(context)
+    assert MAIN_ONLY_MARKER not in blob                          # the checkout's README did not leak
+    assert "only_on_main" not in blob and "only_on_main" not in str(result.get("interface_map", {}))
+    assert "[BASE] LLD analysis reads origin/arc via" in capsys.readouterr().out
+
+
+def test_analysis_without_base_reads_the_checkout(divergent_repo: Path):
+    result = analyze_codebase({
+        "repo_path": str(divergent_repo), "issue_number": 41,
+        "issue_text": "add a thing to base.py",
+    })
+    assert MAIN_ONLY_MARKER in str(result["codebase_context"])   # pre-#2684 behaviour, unchanged
+
+
+def test_analysis_fails_closed_when_the_arc_cannot_be_cut(divergent_repo: Path):
+    result = analyze_codebase({
+        "repo_path": str(divergent_repo), "issue_number": 41, "base_branch": "no-such-branch",
+        "issue_text": "anything",
+    })
+    assert "cannot read the arc" in result["error_message"]
+    assert "Refusing to read the checkout" in result["error_message"]
+    assert result["codebase_context"]["key_file_excerpts"] == {}
+
+
+# ---- finalize threads the base into the cut ---------------------------------
+
+
+@patch("assemblyzero.workflows.requirements.nodes.finalize.setup_lld_worktree")
+@patch("assemblyzero.workflows.requirements.nodes.finalize.commit_and_pr")
+@patch("assemblyzero.workflows.requirements.nodes.finalize._mirror_to_worktree")
+def test_finalize_cuts_the_worktree_from_the_base(mock_mirror, mock_commit_and_pr, mock_setup, tmp_path):
+    from assemblyzero.workflows.requirements.nodes.finalize import _commit_and_push_files
+
+    mock_setup.return_value = (tmp_path / "wt", "42-lld")
+    mock_mirror.return_value = ["mirrored/file1.md"]
+    mock_commit_and_pr.return_value = ("abc123", "https://example.com/pr/1")
+    _commit_and_push_files({
+        "target_repo": str(tmp_path), "issue_number": 42, "base_branch": "arc",
+        "created_files": ["docs/lld/active/LLD-042.md"], "input_type": "issue",
+    })
+    mock_setup.assert_called_once()
+    assert mock_setup.call_args.kwargs.get("base_branch") == "arc"
+    assert mock_commit_and_pr.call_args.kwargs["base_branch"] == "arc"


### PR DESCRIPTION
Closes #2684

## What changes

The LLD stage now reads and cuts from the **arc**, never from the checkout's HEAD.

- `git_operations.setup_lld_worktree(target_repo, issue_number, base_branch="")` — with a base, the `<issue>-lld` branch is cut from `origin/<base>` (fetched first; local `<base>` if origin lacks it; `GitOperationError` if neither resolves). Without a base, unchanged. New helper `lld_start_point`.
- `nodes/analyze_codebase` — with `base_branch` in state, cuts (or reuses) that worktree before reading anything and analyzes it; prints `[BASE] LLD analysis reads origin/<base> via <worktree>` the way the spec stage prints its `[BASE]` line. **Fails closed:** if the arc cannot be cut it returns `error_message` (the graph halts) rather than reading the checkout in the arc's place.
- `nodes/finalize` — passes `base_branch` into the cut; finds the worktree already present in the normal path and rides it.

## Why

Observed on boostgauge 2026-09-01 (boostgauge #421, launch `run-issue41-182806`): boostgauge `main` holds the finished product, the attempt branch `hardening-run-20` is a seed with `src/` stripped. The LLD drafter's output named a private method that exists only on `main`; `data/worktrees/41-lld` had been cut from `main` and contained the entire product; LLD PR #425, targeting the arc, would have re-added every stripped feature on merge. The spec stage already reads the base (#2667); the LLD stage did not. It hid until now because every earlier arc either stood the checkout on the attempt branch (pre-#2012) or rolled a repo whose default branch had no code.

## Tests — `tests/unit/test_issue_2684.py`

A temp repo whose `main` is ahead of `arc` (an extra module and a README marker only on `main`):

- with a base, the worktree lacks the main-only module and marker, `arc` is its ancestor and `main` is not; without a base, cut from HEAD as before; reuse when present; `lld_start_point` prefers origin, then local, then refuses; an unresolvable base refuses and leaves no worktree.
- `analyze_codebase` with a base: the main-only marker and symbol appear nowhere in the context or the interface map, and the `[BASE]` line is printed; without a base, the marker is present (pre-#2684 behaviour pinned); with an unresolvable base, `error_message` names the refusal and the context is empty.
- `finalize` threads `base_branch` into the cut and into the PR base.

Neighbouring suites (`test_requirements_nodes.py`, `test_issue_162.py`, `test_spec_rides_lld_pr.py`) pass unchanged.

Out of scope: the pre-existing extraneous-`f` ruff finding at `finalize.py:554` (see #2671).
