### PR TITLE
feat: factory_report says how each run ended and how far it got — outcome, cause of death, and a per-day convergence table (Closes #2717, Closes #2718)

### DIFF
--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -99,6 +99,287 @@ _RE_REVIEW_ROUND = re.compile(
 #: rather than silently attributed.
 _RE_RUN_NAME = re.compile(r"^run-issue(?P<issue>\d+)-(?P<stamp>\d+)\.log$")
 
+# ---------------------------------------------------------------------------
+# How a run ended (#2717) and how far it got (#2718)
+# ---------------------------------------------------------------------------
+#
+# The report counted what fired INSIDE a run and never said how the run
+# ended. Counted over boostgauge's 180 logs on 2026-09-02: 135 carry an
+# `ORCHESTRATION FAILED at stage:` banner (lld 49, impl 45, spec 40, pr 1),
+# 26 carry `[ORCHESTRATOR] All stages passed.`, and 19 carry neither -- the
+# process was killed mid-call. The `Error:` line under a failure banner is a
+# closed set of prefixes the pipeline's own code emits, so a run's cause of
+# death is a table lookup, not a judgment.
+
+#: The orchestrator's stage order, mirrored so this module stays free of
+#: workflow imports. test_factory_report.py asserts it equals
+#: `assemblyzero.workflows.orchestrator.state.STAGE_ORDER`.
+_STAGE_ORDER: tuple[str, ...] = (
+    "triage", "lld", "visual", "spec", "impl", "pr", "cleanup",
+)
+
+#: The implementation workflow's node markers in graph order. The run log
+#: prints them as `[HH:MM:SS] [N5] ...`; the timestamp prefix is what
+#: separates them from the spec workflow's untimestamped `[N2] Generating`.
+#: Kept honest by test_factory_report.py, which greps the testing workflow
+#: for every `[N..]` literal it prints.
+_IMPL_NODE_ORDER: tuple[str, ...] = (
+    "N0", "N1", "N1.5", "N2", "N2.5", "N3", "N4", "N4b", "N4c",
+    "N5", "N6", "N7", "N8", "N9",
+)
+
+#: One row of the closing STAGE / VERDICT / TIME table the orchestrator
+#: prints: `{stage:<9} {status:<9} {secs:>6.1f}s  {detail}`, or
+#: `{stage:<9} -         -` for a stage never reached.
+_RE_STAGE_ROW = re.compile(
+    r"^(?P<stage>triage|lld|visual|spec|impl|pr|cleanup)\s+"
+    r"(?P<verdict>passed|failed|blocked|skipped|-)\s+"
+    r"(?P<secs>\d+\.\d+s|-)(?:\s+(?P<detail>.*))?$"
+)
+_RE_FAILED_BANNER = re.compile(
+    r"^\s*ORCHESTRATION FAILED at stage:\s*(?P<stage>\S+)"
+)
+#: The first `  Error:` line AFTER the failure banner. Fifteen of the 135
+#: banners carry an empty one; that is `unrecorded`, not `unclassified`.
+_RE_BANNER_ERROR = re.compile(r"^\s{2}Error:\s?(?P<msg>.*)$")
+_RE_ALL_PASSED = re.compile(r"\[ORCHESTRATOR\] All stages passed\.")
+#: The exit classifier label the spec stage prints since #2383. Eight of
+#: 180 logs carry one, so it is recorded when present and never required.
+_RE_EXIT_LABEL = re.compile(r"^\s{2}exit:\s*(?P<label>\S+)")
+_RE_IMPL_NODE = re.compile(
+    r"^\[\d\d:\d\d:\d\d\]\s+\[(?P<node>N\d+(?:\.\d+)?[a-z]?)\]"
+)
+
+OUTCOME_PASSED = "passed"
+OUTCOME_FAILED = "failed"
+OUTCOME_KILLED = "killed"
+
+CAUSE_UNRECORDED = "unrecorded"
+CAUSE_UNCLASSIFIED = "unclassified"
+CAUSE_KILLED = "killed"
+
+
+@dataclass(frozen=True)
+class Cause:
+    """One authored row of the cause-of-death table.
+
+    `pattern` is anchored at the start of the banner's Error line. `example`
+    is a real Error line from the boostgauge logs, and the test suite asserts
+    every row matches its own example and no earlier row's. `source_literal`
+    is a static fragment of the message that must appear in `emitted_by`, so
+    a row cannot name code that does not say what the row claims.
+    """
+
+    key: str
+    pattern: str
+    emitted_by: str
+    judges: str
+    example: str
+    source_literal: str
+
+
+#: Authored from the 135 banners on disk, most frequent first within a stage.
+#: A message matching no row is `unclassified` and the report prints it
+#: verbatim, so this table grows deliberately rather than by guessing.
+#: `judges` is what the gate reads: the drafter's output, the issue body,
+#: a spending limit, or the environment. That column is the seed of the gate
+#: registry (#2719) and of the routing policy (#2723).
+CAUSE_TABLE: tuple[Cause, ...] = (
+    Cause(
+        "lld.mechanical_validation", r"MECHANICAL VALIDATION FAILED",
+        "assemblyzero/workflows/requirements/nodes/validate_mechanical.py", "model_output",
+        "MECHANICAL VALIDATION FAILED:", "MECHANICAL VALIDATION FAILED:",
+    ),
+    Cause(
+        "spec.requirements_conflict",
+        r"Spec review BLOCKED: REQUIREMENTS CONFLICT",
+        "assemblyzero/workflows/implementation_spec/nodes/review_spec.py", "issue_body",
+        "Spec review BLOCKED: REQUIREMENTS CONFLICT: The LLD contains an "
+        "unresolvable contradiction",
+        "REQUIREMENTS CONFLICT:",
+    ),
+    Cause(
+        "lld.requirements_conflict", r"REQUIREMENTS CONFLICT",
+        "assemblyzero/workflows/requirements/nodes/analyze_requirements.py", "issue_body",
+        "REQUIREMENTS CONFLICT: the issue's requirements are internally "
+        "inconsistent",
+        "REQUIREMENTS CONFLICT:",
+    ),
+    Cause(
+        "lld.test_plan_validation", r"test plan validation failed",
+        "assemblyzero/workflows/requirements/nodes/validate_test_plan.py", "model_output",
+        "test plan validation failed after 6 revision(s): Requirement REQ-1 "
+        "has no test coverage",
+        "test plan validation failed after",
+    ),
+    Cause(
+        "spec.completeness_cap", r"Iteration cap: \d+ revision\(s\) ended with",
+        "assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py",
+        "budget",
+        "Iteration cap: 3 revision(s) ended with 1 unresolved completeness "
+        "check(s).",
+        "Iteration cap:",
+    ),
+    Cause(
+        # The verdict word varies: REVISE on the ordinary ceiling, BLOCKED
+        # when the reviewer blocked on the round that hit it. Same emitter,
+        # same spending limit, one row.
+        "spec.review_cap", r"Iteration cap: \d+ review rounds ended \w+",
+        "assemblyzero/core/halt_node.py", "budget",
+        "Iteration cap: 3 review rounds ended REVISE, so the run stopped "
+        "rather than spend another round on the same objection.",
+        "Iteration cap:",
+    ),
+    Cause(
+        "spec.edit_script_rejected", r"\[EDIT-SCRIPT\] spec revision rejected",
+        "assemblyzero/workflows/implementation_spec/nodes/generate_spec.py", "model_output",
+        "[EDIT-SCRIPT] spec revision rejected after 3 attempt(s): block 1: "
+        "SEARCH text not found",
+        "spec revision rejected after",
+    ),
+    Cause(
+        "impl.scenario_ratio_guard", r"GUARD: Mechanical pre-checks failed",
+        "assemblyzero/workflows/testing/nodes/review_test_plan.py", "model_output",
+        "GUARD: Mechanical pre-checks failed \u2014 Only 1 scenario(s) for "
+        "2 requirement(s)",
+        "Mechanical pre-checks failed",
+    ),
+    Cause(
+        "impl.stagnation.coverage", r"Coverage stagnant",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "Coverage stagnant: 97.0% -> 97.0% (< 1% improvement). Halting to "
+        "prevent token waste.",
+        "Coverage stagnant:",
+    ),
+    Cause(
+        "impl.stagnation.test_count", r"Test count stagnant",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "Test count stagnant: 44/94 passed (unchanged from previous "
+        "iteration). Halting to prevent token waste.",
+        "Test count stagnant:",
+    ),
+    Cause(
+        "impl.stagnation.test_identity", r"Test identity stagnant",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "Test identity stagnant: same 47 test(s) failing across iterations. "
+        "Halting to prevent token waste.",
+        "Test identity stagnant:",
+    ),
+    Cause(
+        "impl.stagnation.full_suite", r"Full suite regression stagnant",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "Full suite regression stagnant: same 4 test(s) failing across "
+        "iterations. Halting.",
+        "Full suite regression stagnant:",
+    ),
+    Cause(
+        "impl.file_generation_failed",
+        r"Implementation stage error: FATAL: Failed to implement",
+        "assemblyzero/workflows/testing/nodes/implementation/claude_client.py",
+        "model_output",
+        "Implementation stage error: FATAL: Failed to implement "
+        "src/boostgauge/skins/stingray.py",
+        "FATAL: Failed to implement",
+    ),
+    Cause(
+        "impl.branch_exists",
+        r"Implementation stage error: branch '[^']+' already exists",
+        "assemblyzero/workflows/orchestrator/stages.py", "infrastructure",
+        "Implementation stage error: branch 'issue-384' already exists and "
+        "carries 1 commit(s)",
+        "already exists and carries",
+    ),
+    Cause(
+        "impl.deterministic_failure", r"DETERMINISTIC FAILURE",
+        "assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py", "model_output",
+        "DETERMINISTIC FAILURE: the generated test suite cannot be validated "
+        "and the scaffolder",
+        "DETERMINISTIC FAILURE",
+    ),
+    Cause(
+        "impl.red_phase_failed", r"Red phase failed",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "model_output",
+        "Red phase failed: 23 tests passed unexpectedly. Tests should fail "
+        "before implementation",
+        "Red phase failed:",
+    ),
+    Cause(
+        "impl.green_phase_stopped", r"Green phase stopped",
+        "assemblyzero/workflows/testing/nodes/verify_phases.py", "infrastructure",
+        "Green phase stopped: pytest test execution interrupted (exit code 2)",
+        "Green phase stopped:",
+    ),
+    Cause(
+        "infra.worktree", r"Git worktree error",
+        "assemblyzero/workflows/orchestrator/stages.py", "infrastructure",
+        "Git worktree error (exit 255): Preparing worktree (new branch "
+        "'issue-7')",
+        "Git worktree error",
+    ),
+    Cause(
+        "infra.pr_creation", r"PR creation error",
+        "assemblyzero/workflows/orchestrator/stages.py", "infrastructure",
+        "PR creation error: To https://github.com/martymcenroe/boostgauge.git",
+        "PR creation error:",
+    ),
+    Cause(
+        "infra.lld_stage_exception", r"LLD stage error",
+        "assemblyzero/workflows/orchestrator/stages.py", "infrastructure",
+        "LLD stage error: 'charmap' codec can't encode character '\\u2265' "
+        "in position 239",
+        "LLD stage error:",
+    ),
+    Cause(
+        # The 2026-08 logs carry the bare form; load_lld.py now prefixes it
+        # with MISSING REQUIRED INPUT. Both are the same precondition.
+        "infra.missing_spec",
+        r"(?:MISSING REQUIRED INPUT: )?[Nn]o implementation spec found",
+        "assemblyzero/workflows/testing/nodes/load_lld.py", "infrastructure",
+        "No implementation spec found for issue #7. Run: poetry run python "
+        "tools/run_implementation",
+        "no implementation spec found",
+    ),
+)
+
+_COMPILED_CAUSES: tuple[tuple[Cause, re.Pattern[str]], ...] = tuple(
+    (cause, re.compile(cause.pattern)) for cause in CAUSE_TABLE
+)
+
+
+def classify_cause(error_head: str) -> str:
+    """The cause key for a banner's first Error line, or a named absence.
+
+    An empty line is `unrecorded`: the banner printed and carried nothing,
+    which is a fact about the halt path, not about the run. A line no row
+    matches is `unclassified`, never the nearest bucket.
+    """
+    head = (error_head or "").strip()
+    if not head:
+        return CAUSE_UNRECORDED
+    for cause, pattern in _COMPILED_CAUSES:
+        if pattern.match(head):
+            return cause.key
+    return CAUSE_UNCLASSIFIED
+
+
+def _node_rank(node: str) -> int:
+    try:
+        return _IMPL_NODE_ORDER.index(node)
+    except ValueError:
+        return -1
+
+
+def _stage_rank(stage: str) -> int:
+    try:
+        return _STAGE_ORDER.index(stage)
+    except ValueError:
+        return -1
+
+
+def _normalize_digits(text: str) -> str:
+    """`Calling Claude... (645s)` and `(15s)` are one event for a tally."""
+    return re.sub(r"\d+", "N", text)
+
 
 def parse_since(spec: str, *, now: datetime | None = None) -> datetime | None:
     """`7d` / `24h` / `2026-08-27` / `2026-08-27 09:00:00` -> a lower bound.
@@ -190,6 +471,41 @@ class RunLogFacts:
     #: and the report says so rather than presenting it as a measurement.
     stage_elapsed: dict[str, tuple[int, int]] = field(default_factory=dict)
     unreadable: bool = False
+    # -- how the run ended (#2717) and how far it got (#2718) --------------
+    #: `passed` (the all-stages banner), `failed` (a failure banner), or
+    #: `killed` (neither: the process died mid-call and the log just stops).
+    outcome: str = OUTCOME_KILLED
+    #: The stage the failure banner names; "" unless outcome is `failed`.
+    failed_stage: str = ""
+    #: The last stage with any verdict in the closing table, or for a killed
+    #: run the last stage a watchdog line saw running.
+    furthest_stage: str = ""
+    #: For a run that reached impl, the highest node marker printed.
+    furthest_node: str = ""
+    #: The first line of the banner's Error, or a killed run's last line.
+    error_head: str = ""
+    #: A CAUSE_TABLE key, or unrecorded / unclassified / killed.
+    cause: str = CAUSE_KILLED
+    #: The exit classifier label when the log printed one (#2383).
+    exit_label: str = ""
+    #: stage -> verdict from the closing table, in table order.
+    stage_verdicts: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def furthest(self) -> str:
+        """`impl:N5`, `spec`, `cleanup` -- one token for the reader."""
+        if self.furthest_stage == "impl" and self.furthest_node:
+            return f"impl:{self.furthest_node}"
+        return self.furthest_stage or "(none)"
+
+    @property
+    def furthest_key(self) -> tuple[int, int, int]:
+        """Sortable: a passed run beats any failed one at the same stage."""
+        return (
+            _stage_rank(self.furthest_stage),
+            _node_rank(self.furthest_node) if self.furthest_stage == "impl" else -1,
+            1 if self.outcome == OUTCOME_PASSED else 0,
+        )
 
 
 def scan_run_log(path: Path) -> RunLogFacts:
@@ -222,6 +538,9 @@ def scan_run_log(path: Path) -> RunLogFacts:
         facts.unreadable = True
         return facts
 
+    last_stage_running = ""
+    last_nonblank = ""
+    awaiting_error = False
     for line in text.splitlines():
         if _RE_PINNING_REFUSED.search(line):
             facts.pinning_refusals += 1
@@ -252,6 +571,55 @@ def scan_run_log(path: Path) -> RunLogFacts:
             nominal = int(watchdog.group("nominal"))
             prior = facts.stage_elapsed.get(stage, (0, nominal))
             facts.stage_elapsed[stage] = (max(prior[0], elapsed), nominal)
+            last_stage_running = stage
+        # -- terminal parse (#2717 / #2718) --------------------------------
+        row = _RE_STAGE_ROW.match(line)
+        if row:
+            facts.stage_verdicts[row.group("stage")] = row.group("verdict")
+        node = _RE_IMPL_NODE.match(line)
+        if node and _node_rank(node.group("node")) > _node_rank(
+            facts.furthest_node
+        ):
+            facts.furthest_node = node.group("node")
+        banner = _RE_FAILED_BANNER.match(line)
+        if banner:
+            facts.outcome = OUTCOME_FAILED
+            facts.failed_stage = banner.group("stage")
+            awaiting_error = True
+        elif awaiting_error:
+            error = _RE_BANNER_ERROR.match(line)
+            if error:
+                facts.error_head = error.group("msg").strip()[:200]
+                awaiting_error = False
+        if _RE_ALL_PASSED.search(line):
+            facts.outcome = OUTCOME_PASSED
+        exit_label = _RE_EXIT_LABEL.match(line)
+        if exit_label:
+            facts.exit_label = exit_label.group("label")
+        if line.strip():
+            last_nonblank = line.strip()
+
+    # The furthest stage is the last row of the closing table that carries a
+    # verdict. A run that resumed at spec shows lld as `skipped`, which still
+    # counts as reached: the pipeline stood on that artifact.
+    reached = [s for s, v in facts.stage_verdicts.items() if v != "-"]
+    if reached:
+        facts.furthest_stage = max(reached, key=_stage_rank)
+    elif last_stage_running:
+        facts.furthest_stage = last_stage_running
+    if facts.furthest_stage != "impl":
+        facts.furthest_node = ""
+
+    if facts.outcome == OUTCOME_FAILED:
+        facts.cause = classify_cause(facts.error_head)
+    elif facts.outcome == OUTCOME_PASSED:
+        facts.cause = ""
+        facts.error_head = ""
+    else:
+        # Killed: no banner at all. The last line is the only evidence of
+        # where it died, and it is carried verbatim rather than guessed at.
+        facts.cause = CAUSE_KILLED
+        facts.error_head = last_nonblank[:120]
 
     return facts
 
@@ -477,6 +845,66 @@ def build_report(
             f"{bundle.get('workflow', '?')}:{bundle.get('stage', '?')}"
         ] += 1
 
+    # -- outcomes and cause of death (#2717) -----------------------------
+    outcomes: dict[str, int] = defaultdict(int)
+    failed_by_stage: dict[str, int] = defaultdict(int)
+    kills_by_cause: dict[str, int] = defaultdict(int)
+    kills_by_stage_cause: dict[str, int] = defaultdict(int)
+    unclassified: list[tuple[str, str]] = []
+    killed_tails: dict[str, int] = defaultdict(int)
+    for run in runs:
+        outcomes[run.outcome] += 1
+        if run.outcome == OUTCOME_FAILED:
+            stage = run.failed_stage or "?"
+            failed_by_stage[stage] += 1
+            kills_by_cause[run.cause] += 1
+            kills_by_stage_cause[f"{stage}:{run.cause}"] += 1
+            if run.cause == CAUSE_UNCLASSIFIED:
+                unclassified.append((run.run_id, run.error_head))
+        elif run.outcome == OUTCOME_KILLED:
+            killed_tails[
+                _normalize_digits(run.error_head) or "(empty log)"
+            ] += 1
+    judges_by_key = {cause.key: cause.judges for cause in CAUSE_TABLE}
+    kills_by_judges: dict[str, int] = defaultdict(int)
+    for key, count in kills_by_cause.items():
+        kills_by_judges[judges_by_key.get(key, key)] += count
+
+    # -- convergence (#2718): how far the furthest run got, per day -------
+    # Days are by run-log mtime: the only date the filesystem knows. The
+    # best run of a day is the furthest one; ties go to the later stamp.
+    by_day: dict[str, list[RunLogFacts]] = defaultdict(list)
+    for run in runs:
+        by_day[run.mtime[:10] if run.mtime else "(undated)"].append(run)
+    convergence_rows: list[dict] = []
+    previous_key: tuple[int, int, int] | None = None
+    for day in sorted(by_day):
+        day_runs = by_day[day]
+        best = max(day_runs, key=lambda r: (r.furthest_key, r.run_id))
+        if previous_key is None:
+            trend = "first"
+        elif best.furthest_key > previous_key:
+            trend = "up"
+        elif best.furthest_key == previous_key:
+            trend = "same"
+        else:
+            trend = "down"
+        convergence_rows.append(
+            {
+                "day": day,
+                "launches": len(day_runs),
+                "furthest": best.furthest,
+                "run_id": best.run_id,
+                "outcome": best.outcome,
+                "cause": best.cause,
+                "trend": trend,
+            }
+        )
+        previous_key = best.furthest_key
+    best_run = (
+        max(runs, key=lambda r: (r.furthest_key, r.run_id)) if runs else None
+    )
+
     return {
         "repo": str(repo),
         "since": since.strftime(_TS_FMT) if since else "",
@@ -546,6 +974,28 @@ def build_report(
             "by_stage": dict(halts_by_stage),
             "total": len(bundles),
         },
+        "outcomes": {
+            "counts": dict(outcomes),
+            "failed_by_stage": dict(failed_by_stage),
+            "kills_by_cause": dict(kills_by_cause),
+            "kills_by_stage_cause": dict(kills_by_stage_cause),
+            "kills_by_judges": dict(kills_by_judges),
+            "unclassified": unclassified,
+            "killed_tails": dict(killed_tails),
+        },
+        "convergence": {
+            "by_day": convergence_rows,
+            "best": (
+                {
+                    "run_id": best_run.run_id,
+                    "furthest": best_run.furthest,
+                    "outcome": best_run.outcome,
+                    "cause": best_run.cause,
+                }
+                if best_run
+                else None
+            ),
+        },
     }
 
 
@@ -560,6 +1010,107 @@ def render_report(data: dict) -> str:
     lines.append(f"# Factory report — {data['repo']}")
     lines.append("")
     lines.append(f"Window: since {window}. Generated {data['generated_at']}.")
+    lines.append("")
+
+    # Convergence first: it is the number the operator reads (#2718). A
+    # session's report card is this table, not its count of closed issues.
+    conv = data["convergence"]
+    lines.append("## Convergence: how far the furthest run got, per day")
+    lines.append("")
+    if conv["by_day"]:
+        lines.append(
+            "Days are by run-log mtime. `furthest` is the last stage with a "
+            "verdict; for impl, the highest node marker printed."
+        )
+        lines.append("")
+        lines.append("| day | launches | furthest | trend | run | ended by |")
+        lines.append("|---|---|---|---|---|---|")
+        for row in conv["by_day"]:
+            ended = (
+                row["cause"] if row["outcome"] == OUTCOME_FAILED
+                else row["outcome"]
+            )
+            lines.append(
+                f"| {row['day']} | {row['launches']} | {row['furthest']} | "
+                f"{row['trend']} | {row['run_id']} | {ended} |"
+            )
+        lines.append("")
+        best = conv["best"]
+        ended = (
+            best["cause"] if best["outcome"] == OUTCOME_FAILED
+            else best["outcome"]
+        )
+        lines.append(
+            f"Furthest run in window: {best['run_id']} reached "
+            f"{best['furthest']} ({ended})."
+        )
+    else:
+        lines.append("No run logs in this window, so nothing to place.")
+    lines.append("")
+
+    outcomes = data["outcomes"]
+    lines.append("## Outcomes")
+    lines.append("")
+    counts = outcomes["counts"]
+    total_runs = sum(counts.values())
+    if total_runs:
+        failed_split = ", ".join(
+            f"{stage} {n}"
+            for stage, n in sorted(
+                outcomes["failed_by_stage"].items(),
+                key=lambda kv: (-kv[1], kv[0]),
+            )
+        )
+        lines.append(
+            f"{total_runs} run(s): passed {counts.get(OUTCOME_PASSED, 0)}, "
+            f"failed {counts.get(OUTCOME_FAILED, 0)}"
+            + (f" ({failed_split})" if failed_split else "")
+            + f", killed {counts.get(OUTCOME_KILLED, 0)} (no terminal "
+            f"banner: the process died mid-call)."
+        )
+    else:
+        lines.append("No run logs in this window.")
+    lines.append("")
+
+    lines.append(
+        "## Cause of death (failed runs, by the Error line under the banner)"
+    )
+    lines.append("")
+    if outcomes["kills_by_cause"]:
+        width = max(len(k) for k in outcomes["kills_by_cause"])
+        judges = {cause.key: cause.judges for cause in CAUSE_TABLE}
+        for key, count in sorted(
+            outcomes["kills_by_cause"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(f"  {count:>4}  {key.ljust(width)}  {judges.get(key, '-')}")
+        lines.append("")
+        lines.append(
+            "By what the gate judges: "
+            + ", ".join(
+                f"{k} {v}"
+                for k, v in sorted(
+                    outcomes["kills_by_judges"].items(),
+                    key=lambda kv: (-kv[1], kv[0]),
+                )
+            )
+        )
+    else:
+        lines.append("No failed runs in this window.")
+    if outcomes["unclassified"]:
+        lines.append("")
+        lines.append(
+            "Unclassified Error lines -- add a CAUSE_TABLE row deliberately, "
+            "never by guessing:"
+        )
+        for run_id, head in outcomes["unclassified"]:
+            lines.append(f"  {run_id}: {head}")
+    if outcomes["killed_tails"]:
+        lines.append("")
+        lines.append("Killed runs end on (digits normalized to N):")
+        for tail, count in sorted(
+            outcomes["killed_tails"].items(), key=lambda kv: (-kv[1], kv[0])
+        ):
+            lines.append(f"  {count:>4}  {tail}")
     lines.append("")
 
     # Stores read, with their denominators. A store that does not exist is
@@ -735,6 +1286,13 @@ def render_report(data: dict) -> str:
             "No store carried records in this window -- every zero below is "
             "an absence of data, not an absence of events."
         )
+    if conv["best"]:
+        shortlist.append(
+            f"Furthest run in window: {conv['best']['run_id']} reached "
+            f"{conv['best']['furthest']}"
+        )
+    for key, count in _top(outcomes["kills_by_cause"], 1):
+        shortlist.append(f"Top cause of death: {key} ({count})")
     for key, count in _top(gates["per_check"]):
         shortlist.append(f"Top check by failure volume: {key} ({count})")
     if fell_back and total:

--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -362,18 +362,21 @@ def classify_cause(error_head: str) -> str:
     return CAUSE_UNCLASSIFIED
 
 
+_NODE_RANKS: dict[str, int] = {n: i for i, n in enumerate(_IMPL_NODE_ORDER)}
+_STAGE_RANKS: dict[str, int] = {s: i for i, s in enumerate(_STAGE_ORDER)}
+
+
 def _node_rank(node: str) -> int:
-    try:
-        return _IMPL_NODE_ORDER.index(node)
-    except ValueError:
-        return -1
+    """-1 for "" and for a marker the order does not rank. An unranked
+    marker is a test failure (the order must cover every marker printed),
+    never a silent substitution here."""
+    return _NODE_RANKS.get(node, -1)
 
 
 def _stage_rank(stage: str) -> int:
-    try:
-        return _STAGE_ORDER.index(stage)
-    except ValueError:
-        return -1
+    """-1 for "": the closing table and the watchdog only ever name the
+    seven stages, so no other value reaches this."""
+    return _STAGE_RANKS.get(stage, -1)
 
 
 def _normalize_digits(text: str) -> str:

--- a/docs/audits/0904-factory-report-boostgauge-2026-09-03.md
+++ b/docs/audits/0904-factory-report-boostgauge-2026-09-03.md
@@ -1,0 +1,180 @@
+# Factory report — C:\Users\mcwiz\Projects\boostgauge
+
+Window: since (all time). Generated 2026-09-03 00:11:13.
+
+## Convergence: how far the furthest run got, per day
+
+Days are by run-log mtime. `furthest` is the last stage with a verdict; for impl, the highest node marker printed.
+
+| day | launches | furthest | trend | run | ended by |
+|---|---|---|---|---|---|
+| 2026-07-31 | 30 | cleanup | first | run-issue7-131616 | passed |
+| 2026-08-01 | 38 | cleanup | same | run-issue7-080837 | passed |
+| 2026-08-09 | 9 | lld | down | run-issue7-233727 | lld.requirements_conflict |
+| 2026-08-10 | 24 | cleanup | up | run-issue4-023810 | passed |
+| 2026-08-11 | 6 | spec | down | run-issue1-014959 | unrecorded |
+| 2026-08-12 | 2 | spec | same | run-issue7-082047 | unrecorded |
+| 2026-08-13 | 6 | pr | up | run-issue7-231606 | infra.pr_creation |
+| 2026-08-14 | 4 | cleanup | up | run-issue7-011504 | passed |
+| 2026-08-15 | 5 | cleanup | same | run-issue41-014846 | passed |
+| 2026-08-16 | 1 | spec | down | run-issue331-153544 | killed |
+| 2026-08-25 | 6 | spec | same | run-issue331-233939 | spec.review_cap |
+| 2026-08-26 | 5 | impl:N5 | up | run-issue331-235455 | impl.stagnation.coverage |
+| 2026-08-27 | 4 | spec | down | run-issue331-170916 | spec.review_cap |
+| 2026-08-28 | 4 | impl:N5 | up | run-issue331-201554 | impl.stagnation.coverage |
+| 2026-08-29 | 5 | cleanup | up | run-issue331-101529 | passed |
+| 2026-08-30 | 19 | cleanup | same | run-issue384-102849 | passed |
+| 2026-09-01 | 7 | spec | down | run-issue41-184913 | spec.edit_script_rejected |
+| 2026-09-02 | 5 | impl:N5 | up | run-issue4-172600 | impl.stagnation.coverage |
+
+Furthest run in window: run-issue7-131616 reached cleanup (passed).
+
+## Outcomes
+
+180 run(s): passed 26, failed 135 (lld 49, impl 45, spec 40, pr 1), killed 19 (no terminal banner: the process died mid-call).
+
+## Cause of death (failed runs, by the Error line under the banner)
+
+    29  lld.requirements_conflict      issue_body
+    15  lld.mechanical_validation      model_output
+    15  unrecorded                     -
+    12  spec.completeness_cap          budget
+    11  impl.stagnation.coverage       model_output
+    11  impl.stagnation.test_count     model_output
+     7  spec.review_cap                budget
+     6  impl.file_generation_failed    model_output
+     5  impl.deterministic_failure     model_output
+     5  spec.requirements_conflict     issue_body
+     3  impl.stagnation.full_suite     model_output
+     3  spec.edit_script_rejected      model_output
+     2  impl.green_phase_stopped       infrastructure
+     2  infra.worktree                 infrastructure
+     2  lld.test_plan_validation       model_output
+     1  impl.branch_exists             infrastructure
+     1  impl.red_phase_failed          model_output
+     1  impl.scenario_ratio_guard      model_output
+     1  impl.stagnation.test_identity  model_output
+     1  infra.lld_stage_exception      infrastructure
+     1  infra.missing_spec             infrastructure
+     1  infra.pr_creation              infrastructure
+
+By what the gate judges: model_output 59, issue_body 34, budget 19, unrecorded 15, infrastructure 8
+
+Killed runs end on (digits normalized to N):
+     5  Calling Claude... (Ns)
+     5  Drafter: gemini:N.N-pro
+     2  Reviewer: gemini:N.N-pro
+     1  During task with name 'run_stage' and id 'NbeN-eN-NaNc-NaN-NbNeNbeN'
+     1  [EDIT-SCRIPT] attempt N/N: every edit touched locked content and was refused by pinning (N refusal(s)) -- re-prompting w
+     1  [NNc] Requirements-ambiguity analysis (#N)...
+     1  [ORCHESTRATOR] ERROR: Model 'claude-opus-N-N' is not a valid Gemini model. Expected format: gemini-*
+     1  [STAGE] lld running Ns (nominal ~Ns) - SLOW, Nx nominal
+     1  [STAGE] spec running Ns (nominal ~Ns)
+     1  [spec] implementation spec committed to the LLD PR (issue #N)
+
+## Stores read
+
+| store | present | records in window |
+|---|---|---|
+| halt_bundles | yes | 8 |
+| heals | yes | 84 |
+| preserved | yes | 27 |
+| prompt_failures | yes | 154 |
+| run_logs | yes | 180 |
+
+## Gates: which fire, which never do
+
+Failures per stage:check:
+  lld:requirements-conflict  77
+  lld:mechanical             52
+  spec:reviewer-revise       16
+  lld:test-plan              9
+
+Zero-fire gates: none — every declared gate fired.
+
+Top fingerprints by volume:
+    10  lld:mechanical:critical-section-11-missing-from-lld
+     8  lld:mechanical:critical-section-12-missing-from-lld
+     6  lld:mechanical:critical-section-2-1-missing-from-lld
+
+## Loops: revision rounds, caps, edit-script health
+
+Edit scripts: 293 applied, 16 fell back to full revision (5.2% of 309 attempts).
+
+Fallback reasons by volume:
+     5  edits produced no change
+     3  All credentials failed via agy (Antigravity CLI):
+     2  block 3: SEARCH text not found (model did not copy verbatim): 'SUPPORTED_SKINS = {\n    "stingray": render_stingray,\n}\
+     1  block 1: SEARCH text not found (model did not copy verbatim): 'from __future__ annotations\n\nfrom typing import Any'
+     1  block 2: SEARCH text not found (model did not copy verbatim): '**Change 2:** Add `_draw_telltales()` and `_draw_legend()
+
+Highest review round reached, per issue and loop:
+  #331:spec  9
+  #4:spec    9
+  #379:spec  8
+  #1:spec    7
+  #384:spec  7
+  #41:spec   3
+
+Cap grants (7):
+  run-issue331-123221: 3 revision(s) spent, but criteria_have_tests has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue331-123221: 3 revision(s) spent, but change_instructions_specific has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue331-150920: 3 revision(s) spent, but change_instructions_specific has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue331-200815: 3 revision(s) spent, but change_instructions_specific has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue331-111729: 3 revision(s) spent, but criteria_have_tests has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue379-010841: 3 revision(s) spent, but api_symbols_exist has never been shown to the drafter. Granting one revision for it (#2304).
+  run-issue384-063258: 3 revision(s) spent, but criteria_have_tests has never been shown to the drafter. Granting one revision for it (#2304).
+
+## Pinning enforcement
+
+145 refusal(s), 118 regression-class event(s) across 180 run log(s).
+
+## Janitor and preservation activity
+
+Heals by category:
+  restore-reconcile  35
+  reset              24
+  janitor            9
+  reset-refused      7
+  sweep              5
+  base-replace       2
+  base-settled       2
+
+Outcomes: healed 76, partial 1, refused 7
+
+Targets healed more than once (a spike here is the signal — three sweeps of one file in one day should be visible, not discovered by forensics):
+    12  restore-reconcile:docs/lld/active/LLD-331.md
+    11  reset:#1
+    11  restore-reconcile:docs/lld/active/LLD-001.md
+     6  restore-reconcile:docs/lld/active/LLD-007.md
+     5  reset:#331
+     4  janitor:docs/lld/active/LLD-001.md
+     4  janitor:docs/lld/active/LLD-331.md
+     4  reset-refused:#331
+     4  reset:#384
+     4  restore-reconcile:docs/lld/drafts/spec-0007-implementation-readiness.md
+     3  reset:#7
+     2  base-settled:hardening-run-19
+     2  sweep:384
+
+Preservations: 27 in window (leavings 25, sweep 2).
+
+## Halts (from #2574 evidence bundles)
+
+8 bundle(s):
+     3  implementation_spec:N5_review_iter3
+     2  requirements:requirements_unknown
+     1  implementation_spec:N5_review_iter5
+     1  implementation_spec:N5_review_iter7
+     1  requirements:N1_draft_iter3
+
+## Shortlist (computed)
+
+- Furthest run in window: run-issue7-131616 reached cleanup
+- Top cause of death: lld.requirements_conflict (29)
+- Top check by failure volume: lld:requirements-conflict (77)
+- Top check by failure volume: lld:mechanical (52)
+- Top check by failure volume: spec:reviewer-revise (16)
+- Edit-script fallback rate: 16/309 (5.2%)
+- Most-repeated heal target: restore-reconcile:docs/lld/active/LLD-331.md (12)
+

--- a/tests/unit/test_factory_report.py
+++ b/tests/unit/test_factory_report.py
@@ -437,3 +437,294 @@ class TestCli:
         )
         assert path.name == "0904-factory-report-boostgauge-2026-08-28.md"
         assert path.parent.name == "audits"
+
+
+# ---------------------------------------------------------------------------
+# How a run ended (#2717) and how far it got (#2718)
+# ---------------------------------------------------------------------------
+
+import os  # noqa: E402
+
+from assemblyzero.speedrun.factory_report import (  # noqa: E402
+    CAUSE_TABLE,
+    CAUSE_UNCLASSIFIED,
+    CAUSE_UNRECORDED,
+    _IMPL_NODE_ORDER,
+    _STAGE_ORDER,
+    classify_cause,
+)
+
+_TABLE_HEADER = [
+    "STAGE     VERDICT      TIME  ARTIFACT / ERROR",
+    "----------------------------------------------------------------------",
+]
+
+#: The closing lines of a run that finished: `run-issue1-*` merged PR #200.
+PASSED_TAIL = "\n".join(
+    _TABLE_HEADER
+    + [
+        "triage    skipped      0.0s  C:\\Users\\mcwiz\\Projects\\boostgauge\\docs\\lineage\\1\\issue-brie",
+        "lld       passed      87.7s  C:\\Users\\mcwiz\\Projects\\boostgauge\\docs\\lld\\active\\LLD-001.m",
+        "spec      passed      84.7s  C:\\Users\\mcwiz\\Projects\\boostgauge\\docs\\lld\\drafts\\spec-0001",
+        "impl      passed     179.4s  C:\\Users\\mcwiz\\Projects\\boostgauge-1",
+        "pr        passed       2.2s  https://github.com/martymcenroe/boostgauge/pull/200",
+        "cleanup   passed      66.6s  https://github.com/martymcenroe/boostgauge/pull/200",
+        "",
+        "[ORCHESTRATOR] All stages passed.",
+        "[ORCHESTRATOR] PR: https://github.com/martymcenroe/boostgauge/pull/200",
+        "[ORCHESTRATOR] Duration: 420.7s",
+    ]
+)
+
+#: run-issue4-183941, 2026-09-02: nine review rounds, the hard ceiling.
+FAILED_SPEC_TAIL = "\n".join(
+    _TABLE_HEADER
+    + [
+        "triage    skipped      0.0s  C:\\...\\issue-brie",
+        "lld       passed     299.7s  C:\\...\\LLD-004.m",
+        "visual    skipped      0.0s  no visual deliverable declared for this issue",
+        "spec      failed    2341.5s  Iteration cap: 3 review rounds ended REVISE, so the run stop",
+        "impl      -               -",
+        "pr        -               -",
+        "cleanup   -               -",
+        "",
+        "==========================================================",
+        "  ORCHESTRATION FAILED at stage: spec",
+        "==========================================================",
+        "  Error: Iteration cap: 3 review rounds ended REVISE, so the run stopped rather than spend another round on the same objection. Last feedback: ...",
+        "  exit: hard-ceiling",
+        "  the loop was still converging at round 8, and stopped only because it reached the hard ceiling of 9 (3x the base cap of 3).",
+        "  Attempts: 3 | Duration: 39m 1s",
+    ]
+)
+
+#: The shape of run-issue4-172600: green reached, then the coverage guard.
+#: The untimestamped `[N2] Generating Implementation Spec` line is the SPEC
+#: workflow's marker and must not count as an implementation node.
+FAILED_IMPL_TAIL = "\n".join(
+    [
+        "[N2] Generating Implementation Spec revision (iteration 2)...",
+        "[09:24:13] [N3] Verifying red phase (all tests should fail)...",
+        "[09:24:31] [N4] Implementing code file-by-file (iteration 0)...",
+        "[09:31:02] [N5] Verifying green phase (all tests should pass)...",
+        "[09:31:40] [N4] Implementing code file-by-file (iteration 1)...",
+        "[09:40:12] [N5] Verifying green phase (all tests should pass)...",
+    ]
+    + _TABLE_HEADER
+    + [
+        "triage    skipped      0.0s  C:\\...\\issue-brie",
+        "lld       skipped      0.0s  C:\\...\\LLD-004.m",
+        "spec      passed     605.0s  C:\\...\\spec-0004",
+        "impl      failed    2518.4s  Coverage stagnant: 97.0% -> 97.0% (< 1% improvement). Haltin",
+        "pr        -               -",
+        "cleanup   -               -",
+        "",
+        "==========================================================",
+        "  ORCHESTRATION FAILED at stage: impl",
+        "==========================================================",
+        "  Error: Coverage stagnant: 97.0% -> 97.0% (< 1% improvement). Halting to prevent token waste.",
+        "  Attempts: 3 | Duration: 41m 58s",
+    ]
+)
+
+#: A run killed mid-call: no table, no banner, the log just stops.
+KILLED_TAIL = "\n".join(
+    [
+        "NODE [5/9] generate spec -- The drafter model writes the implementation spec.",
+        "[N2] Generating Implementation Spec revision (iteration 2)...",
+        "    [PREFLIGHT] Gemini: 4/4 credentials",
+        "    Drafter: gemini:3.1-pro",
+        "    [STAGE] spec running 240s (nominal ~90s)",
+        "        Calling Claude... (585s)",
+        "        Calling Claude... (600s)",
+    ]
+)
+
+#: Fifteen of the 135 banners on disk carry an empty Error line.
+EMPTY_ERROR_TAIL = "\n".join(
+    _TABLE_HEADER
+    + [
+        "lld       failed     86.1s  ",
+        "==========================================================",
+        "  ORCHESTRATION FAILED at stage: lld",
+        "==========================================================",
+        "  Error: ",
+        "  Attempts: 3 | Duration: 3m 58s",
+    ]
+)
+
+
+class TestTerminalParse:
+    def test_a_passed_run(self, tmp_path):
+        facts = scan_run_log(
+            _write_run_log(tmp_path, "run-issue1-010101.log", PASSED_TAIL)
+        )
+        assert facts.outcome == "passed"
+        assert facts.furthest == "cleanup"
+        assert facts.cause == ""
+        assert facts.stage_verdicts["triage"] == "skipped"
+
+    def test_a_run_that_failed_at_spec_on_the_review_ceiling(self, tmp_path):
+        facts = scan_run_log(
+            _write_run_log(tmp_path, "run-issue4-183941.log", FAILED_SPEC_TAIL)
+        )
+        assert facts.outcome == "failed"
+        assert facts.failed_stage == "spec"
+        assert facts.furthest == "spec"
+        assert facts.cause == "spec.review_cap"
+        assert facts.exit_label == "hard-ceiling"
+        assert facts.error_head.startswith(
+            "Iteration cap: 3 review rounds ended REVISE"
+        )
+
+    def test_a_run_that_failed_at_impl_names_its_furthest_node(self, tmp_path):
+        facts = scan_run_log(
+            _write_run_log(tmp_path, "run-issue4-172600.log", FAILED_IMPL_TAIL)
+        )
+        assert facts.outcome == "failed"
+        assert facts.failed_stage == "impl"
+        # N5 (green) was the highest node reached; the loop back to N4 does
+        # not lower it, and the spec workflow's [N2] never counted.
+        assert facts.furthest == "impl:N5"
+        assert facts.cause == "impl.stagnation.coverage"
+
+    def test_a_killed_run_has_no_banner_and_carries_its_last_line(self, tmp_path):
+        facts = scan_run_log(
+            _write_run_log(tmp_path, "run-issue7-180539.log", KILLED_TAIL)
+        )
+        assert facts.outcome == "killed"
+        assert facts.cause == "killed"
+        # No table: the watchdog is the only witness to the stage.
+        assert facts.furthest == "spec"
+        assert facts.error_head == "Calling Claude... (600s)"
+
+    def test_an_empty_error_line_is_unrecorded_not_unclassified(self, tmp_path):
+        facts = scan_run_log(
+            _write_run_log(tmp_path, "run-issue2-133746.log", EMPTY_ERROR_TAIL)
+        )
+        assert facts.outcome == "failed"
+        assert facts.furthest == "lld"
+        assert facts.cause == CAUSE_UNRECORDED
+
+    def test_an_unknown_message_is_unclassified_never_the_nearest_bucket(self):
+        assert (
+            classify_cause("Something the pipeline never said before")
+            == CAUSE_UNCLASSIFIED
+        )
+
+    def test_a_passed_run_outranks_a_failed_one(self, tmp_path):
+        passed = scan_run_log(
+            _write_run_log(tmp_path, "run-issue1-000001.log", PASSED_TAIL)
+        )
+        failed = scan_run_log(
+            _write_run_log(tmp_path, "run-issue1-000002.log", FAILED_IMPL_TAIL)
+        )
+        assert passed.furthest_key > failed.furthest_key
+
+
+class TestCauseTable:
+    """The table is authored from real banners, and it stays true to both
+    the logs it was read from and the code that emits the messages."""
+
+    def test_every_row_matches_its_own_example(self):
+        for cause in CAUSE_TABLE:
+            assert classify_cause(cause.example) == cause.key, cause.key
+
+    def test_keys_are_unique(self):
+        keys = [cause.key for cause in CAUSE_TABLE]
+        assert len(keys) == len(set(keys))
+
+    def test_every_row_names_code_that_says_what_the_row_claims(self):
+        for cause in CAUSE_TABLE:
+            path = REPO_ROOT / cause.emitted_by
+            assert path.is_file(), f"{cause.key}: {cause.emitted_by} is not a file"
+            text = path.read_text(encoding="utf-8", errors="replace")
+            assert cause.source_literal in text, (
+                f"{cause.key}: {cause.emitted_by} does not contain "
+                f"{cause.source_literal!r}; the row names the wrong code"
+            )
+
+    def test_stage_order_mirrors_the_orchestrator(self):
+        from assemblyzero.workflows.orchestrator.state import STAGE_ORDER
+
+        assert list(_STAGE_ORDER) == list(STAGE_ORDER)
+
+    def test_impl_node_order_covers_every_marker_the_workflow_prints(self):
+        printed: set[str] = set()
+        testing = REPO_ROOT / "assemblyzero" / "workflows" / "testing"
+        marker = re.compile(r"\[(N\d+(?:\.\d+)?[a-z]?)\]")
+        for path in testing.rglob("*.py"):
+            printed.update(
+                marker.findall(path.read_text(encoding="utf-8", errors="replace"))
+            )
+        assert printed, "found no [N..] markers in the testing workflow"
+        missing = printed - set(_IMPL_NODE_ORDER)
+        assert not missing, f"markers printed but not ranked: {sorted(missing)}"
+
+
+class TestConvergence:
+    def _seed(self, tmp_path) -> Path:
+        """Three days: lld only, then green reached, then back to spec."""
+        runs = tmp_path / "data" / "speedrun" / "runs"
+        day1 = _write_run_log(runs, "run-issue4-090000.log", EMPTY_ERROR_TAIL)
+        day2 = _write_run_log(runs, "run-issue4-100000.log", FAILED_IMPL_TAIL)
+        day2b = _write_run_log(runs, "run-issue4-110000.log", FAILED_SPEC_TAIL)
+        day3 = _write_run_log(runs, "run-issue4-120000.log", FAILED_SPEC_TAIL)
+        base = datetime(2026, 9, 1, 12, 0, 0).timestamp()
+        for path, offset in (
+            (day1, 0),
+            (day2, 86400),
+            (day2b, 86400 + 3600),
+            (day3, 2 * 86400),
+        ):
+            os.utime(path, (base + offset, base + offset))
+        return tmp_path
+
+    def test_per_day_furthest_and_trend(self, tmp_path):
+        data = build_report(self._seed(tmp_path))
+        rows = data["convergence"]["by_day"]
+        assert [
+            (r["day"], r["launches"], r["furthest"], r["trend"]) for r in rows
+        ] == [
+            ("2026-09-01", 1, "lld", "first"),
+            ("2026-09-02", 2, "impl:N5", "up"),
+            ("2026-09-03", 1, "spec", "down"),
+        ]
+        assert rows[1]["run_id"] == "run-issue4-100000"
+        assert data["convergence"]["best"]["run_id"] == "run-issue4-100000"
+
+    def test_outcomes_and_causes_are_counted(self, tmp_path):
+        data = build_report(self._seed(tmp_path))
+        assert data["outcomes"]["counts"] == {"failed": 4}
+        assert data["outcomes"]["failed_by_stage"] == {
+            "lld": 1, "impl": 1, "spec": 2,
+        }
+        assert data["outcomes"]["kills_by_cause"]["spec.review_cap"] == 2
+        assert data["outcomes"]["kills_by_cause"][CAUSE_UNRECORDED] == 1
+        assert data["outcomes"]["kills_by_judges"]["budget"] == 2
+
+    def test_render_puts_convergence_first_and_prints_unclassified(
+        self, tmp_path
+    ):
+        repo = self._seed(tmp_path)
+        _write_run_log(
+            repo / "data" / "speedrun" / "runs",
+            "run-issue4-130000.log",
+            EMPTY_ERROR_TAIL.replace("  Error: ", "  Error: A message no row knows"),
+        )
+        text = render_report(build_report(repo))
+        assert text.index("## Convergence") < text.index("## Stores read")
+        assert (
+            "| 2026-09-02 | 2 | impl:N5 | up | run-issue4-100000 | "
+            "impl.stagnation.coverage |"
+        ) in text
+        assert "run-issue4-130000: A message no row knows" in text
+        assert "Top cause of death: spec.review_cap (2)" in text
+
+    def test_an_empty_window_places_nothing(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        data = build_report(empty)
+        assert data["convergence"]["by_day"] == []
+        assert data["convergence"]["best"] is None
+        assert "nothing to place" in render_report(data)


### PR DESCRIPTION
Closes #2717
Closes #2718

## What the report could not say

`factory_report.py` counted what fired inside a run and never said how the run ended or how far it got. Those are the two numbers that measure whether the factory is converging, and a session's report card was "N issues closed" because nothing else existed.

## What it says now

Run against boostgauge's 180 run logs, the report opens with:

```
| day        | launches | furthest | trend | run                 | ended by                  |
| 2026-08-30 |       19 | cleanup  | same  | run-issue384-102849 | passed                    |
| 2026-09-01 |        7 | spec     | down  | run-issue41-184913  | spec.edit_script_rejected |
| 2026-09-02 |        5 | impl:N5  | up    | run-issue4-172600   | impl.stagnation.coverage  |

180 run(s): passed 26, failed 135 (lld 49, impl 45, spec 40, pr 1), killed 19 (no terminal banner).

    29  lld.requirements_conflict      issue_body
    15  lld.mechanical_validation      model_output
    15  unrecorded                     -
    12  spec.completeness_cap          budget
    11  impl.stagnation.coverage       model_output
    11  impl.stagnation.test_count     model_output
     7  spec.review_cap                budget
     ...
By what the gate judges: model_output 59, issue_body 34, budget 19, unrecorded 15, infrastructure 8
```

## How

- `scan_run_log` parses the closing STAGE / VERDICT table, the failure banner and its first `Error:` line, the `All stages passed` line, the `exit:` classifier label, and the implementation workflow's timestamped `[N..]` node markers. New `RunLogFacts` fields: `outcome`, `failed_stage`, `furthest_stage`, `furthest_node`, `error_head`, `cause`, `exit_label`, `stage_verdicts`, plus `furthest` and `furthest_key`.
- `CAUSE_TABLE` is a closed table of 21 rows authored from the 135 banners on disk. Each row carries the anchored pattern, the file that emits the message, what the gate judges (`model_output` / `issue_body` / `budget` / `infrastructure`), a real example, and a source literal. An empty Error line is `unrecorded`; a message no row matches is `unclassified` and printed verbatim, never binned.
- Three new sections, printed first: **Convergence** (per-day furthest stage, trend against the previous day, the run that reached it), **Outcomes**, and **Cause of death** (kills per key, per what the gate judges, the unclassified remainder, and what killed runs end on).
- The shortlist gains the furthest run and the top cause.

## Tests

`tests/unit/test_factory_report.py`: 47 pass (17 new). Fixtures are real closing banners copied from boostgauge logs. The table has three honesty tests: every row matches its own example; every row's `emitted_by` file contains its `source_literal`; and `_STAGE_ORDER` equals the orchestrator's `STAGE_ORDER`, `_IMPL_NODE_ORDER` covers every `[N..]` marker the testing workflow prints. Ruff clean.

## What this is the first program of

Operator ruling 2026-09-02: the audit of the gates happens now, over the 180 runs already on disk. This is its first program. The `judges` column seeds the gate registry (#2719) and the routing policy (#2723); the convergence section is the session report card (#2718) until the graph writes the record itself (#2721).
