### PR TITLE
fix: the reviewer's itemized feedback reaches the drafter and the revision lock — review_feedback carries the rationale and every item (Closes #2715)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/review_spec.py
@@ -29,11 +29,9 @@ from assemblyzero.core.halt_node import describe_iteration_cap  # #2197
 from assemblyzero.core.llm_provider import get_cumulative_cost, get_provider
 from assemblyzero.utils.cost_tracker import accumulate_node_cost, accumulate_node_tokens
 from assemblyzero.core.verdict_schema import (
-    VERDICT_SCHEMA,
     REVIEW_SPEC_SCHEMA,
     ReviewSpecResult,
     StructuredContractError,
-    parse_structured_verdict,
     parse_structured_review_spec,
 )
 from assemblyzero.workflows.requirements.audit import (
@@ -361,9 +359,9 @@ def review_spec(state: ImplementationSpecState) -> dict[str, Any]:
         msg = "Spec review response yielded no extractable verdict"
         print(f"    ERROR: {msg}")
         return {"error_message": msg}
-    feedback = spec_result["rationale"]
-    if not feedback and spec_result["feedback_items"]:
-        feedback = "\n".join(f"- {item}" for item in spec_result["feedback_items"])
+    feedback = review_feedback_text(
+        spec_result["rationale"], spec_result["feedback_items"]
+    )
 
     # -------------------------------------------------------------------------
     # Save verdict to audit trail
@@ -555,7 +553,7 @@ def _build_review_content(
     sections: list[str] = []
 
     # Context header
-    context = f"## Review Context\n\n"
+    context = "## Review Context\n\n"
     context += f"- **Issue:** #{issue_number}\n"
     context += f"- **Review Iteration:** {review_iteration}\n"
     if review_iteration > 0:
@@ -731,10 +729,33 @@ def parse_review_verdict(response: str) -> tuple[str, str]:
         return "BLOCKED", ""
     result = parse_structured_review_spec(response)
     verdict = result["verdict"]
-    feedback = result["rationale"]
-    if not feedback and result["feedback_items"]:
-        feedback = "\n".join(f"- {item}" for item in result["feedback_items"])
+    feedback = review_feedback_text(result["rationale"], result["feedback_items"])
     return verdict, feedback
+
+
+def review_feedback_text(rationale: str, feedback_items: list[str] | None) -> str:
+    """The reviewer's verdict as the drafter and the revision lock read it (#2715).
+
+    Rationale first, then every feedback item on its own line -- the shape the
+    verdict file on disk has always had. Until #2715 the items were appended
+    only when the rationale was EMPTY, and a structured verdict always has
+    one, so both consumers of `review_feedback` saw a summary: the drafter
+    revised against "adhere to the precise tolerances defined in the LLD"
+    without ever being shown the number, and guessed four rounds running on
+    boostgauge run-issue4-183941; the lock opened only what the summary
+    happened to backtick, and on the round whose summary quoted nothing it
+    refused the fix every item had demanded.
+
+    One helper, both assembly sites, so the next repair lands on both.
+    """
+    parts: list[str] = []
+    text = (rationale or "").strip()
+    if text:
+        parts.append(text)
+    items = [str(item).strip() for item in (feedback_items or []) if str(item).strip()]
+    if items:
+        parts.append("\n".join(f"- {item}" for item in items))
+    return "\n\n".join(parts)
 
 
 def _extract_feedback(response: str, verdict: str) -> str:

--- a/tests/fixtures/boostgauge4_review_items/021-spec-draft.md
+++ b/tests/fixtures/boostgauge4_review_items/021-spec-draft.md
@@ -1,0 +1,811 @@
+# Implementation Spec: Issue #4 - Feature: Windows data collector — ConPTY, processes, memory, handles
+
+<!-- Metadata -->
+| Field | Value |
+|-------|-------|
+| Issue | #4 |
+| LLD | `docs/lld/done/004-windows-data-collector.md` |
+| Generated | 2026-09-02 |
+| Status | APPROVED |
+
+## 1. Overview
+
+**Objective:** Build a Windows-specific data collector that polls system metrics (ConPTY, processes, memory, handles) via a single `NtQuerySystemInformation` sweep per tick and feeds them to the gauge.
+
+**Success Criteria:**
+- The collector must run on a background thread pushing `SystemSnapshot` objects to a queue.
+- All process-derived metrics MUST be gathered from a single `NtQuerySystemInformation` API call per tick, without using `psutil.process_iter`.
+- The collector must identify ConPTY counts (`conhost.exe`, `OpenConsole.exe`), memory percentage, total process counts, total handle counts, and unleashed sessions from Python command line arguments.
+- It must calculate a normalized 0-100 composite metric and identify the driver metric causing the highest load, executing with < 1% CPU overhead.
+
+## 2. Files to Implement
+
+| Order | File | Change Type | Description |
+|-------|------|-------------|-------------|
+| 1 | `src/boostgauge/collector.py` | Add | Abstract base class `DataCollector` and `SystemSnapshot` dataclass |
+| 2 | `src/boostgauge/collectors/__init__.py` | Add | Package init for platform collectors |
+| 3 | `src/boostgauge/collectors/windows.py` | Add | Windows implementation using `NtQuerySystemInformation` and `psutil` |
+| 4 | `tests/unit/test_windows_collector.py` | Add | Unit tests asserting single-call behavior via mocked `ctypes` |
+| 5 | `tests/integration/test_windows_collector_live.py` | Add | Live cross-checks against `psutil` on the running machine |
+| 6 | `tests/benchmark/test_windows_collector_perf.py` | Add | Performance benchmarks asserting execution time |
+
+**Implementation Order Rationale:** The core domain types (`collector.py`) must be built first, followed by the platform-specific implementation (`windows.py`). Tests are ordered unit -> integration -> benchmark to progressively prove functionality and performance.
+
+## 3. Current State (for Modify/Delete files)
+
+*No existing files are modified or deleted in this issue. All files are new additions.*
+
+## 4. Data Structures
+
+### 4.1 SystemSnapshot
+
+**Definition:**
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class SystemSnapshot:
+    timestamp: float
+    conpty_count: int
+    process_count: int
+    memory_percent: float
+    handle_count: int
+    unleashed_sessions: int
+    driver: str
+    composite_value: float
+```
+
+**Concrete Example:**
+
+```json
+{
+    "timestamp": 1709664532.123,
+    "conpty_count": 5,
+    "process_count": 312,
+    "memory_percent": 68.4,
+    "handle_count": 84300,
+    "unleashed_sessions": 2,
+    "driver": "memory_percent",
+    "composite_value": 68.4
+}
+```
+
+## 5. Function Specifications
+
+### 5.1 `DataCollector.__init__()`
+
+**File:** `src/boostgauge/collector.py`
+
+**Signature:**
+
+```python
+def __init__(self, output_queue: Queue, thresholds: dict, poll_interval: float = 2.0):
+    """Initialize the background thread collector."""
+    ...
+```
+
+**Input Example:**
+
+```python
+import queue
+output_queue = queue.Queue()
+thresholds = {
+    "conpty": {"yellow": 60, "red": 80},
+    "memory_percent": {"yellow": 60, "red": 80},
+    "process_count": {"yellow": 400, "red": 500},
+    "handle_count": {"yellow": 80000, "red": 100000}
+}
+poll_interval = 2.0
+```
+
+**Output Example:**
+
+```python
+# Constructor returns None, object is initialized
+None
+```
+
+**Edge Cases:**
+- `poll_interval <= 0` -> sets to a minimum safe limit (e.g., 0.1) or proceeds if caller intentionally forces fast polling for tests.
+- Empty `thresholds` -> valid, but forces `_normalize` to return 0.0.
+
+### 5.2 `DataCollector._normalize()`
+
+**File:** `src/boostgauge/collector.py`
+
+**Signature:**
+
+```python
+def _normalize(self, value: float, thresholds: dict) -> float:
+    """Map raw value to 0-100 based on yellow/red thresholds."""
+    ...
+```
+
+**Input Example:**
+
+```python
+value = 65.0
+thresholds = {"yellow": 60.0, "red": 80.0}
+```
+
+**Output Example:**
+
+```python
+65.0 # Interpolates linearly between 60(yellow)->60 and 80(red)->80.
+```
+
+**Edge Cases:**
+- `thresholds` missing "yellow" or "red" -> gracefully handles by returning 0.0 or avoiding divide-by-zero.
+- `value > red` -> clamps result to maximum 100.0.
+
+### 5.3 `WindowsCollector._take_snapshot()`
+
+**File:** `src/boostgauge/collectors/windows.py`
+
+**Signature:**
+
+```python
+def _take_snapshot(self) -> SystemSnapshot:
+    """Sweep the process table exactly once and calculate all metrics."""
+    ...
+```
+
+**Input Example:**
+
+```python
+# No arguments other than self. Requires a live OS or mocked ctypes behavior.
+```
+
+**Output Example:**
+
+```python
+SystemSnapshot(
+    timestamp=1709664532.123, 
+    conpty_count=2, 
+    process_count=150, 
+    memory_percent=45.0, 
+    handle_count=12000, 
+    unleashed_sessions=1, 
+    driver='memory_percent', 
+    composite_value=45.0
+)
+```
+
+**Edge Cases:**
+- `NtQuerySystemInformation` buffer resizing -> automatically handles `STATUS_INFO_LENGTH_MISMATCH` by expanding the buffer and retrying.
+- `psutil.AccessDenied` when querying command lines -> catches exception and proceeds without adding to the unleashed session count, ensuring the sweep continues.
+
+## 6. Change Instructions
+
+### 6.1 `src/boostgauge/collector.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Data collector base classes and data structures.
+
+Issue #4: Windows data collector — ConPTY, processes, memory, handles
+"""
+
+import abc
+import time
+import logging
+from dataclasses import dataclass
+from threading import Thread, Event
+from queue import Queue
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class SystemSnapshot:
+    timestamp: float
+    conpty_count: int
+    process_count: int
+    memory_percent: float
+    handle_count: int
+    unleashed_sessions: int
+    driver: str
+    composite_value: float
+
+class DataCollector(abc.ABC):
+    """Background thread that polls system metrics into a queue."""
+
+    def __init__(self, output_queue: Queue, thresholds: dict, poll_interval: float = 2.0):
+        self.output_queue = output_queue
+        self.thresholds = thresholds
+        self.poll_interval = poll_interval
+        self._stop_event = Event()
+        self._thread = None
+
+    def start(self) -> None:
+        """Start the background polling thread."""
+        self._stop_event.clear()
+        self._thread = Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the thread to stop and wait for it."""
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join()
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.wait(self.poll_interval):
+            try:
+                snapshot = self._take_snapshot()
+                self.output_queue.put(snapshot)
+            except Exception as e:
+                logger.error(f"Error taking snapshot: {e}")
+
+    @abc.abstractmethod
+    def _take_snapshot(self) -> SystemSnapshot:
+        """Take a single snapshot of the system state."""
+        pass
+
+    def _normalize(self, value: float, thresholds: dict) -> float:
+        """Map raw value to 0-100 based on yellow/red thresholds."""
+        if not thresholds:
+            return 0.0
+        
+        yellow = thresholds.get("yellow", 0)
+        red = thresholds.get("red", 0)
+        
+        if yellow == 0 and red == 0:
+            return 0.0
+            
+        if value < yellow:
+            return (value / yellow) * 60 if yellow > 0 else 0
+        elif value < red:
+            return 60 + ((value - yellow) / (red - yellow)) * 20 if red > yellow else 80
+        else:
+            val = 80 + ((value - red) / (red - yellow)) * 20 if red > yellow else 100.0
+            return min(val, 100.0)
+```
+
+### 6.2 `src/boostgauge/collectors/__init__.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Platform specific data collectors.
+
+Issue #4: Windows data collector — ConPTY, processes, memory, handles
+"""
+```
+
+### 6.3 `src/boostgauge/collectors/windows.py` (Add)
+
+**Complete file contents:**
+
+```python
+"""Windows specific collector utilizing NtQuerySystemInformation.
+
+Issue #4: Windows data collector — ConPTY, processes, memory, handles
+"""
+
+import ctypes
+from ctypes import wintypes
+import time
+import psutil
+import logging
+
+from boostgauge.collector import DataCollector, SystemSnapshot
+
+logger = logging.getLogger(__name__)
+
+class UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", wintypes.USHORT),
+        ("MaximumLength", wintypes.USHORT),
+        ("Buffer", wintypes.LPWSTR),
+    ]
+
+class SYSTEM_PROCESS_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("NextEntryOffset", wintypes.ULONG),
+        ("NumberOfThreads", wintypes.ULONG),
+        ("WorkingSetPrivateSize", ctypes.c_int64),
+        ("HardFaultCount", wintypes.ULONG),
+        ("NumberOfThreadsHighWatermark", wintypes.ULONG),
+        ("CycleTime", ctypes.c_uint64),
+        ("CreateTime", ctypes.c_int64),
+        ("UserTime", ctypes.c_int64),
+        ("KernelTime", ctypes.c_int64),
+        ("ImageName", UNICODE_STRING),
+        ("BasePriority", ctypes.c_int32),
+        ("UniqueProcessId", ctypes.c_void_p),
+        ("InheritedFromUniqueProcessId", ctypes.c_void_p),
+        ("HandleCount", wintypes.ULONG),
+    ]
+
+ntdll = ctypes.WinDLL("ntdll.dll")
+SystemProcessInformation = 5
+STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
+
+
+class WindowsCollector(DataCollector):
+    """Windows specific collector utilizing NtQuerySystemInformation."""
+
+    def _take_snapshot(self) -> SystemSnapshot:
+        """Sweep the process table exactly once and calculate all metrics."""
+        memory_percent = psutil.virtual_memory().percent
+        
+        buffer_size = ctypes.c_ulong(1024 * 1024)
+        buffer = ctypes.create_string_buffer(buffer_size.value)
+        
+        while True:
+            status = ntdll.NtQuerySystemInformation(
+                SystemProcessInformation,
+                buffer,
+                buffer_size,
+                ctypes.byref(buffer_size)
+            )
+            # Handle STATUS_INFO_LENGTH_MISMATCH (overflow integer matching)
+            if status == STATUS_INFO_LENGTH_MISMATCH or status == -1073741820:
+                buffer = ctypes.create_string_buffer(buffer_size.value)
+            elif status >= 0:
+                break
+            else:
+                logger.error(f"NtQuerySystemInformation failed with status: {status}")
+                return SystemSnapshot(time.time(), 0, 0, memory_percent, 0, 0, "memory_percent", 0.0)
+                
+        conpty_count = 0
+        process_count = 0
+        handle_count = 0
+        unleashed_sessions = 0
+        
+        offset = 0
+        while True:
+            process_info = ctypes.cast(
+                ctypes.addressof(buffer) + offset,
+                ctypes.POINTER(SYSTEM_PROCESS_INFORMATION)
+            ).contents
+            
+            process_count += 1
+            handle_count += process_info.HandleCount
+            
+            if process_info.ImageName.Buffer:
+                try:
+                    image_name = ctypes.wstring_at(process_info.ImageName.Buffer, process_info.ImageName.Length // 2)
+                    image_name_lower = image_name.lower()
+                    
+                    if image_name_lower in ('conhost.exe', 'openconsole.exe'):
+                        conpty_count += 1
+                        
+                    elif image_name_lower in ('python.exe', 'pythonw.exe'):
+                        pid = process_info.UniqueProcessId
+                        if pid:
+                            try:
+                                proc = psutil.Process(pid)
+                                cmdline = proc.cmdline()
+                                if any(arg.startswith('unleashed-c-') and arg.endswith('.py') for arg in cmdline):
+                                    unleashed_sessions += 1
+                            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                                logger.debug("Process access denied")
+                except ValueError:
+                    logger.debug("Invalid buffer")
+            
+            if process_info.NextEntryOffset == 0:
+                break
+                
+            offset += process_info.NextEntryOffset
+
+        metrics = {
+            "memory_percent": memory_percent,
+            "conpty": conpty_count,
+            "process_count": process_count,
+            "handle_count": handle_count
+        }
+        
+        max_val = -1.0
+        driver = "memory_percent"
+        
+        for metric, val in metrics.items():
+            norm = self._normalize(val, self.thresholds.get(metric, {}))
+            if norm > max_val:
+                max_val = norm
+                driver = metric
+                
+        return SystemSnapshot(
+            timestamp=time.time(),
+            conpty_count=conpty_count,
+            process_count=process_count,
+            memory_percent=memory_percent,
+            handle_count=handle_count,
+            unleashed_sessions=unleashed_sessions,
+            driver=driver,
+            composite_value=max_val
+        )
+```
+
+### 6.4 `tests/unit/test_windows_collector.py` (Add)
+
+**Complete file contents:**
+
+```python
+import pytest
+from queue import Queue
+from boostgauge.collectors.windows import WindowsCollector
+
+# Mocking tests for the scenarios
+```
+
+### 6.5 `tests/integration/test_windows_collector_live.py` (Add)
+
+**Complete file contents:**
+
+```python
+import pytest
+from queue import Queue
+from boostgauge.collectors.windows import WindowsCollector
+
+# Live execution tests mapping to scenarios
+```
+
+### 6.6 `tests/benchmark/test_windows_collector_perf.py` (Add)
+
+**Complete file contents:**
+
+```python
+import pytest
+from queue import Queue
+from boostgauge.collectors.windows import WindowsCollector
+
+# Benchmark tests mapping to scenarios
+```
+
+## 7. Pattern References
+
+### 7.1 Class Initialization and Pure Functions
+**File:** `src/boostgauge/telltale.py` (lines 44-55)
+
+```python
+class Telltale:
+    """Peak-hold over `window` seconds (or all-time when `window` is None)."""
+    def __init__(self, window: float | None, decay_rate: float | None = None) -> None:
+        pass
+```
+
+**Relevance:** Demonstrates class-based encapsulation and pure function semantics used across the project to maintain state without unnecessary external dependencies.
+
+## 8. Dependencies & Imports
+
+| Import | Source | Used In |
+|--------|--------|---------|
+| `import abc` | stdlib | `collector.py` |
+| `import time` | stdlib | `collector.py`, `windows.py` |
+| `from dataclasses import dataclass` | stdlib | `collector.py` |
+| `from threading import Thread, Event` | stdlib | `collector.py` |
+| `from queue import Queue` | stdlib | `collector.py` |
+| `import ctypes` | stdlib | `windows.py` |
+| `from ctypes import wintypes` | stdlib | `windows.py` |
+| `import psutil` | PyPI | `windows.py` |
+| `import logging` | stdlib | `collector.py`, `windows.py` |
+
+**New Dependencies:** None (psutil is already in project requirements)
+
+## 9. Placeholder
+
+*Reserved for future use to maintain alignment with LLD section numbering.*
+
+## 10. Test Mapping
+
+| Test ID | Tests Function | Input | Expected Output |
+|---------|---------------|-------|-----------------|
+| 010 | `test_req_010_mocked_sweep()` | Mocked buffer with 10 procs, 2 ConPTY | `process_count==10`, `conpty_count==2` |
+| 020 | `test_req_020_case_insensitive_conpty()` | Mocked buffer with "CoNHoST.eXe" | `conpty_count==1` |
+| 030 | `test_req_030_memory_percentage()` | Mocked `virtual_memory()` returns 45.0 | `memory_percent==45.0` |
+| 040 | `test_req_040_exact_process_count()` | Mocked buffer of 14 processes | `process_count==14` |
+| 050 | `test_req_050_handle_count()` | Mocked buffer with handles summing 8500 | `handle_count==8500` |
+| 060 | `test_req_060_unleashed_matching()` | Mocked "notepad.exe" with python args | `unleashed_sessions==0` |
+| 070 | `test_req_070_graceful_access_denied()` | Mocked python process throws AccessDenied | Tick completes without failure |
+| 080 | `test_req_080_composite_calculation()` | Thresholds dict producing varying norms | `driver=='memory_percent'` and `composite_value==75.0` |
+| 090 | `test_req_090_live_process_count()` | Live OS execution | Match of `psutil.process_iter()` len within tolerance |
+| 100 | `test_req_100_live_conpty_count()` | Live OS execution | Match of `psutil` conhost search within tolerance |
+| 110 | `test_req_110_live_handle_count()` | Live OS execution | Match of `psutil` handle sum within tolerance |
+| 120 | `test_req_120_background_threading()` | Initialize with poll interval 0.01s | Queue receives >3 snapshots |
+| 130 | `test_req_130_performance_baseline()` | Live OS benchmark 8 ticks | Mean execution time < 20ms |
+
+### 10.1 Per-criterion test functions
+
+```python
+def test_req_010_mocked_sweep(monkeypatch):
+    # Happy path object creation and metric extraction via mocked ctypes (REQ-2) -- expected: conpty_count == 2, process_count == 10
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    class MockProcessInfo:
+        def __init__(self, name, next_offset, idx):
+            self.HandleCount = 5
+            self.NextEntryOffset = next_offset
+            self.UniqueProcessId = 123
+            self.ImageName = type("MockName", (), {"Buffer": idx, "Length": len(name) * 2})()
+            self._name = name
+            
+    procs = [MockProcessInfo("conhost.exe", 100, i+1) for i in range(2)]
+    procs += [MockProcessInfo("other.exe", 100, i+1) for i in range(2, 9)]
+    procs += [MockProcessInfo("other.exe", 0, 10)]
+    mock_iter = iter(procs)
+    
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": next(mock_iter)})())
+    monkeypatch.setattr(ctypes, "wstring_at", lambda buf, length: procs[buf-1]._name)
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.process_count == 10
+    assert snap.conpty_count == 2
+
+def test_req_020_case_insensitive_conpty(monkeypatch):
+    # ConPTY process counting strictly case-insensitive (REQ-3) -- expected: conpty_count == 1
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    proc = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 0, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": 1, "Length": 22})()})()
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": proc})())
+    monkeypatch.setattr(ctypes, "wstring_at", lambda buf, length: "CoNHoST.eXe")
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.conpty_count == 1
+
+def test_req_030_memory_percentage(monkeypatch):
+    # Memory percentage read passes directly through (REQ-4) -- expected: memory_percent == 45.0
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 45.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    proc = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 0, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})()
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": proc})())
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.memory_percent == 45.0
+    
+def test_req_040_exact_process_count(monkeypatch):
+    # Process count is exact row length of sweep buffer (REQ-5) -- expected: process_count == 14
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    procs = [type("MockProcessInfo", (), {"HandleCount": 1, "NextEntryOffset": 100, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})() for _ in range(13)]
+    procs.append(type("MockProcessInfo", (), {"HandleCount": 1, "NextEntryOffset": 0, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})())
+    mock_iter = iter(procs)
+    
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": next(mock_iter)})())
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.process_count == 14
+    
+def test_req_050_handle_count(monkeypatch):
+    # Total handle count matches exact sum of rows (REQ-6) -- expected: handle_count == 8500
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    procs = [
+        type("MockProcessInfo", (), {"HandleCount": 4000, "NextEntryOffset": 100, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})(),
+        type("MockProcessInfo", (), {"HandleCount": 4500, "NextEntryOffset": 0, "UniqueProcessId": 124, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})()
+    ]
+    mock_iter = iter(procs)
+    
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": next(mock_iter)})())
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.handle_count == 8500
+    
+def test_req_060_unleashed_matching(monkeypatch):
+    # Unleashed matching ignores non-Python processes with matching string (REQ-7) -- expected: unleashed_sessions == 0
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    import psutil
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    proc = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 0, "UniqueProcessId": 999, "ImageName": type("MockName", (), {"Buffer": 1, "Length": 22})()})()
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": proc})())
+    monkeypatch.setattr(ctypes, "wstring_at", lambda buf, length: "notepad.exe")
+    
+    monkeypatch.setattr(psutil, "Process", lambda pid: type("MockProc", (), {"cmdline": lambda: ["unleashed-c-123.py"]})())
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap.unleashed_sessions == 0
+    
+def test_req_070_graceful_access_denied(monkeypatch, caplog):
+    # Graceful degradation on AccessDenied during cmdline read and ValueError on wstring_at (REQ-8) -- expected: Tick completes successfully
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    import psutil
+    import logging
+    
+    caplog.set_level(logging.DEBUG)
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 50.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    proc1 = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 100, "UniqueProcessId": 998, "ImageName": type("MockName", (), {"Buffer": 1, "Length": 20})()})()
+    proc2 = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 0, "UniqueProcessId": 999, "ImageName": type("MockName", (), {"Buffer": 2, "Length": 20})()})()
+    
+    mock_iter = iter([proc1, proc2])
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": next(mock_iter)})())
+    
+    def mock_wstring_at(buf, length):
+        if buf == 1:
+            raise ValueError("Buffer invalid")
+        return "python.exe"
+    monkeypatch.setattr(ctypes, "wstring_at", mock_wstring_at)
+    
+    def mock_process(pid):
+        raise psutil.AccessDenied()
+    monkeypatch.setattr(psutil, "Process", mock_process)
+    
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    assert snap is not None
+    assert snap.unleashed_sessions == 0
+    assert "Invalid buffer" in caplog.text
+    assert "Process access denied" in caplog.text
+    
+def test_req_080_composite_calculation(monkeypatch):
+    # Composite value calculation selects correct highest driver (REQ-9) -- expected: driver == 'memory_percent', composite_value == 75.0
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import ctypes
+    
+    monkeypatch.setattr("psutil.virtual_memory", lambda: type("vmem", (), {"percent": 75.0})())
+    monkeypatch.setattr("boostgauge.collectors.windows.ntdll.NtQuerySystemInformation", lambda *args: 0)
+    
+    proc = type("MockProcessInfo", (), {"HandleCount": 5, "NextEntryOffset": 0, "UniqueProcessId": 123, "ImageName": type("MockName", (), {"Buffer": None, "Length": 0})()})()
+    monkeypatch.setattr(ctypes, "cast", lambda *args: type("MockPointer", (), {"contents": proc})())
+    
+    thresholds = {
+        "memory_percent": {"yellow": 60, "red": 80},
+        "process_count": {"yellow": 400, "red": 500},
+        "handle_count": {"yellow": 80000, "red": 100000}
+    }
+    
+    c = WindowsCollector(Queue(), thresholds)
+    snap = c._take_snapshot()
+    assert snap.driver == 'memory_percent'
+    assert snap.composite_value == 75.0
+    
+def test_req_090_live_process_count():
+    # Live cross check of process counting against psutil (REQ-5) -- expected: count matches psutil.process_iter() within tolerance
+    from boostgauge.collectors.windows import WindowsCollector
+    import psutil
+    from queue import Queue
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    expected = len(list(psutil.process_iter()))
+    assert abs(snap.process_count - expected) <= 5
+    
+def test_req_100_live_conpty_count():
+    # Live cross check of ConPTY counting against psutil (REQ-3) -- expected: matches psutil console hosts within tolerance
+    from boostgauge.collectors.windows import WindowsCollector
+    import psutil
+    from queue import Queue
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    expected = len([p for p in psutil.process_iter(['name']) if p.info['name'] and p.info['name'].lower() in ('conhost.exe', 'openconsole.exe')])
+    assert abs(snap.conpty_count - expected) <= 2
+    
+def test_req_110_live_handle_count():
+    # Live cross check of handle counting against psutil (REQ-6) -- expected: matches psutil num_handles sum within tolerance
+    from boostgauge.collectors.windows import WindowsCollector
+    import psutil
+    from queue import Queue
+    c = WindowsCollector(Queue(), {})
+    snap = c._take_snapshot()
+    
+    psutil_handles = 0
+    for p in psutil.process_iter():
+        try:
+            psutil_handles += p.num_handles()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+            
+    assert abs(snap.handle_count - psutil_handles) <= 500
+    
+def test_req_120_background_threading(monkeypatch, caplog):
+    # Background threading executes ticks without blocking (REQ-1) -- expected: Queue populated with >3 items, coverage for exception
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import time
+    q = Queue()
+    c = WindowsCollector(q, {}, poll_interval=0.01)
+    
+    original_take = c._take_snapshot
+    fail_state = [True]
+    def mock_take_snapshot():
+        if fail_state[0]:
+            fail_state[0] = False
+            raise Exception("Simulate snapshot error")
+        return original_take()
+    monkeypatch.setattr(c, "_take_snapshot", mock_take_snapshot)
+    
+    c.start()
+    time.sleep(0.1)
+    c.stop()
+    assert q.qsize() > 3
+    assert "Simulate snapshot error" in caplog.text
+    
+def test_req_130_performance_baseline():
+    # CPU Performance baseline (REQ-10) -- expected: Mean process_time < 20ms
+    from boostgauge.collectors.windows import WindowsCollector
+    from queue import Queue
+    import time
+    c = WindowsCollector(Queue(), {})
+    
+    times = []
+    for _ in range(8):
+        start = time.process_time()
+        c._take_snapshot()
+        times.append(time.process_time() - start)
+        
+    mean_time = sum(times) / len(times)
+    assert mean_time < 0.02
+```
+
+## 11. Implementation Notes
+
+### 11.1 Windows `NtQuerySystemInformation` Buffer Strategy
+
+The `NtQuerySystemInformation` buffer requires a specific resizing loop because the process list changes rapidly in a real OS. If the allocated buffer is slightly too small by the time the kernel writes to it, the kernel returns `STATUS_INFO_LENGTH_MISMATCH` (often mapped to `-1073741820` or `0xC0000004`). We loop on this condition, expanding the string buffer allocation to match the size hinted by the kernel via `byref(buffer_size)`, up until a successful sweep occurs.
+
+### 11.2 Error Handling Strategy
+
+`psutil.NoSuchProcess` and `psutil.AccessDenied` are expected exceptions when reading `cmdline()` from another process, even if identified as a Python process. We catch these locally during the tick and simply `pass` rather than aborting the loop, acting as a skip on that specific session.
+
+### 11.3 Constants
+
+| Constant | Value | Rationale |
+|----------|-------|-----------|
+| `STATUS_INFO_LENGTH_MISMATCH` | `0xC0000004` | Standard Windows NT kernel response indicating the buffer must be enlarged |
+| `SystemProcessInformation` | `5` | Required flag for system process iteration under NtQuerySystemInformation |
+
+---
+
+## Completeness Checklist
+
+- [x] Every "Modify" file has a current state excerpt (Section 3) - N/A (all files are additions)
+- [x] Every data structure has a concrete JSON/YAML example (Section 4)
+- [x] Every **non-test** function has input/output examples with realistic values (Section 5)
+- [x] Every LLD pass criterion has a test function (Section 10.1) — these are exempt from the rule above
+- [x] Change instructions are diff-level specific (Section 6)
+- [x] Pattern references include file:line and are verified to exist (Section 7)
+- [x] All imports are listed and verified (Section 8)
+- [x] Test mapping covers all LLD test scenarios (Section 10)
+
+---
+
+## Review Log
+
+| Field | Value |
+|-------|-------|
+| Issue | #4 |
+| Verdict | APPROVED |
+| Date | 2026-09-02 |
+| Iterations | 1 |
+| Finalized | 2026-09-02T18:44:48-05:00 |

--- a/tests/fixtures/boostgauge4_review_items/023-readiness-verdict.md
+++ b/tests/fixtures/boostgauge4_review_items/023-readiness-verdict.md
@@ -1,0 +1,8 @@
+Verdict: REVISE
+
+Rationale: The Implementation Spec fails the Assertion Traceability check (Issue #1866). Three live integration tests implement assertions that directly contradict the explicit pass criteria defined in the LLD's Test Scenarios (Section 10.1).
+
+## Feedback Items
+- Assertion `assert abs(snap.process_count - expected) <= 5` in `test_req_090_live_process_count` contradicts LLD 10.1 Scenario 090, which strictly requires: 'Process count matches psutil.process_iter() count ±1'.
+- Assertion `assert abs(snap.conpty_count - expected) <= 2` in `test_req_100_live_conpty_count` contradicts LLD 10.1 Scenario 100, which strictly requires: 'ConPTY count matches psutil.process_iter() console hosts ±1'.
+- Assertion `assert abs(snap.handle_count - psutil_handles) <= 500` in `test_req_110_live_handle_count` contradicts LLD 10.1 Scenario 110, which strictly requires: 'Handle count within 1% of psutil num_handles sum' (e.g., the assertion should use `psutil_handles * 0.01`).

--- a/tests/unit/test_review_feedback_carries_items.py
+++ b/tests/unit/test_review_feedback_carries_items.py
@@ -1,0 +1,155 @@
+"""The reviewer's itemized feedback reaches the drafter and the lock (#2715).
+
+boostgauge run-issue4-183941, spec stage, review round 8: the verdict file
+quoted three assertions verbatim, named their functions, and cited the LLD
+scenario binding each -- and the revision lock refused the drafter's fix to
+all three as "locked content the verdict did not name". Rounds 5 through 7
+had sent the same three assertions back while the drafter guessed at the
+tolerance: 5 %, exact, 10 %, absolute. It was never shown "±1".
+
+`review_feedback` was the rationale paragraph; the items were appended only
+when the rationale was empty. The fixtures are that round's verdict and the
+draft it judged, verbatim; the control proves the old text left the lines
+locked, and the new text opens them and admits the fix.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+
+from assemblyzero.workflows.implementation_spec.nodes.review_spec import (
+    review_feedback_text,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    enforce_pinning,
+    named_line_flags,
+    named_tokens,
+)
+
+#: `nodes/__init__.py` re-exports the FUNCTION `review_spec`, which shadows
+#: the module of the same name; the module is reached by path.
+review_spec = importlib.import_module(
+    "assemblyzero.workflows.implementation_spec.nodes.review_spec"
+)
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "boostgauge4_review_items"
+VERDICT = (FIXTURES / "023-readiness-verdict.md").read_text(encoding="utf-8")
+DRAFT = (FIXTURES / "021-spec-draft.md").read_text(encoding="utf-8")
+
+#: 1-based lines of the three assertions in the draft the verdict judged.
+ASSERTION_LINES = (702, 712, 729)
+
+
+def _parse_verdict(text: str) -> tuple[str, list[str]]:
+    """The verdict file's own rendering: a Rationale paragraph, then
+    `## Feedback Items` as `- ` lines. Reading it back is the test's
+    business; the pipeline renders it, nothing parses it in production."""
+    head, _, items_block = text.partition("## Feedback Items")
+    rationale = head.split("Rationale:", 1)[1].strip()
+    items = [line[2:].strip() for line in items_block.splitlines() if line.startswith("- ")]
+    return rationale, items
+
+
+RATIONALE, ITEMS = _parse_verdict(VERDICT)
+
+
+class TestTheFixtureIsWhatTheRunSaw:
+    def test_three_items_each_quoting_an_assertion(self) -> None:
+        assert len(ITEMS) == 3
+        assert "`assert abs(snap.process_count - expected) <= 5`" in ITEMS[0]
+        assert "`test_req_090_live_process_count`" in ITEMS[0]
+
+    def test_the_rationale_quotes_nothing(self) -> None:
+        """Which is exactly why the lock opened nothing on this round."""
+        assert "`" not in RATIONALE
+
+    def test_the_draft_carries_the_three_lines(self) -> None:
+        lines = DRAFT.splitlines()
+        assert lines[ASSERTION_LINES[0] - 1].strip() == "assert abs(snap.process_count - expected) <= 5"
+        assert lines[ASSERTION_LINES[1] - 1].strip() == "assert abs(snap.conpty_count - expected) <= 2"
+        assert lines[ASSERTION_LINES[2] - 1].strip() == "assert abs(snap.handle_count - psutil_handles) <= 500"
+
+
+class TestTheTextCarriesBoth:
+    def test_rationale_then_items(self) -> None:
+        text = review_feedback_text("Summary.", ["first thing", "second thing"])
+        assert text == "Summary.\n\n- first thing\n- second thing"
+
+    def test_rationale_alone(self) -> None:
+        assert review_feedback_text("Summary.", []) == "Summary."
+        assert review_feedback_text("Summary.", None) == "Summary."
+
+    def test_items_alone_is_unchanged(self) -> None:
+        assert review_feedback_text("", ["only item"]) == "- only item"
+
+    def test_nothing_is_nothing(self) -> None:
+        assert review_feedback_text("", []) == ""
+        assert review_feedback_text("   ", ["  "]) == ""
+
+
+class TestRunElevensRoundEight:
+    """The control and the repair, on the real artifacts."""
+
+    def test_the_old_text_left_the_three_lines_locked(self) -> None:
+        old_text = RATIONALE  # what review_feedback used to be
+        flags = named_line_flags(DRAFT, named_tokens(old_text, []))
+        assert not any(flags[line - 1] for line in ASSERTION_LINES), (
+            "the fixture no longer reproduces the refusal"
+        )
+
+    def test_the_new_text_names_the_functions_and_the_lines(self) -> None:
+        tokens = named_tokens(review_feedback_text(RATIONALE, ITEMS), [])
+        assert "test_req_090_live_process_count" in tokens
+        assert "assert abs(snap.process_count - expected) <= 5" in tokens
+
+    def test_the_new_text_opens_the_three_lines(self) -> None:
+        tokens = named_tokens(review_feedback_text(RATIONALE, ITEMS), [])
+        flags = named_line_flags(DRAFT, tokens)
+        assert all(flags[line - 1] for line in ASSERTION_LINES)
+
+    def test_the_drafters_fix_is_accepted(self) -> None:
+        """The edit the run tried on round 8, with the bounds the items stated."""
+        revised = (
+            DRAFT.replace("assert abs(snap.process_count - expected) <= 5",
+                          "assert abs(snap.process_count - expected) <= 1")
+            .replace("assert abs(snap.conpty_count - expected) <= 2",
+                     "assert abs(snap.conpty_count - expected) <= 1")
+            .replace("assert abs(snap.handle_count - psutil_handles) <= 500",
+                     "assert abs(snap.handle_count - psutil_handles) <= psutil_handles * 0.01")
+        )
+        assert revised != DRAFT
+        tokens = named_tokens(review_feedback_text(RATIONALE, ITEMS), [])
+
+        result = enforce_pinning(
+            DRAFT, revised, current_tokens=tokens, ever_tokens=tokens,
+        )
+
+        assert result.refusals == (), result.refusals
+        assert "<= psutil_handles * 0.01" in result.text
+
+    def test_a_line_no_item_named_stays_locked(self) -> None:
+        """The control on the repair side: opening the items' lines opens
+        nothing else."""
+        target = 'logger.debug("Invalid buffer")'
+        assert target in DRAFT
+        revised = DRAFT.replace(target, 'logger.debug("changed")', 1)
+        tokens = named_tokens(review_feedback_text(RATIONALE, ITEMS), [])
+
+        result = enforce_pinning(
+            DRAFT, revised, current_tokens=tokens, ever_tokens=tokens,
+        )
+
+        assert result.refusals != ()
+        assert target in result.text
+
+
+class TestOneHelperTwoSites:
+    def test_both_assembly_sites_use_the_helper(self) -> None:
+        source = inspect.getsource(review_spec)
+        calls = source.count("review_feedback_text(") - 1  # minus the def
+        assert calls == 2, calls
+        assert "if not feedback and" not in source, (
+            "the rationale-only assembly has reappeared"
+        )


### PR DESCRIPTION
## What happened

boostgauge #421, Phase 2 run 11 (`run-issue4-183941`, 2026-09-02), spec stage. The adversarial reviewer sent the same three live-test assertions back four rounds running — the LLD binds them at ±1, ±1 and 1 % — while the drafter guessed: 5 %, then exact equality, then 10 %, then absolute 5 / 2 / 500. On round 8 the verdict quoted each assertion verbatim, named each function and cited each LLD scenario, and the revision lock refused the drafter's edits to all three lines as content the verdict did not name. Seven edits, 100 % preserved, nothing changed. Round 9 was the ceiling.

## Mechanism

`review_spec.py` assembled `review_feedback` as the rationale paragraph, appending the itemized feedback **only when the rationale was empty** — and a structured verdict always has one. The verdict file on disk carried both; the state carried the summary. Two consumers read that state and both were blind:

- the **drafter's revision prompt** saw "adhere to the precise tolerances explicitly defined in the LLD" and never a number, so every guess was reasonable against the text it had;
- the **revision lock** derived its tokens from the rationale's backticks. Rounds 5–7 passed because those rationales happened to quote the assertion; round 8's quoted nothing, so the lines every item named stayed locked against the very edit the items demanded — the #2532 deadlock in reviewer form. An earlier round of the same run logged `the verdict names nothing extractable — pinning not applied`, the same defect in its other costume.

## What this does

`review_feedback_text(rationale, feedback_items)`: rationale first, then one line per item, always — the shape the verdict file has always had. Both assembly sites call it; the old branch is gone. `review_feedback_history` inherits the same content, so the lock's ever-named set sees every item ever raised.

## Proven

Fixtures are run 11's round-8 verdict and the draft it judged, verbatim:

- the fixture is what the run saw: three items each quoting an assertion and naming its function; a rationale with no backticks; the three lines at 702, 712, 729 of the draft;
- the control: tokens from the rationale alone leave all three lines locked — the refusal reproduces;
- the repair: the assembled text names `test_req_090_live_process_count` and the quoted assertion; `named_line_flags` opens all three lines; `enforce_pinning` accepts the drafter's `<= 1` / `<= 1` / `<= psutil_handles * 0.01` edit with zero refusals; a `logger.debug` line no item named is still refused;
- the helper: rationale then items; rationale alone; items alone unchanged; nothing is nothing;
- a source pin that both sites call the helper and the rationale-only branch is gone.

13 new tests; the diff-aware review, cap-grace, ceiling, spec-workflow and fail-open suites pass (309 in the targeted run); full unit suite green. Three pre-existing lint findings in `review_spec.py` (two unused imports, one placeholder-free f-string, all on #2698's list) fixed in passing.

## Not proven

That the drafter converges in fewer rounds once it can read the number — that is the next run's to say. What this removes is a reviewer whose precise findings never left the audit file.

Closes #2715
