### PR TITLE
fix: the manifest-traceability complaint names the rows it is holding (Closes #2593)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1801,12 +1801,24 @@ def check_manifest_traceability(
     if not tests:
         # No parseable test functions at all: with a binding manifest this is
         # a real gap, not an abstention — every row is untested.
+        #
+        # #2593: NAME the rows. This branch reported a COUNT while holding the
+        # ids, and a count addresses nothing: `_ROW_ID_RE` (`\b[A-Z]\d{0,3}
+        # [a-z]?\.\d+\b`) reads `N4.1` exactly, so the one vocabulary pinning
+        # has for this artifact was being withheld by the only check that has
+        # the artifact. The `problems` branch below already lists them under
+        # `manifest rows are ...`; this branch was the odd one out. Truncated
+        # at twelve to match it.
+        listed = ", ".join(row_ids[:12]) if row_ids else "none"
+        more = f" (and {len(row_ids) - 12} more)" if len(row_ids) > 12 else ""
         return CompletenessCheck(
             check_name="manifest_traceability",
             passed=False,
             details=(
                 f"The assertion manifest binds {len(row_ids)} row(s) but the "
-                f"spec contains no parseable test functions citing them."
+                f"spec contains no parseable test functions citing them. "
+                f"Manifest rows are {listed}{more}. Section 10 owes each a "
+                f"test."
                 + abstain_note
             ),
         )

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -42,6 +42,9 @@ from assemblyzero.workflows.implementation_spec.message_addressability import (
 vc = importlib.import_module(
     "assemblyzero.workflows.implementation_spec.nodes.validate_completeness"
 )
+rp = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.revision_pinning"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -207,6 +210,49 @@ class TestAddressableToday:
         assert verdict.matched_lines != ()
         assert verdict.verdict == ADDRESSED
 
+    def test_manifest_traceability_names_the_rows_it_holds(self):
+        """#2593, repaired. The no-tests branch reported a COUNT ("binds 2
+        row(s)") while holding the ids, and a count addresses nothing --
+        `_ROW_ID_RE` reads `N4.1` exactly, so the one vocabulary pinning has
+        for this artifact was being withheld by the only check that has the
+        artifact.
+
+        **The fixture's key is corrected here, and that matters.** #2593 was
+        filed with `{"id": "N4.1"}`, but `check_manifest_traceability` reads
+        `row_id` -- the key `assertion_manifest.to_dicts` actually emits. With
+        the wrong key the row list came out EMPTY, which is why the issue
+        quotes "binds 0 row(s)" and frames the zero-bound branch as the
+        notable one. Measured against the real shape the message said "binds
+        2 row(s)" and still named neither id, so the defect was real and the
+        framing was an artifact of the fixture. A test carrying the wrong key
+        would have gone green on a message that names nothing.
+        """
+        rows = [
+            {"row_id": "N4.1", "criterion": "needle within arc"},
+            {"row_id": "N4.2", "criterion": "band background"},
+        ]
+        result = vc.check_manifest_traceability(NO_CITING_TESTS, rows)
+        verdict = _classify(result, NO_CITING_TESTS)
+
+        assert "N4.1" in result["details"]
+        assert "N4.2" in result["details"]
+        assert verdict.tokens == ("n4.1", "n4.2", "section 10")
+        assert verdict.verdict == ADDRESSED
+
+    def test_the_demand_to_add_tests_is_exempt_under_2560(self):
+        """Naming the rows is necessary and not sufficient.
+
+        This branch demands NEW tests, and #2560's rule is that a locked
+        region introducing one passes only when the round's failures carry
+        the addition vocabulary. Without it, pinning would refuse the very
+        tests the complaint asks for -- the #2686 deadlock shape, one check
+        over.
+        """
+        rows = [{"row_id": "N4.1", "criterion": "needle within arc"}]
+        details = vc.check_manifest_traceability(NO_CITING_TESTS, rows)["details"]
+
+        assert rp.demands_additions([details]) is True
+
 
 class TestUnaddressableToday:
     """The deadlock class, pinned. Each test asserts the CURRENT broken state
@@ -236,20 +282,6 @@ class TestUnaddressableToday:
         assert verdict.ranges == ()
         assert verdict.verdict == UNADDRESSABLE
 
-    def test_manifest_traceability_omits_the_row_ids_it_holds(self):
-        """#2593. Row ids are exactly what the vocabulary parses (`_ROW_ID_RE`
-        reads N4.1), and the check is holding them -- it just does not put
-        them in the message on this branch."""
-        rows = [
-            {"id": "N4.1", "criterion": "needle within arc"},
-            {"id": "N4.2", "criterion": "band background"},
-        ]
-        verdict = _classify(
-            vc.check_manifest_traceability(NO_CITING_TESTS, rows),
-            NO_CITING_TESTS,
-        )
-        assert verdict.tokens == ()
-        assert verdict.verdict == UNADDRESSABLE
 
 
 class TestTheSweepIsExhaustive:


### PR DESCRIPTION
## What this fixes

`check_manifest_traceability`'s no-parseable-tests branch reported a **count** while holding the ids:

```
The assertion manifest binds 2 row(s) but the spec contains no parseable test functions citing them.
```

A count addresses nothing. `_ROW_ID_RE` (`\b[A-Z]\d{0,3}[a-z]?\.\d+\b`) reads `N4.1` exactly, so the one vocabulary pinning has for this artifact was being withheld by the only check that holds the artifact. The `problems` branch below it already lists them under `manifest rows are ...` — this branch was the odd one out, and it is the branch that fires when the spec has no tests at all, the case where naming the rows is the entire content of the complaint.

```
AFTER:
The assertion manifest binds 2 row(s) but the spec contains no parseable test
functions citing them. Manifest rows are N4.1, N4.2. Section 10 owes each a test.

  tokens pinning parses: ['n4.1', 'n4.2', 'section 10']   (was: [])
  demands_additions:     True                             (was: False)
```

## The addition vocabulary is load-bearing, not scope creep from #2591

This branch demands **new** tests, and #2560's rule is that a locked region introducing one passes only when the round's failures carry that vocabulary. Naming the rows alone would have made the complaint readable while pinning still refused the very tests it asks for — the #2686 deadlock shape, one check over. Both halves are asserted.

## The issue's fixture used a key production does not read

Measured before implementing, against both shapes:

```
--- issue fixture (key 'id')
    The assertion manifest binds 0 row(s) but the spec contains no parseable test functions citing them.
    names N4.1? False

--- real shape (key 'row_id')
    The assertion manifest binds 2 row(s) but the spec contains no parseable test functions citing them.
    names N4.1? False
```

The check reads `r.get("row_id", "")`, and `row_id` is what `assertion_manifest.to_dicts` emits (`"row_id": r.row_id`, confirmed from its source). #2593's fixture uses `id`, so its row list came out **empty** — which is why the issue quotes "binds 0 row(s)" and frames the zero-bound branch as the notable one, "where the count is zero and the ids are the only useful content."

**The core claim holds and the fix is the one the issue asked for; only that framing was an artifact.** It is worth stating because a test carrying the wrong key would have gone green against a message that names nothing — the acceptance would have passed while the defect stood. The fixture is corrected in the test, with the reason recorded there. Refutation posted on the issue.

## Test

`test_manifest_traceability_omits_the_row_ids_it_holds` moves from `TestUnaddressableToday` to `TestAddressableToday` as `test_manifest_traceability_names_the_rows_it_holds` — that file's own documented convention for a repaired member of the class ("Repairing one flips its test, which is the signal to move it into TestAddressableToday"). A second test pins the #2560 exemption.

## Verification

Full unit suite: **9509 passed**, 21 skipped, 5 xfailed, 0 failures. Ruff clean on both changed files.

Closes #2593
