### PR TITLE
feat: replay a recorded run through the real graph, and say where it stops (Closes #2724)

### DIFF
--- a/assemblyzero/speedrun/replay.py
+++ b/assemblyzero/speedrun/replay.py
@@ -1,0 +1,634 @@
+"""Replaying a recorded run through the current graph (#2724).
+
+Every gate fix since 2026-08-01 was proven against a hand-made fixture of one
+death and then verified by launching a run that costs real money and an hour of
+attention. Twelve launches were allowed on boostgauge #421 and all twelve are
+spent. The operator's ruling of 2026-09-02 is that nothing relaunches until the
+recorded runs replay past the walls that killed them.
+
+This module is the replay. `ScriptedProvider` (#2567) replaces the transport and
+only the transport: the graph, the routers, the janitors, the gates, the pinning
+enforcement, the file writes and the halt path all run for real, in seconds,
+against a throwaway clone, with no network.
+
+## What replay proves, and what it cannot
+
+It proves that **the gate which killed a recorded run no longer kills that run's
+recorded content under the current code**. It cannot prove the run would have
+finished: once a code change alters a prompt, the recorded response is no longer
+the response the model would give, and the honest answer is to stop and name the
+divergence rather than invent a verdict. `ReplayResult.verdict` is never
+``passed`` on a divergence, and `DIVERGED` is a first-class outcome, not a
+failure of the runner.
+
+## Reconstruction, and why the fidelity is stated rather than assumed
+
+The pipeline does NOT persist raw model responses. It persists the artifacts it
+derived from them, so every rule here is a reconstruction and each one is
+declared in `Reconstruction` so the report can carry it:
+
+* ``NNN-spec-draft.md`` is written by `generate_spec` AFTER preamble stripping,
+  pinning adjudication and decision-table re-assertion. It is the round's
+  outcome, not the drafter's words.
+* ``NNN-readiness-verdict.md`` is markdown assembled from the parsed verdict,
+  while the reviewer is called with `REVIEW_SPEC_SCHEMA` and Standard 0028
+  leaves no regex fallback. Replaying the file verbatim would be parsed as an
+  infrastructure failure, so `verdict_to_json` re-encodes it into the shape the
+  parser expects. The three schema fields round-trip; anything the model said
+  outside them was never recorded and cannot be replayed.
+* A revision round calls the drafter with `EDIT_SCRIPT_SYSTEM_PROMPT` and
+  expects SEARCH/REPLACE blocks, not a document. `synthesize_edit_script`
+  derives blocks that carry the recorded draft N to the recorded draft N+1, so
+  the real parse, the real application and the real pinning enforcement all run
+  on the real change. Where a minimal unique anchor cannot be found the round
+  degrades to a full-document answer, which is counted and reported rather than
+  hidden.
+
+``hallucination-check.json`` is deterministic telemetry, not an LLM call, and is
+deliberately not scripted.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assemblyzero.core.scripted_provider import ScriptedRule
+
+# ---------------------------------------------------------------------------
+# Closed vocabularies
+# ---------------------------------------------------------------------------
+
+#: A run-scoped lineage directory is named by `make_run_id()`, second-resolution
+#: UTC. The NAME is authoritative and a copy cannot change it, which is why the
+#: run-to-directory match keys on it rather than on a filesystem timestamp.
+AUDIT_DIR_FMT = "%Y-%m-%dT%H-%M-%SZ"
+
+KIND_LLD = "lld"
+KIND_SPEC = "spec"
+KINDS: tuple[str, ...] = (KIND_LLD, KIND_SPEC)
+
+#: The stage labels the scripted rules carry. `ScriptedProvider` fails a call
+#: that matches rules for two different stages, so these must stay disjoint.
+CALLER_DRAFTER = "spec-drafter"
+CALLER_EDITOR = "spec-editor"
+#: A retry of the SAME round, which the recording cannot answer. It gets its own
+#: stage so the round counter on `CALLER_EDITOR` keeps counting rounds rather
+#: than attempts -- the two are only the same while nothing goes wrong.
+CALLER_EDITOR_RETRY = "spec-editor-retry"
+CALLER_REVIEWER = "spec-reviewer"
+
+#: Where the replay ended relative to where the recording ended.
+VERDICT_SAME_GATE = "same_gate"
+VERDICT_OTHER_GATE = "other_gate"
+VERDICT_LATER = "later"
+VERDICT_EARLIER = "earlier"
+VERDICT_DIVERGED = "diverged"
+VERDICT_PASSED = "passed"
+VERDICTS: tuple[str, ...] = (
+    VERDICT_SAME_GATE, VERDICT_OTHER_GATE, VERDICT_LATER, VERDICT_EARLIER,
+    VERDICT_DIVERGED, VERDICT_PASSED,
+)
+
+#: One line each, printed under the table so the words in it are defined where
+#: they are read rather than in a doc nobody opens.
+VERDICT_MEANING: dict[str, str] = {
+    VERDICT_SAME_GATE: "died at the same gate, the same distance in",
+    VERDICT_OTHER_GATE: "same distance in, but a different gate ended it",
+    VERDICT_LATER: "got further than the recording did",
+    VERDICT_EARLIER: "got less far than the recording did",
+    VERDICT_DIVERGED: (
+        "the recorded responses stopped fitting the code's prompts, so the "
+        "replay could not continue and reports no verdict on the gate"
+    ),
+    VERDICT_PASSED: "ran to the end of the stage without a halt",
+}
+
+#: Roots a recorded lineage directory can be found under. `reset-artifacts` is
+#: load-bearing: `speedrun_reset` moves a run's lineage there before clearing
+#: it, so runs 10 and 11 of boostgauge #4 exist ONLY there.
+LINEAGE_ROOTS: tuple[tuple[str, ...], ...] = (
+    ("docs", "lineage", "active"),
+    ("docs", "lineage", "done"),
+    ("data", "speedrun", "reset-artifacts"),
+)
+
+_RE_AUDIT_STAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z$")
+_RE_NUMBERED = re.compile(r"^(\d{3})-(.+?)\.(md|json)$")
+_RE_VERDICT = re.compile(r"^Verdict:\s*(\S+)\s*$", re.MULTILINE)
+_RE_RATIONALE = re.compile(
+    r"^Rationale:\s*(.*?)(?=\n##\s|\Z)", re.MULTILINE | re.DOTALL
+)
+
+
+# ---------------------------------------------------------------------------
+# Recorded artifacts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuditDir:
+    """One run-scoped lineage directory found on disk."""
+
+    kind: str
+    stamp: datetime
+    path: Path
+    file_count: int
+
+
+@dataclass(frozen=True)
+class RecordedResponse:
+    """One numbered artifact inside an audit directory."""
+
+    number: int
+    suffix: str
+    path: Path
+    text: str
+
+
+@dataclass
+class Reconstruction:
+    """How faithful this replay's rules are, counted rather than asserted.
+
+    Every field is a count of a place where the recording did not hold what the
+    transport actually carried. The report prints this beside the verdict so a
+    reader can tell a clean replay from one held together with reconstruction.
+    """
+
+    drafts: int = 0
+    verdicts: int = 0
+    edit_scripts: int = 0
+    #: Revision rounds where no unique anchor could be built and the round
+    #: degrades to answering with the whole document.
+    edit_script_degraded: int = 0
+    notes: list[str] = field(default_factory=list)
+
+
+def parse_audit_stamp(name: str) -> datetime | None:
+    """The UTC instant a run-scoped lineage directory name encodes.
+
+    Two different answers, deliberately kept apart. A name that is not a stamp
+    at all -- `4-implspec`, `issue-brief.md`, every ordinary directory in a
+    lineage tree -- returns None, because walking past it is the normal case.
+    A name that has the SHAPE of a stamp but is not a real instant raises,
+    because `make_run_id()` cannot have written it and something that is not the
+    pipeline has been naming run directories.
+
+    The shape test is a regex over a closed, authored format, not a judgement
+    about content (standard 0028a, §28a).
+    """
+    if not _RE_AUDIT_STAMP.match(name):
+        return None
+    return datetime.strptime(name, AUDIT_DIR_FMT).replace(tzinfo=timezone.utc)
+
+
+def discover_audit_dirs(target_repo: Path, issue: int) -> list[AuditDir]:
+    """Every run-scoped lineage directory for one issue, wherever it landed.
+
+    Both stage kinds and all three roots, because a reset moves a directory out
+    of `docs/lineage/` entirely and a replay that only looked where the pipeline
+    writes would silently find nothing for exactly the runs worth replaying.
+    """
+    found: list[AuditDir] = []
+    for parts in LINEAGE_ROOTS:
+        root = target_repo.joinpath(*parts)
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_dir():
+                continue
+            stamp = parse_audit_stamp(path.name)
+            if stamp is None:
+                continue
+            parent = path.parent.name
+            if not parent.startswith(f"{issue}-"):
+                continue
+            if "lld" in parent:
+                kind = KIND_LLD
+            elif "implspec" in parent:
+                kind = KIND_SPEC
+            else:
+                continue
+            count = sum(1 for f in path.iterdir() if f.is_file())
+            found.append(AuditDir(kind, stamp, path, count))
+    return sorted(found, key=lambda d: (d.stamp, d.kind, -d.file_count))
+
+
+def run_window(log_path: Path) -> tuple[datetime, datetime]:
+    """When a run started and last wrote, in UTC.
+
+    `st_ctime` is creation time on Windows, which is where every recorded run in
+    the corpus was produced. The window is used only to associate a run with the
+    lineage directories it created, and a directory's own name supplies the
+    precision.
+    """
+    stat = log_path.stat()
+    return (
+        datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc),
+        datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+    )
+
+
+def audit_dirs_for_run(
+    dirs: list[AuditDir], start: datetime, end: datetime
+) -> tuple[dict[str, AuditDir], list[str]]:
+    """The lineage directories one run created, one per stage kind.
+
+    Returns (chosen, notes). A reset can leave SEVERAL copies of one directory
+    under different reset stamps -- boostgauge run 11's spec lineage exists
+    twice, once with 26 files and once with 4 -- so a tie on the directory name
+    is broken by file count and the choice is recorded in `notes` rather than
+    made silently. Two DIFFERENT names for one kind inside one run's window is
+    not a tie and is reported as ambiguity, not resolved by guessing.
+    """
+    notes: list[str] = []
+    chosen: dict[str, AuditDir] = {}
+    for kind in KINDS:
+        candidates = [
+            d for d in dirs if d.kind == kind and start <= d.stamp <= end
+        ]
+        if not candidates:
+            continue
+        stamps = {d.stamp for d in candidates}
+        if len(stamps) > 1:
+            notes.append(
+                f"{kind}: {len(stamps)} different lineage directories fall in "
+                f"this run's window "
+                f"({', '.join(sorted(s.strftime(AUDIT_DIR_FMT) for s in stamps))}). "
+                f"The run cannot be told apart from a neighbour; not replayed."
+            )
+            continue
+        best = max(candidates, key=lambda d: d.file_count)
+        if len(candidates) > 1:
+            notes.append(
+                f"{kind}: {len(candidates)} copies of "
+                f"{best.stamp.strftime(AUDIT_DIR_FMT)} exist (a reset copied "
+                f"the lineage); took the one with the most files "
+                f"({best.file_count} vs "
+                f"{', '.join(str(c.file_count) for c in candidates if c is not best)})."
+            )
+        chosen[kind] = best
+    return chosen, notes
+
+
+def responses_in(audit_dir: Path) -> list[RecordedResponse]:
+    """Every numbered artifact in an audit directory, in call order."""
+    out: list[RecordedResponse] = []
+    for path in sorted(audit_dir.iterdir()):
+        if not path.is_file():
+            continue
+        match = _RE_NUMBERED.match(path.name)
+        if not match:
+            continue
+        out.append(
+            RecordedResponse(
+                number=int(match.group(1)),
+                suffix=match.group(2),
+                path=path,
+                text=path.read_text(encoding="utf-8", errors="replace"),
+            )
+        )
+    return sorted(out, key=lambda r: r.number)
+
+
+# ---------------------------------------------------------------------------
+# Re-encoding a persisted verdict into the shape the parser needs
+# ---------------------------------------------------------------------------
+
+
+def parse_verdict_file(text: str) -> dict:
+    """Read back what `review_spec` wrote to ``NNN-readiness-verdict.md``.
+
+    The writer's format is fixed at review_spec.py: a ``Verdict:`` line, a
+    ``Rationale:`` block that runs to the next heading, and an optional
+    ``## Feedback Items`` list. Reading it back is therefore a parse of a known
+    format, not a guess at prose.
+    """
+    verdict_match = _RE_VERDICT.search(text)
+    rationale_match = _RE_RATIONALE.search(text)
+    items: list[str] = []
+    in_items = False
+    for line in text.splitlines():
+        if line.startswith("## Feedback Items"):
+            in_items = True
+            continue
+        if in_items:
+            if line.startswith("## "):
+                break
+            if line.startswith("- "):
+                items.append(line[2:].strip())
+    return {
+        "verdict": verdict_match.group(1) if verdict_match else "",
+        "rationale": (
+            rationale_match.group(1).strip() if rationale_match else ""
+        ),
+        "feedback_items": items,
+    }
+
+
+def verdict_to_json(text: str) -> str:
+    """A persisted verdict, re-encoded for `REVIEW_SPEC_SCHEMA`.
+
+    The reviewer is called with a schema and Standard 0028 removed the regex
+    fallback, so handing the markdown back verbatim would be parsed as "no
+    extractable verdict" -- an infrastructure failure the recording never had.
+    """
+    return json.dumps(parse_verdict_file(text), ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Synthesising the edit script a revision round expects
+# ---------------------------------------------------------------------------
+
+
+def synthesize_edit_script(before: str, after: str) -> str:
+    """SEARCH/REPLACE blocks carrying ``before`` to ``after``.
+
+    A revision round asks the drafter for edit blocks, not a document, so a
+    replay that answered with the recorded draft would exercise the fallback
+    path instead of the pinning enforcement that actually adjudicates a
+    revision. Deriving the blocks from the two recorded drafts runs the real
+    parse, the real application and the real enforcement over the real change.
+
+    Each SEARCH must occur exactly once in ``before`` (`apply_edit_blocks`
+    rejects an ambiguous anchor), so a hunk's context is widened until it is
+    unique. Returns "" when no unique anchor can be built -- the caller then
+    degrades to a whole-document answer and counts it.
+    """
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    blocks: list[tuple[str, str]] = []
+
+    matcher = difflib.SequenceMatcher(None, before_lines, after_lines, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        # A hunk with nothing on one side is degenerate line-wise: an insertion
+        # has no SEARCH text of its own, and a deletion would leave an empty
+        # REPLACE, which substring-replaces the lines away but leaves the
+        # newline that separated them -- a blank line where the deleted text
+        # was. Borrowing a line of context on each side makes both halves whole
+        # lines, so the edit is a line replacement in both directions.
+        degenerate = i1 == i2 or j1 == j2
+        anchor = _unique_anchor(
+            before_lines, before, i1, i2, context=1 if degenerate else 0
+        )
+        if anchor is None:
+            return ""
+        lo, hi = anchor
+        search = "\n".join(before_lines[lo:hi])
+        replace = "\n".join(
+            before_lines[lo:i1] + after_lines[j1:j2] + before_lines[i2:hi]
+        )
+        blocks.append((search, replace))
+
+    if not blocks:
+        return ""
+    return "\n\n".join(
+        f"<<<<<<< SEARCH\n{search}\n=======\n{replace}\n>>>>>>> REPLACE"
+        for search, replace in blocks
+    )
+
+
+def _unique_anchor(
+    lines: list[str],
+    whole: str,
+    i1: int,
+    i2: int,
+    *,
+    context: int = 0,
+    limit: int = 40,
+) -> tuple[int, int] | None:
+    """Widen ``lines[i1:i2]`` until it appears exactly once in ``whole``.
+
+    ``context`` is the minimum number of surrounding lines to take before the
+    first uniqueness test, which is what a degenerate hunk needs -- an insertion
+    has no text of its own to anchor on, and a deletion needs a neighbour so its
+    replacement is a whole line rather than nothing.
+    """
+    lo = max(0, i1 - context)
+    hi = min(len(lines), i2 + context)
+    for _ in range(limit):
+        if hi > lo:
+            candidate = "\n".join(lines[lo:hi])
+            if candidate and whole.count(candidate) == 1:
+                return lo, hi
+        if lo == 0 and hi >= len(lines):
+            return None
+        lo = max(0, lo - 1)
+        hi = min(len(lines), hi + 1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+#: Anchored on wording unique to each system prompt. `ScriptedProvider` refuses
+#: a call that matches two stages, so an overlap here fails loudly at the first
+#: call rather than misrouting the reviewer to the drafter.
+PATTERN_DRAFTER = r"technical architect creating an Implementation Specification"
+PATTERN_EDITOR = r"precision patch engine"
+PATTERN_REVIEWER = r"Implementation Readiness Review"
+
+#: The heading `build_edit_script_prompt` adds when re-prompting after a script
+#: failed to apply (#2569). Its presence is what tells a fresh round apart from
+#: a retry of one, and the two rule sets below are mutually exclusive on it, so
+#: exactly one stage ever matches an editor call.
+RETRY_MARK = r"YOUR PREVIOUS ATTEMPT FAILED TO APPLY"
+PATTERN_FIRST_ATTEMPT = rf"\A(?!.*{RETRY_MARK})"
+
+#: Why a retry is a finding rather than something to answer. The recording holds
+#: one outcome per round because the original script applied; if the code is
+#: asking again, the draft this replay built is not the draft the recording had,
+#: and inventing a second answer would bury exactly the fact worth reporting.
+RETRY_IS_DIVERGENCE = (
+    "ScriptedProvider: the code asked for another edit-script attempt at this "
+    "round. The recording holds one outcome per round, because in the recording "
+    "the script applied. Being asked again means the draft this replay built is "
+    "no longer the draft the recording had, so there is nothing faithful to "
+    "answer with -- this is the divergence point (#2724)."
+)
+
+
+def build_spec_rules(
+    spec_dir: Path,
+) -> tuple[list[ScriptedRule], Reconstruction]:
+    """Rules for one recorded spec stage, in call order.
+
+    Round 1 is a full draft; every later round is an edit script derived from
+    the pair of recorded drafts around it. The reviewer's rounds are the
+    re-encoded verdicts.
+    """
+    recon = Reconstruction()
+    responses = responses_in(spec_dir)
+    drafts = [r for r in responses if r.suffix == "spec-draft"]
+    verdicts = [r for r in responses if r.suffix == "readiness-verdict"]
+
+    rules: list[ScriptedRule] = []
+
+    if drafts:
+        rules.append(
+            ScriptedRule(
+                CALLER_DRAFTER,
+                system_pattern=PATTERN_DRAFTER,
+                response=drafts[0].text,
+                on_call=1,
+            )
+        )
+        recon.drafts += 1
+
+    # #2569 removed the full-regeneration fallback: a revision is edit blocks or
+    # it is a halt. So the drafter's own prompt is used exactly once, for the
+    # initial draft, and every later round is an edit script.
+    for index, draft in enumerate(drafts[1:], start=1):
+        previous = drafts[index - 1].text
+        script = synthesize_edit_script(previous, draft.text)
+        if script:
+            rules.append(
+                ScriptedRule(
+                    CALLER_EDITOR,
+                    system_pattern=PATTERN_EDITOR,
+                    content_pattern=PATTERN_FIRST_ATTEMPT,
+                    response=script,
+                    on_call=index,
+                )
+            )
+            recon.edit_scripts += 1
+        else:
+            # Declared, not swallowed: a whole document in answer to an
+            # edit-script call is not what the recording's drafter sent, and the
+            # round replays a different path because of it.
+            rules.append(
+                ScriptedRule(
+                    CALLER_EDITOR,
+                    system_pattern=PATTERN_EDITOR,
+                    content_pattern=PATTERN_FIRST_ATTEMPT,
+                    response=draft.text,
+                    on_call=index,
+                )
+            )
+            recon.edit_script_degraded += 1
+            recon.notes.append(
+                f"round {index + 1}: no unique SEARCH anchor between "
+                f"{drafts[index - 1].path.name} and {draft.path.name}; "
+                f"answered with the whole document, so this round does not "
+                f"replay the edit path."
+            )
+        recon.drafts += 1
+
+    if len(drafts) > 1:
+        rules.append(
+            ScriptedRule(
+                CALLER_EDITOR_RETRY,
+                system_pattern=PATTERN_EDITOR,
+                content_pattern=RETRY_MARK,
+                fail_with=RETRY_IS_DIVERGENCE,
+            )
+        )
+
+    for index, verdict in enumerate(verdicts, start=1):
+        rules.append(
+            ScriptedRule(
+                CALLER_REVIEWER,
+                system_pattern=PATTERN_REVIEWER,
+                response=verdict_to_json(verdict.text),
+                on_call=index,
+            )
+        )
+        recon.verdicts += 1
+
+    recon.notes.append(
+        f"{len(drafts)} recorded draft(s) and {len(verdicts)} recorded "
+        f"verdict(s); drafts are post-pinning artifacts, verdicts are "
+        f"re-encoded into REVIEW_SPEC_SCHEMA."
+    )
+    return rules, recon
+
+
+# ---------------------------------------------------------------------------
+# The verdict
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReplayResult:
+    """One recorded run, replayed. Every field is measured, none inferred."""
+
+    tag: str
+    stage: str
+    #: What the recording did: the registry key that ended it, and how far in.
+    recorded_cause: str
+    recorded_progress: int
+    #: What the replay did.
+    replay_cause: str = ""
+    replay_progress: int = 0
+    #: Set when `ScriptedProvider` refused a call: the recorded responses no
+    #: longer fit the prompts the code sends. Non-empty means DIVERGED.
+    divergence: str = ""
+    verdict: str = VERDICT_DIVERGED
+    reconstruction: Reconstruction = field(default_factory=Reconstruction)
+    notes: list[str] = field(default_factory=list)
+    #: The stage labels the provider was actually asked for, in order. A roll
+    #: that reaches the right end state by the wrong route is a defect an
+    #: end-state assertion does not catch.
+    path: list[str] = field(default_factory=list)
+
+
+def classify(
+    *,
+    recorded_cause: str,
+    recorded_progress: int,
+    replay_cause: str,
+    replay_progress: int,
+    divergence: str,
+    finished: bool,
+) -> str:
+    """Where the replay ended, against where the recording ended.
+
+    Divergence is tested FIRST and beats everything, including a clean finish.
+    Once the recorded responses stop fitting the prompts the code sends, the run
+    is no longer the recorded run, and a `passed` here would be the runner
+    inventing the one verdict replay is least able to justify (#2724).
+    """
+    if divergence:
+        return VERDICT_DIVERGED
+    if finished and not replay_cause:
+        return VERDICT_PASSED
+    if replay_progress > recorded_progress:
+        return VERDICT_LATER
+    if replay_progress < recorded_progress:
+        return VERDICT_EARLIER
+    if replay_cause == recorded_cause:
+        return VERDICT_SAME_GATE
+    return VERDICT_OTHER_GATE
+
+
+def render_table(results: list[ReplayResult]) -> str:
+    """The replay table a pipeline PR carries in its body (#2724).
+
+    The legend is printed with the table rather than kept in a doc, because the
+    table travels into PR bodies read by people who will not open the doc.
+    """
+    lines = [
+        "| run | stage | recorded ended at | replay ended at | verdict |",
+        "|---|---|---|---|---|",
+    ]
+    for r in results:
+        recorded = f"`{r.recorded_cause}` at round {r.recorded_progress}"
+        if r.divergence:
+            reached = f"diverged at round {r.replay_progress}"
+        elif r.verdict == VERDICT_PASSED:
+            reached = "finished the stage"
+        else:
+            reached = f"`{r.replay_cause}` at round {r.replay_progress}"
+        lines.append(
+            f"| {r.tag} | {r.stage} | {recorded} | {reached} | **{r.verdict}** |"
+        )
+    shown = [name for name in VERDICTS if any(r.verdict == name for r in results)]
+    legend = [f"- **{name}** — {VERDICT_MEANING[name]}" for name in shown]
+    return "\n".join([*lines, "", *legend])

--- a/tests/unit/test_replay_run.py
+++ b/tests/unit/test_replay_run.py
@@ -1,0 +1,463 @@
+"""The replay runner, and the one thing it must never do (#2724).
+
+The launch gate is that the recorded runs replay past the walls that killed
+them, so the runner's verdict is load-bearing: a wrong `passed` here would clear
+a launch the evidence does not support. `TestDivergenceNeverPasses` is that
+acceptance, and the rest of this file exists to make its inputs trustworthy --
+a synthesised edit script that does not actually carry draft N to draft N+1
+would produce divergence findings that are the runner's fault rather than the
+recording's.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from assemblyzero.speedrun.replay import (
+    AUDIT_DIR_FMT,
+    CALLER_EDITOR,
+    CALLER_EDITOR_RETRY,
+    KIND_LLD,
+    KIND_SPEC,
+    RETRY_MARK,
+    VERDICT_DIVERGED,
+    VERDICT_EARLIER,
+    VERDICT_LATER,
+    VERDICT_OTHER_GATE,
+    VERDICT_PASSED,
+    VERDICT_SAME_GATE,
+    AuditDir,
+    ReplayResult,
+    audit_dirs_for_run,
+    build_spec_rules,
+    classify,
+    discover_audit_dirs,
+    parse_audit_stamp,
+    parse_verdict_file,
+    render_table,
+    responses_in,
+    synthesize_edit_script,
+    verdict_to_json,
+)
+from assemblyzero.workflows.implementation_spec.nodes.edit_script import (
+    apply_edit_blocks,
+    parse_edit_blocks,
+)
+
+
+def _stamp(text: str) -> datetime:
+    return datetime.strptime(text, AUDIT_DIR_FMT).replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# The acceptance: a divergence is never a pass
+# ---------------------------------------------------------------------------
+
+
+class TestDivergenceNeverPasses:
+    """#2724's third acceptance criterion, as a test rather than a promise.
+
+    Once a code change alters a prompt, the recorded response is no longer the
+    response the model would give. Everything after that point is the runner's
+    invention, and the one invention that does real damage is `passed`, because
+    it is what a launch decision reads.
+    """
+
+    def test_a_divergence_beats_a_clean_finish(self):
+        assert classify(
+            recorded_cause="spec.review_cap",
+            recorded_progress=9,
+            replay_cause="",
+            replay_progress=9,
+            divergence="the recording could not answer call 7",
+            finished=True,
+        ) == VERDICT_DIVERGED
+
+    def test_a_divergence_beats_getting_further(self):
+        assert classify(
+            recorded_cause="spec.review_cap",
+            recorded_progress=3,
+            replay_cause="spec.review_cap",
+            replay_progress=99,
+            divergence="the recording could not answer call 7",
+            finished=False,
+        ) == VERDICT_DIVERGED
+
+    def test_only_a_finish_with_no_cause_is_a_pass(self):
+        assert classify(
+            recorded_cause="spec.review_cap",
+            recorded_progress=9,
+            replay_cause="",
+            replay_progress=9,
+            divergence="",
+            finished=True,
+        ) == VERDICT_PASSED
+
+    def test_a_finish_that_still_named_a_cause_is_not_a_pass(self):
+        """`finished` reads a spec path on the state, and a halt path can leave
+        one behind. The cause is what decides."""
+        assert classify(
+            recorded_cause="spec.review_cap",
+            recorded_progress=9,
+            replay_cause="spec.review_cap",
+            replay_progress=9,
+            divergence="",
+            finished=True,
+        ) == VERDICT_SAME_GATE
+
+
+class TestClassifyMeasuresDistanceFirst:
+    def test_further_in_is_later_whatever_ended_it(self):
+        assert classify(
+            recorded_cause="spec.review_cap", recorded_progress=3,
+            replay_cause="spec.completeness_cap", replay_progress=6,
+            divergence="", finished=False,
+        ) == VERDICT_LATER
+
+    def test_less_far_is_earlier(self):
+        assert classify(
+            recorded_cause="spec.review_cap", recorded_progress=9,
+            replay_cause="spec.edit_script_rejected", replay_progress=3,
+            divergence="", finished=False,
+        ) == VERDICT_EARLIER
+
+    def test_same_distance_other_gate_is_named_as_such(self):
+        """Softening one gate so a different one kills at the same round is not
+        progress, and calling it `same_gate` would hide that."""
+        assert classify(
+            recorded_cause="spec.review_cap", recorded_progress=4,
+            replay_cause="spec.completeness_cap", replay_progress=4,
+            divergence="", finished=False,
+        ) == VERDICT_OTHER_GATE
+
+
+# ---------------------------------------------------------------------------
+# The synthesised edit script has to actually carry the draft
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeEditScript:
+    """A revision round asks for edit blocks, not a document. If the blocks this
+    module derives do not apply, every replay diverges at round 2 and the
+    finding is the runner's rather than the recording's."""
+
+    def _carry(self, before: str, after: str) -> str:
+        script = synthesize_edit_script(before, after)
+        assert script, "no script was produced"
+        blocks = parse_edit_blocks(script)
+        assert blocks, "the produced script does not parse as edit blocks"
+        patched, failures = apply_edit_blocks(before, blocks)
+        assert failures == [], f"blocks did not apply: {failures}"
+        return patched
+
+    def test_a_replacement_lands_exactly(self):
+        before = "# Spec\n\nalpha\nbeta\ngamma\n"
+        after = "# Spec\n\nalpha\nBETA\ngamma\n"
+        assert self._carry(before, after) == after
+
+    def test_an_insertion_borrows_a_neighbour_to_anchor_on(self):
+        """A pure insertion has no text of its own to put in SEARCH, so the
+        anchor must widen before the first uniqueness test rather than after."""
+        before = "one\ntwo\nthree\n"
+        after = "one\ntwo\nINSERTED\nthree\n"
+        assert self._carry(before, after) == after
+
+    def test_a_deletion_lands(self):
+        before = "one\ntwo\nthree\nfour\n"
+        after = "one\nthree\nfour\n"
+        assert self._carry(before, after) == after
+
+    def test_a_repeated_line_is_disambiguated_by_widening(self):
+        """`apply_edit_blocks` refuses an anchor that matches twice, so a change
+        to one of several identical lines must widen until it is unique."""
+        before = "x\nsame\ny\nsame\nz\n"
+        after = "x\nsame\ny\nCHANGED\nz\n"
+        assert self._carry(before, after) == after
+
+    def test_a_change_to_the_last_line_keeps_the_trailing_newline(self):
+        """The blocks are joined from `splitlines()`, which drops the final
+        newline; `apply_edit_blocks` replaces a substring of the original, so
+        the newline survives. Pinned because losing it would make every
+        subsequent round's anchors miss by one byte."""
+        before = "alpha\nomega\n"
+        after = "alpha\nOMEGA\n"
+        assert self._carry(before, after) == after
+
+    def test_several_separate_hunks_all_land(self):
+        before = "\n".join(f"line{n}" for n in range(20))
+        after = before.replace("line3", "LINE3").replace("line17", "LINE17")
+        assert self._carry(before, after) == after
+
+    def test_no_change_produces_no_script(self):
+        assert synthesize_edit_script("same\n", "same\n") == ""
+
+    def test_an_unanchorable_change_returns_empty_rather_than_a_bad_block(self):
+        """A document that is one repeated line has no unique anchor anywhere.
+        Returning a block that cannot apply would be worse than saying so: the
+        caller degrades to a whole document and counts it."""
+        before = "dup\n" * 6
+        after = "dup\n" * 5 + "other\n"
+        script = synthesize_edit_script(before, after)
+        if script:
+            blocks = parse_edit_blocks(script)
+            _, failures = apply_edit_blocks(before, blocks)
+            assert failures == [], "a produced script must apply"
+
+
+# ---------------------------------------------------------------------------
+# Re-encoding the persisted verdict
+# ---------------------------------------------------------------------------
+
+
+VERDICT_FILE = """\
+Verdict: REVISE
+
+Rationale: The spec fails the Assertion Traceability check and contains
+tests whose inputs cannot distinguish correct from incorrect behaviour.
+
+## Feedback Items
+- Assertion Traceability Violation: `assert snapshot.conpty_count == 2`
+- Section 10.1 carries a pointer, not test functions
+"""
+
+
+class TestVerdictReEncoding:
+    """The reviewer is called with a schema and Standard 0028 left no regex
+    fallback, so the persisted markdown handed back verbatim would be read as an
+    infrastructure failure the recording never had."""
+
+    def test_the_three_schema_fields_round_trip(self):
+        parsed = parse_verdict_file(VERDICT_FILE)
+        assert parsed["verdict"] == "REVISE"
+        assert parsed["rationale"].startswith("The spec fails")
+        assert "distinguish correct from incorrect" in parsed["rationale"]
+        assert len(parsed["feedback_items"]) == 2
+        assert parsed["feedback_items"][1].endswith("not test functions")
+
+    def test_the_rationale_stops_at_the_feedback_heading(self):
+        assert "Feedback Items" not in parse_verdict_file(VERDICT_FILE)["rationale"]
+
+    def test_the_json_parses_under_the_real_contract(self):
+        from assemblyzero.core.verdict_schema import parse_structured_review_spec
+
+        result = parse_structured_review_spec(verdict_to_json(VERDICT_FILE))
+        assert result["verdict"] == "REVISE"
+        assert len(result["feedback_items"]) == 2
+
+    def test_a_verdict_with_no_feedback_items_is_still_valid(self):
+        text = "Verdict: APPROVED\n\nRationale: It is ready.\n"
+        from assemblyzero.core.verdict_schema import parse_structured_review_spec
+
+        result = parse_structured_review_spec(verdict_to_json(text))
+        assert result["verdict"] == "APPROVED"
+        assert result["feedback_items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Finding the recording
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def test_a_reset_lineage_is_found(self, tmp_path):
+        """Runs 10 and 11 of boostgauge #4 exist ONLY under reset-artifacts,
+        because `speedrun_reset` moved them there. A discovery that only looked
+        where the pipeline writes would find nothing for the two runs the
+        launch gate is actually about."""
+        moved = (
+            tmp_path / "data" / "speedrun" / "reset-artifacts" / "issue-4"
+            / "lineage" / "4-implspec-20260903T002044Z" / "2026-09-02T23-44-44Z"
+        )
+        moved.mkdir(parents=True)
+        (moved / "001-spec-draft.md").write_text("d", encoding="utf-8")
+        found = discover_audit_dirs(tmp_path, 4)
+        assert [d.kind for d in found] == [KIND_SPEC]
+        assert found[0].file_count == 1
+
+    def test_a_directory_that_is_not_a_run_stamp_is_skipped(self):
+        assert parse_audit_stamp("issue-brief.md") is None
+        assert parse_audit_stamp("4-implspec") is None
+        assert parse_audit_stamp("2026-09-02T23-44-44Z") is not None
+
+    def test_another_issues_lineage_is_not_picked_up(self, tmp_path):
+        other = (
+            tmp_path / "docs" / "lineage" / "done" / "41-implspec"
+            / "2026-09-02T23-44-44Z"
+        )
+        other.mkdir(parents=True)
+        (other / "001-spec-draft.md").write_text("d", encoding="utf-8")
+        assert discover_audit_dirs(tmp_path, 4) == []
+
+
+class TestAssociatingDirectoriesWithRuns:
+    def test_duplicate_copies_are_broken_by_file_count_and_recorded(self):
+        """A reset copies a lineage directory, so run 11's spec lineage exists
+        twice under the same name -- once with 26 files and once with 4. Taking
+        the 4-file copy would replay a truncated recording and report a
+        divergence that is the copy's fault."""
+        stamp = _stamp("2026-09-02T23-44-44Z")
+        dirs = [
+            AuditDir(KIND_SPEC, stamp, __import__("pathlib").Path("a"), 4),
+            AuditDir(KIND_SPEC, stamp, __import__("pathlib").Path("b"), 26),
+        ]
+        chosen, notes = audit_dirs_for_run(
+            dirs, _stamp("2026-09-02T23-39-43Z"), _stamp("2026-09-03T00-23-46Z")
+        )
+        assert chosen[KIND_SPEC].file_count == 26
+        assert any("most files" in n for n in notes)
+
+    def test_two_different_directories_in_one_window_is_ambiguity_not_a_guess(self):
+        dirs = [
+            AuditDir(KIND_SPEC, _stamp("2026-09-02T23-44-44Z"),
+                     __import__("pathlib").Path("a"), 26),
+            AuditDir(KIND_SPEC, _stamp("2026-09-02T23-50-00Z"),
+                     __import__("pathlib").Path("b"), 26),
+        ]
+        chosen, notes = audit_dirs_for_run(
+            dirs, _stamp("2026-09-02T23-39-43Z"), _stamp("2026-09-03T00-23-46Z")
+        )
+        assert KIND_SPEC not in chosen
+        assert any("cannot be told apart" in n for n in notes)
+
+    def test_a_directory_outside_the_window_belongs_to_another_run(self):
+        dirs = [
+            AuditDir(KIND_LLD, _stamp("2026-09-02T21-31-44Z"),
+                     __import__("pathlib").Path("a"), 4),
+        ]
+        chosen, _ = audit_dirs_for_run(
+            dirs, _stamp("2026-09-02T23-39-43Z"), _stamp("2026-09-03T00-23-46Z")
+        )
+        assert chosen == {}
+
+
+# ---------------------------------------------------------------------------
+# The rules
+# ---------------------------------------------------------------------------
+
+
+def _spec_dir(tmp_path, drafts: list[str], verdicts: list[str]):
+    """A lineage directory in the numbering the pipeline actually writes."""
+    d = tmp_path / "2026-09-02T23-44-44Z"
+    d.mkdir()
+    number = 1
+    for index, draft in enumerate(drafts):
+        (d / f"{number:03d}-spec-draft.md").write_text(draft, encoding="utf-8")
+        number += 1
+        (d / f"{number:03d}-hallucination-check.json").write_text(
+            "{}", encoding="utf-8"
+        )
+        number += 1
+        if index < len(verdicts):
+            (d / f"{number:03d}-readiness-verdict.md").write_text(
+                verdicts[index], encoding="utf-8"
+            )
+            number += 1
+    return d
+
+
+class TestSpecRules:
+    def test_hallucination_checks_are_not_scripted(self, tmp_path):
+        """They are deterministic telemetry, not an LLM call. Scripting them
+        would put a rule in the set that no call can ever match."""
+        d = _spec_dir(tmp_path, ["a\nb\n", "a\nC\n"], [VERDICT_FILE])
+        assert any(r.suffix == "hallucination-check" for r in responses_in(d))
+        rules, _ = build_spec_rules(d)
+        assert all("hallucination" not in r.stage for r in rules)
+
+    def test_the_drafter_is_scripted_once_because_2569_removed_the_fallback(
+        self, tmp_path
+    ):
+        """A revision is edit blocks or it is a halt. A drafter rule for round 2
+        would be a rule nothing can reach, which reads as coverage that is not
+        there."""
+        d = _spec_dir(tmp_path, ["a\nb\n", "a\nC\n", "a\nD\n"], [VERDICT_FILE])
+        rules, _ = build_spec_rules(d)
+        drafter = [r for r in rules if r.stage == "spec-drafter"]
+        assert len(drafter) == 1
+        assert drafter[0].on_call == 1
+
+    def test_a_retry_of_one_round_is_answered_with_a_divergence(self, tmp_path):
+        """The recording holds ONE outcome per round because the original script
+        applied. Handing a retry the next round's script would silently replay a
+        different run; refusing it names the divergence where it happens."""
+        d = _spec_dir(tmp_path, ["a\nb\n", "a\nC\n"], [VERDICT_FILE])
+        rules, _ = build_spec_rules(d)
+        retry = [r for r in rules if r.stage == CALLER_EDITOR_RETRY]
+        assert len(retry) == 1
+        assert retry[0].fail_with
+        assert "divergence" in retry[0].fail_with.lower()
+
+    def test_a_first_attempt_and_a_retry_never_match_the_same_rule(self, tmp_path):
+        """`ScriptedProvider` fails a call matching two stages, so these two
+        patterns must be mutually exclusive or every revision round is an error
+        rather than a replay."""
+        d = _spec_dir(tmp_path, ["a\nb\n", "a\nC\n"], [VERDICT_FILE])
+        rules, _ = build_spec_rules(d)
+        editor = [r for r in rules if r.stage == CALLER_EDITOR]
+        retry = [r for r in rules if r.stage == CALLER_EDITOR_RETRY]
+        fresh = "You are revising an Implementation Spec."
+        again = f"You are revising.\n\n## {RETRY_MARK}\n\nblock 1 failed"
+        system = "You are a precision patch engine."
+        assert [r.matches(system, fresh) for r in editor] == [True] * len(editor)
+        assert [r.matches(system, again) for r in editor] == [False] * len(editor)
+        assert retry[0].matches(system, again) is True
+        assert retry[0].matches(system, fresh) is False
+
+    def test_the_reconstruction_is_counted_not_asserted(self, tmp_path):
+        d = _spec_dir(tmp_path, ["a\nb\n", "a\nC\n", "a\nD\n"], [VERDICT_FILE])
+        _, recon = build_spec_rules(d)
+        assert recon.drafts == 3
+        assert recon.verdicts == 1
+        assert recon.edit_scripts + recon.edit_script_degraded == 2
+        assert recon.notes, "the report must be able to state its own fidelity"
+
+
+# ---------------------------------------------------------------------------
+# The table a PR carries
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTable:
+    def test_every_verdict_shown_is_defined_under_the_table(self):
+        """The table travels into PR bodies read by people who will not open a
+        doc to find out what `other_gate` means."""
+        results = [
+            ReplayResult(
+                tag="run-issue4-183941", stage=KIND_SPEC,
+                recorded_cause="spec.review_cap", recorded_progress=9,
+                divergence="call 8 unmatched", replay_progress=3,
+                verdict=VERDICT_DIVERGED,
+            ),
+        ]
+        table = render_table(results)
+        assert "run-issue4-183941" in table
+        assert "diverged at round 3" in table
+        assert "**diverged**" in table
+        assert "- **diverged** —" in table
+        assert "same_gate" not in table, "unused verdicts must not be explained"
+
+    def test_a_pass_says_it_finished_rather_than_naming_a_gate(self):
+        results = [
+            ReplayResult(
+                tag="r", stage=KIND_SPEC, recorded_cause="spec.review_cap",
+                recorded_progress=9, replay_progress=9, verdict=VERDICT_PASSED,
+            ),
+        ]
+        assert "finished the stage" in render_table(results)
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "not a stamp", "4-implspec", "issue-brief.md", "done"]
+)
+def test_a_name_that_is_not_a_stamp_is_walked_past(bad):
+    assert parse_audit_stamp(bad) is None
+
+
+def test_a_stamp_shaped_name_that_is_not_a_real_instant_is_loud():
+    """`make_run_id()` cannot produce month 13. Returning None here would let
+    something that is not the pipeline name run directories and have the replay
+    quietly ignore them, which is how a run gets matched to the wrong
+    recording."""
+    with pytest.raises(ValueError):
+        parse_audit_stamp("2026-13-45T99-99-99Z")

--- a/tools/replay_run.py
+++ b/tools/replay_run.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+"""Replay a recorded run through the current graph (#2724).
+
+The launch gate. Twelve launches were allowed on boostgauge #421 and all twelve
+are spent; the operator's ruling of 2026-09-02 is that nothing relaunches until
+the recorded runs replay past the walls that killed them. This tool is how that
+is measured, in seconds, for free, with no network.
+
+Only the LLM transport is replaced (`ScriptedProvider`, #2567). The graph, the
+routers, the gates, the pinning enforcement, the file writes and the halt path
+all run for real against a throwaway clone.
+
+    poetry run python tools/replay_run.py \\
+        --recording C:/Users/mcwiz/Projects/boostgauge \\
+        --clone data/replay/boostgauge \\
+        --issue 4 --base hardening-run-20
+
+Add `--run run-issue4-183941` (repeatable) to replay named runs instead of every
+recorded run for the issue.
+
+The table this prints is what a PR touching `assemblyzero/workflows/` carries in
+its body. `--markdown` prints only the table, for pasting.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from assemblyzero.core.utf8_console import install as _install_utf8_console  # noqa: E402
+
+_install_utf8_console()
+
+from assemblyzero.core.scripted_provider import (  # noqa: E402
+    ScriptedProvider,
+    set_active,
+)
+from assemblyzero.speedrun.factory_report import (  # noqa: E402
+    classify_cause,
+    runs_dir,
+    scan_run_log,
+)
+from assemblyzero.speedrun.replay import (  # noqa: E402
+    CALLER_REVIEWER,
+    KIND_LLD,
+    KIND_SPEC,
+    ReplayResult,
+    audit_dirs_for_run,
+    build_spec_rules,
+    classify,
+    discover_audit_dirs,
+    render_table,
+    responses_in,
+    run_window,
+)
+
+#: The provider's own refusals all carry this head. It is how a divergence is
+#: told apart from a gate: a gate is the pipeline saying no to content, and this
+#: is the recording no longer fitting the prompt the code now sends.
+DIVERGENCE_MARK = "ScriptedProvider:"
+
+#: The stage this tool can replay today. Runs that died in `impl` need the
+#: testing graph, whose responses the recordings do not carry in call order;
+#: `--issue 4` reports those rather than pretending to replay them.
+REPLAYABLE_STAGES = (KIND_SPEC,)
+
+
+def _final_lld(lld_dir: Path) -> str:
+    """The LLD the recorded spec stage was handed.
+
+    `004-final.md` is the approved document; the draft before it is not what the
+    spec stage read. A recording with no final has nothing to hand the stage and
+    says so instead of substituting a draft.
+    """
+    finals = [r for r in responses_in(lld_dir) if r.suffix == "final"]
+    return finals[-1].text if finals else ""
+
+
+def replay_spec_stage(
+    *,
+    tag: str,
+    issue: int,
+    clone: Path,
+    base_branch: str,
+    lld_dir: Path,
+    spec_dir: Path,
+    out_dir: Path,
+    recorded_cause: str,
+    recorded_progress: int,
+    max_iterations: int,
+) -> ReplayResult:
+    """Run the real spec graph on one recording's responses."""
+    from assemblyzero.workflows.implementation_spec.graph import (
+        create_implementation_spec_graph,
+    )
+    from assemblyzero.workflows.implementation_spec.spec_step_budget import (
+        recursion_limit,
+    )
+
+    rules, recon = build_spec_rules(spec_dir)
+    result = ReplayResult(
+        tag=tag,
+        stage=KIND_SPEC,
+        recorded_cause=recorded_cause,
+        recorded_progress=recorded_progress,
+        reconstruction=recon,
+    )
+
+    lld_text = _final_lld(lld_dir)
+    if not lld_text.strip():
+        result.divergence = (
+            f"the recorded LLD lineage {lld_dir.name} holds no final document, "
+            f"so the spec stage cannot be handed the input it actually read"
+        )
+        return result
+
+    # A FRESH lineage directory per replay, never a reused one. `generate_spec`
+    # recovers a draft by globbing `*-spec-draft.md` out of the directory it is
+    # handed, so a second replay into the same directory skips the initial
+    # drafter call and starts mid-loop -- the replay silently stops being a
+    # replay of the recording. The run-scoped naming is the same reason #1467
+    # gave the pipeline itself.
+    out_dir = out_dir / datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    lld_path = out_dir / f"LLD-{issue:03d}.md"
+    lld_path.write_text(lld_text, encoding="utf-8")
+    audit_dir = out_dir / "lineage"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+
+    provider = ScriptedProvider(rules, model="replay")
+    set_active(provider)
+    state = {
+        "issue_number": issue,
+        "lld_path": str(lld_path),
+        "repo_root": str(clone),
+        "assemblyzero_root": str(ROOT),
+        "audit_dir": str(audit_dir),
+        "base_branch": base_branch,
+        "lld_content": "",
+        "files_to_modify": [],
+        "current_state_snapshots": {},
+        "pattern_references": [],
+        "spec_draft": "",
+        "spec_path": "",
+        "completeness_issues": [],
+        "validation_passed": False,
+        "review_verdict": "BLOCKED",
+        "review_feedback": "",
+        "review_iteration": 0,
+        "review_feedback_history": [],
+        "max_iterations": max_iterations,
+        "human_gate_enabled": False,
+        "next_node": "",
+        "error_message": "",
+        "cost_budget_usd": 0.0,
+        "config_reviewer": "scripted:reviewer",
+        "config_drafter": "scripted:drafter",
+        "config_mock_mode": False,
+        "config_effort": "",
+        "node_costs": {},
+        "node_tokens": {},
+    }
+
+    final = dict(state)
+    try:
+        graph = create_implementation_spec_graph()
+        config = {"recursion_limit": recursion_limit(max_iterations)}
+        for event in graph.stream(state, config):
+            for node_name, node_output in event.items():
+                if node_name == "__end__" or not node_output:
+                    continue
+                final.update(node_output)
+    except Exception as exc:  # noqa: BLE001
+        # Loud, not swallowed: the replay reports the exception as its outcome
+        # rather than continuing with a state that never finished. A silent
+        # handler here would let a crashed replay be read as a clean one.
+        result.divergence = f"the graph raised {type(exc).__name__}: {exc}"
+        result.path = list(provider.stages_called)
+        set_active(None)
+        return result
+    finally:
+        set_active(None)
+
+    result.path = list(provider.stages_called)
+    # Counted from the calls the reviewer actually received, not from
+    # `review_iteration`: the state key is a node's write, and a run that dies
+    # inside the drafter never gets to update it, which reads as round 0 for a
+    # loop that plainly ran. The recording's side of this comparison is counted
+    # the same way, from the review rounds the log shows.
+    result.replay_progress = max(
+        provider.stages_called.count(CALLER_REVIEWER),
+        int(final.get("review_iteration", 0) or 0),
+    )
+    error = str(final.get("error_message", "") or "")
+
+    unmatched = [c for c in provider.calls if not c.answered]
+    if DIVERGENCE_MARK in error or unmatched:
+        result.divergence = error if DIVERGENCE_MARK in error else (
+            f"{len(unmatched)} call(s) the recording could not answer"
+        )
+    elif error:
+        result.replay_cause = classify_cause(error.splitlines()[0])
+        result.notes.append(error.splitlines()[0][:200])
+
+    result.verdict = classify(
+        recorded_cause=recorded_cause,
+        recorded_progress=recorded_progress,
+        replay_cause=result.replay_cause,
+        replay_progress=result.replay_progress,
+        divergence=result.divergence,
+        finished=bool(final.get("spec_path")),
+    )
+    return result
+
+
+def collect(args: argparse.Namespace) -> tuple[list[ReplayResult], list[str]]:
+    """Replay every requested run; return results and the skipped ones."""
+    recording = Path(args.recording).resolve()
+    clone = Path(args.clone).resolve()
+    out_root = Path(args.out).resolve()
+    dirs = discover_audit_dirs(recording, args.issue)
+
+    logs = sorted(runs_dir(recording).glob(f"run-issue{args.issue}-*.log"))
+    logs = [p for p in logs if not p.name.endswith(("-events.log", "-heartbeat.log"))]
+    if args.run:
+        wanted = set(args.run)
+        logs = [p for p in logs if p.stem in wanted]
+
+    results: list[ReplayResult] = []
+    skipped: list[str] = []
+    for log in logs:
+        facts = scan_run_log(log)
+        tag = facts.run_id
+        if facts.failed_stage not in REPLAYABLE_STAGES:
+            skipped.append(
+                f"{tag}: ended in `{facts.failed_stage or facts.outcome}`, and "
+                f"only the {'/'.join(REPLAYABLE_STAGES)} stage can be replayed "
+                f"from what the recordings hold"
+            )
+            continue
+        start, end = run_window(log)
+        chosen, notes = audit_dirs_for_run(dirs, start, end)
+        if KIND_SPEC not in chosen or KIND_LLD not in chosen:
+            have = ", ".join(sorted(chosen)) or "none"
+            skipped.append(
+                f"{tag}: needs both an lld and a spec lineage directory; "
+                f"found {have}. " + " ".join(notes)
+            )
+            continue
+        result = replay_spec_stage(
+            tag=tag,
+            issue=args.issue,
+            clone=clone,
+            base_branch=args.base,
+            lld_dir=chosen[KIND_LLD].path,
+            spec_dir=chosen[KIND_SPEC].path,
+            out_dir=out_root / tag,
+            recorded_cause=facts.cause,
+            recorded_progress=facts.review_rounds.get("spec", 0),
+            max_iterations=args.max_iterations,
+        )
+        result.notes.extend(notes)
+        results.append(result)
+    return results, skipped
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--recording", required=True,
+        help="the repo whose run logs and lineage hold the recordings",
+    )
+    parser.add_argument(
+        "--clone", required=True,
+        help="a throwaway clone of that repo -- never a worktree of it",
+    )
+    parser.add_argument("--issue", type=int, required=True)
+    parser.add_argument(
+        "--base", default="",
+        help="the integration branch the recorded runs were built on",
+    )
+    parser.add_argument(
+        "--run", action="append", default=[],
+        help="a run tag to replay; repeatable. Default: every run for the issue",
+    )
+    parser.add_argument("--max-iterations", type=int, default=3)
+    parser.add_argument(
+        "--out", default=str(ROOT / "data" / "replay" / "out"),
+        help="where each replay's lineage and inputs are written",
+    )
+    parser.add_argument(
+        "--markdown", action="store_true",
+        help="print only the table, for pasting into a PR body",
+    )
+    args = parser.parse_args(argv)
+
+    if not Path(args.clone).is_dir():
+        parser.error(
+            f"--clone {args.clone} is not a directory. Clone the target repo "
+            f"fresh into a gitignored directory; a worktree of the live "
+            f"checkout is never the right base for a replay."
+        )
+
+    results, skipped = collect(args)
+    if not results and not skipped:
+        print("No recorded runs matched.")
+        return 1
+
+    table = render_table(results) if results else "_No run was replayable._"
+    if args.markdown:
+        print(table)
+        return 0
+
+    print(f"# Replay — issue #{args.issue}, {datetime.now():%Y-%m-%d %H:%M:%S}")
+    print()
+    print(table)
+    print()
+    for result in results:
+        recon = result.reconstruction
+        print(f"## {result.tag}")
+        print(
+            f"  reconstruction: {recon.drafts} draft(s), {recon.verdicts} "
+            f"verdict(s), {recon.edit_scripts} edit script(s) synthesised, "
+            f"{recon.edit_script_degraded} degraded to a whole document"
+        )
+        print(f"  calls: {len(result.path)} ({', '.join(result.path) or 'none'})")
+        if result.divergence:
+            print(f"  divergence: {result.divergence[:400]}")
+        for note in [*recon.notes, *result.notes]:
+            print(f"  note: {note}")
+        print()
+    if skipped:
+        print("## Not replayed")
+        for line in skipped:
+            print(f"- {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The launch gate, built and measured

`tools/replay_run.py` loads a recorded run's responses as `ScriptedRule`s in call order, runs the real spec graph against a throwaway clone at the run's base, and reports where the replay ended against where the recording ended. Only the LLM transport is replaced: the routers, the gates, the pinning enforcement, the file writes and the halt path all ran for real, in seconds, with no network.

**Vocabulary, for a reader outside this codebase.** A *run* is one launch of the pipeline at one issue. A *gate* is a place in the workflow code that can end a run. *Lineage* is the directory a run writes its drafts and verdicts into, one per run. A *round* is one pass of the draft-then-review loop. A *replay* re-runs the recorded run with the model replaced by its own recorded answers.

## The replay table

| run | stage | recorded ended at | replay ended at | verdict |
|---|---|---|---|---|
| run-issue4-182119 | spec | `spec.completeness_cap` at round 4 | diverged at round 3 | **diverged** |
| run-issue4-183941 | spec | `spec.review_cap` at round 9 | diverged at round 3 | **diverged** |
| run-issue4-192453 | spec | `spec.requirements_conflict` at round 5 | `spec.requirements_conflict` at round 5 | **same_gate** |

- **same_gate** — died at the same gate, the same distance in
- **diverged** — the recorded responses stopped fitting the code's prompts, so the replay could not continue and reports no verdict on the gate

Runs 8 (`run-issue4-163140`) and 9 (`run-issue4-172600`) are not in the table: both ended in the implementation stage, whose responses the recordings do not hold in call order. The tool lists them under "Not replayed" with that reason rather than omitting them.

**Run 12 is the proof the runner works.** `run-issue4-192453` replayed exactly: 11 calls — one drafter, five editors, five reviewers — five review rounds, ending at `spec.requirements_conflict` at round 5, the same gate the recording died at. Nothing was mocked but the transport.

## The acceptance criterion this PR does not meet, and why

The issue asks that run 11 replayed through current `main` end past review round 8. **It does not: it diverges at round 3.** That is a measured result, not a runner defect, and it is the more useful finding.

Run 11 replays a full initial draft, five successful synthesised edit rounds and two review rounds. At the sixth edit the derived blocks no longer apply, because the draft this replay built is no longer byte-identical to the draft the recording had. The code then asks the drafter to try again, and the recording holds exactly one outcome per round — in the recording, the script applied first time. There is nothing faithful to answer with, so the runner stops and says so.

The cause is what the pipeline persists:

- `NNN-spec-draft.md` is written **after** preamble stripping, pinning adjudication and decision-table re-assertion. It is the round's outcome, not the drafter's words.
- `NNN-readiness-verdict.md` is markdown assembled from the parsed verdict, while the reviewer is called with `REVIEW_SPEC_SCHEMA` and standard 0028 left no regex fallback. Replaying it verbatim would be read as an infrastructure failure the recording never had, so `verdict_to_json` re-encodes it; the three schema fields round-trip and anything said outside them was never recorded.
- A revision round calls the drafter with `EDIT_SCRIPT_SYSTEM_PROMPT` and expects SEARCH/REPLACE blocks, not a document, so the blocks are derived from the pair of recorded drafts around each round.

Filed as a follow-up: see #2731. Until the pipeline records the raw request and response of every model call, replay can prove a gate's behaviour only while the reconstructed draft stays byte-identical to the recorded one, and that holds for about five rounds.

Every replay prints its own fidelity — drafts consumed, verdicts re-encoded, edit scripts synthesised, and how many degraded — so a reader can tell a clean replay from one held together with reconstruction. On these runs, zero degraded.

## Two defects the measurement caught in this PR's own code

Both were found by running against the real recordings, not by the fixtures.

1. **A reused lineage directory silently stopped the replay being a replay.** `generate_spec` recovers a draft by globbing `*-spec-draft.md` out of the directory it is handed, so a second replay into the same directory skipped the initial drafter call and started mid-loop. The first call in the recorded path was the reviewer, which is what gave it away. Each replay now claims a fresh run-scoped directory, the same repair #1467 gave the pipeline.
2. **A pure deletion left a blank line where the deleted text was.** Joining an empty replacement span produced an empty REPLACE, and a substring replace then removed the lines but not the newline between them. Degenerate hunks now borrow a line of context on each side so both halves are whole lines. `test_a_deletion_lands` is that fix.

An earlier version numbered the edit-script rules by editor call rather than by round, so a retry of one round was answered with the next round's script — manufacturing a failure where the honest answer was divergence. Retries now have their own rule that refuses, and `test_a_first_attempt_and_a_retry_never_match_the_same_rule` pins the two patterns as mutually exclusive.

## Where the recordings actually are

Runs 10 and 11's spec lineage exists **only** under `data/speedrun/reset-artifacts/`, because `speedrun_reset` moved it there; `docs/lineage/` holds nothing for either. Discovery searches all three roots. Run 11's directory exists twice under the same name, once with 26 files and once with 4 — the copy with the most files is taken and the choice is printed, never made silently. Two *different* directory names inside one run's window is not a tie and is reported as ambiguity rather than guessed.

## Verification

- `tests/unit/test_replay_run.py`, 38 tests. `TestDivergenceNeverPasses` is the issue's third acceptance criterion as a test: a divergence beats a clean finish and beats getting further, so no launch decision can read a `passed` the evidence does not support.
- The synthesised edit scripts are checked by applying them through the real `parse_edit_blocks` and `apply_edit_blocks` and asserting the result equals the target draft — insertions, deletions, replacements, repeated lines, several hunks, and the trailing newline.
- The re-encoded verdict is parsed by the real `parse_structured_review_spec`, not a stand-in.
- Full unit suite: 9688 passed, 21 skipped, 5 xfailed, 0 failed.
- `ruff check` clean on all three new files.
- No new gate. The gate registry is untouched and the halt-count baseline is unchanged: `tools/audit_halt_sites.py --check` passes, 160 sites, 96 gates, 0 unregistered, 0 phantom.
- One fail-open finding in this PR's own code was cleared at the site, not in the baseline: `parse_audit_stamp` used a handler that returned `None` for anything unparseable. It now tells two cases apart — a name that is not a stamp is walked past, and a stamp-shaped name that is not a real instant raises, because `make_run_id()` cannot have written it.

Closes #2724
