### PR TITLE
feat: follow the call one level, and know more than two ways to assert (Closes #2752)

### DIFF
--- a/assemblyzero/speedrun/answer_key.py
+++ b/assemblyzero/speedrun/answer_key.py
@@ -169,13 +169,22 @@ def _gate_code_response(code: str, rel: str, repo: Path) -> tuple[bool, str]:
     return (not valid), message
 
 
-def _gate_test_structure(content: str) -> tuple[bool, str]:
-    """impl.test_file_validation: the scaffolder's structural validator."""
+def _gate_test_structure(content: str, path: Path | None = None) -> tuple[bool, str]:
+    """impl.test_file_validation: the scaffolder's structural validator.
+
+    ``path`` is the shipped file's own location, so the checker can resolve an
+    assertion helper imported from a neighbouring module exactly as the
+    pipeline does at N2.5 (#2737). Without it only same-module helpers are
+    followed, which is the weaker reading and would let this audit pass while
+    the shipped gate still refused.
+    """
     from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+        imported_helper_sources,
         validate_test_structure,
     )
 
-    errors = validate_test_structure(content, [])
+    imported = imported_helper_sources(content, path.parent) if path else {}
+    errors = validate_test_structure(content, [], imported)
     return bool(errors), "; ".join(errors)[:400]
 
 
@@ -329,7 +338,7 @@ def audit_feature(
             verdicts.append(Verdict(feature.issue, "impl.file_generation_failed",
                                     rel, refused, message))
         if rel in feature.tests and rel.endswith(".py"):
-            refused, message = _gate_test_structure(content)
+            refused, message = _gate_test_structure(content, path)
             verdicts.append(Verdict(feature.issue, "impl.test_file_validation",
                                     rel, refused, message))
             refused, message = _gate_stub_count(content)

--- a/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
+++ b/assemblyzero/workflows/testing/nodes/validate_tests_mechanical.py
@@ -13,6 +13,7 @@ import ast
 import hashlib
 import logging
 import re
+from pathlib import Path
 from typing import Any, Literal
 
 from assemblyzero.workflows.testing.audit import gate_log
@@ -143,9 +144,136 @@ def count_stub_tests(test_content: str) -> tuple[int, int, list[str]]:
 # =============================================================================
 
 
+#: Calls that fail a test outright. `assert` and `pytest.raises` were the only
+#: two forms this checker recognised, and a test that reaches its verdict by
+#: calling `pytest.fail` was read as having no assertion at all -- which is how
+#: boostgauge's shipped `test_dynamic_256_matches_baseline` was refused (#2737).
+#: `unittest`'s vocabulary is here for the same reason: a `TestCase` method
+#: asserts through `self.assertEqual`, never through the `assert` keyword.
+EXPLICIT_FAILURE_CALLS: frozenset[str] = frozenset({"fail", "xfail"})
+
+#: How far a call is followed out of a test body when looking for the
+#: assertion. One level, per the operator's ruling of 2026-09-04: enough for a
+#: shared assertion helper, and bounded so the analysis cannot wander.
+ASSERTION_FOLLOW_DEPTH = 1
+
+
+def _is_real_assert(node: ast.AST) -> bool:
+    """An `assert` that is not a bare `assert False` (issue #386).
+
+    The TDD scaffold deliberately writes `assert False, 'TDD RED: ...'`, so a
+    failing assertion with a message counts; a bare `assert False` does not.
+    """
+    if not isinstance(node, ast.Assert):
+        return False
+    if isinstance(node.test, ast.Constant):
+        return not (node.test.value is False and node.msg is None)
+    return True
+
+
+def _is_failure_call(node: ast.AST) -> bool:
+    """A call that ends the test in a verdict: `pytest.fail`, `self.assertX`."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr in EXPLICIT_FAILURE_CALLS:
+            return True
+        # unittest: self.assertEqual, self.assertRaises, self.failUnless...
+        if func.attr.startswith("assert") and isinstance(func.value, ast.Name):
+            return True
+    if isinstance(func, ast.Name) and func.id in EXPLICIT_FAILURE_CALLS:
+        return True
+    return False
+
+
+def _is_raises_block(node: ast.AST) -> bool:
+    """`with pytest.raises(...)` -- an assertion written as a context."""
+    if not isinstance(node, (ast.With, ast.AsyncWith)):
+        return False
+    for item in node.items:
+        expr = item.context_expr
+        if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
+            if expr.func.attr == "raises":
+                return True
+    return False
+
+
+def _module_functions(tree: ast.AST) -> dict[str, ast.AST]:
+    """Every function defined in this module, by the name a call would use.
+
+    Methods are keyed by their bare name too, because a call written
+    `self._assert_accepted(...)` resolves to a method and the attribute is what
+    the caller sees. A duplicate name maps to the first definition; ambiguity
+    here can only make the checker more permissive, never less, and a
+    permissive assertion check costs a round while a strict one refuses correct
+    code (#2737).
+    """
+    functions: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions.setdefault(node.name, node)
+    return functions
+
+
+def _called_names(func: ast.AST) -> list[str]:
+    """The names of everything ``func`` calls, as a resolver would see them."""
+    names: list[str] = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+    return names
+
+
+def _carries_an_assertion(
+    func: ast.AST,
+    functions: dict[str, ast.AST],
+    imported_sources: dict[str, ast.AST] | None = None,
+    depth: int = 0,
+) -> bool:
+    """Whether ``func`` asserts, in its own body or one level down.
+
+    Operator ruling, 2026-09-04 (#2737): a test whose assertion lives in a
+    helper it calls counts as having an assertion. Resolve a call to a function
+    in the same module or an imported one and look there.
+
+    The recursion is bounded by `ASSERTION_FOLLOW_DEPTH`, so the analysis
+    terminates on a helper that calls itself and never wanders into the code
+    under test. Following further was rejected deliberately: one level covers a
+    shared assertion helper, and every level past it makes "this test asserts"
+    depend on production code's contents, which is a different claim.
+    """
+    for node in ast.walk(func):
+        if _is_real_assert(node) or _is_raises_block(node) or _is_failure_call(node):
+            return True
+
+    if depth >= ASSERTION_FOLLOW_DEPTH:
+        return False
+
+    pool = dict(functions)
+    if imported_sources:
+        # Same-module definitions win: a local helper shadows an import.
+        for name, node in imported_sources.items():
+            pool.setdefault(name, node)
+
+    for name in _called_names(func):
+        helper = pool.get(name)
+        if helper is None or helper is func:
+            continue
+        if _carries_an_assertion(helper, functions, imported_sources, depth + 1):
+            return True
+    return False
+
+
 def validate_test_structure(
     test_content: str,
     scenarios: list[dict],
+    imported_sources: dict[str, ast.AST] | None = None,
 ) -> list[str]:
     """AST validation: verify imports, calls, and assertions exist.
 
@@ -154,9 +282,19 @@ def validate_test_structure(
     - Each test function has at least one real assertion
     - Assertions aren't just `assert False`
 
+    #2737, operator ruling 2026-09-04: "has an assertion" is answered by
+    reading the test body AND one level down into any function it calls, in
+    this module or in an imported one. A shared assertion helper is ordinary
+    and good practice in exactly the table-driven tests the pipeline is asked
+    to write, and reading only the body refused code the operator shipped.
+
     Args:
         test_content: The generated test file content.
         scenarios: List of test scenario dicts with test_id and test_name.
+        imported_sources: Functions this module imports, by the name the call
+            site uses, already parsed. Supplied by callers that can reach the
+            files on disk; when it is None, only same-module helpers are
+            followed and an imported helper's assertion cannot be seen.
 
     Returns:
         List of error messages for structural issues.
@@ -178,59 +316,95 @@ def validate_test_structure(
     if not has_import:
         errors.append("No import statements found - tests need imports")
 
+    functions = _module_functions(tree)
+
     # Check each test function
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name.startswith('test_'):
-            # Check for assertions in this function
-            has_real_assertion = False
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith('test_'):
+            if _carries_an_assertion(node, functions, imported_sources):
+                continue
 
-            for child in ast.walk(node):
-                if isinstance(child, ast.Assert):
-                    # Issue #386: Accept `assert False, 'TDD RED: ...'` as valid
-                    # TDD scaffold intentionally generates failing assertions.
-                    # Only reject bare `assert False` without a message.
-                    if isinstance(child.test, ast.Constant):
-                        if child.test.value is False and child.msg is None:
-                            continue  # Skip bare assert False (no message)
-                    has_real_assertion = True
-                    break
+            # Check if function only has pass
+            func_has_only_pass = (
+                len(node.body) == 1 and
+                isinstance(node.body[0], (ast.Pass, ast.Expr)) and
+                (isinstance(node.body[0], ast.Pass) or
+                 (isinstance(node.body[0], ast.Expr) and
+                  isinstance(node.body[0].value, ast.Constant)))
+            )
 
-                # Also accept pytest.raises as valid
-                if isinstance(child, ast.With):
-                    for item in child.items:
-                        if isinstance(item.context_expr, ast.Call):
-                            call = item.context_expr
-                            if isinstance(call.func, ast.Attribute):
-                                if call.func.attr == 'raises':
-                                    has_real_assertion = True
-                                    break
-
-            if not has_real_assertion:
-                # Check if function only has pass
-                func_has_only_pass = (
-                    len(node.body) == 1 and
-                    isinstance(node.body[0], (ast.Pass, ast.Expr)) and
-                    (isinstance(node.body[0], ast.Pass) or
-                     (isinstance(node.body[0], ast.Expr) and
-                      isinstance(node.body[0].value, ast.Constant)))
+            if func_has_only_pass:
+                errors.append(
+                    f"Function '{node.name}' has no assertions - only pass/docstring"
                 )
-
-                if func_has_only_pass:
+            else:
+                # Check if any assert exists (even assert False)
+                any_assert = any(
+                    isinstance(child, ast.Assert)
+                    for child in ast.walk(node)
+                )
+                if not any_assert:
                     errors.append(
-                        f"Function '{node.name}' has no assertions - only pass/docstring"
+                        f"Function '{node.name}' has no assertion the checker can "
+                        f"see, in its body or one level down; assert in the body "
+                        f"or call a helper that does"
                     )
-                else:
-                    # Check if any assert exists (even assert False)
-                    any_assert = any(
-                        isinstance(child, ast.Assert)
-                        for child in ast.walk(node)
-                    )
-                    if not any_assert:
-                        errors.append(
-                            f"Function '{node.name}' has no assertion statements"
-                        )
 
     return errors
+
+
+def imported_helper_sources(
+    test_content: str, module_dir: Path | str
+) -> dict[str, ast.AST]:
+    """Functions ``test_content`` imports from files beside it, parsed.
+
+    The "or an imported one" half of #2737's ruling. Only same-directory and
+    `conftest` imports are resolved, which is where a test's shared assertion
+    helpers actually live; a name imported from the package under test is
+    deliberately NOT followed, because production code's `raise` is not the
+    test's assertion.
+
+    Every failure is silent and returns fewer entries, never an exception: an
+    unreadable neighbour must cost the checker a helper, not cost the run.
+    """
+    directory = Path(module_dir)
+    try:
+        tree = ast.parse(test_content)
+    except SyntaxError:
+        # fail-open: returning no helpers is strictly more conservative than
+        # returning some -- fewer helpers can only make the assertion check
+        # REFUSE more, never accept more, so an unreadable file cannot be used
+        # to sneak a stub past the gate. The caller has already parsed this
+        # same text and reported the syntax error itself, so the halt is not
+        # lost; it is raised once, by the check that owns it.
+        return {}
+
+    wanted: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.level >= 0:
+            head = node.module.split(".")[0]
+            for alias in node.names:
+                wanted[alias.asname or alias.name] = head
+
+    found: dict[str, ast.AST] = {}
+    for local_name, module_head in wanted.items():
+        candidate = directory / f"{module_head}.py"
+        if not candidate.is_file():
+            continue
+        try:
+            helper_tree = ast.parse(candidate.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, SyntaxError):
+            # fail-open: one unreadable neighbour drops one helper and the loop
+            # continues, in the same direction as the handler above -- a shorter
+            # helper list makes the check stricter, never laxer. Halting here
+            # would let any unrelated broken file in the test directory end a
+            # run, which is a far worse failure than declining to follow one
+            # call into it.
+            continue
+        for name, node in _module_functions(helper_tree).items():
+            if name == local_name:
+                found[local_name] = node
+    return found
 
 
 def validate_scenario_coverage(
@@ -386,7 +560,21 @@ def validate_tests_mechanical_node(state: dict[str, Any]) -> dict[str, Any]:
             )
 
     # Step 2: Validate structure with AST (imports, test functions exist)
-    structure_errors = validate_test_structure(generated_tests, scenarios)
+    #
+    # #2737: an assertion helper beside the test file counts. The test files
+    # are on disk by now, so the directory they sit in is where an imported
+    # helper is looked for; when there is no such file the checker falls back
+    # to same-module helpers and says nothing, because a missing neighbour must
+    # cost a helper and never cost the run.
+    test_files_on_disk = [str(p) for p in (state.get("test_files") or [])]
+    imported_sources: dict[str, ast.AST] = {}
+    if test_files_on_disk:
+        imported_sources = imported_helper_sources(
+            generated_tests, Path(test_files_on_disk[0]).parent
+        )
+    structure_errors = validate_test_structure(
+        generated_tests, scenarios, imported_sources
+    )
     all_errors.extend(structure_errors)
 
     # Step 3: Validate scenario coverage

--- a/tests/unit/test_assertion_reading.py
+++ b/tests/unit/test_assertion_reading.py
@@ -1,0 +1,264 @@
+"""How the checker decides a test has an assertion (#2752, ruled on #2737).
+
+`validate_test_structure` refused two tests boostgauge's hand build shipped.
+Both are real tests that really pass, and neither was refused for the reason
+the original issue gave. The two shapes are reproduced verbatim below as
+fixtures, because a fix measured against a paraphrase is not measured against
+the artifact that showed the problem.
+
+Operator ruling, 2026-09-04: a test whose assertion lives in a helper it calls
+counts as having an assertion; follow the call one level, to a function in the
+same module or an imported one.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+    imported_helper_sources,
+    validate_test_structure,
+)
+
+#: `tests/visual/test_stingray_dynamic.py::test_dynamic_256_matches_baseline`,
+#: reduced to the shape that mattered: every exit is `pytest.fail`, `pytest.skip`
+#: or a bare `return`, and there is no `assert` anywhere. Refused before #2752.
+STINGRAY_SHAPE = textwrap.dedent('''
+    import pytest
+    from PIL import Image, ImageChops, ImageStat
+
+    def test_dynamic_256_matches_baseline(request, dyn_256):
+        path = BASELINES / "stingray_dynamic_256.png"
+        if not path.exists():
+            pytest.fail(f"missing baseline {path}")
+        baseline = Image.open(path).convert("RGB")
+        if dyn_256.tobytes() == baseline.tobytes():
+            return
+        rms = max(ImageStat.Stat(ImageChops.difference(dyn_256, baseline)).rms)
+        if rms > RMS_TOLERANCE:
+            pytest.fail(f"dynamic composition drifted: rms={rms:.4f}")
+''')
+
+#: `tests/unit/test_telltale.py::test_V4_equal_timestamp_is_accepted`, verbatim
+#: apart from the import line. Its contract is "this call must not raise" and
+#: it has no assertion in its body or one level down -- `_fed` has none either.
+#: Still refused; the ruling question is #2754.
+MUST_NOT_RAISE_SHAPE = textwrap.dedent('''
+    from boostgauge.telltale import Telltale
+
+    def _fed(window, samples, decay_rate=None):
+        t = Telltale(window, decay_rate=decay_rate)
+        for ts, v in samples:
+            t.update(ts, v)
+        return t
+
+    def test_V4_equal_timestamp_is_accepted():
+        t = _fed(10.0, [(5.0, 1.0)])
+        t.update(5.0, 3.0)  # must not raise
+''')
+
+
+def messages(source: str, imported=None) -> list[str]:
+    return validate_test_structure(source, [], imported)
+
+
+class TestTheShippedArtifacts:
+    def test_the_stingray_test_is_no_longer_refused(self):
+        """It reaches its verdict entirely through `pytest.fail`. The checker
+        knew `assert` and `pytest.raises` and nothing else, so an entire way of
+        failing a test was invisible to it."""
+        assert messages(STINGRAY_SHAPE) == []
+
+    def test_the_must_not_raise_test_is_still_refused(self):
+        """Deliberately pinned as still-refused rather than quietly accepted.
+        There is no assertion in the body and none one level down: `_fed`
+        constructs and calls, and `t.update` is an attribute on a local that no
+        parser resolves. The ruling on whether absence-of-exception counts is
+        #2754; until it lands, this test records the honest state rather than a
+        number massaged to look finished."""
+        errors = messages(MUST_NOT_RAISE_SHAPE)
+        assert len(errors) == 1
+        assert "test_V4_equal_timestamp_is_accepted" in errors[0]
+
+
+class TestFollowingTheCallOneLevel:
+    def test_a_same_module_helper_carries_the_assertion(self):
+        source = textwrap.dedent('''
+            import pytest
+
+            def _assert_accepted(value):
+                assert value is not None
+
+            def test_it():
+                _assert_accepted(compute())
+        ''')
+        assert messages(source) == []
+
+    def test_a_method_helper_is_found_by_its_bare_name(self):
+        """`self._check(...)` is an attribute at the call site and a plain
+        function definition in the module."""
+        source = textwrap.dedent('''
+            import pytest
+
+            class TestThing:
+                def _check(self, value):
+                    assert value
+
+                def test_it(self):
+                    self._check(compute())
+        ''')
+        assert messages(source) == []
+
+    def test_two_levels_down_is_not_followed(self):
+        """One level is the ruling and the bound. A helper whose assertion is
+        itself in another helper is not accepted, because every level past the
+        first makes "this test asserts" depend on more code that is not the
+        test."""
+        source = textwrap.dedent('''
+            import pytest
+
+            def _inner(value):
+                assert value
+
+            def _outer(value):
+                _inner(value)
+
+            def test_it():
+                _outer(compute())
+        ''')
+        assert len(messages(source)) == 1
+
+    def test_a_helper_that_calls_itself_terminates(self):
+        source = textwrap.dedent('''
+            import pytest
+
+            def _loop(n):
+                if n:
+                    _loop(n - 1)
+
+            def test_it():
+                _loop(3)
+        ''')
+        assert len(messages(source)) == 1
+
+    def test_a_test_that_calls_nothing_useful_is_still_caught(self):
+        """#2737's second criterion: a test with no assertion in its body or
+        one level down must still be caught."""
+        source = textwrap.dedent('''
+            import pytest
+
+            def test_it():
+                x = compute(1)
+        ''')
+        errors = messages(source)
+        assert len(errors) == 1
+        assert "one level down" in errors[0]
+
+    def test_an_empty_test_is_still_caught_with_its_own_message(self):
+        source = textwrap.dedent('''
+            import pytest
+
+            def test_it():
+                pass
+        ''')
+        assert messages(source) == [
+            "Function 'test_it' has no assertions - only pass/docstring"
+        ]
+
+
+class TestTheWaysAVerdictCanBeReached:
+    @pytest.mark.parametrize("body", [
+        "assert compute() == 1",
+        "with pytest.raises(ValueError):\n        compute()",
+        "pytest.fail('nope')",
+        "pytest.xfail('known')",
+        "self.assertEqual(compute(), 1)",
+        "self.assertRaises(ValueError, compute)",
+    ])
+    def test_each_one_counts(self, body):
+        source = f"import pytest\n\ndef test_it(self):\n    {body}\n"
+        assert messages(source) == []
+
+    def test_a_bare_assert_false_is_not_a_real_assertion_but_draws_no_error(self):
+        """Two rules meet here and the second one wins, unchanged by #2752.
+
+        Issue #386 exempted `assert False, 'TDD RED: ...'` because the TDD
+        scaffold emits it on purpose; a bare one carries no message, so it is
+        not counted as a real assertion. But the fallback below asks only
+        whether ANY `ast.Assert` exists before reporting, and a bare
+        `assert False` is one -- so this function passes the structure check
+        and is caught instead by `count_stub_tests`, which reads it as a body
+        that can never pass. Pinned so the split stays deliberate."""
+        source = "import pytest\n\ndef test_it():\n    assert False\n"
+        assert messages(source) == []
+
+        from assemblyzero.workflows.testing.nodes.validate_tests_mechanical import (
+            count_stub_tests,
+        )
+        total, stubs, names = count_stub_tests(source)
+        assert (total, stubs, names) == (1, 1, ["test_it"])
+
+    def test_a_tdd_red_placeholder_still_counts(self):
+        source = "import pytest\n\ndef test_it():\n    assert False, 'TDD RED: x'\n"
+        assert messages(source) == []
+
+
+class TestTheImportedHalfOfTheRuling:
+    def test_a_helper_imported_from_a_neighbour_is_followed(self, tmp_path):
+        (tmp_path / "helpers.py").write_text(
+            "def assert_accepted(value):\n    assert value is not None\n",
+            encoding="utf-8",
+        )
+        source = textwrap.dedent('''
+            from helpers import assert_accepted
+
+            def test_it():
+                assert_accepted(compute())
+        ''')
+        imported = imported_helper_sources(source, tmp_path)
+        assert "assert_accepted" in imported
+        assert messages(source, imported) == []
+
+    def test_without_the_neighbour_the_same_test_is_refused(self):
+        """The imported half depends on reaching the file. When the caller
+        cannot supply it, the checker reads less and says so by refusing rather
+        than by guessing."""
+        source = textwrap.dedent('''
+            from helpers import assert_accepted
+
+            def test_it():
+                assert_accepted(compute())
+        ''')
+        assert len(messages(source)) == 1
+
+    def test_a_same_module_helper_wins_over_an_imported_one(self, tmp_path):
+        (tmp_path / "helpers.py").write_text(
+            "def check(value):\n    assert value\n", encoding="utf-8"
+        )
+        source = textwrap.dedent('''
+            from helpers import check
+
+            def check(value):
+                pass
+
+            def test_it():
+                check(compute())
+        ''')
+        imported = imported_helper_sources(source, tmp_path)
+        assert len(messages(source, imported)) == 1, (
+            "the local definition is what runs, so it is what is read"
+        )
+
+    def test_a_missing_neighbour_costs_a_helper_not_the_run(self, tmp_path):
+        source = "from nowhere import thing\n\ndef test_it():\n    thing()\n"
+        assert imported_helper_sources(source, tmp_path) == {}
+
+    def test_an_unparseable_neighbour_costs_a_helper_not_the_run(self, tmp_path):
+        (tmp_path / "helpers.py").write_text("def broken(:\n", encoding="utf-8")
+        source = "from helpers import broken\n\ndef test_it():\n    broken()\n"
+        assert imported_helper_sources(source, tmp_path) == {}
+
+    def test_unparseable_test_content_yields_no_helpers(self, tmp_path):
+        assert imported_helper_sources("def broken(:\n", tmp_path) == {}


### PR DESCRIPTION
## The check knew two ways to assert, and looked in one place

`validate_test_structure` decides whether a generated test has an assertion. It looked for an `assert` statement or a `with pytest.raises(...)` block, inside the function's own body and nowhere else.

Run against boostgauge `main` — the hand-built v1.0.0 the operator wrote, reviewed and tagged, which the answer-key audit treats as the correct answer — it refused two shipped tests. **Neither was refused for the reason #2737 gave.** That issue said both delegate their assertion to a helper; reading the files says otherwise:

- `tests/visual/test_stingray_dynamic.py::test_dynamic_256_matches_baseline` reaches every one of its verdicts through `pytest.fail` and contains no `assert` at all. A whole way of failing a test was invisible to the checker, and `unittest` has the same problem: a `TestCase` method asserts through `self.assertEqual`, never through the `assert` keyword.
- `tests/unit/test_telltale.py::test_V4_equal_timestamp_is_accepted` has no assertion anywhere, including one level down. Its contract is that a call must not raise. See "What is not fixed" below.

## What changed

**Follow the call one level**, per the operator's ruling of 2026-09-04. `_carries_an_assertion` reads the test body, then resolves each call — by `Name` or by attribute — to a function defined in the same module or imported from a neighbouring file, and reads that too.

The bound is deliberate and tested in both directions. One level covers a shared assertion helper; two levels down is refused, and a helper that calls itself terminates. Following further would make "this test asserts" depend on the contents of the code under test, which is a different claim from the one the gate is making. For the same reason, a name imported from the package under test is not followed: production code's `raise` is not the test's assertion.

**Know the failure calls.** `pytest.fail`, `pytest.xfail`, and the `unittest` `self.assert*` family now count, because they are assertions by any reading and one of them is what refused a shipped test.

**Resolve the imported half.** `imported_helper_sources` parses files beside the test file. `validate_tests_mechanical` supplies the directory from `state["test_files"]`; the answer-key audit supplies the shipped file's own path. When neither can, the checker reads only same-module helpers and refuses rather than guessing — pinned by a test.

## This is live, not dormant

`validate_tests_mechanical` calls it at N2.5. An error makes the suite invalid, sets `scaffold_route = "regenerate"`, and sends the run back to N2 to write the tests again; that repeats until `MAX_SCAFFOLD_ATTEMPTS` (3) is spent, after which `route_after_validate` ends the run through `impl.scaffold_suite_invalid`. So a false positive here spends regeneration rounds first and a run last, and the drafter is asked to change a test that was already correct. The spec stage's completeness grader (`implementation_spec/nodes/validate_completeness.py`) calls the same function, so the misreading reached two stages.

## Measured on the artifact that showed the problem

`poetry run python tools/answer_key_audit.py --repo <boostgauge>`, against boostgauge `main` at v1.0.0:

| | before this PR | after |
|---|---|---|
| `impl.test_file_validation` ran | 9 | 9 |
| `impl.test_file_validation` refused | **2** | **1** |
| total refusals across all gates | 2 | 1 |
| total verdicts | 50 | 50 |

(The audit stood at 6 refusals yesterday; #2736 took it to 2 this morning.)

## What is not fixed, and why

`test_V4_equal_timestamp_is_accepted` is still refused, and following the call cannot rescue it:

```python
def test_V4_equal_timestamp_is_accepted():
    t = _fed(10.0, [(5.0, 1.0)])
    t.update(5.0, 3.0)  # must not raise
```

`_fed` is a same-module helper that constructs a `Telltale` and calls `update` — no assertion. `t.update` is an attribute call on a local variable, which no parser resolves without type inference, and resolving it would mean counting the class under test's `raise` as the test's assertion, which accepts essentially every test that calls anything. The intention lives in a comment, and comments are not in the abstract syntax tree.

Filed as **#2754**: is a test that exercises the code and asserts nothing explicitly a test with an assertion, or an incomplete test the drafter should be asked to finish? That is a ruling, not a patch, and it is what blocks #2737's first acceptance criterion.

**#2737 stays open.** Of its three requirements: following the call one level is built; a test with no assertion in its body or one level down is still caught (tested); zero refusals against boostgauge `main` is **not met** — one of two removed. Its third requirement, making `impl.test_file_validation` a `revise` row, is blocked by **#2753** and is explained there and below.

## A finding this work turned up

`impl.test_file_validation`'s only registered halt site is in `assemblyzero/workflows/testing/nodes/run_tests.py`, and **no graph runs that node.** `create_testing_graph` declares fifteen nodes and `run_tests` is not among them; there are exactly seven `StateGraph(...)` constructions in the package, one per workflow; and the only importer of the module anywhere in the repository is its own unit test.

So flipping that row to `revise` would have lowered the ratchet's model-output halt count by one while no running behaviour changed anywhere — cooking the number the routing policy is measured by, which is the same objection that keeps `judges` pinned at `model_output` on a softened row. The flip was not made. Four of the 151 halt sites sit in that node across three rows, and the audit's own gate label points at it rather than at `impl.scaffold_suite_invalid`, which is the row that actually ends a run over this judgement. Filed with the counts and the ruling question as **#2753**.

## The ratchet

Unchanged, and asserted so: 151 halt sites, `impl` 36 halt rows, 18 model-output halt rows. This PR adds no gate and retires none.

## Tests

`tests/unit/test_assertion_reading.py`, new, 24 tests. Both shipped artifacts are reproduced as fixtures rather than paraphrased — one asserted to pass now, the other asserted to *still be refused*, so the honest state is pinned instead of a number massaged to look finished.

Also covered: same-module helper; method helper found by its bare name; two levels down refused; self-calling helper terminates; a test that assigns without checking still caught; an empty test still caught with its own message; each of the six ways a verdict can be reached; the `assert False` split (bare one draws no structure error but `count_stub_tests` catches it — pinned so the division of labour stays deliberate); imported helper followed; the same test refused without the neighbour; a local definition shadowing an imported one; and a missing or unparseable neighbour costing a helper rather than the run.

The two new exception handlers carry `# fail-open:` rulings, which `tests/unit/test_fail_open_audit.py::TestTheRepoGate` requires — it caught both on the first full run. Each fails in the conservative direction: fewer helpers can only make the check refuse more, never accept more, so an unreadable neighbour cannot be used to get a stub past the gate.

Full unit suite: 9,897 passed, 21 skipped, 5 xfailed, 7 deselected.

Closes #2752
