### PR TITLE
fix: the impl stage requires the testing workflow to say it finished, not merely to end quietly (Closes #2677)

### DIFF
--- a/assemblyzero/workflows/orchestrator/stages.py
+++ b/assemblyzero/workflows/orchestrator/stages.py
@@ -321,6 +321,29 @@ def _unresolved_test_failures(sub_result: dict) -> int:
     return total
 
 
+def _phases_not_run(sub_result: dict) -> str:
+    """Which TDD phases produced no output, named in the halt text (#2677).
+
+    "Ended without reaching finalize" says a route was not taken. This says
+    what was not DONE, which is the part an operator reading `impl passed
+    3.5s` needed and did not get: on run-issue384-044442 the red phase, the
+    implementation loop, the green phase and the regression check had all
+    never run, and nothing in the stage table showed it.
+
+    Reports only phases with NO recorded output. A phase that ran and failed
+    is a different fact and is already named by the checks above.
+    """
+    phases = (
+        ("red phase", "red_phase_output"),
+        ("implementation", "implementation_files"),
+        ("green phase", "green_phase_output"),
+    )
+    missing = [label for label, key in phases if not sub_result.get(key)]
+    if not missing:
+        return "Every phase produced output, so the workflow stopped after them."
+    return f"Never ran: {', '.join(missing)}."
+
+
 def _is_non_transient_halt(sub_result: dict) -> bool:
     """Sub-workflow halts write a recovery_plan_path. Non-transient by default
     since the resume command — not a 10-second retry — is the recovery path.
@@ -1580,6 +1603,32 @@ def run_impl_stage(state: OrchestrationState) -> OrchestrationState:
                     f"green-phase measurement did not pass, so the stage did "
                     f"not pass."
                 )
+
+        # #2677: COMPLETION MUST BE AS EXPLICIT AS FAILURE.
+        #
+        # Every check above this line is a negative: it names one way the
+        # sub-workflow can end badly while leaving `error_message` empty.
+        # #1779 added the BLOCK verdict after one escape and #2344 added
+        # unresolved failures after another, and run-issue384-044442 found a
+        # third -- the testing workflow stopped at N2.5 on an exhausted
+        # scaffolder, said nothing, and the stage recorded `impl passed 3.5s`
+        # with the red phase, the implementation loop, the green phase and the
+        # regression check all never run. A PR carrying an assertion-free stub
+        # and no code was opened and merged from that verdict.
+        #
+        # Enumerating failures cannot terminate: any new END that forgets to
+        # set an error re-creates the class. So the stage asks the workflow to
+        # SAY it finished. `workflow_status` is set in exactly one place, N7
+        # finalize, which is reached only after the green phase has passed --
+        # every other route to END is a failure, a halt, or `scaffold_only`,
+        # which the orchestrator never sets. This is #2297's halted-is-
+        # authoritative reading in the positive direction.
+        if not error_msg and sub_result.get("workflow_status") != "completed":
+            error_msg = (
+                "Testing workflow ended without reaching N7 finalize, so the "
+                "implementation stage did not pass. "
+                + _phases_not_run(sub_result)
+            )
 
         if not error_msg:
             result = _make_stage_result(

--- a/assemblyzero/workflows/testing/nodes/finalize.py
+++ b/assemblyzero/workflows/testing/nodes/finalize.py
@@ -256,6 +256,11 @@ def finalize(state: TestingWorkflowState) -> dict[str, Any]:
     return {
         "test_report_path": str(report_path),
         "archived_files": archived_files,
+        # #2677: the only place this is ever set. The line above prints
+        # "Testing workflow COMPLETE"; this is that same claim in a field the
+        # orchestrator can read, so a run that never reached N7 cannot be
+        # recorded as a passed impl stage however quietly it ended.
+        "workflow_status": "completed",
         "error_message": "",
     }
 

--- a/assemblyzero/workflows/testing/state.py
+++ b/assemblyzero/workflows/testing/state.py
@@ -236,6 +236,21 @@ class TestingWorkflowState(TypedDict, total=False):
     # Output
     test_report_path: str
     implementation_report_path: str
+    #: Explicit terminal verdict: "" while running, "completed" when N7
+    #: finalize ran. Set in exactly one place, and the orchestrator's impl
+    #: stage requires it (#2677).
+    #:
+    #: Completion must be as explicit as failure. The stage used to pass on
+    #: `not error_message`, so a workflow that ended anywhere without setting
+    #: an error read as one that had done its job -- run-issue384-044442
+    #: stopped at N2.5 on an exhausted scaffolder and was recorded `impl
+    #: passed 3.5s`, with the red phase, the implementation loop, the green
+    #: phase and the regression check all never run, and a PR of an
+    #: assertion-free stub opened and merged from it. #1779 and #2344 each
+    #: added one more negative check after one more escape; this asks the
+    #: workflow to say it finished, which is #2297's reading in the positive
+    #: direction.
+    workflow_status: str
 
     # Error handling
     error_message: str

--- a/tests/unit/test_explicit_completion_marker.py
+++ b/tests/unit/test_explicit_completion_marker.py
@@ -1,0 +1,193 @@
+"""Completion must be as explicit as failure (#2677).
+
+`run-issue384-044442`: the testing workflow stopped at N2.5 on an exhausted
+scaffolder, set no `error_message`, and the orchestrator recorded `impl passed
+3.5s`. The red phase, the implementation loop, the green phase and the
+full-suite regression check had none of them run, and a PR carrying an
+assertion-free stub and no code was opened and merged from that verdict.
+
+The stage's rule had been `not error_message` -> passed, patched twice with one
+more negative check each time (#1779's BLOCK verdict, #2344's unresolved
+failures). Enumerating the ways a workflow can end badly cannot terminate: any
+new route to END that forgets to set an error re-creates the class. #2297
+settled the negative direction for the spec stage -- `halted` is authoritative
+-- and this is the same reading positively: the workflow says it finished, in
+one place, and the stage requires the claim.
+
+These tests own the WORKFLOW half. The stage half lives in
+`test_orchestrator_stages.py::TestCompletionMustBeAsExplicitAsFailure`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from assemblyzero.workflows.testing.state import TestingWorkflowState
+
+TESTING_PKG = (
+    Path(__file__).resolve().parents[2]
+    / "assemblyzero" / "workflows" / "testing"
+)
+
+
+class TestTheMarkerSurvivesTheGraphMerge:
+    """#2679's lesson: a key a node returns but the schema does not declare is
+    dropped by the merge, so the orchestrator would never see it."""
+
+    def test_workflow_status_is_declared_in_the_state_schema(self) -> None:
+        assert "workflow_status" in TestingWorkflowState.__annotations__
+
+    def test_it_is_declared_as_a_string(self) -> None:
+        assert TestingWorkflowState.__annotations__["workflow_status"] is str
+
+
+class TestFinalizeIsTheOnlyPlaceItIsSet:
+    """"Set in exactly one place" as a program, not a comment (rule 6).
+
+    The guarantee the orchestrator leans on is not that finalize sets the
+    marker -- it is that NOTHING ELSE does. A second writer anywhere in the
+    testing package would restore the false-success hole silently, and no
+    behavioural test would notice, because every such test would still pass.
+    """
+
+    def _writers(self) -> dict[str, list[str]]:
+        pattern = re.compile(r"""["']workflow_status["']\s*:""")
+        found: dict[str, list[str]] = {}
+        for path in TESTING_PKG.rglob("*.py"):
+            hits = [
+                line.strip()
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if pattern.search(line)
+            ]
+            if hits:
+                found[path.name] = hits
+        return found
+
+    def test_only_finalize_assigns_it(self) -> None:
+        writers = self._writers()
+
+        assert set(writers) == {"finalize.py"}, (
+            f"workflow_status is assigned in {sorted(writers)}; the "
+            f"orchestrator's guarantee is that only N7 finalize sets it"
+        )
+
+    def test_it_is_assigned_exactly_once(self) -> None:
+        assert len(self._writers()["finalize.py"]) == 1
+
+    def test_the_scanner_can_actually_find_an_assignment(self) -> None:
+        """Guards the two tests above from passing vacuously.
+
+        A regex that matched nothing would make both assertions above trivially
+        satisfiable by deleting the marker entirely.
+        """
+        assert self._writers(), "the scan found no assignment anywhere"
+
+
+class TestFinalizeSetsIt:
+    def test_the_return_carries_completed(self) -> None:
+        """Read from the node's own return, at the line that emits it."""
+        source = (TESTING_PKG / "nodes" / "finalize.py").read_text(
+            encoding="utf-8"
+        )
+
+        assert '"workflow_status": "completed",' in source
+
+    def test_the_marker_sits_inside_finalize(self) -> None:
+        """Not in a helper that some other route could reach."""
+        source = (TESTING_PKG / "nodes" / "finalize.py").read_text(
+            encoding="utf-8"
+        )
+        marker_at = source.index('"workflow_status": "completed"')
+        defs_before = [
+            m.group(1)
+            for m in re.finditer(r"^def (\w+)", source[:marker_at], re.M)
+        ]
+
+        assert defs_before[-1] == "finalize", defs_before[-1]
+
+
+class TestEveryOtherTerminalLeavesItUnset:
+    """The complement of the guarantee, read off the graph's own wiring.
+
+    Every route to END other than through N7 is a failure, a halt, or
+    `scaffold_only` -- which the orchestrator's impl stage never sets. This
+    asserts the routers that can reach END are the ones we believe they are,
+    so a new terminal added later shows up here rather than as another
+    `passed 3.5s`.
+    """
+
+    def test_finalize_is_the_only_node_that_reports_completion(self) -> None:
+        graph_source = (TESTING_PKG / "graph.py").read_text(encoding="utf-8")
+
+        assert '"N7_finalize"' in graph_source
+        assert "workflow_status" not in graph_source, (
+            "routing must not set the completion marker; only N7 does"
+        )
+
+    def test_scaffold_only_is_never_set_by_the_impl_stage(self) -> None:
+        """The one non-failure route to END that bypasses N7."""
+        stages = (
+            Path(__file__).resolve().parents[2]
+            / "assemblyzero" / "workflows" / "orchestrator" / "stages.py"
+        ).read_text(encoding="utf-8")
+
+        assert '"scaffold_only"' not in stages
+
+
+class TestARealRunStillPasses:
+    """The safety half, and the one that matters most.
+
+    A gate that refuses the observed failure is worthless if it also refuses
+    every good run. This drives the actual graph end to end in mock mode --
+    every node, every router, the real merge -- and asserts the marker is
+    present in the state the orchestrator receives.
+
+    `app.invoke` rather than `app.stream`: the stream yields one node's output
+    at a time, so the neighbouring test that keeps the last event sees N9's
+    return and could never observe a field N7 set. The merged state is what
+    `run_impl_stage` actually reads.
+    """
+
+    def _mock_run(self, tmp_path: Path) -> dict:
+        from assemblyzero.workflows.testing.graph import build_testing_workflow
+
+        lld_dir = tmp_path / "docs" / "lld" / "active"
+        lld_dir.mkdir(parents=True)
+        (lld_dir / "LLD-042.md").write_text(
+            "# LLD-042: Mock Feature\n\n"
+            "## 1. Context\n* **Status:** Approved (Gemini Review, 2026-01-30)\n\n"
+            "## 3. Requirements\n1. REQ-1: User login\n"
+            "2. REQ-2: Input validation\n\n"
+            "## 10. Test Plan\n\n### test_login\nVerify login works.\n"
+            "Requirement: REQ-1\n\n**Final Status:** APPROVED\n"
+        )
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "docs" / "lineage" / "active").mkdir(parents=True)
+
+        app = build_testing_workflow().compile()
+        return app.invoke(
+            {
+                "issue_number": 42,
+                "repo_root": str(tmp_path),
+                "mock_mode": True,
+                "skip_e2e": True,
+                "auto_mode": True,
+            },
+            {"recursion_limit": 50},
+        )
+
+    def test_the_marker_reaches_the_orchestrator(self, tmp_path) -> None:
+        final_state = self._mock_run(tmp_path)
+
+        assert final_state.get("workflow_status") == "completed", (
+            f"a completed run must carry the marker; got "
+            f"{final_state.get('workflow_status')!r}"
+        )
+
+    def test_the_stage_would_record_it_as_passed(self, tmp_path) -> None:
+        """The two halves joined: this state passes the stage's own rule."""
+        final_state = self._mock_run(tmp_path)
+
+        assert final_state.get("error_message", "") == ""
+        assert final_state.get("workflow_status") == "completed"

--- a/tests/unit/test_orchestrator_stages.py
+++ b/tests/unit/test_orchestrator_stages.py
@@ -223,11 +223,104 @@ class TestImplCompletenessGateHonesty:
         assert "stub function detected" in impl["error_message"]
 
     def test_pass_verdict_still_passes(self, tmp_path):
+        # `workflow_status` is required since #2677: a sub-result that never
+        # says it reached N7 finalize is not a passed stage, so a stub
+        # standing in for a COMPLETED workflow has to say so too.
         result_state = self._run_impl(
-            {"error_message": "", "completeness_verdict": "PASS"},
+            {
+                "error_message": "",
+                "completeness_verdict": "PASS",
+                "workflow_status": "completed",
+            },
             tmp_path,
         )
         assert result_state["stage_results"]["impl"]["status"] == "passed"
+
+
+class TestCompletionMustBeAsExplicitAsFailure:
+    """#2677: the stage verdict is the workflow's own claim to have finished.
+
+    run-issue384-044442's testing workflow stopped at N2.5 on an exhausted
+    scaffolder, set no error, and the stage recorded `impl passed 3.5s` --
+    with the red phase, the implementation loop, the green phase and the
+    full-suite regression check all never run. A PR carrying an
+    assertion-free stub and no code was opened and merged from that verdict.
+
+    #1779 added the BLOCK check after one such escape and #2344 added the
+    unresolved-failures check after another. Enumerating failure modes cannot
+    terminate; this asks for the positive claim instead.
+    """
+
+    def _run_impl(self, sub_result: dict, tmp_path):
+        return TestImplCompletenessGateHonesty()._run_impl(sub_result, tmp_path)
+
+    def test_the_observed_shape_is_recorded_as_failed(self, tmp_path):
+        """N2.5 exhaustion: empty error, nothing else set. The exact case."""
+        result_state = self._run_impl({"error_message": ""}, tmp_path)
+        impl = result_state["stage_results"]["impl"]
+
+        assert impl["status"] == "failed"
+        assert "without reaching N7 finalize" in impl["error_message"]
+
+    def test_the_failure_names_the_phases_that_never_ran(self, tmp_path):
+        result_state = self._run_impl({"error_message": ""}, tmp_path)
+        message = result_state["stage_results"]["impl"]["error_message"]
+
+        assert "Never ran:" in message
+        for phase in ("red phase", "implementation", "green phase"):
+            assert phase in message, message
+
+    def test_a_completed_workflow_is_unaffected(self, tmp_path):
+        result_state = self._run_impl(
+            {"error_message": "", "workflow_status": "completed"}, tmp_path
+        )
+
+        assert result_state["stage_results"]["impl"]["status"] == "passed"
+
+    def test_a_completed_run_passes_whatever_its_phase_inventory(
+        self, tmp_path
+    ):
+        """Completion is the marker; the phase listing never gates."""
+        result_state = self._run_impl(
+            {
+                "error_message": "",
+                "workflow_status": "completed",
+                "red_phase_output": "1 failed",
+                "green_phase_output": "3 passed",
+                "implementation_files": ["src/x.py"],
+            },
+            tmp_path,
+        )
+
+        assert result_state["stage_results"]["impl"]["status"] == "passed"
+
+    def test_an_explicit_error_still_wins_and_keeps_its_own_words(
+        self, tmp_path
+    ):
+        """The new check must not overwrite a diagnosis that already exists."""
+        result_state = self._run_impl(
+            {"error_message": "LLD could not be loaded"}, tmp_path
+        )
+        impl = result_state["stage_results"]["impl"]
+
+        assert impl["status"] == "failed"
+        assert impl["error_message"] == "LLD could not be loaded"
+        assert "N7 finalize" not in impl["error_message"]
+
+    def test_a_block_verdict_keeps_its_own_message(self, tmp_path):
+        """#1779's check runs first and is more specific, so it survives."""
+        result_state = self._run_impl(
+            {
+                "error_message": "",
+                "completeness_verdict": "BLOCK",
+                "completeness_issues": ["stub function detected"],
+            },
+            tmp_path,
+        )
+        message = result_state["stage_results"]["impl"]["error_message"]
+
+        assert "Completeness gate BLOCK" in message
+        assert "N7 finalize" not in message
 
 
 class TestFormatStageTable:


### PR DESCRIPTION
## What this fixes

The impl stage's verdict was `not error_message` → passed. On `run-issue384-044442` the testing workflow stopped at N2.5 with an exhausted scaffolder, set no error, and the stage recorded:

```
impl      passed       3.5s  C:\...\boostgauge\data\worktrees\384
pr        passed       4.3s  https://github.com/martymcenroe/boostgauge/pull/395
[ORCHESTRATOR] All stages passed.
```

The red phase, the implementation loop, the green phase and the full-suite regression check had none of them run. PR #395 was opened and merged carrying an assertion-free stub and no code.

## Why one more negative check would not have been enough

`#1779` added the BLOCK-verdict check after one escape of this shape. `#2344` added the unresolved-failures check after another. Each names one more way for the sub-workflow to end badly while leaving the error field empty — and any new route to `END` that forgets to set an error re-creates the class. The list cannot be completed by enumeration.

So the workflow states the positive instead. `TestingWorkflowState.workflow_status` is set in exactly one place — N7 finalize, on the line below the one that already prints `Testing workflow COMPLETE` — and the stage requires the claim. This is #2297's `halted`-is-authoritative reading run in the other direction: **completion must be as explicit as failure.**

## Why this cannot refuse a good run

Every route to `END` other than through N7 is a failure, a halt, or `scaffold_only`, which the orchestrator's impl stage never sets (asserted). N7 is reached only from N5 or N6, after the green phase has passed. Mock mode traverses every node normally rather than short-circuiting, so a rehearsal is unaffected.

That reasoning is not left as reasoning. `TestARealRunStillPasses` drives the real graph end to end in mock mode and asserts the marker is present in the state the orchestrator receives. It uses `app.invoke` rather than `app.stream` deliberately — streaming yields one node's output at a time, so the neighbouring test that keeps the last event sees N9's return and could never observe a field N7 set.

## The refusal says what did not happen

"Ended without reaching finalize" names a route that was not taken. The operator staring at `impl passed 3.5s` needed the other fact, so the message carries it:

```
Testing workflow ended without reaching N7 finalize, so the implementation
stage did not pass. Never ran: red phase, implementation, green phase.
```

Only phases with no recorded output are listed. A phase that ran and failed is a different fact and is already named by the checks above.

## The single-writer guarantee, as a program

The thing the stage leans on is not that finalize sets the marker — it is that **nothing else does**. A second writer anywhere in the testing package would restore the hole silently, and no behavioural test would notice, because every such test would still pass.

`TestFinalizeIsTheOnlyPlaceItIsSet` scans the package and asserts one writer, in one file, once — with a third test guarding the scan from passing vacuously if the marker were deleted outright. `TestTheMarkerSurvivesTheGraphMerge` pins the schema declaration, which is #2679's lesson: a key a node returns but the state does not declare is dropped by the merge, and the orchestrator would never see it.

## Weighed, as the issue asked: the other wrapped sub-workflows

Neither sibling has the gap, and the reason is worth recording.

- **spec stage** — passes on `spec_path` being a real file plus an explicit `halted` check. `spec_path` is set by `finalize_spec` alone (`implementation_spec/state.py` says so, and #2297 split `spec_draft_path` off precisely so a draft could not masquerade as one). The artifact **is** a completion marker.
- **lld stage** — passes on `final_lld_path` being a real file, written only at `requirements/nodes/finalize.py:570`. Its `or sub_result.get("lld_path", "")` fallback reads a key the requirements state does not declare at all, so it is always empty: dead, not a hole.

**The impl stage was the odd one out because its artifact is a worktree, which exists from the moment the stage starts.** LLD and spec each finish by writing a document whose path is recorded only at finalize, so "the artifact exists" already means "it finished". That could never be true for impl, which is exactly why it needed an explicit field rather than a better artifact check.

## Tests

11 new in `test_explicit_completion_marker.py`, 6 new in `test_orchestrator_stages.py::TestCompletionMustBeAsExplicitAsFailure` — including that an existing `error_message` keeps its own words and a BLOCK verdict keeps its more specific message, so the new check never overwrites a diagnosis that already exists.

One existing test changed: `test_pass_verdict_still_passes`'s stub `sub_result` now declares `workflow_status: "completed"`. That is the contract change showing up exactly where it should — a stub standing in for a completed workflow has to say it completed.

Full unit suite: **9459 passed**, 21 skipped, 5 xfailed, 0 failures. Ruff introduces no new findings (the four in the touched files pre-exist on `origin/main`; verified against `git show origin/main:<path>`).

Closes #2677
