### PR TITLE
fix: the spec stage grades Section 10's test functions with the implementation stage's own validator — assertions present, fixture parameters resolvable (Closes #2706, Closes #2707)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/check_classification.py
+++ b/assemblyzero/workflows/implementation_spec/check_classification.py
@@ -147,6 +147,33 @@ CLASSIFICATIONS: dict[str, Classification] = {
             "ValueError' is a fact (#2333)."
         ),
     ),
+    "spec_test_functions_have_assertions": Classification(
+        check="spec_test_functions_have_assertions",
+        kind=FACT,
+        reads=(
+            "Section 10's extracted test functions, assembled exactly as the "
+            "scaffolder emits them, under `validate_test_structure`'s AST rule"
+        ),
+        reason=(
+            "a function body is a lone pass/docstring or it carries an assert "
+            "-- the same fact the implementation stage's scaffolder validator "
+            "refuses on, asked one stage earlier with the same code (#2706)."
+        ),
+    ),
+    "spec_test_fixtures_resolvable": Classification(
+        check="spec_test_fixtures_resolvable",
+        kind=FACT,
+        reads=(
+            "each test-function parameter against pytest's builtin fixtures, "
+            "the block's own @pytest.fixture definitions, and the plugins the "
+            "target repo's pyproject declares"
+        ),
+        reason=(
+            "a parameter names a fixture one of those three routes provides or "
+            "it does not; pytest errors at setup on the latter, which is the "
+            "fact this check reports early (#2707)."
+        ),
+    ),
     "visual_baselines_not_self_referential": Classification(
         check="visual_baselines_not_self_referential",
         kind=FACT,

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -1732,8 +1732,8 @@ def _normalise_distribution(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).lower()
 
 
-def _declared_dependencies(pyproject_text: str) -> set[str]:
-    """Every distribution a pyproject declares, normalised.
+def _declared_dependencies(pyproject_text: str) -> set[str] | None:
+    """Every distribution a pyproject declares, normalised; None if not TOML.
 
     Reads the three shapes in use: PEP 621 lists (``[project] dependencies``,
     ``[project.optional-dependencies]``), Poetry tables
@@ -1748,7 +1748,11 @@ def _declared_dependencies(pyproject_text: str) -> set[str]:
     try:
         data = tomllib.loads(pyproject_text)
     except tomllib.TOMLDecodeError:
-        return set()
+        # fail-open: an unparseable pyproject declares no plugins, which makes
+        # the fixture check STRICTER, never quieter -- every plugin fixture is
+        # then reported as undeclared -- and None lets the report say "could
+        # not be parsed" rather than "declares none".
+        return None
 
     names: set[str] = set()
 
@@ -1779,26 +1783,38 @@ def _declared_dependencies(pyproject_text: str) -> set[str]:
     return names
 
 
-def _pyproject_for_run(repo_root_str: str, base_branch: str) -> str:
+def _pyproject_for_run(repo_root_str: str, base_branch: str) -> tuple[str, str]:
     """The target repo's pyproject as the run's base ships it (#2684, #2668),
-    falling back to the checkout when the run names no base or the base has
-    none. Empty when there is no repo to read."""
+    and where it came from -- so a fallback is named in the report rather
+    than taken silently. Falls to the checkout when the run names no base or
+    the base has none; ``("", <why>)`` when nothing can be read."""
     if not repo_root_str:
-        return ""
+        return "", "no repo root given"
     repo_root = Path(repo_root_str)
     if base_branch:
+        ref = ""
         try:
-            text = read_from_base(
-                repo_root, base_ref(repo_root, base_branch), "pyproject.toml"
+            ref = base_ref(repo_root, base_branch)
+            text = read_from_base(repo_root, ref, "pyproject.toml")
+        except (OSError, subprocess.SubprocessError) as exc:
+            # fail-open: a base that cannot be read falls to the checkout's
+            # own pyproject, and the fallback is printed here and named in
+            # the report. The direction is stricter (fewer declared plugins),
+            # never quieter.
+            print(
+                f"    [FIXTURES] pyproject unreadable on base {base_branch!r} "
+                f"({exc}); reading the checkout's instead"
             )
-        except (OSError, subprocess.SubprocessError):
             text = ""
         if text:
-            return text
+            return text, f"read from {ref}"
     try:
-        return (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+        checkout = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
     except OSError:
-        return ""
+        # fail-open: no pyproject anywhere means no declared plugins, which
+        # the report states outright; the check gets stricter, not quieter.
+        return "", "no pyproject could be read"
+    return checkout, "read from the checkout"
 
 
 def _spec_test_functions(spec: str) -> dict[str, Any]:
@@ -1986,6 +2002,9 @@ def check_spec_test_fixtures_resolvable(
     try:
         tree = ast.parse(block)
     except SyntaxError:
+        # fail-open: abstains audibly -- the details say not applicable, the
+        # summary counts it as such, and python_fences_parse fails the same
+        # draft on the same syntax (#2526's unknown-is-not-guilty).
         return CompletenessCheck(
             check_name="spec_test_fixtures_resolvable",
             passed=True,
@@ -2001,7 +2020,11 @@ def check_spec_test_fixtures_resolvable(
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and _is_fixture_decorated(node)
     }
-    declared = _declared_dependencies(_pyproject_for_run(repo_root_str, base_branch))
+    pyproject_text, pyproject_source = _pyproject_for_run(repo_root_str, base_branch)
+    declared = _declared_dependencies(pyproject_text)
+    if declared is None:
+        pyproject_source = "the repo's pyproject could not be parsed"
+        declared = set()
     from_declared_plugins: set[str] = set()
     from_undeclared_plugins: dict[str, str] = {}
     for distribution, fixtures in _PLUGIN_FIXTURES.items():
@@ -2058,8 +2081,9 @@ def check_spec_test_fixtures_resolvable(
     listed = "; ".join(failures)
     declared_plugins = sorted(d for d in _PLUGIN_FIXTURES if d in declared)
     declared_note = (
-        f" (declared: {', '.join(declared_plugins)})" if declared_plugins
-        else " (the repo declares none)"
+        f" (declared: {', '.join(declared_plugins)}; {pyproject_source})"
+        if declared_plugins
+        else f" (the repo declares none; {pyproject_source})"
     )
     return CompletenessCheck(
         check_name="spec_test_fixtures_resolvable",

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 import sys
 import textwrap
+import tomllib
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -36,6 +37,7 @@ from assemblyzero.workflows.implementation_spec.state import (
 from assemblyzero.workflows.implementation_spec.base_tree import (
     base_ref,
     exists_on_base,
+    read_from_base,
 )
 from assemblyzero.workflows.implementation_spec.check_classification import (
     advisory_details,
@@ -215,6 +217,27 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     check_error_paths = check_error_paths_have_tests(spec_draft)
     checks.append(check_error_paths)
     _log_check(check_error_paths)
+
+    # Check 10b (#2706): Section 10's test functions must survive the
+    # scaffolder's validator. The scaffolder emits them verbatim (#2316) and
+    # the implementation stage refuses a suite that asserts nothing --
+    # run-issue4-163140 lost 605 s of approved spec work to that refusal
+    # 3.4 s into the next stage. Same extractor, same rule, one stage earlier.
+    check_spec_asserts = check_spec_test_functions_have_assertions(
+        spec_draft, state.get("issue_number", 0), files_to_modify
+    )
+    checks.append(check_spec_asserts)
+    _log_check(check_spec_asserts)
+
+    # Check 10c (#2707): every test-function parameter must name a fixture
+    # the run can resolve -- a pytest builtin, one defined in the block, or
+    # one from a plugin the target repo declares. The same spec took `mocker`
+    # with no pytest-mock declared and `live_environment` defined nowhere.
+    check_spec_fixtures = check_spec_test_fixtures_resolvable(
+        spec_draft, repo_root_str, base_branch
+    )
+    checks.append(check_spec_fixtures)
+    _log_check(check_spec_fixtures)
 
     # Check 11: Manifest traceability — every manifest row in exactly one
     # test, every test tracing to a real identifier (Issue #2533). A diff, not
@@ -1652,6 +1675,404 @@ def check_error_paths_have_tests(spec: str) -> CompletenessCheck:
         check_name="error_paths_have_tests",
         passed=report.ok,
         details=format_error_path_report(report),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 10's test functions, graded by the stage that will run them
+# (#2706, #2707)
+# ---------------------------------------------------------------------------
+#
+# Since #2316 the scaffolder emits the spec's Section 10 test functions
+# verbatim, and `validate_tests_mechanical` then refuses a suite whose
+# functions assert nothing. Both were right on boostgauge run-issue4-163140
+# (2026-09-02): the spec passed twelve completeness checks and an APPROVED
+# review, and the implementation stage refused it 3.4 s later, deterministic
+# on regeneration, because eleven of its thirteen tests were a comment and
+# `pass`, and seven took `mocker` (no pytest-mock declared), `benchmark` (no
+# pytest-benchmark declared) or `live_environment` (defined nowhere).
+#
+# These two checks ask the same questions one stage earlier, where the drafter
+# can still respond -- with the SAME extractor and the SAME rule the testing
+# workflow uses, so the verdicts cannot drift (#1698). Each complaint names the
+# function in backticks and cites its `lines N-M` span, the #2686 shape, so
+# revision pinning opens exactly the function the drafter has to rewrite and
+# nothing beside it.
+
+#: Fixtures a pytest plugin injects by parameter name, keyed by the
+#: distribution the target repo would have to declare. A closed map, never a
+#: pattern: a name is added only with the plugin that provides it named
+#: beside it, and a plugin absent from this map is treated as providing
+#: nothing (#2707).
+_PLUGIN_FIXTURES: dict[str, frozenset[str]] = {
+    "pytest-mock": frozenset({
+        "mocker", "class_mocker", "module_mocker", "package_mocker",
+        "session_mocker",
+    }),
+    "pytest-asyncio": frozenset({
+        "event_loop", "unused_tcp_port", "unused_tcp_port_factory",
+        "unused_udp_port", "unused_udp_port_factory",
+    }),
+    "pytest-httpx": frozenset({"httpx_mock"}),
+    "pytest-benchmark": frozenset({"benchmark", "benchmark_weave"}),
+    "pytest-xdist": frozenset({"worker_id", "testrun_uid"}),
+    "pytest-cov": frozenset({"cov"}),
+}
+
+#: The leading distribution name of a PEP 508 requirement string
+#: (``pytest-mock>=3``, ``pytest_mock (>=3,<4)``, ``pytest-mock[extra]``).
+_REQUIREMENT_NAME_RE = re.compile(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+#: The validator's per-function complaint, ``Function 'test_x' <what>``.
+_VALIDATOR_FUNCTION_RE = re.compile(r"^Function '(test_\w+)' (.+)$")
+
+
+def _normalise_distribution(name: str) -> str:
+    """PEP 503 normalisation: case-insensitive, `_` and `.` read as `-`."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _declared_dependencies(pyproject_text: str) -> set[str]:
+    """Every distribution a pyproject declares, normalised.
+
+    Reads the three shapes in use: PEP 621 lists (``[project] dependencies``,
+    ``[project.optional-dependencies]``), Poetry tables
+    (``[tool.poetry.dependencies]``, ``[tool.poetry.group.*.dependencies]``)
+    and PEP 735 ``[dependency-groups]``. Under any key ending in
+    ``dependencies`` (or ``dependency-groups``), a table contributes the keys
+    whose values are a version string or a spec table, and a list contributes
+    the leading name of each string. Nothing else in the file is read.
+    """
+    if not pyproject_text:
+        return set()
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError:
+        return set()
+
+    names: set[str] = set()
+
+    def in_scope(path: tuple[str, ...]) -> bool:
+        return any(
+            part.endswith("dependencies") or part == "dependency-groups"
+            for part in path
+        )
+
+    def walk(node: Any, path: tuple[str, ...]) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if in_scope(path) and isinstance(value, (str, dict)):
+                    names.add(_normalise_distribution(key))
+                    continue
+                walk(value, path + (key,))
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, str):
+                    if in_scope(path):
+                        match = _REQUIREMENT_NAME_RE.match(item)
+                        if match:
+                            names.add(_normalise_distribution(match.group(1)))
+                else:
+                    walk(item, path)
+
+    walk(data, ())
+    return names
+
+
+def _pyproject_for_run(repo_root_str: str, base_branch: str) -> str:
+    """The target repo's pyproject as the run's base ships it (#2684, #2668),
+    falling back to the checkout when the run names no base or the base has
+    none. Empty when there is no repo to read."""
+    if not repo_root_str:
+        return ""
+    repo_root = Path(repo_root_str)
+    if base_branch:
+        try:
+            text = read_from_base(
+                repo_root, base_ref(repo_root, base_branch), "pyproject.toml"
+            )
+        except (OSError, subprocess.SubprocessError):
+            text = ""
+        if text:
+            return text
+    try:
+        return (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _spec_test_functions(spec: str) -> dict[str, Any]:
+    """Section 10's executable test functions, by the testing workflow's own
+    extractor -- a second parser here would be the #1698 class."""
+    from assemblyzero.workflows.testing.nodes.load_lld import (
+        extract_spec_test_functions,
+    )
+
+    return extract_spec_test_functions(spec)
+
+
+def _test_function_spans(
+    spec: str, functions: list[dict[str, str]]
+) -> dict[str, tuple[int, int]]:
+    """1-based line span of each extracted function in the draft.
+
+    The extractor slices sources verbatim out of the draft, so each is found
+    by text; the cursor advances so two identical bodies map to their own
+    positions rather than both to the first.
+    """
+    spans: dict[str, tuple[int, int]] = {}
+    cursor = 0
+    for fn in functions:
+        source = fn["source"]
+        idx = spec.find(source, cursor)
+        if idx < 0:
+            idx = spec.find(source)
+        if idx < 0:
+            continue
+        start = spec.count("\n", 0, idx) + 1
+        spans[fn["name"]] = (start, start + source.count("\n"))
+        cursor = idx + len(source)
+    return spans
+
+
+def check_spec_test_functions_have_assertions(
+    spec: str,
+    issue_number: int = 0,
+    files_to_modify: list[dict] | None = None,
+) -> CompletenessCheck:
+    """Section 10's test functions must survive the scaffolder's validator (#2706).
+
+    Builds the file exactly as `scaffold_tests.generate_spec_test_file_content`
+    will and grades it with `validate_tests_mechanical.validate_test_structure`
+    -- the implementation stage's own transcription and its own rule -- so
+    this check and that stage cannot disagree. Not applicable when the spec
+    ships no executable functions (the table-derived path).
+
+    The complaint backticks nothing but function names: a backticked word is a
+    pinning token that unlocks every line carrying it, and `pass` or `assert`
+    as tokens would open half the draft.
+    """
+    suite = _spec_test_functions(spec)
+    functions = suite["functions"]
+    if not functions:
+        return CompletenessCheck(
+            check_name="spec_test_functions_have_assertions",
+            passed=True,
+            details=(
+                "Section 10 carries no executable test functions — check not "
+                "applicable (the scaffolder falls back to table-derived scenarios)."
+            ),
+        )
+
+    from assemblyzero.workflows.testing.nodes.load_lld import (
+        scenarios_from_spec_functions,
+    )
+    from assemblyzero.workflows.testing.nodes.scaffold_tests import (
+        generate_spec_test_file_content,
+    )
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        validate_test_structure,
+    )
+
+    content = generate_spec_test_file_content(
+        suite, issue_number, files_to_modify or []
+    )
+    errors = validate_test_structure(content, scenarios_from_spec_functions(functions))
+    if not errors:
+        return CompletenessCheck(
+            check_name="spec_test_functions_have_assertions",
+            passed=True,
+            details=(
+                f"All {len(functions)} Section 10 test function(s) carry an "
+                f"assertion; the scaffolder will emit them verbatim (#2316)."
+            ),
+        )
+
+    spans = _test_function_spans(spec, functions)
+    by_function: list[str] = []
+    other: list[str] = []
+    for error in errors:
+        match = _VALIDATOR_FUNCTION_RE.match(error)
+        if match and match.group(1) in spans:
+            start, end = spans[match.group(1)]
+            by_function.append(
+                f"`{match.group(1)}` (lines {start}-{end}) {match.group(2)}"
+            )
+        else:
+            other.append(error)
+
+    parts: list[str] = []
+    if by_function:
+        # Every refused function is cited, never a truncated list: the span
+        # is what pinning unlocks, and a function left off the list stays
+        # locked against the very edit this complaint demands.
+        listed = "; ".join(by_function)
+        parts.append(
+            f"{len(by_function)} of {len(functions)} §10 test function(s) "
+            f"would be refused by the implementation stage's scaffolder: {listed}. "
+            "Replace each pass body with the setup and at least one assert "
+            "statement (or a pytest.raises block) that checks the value its "
+            "comment states — the scaffolder emits these functions verbatim "
+            "(#2316) and the implementation stage refuses a suite that asserts "
+            "nothing."
+        )
+    if other:
+        parts.append("Also refused by that validator: " + "; ".join(other))
+    return CompletenessCheck(
+        check_name="spec_test_functions_have_assertions",
+        passed=False,
+        details=" ".join(parts),
+    )
+
+
+def _is_fixture_decorated(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name) and target.id == "fixture":
+            return True
+        if isinstance(target, ast.Attribute) and target.attr == "fixture":
+            return True
+    return False
+
+
+def _parametrized_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Names a ``@pytest.mark.parametrize`` decorator supplies as parameters."""
+    names: set[str] = set()
+    for decorator in node.decorator_list:
+        if not (
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Attribute)
+            and decorator.func.attr == "parametrize"
+            and decorator.args
+        ):
+            continue
+        first = decorator.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            names.update(n.strip() for n in first.value.split(",") if n.strip())
+        elif isinstance(first, (ast.List, ast.Tuple)):
+            names.update(
+                element.value
+                for element in first.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            )
+    return names
+
+
+def check_spec_test_fixtures_resolvable(
+    spec: str, repo_root_str: str = "", base_branch: str = ""
+) -> CompletenessCheck:
+    """Every parameter of a Section 10 test function must name a fixture (#2707).
+
+    Three routes satisfy it: a pytest builtin, a ``@pytest.fixture`` function
+    in the same block, or a fixture from a plugin the target repo's pyproject
+    declares (`_PLUGIN_FIXTURES`, read from the run's base branch). A name
+    that takes none of them errors at setup one stage later, before any
+    assertion runs. Abstains when the block does not parse --
+    `python_fences_parse` reports that (#2526's unknown-is-not-guilty).
+    """
+    suite = _spec_test_functions(spec)
+    functions = suite["functions"]
+    if not functions:
+        return CompletenessCheck(
+            check_name="spec_test_fixtures_resolvable",
+            passed=True,
+            details=(
+                "Section 10 carries no executable test functions — check not "
+                "applicable."
+            ),
+        )
+
+    block = "\n\n".join([suite["imports"]] + [fn["source"] for fn in functions])
+    try:
+        tree = ast.parse(block)
+    except SyntaxError:
+        return CompletenessCheck(
+            check_name="spec_test_fixtures_resolvable",
+            passed=True,
+            details=(
+                "Section 10 test block does not parse — check not applicable; "
+                "python_fences_parse reports the syntax."
+            ),
+        )
+
+    defined = {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and _is_fixture_decorated(node)
+    }
+    declared = _declared_dependencies(_pyproject_for_run(repo_root_str, base_branch))
+    from_declared_plugins: set[str] = set()
+    from_undeclared_plugins: dict[str, str] = {}
+    for distribution, fixtures in _PLUGIN_FIXTURES.items():
+        if distribution in declared:
+            from_declared_plugins |= fixtures
+        else:
+            for fixture in fixtures:
+                from_undeclared_plugins[fixture] = distribution
+
+    spans = _test_function_spans(spec, functions)
+    failures: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not node.name.startswith("test_"):
+            continue
+        supplied = _parametrized_names(node)
+        for arg in node.args.posonlyargs + node.args.args + node.args.kwonlyargs:
+            param = arg.arg
+            if (
+                param in _NON_RECEIVER_PARAMS
+                or param in _PYTEST_BUILTIN_FIXTURES
+                or param in defined
+                or param in from_declared_plugins
+                or param in supplied
+            ):
+                continue
+            start, end = spans.get(node.name, (0, 0))
+            where = f" (lines {start}-{end})" if start else ""
+            if param in from_undeclared_plugins:
+                why = (
+                    f" — provided by {from_undeclared_plugins[param]}, which the "
+                    "repo's pyproject does not declare"
+                )
+            else:
+                why = (
+                    " — not a pytest builtin, not decorated as a fixture in "
+                    "§10, and no declared plugin provides it"
+                )
+            failures.append(f"`{node.name}`{where} takes `{param}`{why}")
+
+    if not failures:
+        return CompletenessCheck(
+            check_name="spec_test_fixtures_resolvable",
+            passed=True,
+            details=(
+                f"Every parameter of the {len(functions)} Section 10 test "
+                "function(s) resolves to a fixture."
+            ),
+        )
+
+    # Every failure is cited, never a truncated list -- the span unlocks the
+    # function, and an uncited one stays locked against its own repair.
+    listed = "; ".join(failures)
+    declared_plugins = sorted(d for d in _PLUGIN_FIXTURES if d in declared)
+    declared_note = (
+        f" (declared: {', '.join(declared_plugins)})" if declared_plugins
+        else " (the repo declares none)"
+    )
+    return CompletenessCheck(
+        check_name="spec_test_fixtures_resolvable",
+        passed=False,
+        details=(
+            f"{len(failures)} test-function parameter(s) name no fixture and "
+            f"would error at setup in the implementation stage: {listed}. A "
+            "parameter must be a pytest builtin fixture (monkeypatch, tmp_path, "
+            "capsys, ...), a function decorated with pytest.fixture inside the "
+            "§10 test block, or a fixture from a plugin the repo's pyproject "
+            f"declares{declared_note}. Drop the parameter, define the fixture "
+            "in §10, or use monkeypatch or unittest.mock instead."
+        ),
     )
 
 

--- a/tests/fixtures/boostgauge4_stub_tests/spec-0004-final-spec.md
+++ b/tests/fixtures/boostgauge4_stub_tests/spec-0004-final-spec.md
@@ -1,0 +1,620 @@
+# Implementation Spec: Issue #4 - Feature: Windows data collector
+
+<!-- Metadata -->
+| Field | Value |
+|-------|-------|
+| Issue | #4 |
+| LLD | `docs/lld/done/004-windows-collector.md` |
+| Generated | 2026-09-02 |
+| Status | APPROVED |
+
+## 1. Overview
+
+**Objective:** Build the Windows-specific data collector that polls system metrics (ConPTY, process count, memory, handles, unleashed sessions) in a single OS sweep per tick and feeds them to the gauge.
+
+**Success Criteria:** The collector must gather all process metrics via a single `NtQuerySystemInformation` call per tick, execute within a non-blocking background thread with <20ms latency, compute a normalized composite score, and gracefully handle ephemeral process errors (`AccessDenied`, `NoSuchProcess`).
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/collector.py` | Add | Abstract base class `DataCollector` and `SystemSnapshot` dataclass |
+| 2 | `src/boostgauge/collectors/__init__.py` | Add | Package init for collectors |
+| 3 | `src/boostgauge/collectors/windows.py` | Add | `WindowsCollector` implementation using `NtQuerySystemInformation` via ctypes |
+| 4 | `tests/unit/test_windows_collector.py` | Add | Unit tests for `WindowsCollector` with stubbed OS calls |
+| 5 | `tests/integration/test_collector_live.py` | Add | Live cross-checks against `psutil` on a real Windows host |
+| 6 | `tests/benchmark/test_collector_benchmark.py` | Add | Benchmark suite enforcing the <20ms mean overhead constraint |
+
+**Implementation Order Rationale:** The core abstractions (`collector.py`) must exist before the Windows-specific implementation (`windows.py`). The tests follow to assert behaviors (unit) and validate performance/accuracy on a live system (integration, benchmark).
+
+## 3. Current State (for Modify/Delete files)
+
+*Note: There are no files with "Modify" or "Delete" change types in this implementation. All files in Section 2 are new additions.*
+
+## 4. Data Structures
+
+### 4.1 SystemSnapshot
+
+**Definition:**
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class SystemSnapshot:
+    timestamp: float
+    conpty_count: int
+    process_count: int
+    memory_percent: float
+    handle_count: int
+    unleashed_sessions: int
+    driver: str
+    composite_value: float
+```
+
+**Concrete Example:**
+
+```json
+{
+    "timestamp": 1693683059.123,
+    "conpty_count": 3,
+    "process_count": 250,
+    "memory_percent": 45.2,
+    "handle_count": 8500,
+    "unleashed_sessions": 1,
+    "driver": "conpty",
+    "composite_value": 36.0
+}
+```
+
+## 5. Function Specifications
+
+### 5.1 `DataCollector.start()`
+
+**File:** `src/boostgauge/collector.py`
+
+**Signature:**
+```python
+def start(self, interval: float, out_queue: queue.Queue, thresholds: dict) -> None:
+    """Start polling loop in background thread. Abstract."""
+    raise NotImplementedError # pragma: no cover
+```
+
+**Input Example:**
+```python
+interval = 2.0
+out_queue = queue.Queue()
+thresholds = {
+    "conpty": {"yellow": 5, "red": 10},
+    "memory_percent": {"yellow": 80, "red": 90},
+    "process_count": {"yellow": 300, "red": 400},
+    "handle_count": {"yellow": 10000, "red": 15000}
+}
+```
+**Output Example:**
+```python
+None
+```
+**Edge Cases:**
+- Abstract method; cannot be called directly.
+
+### 5.2 `DataCollector.stop()`
+
+**File:** `src/boostgauge/collector.py`
+
+**Signature:**
+```python
+def stop(self) -> None:
+    """Signal polling loop to terminate and wait for exit. Abstract."""
+    raise NotImplementedError # pragma: no cover
+```
+
+**Input Example:**
+```python
+# No arguments
+```
+**Output Example:**
+```python
+None
+```
+**Edge Cases:**
+- Abstract method; cannot be called directly.
+
+### 5.3 `WindowsCollector.start()`
+
+**File:** `src/boostgauge/collectors/windows.py`
+
+**Signature:**
+```python
+def start(self, interval: float, out_queue: queue.Queue, thresholds: dict) -> None:
+    """Starts the background thread for Windows collection."""
+    pass
+```
+
+**Input Example:**
+```python
+interval = 2.0
+out_queue = queue.Queue()
+thresholds = {
+    "conpty": {"yellow": 5, "red": 10},
+    "memory_percent": {"yellow": 80, "red": 90},
+    "process_count": {"yellow": 300, "red": 400},
+    "handle_count": {"yellow": 10000, "red": 15000}
+}
+```
+**Output Example:**
+```python
+None
+```
+**Edge Cases:**
+- Called when the thread is already running -> safely ignores or restarts.
+
+### 5.4 `WindowsCollector.stop()`
+
+**File:** `src/boostgauge/collectors/windows.py`
+
+**Signature:**
+```python
+def stop(self) -> None:
+    """Signals stop event and joins the background thread."""
+    pass
+```
+
+**Input Example:**
+```python
+# No arguments
+```
+**Output Example:**
+```python
+None
+```
+**Edge Cases:**
+- Called when thread is not alive -> returns cleanly without error.
+
+### 5.5 `WindowsCollector._run()`
+
+**File:** `src/boostgauge/collectors/windows.py`
+
+**Signature:**
+```python
+def _run(self) -> None:
+    """Background thread loop executing the sweep and queue push."""
+    pass
+```
+
+**Input Example:**
+```python
+# No arguments (uses instance state initialized by start)
+```
+**Output Example:**
+```python
+None  # Side effect: puts SystemSnapshot items onto self._out_queue
+```
+**Edge Cases:**
+- `psutil` raises `AccessDenied` reading `cmdline` -> ignores row and continues.
+- Thread `stop_event` is set -> exits loop gracefully.
+
+### 5.6 `WindowsCollector._normalize()`
+
+**File:** `src/boostgauge/collectors/windows.py`
+
+**Signature:**
+```python
+def _normalize(self, value: float, yellow_thresh: float, red_thresh: float) -> float:
+    """Maps a raw metric value to a 0-100 scale using the threshold bands."""
+    pass
+```
+
+**Input Example:**
+```python
+value = 7.5
+yellow_thresh = 5.0
+red_thresh = 10.0
+```
+**Output Example:**
+```python
+80.0
+```
+**Edge Cases:**
+- `value <= yellow_thresh` -> linearly maps to 0-60.
+- `value >= red_thresh` -> capped at 100.
+- `yellow_thresh == red_thresh` -> returns 100 if `value >= red_thresh`, else linearly maps 0-60 based on yellow.
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/collector.py` (Add)
+
+**Complete file contents:**
+```python
+"""Abstract data collector and structures.
+
+Issue #4: Windows data collector
+"""
+from abc import ABC, abstractmethod
+import queue
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class SystemSnapshot:
+    timestamp: float
+    conpty_count: int
+    process_count: int
+    memory_percent: float
+    handle_count: int
+    unleashed_sessions: int
+    driver: str
+    composite_value: float
+
+class DataCollector(ABC):
+    @abstractmethod
+    def start(self, interval: float, out_queue: queue.Queue, thresholds: dict) -> None:
+        """Start polling loop in background thread. Abstract."""
+        raise NotImplementedError # pragma: no cover
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Signal polling loop to terminate and wait for exit. Abstract."""
+        raise NotImplementedError # pragma: no cover
+```
+
+### 6.2 `src/boostgauge/collectors/__init__.py` (Add)
+
+**Complete file contents:**
+```python
+"""Collectors package."""
+```
+
+### 6.3 `src/boostgauge/collectors/windows.py` (Add)
+
+**Complete file contents:**
+```python
+"""Windows data collector using NtQuerySystemInformation.
+
+Issue #4: Windows data collector
+"""
+import ctypes
+import fnmatch
+import queue
+import threading
+import time
+import psutil
+
+from boostgauge.collector import DataCollector, SystemSnapshot
+
+# C-Struct definitions for NtQuerySystemInformation
+class UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", ctypes.c_ushort),
+        ("MaximumLength", ctypes.c_ushort),
+        ("Buffer", ctypes.c_void_p),
+    ]
+
+class SYSTEM_PROCESS_INFORMATION(ctypes.Structure):
+    pass
+
+SYSTEM_PROCESS_INFORMATION._fields_ = [
+    ("NextEntryOffset", ctypes.c_ulong),
+    ("NumberOfThreads", ctypes.c_ulong),
+    ("Reserved1", ctypes.c_ubyte * 48),
+    ("ImageName", UNICODE_STRING),
+    ("BasePriority", ctypes.c_long),
+    ("UniqueProcessId", ctypes.c_void_p),
+    ("Reserved2", ctypes.c_void_p),
+    ("HandleCount", ctypes.c_ulong),
+]
+
+class WindowsCollector(DataCollector):
+    def __init__(self):
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._interval = 2.0
+        self._out_queue = None
+        self._thresholds = {}
+
+    def start(self, interval: float, out_queue: queue.Queue, thresholds: dict) -> None:
+        """Starts the background thread for Windows collection."""
+        self._interval = interval
+        self._out_queue = out_queue
+        self._thresholds = thresholds
+        self._stop_event.clear()
+        
+        if self._thread is None or not self._thread.is_alive():
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Signals stop event and joins the background thread."""
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join()
+
+    def _normalize(self, value: float, yellow_thresh: float, red_thresh: float) -> float:
+        """Maps a raw metric value to a 0-100 scale using the threshold bands."""
+        if value <= yellow_thresh:
+            if yellow_thresh == 0:
+                return 60.0 if value > 0 else 0.0
+            return (value / yellow_thresh) * 60.0
+        elif value >= red_thresh:
+            return 100.0
+        else:
+            range_val = red_thresh - yellow_thresh
+            if range_val == 0:
+                return 100.0
+            return 60.0 + ((value - yellow_thresh) / range_val) * 40.0
+
+    def _run(self) -> None:
+        """Background thread loop executing the sweep and queue push."""
+        ntdll = ctypes.windll.ntdll
+        while not self._stop_event.wait(timeout=self._interval):
+            process_count = 0
+            conpty_count = 0
+            handle_count = 0
+            unleashed_sessions = 0
+            
+            # Initial buffer sizing for NtQuerySystemInformation (SystemProcessInformation = 5)
+            buffer_size = ctypes.c_ulong(512 * 1024)
+            buffer = ctypes.create_string_buffer(buffer_size.value)
+            
+            status = ntdll.NtQuerySystemInformation(5, buffer, buffer_size, ctypes.byref(buffer_size))
+            
+            if status == 0:
+                offset = 0
+                while True:
+                    process_info = ctypes.cast(ctypes.byref(buffer, offset), ctypes.POINTER(SYSTEM_PROCESS_INFORMATION)).contents
+                    process_count += 1
+                    handle_count += process_info.HandleCount
+                    
+                    if process_info.ImageName.Buffer:
+                        image_name = ctypes.wstring_at(process_info.ImageName.Buffer, process_info.ImageName.Length // 2).lower()
+                        if image_name in ("conhost.exe", "openconsole.exe"):
+                            conpty_count += 1
+                        elif image_name in ("python.exe", "pythonw.exe"):
+                            pid = process_info.UniqueProcessId
+                            try:
+                                proc = psutil.Process(pid)
+                                cmdline = proc.cmdline()
+                                if any(fnmatch.fnmatch(arg, "unleashed-c-*.py") for arg in cmdline):
+                                    unleashed_sessions += 1
+                            except (psutil.AccessDenied, psutil.NoSuchProcess):
+                                pass
+                                
+                    if process_info.NextEntryOffset == 0:
+                        break
+                    offset += process_info.NextEntryOffset
+
+            memory_percent = psutil.virtual_memory().percent
+            
+            # Compute composite
+            metrics = {
+                "conpty": conpty_count,
+                "memory_percent": memory_percent,
+                "process_count": process_count,
+                "handle_count": handle_count
+            }
+            
+            max_score = 0.0
+            driver = "memory_percent"
+            
+            for m_name, m_val in metrics.items():
+                if m_name in self._thresholds:
+                    score = self._normalize(
+                        m_val, 
+                        self._thresholds[m_name].get("yellow", 0), 
+                        self._thresholds[m_name].get("red", 0)
+                    )
+                    if score > max_score:
+                        max_score = score
+                        driver = m_name
+            
+            snapshot = SystemSnapshot(
+                timestamp=time.time(),
+                conpty_count=conpty_count,
+                process_count=process_count,
+                memory_percent=memory_percent,
+                handle_count=handle_count,
+                unleashed_sessions=unleashed_sessions,
+                driver=driver,
+                composite_value=max_score
+            )
+            
+            try:
+                self._out_queue.put_nowait(snapshot)
+            except queue.Full:
+                pass
+```
+
+### 6.4 `tests/unit/test_windows_collector.py` (Add)
+Create test file containing unit tests for `WindowsCollector` covering `start`, `stop`, `_normalize`, and `_run` (using mocked `ctypes.windll.ntdll.NtQuerySystemInformation` to avoid real system calls in unit mode).
+
+### 6.5 `tests/integration/test_collector_live.py` (Add)
+Create test file verifying the live collector matches `psutil` counts directly on the running Windows host.
+
+### 6.6 `tests/benchmark/test_collector_benchmark.py` (Add)
+Create test file asserting the execution time of `_run` falls within the <20ms latency budget.
+
+## 7. Pattern References
+
+### 7.1 Pure Abstract Base Class
+
+**File:** `src/boostgauge/telltale.py` (lines 42-45)
+```python
+class Telltale:
+    """Peak-hold over `window` seconds (or all-time when `window` is None)."""
+    def __init__(self, window: float | None, decay_rate: float | None = None) -> None:
+        pass
+```
+**Relevance:** Emulates the purely isolated, cleanly designed class initialization pattern used in `Telltale` to keep dependencies strict and behaviors encapsulated.
+
+### 7.2 Configuration Dictionary Access
+
+**File:** `src/boostgauge/config.py` (lines 40-41)
+```python
+class ThresholdsConfig(TypedDict):
+    pass
+```
+**Relevance:** Ensures the `thresholds` dictionary passed to `start()` acts like the expected `ThresholdsConfig` type and uses `.get()` extraction to avoid runtime `KeyError` crashes.
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import ctypes` | stdlib | `windows.py` |
+| `import fnmatch` | stdlib | `windows.py` |
+| `import queue` | stdlib | `collector.py`, `windows.py` |
+| `import threading` | stdlib | `windows.py` |
+| `import time` | stdlib | `windows.py` |
+| `import psutil` | PyPI | `windows.py` |
+| `from dataclasses import dataclass` | stdlib | `collector.py` |
+| `from abc import ABC, abstractmethod` | stdlib | `collector.py` |
+
+**New Dependencies:** None (psutil is already in `pyproject.toml`).
+
+## 9. Placeholder
+
+*Reserved for future use to maintain alignment with LLD section numbering.*
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| T010 | `_run()` | Stubbed OS call | Makes exactly 1 call to `NtQuerySystemInformation` per tick |
+| T015 | Source text | `windows.py` text | Text contains no banned `psutil.pids`, `psutil.process_iter`, `Get-Process` |
+| T020 | `_run()` | Windows host | Sweep ConPTY equals psutil `process_iter` ConPTY count ±1 |
+| T030 | `_run()` | Windows host | Process count ±1, Handle within 1% of psutil |
+| T040 | `_run()` | Mocked sweep with Python | Unleashed count exactly matches python rows with `unleashed-c-*.py` |
+| T050 | `start()`, `stop()` | `interval=0.01` | Pushes items to queue, safely joins thread |
+| T060 | `_run()` | Mocked `AccessDenied` | Exception caught, count unaffected |
+| T065 | `_run()` | Mocked `NoSuchProcess` | Exception caught, count unaffected |
+| T070 | `_run()` | Benchmark iterations | Mean process_time < 20 ms |
+| T080 | `_normalize()` | `value=7.5`, `yellow=5`, `red=10` | Composite value maps to `80.0` |
+| T090 | `_run()` | Mocked threshold metrics | Driver maps to max metric name |
+| T100 | `_run()` | Mocked `psutil.virtual_memory()` | Memory percent derived directly |
+| T110 | `DataCollector` | Base class instantiation | Raises `NotImplementedError` |
+
+### 10.1 Per-criterion test functions
+
+```python
+def test_req_6_mocked_single_sweep():
+    # The collector MUST derive system metrics from a single sweep per tick (REQ-6) 
+    # expected: ntdll.NtQuerySystemInformation.call_count == 1 per tick
+    pass
+
+def test_req_6_source_anti_pattern():
+    # Source code MUST NOT reference banned process APIs (REQ-6) 
+    # expected: "psutil.pids" not in source_text
+    import pathlib
+    source = pathlib.Path("src/boostgauge/collectors/windows.py").read_text()
+    assert "psutil.pids" not in source
+    assert "psutil.process_iter" not in source
+    assert "Get-Process" not in source
+
+def test_req_1_conpty_count(live_environment):
+    # Collector MUST return an accurate ConPTY count (REQ-1) 
+    # expected: collector snapshot conpty_count == psutil conpty_count +/- 1
+    pass
+
+def test_req_2_basic_metrics_accuracy(live_environment):
+    # Collector MUST return accurate memory, process, and handle count (REQ-2) 
+    # expected: process count matches psutil +/- 1; handle count within 1%
+    pass
+
+def test_req_3_unleashed_detection(mocker):
+    # Collector MUST accurately detect unleashed sessions (REQ-3) 
+    # expected: unleashed_sessions count exactly matches rows with unleashed-c-*.py
+    pass
+
+def test_req_4_non_blocking_polling():
+    # Polling MUST be non-blocking in a background thread (REQ-4) 
+    # expected: start() doesn't block, thread is alive, items populate queue
+    pass
+
+def test_req_5_permission_error(mocker):
+    # Collector MUST gracefully handle AccessDenied (REQ-5) 
+    # expected: exception caught, iteration continues seamlessly
+    pass
+
+def test_req_5_process_exit_error(mocker):
+    # Collector MUST gracefully handle NoSuchProcess (REQ-5) 
+    # expected: exception caught, iteration continues seamlessly
+    pass
+
+def test_req_7_cpu_overhead_benchmark(benchmark):
+    # Sweep's mean process_time must be < 20 ms over 8 ticks (REQ-7) 
+    # expected: benchmark time < 0.020
+    pass
+
+def test_req_8_composite_value_calculation():
+    # Composite value MUST map 0-100 based on thresholds (REQ-8) 
+    # expected: max_score calculated accurately
+    pass
+
+def test_req_9_driver_metric_reporting():
+    # Driver field MUST correctly report max normalized metric (REQ-9) 
+    # expected: driver == "conpty" (when conpty is the highest)
+    pass
+
+def test_req_10_memory_percent(mocker):
+    # Memory percent MUST derive from single direct psutil virtual_memory call (REQ-10) 
+    # expected: psutil.virtual_memory.call_count == 1
+    pass
+
+def test_data_collector_not_implemented():
+    # Base DataCollector MUST raise NotImplementedError on start and stop
+    import pytest
+    from boostgauge.collector import DataCollector
+    class Dummy(DataCollector):
+        def start(self, interval, out_queue, thresholds):
+            super().start(interval, out_queue, thresholds)
+        def stop(self):
+            super().stop()
+    dummy = Dummy()
+    with pytest.raises(NotImplementedError):
+        dummy.start(1.0, None, {})
+    with pytest.raises(NotImplementedError):
+        dummy.stop()
+```
+
+## 11. Implementation Notes
+
+### 11.1 Error Handling Convention
+The thread loop must gracefully bypass missing or strictly protected processes. We explicitly trap `psutil.AccessDenied` and `psutil.NoSuchProcess` internally to prevent the background thread from crashing. No exceptions from process enumeration should ever propagate to the top-level thread boundary.
+
+### 11.2 String Comparison
+Process names extracted from the C-Structs using `NtQuerySystemInformation` are raw `WCHAR` pointers. `image_name` matching must always be case-insensitive (e.g., matching against `.lower()`).
+
+### 11.3 Constants
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `SYSTEM_PROCESS_INFORMATION_CLASS` | `5` | Required NT syscall argument enum to return process lists |
+| `STATUS_INFO_LENGTH_MISMATCH` | `0xC0000004` | Windows NT status indicating buffer is too small |
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3) - *Not applicable, verified as pure additions.*
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every **non-test** function has input/output examples with realistic values (Section 5)
+- [x] Every LLD pass criterion has a test function (Section 10.1) — these are exempt from the rule above
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #4 |
+| Verdict | APPROVED |
+| Date | 2026-09-02 |
+| Iterations | 3 |
+| Finalized | 2026-09-02T21:47:40Z |
+
+### Review Feedback Summary
+
+The spec correctly resolves prior feedback by removing the retry loop that caused multiple NtQuerySystemInformation references, thereby strictly satisfying REQ-6. All assertions in the test code (`test_req_6_source_anti_pattern` and `test_data_collector_not_implemented`) explicitly trace back to LLD Requirement 6 and the spec's own DataCollector behavior definitions, respectively. There are no unwinnable tests, requirements conflicts, or baseline issues. The implementation is highly concrete and...

--- a/tests/unit/test_check_classification.py
+++ b/tests/unit/test_check_classification.py
@@ -77,10 +77,14 @@ class TestTheSweepIsExhaustive:
         twelfth is `python_fences_parse`, which reports under its own name
         since #2556 and appears in no issue list. The thirteenth is
         `function_spec_sections_have_examples`, built by #2620 as the path
-        back to a hard gate."""
+        back to a hard gate. The fourteenth and fifteenth grade Section 10's
+        test functions with the implementation stage's own validator, one
+        stage earlier (#2706, #2707)."""
         assert "python_fences_parse" in CLASSIFICATIONS
         assert "function_spec_sections_have_examples" in CLASSIFICATIONS
-        assert len(CLASSIFICATIONS) == 13
+        assert "spec_test_functions_have_assertions" in CLASSIFICATIONS
+        assert "spec_test_fixtures_resolvable" in CLASSIFICATIONS
+        assert len(CLASSIFICATIONS) == 15
 
     @pytest.mark.parametrize("name", sorted(CLASSIFICATIONS))
     def test_each_entry_states_what_it_reads_and_why(self, name: str) -> None:

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -165,6 +165,36 @@ class TestAddressableToday:
     is a rewording guard: change the message so it drops its address and this
     fails."""
 
+    def test_spec_test_functions_have_assertions_addresses_each_stub(self):
+        """#2706, swept BEFORE its first live roll. The complaint backticks
+        the function and cites its `lines N-M` span -- both halves of the
+        vocabulary -- so the drafter's rewrite of the stub body lands."""
+        draft = (
+            "# Spec\n\n## 10. Test Mapping\n\n### 10.1 Per-criterion test "
+            "functions\n\n```python\nimport pytest\n\n\n"
+            "def test_req_1_value():\n    # expected: value == 1\n    pass\n```\n"
+        )
+        verdict = _classify(
+            vc.check_spec_test_functions_have_assertions(draft, 1, []), draft
+        )
+        assert "test_req_1_value" in verdict.tokens
+        assert verdict.verdict == ADDRESSED
+
+    def test_spec_test_fixtures_resolvable_addresses_the_function(self):
+        """#2707. The complaint names the function and the parameter, and
+        cites the function's span, so both the signature and the body that
+        uses the phantom fixture are open to the drafter."""
+        draft = (
+            "# Spec\n\n## 10. Test Mapping\n\n### 10.1 Per-criterion test "
+            "functions\n\n```python\n"
+            "def test_req_1_value(mocker):\n    assert mocker is not None\n```\n"
+        )
+        verdict = _classify(
+            vc.check_spec_test_fixtures_resolvable(draft, "", ""), draft
+        )
+        assert {"test_req_1_value", "mocker"} <= set(verdict.tokens)
+        assert verdict.verdict == ADDRESSED
+
     def test_function_spec_sections_addresses_its_subsection(self):
         """#2620's new hard gate, swept BEFORE it ships rather than discovered
         to deadlock on a live roll (#2617's discipline).
@@ -360,6 +390,8 @@ class TestTheSweepIsExhaustive:
             "check_modify_files_have_excerpts",
             "check_change_instructions_specific",
             "check_manifest_traceability",
+            "check_spec_test_functions_have_assertions",
+            "check_spec_test_fixtures_resolvable",
         }
         #: Checks this sweep does NOT drive, each with the reason. They need
         #: a real repo tree, a populated symbol table, or an LLD whose

--- a/tests/unit/test_spec_test_suite_checks.py
+++ b/tests/unit/test_spec_test_suite_checks.py
@@ -1,0 +1,326 @@
+"""Section 10's test functions, graded by the stage that will run them (#2706, #2707).
+
+On boostgauge run-issue4-163140 (2026-09-02) the spec stage approved a spec
+whose thirteen test functions were, eleven times, a comment and ``pass``, and
+seven of which took a parameter no fixture provides. The implementation stage's
+scaffolder emits those functions verbatim (#2316) and its validator refused the
+suite 3.4 s later, byte-identical on regeneration, deterministic -- after 605 s
+of approved spec work.
+
+These two checks ask the same questions in the spec stage, with the testing
+workflow's own extractor and its own rule, and cite each function's line span
+so revision pinning opens exactly the lines the drafter has to rewrite
+(#2686's shape). The fixture is the approved spec, verbatim.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    _declared_dependencies,
+    check_spec_test_fixtures_resolvable,
+    check_spec_test_functions_have_assertions,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_ranges,
+    named_tokens,
+)
+
+FIXTURE = (
+    Path(__file__).parent.parent
+    / "fixtures"
+    / "boostgauge4_stub_tests"
+    / "spec-0004-final-spec.md"
+)
+SPEC = FIXTURE.read_text(encoding="utf-8")
+
+#: The first five functions the implementation stage's validator named on the
+#: run, in the order its log listed them. The count it reported was 11.
+STUBS_THE_RUN_NAMED = (
+    "test_req_6_mocked_single_sweep",
+    "test_req_1_conpty_count",
+    "test_req_2_basic_metrics_accuracy",
+    "test_req_3_unleashed_detection",
+    "test_req_4_non_blocking_polling",
+)
+
+PYPROJECT_WITHOUT_MOCK = (
+    '[project]\nname = "boostgauge"\n'
+    'dependencies = ["psutil (>=7,<8)", "Pillow (>=10)"]\n'
+    "[tool.poetry.group.dev.dependencies]\n"
+    'pytest = "^9"\npytest-cov = "^7"\n'
+)
+PYPROJECT_WITH_MOCK = PYPROJECT_WITHOUT_MOCK + 'pytest-mock = "^3"\n'
+
+
+def _section_10(body: str) -> str:
+    return (
+        "# Implementation Spec\n\n## 1. Overview\n\nx\n\n"
+        "## 10. Test Mapping\n\n### 10.1 Per-criterion test functions\n\n"
+        "```python\n" + body + "```\n"
+    )
+
+
+def _all_test_names(spec: str) -> list[str]:
+    return re.findall(r"^def (test_\w+)\(", spec, re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# #2706: assertions
+# ---------------------------------------------------------------------------
+
+
+class TestAssertionsOnTheRealSpec:
+    def test_the_approved_spec_is_refused_here_as_it_was_there(self) -> None:
+        result = check_spec_test_functions_have_assertions(SPEC, 4, [])
+        assert result["passed"] is False
+        assert "11 of 13" in result["details"]
+        for name in STUBS_THE_RUN_NAMED:
+            assert f"`{name}`" in result["details"]
+
+    def test_every_stub_is_named_and_nothing_else(self) -> None:
+        """All eleven, never a truncated list: the cited span is what pinning
+        unlocks, so a function left off the list would stay locked against
+        the very edit the complaint demands."""
+        details = check_spec_test_functions_have_assertions(SPEC, 4, [])["details"]
+        names = _all_test_names(SPEC)
+        assert len(names) == 13
+        named = [n for n in names if f"`{n}`" in details]
+        assert len(named) == 11
+        assert set(STUBS_THE_RUN_NAMED) <= set(named)
+        assert "more)" not in details
+
+    def test_each_stub_is_cited_by_its_own_line_span(self) -> None:
+        """The span is what pinning unlocks. It must be the function's lines
+        in the draft, checked against the file rather than trusted."""
+        details = check_spec_test_functions_have_assertions(SPEC, 4, [])["details"]
+        lines = SPEC.splitlines()
+        assert "`test_req_6_mocked_single_sweep` (lines 498-501)" in details
+        assert lines[497].startswith("def test_req_6_mocked_single_sweep(")
+        assert lines[500].strip() == "pass"
+        assert "`test_req_1_conpty_count` (lines 512-515)" in details
+        assert lines[511].startswith("def test_req_1_conpty_count(")
+        assert lines[514].strip() == "pass"
+
+
+class TestAssertionsControls:
+    def test_the_same_spec_with_real_assertions_passes(self) -> None:
+        repaired = SPEC.replace("    pass\n", "    assert 1 == 1\n")
+        result = check_spec_test_functions_have_assertions(repaired, 4, [])
+        assert result["passed"] is True, result["details"]
+        assert "13" in result["details"]
+
+    def test_no_executable_functions_is_not_applicable(self) -> None:
+        table_only = (
+            "# Spec\n\n## 10. Test Mapping\n\n| ID | Scenario |\n|---|---|\n"
+            "| 010 | x |\n"
+        )
+        result = check_spec_test_functions_have_assertions(table_only, 4, [])
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_one_stub_among_real_tests_is_the_only_one_named(self) -> None:
+        body = (
+            "import pytest\n\n\n"
+            "def test_a():\n    assert 1 == 1\n\n\n"
+            "def test_b():\n    # expected: 2\n    pass\n\n\n"
+            "def test_c():\n    with pytest.raises(ValueError):\n        int('x')\n"
+        )
+        result = check_spec_test_functions_have_assertions(_section_10(body), 1, [])
+        assert result["passed"] is False
+        assert "1 of 3" in result["details"]
+        assert "`test_b`" in result["details"]
+        assert "`test_a`" not in result["details"]
+        assert "`test_c`" not in result["details"]
+
+    def test_the_message_backticks_only_function_names(self) -> None:
+        """A backticked word becomes a pinning token that unlocks every line
+        carrying it. `pass` or `assert` as tokens would open half the draft."""
+        details = check_spec_test_functions_have_assertions(SPEC, 4, [])["details"]
+        tokens = named_tokens("", [details])
+        assert all(t.startswith("test_") for t in tokens), sorted(tokens)
+
+
+class TestPinningOpensTheCitedFunction:
+    """End to end on the real draft: the complaint's span lets the drafter
+    rewrite the stub body in place, and the lock refuses nothing."""
+
+    REAL_BODY = [
+        "    ntdll = MagicMock()",
+        "    ntdll.NtQuerySystemInformation.return_value = 0",
+        "    with patch('ctypes.windll', create=True) as windll:",
+        "        windll.ntdll = ntdll",
+        "        WindowsCollector().collect()",
+        "    assert ntdll.NtQuerySystemInformation.call_count == 1",
+    ]
+
+    def test_the_rewritten_stub_is_accepted(self) -> None:
+        details = check_spec_test_functions_have_assertions(SPEC, 4, [])["details"]
+        lines = SPEC.splitlines()
+        assert lines[500].strip() == "pass"  # line 501, inside the cited span
+        revised = "\n".join(lines[:500] + self.REAL_BODY + lines[501:]) + "\n"
+
+        result = enforce_pinning(
+            SPEC,
+            revised,
+            current_tokens=named_tokens("", [details]),
+            ever_tokens=named_tokens("", [details]),
+            current_ranges=named_line_ranges([details]),
+        )
+
+        assert result.refusals == (), result.refusals
+        assert "assert ntdll.NtQuerySystemInformation.call_count == 1" in result.text
+
+    def test_a_line_outside_every_span_is_still_locked(self) -> None:
+        """The control: the spans open the stubs and nothing else."""
+        details = check_spec_test_functions_have_assertions(SPEC, 4, [])["details"]
+        lines = SPEC.splitlines()
+        assert lines[0].startswith("# ")
+        revised = "\n".join(["# Retitled by a drafter nobody asked"] + lines[1:]) + "\n"
+
+        result = enforce_pinning(
+            SPEC,
+            revised,
+            current_tokens=named_tokens("", [details]),
+            ever_tokens=named_tokens("", [details]),
+            current_ranges=named_line_ranges([details]),
+        )
+
+        assert result.refusals != ()
+        assert result.text.splitlines()[0] == lines[0]
+
+
+# ---------------------------------------------------------------------------
+# #2707: fixture parameters
+# ---------------------------------------------------------------------------
+
+
+class TestFixturesOnTheRealSpec:
+    def test_six_parameters_name_no_fixture(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_WITHOUT_MOCK, encoding="utf-8")
+        result = check_spec_test_fixtures_resolvable(SPEC, str(tmp_path), "")
+        assert result["passed"] is False
+        assert "7 test-function parameter(s)" in result["details"]
+        assert result["details"].count("takes `mocker`") == 4
+        assert result["details"].count("takes `live_environment`") == 2
+        assert result["details"].count("takes `benchmark`") == 1
+        assert "provided by pytest-mock, which the repo's pyproject does not declare" in (
+            result["details"]
+        )
+        assert "provided by pytest-benchmark" in result["details"]
+        assert "`test_req_3_unleashed_detection` (lines 522-" in result["details"]
+
+    def test_declaring_pytest_mock_resolves_mocker_and_only_mocker(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_WITH_MOCK, encoding="utf-8")
+        result = check_spec_test_fixtures_resolvable(SPEC, str(tmp_path), "")
+        assert result["passed"] is False
+        assert "takes `mocker`" not in result["details"]
+        assert result["details"].count("takes `live_environment`") == 2
+
+    def test_defining_the_fixture_and_using_monkeypatch_passes(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_WITHOUT_MOCK, encoding="utf-8")
+        repaired = SPEC.replace("(mocker):", "(monkeypatch):").replace(
+            "(benchmark):", "():"
+        ).replace(
+            "def test_req_1_conpty_count(live_environment):",
+            "@pytest.fixture\ndef live_environment():\n    return None\n\n\n"
+            "def test_req_1_conpty_count(live_environment):",
+        )
+        result = check_spec_test_fixtures_resolvable(repaired, str(tmp_path), "")
+        assert result["passed"] is True, result["details"]
+
+    def test_the_message_backticks_only_functions_and_parameters(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_WITHOUT_MOCK, encoding="utf-8")
+        details = check_spec_test_fixtures_resolvable(SPEC, str(tmp_path), "")["details"]
+        tokens = named_tokens("", [details])
+        assert tokens <= {
+            "test_req_1_conpty_count", "test_req_2_basic_metrics_accuracy",
+            "test_req_3_unleashed_detection", "test_req_5_permission_error",
+            "test_req_5_process_exit_error", "test_req_7_cpu_overhead_benchmark",
+            "test_req_10_memory_percent",
+            "mocker", "live_environment", "benchmark",
+        }, sorted(tokens)
+
+
+class TestFixtureControls:
+    def test_builtins_parametrize_and_local_fixtures_pass(self, tmp_path: Path) -> None:
+        body = (
+            "import pytest\n\n\n"
+            "@pytest.fixture\ndef collector():\n    return object()\n\n\n"
+            "@pytest.mark.parametrize('value,expected', [(1, 2)])\n"
+            "def test_a(value, expected, monkeypatch, tmp_path, collector):\n"
+            "    assert value < expected\n"
+        )
+        result = check_spec_test_fixtures_resolvable(_section_10(body), str(tmp_path), "")
+        assert result["passed"] is True, result["details"]
+
+    def test_a_fixture_defined_between_tests_is_seen(self, tmp_path: Path) -> None:
+        """The extractor slices from one `def test_` to the next, so a fixture
+        defined between two tests rides inside the first one's source. The
+        check parses the whole block and must still find it."""
+        body = (
+            "import pytest\n\n\n"
+            "def test_a():\n    assert True\n\n\n"
+            "@pytest.fixture\ndef thing():\n    return 1\n\n\n"
+            "def test_b(thing):\n    assert thing == 1\n"
+        )
+        result = check_spec_test_fixtures_resolvable(_section_10(body), str(tmp_path), "")
+        assert result["passed"] is True, result["details"]
+
+    def test_an_unparseable_block_abstains(self, tmp_path: Path) -> None:
+        result = check_spec_test_fixtures_resolvable(
+            _section_10("def test_a(:\n    pass\n"), str(tmp_path), ""
+        )
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_no_functions_is_not_applicable(self, tmp_path: Path) -> None:
+        result = check_spec_test_fixtures_resolvable(
+            "# Spec\n\n## 10. Test Mapping\n\nnone\n", str(tmp_path), ""
+        )
+        assert result["passed"] is True
+        assert "not applicable" in result["details"]
+
+    def test_no_repo_root_means_no_plugins(self) -> None:
+        body = "def test_a(mocker):\n    assert mocker\n"
+        result = check_spec_test_fixtures_resolvable(_section_10(body), "", "")
+        assert result["passed"] is False
+        assert "takes `mocker`" in result["details"]
+
+
+class TestDeclaredDependencies:
+    def test_pep621_lists(self) -> None:
+        text = (
+            '[project]\nname = "x"\n'
+            'dependencies = ["pytest-mock>=3", "Pillow (>=10)"]\n'
+            "[project.optional-dependencies]\ndev = ['pytest_cov']\n"
+        )
+        deps = _declared_dependencies(text)
+        assert {"pytest-mock", "pillow", "pytest-cov"} <= deps
+        assert "dev" not in deps
+
+    def test_poetry_tables(self) -> None:
+        text = (
+            '[tool.poetry.dependencies]\npython = "^3.14"\npsutil = "^7"\n'
+            "[tool.poetry.group.dev.dependencies]\n"
+            'pytest-mock = {version = "^3", optional = true}\n'
+        )
+        deps = _declared_dependencies(text)
+        assert {"psutil", "pytest-mock"} <= deps
+        assert "version" not in deps
+
+    def test_dependency_groups(self) -> None:
+        assert "pytest-mock" in _declared_dependencies(
+            '[dependency-groups]\ntest = ["pytest-mock"]\n'
+        )
+
+    def test_empty_and_unparseable(self) -> None:
+        assert _declared_dependencies("") == set()
+        assert _declared_dependencies("not = [toml") == set()

--- a/tests/unit/test_spec_test_suite_checks.py
+++ b/tests/unit/test_spec_test_suite_checks.py
@@ -321,6 +321,21 @@ class TestDeclaredDependencies:
             '[dependency-groups]\ntest = ["pytest-mock"]\n'
         )
 
-    def test_empty_and_unparseable(self) -> None:
+    def test_empty_declares_nothing_and_unparseable_says_so(self) -> None:
+        """None, not an empty set, so the report can say "could not be parsed"
+        rather than "declares none" -- the fail-open ruling on the site."""
         assert _declared_dependencies("") == set()
-        assert _declared_dependencies("not = [toml") == set()
+        assert _declared_dependencies("not = [toml") is None
+
+    def test_an_unparseable_pyproject_is_named_in_the_report(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("not = [toml", encoding="utf-8")
+        body = "def test_a(mocker):\n    assert mocker\n"
+        result = check_spec_test_fixtures_resolvable(_section_10(body), str(tmp_path), "")
+        assert result["passed"] is False
+        assert "could not be parsed" in result["details"]
+
+    def test_a_missing_pyproject_is_named_in_the_report(self, tmp_path: Path) -> None:
+        body = "def test_a(mocker):\n    assert mocker\n"
+        result = check_spec_test_fixtures_resolvable(_section_10(body), str(tmp_path), "")
+        assert result["passed"] is False
+        assert "no pyproject could be read" in result["details"]


### PR DESCRIPTION
## What happened

boostgauge #421, Phase 2 run 8 (`run-issue4-163140`, 2026-09-02): design passed (351 s), spec passed (605 s, three revisions, reviewer APPROVED), and the implementation stage halted **3.4 seconds** in. The scaffolder emits the spec's Section 10 test functions verbatim (#2316) and its validator refused the suite — eleven of thirteen functions were a comment and `pass` — then regenerated it byte-identical and stopped as deterministic. Seven of the same functions also took a parameter no fixture provides: `mocker` ×4 (no `pytest-mock` declared), `live_environment` ×2 (defined nowhere), `benchmark` ×1 (no `pytest-benchmark` declared). The adversarial reviewer had quoted a `# expected:` comment as "the assertion in `test_req_6_mocked_single_sweep`."

Nothing in the spec stage asked either question. Twelve completeness checks, none looks inside a test function. The #2675 shape: the cheap mechanical rule sat one stage after the paid stage that could have acted on it.

## What this does

Two completeness checks in the spec stage, both fact-verifiers (they block):

- **`spec_test_functions_have_assertions`** (#2706) — extracts Section 10's functions with `load_lld.extract_spec_test_functions`, assembles them exactly as `scaffold_tests.generate_spec_test_file_content` will, and grades them with `validate_tests_mechanical.validate_test_structure`. The testing workflow's own extractor, transcription, and rule — no second parser (#1698), so this check and the scaffolder cannot disagree.
- **`spec_test_fixtures_resolvable`** (#2707) — every parameter of every test function must be a pytest builtin fixture (`_PYTEST_BUILTIN_FIXTURES`, already on disk), a `@pytest.fixture` function in the same block, or a fixture from a plugin the target repo's `pyproject.toml` declares — a closed map, `_PLUGIN_FIXTURES`, read from the run's base branch (#2684, #2668). `@pytest.mark.parametrize` names are honoured. Abstains when the block does not parse; `python_fences_parse` owns that.

Each complaint names the function in backticks and cites its `lines N-M` span — the #2686 mechanism — so revision pinning opens exactly the function the drafter has to rewrite and nothing beside it. **Every failing function is cited, never a truncated list**: the first draft cut the list at eight, and since the span is what unlocks, the three left off would have stayed locked against the very edit the complaint demanded. A test pins that no `(and N more)` appears. The messages backtick nothing but function and parameter names, because a backticked `pass` or `assert` would become a token that unlocks half the draft.

Registered in `check_classification.py` (fact, both) and in the addressability sweep, where each message classifies as ADDRESSED on a failing fixture.

## Proven against the artifact

`tests/fixtures/boostgauge4_stub_tests/spec-0004-final-spec.md` is the approved spec, verbatim. Against it:

- assertions: refused, `11 of 13`, all eleven named with spans checked against the file's own lines (`test_req_6_mocked_single_sweep` at 498–501, `test_req_1_conpty_count` at 512–515); the two functions that assert are not named.
- fixtures: refused, seven parameters — `mocker` ×4 with "provided by pytest-mock, which the repo's pyproject does not declare", `live_environment` ×2, `benchmark` ×1.
- end to end through `enforce_pinning` on the real draft: the stub body rewritten in place is accepted with zero refusals; a line outside every cited span is still refused.
- controls: the same spec with `assert` bodies passes; with `live_environment` defined, `mocker` → `monkeypatch`, and `benchmark` dropped, passes; a pyproject declaring `pytest-mock` resolves `mocker` and only `mocker`; no functions → not applicable; unparseable block → abstains.
- `_declared_dependencies` reads PEP 621 lists, Poetry tables, and PEP 735 groups; group names and spec-table keys are not mistaken for distributions.

26 new tests (24 in `test_spec_test_suite_checks.py`, 2 in the addressability sweep). The sweep, #2686's span tests, and the classification lint pass; the full unit suite is green.

The repo's fail-open audit found four new sites in this code. Each is ruled on where it sits with `# fail-open: <why>`, and the two that could have misled the report no longer can: an unparseable pyproject reads as "could not be parsed" rather than "declares none", and a fallback from the base branch to the checkout is printed and named in the report. Every direction is stricter — fewer declared plugins — never quieter.

## Not proven

A live roll. The fix is proven against the draft that halted; whether the drafter, under these two complaints, produces a suite the scaffolder accepts is the next run's to say.

Closes #2706
Closes #2707
