### PR TITLE
fix: the edit-script wiring test writes its audit trail to its own tmp repo (Closes #2699)

### DIFF
--- a/tests/unit/test_edit_script_reaches_the_mid_arc_fix.py
+++ b/tests/unit/test_edit_script_reaches_the_mid_arc_fix.py
@@ -37,6 +37,8 @@ cover the wiring the unit test cannot see.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import importlib
 
 import pytest
@@ -140,6 +142,14 @@ class TestTheOrchestratorReadsAfterResolving:
             "issue_number": 331,
             "repo_root": str(repo),
             "worktree_path": str(repo),
+            # #2699: REQUIRED, not decorative. `implement_code` resolves this
+            # as `Path(state.get("audit_dir", ""))`, and `Path("")` is `.`,
+            # whose `.exists()` is always true -- so omitting it does not mean
+            # "no audit trail", it means "write the audit trail into whatever
+            # directory pytest was started from". This test left four prompt
+            # and response files in the AssemblyZero repo root the first time
+            # it ran.
+            "audit_dir": str(repo / "audit"),
             "lld_content": "# LLD\n\n## Files\n- src/boostgauge/skins/stingray.py\n",
             "spec_content": "# Spec\n",
             "files_to_modify": [
@@ -155,6 +165,7 @@ class TestTheOrchestratorReadsAfterResolving:
             "test_files": [],
             "completed_files": [],
         }
+        seen["state"] = state
         try:
             orch.implement_code(state)
         except Exception:  # noqa: BLE001 — the gate call is the subject
@@ -189,3 +200,44 @@ class TestTheOrchestratorReadsAfterResolving:
         seen = self._run(repo, monkeypatch, "Add")
 
         assert FAILURES.strip() in seen["failures"]
+
+    def test_the_run_writes_nothing_outside_its_tmp_repo(
+        self, repo, monkeypatch, tmp_path
+    ):
+        """#2699: this test drives the real loop, so it can litter.
+
+        `implement_code` resolves `Path(state.get("audit_dir", ""))`, and
+        `Path("")` is the current directory -- so a state dict missing
+        `audit_dir` writes its prompt and response artifacts wherever pytest
+        was started. That is the AssemblyZero repo root, and it happened: four
+        files, untracked, indistinguishable from somebody's work in progress.
+
+        Asserting on the process's own working directory is what catches a
+        recurrence, because the failure is a file appearing somewhere nobody
+        is looking.
+        """
+        cwd = Path.cwd()
+        before = {p.name for p in cwd.iterdir()}
+
+        self._run(repo, monkeypatch, "Add")
+
+        new = {p.name for p in cwd.iterdir()} - before
+        assert not new, f"the run wrote into the working directory: {sorted(new)}"
+
+    def test_the_driver_points_the_audit_trail_at_the_tmp_repo(
+        self, repo, monkeypatch
+    ):
+        """The containment itself, asserted directly.
+
+        The guard above is a net, not a proof: with both the edit-script and
+        the full-file paths stubbed, nothing writes an audit file at all, so
+        it would stay green even if `audit_dir` went missing again. What
+        actually prevents a recurrence is the field being SET to somewhere
+        disposable, and that is what this asserts. Said plainly, because a
+        test whose green light means nothing is worse than no test.
+        """
+        seen = self._run(repo, monkeypatch, "Add")
+        audit_dir = seen["state"]["audit_dir"]
+
+        assert audit_dir, "unset means Path('') means the working directory"
+        assert str(repo) in audit_dir


### PR DESCRIPTION
## What happened

`implement_code` resolves its audit directory as `Path(state.get("audit_dir", ""))`. `Path("")` is `.`, and `.exists()` on it is always true — so omitting the field does not mean "no audit trail". It means "write the audit trail into whatever directory the process was started from", which for anything run from a checkout is the repo.

`test_edit_script_reaches_the_mid_arc_fix.py`, which landed in #2644 an hour ago, omitted it. Running it left four files in the AssemblyZero repo root:

```
001-prompt-src-boostgauge-skins-stingray.py.md
002-response-src-boostgauge-skins-stingray.py.md
003-prompt-src-boostgauge-skins-stingray.py.md
004-response-src-boostgauge-skins-stingray.py.md
```

Untracked, at the top level, indistinguishable in `git status` from somebody's work in progress. They were preserved to `data/scratch-2026-09-02-phase2/stray-audit-from-my-test/` rather than deleted.

## Two faults; this is the second

The first version of that test stubbed the edit-script path but not `generate_file_with_retry`, so the fallback made **real model calls** — 96 seconds, real cost. That was caught and fixed while writing it, and it is a test-authoring error rather than a product defect.

This PR is the other one: even with the model calls gone, the audit trail had nowhere to go but the working directory, because the field was never set.

## The fix, and which test actually carries it

`audit_dir` now points inside the test's own tmp repo. Two tests guard it, and the docstrings say plainly which one does the work:

- `test_the_driver_points_the_audit_trail_at_the_tmp_repo` asserts the field is set and points inside tmp. **This is the containment.**
- `test_the_run_writes_nothing_outside_its_tmp_repo` diffs the process working directory across the run. This is a **net, not a proof** — with both write paths stubbed, nothing writes an audit file at all, so it would stay green even if the field went missing again. It is worth keeping as a tripwire for a future un-stubbed path, and it is documented as exactly that.

Recording which assertion is load-bearing matters here, because the alternative is a test whose green light means nothing — and this whole PR exists because a green suite said nothing about four files in the repo root.

## The other half is filed, not deferred

Whether an unset `audit_dir` should mean "write nothing" instead of "write here" is a behaviour change on the path every roll takes, and boostgauge #421 is mid-campaign with four features left. It needs a ruling, not a patch, so it is **#2700**, with the three coherent answers and the scope written down — filed before this closes, per the deferred-scope rule.

## Verification

8 tests in the file pass. Full unit suite: **9523 passed**, 21 skipped, 5 xfailed, 0 failures — and `git status` on the checkout was unchanged across that whole run, which is the property in question. Ruff clean.

Closes #2699
