### PR TITLE
fix: the follower stops calling an orphaned roll done, and the reset refuses under a live orchestrator (Closes #2744, Closes #2745)

### DIFF
--- a/assemblyzero/workflows/orchestrator/resume.py
+++ b/assemblyzero/workflows/orchestrator/resume.py
@@ -152,3 +152,31 @@ def release_orchestration_lock(issue_number: int) -> None:
     """Release lock file for an issue. No-op if lock doesn't exist."""
     lock_path = LOCK_DIR / f"{issue_number}.lock"
     lock_path.unlink(missing_ok=True)
+
+
+def live_orchestrator_pid(issue_number: int) -> int | None:
+    """The pid of an orchestrator currently holding this issue's lock, or None.
+
+    The same two facts `acquire_orchestration_lock` reads, exposed so a
+    DESTRUCTIVE tool can read them too. `speedrun_reset.py` could not, and on
+    2026-09-02 at 19:20 it ran against a live orchestrator: it closed the run's
+    LLD PR, deleted the branch locally and on origin, and archived the lineage
+    out from under a process that was still writing into it (#2510).
+
+    A missing, corrupt or stale lock returns None -- there is no live run to
+    protect. A lock naming a live pid returns that pid, and the caller refuses.
+    """
+    lock_path = LOCK_DIR / f"{issue_number}.lock"
+    if not lock_path.exists():
+        return None
+    try:
+        pid = int(json.loads(lock_path.read_text(encoding="utf-8"))["pid"])
+    except (json.JSONDecodeError, OSError, KeyError, TypeError, ValueError):
+        # fail-open: a lock nobody can read is not evidence of a live run. The
+        # caller then behaves exactly as it did before this existed, so an
+        # unreadable lock can only lose the new protection rather than invent a
+        # refusal that blocks a legitimate reset -- and a stale or corrupt lock
+        # is the ordinary case after any crash, which is when a reset is most
+        # needed.
+        return None
+    return pid if _is_pid_alive(pid) else None

--- a/tests/unit/test_orphaned_roll_guards.py
+++ b/tests/unit/test_orphaned_roll_guards.py
@@ -1,0 +1,355 @@
+"""Two guards for a roll whose wrapper died and whose run did not (#2510).
+
+Three detached rolls in ten days had their wrapper killed while the
+orchestrator carried on: 2026-08-24 at 00:00:25, 2026-09-02 at 17:28:45, and
+2026-09-02 at 19:20:13. Each time the scheduled task reported exit 1, and each
+time the follower read that state and announced `The roll is done: FAILED`
+while the run was mid-stage.
+
+On the third, an operator believed the verdict and ran `speedrun_reset.py`. It
+closed the run's LLD PR, removed its worktree, deleted branch `4-lld` locally
+and on origin, and archived `docs/lineage/active/4-implspec` and `4-lld` out
+from under a process that was still writing into them. The run happened to be
+in its ninth of nine review rounds with no path to approval, so nothing that
+could have shipped was lost. That is luck.
+
+The two guards are independent on purpose, because the failure needed both to
+line up: the follower has to stop lying, AND the reset has to refuse even when
+something lies to it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import speedrun_reset  # noqa: E402
+import speedrun_roll  # noqa: E402
+
+from assemblyzero.workflows.orchestrator import resume  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Guard 1: the follower stops calling a live run done
+# ---------------------------------------------------------------------------
+
+
+def _log(dir_: Path, name: str, age_seconds: float, *, now: float = 1_000_000.0):
+    path = dir_ / name
+    path.write_text("alive\n", encoding="utf-8")
+    os.utime(path, (now - age_seconds, now - age_seconds))
+    return path
+
+
+NOW = 1_000_000.0
+
+
+class TestRunStillWriting:
+    def test_a_fresh_heartbeat_means_the_run_is_alive(self, tmp_path):
+        _log(tmp_path, "run-issue4-183941-heartbeat.log", 5)
+        still, why = speedrun_roll.run_still_writing(tmp_path, now=NOW)
+        assert still is True
+        assert "heartbeat" in why and "5s ago" in why
+
+    def test_a_growing_run_log_means_the_run_is_alive(self, tmp_path):
+        """The heartbeat is the wrapper's; the run log is the orchestrator's.
+        In all three incidents the heartbeat stopped and the log kept growing,
+        so the log alone has to be enough."""
+        _log(tmp_path, "run-issue4-183941-heartbeat.log", 600)
+        _log(tmp_path, "run-issue4-183941.log", 10)
+        still, why = speedrun_roll.run_still_writing(tmp_path, now=NOW)
+        assert still is True
+        assert "run-issue4-183941.log" in why
+
+    def test_a_stale_heartbeat_alone_is_not_life(self, tmp_path):
+        _log(tmp_path, "run-issue4-183941-heartbeat.log", 600)
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+    def test_an_empty_directory_is_not_life(self, tmp_path):
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW) == (False, "")
+
+    def test_the_events_log_does_not_count_as_life(self, tmp_path):
+        """The events log gets its LAUNCH line at the start and then nothing
+        until the wrapper writes EXIT -- which in all three incidents it never
+        did. Counting it would read the launch as a sign of life for a minute
+        after the wrapper was already dead."""
+        _log(tmp_path, "run-issue4-183941-events.log", 5)
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+    def test_the_boundary_is_four_missed_beats(self, tmp_path):
+        """15-second cadence, so 60s is four missed beats. Pinned because the
+        number is the whole judgement: too small and jitter reads as death,
+        too large and the operator waits on a finished run."""
+        assert speedrun_roll.HEARTBEAT_FRESH_SECONDS == 60
+        _log(tmp_path, "run-issue4-183941.log", 59)
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is True
+        _log(tmp_path, "run-issue4-183941.log", 60)
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+    def test_a_log_that_says_how_it_ended_has_ended(self, tmp_path):
+        """The cost of getting this wrong falls on every roll, not the rare
+        one: a normal run writes its closing banner seconds before the task
+        flips to Ready, so freshness alone would hold the follower silent for a
+        minute after every success."""
+        path = _log(tmp_path, "run-issue4-183941.log", 2)
+        path.write_text(
+            "[ORCHESTRATOR] All stages passed.\n", encoding="utf-8"
+        )
+        os.utime(path, (NOW - 2, NOW - 2))
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+    def test_a_failure_banner_also_ends_it(self, tmp_path):
+        path = _log(tmp_path, "run-issue4-183941.log", 2)
+        path.write_text(
+            "  ORCHESTRATION FAILED at stage: spec\n", encoding="utf-8"
+        )
+        os.utime(path, (NOW - 2, NOW - 2))
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+    def test_a_fresh_log_with_no_banner_is_the_orphan(self, tmp_path):
+        """The shape of all three incidents: the run is mid-stage, so it has
+        written recently and has not said how it ended."""
+        path = _log(tmp_path, "run-issue4-183941.log", 2)
+        path.write_text(
+            "NODE [7/11] generate draft -- the drafter writes it.\n",
+            encoding="utf-8",
+        )
+        os.utime(path, (NOW - 2, NOW - 2))
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is True
+
+    def test_an_unstattable_log_is_not_treated_as_life(self, tmp_path, monkeypatch):
+        """Fail-open toward the old behaviour: without evidence of life the
+        caller prints the verdict it printed before this existed. The guard can
+        only be lost, never invented."""
+        _log(tmp_path, "run-issue4-183941.log", 1)
+
+        def _boom(self, *a, **k):
+            raise OSError("gone")
+
+        monkeypatch.setattr(Path, "stat", _boom)
+        assert speedrun_roll.run_still_writing(tmp_path, now=NOW)[0] is False
+
+
+class TestTheFollowerDoesNotCallAnOrphanDone:
+    """The whole loop, driven the way the three incidents drove it: the task
+    flips out of Running while the run log keeps growing."""
+
+    def _runs(self, tmp_path: Path) -> Path:
+        runs = tmp_path / "runs"
+        runs.mkdir()
+        (runs / "detached-launcher.log").write_bytes(b"")
+        return runs
+
+    def test_it_says_the_wrapper_ended_and_keeps_following(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        runs = self._runs(tmp_path)
+        roll = runs / "run-issue4-183941.log"
+        roll.write_bytes(b"")
+
+        def _orphan():
+            with roll.open("ab") as fh:
+                fh.write(b"NODE [7/11] generate draft\n")
+            return "Ready"
+
+        def _finish():
+            with roll.open("ab") as fh:
+                fh.write(b"[ORCHESTRATOR] All stages passed.\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _orphan, _finish])
+        monkeypatch.setattr(speedrun_roll, "_task_status", lambda: next(statuses)())
+        monkeypatch.setattr(speedrun_roll, "_task_last_result", lambda: 1)
+        monkeypatch.setattr(speedrun_roll.time, "sleep", lambda s: None)
+        monkeypatch.setattr(speedrun_roll, "_poll_view_keys", lambda v: None)
+
+        speedrun_roll.follow_roll(runs)
+        out = capsys.readouterr().out
+
+        assert "Wrapper ended at" in out
+        assert "the run is still writing" in out
+        assert "Do NOT reset or relaunch" in out
+        assert out.index("Wrapper ended at") < out.index("The roll is done")
+
+    def test_the_final_verdict_says_whose_exit_code_it_is(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The exit code belongs to the wrapper, which was killed. Printing it
+        as the roll's verdict is what said FAILED about a run two stages from a
+        PR."""
+        runs = self._runs(tmp_path)
+        roll = runs / "run-issue4-183941.log"
+        roll.write_bytes(b"")
+
+        def _orphan():
+            with roll.open("ab") as fh:
+                fh.write(b"NODE [7/11] generate draft\n")
+            return "Ready"
+
+        def _finish():
+            with roll.open("ab") as fh:
+                fh.write(b"[ORCHESTRATOR] All stages passed.\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _orphan, _finish])
+        monkeypatch.setattr(speedrun_roll, "_task_status", lambda: next(statuses)())
+        monkeypatch.setattr(speedrun_roll, "_task_last_result", lambda: 1)
+        monkeypatch.setattr(speedrun_roll.time, "sleep", lambda s: None)
+        monkeypatch.setattr(speedrun_roll, "_poll_view_keys", lambda v: None)
+
+        speedrun_roll.follow_roll(runs)
+        out = capsys.readouterr().out
+        assert "the exit code above is the wrapper's and not the run's" in out
+
+    def test_a_clean_finish_signs_off_at_once(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The control, and the one that matters most for cost: a roll that
+        ends normally must not be held for a minute by a guard meant for
+        orphans."""
+        runs = self._runs(tmp_path)
+        roll = runs / "run-issue4-183941.log"
+        roll.write_bytes(b"")
+
+        def _finish():
+            with roll.open("ab") as fh:
+                fh.write(b"[ORCHESTRATOR] All stages passed.\n")
+            return "Ready"
+
+        statuses = iter([lambda: "Running", _finish])
+        monkeypatch.setattr(speedrun_roll, "_task_status", lambda: next(statuses)())
+        monkeypatch.setattr(speedrun_roll, "_task_last_result", lambda: 0)
+        monkeypatch.setattr(speedrun_roll.time, "sleep", lambda s: None)
+        monkeypatch.setattr(speedrun_roll, "_poll_view_keys", lambda v: None)
+
+        assert speedrun_roll.follow_roll(runs) == 0
+        out = capsys.readouterr().out
+        assert "The roll is done: SUCCEEDED" in out
+        assert "Wrapper ended at" not in out
+
+
+# ---------------------------------------------------------------------------
+# Guard 2: the reset refuses under a live orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A repo whose lock directory is where the orchestrator would write it."""
+    root = tmp_path / "target"
+    (root / ".assemblyzero" / "orchestrator" / "locks").mkdir(parents=True)
+    monkeypatch.setattr(resume, "LOCK_DIR", Path(".assemblyzero/orchestrator/locks"))
+    return root
+
+
+def _lock(repo: Path, issue: int, pid: int) -> Path:
+    path = repo / ".assemblyzero" / "orchestrator" / "locks" / f"{issue}.lock"
+    path.write_text(json.dumps({"pid": pid, "hostname": "h"}), encoding="utf-8")
+    return path
+
+
+class TestTheResetRefusesUnderALiveOrchestrator:
+    def test_a_live_lock_raises_rather_than_warning(self, repo, monkeypatch):
+        """`raise`, not `print`. A warning is what the operator read past on
+        2026-09-02; a reset that can run under a live orchestrator is the same
+        class as a `git clean` in someone else's checkout."""
+        _lock(repo, 4, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: pid == 36848)
+        with pytest.raises(speedrun_reset.LiveOrchestratorError) as caught:
+            speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+        assert "36848" in str(caught.value)
+        assert "#4" in str(caught.value)
+
+    def test_a_dead_pid_does_not_block_a_legitimate_reset(self, repo, monkeypatch):
+        """A stale lock is the ordinary case after any crash, and refusing on
+        one would make the tool useless exactly when it is needed."""
+        _lock(repo, 4, 26780)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: False)
+        speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+
+    def test_no_lock_at_all_does_not_block(self, repo):
+        speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+
+    def test_a_corrupt_lock_does_not_block(self, repo):
+        path = repo / ".assemblyzero" / "orchestrator" / "locks" / "4.lock"
+        path.write_text("{not json", encoding="utf-8")
+        speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+
+    def test_another_issues_live_lock_does_not_block_this_one(
+        self, repo, monkeypatch
+    ):
+        _lock(repo, 331, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: True)
+        speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+
+    def test_the_lock_is_read_from_the_target_repo_not_the_cwd(
+        self, repo, monkeypatch, tmp_path
+    ):
+        """`LOCK_DIR` is repo-relative, and the reset is invoked from wherever
+        the operator happens to be. Reading it from the cwd would look in
+        AssemblyZero's own lock directory and find nothing, every time."""
+        _lock(repo, 4, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        with pytest.raises(speedrun_reset.LiveOrchestratorError):
+            speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+
+    def test_the_working_directory_is_restored_after_a_refusal(
+        self, repo, monkeypatch, tmp_path
+    ):
+        _lock(repo, 4, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        with pytest.raises(speedrun_reset.LiveOrchestratorError):
+            speedrun_reset.refuse_if_orchestrator_is_live(repo, 4)
+        assert Path.cwd() == elsewhere.resolve()
+
+
+class TestTheRefusalComesBeforeAnyWrite:
+    def test_reset_one_issue_checks_before_it_pins(self, repo, monkeypatch):
+        """The checkpoint pin is itself a write and everything after it is
+        destructive, so the refusal has to precede the first step and not sit
+        among them."""
+        _lock(repo, 4, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: True)
+        touched: list[str] = []
+        for name in (
+            "pin_checkpoint", "close_open_prs", "remove_worktree",
+            "delete_local_branches", "delete_remote_branches",
+            "archive_lineage_dirs", "relocate_lld_artifacts", "reopen_issue",
+        ):
+            monkeypatch.setattr(
+                speedrun_reset, name,
+                lambda *a, _n=name, **k: touched.append(_n),
+            )
+        with pytest.raises(speedrun_reset.LiveOrchestratorError):
+            speedrun_reset.reset_one_issue(repo, "owner/repo", 4)
+        assert touched == [], (
+            f"the reset touched {touched} before refusing; on 2026-09-02 that "
+            f"list was a closed PR and two deleted branches"
+        )
+
+
+class TestLiveOrchestratorPid:
+    def test_it_reads_the_pid_the_lock_already_carried(self, repo, monkeypatch):
+        _lock(repo, 4, 36848)
+        monkeypatch.setattr(resume, "_is_pid_alive", lambda pid: True)
+        monkeypatch.chdir(repo)
+        assert resume.live_orchestrator_pid(4) == 36848
+
+    def test_a_lock_with_no_pid_field_is_not_a_live_run(self, repo, monkeypatch):
+        path = repo / ".assemblyzero" / "orchestrator" / "locks" / "4.lock"
+        path.write_text(json.dumps({"hostname": "h"}), encoding="utf-8")
+        monkeypatch.chdir(repo)
+        assert resume.live_orchestrator_pid(4) is None

--- a/tests/unit/test_quiz_mode.py
+++ b/tests/unit/test_quiz_mode.py
@@ -136,6 +136,10 @@ class TestFollowIntegration:
                     b"NODE [4/11] generate draft -- "
                     b"The drafter model writes the document.\n"
                 )
+                # #2510: a fresh log with no closing banner is what an ORPHANED
+                # roll looks like, and the follower now keeps watching one.
+                # This test is about the quiz, so the roll finishes properly.
+                fh.write(b"[ORCHESTRATOR] All stages passed.\n")
             return "Ready"
 
         statuses = iter([lambda: "Running", _flip])

--- a/tests/unit/test_speedrun_roll_follow.py
+++ b/tests/unit/test_speedrun_roll_follow.py
@@ -254,6 +254,11 @@ class TestFollowLoop:
         def _flip():
             with roll.open("ab") as fh:
                 fh.write(b"NODE [3/11] requirements consistency gate\n")
+                # #2510: a roll that has actually ended says so in its own log.
+                # Without the banner this fixture describes an ORPHANED roll --
+                # fresh log, task gone, no last words -- and the follower is
+                # now required to keep watching rather than call that done.
+                fh.write(b"[ORCHESTRATOR] All stages passed.\n")
             return "Ready"
 
         statuses = iter([lambda: "Running", _flip])
@@ -278,7 +283,12 @@ class TestFollowLoop:
             with first.open("ab") as fh:
                 fh.write(b"attempt 1 tail\n")
             second = runs / "run-issue1-202020.log"
-            second.write_bytes(b"attempt 2 begins\n")
+            # #2510: the banner is what tells the follower the run ended. This
+            # test is about the newest-file race, so the second attempt has to
+            # look finished or the follower correctly keeps watching it.
+            second.write_bytes(
+                b"attempt 2 begins\n[ORCHESTRATOR] All stages passed.\n"
+            )
             # Same-tick writes tie on mtime granularity; the new attempt
             # must win the newest-file race deterministically.
             newer = first.stat().st_mtime + 10

--- a/tools/speedrun_reset.py
+++ b/tools/speedrun_reset.py
@@ -672,6 +672,50 @@ def reopen_issue(repo: str, issue: int) -> bool:
     return False
 
 
+class LiveOrchestratorError(RuntimeError):
+    """Raised when a reset is asked to run under a live orchestrator (#2510)."""
+
+
+def refuse_if_orchestrator_is_live(repo_root: Path, issue: int) -> None:
+    """Refuse -- not warn -- while this issue's lock names a live process.
+
+    On 2026-09-02 at 19:20 the follower announced `The roll is done: FAILED`
+    because the WRAPPER had been killed, and the orchestrator was still working.
+    A reset run on that verdict closed the run's LLD PR (#431), removed its
+    worktree, deleted branch `4-lld` locally and on origin, and archived the
+    lineage out from under a process that was still writing into it. The run had
+    no path to approval, so nothing that could have shipped was lost; that is
+    luck and not a defence.
+
+    A reset that can run under a live orchestrator is the same class as a
+    `git clean` in someone else's checkout, so this raises rather than printing.
+    The lock has carried the pid the whole time -- nothing needed to be recorded
+    that was not already there, only read.
+    """
+    from assemblyzero.workflows.orchestrator.resume import live_orchestrator_pid
+
+    previous = Path.cwd()
+    try:
+        # The lock directory is repo-relative, so it is read from the repo the
+        # reset is about rather than from wherever the operator invoked this.
+        os.chdir(repo_root)
+        pid = live_orchestrator_pid(issue)
+    finally:
+        os.chdir(previous)
+    if pid is None:
+        return
+    raise LiveOrchestratorError(
+        f"issue #{issue} has a live orchestrator: the lock at "
+        f"{repo_root / '.assemblyzero' / 'orchestrator' / 'locks' / f'{issue}.lock'} "
+        f"names pid {pid}, and that process is running. Refusing to reset.\n"
+        f"A reset here closes the run's PRs, deletes its branches locally and "
+        f"on origin, and archives the lineage the run is still writing (#2510).\n"
+        f"The wrapper's own pid file can name a DEAD process while the "
+        f"orchestrator lives, so a follower saying the roll is done is not "
+        f"evidence. Stop the run first, or wait for the lock to clear."
+    )
+
+
 def reset_one_issue(
     repo_root: Path, repo: str, issue: int, preserve: set[str] | None = None
 ) -> None:
@@ -682,7 +726,11 @@ def reset_one_issue(
     has to precede it or the ordering is the bug.
 
     #2609: ``preserve`` names settled artifacts the reset must leave in place.
+
+    #2510: the live-orchestrator refusal comes before the pin, because the pin
+    is already a write and everything after it is destructive.
     """
+    refuse_if_orchestrator_is_live(repo_root, issue)
     print(f"\nResetting issue #{issue}:")
     pin_checkpoint(repo_root, issue)
     close_open_prs(repo, issue)
@@ -741,18 +789,27 @@ def main() -> int:
         print(f"ERROR: {e}")
         return 1
 
-    if args.issue:
-        reset_issues = [args.issue]
-        reset_one_issue(repo_root, repo, args.issue)
-    else:
-        issues = all_logged_issues(repo_root)
-        if not issues:
-            print("No issues in run-log.jsonl — nothing to reset.")
-            return 0
-        print(f"Resetting {len(issues)} issue(s) from run-log: {issues}")
-        for issue in issues:
-            reset_one_issue(repo_root, repo, issue)
-        reset_issues = issues
+    # #2510: a live orchestrator stops the whole reset, not just its own issue.
+    # A sweep that reset four issues and then refused the fifth would have done
+    # four issues' worth of irreversible work before saying so.
+    try:
+        if args.issue:
+            reset_issues = [args.issue]
+            reset_one_issue(repo_root, repo, args.issue)
+        else:
+            issues = all_logged_issues(repo_root)
+            if not issues:
+                print("No issues in run-log.jsonl — nothing to reset.")
+                return 0
+            for issue in issues:
+                refuse_if_orchestrator_is_live(repo_root, issue)
+            print(f"Resetting {len(issues)} issue(s) from run-log: {issues}")
+            for issue in issues:
+                reset_one_issue(repo_root, repo, issue)
+            reset_issues = issues
+    except LiveOrchestratorError as exc:
+        print(f"\nREFUSED: {exc}")
+        return 1
 
     # #1918: a reset that cannot prove it finished did not finish. The
     # clean-check enumerates every debris class this tool is supposed to

--- a/tools/speedrun_roll.py
+++ b/tools/speedrun_roll.py
@@ -1999,6 +1999,81 @@ def _newest_roll_log(log_dir: Path) -> Path | None:
     return max(candidates, key=lambda p: p.stat().st_mtime)
 
 
+#: A heartbeat lands every 15 seconds, so four missed beats is the line between
+#: "between beats" and "stopped". Long enough that ordinary scheduling jitter
+#: does not read as death; short enough that an operator is not told to keep
+#: waiting on a run that ended a minute ago.
+HEARTBEAT_FRESH_SECONDS = 60
+
+#: The run's OWN last words, in the orchestrator's wording. A log carrying
+#: either has ended and is not coming back, whatever its mtime says -- which is
+#: what stops a freshly-finished roll being read as a live one for a minute.
+_RE_RUN_ENDED = re.compile(
+    r"ORCHESTRATION FAILED at stage:|\[ORCHESTRATOR\] All stages passed\."
+)
+
+
+def run_still_writing(
+    log_dir: Path, *, now: float | None = None,
+    fresh_seconds: float = HEARTBEAT_FRESH_SECONDS,
+) -> tuple[bool, str]:
+    """Is anything still being written for this roll? (still writing, why).
+
+    #2510: three detached rolls in ten days had their WRAPPER killed while the
+    orchestrator carried on working. The follower reads the scheduled task's
+    state, so all three times it announced `The roll is done: FAILED` while the
+    run was mid-stage -- and on 2026-09-02 at 19:20 an operator believed it and
+    ran `speedrun_reset.py` against a live orchestrator, which closed the run's
+    LLD PR, deleted its branch locally and on origin, and archived the lineage
+    out from under a process still writing into it.
+
+    The task's state is a fact about the WRAPPER. These are the facts about the
+    RUN, and both are on disk the whole time.
+
+    Freshness alone is not enough, and getting that wrong costs every roll. A
+    run that has just finished normally wrote its closing banner seconds before
+    the task flipped to Ready, so an mtime test on its own would hold the
+    follower silent for a minute after every successful roll. So the run log's
+    own terminal banner wins over its mtime: a log that says how it ended has
+    ended. What remains -- fresh, and no banner -- is exactly the orphan.
+
+    Silent on a stat failure by design. A follower that cannot stat a log has
+    no evidence the run is alive, and "no evidence" is the answer that lets the
+    caller print the verdict it printed before this existed.
+    """
+    moment = time.time() if now is None else now
+    newest_name, newest_age, newest_path = "", None, None
+    for pattern in ("*-heartbeat.log", "run-*.log"):
+        for path in log_dir.glob(pattern):
+            if path.name.endswith("-events.log"):
+                continue
+            try:
+                age = moment - path.stat().st_mtime
+            except OSError:
+                # fail-open: an unstattable log is no evidence of life. The
+                # caller then prints the verdict it would have printed anyway,
+                # so this can only lose the new protection, never invent it.
+                continue
+            if newest_age is None or age < newest_age:
+                newest_age, newest_name, newest_path = age, path.name, path
+    if newest_age is None or newest_age >= fresh_seconds:
+        return False, ""
+    if newest_path is not None and not newest_path.name.endswith(
+        "-heartbeat.log"
+    ):
+        try:
+            if _RE_RUN_ENDED.search(
+                newest_path.read_text(encoding="utf-8", errors="replace")
+            ):
+                return False, ""
+        except OSError:
+            # fail-open, same direction as the stat above: an unreadable log
+            # cannot be shown to have ended, so freshness decides and the
+            # follower keeps watching. Erring toward watching is the safe half.
+            pass
+    return True, f"{newest_name} was written {int(newest_age)}s ago"
+
+
 def _newest_heartbeat(log_dir: Path) -> str:
     """`<file>: <last line>` for the freshest heartbeat, or "" without one."""
     beats = sorted(
@@ -2392,6 +2467,9 @@ def follow_roll(
     unknown_streak = 0
     start_deadline = time.time() + _START_GRACE_SECONDS
     last_line_at = time.time()
+    #: #2510: set when the scheduled task has ended but the run is still
+    #: writing, so the notice is printed once rather than every poll.
+    wrapper_ended_at = ""
     try:
         while True:
             _poll_view_keys(view)
@@ -2436,17 +2514,44 @@ def follow_roll(
                 _drain_roll_log()
                 if seen_running or wait_for_start:
                     code = _task_last_result() or 0
+                    # #2510: the task's state is a fact about the WRAPPER. Three
+                    # times in ten days the wrapper was killed and the
+                    # orchestrator carried on, and this line said FAILED while
+                    # the run was two stages from a PR. Say what actually
+                    # happened and keep following.
+                    still, why = run_still_writing(log_dir)
+                    if still:
+                        if not wrapper_ended_at:
+                            wrapper_ended_at = time.strftime("%H:%M:%S")
+                            print(
+                                f"\nWrapper ended at {wrapper_ended_at} "
+                                f"(task status: {status}, exit {code}), but the "
+                                f"run is still writing -- {why}.\n"
+                                f"Still following. Do NOT reset or relaunch "
+                                f"this issue: the orchestrator is alive and "
+                                f"--kill names the dead wrapper (#2510).",
+                                flush=True,
+                            )
+                        time.sleep(FOLLOW_POLL_SECONDS)
+                        continue
                     # #2165: the word, not just the number. The full verdict
                     # block streams above this from the narration; this line
                     # is the follower's own sign-off.
                     if quiz is not None:
                         print(f"\n{quiz.tally()}", flush=True)
                     word = "SUCCEEDED" if code == 0 else "FAILED"
-                    print(
+                    tail = (
                         f"\nThe roll is done: {word} "
-                        f"(task status: {status}, exit {code}).",
-                        flush=True,
+                        f"(task status: {status}, exit {code})."
                     )
+                    if wrapper_ended_at:
+                        tail += (
+                            f"\nThe wrapper had ended at {wrapper_ended_at}; "
+                            f"the run kept writing until now, so the exit code "
+                            f"above is the wrapper's and not the run's -- read "
+                            f"the run log's own closing banner."
+                        )
+                    print(tail, flush=True)
                     return code
                 print(f"\nNo roll is running (task status: {status}).", flush=True)
                 return 0


### PR DESCRIPTION
## Two guards for a roll whose wrapper died and whose run did not

**Vocabulary, for a reader outside this codebase.** A *roll* is one launch of the pipeline at one issue. A detached roll runs under Windows Task Scheduler: a *wrapper* process starts the *orchestrator*, and a *follower* streams the roll's log to whoever launched it. A *heartbeat* is a line the wrapper writes every 15 seconds.

Three detached rolls in ten days had their wrapper killed while the orchestrator carried on working — 2026-08-24 at 00:00:25, 2026-09-02 at 17:28:45, 2026-09-02 at 19:20:13. Each time the task reported exit 1 and the follower printed `The roll is done: FAILED` while the run was mid-stage.

On the third, an operator believed it and ran `speedrun_reset.py` against a live orchestrator. That closed the run's LLD PR (#431), removed its worktree, deleted branch `4-lld` locally and on origin, and archived the lineage out from under a process still writing into it. The run was in its ninth of nine review rounds with no path to approval, so nothing that could have shipped was lost. That is luck, not a defence.

The two guards are independent on purpose, because the harm needed both to line up: the follower has to stop lying, **and** the destructive tool has to refuse even when something lies to it.

## Guard 1 — the follower consults the run, not just the task (#2744)

`run_still_writing(log_dir)` reads two facts that were on disk the whole time: the newest heartbeat or run-log mtime, and whether the run log carries its own closing banner.

The banner is the part that makes this cheap rather than expensive. A run that finishes normally writes `[ORCHESTRATOR] All stages passed.` seconds before the task flips to Ready, so **freshness alone would hold the follower silent for a minute after every successful roll** — a fix costing more than the bug. The banner wins over the mtime: a log that says how it ended has ended. What remains — fresh, and no last words — is exactly the orphan.

When that fires the follower says so and keeps going:

```
Wrapper ended at 19:20:25 (task status: Ready, exit 1), but the run is still
writing -- run-issue4-183941.log was written 3s ago.
Still following. Do NOT reset or relaunch this issue: the orchestrator is alive
and --kill names the dead wrapper (#2510).
```

and when the run does end, the sign-off says whose exit code it was quoting.

The `--kill` half of #2510 — falling back to the orchestrator's lock pid when the wrapper pid is dead — is not in this PR and stays on #2510, with the postmortem the launcher should write.

## Guard 2 — the reset refuses under a live orchestrator (#2745)

`refuse_if_orchestrator_is_live` raises `LiveOrchestratorError` while the issue's lock names a live pid. Four details decide whether the guard is worth having, and all four are tested:

- **It raises, it does not warn.** A warning is what was read past on 2026-09-02.
- **It runs before the first write.** `reset_one_issue` pins a checkpoint first and that is itself a write. `test_reset_one_issue_checks_before_it_pins` asserts *nothing* was touched — on 2026-09-02 that list was a closed PR and two deleted branches.
- **It runs before the first issue of a sweep.** The no-`--issue` form resets every issue in the run log; refusing on the fifth after four issues of irreversible work would be worse than not checking.
- **A stale or corrupt lock does not block.** That is the ordinary state after any crash, which is when a reset is most needed.

One trap that would have made the guard silently useless: `LOCK_DIR` is repo-relative and the reset is invoked from wherever the operator is standing. Read from the current directory it would look in AssemblyZero's own lock directory, find nothing, and always pass. It reads from the target repo, with the working directory restored on both paths, and there is a test for each.

`live_orchestrator_pid` is the reading, added beside the lock in `resume.py` — the same two facts `acquire_orchestration_lock` already checks, exposed so a destructive tool can check them too. Nothing new is recorded; it was only never read.

## Verification

- `tests/unit/test_orphaned_roll_guards.py`, 23 tests, including the whole follower loop driven the way the three incidents drove it.
- **Three existing follower tests were updated, and the reason is the finding.** Their fixtures flipped the task to Ready while the run log had a fresh NODE line and no closing banner — which is precisely an orphaned roll, so under the new rule the follower correctly keeps watching. They now write a banner, because a roll that has ended says so. The old fixtures were describing the behaviour that caused the harm.
- Full unit suite: 9810 passed, 21 skipped, 5 xfailed, 0 failed.
- `ruff check` clean on all four touched files.
- Two fail-open handlers, both declared with `# fail-open:` markers and both pointed the same way: without evidence of life, behave exactly as before. The guards can only be lost, never invented — so neither can block a legitimate reset or hold a finished roll.
- No new gate; the halt registry and its baseline are untouched.

Closes #2744, Closes #2745
