### PR TITLE
feat: the graph writes its own convergence record instead of the report parsing prose (Closes #2721)

### DIFF
--- a/assemblyzero/speedrun/convergence.py
+++ b/assemblyzero/speedrun/convergence.py
@@ -1,0 +1,247 @@
+"""The convergence record the graph writes for itself (#2721).
+
+`factory_report.py` learned to say how each run ended by parsing the closing
+`STAGE / VERDICT` table and the `Error:` line out of a prose log (#2717). That
+is a bridge, and it has the failure a parser of prose always has: a run whose
+banner never printed -- the process died mid-call, 19 of boostgauge's 180 runs
+-- leaves nothing to read, and a change to the banner's wording silently
+changes what the report counts.
+
+The operator's ruling of 2026-09-02: the convergence number is not a prose field
+in a handoff and not a line in CLAUDE.md. It is a row the graph wrote.
+
+So the graph writes it. Three event kinds, appended to one JSONL beside the
+other per-repo speedrun stores:
+
+* ``stage.enter`` -- the orchestrator entering a pipeline stage, with its
+  position in `STAGE_ORDER`.
+* ``node.enter`` -- a sub-workflow node, with its position in that graph's
+  atlas. Emitted from `narrated()`, which is already the single place every
+  graph announces a node, so no graph can grow a node that forgets to record.
+* ``run.terminal`` -- one per run, written where the outcome is actually known:
+  the outcome, the furthest stage and node reached, and the registry key of the
+  gate that ended it.
+
+**A record never costs a run.** Every function here returns False rather than
+raising, exactly as `record_heal` does. That is a deliberate fall-through and it
+is loud in the only way that matters: `read_records` reports what it could not
+read, and the report says which source it used, so a run with no record is
+visible as a run with no record rather than as a run that passed.
+
+**Why the tag can be empty.** `SPEEDRUN_RUN_TAG` is set by the launcher, so a
+roll has one and a standalone workflow invocation does not. An unknown tag is
+recorded as `""` and the reader keys on it honestly, rather than inventing a
+tag that would merge unrelated runs into one.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+#: One store, beside `heals.jsonl` and `prompt-failures.jsonl`. Under
+#: `data/speedrun/telemetry/`, which is structurally exempt from every janitor.
+RECORDS_FILENAME = "run-records.jsonl"
+
+#: Set by `speedrun_roll.py` for the whole roll. Absent outside a roll.
+RUN_TAG_ENV = "SPEEDRUN_RUN_TAG"
+
+EVENT_STAGE_ENTER = "stage.enter"
+EVENT_NODE_ENTER = "node.enter"
+EVENT_RUN_TERMINAL = "run.terminal"
+EVENTS: tuple[str, ...] = (
+    EVENT_STAGE_ENTER, EVENT_NODE_ENTER, EVENT_RUN_TERMINAL,
+)
+
+OUTCOME_PASSED = "passed"
+OUTCOME_FAILED = "failed"
+OUTCOMES: tuple[str, ...] = (OUTCOME_PASSED, OUTCOME_FAILED)
+
+#: What ended the run, when it was not a registry gate. `cap:` is a budget
+#: naming itself; `finalize` is a run that reached the end.
+KEY_FINALIZE = "finalize"
+CAP_PREFIX = "cap:"
+
+#: How the reader says where a fact came from. The report prints this, because
+#: "the record said so" and "a banner was parsed" are different evidence and a
+#: reader deciding whether to launch is entitled to know which they have.
+SOURCE_RECORD = "record"
+SOURCE_BANNER = "banner"
+
+
+def records_path(repo_root: Path | str) -> Path:
+    return Path(repo_root) / "data" / "speedrun" / "telemetry" / RECORDS_FILENAME
+
+
+def current_run_tag() -> str:
+    """The roll's tag, or "" outside a roll. Never invented."""
+    return os.environ.get(RUN_TAG_ENV, "").strip()
+
+
+def _append(repo_root: Path | str, record: dict) -> bool:
+    try:
+        path = records_path(repo_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+        return True
+    except Exception:  # noqa: BLE001 - the record must never cost a roll
+        # fail-open: a run that cannot write its record still has to finish.
+        # The absence is visible downstream -- `read_records` returns nothing
+        # for the run and the report falls back to the banner and says so --
+        # so nothing here is mistaken for a run that passed.
+        return False
+
+
+def _base(event: str, run_tag: str) -> dict:
+    return {
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "event": event,
+        "run_tag": run_tag or current_run_tag(),
+    }
+
+
+def record_stage_enter(
+    repo_root: Path | str,
+    stage: str,
+    ordinal: int,
+    total: int,
+    *,
+    run_tag: str = "",
+) -> bool:
+    """The orchestrator entering one pipeline stage."""
+    record = _base(EVENT_STAGE_ENTER, run_tag)
+    record.update({"stage": stage, "ordinal": ordinal, "total": total})
+    return _append(repo_root, record)
+
+
+def record_node_enter(
+    repo_root: Path | str,
+    stage: str,
+    node: str,
+    ordinal: int,
+    total: int,
+    *,
+    run_tag: str = "",
+) -> bool:
+    """One sub-workflow node, at the moment it is entered."""
+    record = _base(EVENT_NODE_ENTER, run_tag)
+    record.update(
+        {"stage": stage, "node": node, "ordinal": ordinal, "total": total}
+    )
+    return _append(repo_root, record)
+
+
+def record_terminal(
+    repo_root: Path | str,
+    *,
+    outcome: str,
+    furthest_stage: str,
+    furthest_node: str = "",
+    gate_key: str = "",
+    run_tag: str = "",
+) -> bool:
+    """The one record per run that says how it ended.
+
+    Written where the outcome is known rather than where it is printed, so a run
+    whose banner never reached the log still leaves the fact behind.
+    """
+    record = _base(EVENT_RUN_TERMINAL, run_tag)
+    record.update(
+        {
+            "outcome": outcome,
+            "furthest_stage": furthest_stage,
+            "furthest_node": furthest_node,
+            "gate_key": gate_key,
+        }
+    )
+    return _append(repo_root, record)
+
+
+def read_records(repo_root: Path | str) -> tuple[list[dict], int]:
+    """Every readable record, and how many lines were not readable.
+
+    The unreadable count is returned rather than logged, because a caller that
+    reports "12 runs recorded" while silently dropping three corrupt lines is
+    stating a number it did not count.
+    """
+    path = records_path(repo_root)
+    if not path.exists():
+        return [], 0
+    records: list[dict] = []
+    unreadable = 0
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            # fail-open: one truncated line -- a roll killed mid-write -- must
+            # not make the whole store unreadable. It is COUNTED rather than
+            # dropped, and the count is returned, so no caller can report a
+            # number of runs while silently having lost some.
+            unreadable += 1
+            continue
+        if isinstance(parsed, dict) and parsed.get("event") in EVENTS:
+            records.append(parsed)
+        else:
+            unreadable += 1
+    return records, unreadable
+
+
+def terminals_by_run(records: list[dict]) -> dict[str, dict]:
+    """The terminal record for each run that wrote one.
+
+    The LAST terminal for a tag wins. A resumed run appends a second terminal,
+    and the later one is the one that describes how the run actually ended.
+    Records with no tag are dropped rather than merged under one blank key,
+    which would make several unrelated runs look like one.
+    """
+    out: dict[str, dict] = {}
+    for record in records:
+        if record.get("event") != EVENT_RUN_TERMINAL:
+            continue
+        tag = record.get("run_tag") or ""
+        if not tag:
+            continue
+        out[tag] = record
+    return out
+
+
+def furthest_by_run(records: list[dict]) -> dict[str, tuple[str, str]]:
+    """(stage, node) of the highest-ordinal entry each run reached.
+
+    Read from the entry events rather than from the terminal record, so a run
+    that died before writing a terminal still says how far it got -- which is
+    exactly the 19 killed runs the banner parse can say nothing about.
+    """
+    # A stage ordinal and a node ordinal are different scales and must never be
+    # compared to each other: the stage decides how far the run got, and the
+    # node only says how far INTO that stage. So the best stage is tracked
+    # first, and a node counts only while it belongs to that stage -- a node
+    # ordinal from an earlier stage cannot overtake a later stage's.
+    best_stage: dict[str, tuple[int, str]] = {}
+    best_node: dict[str, tuple[int, str]] = {}
+    for record in records:
+        event = record.get("event")
+        tag = record.get("run_tag") or ""
+        if not tag or event not in (EVENT_STAGE_ENTER, EVENT_NODE_ENTER):
+            continue
+        stage = str(record.get("stage", ""))
+        ordinal = int(record.get("ordinal", 0) or 0)
+        if event == EVENT_STAGE_ENTER:
+            if ordinal > best_stage.get(tag, (-1, ""))[0]:
+                best_stage[tag] = (ordinal, stage)
+                best_node.pop(tag, None)
+            continue
+        if stage != best_stage.get(tag, (-1, ""))[1]:
+            continue
+        if ordinal > best_node.get(tag, (-1, ""))[0]:
+            best_node[tag] = (ordinal, str(record.get("node", "")))
+    return {
+        tag: (stage, best_node.get(tag, (0, ""))[1])
+        for tag, (_, stage) in best_stage.items()
+    }

--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -58,6 +58,14 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from assemblyzero.speedrun.convergence import (
+    SOURCE_BANNER,
+    SOURCE_RECORD,
+    furthest_by_run,
+    read_records,
+    terminals_by_run,
+)
+
 _TS_FMT = "%Y-%m-%d %H:%M:%S"
 
 #: Every (stage, check) pair a `record_failure`/`record_failures` call site
@@ -496,6 +504,11 @@ class RunLogFacts:
     exit_label: str = ""
     #: stage -> verdict from the closing table, in table order.
     stage_verdicts: dict[str, str] = field(default_factory=dict)
+    #: Where `outcome`, `furthest_stage` and `cause` came from (#2721):
+    #: `record` if the graph wrote one, `banner` if they were parsed out of the
+    #: log's prose. Printed, because the two are different evidence and a reader
+    #: deciding whether to launch is entitled to know which they have.
+    source: str = SOURCE_BANNER
 
     @property
     def furthest(self) -> str:
@@ -663,7 +676,64 @@ def scan_run_logs(
         ):
             continue
         facts.append(scanned)
+    facts = apply_records(facts, repo_root)
     return sorted(facts, key=lambda f: (f.mtime, f.run_id))
+
+
+def apply_records(
+    facts: list[RunLogFacts], repo_root: Path | str
+) -> list[RunLogFacts]:
+    """Let the graph's own terminal record override the banner parse (#2721).
+
+    The record wins wherever it exists, because it was written by the code that
+    knew, at the moment it knew, rather than recovered from prose afterwards.
+    Where it does not exist -- every run before this landed, and any run whose
+    write failed -- the banner parse stands and the run says `banner`, so the
+    two are never silently mixed into one number.
+
+    `furthest_stage` is deliberately NOT overwritten from the terminal record's
+    field alone: the entry records are the better source for it, since they are
+    written as the run advances and survive a run that died before it could
+    write anything terminal.
+    """
+    records, _ = read_records(repo_root)
+    if not records:
+        return facts
+    terminals = terminals_by_run(records)
+    furthest = furthest_by_run(records)
+    for run in facts:
+        entry = terminals.get(run.run_id)
+        reached = furthest.get(run.run_id)
+        if entry is None and reached is None:
+            continue
+        run.source = SOURCE_RECORD
+        if reached:
+            stage, node = reached
+            if stage:
+                run.furthest_stage = stage
+            if node:
+                run.furthest_node = node
+        if entry is None:
+            # Entries but no terminal: the run died before it could say how it
+            # ended. That is exactly the killed run the banner parse cannot
+            # describe, and the entries still say how far it got.
+            continue
+        outcome = str(entry.get("outcome") or "")
+        if outcome in (OUTCOME_PASSED, OUTCOME_FAILED):
+            run.outcome = outcome
+        key = str(entry.get("gate_key") or "")
+        if key and outcome == OUTCOME_FAILED:
+            run.cause = key
+            run.failed_stage = str(entry.get("furthest_stage") or run.failed_stage)
+    return facts
+
+
+def source_counts(facts: list[RunLogFacts]) -> dict[str, int]:
+    """How many runs each source accounts for. Counted, never estimated."""
+    counts = {SOURCE_RECORD: 0, SOURCE_BANNER: 0}
+    for run in facts:
+        counts[run.source] = counts.get(run.source, 0) + 1
+    return counts
 
 
 # ---------------------------------------------------------------------------
@@ -988,6 +1058,7 @@ def build_report(
             "kills_by_judges": dict(kills_by_judges),
             "unclassified": unclassified,
             "killed_tails": dict(killed_tails),
+            "sources": source_counts(runs),
         },
         "convergence": {
             "by_day": convergence_rows,
@@ -1076,6 +1147,18 @@ def render_report(data: dict) -> str:
         )
     else:
         lines.append("No run logs in this window.")
+    sources = outcomes.get("sources") or {}
+    if total_runs:
+        # #2721: which evidence this section rests on, said rather than assumed.
+        # A record was written by the graph at the moment it knew; a banner was
+        # recovered from prose afterwards and cannot describe a run that died
+        # before printing one.
+        lines.append("")
+        lines.append(
+            f"Source: {sources.get(SOURCE_RECORD, 0)} run(s) from the graph's "
+            f"own terminal record, {sources.get(SOURCE_BANNER, 0)} parsed from "
+            f"the closing banner."
+        )
     lines.append("")
 
     lines.append(

--- a/assemblyzero/workflows/implementation_spec/graph.py
+++ b/assemblyzero/workflows/implementation_spec/graph.py
@@ -399,7 +399,7 @@ def create_implementation_spec_graph() -> CompiledStateGraph:
     from assemblyzero.workflows.narration import narrated
 
     def _add(name, fn):
-        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS))
+        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS, stage="spec"))
 
     # Add nodes
     from assemblyzero.workflows.implementation_spec.nodes.compile_manifest import (

--- a/assemblyzero/workflows/narration.py
+++ b/assemblyzero/workflows/narration.py
@@ -87,8 +87,19 @@ def _line_for(node_id: str, atlas: dict, total: int, state=None) -> list[str]:
     return lines
 
 
-def narrated(node_id: str, fn, atlas: dict, total: int):
-    """Wrap a graph node so entering it narrates its position."""
+def narrated(node_id: str, fn, atlas: dict, total: int, stage: str = ""):
+    """Wrap a graph node so entering it narrates and records its position.
+
+    Two outputs from one wrap, deliberately. The printed lines are for a human
+    watching the roll; the record is for the report (#2721), which must not have
+    to parse those lines back out of a log afterwards. Wrapping here means a
+    graph cannot grow a node that forgets to record, because this is already the
+    one place every node announces itself.
+
+    ``stage`` names the sub-workflow for the record. A caller that omits it
+    still narrates, and the record is skipped rather than filed under a blank
+    stage that would make two graphs' nodes indistinguishable.
+    """
 
     def _wrapped(state, *args, **kwargs):
         try:
@@ -96,7 +107,38 @@ def narrated(node_id: str, fn, atlas: dict, total: int):
                 print(line, flush=True)
         except Exception:  # noqa: BLE001 - narration never costs a run
             pass
+        if stage:
+            _record_entry(node_id, atlas, total, stage, state)
         return fn(state, *args, **kwargs)
 
     _wrapped.__name__ = getattr(fn, "__name__", node_id)
     return _wrapped
+
+
+def _record_entry(node_id: str, atlas: dict, total: int, stage: str, state) -> None:
+    """Append this node's entry to the convergence record (#2721).
+
+    Silent on every failure, for the same reason narration is: a run must not
+    die because a diagnostic could not be written. The absence is visible at the
+    other end -- the report says which source it used, so a run with no records
+    reads as a run with no records and never as a run that passed.
+    """
+    try:
+        from assemblyzero.speedrun.convergence import record_node_enter
+
+        repo_root = state.get("repo_root", "") if hasattr(state, "get") else ""
+        if not repo_root:
+            return
+        record_node_enter(
+            repo_root,
+            stage,
+            node_id,
+            int((atlas.get(node_id) or {}).get("ordinal", 0) or 0),
+            total,
+        )
+    except Exception:  # noqa: BLE001 - the record never costs a run
+        # fail-open: a diagnostic that can take a roll down is worse than a
+        # missing diagnostic, and the missing one is reported -- the factory
+        # report names its source, so a run with no records reads as a run with
+        # no records rather than as a run that passed.
+        return

--- a/assemblyzero/workflows/orchestrator/graph.py
+++ b/assemblyzero/workflows/orchestrator/graph.py
@@ -44,10 +44,10 @@ from assemblyzero.workflows.orchestrator.state import (
     StageResult,
     create_initial_state,
     default_assemblyzero_root,
-    get_next_stage,
     update_stage_result,
 )
 from assemblyzero.core.errors import is_capacity_message
+from assemblyzero.speedrun.convergence import KEY_FINALIZE
 from assemblyzero.core.halt_node import create_halt_node
 from assemblyzero.core.stage_watchdog import StageWatchdog
 
@@ -78,6 +78,30 @@ def _init_node(state: OrchestrationState) -> dict[str, Any]:
     return {
         "stage_started_at": now,
     }
+
+
+def _record_stage_entry(state: OrchestrationState, stage: str) -> None:
+    """Append this stage's entry to the convergence record (#2721).
+
+    Silent on failure: a run must not die because a diagnostic could not be
+    written, and a missing record is visible at the other end because the report
+    says which source it used.
+    """
+    try:
+        from assemblyzero.speedrun.convergence import record_stage_enter
+
+        repo = state.get("target_repo", "")
+        if not repo:
+            return
+        ordinal = (
+            STAGE_ORDER.index(stage) + 1 if stage in STAGE_ORDER else 0
+        )
+        record_stage_enter(repo, stage, ordinal, len(STAGE_ORDER))
+    except Exception:  # noqa: BLE001 - the record never costs a run
+        # fail-open: a stage must not fail to run because its diagnostic could
+        # not be written. The absence is reported at the other end: the factory
+        # report names the source it used for every run.
+        return
 
 
 def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
@@ -127,6 +151,12 @@ def _run_stage_node(state: OrchestrationState) -> dict[str, Any]:
 
     runner = STAGE_RUNNERS[current_stage]
     last_state = state
+
+    # #2721: the stage records where it is, once, before any attempt. At the
+    # dispatch point rather than inside each runner, for the same reason the
+    # mock guard above is here: a stage nobody remembers to instrument still
+    # records.
+    _record_stage_entry(state, current_stage)
 
     for attempt in range(1, max_retries + 1):
         # Update state with start time for this stage
@@ -411,6 +441,73 @@ def format_stage_table(stage_results: dict) -> str:
     return "\n".join(lines)
 
 
+def _furthest_recorded_stage(stage_results: dict) -> str:
+    """The last stage in `STAGE_ORDER` that produced any result.
+
+    `current_stage` is `done` on a success, which is a graph node and not a
+    pipeline stage; recording it as the furthest stage reached would make every
+    passed run sort below every failed one.
+    """
+    reached = [s for s in STAGE_ORDER if s in (stage_results or {})]
+    return reached[-1] if reached else ""
+
+
+def _terminal_gate_key(error_message: str) -> str:
+    """The registry key that ended the run, by the same two readings the report
+    uses -- the tag a `halted()` site appends, else the cause classifier.
+
+    Both are consulted because the retagging of legacy sites is #2723's job and
+    most sites still emit untagged prose. The classifier is the bridge; the tag
+    is what replaces it, one site at a time.
+    """
+    head = (error_message or "").strip().splitlines()
+    if not head:
+        return KEY_FINALIZE
+    from assemblyzero.core.gate_registry import gate_key_of
+    from assemblyzero.speedrun.factory_report import classify_cause
+
+    return gate_key_of(error_message) or classify_cause(head[0])
+
+
+def _record_terminal(
+    repo: str,
+    success: bool,
+    final_stage: str,
+    stage_results: dict,
+    error_message: str,
+) -> None:
+    """Write the one record per run that says how it ended (#2721).
+
+    Silent on failure, like the entry records: the console banner and the resume
+    state already carry the outcome for a human, and a diagnostic that can take
+    a run down is worse than a missing one.
+    """
+    try:
+        from assemblyzero.speedrun.convergence import (
+            OUTCOME_FAILED,
+            OUTCOME_PASSED,
+            record_terminal,
+        )
+
+        if not repo:
+            return
+        record_terminal(
+            repo,
+            outcome=OUTCOME_PASSED if success else OUTCOME_FAILED,
+            furthest_stage=(
+                _furthest_recorded_stage(stage_results) if success
+                else (final_stage or _furthest_recorded_stage(stage_results))
+            ),
+            gate_key=KEY_FINALIZE if success else _terminal_gate_key(error_message),
+        )
+    except Exception:  # noqa: BLE001 - the record never costs a run
+        # fail-open: the console banner and the resume state already carry the
+        # outcome for a human. A run that has finished must not be turned into a
+        # crash by the write that describes it, and a missing terminal record is
+        # visible -- the report falls back to the banner parse and says so.
+        return
+
+
 def _write_run_record(issue_number: int, table: str, success: bool) -> None:
     """Persist the per-run record next to the resume state (#1785)."""
     from assemblyzero.workflows.orchestrator.resume import STATE_DIR
@@ -601,6 +698,15 @@ def orchestrate(
         # #1785: every run leaves a readable record beside its resume state.
         _write_run_record(
             issue_number, format_stage_table(stage_results), success
+        )
+
+        # #2721: the run says how it ended, here, where the outcome is known --
+        # not where the banner is printed. A run whose banner never reached the
+        # log still leaves the fact behind, which is the whole difference
+        # between this and parsing prose after the fact.
+        _record_terminal(
+            state.get("target_repo", ""), success, final_stage,
+            stage_results, error_message,
         )
 
         return OrchestrationResult(

--- a/assemblyzero/workflows/requirements/graph.py
+++ b/assemblyzero/workflows/requirements/graph.py
@@ -538,7 +538,7 @@ def create_requirements_graph() -> StateGraph:
     from assemblyzero.workflows.requirements.atlas import ATLAS, TOTAL_STEPS
 
     def _add(name, fn):
-        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS))
+        graph.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS, stage="lld"))
 
     # Add nodes
     _add(N0_LOAD_INPUT, load_input)

--- a/tests/unit/test_convergence_record.py
+++ b/tests/unit/test_convergence_record.py
@@ -1,0 +1,363 @@
+"""The record the graph writes for itself, and the report reading it (#2721).
+
+The report learned to say how each run ended by parsing a prose log. This is the
+replacement: rows the graph wrote at the moment it knew. The two acceptance
+criteria from the issue are `TestTheRollWritesItsOwnRecord` (a roll produces a
+terminal record for a passed roll and for a halted one) and
+`TestTheReportPrefersTheRecord` (given both, the record wins and the source is
+stated).
+
+The rest of this file exists so those two can be trusted. A record store that
+silently drops a corrupt line, or a furthest-reached reading that compares a
+node ordinal to a stage ordinal, would produce convergence numbers that look
+measured and are not.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from assemblyzero.speedrun.convergence import (
+    EVENT_NODE_ENTER,
+    EVENT_RUN_TERMINAL,
+    EVENT_STAGE_ENTER,
+    KEY_FINALIZE,
+    OUTCOME_FAILED,
+    OUTCOME_PASSED,
+    SOURCE_BANNER,
+    SOURCE_RECORD,
+    current_run_tag,
+    furthest_by_run,
+    read_records,
+    record_node_enter,
+    record_stage_enter,
+    record_terminal,
+    records_path,
+    terminals_by_run,
+)
+from assemblyzero.speedrun.factory_report import (
+    RunLogFacts,
+    apply_records,
+    source_counts,
+)
+
+TAG = "run-issue4-183941"
+
+
+@pytest.fixture
+def tagged(monkeypatch):
+    monkeypatch.setenv("SPEEDRUN_RUN_TAG", TAG)
+    return TAG
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 1: a roll writes its own terminal record
+# ---------------------------------------------------------------------------
+
+
+class TestTheRollWritesItsOwnRecord:
+    def test_a_halted_roll_records_the_gate_that_ended_it(self, tmp_path, tagged):
+        record_stage_enter(tmp_path, "lld", 2, 7)
+        record_node_enter(tmp_path, "lld", "N1_generate_draft", 4, 11)
+        record_stage_enter(tmp_path, "spec", 4, 7)
+        record_terminal(
+            tmp_path,
+            outcome=OUTCOME_FAILED,
+            furthest_stage="spec",
+            gate_key="spec.review_cap",
+        )
+        records, unreadable = read_records(tmp_path)
+        assert unreadable == 0
+        terminal = terminals_by_run(records)[TAG]
+        assert terminal["outcome"] == OUTCOME_FAILED
+        assert terminal["gate_key"] == "spec.review_cap"
+        assert terminal["furthest_stage"] == "spec"
+
+    def test_a_passed_roll_records_finalize_rather_than_a_gate(
+        self, tmp_path, tagged
+    ):
+        record_stage_enter(tmp_path, "cleanup", 7, 7)
+        record_terminal(
+            tmp_path,
+            outcome=OUTCOME_PASSED,
+            furthest_stage="cleanup",
+            gate_key=KEY_FINALIZE,
+        )
+        terminal = terminals_by_run(read_records(tmp_path)[0])[TAG]
+        assert terminal["outcome"] == OUTCOME_PASSED
+        assert terminal["gate_key"] == KEY_FINALIZE
+
+    def test_every_event_kind_lands_in_one_store(self, tmp_path, tagged):
+        record_stage_enter(tmp_path, "lld", 2, 7)
+        record_node_enter(tmp_path, "lld", "N1", 4, 11)
+        record_terminal(
+            tmp_path, outcome=OUTCOME_PASSED, furthest_stage="lld"
+        )
+        records, _ = read_records(tmp_path)
+        assert [r["event"] for r in records] == [
+            EVENT_STAGE_ENTER, EVENT_NODE_ENTER, EVENT_RUN_TERMINAL,
+        ]
+        assert records_path(tmp_path).name == "run-records.jsonl"
+        assert records_path(tmp_path).parent.name == "telemetry"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 2: the report prefers the record and says so
+# ---------------------------------------------------------------------------
+
+
+def _banner_facts(**kwargs) -> RunLogFacts:
+    base = dict(
+        run_id=TAG, issue=4, path="", mtime="2026-09-02 18:39:41",
+        outcome="failed", failed_stage="spec", furthest_stage="spec",
+        cause="spec.review_cap",
+    )
+    base.update(kwargs)
+    return RunLogFacts(**base)
+
+
+class TestTheReportPrefersTheRecord:
+    def test_the_record_overrides_the_banner_parse(self, tmp_path, tagged):
+        record_terminal(
+            tmp_path,
+            outcome=OUTCOME_FAILED,
+            furthest_stage="impl",
+            gate_key="impl.stagnation.coverage",
+        )
+        [run] = apply_records([_banner_facts()], tmp_path)
+        assert run.cause == "impl.stagnation.coverage"
+        assert run.failed_stage == "impl"
+        assert run.source == SOURCE_RECORD
+
+    def test_a_run_with_no_record_keeps_the_banner_and_says_so(
+        self, tmp_path, tagged
+    ):
+        """The two sources are never mixed into one number without saying which
+        is which -- that is the whole point of carrying the field."""
+        record_terminal(
+            tmp_path, outcome=OUTCOME_PASSED, furthest_stage="cleanup"
+        )
+        older = _banner_facts(run_id="run-issue4-010710")
+        runs = apply_records([_banner_facts(), older], tmp_path)
+        assert [r.source for r in runs] == [SOURCE_RECORD, SOURCE_BANNER]
+        assert source_counts(runs) == {SOURCE_RECORD: 1, SOURCE_BANNER: 1}
+
+    def test_no_records_at_all_leaves_every_run_on_the_banner(self, tmp_path):
+        runs = apply_records([_banner_facts()], tmp_path)
+        assert runs[0].source == SOURCE_BANNER
+        assert runs[0].cause == "spec.review_cap"
+
+    def test_entries_without_a_terminal_still_say_how_far_it_got(
+        self, tmp_path, tagged
+    ):
+        """This is the case the banner parse cannot describe at all: 19 of
+        boostgauge's 180 runs died mid-call and printed no banner. The entries
+        are written as the run advances, so they survive it."""
+        record_stage_enter(tmp_path, "impl", 5, 7)
+        [run] = apply_records(
+            [_banner_facts(outcome="killed", furthest_stage="", cause="killed")],
+            tmp_path,
+        )
+        assert run.furthest_stage == "impl"
+        assert run.source == SOURCE_RECORD
+        assert run.outcome == "killed", (
+            "no terminal record means no claim about the outcome -- inventing "
+            "one here is exactly the failure this record exists to prevent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reading the store
+# ---------------------------------------------------------------------------
+
+
+class TestReadingIsCounted:
+    def test_a_corrupt_line_is_counted_rather_than_dropped(self, tmp_path, tagged):
+        record_stage_enter(tmp_path, "lld", 2, 7)
+        with records_path(tmp_path).open("a", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+            fh.write(json.dumps({"event": "something.else"}) + "\n")
+        records, unreadable = read_records(tmp_path)
+        assert len(records) == 1
+        assert unreadable == 2, (
+            "a reader that reports a count while silently dropping lines is "
+            "stating a number it did not count"
+        )
+
+    def test_a_missing_store_is_empty_not_an_error(self, tmp_path):
+        assert read_records(tmp_path) == ([], 0)
+
+    def test_an_untagged_record_is_dropped_rather_than_merged(
+        self, tmp_path, monkeypatch
+    ):
+        """Several untagged runs under one blank key would read as one run."""
+        monkeypatch.delenv("SPEEDRUN_RUN_TAG", raising=False)
+        record_terminal(tmp_path, outcome=OUTCOME_PASSED, furthest_stage="lld")
+        records, _ = read_records(tmp_path)
+        assert len(records) == 1
+        assert terminals_by_run(records) == {}
+
+    def test_the_tag_is_read_from_the_launcher_and_never_invented(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("SPEEDRUN_RUN_TAG", raising=False)
+        assert current_run_tag() == ""
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "  run-issue7-080837  ")
+        assert current_run_tag() == "run-issue7-080837"
+
+    def test_a_resume_appends_and_the_later_terminal_wins(self, tmp_path, tagged):
+        record_terminal(
+            tmp_path, outcome=OUTCOME_FAILED, furthest_stage="spec",
+            gate_key="spec.review_cap",
+        )
+        record_terminal(
+            tmp_path, outcome=OUTCOME_PASSED, furthest_stage="cleanup",
+            gate_key=KEY_FINALIZE,
+        )
+        terminal = terminals_by_run(read_records(tmp_path)[0])[TAG]
+        assert terminal["outcome"] == OUTCOME_PASSED
+
+
+class TestFurthestReached:
+    def test_a_later_stage_beats_an_earlier_stages_node(self, tmp_path, tagged):
+        """A stage ordinal and a node ordinal are different scales. Comparing
+        them would let node 11 of the LLD outrank stage 5, and every run that
+        reached implementation would sort below one that never left drafting."""
+        record_stage_enter(tmp_path, "lld", 2, 7)
+        record_node_enter(tmp_path, "lld", "N11_finalize", 11, 11)
+        record_stage_enter(tmp_path, "impl", 5, 7)
+        records, _ = read_records(tmp_path)
+        assert furthest_by_run(records)[TAG] == ("impl", "")
+
+    def test_the_node_reported_is_the_furthest_within_the_furthest_stage(
+        self, tmp_path, tagged
+    ):
+        record_stage_enter(tmp_path, "spec", 4, 7)
+        record_node_enter(tmp_path, "spec", "N2_generate_spec", 5, 10)
+        record_node_enter(tmp_path, "spec", "N5_review_spec", 8, 10)
+        record_node_enter(tmp_path, "spec", "N2_generate_spec", 5, 10)
+        records, _ = read_records(tmp_path)
+        assert furthest_by_run(records)[TAG] == ("spec", "N5_review_spec")
+
+    def test_two_runs_do_not_bleed_into_each_other(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-a")
+        record_stage_enter(tmp_path, "impl", 5, 7)
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-b")
+        record_stage_enter(tmp_path, "lld", 2, 7)
+        records, _ = read_records(tmp_path)
+        furthest = furthest_by_run(records)
+        assert furthest["run-a"] == ("impl", "")
+        assert furthest["run-b"] == ("lld", "")
+
+
+# ---------------------------------------------------------------------------
+# The wrap that emits the node entries
+# ---------------------------------------------------------------------------
+
+
+class TestNarrationRecordsEveryNode:
+    """`narrated()` is already the one place every sub-workflow node announces
+    itself, so wrapping the record there means a graph cannot grow a node that
+    forgets to record."""
+
+    ATLAS = {"N2_generate_spec": {"ordinal": 5, "title": "draft", "goal": "g"}}
+
+    def test_entering_a_node_records_it(self, tmp_path, tagged, capsys):
+        from assemblyzero.workflows.narration import narrated
+
+        wrapped = narrated(
+            "N2_generate_spec", lambda s: {"ok": True}, self.ATLAS, 10,
+            stage="spec",
+        )
+        assert wrapped({"repo_root": str(tmp_path)}) == {"ok": True}
+        capsys.readouterr()
+        records, _ = read_records(tmp_path)
+        assert [r["event"] for r in records] == [EVENT_NODE_ENTER]
+        assert records[0]["node"] == "N2_generate_spec"
+        assert records[0]["ordinal"] == 5
+        assert records[0]["stage"] == "spec"
+
+    def test_a_node_still_runs_when_the_record_cannot_be_written(
+        self, tmp_path, tagged, capsys
+    ):
+        """A diagnostic that can take a roll down is worse than a missing one."""
+        from assemblyzero.workflows.narration import narrated
+
+        wrapped = narrated(
+            "N2_generate_spec", lambda s: {"ok": True}, self.ATLAS, 10,
+            stage="spec",
+        )
+        assert wrapped({"repo_root": "\0not a path"}) == {"ok": True}
+        capsys.readouterr()
+
+    def test_a_wrap_with_no_stage_narrates_but_does_not_record(
+        self, tmp_path, tagged, capsys
+    ):
+        from assemblyzero.workflows.narration import narrated
+
+        wrapped = narrated(
+            "N2_generate_spec", lambda s: {"ok": True}, self.ATLAS, 10
+        )
+        wrapped({"repo_root": str(tmp_path)})
+        assert "NODE" in capsys.readouterr().out
+        assert read_records(tmp_path) == ([], 0)
+
+    def test_a_state_with_no_repo_root_records_nothing_rather_than_guessing(
+        self, tmp_path, tagged, capsys
+    ):
+        from assemblyzero.workflows.narration import narrated
+
+        wrapped = narrated(
+            "N2_generate_spec", lambda s: {"ok": True}, self.ATLAS, 10,
+            stage="spec",
+        )
+        wrapped({})
+        capsys.readouterr()
+        assert read_records(tmp_path) == ([], 0)
+
+
+class TestTheGraphsPassTheirStage:
+    """Pinned because a missing `stage=` is silent: the graph narrates exactly
+    as before and simply records nothing, which is invisible until a report
+    reads a source it does not have."""
+
+    def test_both_narrating_graphs_name_themselves(self):
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        spec = (
+            root / "assemblyzero" / "workflows" / "implementation_spec"
+            / "graph.py"
+        ).read_text(encoding="utf-8")
+        lld = (
+            root / "assemblyzero" / "workflows" / "requirements" / "graph.py"
+        ).read_text(encoding="utf-8")
+        assert 'narrated(name, fn, ATLAS, TOTAL_STEPS, stage="spec")' in spec
+        assert 'narrated(name, fn, ATLAS, TOTAL_STEPS, stage="lld")' in lld
+
+
+class TestTheOrchestratorTerminal:
+    def test_a_passed_run_reports_the_last_stage_that_ran(self):
+        """`current_stage` is `done` on a success, which is a graph node and not
+        a pipeline stage. Recording it would sort every passed run below every
+        failed one."""
+        from assemblyzero.workflows.orchestrator.graph import (
+            _furthest_recorded_stage,
+        )
+
+        assert _furthest_recorded_stage(
+            {"triage": {}, "lld": {}, "spec": {}, "impl": {}}
+        ) == "impl"
+        assert _furthest_recorded_stage({}) == ""
+
+    def test_the_gate_key_reads_the_tag_first_and_the_classifier_second(self):
+        from assemblyzero.core.gate_registry import halted
+        from assemblyzero.workflows.orchestrator.graph import _terminal_gate_key
+
+        tagged_message = halted("spec.review_cap", "Iteration cap: 3 rounds")
+        assert _terminal_gate_key(tagged_message) == "spec.review_cap"
+        assert _terminal_gate_key(
+            "Coverage stagnant: 72.0% -> 70.0% (< 1% improvement)."
+        ) == "impl.stagnation.coverage"
+        assert _terminal_gate_key("") == KEY_FINALIZE

--- a/tests/unit/test_mock_roll.py
+++ b/tests/unit/test_mock_roll.py
@@ -425,6 +425,101 @@ class TestRollShape:
         provider.invoke("You review the draft", "")
         assert provider.stages_called == ["analyze", "draft", "review"]
 
+
+class TestTheGraphRecordsWhereItWent:
+    """The compiled spec graph, streamed for real, writing its own record.
+
+    #2721's acceptance asks a mock roll to produce the convergence record. The
+    full green-path roll is still #2596's increment -- it needs a fixture per
+    stage -- so what this drives is the real `create_implementation_spec_graph()`
+    with the real atlas, the real routers and the real halt node, and asserts the
+    records the nodes wrote as it went. Nothing here is a stand-in for the
+    graph: if a node stops narrating, or a graph stops naming its stage, these
+    assertions go red.
+    """
+
+    def _run(self, target_repo: Path, lld_text: str | None) -> list[dict]:
+        from assemblyzero.core.scripted_provider import ScriptedProvider, set_active
+        from assemblyzero.speedrun.convergence import read_records
+        from assemblyzero.workflows.implementation_spec.graph import (
+            create_implementation_spec_graph,
+        )
+
+        lld_path = target_repo / "docs" / "lld" / "active" / "LLD-004.md"
+        if lld_text is not None:
+            lld_path.parent.mkdir(parents=True, exist_ok=True)
+            lld_path.write_text(lld_text, encoding="utf-8")
+        audit = target_repo / "docs" / "lineage" / "active" / "4-implspec" / "r"
+        audit.mkdir(parents=True, exist_ok=True)
+
+        set_active(ScriptedProvider([], model="mock-roll"))
+        try:
+            graph = create_implementation_spec_graph()
+            for _ in graph.stream(
+                {
+                    "issue_number": 4,
+                    "lld_path": str(lld_path),
+                    "repo_root": str(target_repo),
+                    "audit_dir": str(audit),
+                    "max_iterations": 1,
+                    "human_gate_enabled": False,
+                    "config_drafter": "scripted:drafter",
+                    "config_reviewer": "scripted:reviewer",
+                    "review_iteration": 0,
+                    "error_message": "",
+                },
+                {"recursion_limit": 30},
+            ):
+                pass
+        finally:
+            set_active(None)
+        records, unreadable = read_records(target_repo)
+        assert unreadable == 0
+        return records
+
+    def test_a_run_through_the_real_graph_records_every_node_it_entered(
+        self, target_repo, monkeypatch, capsys
+    ):
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-mockroll")
+        records = self._run(target_repo, None)
+        capsys.readouterr()
+        assert records, "the graph ran and recorded nothing"
+        assert {r["event"] for r in records} == {"node.enter"}
+        assert {r["stage"] for r in records} == {"spec"}
+        assert {r["run_tag"] for r in records} == {"run-issue4-mockroll"}
+        entered = [r["node"] for r in records]
+        assert entered[0] == "N0_load_lld", (
+            f"the graph's entry node changed: it went {entered}"
+        )
+        assert "HALT" in entered, (
+            "an absent LLD must reach the halt node, and the halt must record "
+            "itself like any other node"
+        )
+
+    def test_every_recorded_node_carries_its_atlas_position(
+        self, target_repo, monkeypatch, capsys
+    ):
+        """The ordinal is what "how far did it get" is measured from, so a node
+        recorded at a position the atlas does not agree with is a node the
+        convergence number reads wrongly.
+
+        `HALT` is deliberately unnumbered in the atlas -- it is not a step of
+        the document's construction -- and records as 0, which sorts it below
+        every real node. That is right: reaching the halt is not progress.
+        """
+        from assemblyzero.workflows.implementation_spec.atlas import (
+            ATLAS, TOTAL_STEPS,
+        )
+
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-mockroll")
+        records = self._run(target_repo, None)
+        capsys.readouterr()
+        for record in records:
+            expected = (ATLAS.get(record["node"]) or {}).get("ordinal") or 0
+            assert record["ordinal"] == expected, record["node"]
+            assert record["total"] == TOTAL_STEPS
+        assert [r["ordinal"] for r in records if r["node"] == "HALT"] == [0]
+
     def test_a_halt_path_roll_carries_the_failure_message(self, scripted):
         provider = scripted([
             ScriptedRule("draft", system_pattern="draft",


### PR DESCRIPTION
## The graph writes the convergence record itself

`factory_report` learned to say how each run ended by parsing the closing `STAGE / VERDICT` table and the `Error:` line out of a prose log (#2717). That was the bridge. This is the thing it was a bridge to: rows the graph wrote, at the moment it knew.

**Vocabulary, for a reader outside this codebase.** A *run* is one launch of the pipeline at one issue. A *stage* is one step of the pipeline (triage, lld, spec, impl, pr, cleanup). A *node* is one step inside a stage's own graph. A *gate* is a place in the code that can end a run, each with a key in the gate registry. The *banner* is the summary block a finished run prints to its log.

Three event kinds in one store, `data/speedrun/telemetry/run-records.jsonl`, beside `heals.jsonl` and `prompt-failures.jsonl`:

- `stage.enter` — the orchestrator entering a pipeline stage, with its position in `STAGE_ORDER`. Emitted at the dispatch point in `_run_stage_node`, for the same reason the mock guard lives there: a stage nobody remembers to instrument still records.
- `node.enter` — a sub-workflow node with its atlas position. Emitted from `narrated()`, which is already the one place every node announces itself, so a graph cannot grow a node that forgets to record.
- `run.terminal` — one per run, written in `orchestrate()` where the outcome is actually known rather than where the banner is printed. Carries the outcome, the furthest stage, and the registry key of the gate that ended it.

## What this changes about what the report can say

`apply_records` overlays the record on the banner parse. The record wins where it exists; the banner stands where it does not; and every run carries which of the two it came from, printed under the Outcomes section:

```
180 run(s): passed 26, failed 135 (lld 49, impl 45, spec 40, pr 1), killed 19 (no terminal banner: the process died mid-call).

Source: 0 run(s) from the graph's own terminal record, 180 parsed from the closing banner.
```

That is the report run against boostgauge on this branch. **0 and 180 is the correct answer today** — no run has been launched since this landed — and it is the proof the overlay is a no-op on the existing corpus rather than quietly restating it. Every number in that line is unchanged from `main`.

The case worth naming is the 19 killed runs. They printed no banner, so the parse can say nothing about them beyond the last line in the log. Their entry records are written as the run advances, so they survive the run: `apply_records` reports how far such a run got and, deliberately, makes **no claim about its outcome**, because no terminal record was written. `test_entries_without_a_terminal_still_say_how_far_it_got` pins exactly that — inventing an outcome there is the failure this record exists to prevent.

## The gate key

`_terminal_gate_key` reads two things in order: the `[gate:<key>]` tag a `halted()` site appends (#2719), then the cause classifier as the bridge. Both, because retagging the 160 legacy sites is #2723's job and most still emit untagged prose. The tag is what replaces the classifier, one site at a time.

## Coverage, stated rather than assumed

`node.enter` covers the requirements and implementation_spec graphs. The testing graph — the implementation stage — calls `add_node` directly and has no atlas, so it emits no node entries. Its `stage.enter` is still recorded, because that comes from the orchestrator, so a run's furthest *stage* is right; the node within it still comes from the banner, and the report says so. Filed as #2733 with the counts: the implementation stage is where 45 of 135 failures happened and where the furthest run in the record died, so it is the one worth closing next.

## Verification

- `tests/unit/test_convergence_record.py`, 22 tests.
- **The issue's first acceptance**, `TestTheGraphRecordsWhereItWent` in `tests/unit/test_mock_roll.py`: the real `create_implementation_spec_graph()` is streamed with a `ScriptedProvider` against a throwaway repo, and the records it wrote are asserted — the entry node, the halt node, and every ordinal checked against the real atlas. The full green-path roll is still #2596's increment, so what this drives is the real graph, real routers and real halt node rather than a stand-in for them.
- **The issue's second acceptance**, `TestTheReportPrefersTheRecord`: given a run with both, the record wins and the source is `record`; given one with only a banner, the banner stands and the source is `banner`; `source_counts` counts them.
- `TestFurthestReached` pins that a stage ordinal is never compared to a node ordinal. Comparing them would let node 11 of the LLD outrank stage 5, and every run that reached implementation would sort below one that never left drafting.
- Full unit suite: 9712 passed, 21 skipped, 5 xfailed, 0 failed.
- `ruff check` clean on all six touched files.
- No new gate. `tools/audit_halt_sites.py --check` passes unchanged: 160 sites, 96 gates, halt rows impl 42, lld 15, orchestrator 16, pr 1, spec 19.
- Four fail-open sites are introduced deliberately and all four are declared with `# fail-open:` markers rather than added to the baseline. A record must never cost a roll — but the absence is never silent, because the report names its source. `read_records` is the one that could have been silent and is not: it counts the lines it could not parse and returns the count, so no caller can report a number of runs while having lost some.

One unrelated dead import (`get_next_stage`, imported into `orchestrator/graph.py` and used nowhere; every real caller takes it from `state` or `__init__`) is removed, since it is a one-line fix in a file this PR already edits.

Closes #2721
