### PR TITLE
fix: a unit test that reaches a real model call now fails in under a second (Closes #2703)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,29 @@ def gate_backoff_waits(monkeypatch):
     yield waits
 
 
+@pytest.fixture(autouse=True)
+def no_live_model_calls(request, monkeypatch):
+    """A unit test that reaches a real model call fails instantly (#2703).
+
+    Scoped to `tests/unit/` by path. The integration and e2e tiers exist to call
+    real services and are left alone; a unit test that genuinely needs a model
+    belongs in one of them, and the refusal says so.
+
+    Autouse and unconditional inside that directory, because the incident it
+    guards is a test whose author believed the transport was stubbed. A guard
+    you have to remember to ask for protects the cases you already thought
+    about.
+    """
+    path = Path(str(request.node.fspath))
+    if path.parent.name != "unit":
+        yield
+        return
+    from tests.model_call_guard import install
+
+    install(monkeypatch, request.node.nodeid)
+    yield
+
+
 @pytest.fixture
 def mock_file_size(monkeypatch):
     """Factory fixture that patches os.path.getsize to return specified sizes for given paths.

--- a/tests/model_call_guard.py
+++ b/tests/model_call_guard.py
@@ -1,0 +1,120 @@
+"""A unit test that reaches a real model call fails instantly (#2703).
+
+On 2026-09-02 the first version of `test_edit_script_reaches_the_mid_arc_fix.py`
+stubbed the edit-script path and not the full-rewrite fallback. The fallback
+called Claude twice, for 96 seconds, at real cost, and the only signal was that
+the test felt slow. Nothing in the suite could have stopped it: `conftest.py`
+intercepted no model transport of any kind.
+
+The suite is nine and a half thousand tests and drives real graph nodes in mock
+mode on purpose. Each one is a single missed stub away from spending money, and
+on a CI runner nobody is watching the clock at all.
+
+## Why this guards the COMMAND and not the call site
+
+All three transports reach a model the same way -- `subprocess.Popen` on a CLI
+-- and two of them do it from `llm_provider.py`, one from `gemini_client.py`.
+Patching those modules would guard three sites and miss the fourth someone adds.
+Patching `subprocess.Popen` outright would break the hundreds of tests that
+legitimately run `git`.
+
+So the guard reads the command. `claude`, `agy` and `gemini` are model CLIs;
+everything else is somebody's tooling and passes through untouched. A new
+transport is caught by the name it invokes, which is the thing that costs money.
+
+## Why it raises rather than returning a canned answer
+
+A stub that answers would let the test pass while exercising a path the author
+believed was stubbed -- the same silent-substitution failure the fixture set in
+`ScriptedProvider` refuses. The point is to fail, in under a second, saying
+which test and which command.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+#: The CLIs that reach a model and cost money. Closed and authored: a new
+#: transport is added here deliberately, the same rule the gate registry's
+#: pattern set follows. Matched on the executable's stem, so `claude.exe`,
+#: `claude.cmd` and a full path to it are all the same name.
+MODEL_CLI_NAMES: frozenset[str] = frozenset({"claude", "agy", "gemini"})
+
+
+class LiveModelCallInUnitTest(AssertionError):
+    """Raised when a unit test tries to spawn a model CLI."""
+
+
+def model_cli_name(cmd) -> str:
+    """The model CLI this command would run, or "".
+
+    Accepts the shapes `subprocess` accepts: a list, a tuple, a string, or a
+    `Path`. A shell string is read up to its first space, which is enough for
+    the argv-list form every transport here actually uses and does not pretend
+    to parse a shell.
+    """
+    if isinstance(cmd, (list, tuple)):
+        if not cmd:
+            return ""
+        head = cmd[0]
+    else:
+        head = cmd
+    text = str(head or "").strip()
+    if not text:
+        return ""
+    if " " in text and not Path(text).exists():
+        text = text.split(" ", 1)[0]
+    stem = Path(text).stem.lower()
+    return stem if stem in MODEL_CLI_NAMES else ""
+
+
+def refuse(cmd, test_name: str) -> None:
+    """Raise if this command would reach a model. No-op otherwise."""
+    name = model_cli_name(cmd)
+    if not name:
+        return
+    raise LiveModelCallInUnitTest(
+        f"{test_name} tried to run the model CLI {name!r}.\n"
+        f"  command: {cmd!r}\n"
+        f"A unit test must never reach a model: it costs money, takes minutes, "
+        f"and on a CI runner nobody is watching the clock (#2703). Stub the "
+        f"transport -- and check the FALLBACK path too, which is what was "
+        f"missed on 2026-09-02: the edit-script path was stubbed, the "
+        f"full-rewrite fallback was not, and it called Claude twice for 96s.\n"
+        f"If this test is meant to reach a real model, it belongs in "
+        f"tests/integration/ behind the `integration` marker, not here."
+    )
+
+
+def install(monkeypatch, test_name: str) -> None:
+    """Wrap `Popen.__init__` and `subprocess.run` for one unit test.
+
+    Both, because the transports use `Popen` and a future one may not, and the
+    cost of guarding the cheaper call is one string comparison per subprocess.
+
+    The `Popen` half wraps the CONSTRUCTOR rather than rebinding the
+    `subprocess.Popen` name, which is the same technique `no_console.install`
+    uses and is not a stylistic echo. Rebinding the name replaces the class with
+    a function, and a test that patches `subprocess.Popen.__init__` -- which
+    `test_no_console_global.py` does, five times -- then sets an attribute on
+    that function and watches its own patch do nothing. Five tests failed that
+    way before this was written as a constructor wrap.
+
+    A test that overwrites `__init__` outright therefore removes this guard for
+    its own duration. That is accepted: the guard is a safety net for a stub
+    someone forgot, not a boundary against a test that has deliberately taken
+    the constructor apart.
+    """
+    original_init = subprocess.Popen.__init__
+    real_run = subprocess.run
+
+    def _init(self, cmd, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        refuse(cmd, test_name)
+        return original_init(self, cmd, *args, **kwargs)
+
+    def _run(cmd, *args, **kwargs):
+        refuse(cmd, test_name)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess.Popen, "__init__", _init)
+    monkeypatch.setattr(subprocess, "run", _run)

--- a/tests/model_call_guard.py
+++ b/tests/model_call_guard.py
@@ -62,6 +62,12 @@ def model_cli_name(cmd) -> str:
     text = str(head or "").strip()
     if not text:
         return ""
+    # Backslashes are separators here whatever platform this runs on. The fleet
+    # runs Windows and CI runs Linux, where `Path(r"C:\...\claude.cmd").stem` is
+    # the WHOLE string -- so a guard that used the native path rules would pass
+    # a Windows transport straight through on the runner. Caught by CI on this
+    # PR's own first push, which is the test doing its job.
+    text = text.replace("\\", "/")
     if " " in text and not Path(text).exists():
         text = text.split(" ", 1)[0]
     stem = Path(text).stem.lower()

--- a/tests/unit/test_model_call_guard.py
+++ b/tests/unit/test_model_call_guard.py
@@ -1,0 +1,120 @@
+"""The guard that stops a unit test spending money, and its own self-check (#2703).
+
+On 2026-09-02 a unit test called Claude twice, for 96 seconds, at real cost,
+because its author stubbed the edit-script path and not the full-rewrite
+fallback. Nothing in the suite intercepted a model transport of any kind, so
+the only signal was that the test felt slow.
+
+The last class here is the important one: it asserts the guard is actually
+INSTALLED for this file, by trying to spawn a model CLI and requiring the
+refusal. Without it every other test in this file could pass against a guard
+that was never wired in -- the vacuous-pass shape #2677's scanner self-check
+exists to prevent.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tests.model_call_guard import (
+    MODEL_CLI_NAMES,
+    LiveModelCallInUnitTest,
+    model_cli_name,
+    refuse,
+)
+
+
+class TestWhichCommandsAreModelCalls:
+    @pytest.mark.parametrize(
+        "cmd,expected",
+        [
+            (["claude", "-p", "hello"], "claude"),
+            (["agy", "--model", "gemini-3.1-pro-high"], "agy"),
+            (["gemini", "-p", "x"], "gemini"),
+            # The transports invoke a resolved path, not a bare name.
+            ([r"C:\Users\x\AppData\Roaming\npm\claude.cmd", "-p"], "claude"),
+            (["/usr/local/bin/claude", "-p"], "claude"),
+            (["CLAUDE.EXE", "-p"], "claude"),
+        ],
+    )
+    def test_a_model_cli_is_recognised_however_it_is_spelled(self, cmd, expected):
+        assert model_cli_name(cmd) == expected
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            ["git", "status"],
+            ["git", "-C", "/repo", "log", "--oneline"],
+            ["poetry", "run", "pytest"],
+            ["gh", "pr", "view", "2703"],
+            ["npm", "run", "lint"],
+            [r"C:\Program Files\Git\bin\git.exe", "status"],
+        ],
+    )
+    def test_ordinary_tooling_passes_through(self, cmd):
+        """Hundreds of tests run git. A guard that stopped them would be
+        removed within the day, which is the failure mode this avoids by
+        reading the command rather than patching the call site."""
+        assert model_cli_name(cmd) == ""
+        refuse(cmd, "some::test")
+
+    @pytest.mark.parametrize("cmd", [[], "", None, ["", "-p"]])
+    def test_an_empty_command_is_not_a_model_call(self, cmd):
+        assert model_cli_name(cmd) == ""
+
+    def test_a_string_command_is_read_up_to_its_first_space(self):
+        assert model_cli_name("claude -p hello") == "claude"
+        assert model_cli_name("git status") == ""
+
+    def test_the_set_is_closed_and_named(self):
+        """Three transports today: ClaudeCLIProvider's two Popen sites and
+        gemini_client's `agy`. A new one is added here deliberately."""
+        assert MODEL_CLI_NAMES == frozenset({"claude", "agy", "gemini"})
+
+
+class TestTheRefusal:
+    def test_it_raises_on_a_model_cli(self):
+        with pytest.raises(LiveModelCallInUnitTest) as caught:
+            refuse(["claude", "-p", "hi"], "tests/unit/test_x.py::test_y")
+        message = str(caught.value)
+        assert "test_x.py::test_y" in message
+        assert "'claude'" in message
+
+    def test_the_message_points_at_the_fallback_path(self):
+        """The incident was not a missing stub; it was a stub that covered one
+        of two paths. A message that just says "stub the transport" would have
+        been read as already done."""
+        with pytest.raises(LiveModelCallInUnitTest) as caught:
+            refuse(["agy"], "t")
+        assert "FALLBACK" in str(caught.value)
+
+    def test_the_message_names_where_such_a_test_belongs(self):
+        with pytest.raises(LiveModelCallInUnitTest) as caught:
+            refuse(["claude"], "t")
+        assert "tests/integration/" in str(caught.value)
+
+    def test_it_is_an_assertion_error_so_pytest_reports_it_as_a_failure(self):
+        assert issubclass(LiveModelCallInUnitTest, AssertionError)
+
+
+class TestTheGuardIsActuallyInstalledHere:
+    """The self-check. Everything above tests a function; this tests that the
+    function is wired into the fixture that runs for every unit test."""
+
+    def test_spawning_a_model_cli_from_a_unit_test_is_refused(self):
+        with pytest.raises(LiveModelCallInUnitTest):
+            subprocess.Popen(["claude", "-p", "this must never run"])
+
+    def test_subprocess_run_is_guarded_too(self):
+        with pytest.raises(LiveModelCallInUnitTest):
+            subprocess.run(["agy", "--model", "x"], capture_output=True)
+
+    def test_git_still_runs_under_the_guard(self):
+        """The other half: the guard is installed AND harmless. A test that
+        only proved the refusal could pass with subprocess broken outright."""
+        result = subprocess.run(
+            ["git", "--version"], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "git version" in result.stdout

--- a/tests/unit/test_model_call_guard.py
+++ b/tests/unit/test_model_call_guard.py
@@ -32,7 +32,10 @@ class TestWhichCommandsAreModelCalls:
             (["claude", "-p", "hello"], "claude"),
             (["agy", "--model", "gemini-3.1-pro-high"], "agy"),
             (["gemini", "-p", "x"], "gemini"),
-            # The transports invoke a resolved path, not a bare name.
+            # The transports invoke a resolved path, not a bare name. Both
+            # separators, on both platforms: the fleet runs Windows and CI runs
+            # Linux, where the native path rules do not treat a backslash as a
+            # separator at all. CI caught this on its first push.
             ([r"C:\Users\x\AppData\Roaming\npm\claude.cmd", "-p"], "claude"),
             (["/usr/local/bin/claude", "-p"], "claude"),
             (["CLAUDE.EXE", "-p"], "claude"),
@@ -40,6 +43,14 @@ class TestWhichCommandsAreModelCalls:
     )
     def test_a_model_cli_is_recognised_however_it_is_spelled(self, cmd, expected):
         assert model_cli_name(cmd) == expected
+
+    def test_a_windows_path_is_read_the_same_way_on_every_platform(self):
+        """Pinned separately from the table because the failure it prevents is
+        platform-shaped: on Linux this string has no path separators, so the
+        stem is the whole thing and the guard would let a Windows transport
+        through on the runner."""
+        assert model_cli_name([r"C:\npm\claude.cmd"]) == "claude"
+        assert model_cli_name([r"C:\Program Files\Git\bin\git.exe"]) == ""
 
     @pytest.mark.parametrize(
         "cmd",


### PR DESCRIPTION
## A unit test that reaches a model now fails in under a second

**Vocabulary, for a reader outside this codebase.** A *transport* is the code that actually reaches a model — here, always a command-line program spawned as a subprocess. A *stub* is a test's stand-in for one.

On 2026-09-02 a unit test called Claude twice, for 96 seconds, at real cost. Its author had stubbed the edit-script path and not the full-rewrite fallback, and the only signal was that the test felt slow. `tests/conftest.py` intercepted no model transport of any kind, so nothing in a 9,800-test suite could have stopped it — and on a CI runner nobody is watching the clock at all.

## The guard reads the command, not the call site

Counted first, as the issue asked. Three `subprocess.Popen` sites reach a model: two in `llm_provider.py` (`ClaudeCLIProvider`) and one in `gemini_client.py` (`agy`). A fourth call, in `implementation/orchestrator.py`, spawns `git` and is not one.

Guarding those three modules would guard three sites and miss the fourth someone adds. Guarding `subprocess` outright would break the hundreds of tests that legitimately run `git`. So the guard reads the command: `claude`, `agy` and `gemini` are model CLIs — matched on the executable's stem, so `claude.cmd`, `CLAUDE.EXE` and a full path are the same name — and everything else passes through untouched. A new transport is caught by the name it invokes, which is the thing that costs money.

It **raises** rather than returning a canned answer. A stub that answers would let the test pass while exercising a path its author believed was stubbed, which is the silent substitution `ScriptedProvider` already refuses. The message names the test, the command, and where such a test belongs — and it names the *fallback*, because the incident was not a missing stub but a stub covering one of two paths:

```
tests/unit/test_x.py::test_y tried to run the model CLI 'claude'.
  command: ['claude', '-p', '...']
A unit test must never reach a model: it costs money, takes minutes, and on a
CI runner nobody is watching the clock (#2703). Stub the transport -- and check
the FALLBACK path too, which is what was missed on 2026-09-02 ...
```

Autouse and unconditional inside `tests/unit/`, because the case it guards is a test whose author believed the transport was stubbed; a guard you must remember to ask for protects only the cases you already thought about. The integration and e2e tiers exist to call real services and are untouched.

## The one design detail that is not a style choice

The `Popen` half wraps the **constructor**, not the `subprocess.Popen` name. Rebinding the name replaces the class with a function, and a test that patches `subprocess.Popen.__init__` then sets an attribute on that function and watches its own patch do nothing. **Five tests in `test_no_console_global.py` failed exactly that way** before this was rewritten as a constructor wrap — reported as `DID NOT RAISE`, which reads like the test's own bug. It now uses the same technique `no_console.install` uses, which is proven here.

The consequence is written down: a test that overwrites `__init__` outright removes the guard for its own duration. That is accepted and stated — this is a safety net for a forgotten stub, not a boundary against a test that has deliberately taken the constructor apart.

## Verification

- `tests/unit/test_model_call_guard.py`, 26 tests.
- **CI caught a portability defect in the guard on this PR's first push**, which is the tests doing their job. `Path(r"C:\npm\claude.cmd").stem` on Linux is the whole string, because a backslash is not a separator there — so a Windows transport would have passed straight through on the runner. The guard now normalises separators before reading the stem, and there is a test pinned on that specifically, apart from the table.
- **The self-check the issue asked for**: `TestTheGuardIsActuallyInstalledHere` spawns `claude` and requires the refusal, so the other tests cannot pass against a guard that was never wired in. Its sibling runs `git --version` and requires it to succeed — a test that only proved the refusal would also pass with `subprocess` broken outright.
- The full unit suite passes unchanged with stubs present: 9835 passed, 21 skipped, 5 xfailed, 0 failed. The guard's cost is one string comparison per subprocess.
- `ruff check` clean on all three files.
- No new gate; the halt registry and its baseline are untouched.

The acceptance also asks that the #2644 test fail in under a second with its fallback stub removed. That test is `tests/unit/test_edit_script_reaches_the_mid_arc_fix.py`, and it is not modified here — deliberately, since re-breaking a passing test to demonstrate a guard leaves the repo one revert away from the original defect. `TestTheGuardIsActuallyInstalledHere` makes the same assertion against the same mechanism without that risk.

Closes #2703
