### PR TITLE
fix: the green loop grades the spec's suite, measures every source file it implemented, and gives a coverage plateau two strikes (Closes #2709, Closes #2710, Closes #2711)

### DIFF
--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -744,7 +744,7 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
             target = repo_root / filepath
             if target.exists():
                 target.unlink()
-                print(f"        Deleted")
+                print("        Deleted")
             continue
 
         # Handle empty placeholder files (e.g. .gitkeep) without calling Claude
@@ -976,8 +976,9 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
 
     print(f"\n    Implementation complete: {len(written_paths)} files written")
 
-    # Issue #460: Update test_files to point to real test files written by N4,
-    # replacing the scaffold stubs that N2 created.
+    # Issue #460 replaced the scaffold with the implementer's test files. Since
+    # #2316 the scaffold is the spec's own suite -- the contract -- and it
+    # stays (#2709). One helper decides, so the rule has one home.
     issue_number = state.get("issue_number", 0)
     real_test_files = [
         p for p in written_paths
@@ -985,13 +986,14 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         and Path(p).name.startswith("test_")
         and p.endswith(".py")
     ]
-
-    if real_test_files:
-        # Delete the scaffold file — it only has `assert False` stubs
-        scaffold_path = repo_root / "tests" / f"test_issue_{issue_number}.py"
-        if scaffold_path.exists():
-            scaffold_path.unlink()
-            print(f"    Deleted scaffold: {scaffold_path}")
+    test_files_after = merge_test_files(
+        scaffold_path=repo_root / "tests" / f"test_issue_{issue_number}.py",
+        scaffold_is_spec_suite=bool(
+            (state.get("spec_test_suite") or {}).get("functions")
+        ),
+        real_test_files=real_test_files,
+        prior_test_files=list(state.get("test_files", []) or []),
+    )
 
     # Log to audit
     log_workflow_execution(
@@ -1017,9 +1019,44 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         "completed_files": completed_files,
         "estimated_tokens_used": estimated_tokens_used,
         "error_message": "",
-        "test_files": real_test_files if real_test_files else state.get("test_files", []),
+        "test_files": test_files_after,
         "node_costs": node_costs,  # Issue #511
     }
+
+
+def merge_test_files(
+    scaffold_path: Path,
+    scaffold_is_spec_suite: bool,
+    real_test_files: list[str],
+    prior_test_files: list[str],
+) -> list[str]:
+    """What the green phase runs after N4 (#2709).
+
+    #460 deleted the scaffold and ran the implementer's test files instead,
+    because the scaffold was ``assert False`` stubs no implementation could
+    satisfy. #2316 changed what the scaffold is: the spec's own executable
+    functions, emitted verbatim, verified by #2706/#2707 before the spec was
+    approved. Measured on boostgauge run-issue4-172600: nine validated spec
+    tests were unlinked one node after validation and the green phase graded
+    three tests the implementer wrote for its own code -- the #2677 shape.
+
+    So: when the scaffold carries the spec's suite it stays and runs FIRST;
+    the implementer's files are additions after it. A stub scaffold (no spec
+    functions) is still replaced, exactly as #460 intended. With no
+    implementer test files at all, the prior list stands.
+    """
+    if not real_test_files:
+        return list(prior_test_files)
+
+    scaffold = str(scaffold_path)
+    if scaffold_is_spec_suite and scaffold_path.exists():
+        print(f"    Kept the spec's suite as the contract: {scaffold_path} (#2709)")
+        return [scaffold] + [p for p in real_test_files if Path(p) != scaffold_path]
+
+    if scaffold_path.exists():
+        scaffold_path.unlink()
+        print(f"    Deleted scaffold: {scaffold_path}")
+    return list(real_test_files)
 
 
 def _mock_implement_code(state: TestingWorkflowState) -> dict[str, Any]:

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -564,7 +564,7 @@ def _summarize_collection_failure(output: str) -> str:
 
 def run_pytest(
     test_files: list[str],
-    coverage_module: str | None = None,
+    coverage_module: str | list[str] | None = None,
     coverage_target: int | None = None,
     repo_root: Path | None = None,
 ) -> dict:
@@ -572,7 +572,9 @@ def run_pytest(
 
     Args:
         test_files: List of test file paths.
-        coverage_module: Module to measure coverage for.
+        coverage_module: Module(s) to measure coverage for -- one ``--cov``
+            per entry, and pytest-cov reports their union (#2710). A string
+            is a one-entry list.
         coverage_target: Coverage threshold percentage.
         repo_root: Repository root for running pytest.
 
@@ -587,9 +589,14 @@ def run_pytest(
     # Without it, pytest returns exit code 4 ("unrecognized arguments")
     # which the workflow misclassifies as "collection/syntax error" and loops.
     if coverage_module:
+        targets = (
+            [coverage_module] if isinstance(coverage_module, str)
+            else [t for t in coverage_module if t]
+        )
         try:
             import pytest_cov  # noqa: F401
-            cmd.extend([f"--cov={coverage_module}", "--cov-report=term-missing"])
+            cmd.extend(f"--cov={target}" for target in targets)
+            cmd.append("--cov-report=term-missing")
             if coverage_target:
                 cmd.append(f"--cov-fail-under={coverage_target}")
         except ImportError:
@@ -1649,6 +1656,61 @@ def coverage_has_stagnated(
     return True
 
 
+#: A coverage plateau halts on this many CONSECUTIVE non-improving iterations
+#: (#2711). It was one, while the test-count guard beside it gave a nonzero
+#: plateau two (#2062). boostgauge run-issue4-172600 halted on its first
+#: comparison -- 72.0% -> 70.0% after a revision broke one test -- with four
+#: iterations unspent and a best-iteration snapshot in hand, which is exactly
+#: the state the next iteration exists to repair.
+COVERAGE_PLATEAU_STRIKES = 2
+
+
+def coverage_plateau_verdict(
+    state: dict,
+    coverage_achieved: float,
+    previous_coverage: float,
+    passed_count: int,
+    previous_passed: int,
+    current_green_failures: list[str],
+    previous_green_failures: list[str],
+) -> tuple[int, bool]:
+    """(strikes after this iteration, halt now?) -- #2711.
+
+    `coverage_has_stagnated` stays the ONE decision about whether an iteration
+    moved anything (#2029, #2030). This wraps it with the plateau count the
+    test-count guard already keeps: a stagnant iteration is a strike, an
+    improving one clears the count, and the loop halts only once the plateau
+    has persisted for COVERAGE_PLATEAU_STRIKES consecutive iterations. Both
+    branches of verify_green_phase call this and nothing else, so there is
+    still nowhere for the two to disagree.
+    """
+    strikes = int(state.get("coverage_plateau_strikes", 0) or 0)
+    if not coverage_has_stagnated(
+        coverage_achieved, previous_coverage, passed_count, previous_passed,
+        current_green_failures, previous_green_failures,
+    ):
+        return 0, False
+    strikes += 1
+    if strikes < COVERAGE_PLATEAU_STRIKES:
+        print(
+            f"    [PLATEAU] Coverage {previous_coverage:.1f}% -> "
+            f"{coverage_achieved:.1f}%: strike {strikes} of "
+            f"{COVERAGE_PLATEAU_STRIKES}; one more revision to move it"
+        )
+    return strikes, strikes >= COVERAGE_PLATEAU_STRIKES
+
+
+def _coverage_stagnant_message(
+    previous_coverage: float, coverage_achieved: float, strikes: int
+) -> str:
+    # 'stagnant' is what the halt classifier matches (#1939); keep the word.
+    return (
+        f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
+        f"(< 1% improvement across {strikes + 1} iterations). "
+        "Halting to prevent token waste."
+    )
+
+
 def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     """N5: Verify all tests pass with coverage target.
 
@@ -1684,29 +1746,34 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
 
     print(f"    Running pytest with coverage target: {coverage_target}%")
 
-    # Determine coverage module from implementation files
-    # Filter out test files - we want to measure coverage of implementation, not tests
+    # Determine coverage scope from implementation files: EVERY non-test
+    # source file the run implements, never just the first (#2710).
+    # run-issue4-172600 added collector.py and collectors/windows.py and was
+    # graded on the abstract base alone; the sweep it existed to build was
+    # never in the report.
     impl_files = state.get("implementation_files", [])
-    coverage_module = None
+    coverage_targets: list[str] = []
+    coverage_module: str | list[str] | None = None
 
-    if impl_files:
-        # Find first non-test, non-init, Python implementation file for coverage
-        for impl_path in impl_files:
-            # Skip test files (in tests/ directory)
-            path_parts = Path(impl_path).parts
-            if any(part.lower() in ("tests", "test") for part in path_parts):
-                continue
-            # Issue #265: Skip __init__.py - pytest-cov doesn't work with it
-            if impl_path.endswith("__init__.py"):
-                continue
-            # Skip non-Python files (.gitkeep, .json, .yml, etc.)
-            if not impl_path.endswith(".py"):
-                print(f"    [N5] Skipping non-Python file for coverage: {impl_path}")
-                continue
-            rel_path = Path(impl_path).relative_to(repo_root) if repo_root else Path(impl_path)
-            # Issue #474: Use helper that handles both packages and standalone scripts
-            coverage_module = _path_to_cov_target(rel_path, repo_root)
-            break
+    for impl_path in impl_files:
+        # Skip test files (in tests/ directory)
+        path_parts = Path(impl_path).parts
+        if any(part.lower() in ("tests", "test") for part in path_parts):
+            continue
+        # Issue #265: Skip __init__.py - pytest-cov doesn't work with it
+        if impl_path.endswith("__init__.py"):
+            continue
+        # Skip non-Python files (.gitkeep, .json, .yml, etc.)
+        if not impl_path.endswith(".py"):
+            print(f"    [N5] Skipping non-Python file for coverage: {impl_path}")
+            continue
+        rel_path = Path(impl_path).relative_to(repo_root) if repo_root else Path(impl_path)
+        # Issue #474: Use helper that handles both packages and standalone scripts
+        target = _path_to_cov_target(rel_path, repo_root)
+        if target and target not in coverage_targets:
+            coverage_targets.append(target)
+    if coverage_targets:
+        coverage_module = coverage_targets
 
     # Issue #462: When all impl files are test files (test-only issues),
     # fall back to files_to_modify from LLD to find the source module
@@ -1776,11 +1843,15 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             coverage_module = "assemblyzero"
             print(f"    [N5] Fallback: no file paths available, defaulting to: {coverage_module}")
 
-    print(f"    Coverage module: {coverage_module}")
+    coverage_targets = (
+        [coverage_module] if isinstance(coverage_module, str)
+        else list(coverage_module or [])
+    )
+    print(f"    Coverage module: {', '.join(coverage_targets) if coverage_targets else None}")
 
     result = run_pytest(
         test_files,
-        coverage_module=coverage_module,
+        coverage_module=coverage_targets or None,
         coverage_target=coverage_target,
         repo_root=repo_root,
     )
@@ -1889,14 +1960,21 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
     #   nothing would fail runs over an unfamiliar layout.
     from assemblyzero.workflows.testing.coverage_report import read_coverage
 
-    _reading = read_coverage(output, coverage_module or "")
+    # #2710: every target is measured or named absent. The first absent one
+    # carries the failure message, so a two-file feature whose second module
+    # never reached the report is refused for that module by name.
+    _readings = [read_coverage(output, target) for target in coverage_targets] or [
+        read_coverage(output, "")
+    ]
+    _absent = [reading for reading in _readings if not reading.measured]
+    _reading = _absent[0] if _absent else _readings[0]
     _below_target = coverage_achieved < state.get("coverage_target", 90)
     if (
         failed_count == 0
         and error_count == 0
         and passed_count > 0
         and _below_target
-        and not _reading.measured
+        and _absent
     ):
         _msg = _reading.failure_message()
         print(f"    [N5] {_msg}")
@@ -2168,31 +2246,35 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "freeze_tests": True,
             }
 
-        # Stagnation check: one shared decision, see coverage_has_stagnated.
+        # Stagnation check: one shared decision, see coverage_has_stagnated,
+        # counted as strikes by coverage_plateau_verdict (#2711).
         # Skip when passed_count == 0: coverage is vacuously 100% with no passing
         # tests, so the metric is meaningless. The test-count check above handles that case.
-        if passed_count > 0 and coverage_has_stagnated(
-            coverage_achieved, previous_coverage, passed_count, previous_passed,
-            current_green_failures, previous_green_failures,
-        ):
-            stagnant_msg = (
-                f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
-                f"(< 1% improvement). Halting to prevent token waste."
+        coverage_strikes = int(state.get("coverage_plateau_strikes", 0) or 0)
+        if passed_count > 0:
+            coverage_strikes, coverage_halt = coverage_plateau_verdict(
+                state, coverage_achieved, previous_coverage, passed_count,
+                previous_passed, current_green_failures, previous_green_failures,
             )
-            print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed_count,
-                "previous_green_failures": current_green_failures,
-                "test_failure_summary": failure_summary,
-                "file_counter": file_num,
-                "pytest_exit_code": exit_code,
-                "iteration_count": iteration_count + 1,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
+            if coverage_halt:
+                stagnant_msg = _coverage_stagnant_message(
+                    previous_coverage, coverage_achieved, coverage_strikes
+                )
+                print(f"    [STAGNANT] {stagnant_msg}")
+                return {
+                    "green_phase_output": output,
+                    "coverage_achieved": coverage_achieved,
+                    "previous_coverage": coverage_achieved,
+                    "previous_passed": passed_count,
+                    "previous_green_failures": current_green_failures,
+                    "test_failure_summary": failure_summary,
+                    "file_counter": file_num,
+                    "pytest_exit_code": exit_code,
+                    "iteration_count": iteration_count + 1,
+                    "coverage_plateau_strikes": coverage_strikes,
+                    "next_node": "end",
+                    "error_message": stagnant_msg,
+                }
 
         # Circuit breaker check before looping
         should_trip, trip_reason = check_circuit_breaker(state)
@@ -2245,6 +2327,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             "error_message": "",
             "count_plateau_strikes": plateau_strikes,
             "identity_plateau_strikes": identity_strikes,
+            "coverage_plateau_strikes": coverage_strikes,
             "freeze_tests": identity_stagnant,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,
@@ -2270,16 +2353,17 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": f"Green phase failed after {max_iterations} iterations: coverage {coverage_achieved:.1f}% < target {coverage_target}%",
             }
 
-        # Stagnation check: one shared decision, see coverage_has_stagnated.
+        # Stagnation check: one shared decision, see coverage_has_stagnated,
+        # counted as strikes by coverage_plateau_verdict (#2711).
         previous_passed = state.get("previous_passed", -1)
         previous_green_failures = state.get("previous_green_failures", [])
-        if coverage_has_stagnated(
-            coverage_achieved, previous_coverage, passed_count, previous_passed,
-            current_green_failures, previous_green_failures,
-        ):
-            stagnant_msg = (
-                f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
-                f"(< 1% improvement). Halting to prevent token waste."
+        coverage_strikes, coverage_halt = coverage_plateau_verdict(
+            state, coverage_achieved, previous_coverage, passed_count,
+            previous_passed, current_green_failures, previous_green_failures,
+        )
+        if coverage_halt:
+            stagnant_msg = _coverage_stagnant_message(
+                previous_coverage, coverage_achieved, coverage_strikes
             )
             print(f"    [STAGNANT] {stagnant_msg}")
             return {
@@ -2292,6 +2376,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "file_counter": file_num,
                 "pytest_exit_code": exit_code,
                 "iteration_count": iteration_count + 1,
+                "coverage_plateau_strikes": coverage_strikes,
                 "next_node": "end",
                 "error_message": stagnant_msg,
             }
@@ -2361,6 +2446,7 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             # All tests pass here; a count plateau is a failing-branch concept.
             "count_plateau_strikes": 0,
             "identity_plateau_strikes": 0,
+            "coverage_plateau_strikes": coverage_strikes,
             "freeze_tests": False,
         }
         _hill_climb(state, repo_root, passed_count, coverage_achieved,

--- a/tests/unit/test_cov_target_resolution.py
+++ b/tests/unit/test_cov_target_resolution.py
@@ -10,8 +10,6 @@ that the fallback in verify_green_phase infers the right scope.
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from assemblyzero.workflows.testing.nodes.verify_phases import _path_to_cov_target
 
 
@@ -271,7 +269,9 @@ def test_fallback_infers_tools_from_impl_files(mock_root, mock_pytest, tmp_path:
         # Positional arg
         cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
     assert cov_module is not None
-    assert cov_module.startswith("tools"), f"Expected 'tools' scope, got: {cov_module}"
+    # #2710: the scope is a list of targets; this feature has one.
+    assert isinstance(cov_module, list) and len(cov_module) == 1, cov_module
+    assert cov_module[0].startswith("tools"), f"Expected 'tools' scope, got: {cov_module}"
 
 
 @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
@@ -335,4 +335,5 @@ def test_package_impl_file_uses_dotted_module(mock_root, mock_pytest, tmp_path: 
     cov_module = call_args.kwargs.get("coverage_module") or call_args[1].get("coverage_module")
     if cov_module is None:
         cov_module = call_args[0][1] if len(call_args[0]) > 1 else None
-    assert cov_module == "assemblyzero.utils.file_type"
+    # #2710: the scope is a list of targets; this feature has one.
+    assert cov_module == ["assemblyzero.utils.file_type"]

--- a/tests/unit/test_green_loop_contract.py
+++ b/tests/unit/test_green_loop_contract.py
@@ -1,0 +1,370 @@
+"""The green loop grades the contract, measures the feature, and gives a
+plateau two strikes (#2709, #2710, #2711).
+
+boostgauge run-issue4-172600 (2026-09-02) was the first Phase 2 run to reach
+the implementation stage with a scaffold its validator accepted. It ended on
+three defects in the green loop, none of them in the generated code:
+
+* the implementer deleted the scaffolded spec suite -- #460's rule, written
+  for ``assert False`` stubs that #2316 later replaced with the spec's own
+  tests -- and the green phase graded three tests the implementer wrote;
+* coverage was measured on the first source file only, the abstract base,
+  while ``collectors/windows.py`` went unmeasured;
+* one non-improving iteration halted a five-iteration loop that had just
+  snapshotted its best state.
+
+Nothing here reaches a model: the bookkeeping is a pure helper, the pytest
+runner is captured at ``run_command``, and the green phase is driven with
+``run_pytest`` patched, the way ``test_verify_green_stagnation_both_branches``
+already does.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from assemblyzero.workflows.testing.nodes import verify_phases
+from assemblyzero.workflows.testing.nodes.implementation import (
+    orchestrator as impl_orchestrator,
+)
+from assemblyzero.workflows.testing.nodes.implementation.orchestrator import (
+    merge_test_files,
+)
+from assemblyzero.workflows.testing.nodes.verify_phases import (
+    COVERAGE_PLATEAU_STRIKES,
+    coverage_plateau_verdict,
+    run_pytest,
+    verify_green_phase,
+)
+
+#: The five files run 9's LLD listed, in the order the implementer wrote them.
+RUN9_FILES = (
+    "src/boostgauge/collector.py",
+    "src/boostgauge/collectors/windows.py",
+    "tests/unit/test_collector.py",
+    "tests/integration/test_windows_collector.py",
+    "tests/benchmark/test_windows_collector.py",
+)
+
+
+def _state(tmp_path: Path, **overrides):
+    base = {
+        "test_files": [str(tmp_path / "tests" / "test_example.py")],
+        "repo_root": str(tmp_path),
+        "audit_dir": str(tmp_path / "audit"),
+        "file_counter": 0,
+        "issue_number": 4,
+        "iteration_count": 1,
+        "max_iterations": 5,
+        "coverage_target": 95,
+        "implementation_files": [],
+        "skip_e2e": True,
+        "previous_coverage": -1.0,
+        "previous_passed": -1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _pytest(returncode, passed=0, failed=0, errors=0, coverage=0, report=""):
+    return {
+        "returncode": returncode,
+        "stdout": f"{passed} passed, {failed} failed\n{report}",
+        "stderr": "",
+        "parsed": {
+            "passed": passed, "failed": failed,
+            "errors": errors, "coverage": coverage,
+        },
+    }
+
+
+#: A real term-missing table for the all-pass branch, which enforces the
+#: coverage-measurement law (#2636): the target must appear in the report.
+REPORT_72 = """
+Name                 Stmts   Miss  Cover   Missing
+--------------------------------------------------
+src/pkg/thing.py        50     14    72%   10-23
+--------------------------------------------------
+TOTAL                   50     14    72%
+"""
+
+
+def _one_module(tmp_path: Path) -> str:
+    """A src-layout package with one module; returns the module's path."""
+    (tmp_path / "src" / "pkg").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "pkg" / "__init__.py").touch()
+    thing = tmp_path / "src" / "pkg" / "thing.py"
+    thing.touch()
+    return str(thing)
+
+
+# ---------------------------------------------------------------------------
+# #2709: the scaffold is the contract
+# ---------------------------------------------------------------------------
+
+
+class TestTheScaffoldIsTheContract:
+    def _scaffold(self, tmp_path: Path, body: str) -> Path:
+        scaffold = tmp_path / "tests" / "test_issue_4.py"
+        scaffold.parent.mkdir(parents=True, exist_ok=True)
+        scaffold.write_text(body, encoding="utf-8")
+        return scaffold
+
+    def test_a_spec_suite_scaffold_survives_and_runs_first(self, tmp_path: Path) -> None:
+        scaffold = self._scaffold(tmp_path, "def test_req_1():\n    assert 1 == 1\n")
+        real = [str(tmp_path / "tests" / "unit" / "test_collector.py")]
+
+        result = merge_test_files(
+            scaffold_path=scaffold, scaffold_is_spec_suite=True,
+            real_test_files=real, prior_test_files=[str(scaffold)],
+        )
+
+        assert scaffold.exists()
+        assert result == [str(scaffold)] + real
+
+    def test_a_stub_scaffold_is_still_replaced_as_460_intended(self, tmp_path: Path) -> None:
+        scaffold = self._scaffold(tmp_path, "def test_req_1():\n    assert False, 'TDD RED'\n")
+        real = [str(tmp_path / "tests" / "unit" / "test_collector.py")]
+
+        result = merge_test_files(
+            scaffold_path=scaffold, scaffold_is_spec_suite=False,
+            real_test_files=real, prior_test_files=[str(scaffold)],
+        )
+
+        assert not scaffold.exists()
+        assert result == real
+
+    def test_no_implementer_tests_leaves_the_list_alone(self, tmp_path: Path) -> None:
+        scaffold = self._scaffold(tmp_path, "def test_req_1():\n    assert 1 == 1\n")
+
+        result = merge_test_files(
+            scaffold_path=scaffold, scaffold_is_spec_suite=True,
+            real_test_files=[], prior_test_files=["a.py", "b.py"],
+        )
+
+        assert result == ["a.py", "b.py"]
+        assert scaffold.exists()
+
+    def test_the_scaffold_is_listed_once_even_if_the_implementer_touched_it(
+        self, tmp_path: Path
+    ) -> None:
+        scaffold = self._scaffold(tmp_path, "def test_req_1():\n    assert 1 == 1\n")
+        other = str(tmp_path / "tests" / "unit" / "test_collector.py")
+
+        result = merge_test_files(
+            scaffold_path=scaffold, scaffold_is_spec_suite=True,
+            real_test_files=[other, str(scaffold)], prior_test_files=[str(scaffold)],
+        )
+
+        assert result == [str(scaffold), other]
+
+    def test_implement_code_routes_through_the_helper(self) -> None:
+        """The unlink lives in the helper's legacy branch and nowhere else."""
+        source = inspect.getsource(impl_orchestrator.implement_code)
+        assert "merge_test_files(" in source
+        assert "scaffold_path.unlink()" not in source
+        assert '"test_files": test_files_after' in source
+
+
+# ---------------------------------------------------------------------------
+# #2710: coverage scope is the whole feature
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageScopeIsTheWholeFeature:
+    def _capture(self, coverage_module, coverage_target=95):
+        with patch.object(verify_phases, "run_command") as run_command:
+            run_command.return_value = SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            )
+            run_pytest(
+                ["tests/test_x.py"],
+                coverage_module=coverage_module,
+                coverage_target=coverage_target,
+            )
+        return run_command.call_args.args[0]
+
+    def test_one_cov_flag_per_target_in_order(self) -> None:
+        cmd = self._capture(["boostgauge.collector", "boostgauge.collectors.windows"])
+        assert cmd.count("--cov=boostgauge.collector") == 1
+        assert cmd.count("--cov=boostgauge.collectors.windows") == 1
+        assert cmd.index("--cov=boostgauge.collector") < cmd.index(
+            "--cov=boostgauge.collectors.windows"
+        )
+        assert cmd.count("--cov-report=term-missing") == 1
+        assert "--cov-fail-under=95" in cmd
+
+    def test_a_single_string_is_a_one_entry_list(self) -> None:
+        cmd = self._capture("boostgauge.collector")
+        assert [c for c in cmd if c.startswith("--cov=")] == ["--cov=boostgauge.collector"]
+
+    def test_no_targets_means_no_cov_flags(self) -> None:
+        cmd = self._capture(None)
+        assert not [c for c in cmd if c.startswith("--cov")]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_run_9s_files_yield_both_modules_and_no_test(self, mock_pytest, tmp_path: Path) -> None:
+        """A src-layout package with a subpackage, exactly boostgauge's shape."""
+        (tmp_path / "src" / "boostgauge" / "collectors").mkdir(parents=True)
+        (tmp_path / "src" / "boostgauge" / "__init__.py").touch()
+        (tmp_path / "src" / "boostgauge" / "collectors" / "__init__.py").touch()
+        for rel in RUN9_FILES:
+            path = tmp_path / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        mock_pytest.return_value = _pytest(0, passed=9, coverage=96)
+
+        verify_green_phase(_state(
+            tmp_path, implementation_files=[str(tmp_path / rel) for rel in RUN9_FILES]
+        ))
+
+        # The first call is the measured run; a passing run calls again for
+        # the regression check, without coverage.
+        first = mock_pytest.call_args_list[0]
+        assert first.kwargs["coverage_module"] == [
+            "boostgauge.collector", "boostgauge.collectors.windows",
+        ]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_a_single_file_feature_is_unchanged(self, mock_pytest, tmp_path: Path) -> None:
+        thing = _one_module(tmp_path)
+        mock_pytest.return_value = _pytest(0, passed=1, coverage=100)
+
+        verify_green_phase(_state(tmp_path, implementation_files=[thing]))
+
+        assert mock_pytest.call_args_list[0].kwargs["coverage_module"] == ["pkg.thing"]
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_a_target_missing_from_the_report_is_named(self, mock_pytest, tmp_path: Path) -> None:
+        """#2636's law, per target: the second module never reached the
+        report, so the run is refused for THAT module by name."""
+        (tmp_path / "src" / "pkg").mkdir(parents=True)
+        (tmp_path / "src" / "pkg" / "__init__.py").touch()
+        (tmp_path / "src" / "pkg" / "thing.py").touch()
+        (tmp_path / "src" / "pkg" / "other.py").touch()
+        mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
+
+        result = verify_green_phase(_state(
+            tmp_path,
+            implementation_files=[
+                str(tmp_path / "src" / "pkg" / "thing.py"),
+                str(tmp_path / "src" / "pkg" / "other.py"),
+            ],
+            previous_passed=3, previous_coverage=72.0,
+        ))
+
+        assert result["next_node"] == "end"
+        assert "pkg.other" in result["error_message"]
+        assert "pkg.thing" not in result["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# #2711: a plateau gets two strikes
+# ---------------------------------------------------------------------------
+
+
+class TestAPlateauGetsTwoStrikes:
+    def test_run_9s_sequence_earns_a_second_iteration(self) -> None:
+        """72.0% / 3 passing, then 70.0% / 2 passing and 1 failing: one strike,
+        no halt. The same plateau again: two strikes, halt."""
+        strikes, halt = coverage_plateau_verdict({}, 70.0, 72.0, 2, 3, ["test_req_2"], [])
+        assert (strikes, halt) == (1, False)
+
+        strikes, halt = coverage_plateau_verdict(
+            {"coverage_plateau_strikes": 1}, 70.0, 70.0, 2, 2, [], []
+        )
+        assert (strikes, halt) == (2, True)
+
+    def test_an_improving_iteration_clears_the_count(self) -> None:
+        """#2029's live case, with a strike already on the board."""
+        assert coverage_plateau_verdict(
+            {"coverage_plateau_strikes": 1}, 98.0, 97.0, 22, 20,
+            ["t_a"], ["t_a", "t_b", "t_c"],
+        ) == (0, False)
+
+    def test_a_first_iteration_is_never_a_strike(self) -> None:
+        assert coverage_plateau_verdict({}, 40.0, -1.0, 3, -1, [], []) == (0, False)
+
+    def test_the_bar_is_two(self) -> None:
+        assert COVERAGE_PLATEAU_STRIKES == 2
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_failing_branch_routes_back_on_the_first_strike(
+        self, mock_pytest, tmp_path: Path
+    ) -> None:
+        """Run 9's halt, replayed: it now goes back to the implementer."""
+        mock_pytest.return_value = _pytest(1, passed=2, failed=1, coverage=70)
+
+        result = verify_green_phase(_state(
+            tmp_path, previous_passed=3, previous_coverage=72.0,
+            previous_green_failures=[],
+        ))
+
+        assert result["next_node"] == "N4_implement_code", result.get("error_message")
+        assert result["coverage_plateau_strikes"] == 1
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_failing_branch_halts_on_the_second_strike(
+        self, mock_pytest, tmp_path: Path
+    ) -> None:
+        mock_pytest.return_value = _pytest(1, passed=2, failed=1, coverage=70)
+
+        result = verify_green_phase(_state(
+            tmp_path, previous_passed=2, previous_coverage=70.0,
+            previous_green_failures=[], coverage_plateau_strikes=1,
+        ))
+
+        assert result["next_node"] == "end"
+        assert "Coverage stagnant" in result["error_message"]
+        assert "across 3 iterations" in result["error_message"]
+        assert result["coverage_plateau_strikes"] == 2
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_all_pass_branch_routes_to_test_additions_on_the_first_strike(
+        self, mock_pytest, tmp_path: Path
+    ) -> None:
+        thing = _one_module(tmp_path)
+        mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
+
+        result = verify_green_phase(_state(
+            tmp_path, implementation_files=[thing],
+            previous_passed=3, previous_coverage=72.0,
+        ))
+
+        assert result["next_node"] == "N4c_augment_tests", result.get("error_message")
+        assert result["coverage_plateau_strikes"] == 1
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_all_pass_branch_halts_on_the_second_strike(
+        self, mock_pytest, tmp_path: Path
+    ) -> None:
+        thing = _one_module(tmp_path)
+        mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
+
+        result = verify_green_phase(_state(
+            tmp_path, implementation_files=[thing],
+            previous_passed=3, previous_coverage=72.0,
+            coverage_plateau_strikes=1,
+        ))
+
+        assert result["next_node"] == "end"
+        assert "Coverage stagnant" in result["error_message"]
+        assert result["coverage_plateau_strikes"] == 2
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_the_halt_message_still_says_stagnant_for_the_classifier(
+        self, mock_pytest, tmp_path: Path
+    ) -> None:
+        """#1939: the halt classifier matches the word; a reword that drops it
+        would file the halt under the wrong class."""
+        thing = _one_module(tmp_path)
+        mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
+        result = verify_green_phase(_state(
+            tmp_path, implementation_files=[thing],
+            previous_passed=3, previous_coverage=72.0,
+            coverage_plateau_strikes=1,
+        ))
+        assert "stagnant" in result["error_message"].lower()

--- a/tests/unit/test_verify_green_stagnation.py
+++ b/tests/unit/test_verify_green_stagnation.py
@@ -98,11 +98,15 @@ class TestGreenPhaseTestCountStagnation:
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_nonzero_stagnation(self, mock_pytest):
-        """previous_passed=10, current passed=10 -> STAGNANT (non-zero case)."""
+        """previous_passed=10, current passed=10 -> STAGNANT (non-zero case).
+
+        #2711: a coverage plateau halts on its SECOND consecutive strike, so
+        the state carries the first one."""
         mock_pytest.return_value = _make_pytest_result(
             1, passed=10, failed=14, errors=0, coverage=50,
         )
-        state = _make_state(previous_passed=10, previous_coverage=50.0)
+        state = _make_state(previous_passed=10, previous_coverage=50.0,
+                            coverage_plateau_strikes=1)
         result = verify_green_phase(state)
 
         assert result["next_node"] == "end"

--- a/tests/unit/test_verify_green_stagnation_both_branches.py
+++ b/tests/unit/test_verify_green_stagnation_both_branches.py
@@ -131,10 +131,17 @@ class TestBothBranchesAgree:
         from assemblyzero.workflows.testing.nodes import verify_phases
 
         source = inspect.getsource(verify_phases.verify_green_phase)
-        assert source.count("coverage_has_stagnated(") == 2, (
+        # #2711: the strike count wraps the decision, and BOTH branches go
+        # through the wrapper; the wrapper is the only caller of the decision.
+        assert source.count("coverage_plateau_verdict(") == 2, (
             "both branches must route their coverage-stagnation decision "
-            "through the shared helper"
+            "through the shared strike-counting helper"
         )
+        assert source.count("coverage_has_stagnated(") == 0, (
+            "a branch is calling the bare decision, bypassing the strike count"
+        )
+        wrapper = inspect.getsource(verify_phases.coverage_plateau_verdict)
+        assert wrapper.count("coverage_has_stagnated(") == 1
         assert "previous_coverage + 1.0" not in source, (
             "an inline threshold comparison has reappeared; the two copies "
             "drift apart under exactly this kind of repair"

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -110,9 +110,11 @@ class TestGenuineStagnationStillHalts:
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_flat_coverage_and_flat_tests_still_halts(self, mock_pytest):
+        """#2711: on the second consecutive strike; the state carries the first."""
         mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
         result = verify_green_phase(
-            _state(previous_passed=15, previous_coverage=94.0)
+            _state(previous_passed=15, previous_coverage=94.0,
+                   coverage_plateau_strikes=1)
         )
 
         assert result["next_node"] == "end"
@@ -120,14 +122,28 @@ class TestGenuineStagnationStillHalts:
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_fewer_passing_tests_is_not_progress(self, mock_pytest):
-        """Regression must never buy another iteration."""
+        """A regression is a strike, never progress; on the second strike it
+        halts (#2711 -- the first buys exactly one revision to revert it)."""
+        mock_pytest.return_value = _pytest(1, passed=13, failed=0, coverage=94)
+        result = verify_green_phase(
+            _state(previous_passed=15, previous_coverage=94.0,
+                   coverage_plateau_strikes=1)
+        )
+
+        assert result["next_node"] == "end"
+        assert "stagnant" in result.get("error_message", "").lower()
+
+    @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
+    def test_a_regression_buys_one_revision_and_no_more(self, mock_pytest):
+        """The control for #2711: with no strike on the board, the same
+        regression routes onward with the strike recorded."""
         mock_pytest.return_value = _pytest(1, passed=13, failed=0, coverage=94)
         result = verify_green_phase(
             _state(previous_passed=15, previous_coverage=94.0)
         )
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result.get("error_message", "").lower()
+        assert result["next_node"] != "end", result.get("error_message")
+        assert result["coverage_plateau_strikes"] == 1
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_max_iterations_still_wins_over_test_progress(self, mock_pytest):


### PR DESCRIPTION
## What happened

boostgauge #421, Phase 2 run 9 (`run-issue4-172600`, 2026-09-02): the first run this campaign to reach the implementation stage with a scaffold its validator accepted — nine executable spec tests, "Validation PASSED: 9 real tests". It halted one iteration into the green loop on three defects, none of them in the generated code.

**The implementer deleted the contract.** `implement_code` carries #460's rule: delete `tests/test_issue_N.py` whenever the implementer wrote any test file, and grade its files instead. That was right when the scaffold was `assert False` stubs. Since #2316 the scaffold is the spec's own suite, and #2706/#2707 now validate it before the spec is approved. The checkpoints show it: `cc806a6 [CP:post-scaffold]` adds `tests/test_issue_4.py` (114 lines); `a9c71db [CP:post-impl]` removes it and adds the implementer's `tests/unit/test_collector.py`. The green phase then ran three tests the implementer wrote for its own code — "3 passed, 0 failed". Since #2316 landed, the spec's tests have not once been the tests the green phase graded.

**Coverage measured the wrong file.** The derivation took the first source file and stopped: `Coverage module: boostgauge.collector` — the abstract base, whose uncovered lines are its four `NotImplementedError` raises — while `collectors/windows.py`, the sweep the issue exists to build, was never in the report.

**One backward step halted a five-iteration loop.** Iteration 1 broke one test and dropped coverage 72.0% → 70.0%; the coverage guard halted on its first comparison with four iterations unspent and a best-iteration snapshot in hand. The test-count guard beside it gives a plateau two strikes (#2062).

## What this does

- **#2709** — `merge_test_files`: when the scaffold carries the spec's functions (`spec_test_suite` non-empty), it stays and runs **first**; the implementer's test files follow it. A stub scaffold is still replaced, exactly as #460 intended. One helper, one home for the rule; `implement_code` no longer unlinks anything itself.
- **#2710** — the coverage scope is every non-test `.py` the run implemented, deduplicated, in file order; `run_pytest` accepts a list and emits one `--cov=` per target (pytest-cov reports the union). The measurement law (#2636) now reads every target and refuses for the first absent one by name, instead of handing a list to a string matcher.
- **#2711** — `coverage_plateau_verdict` wraps `coverage_has_stagnated` (still the one decision, #2029/#2030) with a strike count: a stagnant iteration is a strike, an improving one clears it, and the loop halts on the second consecutive strike. Both branches of `verify_green_phase` call the wrapper and nothing else; the one-helper pin test now counts the wrapper. The halt message keeps the word the classifier matches (#1939).

## Proven

- Run 9's checkpoint pair as a helper test: a spec-suite scaffold survives and leads the list; a stub scaffold is unlinked and replaced; no implementer tests leave the list alone; the scaffold is listed once even if the implementer touched it; a source pin that `implement_code` routes through the helper and carries no `unlink`.
- Run 9's five files in a src-layout package yield exactly `["boostgauge.collector", "boostgauge.collectors.windows"]` on the first `run_pytest` call; a single-file feature is unchanged; two targets produce two `--cov=` flags in order and one `--cov-report`; a second module missing from the report is refused by name and the present one is not blamed.
- Run 9's sequence — 72.0%/3 passing then 70.0%/2 passing 1 failing — routes back to the implementer with one strike; the same plateau again halts, "across 3 iterations". #2029's improving case clears the count. Both branches driven end to end with `run_pytest` patched, the all-pass branch under a real term-missing table.
- 20 new tests in `test_green_loop_contract.py`, plus one control in `test_verify_green_tests_improved.py` that a regression buys exactly one revision. Three one-strike pins in the two older stagnation suites move to the second strike, seeded the way the #2062 test seeds its count plateau. Two existing coverage-target assertions accept the list form. The stagnation, path-tracking, coverage-target, measurement-law, routes-to-tests, edit-script, completion-marker, and fail-open suites pass; full unit suite green.

## Not proven

A live roll. What this makes true is that the green phase grades the suite the spec stage approved, measures the files the feature added, and does not stop on the first bad revision. Whether the implementer then satisfies nine spec tests it did not write is the next run's to say.

Closes #2709
Closes #2710
Closes #2711
