### PR TITLE
feat: a poll that ends when its pull request does (Closes #2702)

### DIFF
--- a/assemblyzero/core/pr_poll.py
+++ b/assemblyzero/core/pr_poll.py
@@ -1,0 +1,106 @@
+"""When to stop polling a pull request (#2702).
+
+Two backgrounded shell loops from the 2026-09-01 session were still running
+twelve hours later, polling the GitHub API every thirty seconds for PRs that had
+merged that night:
+
+    until [ "$(gh api repos/.../pulls/2691 --jq '.mergeable_state')" = "clean" ]
+    do sleep 30; done
+
+**A merged PR reports `mergeable_state` as `unknown`, and never as `clean`.** So
+the loop's only exit condition becomes unreachable at the moment its job is
+done. It cannot notice that it has finished; it can only be killed. Both loops
+surfaced as `2 shells still running` in a completion line, which the operator
+read as two agents.
+
+The documented merge sequence is where that loop comes from, so the same shape
+is in every session that follows it and in twelve one-shot tools in `tools/`.
+
+## The rule
+
+A poll ends for one of three reasons, and only the first was ever checked:
+
+* **ready** -- `clean`, or `unstable` when the caller accepts it. `unstable`
+  means only non-required checks are failing and `gh pr merge` succeeds, which
+  is what a PR that removes its own failing check looks like.
+* **gone** -- `merged` or `closed`. The work is done or abandoned; there is
+  nothing left to wait for, whatever `mergeable_state` says.
+* **stuck** -- `dirty` (a conflict) or `behind` (needs a rebase). Neither
+  resolves by waiting.
+
+Anything else keeps polling, bounded. `blocked` is deliberately in that group:
+it usually means the approving review has not landed yet, and it does resolve on
+its own.
+
+The decision is a pure function of one API payload so it can be tested against
+the exact JSON shape a merged PR returns, which is what the twelve-hour loops
+were never able to see.
+"""
+
+from __future__ import annotations
+
+#: What one poll concluded.
+VERDICT_READY = "ready"
+VERDICT_GONE = "gone"
+VERDICT_STUCK = "stuck"
+VERDICT_WAIT = "wait"
+VERDICTS: tuple[str, ...] = (
+    VERDICT_READY, VERDICT_GONE, VERDICT_STUCK, VERDICT_WAIT,
+)
+
+#: Mergeable states a merge can proceed from. `unstable` is included by the
+#: caller's choice, not by default: a PR that removes the very check making it
+#: unstable can never reach `clean` (#2585's self-referential landings), while
+#: an ordinary PR should wait for its checks.
+STATE_CLEAN = "clean"
+STATE_UNSTABLE = "unstable"
+
+#: States that will not improve by waiting. Measured on the 2026-07-30 fleet
+#: run: 328 polls sat in `behind` for about 55 minutes and four PRs burned the
+#: whole budget without ever clearing.
+STUCK_STATES: frozenset[str] = frozenset({"dirty", "behind"})
+
+#: The three fields one `gh api repos/{repo}/pulls/{n}` call already returns.
+#: Nothing extra is fetched to answer this; the old loop asked for one of them
+#: and threw the other two away.
+POLL_FIELDS: tuple[str, ...] = ("mergeable_state", "merged", "state")
+
+
+def poll_verdict(payload: dict, *, accept_unstable: bool = False) -> str:
+    """What this PR's current state says a poller should do.
+
+    Terminal-first, deliberately. A merged PR's `mergeable_state` is `unknown`,
+    so a reading that consulted the state before the terminal fields would put
+    the finished case in the same bucket as "no information yet" -- which is
+    exactly the bucket the twelve-hour loops sat in.
+    """
+    if payload.get("merged") is True:
+        return VERDICT_GONE
+    if str(payload.get("state") or "").lower() == "closed":
+        return VERDICT_GONE
+    state = str(payload.get("mergeable_state") or "").lower()
+    if state == STATE_CLEAN or (accept_unstable and state == STATE_UNSTABLE):
+        return VERDICT_READY
+    if state in STUCK_STATES:
+        return VERDICT_STUCK
+    return VERDICT_WAIT
+
+
+def describe(verdict: str, payload: dict) -> str:
+    """One line a human can act on, naming the fields it read."""
+    state = str(payload.get("mergeable_state") or "unknown")
+    if verdict == VERDICT_GONE:
+        how = "merged" if payload.get("merged") is True else "closed"
+        return (
+            f"the pull request is already {how}; nothing left to wait for "
+            f"(mergeable_state reads {state!r}, which is what a merged PR "
+            f"always reports)"
+        )
+    if verdict == VERDICT_READY:
+        return f"mergeable_state is {state!r} -- ready to merge"
+    if verdict == VERDICT_STUCK:
+        return (
+            f"mergeable_state is {state!r}, which does not resolve by waiting: "
+            f"'dirty' is a conflict and 'behind' needs a rebase"
+        )
+    return f"mergeable_state is {state!r} -- still waiting"

--- a/tests/tools/test_dependabot_review.py
+++ b/tests/tools/test_dependabot_review.py
@@ -190,12 +190,26 @@ class TestWaitForMergeable:
     where cerberus-az took longer than POLL_INTERVAL_S to arrive)."""
 
     def _stub_state(self, monkeypatch, states):
-        """Make `run` return a sequence of mergeable_state values."""
+        """Make `run` return a sequence of mergeable_state values.
+
+        #2702: the call now asks for three fields and parses JSON, because a
+        merged PR reports `mergeable_state` as `unknown` and a poll reading
+        that one field cannot tell "not ready yet" from "finished without me".
+        A bare-string stub parses as `{}`, reads as `wait`, and sits here for
+        the whole 900-second budget -- which is how this stub announced the
+        change: by hanging rather than failing.
+
+        A dict entry passes through, for a case that needs `merged` or `state`.
+        """
         it = iter(states)
 
         def _capture(cmd, *args, **kwargs):
+            state = next(it)
+            payload = state if isinstance(state, dict) else {
+                "mergeable_state": state, "merged": False, "state": "open",
+            }
             return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout=next(it), stderr=""
+                args=cmd, returncode=0, stdout=json.dumps(payload), stderr=""
             )
 
         monkeypatch.setattr(dependabot_review, "run", mock.Mock(side_effect=_capture))
@@ -216,6 +230,42 @@ class TestWaitForMergeable:
         self._stub_state(monkeypatch, ["dirty"])
         assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
 
+    def test_a_pr_merged_by_another_route_stops_the_wait(self, monkeypatch):
+        """#2702: `mergeable_state` is `unknown` on a merged PR and never
+        `clean`, so before this the poll sat out its whole 900-second budget on
+        a PR that had already landed. Two shell loops with the same condition
+        and no budget polled for twelve hours."""
+        self._stub_state(monkeypatch, [
+            {"mergeable_state": "blocked", "merged": False, "state": "open"},
+            {"mergeable_state": "unknown", "merged": True, "state": "closed"},
+        ])
+        assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
+
+    def test_a_closed_pr_stops_the_wait(self, monkeypatch):
+        self._stub_state(monkeypatch, [
+            {"mergeable_state": "unknown", "merged": False, "state": "closed"},
+        ])
+        assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
+
+    def test_an_unreadable_answer_says_so_on_the_first_poll(
+        self, monkeypatch, capsys
+    ):
+        """An answer this loop cannot read is indistinguishable from 'not
+        ready yet', so it waits out the whole budget in silence. It cost 900
+        real seconds in this very test file when a stub still returned the
+        single-field shape."""
+        monkeypatch.setattr(dependabot_review, "MERGEABLE_TIMEOUT_S", 0.01)
+        monkeypatch.setattr(
+            dependabot_review, "run",
+            lambda *a, **kw: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout='"behind"', stderr=""),
+        )
+        monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
+        assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
+        out = capsys.readouterr().out
+        assert "cannot read" in out
+        assert "behind" in out
+
     def test_persistent_blocked_returns_false_at_timeout(self, monkeypatch):
         """#1399: persistent blocked polls until the full timeout, then
         returns False. Pre-#1399 it bailed after poll #2 (~10s), which
@@ -226,7 +276,12 @@ class TestWaitForMergeable:
         monkeypatch.setattr(
             dependabot_review, "run",
             lambda *a, **kw: subprocess.CompletedProcess(
-                args=[], returncode=0, stdout="blocked", stderr=""),
+                args=[], returncode=0,
+                stdout=json.dumps({
+                    "mergeable_state": "blocked", "merged": False,
+                    "state": "open",
+                }),
+                stderr=""),
         )
         monkeypatch.setattr(dependabot_review.time, "sleep", lambda s: None)
         assert dependabot_review.wait_for_mergeable(1, "owner/repo") is False
@@ -702,8 +757,18 @@ class TestWaitForMergeableTimeoutDeferred:
 
         def _fake(cmd, *a, **kw):
             polls.append(cmd)
+            # #2702: the poll asks for three fields now. A bare `"behind"`
+            # parses to a string, not an object, so it reads as no information
+            # -- and this test then spun for the whole real 900-second budget,
+            # because `time.time` is not stubbed here. That hang is what a
+            # single-field stub looks like after the field count changed.
             return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout='"behind"', stderr="")
+                args=cmd, returncode=0,
+                stdout=json.dumps({
+                    "mergeable_state": "behind", "merged": False,
+                    "state": "open",
+                }),
+                stderr="")
         monkeypatch.setattr(dependabot_review, "run", _fake)
         monkeypatch.setattr(dependabot_review.time, "sleep",
                             lambda s: sleeps.append(s))

--- a/tests/unit/test_pr_poll.py
+++ b/tests/unit/test_pr_poll.py
@@ -1,0 +1,208 @@
+"""A poll that ends when its PR does (#2702).
+
+Two backgrounded shell loops from 2026-09-01 were still polling the GitHub API
+every thirty seconds twelve hours after their PRs merged. The loop's exit
+condition was `mergeable_state == clean`, and **a merged PR reports
+`mergeable_state` as `unknown`** -- so the condition became unreachable at the
+moment the work was done. They surfaced as `2 shells still running`, which the
+operator read as two agents.
+
+The first class here is the whole finding: the exact JSON a merged PR returns,
+which is what those loops could never see.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[2] / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import wait_for_pr  # noqa: E402
+
+from assemblyzero.core.pr_poll import (  # noqa: E402
+    VERDICT_GONE,
+    VERDICT_READY,
+    VERDICT_STUCK,
+    VERDICT_WAIT,
+    describe,
+    poll_verdict,
+)
+
+#: What `gh api repos/{repo}/pulls/{n}` returns for PR #2691 after it merged as
+#: ddf7b545. `mergeable_state` is `unknown`, which is the entire defect.
+MERGED = {"mergeable_state": "unknown", "merged": True, "state": "closed"}
+
+
+class TestAMergedPullRequestEndsThePoll:
+    def test_the_shape_that_span_for_twelve_hours(self):
+        assert poll_verdict(MERGED) == VERDICT_GONE
+
+    def test_the_old_condition_would_never_have_fired(self):
+        """The control that makes the test above mean something: the loop was
+        not merely slow to notice, it could not notice at all."""
+        assert MERGED["mergeable_state"] != "clean"
+
+    def test_merged_is_read_before_mergeable_state(self):
+        """Terminal-first. A reading that consulted the state first would put
+        the finished case in the same bucket as 'no information yet', which is
+        the bucket the two loops sat in."""
+        assert poll_verdict(
+            {"mergeable_state": "blocked", "merged": True, "state": "open"}
+        ) == VERDICT_GONE
+
+    def test_a_closed_unmerged_pull_request_also_ends_it(self):
+        assert poll_verdict(
+            {"mergeable_state": "unknown", "merged": False, "state": "closed"}
+        ) == VERDICT_GONE
+
+    def test_the_message_says_why_the_state_looks_unhelpful(self):
+        said = describe(VERDICT_GONE, MERGED)
+        assert "already merged" in said
+        assert "what a merged PR always reports" in said
+
+
+class TestTheOtherVerdicts:
+    def test_clean_is_ready(self):
+        assert poll_verdict(
+            {"mergeable_state": "clean", "merged": False, "state": "open"}
+        ) == VERDICT_READY
+
+    def test_unstable_is_ready_only_when_the_caller_accepts_it(self):
+        """A PR that removes the very check making it unstable can never reach
+        `clean`; an ordinary PR should wait for its checks. The caller knows
+        which it has, so this is its choice and not a default."""
+        payload = {"mergeable_state": "unstable", "merged": False, "state": "open"}
+        assert poll_verdict(payload) == VERDICT_WAIT
+        assert poll_verdict(payload, accept_unstable=True) == VERDICT_READY
+
+    @pytest.mark.parametrize("state", ["dirty", "behind"])
+    def test_a_conflict_or_a_rebase_is_stuck(self, state):
+        assert poll_verdict(
+            {"mergeable_state": state, "merged": False, "state": "open"}
+        ) == VERDICT_STUCK
+
+    def test_blocked_keeps_waiting(self):
+        """#1399: it usually means the approving review has not landed, and it
+        does resolve on its own. Polling through it is the whole reason the
+        loop has a budget rather than a strike count."""
+        assert poll_verdict(
+            {"mergeable_state": "blocked", "merged": False, "state": "open"}
+        ) == VERDICT_WAIT
+
+    def test_an_empty_payload_waits_rather_than_deciding(self):
+        """A transient API failure must cost one interval, not a verdict."""
+        assert poll_verdict({}) == VERDICT_WAIT
+
+
+class TestTheLoopTerminates:
+    """The acceptance: a poll started against a PR that is then merged by
+    another path exits within one interval."""
+
+    def _wait(self, payloads, **kwargs):
+        served = iter(payloads)
+        slept: list[float] = []
+        clock = {"t": 0.0}
+
+        def _now():
+            return clock["t"]
+
+        def _sleep(seconds):
+            slept.append(seconds)
+            clock["t"] += seconds
+
+        verdict, _ = wait_for_pr.wait(
+            "owner/repo", 1, timeout=kwargs.pop("timeout", 900.0),
+            interval=kwargs.pop("interval", 15.0),
+            now=_now, sleep=_sleep, log=lambda *a: None, **kwargs,
+        )
+        return verdict, slept, served
+
+    def test_a_pr_merged_between_polls_ends_the_loop(self, monkeypatch):
+        payloads = iter([
+            {"mergeable_state": "blocked", "merged": False, "state": "open"},
+            MERGED,
+        ])
+        monkeypatch.setattr(wait_for_pr, "fetch", lambda r, p: next(payloads))
+        verdict, slept, _ = self._wait([])
+        assert verdict == VERDICT_GONE
+        assert slept == [15.0], "it waited exactly one interval, then stopped"
+
+    def test_a_pr_that_never_resolves_is_bounded(self, monkeypatch):
+        """The backstop. A loop that is wrong for a reason nobody predicted
+        still ends -- which the twelve-hour loops did not."""
+        monkeypatch.setattr(
+            wait_for_pr, "fetch",
+            lambda r, p: {"mergeable_state": "blocked", "merged": False,
+                          "state": "open"},
+        )
+        verdict, slept, _ = self._wait([], timeout=60.0, interval=15.0)
+        assert verdict == VERDICT_WAIT
+        assert sum(slept) <= 60.0
+
+    def test_a_ready_pr_returns_at_once(self, monkeypatch):
+        monkeypatch.setattr(
+            wait_for_pr, "fetch",
+            lambda r, p: {"mergeable_state": "clean", "merged": False,
+                          "state": "open"},
+        )
+        verdict, slept, _ = self._wait([])
+        assert verdict == VERDICT_READY
+        assert slept == []
+
+
+class TestTheExitCodesAreTheVerdict:
+    """The tool drops into a `&&` chain where the shell loop used to sit, so
+    the exit code has to carry the answer."""
+
+    def test_ready_is_zero_and_the_others_are_not(self, monkeypatch, capsys):
+        for payload, expected in (
+            ({"mergeable_state": "clean", "merged": False, "state": "open"},
+             wait_for_pr.EXIT_READY),
+            (MERGED, wait_for_pr.EXIT_GONE),
+            ({"mergeable_state": "dirty", "merged": False, "state": "open"},
+             wait_for_pr.EXIT_STUCK),
+        ):
+            monkeypatch.setattr(wait_for_pr, "fetch", lambda r, p, _p=payload: _p)
+            code = wait_for_pr.main(["--repo", "o/r", "--pr", "1"])
+            capsys.readouterr()
+            assert code == expected
+
+    def test_a_timeout_has_its_own_code(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            wait_for_pr, "fetch",
+            lambda r, p: {"mergeable_state": "blocked", "merged": False,
+                          "state": "open"},
+        )
+        monkeypatch.setattr(wait_for_pr.time, "sleep", lambda s: None)
+        code = wait_for_pr.main(
+            ["--repo", "o/r", "--pr", "1", "--timeout", "0", "--interval", "0"]
+        )
+        assert code == wait_for_pr.EXIT_TIMEOUT
+        assert "no verdict" in capsys.readouterr().out
+
+
+class TestFetchIsForgiving:
+    def test_a_failed_gh_call_reads_as_wait(self, monkeypatch):
+        class _Result:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(
+            wait_for_pr.subprocess, "run", lambda *a, **k: _Result()
+        )
+        assert wait_for_pr.fetch("o/r", 1) == {}
+        assert poll_verdict(wait_for_pr.fetch("o/r", 1)) == VERDICT_WAIT
+
+    def test_unparseable_output_reads_as_wait(self, monkeypatch):
+        class _Result:
+            returncode = 0
+            stdout = "not json"
+
+        monkeypatch.setattr(
+            wait_for_pr.subprocess, "run", lambda *a, **k: _Result()
+        )
+        assert wait_for_pr.fetch("o/r", 1) == {}

--- a/tools/dependabot_review.py
+++ b/tools/dependabot_review.py
@@ -81,6 +81,15 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assemblyzero.core.pr_poll import (  # noqa: E402
+    VERDICT_GONE,
+    VERDICT_READY,
+    VERDICT_STUCK,
+    poll_verdict,
+)
+
 GITHUB_USER = "martymcenroe"
 DEFAULT_REPO = f"{GITHUB_USER}/AssemblyZero"
 
@@ -914,14 +923,42 @@ def wait_for_mergeable(pr_number: int, repo: str) -> bool:
     start = time.time()
     deadline = start + MERGEABLE_TIMEOUT_S
     while time.time() < deadline:
+        # #2702: three fields, not one. A merged PR reports `mergeable_state`
+        # as `unknown` and never as `clean`, so a poll reading that field alone
+        # cannot tell "not ready yet" from "finished without me", and waits out
+        # its whole budget on a PR that landed by another route.
         result = run(["gh", "api", f"repos/{repo}/pulls/{pr_number}",
-                      "--jq", ".mergeable_state"])
-        state = (result.stdout or "").strip().strip('"')
+                      "--jq", "{mergeable_state:.mergeable_state,"
+                              "merged:.merged,state:.state}"])
+        raw = (result.stdout or "").strip()
+        try:
+            payload = json.loads(raw or "{}")
+        except ValueError:
+            payload = None
+        if not isinstance(payload, dict):
+            # Said out loud on the FIRST poll, not discovered after 900
+            # seconds. An answer this loop cannot read reads as "no
+            # information", which is indistinguishable from "not ready yet" --
+            # so without this line the tool waits out its entire budget in
+            # silence. That is exactly what happened when a test stub still
+            # returned the single-field shape after the field count changed.
+            print(
+                f"  WARNING: the mergeable query returned something this poll "
+                f"cannot read ({raw[:120]!r}). Treating it as no information; "
+                f"the poll will run to its {MERGEABLE_TIMEOUT_S}s bound unless "
+                f"it clears."
+            )
+            payload = {}
+        state = str(payload.get("mergeable_state") or "")
         elapsed = int(time.time() - start)
         print(f"  mergeable_state: {state} (elapsed {elapsed}s)")
-        if state in ("clean", "unstable"):
+        verdict = poll_verdict(payload, accept_unstable=True)
+        if verdict == VERDICT_READY:
             return True
-        if state in ("dirty", "behind"):
+        if verdict == VERDICT_GONE:
+            print("  already merged or closed -- nothing left to wait for")
+            return False
+        if verdict == VERDICT_STUCK:
             # #1975: neither resolves by waiting. 'dirty' is a merge
             # conflict; 'behind' means the head is behind base and clears
             # only when the branch is rebased. Measured on the 2026-07-30

--- a/tools/wait_for_pr.py
+++ b/tools/wait_for_pr.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Wait for a pull request to be mergeable, and stop when it cannot be (#2702).
+
+The shell loop the merge sequence documents cannot end once its PR has merged,
+because a merged PR reports `mergeable_state` as `unknown` and never as
+`clean`. Two of them polled the API every thirty seconds for twelve hours after
+their PRs landed.
+
+    poetry run python tools/wait_for_pr.py --repo martymcenroe/AssemblyZero --pr 2691
+
+Exit codes are the verdict, so this drops into a `&&` chain where the loop used
+to sit:
+
+    0  ready      -- merge it
+    2  gone       -- already merged or closed; do not merge, do not wait
+    3  stuck      -- a conflict or a rebase is needed
+    4  timed out  -- the bound was reached with no verdict
+
+Bounded by `--timeout`, so a poll that is wrong for a reason nobody predicted
+still ends. That is the backstop, not the fix: the fix is that the terminal
+states are checked at all.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from assemblyzero.core.pr_poll import (  # noqa: E402
+    POLL_FIELDS,
+    VERDICT_GONE,
+    VERDICT_READY,
+    VERDICT_STUCK,
+    VERDICT_WAIT,
+    describe,
+    poll_verdict,
+)
+
+EXIT_READY = 0
+EXIT_GONE = 2
+EXIT_STUCK = 3
+EXIT_TIMEOUT = 4
+
+_EXIT_FOR = {
+    VERDICT_READY: EXIT_READY,
+    VERDICT_GONE: EXIT_GONE,
+    VERDICT_STUCK: EXIT_STUCK,
+}
+
+
+def fetch(repo: str, pr: int) -> dict:
+    """The three fields the verdict reads, in one call. {} on any failure.
+
+    An empty payload reads as `wait`, so a transient API failure costs one poll
+    interval rather than a wrong verdict. The bound is what stops that being
+    forever.
+    """
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/pulls/{pr}",
+         "--jq", "{" + ",".join(f"{f}:.{f}" for f in POLL_FIELDS) + "}"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    if result.returncode != 0:
+        return {}
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except ValueError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def wait(
+    repo: str, pr: int, *, timeout: float, interval: float,
+    accept_unstable: bool = False, now=time.time, sleep=time.sleep,
+    log=print,
+) -> tuple[str, dict]:
+    """Poll until a terminal verdict or the bound. Returns (verdict, payload)."""
+    deadline = now() + timeout
+    payload: dict = {}
+    while True:
+        payload = fetch(repo, pr)
+        verdict = poll_verdict(payload, accept_unstable=accept_unstable)
+        log(f"  {describe(verdict, payload)}")
+        if verdict != VERDICT_WAIT:
+            return verdict, payload
+        if now() >= deadline:
+            return VERDICT_WAIT, payload
+        sleep(interval)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument("--interval", type=float, default=15.0)
+    parser.add_argument(
+        "--accept-unstable", action="store_true",
+        help=(
+            "treat 'unstable' as ready. For a PR that removes the very check "
+            "making it unstable, which can never reach 'clean'"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    print(f"Waiting for {args.repo}#{args.pr} (bound {args.timeout:.0f}s):")
+    verdict, _ = wait(
+        args.repo, args.pr, timeout=args.timeout, interval=args.interval,
+        accept_unstable=args.accept_unstable,
+    )
+    if verdict == VERDICT_WAIT:
+        print(
+            f"  gave up after {args.timeout:.0f}s with no verdict. The PR is "
+            f"neither ready nor finished; look at its checks."
+        )
+        return EXIT_TIMEOUT
+    return _EXIT_FOR[verdict]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## A merged pull request reports `mergeable_state` as `unknown`, and never as `clean`

**Vocabulary, for a reader outside this codebase.** `mergeable_state` is a field GitHub returns for a pull request: `clean` means every required check passed, `blocked` usually means the approving review has not arrived, `dirty` is a merge conflict, `behind` needs a rebase. A *poll* is a loop that asks for it until the answer is one it can act on.

Two backgrounded shell loops from the 2026-09-01 session were still running twelve hours later, asking the API every thirty seconds about PRs that had merged that night:

```
until [ "$(gh api repos/.../pulls/2691 --jq '.mergeable_state')" = "clean" ]; do sleep 30; done
```

PR #2691 merged as `ddf7b545` and #2692 as `e64e18cb`. A merged PR's `mergeable_state` is `unknown`, so **the loop's only exit condition became unreachable at the moment its job was done.** It could not notice it had finished; it could only be killed. Both surfaced as `2 shells still running`, which the operator read as two agents.

## The rule, as a pure function

`assemblyzero/core/pr_poll.py` answers one question about one payload, and the answer is terminal-first — a reading that consulted `mergeable_state` before the terminal fields would put the finished case in the same bucket as "no information yet", which is the bucket the two loops sat in.

| verdict | when | why |
|---|---|---|
| **ready** | `clean`, or `unstable` if the caller accepts it | `unstable` means only non-required checks fail and `gh pr merge` succeeds |
| **gone** | `merged` or `closed` | nothing left to wait for, whatever the state says |
| **stuck** | `dirty`, `behind` | neither resolves by waiting |
| **wait** | anything else, including `blocked` | that one does resolve on its own (#1399) |

The three fields come from the call that already ran. The old loop asked for one of them and threw the other two away.

## A tool the merge sequence can call instead of embedding a loop

`tools/wait_for_pr.py --repo owner/name --pr N`. Exit codes carry the verdict — `0` ready, `2` gone, `3` stuck, `4` timed out — so it drops into a `&&` chain where the shell loop used to sit, and it is bounded, so a poll that is wrong for a reason nobody predicted still ends. **The bound is the backstop, not the fix**: the fix is that the terminal states are checked at all. A twelve-hour loop with a bound would have been a fifteen-minute loop that still learned nothing.

`dependabot_review.wait_for_mergeable` — the one poll that runs regularly rather than once — now reads the same verdict. Twelve one-shot landing tools in `tools/` carry their own copy of this loop; they are one-shots that already ran, all bounded by a timeout, and they are counted here rather than edited: `merge_aletheia_603_audit_gate`, `land_dependabot_skip_1251`, `land_aletheia_ci_oidc`, `land_aletheia_ci_pipestatus`, `hermes_add_ci_workflow`, `land_1104_auto_reviewer_fix`, `land_aletheia_775`, `generate_dependabot_yml`, `fleet_set_permission_mode`, `fleet_delete_pr_sentinel`, `fleet_remove_claude_key`.

## What changing the field count cost, and what that bought

Widening one query from one field to three broke two test stubs that still returned the single-field shape. One of them announced itself by **hanging for the full real 900-second budget** rather than failing, because an answer the loop cannot read is indistinguishable from "not ready yet" — the same confusion as the original bug, arriving from the other direction.

So the tool now says so on the first poll:

```
WARNING: the mergeable query returned something this poll cannot read ('"behind"').
Treating it as no information; the poll will run to its 900s bound unless it clears.
```

That line is worth more than the stub fix. In production the same silence would follow any change to what `gh` returns, and it would look like a slow PR rather than a broken query.

## Verification

- `tests/unit/test_pr_poll.py`, 18 tests. The first class is the finding itself: the exact payload PR #2691 returned after merging, asserted to end the poll — plus the control that the old condition could never have fired, so the test means something.
- `TestTheLoopTerminates` is the acceptance: a PR merged between two polls exits after exactly one interval, and a PR that never resolves is bounded.
- `tests/tools/test_dependabot_review.py` gains the merged-PR case, the closed case, and the unreadable-answer case; 148 pass in 15 seconds, down from a 900-second hang.
- Full unit and tools suites pass.
- `ruff check` clean on all five touched files.
- No new gate; the halt registry and its baseline are untouched.

The documented merge sequence in the universal `CLAUDE.md` is where the shell loop comes from. It lives outside this repo, so it is not changed here — `tools/wait_for_pr.py` is what it should call, and that is the note to carry over.

Closes #2702
