### PR TITLE
fix: verify_phases is lint-clean, and the mock green phase honours the coverage target it was already reading (Closes #2671)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -27,6 +27,12 @@ from assemblyzero.workflows.testing.audit import (
 )
 from assemblyzero.workflows.testing.circuit_breaker import check_circuit_breaker
 from assemblyzero.workflows.testing.nodes.e2e_validation import _extract_failed_test_names
+# `route_by_exit_code` is deliberately NOT imported here (#2671). It was, and
+# was never called: the exit-code branching that actually runs is inline below
+# on these same constants. Removing the import is the lint fix; the two
+# implementations of one decision are #2690, which must not be resolved as a
+# drive-by -- adopting the router would change routing on the path Phase 2 is
+# rolling through, and the mapping diff has not been measured.
 from assemblyzero.workflows.testing.exit_code_router import (
     EXIT_INTERRUPTED,
     EXIT_INTERNALERROR,
@@ -34,7 +40,6 @@ from assemblyzero.workflows.testing.exit_code_router import (
     EXIT_NOTESTSCOLLECTED,
     describe_exit_code,
     describe_run_outcome,
-    route_by_exit_code,
 )
 from assemblyzero.workflows.testing.framework_detector import CoverageType, TestFramework
 from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
@@ -2934,11 +2939,28 @@ FAILED tests/test_issue_42.py::test_input_validation - AssertionError: TDD: Impl
 
 
 def _mock_verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
-    """Mock implementation for testing."""
+    """Mock implementation for testing.
+
+    `coverage_target` was read here and then ignored, which ruff flagged as an
+    unused local (#2671). Answering "was it meant to gate something" from the
+    code around it: yes. The second branch hardcodes 92.0% and routes onward
+    unconditionally, and the f-string it builds carries no placeholder --
+    someone began interpolating the measured number against the target and
+    stopped. Two of the three lint findings in this file are halves of that
+    one unfinished edit.
+
+    So it gates now, and the mock can rehearse a coverage shortfall. This
+    changes nothing at the default: `augment_tests` reads
+    `coverage_target` with a fallback of 90, 92.0 clears it, and every
+    existing caller keeps the old routing. A rehearsal that asks for 95 --
+    the boostgauge #331 configuration whose real 92.0%-vs-95% shortfall
+    killed a stage for 22 minutes (#2644) -- can now exercise that path
+    instead of reporting green.
+    """
     audit_dir_str = state.get("audit_dir", "")
     audit_dir = Path(audit_dir_str) if audit_dir_str else None
     iteration_count = state.get("iteration_count", 0)
-    coverage_target = state.get("coverage_target", 90)
+    coverage_target = float(state.get("coverage_target", 90) or 90)
 
     # First iteration: fail, second: pass
     if iteration_count <= 1:
@@ -2956,6 +2978,7 @@ FAILED tests/test_issue_42.py::test_login_failure - AssertionError
         coverage_achieved = 75.0
         next_node = "N4_implement_code"
     else:
+        coverage_achieved = 92.0
         mock_output = f"""============================= test session starts ==============================
 collected 3 items
 
@@ -2969,12 +2992,22 @@ Name                      Stmts   Miss  Cover
 assemblyzero/__init__.py          10      0   100%
 assemblyzero/module.py            50      5    90%
 ---------------------------------------------
-TOTAL                        60      5    92%
+TOTAL                        60      5    {coverage_achieved:.0f}%
 
 ============================== 3 passed in 0.18s ===============================
 """
-        coverage_achieved = 92.0
-        next_node = "N7_finalize" if state.get("skip_e2e") else "N6_e2e_validation"
+        # The f-string above now has a placeholder, which is what it was
+        # reaching for: the printed report and the recorded number are one
+        # fact, so a rehearsal cannot show 92% in the text while carrying
+        # something else in state.
+        if coverage_achieved < coverage_target:
+            # #2327: a coverage shortfall goes to test augmentation, never to
+            # implementation. Same destination the live path takes.
+            next_node = "N4c_augment_tests"
+        else:
+            next_node = (
+                "N7_finalize" if state.get("skip_e2e") else "N6_e2e_validation"
+            )
 
     if audit_dir and audit_dir.exists():
         file_num = next_file_number(audit_dir)
@@ -2982,13 +3015,22 @@ TOTAL                        60      5    92%
     else:
         file_num = state.get("file_counter", 0)
 
-    print(f"    [MOCK] Green phase: coverage {coverage_achieved}%")
+    print(
+        f"    [MOCK] Green phase: coverage {coverage_achieved}% "
+        f"vs {coverage_target}% target -> {next_node}"
+    )
+
+    # Every route that loops BACK for more work advances the counter, which is
+    # what lets the cap end the loop. The live shortfall branch increments on
+    # its way to N4c for exactly that reason; a mock that routed there without
+    # incrementing would rehearse an infinite loop rather than a shortfall.
+    loops_back = next_node in ("N4_implement_code", "N4c_augment_tests")
 
     return {
         "green_phase_output": mock_output,
         "coverage_achieved": coverage_achieved,
         "file_counter": file_num,
-        "iteration_count": iteration_count + 1 if next_node == "N4_implement_code" else iteration_count,
+        "iteration_count": iteration_count + 1 if loops_back else iteration_count,
         "next_node": next_node,
         "error_message": "",
     }

--- a/tests/unit/test_verify_phases_lint_and_mock_target.py
+++ b/tests/unit/test_verify_phases_lint_and_mock_target.py
@@ -18,6 +18,7 @@ substitute for this one file, deliberately not a fleet CI change.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -39,15 +40,25 @@ class TestThisFileIsClean:
         Scoped to this one file on purpose. A fleet-wide lint gate is a
         separate decision with a separate blast radius, and this issue does
         not license it.
+
+        The availability check asks whether the module is importable rather
+        than reading an exit code. The first version of this test guarded on
+        `returncode == 2`, reasoning that a missing module is a usage error;
+        `python -m ruff` with no ruff installed actually exits **1**, which is
+        also what "ruff ran and found violations" returns. It passed on this
+        machine, where ruff is installed, and failed on CI, where it is not --
+        the exact shape of a test asserting on a symptom instead of the
+        mechanism it means to test.
         """
+        if importlib.util.find_spec("ruff") is None:
+            pytest.skip("ruff is not installed in this environment")
+
         result = subprocess.run(
             [sys.executable, "-m", "ruff", "check", str(TARGET),
              "--output-format", "concise"],
             capture_output=True, text=True, cwd=str(REPO_ROOT),
         )
 
-        if result.returncode == 2 and "No module named" in result.stderr:
-            pytest.skip("ruff is not installed in this environment")
         assert result.returncode == 0, result.stdout or result.stderr
 
     def test_the_dead_router_import_is_gone(self) -> None:

--- a/tests/unit/test_verify_phases_lint_and_mock_target.py
+++ b/tests/unit/test_verify_phases_lint_and_mock_target.py
@@ -1,0 +1,144 @@
+"""The three ruff findings in `verify_phases.py`, and what they were hiding (#2671).
+
+They are not three unrelated bits of untidiness. Two of them -- an unused
+`coverage_target` local and an f-string with no placeholder -- are halves of one
+unfinished edit: somebody began making the mock green phase compare its
+measured coverage against the target and interpolate the number into the
+report, and stopped. The third, an unused `route_by_exit_code` import, is the
+visible end of a larger problem filed separately as #2690.
+
+**What the lint gate actually checks: nothing.** `.github/workflows/ci.yml`
+runs `tools/test-gate.py` over `tests/unit/` and `tests/integration/` plus a
+coverage upload, and `grep -rn ruff .github/` returns no hits. There is no lint
+step in CI at all, so "the gate that should have caught them did not" is
+literally true -- the only enforcement is the convention that an agent runs
+`ruff check` before finishing. `TestThisFileIsClean` below is a local
+substitute for this one file, deliberately not a fleet CI change.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    _mock_verify_green_phase,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = REPO_ROOT / "assemblyzero" / "workflows" / "testing" / "nodes" / "verify_phases.py"
+
+
+class TestThisFileIsClean:
+    def test_ruff_reports_nothing(self) -> None:
+        """A program, not an inspection (rule 6).
+
+        Scoped to this one file on purpose. A fleet-wide lint gate is a
+        separate decision with a separate blast radius, and this issue does
+        not license it.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", str(TARGET),
+             "--output-format", "concise"],
+            capture_output=True, text=True, cwd=str(REPO_ROOT),
+        )
+
+        if result.returncode == 2 and "No module named" in result.stderr:
+            pytest.skip("ruff is not installed in this environment")
+        assert result.returncode == 0, result.stdout or result.stderr
+
+    def test_the_dead_router_import_is_gone(self) -> None:
+        """#2690 owns the duplication; this owns the unused import."""
+        source = TARGET.read_text(encoding="utf-8")
+
+        assert "    route_by_exit_code,\n" not in source
+
+    def test_the_constants_it_shared_are_still_imported(self) -> None:
+        """The inline branching that DOES run still needs them."""
+        source = TARGET.read_text(encoding="utf-8")
+
+        for name in (
+            "EXIT_INTERRUPTED", "EXIT_INTERNALERROR",
+            "EXIT_USAGEERROR", "EXIT_NOTESTSCOLLECTED",
+        ):
+            assert name in source, name
+
+
+class TestTheMockHonoursTheTarget:
+    """`coverage_target` was read and ignored; it gates now.
+
+    The second branch hardcoded 92.0% and routed onward unconditionally, so a
+    rehearsal could never exercise a coverage shortfall -- which is exactly
+    the situation that killed a real stage for 22 minutes on boostgauge #331
+    (92.0% against a 95% target, #2644).
+    """
+
+    def _green(self, **extra) -> dict:
+        state = {"iteration_count": 2, "skip_e2e": True}
+        state.update(extra)
+        return _mock_verify_green_phase(state)  # type: ignore[arg-type]
+
+    def test_the_default_target_is_unchanged(self) -> None:
+        """92.0 clears 90, so every existing caller keeps its old routing."""
+        result = self._green()
+
+        assert result["coverage_achieved"] == 92.0
+        assert result["next_node"] == "N7_finalize"
+
+    def test_an_explicit_90_behaves_the_same(self) -> None:
+        assert self._green(coverage_target=90)["next_node"] == "N7_finalize"
+
+    def test_a_higher_target_routes_to_test_additions(self) -> None:
+        """Mirrors the live branch, which never routes a coverage gap to
+        implementation (#2327): the cheapest way to raise statement coverage
+        is to delete the uncovered code."""
+        result = self._green(coverage_target=95)
+
+        assert result["next_node"] == "N4c_augment_tests"
+
+    def test_the_shortfall_route_advances_the_iteration_counter(self) -> None:
+        """Load-bearing. `route_after_green` ends the N4c loop on
+        `iteration_count >= max_iterations`, and N4c returns unconditionally
+        to N5 -- so a shortfall that did not increment would rehearse an
+        infinite loop instead of a shortfall."""
+        result = self._green(coverage_target=95)
+
+        assert result["iteration_count"] == 3
+
+    def test_a_clearing_run_does_not_advance_it(self) -> None:
+        assert self._green()["iteration_count"] == 2
+
+    def test_the_first_iteration_still_fails_to_implementation(self) -> None:
+        """Unchanged: a failing suite is an implementation gap, not a
+        coverage one."""
+        result = _mock_verify_green_phase(  # type: ignore[arg-type]
+            {"iteration_count": 0, "skip_e2e": True, "coverage_target": 95}
+        )
+
+        assert result["next_node"] == "N4_implement_code"
+        assert result["coverage_achieved"] == 75.0
+
+    def test_a_missing_target_falls_back_rather_than_crashing(self) -> None:
+        for value in (None, 0, ""):
+            result = self._green(coverage_target=value)
+            assert result["next_node"] == "N7_finalize", value
+
+
+class TestTheReportAndTheNumberAgree:
+    """The f-string had no placeholder because the number was never
+    interpolated. A rehearsal that printed 92% while carrying something else
+    in state would be a small lie of exactly the kind #2677 is about."""
+
+    def test_the_printed_total_matches_the_recorded_coverage(self) -> None:
+        result = _mock_verify_green_phase(  # type: ignore[arg-type]
+            {"iteration_count": 2, "skip_e2e": True}
+        )
+        achieved = result["coverage_achieved"]
+
+        assert f"{achieved:.0f}%" in result["green_phase_output"]
+        assert "TOTAL                        60      5    92%" in (
+            result["green_phase_output"]
+        )


### PR DESCRIPTION
## Three findings, and they are not three unrelated bits of untidiness

| | finding | what it actually was |
|---|---|---|
| `verify_phases.py:2941` | F841 `coverage_target` assigned, never used | half of an unfinished edit |
| `verify_phases.py:2959` | F541 f-string with no placeholder | the other half |
| `verify_phases.py:37` | F401 `route_by_exit_code` imported, never used | the visible end of #2690 |

## `coverage_target` was meant to gate something — the code says so

`_mock_verify_green_phase`'s second branch hardcoded `coverage_achieved = 92.0`, routed onward unconditionally, and built its report with an f-string carrying **no placeholder** — the `92%` in the report text was typed, not interpolated. Somebody began making the mock compare its measured coverage against the target and interpolate the number, and stopped partway. The two findings are the two halves of that.

It gates now. A shortfall routes to `N4c_augment_tests` — which is exactly what the live branch does (`verify_phases.py:2359`), and never to implementation, per #2327's reasoning that the cheapest way to raise statement coverage is to delete the uncovered code, so pointing the implementation loop at a coverage gap rewards removing the error handling the spec mandates.

**Nothing changes at the default.** `augment_tests` reads `coverage_target` with a fallback of 90, 92.0 clears it, every existing caller keeps its old routing — asserted, including for `None`, `0` and `""`. What becomes possible is rehearsing the boostgauge #331 configuration — 92.0% against a 95% target — whose real shortfall killed a stage for 22 minutes (#2644) and which the mock previously reported as green.

### The bit that was nearly missed

The shortfall route must **advance `iteration_count`**. `N4c_augment_tests` returns to `N5_verify_green` unconditionally, and `route_after_green` ends that loop on `iteration_count >= max_iterations` — so a shortfall that did not increment would have rehearsed an infinite loop rather than a shortfall. The live branch increments for the same reason. There is a test on it.

## The unused import, and what is deliberately not done here

`route_by_exit_code` was imported and never called: the exit-code branching that actually runs is inline in this file on the same `EXIT_*` constants, while the router carries 20 tests covering a branch the pipeline does not execute.

Removing the import is the lint fix and is all this PR does. **The duplication is #2690 and is deliberately not resolved as a drive-by** — adopting the router would change routing on the path Phase 2 is currently rolling through, and the mapping diff (the inline branches do not cover `EXIT_TESTSFAILED` or `EXIT_TIMEOUT`) has not been measured. A comment at the import site says so, so the next person to notice the asymmetry finds the reason rather than re-deriving it.

## What the lint gate actually checks: nothing

`.github/workflows/ci.yml` runs `tools/test-gate.py` over `tests/unit/` and `tests/integration/` plus a coverage upload. `grep -rn ruff .github/` returns no hits. **There is no lint step in CI**, so "the gate that should have caught them did not" is literally true — the only enforcement is the convention that an agent runs `ruff check` before finishing.

That is not local to this file. Working other issues tonight I found seven further pre-existing violations across four files (`finalize.py`, `test_orchestrator_stages.py`, `recovery_plan.py`, `orchestrate.py`, `gemini_client.py`), each verified pre-existing against `origin/main` via `git show origin/main:<path>` piped to `ruff --stdin-filename`. That is the accumulation an unenforced convention predicts. Full detail is on the issue.

**No fleet CI change is built from this, per the issue's own instruction.** The countermeasure is scoped to one file: `TestThisFileIsClean::test_ruff_reports_nothing` shells out to ruff against `verify_phases.py` and fails if it reports anything. Whether the fleet gets a real lint gate is a separate decision with a separate blast radius — every repo, every existing violation — and is the operator's to make.

## Verification

11 new tests. Full unit suite: **9508 passed**, 21 skipped, 5 xfailed, 0 failures. `ruff check` on `verify_phases.py`: clean.

Closes #2671

## CI caught a real bug in this PR's own test

The first push failed on the runner while the local full suite was green. `test_ruff_reports_nothing` guarded on `returncode == 2`, reasoning that a missing module is a usage error. It is not — `python -m ruff` with no ruff installed exits **1**, measured:

```
missing-module exit code: 1  (the old guard expected 2)
```

which is the same code ruff returns when it runs and finds violations. So the guard could never fire: it passed here, where ruff is installed, and failed on the runner, where it is not.

Worth stating what the exit-code approach would have cost even with the right number — 1 is also "found violations", so a guard reading the code alone would have skipped on exactly the failures the test exists to catch. The fix asks the mechanism instead: `importlib.util.find_spec("ruff")` answers "is ruff available" directly and does not care what any exit code means.
