### PR TITLE
feat: the answer-key audit — every mechanical gate run against the hand-built code on boostgauge main, and the six refusals it produces (Closes #2722)

### DIFF
--- a/assemblyzero/speedrun/answer_key.py
+++ b/assemblyzero/speedrun/answer_key.py
@@ -1,0 +1,406 @@
+"""The answer-key audit: run the gates over code that is known to be right (#2722).
+
+boostgauge `main` carries v1.0.0, built by hand on 2026-09-01 in one session:
+the six features the factory has been asked to build, approved by the operator
+and by the visual gate. That is the correct answer. A gate that judges the
+drafter's output and refuses content the shipped code also contains is a false
+positive by construction, and that is checkable without launching anything.
+
+Run 11 (`run-issue4-183941`) is the exhibit: nine review rounds refusing the
+drafter's ±1 tolerances, which are the tolerances the shipped collector's own
+cross-check uses.
+
+## What runs here, and what does not
+
+Only gates that are pure functions over text can be run against a finished
+artifact. The ones that need a live loop (stagnation, iteration caps, the
+red phase, coverage) are named in `NOT_RUNNABLE_HERE` with the reason, so the
+report says which gates it could not judge rather than implying it judged
+them all. Each runnable gate is keyed by its `gate_registry` key, and the
+test suite asserts every key names a registered gate that judges the
+drafter's output or an upstream artifact -- the only two kinds an answer key
+can speak to.
+
+## Refusal is the finding, not the verdict
+
+A refusal here means the gate would have rejected code the operator shipped.
+That is the defect this audit exists to find. It does not mean the shipped
+code is wrong; it means the gate's rule and the operator's judgment disagree,
+and the operator's judgment is the answer key.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass(frozen=True)
+class Feature:
+    """One issue in the arc and the artifacts the hand-build shipped for it."""
+
+    issue: int
+    title: str
+    sources: tuple[str, ...]
+    tests: tuple[str, ...]
+    #: The LLD the factory drafted for it, where one survives on main.
+    lld: str = ""
+
+
+#: The six-feature arc, as shipped on boostgauge main by the 2026-09-01 hand
+#: build (PRs #407, #408, #410, #411, #412, #413). File lists are the PRs' own
+#: file lists. Authored; the tool refuses to guess a file that is not here.
+BOOSTGAUGE_ARC: tuple[Feature, ...] = (
+    Feature(
+        4, "Windows collector",
+        ("src/boostgauge/collector.py", "src/boostgauge/collectors/__init__.py",
+         "src/boostgauge/collectors/windows.py"),
+        ("tests/unit/test_collector.py", "tests/unit/test_collector_source_pin.py",
+         "tests/integration/test_windows_sweep_crosscheck.py",
+         "tests/benchmark/test_sweep_cost.py"),
+        lld="docs/lld/active/LLD-004.md",
+    ),
+    Feature(
+        41, "Telltale peak-hold logic",
+        ("src/boostgauge/telltale.py",), ("tests/unit/test_telltale.py",),
+    ),
+    Feature(
+        332, "Stingray dynamic layer",
+        ("src/boostgauge/skins/stingray.py",),
+        ("tests/visual/test_stingray_dynamic.py",),
+    ),
+    Feature(
+        7, "configuration file and CLI",
+        ("src/boostgauge/config.py",), ("tests/unit/test_config.py",),
+    ),
+    Feature(
+        2, "telltale wiring",
+        ("src/boostgauge/session.py",), ("tests/unit/test_session.py",),
+    ),
+    Feature(
+        5, "the window",
+        ("src/boostgauge/app.py",), ("tests/unit/test_app.py",),
+    ),
+)
+
+#: Gates this audit can run, by registry key, and what artifact each reads.
+RUNNABLE_GATES: tuple[tuple[str, str], ...] = (
+    ("impl.file_generation_failed", "every shipped .py file, as the implementer validates a file it wrote"),
+    ("impl.test_file_validation", "every shipped test file, as the scaffolder's structural validator"),
+    ("impl.deterministic_failure", "every shipped test file, as the scaffolder's stub count"),
+    ("impl.path_enforcement", "every shipped file against the LLD's allowed paths"),
+    ("lld.mechanical_validation", "the LLD, where one survives on main"),
+    ("impl.scenario_ratio_guard", "the LLD's requirements against its test plan"),
+    ("pr.commit_message_guard", "the merged commit's subject line"),
+)
+
+#: Gates that judge model output but need a live loop, a run, or a second
+#: draft, so an answer key cannot exercise them. Named so the report's
+#: coverage is honest.
+NOT_RUNNABLE_HERE: tuple[tuple[str, str], ...] = (
+    ("impl.stagnation.coverage", "needs two iterations of a live green loop"),
+    ("impl.stagnation.test_count", "needs two iterations of a live green loop"),
+    ("impl.stagnation.test_identity", "needs two iterations of a live green loop"),
+    ("impl.stagnation.full_suite", "needs a live full-suite run"),
+    ("impl.stagnation.e2e", "needs a live e2e loop"),
+    ("impl.red_phase_failed", "needs pytest run against the pre-implementation tree"),
+    ("impl.red.import_errors", "needs pytest run against the pre-implementation tree"),
+    ("impl.green.collection_broken", "needs a pytest collection run"),
+    ("spec.pinning_refusal", "needs a previous draft and a revision"),
+    ("spec.conservation_gate", "needs a previous draft and a revision"),
+    ("spec.edit_script_rejected", "needs a spec and a SEARCH/REPLACE revision"),
+    ("spec.finalize.draft_guard", "needs a spec draft; none survives on main"),
+    ("spec.review.empty_draft", "needs a spec draft; none survives on main"),
+    ("spec.review_blocked", "is a reviewer model's verdict, not a mechanical rule"),
+    ("spec.reviewer_verdict_unreadable", "is about the reviewer's output"),
+    ("impl.reviewer_verdict_unreadable", "is about the reviewer's output"),
+    ("impl.test_plan_revision_incomplete", "needs a test-plan revision"),
+    ("lld.test_plan_validation", "needs the LLD draft loop"),
+    ("lld.best_of_n_unusable", "needs N drafts"),
+    ("lld.edit_script_rejected", "needs an LLD and a SEARCH/REPLACE revision"),
+)
+
+
+@dataclass
+class Verdict:
+    """One gate, run over one artifact of one feature."""
+
+    issue: int
+    gate: str
+    artifact: str
+    refused: bool
+    message: str = ""
+
+    @property
+    def outcome(self) -> str:
+        return "REFUSE" if self.refused else "pass"
+
+
+@dataclass
+class AuditCoverage:
+    """What was examined. Counted, never estimated."""
+
+    features: int = 0
+    files_examined: int = 0
+    files_missing: list[str] = field(default_factory=list)
+    llds_examined: int = 0
+    commits_examined: int = 0
+    #: Features whose merged commit could not be asked for: the target is not
+    #: a git checkout, or git is not on PATH. Printed, never silently zero.
+    git_unreadable: int = 0
+
+
+# ---------------------------------------------------------------------------
+# The gates, each as the pipeline's own function
+# ---------------------------------------------------------------------------
+
+
+def _gate_code_response(code: str, rel: str, repo: Path) -> tuple[bool, str]:
+    """impl.file_generation_failed: the implementer's mechanical validation."""
+    from assemblyzero.workflows.testing.nodes.implementation.parsers import (
+        validate_code_response,
+    )
+
+    valid, message = validate_code_response(code, rel, "", str(repo))
+    return (not valid), message
+
+
+def _gate_test_structure(content: str) -> tuple[bool, str]:
+    """impl.test_file_validation: the scaffolder's structural validator."""
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        validate_test_structure,
+    )
+
+    errors = validate_test_structure(content, [])
+    return bool(errors), "; ".join(errors)[:400]
+
+
+def _gate_stub_count(content: str) -> tuple[bool, str]:
+    """impl.deterministic_failure: the scaffolder's stub count."""
+    from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        count_stub_tests,
+    )
+
+    total, stubs, names = count_stub_tests(content)
+    if stubs:
+        return True, f"{stubs} of {total} test(s) read as stubs: {', '.join(names[:5])}"
+    return False, f"0 of {total} test(s) read as stubs"
+
+
+def _gate_path_enforcement(rel: str, lld_content: str) -> tuple[bool, str]:
+    """impl.path_enforcement: the file is one the LLD allows the run to write."""
+    from assemblyzero.hooks.file_write_validator import validate_file_write
+    from assemblyzero.utils.lld_path_enforcer import extract_paths_from_lld
+
+    spec = extract_paths_from_lld(lld_content)
+    allowed = set(spec.get("all_allowed_paths") or ())
+    if not allowed:
+        return False, "LLD declares no paths; the gate is inert"
+    result = validate_file_write(rel, allowed)
+    return (not result.get("allowed", True)), str(result.get("reason", ""))
+
+
+def _gate_lld_mechanical(lld_content: str, repo: Path, issue: int) -> tuple[bool, str]:
+    """lld.mechanical_validation over the LLD as the requirements stage runs it."""
+    from assemblyzero.workflows.requirements.nodes.validate_mechanical import (
+        _validate_lld_mechanical_inner,
+    )
+
+    result = _validate_lld_mechanical_inner(
+        {"current_draft": lld_content, "target_repo": str(repo), "issue_number": issue}
+    )
+    errors = [str(e) for e in (result.get("validation_errors") or [])]
+    return bool(errors), "; ".join(errors)[:400]
+
+
+def _gate_scenario_ratio(lld_content: str) -> tuple[bool, str]:
+    """impl.scenario_ratio_guard: the LLD's test plan against its requirements."""
+    from assemblyzero.workflows.testing.nodes.load_lld import (
+        extract_requirements,
+        extract_test_plan_section,
+        parse_test_scenarios,
+    )
+    from assemblyzero.workflows.testing.nodes.review_test_plan import (
+        _run_mechanical_gates,
+    )
+
+    requirements = extract_requirements(lld_content)
+    scenarios = parse_test_scenarios(extract_test_plan_section(lld_content))
+    errors = _run_mechanical_gates(
+        {
+            "lld_content": lld_content,
+            "test_scenarios": list(scenarios),
+            "requirements": list(requirements),
+        }
+    )
+    detail = f"{len(scenarios)} scenario(s), {len(requirements)} requirement(s)"
+    return bool(errors), ("; ".join(errors)[:300] + " | " if errors else "") + detail
+
+
+def _gate_commit_message(issue: int, subject: str) -> tuple[bool, str]:
+    """pr.commit_message_guard over the merged commit's subject."""
+    from assemblyzero.workflows.testing.nodes.validate_commit_message import (
+        validate_commit_message,
+    )
+
+    result = validate_commit_message(
+        {"issue_number": issue, "commit_message": subject}
+    )
+    message = result.get("error_message", "")
+    return bool(message), message or subject[:100]
+
+
+# ---------------------------------------------------------------------------
+# The audit
+# ---------------------------------------------------------------------------
+
+
+def merged_subject(repo: Path, issue: int) -> str | None:
+    """The subject of the commit that closed the issue.
+
+    "" when no commit in the last two hundred carries `Closes #N`; None when
+    git could not be asked at all, which the caller counts and the report
+    prints as its own line.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "log", "--format=%s", "-200", "HEAD"],
+            cwd=str(repo), capture_output=True, text=True, check=True,
+            encoding="utf-8", errors="replace",
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        # fail-open: a target that is not a git checkout has no merged commit
+        # to examine. The caller records it in coverage.git_unreadable and the
+        # report prints that count beside commits_examined, so the shortfall
+        # is in the data rather than disguised as "no commit closes this".
+        return None
+    needle = f"closes #{issue}"
+    for line in out.splitlines():
+        if needle in line.lower():
+            return line
+    return ""
+
+
+def audit_feature(
+    repo: Path, feature: Feature, coverage: AuditCoverage
+) -> list[Verdict]:
+    """Every runnable gate over every artifact of one feature."""
+    verdicts: list[Verdict] = []
+    coverage.features += 1
+
+    lld_content = ""
+    if feature.lld:
+        lld_path = repo / feature.lld
+        if lld_path.is_file():
+            lld_content = lld_path.read_text(encoding="utf-8", errors="replace")
+            coverage.llds_examined += 1
+            refused, message = _gate_lld_mechanical(lld_content, repo, feature.issue)
+            verdicts.append(Verdict(feature.issue, "lld.mechanical_validation",
+                                    feature.lld, refused, message))
+            refused, message = _gate_scenario_ratio(lld_content)
+            verdicts.append(Verdict(feature.issue, "impl.scenario_ratio_guard",
+                                    feature.lld, refused, message))
+        else:
+            coverage.files_missing.append(feature.lld)
+
+    for rel in feature.sources + feature.tests:
+        path = repo / rel
+        if not path.is_file():
+            coverage.files_missing.append(rel)
+            continue
+        coverage.files_examined += 1
+        content = path.read_text(encoding="utf-8", errors="replace")
+        if rel.endswith(".py"):
+            refused, message = _gate_code_response(content, rel, repo)
+            verdicts.append(Verdict(feature.issue, "impl.file_generation_failed",
+                                    rel, refused, message))
+        if rel in feature.tests and rel.endswith(".py"):
+            refused, message = _gate_test_structure(content)
+            verdicts.append(Verdict(feature.issue, "impl.test_file_validation",
+                                    rel, refused, message))
+            refused, message = _gate_stub_count(content)
+            verdicts.append(Verdict(feature.issue, "impl.deterministic_failure",
+                                    rel, refused, message))
+        if lld_content:
+            refused, message = _gate_path_enforcement(rel, lld_content)
+            verdicts.append(Verdict(feature.issue, "impl.path_enforcement",
+                                    rel, refused, message))
+
+    subject = merged_subject(repo, feature.issue)
+    if subject is None:
+        coverage.git_unreadable += 1
+    elif subject:
+        coverage.commits_examined += 1
+        refused, message = _gate_commit_message(feature.issue, subject)
+        verdicts.append(Verdict(feature.issue, "pr.commit_message_guard",
+                                "merged commit subject", refused, message))
+    return verdicts
+
+
+def audit(repo: Path, arc: tuple[Feature, ...] = BOOSTGAUGE_ARC) -> tuple[list[Verdict], AuditCoverage]:
+    coverage = AuditCoverage()
+    verdicts: list[Verdict] = []
+    for feature in arc:
+        verdicts.extend(audit_feature(repo, feature, coverage))
+    return verdicts, coverage
+
+
+def render(repo: Path, verdicts: list[Verdict], coverage: AuditCoverage,
+           *, generated_at: str = "") -> str:
+    """The report. Deterministic for a given input, except the timestamp."""
+    stamp = generated_at or datetime.now().strftime(_TS_FMT)
+    refusals = [v for v in verdicts if v.refused]
+    by_gate: dict[str, tuple[int, int]] = {}
+    for v in verdicts:
+        ran, refused = by_gate.get(v.gate, (0, 0))
+        by_gate[v.gate] = (ran + 1, refused + (1 if v.refused else 0))
+
+    lines = [
+        f"# Answer-key audit — {repo}",
+        "",
+        f"Generated {stamp}. The shipped code on main is the answer key; a "
+        "refusal below is a gate rejecting content the operator shipped.",
+        "",
+        "A refusal on `impl.path_enforcement` means the LLD's file plan and "
+        "the shipped file names disagree: the gate holds the drafter to a "
+        "plan the hand build did not follow. A refusal on the test-file gates "
+        "means a hand-written test delegates its assertion to a helper the "
+        "gate cannot see.",
+        "",
+        "## Coverage — counted, not estimated",
+        "",
+        f"- Features: {coverage.features}",
+        f"- Files examined: {coverage.files_examined}"
+        + (f" (missing: {', '.join(coverage.files_missing)})" if coverage.files_missing else ""),
+        f"- LLDs examined: {coverage.llds_examined}",
+        f"- Merged commits examined: {coverage.commits_examined}"
+        + (f" (git unreadable for {coverage.git_unreadable} feature(s))"
+           if coverage.git_unreadable else ""),
+        f"- Verdicts: {len(verdicts)}; refusals: {len(refusals)}",
+        "",
+        "## Per gate",
+        "",
+        "| gate | ran | refused |",
+        "|---|---|---|",
+    ]
+    for gate, (ran, refused) in sorted(by_gate.items()):
+        lines.append(f"| {gate} | {ran} | {refused} |")
+    lines += ["", "## Refusals — each one is a false positive by construction", ""]
+    if refusals:
+        for v in sorted(refusals, key=lambda v: (v.issue, v.gate, v.artifact)):
+            lines.append(f"- #{v.issue} `{v.gate}` on `{v.artifact}`: {v.message}")
+    else:
+        lines.append("None. Every runnable gate accepted every shipped artifact.")
+    lines += ["", "## Every verdict", "", "| issue | gate | artifact | outcome | detail |", "|---|---|---|---|---|"]
+    for v in sorted(verdicts, key=lambda v: (v.issue, v.gate, v.artifact)):
+        detail = v.message.replace("|", "\\|").replace("\n", " ")[:160]
+        lines.append(f"| #{v.issue} | {v.gate} | `{v.artifact}` | {v.outcome} | {detail} |")
+    lines += ["", "## Not runnable against a finished artifact", ""]
+    for gate, reason in NOT_RUNNABLE_HERE:
+        lines.append(f"- `{gate}`: {reason}")
+    lines.append("")
+    return "\n".join(lines)

--- a/docs/audits/0907-answer-key-audit-boostgauge-2026-09-03.md
+++ b/docs/audits/0907-answer-key-audit-boostgauge-2026-09-03.md
@@ -1,0 +1,112 @@
+# Answer-key audit — C:\Users\mcwiz\Projects\boostgauge
+
+Generated 2026-09-03 12:16:46. The shipped code on main is the answer key; a refusal below is a gate rejecting content the operator shipped.
+
+A refusal on `impl.path_enforcement` means the LLD's file plan and the shipped file names disagree: the gate holds the drafter to a plan the hand build did not follow. A refusal on the test-file gates means a hand-written test delegates its assertion to a helper the gate cannot see.
+
+## Coverage — counted, not estimated
+
+- Features: 6
+- Files examined: 17
+- LLDs examined: 1
+- Merged commits examined: 6
+- Verdicts: 50; refusals: 6
+
+## Per gate
+
+| gate | ran | refused |
+|---|---|---|
+| impl.deterministic_failure | 9 | 0 |
+| impl.file_generation_failed | 17 | 0 |
+| impl.path_enforcement | 7 | 4 |
+| impl.scenario_ratio_guard | 1 | 0 |
+| impl.test_file_validation | 9 | 2 |
+| lld.mechanical_validation | 1 | 0 |
+| pr.commit_message_guard | 6 | 0 |
+
+## Refusals — each one is a false positive by construction
+
+- #4 `impl.path_enforcement` on `src/boostgauge/collectors/__init__.py`: Rejected: 'src/boostgauge/collectors/__init__.py' not in LLD-specified paths. Did you mean 'src/boostgauge/collectors/windows.py'?
+- #4 `impl.path_enforcement` on `tests/benchmark/test_sweep_cost.py`: Rejected: 'tests/benchmark/test_sweep_cost.py' not in LLD-specified paths. Did you mean 'tests/benchmark/test_windows_sweep.py'?
+- #4 `impl.path_enforcement` on `tests/integration/test_windows_sweep_crosscheck.py`: Rejected: 'tests/integration/test_windows_sweep_crosscheck.py' not in LLD-specified paths. Did you mean 'tests/integration/test_windows_collector.py'?
+- #4 `impl.path_enforcement` on `tests/unit/test_collector_source_pin.py`: Rejected: 'tests/unit/test_collector_source_pin.py' not in LLD-specified paths. Did you mean 'tests/unit/test_collector.py'?
+- #41 `impl.test_file_validation` on `tests/unit/test_telltale.py`: Function 'test_V4_equal_timestamp_is_accepted' has no assertion statements
+- #332 `impl.test_file_validation` on `tests/visual/test_stingray_dynamic.py`: Function 'test_dynamic_256_matches_baseline' has no assertion statements
+
+## Every verdict
+
+| issue | gate | artifact | outcome | detail |
+|---|---|---|---|---|
+| #2 | impl.deterministic_failure | `tests/unit/test_session.py` | pass | 0 of 16 test(s) read as stubs |
+| #2 | impl.file_generation_failed | `src/boostgauge/session.py` | pass |  |
+| #2 | impl.file_generation_failed | `tests/unit/test_session.py` | pass |  |
+| #2 | impl.test_file_validation | `tests/unit/test_session.py` | pass |  |
+| #2 | pr.commit_message_guard | `merged commit subject` | pass | feat: telltale wiring — four instances from config, sample fan-out, four-slot peaks with None passed |
+| #4 | impl.deterministic_failure | `tests/benchmark/test_sweep_cost.py` | pass | 0 of 1 test(s) read as stubs |
+| #4 | impl.deterministic_failure | `tests/integration/test_windows_sweep_crosscheck.py` | pass | 0 of 1 test(s) read as stubs |
+| #4 | impl.deterministic_failure | `tests/unit/test_collector.py` | pass | 0 of 8 test(s) read as stubs |
+| #4 | impl.deterministic_failure | `tests/unit/test_collector_source_pin.py` | pass | 0 of 3 test(s) read as stubs |
+| #4 | impl.file_generation_failed | `src/boostgauge/collector.py` | pass |  |
+| #4 | impl.file_generation_failed | `src/boostgauge/collectors/__init__.py` | pass |  |
+| #4 | impl.file_generation_failed | `src/boostgauge/collectors/windows.py` | pass |  |
+| #4 | impl.file_generation_failed | `tests/benchmark/test_sweep_cost.py` | pass |  |
+| #4 | impl.file_generation_failed | `tests/integration/test_windows_sweep_crosscheck.py` | pass |  |
+| #4 | impl.file_generation_failed | `tests/unit/test_collector.py` | pass |  |
+| #4 | impl.file_generation_failed | `tests/unit/test_collector_source_pin.py` | pass |  |
+| #4 | impl.path_enforcement | `src/boostgauge/collector.py` | pass | Path matches LLD specification |
+| #4 | impl.path_enforcement | `src/boostgauge/collectors/__init__.py` | REFUSE | Rejected: 'src/boostgauge/collectors/__init__.py' not in LLD-specified paths. Did you mean 'src/boostgauge/collectors/windows.py'? |
+| #4 | impl.path_enforcement | `src/boostgauge/collectors/windows.py` | pass | Path matches LLD specification |
+| #4 | impl.path_enforcement | `tests/benchmark/test_sweep_cost.py` | REFUSE | Rejected: 'tests/benchmark/test_sweep_cost.py' not in LLD-specified paths. Did you mean 'tests/benchmark/test_windows_sweep.py'? |
+| #4 | impl.path_enforcement | `tests/integration/test_windows_sweep_crosscheck.py` | REFUSE | Rejected: 'tests/integration/test_windows_sweep_crosscheck.py' not in LLD-specified paths. Did you mean 'tests/integration/test_windows_collector.py'? |
+| #4 | impl.path_enforcement | `tests/unit/test_collector.py` | pass | Path matches LLD specification |
+| #4 | impl.path_enforcement | `tests/unit/test_collector_source_pin.py` | REFUSE | Rejected: 'tests/unit/test_collector_source_pin.py' not in LLD-specified paths. Did you mean 'tests/unit/test_collector.py'? |
+| #4 | impl.scenario_ratio_guard | `docs/lld/active/LLD-004.md` | pass | 26 scenario(s), 8 requirement(s) |
+| #4 | impl.test_file_validation | `tests/benchmark/test_sweep_cost.py` | pass |  |
+| #4 | impl.test_file_validation | `tests/integration/test_windows_sweep_crosscheck.py` | pass |  |
+| #4 | impl.test_file_validation | `tests/unit/test_collector.py` | pass |  |
+| #4 | impl.test_file_validation | `tests/unit/test_collector_source_pin.py` | pass |  |
+| #4 | lld.mechanical_validation | `docs/lld/active/LLD-004.md` | pass |  |
+| #4 | pr.commit_message_guard | `merged commit subject` | pass | feat: auto-calibrated thresholds — 100 is this machine's own high; seed at 2.5x so the needle starts |
+| #5 | impl.deterministic_failure | `tests/unit/test_app.py` | pass | 0 of 7 test(s) read as stubs |
+| #5 | impl.file_generation_failed | `src/boostgauge/app.py` | pass |  |
+| #5 | impl.file_generation_failed | `tests/unit/test_app.py` | pass |  |
+| #5 | impl.test_file_validation | `tests/unit/test_app.py` | pass |  |
+| #5 | pr.commit_message_guard | `merged commit subject` | pass | feat: the window — frameless always-on-top gauge, drag, keyed transparency, wheel resize, hover tool |
+| #7 | impl.deterministic_failure | `tests/unit/test_config.py` | pass | 0 of 25 test(s) read as stubs |
+| #7 | impl.file_generation_failed | `src/boostgauge/config.py` | pass |  |
+| #7 | impl.file_generation_failed | `tests/unit/test_config.py` | pass |  |
+| #7 | impl.test_file_validation | `tests/unit/test_config.py` | pass |  |
+| #7 | pr.commit_message_guard | `merged commit subject` | pass | feat: configuration file and CLI — three write moments, threshold-only hot reload, session-only CLI  |
+| #41 | impl.deterministic_failure | `tests/unit/test_telltale.py` | pass | 0 of 24 test(s) read as stubs |
+| #41 | impl.file_generation_failed | `src/boostgauge/telltale.py` | pass |  |
+| #41 | impl.file_generation_failed | `tests/unit/test_telltale.py` | pass |  |
+| #41 | impl.test_file_validation | `tests/unit/test_telltale.py` | REFUSE | Function 'test_V4_equal_timestamp_is_accepted' has no assertion statements |
+| #41 | pr.commit_message_guard | `merged commit subject` | pass | feat: auto-calibrated thresholds — 100 is this machine's own high; seed at 2.5x so the needle starts |
+| #332 | impl.deterministic_failure | `tests/visual/test_stingray_dynamic.py` | pass | 0 of 14 test(s) read as stubs |
+| #332 | impl.file_generation_failed | `src/boostgauge/skins/stingray.py` | pass |  |
+| #332 | impl.file_generation_failed | `tests/visual/test_stingray_dynamic.py` | pass |  |
+| #332 | impl.test_file_validation | `tests/visual/test_stingray_dynamic.py` | REFUSE | Function 'test_dynamic_256_matches_baseline' has no assertion statements |
+| #332 | pr.commit_message_guard | `merged commit subject` | pass | feat: Stingray dynamic layer — four telltales, main needle, pivot cap over the cached face; approved |
+
+## Not runnable against a finished artifact
+
+- `impl.stagnation.coverage`: needs two iterations of a live green loop
+- `impl.stagnation.test_count`: needs two iterations of a live green loop
+- `impl.stagnation.test_identity`: needs two iterations of a live green loop
+- `impl.stagnation.full_suite`: needs a live full-suite run
+- `impl.stagnation.e2e`: needs a live e2e loop
+- `impl.red_phase_failed`: needs pytest run against the pre-implementation tree
+- `impl.red.import_errors`: needs pytest run against the pre-implementation tree
+- `impl.green.collection_broken`: needs a pytest collection run
+- `spec.pinning_refusal`: needs a previous draft and a revision
+- `spec.conservation_gate`: needs a previous draft and a revision
+- `spec.edit_script_rejected`: needs a spec and a SEARCH/REPLACE revision
+- `spec.finalize.draft_guard`: needs a spec draft; none survives on main
+- `spec.review.empty_draft`: needs a spec draft; none survives on main
+- `spec.review_blocked`: is a reviewer model's verdict, not a mechanical rule
+- `spec.reviewer_verdict_unreadable`: is about the reviewer's output
+- `impl.reviewer_verdict_unreadable`: is about the reviewer's output
+- `impl.test_plan_revision_incomplete`: needs a test-plan revision
+- `lld.test_plan_validation`: needs the LLD draft loop
+- `lld.best_of_n_unusable`: needs N drafts
+- `lld.edit_script_rejected`: needs an LLD and a SEARCH/REPLACE revision

--- a/tests/unit/test_answer_key.py
+++ b/tests/unit/test_answer_key.py
@@ -1,0 +1,204 @@
+"""The answer-key audit (#2722): the gates run over code known to be right.
+
+Driven against a synthetic repo so the suite does not depend on boostgauge
+being checked out beside this one.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import answer_key_audit as cli  # noqa: E402
+
+from assemblyzero.core.gate_registry import (  # noqa: E402
+    JUDGES_MODEL_OUTPUT,
+    JUDGES_UPSTREAM,
+    registry_by_key,
+)
+from assemblyzero.speedrun.answer_key import (  # noqa: E402
+    BOOSTGAUGE_ARC,
+    NOT_RUNNABLE_HERE,
+    RUNNABLE_GATES,
+    Feature,
+    audit,
+    render,
+)
+
+GOOD_SOURCE = '''"""A module."""
+
+from __future__ import annotations
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+def sub(a: int, b: int) -> int:
+    return a - b
+'''
+
+GOOD_TEST = '''"""Tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from widget.core import add
+
+
+def test_add():
+    assert add(1, 2) == 3
+
+
+def test_add_raises_on_none():
+    with pytest.raises(TypeError):
+        add(None, 1)
+'''
+
+STUB_TEST = '''"""Stubs."""
+
+import pytest
+
+
+def test_one():
+    pass
+
+
+def test_two():
+    """TODO"""
+'''
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(repo), check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture()
+def answer_repo(tmp_path) -> Path:
+    repo = tmp_path / "widget"
+    (repo / "src" / "widget").mkdir(parents=True)
+    (repo / "tests" / "unit").mkdir(parents=True)
+    (repo / "src" / "widget" / "__init__.py").write_text("", encoding="utf-8")
+    (repo / "src" / "widget" / "core.py").write_text(GOOD_SOURCE, encoding="utf-8")
+    (repo / "tests" / "unit" / "test_core.py").write_text(GOOD_TEST, encoding="utf-8")
+    (repo / "tests" / "unit" / "test_stubs.py").write_text(STUB_TEST, encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "add", ".")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+         "-m", "feat: the core (Closes #9)")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q",
+         "--allow-empty", "-m", "feat: stubs, closes nothing")
+    return repo
+
+
+ARC = (
+    Feature(9, "the core", ("src/widget/core.py",), ("tests/unit/test_core.py",)),
+    Feature(10, "stubs", (), ("tests/unit/test_stubs.py",)),
+    Feature(11, "missing", ("src/widget/nope.py",), ()),
+)
+
+
+class TestTheGateListIsHonest:
+    def test_every_runnable_gate_is_registered_and_judges_a_draft(self):
+        keys = registry_by_key()
+        for gate, _ in RUNNABLE_GATES:
+            assert gate in keys, gate
+            assert keys[gate].judges in (JUDGES_MODEL_OUTPUT, JUDGES_UPSTREAM), (
+                f"{gate} judges {keys[gate].judges}; an answer key cannot speak to that"
+            )
+
+    def test_every_not_runnable_gate_is_registered(self):
+        keys = registry_by_key()
+        for gate, reason in NOT_RUNNABLE_HERE:
+            assert gate in keys, gate
+            assert reason
+
+    def test_runnable_and_not_runnable_do_not_overlap(self):
+        assert not {g for g, _ in RUNNABLE_GATES} & {g for g, _ in NOT_RUNNABLE_HERE}
+
+    def test_the_arc_names_six_features_with_files(self):
+        assert [f.issue for f in BOOSTGAUGE_ARC] == [4, 41, 332, 7, 2, 5]
+        for feature in BOOSTGAUGE_ARC:
+            assert feature.sources and feature.tests, feature.issue
+
+
+class TestAudit:
+    def test_good_code_passes_every_gate(self, answer_repo):
+        verdicts, coverage = audit(answer_repo, ARC[:1])
+        assert coverage.files_examined == 2
+        assert coverage.commits_examined == 1
+        refused = [v for v in verdicts if v.refused]
+        assert not refused, [(v.gate, v.message) for v in refused]
+        gates = {v.gate for v in verdicts}
+        assert gates == {
+            "impl.file_generation_failed", "impl.test_file_validation",
+            "impl.deterministic_failure", "pr.commit_message_guard",
+        }
+
+    def test_stub_tests_are_refused_by_the_scaffolder_gates(self, answer_repo):
+        verdicts, _ = audit(answer_repo, ARC[1:2])
+        refused = {v.gate for v in verdicts if v.refused}
+        assert "impl.test_file_validation" in refused
+        assert "impl.deterministic_failure" in refused
+        stub = next(v for v in verdicts if v.gate == "impl.deterministic_failure")
+        assert "2 of 2" in stub.message
+
+    def test_a_commit_without_the_close_is_refused(self, answer_repo):
+        verdicts, coverage = audit(answer_repo, ARC[1:2])
+        # No commit on main carries "Closes #10", so the guard never ran.
+        assert coverage.commits_examined == 0
+        assert not [v for v in verdicts if v.gate == "pr.commit_message_guard"]
+
+    def test_missing_files_are_counted_not_skipped_silently(self, answer_repo):
+        _, coverage = audit(answer_repo, ARC[2:3])
+        assert coverage.files_missing == ["src/widget/nope.py"]
+        assert coverage.files_examined == 0
+
+    def test_a_target_that_is_not_a_git_checkout_is_counted(self, tmp_path):
+        plain = tmp_path / "plain"
+        (plain / "src" / "widget").mkdir(parents=True)
+        (plain / "src" / "widget" / "core.py").write_text(GOOD_SOURCE, encoding="utf-8")
+        verdicts, coverage = audit(plain, ARC[:1])
+        assert coverage.git_unreadable == 1
+        assert coverage.commits_examined == 0
+        assert not [v for v in verdicts if v.gate == "pr.commit_message_guard"]
+        text = render(plain, verdicts, coverage, generated_at="x")
+        assert "git unreadable for 1 feature(s)" in text
+
+
+class TestRender:
+    def test_names_the_denominator_and_each_refusal(self, answer_repo):
+        verdicts, coverage = audit(answer_repo, ARC)
+        text = render(answer_repo, verdicts, coverage, generated_at="2026-09-03 01:00:00")
+        assert "Files examined: 3 (missing: src/widget/nope.py)" in text
+        assert "| impl.deterministic_failure | 2 | 1 |" in text
+        assert "#10 `impl.deterministic_failure` on `tests/unit/test_stubs.py`" in text
+        assert "## Not runnable against a finished artifact" in text
+
+    def test_is_deterministic_for_a_fixed_stamp(self, answer_repo):
+        verdicts, coverage = audit(answer_repo, ARC)
+        a = render(answer_repo, verdicts, coverage, generated_at="x")
+        b = render(answer_repo, verdicts, coverage, generated_at="x")
+        assert a == b
+
+
+class TestCli:
+    def test_missing_repo_is_reported(self, tmp_path, capsys):
+        assert cli.main(["--repo", str(tmp_path / "nope")]) == 2
+        assert "No such repository" in capsys.readouterr().out
+
+    def test_default_save_path(self):
+        from datetime import datetime
+
+        path = cli.default_save_path(Path("/c/x/boostgauge"), datetime(2026, 9, 3))
+        assert path.name == "0907-answer-key-audit-boostgauge-2026-09-03.md"

--- a/tools/answer_key_audit.py
+++ b/tools/answer_key_audit.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Run the pipeline's mechanical gates over code known to be right (#2722).
+
+The logic lives in ``assemblyzero.speedrun.answer_key`` so the unit tests run
+the same code this prints.
+
+    poetry run python tools/answer_key_audit.py --repo /c/.../boostgauge
+    poetry run python tools/answer_key_audit.py --repo <path> --save
+
+Read-only against the target repo. Writes nothing except the optional saved
+copy under ``docs/audits/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+from assemblyzero.speedrun.answer_key import audit, render  # noqa: E402
+
+
+def default_save_path(repo: Path, when: datetime | None = None) -> Path:
+    when = when or datetime.now()
+    return (
+        REPO_ROOT / "docs" / "audits"
+        / f"0907-answer-key-audit-{repo.name}-{when:%Y-%m-%d}.md"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", required=True, type=Path,
+                        help="target repository whose main carries the answer key")
+    parser.add_argument("--save", action="store_true",
+                        help="also write the report under docs/audits/")
+    parser.add_argument("--save-path", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    repo = args.repo.resolve()
+    if not repo.is_dir():
+        print(f"No such repository: {repo}")
+        return 2
+
+    verdicts, coverage = audit(repo)
+    text = render(repo, verdicts, coverage)
+    print(text)
+
+    if args.save or args.save_path:
+        target = args.save_path or default_save_path(repo)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+        print(f"Saved to {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #2722

## The answer key

boostgauge `main` carries v1.0.0, built by hand on 2026-09-01: the six features the factory has been asked to build, approved by the operator and the visual gate. A gate that judges the drafter's output and refuses content the shipped code also contains is a false positive by construction. This runs every gate that is a pure function over text against those artifacts, without a launch.

## What it found

```
Features: 6 | Files examined: 17 | LLDs examined: 1 | Merged commits examined: 6
Verdicts: 50; refusals: 6

| gate                          | ran | refused |
| impl.deterministic_failure    |   9 |       0 |
| impl.file_generation_failed   |  17 |       0 |
| impl.path_enforcement         |   7 |       4 |
| impl.scenario_ratio_guard     |   1 |       0 |
| impl.test_file_validation     |   9 |       2 |
| lld.mechanical_validation     |   1 |       0 |
| pr.commit_message_guard       |   6 |       0 |
```

Forty-four of fifty verdicts accept the shipped code. The six refusals:

- **`impl.path_enforcement`, four files of #4.** The LLD planned `tests/integration/test_windows_collector.py`; the hand build shipped `tests/integration/test_windows_sweep_crosscheck.py`. Same for `collectors/__init__.py`, `tests/benchmark/test_sweep_cost.py`, and `tests/unit/test_collector_source_pin.py`. The gate holds the drafter to a file plan the operator did not follow when building it himself.
- **`impl.test_file_validation`, two tests.** `test_V4_equal_timestamp_is_accepted` (#41) and `test_dynamic_256_matches_baseline` (#332) carry no `assert` in their own body: the assertion lives in a helper the gate cannot see. Both are shipped, approved tests.

The saved report is `docs/audits/0907-answer-key-audit-boostgauge-2026-09-03.md`, with every verdict.

## What landed

- `assemblyzero/speedrun/answer_key.py`: the arc as shipped (six features, the PRs' own file lists, the one LLD that survives on main), seven runnable gates keyed by their registry key and each invoked as the pipeline's own function (`validate_code_response`, `validate_test_structure`, `count_stub_tests`, `validate_file_write` against `extract_paths_from_lld`, `_validate_lld_mechanical_inner`, `_run_mechanical_gates`, `validate_commit_message`), and twenty gates named as not runnable against a finished artifact, each with the reason, so the coverage is honest.
- `tools/answer_key_audit.py`: `--repo`, `--save`.
- `tests/unit/test_answer_key.py`, 13 tests, driven against a synthetic git repo so the suite does not depend on boostgauge: every runnable gate is a registered gate that judges a draft or an upstream artifact, good code passes every gate, stub tests are refused by both scaffolder gates, a missing file and an unreadable git are counted rather than skipped, the report is deterministic.

## What it is for

The `judges` column of the registry says which gates the routing policy (#2723) turns into `revise`. This report says which of them refuse code the operator shipped, so the first gates to soften are chosen by evidence rather than by the most recent kill.
