### PR TITLE
feat: find every halt bundle, stop them overwriting each other, and say whether a cap kept the work (Closes #2725)

### DIFF
--- a/assemblyzero/core/halt_evidence.py
+++ b/assemblyzero/core/halt_evidence.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from assemblyzero.core.recovery_plan import build_resume_command
+
 #: How many trailing preserved-branch records travel in the bundle. The
 #: record has no reliable run-id linkage (leavings refs carry run="" by
 #: construction), so the tail is the honest cut, said in the bundle.
@@ -122,13 +124,20 @@ def build_halt_evidence(
     if repo_root_str:
         preserved = _preserved_tail(Path(repo_root_str))
 
+    issue_number = int(state.get("issue_number", 0) or 0)
     return {
-        "bundle_version": 1,
+        "bundle_version": 2,
         "workflow": workflow,
-        "issue": int(state.get("issue_number", 0) or 0),
+        "issue": issue_number,
         "stage": stage,
         "halted_at": datetime.now(tz=timezone.utc).isoformat(),
         "error_message": error_message,
+        # #2725: the three things a reader needs and had to reconstruct by hand.
+        # When only a spending limit may end a run, a cap that fires and leaves
+        # no way to pick the work back up has turned a limit into a loss.
+        "gate_key": gate_key_for(error_message),
+        "outstanding": outstanding_items(state),
+        "resume_command": build_resume_command(workflow, issue_number, state),
         "counters": {
             "review_iteration": state.get("review_iteration", 0),
             "iteration_count": state.get("iteration_count", 0),
@@ -139,6 +148,56 @@ def build_halt_evidence(
         "artifacts": artifacts,
         "preserved_refs_tail": preserved,
     }
+
+
+def gate_key_for(error_message: str) -> str:
+    """The registry key this halt belongs to, by the two readings in use.
+
+    The `[gate:<key>]` tag a `halted()` site appends (#2719) is authoritative
+    where it exists. Retagging the 160 legacy sites is #2723's job, so most
+    halts still emit untagged prose and the cause classifier is the bridge --
+    the same pair of readings the terminal record uses (#2721), deliberately,
+    so a bundle and a record never disagree about which gate fired.
+    """
+    head = (error_message or "").strip().splitlines()
+    if not head:
+        return ""
+    from assemblyzero.core.gate_registry import gate_key_of
+    from assemblyzero.speedrun.factory_report import classify_cause
+
+    return gate_key_of(error_message) or classify_cause(head[0])
+
+
+def outstanding_items(state: dict[str, Any]) -> list[str]:
+    """What the run was still being asked for when the cap fired.
+
+    A review cap's whole content is the last verdict's items: run
+    run-issue4-183941 stopped at the ninth round with three assertions still
+    demanded, and nothing in the bundle said which three. `review_feedback`
+    holds the last verdict, and `review_feedback_history` is consulted only if
+    the last round left the field empty -- a cap can fire on a round whose
+    feedback never landed on the state.
+
+    Deliberately NOT merged with `completeness_issues`: those are the mechanical
+    validator's findings and already have their own field. Two different judges
+    with two different remedies do not belong in one list.
+    """
+    feedback = str(state.get("review_feedback", "") or "").strip()
+    if not feedback:
+        history = [
+            str(entry).strip()
+            for entry in (state.get("review_feedback_history") or [])
+            if str(entry).strip()
+        ]
+        feedback = history[-1] if history else ""
+    if not feedback:
+        return []
+    items = [
+        line.strip().lstrip("-").strip()
+        for line in feedback.splitlines()
+        if line.strip().startswith("-")
+    ]
+    return items or [feedback]
 
 
 def _md_events(title: str, lines: list[str]) -> list[str]:
@@ -175,6 +234,20 @@ def render_halt_evidence_md(evidence: dict[str, Any]) -> str:
         f"{evidence['counters']['iteration_count']} (loop).",
         "",
     ]
+    # #2725: gate, outstanding work, and the way back in -- above the artifact
+    # inventory, because a reader arriving at a cap needs those three first.
+    if evidence.get("gate_key"):
+        lines += [f"Gate: `{evidence['gate_key']}`", ""]
+    outstanding = evidence.get("outstanding") or []
+    if outstanding:
+        lines += [
+            f"## Still outstanding when the run stopped ({len(outstanding)})",
+            "",
+        ]
+        lines += [f"- {item}" for item in outstanding]
+        lines.append("")
+    if evidence.get("resume_command"):
+        lines += ["## Resume", "", f"```\n{evidence['resume_command']}\n```", ""]
     events = evidence["events"]
     lines += _md_events("Pinning events", events["pinning_events"])
     lines += _md_events("Completeness issues", events["completeness_issues"])

--- a/assemblyzero/core/halt_node.py
+++ b/assemblyzero/core/halt_node.py
@@ -32,7 +32,13 @@ from assemblyzero.core.errors import (
     is_capacity_message,
 )
 from assemblyzero.core.recovery_plan import generate_recovery_plan
-from assemblyzero.core.state_persistence import STATE_DIR, save_state_snapshot
+#: STATE_DIR looks unused and is not: `tests/unit/test_halt_node.py` patches it
+#: HERE, on this module, to redirect the snapshot away from the real state
+#: directory. Removing it makes eight tests fail with AttributeError.
+from assemblyzero.core.state_persistence import (  # noqa: F401
+    STATE_DIR,
+    save_state_snapshot,
+)
 
 
 def classify_error(error_message: str) -> str:
@@ -175,6 +181,32 @@ def describe_halt_from_state(state: dict, workflow_name: str) -> str:
     )
 
 
+def _halt_bundle_dirname(workflow_name: str, state: dict) -> str:
+    """A directory name unique to this halt, for the shared state directory.
+
+    Three parts, each earning its place. The WORKFLOW keeps a sub-workflow's
+    halt apart from the orchestrator's relay of the same halt -- run
+    run-issue4-183941 wrote a 2-artifact bundle and then a 0-artifact one over
+    the top of it. The ISSUE keeps two issues apart. The RUN TAG keeps two rolls
+    of one issue apart, and is empty outside a roll, which is honest rather than
+    invented: an unrolled halt lands in the `norun` slot and may be overwritten
+    by the next unrolled halt of the same workflow and issue.
+
+    Only characters known safe on every filesystem the fleet runs on -- the run
+    tag is machine-made (`run-issue4-183941`), but the workflow name reaches
+    here from a caller.
+    """
+    from assemblyzero.speedrun.convergence import current_run_tag
+
+    issue = state.get("issue_number", 0) if hasattr(state, "get") else 0
+    parts = [str(workflow_name), str(issue), current_run_tag() or "norun"]
+    cleaned = [
+        "".join(c if (c.isalnum() or c in "-_") else "-" for c in part) or "x"
+        for part in parts
+    ]
+    return "halt-" + "-".join(cleaned)
+
+
 def create_halt_node(workflow_name: str):
     """Factory: returns a LangGraph-compatible node function.
 
@@ -276,7 +308,21 @@ def create_halt_node(workflow_name: str):
                 state, workflow_name,
                 stage=stage, error_message=error_message,
             )
-            write_halt_evidence(evidence, state_path.parent)
+            # #2725: the copy beside the state snapshot goes in a directory
+            # named for the halt, not straight into the shared state dir.
+            # `write_halt_evidence` writes fixed filenames, and that directory
+            # is global across every repo the fleet has ever rolled -- so the
+            # old form left ONE `halt-evidence.json` on the whole machine,
+            # overwritten by every halt of every repo. Measured on boostgauge
+            # 2026-09-03: 39 bundles in the repo, exactly 1 in the state dir.
+            # It also clobbered within a single run, because a sub-workflow's
+            # halt and the orchestrator's relay of it are two halts: run
+            # run-issue4-183941 wrote 2 artifacts, then 0 over the top.
+            write_halt_evidence(
+                evidence, state_path.parent / _halt_bundle_dirname(
+                    workflow_name, state
+                )
+            )
             audit_dir_str = str(state.get("audit_dir", "") or "")
             if audit_dir_str and Path(audit_dir_str).is_dir():
                 write_halt_evidence(evidence, Path(audit_dir_str))
@@ -326,7 +372,7 @@ def _infer_stage(state: dict, workflow_name: str) -> str:
             return f"N3_review_iter{iteration}"
         if state.get("current_draft"):
             return f"N1_draft_iter{iteration}"
-        return f"N0_load"
+        return "N0_load"
     elif "next_node" in state:
         return state.get("next_node", "unknown")
     else:

--- a/assemblyzero/speedrun/factory_report.py
+++ b/assemblyzero/speedrun/factory_report.py
@@ -55,9 +55,10 @@ import json
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from assemblyzero.core.gate_registry import JUDGES_BUDGET
 from assemblyzero.speedrun.convergence import (
     SOURCE_BANNER,
     SOURCE_RECORD,
@@ -504,6 +505,11 @@ class RunLogFacts:
     exit_label: str = ""
     #: stage -> verdict from the closing table, in table order.
     stage_verdicts: dict[str, str] = field(default_factory=dict)
+    #: The run's window in UTC, from the log file's creation and last write.
+    #: Used to join halt bundles to runs (#2725); None when the log could not
+    #: be stat'd, in which case the run takes part in no join.
+    started: datetime | None = None
+    ended: datetime | None = None
     #: Where `outcome`, `furthest_stage` and `cause` came from (#2721):
     #: `record` if the graph wrote one, `banner` if they were parsed out of the
     #: log's prose. Printed, because the two are different evidence and a reader
@@ -534,8 +540,17 @@ def scan_run_log(path: Path) -> RunLogFacts:
     issue = int(match.group("issue")) if match else None
     run_id = name[:-4] if name.endswith(".log") else name
 
+    started: datetime | None = None
+    ended: datetime | None = None
     try:
-        mtime = datetime.fromtimestamp(path.stat().st_mtime).strftime(_TS_FMT)
+        stat = path.stat()
+        mtime = datetime.fromtimestamp(stat.st_mtime).strftime(_TS_FMT)
+        # #2725: the run's window, in UTC, for joining halt bundles to runs. A
+        # bundle names no run tag, so the instant it was written is the only
+        # join the data supports. `st_ctime` is creation time on Windows, which
+        # is where every recorded run in the corpus was produced.
+        started = datetime.fromtimestamp(stat.st_ctime, tz=timezone.utc)
+        ended = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
     except OSError:
         # fail-open: an unstattable log keeps an empty mtime, and scan_run_logs
         # INCLUDES a log it cannot date rather than filtering it out. Excluding
@@ -543,7 +558,10 @@ def scan_run_log(path: Path) -> RunLogFacts:
         # only ever widen the count, which is visible in the printed total.
         mtime = ""
 
-    facts = RunLogFacts(run_id=run_id, issue=issue, path=str(path), mtime=mtime)
+    facts = RunLogFacts(
+        run_id=run_id, issue=issue, path=str(path), mtime=mtime,
+        started=started, ended=ended,
+    )
 
     try:
         # errors="replace": see the module docstring. Model output leaves
@@ -755,6 +773,80 @@ def _under(path: Path, root: Path) -> bool:
         return False
 
 
+#: Every place inside a target repo a halt bundle can come to rest. `docs/lineage`
+#: is where the halt writes it; the other two are where it is MOVED to, by
+#: `speedrun_reset` and by the run archiver. Counted on boostgauge 2026-09-03:
+#: 39 bundles exist, and scanning `docs/lineage` alone finds 8 of them. A report
+#: that says "7 bundles against 135 kills" while 31 sit in directories it never
+#: opens is not measuring coverage, it is measuring its own search path (#2725).
+HALT_BUNDLE_SUBDIRS: tuple[tuple[str, ...], ...] = (
+    ("docs", "lineage"),
+    ("data", "speedrun", "reset-artifacts"),
+    ("data", "speedrun", "archives"),
+)
+
+
+def halt_bundle_roots(repo_root: Path | str) -> list[Path]:
+    """The directories under one repo that can hold a halt bundle."""
+    repo = Path(repo_root)
+    return [repo.joinpath(*parts) for parts in HALT_BUNDLE_SUBDIRS]
+
+
+def attribute_bundles(
+    bundles: list[dict], runs: list[RunLogFacts]
+) -> tuple[dict[str, int], int]:
+    """Which run each bundle belongs to, by its `halted_at` instant.
+
+    A bundle names no run tag -- #2574 predates the run record (#2721) -- so the
+    join is built from the two things it does carry: the ISSUE it halted on, and
+    the INSTANT it halted at. Issue first, because rolls of different issues run
+    concurrently and their log windows overlap freely; within one issue's runs
+    the windows are effectively sequential.
+
+    Returns (bundles per run id, bundles that could not be placed). The second
+    number is returned rather than dropped: a coverage figure whose denominator
+    quietly excludes what it could not place is not a measurement. A bundle that
+    lands in two windows of the SAME issue is left unplaced rather than assigned
+    to the earlier one, because putting a real halt against the wrong run's name
+    is worse than admitting the join is ambiguous.
+    """
+    by_issue: dict[int, list[tuple[datetime, datetime, str]]] = defaultdict(list)
+    for run in runs:
+        if run.started and run.ended and run.issue is not None:
+            by_issue[run.issue].append((run.started, run.ended, run.run_id))
+    per_run: dict[str, int] = defaultdict(int)
+    unplaced = 0
+    for bundle in bundles:
+        when = _parse_halted_at(str(bundle.get("halted_at", "")))
+        issue = bundle.get("issue")
+        if when is None or not isinstance(issue, int):
+            unplaced += 1
+            continue
+        hit = [
+            tag for start, end, tag in by_issue.get(issue, ())
+            if start <= when <= end
+        ]
+        if len(hit) == 1:
+            per_run[hit[0]] += 1
+        else:
+            unplaced += 1
+    return dict(per_run), unplaced
+
+
+def _parse_halted_at(raw: str) -> datetime | None:
+    if not raw:
+        return None
+    text = raw.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        # fail-open: a bundle with an unreadable stamp cannot be placed against
+        # a run. It is COUNTED as unplaced by the caller and reported, never
+        # silently folded into the coverage figure.
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
 def read_halt_bundles(
     search_roots: list[Path],
     since: datetime | None = None,
@@ -859,7 +951,7 @@ def build_report(
 
     halt_roots = list(extra_halt_roots or [])
     halt_roots.append(Path.home() / ".assemblyzero" / "workflow_state")
-    halt_roots.append(repo / "docs" / "lineage")
+    halt_roots.extend(halt_bundle_roots(repo))
     # scope_repo: the state dir is shared across every repo the fleet rolls.
     # See read_halt_bundles -- counting it unscoped would attribute other
     # repos' halts to this one.
@@ -920,6 +1012,24 @@ def build_report(
         halts_by_stage[
             f"{bundle.get('workflow', '?')}:{bundle.get('stage', '?')}"
         ] += 1
+
+    # -- cap coverage (#2725) --------------------------------------------
+    # The question the launch gate actually needs answered: when a spending
+    # limit ends a run, is the work preserved? "N bundles exist" cannot answer
+    # it -- a bundle count against a kill count compares two different things,
+    # since most kills are gates rather than caps. This joins the two.
+    judges_by_cause = {cause.key: cause.judges for cause in CAUSE_TABLE}
+    bundles_per_run, bundles_unplaced = attribute_bundles(bundles, runs)
+    cap_runs = [
+        run for run in runs
+        if run.outcome == OUTCOME_FAILED
+        and judges_by_cause.get(run.cause) == JUDGES_BUDGET
+    ]
+    cap_covered = [run for run in cap_runs if bundles_per_run.get(run.run_id)]
+    cap_uncovered = sorted(
+        (run.mtime, run.run_id, run.cause)
+        for run in cap_runs if not bundles_per_run.get(run.run_id)
+    )
 
     # -- outcomes and cause of death (#2717) -----------------------------
     outcomes: dict[str, int] = defaultdict(int)
@@ -1049,6 +1159,10 @@ def build_report(
         "halts": {
             "by_stage": dict(halts_by_stage),
             "total": len(bundles),
+            "cap_runs": len(cap_runs),
+            "cap_covered": len(cap_covered),
+            "cap_uncovered": cap_uncovered,
+            "unplaced": bundles_unplaced,
         },
         "outcomes": {
             "counts": dict(outcomes),
@@ -1361,6 +1475,30 @@ def render_report(data: dict) -> str:
             "halts before it left no bundle; their count is not zero, it "
             "is unrecorded."
         )
+    if halts.get("unplaced"):
+        lines.append(
+            f"  ({halts['unplaced']} bundle(s) could not be placed against a "
+            f"run and are excluded from the coverage figure below.)"
+        )
+    lines.append("")
+
+    # #2725: the question a launch decision needs answered. A bundle count on
+    # its own cannot answer it -- most kills are gates, not caps -- so this
+    # joins bundles to the runs a spending limit actually ended.
+    lines.append("### When a cap ended a run, was the work preserved?")
+    lines.append("")
+    if halts["cap_runs"]:
+        lines.append(
+            f"{halts['cap_covered']} of {halts['cap_runs']} cap-ended run(s) "
+            f"left a halt bundle."
+        )
+        if halts["cap_uncovered"]:
+            lines.append("")
+            lines.append("Cap-ended runs with no bundle, oldest first:")
+            for when, run_id, cause in halts["cap_uncovered"]:
+                lines.append(f"  {when or '(undated)':<20}  {run_id:<24}  {cause}")
+    else:
+        lines.append("No run in this window was ended by a cap.")
     lines.append("")
 
     # The shortlist the report COMPUTES, not the reader.

--- a/tests/unit/test_cap_bundles.py
+++ b/tests/unit/test_cap_bundles.py
@@ -1,0 +1,355 @@
+"""Every cap keeps the work, and the report can count that (#2725).
+
+Under the routing policy a spending limit becomes the only thing allowed to end
+a run on the model's own path. A cap that fires and leaves no draft, no list of
+what was still being asked for, and no way back in has turned a limit into a
+loss.
+
+Two halves here, and the measurement that separated them is worth stating
+because the issue was filed on the other reading. The caps DO write their
+bundle: counted on boostgauge 2026-09-03, every cap-ended run since 2026-08-28
+left one, 6 of 6, and the four that did not are all dated on or before the day
+`build_halt_evidence` landed. What was wrong was the counting -- the report
+scanned `docs/lineage` alone and found 8 of the 39 bundles in the repo -- and
+what the bundle held: no gate key, no outstanding items, no resume line.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from assemblyzero.core.halt_evidence import (
+    build_halt_evidence,
+    gate_key_for,
+    outstanding_items,
+    render_halt_evidence_md,
+    write_halt_evidence,
+)
+from assemblyzero.core.halt_node import _halt_bundle_dirname
+from assemblyzero.speedrun.factory_report import (
+    HALT_BUNDLE_SUBDIRS,
+    RunLogFacts,
+    attribute_bundles,
+    halt_bundle_roots,
+)
+
+#: The three assertions run-issue4-183941's ninth review round was still
+#: demanding when the hard ceiling stopped it. Nothing in that run's bundle
+#: named them, which is the shape #2725's acceptance calls out.
+RUN_11_FEEDBACK = "\n".join([
+    "The spec's test mapping still disagrees with the LLD in three places.",
+    "- test_req_090_live_process_count must assert within 1, not exactly",
+    "- test_req_110_live_conpty_count must assert within 1, not exactly",
+    "- test_req_130_live_handle_count must assert within 1%, not exactly",
+])
+
+
+def _cap_state(**kwargs) -> dict:
+    base = {
+        "issue_number": 4,
+        "repo_root": "",
+        "audit_dir": "",
+        "review_iteration": 9,
+        "max_iterations": 3,
+        "review_feedback": RUN_11_FEEDBACK,
+    }
+    base.update(kwargs)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The acceptance: run 11's shape names its three outstanding assertions
+# ---------------------------------------------------------------------------
+
+
+class TestTheCeilingBundleNamesWhatWasOutstanding:
+    def test_the_three_assertions_are_in_the_bundle(self):
+        evidence = build_halt_evidence(
+            _cap_state(), "implementation_spec",
+            stage="N5_review_iter9",
+            error_message=(
+                "Iteration cap: 3 review rounds ended REVISE, so the run "
+                "stopped rather than spend another round on the same objection."
+            ),
+        )
+        assert len(evidence["outstanding"]) == 3
+        assert all("within 1" in item for item in evidence["outstanding"])
+
+    def test_the_bundle_names_the_gate_that_fired(self):
+        evidence = build_halt_evidence(
+            _cap_state(), "implementation_spec", stage="N5_review_iter9",
+            error_message=(
+                "Iteration cap: 3 review rounds ended REVISE, so the run "
+                "stopped rather than spend another round on the same objection."
+            ),
+        )
+        assert evidence["gate_key"] == "spec.review_cap"
+
+    def test_the_bundle_carries_a_way_back_in(self):
+        evidence = build_halt_evidence(
+            _cap_state(), "implementation_spec", stage="N5_review_iter9",
+            error_message="Iteration cap: 3 review rounds ended REVISE",
+        )
+        assert evidence["resume_command"]
+        assert "4" in evidence["resume_command"]
+
+    def test_the_document_puts_all_three_above_the_inventory(self, tmp_path):
+        """A reader arriving at a cap needs the gate, the outstanding work and
+        the resume line before a table of file hashes."""
+        evidence = build_halt_evidence(
+            _cap_state(), "implementation_spec", stage="N5_review_iter9",
+            error_message="Iteration cap: 3 review rounds ended REVISE",
+        )
+        rendered = render_halt_evidence_md(evidence)
+        assert "Still outstanding when the run stopped (3)" in rendered
+        assert "## Resume" in rendered
+        assert "Gate: `spec.review_cap`" in rendered
+        _, md_path = write_halt_evidence(evidence, tmp_path)
+        assert "within 1%" in md_path.read_text(encoding="utf-8")
+
+
+class TestOutstandingItems:
+    def test_a_bulleted_verdict_becomes_one_item_per_bullet(self):
+        assert len(outstanding_items(_cap_state())) == 3
+
+    def test_an_unbulleted_verdict_is_kept_whole_rather_than_dropped(self):
+        state = _cap_state(review_feedback="The spec is not implementable yet.")
+        assert outstanding_items(state) == ["The spec is not implementable yet."]
+
+    def test_the_history_is_used_when_the_last_round_left_nothing(self):
+        """A cap can fire on a round whose feedback never landed on the state,
+        and an empty list would read as 'nothing was outstanding'."""
+        state = _cap_state(
+            review_feedback="",
+            review_feedback_history=["- earlier round", "- last round"],
+        )
+        assert outstanding_items(state) == ["last round"]
+
+    def test_no_feedback_at_all_is_an_empty_list_not_an_invention(self):
+        state = _cap_state(review_feedback="", review_feedback_history=[])
+        assert outstanding_items(state) == []
+
+    def test_completeness_issues_are_not_folded_in(self):
+        """Two different judges with two different remedies. The mechanical
+        validator's findings already have their own field, and merging them
+        would make a review cap look like a validation failure."""
+        state = _cap_state(
+            review_feedback="", review_feedback_history=[],
+            completeness_issues=["section 10.1 is a pointer, not tests"],
+        )
+        evidence = build_halt_evidence(
+            state, "implementation_spec", stage="N5", error_message="cap"
+        )
+        assert evidence["outstanding"] == []
+        assert evidence["events"]["completeness_issues"] == [
+            "section 10.1 is a pointer, not tests"
+        ]
+
+
+class TestGateKey:
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Iteration cap: 3 review rounds ended REVISE", "spec.review_cap"),
+            (
+                "Coverage stagnant: 72.0% -> 70.0% (< 1% improvement). "
+                "Halting to prevent token waste.",
+                "impl.stagnation.coverage",
+            ),
+            ("", ""),
+        ],
+    )
+    def test_the_classifier_is_the_bridge_until_the_sites_are_tagged(
+        self, message, expected
+    ):
+        assert gate_key_for(message) == expected
+
+    def test_a_tagged_site_beats_the_classifier(self):
+        """#2719's `halted()` appends the key. Where it is present it is
+        authoritative, so a retagged site stops depending on prose."""
+        from assemblyzero.core.gate_registry import halted
+
+        assert gate_key_for(
+            halted("spec.review_ceiling", "Iteration cap: 3 review rounds")
+        ) == "spec.review_ceiling"
+
+
+# ---------------------------------------------------------------------------
+# Every cap path reaches the writer
+# ---------------------------------------------------------------------------
+
+
+class TestEveryGraphRoutesItsCapsToTheWriter:
+    """The bundle is written by `create_halt_node`, so the claim "every cap
+    writes a bundle" reduces to "every graph's terminal node is that one".
+    Pinned as a structure rather than a behaviour because a fourth graph, or a
+    graph that grew its own halt node, would otherwise pass silently.
+    """
+
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            ("assemblyzero.workflows.requirements.graph", "lld"),
+            ("assemblyzero.workflows.implementation_spec.graph", "spec"),
+            ("assemblyzero.workflows.testing.graph", "impl"),
+            ("assemblyzero.workflows.orchestrator.graph", "orchestrator"),
+        ],
+    )
+    def test_the_graph_builds_its_terminal_node_with_create_halt_node(
+        self, module, name
+    ):
+        import importlib
+        from pathlib import Path
+
+        source = Path(
+            importlib.import_module(module).__file__
+        ).read_text(encoding="utf-8")
+        assert "create_halt_node(" in source, (
+            f"the {name} graph no longer builds its terminal node with "
+            f"create_halt_node, so its caps may write no evidence bundle"
+        )
+
+
+class TestTheSharedCopyIsScopedToOneHalt:
+    """`write_halt_evidence` writes fixed filenames, and the state directory is
+    global across every repo the fleet has rolled. Measured 2026-09-03: 39
+    bundles in boostgauge, exactly 1 in the state directory -- every halt of
+    every repo had been overwriting the same file."""
+
+    def test_two_workflows_of_one_run_do_not_collide(self, monkeypatch):
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-183941")
+        state = {"issue_number": 4}
+        assert _halt_bundle_dirname("implementation_spec", state) != (
+            _halt_bundle_dirname("orchestrator", state)
+        )
+
+    def test_two_runs_of_one_workflow_do_not_collide(self, monkeypatch):
+        state = {"issue_number": 4}
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-183941")
+        first = _halt_bundle_dirname("implementation_spec", state)
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-192453")
+        assert _halt_bundle_dirname("implementation_spec", state) != first
+
+    def test_two_issues_do_not_collide(self, monkeypatch):
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-183941")
+        assert _halt_bundle_dirname(
+            "implementation_spec", {"issue_number": 4}
+        ) != _halt_bundle_dirname(
+            "implementation_spec", {"issue_number": 331}
+        )
+
+    def test_outside_a_roll_the_slot_is_named_rather_than_invented(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("SPEEDRUN_RUN_TAG", raising=False)
+        assert _halt_bundle_dirname("testing", {"issue_number": 7}) == (
+            "halt-testing-7-norun"
+        )
+
+    def test_a_workflow_name_with_separators_cannot_escape_the_directory(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("SPEEDRUN_RUN_TAG", raising=False)
+        name = _halt_bundle_dirname("../../etc", {"issue_number": 1})
+        assert "/" not in name and "\\" not in name and ".." not in name
+
+
+# ---------------------------------------------------------------------------
+# The report can find and attribute the bundles
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryLooksWhereBundlesActuallyLand:
+    def test_the_two_directories_a_reset_moves_them_to_are_searched(self):
+        """`docs/lineage` is where the halt writes; the other two are where the
+        bundle is MOVED. Scanning only the first found 8 of 39 on boostgauge."""
+        assert ("docs", "lineage") in HALT_BUNDLE_SUBDIRS
+        assert ("data", "speedrun", "reset-artifacts") in HALT_BUNDLE_SUBDIRS
+        assert ("data", "speedrun", "archives") in HALT_BUNDLE_SUBDIRS
+
+    def test_the_roots_are_under_the_repo(self, tmp_path):
+        roots = halt_bundle_roots(tmp_path)
+        assert len(roots) == len(HALT_BUNDLE_SUBDIRS)
+        assert all(str(r).startswith(str(tmp_path)) for r in roots)
+
+
+def _run(tag: str, issue: int, start: datetime, minutes: int) -> RunLogFacts:
+    return RunLogFacts(
+        run_id=tag, issue=issue, path="", mtime=start.strftime("%Y-%m-%d %H:%M:%S"),
+        started=start, ended=start + timedelta(minutes=minutes),
+    )
+
+
+def _bundle(issue: int, when: datetime) -> dict:
+    return {"issue": issue, "halted_at": when.isoformat()}
+
+
+BASE = datetime(2026, 9, 2, 23, 0, tzinfo=timezone.utc)
+
+
+class TestAttribution:
+    def test_a_bundle_lands_against_the_run_that_was_running(self):
+        runs = [_run("run-issue4-a", 4, BASE, 20)]
+        per_run, unplaced = attribute_bundles(
+            [_bundle(4, BASE + timedelta(minutes=5))], runs
+        )
+        assert per_run == {"run-issue4-a": 1}
+        assert unplaced == 0
+
+    def test_another_issues_run_does_not_claim_it(self):
+        """Rolls of different issues run concurrently and their log windows
+        overlap freely, so time alone attributes a halt to the wrong run. On
+        boostgauge, matching on time alone left 31 of 39 bundles ambiguous."""
+        runs = [
+            _run("run-issue331-a", 331, BASE, 60),
+            _run("run-issue4-a", 4, BASE + timedelta(minutes=10), 20),
+        ]
+        per_run, unplaced = attribute_bundles(
+            [_bundle(4, BASE + timedelta(minutes=15))], runs
+        )
+        assert per_run == {"run-issue4-a": 1}
+        assert unplaced == 0
+
+    def test_two_runs_of_one_issue_overlapping_leaves_it_unplaced(self):
+        """Putting a real halt against the wrong run's name is worse than
+        admitting the join is ambiguous."""
+        runs = [
+            _run("run-issue4-a", 4, BASE, 60),
+            _run("run-issue4-b", 4, BASE + timedelta(minutes=5), 30),
+        ]
+        per_run, unplaced = attribute_bundles(
+            [_bundle(4, BASE + timedelta(minutes=10))], runs
+        )
+        assert per_run == {}
+        assert unplaced == 1
+
+    def test_a_bundle_with_no_issue_is_counted_not_dropped(self):
+        per_run, unplaced = attribute_bundles(
+            [{"halted_at": BASE.isoformat()}], [_run("run-issue4-a", 4, BASE, 20)]
+        )
+        assert per_run == {}
+        assert unplaced == 1
+
+    def test_a_bundle_with_an_unreadable_stamp_is_counted_not_dropped(self):
+        per_run, unplaced = attribute_bundles(
+            [{"issue": 4, "halted_at": "not a time"}],
+            [_run("run-issue4-a", 4, BASE, 20)],
+        )
+        assert per_run == {}
+        assert unplaced == 1
+
+    def test_a_naive_stamp_is_read_as_utc_rather_than_refused(self):
+        naive = (BASE + timedelta(minutes=5)).replace(tzinfo=None)
+        per_run, unplaced = attribute_bundles(
+            [{"issue": 4, "halted_at": naive.isoformat()}],
+            [_run("run-issue4-a", 4, BASE, 20)],
+        )
+        assert per_run == {"run-issue4-a": 1}
+        assert unplaced == 0
+
+    def test_a_run_that_could_not_be_dated_takes_part_in_no_join(self):
+        runs = [RunLogFacts(run_id="r", issue=4, path="", mtime="")]
+        per_run, unplaced = attribute_bundles([_bundle(4, BASE)], runs)
+        assert per_run == {}
+        assert unplaced == 1

--- a/tests/unit/test_halt_evidence.py
+++ b/tests/unit/test_halt_evidence.py
@@ -128,11 +128,40 @@ class TestTheHaltEmitsIt:
 
         assert result["workflow_status"] == "halted"
         assert "halt evidence written" in out
-        assert (store / "halt-evidence.md").exists()
-        assert (store / "halt-evidence.json").exists()
+        # #2725: the state-side copy is scoped to this halt. The state
+        # directory is shared across every repo the fleet rolls, and
+        # `write_halt_evidence` writes fixed filenames, so the old unscoped
+        # form left ONE bundle on the whole machine -- overwritten by the next
+        # halt of any repo, and by the orchestrator's own relay of this one.
+        scoped = [p for p in store.iterdir() if p.is_dir()]
+        assert len(scoped) == 1, f"expected one scoped bundle dir, got {scoped}"
+        assert scoped[0].name.startswith("halt-implementation_spec-331-")
+        assert (scoped[0] / "halt-evidence.md").exists()
+        assert (scoped[0] / "halt-evidence.json").exists()
+        assert not (store / "halt-evidence.json").exists(), (
+            "the unscoped path is what every halt of every repo overwrote"
+        )
         lineage_md = Path(state["audit_dir"]) / "halt-evidence.md"
         assert lineage_md.exists(), "the lineage carries the bundle"
         assert REFUSAL in lineage_md.read_text(encoding="utf-8")
+
+    def test_two_workflows_halting_in_one_run_do_not_overwrite_each_other(
+        self, store, tmp_path, capsys, monkeypatch
+    ):
+        """The measured case: run-issue4-183941's spec halt wrote a bundle with
+        2 artifacts, and the orchestrator's relay of the same halt wrote one
+        with 0 artifacts straight over the top of it."""
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-183941")
+        state = _state(tmp_path)
+        state["error_message"] = "Iteration cap: 3 revision(s) ended"
+        create_halt_node("implementation_spec")(state)
+        create_halt_node("orchestrator")(state)
+        capsys.readouterr()
+        names = sorted(p.name for p in store.iterdir() if p.is_dir())
+        assert names == [
+            "halt-implementation_spec-331-run-issue4-183941",
+            "halt-orchestrator-331-run-issue4-183941",
+        ]
 
     def test_a_bundle_failure_never_masks_the_halt(
         self, store, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
## The issue's premise was a counting defect. The caps already write.

**Vocabulary, for a reader outside this codebase.** A *run* is one launch of the pipeline at one issue. A *cap* is a spending limit — rounds, iterations, money, wall clock — that ends a run. A *halt bundle* is the evidence a stopped run leaves behind: the artifacts it produced, hashed, plus what it was doing when it stopped. *Lineage* is the directory a run writes its drafts and verdicts into.

The issue reads "7 bundles against 135 kills — most kills left no bundle". Measured before changing anything:

| counted on boostgauge, 2026-09-03 | |
|---|---|
| halt bundles on disk under the repo | **39** |
| bundles the report could see | **8** |
| under `data/speedrun/reset-artifacts` (never scanned) | 16 |
| under `data/speedrun/archives` (never scanned) | 15 |
| cap-ended runs | 19 |
| cap-ended runs that left a bundle | 6 |
| …of those that started on or after 2026-08-28 | **6 of 6** |

Every cap-ended run since the day after `build_halt_evidence` landed left a bundle. The thirteen that did not are all dated 2026-08-27 or earlier. **The cap paths were not the problem.** Two other things were, and both are fixed here.

## 1. The report scanned one of the three places a bundle comes to rest

`docs/lineage` is where a halt writes the bundle. `speedrun_reset` and the run archiver then *move* it. The report only ever opened the first, so it found 8 of 39 and reported that as coverage. It was measuring its own search path.

`HALT_BUNDLE_SUBDIRS` now names all three. The Halts section goes from 8 bundles to 39 on the same corpus, with no run re-run.

## 2. The state-side copy was one file for the whole machine

`write_halt_evidence` writes fixed filenames, and the copy beside the state snapshot went straight into `~/.assemblyzero/workflow_state` — a directory shared across every repo the fleet has ever rolled. So exactly one `halt-evidence.json` existed there, overwritten by every halt of every repo.

It also clobbered *within a single run*. Run `run-issue4-183941` logged `halt evidence written: 2 artifact(s)` from the spec workflow, then `0 artifact(s)` from the orchestrator relaying the same halt — the empty one landing on top of the useful one. The copy is now written to `halt-<workflow>-<issue>-<run tag>/`, so a sub-workflow's halt and the orchestrator's relay of it no longer collide, and neither do two repos.

## 3. What the bundle did not carry

The issue asks for the gate key, the outstanding items and a runnable resume line. None was in the bundle. All three are now, and they render above the artifact inventory, because a reader arriving at a cap needs those first:

- `gate_key` — the `[gate:…]` tag a `halted()` site appends, else the cause classifier. The same pair of readings the terminal record uses (#2721), deliberately, so a bundle and a record can never disagree about which gate fired.
- `outstanding` — the last review verdict's items, which is the whole content of a review cap. Deliberately not merged with `completeness_issues`: two different judges with two different remedies.
- `resume_command` — via the existing `build_resume_command`, so the bundle names the one command that actually resumes.

`bundle_version` goes 1 → 2.

## The acceptance

> Run 11's shape (review ceiling at round 9 with a draft in lineage) produces a bundle naming the three outstanding assertions.

`TestTheCeilingBundleNamesWhatWasOutstanding` builds a bundle from that state and asserts all three assertions are in `outstanding`, the gate key is `spec.review_cap`, and the rendered document carries them above the file table.

> After this lands, a factory report over new runs shows `halt_bundles` equal to the count of cap-ended runs.

That comparison could not previously be made — a bundle count against a *kill* count compares different things, since most kills are gates rather than caps. The report now answers the question directly:

```
### When a cap ended a run, was the work preserved?

6 of 19 cap-ended run(s) left a halt bundle.

Cap-ended runs with no bundle, oldest first:
  2026-08-14 15:44:51   run-issue1-152716         spec.review_cap
  …
  2026-08-27 17:57:33   run-issue331-170916       spec.review_cap
```

Thirteen rows, none later than 2026-08-27. The join is by issue and then by time: a bundle carries its issue and the instant it was written, and rolls of different issues run concurrently with freely overlapping log windows. Matching on time alone left 31 of 39 ambiguous; adding the issue resolves all but the genuinely ambiguous, and those are counted as unplaced and printed rather than assigned to a guess.

> A test per cap path asserts the bundle exists.

Every cap reaches the writer through `create_halt_node`, so the claim reduces to "every graph's terminal node is that one". `TestEveryGraphRoutesItsCapsToTheWriter` pins that for all four graphs — requirements, implementation_spec, testing, orchestrator — as a structure, so a fifth graph or one that grows its own halt node fails rather than passing silently.

## Verification

- `tests/unit/test_cap_bundles.py`, 31 tests. `tests/unit/test_halt_evidence.py` gains a test for the two-workflows-one-run collision, and its existing assertion about the unscoped path is inverted, since that path was the defect.
- Full unit suite: 9744 passed, 21 skipped, 5 xfailed, 0 failed.
- `ruff check` clean on all five touched files.
- No new gate. `tools/audit_halt_sites.py --check` passes unchanged: 160 sites, 96 gates, halt rows impl 42, lld 15, orchestrator 16, pr 1, spec 19.

One thing I got wrong and am recording: I removed `STATE_DIR` from `halt_node`'s imports as an unused-import cleanup after checking that nothing imported it from there. Eight tests then failed — they patch it *on that module* to redirect the snapshot, which an import-site grep does not see. It is restored with a comment saying so.

Closes #2725
