### PR TITLE
fix: api_symbols_exist reads parameter and variable annotations the way #2399 reads return annotations — result_queue.put is the standard library's (Closes #2713)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -2520,6 +2520,13 @@ class _FenceFacts(NamedTuple):
     # seed the unresolved set directly — a method on one is a method on an
     # unknown type, and unknown is not guilty.
     opaque: frozenset[str] = frozenset()
+    # (name, root of its declared type) for annotated parameters and annotated
+    # assignments (#2713) -- #2399's rule one position over. `def start(self,
+    # q: queue.Queue)` records ("q", "queue"): whoever owns `queue` owns what
+    # `q` holds, so `q.put(...)` is the standard library's API to be right or
+    # wrong about. Only declared annotations are read; an unannotated name
+    # records nothing and stays judged.
+    annotated: tuple[tuple[str, str], ...] = ()
 
 
 class _FenceParseFailure(NamedTuple):
@@ -2592,6 +2599,35 @@ def _value_provenance(node: ast.expr) -> frozenset[str]:
     return frozenset(keys)
 
 
+#: Typing wrappers whose subscript names the type that matters: `Optional[X]`
+#: holds an X. A closed set. Anything else keeps its own root -- `list[X]` IS
+#: a list, whose methods the builtin allowlist already knows -- and `Union`
+#: is two declarations, which is none.
+_TYPING_WRAPPERS: frozenset[str] = frozenset({"Optional", "Annotated", "Final", "ClassVar"})
+_TYPING_UNDECIDED: frozenset[str] = frozenset({"Union"})
+
+
+def _annotation_root(node: ast.expr) -> str | None:
+    """Root name of a declared type, looking through `Optional[...]` (#2713).
+
+    `queue.Queue` -> "queue"; `Optional[queue.Queue]` -> "queue";
+    `list[Gauge]` -> "list". A string annotation, a `Union`, or anything
+    else unreadable yields None: nothing is recorded and the name stays
+    judged, which is the direction #2399 already chose for an unannotated
+    return.
+    """
+    if isinstance(node, ast.Subscript):
+        outer = _leftmost_name(node.value)
+        if outer in _TYPING_UNDECIDED:
+            return None
+        if outer in _TYPING_WRAPPERS:
+            inner = node.slice
+            if isinstance(inner, ast.Tuple) and inner.elts:  # Annotated[X, ...]
+                inner = inner.elts[0]
+            return _annotation_root(inner)
+    return _leftmost_name(node)
+
+
 def _leftmost_name(node: ast.expr) -> str | None:
     """Leftmost name an expression is rooted in: ``tk.Canvas(self.root)`` -> ``tk``."""
     while True:
@@ -2662,6 +2698,7 @@ class _FenceVisitor(ast.NodeVisitor):
         self.returns: dict[str, str] = {}
         self.classes: set[str] = set()
         self.opaque: set[str] = set()
+        self.annotated: list[tuple[str, str]] = []
 
     # ---- imports: receivers the target repo has no authority over (#1948) ----
 
@@ -2684,13 +2721,41 @@ class _FenceVisitor(ast.NodeVisitor):
         self.defined.add(node.name)
         self._record_framework_params(node)
         self._record_return(node)
+        self._record_annotated_params(node)
         self.generic_visit(node)
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self.defined.add(node.name)
         self._record_framework_params(node)
         self._record_return(node)
+        self._record_annotated_params(node)
         self.generic_visit(node)
+
+    def _record_annotated_params(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> None:
+        """What a spec-defined function declares its parameters hold (#2713).
+
+        `def start(self, q: queue.Queue)` records ("q", "queue") -- #2399's
+        rule for return annotations, applied to parameters. boostgauge
+        run-issue4-182119 lost a spec iteration to `result_queue.put(...)`
+        on exactly that signature, because the annotation was never read and
+        `put` is nowhere in the target repo's symbols.
+
+        An unannotated parameter records nothing and stays judged, which is
+        what keeps #1527's founding true positive (pydantic methods on a
+        plain dataclass) catchable; #2391's `state` in `def apply(state)` is
+        unchanged.
+        """
+        args = node.args
+        for arg in (
+            *args.posonlyargs, *args.args, *args.kwonlyargs, args.vararg, args.kwarg,
+        ):
+            if arg is None or arg.annotation is None:
+                continue
+            root = _annotation_root(arg.annotation)
+            if root is not None:
+                self.annotated.append((arg.arg, root))
 
     def _record_return(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef
@@ -2757,6 +2822,11 @@ class _FenceVisitor(ast.NodeVisitor):
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
         self._record_binding([node.target], node.value)
+        # #2713: `q: queue.Queue = ...` declares what `q` holds, value or not.
+        if isinstance(node.target, ast.Name):
+            root = _annotation_root(node.annotation)
+            if root is not None:
+                self.annotated.append((node.target.id, root))
         self.generic_visit(node)
 
     def visit_For(self, node: ast.For) -> None:
@@ -2885,6 +2955,7 @@ def _fence_facts_ast(block: str) -> _FenceFacts:
         returns=tuple(sorted(visitor.returns.items())),
         classes=frozenset(visitor.classes),
         opaque=frozenset(visitor.opaque),
+        annotated=tuple(visitor.annotated),
     )
 
 
@@ -3013,6 +3084,17 @@ def _flag_calls(
     assignments = [
         (bound, source) for fence in facts for bound, source in fence.assignments
     ]
+    # #2713: a declared parameter or variable annotation is a binding from its
+    # type's root -- #2399's rule for return annotations, one position over.
+    # `q: queue.Queue` joins the fixed point as `q <- queue`, so whoever owns
+    # `queue` owns `q`; a name annotated with a class the spec defines or the
+    # repo owns resolves to that class and stays judged, exactly as an
+    # assignment from it would.
+    assignments.extend(
+        (frozenset({name}), frozenset({root}))
+        for fence in facts
+        for name, root in fence.annotated
+    )
     # #2399: a spec-defined function's DECLARED return type answers what a
     # binding from it holds. `def render(...) -> Image.Image` means
     # `img = render(...)` holds a Pillow object, so `img.getpixel(...)` is

--- a/tests/unit/test_annotated_receivers.py
+++ b/tests/unit/test_annotated_receivers.py
@@ -1,0 +1,140 @@
+"""A declared parameter or variable annotation types its receiver (#2713).
+
+boostgauge run-issue4-182119, spec iteration 1:
+
+    [FAIL] api_symbols_exist
+    Spec calls methods not found in the target project's gathered symbols:
+    `put` (e.g. `result_queue.put(snapshot)`)
+
+on `def start(self, result_queue: queue.Queue)`. The check exempted a
+receiver through imports, stdlib roots, framework parameters and -- since
+#2399 -- a spec-defined function's RETURN annotation, and never read a
+parameter's or an annotated assignment's declared type. This is #2399's rule
+one position over, and the tests are the same shape: the founding true
+positive stays catchable, the unannotated case is unchanged.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    _annotation_root,
+    check_api_symbols_exist,
+)
+
+#: The target repo's gathered surface for these specs.
+SYMBOLS = ["DataCollector", "SystemSnapshot", "collect", "start", "stop"]
+
+
+def _spec(code: str) -> str:
+    return "# S\n\n```python\n" + code + "```\n"
+
+
+class TestRunTensReceiver:
+    def test_a_parameter_annotated_with_a_stdlib_type_is_the_librarys(self) -> None:
+        spec = _spec(
+            "import queue\n\n"
+            "class WindowsCollector:\n"
+            "    def start(self, interval: float, result_queue: queue.Queue) -> None:\n"
+            "        result_queue.put(1)\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_a_from_import_annotation(self) -> None:
+        spec = _spec(
+            "from queue import Queue\n\n"
+            "def drain(q: Queue) -> None:\n    q.put(1)\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_an_annotated_assignment_without_a_value(self) -> None:
+        spec = _spec(
+            "import queue\n\n"
+            "q: queue.Queue\n"
+            "q.put(1)\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_optional_is_looked_through(self) -> None:
+        spec = _spec(
+            "import queue\nfrom typing import Optional\n\n"
+            "def drain(q: Optional[queue.Queue]) -> None:\n    q.put(1)\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+    def test_the_thread_worker_shape_from_the_run(self) -> None:
+        """The live draft, reduced: the queue is threaded through two methods."""
+        spec = _spec(
+            "import queue\nimport threading\n\n"
+            "class WindowsCollector:\n"
+            "    def start(self, result_queue: queue.Queue) -> None:\n"
+            "        self._thread = threading.Thread(target=self._run_loop, args=(result_queue,))\n"
+            "        self._thread.start()\n\n"
+            "    def _run_loop(self, result_queue: queue.Queue) -> None:\n"
+            "        result_queue.put(self.collect())\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is True, result["details"]
+
+
+class TestJurisdictionIsUnchanged:
+    def test_a_parameter_annotated_with_a_spec_class_stays_judged(self) -> None:
+        """The founding true positive (#1527) with the annotation on: the
+        spec defines `DataCollector`, so `collector` resolves to it."""
+        spec = _spec(
+            "class DataCollector:\n    def collect(self):\n        return None\n\n"
+            "def run(collector: DataCollector) -> None:\n"
+            "    collector.no_such_method()\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is False
+        assert "no_such_method" in result["details"]
+
+    def test_an_unannotated_parameter_is_unchanged(self) -> None:
+        """#2391's `state` in `def apply(state)`: judged, as before."""
+        spec = _spec(
+            "def run(collector):\n    collector.no_such_method()\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is False
+        assert "no_such_method" in result["details"]
+
+    def test_a_union_declares_nothing_so_the_parameter_stays_judged(self) -> None:
+        """Two candidates is not a declaration: nothing is recorded, and the
+        parameter is judged exactly as an unannotated one is (#2391)."""
+        spec = _spec(
+            "from typing import Union\n"
+            "class DataCollector:\n    pass\n\n"
+            "def run(c: Union[DataCollector, int]) -> None:\n"
+            "    c.no_such_method()\n"
+        )
+        result = check_api_symbols_exist(spec, SYMBOLS)
+        assert result["passed"] is False
+        assert "no_such_method" in result["details"]
+
+
+class TestAnnotationRoot:
+    def _root(self, text: str) -> str | None:
+        return _annotation_root(ast.parse(text, mode="eval").body)
+
+    def test_plain_and_dotted(self) -> None:
+        assert self._root("queue.Queue") == "queue"
+        assert self._root("Queue") == "Queue"
+
+    def test_optional_and_annotated_look_through(self) -> None:
+        assert self._root("Optional[queue.Queue]") == "queue"
+        assert self._root("Annotated[queue.Queue, 'doc']") == "queue"
+        assert self._root("Optional[Optional[queue.Queue]]") == "queue"
+
+    def test_containers_keep_their_own_root(self) -> None:
+        assert self._root("list[Gauge]") == "list"
+        assert self._root("dict[str, Gauge]") == "dict"
+
+    def test_union_and_strings_declare_nothing(self) -> None:
+        assert self._root("Union[Gauge, int]") is None
+        assert self._root("'queue.Queue'") is None


### PR DESCRIPTION
## What happened

boostgauge #421, Phase 2 run 10 (`run-issue4-182119`, 2026-09-02), spec completeness iteration 1:

```
[FAIL] api_symbols_exist
Spec calls methods not found in the target project's gathered symbols: `put` (e.g. `result_queue.put(snapshot)`)
```

on `def start(self, result_queue: queue.Queue) -> None`. `put` is the standard library's. The complaint cost a spec revision, and the drafter's next round tried to rewrite `import queue` and the file table to get past it — six edits the revision lock correctly refused as unnamed content.

## Mechanism

`check_api_symbols_exist` exempts a receiver whose chain is rooted in something the target repo does not own — an import, a stdlib module, a framework-injected parameter (#2391), or, since #2399, a binding from a spec-defined function whose **return annotation** names a foreign type. It never read a **parameter annotation** or an **annotated assignment**. `result_queue: queue.Queue` declares exactly what #2399 reads on the return side, one position over, and the walker recorded nothing for it.

## What this does

- The fence walker records `(name, root of the declared type)` for every annotated parameter (`_record_annotated_params`) and every `name: Type` assignment (`visit_AnnAssign`), through `_annotation_root`: `queue.Queue` → `queue`; `Optional[queue.Queue]` → `queue`; `list[Gauge]` → `list` (the receiver *is* a list, whose methods the builtin allowlist already knows); a `Union` or a string annotation records nothing.
- Each recorded pair joins the exemption fixed point as one more binding, `q ← queue`. Whoever owns the root owns the name; a name annotated with a class the spec defines resolves to that class and stays judged, exactly as an assignment from it would. No new rule, one more source for an existing one.

## Proven

- Run 10's signature, and the run's two-method thread-worker shape: `result_queue.put(...)` passes. `from queue import Queue` / `q: Queue`, `q: queue.Queue` without a value, and `Optional[queue.Queue]` pass.
- Jurisdiction unchanged: `def run(collector: DataCollector): collector.no_such_method()` with `DataCollector` defined in the spec is still flagged (#1527's founding true positive, annotation on); an unannotated parameter is still judged (#2391); a `Union` records nothing and the parameter is judged.
- `_annotation_root` pinned on plain, dotted, nested `Optional`, `Annotated`, containers, `Union`, and string forms.
- 12 new tests; the symbol-analysis, builtin-receiver, pinning-deadlock, contract-fidelity, spec-test-suite, addressability, and fail-open suites pass (231 in the targeted run); full unit suite green.

## Not proven

That the drafter would have needed no revision on run 10 — the same iteration also carried an unparseable fence and an untested exception. What this removes is one refusal that was wrong.

Closes #2713
