### PR TITLE
fix: the edit-script fix path is reached for a mid-arc Add the base already ships (Closes #2644)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -797,6 +797,54 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             change_type, repo_root, filepath, target_path
         )
 
+        # #2644: the edit script's own view of the file, read AFTER the
+        # resolution above.
+        #
+        # `existing_content` is read ~60 lines up, guarded by
+        # `change_type.lower() == "modify"` -- and at that point change_type
+        # still says whatever the LLD said. For a file the LLD calls "Add"
+        # that the base already ships, it is "Add" there and "Modify" here, so
+        # `existing_content` stays "" and `should_use_edit_script` sees an
+        # empty file and declines. That is exactly the mid-arc case the edit
+        # script exists for, and the case every Phase 2 run is in.
+        #
+        # Measured on run-issue331-092220: iteration 0 wrote stingray.py whole
+        # in 67s; iteration 1, fixing 3 failing tests and a 3-point coverage
+        # gap, ran the full-file path for 1200s and was killed
+        # (ceiling_timeout). No `[EDIT-SCRIPT]` line appears anywhere in that
+        # log -- the machinery #2407 landed two weeks earlier never engaged.
+        #
+        # Deliberately a SEPARATE name rather than repairing `existing_content`
+        # in place. That value also reaches `validate_code_response`, where a
+        # non-empty existing file activates #587's drastic-shrink gate; making
+        # it non-empty here would add a refusal surface to the full-file path,
+        # on the campaign's own route, as a side effect of a timeout fix.
+        edit_script_content = existing_content
+        if (
+            not edit_script_content
+            and change_type.lower() == "modify"
+            and target_path.exists()
+        ):
+            try:
+                edit_script_content = target_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                # fail-open: an unreadable file leaves the edit script with
+                # nothing to SEARCH, which is precisely the condition
+                # `should_use_edit_script` declines on. Continuing lands on
+                # the full-file path, which reads the file itself through the
+                # prompt builder and will report its own failure -- so this is
+                # never worse than the behaviour before #2644. Halting here
+                # would turn a read hiccup into a dead stage.
+                #
+                # Audible on purpose: the silent version of this was what the
+                # fail-open gate objected to, and an edit script that quietly
+                # declines is exactly how run-issue331-092220 went unexplained.
+                edit_script_content = ""
+                print(
+                    f"        [EDIT-SCRIPT] could not read {filepath} "
+                    f"({exc}); falling through to the full-file path"
+                )
+
         # Validate change type
         if change_type.lower() == "modify" and not target_path.exists():
             emit("workflow.halt_and_plan", repo="", metadata={"filepath": filepath, "reason": "max_retries_exceeded"})
@@ -877,11 +925,11 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         # below, so this is never worse than the behavior it replaces.
         code = None
         if should_use_edit_script(
-            change_type, existing_content, revision_error_context
+            change_type, edit_script_content, revision_error_context
         ):
             outcome = try_edit_script_fix(
                 filepath=filepath,
-                existing_content=existing_content,
+                existing_content=edit_script_content,
                 failure_context=revision_error_context,
                 model=select_model_for_file(filepath, 0, False),
                 system_prompt=stable_system_prompt,

--- a/tests/unit/test_edit_script_reaches_the_mid_arc_fix.py
+++ b/tests/unit/test_edit_script_reaches_the_mid_arc_fix.py
@@ -1,0 +1,191 @@
+"""The edit script must actually be REACHED, not merely be correct (#2644).
+
+#2407 gave the implementation stage an edit-script fix path: a revision emits
+SEARCH/REPLACE blocks instead of regenerating the file, because a regeneration
+re-derives everything including the parts that already pass. It landed
+2026-08-15.
+
+Two weeks later, `run-issue331-092220` still died the way #2407 was built to
+prevent:
+
+    [09:23:06] [N4] Implementing code file-by-file (iteration 0)...   -> 67s, fine
+    [09:24:13] [N5] Results: 12 passed, 3 failed | Coverage: 92.0%
+    [09:24:31] [N4] Implementing code file-by-file (iteration 1)...
+               Base already ships src/boostgauge/skins/stingray.py;
+               implementing as Modify so the earlier phase's work is extended
+               Calling Claude... (15s) ... (1200s)
+               ERROR=claude -p timed out after 1200s [ceiling_timeout]
+
+`[EDIT-SCRIPT]` appears nowhere in that log, and the fix path prints
+"Calling Claude (edit script)" rather than the plain "Calling Claude" the log
+shows. The machinery never engaged.
+
+**Why: `existing_content` is read before the change type is resolved.** The
+read is guarded by `change_type.lower() == "modify"`, and at that point
+change_type is still whatever the LLD said. For a file the LLD calls "Add"
+that the base already ships -- the mid-arc case, and the case every Phase 2
+run is in -- it is "Add" at the read and "Modify" sixty lines later, so
+`existing_content` stays "" and `should_use_edit_script` declines on the
+"you cannot SEARCH an empty file" condition.
+
+`test_implementation_edit_script_fix.py::test_an_add_that_resolved_to_an_
+existing_file_still_qualifies` already asserts this case returns True. It
+passes, and always did: it hands `should_use_edit_script` the file content
+directly. The unit was right; the caller never gave it the inputs. These tests
+cover the wiring the unit test cannot see.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+orch = importlib.import_module(
+    "assemblyzero.workflows.testing.nodes.implementation.orchestrator"
+)
+esf = importlib.import_module(
+    "assemblyzero.workflows.testing.nodes.implementation.edit_script_fix"
+)
+
+#: Big enough to clear MIN_BYTES_FOR_EDIT_SCRIPT, and shaped like the file the
+#: run died on: an earlier phase's work that this phase extends.
+BASE_FILE = '''"""Stingray skin."""
+
+
+def draw_face(surface, radius):
+    """Fill the dial face."""
+    surface.fill((10, 10, 12))
+    return surface
+
+
+def draw_ticks(surface, radius, count=10):
+    """Draw the major tick marks."""
+    for index in range(count):
+        surface.tick(index, radius)
+    return surface
+
+
+def draw_needle(surface, angle):
+    """Draw the needle at the given angle."""
+    surface.needle(angle)
+    return surface
+'''
+
+FAILURES = (
+    "FAILED tests/unit/test_stingray.py::test_bezel - AssertionError: "
+    "expected a bezel ring\n"
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    target = tmp_path / "src" / "boostgauge" / "skins"
+    target.mkdir(parents=True)
+    (target / "stingray.py").write_text(BASE_FILE, encoding="utf-8")
+    return tmp_path
+
+
+class TestTheGateSeesTheFileOnDisk:
+    """The unit's three conditions, given the inputs the caller really has."""
+
+    def test_the_base_file_clears_the_size_threshold(self):
+        assert len(BASE_FILE) >= esf.MIN_BYTES_FOR_EDIT_SCRIPT
+
+    def test_with_the_content_the_gate_opens(self):
+        assert esf.should_use_edit_script("Modify", BASE_FILE, FAILURES) is True
+
+    def test_with_an_empty_string_it_declines(self):
+        """The observed state: change type resolved to Modify, content "".
+
+        This is what the orchestrator handed it on run-issue331-092220, and
+        why no edit script ran.
+        """
+        assert esf.should_use_edit_script("Modify", "", FAILURES) is False
+
+
+class TestTheOrchestratorReadsAfterResolving:
+    """The wiring, driven through the real loop.
+
+    `implement_code` is exercised with the model call stubbed, so the
+    assertion is about which path the loop CHOOSES, not about model output.
+    """
+
+    def _run(self, repo, monkeypatch, change_type: str, from_base: bool = True):
+        seen: dict = {}
+
+        def fake_should_use(ct, content, failures):
+            seen["change_type"] = ct
+            seen["content_len"] = len(content)
+            seen["failures"] = failures
+            return esf.should_use_edit_script(ct, content, failures)
+
+        # `resolve_change_type` asks git whether the base ships this file.
+        # The tmp tree is not a repo, so the query is the thing to stand in
+        # for -- stubbing `resolve_change_type` itself would stub the subject.
+        monkeypatch.setattr(orch, "came_from_base", lambda *a, **k: from_base)
+        monkeypatch.setattr(orch, "should_use_edit_script", fake_should_use)
+        monkeypatch.setattr(
+            orch, "try_edit_script_fix",
+            lambda **kw: esf.EditScriptOutcome(BASE_FILE, blocks=1, preserved=0.9),
+        )
+        # Keep the full-file fallback from making a model call: this asserts
+        # which path is chosen, not what a model returns.
+        monkeypatch.setattr(
+            orch, "generate_file_with_retry",
+            lambda **kw: (BASE_FILE, True),
+        )
+
+        state = {
+            "issue_number": 331,
+            "repo_root": str(repo),
+            "worktree_path": str(repo),
+            "lld_content": "# LLD\n\n## Files\n- src/boostgauge/skins/stingray.py\n",
+            "spec_content": "# Spec\n",
+            "files_to_modify": [
+                {
+                    "path": "src/boostgauge/skins/stingray.py",
+                    "change_type": change_type,
+                    "reason": "add the bezel ring",
+                }
+            ],
+            "iteration_count": 1,
+            "test_failure_summary": FAILURES,
+            "green_phase_output": FAILURES,
+            "test_files": [],
+            "completed_files": [],
+        }
+        try:
+            orch.implement_code(state)
+        except Exception:  # noqa: BLE001 — the gate call is the subject
+            pass
+        return seen
+
+    def test_an_add_the_base_already_ships_reaches_the_edit_script(
+        self, repo, monkeypatch
+    ):
+        """The regression, in one assertion.
+
+        The LLD says Add; the base ships the file; #2032 resolves it to
+        Modify. The gate must see the file's real content, not "".
+        """
+        seen = self._run(repo, monkeypatch, "Add")
+
+        assert seen, "should_use_edit_script was never called"
+        assert seen["change_type"].lower() == "modify"
+        assert seen["content_len"] == len(BASE_FILE), (
+            "the gate was handed an empty file, so no edit script can run"
+        )
+
+    def test_a_plain_modify_is_unaffected(self, repo, monkeypatch):
+        """The path that always worked keeps working."""
+        seen = self._run(repo, monkeypatch, "Modify")
+
+        assert seen["content_len"] == len(BASE_FILE)
+
+    def test_the_failure_context_reaches_it_too(self, repo, monkeypatch):
+        """The gate's other precondition, so a green result here is not an
+        accident of one condition passing while another is empty."""
+        seen = self._run(repo, monkeypatch, "Add")
+
+        assert FAILURES.strip() in seen["failures"]


### PR DESCRIPTION
## The premise was wrong, and that is the finding

> "The impl stage's file-writer has no equivalent"

It has one. `edit_script_fix.py` — an **edit script** is a revision expressed as SEARCH/REPLACE blocks that a machine applies, so the model names only what changes and everything else carries forward byte-identical — landed as **#2407 / PR #2430, commit `68fe5717`, 2026-08-15**, with 45 tests, wired into the fix site.

`run-issue331-092220` is **2026-08-29**, two weeks later. So the question was never "why is there no edit script" but "why did ours not run".

## Why it did not run

`[EDIT-SCRIPT]` appears nowhere in that log, and the edit path prints `Calling Claude (edit script)` while the log shows the plain `Calling Claude`. It was never entered.

`existing_content` is read ~60 lines before the gate, under this guard:

```python
existing_content = ""
if change_type.lower() == "modify" and target_path.exists():
    existing_content = target_path.read_text(encoding="utf-8")
```

`change_type` there is still whatever the LLD said. `resolve_change_type` — #2032's Add→Modify coercion for a file the base already ships — runs **afterwards**. So for a mid-arc file planned as Add it reads `"Add"` at the read and `"Modify"` at the gate, `existing_content` stays `""`, and `should_use_edit_script` declines on its own third condition: *you cannot SEARCH an empty file.*

The run's own log says this is that case:

```
Base already ships src/boostgauge/skins/stingray.py; implementing as Modify
so the earlier phase's work is extended rather than replaced.
```

**It is the shape every Phase 2 run is in.** The arc accumulates: each feature's spec is drafted against an empty tree and plans every file as Add, while the base already ships the earlier features' files.

```
[09:23:06] iteration 0 ....................   67s, completed
[09:24:13] 12 passed, 3 failed | Coverage 92.0% | Target 95%
[09:24:31] iteration 1 .................... 1200s, ceiling_timeout
```

## The existing test could not catch it

`test_an_add_that_resolved_to_an_existing_file_still_qualifies` asserts precisely this case returns True, and it passes — it always did. It hands `should_use_edit_script` the content directly. **The unit was correct; the caller never gave it the inputs**, and nothing covered the wiring between them.

The new test drives the real `implement_code` loop and asserts the gate is handed the file's actual content. Verified to fail without the change, on `assert seen["content_len"] == len(BASE_FILE)`.

## What this changes, and what it deliberately does not

No second implementation of anything — that would be the duplication this issue warns against. The read is repeated after the change type is resolved, into a separate name used only by the edit-script gate and call.

`existing_content` itself is left alone on purpose. It also reaches `validate_code_response`, where a non-empty existing file activates #587's drastic-shrink gate. Making it non-empty there would add a refusal surface to the full-file path, on the campaign's own route, as a side effect of a timeout fix.

## The fail-open gate caught my first version, and was right to

The unreadable-file branch was originally a silent `except OSError: content = ""`. The repo's fail-open audit rejected it — "output tells you it happened: no". An edit script that quietly declines is exactly how this run went unexplained for a fortnight.

It is now declared with `# fail-open:` and its reason, and it **prints**. Continuing remains correct: an unreadable file leaves nothing to SEARCH, which is the condition the gate declines on anyway, and the full-file path reads the file itself. No baseline was regenerated.

## Verification

58 tests across the new file and the existing #2407 suite pass. Full unit suite: **9521 passed**, 21 skipped, 5 xfailed, 0 failures. Ruff introduces no new findings (the one in the touched file pre-exists on `origin/main` at the same line, verified against `git show origin/main:<path>`).

**Not proven:** no roll has run. What is proven is that the edit-script path is now *reached* for the mid-arc case. Whether a revision then completes under the 1200s ceiling is the roll's to say.

Closes #2644
