### PR TITLE
fix: an excerpt is a demanded addition too, and the exemption now recognises one (Closes #2591)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -236,22 +236,82 @@ _UNLOCK_RE = re.compile(r"^\s*UNLOCK:\s*(.+?)\s*$", re.MULTILINE)
 #: the artifact class completeness checks demand added (#2560).
 _TEST_DEF_RE = re.compile(r"^\s*(?:async\s+)?def\s+(test_[A-Za-z0-9_]+)\s*\(")
 
-#: The phrases our own completeness checks use when they demand ADDITIONS
-#: ("3 LLD pass criterion(s) have no test in the spec ... Add a test for
-#: each", "... have no test asserting them. Section 10 owes each a test").
-#: A demand to add has no line to cite and no existing content to name —
-#: the #2555/#2558 vocabulary addresses only content that exists (#2560).
+#: A fence delimiter. The second artifact class a completeness check demands
+#: added (#2591) — an excerpt, a data-structure example and an I/O example are
+#: all fenced code blocks, and none of them is a test definition.
+_FENCE_OPEN_RE = re.compile(r"^\s*```")
+
+#: EVERY addition-demanding phrase our completeness checks emit, enumerated
+#: from their own `details=` strings rather than guessed at (#2591). The set is
+#: closed and authored: five phrasings, four checks, all in
+#: `validate_completeness.py`, and a new one has to be added here deliberately.
+#:
+#: | phrase | check | artifact demanded |
+#: |---|---|---|
+#: | `have no test` / `add a test` / `owes each a test` | criteria, error paths, manifest | a test definition |
+#: | `MUST include a code block` | `modify_files_have_excerpts` | a fenced excerpt |
+#: | `MUST have at least one JSON/YAML/Python example` | `data_structures_have_examples` | a fenced example |
+#: | `MUST have at least one example` | `functions_have_io_examples` | a fenced example |
+#: | `Add the block inside that subsection` | `function_spec_sections_have_examples` | a fenced example |
+#:
+#: #2560 built this for tests because tests were the only demanded artifact
+#: then. They are not now, and the regex encoded "an addition means a test" as
+#: if it were a law. `check_modify_files_have_excerpts` fires on any spec
+#: missing an excerpt -- a routine condition, not an exotic one -- and its
+#: demand was covered by neither the named-content vocabulary (the path it
+#: cites is absent from the draft BY DEFINITION, which is what it is
+#: complaining about) nor this exemption.
 _ADDITION_DEMAND_RE = re.compile(
-    r"\bhave no test\b|\badd a test\b|\bowes each a test\b", re.IGNORECASE
+    r"\bhave no test\b"
+    r"|\badd a test\b"
+    r"|\bowes each a test\b"
+    r"|\bMUST include a code block\b"
+    r"|\bMUST have at least one\b"
+    r"|\bAdd the block inside that subsection\b",
+    re.IGNORECASE,
 )
 
 
 def demands_additions(completeness_issues: list[str] | None) -> bool:
-    """True when any current completeness failure demands new tests (#2560)."""
+    """True when any current completeness failure demands new content (#2560).
+
+    Widened past tests by #2591's operator ruling. Note this is only HALF the
+    gate: `enforce_pinning` also requires the revised region to introduce the
+    demanded artifact, and until #2591 that predicate was a test definition
+    alone -- so widening this regex on its own changed nothing, measured. Both
+    halves moved together.
+    """
     return any(
         _ADDITION_DEMAND_RE.search(str(issue))
         for issue in completeness_issues or []
     )
+
+
+def _introduces_demanded_artifact(
+    new_region: list[str], prev_test_names: set[str]
+) -> bool:
+    """Does this region carry content a completeness check asked to be added?
+
+    Two artifact classes, because our checks demand two (#2591):
+
+    * a test definition the previous draft lacked -- #2560's original case;
+    * an opening fence -- an excerpt, a data-structure example and an I/O
+      example are all fenced code blocks.
+
+    A fence is not name-checked against the previous draft the way a test is,
+    because a fence has no name. That is a deliberately weaker test and it is
+    bounded by the caller: this is consulted ONLY when the round's own
+    completeness failures demanded an addition, and only for a region that
+    would otherwise be refused outright. The alternative -- refusing the
+    demanded excerpt -- is the deadlock this repairs.
+    """
+    for line in new_region:
+        match = _TEST_DEF_RE.match(line)
+        if match and match.group(1) not in prev_test_names:
+            return True
+        if _FENCE_OPEN_RE.match(line):
+            return True
+    return False
 
 
 def _test_def_names(text: str) -> set[str]:
@@ -384,15 +444,14 @@ def enforce_pinning(
             not current_flags[i] for i in range(i1, i2)
         )
         if locked and not unlock_reason:
-            if additions_demanded and any(
-                (match := _TEST_DEF_RE.match(line))
-                and match.group(1) not in prev_test_names
-                for line in new_region
+            if additions_demanded and _introduces_demanded_artifact(
+                new_region, prev_test_names
             ):
                 # The demanded compliance: this round's completeness
-                # failures asked for new tests and this region carries one
-                # the previous draft lacks (#2560). The regression event
-                # above still fires — visibility without destruction.
+                # failures asked for an addition and this region carries one
+                # the previous draft lacks (#2560, widened past tests by
+                # #2591). The regression event above still fires —
+                # visibility without destruction.
                 out.extend(new_region)
                 additions.append(_preview(new_region, j2 - j1))
             else:

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -239,6 +239,79 @@ class TestAddressableToday:
         assert verdict.tokens == ("n4.1", "n4.2", "section 10")
         assert verdict.verdict == ADDRESSED
 
+    def test_modify_files_have_excerpts_demands_an_addition(self):
+        """#2591, repaired. The complaint backticks a file path that is absent
+        from the draft BY DEFINITION -- absence is what it is complaining
+        about -- so the named-content vocabulary can never address it. It is
+        the addition exemption's business, and `MUST include a code block` is
+        now in the addition vocabulary.
+
+        The fixture is unchanged from when this test lived in
+        `TestUnaddressableToday`; only the expected verdict moved.
+        """
+        verdict = _classify(
+            vc.check_modify_files_have_excerpts(NO_CITING_TESTS, MODIFY_FILES),
+            NO_CITING_TESTS,
+        )
+
+        assert "src/render.py" in verdict.tokens
+        assert verdict.demands_addition is True
+        assert verdict.verdict == DEMANDS_ADDITION
+
+    def test_a_complaint_about_existing_content_still_demands_nothing(self):
+        """The safety half of #2591's ruling, and the reason the vocabulary is
+        a closed enumeration rather than a general notion of "add".
+
+        A wider addition vocabulary frees more locked regions, so a complaint
+        about content that ALREADY EXISTS must not trip it. The density
+        heuristic (#2592) is the sharpest case: it names no target at all, so
+        if anything were going to over-match it would.
+
+        Note which checks are deliberately NOT in this list.
+        `functions_have_io_examples` and `data_structures_have_examples` read
+        like complaints about existing content and are not -- both say "MUST
+        have at least one example", which is a demand to ADD one. They are in
+        the vocabulary on purpose. Writing this test the other way round is
+        what surfaced that: the first draft asserted
+        `functions_have_io_examples` demands nothing, and it was wrong.
+        """
+        existing_content_complaints = [
+            vc.check_change_instructions_specific(SPARSE_SPEC),
+            vc.check_manifest_traceability(
+                NO_CITING_TESTS, [], lld_content=""
+            ),
+        ]
+        for check_result in existing_content_complaints:
+            assert rp.demands_additions([check_result["details"]]) is False, (
+                f"{check_result['check_name']}: {check_result['details']}"
+            )
+
+    def test_the_vocabulary_is_a_closed_set(self):
+        """Six phrasings, enumerated from the checks' own `details=` strings.
+
+        The rule that makes this regex legitimate is that its members can be
+        written down (`voice-analysis.md` §28a's closed-set test). If a new
+        demand phrasing appears, it is added here deliberately rather than
+        matched by a general notion of "add", which would free locked regions
+        nobody demanded.
+        """
+        import re as _re
+
+        members = rp._ADDITION_DEMAND_RE.pattern.split("|")
+
+        assert len(members) == 6
+        for phrase, should_match in (
+            ("3 criteria have no test in the spec", True),
+            ("Each Modify file MUST include a code block showing", True),
+            ("Each function MUST have at least one example", True),
+            ("Add the block inside that subsection", True),
+            ("Change instructions lack diff-level specificity", False),
+            ("test(s) tracing to nothing: test_a, test_b", False),
+        ):
+            assert bool(_re.search(rp._ADDITION_DEMAND_RE, phrase)) is should_match, (
+                phrase
+            )
+
     def test_the_demand_to_add_tests_is_exempt_under_2560(self):
         """Naming the rows is necessary and not sufficient.
 
@@ -258,19 +331,6 @@ class TestUnaddressableToday:
     """The deadlock class, pinned. Each test asserts the CURRENT broken state
     against its filed issue. Repairing one flips its test, which is the
     signal to move it into TestAddressableToday."""
-
-    def test_modify_files_have_excerpts_names_a_path_not_in_the_draft(self):
-        """#2591. The complaint backticks a file path that is absent from the
-        draft BY DEFINITION -- absence is what it is complaining about -- and
-        its 'MUST include a code block' phrasing does not trip the addition
-        vocabulary, which only knows three test-specific phrases."""
-        verdict = _classify(
-            vc.check_modify_files_have_excerpts(NO_CITING_TESTS, MODIFY_FILES),
-            NO_CITING_TESTS,
-        )
-        assert "src/render.py" in verdict.tokens
-        assert verdict.demands_addition is False
-        assert verdict.verdict == UNADDRESSABLE
 
     def test_change_instructions_specific_parses_nothing_at_all(self):
         """#2592. A density heuristic about EXISTING content that names no

--- a/tests/unit/test_pinning_conservation.py
+++ b/tests/unit/test_pinning_conservation.py
@@ -315,6 +315,107 @@ The notes block stays put.
         assert not demands_additions(None)
 
 
+class TestAnExcerptIsAlsoADemandedAddition:
+    """#2591: the demanded artifact is not always a test.
+
+    `check_modify_files_have_excerpts` fires on any spec missing a current-
+    state excerpt -- routine, not exotic -- and its complaint could be
+    satisfied by neither vocabulary. The path it backticks is absent from the
+    draft BY DEFINITION, which is what it is complaining about, so the
+    named-content route can never address it; and `MUST include a code block`
+    matched none of #2560's three test-specific phrases.
+
+    **Widening the vocabulary alone does not fix it, measured.** The exemption
+    has a second gate: the revised region must introduce the demanded
+    artifact, and that predicate was `def test_*`. An excerpt is a fenced code
+    block, so with the vocabulary widened and the predicate untouched the
+    region was still refused and the excerpt still discarded. Both halves
+    moved together.
+    """
+
+    PREVIOUS = """# Implementation Spec
+
+## 1. Overview
+
+We add a bezel ring to the gauge face.
+
+## 6. Change Instructions
+
+Update the renderer to draw the ring.
+
+## 10. Test Mapping
+
+| id | test |
+|----|------|
+| N1.1 | test_bezel |
+"""
+
+    #: The drafter adds the excerpt AND rewords the line above it, which is
+    #: the ordinary shape of an edit and what makes the differ emit a REPLACE
+    #: rather than an insert. A pure insert was never refused -- "adding is
+    #: not un-fixing" -- so the pure-insert fixture does not reproduce this.
+    BUNDLED = PREVIOUS.replace(
+        "Update the renderer to draw the ring.",
+        "Update `src/render.py` to draw the ring. Current state:\n\n"
+        "```python\n"
+        "def render(surface):\n"
+        "    surface.fill(BLACK)\n"
+        "```",
+    )
+
+    #: What the complaint names. It matches no line of the draft, which is the
+    #: whole problem.
+    TOKENS = {"src/render.py"}
+
+    def test_the_demanded_excerpt_lands(self):
+        result = enforce_pinning(
+            self.PREVIOUS, self.BUNDLED,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=True,
+        )
+
+        assert "def render(surface):" in result.text
+        assert result.refusals == ()
+        assert result.additions, "the pass is an event, never silent"
+
+    def test_the_same_edit_is_refused_when_nothing_demanded_it(self):
+        """The inverse, unchanged: an unprompted excerpt stays refusable."""
+        result = enforce_pinning(
+            self.PREVIOUS, self.BUNDLED,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=False,
+        )
+
+        assert "def render(surface):" not in result.text
+        assert result.refusals
+
+    def test_a_locked_rewording_gains_nothing_from_the_demand(self):
+        """The widened predicate frees ADDITIONS, not modifications.
+
+        The same shape as the test-flavoured case above it: a locked edit
+        carrying no new fence and no new test is refused either way.
+        """
+        reworded = self.PREVIOUS.replace(
+            "Update the renderer to draw the ring.",
+            "Update the renderer to draw the bezel.",
+        )
+        result = enforce_pinning(
+            self.PREVIOUS, reworded,
+            current_tokens=set(self.TOKENS),
+            additions_demanded=True,
+        )
+
+        assert "Update the renderer to draw the ring." in result.text
+        assert result.refusals
+
+    def test_the_real_excerpt_complaint_reads_as_a_demand(self):
+        assert demands_additions([
+            "Missing current state excerpts for Modify files: "
+            "`src/render.py`. Each Modify file MUST include a code block "
+            "showing the current code that will be changed."
+        ])
+
+
 class TestIsExpansion:
     def test_ordered_containment_is_an_expansion(self):
         assert _is_expansion(["a", "b"], ["x", "a", "y", "b", "z"])


### PR DESCRIPTION
## What this fixes

When a spec modifies a file it must carry an **excerpt** — a copy of that file's current code, so the implementation stage can see what it is changing. `check_modify_files_have_excerpts` complains when one is missing, and that complaint could be satisfied by neither route the revision step offers.

**Pinning** — the rule that a revision may only touch what a reviewer or a check actually complained about, so a round cannot silently un-fix what an earlier round got right — offers two routes to a legal edit:

1. the complaint *names* the content being changed, or
2. the complaint demands an *addition*, which by definition names nothing that exists yet.

Route 1 cannot reach this complaint: it backticks a file path that is absent from the draft **by definition** — absence is what it is complaining about — so the token parses and matches no line. Route 2 did not cover it either, because the addition vocabulary knew three phrases and all three were about tests. The check fires on any spec missing an excerpt, which is routine.

## Widening the vocabulary alone does not fix it

Measured, not reasoned about. On the reproduction — an excerpt added alongside a reworded neighbouring line, which is the ordinary shape of an edit:

```
today:                             refusals=1  excerpt_kept=False
_ADDITION_DEMAND_RE widened only:  refusals=1  excerpt_kept=False
both halves:                       refusals=0  excerpt_kept=True
```

The exemption has a second gate: the revised region must introduce the demanded artifact, and that predicate was `def test_*`. An excerpt is a fenced code block, so widening the phrase list changed nothing. `_introduces_demanded_artifact` now recognises a new fence as well as a new test definition — an excerpt, a data-structure example and an I/O example are all fences and none is a test.

## Two findings from measuring first, either of which would have made a green-but-wrong test

**A pure insertion was never refused.** "Adding is not un-fixing" — an insert has an empty old region, so it is not locked. The deadlock needs the differ to *bundle* the excerpt with a touched neighbour, which is exactly what #2560's own docstring says killed the REQ-8/9/10 additions while a sibling survived by happening to diff as a pure insert. My first fixture inserted cleanly, showed zero refusals, and proved nothing.

**The check has two failure branches.** When the path *is* mentioned but has no code block near it, the token matches the mention and the region is already addressable (4 of 15 draft lines matched). Only the absent-path branch is unreachable, and that is the one the issue describes.

## The vocabulary stays a closed set

Six phrasings, read off the checks' own `details=` strings and tabulated at the constant, rather than a general notion of "add" — because a wider vocabulary frees more locked regions. A new demand phrasing has to be added deliberately. `test_the_vocabulary_is_a_closed_set` pins the membership both ways.

## The safety test the ruling asked for

`test_a_complaint_about_existing_content_still_demands_nothing` asserts a complaint about content that already exists unlocks nothing. Writing it caught my own error: the first draft asserted `functions_have_io_examples` demands nothing, and it does — "Each function MUST have at least one example" is a demand to add one, and it is in the vocabulary on purpose. The test now records which checks are excluded and why.

`test_a_locked_rewording_gains_nothing_from_the_demand` covers the other direction: an edit carrying no new fence and no new test is refused whether or not the round demanded an addition.

## Verification

64 tests across the three touched files pass, including the pre-existing #2560 suite unchanged. Full unit suite: **9515 passed**, 21 skipped, 5 xfailed, 0 failures. Ruff clean on all three files.

Closes #2591
