### PR TITLE
fix: a halt prints one resume command, and it names a file that exists (Closes #2663)

### DIFF
--- a/assemblyzero/core/recovery_plan.py
+++ b/assemblyzero/core/recovery_plan.py
@@ -21,13 +21,67 @@ from typing import Any
 # Error types classified as transient (will resolve on their own)
 TRANSIENT_ERROR_TYPES = frozenset({"capacity_exhausted", "quota_exhausted"})
 
-# Workflow name → CLI tool for resume commands
+#: Workflow name -> the tool that resumes it, relative to the AssemblyZero
+#: checkout. Every path here is asserted to exist by
+#: `test_resume_commands_resolve.py`; a path string in a dict has no way to be
+#: wrong loudly, and two of these were wrong for an unknown length of time
+#: (#2663).
+#:
+#: `orchestrator` names the RELAUNCH rather than `orchestrate.py` directly.
+#: The two are not equivalent and the relaunch is the one to hand an operator:
+#: `speedrun_roll` computes the resume stage itself (`resume_plan`, and #2206's
+#: ruling that a failure halts for diagnosis and the relaunch resumes from the
+#: failed stage), so the operator does not have to name a stage; and it is what
+#: carries the child environment (#2662's `_child_env`), the kill watch and the
+#: run log. `orchestrate.py --resume-from <stage>` is the inner call it makes.
+#:
+#: All four accept `--issue` and `--repo`, which is what
+#: `build_resume_command` relies on.
 RESUME_COMMANDS = {
     "requirements": "tools/run_requirements_workflow.py",
     "implementation_spec": "tools/run_implementation_spec_workflow.py",
-    "testing": "tools/run_tdd_workflow.py",
-    "orchestrator": "tools/run_orchestrator.py",
+    "testing": "tools/run_implement_from_lld.py",
+    "orchestrator": "tools/speedrun_roll.py",
 }
+
+#: State keys that can name the repo the run was against, best first. The
+#: orchestrator carries `target_repo`; sub-workflows carry the impl worktree in
+#: `repo_root` and the real repo in `original_repo_root`, and a resume must be
+#: pointed at the repo, never at a worktree that the halt may have removed.
+_REPO_KEYS = ("target_repo", "original_repo_root", "repo_root")
+
+
+def build_resume_command(workflow: str, issue_number: int, state: dict) -> str:
+    """The one command that actually resumes this workflow (#2663).
+
+    Every orchestrator halt used to print `poetry run python
+    tools/run_orchestrator.py --issue N` -- a file that exists in neither
+    AssemblyZero nor any target repo -- and `testing` named a second file that
+    does not exist either. A halt is where an operator arrives with the least
+    context and the most urgency, and the resume line is the whole recovery
+    affordance; it is also the one line nobody exercises, because a halt
+    diagnosed by an agent never has its command typed. So it can be wrong
+    indefinitely, and it was.
+
+    Returns a command naming a file that exists, or -- when the workflow is
+    one this map does not know -- says so plainly. The old fallback invented
+    `tools/run_<workflow>_workflow.py` for any unknown name, which is the same
+    defect generalised: a guess that reads exactly like a fact.
+    """
+    tool = RESUME_COMMANDS.get(workflow)
+    if not tool:
+        return (
+            f"(no resume command is defined for workflow {workflow!r} -- "
+            f"see AssemblyZero RESUME_COMMANDS)"
+        )
+
+    parts = [f"poetry run python {tool}", f"--issue {issue_number}"]
+    repo = next(
+        (str(state.get(key)) for key in _REPO_KEYS if state.get(key)), ""
+    )
+    if repo:
+        parts.append(f"--repo {repo}")
+    return " ".join(parts)
 
 
 @dataclass
@@ -141,11 +195,7 @@ def generate_recovery_plan(
     is_transient = error_type in TRANSIENT_ERROR_TYPES
     halted_at = datetime.now(timezone.utc).isoformat()
 
-    # Build resume command
-    tool = RESUME_COMMANDS.get(workflow, f"tools/run_{workflow}_workflow.py")
-    resume_command = (
-        f"poetry run python {tool} --issue {issue_number}"
-    )
+    resume_command = build_resume_command(workflow, issue_number, state)
 
     # Earliest retry for transient errors
     earliest_retry = ""

--- a/tests/unit/test_resume_commands_resolve.py
+++ b/tests/unit/test_resume_commands_resolve.py
@@ -1,0 +1,163 @@
+"""Every resume command names a file that exists, and there is only one (#2663).
+
+Every orchestrator halt printed `poetry run python tools/run_orchestrator.py
+--issue N`. That file exists in neither AssemblyZero nor any target repo, and
+`testing` named `tools/run_tdd_workflow.py`, which does not exist either -- two
+of the four entries were wrong, and the issue that found it had only spotted
+one.
+
+A halt is where an operator arrives with the least context and the most
+urgency, and the resume line is the entire recovery affordance. It is also the
+one line nobody exercises: a halt diagnosed by an agent never has its command
+typed, so the path can be wrong indefinitely without anyone noticing. That is
+precisely the shape a test fixes and a code review does not, and it is the
+"audits are programs" rule -- a path string in a dict has no way to be wrong
+loudly, so something has to ask it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pathlib import Path
+
+from assemblyzero.core.recovery_plan import (
+    RESUME_COMMANDS,
+    build_resume_command,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class TestEveryMappedPathResolves:
+    @pytest.mark.parametrize("workflow", sorted(RESUME_COMMANDS))
+    def test_the_tool_exists(self, workflow: str) -> None:
+        tool = REPO_ROOT / RESUME_COMMANDS[workflow]
+
+        assert tool.is_file(), (
+            f"{workflow!r} resumes with {RESUME_COMMANDS[workflow]}, which "
+            f"does not exist. An operator reading a halt is handed this."
+        )
+
+    @pytest.mark.parametrize("workflow", sorted(RESUME_COMMANDS))
+    def test_the_tool_accepts_the_flags_the_command_passes(
+        self, workflow: str
+    ) -> None:
+        """Existing is not enough -- it has to take `--issue` and `--repo`.
+
+        `build_resume_command` emits both, so a tool that exists and rejects
+        one of them is still a broken instruction, just a slower one to
+        diagnose.
+        """
+        source = (REPO_ROOT / RESUME_COMMANDS[workflow]).read_text(
+            encoding="utf-8"
+        )
+
+        assert '"--issue"' in source, workflow
+        assert '"--repo"' in source, workflow
+
+    def test_the_map_is_not_empty(self) -> None:
+        """Guards the parametrized tests from passing vacuously."""
+        assert len(RESUME_COMMANDS) >= 4
+
+
+class TestTheBuiltCommand:
+    def test_an_orchestrator_halt_names_the_relaunch(self) -> None:
+        command = build_resume_command(
+            "orchestrator", 379, {"target_repo": "C:/x/boostgauge"}
+        )
+
+        assert "tools/speedrun_roll.py" in command
+        assert "--issue 379" in command
+        assert "--repo C:/x/boostgauge" in command
+
+    def test_it_carries_no_placeholder(self) -> None:
+        """The old line printed a literal `N` and a literal `<stage>`."""
+        command = build_resume_command("orchestrator", 379, {})
+
+        assert " N" not in command
+        assert "<" not in command
+
+    def test_a_subworkflow_halt_prefers_the_repo_over_the_worktree(
+        self,
+    ) -> None:
+        """A resume must not be pointed at a worktree the halt may have removed."""
+        command = build_resume_command(
+            "testing",
+            384,
+            {
+                "repo_root": "C:/x/boostgauge/data/worktrees/384",
+                "original_repo_root": "C:/x/boostgauge",
+            },
+        )
+
+        assert "--repo C:/x/boostgauge" in command
+        assert "worktrees" not in command
+
+    def test_the_worktree_is_used_when_it_is_all_there_is(self) -> None:
+        command = build_resume_command(
+            "testing", 384, {"repo_root": "C:/x/boostgauge"}
+        )
+
+        assert "--repo C:/x/boostgauge" in command
+
+    def test_no_repo_in_state_omits_the_flag_rather_than_guessing(
+        self,
+    ) -> None:
+        command = build_resume_command("orchestrator", 379, {})
+
+        assert "--repo" not in command
+        assert "--issue 379" in command
+
+    def test_an_unknown_workflow_says_so_instead_of_inventing_a_path(
+        self,
+    ) -> None:
+        """The old fallback built `tools/run_<name>_workflow.py` for anything.
+
+        That is the same defect generalised: a guess that reads exactly like a
+        fact, and the reason two wrong entries survived unnoticed.
+        """
+        command = build_resume_command("nonesuch", 1, {})
+
+        assert "poetry run python" not in command
+        assert "nonesuch" in command
+        assert "no resume command is defined" in command
+
+
+class TestThereIsOnlyOneProducer:
+    """One halt, one instruction (#2663).
+
+    `orchestrate.py` printed its own resume string in two places while the
+    halt banner printed a third from `RESUME_COMMANDS`. All three disagreed.
+    """
+
+    def test_orchestrate_prints_no_resume_string_of_its_own(self) -> None:
+        """Scoped to what a FAILURE prints, which is the thing that misled.
+
+        `--help` text is deliberately not covered. `%(prog)s --issue 305
+        --resume-from spec` in the argparse epilog documents this tool's own
+        flag surface to someone who asked for the flag surface; it is neither
+        an instruction handed to an operator at a halt nor a claim about which
+        command resumes a run.
+        """
+        source = (REPO_ROOT / "tools" / "orchestrate.py").read_text(
+            encoding="utf-8"
+        )
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if "print(" in line
+            and "Resume" in line
+            and "_resume_line" not in line
+        ]
+
+        assert not offenders, offenders
+
+    def test_both_orchestrate_resume_prints_use_the_shared_builder(
+        self,
+    ) -> None:
+        source = (REPO_ROOT / "tools" / "orchestrate.py").read_text(
+            encoding="utf-8"
+        )
+
+        assert source.count("_resume_line(") == 3  # 1 def + 2 call sites

--- a/tests/unit/test_stage_verdict_is_explicit.py
+++ b/tests/unit/test_stage_verdict_is_explicit.py
@@ -212,6 +212,19 @@ class TestTheResumeHintNamesTheFailedStage:
     verdict fixes the hint; this pins that it stays derived."""
 
     def test_the_hint_names_spec_when_spec_failed(self):
+        """The property, restated for the command that actually resumes (#2663).
+
+        This asserted `--resume-from spec` in the rendered banner. That flag
+        belonged to a hand-written line naming `orchestrate`, which is not a
+        runnable command, alongside a literal `N` for the issue number -- so
+        the assertion held on a string no operator could use. The banner now
+        prints the relaunch, which takes no `--resume-from` because
+        `speedrun_roll.resume_plan` derives the stage from the same recorded
+        stage results the old string was built from (#2206).
+
+        What #2372 pinned is unchanged and still asserted below: the operator
+        is never pointed PAST the failure. `spec` is named, `impl` is not.
+        """
         import sys
 
         sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
@@ -222,11 +235,32 @@ class TestTheResumeHintNamesTheFailedStage:
             "error_message": "Iteration cap: 3 revision(s) ended with 1 unresolved check",
             "attempts": 1,
             "duration_seconds": 287.5,
-        })
+        }, 305, "C:/x/boostgauge")
 
-        assert "--resume-from spec" in rendered
-        assert "--resume-from impl" not in rendered
+        assert "resumes from 'spec'" in rendered
+        assert "impl" not in rendered
         assert "ORCHESTRATION FAILED at stage: spec" in rendered
+
+    def test_the_command_it_prints_is_runnable(self):
+        """The half the old assertion could not see.
+
+        `--resume-from spec` was present and correct inside an instruction
+        naming a command that does not exist, for an issue called `N`.
+        """
+        import sys
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+        from orchestrate import format_error_message
+
+        rendered = format_error_message("spec", {
+            "status": "failed", "error_message": "cap", "attempts": 1,
+            "duration_seconds": 1.0,
+        }, 305, "C:/x/boostgauge")
+
+        assert "poetry run python tools/speedrun_roll.py" in rendered
+        assert "--issue 305" in rendered
+        assert "--repo C:/x/boostgauge" in rendered
+        assert "--issue N" not in rendered
 
 
 class TestGenerateSpecKeepsTheFieldsApart:

--- a/tools/orchestrate.py
+++ b/tools/orchestrate.py
@@ -49,6 +49,9 @@ from assemblyzero.workflows.orchestrator.graph import (  # noqa: E402
     orchestrate,
 )
 from assemblyzero.core import provider_storm
+from assemblyzero.core.recovery_plan import (  # noqa: E402
+    build_resume_command,
+)
 from assemblyzero.workflows.orchestrator.state import (  # noqa: E402
     STAGE_ORDER,
     OrchestrationState,
@@ -99,8 +102,22 @@ def report_progress(state: OrchestrationState) -> None:
     print()
 
 
-def format_error_message(stage: str, stage_result: StageResult) -> str:
-    """Format actionable error message with context."""
+def format_error_message(
+    stage: str,
+    stage_result: StageResult,
+    issue_number: int = 0,
+    target_repo: str = "",
+) -> str:
+    """Format actionable error message with context.
+
+    #2663: the resume line comes from `recovery_plan.build_resume_command`,
+    the same producer the halt banner uses, so an operator reading one failure
+    gets one instruction. This function used to print `Resume: orchestrate
+    --issue N --resume-from <stage>` with a LITERAL `N` and a command name
+    (`orchestrate`) that is not runnable, while the halt banner printed a
+    different and also-broken command from a separate map -- two contradictory
+    lines, neither copy-pasteable.
+    """
     error = stage_result.get("error_message", "Unknown error")
     attempts = stage_result.get("attempts", 0)
     duration = stage_result.get("duration_seconds", 0)
@@ -125,12 +142,30 @@ def format_error_message(stage: str, stage_result: StageResult) -> str:
         f"  Error: {error}",
         attempts_line,
         "",
-        f"  Resume: orchestrate --issue N --resume-from {stage}",
+        f"  Resume: {_resume_line(issue_number, target_repo)}",
+        f"          (resumes from '{stage}', the failed stage, automatically)",
         "=" * 58,
         "",
     ]
 
     return "\n".join(lines)
+
+
+def _resume_line(issue_number: int, target_repo: str) -> str:
+    """The single resume instruction, from the single producer (#2663).
+
+    The relaunch works out which stage to resume from on its own
+    (`speedrun_roll.resume_plan`, per #2206) and takes no `--resume-from`, so
+    the command carries no stage. The line above it still NAMES the failed
+    stage, because the property #2372 pinned is that the operator is never
+    pointed past the failure -- told to resume from `impl` when `spec` was the
+    stage that died, straight back into the same wall. That protection is
+    preserved twice over: the banner states the stage, and `resume_plan`
+    derives it from the same recorded stage results the old string was built
+    from. What is gone is the literal `N` and the literal `<stage>`.
+    """
+    state = {"target_repo": target_repo} if target_repo else {}
+    return build_resume_command("orchestrator", issue_number, state)
 
 
 def main() -> None:
@@ -312,7 +347,9 @@ Examples:
             # Find the failed stage
             for stage_name, stage_result in result["stage_results"].items():
                 if stage_result.get("status") in ("failed", "blocked"):
-                    print(format_error_message(stage_name, stage_result))
+                    print(format_error_message(
+                        stage_name, stage_result, args.issue, target_repo,
+                    ))
                     break
 
             if result["error_summary"]:
@@ -345,7 +382,7 @@ Examples:
         sys.exit(1)
     except KeyboardInterrupt:
         print("\n[ORCHESTRATOR] Interrupted by user. State has been saved.")
-        print(f"[ORCHESTRATOR] Resume with: orchestrate --issue {args.issue} --resume-from <stage>")
+        print(f"[ORCHESTRATOR] Resume with: {_resume_line(args.issue, target_repo)}")
         sys.exit(130)
 
 


### PR DESCRIPTION
## What this fixes

Every orchestrator halt handed the operator `poetry run python tools/run_orchestrator.py --issue N`. That file exists in neither AssemblyZero nor any target repo.

Auditing the rest of the map found **a second dead entry the issue had not spotted**: `testing` named `tools/run_tdd_workflow.py`, also absent. Two of four.

And there were **three** resume lines, not two, all wrong in different ways:

| where | printed | wrong how |
|---|---|---|
| `recovery_plan.py` | `poetry run python tools/run_orchestrator.py --issue N` | file does not exist; no `--repo`, so even the right path would target the wrong repository |
| `orchestrate.py:128` | `orchestrate --issue N --resume-from <stage>` | literal `N`; `orchestrate` is not a runnable command |
| `orchestrate.py:348` | `orchestrate --issue 379 --resume-from <stage>` | literal `<stage>`; same non-command |

## Which command actually resumes — settled from the code, not chosen

The issue listed this as a thing to settle rather than guess at. The code answers it: `speedrun_roll` computes the resume stage itself — `resume_plan()`, then `cmd += ["--resume-from", resume_from]` — which is #2206's ruling that a failure halts for diagnosis and the relaunch resumes from the failed stage. The operator never has to name a stage.

It is also what carries the child environment (#2662's `_child_env`), the kill watch and the run log. `orchestrate.py --resume-from` is the inner call it makes, not the instruction to hand someone.

## One producer

`build_resume_command` — both `orchestrate.py` banners call it, and so does the halt plan. It appends `--repo` from the run's own state, preferring `original_repo_root` over `repo_root` so a resume is never pointed at an impl worktree the halt may already have removed.

An unknown workflow now says it has no resume command instead of inventing `tools/run_<name>_workflow.py`. The old fallback was the same defect generalised — a guess that reads exactly like a fact — and is plausibly why two wrong entries went unnoticed.

Both banners now print, identically:

```
  Resume: poetry run python tools/speedrun_roll.py --issue 379 --repo C:/Users/mcwiz/Projects/boostgauge
          (resumes from 'lld', the failed stage, automatically)
```

## An incident-derived assertion changed — flagging it rather than dropping it quietly

`TestTheResumeHintNamesTheFailedStage` (#2372) asserted `--resume-from spec` appears in the rendered banner. Its incident: with spec wrongly recorded as passed, a roll died at impl and told the operator to resume from **impl** — straight back into the same missing-spec wall.

`speedrun_roll` takes no `--resume-from`, so that literal assertion could not survive as written. **The property it protects does, and is still asserted**: the banner names the failed stage and no later one. It now holds twice over, because `resume_plan` derives the stage from the same recorded stage results the old hand-written string was built from.

A second test was added beside it for the half the old assertion could not see — that the command printed is runnable. `--resume-from spec` was present and correct inside an instruction naming a command that does not exist, for an issue called `N`.

## The test the issue asked for

`test_resume_commands_resolve.py` asserts every mapped path resolves against the repo **and** that each tool accepts the `--issue` and `--repo` the command passes — a file that exists but rejects a flag is still a broken instruction, just slower to diagnose. Plus: no placeholder survives, an unknown workflow refuses to invent a path, sub-workflow halts prefer the repo over the worktree, and `orchestrate.py` prints no resume string of its own.

This is the check that had to be a program. The resume line is the one line nobody exercises — a halt diagnosed by an agent never has its command typed — so it can be wrong indefinitely, and it was.

The `--help` epilog's `%(prog)s --issue 305 --resume-from spec` is deliberately left alone and excluded from the single-producer test: it documents this tool's own flag surface to someone who asked for the flag surface, not an instruction handed to an operator at a halt.

## Verification

Full unit suite: **9477 passed**, 21 skipped, 5 xfailed, 0 failures. The suite is what caught the #2372 conflict above — the targeted tests alone were green. Ruff introduces no new findings (the two in the touched files pre-exist on `origin/main`, verified against `git show origin/main:<path>`).

Closes #2663
