### PR TITLE
fix: the completeness complaint cites the subsection it names, so the demanded block can actually be written (Closes #2686)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -887,11 +887,22 @@ def _outside_fences(pos: int, spans: tuple[tuple[int, int], ...]) -> bool:
     return not any(start <= pos < end for start, end in spans)
 
 
-def function_spec_sections(spec: str) -> list[tuple[str, str, int]]:
-    """Every `### 5.N` subsection as (heading, body, 1-based heading line).
+def function_spec_sections(spec: str) -> list[tuple[str, str, int, int]]:
+    """Every `### 5.N` subsection as (heading, body, first line, last line).
+
+    Both line numbers are 1-based and inclusive, and the subsection owns every
+    line between them.
 
     Bounded by the NEXT heading of any level, so a subsection's body is its
     own -- which is the whole difference between this and a window scan.
+
+    **The end line is measured here, from the offsets (#2686), not derived by
+    a caller from `body`.** `_FUNC_SPEC_HEADING_RE` ends in `\\s*$`, and that
+    `\\s*` eats the heading's own newline before `$` settles, so `body` opens
+    somewhere inside the whitespace after the heading rather than at a
+    predictable place. A caller counting newlines in `body` is short by
+    however much the regex absorbed -- one line for every subsection whose
+    heading is followed by a blank, which is all of them under template 0701.
 
     **Fences are not prose (#2687).** A Python comment at column zero inside an
     example -- `# Called on a Telltale instance with active history` -- matches
@@ -918,7 +929,7 @@ def function_spec_sections(spec: str) -> list[tuple[str, str, int]]:
     if not matches:
         return []
     next_heading = re.compile(r"^#{1,6}\s", re.MULTILINE)
-    out: list[tuple[str, str, int]] = []
+    out: list[tuple[str, str, int, int]] = []
     for index, match in enumerate(matches):
         start = match.end()
         limit = (
@@ -933,7 +944,14 @@ def function_spec_sections(spec: str) -> list[tuple[str, str, int]]:
         )
         body_end = following.start() if following else limit
         line_no = text.count("\n", 0, match.start()) + 1
-        out.append((match.group(0).strip(), text[start:body_end], line_no))
+        # The line holding the last character the subsection owns. Counting to
+        # `body_end` itself would land on the terminating heading whenever the
+        # body ends in a newline, which is the ordinary case.
+        end_line = max(
+            line_no,
+            text.count("\n", 0, max(body_end - 1, 0)) + 1,
+        )
+        out.append((match.group(0).strip(), text[start:body_end], line_no, end_line))
     return out
 
 
@@ -959,6 +977,25 @@ def check_function_spec_sections_have_examples(spec: str) -> CompletenessCheck:
     The complaint names the subsection HEADING, which occurs verbatim in the
     draft, so revision pinning can read the address (#2555's lesson, swept by
     `test_completeness_message_addressability.py`).
+
+    **It cites the whole subsection, not the heading line (#2686.)** Naming
+    `(line 142-142)` addressed the heading and nothing else. `_blocks` splits a
+    draft at every top-level `def` inside a fence, and template 0701 opens each
+    subsection with a `**Signature:**` fence carrying exactly that -- so the
+    cited line named only the six lines from the heading down to `**Signature:**`
+    and the remaining sixteen, including the place the missing block has to go,
+    stayed locked. Measured on boostgauge run `run-issue41-184913`'s draft with
+    one block deleted: 6 of 22 lines free, the insertion point among the locked
+    ones. The drafter wrote the demanded edit three times and pinning refused it
+    three times, then the edit-script transport rejected the no-op revision and
+    the stage halted non-transient.
+
+    A demand to add has no existing line to name, which is the same bind #2560
+    found for demanded tests. The address that works is the region the complaint
+    already names in prose -- "Add the block inside that subsection" -- so the
+    citation now spans it. `named_line_flags` marks every block the range
+    overlaps, which is the generous direction it documents, and the span stops
+    at the subsection's own end so no neighbouring section is freed.
     """
     sections = function_spec_sections(spec)
     if not sections:
@@ -972,11 +1009,11 @@ def check_function_spec_sections_have_examples(spec: str) -> CompletenessCheck:
         )
 
     missing: list[str] = []
-    for heading, body, line_no in sections:
+    for heading, body, line_no, end_line in sections:
         absent = [b for b in _REQUIRED_EXAMPLE_BLOCKS if b not in body]
         if absent:
             missing.append(
-                f"{heading} (line {line_no}-{line_no}) lacks "
+                f"{heading} (lines {line_no}-{end_line}) lacks "
                 f"{' and '.join(absent)}"
             )
 

--- a/tests/unit/test_function_spec_sections.py
+++ b/tests/unit/test_function_spec_sections.py
@@ -25,6 +25,12 @@ from assemblyzero.workflows.implementation_spec.nodes.validate_completeness impo
     check_functions_have_io_examples,
     function_spec_sections,
 )
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_flags,
+    named_line_ranges,
+    named_tokens,
+)
 
 DOCUMENTED = """\
 ### 5.1 `render_face()`
@@ -168,7 +174,7 @@ class TestSectionBounds:
 
     def test_the_heading_line_is_reported(self) -> None:
         draft = spec(DOCUMENTED)
-        _heading, _body, line_no = function_spec_sections(draft)[0]
+        _heading, _body, line_no, _end = function_spec_sections(draft)[0]
         assert draft.splitlines()[line_no - 1].startswith("### 5.1")
 
 
@@ -208,15 +214,20 @@ class TestTheComplaintIsAddressable:
         assert heading in draft, "the cited heading must occur in the draft"
 
     def test_the_message_carries_a_dashed_line_citation(self) -> None:
-        """`named_line_ranges` requires the dash (#2555), so a bare line
-        number would address nothing."""
-        import re
+        """Asserted with the parser's OWN pattern, not a lookalike.
 
+        `named_line_ranges` requires the dash (#2555), so a bare line number
+        would address nothing. This used to assert `line \\d+-\\d+`, which is
+        narrower than what pinning accepts (`\\blines?\\s+...`) -- so widening
+        the citation to a span broke the test while the message stayed
+        perfectly addressable. Reading the real pattern removes the second,
+        drifting definition of what an address is.
+        """
         details = check_function_spec_sections_have_examples(
             spec(UNDOCUMENTED)
         )["details"]
 
-        assert re.search(r"line \d+-\d+", details), details
+        assert named_line_ranges([details]), details
 
 
 #: The shape that halted boostgauge #421's fifth launch: an Input Example
@@ -387,7 +398,7 @@ class TestTheDraftThatHaltedLaunchFive:
         sections = function_spec_sections(draft)
 
         assert len(sections) == 4
-        for heading, body, _line in sections:
+        for heading, body, _line, _end in sections:
             assert "**Input Example:**" in body, heading
             assert "**Output Example:**" in body, heading
 
@@ -409,3 +420,150 @@ class TestTheDraftThatHaltedLaunchFive:
         assert lines[131] == "**Output Example:**"
         assert lines[156].startswith("# Called on a Telltale instance")
         assert lines[159] == "**Output Example:**"
+
+
+def _delete_54s_output_example(draft: str) -> str:
+    """The preserved draft with §5.4's Output Example block removed.
+
+    1-based lines 160-164 — the `**Output Example:**` label, its blank, and
+    the three-line fence. Everything else is byte-identical, so the finding
+    the check then raises is TRUE and the deadlock it addresses is the real
+    one rather than #2687's false alarm wearing its clothes.
+    """
+    lines = draft.splitlines()
+    assert lines[159] == "**Output Example:**"
+    assert lines[163] == "```"
+    return "\n".join(lines[:159] + lines[164:]) + "\n"
+
+
+class TestTheCitationFreesTheInsertionPoint:
+    """#2686: a TRUE finding must be actionable, not merely correct.
+
+    Template 0701 opens every function subsection with a `**Signature:**`
+    fence holding a top-level `def`, and `_blocks` starts a new attribution
+    block at exactly that point (#2681). So a citation naming only the
+    heading line freed the handful of lines above the signature and locked
+    everything below it -- including the only place the demanded block can
+    go. The drafter wrote the edit, pinning refused it, and the stage halted.
+    """
+
+    def _flags(self, draft: str) -> tuple[list[bool], str]:
+        details = check_function_spec_sections_have_examples(draft)["details"]
+        flags = named_line_flags(
+            draft,
+            named_tokens("", [details]),
+            named_line_ranges([details]),
+        )
+        return flags, details
+
+    def test_the_span_covers_the_whole_subsection(self, draft: str) -> None:
+        holed = _delete_54s_output_example(draft)
+        _flags, details = self._flags(holed)
+
+        assert "(lines 142-163)" in details, details
+
+    def test_every_line_of_the_subsection_is_free(self, draft: str) -> None:
+        holed = _delete_54s_output_example(draft)
+        flags, details = self._flags(holed)
+
+        # 1-based 142..163 inclusive -> 0-based slice [141:163]
+        section = flags[141:163]
+        assert len(section) == 22
+        assert all(section), (
+            f"{section.count(False)} of 22 lines still locked; the drafter "
+            f"cannot write the block the check demands. {details}"
+        )
+
+    def test_the_insertion_point_itself_is_free(self, draft: str) -> None:
+        """The line after §5.4's Input Example fence — where the block goes."""
+        holed = _delete_54s_output_example(draft)
+        flags, _details = self._flags(holed)
+        lines = holed.splitlines()
+
+        assert lines[157] == "```", lines[157]
+        assert flags[158] is True, "the line after the Input Example fence"
+
+    def test_the_next_section_is_not_freed(self, draft: str) -> None:
+        """Generous to the subsection, and no further."""
+        holed = _delete_54s_output_example(draft)
+        flags, _details = self._flags(holed)
+        lines = holed.splitlines()
+
+        assert lines[163].startswith("## 6."), lines[163]
+        assert not any(flags[163:180]), (
+            "a passing neighbour must stay pinned"
+        )
+
+    def test_a_passing_subsection_stays_locked(self, draft: str) -> None:
+        """§5.1 is fully documented and no verdict named it."""
+        holed = _delete_54s_output_example(draft)
+        flags, _details = self._flags(holed)
+
+        assert not any(flags[54:83]), "§5.1 must remain pinned"
+
+
+class TestPinningAcceptsTheDemandedEdit:
+    """The acceptance, through the real enforcer (#2686).
+
+    Lock flags are the mechanism; this is the outcome. `enforce_pinning` is
+    the function that refused the drafter three times on
+    `run-issue41-184913`, so the fix is proven by feeding it the same
+    document and the edit it kept reverting.
+    """
+
+    OUTPUT_BLOCK = [
+        "**Output Example:**",
+        "",
+        "```python",
+        "None # History cleared, config intact",
+        "```",
+        "",
+    ]
+
+    def _enforce(self, previous: str, revised: str):
+        details = check_function_spec_sections_have_examples(previous)["details"]
+        return enforce_pinning(
+            previous,
+            revised,
+            current_tokens=named_tokens("", [details]),
+            ever_tokens=named_tokens("", [details]),
+            current_ranges=named_line_ranges([details]),
+        )
+
+    def test_the_block_the_drafter_kept_writing_is_accepted(
+        self, draft: str
+    ) -> None:
+        holed = _delete_54s_output_example(draft)
+        lines = holed.splitlines()
+        # Put it back where it was: after §5.4's Input Example fence.
+        assert lines[157] == "```"
+        revised = "\n".join(
+            lines[:159] + self.OUTPUT_BLOCK + lines[159:]
+        ) + "\n"
+
+        result = self._enforce(holed, revised)
+
+        assert result.refusals == (), result.refusals
+        assert "None # History cleared, config intact" in result.text
+        assert check_function_spec_sections_have_examples(
+            result.text
+        )["passed"] is True
+
+    def test_an_edit_to_an_unnamed_subsection_is_still_refused(
+        self, draft: str
+    ) -> None:
+        """Pinning is not turned off — §5.1 passed and stays protected."""
+        holed = _delete_54s_output_example(draft)
+        lines = holed.splitlines()
+        target = next(
+            i for i, ln in enumerate(lines)
+            if ln.startswith("### 5.1")
+        )
+        vandalised = list(lines)
+        vandalised[target + 2] = "**File:** `src/boostgauge/SOMETHING_ELSE.py`"
+        revised = "\n".join(vandalised) + "\n"
+
+        result = self._enforce(holed, revised)
+
+        assert result.refusals, "an unnamed subsection must stay locked"
+        assert "SOMETHING_ELSE" not in result.text


### PR DESCRIPTION
## What this fixes

The check demanded an Output Example "inside that subsection" and addressed `(line 142-142)` — the heading line alone. Template 0701 opens every function subsection with a `**Signature:**` fence carrying a top-level `def`, and `_blocks` starts a new attribution block at exactly that point (#2681). So the citation freed the six lines from the heading down to `**Signature:**` and left the other sixteen locked — **including the only place the missing block can go.**

## Measured against a true finding, not the false alarm

#2687 removed the false alarm that started `run-issue41-184913`'s halt. This is the other half, and it needed a finding that is actually true — so the measurement deletes §5.4's Output Example from that same preserved draft and leaves everything else byte-identical:

| | cited span | subsection lines free | insertion point |
|---|---|---|---|
| before | `(line 142-142)` | **6 of 22** | locked |
| after | `(lines 142-163)` | **22 of 22** | free |

The locked sixteen begin at `` ```python `` on line 148 and run through `**Edge Cases:**` — the log's refusals name exactly those lines (`'# Called on a Telltale instance with active history'`, `'None # History cleared, config intact'`). Three refusals, then no-op edits, then the edit-script transport rejecting the revision and the stage halting non-transient.

## Why a span is the right address

A demand to **add** has no existing line to name — the same bind #2560 found for demanded tests, where the named-content exemptions could not cover a region that did not exist yet. The address that works is the region the complaint already names in prose. `named_line_flags` marks every block a range overlaps, which is the generous direction it documents, and the span stops at the subsection's own end so nothing beyond it is freed.

Pinning is not weakened. §5.1 (documented, unnamed by any verdict) and §6 both stay locked, and the negative test proves an edit to §5.1 is still refused and reverted.

## The end line is measured, not derived

`function_spec_sections` now returns `(heading, body, first_line, last_line)`, both inclusive.

The obvious alternative — let the caller count newlines in `body` — is wrong, and quietly. `_FUNC_SPEC_HEADING_RE` ends in `\s*$`, and that `\s*` consumes the heading's own newline before `$` settles, so `body` starts somewhere inside the whitespace after the heading rather than at a predictable offset. A caller counting newlines is short by one for every subsection whose heading is followed by a blank line — which is all of them under template 0701. I wrote it that way first and it cited `142-162` for a subsection ending at 163; computing from the offsets where they live gives `142-163`.

## Tests

- `TestPinningAcceptsTheDemandedEdit` runs the real `enforce_pinning` — the same function that refused the drafter three times — feeds it the block the drafter kept writing, and asserts no refusals, the block present in the merged text, and the completeness check passing afterwards. Its negative half asserts an edit to a passing subsection is still refused.
- `TestTheCitationFreesTheInsertionPoint` pins the span, all 22 lines free, the insertion point specifically, and that neither §6 nor §5.1 is freed.
- `test_the_message_carries_a_dashed_line_citation` now asserts with `named_line_ranges` itself rather than a narrower lookalike regex. The old `line \d+-\d+` was stricter than what pinning accepts (`\blines?\s+…`), so widening the citation broke the test while the message stayed perfectly addressable — a second, drifting definition of what an address is.

32 tests in the file, all passing. The 99 tests in the four sibling files that reference `function_spec_sections`, including `test_completeness_pinning_deadlock.py`, pass unchanged. Ruff clean.

Closes #2686
