### PR TITLE
feat: the LLD's file list is a plan, not a contract (Closes #2736)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -433,15 +433,23 @@ GATE_REGISTRY: tuple[Gate, ...] = (
         _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 1),
     ),
     Gate(
-        "impl.path_enforcement", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
-        "Path not in LLD",
-        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 2),
+        "impl.path_enforcement", "impl", JUDGES_MODEL_OUTPUT, ACTION_ADVISE,
+        "is not in the LLD's Section 2.1 list",
+        decided_in="assemblyzero/hooks/file_write_validator.py::path_advisory",
         created_by="#188",
+        justified_by="#2736",
+        notes=(
+            "advisory since #2736 (operator ruling 2026-09-04): the LLD's file "
+            "list is a plan, not a contract. It refused four of issue #4's "
+            "seventeen shipped files on boostgauge main, three of them tests"
+        ),
     ),
     Gate(
         "impl.write_failed", "impl", JUDGES_INFRASTRUCTURE, ACTION_HALT,
         "Failed to write file",
-        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 3),
+        # Index 2, not 3: #2736 retired the path-enforcement raise above this
+        # one in the same function, and a site index is positional (#2738).
+        _s(f"{_TS}/nodes/implementation/orchestrator.py::implement_code::raise", 2),
     ),
     Gate(
         "impl.scenario_ratio_guard", "impl", JUDGES_UPSTREAM, ACTION_HALT,
@@ -1033,7 +1041,12 @@ def gate_key_of(message: str) -> str:
     return match.group(1) if match else ""
 
 
-def advised(key: str, message: str) -> str:
+#: What an advisory says about the run's fate when the caller does not say.
+#: True of every guard inside a bounded loop, which is what #2723 softened.
+ADVISORY_CONTINUES_DEFAULT = "Continuing; the budget decides."
+
+
+def advised(key: str, message: str, *, continues: str = "") -> str:
     """What an `advise` gate prints instead of ending the run (#2723).
 
     An advisory says the same sentence a halt used to say and does not route.
@@ -1042,6 +1055,14 @@ def advised(key: str, message: str) -> str:
     and it says plainly that the run continues, because the identical sentence
     was a terminal message for as long as these guards have existed and a
     reader will remember it that way.
+
+    ``continues`` is that plain statement. It defaults to the stagnation
+    guards' sentence, which is true of a guard inside a bounded loop: the run
+    goes on and a budget above it decides when to stop. A gate outside such a
+    loop must say something else rather than inherit a sentence that is not
+    true of it -- `impl.path_enforcement` (#2736) writes the file and no budget
+    is involved, so an inherited "the budget decides" would be prose nobody
+    could act on.
 
     Refuses a key whose row still halts. An advisory printed by a gate that
     then ends the run anyway would be the worst of both: a log that says the
@@ -1056,4 +1077,5 @@ def advised(key: str, message: str) -> str:
             f"the run. Change the row's action first, and lower the ratchet "
             f"baseline in the same PR (#2720)."
         )
-    return f"{message.rstrip()} Continuing; the budget decides. [gate:{key}]"
+    tail = (continues or ADVISORY_CONTINUES_DEFAULT).strip()
+    return f"{message.rstrip()} {tail} [gate:{key}]"

--- a/assemblyzero/hooks/file_write_validator.py
+++ b/assemblyzero/hooks/file_write_validator.py
@@ -1,13 +1,35 @@
 """Pre-write validation hook for LLD path enforcement.
 
 Issue #188: Validates that file writes target paths specified in the LLD.
-Rejects writes to non-LLD paths with helpful error messages including
-the closest matching LLD path suggestion.
+Reports writes to non-LLD paths with helpful messages including the closest
+matching LLD path suggestion.
+
+**#2736: the LLD's file list is a plan, not a contract.** Operator ruling of
+2026-09-04. `validate_file_write` still answers the question it always
+answered -- is this path in the list -- and `path_advisory` turns that answer
+into the sentence the implementation stage prints. Nothing here ends a run any
+more. The evidence was the answer-key audit against boostgauge `main`: four of
+issue #4's seventeen shipped files, three of them tests, were refused for
+paths LLD-004 never named. The design named four files; the build wrote eight.
+
+The traversal check is the one refusal that survives as a refusal, because it
+is not a judgement about a plan -- a path escaping the repository is an
+infrastructure fact, and no ruling about design documents speaks to it.
 """
 
 from difflib import SequenceMatcher
 from pathlib import PurePosixPath
 from typing import TypedDict
+
+from assemblyzero.core.gate_registry import advised
+
+#: What `path_advisory` says instead of refusing (#2736). The Section 2.1
+#: reference is the LLD heading the path list is read from, named so a reader
+#: of the log knows which document to open.
+PATH_GATE_KEY = "impl.path_enforcement"
+PATH_ADVISORY_CONTINUES = (
+    "The file is written; the LLD's file list is a plan, not a contract."
+)
 
 
 class PathValidationResult(TypedDict):
@@ -124,3 +146,37 @@ def _paths_equivalent(path1: str, path2: str) -> bool:
 def _is_path_traversal(path: str) -> bool:
     """Check if a path contains directory traversal attempts."""
     return ".." in PurePosixPath(path).parts
+
+
+def path_advisory(requested_path: str, allowed_paths: set[str]) -> str:
+    """What `impl.path_enforcement` says about a path it did not expect (#2736).
+
+    Returns "" when the path is in the LLD's list, when the LLD names no paths
+    at all, or when the gate has nothing to say. Otherwise returns the
+    advisory, tagged with the gate key by `advised()` so a log line can be
+    counted against the registry rather than matched as prose.
+
+    This is the whole of the gate now. It is called for its sentence, never for
+    a decision: every caller writes the file either way. `advised()` refuses a
+    key whose registry row still halts, so this function cannot be wired up
+    while the row and the code disagree.
+
+    Path traversal is deliberately NOT advisory here -- it is reported by
+    `validate_file_write` and handled by the caller as the infrastructure fault
+    it is, not as a disagreement with a design document.
+    """
+    if not allowed_paths:
+        return ""
+    result = validate_file_write(requested_path, allowed_paths)
+    if result["allowed"]:
+        return ""
+    suggestion = (
+        f" Closest planned path: '{result['closest_match']}'."
+        if result["closest_match"]
+        else ""
+    )
+    return advised(
+        PATH_GATE_KEY,
+        f"'{requested_path}' is not in the LLD's Section 2.1 list.{suggestion}",
+        continues=PATH_ADVISORY_CONTINUES,
+    )

--- a/assemblyzero/speedrun/answer_key.py
+++ b/assemblyzero/speedrun/answer_key.py
@@ -192,16 +192,26 @@ def _gate_stub_count(content: str) -> tuple[bool, str]:
 
 
 def _gate_path_enforcement(rel: str, lld_content: str) -> tuple[bool, str]:
-    """impl.path_enforcement: the file is one the LLD allows the run to write."""
-    from assemblyzero.hooks.file_write_validator import validate_file_write
+    """impl.path_enforcement: what the gate says about a file it did not plan.
+
+    Advisory since #2736, so this can no longer report a refusal: the gate says
+    its sentence and the implementer writes the file. The sentence is still
+    carried into the report, because "the plan did not name this and it was
+    written anyway" is worth reading -- it is the refusal's evidence, minus the
+    consequence.
+
+    It calls `path_advisory`, the same function the implementation stage calls,
+    so the audit cannot pass while the shipped gate would still object.
+    """
+    from assemblyzero.hooks.file_write_validator import path_advisory
     from assemblyzero.utils.lld_path_enforcer import extract_paths_from_lld
 
     spec = extract_paths_from_lld(lld_content)
     allowed = set(spec.get("all_allowed_paths") or ())
     if not allowed:
         return False, "LLD declares no paths; the gate is inert"
-    result = validate_file_write(rel, allowed)
-    return (not result.get("allowed", True)), str(result.get("reason", ""))
+    notice = path_advisory(rel, allowed)
+    return False, notice or "Path matches LLD specification"
 
 
 def _gate_lld_mechanical(lld_content: str, repo: Path, issue: int) -> tuple[bool, str]:
@@ -365,11 +375,14 @@ def render(repo: Path, verdicts: list[Verdict], coverage: AuditCoverage,
         f"Generated {stamp}. The shipped code on main is the answer key; a "
         "refusal below is a gate rejecting content the operator shipped.",
         "",
-        "A refusal on `impl.path_enforcement` means the LLD's file plan and "
-        "the shipped file names disagree: the gate holds the drafter to a "
-        "plan the hand build did not follow. A refusal on the test-file gates "
-        "means a hand-written test delegates its assertion to a helper the "
-        "gate cannot see.",
+        "`impl.path_enforcement` can no longer refuse anything (#2736, "
+        "operator ruling 2026-09-04: the LLD's file list is a plan, not a "
+        "contract). Where it once refused, its row now carries the advisory "
+        "the implementation stage prints while writing the file anyway, so "
+        "the disagreement between plan and build stays visible without a "
+        "consequence attached. A refusal on the test-file gates means a "
+        "hand-written test states its expectation in a way the gate does not "
+        "recognise.",
         "",
         "## Coverage — counted, not estimated",
         "",

--- a/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
+++ b/assemblyzero/workflows/testing/nodes/implementation/orchestrator.py
@@ -19,7 +19,7 @@ from assemblyzero.workflows.testing.nodes.implementation.edit_script_fix import 
     response_is_a_regeneration,
     should_use_edit_script,
 )
-from assemblyzero.hooks.file_write_validator import validate_file_write
+from assemblyzero.hooks.file_write_validator import path_advisory
 from assemblyzero.telemetry import emit
 from assemblyzero.utils.cost_tracker import accumulate_node_cost
 from assemblyzero.utils.lld_path_enforcer import (
@@ -869,17 +869,14 @@ def implement_code(state: TestingWorkflowState) -> dict[str, Any]:
         if token_estimate > 150000:
             print(f"        [WARN] Context approaching limit ({token_estimate} tokens)")
 
-        # Issue #188: Validate file path against LLD
-        if path_spec["all_allowed_paths"]:
-            validation = validate_file_write(filepath, path_spec["all_allowed_paths"])
-            if not validation["allowed"]:
-                print(f"        [PATH] REJECTED: {validation['reason']}")
-                emit("workflow.halt_and_plan", repo="", metadata={"filepath": filepath, "reason": "max_retries_exceeded"})
-                raise ImplementationError(
-                    filepath=filepath,
-                    reason=f"Path not in LLD: {validation['reason']}",
-                    response_preview=None,
-                )
+        # Issue #188, softened by #2736: say what the plan did not name, then
+        # write the file anyway. The operator ruled on 2026-09-04 that the
+        # LLD's file list is a plan, not a contract. As a refusal this gate
+        # rejected four of the seventeen files boostgauge's hand build shipped
+        # for issue #4 -- three of them tests the design had not thought of.
+        notice = path_advisory(filepath, path_spec["all_allowed_paths"])
+        if notice:
+            print(f"        [PATH] {notice}")
 
         # Build prompt for this single file
         prompt = build_single_file_prompt(

--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -2,15 +2,15 @@
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage or model_output_halt_rows rises above this. Lower it when a gate stops halting; raise it only with an operator ruling named in the new row's created_by, in the same PR.",
   "measured_against": {
     "files_scanned": 184,
-    "halt_sites": 152,
+    "halt_sites": 151,
     "gates": 96
   },
   "halt_rows_per_stage": {
-    "impl": 37,
+    "impl": 36,
     "lld": 15,
     "orchestrator": 16,
     "pr": 1,
     "spec": 19
   },
-  "model_output_halt_rows": 19
+  "model_output_halt_rows": 18
 }

--- a/tests/unit/test_implement_code_routing.py
+++ b/tests/unit/test_implement_code_routing.py
@@ -196,10 +196,11 @@ def test_generate_file_with_retry_passes_routed_model():
             "assemblyzero.workflows.testing.nodes.implementation.orchestrator.save_audit_file",
         ), patch(
             "assemblyzero.workflows.testing.nodes.implementation.orchestrator.emit",
-        ), patch(
-            "assemblyzero.workflows.testing.nodes.implementation.orchestrator.validate_file_write",
-            return_value=(True, None),
         ):
+            # #2736 removed the orchestrator's `validate_file_write` import
+            # along with the raise it guarded, so there is nothing left to
+            # patch here. The call under test is `generate_file_with_retry`,
+            # which never consulted it in the first place.
             generate_file_with_retry(
                 filepath="tests/__init__.py",
                 base_prompt="generate init",

--- a/tests/unit/test_path_advisory.py
+++ b/tests/unit/test_path_advisory.py
@@ -1,0 +1,145 @@
+"""The LLD's file list is a plan, not a contract (#2736).
+
+Operator ruling, 2026-09-04. `impl.path_enforcement` refused four of the
+seventeen files boostgauge's hand build shipped for issue #4 -- three of them
+tests the design had not thought of -- and every one of those files is correct
+code the operator wrote, reviewed and tagged. The gate may now say what it
+sees; it may not refuse the file and it may not end the run.
+
+The artifact that showed the problem is the answer-key audit against boostgauge
+`main`, which needs that repository on disk and so cannot run here. What CAN be
+pinned here is every mechanism the audit's result rests on: the row's action,
+the coupling that makes the advisory unprintable while the row halts, and the
+sentence itself over the four paths the audit refused.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assemblyzero.core.gate_registry import (
+    ACTION_ADVISE,
+    ACTION_HALT,
+    ADVISORY_CONTINUES_DEFAULT,
+    JUDGES_MODEL_OUTPUT,
+    advised,
+    gate_key_of,
+    registry_by_key,
+)
+from assemblyzero.hooks.file_write_validator import (
+    PATH_GATE_KEY,
+    path_advisory,
+    validate_file_write,
+)
+
+#: The paths LLD-004 named, as `extract_paths_from_lld` reads them off the
+#: shipped document. Authored from the audit's own output rather than derived,
+#: so this fixture cannot drift into agreeing with whatever the code does.
+LLD_004_PLANNED = {
+    "src/boostgauge/collector.py",
+    "src/boostgauge/collectors/windows.py",
+    "tests/unit/test_collector.py",
+    "tests/integration/test_windows_collector.py",
+    "tests/benchmark/test_windows_sweep.py",
+}
+
+#: The four files the hand build shipped that the plan did not name. Every one
+#: was refused before this ruling; the audit's `impl.path_enforcement` column
+#: read 7 ran / 4 refused, and reads 7 ran / 0 refused after it.
+SHIPPED_BUT_UNPLANNED = (
+    "src/boostgauge/collectors/__init__.py",
+    "tests/benchmark/test_sweep_cost.py",
+    "tests/integration/test_windows_sweep_crosscheck.py",
+    "tests/unit/test_collector_source_pin.py",
+)
+
+
+class TestTheRow:
+    def test_the_gate_advises_rather_than_halting(self):
+        assert registry_by_key()[PATH_GATE_KEY].action == ACTION_ADVISE
+
+    def test_it_still_judges_model_output(self):
+        """The classification is a fact about the gate and does not change
+        because its consequence did. Rewriting `judges` to make the
+        model-output halt count fall would be cooking the number the routing
+        policy is measured by."""
+        assert registry_by_key()[PATH_GATE_KEY].judges == JUDGES_MODEL_OUTPUT
+
+    def test_a_row_with_no_sites_says_where_it_lives(self):
+        row = registry_by_key()[PATH_GATE_KEY]
+        assert row.sites == ()
+        assert row.decided_in, "a row with no sites is otherwise unfindable"
+
+
+class TestTheAdvisory:
+    @pytest.mark.parametrize("rel", SHIPPED_BUT_UNPLANNED)
+    def test_every_file_the_audit_refused_now_gets_a_sentence(self, rel):
+        notice = path_advisory(rel, LLD_004_PLANNED)
+        assert notice, f"{rel} should draw an advisory, not silence"
+        assert rel in notice
+        assert "Section 2.1" in notice
+
+    @pytest.mark.parametrize("rel", sorted(LLD_004_PLANNED))
+    def test_a_planned_path_draws_no_sentence(self, rel):
+        assert path_advisory(rel, LLD_004_PLANNED) == ""
+
+    def test_it_carries_the_gate_key(self):
+        notice = path_advisory("tests/unit/test_collector_source_pin.py",
+                               LLD_004_PLANNED)
+        assert gate_key_of(notice) == PATH_GATE_KEY
+
+    def test_it_says_the_file_is_written(self):
+        """A reader of the log has seen this sentence end runs for as long as
+        the gate has existed, so the advisory has to say what happens now."""
+        notice = path_advisory("tests/benchmark/test_sweep_cost.py",
+                               LLD_004_PLANNED)
+        assert "The file is written" in notice
+
+    def test_it_does_not_borrow_the_stagnation_guards_sentence(self):
+        """No budget is involved in writing one file, so "the budget decides"
+        would be prose nobody could act on (#2736)."""
+        notice = path_advisory("tests/benchmark/test_sweep_cost.py",
+                               LLD_004_PLANNED)
+        assert ADVISORY_CONTINUES_DEFAULT not in notice
+
+    def test_an_lld_that_names_no_paths_leaves_the_gate_silent(self):
+        assert path_advisory("anything/at/all.py", set()) == ""
+
+    def test_it_names_the_closest_planned_path_when_there_is_one(self):
+        notice = path_advisory("tests/unit/test_collector_source_pin.py",
+                               LLD_004_PLANNED)
+        assert "tests/unit/test_collector.py" in notice
+
+
+class TestTheCouplingToTheRow:
+    def test_the_advisory_is_unprintable_while_the_row_halts(self):
+        """`path_advisory` reaches the log only through `advised()`, which
+        refuses a halting row. So flipping the row back to `halt` without
+        restoring the raise cannot leave a run that says it continued and then
+        did not -- this test fails first."""
+        assert registry_by_key()[PATH_GATE_KEY].action != ACTION_HALT
+        with pytest.raises(ValueError, match="halt row"):
+            advised("impl.write_failed", "Failed to write file: disk full.")
+
+
+class TestTraversalIsNotADesignDisagreement:
+    def test_a_path_escaping_the_repository_is_still_refused(self):
+        """The ruling is about a design document's file list. A path climbing
+        out of the tree is an infrastructure fact, and no ruling about plans
+        speaks to it -- `validate_file_write` still reports it."""
+        result = validate_file_write("../../etc/passwd", LLD_004_PLANNED)
+        assert result["allowed"] is False
+        assert "traversal" in result["reason"]
+
+
+class TestAdvisedTakesACustomContinuation:
+    def test_the_default_is_the_stagnation_guards_sentence(self):
+        message = advised("impl.stagnation.coverage", "Coverage stagnant.")
+        assert ADVISORY_CONTINUES_DEFAULT in message
+
+    def test_a_caller_can_say_something_true_of_its_own_gate(self):
+        message = advised("impl.stagnation.coverage", "Coverage stagnant.",
+                          continues="Something else entirely.")
+        assert "Something else entirely." in message
+        assert ADVISORY_CONTINUES_DEFAULT not in message
+        assert gate_key_of(message) == "impl.stagnation.coverage"

--- a/tests/unit/test_routing_policy.py
+++ b/tests/unit/test_routing_policy.py
@@ -117,15 +117,18 @@ class TestTheRatchet:
         assert halt_counts() == baseline["halt_rows_per_stage"]
 
     def test_the_ratchet_records_what_is_left(self):
-        """19 model-output rows still halt. The number is pinned so it can only
-        fall: this PR took it from 24, and the remaining fourteen impl rows,
-        four lld, five spec and one pr row are the rest of #2723."""
+        """18 model-output rows still halt. The number is pinned so it can only
+        fall: #2723 took it from 24 to 19 by retiring the five stagnation
+        guards, and #2736 took it to 18 by making `impl.path_enforcement`
+        advisory on the operator's ruling of 2026-09-04. The remaining thirteen
+        impl rows, four lld, five spec and one pr row are the rest of the
+        routing policy's scope."""
         baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
         remaining = [
             gate for gate in GATE_REGISTRY
             if gate.action == ACTION_HALT and gate.judges == JUDGES_MODEL_OUTPUT
         ]
-        assert len(remaining) == baseline["model_output_halt_rows"] == 19
+        assert len(remaining) == baseline["model_output_halt_rows"] == 18
 
     def test_no_stagnation_row_is_among_them(self):
         remaining = {


### PR DESCRIPTION
## The gate refused four files the operator shipped

`impl.path_enforcement` rejects a file the implementer writes when its path is not in the LLD's Section 2.1 file list. Run against boostgauge `main` — the hand-built v1.0.0 the operator wrote, reviewed and tagged — it refused four of issue #4's seventeen shipped files, three of them tests:

| shipped file | what the gate said |
|---|---|
| `src/boostgauge/collectors/__init__.py` | not in LLD-specified paths |
| `tests/benchmark/test_sweep_cost.py` | not in LLD-specified paths |
| `tests/integration/test_windows_sweep_crosscheck.py` | not in LLD-specified paths |
| `tests/unit/test_collector_source_pin.py` | not in LLD-specified paths |

The gate was not wrong about the fact. Those paths genuinely are not in LLD-004's plan: the design named four files and the build wrote eight, including a package `__init__.py` and three tests the design had not thought of. It was wrong about the consequence.

**Operator ruling, 2026-09-04:** a file the implementer writes that the LLD's file list did not name is **allowed**. The design's file list is a plan, not a contract. The gate may say what it sees; it may not refuse the file and it may not end the run.

## What changed

The `raise ImplementationError` in `implement_code` is gone. In its place, `path_advisory()` in `assemblyzero/hooks/file_write_validator.py` returns one sentence — `'<path>' is not in the LLD's Section 2.1 list`, plus the closest planned path when there is one — and the implementer writes the file.

`path_advisory` reaches the log only through `advised()`, which refuses a key whose registry row still halts. So the row and the code cannot drift apart: flipping the row back to `halt` without restoring the raise makes the advisory unprintable, and a test asserts exactly that.

The answer-key audit calls `path_advisory`, the same function the implementation stage calls, so the audit cannot report a clean run while the shipped gate would still object.

### `advised()` grew a continuation clause

Its sentence — "Continuing; the budget decides." — is true of the five stagnation guards #2723 softened, because each sits inside a loop a cap or a circuit breaker bounds. No budget decides anything about writing one file. Inheriting that sentence here would have put prose in the log that nobody could act on, so `advised()` now takes an optional `continues=`, defaulting to the old text, and this gate says "The file is written; the LLD's file list is a plan, not a contract."

### Path traversal is still a refusal

The ruling is about a design document's file list. A path climbing out of the repository is an infrastructure fact, not a disagreement with a plan, and `validate_file_write` still reports it. Pinned by a test.

## Measured against the artifact that showed the problem

`poetry run python tools/answer_key_audit.py --repo <boostgauge>`, against boostgauge `main` at v1.0.0:

| | before | after |
|---|---|---|
| `impl.path_enforcement` ran | 7 | 7 |
| `impl.path_enforcement` refused | **4** | **0** |
| total refusals across all gates | 6 | 2 |
| total verdicts | 50 | 50 |

The two remaining refusals are `impl.test_file_validation`, which is #2737's scope and not touched here.

All four advisories are carried into the report's detail column, so the disagreement between plan and build stays visible with the consequence removed rather than the evidence:

```
| #4 | impl.path_enforcement | `tests/unit/test_collector_source_pin.py` | pass |
  'tests/unit/test_collector_source_pin.py' is not in the LLD's Section 2.1 list.
  Closest planned path: 'tests/unit/test_collector.py'. The file is written; the
  LLD's file list is a plan, not a contract. [gate:impl.path_enforcement]
```

## The ratchet, lowered in this PR

`tools/audit_halt_sites.py --check` — the walker re-derives every site that can end a run from the workflow source, and the CI test asserts it agrees with the registry in both directions.

| | before | after |
|---|---|---|
| halt sites | 152 | 151 |
| impl halt rows | 37 | 36 |
| model-output halt rows | 19 | 18 |

`TestTheRatchet::test_the_ratchet_records_what_is_left` pins 18, so the number can only fall.

## A sibling was renumbered, deliberately

A site key is `path::qualname::kind::index` and the index is **positional**, so retiring one halt site renumbers every later site of the same kind in the same function. `impl.write_failed` moves from index 3 to index 2 in this PR for that reason, and the registry row carries a comment saying so. This is the hazard #2738 exists to make the audit explain for itself; here it was caught by re-running `--tsv` and remapping by message head rather than by memory.

## Tests

`tests/unit/test_path_advisory.py`, new: the row advises and still judges model output; a row with no sites names where it lives; every one of the four paths the audit refused draws an advisory naming the path and Section 2.1; every planned path draws silence; the advisory carries the gate key; it says the file is written and does **not** borrow the stagnation guards' sentence; an LLD naming no paths leaves the gate silent; traversal is still refused; and the coupling test above.

The fixture is authored from the audit's own output rather than derived from the code, so it cannot drift into agreeing with whatever the code happens to do. The audit itself needs boostgauge on disk and so cannot run in CI; what CI pins is every mechanism the audit's result rests on.

`tests/unit/test_implement_code_routing.py` lost a `patch()` of `orchestrator.validate_file_write` — the import is gone, and the function under test never consulted it.

Full unit suite: 9,875 passed, 21 skipped, 5 xfailed, 7 deselected.

Closes #2736
