### PR TITLE
fix: recognise the platform-branch complaint as demanding a test, and derive the list from the checks (Closes #2740)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/revision_pinning.py
+++ b/assemblyzero/workflows/implementation_spec/revision_pinning.py
@@ -249,6 +249,7 @@ _FENCE_OPEN_RE = re.compile(r"^\s*```")
 #: | phrase | check | artifact demanded |
 #: |---|---|---|
 #: | `have no test` / `add a test` / `owes each a test` | criteria, error paths, manifest | a test definition |
+#: | `no test varies the platform` | error paths, platform branch | a test definition |
 #: | `MUST include a code block` | `modify_files_have_excerpts` | a fenced excerpt |
 #: | `MUST have at least one JSON/YAML/Python example` | `data_structures_have_examples` | a fenced example |
 #: | `MUST have at least one example` | `functions_have_io_examples` | a fenced example |
@@ -261,10 +262,26 @@ _FENCE_OPEN_RE = re.compile(r"^\s*```")
 #: demand was covered by neither the named-content vocabulary (the path it
 #: cites is absent from the draft BY DEFINITION, which is what it is
 #: complaining about) nor this exemption.
+#:
+#: #2740 added the platform row. `check_error_path_coverage` has two branches
+#: worded differently -- the exception branch says "owes each a test" and was
+#: covered, the platform branch says "no test varies the platform" and was not,
+#: and no other phrase here matches it incidentally. So the drafter could be
+#: told to add a platform test, add one, and have the addition refused because
+#: nothing in the round was recognised as demanding it: a complaint that could
+#: be made and never satisfied.
+#:
+#: Enumerating phrasings by hand is what made that hole, and adding one more
+#: phrase by hand would only postpone the next one.
+#: `tests/unit/test_addition_demands_are_recognised.py` renders each check's
+#: REAL complaint from the check's own code and asserts this pattern matches
+#: it, so the list is now derived from the checks rather than trusted to agree
+#: with them.
 _ADDITION_DEMAND_RE = re.compile(
     r"\bhave no test\b"
     r"|\badd a test\b"
     r"|\bowes each a test\b"
+    r"|\bno test varies the platform\b"
     r"|\bMUST include a code block\b"
     r"|\bMUST have at least one\b"
     r"|\bAdd the block inside that subsection\b",

--- a/tests/unit/test_addition_demands_are_recognised.py
+++ b/tests/unit/test_addition_demands_are_recognised.py
@@ -1,0 +1,158 @@
+"""Every complaint that asks for new content must be recognised as asking (#2740).
+
+The pinning enforcement refuses a revision that adds content the round did not
+demand. `demands_additions` decides what counts as a demand, from a closed list
+of phrasings enumerated BY HAND from the checks' own strings. That hand copy is
+the defect surface: a check whose wording was never fed back into the list emits
+a complaint the drafter is told to satisfy and the enforcement then refuses --
+a complaint that can be made and never satisfied.
+
+It has happened twice. #2591: `check_modify_files_have_excerpts` demanded a
+fenced excerpt and nothing recognised it. #2740: `check_error_path_coverage`'s
+two branches are worded differently, the exception branch says "owes each a
+test" and was covered, and the platform branch says "no test varies the
+platform" and was not.
+
+So this file does not test the list. It renders each check's REAL complaint from
+the check's own code and asserts the pattern matches it. A new check, or a
+reworded one, fails here rather than deadlocking a live run.
+"""
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+    Criterion,
+    CoverageReport,
+)
+from assemblyzero.workflows.implementation_spec.criteria_coverage import (
+    format_report as format_criteria,
+)
+from assemblyzero.workflows.implementation_spec.error_path_coverage import (
+    ErrorPathReport,
+)
+from assemblyzero.workflows.implementation_spec.error_path_coverage import (
+    format_report as format_error_paths,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    demands_additions,
+)
+
+
+#: One row of an LLD pass-criteria table, in the shape `lld_criteria` produces.
+_CRITERION = Criterion(
+    key="REQ-1", row_id="1", scenario="the gauge reads zero at rest",
+    outcome="needle sits on 0", tagged=True,
+)
+
+
+class TestErrorPathCoverage:
+    """Both branches, because they are worded differently and only one of them
+    was recognised until #2740."""
+
+    def test_an_untested_exception_is_recognised_as_demanding_a_test(self):
+        report = ErrorPathReport(
+            ran=True, raised={"ValueError": 1}, asserted=set(),
+            untested=["ValueError"], test_count=3,
+        )
+        complaint = format_error_paths(report)
+        assert "owes each a test" in complaint
+        assert demands_additions([complaint]) is True
+
+    def test_a_platform_gap_is_recognised_as_demanding_a_test(self):
+        """#2740. This was the hole: the drafter is told to add a test that
+        varies the platform, adds one, and the addition is refused because
+        nothing recognised the demand."""
+        report = ErrorPathReport(
+            ran=True, platform_branches=2, platform_tested=False, test_count=3,
+        )
+        complaint = format_error_paths(report)
+        assert "no test varies the platform" in complaint
+        assert demands_additions([complaint]) is True
+
+    def test_both_gaps_at_once_are_recognised(self):
+        report = ErrorPathReport(
+            ran=True, raised={"OSError": 2}, untested=["OSError"],
+            platform_branches=1, platform_tested=False, test_count=4,
+        )
+        assert demands_additions([format_error_paths(report)]) is True
+
+    def test_a_clean_report_demands_nothing(self):
+        """The control. Without it the three above would pass on a pattern that
+        matched every string, which would unlock every revision."""
+        report = ErrorPathReport(
+            ran=True, raised={"ValueError": 1}, asserted={"ValueError"},
+            platform_branches=1, platform_tested=True, test_count=3,
+        )
+        complaint = format_error_paths(report)
+        assert "Every error path" in complaint
+        assert demands_additions([complaint]) is False
+
+    def test_a_check_that_did_not_run_demands_nothing(self):
+        report = ErrorPathReport(ran=False, reason="the spec has no code fences")
+        assert demands_additions([format_error_paths(report)]) is False
+
+
+class TestCriteriaCoverage:
+    def test_an_uncovered_criterion_is_recognised_as_demanding_a_test(self):
+        report = CoverageReport(
+            ran=True, join_mode="id",
+            criteria=[_CRITERION],
+            missing=[_CRITERION],
+            test_count=2,
+        )
+        complaint = format_criteria(report)
+        assert demands_additions([complaint]) is True
+
+    def test_full_coverage_demands_nothing(self):
+        report = CoverageReport(
+            ran=True, join_mode="id",
+            criteria=[_CRITERION],
+            missing=[], test_count=2,
+        )
+        assert demands_additions([format_criteria(report)]) is False
+
+
+class TestTheOtherPhrasingsStillMatch:
+    """The three fenced-artifact demands from #2591, kept as literals because
+    their checks live inside `validate_completeness.py` and are not separately
+    renderable. If one of those is reworded this file will not catch it -- which
+    is why the two renderable checks above are driven from their own code, and
+    why a check that grows a renderer should be moved up there."""
+
+    @pytest.mark.parametrize(
+        "complaint",
+        [
+            "Section 2.1 lists `src/x.py` as Modify and the spec MUST include "
+            "a code block excerpting it.",
+            "Section 7 defines a data structure and MUST have at least one "
+            "JSON/YAML/Python example.",
+            "Section 8.2 documents a function and MUST have at least one "
+            "example of its input and output.",
+            "Section 9.1 has no example. Add the block inside that subsection.",
+        ],
+    )
+    def test_each_fenced_demand_is_recognised(self, complaint):
+        assert demands_additions([complaint]) is True
+
+
+class TestTheGateStaysNarrow:
+    """`demands_additions` unlocks a revision that would otherwise be refused,
+    so a pattern that matched ordinary prose would unlock everything."""
+
+    @pytest.mark.parametrize(
+        "complaint",
+        [
+            "The spec's test mapping table is missing a column.",
+            "Untagged code fence at lines 5-8 (```): tag it ```python.",
+            "Section 10.1 is a pointer to Section 6 rather than test functions.",
+            "REQUIREMENTS CONFLICT: two criteria specify different outcomes.",
+            "",
+        ],
+    )
+    def test_a_complaint_about_existing_content_demands_nothing(self, complaint):
+        assert demands_additions([complaint]) is False
+
+    def test_no_issues_at_all_demands_nothing(self):
+        assert demands_additions([]) is False
+        assert demands_additions(None) is False

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -317,24 +317,34 @@ class TestAddressableToday:
             )
 
     def test_the_vocabulary_is_a_closed_set(self):
-        """Six phrasings, enumerated from the checks' own `details=` strings.
+        """Seven phrasings, enumerated from the checks' own `details=` strings.
 
         The rule that makes this regex legitimate is that its members can be
         written down (`voice-analysis.md` §28a's closed-set test). If a new
         demand phrasing appears, it is added here deliberately rather than
         matched by a general notion of "add", which would free locked regions
         nobody demanded.
+
+        Six until #2740, which found the seventh already being emitted:
+        `check_error_path_coverage`'s platform branch says "no test varies the
+        platform" and nothing recognised it, so that complaint could be made
+        and never satisfied. Counting the members here is what makes the
+        addition deliberate; `test_addition_demands_are_recognised.py` is what
+        finds the next missing one, by rendering each check's real complaint
+        rather than trusting this list to agree with them.
         """
         import re as _re
 
         members = rp._ADDITION_DEMAND_RE.pattern.split("|")
 
-        assert len(members) == 6
+        assert len(members) == 7
         for phrase, should_match in (
             ("3 criteria have no test in the spec", True),
             ("Each Modify file MUST include a code block showing", True),
             ("Each function MUST have at least one example", True),
             ("Add the block inside that subsection", True),
+            ("2 platform branch(es) in the spec's code, and no test varies "
+             "the platform", True),
             ("Change instructions lack diff-level specificity", False),
             ("test(s) tracing to nothing: test_a, test_b", False),
         ):


### PR DESCRIPTION
## A complaint that could be made and never satisfied

**Vocabulary, for a reader outside this codebase.** A *spec* is the document the pipeline drafts before writing code. A *completeness check* reads that document and can complain about it. *Pinning* is the enforcement that stops a revision rewriting parts of the draft nobody objected to — it refuses added content unless something in the round actually demanded an addition.

`check_error_path_coverage` has two branches, worded differently:

> N exception type(s) the spec raises have no test asserting them. **Section 10 owes each a test:**

> N platform branch(es) in the spec's code, and **no test varies the platform**. One side of each branch cannot execute on the machine the gate runs on.

`_ADDITION_DEMAND_RE` is a closed list of phrasings, copied by hand from the checks' own strings. `owes each a test` was on it. `no test varies the platform` was not, and matched none of the other five incidentally.

Measured against `main` before changing anything:

```
complaint: 2 platform branch(es) in the spec's code, and no test varies the platform. ...
matches:   False
```

So the drafter is told to add a test varying the platform, adds one, and pinning refuses the addition because nothing in the round was recognised as demanding it. Read from the code — no run has died on it, because it needs a spec with an `os.name` branch and no platform-varying test, which the corpus has not produced. Cheaper to fix than to wait for.

The other half of the gate was already fine: `_introduces_demanded_artifact` accepts a new test definition, and a platform test is one. Only the recognition half was missing — the asymmetry #2591 warned about, pointed the other way.

## The fix is the test, not the phrase

Adding the seventh phrase takes one line and postpones the eighth. What closes the hole is `tests/unit/test_addition_demands_are_recognised.py`: it renders each check's **real** complaint from the check's own code — `format_report` on an `ErrorPathReport` and a `CoverageReport` — and asserts `demands_additions` matches it. A check that is reworded, or a new branch that demands content in new words, fails there rather than deadlocking a live run.

Both branches of the error-path check are covered, both directions. The clean-report and did-not-run cases are asserted to demand **nothing**, because without them the positive tests would pass on a pattern that matched every string, which would unlock every revision — the opposite defect and a worse one.

The three fenced-artifact demands from #2591 stay as literals, and the test file says why: their checks live inside `validate_completeness.py` and are not separately renderable. That is an honest limit, written down where the next person will read it.

## Verification

- `tests/unit/test_addition_demands_are_recognised.py`, 17 tests.
- The platform test is red against `main`: verified directly by importing `main`'s `revision_pinning` and rendering the complaint, output above.
- `test_the_vocabulary_is_a_closed_set` in `test_completeness_message_addressability.py` counted six members; it now counts seven and carries the platform phrasing as a case. Counting the members is what keeps an addition deliberate, so the count is updated rather than removed.
- Full unit suite: 9787 passed, 21 skipped, 5 xfailed, 0 failed.
- `ruff check` clean on both files.
- No new gate, no action change: the halt registry and its baseline are untouched.

One test, `test_visual_gate_loop.py::TestTheModifyLoopIterates::test_an_adjectival_colour_serves_candidates_side_by_side`, failed once in a full-suite run and then passed both in isolation and on a clean re-run of the whole suite. It has no connection to this change, which touches one regex and one test file. Recorded here rather than filed, because one non-reproducing observation is not yet a finding.

Closes #2740
