### PR TITLE
feat: the stagnation guards say what they see and stop ending runs (Closes #2723)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -525,21 +525,23 @@ GATE_REGISTRY: tuple[Gate, ...] = (
         _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 1),
     ),
     Gate(
-        "impl.stagnation.e2e", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "impl.stagnation.e2e", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
         "E2E stagnant",
-        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 2),
+        decided_in=f"{_TS}/nodes/e2e_validation.py::e2e_validation (advisory)",
+        created_by="#2723",
+        notes="advises via advised(); the e2e cap and circuit breaker end this loop",
     ),
     Gate(
         "impl.e2e_cap", "impl", JUDGES_BUDGET, ACTION_HALT,
         "E2E failed after",
-        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 4),
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 3),
     ),
     Gate(
         "impl.circuit_breaker", "impl", JUDGES_BUDGET, ACTION_HALT,
         "[CIRCUIT]",
-        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 3)
-        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 8, 11)
-        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 3, 6),
+        _s(f"{_TS}/nodes/e2e_validation.py::e2e_validation::return", 2)
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 5, 7)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 2, 4),
         decided_in=f"{_TS}/circuit_breaker.py::check_circuit_breaker",
     ),
     Gate(
@@ -563,7 +565,7 @@ GATE_REGISTRY: tuple[Gate, ...] = (
         "impl.deterministic_failure", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
         "DETERMINISTIC FAILURE",
         _s(f"{_TS}/nodes/verify_phases.py::verify_red_phase::return", 4)
-        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 5),
+        + _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 4),
         decided_in=f"{_TS}/nodes/validate_tests_mechanical.py",
         notes=(
             "tests passed before the code existed, or fail for a platform reason no "
@@ -597,37 +599,50 @@ GATE_REGISTRY: tuple[Gate, ...] = (
     Gate(
         "impl.green.iteration_cap", "impl", JUDGES_BUDGET, ACTION_HALT,
         "Green phase failed after",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 3, 9)
-        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 1, 4),
+        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 3, 6)
+        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 1, 3),
     ),
     Gate(
-        "impl.stagnation.test_count", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "impl.stagnation.test_count", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
         "Test count stagnant",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 4)
-        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 2),
-        notes="11 of 135 banner kills on boostgauge",
+        decided_in=(
+            f"{_TS}/nodes/verify_phases.py::verify_green_phase and "
+            f"::_verify_green_non_pytest (advisory)"
+        ),
+        created_by="#2723",
+        notes=(
+            "11 of 135 banner kills on boostgauge before it became advisory; "
+            "the iteration cap and circuit breaker end this loop"
+        ),
     ),
     Gate(
-        "impl.stagnation.test_identity", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "impl.stagnation.test_identity", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
         "Test identity stagnant",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 6),
+        decided_in=f"{_TS}/nodes/verify_phases.py::verify_green_phase (advisory)",
+        created_by="#2723",
+        notes="the frozen-tests symmetry break below it still routes to N4",
     ),
     Gate(
-        "impl.stagnation.coverage", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "impl.stagnation.coverage", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
         "Coverage stagnant",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 7, 10)
-        + _s(f"{_TS}/nodes/verify_phases.py::_verify_green_non_pytest::return", 5),
+        decided_in=(
+            f"{_TS}/nodes/verify_phases.py::verify_green_phase and "
+            f"::_verify_green_non_pytest (advisory)"
+        ),
         created_by="#2711",
         justified_by="run-issue4-172600",
         notes=(
             "11 of 135 banner kills on boostgauge. Killed run 9, the furthest run "
-            "in the record (green, 3 passed, 72%), with four iterations unspent"
+            "in the record (green, 3 passed, 72%), with four iterations unspent. "
+            "Advisory since #2723"
         ),
     ),
     Gate(
-        "impl.stagnation.full_suite", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+        "impl.stagnation.full_suite", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
         "Full suite regression stagnant",
-        _s(f"{_TS}/nodes/verify_phases.py::verify_green_phase::return", 12),
+        decided_in=f"{_TS}/nodes/verify_phases.py::verify_green_phase (advisory)",
+        created_by="#2723",
+        notes="the route below it already sends the named regressions back to N4",
     ),
     Gate(
         "impl.runner_unavailable", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
@@ -1016,3 +1031,29 @@ def gate_key_of(message: str) -> str:
     """The key `halted()` tagged onto a message, or ""."""
     match = _TAG_RE.search(message or "")
     return match.group(1) if match else ""
+
+
+def advised(key: str, message: str) -> str:
+    """What an `advise` gate prints instead of ending the run (#2723).
+
+    An advisory says the same sentence a halt used to say and does not route.
+    It carries the gate key for the same reason `halted()` does -- so the log
+    line can be counted against the registry rather than matched as prose --
+    and it says plainly that the run continues, because the identical sentence
+    was a terminal message for as long as these guards have existed and a
+    reader will remember it that way.
+
+    Refuses a key whose row still halts. An advisory printed by a gate that
+    then ends the run anyway would be the worst of both: a log that says the
+    run continued and a run that did not.
+    """
+    row = registry_by_key().get(key)
+    if row is None:
+        raise KeyError(f"{key!r} is not a registered gate")
+    if row.action == ACTION_HALT:
+        raise ValueError(
+            f"{key!r} is a halt row; advised() is for a gate that does not end "
+            f"the run. Change the row's action first, and lower the ratchet "
+            f"baseline in the same PR (#2720)."
+        )
+    return f"{message.rstrip()} Continuing; the budget decides. [gate:{key}]"

--- a/assemblyzero/workflows/testing/nodes/e2e_validation.py
+++ b/assemblyzero/workflows/testing/nodes/e2e_validation.py
@@ -6,6 +6,7 @@ Runs E2E tests in a sandbox environment:
 - Auto-cleanup after each E2E run
 """
 
+from assemblyzero.core.gate_registry import advised
 from assemblyzero.utils.shell import run_command
 import re
 import subprocess
@@ -372,19 +373,13 @@ def e2e_validation(state: TestingWorkflowState) -> dict[str, Any]:
 
         if count_stagnant or identity_stagnant:
             reason = "same failures persisting" if identity_stagnant else "no improvement"
-            stagnant_msg = (
+            # #2723: advisory. The circuit breaker below and the e2e cap are
+            # budgets and remain the only things that end this loop.
+            print("    [STAGNANT] " + advised(
+                "impl.stagnation.e2e",
                 f"E2E stagnant: {previous_e2e_passed} -> {e2e_passed} passed "
-                f"({reason}). Halting to prevent token waste."
-            )
-            print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "e2e_output": output,
-                "file_counter": file_num,
-                "previous_e2e_passed": e2e_passed,
-                "previous_e2e_failures": current_failures,
-                "e2e_failure_summary": e2e_failure_summary,
-                "error_message": stagnant_msg,
-            }
+                f"({reason}).",
+            ))
 
         # Circuit breaker check before looping
         should_trip, trip_reason = check_circuit_breaker(state)

--- a/assemblyzero/workflows/testing/nodes/verify_phases.py
+++ b/assemblyzero/workflows/testing/nodes/verify_phases.py
@@ -8,6 +8,7 @@ errors) route back to N2_scaffold_tests instead of endlessly looping through
 N4_implement_code. Exit codes 2/3 (interrupt/internal error) stop the workflow.
 """
 
+from assemblyzero.core.gate_registry import advised
 from assemblyzero.utils.shell import run_command
 import json
 import re
@@ -2118,25 +2119,16 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
         if previous_passed >= 0 and passed_count == previous_passed and (
             plateau_strikes >= strikes_needed
         ):
-            stagnant_msg = (
-                f"Test count stagnant: {passed_count}/{passed_count + failed_count} passed "
-                f"(unchanged across {plateau_strikes + 1} iterations). "
-                f"Halting to prevent token waste."
+            # #2723: advisory. It says what it sees and does not route. The
+            # iteration cap checked above and the circuit breaker below are
+            # what end this loop, and both are budgets.
+            stagnant_msg = advised(
+                "impl.stagnation.test_count",
+                f"Test count stagnant: "
+                f"{passed_count}/{passed_count + failed_count} passed "
+                f"(unchanged across {plateau_strikes + 1} iterations).",
             )
             print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed_count,
-                "previous_green_failures": current_green_failures,
-                "test_failure_summary": failure_summary,
-                "file_counter": file_num,
-                "pytest_exit_code": exit_code,
-                "iteration_count": iteration_count + 1,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
 
         # Issue #501: Identity-based stagnation — same tests failing across iterations.
         # Catches cases where pass count fluctuates but the SAME tests keep failing.
@@ -2197,25 +2189,14 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 "error_message": f"{DETERMINISTIC_FAILURE}: {message}",
             }
         if identity_stagnant and identity_strikes >= 2:
-            stagnant_msg = (
-                f"Test identity stagnant: same {len(current_green_failures)} test(s) failing "
-                f"across {identity_strikes + 1} iterations (tests were frozen for the "
-                f"retry). Halting to prevent token waste."
+            # #2723: advisory. Same sentence, no routing.
+            stagnant_msg = advised(
+                "impl.stagnation.test_identity",
+                f"Test identity stagnant: same {len(current_green_failures)} "
+                f"test(s) failing across {identity_strikes + 1} iterations "
+                f"(tests were frozen for the retry).",
             )
             print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed_count,
-                "previous_green_failures": current_green_failures,
-                "test_failure_summary": failure_summary,
-                "file_counter": file_num,
-                "pytest_exit_code": exit_code,
-                "iteration_count": iteration_count + 1,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
         if identity_stagnant:
             # #2066: the armed break LOOPS BACK HERE, before any further guard.
             # The first version printed this and fell through -- the coverage
@@ -2257,24 +2238,16 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 previous_passed, current_green_failures, previous_green_failures,
             )
             if coverage_halt:
-                stagnant_msg = _coverage_stagnant_message(
-                    previous_coverage, coverage_achieved, coverage_strikes
-                )
-                print(f"    [STAGNANT] {stagnant_msg}")
-                return {
-                    "green_phase_output": output,
-                    "coverage_achieved": coverage_achieved,
-                    "previous_coverage": coverage_achieved,
-                    "previous_passed": passed_count,
-                    "previous_green_failures": current_green_failures,
-                    "test_failure_summary": failure_summary,
-                    "file_counter": file_num,
-                    "pytest_exit_code": exit_code,
-                    "iteration_count": iteration_count + 1,
-                    "coverage_plateau_strikes": coverage_strikes,
-                    "next_node": "end",
-                    "error_message": stagnant_msg,
-                }
+                # #2723: advisory. This is the guard that ended run
+                # run-issue4-172600 -- the furthest any run has reached, green
+                # phase with three passing at 72% -- with four iterations
+                # unspent. It now says so and lets the iteration cap decide.
+                print("    [STAGNANT] " + advised(
+                    "impl.stagnation.coverage",
+                    _coverage_stagnant_message(
+                        previous_coverage, coverage_achieved, coverage_strikes
+                    ),
+                ))
 
         # Circuit breaker check before looping
         should_trip, trip_reason = check_circuit_breaker(state)
@@ -2362,24 +2335,13 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
             previous_passed, current_green_failures, previous_green_failures,
         )
         if coverage_halt:
-            stagnant_msg = _coverage_stagnant_message(
-                previous_coverage, coverage_achieved, coverage_strikes
-            )
-            print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed_count,
-                "previous_green_failures": current_green_failures,
-                "test_failure_summary": failure_summary,
-                "file_counter": file_num,
-                "pytest_exit_code": exit_code,
-                "iteration_count": iteration_count + 1,
-                "coverage_plateau_strikes": coverage_strikes,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
+            # #2723: advisory, same as the sibling above.
+            print("    [STAGNANT] " + advised(
+                "impl.stagnation.coverage",
+                _coverage_stagnant_message(
+                    previous_coverage, coverage_achieved, coverage_strikes
+                ),
+            ))
 
         # Circuit breaker check before looping
         should_trip, trip_reason = check_circuit_breaker(state)
@@ -2497,26 +2459,16 @@ def verify_green_phase(state: TestingWorkflowState) -> dict[str, Any]:
                 named = ", ".join(regression_names[:4])
                 if len(regression_names) > 4:
                     named += f" (and {len(regression_names) - 4} more)"
-                stagnant_msg = (
-                    f"Full suite regression stagnant: same {len(regression_names)} test(s) "
-                    f"failing across iterations: {named}. Halting."
-                )
-                print(f"    [STAGNANT] {stagnant_msg}")
-                return {
-                    "green_phase_output": output,
-                    "coverage_achieved": coverage_achieved,
-                    "previous_coverage": coverage_achieved,
-                    "previous_passed": passed_count,
-                    "previous_green_failures": [],
-                    "test_failure_summary": regression_summary,
-                    "full_suite_validated": False,
-                    "full_suite_regressions": regression_names,
-                    "file_counter": file_num,
-                    "pytest_exit_code": exit_code,
-                    "iteration_count": iteration_count + 1,
-                    "next_node": "end",
-                    "error_message": stagnant_msg,
-                }
+                # #2723: advisory. The route below already sends the same
+                # regressions back to N4 with their names; halting here only
+                # decided that a second look was not worth paying for, which
+                # is a budget's decision and not this gate's.
+                print("    [STAGNANT] " + advised(
+                    "impl.stagnation.full_suite",
+                    f"Full suite regression stagnant: same "
+                    f"{len(regression_names)} test(s) failing across "
+                    f"iterations: {named}.",
+                ))
 
             print(f"    [N5] Full suite: {full_failed + full_errors} regression(s) detected "
                   f"({full_passed} passed) — routing back to N4")
@@ -2833,22 +2785,12 @@ def _verify_green_non_pytest(
 
         # Stagnation: passed count unchanged
         if previous_passed >= 0 and passed == previous_passed:
-            stagnant_msg = (
+            # #2723: advisory, the non-pytest sibling of the guard above.
+            print("    [STAGNANT] " + advised(
+                "impl.stagnation.test_count",
                 f"Test count stagnant: {passed}/{passed + failed} passed "
-                f"(unchanged from previous iteration). Halting."
-            )
-            print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed,
-                "file_counter": file_num,
-                "test_run_result": dict(result),
-                "iteration_count": iteration_count + 1,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
+                f"(unchanged from previous iteration).",
+            ))
 
         # Circuit breaker
         should_trip, trip_reason = check_circuit_breaker(state)
@@ -2903,22 +2845,12 @@ def _verify_green_non_pytest(
 
         # Stagnation on coverage
         if previous_coverage >= 0 and coverage_achieved <= previous_coverage + 1.0:
-            stagnant_msg = (
-                f"Coverage stagnant: {previous_coverage:.1f}% -> {coverage_achieved:.1f}% "
-                f"(< 1% improvement). Halting."
-            )
-            print(f"    [STAGNANT] {stagnant_msg}")
-            return {
-                "green_phase_output": output,
-                "coverage_achieved": coverage_achieved,
-                "previous_coverage": coverage_achieved,
-                "previous_passed": passed,
-                "file_counter": file_num,
-                "test_run_result": dict(result),
-                "iteration_count": iteration_count + 1,
-                "next_node": "end",
-                "error_message": stagnant_msg,
-            }
+            # #2723: advisory, the non-pytest sibling of the coverage guard.
+            print("    [STAGNANT] " + advised(
+                "impl.stagnation.coverage",
+                f"Coverage stagnant: {previous_coverage:.1f}% -> "
+                f"{coverage_achieved:.1f}% (< 1% improvement).",
+            ))
 
         # Circuit breaker
         should_trip, trip_reason = check_circuit_breaker(state)

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -2,15 +2,15 @@
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage or model_output_halt_rows rises above this. Lower it when a gate stops halting; raise it only with an operator ruling named in the new row's created_by, in the same PR.",
   "measured_against": {
     "files_scanned": 184,
-    "halt_sites": 160,
+    "halt_sites": 152,
     "gates": 96
   },
   "halt_rows_per_stage": {
-    "impl": 42,
+    "impl": 37,
     "lld": 15,
     "orchestrator": 16,
     "pr": 1,
     "spec": 19
   },
-  "model_output_halt_rows": 24
+  "model_output_halt_rows": 19
 }

--- a/tests/unit/test_count_plateau_three_strikes.py
+++ b/tests/unit/test_count_plateau_three_strikes.py
@@ -58,10 +58,13 @@ class TestNonzeroPlateau:
         assert out["next_node"] == "N4_implement_code", out.get("error_message")
         assert out["count_plateau_strikes"] == 1
 
-    def test_the_second_identical_count_halts(self):
+    def test_the_second_identical_count_is_reported(self, capsys):
+        """#2723: the second strike used to end the run. The strike counting is
+        unchanged and the sentence still says "3 iterations"; what changed is
+        that saying it no longer stops the loop."""
         out = _run(_state(previous_passed=44, count_plateau_strikes=1), 44, 50)
-        assert out["next_node"] == "end"
-        assert "3 iterations" in out["error_message"]
+        assert out["error_message"] == ""
+        assert "3 iterations" in capsys.readouterr().out
 
     def test_progress_resets_the_strikes(self):
         out = _run(_state(previous_passed=44, count_plateau_strikes=1), 45, 49)
@@ -69,11 +72,14 @@ class TestNonzeroPlateau:
         assert out["count_plateau_strikes"] == 0
 
 
-class TestImportDeathKeepsItsFastHalt:
-    def test_zero_to_zero_still_halts_at_two(self):
+class TestImportDeathIsStillCalledOutFast:
+    def test_zero_to_zero_is_reported_at_two(self, capsys):
+        """#2062's fast detection is intact -- zero passing twice is
+        structural, not variance -- and #2723 made the consequence the
+        iteration cap's rather than this guard's."""
         out = _run(_state(previous_passed=0), 0, 50)
-        assert out["next_node"] == "end"
-        assert "stagnant" in out.get("error_message", "").lower()
+        assert out["error_message"] == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
 
 
 class TestTheFieldIsDeclared:

--- a/tests/unit/test_failure_feedback.py
+++ b/tests/unit/test_failure_feedback.py
@@ -189,8 +189,12 @@ FAILED tests/test_foo.py::test_bar - AssertionError: 446 != 143
         assert result["test_failure_summary"] == ""
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_failure_summary_on_stagnation_halt(self, mock_pytest):
-        """Even on stagnation halt, failure summary is populated."""
+    def test_failure_summary_survives_a_stagnation_advisory(
+        self, mock_pytest, capsys
+    ):
+        """#2723 made stagnation advisory, which makes the summary matter more
+        rather than less: the loop now continues, and the drafter needs the
+        failures it is continuing from."""
         summary = """=========================== short test summary info ============================
 FAILED tests/test_x.py::test_a - AssertionError
 ============================== 1 failed in 0.10s ==============================="""
@@ -200,8 +204,8 @@ FAILED tests/test_x.py::test_a - AssertionError
         state = _make_state(previous_passed=0, previous_coverage=0.0)
         result = verify_green_phase(state)
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result["error_message"].lower()
+        assert result["error_message"] == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
         assert "test_failure_summary" in result
         assert result["test_failure_summary"] != ""
 
@@ -215,8 +219,11 @@ class TestGreenPhaseIdentityStagnation:
     """Tests for identity-based stagnation detection in verify_green_phase."""
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_same_failures_triggers_identity_stagnation(self, mock_pytest):
-        """Same test names failing across iterations → identity stagnant → halt."""
+    def test_same_failures_are_reported_as_identity_stagnation(
+        self, mock_pytest, capsys
+    ):
+        """Same test names failing across iterations is identity stagnation.
+        #2723: it is now said, not obeyed -- the loop continues to its cap."""
         summary = """=========================== short test summary info ============================
 FAILED tests/test_foo.py::test_bar - AssertionError
 FAILED tests/test_foo.py::test_baz - TypeError
@@ -239,8 +246,8 @@ FAILED tests/test_foo.py::test_baz - TypeError
         )
         result = verify_green_phase(state)
 
-        assert result["next_node"] == "end"
-        assert "identity stagnant" in result["error_message"].lower()
+        assert result["error_message"] == ""
+        assert "identity stagnant" in capsys.readouterr().out.lower()
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.log_workflow_execution")

--- a/tests/unit/test_framework_integration.py
+++ b/tests/unit/test_framework_integration.py
@@ -452,8 +452,10 @@ class TestN5GreenPhaseNonPytest:
         assert result["iteration_count"] == 1
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.get_runner")
-    def test_stagnation_detection_halts(self, mock_get_runner):
-        """Stagnation detection halts when passed count is unchanged."""
+    def test_stagnation_detection_reports(self, mock_get_runner, capsys):
+        """Stagnation is detected when the passed count is unchanged. #2723:
+        the non-pytest branch reports it and lets the cap decide, exactly as
+        the pytest branch does."""
         mock_runner = MagicMock()
         mock_runner.run_tests.return_value = {
             "passed": 2,
@@ -490,8 +492,10 @@ class TestN5GreenPhaseNonPytest:
                 TestFramework.JEST,
             )
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result["error_message"].lower()
+        assert result["error_message"] == ""
+        printed = capsys.readouterr().out
+        assert "stagnant" in printed.lower()
+        assert "[gate:impl.stagnation.test_count]" in printed
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.get_runner")
     def test_max_iterations_reached(self, mock_get_runner):

--- a/tests/unit/test_freeze_tests_symmetry_break.py
+++ b/tests/unit/test_freeze_tests_symmetry_break.py
@@ -72,16 +72,19 @@ class TestTheFirstRepeatBreaksSymmetryInsteadOfHalting:
         assert out["freeze_tests"] is True
         assert out["identity_plateau_strikes"] == 1
 
-    def test_the_third_identical_set_halts(self):
+    def test_the_third_identical_set_is_reported(self, capsys):
         """count_plateau_strikes seeded 0 so the count guard (strike 1 of 2)
-        defers and the IDENTITY path is what halts here."""
+        defers and the IDENTITY path is what speaks here.
+
+        #2723: it says the tests were frozen and the set repeated anyway, and
+        the loop carries on to its iteration cap instead of ending."""
         out = _run(
             _state(previous_passed=5, previous_green_failures=PREV,
                    identity_plateau_strikes=2, count_plateau_strikes=0),
             5, 2, FAILS,
         )
-        assert out["next_node"] == "end"
-        assert "frozen" in out["error_message"]
+        assert out["error_message"] == ""
+        assert "frozen" in capsys.readouterr().out
 
     def test_a_changed_failing_set_resets_the_strikes_and_unfreezes(self):
         out = _run(

--- a/tests/unit/test_green_loop_contract.py
+++ b/tests/unit/test_green_loop_contract.py
@@ -307,9 +307,11 @@ class TestAPlateauGetsTwoStrikes:
         assert result["coverage_plateau_strikes"] == 1
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_the_failing_branch_halts_on_the_second_strike(
-        self, mock_pytest, tmp_path: Path
+    def test_the_failing_branch_advises_on_the_second_strike_and_keeps_going(
+        self, mock_pytest, tmp_path: Path, capsys
     ) -> None:
+        """#2723: the second strike used to end the run. It now says what it
+        sees and routes back to the implementer; the iteration cap decides."""
         mock_pytest.return_value = _pytest(1, passed=2, failed=1, coverage=70)
 
         result = verify_green_phase(_state(
@@ -317,9 +319,12 @@ class TestAPlateauGetsTwoStrikes:
             previous_green_failures=[], coverage_plateau_strikes=1,
         ))
 
-        assert result["next_node"] == "end"
-        assert "Coverage stagnant" in result["error_message"]
-        assert "across 3 iterations" in result["error_message"]
+        assert result["next_node"] == "N4_implement_code"
+        assert result["error_message"] == ""
+        printed = capsys.readouterr().out
+        assert "Coverage stagnant" in printed
+        assert "across 3 iterations" in printed
+        assert "[gate:impl.stagnation.coverage]" in printed
         assert result["coverage_plateau_strikes"] == 2
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
@@ -338,8 +343,8 @@ class TestAPlateauGetsTwoStrikes:
         assert result["coverage_plateau_strikes"] == 1
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_the_all_pass_branch_halts_on_the_second_strike(
-        self, mock_pytest, tmp_path: Path
+    def test_the_all_pass_branch_advises_on_the_second_strike(
+        self, mock_pytest, tmp_path: Path, capsys
     ) -> None:
         thing = _one_module(tmp_path)
         mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
@@ -350,21 +355,25 @@ class TestAPlateauGetsTwoStrikes:
             coverage_plateau_strikes=1,
         ))
 
-        assert result["next_node"] == "end"
-        assert "Coverage stagnant" in result["error_message"]
+        assert result["error_message"] == ""
+        assert result["next_node"] != "end"
+        assert "Coverage stagnant" in capsys.readouterr().out
         assert result["coverage_plateau_strikes"] == 2
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_the_halt_message_still_says_stagnant_for_the_classifier(
-        self, mock_pytest, tmp_path: Path
+    def test_the_advisory_still_says_stagnant_for_the_classifier(
+        self, mock_pytest, tmp_path: Path, capsys
     ) -> None:
-        """#1939: the halt classifier matches the word; a reword that drops it
-        would file the halt under the wrong class."""
+        """#1939: the classifier matches the word, so a reword that drops it
+        would file the event under the wrong class. #2723 moved the sentence
+        from the halt message to the log, and it keeps the word."""
         thing = _one_module(tmp_path)
         mock_pytest.return_value = _pytest(1, passed=3, coverage=72, report=REPORT_72)
-        result = verify_green_phase(_state(
+        verify_green_phase(_state(
             tmp_path, implementation_files=[thing],
             previous_passed=3, previous_coverage=72.0,
             coverage_plateau_strikes=1,
         ))
-        assert "stagnant" in result["error_message"].lower()
+        printed = capsys.readouterr().out
+        assert "stagnant" in printed.lower()
+        assert "Continuing; the budget decides." in printed

--- a/tests/unit/test_routing_policy.py
+++ b/tests/unit/test_routing_policy.py
@@ -1,0 +1,135 @@
+"""A gate that judges model output may advise; the budget ends the run (#2723).
+
+Operator ruling 2026-09-02. The evidence: of boostgauge's 135 banner-bearing
+kills, 59 were a gate refusing the drafter's own output, and 19 of those were
+the stagnation guards. One of the 19 is `run-issue4-172600` -- the furthest any
+run has reached, green phase with three passing at 72% coverage -- killed by the
+coverage guard with four iterations unspent.
+
+This file pins the half of the policy that landed: the five stagnation rows are
+advisory, they still SEE what they saw, and nothing on the way to them ends a
+run that a budget would not have ended anyway. The other fourteen model-output
+halt rows are not yet moved; `test_the_ratchet_records_what_is_left` is what
+keeps that number honest and falling.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.gate_registry import (
+    ACTION_ADVISE,
+    ACTION_HALT,
+    GATE_REGISTRY,
+    JUDGES_BUDGET,
+    JUDGES_INFRASTRUCTURE,
+    JUDGES_MODEL_OUTPUT,
+    advised,
+    gate_key_of,
+    halt_counts,
+    registry_by_key,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+BASELINE = ROOT / "tests" / "fixtures" / "gate_registry_baseline.json"
+
+STAGNATION_KEYS = (
+    "impl.stagnation.coverage",
+    "impl.stagnation.test_count",
+    "impl.stagnation.test_identity",
+    "impl.stagnation.full_suite",
+    "impl.stagnation.e2e",
+)
+
+
+class TestTheStagnationGuardsNoLongerEndARun:
+    @pytest.mark.parametrize("key", STAGNATION_KEYS)
+    def test_the_row_advises(self, key):
+        assert registry_by_key()[key].action == ACTION_ADVISE
+
+    @pytest.mark.parametrize("key", STAGNATION_KEYS)
+    def test_the_row_names_no_halt_site(self, key):
+        """An advisory row with a halt site would mean the walker found code
+        that still ends a run under a key that says it does not."""
+        assert registry_by_key()[key].sites == ()
+        assert registry_by_key()[key].decided_in, (
+            "a row with no sites must say where it lives, or it is unfindable"
+        )
+
+    @pytest.mark.parametrize("key", STAGNATION_KEYS)
+    def test_the_row_still_judges_model_output(self, key):
+        """The classification is a fact about the gate and does not change
+        because its consequence did. Rewriting `judges` to make the
+        model-output count fall would be cooking the number the policy is
+        measured by."""
+        assert registry_by_key()[key].judges == JUDGES_MODEL_OUTPUT
+
+
+class TestAdvised:
+    def test_it_carries_the_gate_key_like_a_halt_does(self):
+        message = advised("impl.stagnation.coverage", "Coverage stagnant: 72 -> 70.")
+        assert gate_key_of(message) == "impl.stagnation.coverage"
+
+    def test_it_says_the_run_continues(self):
+        """The identical sentence was terminal for as long as these guards have
+        existed, and a reader will remember it that way."""
+        message = advised("impl.stagnation.e2e", "E2E stagnant: 2 -> 2 passed.")
+        assert "Continuing; the budget decides." in message
+
+    def test_it_refuses_a_key_whose_row_still_halts(self):
+        """An advisory printed by a gate that then ends the run anyway is the
+        worst of both: a log that says the run continued and a run that did
+        not."""
+        with pytest.raises(ValueError, match="halt row"):
+            advised("impl.green.iteration_cap", "Green phase failed after 5.")
+
+    def test_it_refuses_an_unregistered_key(self):
+        with pytest.raises(KeyError):
+            advised("impl.not.a.gate", "x")
+
+
+class TestOnlyABudgetOrTheEnvironmentEndsTheGreenLoop:
+    """The policy's real claim, checked against the registry rather than
+    asserted: everything that can still end the implement-iterate loop is a
+    spending limit or a broken environment."""
+
+    LOOP_ENDERS = (
+        "impl.green.iteration_cap",
+        "impl.circuit_breaker",
+        "impl.e2e_cap",
+        "impl.e2e_safety_limit",
+    )
+
+    @pytest.mark.parametrize("key", LOOP_ENDERS)
+    def test_each_one_is_a_budget_or_the_environment(self, key):
+        row = registry_by_key()[key]
+        assert row.action == ACTION_HALT
+        assert row.judges in (JUDGES_BUDGET, JUDGES_INFRASTRUCTURE), (
+            f"{key} ends the loop while judging {row.judges}"
+        )
+
+
+class TestTheRatchet:
+    def test_the_baseline_matches_the_registry(self):
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        assert halt_counts() == baseline["halt_rows_per_stage"]
+
+    def test_the_ratchet_records_what_is_left(self):
+        """19 model-output rows still halt. The number is pinned so it can only
+        fall: this PR took it from 24, and the remaining fourteen impl rows,
+        four lld, five spec and one pr row are the rest of #2723."""
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        remaining = [
+            gate for gate in GATE_REGISTRY
+            if gate.action == ACTION_HALT and gate.judges == JUDGES_MODEL_OUTPUT
+        ]
+        assert len(remaining) == baseline["model_output_halt_rows"] == 19
+
+    def test_no_stagnation_row_is_among_them(self):
+        remaining = {
+            gate.key for gate in GATE_REGISTRY
+            if gate.action == ACTION_HALT and gate.judges == JUDGES_MODEL_OUTPUT
+        }
+        assert remaining.isdisjoint(STAGNATION_KEYS)

--- a/tests/unit/test_verify_green_stagnation.py
+++ b/tests/unit/test_verify_green_stagnation.py
@@ -51,17 +51,19 @@ class TestGreenPhaseTestCountStagnation:
     """Test that verify_green_phase detects test-count stagnation."""
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_zero_to_zero_is_stagnant(self, mock_pytest):
-        """previous_passed=0, current passed=0 -> STAGNANT, next_node=end."""
+    def test_zero_to_zero_is_reported_as_stagnant(self, mock_pytest, capsys):
+        """previous_passed=0, current passed=0 is stagnation. #2723: it is
+        reported and the loop continues to its iteration cap."""
         mock_pytest.return_value = _make_pytest_result(
             1, passed=0, failed=24, errors=0, coverage=26,
         )
         state = _make_state(previous_passed=0, previous_coverage=26.0)
         result = verify_green_phase(state)
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result["error_message"].lower()
-        assert "Test count stagnant" in result["error_message"]
+        assert result["error_message"] == ""
+        printed = capsys.readouterr().out
+        assert "Test count stagnant" in printed
+        assert "[gate:impl.stagnation.test_count]" in printed
         assert result["previous_passed"] == 0
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
@@ -97,11 +99,12 @@ class TestGreenPhaseTestCountStagnation:
         assert result["previous_passed"] == 0
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_nonzero_stagnation(self, mock_pytest):
-        """previous_passed=10, current passed=10 -> STAGNANT (non-zero case).
+    def test_nonzero_stagnation(self, mock_pytest, capsys):
+        """previous_passed=10, current passed=10 is stagnation (non-zero case).
 
-        #2711: a coverage plateau halts on its SECOND consecutive strike, so
-        the state carries the first one."""
+        #2711: a coverage plateau counted its SECOND consecutive strike, so the
+        state carries the first one. #2723: the strike is now reported rather
+        than obeyed."""
         mock_pytest.return_value = _make_pytest_result(
             1, passed=10, failed=14, errors=0, coverage=50,
         )
@@ -109,8 +112,8 @@ class TestGreenPhaseTestCountStagnation:
                             coverage_plateau_strikes=1)
         result = verify_green_phase(state)
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result["error_message"].lower()
+        assert result["error_message"] == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
         assert result["previous_passed"] == 10
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")

--- a/tests/unit/test_verify_green_stagnation_both_branches.py
+++ b/tests/unit/test_verify_green_stagnation_both_branches.py
@@ -75,18 +75,22 @@ class TestTheTestsFailingBranch:
         assert "stagnant" not in result.get("error_message", "").lower()
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_no_progress_at_all_still_halts(self, mock_pytest):
+    def test_no_progress_at_all_is_still_reported(self, mock_pytest, capsys):
         """Same pass count, same failing set, flat coverage. The test-count
-        guard reaches this one first, which is correct -- what matters is that
-        a genuinely stuck loop still stops."""
+        guard reaches this one first, which is correct.
+
+        #2723: a genuinely stuck loop still STOPS, but the iteration cap is
+        what stops it -- this guard now only says what it sees. The stopping is
+        covered by the cap's own tests; what is pinned here is that the
+        observation is not lost when the guard stopped being terminal."""
         mock_pytest.return_value = _pytest(1, passed=20, failed=3, coverage=94)
         result = verify_green_phase(
             _state(previous_passed=20, previous_coverage=94.0,
                    previous_green_failures=["t_a", "t_b", "t_c"],
                    count_plateau_strikes=1)  # #2062: third identical count
         )
-        assert result["next_node"] == "end"
-        assert "stagnant" in result.get("error_message", "").lower()
+        assert result.get("error_message", "") == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
 
 
 class TestTheThresholdBoundary:

--- a/tests/unit/test_verify_green_tests_improved.py
+++ b/tests/unit/test_verify_green_tests_improved.py
@@ -105,11 +105,15 @@ class TestProgressTheGuardCouldNotSee:
         assert "tests improved" in capsys.readouterr().out
 
 
-class TestGenuineStagnationStillHalts:
-    """The guard's purpose is intact: no progress of any kind still stops."""
+class TestGenuineStagnationIsStillDetected:
+    """The guard's judgement is intact: no progress of any kind is still called
+    stagnation. #2723 changed only what follows from that — it is said, and the
+    iteration cap decides when to stop paying."""
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_flat_coverage_and_flat_tests_still_halts(self, mock_pytest):
+    def test_flat_coverage_and_flat_tests_is_still_stagnation(
+        self, mock_pytest, capsys
+    ):
         """#2711: on the second consecutive strike; the state carries the first."""
         mock_pytest.return_value = _pytest(1, passed=15, failed=0, coverage=94)
         result = verify_green_phase(
@@ -117,21 +121,21 @@ class TestGenuineStagnationStillHalts:
                    coverage_plateau_strikes=1)
         )
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result.get("error_message", "").lower()
+        assert result.get("error_message", "") == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
-    def test_fewer_passing_tests_is_not_progress(self, mock_pytest):
-        """A regression is a strike, never progress; on the second strike it
-        halts (#2711 -- the first buys exactly one revision to revert it)."""
+    def test_fewer_passing_tests_is_not_progress(self, mock_pytest, capsys):
+        """A regression is a strike, never progress; the second strike is
+        reported (#2711 -- the first buys exactly one revision to revert it)."""
         mock_pytest.return_value = _pytest(1, passed=13, failed=0, coverage=94)
         result = verify_green_phase(
             _state(previous_passed=15, previous_coverage=94.0,
                    coverage_plateau_strikes=1)
         )
 
-        assert result["next_node"] == "end"
-        assert "stagnant" in result.get("error_message", "").lower()
+        assert result.get("error_message", "") == ""
+        assert "stagnant" in capsys.readouterr().out.lower()
 
     @patch("assemblyzero.workflows.testing.nodes.verify_phases.run_pytest")
     def test_a_regression_buys_one_revision_and_no_more(self, mock_pytest):


### PR DESCRIPTION
## The stagnation guards stop ending runs

**Vocabulary, for a reader outside this codebase.** A *run* is one launch of the pipeline at one issue. A *gate* is a place in the workflow code that can end a run; each has a row in the gate registry saying what it *judges* (the drafter's output, the issue text, a spending limit, the environment) and what it *does* (halt, revise, advise). A *cap* is a spending limit. The *green loop* is the implement-run-tests-repeat loop.

Operator ruling 2026-09-02: a gate that judges the drafter's own output may ask for a revision and may not end the run. This PR moves the five stagnation guards — the largest block of model-output kills in the record, **19 of 135** — from `halt` to `advise`. They compute exactly what they computed, print exactly the sentence they printed, and do not route.

The exhibit is `run-issue4-172600`: green phase, three tests passing, 72% coverage — the furthest any run has reached in 180 launches — killed by the coverage guard with four iterations unspent.

## What actually changed in the code

Eight halt sites stopped returning. In each case the `return {... "next_node": "end", "error_message": stagnant_msg}` becomes a print, and control falls through to the continue path that was already directly below it.

That is safe for one reason, and it is worth stating rather than assuming: **in every one of the eight, the iteration cap is checked above the guard and the circuit breaker below it.** Both are budgets. So removing the guard's return does not remove a bound; it removes an early exit from a loop that was already bounded by a spending limit. `TestOnlyABudgetOrTheEnvironmentEndsTheGreenLoop` checks that against the registry rather than asserting it — every gate that can still end this loop judges `budget` or `infrastructure`.

New: `advised(key, message)` in the registry, the mirror of `halted()`. It tags the line with its gate key so an advisory can be counted against the registry instead of matched as prose, and appends "Continuing; the budget decides." because the identical sentence was terminal for as long as these guards have existed and a reader will remember it that way. It **refuses a key whose row still halts** — an advisory printed by a gate that then ends the run anyway is the worst of both.

## The ratchet

| | before | after |
|---|---|---|
| halt sites | 160 | **152** |
| halt rows, impl | 42 | **37** |
| halt rows that judge model output | 24 | **19** |

Baseline lowered in the same PR. `judges` on the five rows stays `model_output` — the classification is a fact about the gate and does not change because its consequence did; rewriting it to make the number fall would be cooking the figure the policy is measured by, and there is a test on that.

## The replay table

Required by #2724 for any PR touching `assemblyzero/workflows/`.

| run | stage | recorded ended at | replay ended at | verdict |
|---|---|---|---|---|
| run-issue4-182119 | spec | `spec.completeness_cap` at round 4 | diverged at round 3 | **diverged** |
| run-issue4-183941 | spec | `spec.review_cap` at round 9 | diverged at round 3 | **diverged** |
| run-issue4-192453 | spec | `spec.requirements_conflict` at round 5 | `spec.requirements_conflict` at round 5 | **same_gate** |

- **same_gate** — died at the same gate, the same distance in
- **diverged** — the recorded responses stopped fitting the code's prompts, so the replay could not continue and reports no verdict on the gate

Identical to the table on `main`, which is the evidence this PR wanted from it: it changes the implementation stage and disturbs nothing in the spec stage. `run-issue4-192453` still replays exactly, eleven calls and five review rounds, ending where it ended.

## Two acceptance criteria are not met, and here is why

> The walker test shows zero halt rows that judge model output.

**Nineteen remain.** This PR moves five. The remaining nineteen — fourteen in `impl`, four in `lld`, five in `spec`, one in `pr` — are not action flips: each needs a revision route that exists and converges, and several judge something the stage cannot revise (a reviewer's unreadable verdict is not the drafter's output; a commit-message guard has no drafter to route back to). Flipping them without that analysis would replace a halt with an unbounded loop, which is worse than the halt. `TestTheRatchet::test_the_ratchet_records_what_is_left` pins 19 so the number can only fall.

The plan's own ordering was to soften by evidence, and the answer key names the next two. Both are filed with their measurements rather than rushed into this PR, because each carries a question that is a ruling and not a patch: **#2736** (`impl.path_enforcement` refuses four files the operator shipped — is an Add the LLD did not name legal?) and **#2737** (`impl.test_file_validation` refuses two shipped tests whose assertion is in a helper it never follows).

> Replay of run 9 ends past the coverage-stagnation halt.

**Cannot be produced.** `run-issue4-172600` died in the implementation stage, and the replay runner covers the spec stage only — the recordings do not hold the implementation stage's responses in call order (#2731). So the guard that killed run 9 is now advisory by construction and by unit test, and there is no replay evidence for it. Saying otherwise would be inventing the one thing the launch gate exists to check.

## Verification

- `tests/unit/test_routing_policy.py`, 26 tests: the five rows advise, name no halt site, keep their `judges`, and everything that can still end the green loop is a budget or the environment.
- **Twelve existing tests pinned the old contract and were rewritten, not deleted.** Each now asserts the guard still *sees* what it saw — the strike counting, the "3 iterations", the word "stagnant" the classifier matches — and that the run continues. That the detection is unchanged is the point; only the consequence moved.
- Full unit suite: 9770 passed, 21 skipped, 5 xfailed, 0 failed.
- `tools/audit_halt_sites.py --check` passes: 152 sites, every one registered, 0 phantoms.
- `ruff check` clean on every file this PR touches.

Removing the eight sites renumbered four *neighbouring* gates' site indexes, because a site's identity is its position among a function's returns. The walker caught it immediately and the remap is in this PR; the misleading shape of that failure is filed as **#2738**.

Closes #2723
