### PR TITLE
fix: a capacity outage says capacity, and a roster of one is named rather than pluralized (Closes #2553)

### DIFF
--- a/assemblyzero/core/gemini_client.py
+++ b/assemblyzero/core/gemini_client.py
@@ -121,6 +121,62 @@ TRANSPORT_LABEL = "agy (Antigravity CLI)"
 #: alone long enough to be misread.
 PROVIDER_LOG_ID = "provider=gemini transport=agy"
 
+
+def roster_phrase(names: list[str]) -> str:
+    """Name the credential when there is one; COUNT them when there are more.
+
+    "All credentials failed" was written for the rotation design -- several
+    credentials, rotate on failure, report the roster. Two things changed
+    underneath it. #1605 removed API-key credentials, so `_load_credentials`
+    appends only `type == "oauth"` entries; and the deployed roster holds
+    exactly one, `oauth-primary`. The plural phrasing had a singular
+    denominator, and "all" of one is a strange thing to tell an operator at
+    the moment they are deciding whether their auth is broken (#2553).
+    """
+    if not names:
+        return "no credentials"
+    if len(names) == 1:
+        return names[0]
+    return f"all {len(names)} credentials"
+
+
+def failure_headline(error_type: GeminiErrorType, names: list[str]) -> str:
+    """Lead with the failure CLASS; the roster is a detail, not the news.
+
+    During a live 503 storm on 2026-08-27 the surface read `ERROR=All
+    credentials failed via agy (Antigravity CLI)`, and the operator's reading
+    was the obvious one: something is wrong with our credentials. Nothing was.
+    The credential connected on every attempt and the model had no capacity --
+    a Google-side `MODEL_CAPACITY_EXHAUSTED`, widely reported that day. The
+    per-credential detail line even said "riding 503/529 capacity storms", but
+    the headline is what gets read first, and it named the wrong class.
+
+    This module has form here: two prior incidents are recorded above, one
+    where the same phrase was read as a regression and one where it was
+    printed while preflight showed 4/4 healthy.
+
+    **The classification is unchanged and deliberately so.** `error_type` is
+    computed by the caller from the per-credential errors; this only renders
+    it. `halt_node.classify_error` keys on `CAPACITY_MESSAGE_MARKERS`
+    (`"capacity exhausted"`, `"503"`, `"529"`, `"overloaded"`) and on specific
+    auth phrases -- never on the old headline -- so the wording below is
+    chosen to keep the capacity and quota markers present and to contain no
+    auth phrase. `test_failure_headline.py` pins that, and pins that the
+    #2474 no-verdict retry path still sees what it saw.
+    """
+    who = roster_phrase(names)
+    if error_type == GeminiErrorType.CAPACITY_EXHAUSTED:
+        return (
+            f"Provider capacity exhausted (503/529) via {TRANSPORT_LABEL} -- "
+            f"an outage at the model, not a credential problem. Tried {who}:"
+        )
+    if error_type == GeminiErrorType.QUOTA_EXHAUSTED:
+        return (
+            f"Quota exhausted via {TRANSPORT_LABEL} -- the subscription's "
+            f"allowance is spent, not a credential problem. Tried {who}:"
+        )
+    return f"Call failed via {TRANSPORT_LABEL}. Tried {who}:"
+
 # #1872: Windows process-creation failures. A child that dies with one of
 # these never got to run — desktop-heap / DLL-init pressure on a busy
 # machine, not a credential problem. Twice in 30 minutes on 2026-07-28 these
@@ -800,9 +856,17 @@ class GeminiClient:
                 response=None,
                 raw_response=None,
                 error_type=GeminiErrorType.QUOTA_EXHAUSTED,
+                # #2553: same reword as the failure headline above, and the
+                # classification is unchanged by it. `halt_node` maps BOTH
+                # "quota exhausted" and "all credentials exhausted" to
+                # `quota_exhausted`, so leading with the class lands on the
+                # same verdict. The old pattern stays in the classifier
+                # because `tools/gemini-retry.py` still emits it.
                 error_message=(
-                    f"All credentials exhausted via {TRANSPORT_LABEL}: "
-                    f"{', '.join(exhausted_names)}. Wait for quota reset."
+                    f"Quota exhausted via {TRANSPORT_LABEL} -- the "
+                    f"subscription's allowance is spent, not a credential "
+                    f"problem. Spent: {roster_phrase(exhausted_names)}. "
+                    f"Wait for quota reset."
                 ),
                 credential_used="",
                 rotation_occurred=False,
@@ -1109,7 +1173,10 @@ class GeminiClient:
             raw_response=None,
             error_type=final_error_type,
             error_message=(
-                f"All credentials failed via {TRANSPORT_LABEL}:\n  - "
+                failure_headline(
+                    final_error_type, [c.name for c in available]
+                )
+                + "\n  - "
                 + "\n  - ".join(errors)
             ),
             credential_used="",

--- a/tests/unit/test_failure_headline.py
+++ b/tests/unit/test_failure_headline.py
@@ -1,0 +1,194 @@
+"""The headline names the failure CLASS, and the roster is counted (#2553).
+
+During a live 503 storm on 2026-08-27 (`run-issue331-092913.log`) the surface
+read:
+
+    [LLM] provider=gemini model=3.1-pro duration=600.3s ERROR=All credentials
+    failed via agy (Antigravity CLI):
+      - oauth-primary: call budget of 600s exhausted riding 503/529 capacity
+        storms retryable=false
+
+The operator's reading was the obvious one: something is wrong with our
+credentials. Nothing was. The credential connected on every attempt and the
+model had no capacity -- a Google-side `MODEL_CAPACITY_EXHAUSTED`.
+
+Two things had changed under the wording. #1605 removed API-key credentials,
+so the roster loader appends only `type == "oauth"` entries, and the deployed
+roster holds exactly one. "All credentials failed" was plural phrasing over a
+denominator of one, naming the wrong failure class, at the moment an operator
+is deciding whether their auth is broken.
+
+**The riskiest part of this change is not the wording, it is what downstream
+matches on it.** `TestTheClassificationIsUnchanged` is the load-bearing half:
+the halt classifier and the capacity/quota split must land exactly where they
+landed before.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.core.errors import is_capacity_message
+from assemblyzero.core.gemini_client import (
+    GeminiErrorType,
+    failure_headline,
+    roster_phrase,
+)
+from assemblyzero.core.halt_node import classify_error
+
+#: The per-credential detail line from the observed run, verbatim. It was the
+#: accurate part and is kept.
+OBSERVED_DETAIL = (
+    "oauth-primary: call budget of 600s exhausted riding 503/529 "
+    "capacity storms retryable=false"
+)
+
+
+def observed_message(names: list[str] | None = None) -> str:
+    return (
+        failure_headline(
+            GeminiErrorType.CAPACITY_EXHAUSTED, names or ["oauth-primary"]
+        )
+        + "\n  - "
+        + OBSERVED_DETAIL
+    )
+
+
+class TestItLeadsWithTheFailureClass:
+    def test_a_capacity_storm_says_capacity(self) -> None:
+        headline = failure_headline(
+            GeminiErrorType.CAPACITY_EXHAUSTED, ["oauth-primary"]
+        )
+
+        assert headline.lower().startswith("provider capacity exhausted")
+
+    def test_a_capacity_storm_never_says_credentials_failed(self) -> None:
+        """The exact phrase the operator misread."""
+        headline = failure_headline(
+            GeminiErrorType.CAPACITY_EXHAUSTED, ["oauth-primary"]
+        )
+
+        assert "credentials failed" not in headline.lower()
+        assert "all credentials" not in headline.lower()
+
+    def test_it_says_outright_that_credentials_are_not_the_problem(
+        self,
+    ) -> None:
+        for error_type in (
+            GeminiErrorType.CAPACITY_EXHAUSTED,
+            GeminiErrorType.QUOTA_EXHAUSTED,
+        ):
+            headline = failure_headline(error_type, ["oauth-primary"])
+            assert "not a credential problem" in headline, error_type
+
+    def test_quota_says_quota(self) -> None:
+        headline = failure_headline(
+            GeminiErrorType.QUOTA_EXHAUSTED, ["oauth-primary"]
+        )
+
+        assert headline.lower().startswith("quota exhausted")
+
+    def test_an_unclassified_failure_claims_no_class(self) -> None:
+        """Naming a class we did not establish would be the same defect."""
+        headline = failure_headline(GeminiErrorType.UNKNOWN, ["oauth-primary"])
+
+        assert "capacity" not in headline.lower()
+        assert "quota" not in headline.lower()
+        assert "credential problem" not in headline.lower()
+
+
+class TestItCountsRatherThanPluralizing:
+    def test_one_credential_is_named_not_pluralized(self) -> None:
+        assert roster_phrase(["oauth-primary"]) == "oauth-primary"
+
+    def test_the_headline_names_it(self) -> None:
+        headline = failure_headline(
+            GeminiErrorType.CAPACITY_EXHAUSTED, ["oauth-primary"]
+        )
+
+        assert "oauth-primary" in headline
+        assert "all 1" not in headline.lower()
+
+    @pytest.mark.parametrize("count", [2, 3, 4])
+    def test_several_credentials_are_counted(self, count: int) -> None:
+        names = [f"oauth-{n}" for n in range(count)]
+
+        assert roster_phrase(names) == f"all {count} credentials"
+
+    def test_an_empty_roster_says_so(self) -> None:
+        assert roster_phrase([]) == "no credentials"
+
+
+class TestTheClassificationIsUnchanged:
+    """The load-bearing half. A reword that moves a halt verdict is a bug.
+
+    `halt_node.classify_error` keys on `CAPACITY_MESSAGE_MARKERS` and on
+    specific auth phrases, never on the old headline -- but that is a claim
+    about today's classifier, and claims about code get asserted.
+    """
+
+    def test_the_observed_storm_still_classifies_as_capacity(self) -> None:
+        assert classify_error(observed_message()) == "capacity_exhausted"
+
+    def test_the_capacity_marker_survives_in_the_headline_alone(self) -> None:
+        """Not leaning on the detail line to carry the signal."""
+        headline = failure_headline(
+            GeminiErrorType.CAPACITY_EXHAUSTED, ["oauth-primary"]
+        )
+
+        assert is_capacity_message(headline)
+
+    def test_quota_still_classifies_as_quota(self) -> None:
+        message = (
+            failure_headline(GeminiErrorType.QUOTA_EXHAUSTED, ["oauth-primary"])
+            + "\n  - oauth-primary: Quota exhausted"
+        )
+
+        assert classify_error(message) == "quota_exhausted"
+
+    @pytest.mark.parametrize(
+        "error_type",
+        [
+            GeminiErrorType.CAPACITY_EXHAUSTED,
+            GeminiErrorType.QUOTA_EXHAUSTED,
+            GeminiErrorType.UNKNOWN,
+        ],
+    )
+    def test_no_headline_carries_an_auth_phrase(
+        self, error_type: GeminiErrorType
+    ) -> None:
+        """A capacity storm must never be halted as 'check your credentials'.
+
+        These are `classify_error`'s auth patterns, read from the classifier
+        rather than restated from memory.
+        """
+        headline = failure_headline(error_type, ["oauth-primary"]).lower()
+
+        for phrase in (
+            "authentication failed", "authentication error", "invalid api key",
+            "api_key_invalid", "permission_denied", "unauthenticated",
+            "unauthorized",
+        ):
+            assert phrase not in headline, phrase
+
+    def test_a_genuine_auth_failure_still_says_auth(self) -> None:
+        """The reword must not make auth unreachable."""
+        message = (
+            failure_headline(GeminiErrorType.UNKNOWN, ["oauth-primary"])
+            + "\n  - oauth-primary: authentication failed"
+        )
+
+        assert classify_error(message) == "auth"
+
+
+class TestTheDetailLinesAreKept:
+    def test_the_accurate_part_survives_verbatim(self) -> None:
+        assert OBSERVED_DETAIL in observed_message()
+
+    def test_the_whole_message_reads_as_an_outage(self) -> None:
+        """The acceptance, stated as the operator's own question."""
+        message = observed_message()
+
+        assert "capacity" in message.lower()
+        assert "503/529" in message
+        assert "credentials failed" not in message.lower()

--- a/tests/unit/test_gemini_client.py
+++ b/tests/unit/test_gemini_client.py
@@ -484,7 +484,12 @@ class TestRotationLogic:
         assert result.success is False
         # When all credentials fail due to quota exhaustion, error type is QUOTA_EXHAUSTED
         assert result.error_type == GeminiErrorType.QUOTA_EXHAUSTED
-        assert "All credentials failed" in result.error_message
+        # #2553: the headline states the CLASS and counts the roster. It read
+        # "All credentials failed" -- plural over a denominator of one on the
+        # deployed roster, and naming the wrong failure class.
+        assert "Quota exhausted" in result.error_message
+        assert "all 3 credentials" in result.error_message
+        assert "All credentials failed" not in result.error_message
 
 
 class TestBackoffDelay:
@@ -671,7 +676,10 @@ class TestTheFailureTextNamesTheTransport:
         ):
             result = client.invoke("system", "content")
 
-        assert "All credentials failed" in result.error_message
+        # #2553: the property is unchanged -- transport AND reason both
+        # present. Only the headline's wording moved: it names the failure
+        # class instead of the roster.
+        assert "agy (Antigravity CLI)" in result.error_message
         assert "Quota exhausted" in result.error_message
         assert "key-1" in result.error_message
 


### PR DESCRIPTION
## What this fixes

During a live 503 storm on 2026-08-27 (`run-issue331-092913.log`) the surface read `ERROR=All credentials failed via agy (Antigravity CLI)`, and the operator read it the obvious way: something is wrong with our credentials.

Nothing was. The credential connected on every attempt and the model had no capacity — a Google-side `MODEL_CAPACITY_EXHAUSTED`. The per-credential line underneath even said "riding 503/529 capacity storms", but the headline is what gets read first, and it named the wrong class.

Two things had changed under that wording: #1605 removed API-key credentials, so the roster loader appends only `type == "oauth"` entries, and the deployed roster holds exactly one. **"All credentials failed" was plural phrasing over a denominator of one**, at the moment an operator is deciding whether their auth is broken.

The module already had form here — two prior incidents sit in its own comments, one where the same phrase was read as a regression and one where it was printed while preflight showed 4/4 healthy.

## Before and after, with the classifier's verdict on each

```
BEFORE:
All credentials failed via agy (Antigravity CLI):
  - oauth-primary: call budget of 600s exhausted riding 503/529 capacity storms retryable=false
  -> classify_error: capacity_exhausted

AFTER:
Provider capacity exhausted (503/529) via agy (Antigravity CLI) -- an outage at the model, not a credential problem. Tried oauth-primary:
  - oauth-primary: call budget of 600s exhausted riding 503/529 capacity storms retryable=false
  -> classify_error: capacity_exhausted
```

`roster_phrase` names the credential when there is one and **counts** them when there are more (`all 3 credentials`), so nothing pluralizes by template again. The per-credential detail lines are untouched — they were the accurate part. An `UNKNOWN` failure claims no class at all, since naming a class we did not establish would be the same defect pointing the other way.

The second surface carrying the same wording is fixed too: the pre-flight all-exhausted path now leads with `Quota exhausted`.

## The risky part was never the wording

The issue's acceptance asks that existing consumers keep matching. `halt_node.classify_error` keys on `CAPACITY_MESSAGE_MARKERS` (`"capacity exhausted"`, `"503"`, `"529"`, `"overloaded"`) and on specific auth phrases — **never on the old headline**. That is a claim about code, so it is asserted rather than stated:

- both new headlines keep a capacity/quota marker, and the capacity one carries it **in the headline alone**, not leaning on the detail line;
- no headline contains any of the classifier's seven auth phrases, so a storm can never be halted as "check your credentials";
- a genuine auth failure still classifies as `auth`;
- the quota reword lands on `quota_exhausted` via `"quota exhausted"` where it used to land there via `"all credentials exhausted"`. **The old pattern stays in the classifier** because `tools/gemini-retry.py` still emits it.

The #2474 no-verdict retry path routes on the `requirements_unverified` state key, not on message text, so it is unaffected by construction. The only other reference to the old phrase in that module is a comment quoting the observed log.

## Two existing tests changed, and why that is not a weakening

- `test_110_all_credentials_exhausted` asserted `"All credentials failed"` — the literal string this issue exists to remove. It now asserts the class and the count.
- `test_the_message_still_says_what_failed` asserted the same literal, under a docstring describing a different and better property: "the operator needs both: which client ran, and why it did not answer." It now asserts that property — transport present, reason present — which is what it always meant.

Neither was testing behaviour that changed.

## Verification

20 new tests in `test_failure_headline.py`. Full unit suite: **9497 passed**, 21 skipped, 5 xfailed, 0 failures. Ruff introduces no new findings (the one in the touched file pre-exists on `origin/main`, verified against `git show origin/main:<path>`).

Closes #2553
