### PR TITLE
feat: the gate registry — every site that can end a run is walked, named, and classified, and the count that halts may not rise (Closes #2719, Closes #2720)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -1,0 +1,1018 @@
+"""The gate registry: every site that can end a run, named and classified (#2719).
+
+The factory is killed by its own immune system. Counted over boostgauge's 180
+run logs on 2026-09-02: 135 ended at a failure banner, and 59 of those were a
+gate refusing the drafter's own output (`factory_report.py`, cause-of-death
+section). Each gate was added after one death to prevent one bad outcome, and
+nothing retired one, because nothing recorded why any of them existed. The
+operator's framing: 189 places to say no, fitted to 180 runs. Overtraining.
+
+This module is the map of the maze. It has two halves that keep each other
+honest:
+
+**The walker** (`scan_halt_sites`) re-derives the set of halt sites from the
+workflow source on every run, by a closed, authored pattern set (§28a: syntax
+goes to a parser). A halt site is one of:
+
+* ``raise ImplementationError(...)``
+* ``return {..., "error_message": <non-empty>, ...}`` from a node
+* ``StageResult(..., error_message=<non-empty>)`` in the orchestrator
+* ``refusals.append(...)`` and ``conservation_event=<non-empty>`` in
+  revision pinning, which refuse a revision rather than end a run
+
+Each site's identity is ``path::qualname::kind::index`` -- no line number, so
+an unrelated edit above the site does not churn it (the fail-open audit's
+scheme, #2475).
+
+**The registry** (`GATE_REGISTRY`) is the authored table: one row per gate,
+naming the sites it covers, the stage it runs in, what it judges, what it does
+today, the issue that created it, and the run that justified it. The CI test
+asserts the two halves agree in both directions: every walked site names a
+row (no unregistered gate), and every row's sites exist (no phantom gate).
+
+``judges`` is the column the routing policy (#2723) reads:
+
+* ``model_output`` -- the drafter's own draft, code, or tests
+* ``upstream_artifact`` -- an earlier stage's approved artifact (the LLD, the
+  spec, the test plan): this stage cannot revise it
+* ``issue_body`` -- the operator's issue text
+* ``budget`` -- a spending limit: money, wall clock, rounds, iterations
+* ``infrastructure`` -- the environment: files, git, gh, credentials, a
+  transport that did not answer
+* ``operator`` -- a human gate waiting on a person
+
+``action`` is what the gate DOES today, not what it should do. Under the
+routing policy a gate that judges model output may only ``revise``; today
+nearly all of them ``halt``, and the ratchet (#2720) is what stops that count
+rising while it is being brought down.
+
+Python, not YAML: the walker, the ratchet, and the routing policy all import
+this table (operator ruling, 2026-09-02).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+JUDGES_MODEL_OUTPUT = "model_output"
+JUDGES_UPSTREAM = "upstream_artifact"
+JUDGES_ISSUE_BODY = "issue_body"
+JUDGES_BUDGET = "budget"
+JUDGES_INFRASTRUCTURE = "infrastructure"
+JUDGES_OPERATOR = "operator"
+#: The orchestrator relaying a halt a sub-workflow already decided. Not a
+#: gate of its own; listed so the walker's site is named and not double
+#: counted as a second death.
+JUDGES_RELAY = "relay"
+JUDGES: tuple[str, ...] = (
+    JUDGES_MODEL_OUTPUT,
+    JUDGES_UPSTREAM,
+    JUDGES_ISSUE_BODY,
+    JUDGES_BUDGET,
+    JUDGES_INFRASTRUCTURE,
+    JUDGES_OPERATOR,
+    JUDGES_RELAY,
+)
+
+ACTION_HALT = "halt"
+ACTION_REVISE = "revise"
+ACTION_ADVISE = "advise"
+ACTIONS: tuple[str, ...] = (ACTION_HALT, ACTION_REVISE, ACTION_ADVISE)
+
+STAGES: tuple[str, ...] = ("lld", "spec", "impl", "pr", "orchestrator")
+
+#: The four kinds of halt site the walker recognises. Closed and authored; a
+#: new kind is added here deliberately, never discovered.
+KIND_RAISE = "raise"
+KIND_RETURN = "return"
+KIND_STAGE_RESULT = "stage_result"
+KIND_REFUSAL = "refusal"
+KIND_CONSERVATION = "conservation"
+KINDS: tuple[str, ...] = (
+    KIND_RAISE, KIND_RETURN, KIND_STAGE_RESULT, KIND_REFUSAL, KIND_CONSERVATION,
+)
+
+#: The exception classes a node raises to end a run. ``ValueError`` and
+#: ``RuntimeError`` are bugs, not gates, and are deliberately not here.
+HALT_EXCEPTIONS: tuple[str, ...] = ("ImplementationError",)
+
+#: The orchestrator reports a stage failure by constructing a `StageResult`,
+#: nearly always through its `_make_stage_result` helper. Both are the same
+#: site shape.
+STAGE_RESULT_CALLS: tuple[str, ...] = ("StageResult", "_make_stage_result")
+
+#: Where the walker looks. The package's workflow tree, orchestrator included.
+WALK_SUBDIR = Path("assemblyzero") / "workflows"
+
+#: Appended to a message by `halted()` so the terminal record and the report
+#: can join a death to its gate without parsing prose (#2721).
+_TAG_RE = re.compile(r"\[gate:([a-z0-9_.]+)\]\s*$")
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Gate:
+    """One row: a named reason a run can end, and the code that does it."""
+
+    key: str
+    stage: str
+    judges: str
+    action: str
+    #: The static head of the message the gate emits, as the run log shows it.
+    emits: str
+    #: Walker site keys this row covers. Empty only for a gate whose halt is
+    #: decided outside the walked tree (a router edge, a core budget); such a
+    #: row names where in `decided_in`.
+    sites: tuple[str, ...] = ()
+    decided_in: str = ""
+    created_by: str = ""
+    justified_by: str = ""
+    notes: str = ""
+
+
+def _s(prefix: str, *indexes: int) -> tuple[str, ...]:
+    """``_s("a.py::f::return", 0, 2)`` -> the two site keys, spelled once."""
+    return tuple(f"{prefix}::{i}" for i in indexes)
+
+
+_IS = "assemblyzero/workflows/implementation_spec"
+_RQ = "assemblyzero/workflows/requirements"
+_TS = "assemblyzero/workflows/testing"
+_OR = "assemblyzero/workflows/orchestrator"
+
+#: Authored 2026-09-03 from the walker's 160 sites. `created_by` and
+#: `justified_by` are filled where the code itself names the issue or the run;
+#: the rest is git archaeology for a later pass and is left empty rather than
+#: guessed. `action` is what the gate does TODAY.
+GATE_REGISTRY: tuple[Gate, ...] = (
+    # ---- lld: the requirements workflow ----------------------------------
+    Gate(
+        "lld.input_precondition", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "No issue number specified",
+        _s(f"{_RQ}/nodes/load_input.py::_load_brief::return", 0, 1, 2)
+        + _s(f"{_RQ}/nodes/load_input.py::_load_issue::return", 0, 1)
+        + _s(f"{_RQ}/nodes/validate_test_plan.py::validate_test_plan_node::return", 1),
+        notes="the brief or issue the run was pointed at is missing or unreadable",
+    ),
+    Gate(
+        "lld.arc_unreadable", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "LLD analysis cannot read the arc",
+        _s(f"{_RQ}/nodes/analyze_codebase.py::analyze_codebase::return", 0),
+        created_by="#2684",
+    ),
+    Gate(
+        "lld.requirements_unverified", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "the consistency gate did not run",
+        _s(f"{_RQ}/nodes/analyze_requirements.py::_halt_unverified::return", 0),
+        created_by="#2474", notes="the gate could not reach its model; fail closed",
+    ),
+    Gate(
+        "lld.requirements_conflict", "lld", JUDGES_ISSUE_BODY, ACTION_HALT,
+        "REQUIREMENTS CONFLICT",
+        _s(f"{_RQ}/nodes/analyze_requirements.py::analyze_requirements::return", 0),
+        decided_in=f"{_RQ}/nodes/analyze_requirements.py::_format_conflict_message",
+        created_by="#1899",
+        notes="29 of 135 banner kills on boostgauge; the fix is an issue-body ruling",
+    ),
+    Gate(
+        "lld.drafter_failed", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Drafter failed",
+        _s(f"{_RQ}/nodes/generate_draft.py::generate_draft::return", 0, 3),
+    ),
+    Gate(
+        "lld.preflight", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "[PREFLIGHT] Gemini unavailable",
+        _s(f"{_RQ}/nodes/generate_draft.py::generate_draft::return", 1),
+    ),
+    Gate(
+        "lld.invalid_model_config", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Invalid drafter",
+        _s(f"{_RQ}/nodes/generate_draft.py::generate_draft::return", 2)
+        + _s(f"{_RQ}/nodes/review.py::review::return", 1),
+    ),
+    Gate(
+        "lld.budget.cost", "lld", JUDGES_BUDGET, ACTION_HALT,
+        "[BUDGET]",
+        _s(f"{_RQ}/nodes/generate_draft.py::generate_draft::return", 4)
+        + _s(f"{_RQ}/nodes/review.py::review::return", 3),
+    ),
+    Gate(
+        "lld.step_budget", "lld", JUDGES_BUDGET, ACTION_HALT,
+        "budget",
+        _s(f"{_RQ}/step_budget.py::invoke_with_budget::return", 0),
+        decided_in=f"{_RQ}/step_budget.py::describe_budget_exhaustion",
+    ),
+    Gate(
+        "lld.best_of_n_unusable", "lld", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "BEST-OF-N: all",
+        _s(f"{_RQ}/nodes/generate_draft.py::_generate_best_of_n::return", 0),
+        created_by="#2573",
+    ),
+    Gate(
+        "lld.edit_script_rejected", "lld", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "SEARCH/REPLACE",
+        _s(f"{_RQ}/nodes/generate_draft.py::generate_draft::return", 5, 6, 7, 8),
+        notes="a revision that was not a usable edit script, or that changed nothing",
+    ),
+    Gate(
+        "lld.reviewer_failed", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Reviewer response rejected",
+        _s(f"{_RQ}/nodes/review.py::review::return", 0, 2),
+    ),
+    Gate(
+        "lld.mechanical_validation", "lld", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "MECHANICAL VALIDATION FAILED",
+        _s(f"{_RQ}/nodes/validate_mechanical.py::_validate_lld_mechanical_inner::return",
+           0, 1, 2, 3, 4),
+        notes="15 of 135 banner kills on boostgauge",
+    ),
+    Gate(
+        "lld.test_plan_validation", "lld", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Test plan validation failed after",
+        _s(f"{_RQ}/nodes/validate_test_plan.py::validate_test_plan_node::return", 0),
+    ),
+    Gate(
+        "lld.finalize.issue_creation", "lld", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Failed to create issue",
+        _s(f"{_RQ}/nodes/finalize.py::_finalize_issue::return", 0, 1, 2, 3),
+    ),
+    # ---- spec: the implementation-spec workflow -------------------------
+    Gate(
+        "spec.input_precondition", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "No issue number provided",
+        _s(f"{_IS}/nodes/load_lld.py::load_lld::return", 0, 1, 2)
+        + _s(f"{_IS}/nodes/analyze_codebase.py::analyze_codebase::return", 0)
+        + _s(f"{_IS}/nodes/human_gate.py::human_gate::return", 0),
+    ),
+    Gate(
+        "spec.lld_not_usable", "spec", JUDGES_UPSTREAM, ACTION_HALT,
+        "GUARD: LLD content too short",
+        _s(f"{_IS}/nodes/load_lld.py::load_lld::return", 3, 4),
+        notes="the LLD is too short or not approved; this stage cannot revise it",
+    ),
+    Gate(
+        "spec.manifest_uncompilable", "spec", JUDGES_UPSTREAM, ACTION_HALT,
+        "ASSERTION MANIFEST UNCOMPILABLE",
+        _s(f"{_IS}/nodes/compile_manifest.py::compile_assertion_manifest::return", 0),
+        created_by="#2533",
+    ),
+    Gate(
+        "spec.manifest_gate", "spec", JUDGES_UPSTREAM, ACTION_HALT,
+        "ASSERTION MANIFEST GATE",
+        _s(f"{_IS}/nodes/compile_manifest.py::manifest_gate::return", 0),
+        created_by="#2533",
+    ),
+    Gate(
+        "spec.finalize.draft_guard", "spec", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "GUARD: Cannot finalize empty spec draft",
+        _s(f"{_IS}/nodes/finalize_spec.py::finalize_spec::return", 0, 1),
+    ),
+    Gate(
+        "spec.finalize.precondition", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "GUARD: Cannot finalize spec with verdict",
+        _s(f"{_IS}/nodes/finalize_spec.py::finalize_spec::return", 2, 3, 4, 5),
+    ),
+    Gate(
+        "spec.drafter_failed", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Drafter failed",
+        _s(f"{_IS}/nodes/generate_spec.py::generate_spec::return", 0, 4),
+    ),
+    Gate(
+        "spec.preflight", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "[PREFLIGHT] Gemini unavailable",
+        _s(f"{_IS}/nodes/generate_spec.py::generate_spec::return", 1),
+    ),
+    Gate(
+        "spec.invalid_model_config", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Invalid drafter",
+        _s(f"{_IS}/nodes/generate_spec.py::generate_spec::return", 2)
+        + _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 2),
+    ),
+    Gate(
+        "spec.edit_script_rejected", "spec", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "[EDIT-SCRIPT] spec revision rejected",
+        _s(f"{_IS}/nodes/generate_spec.py::generate_spec::return", 3),
+        decided_in=f"{_IS}/nodes/generate_spec.py::_spec_edit_halt",
+        notes="the revision's edit blocks did not apply, or pinning refused every one",
+    ),
+    Gate(
+        "spec.budget.cost", "spec", JUDGES_BUDGET, ACTION_HALT,
+        "[BUDGET]",
+        _s(f"{_IS}/nodes/generate_spec.py::generate_spec::return", 5)
+        + _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 3),
+    ),
+    Gate(
+        "spec.review_ceiling", "spec", JUDGES_BUDGET, ACTION_HALT,
+        "Spec review stopped",
+        _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 0),
+        created_by="#2383",
+        notes="the grant's hard ceiling reached inside the node",
+    ),
+    Gate(
+        "spec.review_cap", "spec", JUDGES_BUDGET, ACTION_HALT,
+        "Iteration cap:",
+        decided_in="assemblyzero/core/halt_node.py::describe_iteration_cap",
+        notes=(
+            "decided by route_after_review in implementation_spec/graph.py; the "
+            "message is synthesized by the halt node from state. 7 of 135 banner "
+            "kills on boostgauge; run 11 (run-issue4-183941) is the exhibit"
+        ),
+    ),
+    Gate(
+        "spec.review.empty_draft", "spec", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "GUARD: Spec draft is empty",
+        _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 1),
+    ),
+    Gate(
+        "spec.reviewer_failed", "spec", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Spec review LLM call failed",
+        _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 4),
+    ),
+    Gate(
+        "spec.reviewer_verdict_unreadable", "spec", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Spec review response yielded no extractable verdict",
+        _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 5),
+        notes="the reviewer's output, not the drafter's",
+    ),
+    Gate(
+        "spec.review_blocked", "spec", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Spec review BLOCKED",
+        _s(f"{_IS}/nodes/review_spec.py::review_spec::return", 6),
+        decided_in=f"{_IS}/nodes/review_spec.py::review_spec",
+        notes="a BLOCKED verdict; carries the requirements-conflict escalation too",
+    ),
+    Gate(
+        "spec.requirements_conflict", "spec", JUDGES_ISSUE_BODY, ACTION_HALT,
+        "REQUIREMENTS CONFLICT",
+        decided_in=f"{_IS}/nodes/review_spec.py::review_spec",
+        created_by="#1900",
+        notes="the reviewer's escalation marker inside a BLOCKED verdict (spec.review_blocked)",
+    ),
+    Gate(
+        "spec.completeness_cap", "spec", JUDGES_BUDGET, ACTION_HALT,
+        "Iteration cap:",
+        _s(f"{_IS}/nodes/validate_completeness.py::validate_completeness::return", 0),
+        notes="12 of 135 banner kills on boostgauge",
+    ),
+    Gate(
+        "spec.pinning_refusal", "spec", JUDGES_MODEL_OUTPUT, ACTION_REVISE,
+        "pinning refusal",
+        _s(f"{_IS}/revision_pinning.py::enforce_pinning::refusal", 0),
+        created_by="#2532",
+        notes="restores the locked span and continues; 145 refusals across 180 runs",
+    ),
+    Gate(
+        "spec.conservation_gate", "spec", JUDGES_MODEL_OUTPUT, ACTION_REVISE,
+        "the walked merge",
+        _s(f"{_IS}/revision_pinning.py::_conservation_override::conservation", 0, 1, 2),
+        created_by="#2559",
+        notes="emits the revision unenforced or the previous draft; never halts",
+    ),
+    # ---- impl: the testing workflow --------------------------------------
+    Gate(
+        "impl.input_precondition", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "No issue number provided",
+        _s(f"{_TS}/nodes/load_lld.py::load_lld::return", 0, 2)
+        + _s(f"{_TS}/nodes/load_lld.py::_load_from_issue::return", 0, 1, 2, 3),
+    ),
+    Gate(
+        "infra.missing_spec", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "no implementation spec found",
+        _s(f"{_TS}/nodes/load_lld.py::load_lld::return", 1),
+    ),
+    Gate(
+        "impl.lld_not_usable", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "GUARD: LLD content too short",
+        _s(f"{_TS}/nodes/load_lld.py::load_lld::return", 3),
+    ),
+    Gate(
+        "impl.no_files_to_implement", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "Implementation failed: No files to implement",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::return", 0),
+    ),
+    Gate(
+        "impl.path_guard", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "file path(s) in LLD do not match",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::return", 1),
+        created_by="#445",
+    ),
+    Gate(
+        "impl.api_error", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "API error after",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::generate_file_with_retry::raise", 0, 1),
+        created_by="#2423",
+    ),
+    Gate(
+        "impl.file_generation_failed", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "FATAL: Failed to implement",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::generate_file_with_retry::raise",
+           2, 3, 4, 5),
+        decided_in=f"{_TS}/nodes/implementation/claude_client.py::ImplementationError",
+        notes="a summary instead of code, no code block, or validation failed, N times",
+    ),
+    Gate(
+        "impl.modify_target_missing", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "File marked as 'Modify' but does not exist",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 0),
+    ),
+    Gate(
+        "impl.context_too_large", "impl", JUDGES_BUDGET, ACTION_HALT,
+        "Context too large",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 1),
+    ),
+    Gate(
+        "impl.path_enforcement", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Path not in LLD",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 2),
+        created_by="#188",
+    ),
+    Gate(
+        "impl.write_failed", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Failed to write file",
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 3),
+    ),
+    Gate(
+        "impl.scenario_ratio_guard", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "GUARD: Mechanical pre-checks failed",
+        _s(f"{_TS}/nodes/review_test_plan.py::review_test_plan::return", 0),
+        notes="judges the LLD's test plan; see #2675 for moving it into the spec stage",
+    ),
+    Gate(
+        "impl.invalid_model_config", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Invalid reviewer",
+        _s(f"{_TS}/nodes/review_test_plan.py::review_test_plan::return", 1)
+        + _s(f"{_TS}/nodes/revise_test_plan.py::revise_test_plan::return", 1),
+    ),
+    Gate(
+        "impl.reviewer_failed", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Reviewer failed after up to",
+        _s(f"{_TS}/nodes/review_test_plan.py::review_test_plan::return", 2, 3),
+    ),
+    Gate(
+        "impl.reviewer_verdict_unreadable", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Test-plan reviewer response rejected",
+        _s(f"{_TS}/nodes/review_test_plan.py::review_test_plan::return", 4),
+        notes="the reviewer's output, not the drafter's",
+    ),
+    Gate(
+        "impl.test_plan_no_requirements", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "Test plan revision blocked: no requirements",
+        _s(f"{_TS}/nodes/revise_test_plan.py::revise_test_plan::return", 0),
+    ),
+    Gate(
+        "impl.revisor_failed", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Test plan revision LLM call failed",
+        _s(f"{_TS}/nodes/revise_test_plan.py::revise_test_plan::return", 2),
+    ),
+    Gate(
+        "impl.test_plan_revision_incomplete", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Revised plan covers only",
+        _s(f"{_TS}/nodes/revise_test_plan.py::revise_test_plan::return", 3),
+    ),
+    Gate(
+        "impl.no_test_files", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "No test",
+        _s(f"{_TS}/nodes/run_tests.py::run_tests::return", 0)
+        + _s(f"{_TS}/nodes/scaffold_tests.py::scaffold_tests::return", 0)
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 0, 1)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_red_non_pytest::return", 0),
+        notes="no scenarios, no test files, or the named file is not on disk",
+    ),
+    Gate(
+        "impl.test_file_validation", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Test file validation failed",
+        _s(f"{_TS}/nodes/run_tests.py::run_tests::return", 2),
+    ),
+    Gate(
+        "impl.test_execution_failed", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Test execution failed",
+        _s(f"{_TS}/nodes/run_tests.py::run_tests::return", 1, 3),
+    ),
+    Gate(
+        "impl.completeness_gate_zero_requirements", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "Completeness gate: cannot certify",
+        _s(f"{_TS}/nodes/completeness_gate.py::completeness_gate::return", 0),
+        created_by="#2552",
+    ),
+    Gate(
+        "impl.coverage_unreadable", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "COVERAGE MEASUREMENT FAILED",
+        _s(f"{_TS}/nodes/augment_tests.py::augment_tests_for_coverage::return", 0)
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 1),
+        decided_in=f"{_TS}/coverage_report.py",
+        notes="a harness defect, never a test gap; see #2690's mapping",
+    ),
+    Gate(
+        "impl.e2e_safety_limit", "impl", JUDGES_BUDGET, ACTION_HALT,
+        "GUARD: E2E safety limit exceeded",
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 0),
+    ),
+    Gate(
+        "impl.e2e_error", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "E2E validation error",
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 1),
+    ),
+    Gate(
+        "impl.stagnation.e2e", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "E2E stagnant",
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 2),
+    ),
+    Gate(
+        "impl.e2e_cap", "impl", JUDGES_BUDGET, ACTION_HALT,
+        "E2E failed after",
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 4),
+    ),
+    Gate(
+        "impl.circuit_breaker", "impl", JUDGES_BUDGET, ACTION_HALT,
+        "[CIRCUIT]",
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 3)
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 8, 11)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 3, 6),
+        decided_in=f"{_TS}/circuit_breaker.py::check_circuit_breaker",
+    ),
+    Gate(
+        "impl.green_phase_stopped", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Green phase stopped",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 0),
+        notes="pytest exit 2 or 3: interrupted or an internal error",
+    ),
+    Gate(
+        "impl.red_phase_stopped", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Red phase stopped",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 2),
+    ),
+    Gate(
+        "impl.red.import_errors", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Red phase detected",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 3),
+        notes="the tests import modules the codebase does not have",
+    ),
+    Gate(
+        "impl.deterministic_failure", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "DETERMINISTIC FAILURE",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 4)
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 5),
+        decided_in=f"{_TS}/nodes/validate_tests_mechanical.py",
+        notes=(
+            "tests passed before the code existed, or fail for a platform reason no "
+            "implementation can fix; the scaffolder's suite-invalid halt shares the "
+            "prefix and is impl.scaffold_suite_invalid"
+        ),
+    ),
+    Gate(
+        "impl.scaffold_suite_invalid", "impl", JUDGES_UPSTREAM, ACTION_HALT,
+        "the generated test suite cannot be",
+        decided_in=f"{_TS}/nodes/validate_tests_mechanical.py",
+        notes=(
+            "the spec's own test functions were stubs or used phantom fixtures; "
+            "decided by route_after_validate in testing/graph.py. Run 8 "
+            "(run-issue4-163140) is the exhibit; #2706 and #2707 moved the check "
+            "into the spec stage where it is revisable"
+        ),
+    ),
+    Gate(
+        "impl.red_phase_failed", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Red phase failed",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 5)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_red_non_pytest::return", 2, 3),
+    ),
+    Gate(
+        "impl.green.collection_broken", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "collected 0 tests",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 2),
+        created_by="#2546",
+    ),
+    Gate(
+        "impl.green.iteration_cap", "impl", JUDGES_BUDGET, ACTION_HALT,
+        "Green phase failed after",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 3, 9)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 1, 4),
+    ),
+    Gate(
+        "impl.stagnation.test_count", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Test count stagnant",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 4)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 2),
+        notes="11 of 135 banner kills on boostgauge",
+    ),
+    Gate(
+        "impl.stagnation.test_identity", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Test identity stagnant",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 6),
+    ),
+    Gate(
+        "impl.stagnation.coverage", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Coverage stagnant",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 7, 10)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 5),
+        created_by="#2711",
+        justified_by="run-issue4-172600",
+        notes=(
+            "11 of 135 banner kills on boostgauge. Killed run 9, the furthest run "
+            "in the record (green, 3 passed, 72%), with four iterations unspent"
+        ),
+    ),
+    Gate(
+        "impl.stagnation.full_suite", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "Full suite regression stagnant",
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 12),
+    ),
+    Gate(
+        "impl.runner_unavailable", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Runner unavailable",
+        _s(f"{_TS}/nodes/verify_phases.py::_verify_red_non_pytest::return", 1)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 0),
+    ),
+    Gate(
+        "impl.branch_exists", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "already exists and carries",
+        decided_in=f"{_OR}/stages.py::run_impl_stage",
+        notes="raised as RuntimeError inside the impl stage; wrapped as 'Implementation stage error'",
+    ),
+    # ---- pr ----------------------------------------------------------------
+    Gate(
+        "pr.commit_message_guard", "pr", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "BLOCKED:",
+        _s(f"{_TS}/nodes/validate_commit_message.py::validate_commit_message::return", 0, 1),
+    ),
+    # ---- orchestrator ------------------------------------------------------
+    Gate(
+        "orchestrator.mock_outward_effects", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT, "mock mode:",
+        _s(f"{_OR}/graph.py::_run_stage_node::stage_result", 0),
+        notes="a mock roll stops before any stage with outward effects",
+    ),
+    Gate(
+        "orchestrator.human_gate", "orchestrator", JUDGES_OPERATOR, ACTION_HALT,
+        "Human gate enabled",
+        _s(f"{_OR}/graph.py::_run_stage_node::stage_result", 1),
+    ),
+    Gate(
+        "orchestrator.subworkflow_halted", "orchestrator", JUDGES_RELAY, ACTION_HALT,
+        "workflow halted before finalizing",
+        _s(f"{_OR}/stages.py::_make_stage_result::stage_result", 0)
+        + _s(f"{_OR}/stages.py::run_lld_stage::stage_result", 1)
+        + _s(f"{_OR}/stages.py::run_spec_stage::stage_result", 0)
+        + _s(f"{_OR}/stages.py::run_impl_stage::stage_result", 1)
+        + _s(f"{_OR}/stages.py::run_cleanup_stage::stage_result", 0),
+        created_by="#2677",
+        notes="relays a halt a sub-workflow already decided; not a second death",
+    ),
+    Gate(
+        "orchestrator.lld_review_verdict", "orchestrator", JUDGES_OPERATOR, ACTION_HALT,
+        "LLD review verdict",
+        _s(f"{_OR}/stages.py::run_lld_stage::stage_result", 0),
+    ),
+    Gate(
+        "infra.lld_stage_exception", "orchestrator", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "LLD stage error",
+        _s(f"{_OR}/stages.py::run_lld_stage::stage_result", 2),
+    ),
+    Gate(
+        "orchestrator.spec_stage_exception", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT, "Spec stage error",
+        _s(f"{_OR}/stages.py::run_spec_stage::stage_result", 1),
+    ),
+    Gate(
+        "orchestrator.impl_stage_exception", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT, "Implementation stage error",
+        _s(f"{_OR}/stages.py::run_impl_stage::stage_result", 3),
+    ),
+    Gate(
+        "orchestrator.pr_stage_exception", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT, "PR stage error",
+        _s(f"{_OR}/stages.py::run_pr_stage::stage_result", 2),
+    ),
+    Gate(
+        "orchestrator.triage_failed", "orchestrator", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Triage stage: cannot synthesize brief",
+        _s(f"{_OR}/stages.py::run_triage_stage::stage_result", 0),
+    ),
+    Gate(
+        "orchestrator.visual.declaration_unreadable", "orchestrator",
+        JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "visual-gate declaration unreadable",
+        _s(f"{_OR}/stages.py::run_visual_stage::stage_result", 0),
+    ),
+    Gate(
+        "orchestrator.visual.no_deliverable", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_ADVISE, "no visual deliverable declared",
+        _s(f"{_OR}/stages.py::run_visual_stage::stage_result", 1),
+        notes="a skip with a message, not a halt",
+    ),
+    Gate(
+        "orchestrator.visual_gate_halted", "orchestrator", JUDGES_OPERATOR, ACTION_HALT,
+        "visual gate halted",
+        _s(f"{_OR}/stages.py::run_visual_stage::stage_result", 2),
+        notes="the operator's picture ruling",
+    ),
+    Gate(
+        "impl.worktree_env_provisioning", "orchestrator", JUDGES_INFRASTRUCTURE,
+        ACTION_HALT, "Worktree environment provisioning failed",
+        _s(f"{_OR}/stages.py::run_impl_stage::stage_result", 0),
+    ),
+    Gate(
+        "infra.worktree", "orchestrator", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "Git worktree error",
+        _s(f"{_OR}/stages.py::run_impl_stage::stage_result", 2),
+    ),
+    Gate(
+        "orchestrator.pr.no_worktree", "orchestrator", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "No worktree path available for PR creation",
+        _s(f"{_OR}/stages.py::run_pr_stage::stage_result", 0),
+    ),
+    Gate(
+        "infra.pr_creation", "orchestrator", JUDGES_INFRASTRUCTURE, ACTION_HALT,
+        "PR creation error",
+        _s(f"{_OR}/stages.py::run_pr_stage::stage_result", 1),
+    ),
+    Gate(
+        "budget.ceiling_timeout", "orchestrator", JUDGES_BUDGET, ACTION_HALT,
+        "ceiling_timeout",
+        decided_in="assemblyzero/core/retry_gate.py",
+        created_by="#2423",
+        notes="the wall-clock ceiling on one model call; 1 of 180 logs carries it",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# The walker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HaltSite:
+    """One place the workflow code can end a run, as the walker found it."""
+
+    path: str
+    qualname: str
+    kind: str
+    index: int
+    line: int
+    head: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.path}::{self.qualname}::{self.kind}::{self.index}"
+
+
+@dataclass
+class WalkCoverage:
+    """What the walker examined. Counted, never estimated."""
+
+    files_scanned: int = 0
+    files_unparseable: list[str] = field(default_factory=list)
+    functions_scanned: int = 0
+
+
+def _static_head(node: ast.AST | None, resolve) -> str:
+    """The literal prefix of a message expression, or ``<...>`` when none.
+
+    Reads constants, f-strings (dynamic parts become ``{}``), the left side of
+    a concatenation, a name (through `resolve`), and the first literal
+    argument of a call. Anything else is reported as its node type so the
+    inventory says what it could not read rather than guessing.
+    """
+    if node is None:
+        return "<none>"
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                parts.append("{}")
+        return "".join(parts)
+    if isinstance(node, ast.BinOp):
+        return _static_head(node.left, resolve)
+    if isinstance(node, ast.Name):
+        return resolve(node.id, node.lineno)
+    if isinstance(node, ast.Call):
+        for arg in node.args:
+            head = _static_head(arg, resolve)
+            if not head.startswith("<"):
+                return head
+        for keyword in node.keywords:
+            if keyword.arg in ("reason", "message", "msg"):
+                return _static_head(keyword.value, resolve)
+        return f"<call {ast.unparse(node.func)[:40]}>"
+    if isinstance(node, ast.IfExp):
+        return _static_head(node.body, resolve)
+    if isinstance(node, ast.Subscript):
+        return _static_head(node.value, resolve)
+    return f"<{type(node).__name__}>"
+
+
+def _make_resolver(func: ast.AST):
+    """Resolve a name at a line to the head of its nearest prior assignment."""
+    assigns: dict[str, list[ast.Assign]] = defaultdict(list)
+    for node in ast.walk(func):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            assigns[node.targets[0].id].append(node)
+
+    def resolve(name: str, lineno: int, depth: int = 0) -> str:
+        if depth > 4:
+            return f"<var {name}>"
+        before = [a for a in assigns.get(name, []) if a.lineno < lineno]
+        if not before:
+            return f"<var {name}>"
+        nearest = max(before, key=lambda a: a.lineno)
+
+        def inner(name_: str, line: int) -> str:
+            return resolve(name_, line, depth + 1)
+
+        head = _static_head(nearest.value, inner)
+        if head == "" and len(before) > 1:
+            # An initializer (`message = ""`); the real text is the one before.
+            others = [a for a in before if a is not nearest]
+            head = _static_head(max(others, key=lambda a: a.lineno).value, inner)
+        return head
+
+    return resolve
+
+
+def _call_name(node: ast.Call) -> str:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _is_empty_string(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value == ""
+
+
+def _sites_in_function(func: ast.AST, rel: str) -> list[tuple[str, int, str]]:
+    """(kind, line, head) for every halt site in one function body."""
+    resolve = _make_resolver(func)
+    found: list[tuple[str, int, str]] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call):
+            if _call_name(node.exc) in HALT_EXCEPTIONS:
+                head = "<none>"
+                for keyword in node.exc.keywords:
+                    if keyword.arg == "reason":
+                        head = _static_head(keyword.value, resolve)
+                found.append((KIND_RAISE, node.lineno, head))
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
+            for key, value in zip(node.value.keys, node.value.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "error_message"
+                    and not _is_empty_string(value)
+                ):
+                    found.append(
+                        (KIND_RETURN, node.lineno, _static_head(value, resolve))
+                    )
+        if isinstance(node, ast.Call):
+            name = _call_name(node)
+            if name in STAGE_RESULT_CALLS:
+                for keyword in node.keywords:
+                    if keyword.arg == "error_message" and not _is_empty_string(
+                        keyword.value
+                    ):
+                        found.append(
+                            (
+                                KIND_STAGE_RESULT,
+                                node.lineno,
+                                _static_head(keyword.value, resolve),
+                            )
+                        )
+            if (
+                name == "append"
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "refusals"
+            ):
+                found.append((KIND_REFUSAL, node.lineno, "pinning refusal"))
+            for keyword in node.keywords:
+                if keyword.arg == "conservation_event" and not _is_empty_string(
+                    keyword.value
+                ):
+                    found.append(
+                        (
+                            KIND_CONSERVATION,
+                            node.lineno,
+                            _static_head(keyword.value, resolve),
+                        )
+                    )
+    return found
+
+
+def scan_halt_sites(
+    root: Path, subdir: Path = WALK_SUBDIR
+) -> tuple[list[HaltSite], WalkCoverage]:
+    """Every halt site under ``root/subdir``, keyed, in path order."""
+    coverage = WalkCoverage()
+    sites: list[HaltSite] = []
+    base = root / subdir
+    for path in sorted(base.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        rel = str(path.relative_to(root)).replace("\\", "/")
+        try:
+            # utf-8-sig: two files in this tree carry a BOM (see the fail-open
+            # audit, which found the same).
+            tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+        except (SyntaxError, ValueError, OSError):
+            # fail-open: a file that will not parse is recorded in
+            # coverage.files_unparseable, which the report prints and the
+            # test asserts empty, so the shortfall is carried in the data
+            # rather than hidden; the sweep continues so one bad file does
+            # not blank the other hundred and eighty-three.
+            coverage.files_unparseable.append(rel)
+            continue
+        coverage.files_scanned += 1
+        per_function: dict[tuple[str, str], list[tuple[int, str]]] = defaultdict(list)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                coverage.functions_scanned += 1
+                for kind, line, head in _sites_in_function(node, rel):
+                    per_function[(node.name, kind)].append((line, head))
+        for (qualname, kind), found in sorted(per_function.items()):
+            for index, (line, head) in enumerate(sorted(found)):
+                sites.append(HaltSite(rel, qualname, kind, index, line, head))
+    return sites, coverage
+
+
+# ---------------------------------------------------------------------------
+# Registry queries
+# ---------------------------------------------------------------------------
+
+
+def registry_by_key() -> dict[str, Gate]:
+    return {gate.key: gate for gate in GATE_REGISTRY}
+
+
+def site_to_gate() -> dict[str, str]:
+    """site key -> gate key, over the whole registry."""
+    mapping: dict[str, str] = {}
+    for gate in GATE_REGISTRY:
+        for site in gate.sites:
+            mapping[site] = gate.key
+    return mapping
+
+
+def unregistered(sites: list[HaltSite]) -> list[HaltSite]:
+    """Walked sites no row names. The gate the ratchet exists to catch."""
+    known = site_to_gate()
+    return [site for site in sites if site.key not in known]
+
+
+def phantoms(sites: list[HaltSite]) -> list[tuple[str, str]]:
+    """(gate key, site key) for registry sites the walker did not find."""
+    walked = {site.key for site in sites}
+    return [
+        (gate.key, site)
+        for gate in GATE_REGISTRY
+        for site in gate.sites
+        if site not in walked
+    ]
+
+
+def halt_counts() -> dict[str, int]:
+    """Rows whose action is `halt`, per stage. The ratchet's quantity (#2720)."""
+    counts: dict[str, int] = defaultdict(int)
+    for gate in GATE_REGISTRY:
+        if gate.action == ACTION_HALT:
+            counts[gate.stage] += 1
+    return dict(sorted(counts.items()))
+
+
+def halted(key: str, message: str) -> str:
+    """Tag a halt message with its gate key.
+
+    For new sites. A legacy site is covered by its walker key in the registry;
+    a site written after this module exists calls `halted()` so the terminal
+    record (#2721) reads the key instead of matching prose.
+    """
+    if key not in registry_by_key():
+        raise KeyError(f"{key!r} is not a registered gate")
+    return f"{message.rstrip()} [gate:{key}]"
+
+
+def gate_key_of(message: str) -> str:
+    """The key `halted()` tagged onto a message, or ""."""
+    match = _TAG_RE.search(message or "")
+    return match.group(1) if match else ""

--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -238,8 +238,11 @@ CAUSE_TABLE: tuple[Cause, ...] = (
         "spec revision rejected after",
     ),
     Cause(
+        # Judges the LLD's test plan, an earlier stage's artifact this stage
+        # cannot revise (#2675 moves the check upstream).
         "impl.scenario_ratio_guard", r"GUARD: Mechanical pre-checks failed",
-        "assemblyzero/workflows/testing/nodes/review_test_plan.py", "model_output",
+        "assemblyzero/workflows/testing/nodes/review_test_plan.py",
+        "upstream_artifact",
         "GUARD: Mechanical pre-checks failed \u2014 Only 1 scenario(s) for "
         "2 requirement(s)",
         "Mechanical pre-checks failed",

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage or model_output_halt_rows rises above this. Lower it when a gate stops halting; raise it only with an operator ruling named in the new row's created_by, in the same PR.",
+  "measured_against": {
+    "files_scanned": 184,
+    "halt_sites": 160,
+    "gates": 96
+  },
+  "halt_rows_per_stage": {
+    "impl": 42,
+    "lld": 15,
+    "orchestrator": 16,
+    "pr": 1,
+    "spec": 19
+  },
+  "model_output_halt_rows": 24
+}

--- a/tests/unit/test_gate_registry.py
+++ b/tests/unit/test_gate_registry.py
@@ -1,0 +1,307 @@
+"""The gate registry and the walker that keeps it honest (#2719, #2720).
+
+Two halves, tested in both directions: every halt site the walker finds in the
+workflow tree names a registry row, and every row's sites exist. Plus the
+ratchet: the count of rows that halt may fall and may not rise.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import audit_halt_sites as cli  # noqa: E402
+
+from assemblyzero.core.gate_registry import (  # noqa: E402
+    ACTION_HALT,
+    ACTIONS,
+    GATE_REGISTRY,
+    JUDGES,
+    JUDGES_MODEL_OUTPUT,
+    KIND_RAISE,
+    KIND_RETURN,
+    KIND_STAGE_RESULT,
+    STAGES,
+    gate_key_of,
+    halt_counts,
+    halted,
+    phantoms,
+    registry_by_key,
+    scan_halt_sites,
+    unregistered,
+)
+from assemblyzero.speedrun.factory_report import (  # noqa: E402
+    CAUSE_KILLED,
+    CAUSE_TABLE,
+    CAUSE_UNCLASSIFIED,
+    CAUSE_UNRECORDED,
+)
+
+BASELINE_PATH = REPO_ROOT / "tests" / "fixtures" / "gate_registry_baseline.json"
+
+
+@pytest.fixture(scope="module")
+def walked():
+    sites, coverage = scan_halt_sites(REPO_ROOT)
+    assert coverage.files_scanned > 0, "the walker scanned nothing"
+    assert not coverage.files_unparseable, coverage.files_unparseable
+    return sites
+
+
+# ---------------------------------------------------------------------------
+# The table itself
+# ---------------------------------------------------------------------------
+
+
+class TestVocabulary:
+    def test_keys_are_unique(self):
+        keys = [gate.key for gate in GATE_REGISTRY]
+        assert len(keys) == len(set(keys)), sorted(
+            k for k in keys if keys.count(k) > 1
+        )
+
+    def test_every_row_uses_the_closed_vocabularies(self):
+        for gate in GATE_REGISTRY:
+            assert gate.stage in STAGES, gate.key
+            assert gate.judges in JUDGES, gate.key
+            assert gate.action in ACTIONS, gate.key
+            assert gate.emits.strip(), f"{gate.key} emits nothing"
+
+    def test_every_row_names_where_it_is_decided(self):
+        """Sites from the walker, or a decided_in for a gate whose halt is a
+        router edge or a core budget the walker does not see."""
+        for gate in GATE_REGISTRY:
+            assert gate.sites or gate.decided_in, (
+                f"{gate.key} names no site and no decided_in"
+            )
+
+    def test_no_site_belongs_to_two_rows(self):
+        seen: dict[str, str] = {}
+        for gate in GATE_REGISTRY:
+            for site in gate.sites:
+                assert site not in seen, (
+                    f"{site} is in both {seen[site]} and {gate.key}"
+                )
+                seen[site] = gate.key
+
+    def test_decided_in_names_a_real_file(self):
+        for gate in GATE_REGISTRY:
+            if not gate.decided_in:
+                continue
+            path = REPO_ROOT / gate.decided_in.split("::")[0]
+            assert path.is_file(), f"{gate.key}: {gate.decided_in} is not a file"
+
+
+# ---------------------------------------------------------------------------
+# The walker and the registry agree, both ways
+# ---------------------------------------------------------------------------
+
+
+class TestWalkerAgreesWithRegistry:
+    def test_every_walked_site_names_a_row(self, walked):
+        fresh = unregistered(walked)
+        assert not fresh, (
+            "halt sites no registry row names -- add each to a row, or a new "
+            "row with its issue and the run that justified it:\n  "
+            + "\n  ".join(f"{s.key}  line {s.line}  {s.head[:60]!r}" for s in fresh)
+        )
+
+    def test_no_row_names_a_site_the_walker_cannot_find(self, walked):
+        ghosts = phantoms(walked)
+        assert not ghosts, (
+            "registry sites the walker did not find (the code moved or the "
+            "index shifted):\n  "
+            + "\n  ".join(f"{g}: {s}" for g, s in ghosts)
+        )
+
+    def test_emits_is_a_true_statement_about_the_code(self, walked):
+        """A row's `emits` is the head the run log shows. It must be found at
+        one of the row's sites, or in the file the row says decides it."""
+        heads_by_key: dict[str, list[str]] = {}
+        for site in walked:
+            heads_by_key.setdefault(site.key, []).append(site.head)
+        for gate in GATE_REGISTRY:
+            heads = [h for s in gate.sites for h in heads_by_key.get(s, [])]
+            if any(gate.emits in head for head in heads):
+                continue
+            if gate.decided_in:
+                text = (REPO_ROOT / gate.decided_in.split("::")[0]).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+                if gate.emits in text:
+                    continue
+            pytest.fail(
+                f"{gate.key}: emits {gate.emits!r} but no covered site's head "
+                f"carries it (heads: {[h[:50] for h in heads]})"
+            )
+
+    def test_the_cli_check_passes(self, capsys):
+        assert cli.main(["--check"]) == 0
+        assert "PASS" in capsys.readouterr().out
+
+
+class TestWalkerCatchesANewSite:
+    """The zero needs a negative test: a fresh, unregistered gate is found."""
+
+    def _fixture_tree(self, tmp_path: Path) -> Path:
+        module = tmp_path / "assemblyzero" / "workflows" / "fresh" / "node.py"
+        module.parent.mkdir(parents=True)
+        module.write_text(
+            "\n".join(
+                [
+                    "def n1(state):",
+                    "    if state.get('bad'):",
+                    "        return {'error_message': 'NEW GATE: something', 'x': 1}",
+                    "    return {'error_message': ''}",
+                    "",
+                    "def n2(path):",
+                    "    raise ImplementationError(filepath=path, reason=f'Boom {path}')",
+                    "",
+                    "def n3():",
+                    "    msg = 'Stage failed: ' + 'x'",
+                    "    return _make_stage_result(status='failed', error_message=msg)",
+                    "",
+                    "def n4():",
+                    "    raise ValueError('a bug, not a gate')",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_finds_each_kind_and_reads_the_head(self, tmp_path):
+        sites, coverage = scan_halt_sites(self._fixture_tree(tmp_path))
+        assert coverage.files_scanned == 1
+        by_qual = {s.qualname: s for s in sites}
+        assert set(by_qual) == {"n1", "n2", "n3"}, [s.key for s in sites]
+        assert by_qual["n1"].kind == KIND_RETURN
+        assert by_qual["n1"].head == "NEW GATE: something"
+        assert by_qual["n2"].kind == KIND_RAISE
+        assert by_qual["n2"].head == "Boom {}"
+        assert by_qual["n3"].kind == KIND_STAGE_RESULT
+        # The name resolves to its nearest assignment; the concatenation
+        # reads its left side.
+        assert by_qual["n3"].head == "Stage failed: "
+        assert by_qual["n1"].key == (
+            "assemblyzero/workflows/fresh/node.py::n1::return::0"
+        )
+
+    def test_a_fresh_site_is_reported_unregistered(self, tmp_path):
+        sites, _ = scan_halt_sites(self._fixture_tree(tmp_path))
+        assert {s.qualname for s in unregistered(sites)} == {"n1", "n2", "n3"}
+
+    def test_an_empty_error_message_is_not_a_site(self, tmp_path):
+        sites, _ = scan_halt_sites(self._fixture_tree(tmp_path))
+        assert all(s.index == 0 for s in sites if s.qualname == "n1")
+
+
+# ---------------------------------------------------------------------------
+# The tag for new sites
+# ---------------------------------------------------------------------------
+
+
+class TestHaltedTag:
+    def test_tags_and_round_trips(self):
+        key = GATE_REGISTRY[0].key
+        tagged = halted(key, "something went wrong ")
+        assert tagged.endswith(f"[gate:{key}]")
+        assert gate_key_of(tagged) == key
+
+    def test_an_unregistered_key_is_refused(self):
+        with pytest.raises(KeyError):
+            halted("no.such.gate", "x")
+
+    def test_an_untagged_message_has_no_key(self):
+        assert gate_key_of("Iteration cap: 3 review rounds ended REVISE") == ""
+
+
+# ---------------------------------------------------------------------------
+# The join to the report's cause-of-death table
+# ---------------------------------------------------------------------------
+
+
+class TestCauseTableJoins:
+    def test_every_cause_key_is_a_registered_gate(self):
+        absences = {CAUSE_UNRECORDED, CAUSE_UNCLASSIFIED, CAUSE_KILLED}
+        keys = registry_by_key()
+        missing = sorted(
+            cause.key for cause in CAUSE_TABLE
+            if cause.key not in absences and cause.key not in keys
+        )
+        assert not missing, (
+            f"cause keys the report can print but the registry does not know: "
+            f"{missing}"
+        )
+
+    def test_the_judges_columns_agree(self):
+        keys = registry_by_key()
+        for cause in CAUSE_TABLE:
+            gate = keys.get(cause.key)
+            if gate is None:
+                continue
+            assert gate.judges == cause.judges, (
+                f"{cause.key}: report says {cause.judges}, registry says "
+                f"{gate.judges}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# The ratchet (#2720)
+# ---------------------------------------------------------------------------
+
+
+class TestRatchet:
+    """The expense-report rule as a test: the count of gates that halt may
+    fall, and may not rise without the baseline moving in the same PR."""
+
+    def test_baseline_exists(self):
+        assert BASELINE_PATH.is_file(), (
+            f"{BASELINE_PATH} missing -- write it with the current halt_counts()"
+        )
+
+    def test_halt_rows_did_not_rise_in_any_stage(self):
+        baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        allowed = baseline["halt_rows_per_stage"]
+        counts = halt_counts()
+        risen = {
+            stage: (allowed.get(stage, 0), n)
+            for stage, n in counts.items()
+            if n > allowed.get(stage, 0)
+        }
+        assert not risen, (
+            f"halt-action rows rose (baseline, now): {risen}. A new gate that "
+            f"can end a run needs an operator ruling named in its row's "
+            f"created_by, and the baseline raised in the same PR so the "
+            f"increase is in the diff."
+        )
+
+    def test_a_fall_is_reported_so_the_baseline_gets_lowered(self, capsys):
+        baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        allowed = baseline["halt_rows_per_stage"]
+        counts = halt_counts()
+        fallen = {
+            stage: (allowed.get(stage, 0), counts.get(stage, 0))
+            for stage in allowed
+            if counts.get(stage, 0) < allowed.get(stage, 0)
+        }
+        if fallen:
+            print(f"halt rows fell (baseline, now): {fallen} -- lower the baseline")
+
+    def test_model_output_gates_that_halt_are_counted_for_the_policy(self):
+        """Not a gate on the number -- #2723 brings it to zero -- but the
+        number must be visible: it is the maze."""
+        halting = [
+            g.key for g in GATE_REGISTRY
+            if g.action == ACTION_HALT and g.judges == JUDGES_MODEL_OUTPUT
+        ]
+        baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        assert len(halting) <= baseline["model_output_halt_rows"], (
+            f"model-output gates that halt rose to {len(halting)}: {halting}"
+        )

--- a/tests/unit/test_utf8_console.py
+++ b/tests/unit/test_utf8_console.py
@@ -247,6 +247,7 @@ class TestEveryReportRendererInstallsIt:
         fails rather than the guard below silently checking a shorter list."""
         assert {p.name for p in self.renderers()} == {
             "audit_fail_open.py",
+            "audit_halt_sites.py",
             "check_requirements.py",
             "check_requirements_form.py",
             "golden_disasters.py",
@@ -261,6 +262,7 @@ class TestEveryReportRendererInstallsIt:
         "name",
         [
             "audit_fail_open.py",
+            "audit_halt_sites.py",
             "check_requirements.py",
             "check_requirements_form.py",
             "golden_disasters.py",

--- a/tools/audit_halt_sites.py
+++ b/tools/audit_halt_sites.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Audit: every site that can end a run, against the gate registry (#2719).
+
+The walker and the registry live in ``assemblyzero.core.gate_registry`` so the
+CI gate in ``tests/unit/test_gate_registry.py`` runs the same code this prints.
+
+Usage
+-----
+    poetry run python tools/audit_halt_sites.py              # per-gate report
+    poetry run python tools/audit_halt_sites.py --tsv        # one row per site
+    poetry run python tools/audit_halt_sites.py --unregistered
+    poetry run python tools/audit_halt_sites.py --check      # CI mode
+
+``--check`` exits 1 on any walked site no registry row names, or any registry
+site the walker cannot find. It is what the unit test calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+from assemblyzero.core.gate_registry import (  # noqa: E402
+    ACTION_HALT,
+    GATE_REGISTRY,
+    JUDGES_MODEL_OUTPUT,
+    HaltSite,
+    WalkCoverage,
+    halt_counts,
+    phantoms,
+    scan_halt_sites,
+    site_to_gate,
+    unregistered,
+)
+
+BASELINE_PATH = REPO_ROOT / "tests" / "fixtures" / "gate_registry_baseline.json"
+
+
+def model_output_halt_rows() -> int:
+    """Gates that judge the drafter's output and end the run. The maze."""
+    return sum(
+        1 for g in GATE_REGISTRY
+        if g.action == ACTION_HALT and g.judges == JUDGES_MODEL_OUTPUT
+    )
+
+
+def write_baseline(sites: list[HaltSite], coverage: WalkCoverage,
+                   path: Path = BASELINE_PATH) -> dict:
+    """Freeze today's halt-row counts so CI can refuse tomorrow's rise (#2720).
+
+    The counts ride with what they were measured against, so a reader can
+    see the denominator without re-running anything. Lower it by hand when
+    a gate stops halting; raise it only in a PR that names an operator
+    ruling.
+    """
+    payload = {
+        "_comment": (
+            "The ratchet (#2720). tests/unit/test_gate_registry.py fails when "
+            "halt_rows_per_stage or model_output_halt_rows rises above this. "
+            "Lower it when a gate stops halting; raise it only with an operator "
+            "ruling named in the new row's created_by, in the same PR."
+        ),
+        "measured_against": {
+            "files_scanned": coverage.files_scanned,
+            "halt_sites": len(sites),
+            "gates": len(GATE_REGISTRY),
+        },
+        "halt_rows_per_stage": halt_counts(),
+        "model_output_halt_rows": model_output_halt_rows(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return payload
+
+
+def render_tsv(sites: list[HaltSite]) -> str:
+    known = site_to_gate()
+    rows = ["site\tline\tgate\thead"]
+    for site in sites:
+        rows.append(
+            f"{site.key}\t{site.line}\t{known.get(site.key, '-')}\t"
+            f"{site.head[:100]!r}"
+        )
+    return "\n".join(rows)
+
+
+def render_report(sites: list[HaltSite], coverage: WalkCoverage) -> str:
+    fresh = unregistered(sites)
+    ghosts = phantoms(sites)
+    by_gate: dict[str, int] = defaultdict(int)
+    known = site_to_gate()
+    for site in sites:
+        if site.key in known:
+            by_gate[known[site.key]] += 1
+
+    lines = [
+        "=" * 78,
+        "HALT-SITE AUDIT (#2719)",
+        "=" * 78,
+        "",
+        "Coverage -- counted, not estimated:",
+        f"  Files scanned:      {coverage.files_scanned}",
+        f"  Functions scanned:  {coverage.functions_scanned}",
+        f"  Halt sites found:   {len(sites)}",
+        f"  Files that would NOT parse: {len(coverage.files_unparseable)}",
+        "",
+        f"Registry: {len(GATE_REGISTRY)} gate(s); halt-action rows per stage: "
+        + ", ".join(f"{s} {n}" for s, n in halt_counts().items()),
+        f"  Unregistered sites (no row names them): {len(fresh)}",
+        f"  Phantom sites (row names, walker cannot find): {len(ghosts)}",
+        "",
+        f"{'gate':<44} {'stage':<12} {'judges':<18} {'action':<7} sites",
+        "-" * 78,
+    ]
+    for gate in sorted(GATE_REGISTRY, key=lambda g: (g.stage, g.key)):
+        lines.append(
+            f"{gate.key:<44} {gate.stage:<12} {gate.judges:<18} "
+            f"{gate.action:<7} {by_gate.get(gate.key, 0)}"
+            + ("  (decided in " + gate.decided_in + ")" if gate.decided_in else "")
+        )
+    if fresh:
+        lines += ["", "UNREGISTERED -- every one must name a row:"]
+        for site in fresh:
+            lines.append(f"  {site.key}  line {site.line}  {site.head[:70]!r}")
+    if ghosts:
+        lines += ["", "PHANTOM -- the row names a site the walker cannot find:"]
+        for gate_key, site in ghosts:
+            lines.append(f"  {gate_key}: {site}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--tsv", action="store_true", help="one row per site")
+    parser.add_argument("--unregistered", action="store_true",
+                        help="only sites no registry row names")
+    parser.add_argument("--check", action="store_true",
+                        help="exit 1 on any unregistered or phantom site")
+    parser.add_argument("--write-baseline", action="store_true",
+                        help="freeze today's halt-row counts for the ratchet")
+    args = parser.parse_args(argv)
+
+    sites, coverage = scan_halt_sites(args.root)
+
+    if args.write_baseline:
+        payload = write_baseline(sites, coverage)
+        print(
+            f"Baseline written: halt rows {payload['halt_rows_per_stage']}, "
+            f"model-output halt rows {payload['model_output_halt_rows']}"
+        )
+        print(f"  {BASELINE_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    if args.check:
+        fresh = unregistered(sites)
+        ghosts = phantoms(sites)
+        if not fresh and not ghosts:
+            print(
+                f"PASS -- {coverage.files_scanned} files, {len(sites)} halt "
+                f"sites, every one registered; {len(GATE_REGISTRY)} gates, "
+                f"halt rows: {halt_counts()}"
+            )
+            return 0
+        print(f"FAIL -- {len(fresh)} unregistered site(s), {len(ghosts)} phantom(s)")
+        for site in fresh:
+            print(f"  unregistered: {site.key}  line {site.line}  {site.head[:70]!r}")
+        for gate_key, site in ghosts:
+            print(f"  phantom: {gate_key} names {site}")
+        print()
+        print("Add the site to a GATE_REGISTRY row (or a new row with its issue")
+        print("and the run that justified it); a halt-action row also moves the")
+        print("ratchet baseline. Remove a stale site key from its row.")
+        return 1
+
+    if args.unregistered:
+        print(render_tsv(unregistered(sites)))
+        return 0
+    if args.tsv:
+        print(render_tsv(sites))
+        return 0
+    print(render_report(sites, coverage))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2719
Closes #2720

## The map of the maze

Nothing recorded why any gate existed or whether it had ever saved a run, so gates only accumulated. This lands the registry and the walker that keeps it honest, and the ratchet that stops the count rising.

```
PASS -- 184 files, 160 halt sites, every one registered; 96 gates,
        halt rows: impl 42, lld 15, orchestrator 16, pr 1, spec 19
```

## What landed

**`assemblyzero/core/gate_registry.py`**

- `scan_halt_sites(root)`: an AST walker over `assemblyzero/workflows/` that finds every site by a closed, authored pattern set: `raise ImplementationError`, a node `return {... "error_message": <non-empty>}`, a `StageResult(...)` or `_make_stage_result(...)` with a non-empty `error_message`, and revision pinning's `refusals.append` and `conservation_event`. Site identity is `path::qualname::kind::index` with no line number, the fail-open audit's scheme, so an unrelated edit above a site does not churn it. Message heads are read through constants, f-strings, concatenations, and the nearest prior assignment of a name.
- `GATE_REGISTRY`: 96 rows, one per gate, each naming its sites, its stage, what it judges (`model_output`, `upstream_artifact`, `issue_body`, `budget`, `infrastructure`, `operator`, `relay`), what it does today (`halt`, `revise`, `advise`), the message head the run log shows, and, where the code itself says so, the issue that created it and the run that justified it. A gate whose halt is decided outside the walked tree (the review cap in the router, the wall-clock ceiling in `retry_gate`, `branch_exists` raised as a `RuntimeError`) names where in `decided_in`.
- `halted(key, message)` and `gate_key_of(message)`: the tag for sites written from now on, so the terminal record (#2721) reads a key instead of matching prose.
- `halt_counts()`: halt-action rows per stage, the ratchet's quantity.

**`tools/audit_halt_sites.py`**: the report, `--tsv`, `--unregistered`, `--check` (what CI runs), and `--write-baseline`.

**`tests/fixtures/gate_registry_baseline.json`** (#2720): halt rows per stage and the count of model-output gates that halt, frozen. The test fails on any rise; a fall passes and says to lower the baseline. Raising it requires an operator ruling named in the new row's `created_by`, in the same PR, so the increase is in the diff.

**`tests/unit/test_gate_registry.py`**, 21 tests: keys unique, vocabularies closed, no site in two rows, every walked site names a row, every row's sites exist, every `emits` is found at a covered site or in the file the row names, the CLI check passes, a fixture module with three fresh unregistered sites is found by kind with the right heads and reported, an empty `error_message` is not a site, the tag round-trips and refuses an unknown key, every cause key `factory_report.py` can print is a registered gate with the same `judges`, and the ratchet.

## What it says

Of 93 gates that halt today, 24 judge the drafter's own output. Those are the rows the routing policy (#2723) turns into `revise`; the ratchet holds the number while it comes down. The `judges` column and the join to the report's cause table are what the answer-key audit (#2722) and the policy read.

One correction to the report on the way: `impl.scenario_ratio_guard` judges the LLD's test plan, an earlier stage's artifact, not the drafter's output. Its cause row now says `upstream_artifact`, and the registry agrees.

## Scope

Legacy sites are covered by their walker keys in the registry; their messages are not rewritten to carry the tag. Retagging 160 sites is the routing policy's job, since #2723 touches every one of them anyway, and doing it here would change 31 files of live halt text for no behavioural gain.
