### PR TITLE
feat: the implementation graph gets an atlas and records its own position (Closes #2733)

### DIFF
--- a/assemblyzero/workflows/testing/atlas.py
+++ b/assemblyzero/workflows/testing/atlas.py
@@ -1,0 +1,272 @@
+"""The graph atlas for the testing (implementation) workflow (#2157, #2733).
+
+Same contract as the requirements and implementation-spec atlases: position
+narration reads from here, the convergence record (#2721) takes its node
+ordinal from here, and the drift guard in ``tests/unit/test_graph_atlas.py``
+pins this file to the actual compiled ``StateGraph`` so it cannot rot when the
+graph is rewired.
+
+This is the stage where runs get furthest and where they most often die --
+45 of the 135 failures counted over boostgauge's 180 runs, including
+``run-issue4-172600``, the furthest run in the whole record, which stopped at
+N5 with three tests passing at 72% coverage. Until this file existed, the
+report had to grep node markers out of a prose log to say where in the
+implementation stage a run had reached, which is exactly what #2721 set out
+to stop doing.
+
+``ordinal`` is the position on the forward path. A node that exists only to
+loop back consumes no ordinal, so a run that dies inside one reports the
+forward node it came from as its furthest position, which is the truth about
+how far it got. ``HALT`` has none either, for the reason the other atlases
+give: it is an exit, never a step.
+"""
+
+from __future__ import annotations
+
+#: The forward path: N0, N1, N2, N2.5, N3, N4, N4b, N5, N6, N7, N7.5, N8, N9.
+#: `N1_5_revise_test_plan` and `N4c_augment_tests` are loops and are excluded,
+#: as is `HALT`.
+TOTAL_STEPS = 13
+
+ATLAS: dict[str, dict] = {
+    "N0_load_lld": {
+        "title": "load LLD and spec",
+        "ordinal": 1,
+        "goal": "Load the approved LLD and implementation spec to build from.",
+        "teach": (
+            "The implementation stage consumes two upstream documents as "
+            "ground truth and revises neither. A missing spec or an LLD too "
+            "short to be usable stops the run here, before anything is spent."
+        ),
+        "successors": {
+            "N1_review_test_plan": "the LLD and spec loaded",
+            "END": "neither document could be loaded",
+        },
+    },
+    "N1_review_test_plan": {
+        "title": "review test plan",
+        "ordinal": 2,
+        "goal": "Judge the LLD's test plan before any test is written.",
+        "teach": (
+            "Mechanical pre-checks run first and cost nothing; a reviewer "
+            "model follows. A BLOCKED verdict earns one revision rather than "
+            "a stop, which is what N1.5 is for."
+        ),
+        "successors": {
+            "N2_scaffold_tests": "the plan is usable",
+            "N1_5_revise_test_plan": "blocked; revise the plan once",
+            "END": "the reviewer failed, or the plan cannot be revised",
+        },
+    },
+    "N1_5_revise_test_plan": {
+        "title": "revise test plan",
+        "ordinal": None,
+        "goal": "Rewrite the test plan against the reviewer's objection.",
+        "teach": (
+            "A loop, not a step: the revised plan always goes back for "
+            "re-review rather than forward, so no plan reaches the scaffolder "
+            "without having been judged in the state it is in."
+        ),
+        "successors": {
+            "N1_review_test_plan": "always",
+        },
+    },
+    "N2_scaffold_tests": {
+        "title": "scaffold tests",
+        "ordinal": 3,
+        "goal": "Write the test suite from the plan, before any code exists.",
+        "teach": (
+            "The tests are written first and are the specification the code "
+            "must satisfy. Where the spec ships executable Section 10 test "
+            "functions, those are what the scaffold is built from."
+        ),
+        "successors": {
+            "N2_5_validate_tests": "tests were generated",
+            "END": "scaffolding failed, or this was a scaffold-only run",
+        },
+    },
+    "N2_5_validate_tests": {
+        "title": "validate tests",
+        "ordinal": 4,
+        "goal": "Check the generated suite is executable and really asserts.",
+        "teach": (
+            "Mechanical, no model call: imports, test functions, assertions "
+            "(#2752 reads one level into a helper), stub counting and "
+            "scenario coverage. A failure regenerates rather than stopping, "
+            "until the scaffold attempt budget is spent."
+        ),
+        "successors": {
+            "N3_verify_red": "the suite is usable",
+            "N2_scaffold_tests": "unusable; regenerate while attempts remain",
+            # Declared in the router's mapping and never returned: #2331
+            # removed the escalate-to-implementation route, because a suite
+            # the validator had just called unusable was entering the coder
+            # having skipped the red phase. The edge is in the compiled graph
+            # and is named here so the drift guard stays honest about it.
+            "N4_implement_code": "never taken; the edge #2331 stopped using",
+            "END": "still unusable when the attempt budget is spent",
+        },
+    },
+    "N3_verify_red": {
+        "title": "verify red phase",
+        "ordinal": 5,
+        "goal": "Prove the tests fail before the code that satisfies them.",
+        "teach": (
+            "A test that passes against an empty implementation is testing "
+            "nothing. This phase is what makes the suite's later green a "
+            "result rather than a coincidence."
+        ),
+        "successors": {
+            "N4_implement_code": "the tests fail, as they must",
+            "N5_verify_green": "the work is already done (#2337)",
+            "N2_scaffold_tests": "the suite is broken; scaffold again",
+            "END": "the tests pass without code, or the runner is unusable",
+        },
+    },
+    "N4_implement_code": {
+        "title": "implement code",
+        "ordinal": 6,
+        "goal": "Write the code, one file at a time, until the tests can pass.",
+        "teach": (
+            "The stage's spender. A fix asks for edits rather than a rewrite "
+            "(#2407), and a file the LLD's plan did not name is written with "
+            "an advisory rather than refused (#2736)."
+        ),
+        "successors": {
+            "N4b_completeness_gate": "the files were written",
+            "END": "the implementer could not produce usable code",
+        },
+    },
+    "N4b_completeness_gate": {
+        "title": "completeness gate",
+        "ordinal": 7,
+        "goal": "Check every requirement has code before the tests are run.",
+        "teach": (
+            "Cheaper than discovering the gap in the green loop: an "
+            "unimplemented requirement goes back to the coder while "
+            "iterations remain."
+        ),
+        "successors": {
+            "N5_verify_green": "every requirement has code",
+            "N4_implement_code": "something is missing; implement it",
+            "END": "still incomplete at the iteration cap",
+        },
+    },
+    "N4c_augment_tests": {
+        "title": "augment tests for coverage",
+        "ordinal": None,
+        "goal": "Add tests for code the suite does not reach.",
+        "teach": (
+            "A loop, not a step, and deliberately one-way: it always returns "
+            "to verification and never routes to implementation, so a "
+            "coverage shortfall cannot turn into an edit of the code (#2327)."
+        ),
+        "successors": {
+            "N5_verify_green": "always",
+        },
+    },
+    "N5_verify_green": {
+        "title": "verify green phase",
+        "ordinal": 8,
+        "goal": "Run the suite against the code and drive it to passing.",
+        "teach": (
+            "The iterate loop, and where the furthest recorded run stopped. "
+            "Only a budget or a broken environment ends it: the stagnation "
+            "guards advise and the iteration cap and circuit breaker decide "
+            "(#2723)."
+        ),
+        "successors": {
+            "N6_e2e_validation": "green, and end-to-end validation applies",
+            "N7_finalize": "green, with nothing left to validate",
+            "N4_implement_code": "still failing; implement again",
+            "N4c_augment_tests": "green but under-covered; add tests (#2327)",
+            "N2_scaffold_tests": "the suite itself is the problem",
+            "END": "the iteration cap, the circuit breaker, or a dead runner",
+        },
+    },
+    "N6_e2e_validation": {
+        "title": "end-to-end validation",
+        "ordinal": 9,
+        "goal": "Exercise the feature as a user would, not as a unit test does.",
+        "teach": (
+            "Unit tests can all pass on a feature that does not work. This "
+            "loop is bounded by its own cap and the circuit breaker; its "
+            "stagnation guard advises rather than ending the run."
+        ),
+        "successors": {
+            "N7_finalize": "validated, or not applicable",
+            "N4_implement_code": "the feature does not work; implement again",
+            "END": "the e2e cap, the circuit breaker, or an e2e error",
+        },
+    },
+    "N7_finalize": {
+        "title": "finalize",
+        "ordinal": 10,
+        "goal": "Write the test and implementation reports and commit them.",
+        "teach": (
+            "The artifacts a human reads afterwards are produced here and "
+            "committed into the implementation worktree, so they travel to "
+            "the target's main branch with the pull request rather than "
+            "being left untracked (#1626)."
+        ),
+        "successors": {
+            "N7_5_adversarial": "finalized",
+            "END": "finalizing failed, or documentation is being skipped",
+        },
+    },
+    "N7_5_adversarial": {
+        "title": "adversarial review",
+        "ordinal": 11,
+        "goal": "Attack the finished work looking for what the tests missed.",
+        "teach": (
+            "Non-blocking by design: its findings are recorded and the run "
+            "continues, because a late adversarial opinion is evidence for a "
+            "human rather than a gate on the machine."
+        ),
+        "successors": {
+            "N8_document": "always, whatever it found",
+            "END": "the adversarial step itself errored",
+        },
+    },
+    "N8_document": {
+        "title": "document",
+        "ordinal": 12,
+        "goal": "Generate the wiki page, runbook and README the work needs.",
+        "teach": (
+            "Committed into the implementation worktree for the same reason "
+            "the reports are (#1631), so documentation lands with the code "
+            "instead of being written and lost."
+        ),
+        "successors": {
+            "N9_cleanup": "documented",
+            "END": "documentation failed or was skipped",
+        },
+    },
+    "N9_cleanup": {
+        "title": "cleanup",
+        "ordinal": 13,
+        "goal": "Leave the target repository as the run found it.",
+        "teach": (
+            "The last forward step. What it removes is scaffolding the run "
+            "created, never the operator's own working state."
+        ),
+        "successors": {
+            "END": "always",
+        },
+    },
+    "HALT": {
+        "title": "halt",
+        "ordinal": None,
+        "goal": "Record why the run stopped, then end it cleanly.",
+        "teach": (
+            "Declared but unreachable in THIS graph, unlike its counterparts "
+            "in the requirements and implementation-spec workflows. No router "
+            "here returns HALT: every stop routes straight to END carrying an "
+            "`error_message`, which the orchestrator relays. The node and its "
+            "outbound edge are dead code, and `successors` is empty because "
+            "the compiled graph has no edge out of it. Filed as its own issue "
+            "rather than deleted here, since removing a node is a ruling."
+        ),
+        "successors": {},
+    },
+}

--- a/assemblyzero/workflows/testing/graph.py
+++ b/assemblyzero/workflows/testing/graph.py
@@ -514,34 +514,46 @@ def build_testing_workflow() -> StateGraph:
     # Create graph with state type
     workflow = StateGraph(TestingWorkflowState)
 
+    # #2158/#2733: every node narrates its graph position on entry and writes
+    # its entry to the convergence record, sourced from the atlas (#2157) so
+    # neither can drift from the real graph. This stage was the last of the
+    # three without one, which is why the report still had to grep node
+    # markers out of a prose log to say how far into implementation a run got
+    # -- in the stage where runs get furthest and most often die.
+    from assemblyzero.workflows.narration import narrated
+    from assemblyzero.workflows.testing.atlas import ATLAS, TOTAL_STEPS
+
+    def _add(name, fn):
+        workflow.add_node(name, narrated(name, fn, ATLAS, TOTAL_STEPS, stage="impl"))
+
     # Add nodes
-    workflow.add_node("N0_load_lld", load_lld)
-    workflow.add_node("N1_review_test_plan", review_test_plan)
-    workflow.add_node("N1_5_revise_test_plan", revise_test_plan)  # Issue #1072
+    _add("N0_load_lld", load_lld)
+    _add("N1_review_test_plan", review_test_plan)
+    _add("N1_5_revise_test_plan", revise_test_plan)  # Issue #1072
     # Issue #689: checkpoint after N2/N4/N5 so a crash between phases
     # doesn't lose generated tests / implementation code.
-    workflow.add_node("N2_scaffold_tests", _wrap_with_checkpoint(scaffold_tests, "post-scaffold"))
-    workflow.add_node("N2_5_validate_tests", validate_tests_mechanical_node)  # Issue #335
-    workflow.add_node("N3_verify_red", verify_red_phase)
-    workflow.add_node("N4_implement_code", _wrap_with_checkpoint(implement_code, "post-impl"))
-    workflow.add_node("N4b_completeness_gate", completeness_gate)  # Issue #147
-    workflow.add_node("N4c_augment_tests", augment_tests_for_coverage)  # #2327
-    workflow.add_node("N5_verify_green", _wrap_with_checkpoint(verify_green_phase, "post-green"))
-    workflow.add_node("N6_e2e_validation", e2e_validation)
+    _add("N2_scaffold_tests", _wrap_with_checkpoint(scaffold_tests, "post-scaffold"))
+    _add("N2_5_validate_tests", validate_tests_mechanical_node)  # Issue #335
+    _add("N3_verify_red", verify_red_phase)
+    _add("N4_implement_code", _wrap_with_checkpoint(implement_code, "post-impl"))
+    _add("N4b_completeness_gate", completeness_gate)  # Issue #147
+    _add("N4c_augment_tests", augment_tests_for_coverage)  # #2327
+    _add("N5_verify_green", _wrap_with_checkpoint(verify_green_phase, "post-green"))
+    _add("N6_e2e_validation", e2e_validation)
     # Issue #1626: checkpoint after N7 so the test/implementation reports written
     # and archived by finalize() are committed to the impl worktree (and thus
     # land on target main when the impl PR squash-merges) instead of being left
     # untracked. Mirrors the N2/N4/N5 checkpoint pattern.
-    workflow.add_node("N7_finalize", _wrap_with_checkpoint(finalize, "post-finalize"))
-    workflow.add_node("N7_5_adversarial", run_adversarial_node)  # Issue #352
+    _add("N7_finalize", _wrap_with_checkpoint(finalize, "post-finalize"))
+    _add("N7_5_adversarial", run_adversarial_node)  # Issue #352
     # Issue #1631: checkpoint after N8 so the wiki/runbook/README the document
     # node generates are committed to the impl worktree (and land on target main
     # via the impl PR) instead of being left untracked. The 907/908 c/p docs are
     # suppressed for external repos upstream (#1627), so this stages only the
     # keeper docs there.
-    workflow.add_node("N8_document", _wrap_with_checkpoint(document, "post-document"))
-    workflow.add_node("N9_cleanup", cleanup)  # Issue #180
-    workflow.add_node("HALT", create_halt_node("testing"))  # Issue #486
+    _add("N8_document", _wrap_with_checkpoint(document, "post-document"))
+    _add("N9_cleanup", cleanup)  # Issue #180
+    _add("HALT", create_halt_node("testing"))  # Issue #486
 
     # Set entry point
     workflow.set_entry_point("N0_load_lld")

--- a/tests/unit/test_graph_atlas.py
+++ b/tests/unit/test_graph_atlas.py
@@ -23,6 +23,11 @@ from assemblyzero.workflows.requirements.atlas import (
     TOTAL_STEPS as REQ_TOTAL,
 )
 from assemblyzero.workflows.requirements.graph import create_requirements_graph
+from assemblyzero.workflows.testing.atlas import (
+    ATLAS as IMPL_ATLAS,
+    TOTAL_STEPS as IMPL_TOTAL,
+)
+from assemblyzero.workflows.testing.graph import build_testing_workflow
 
 _BOUNDARY = {"__start__", "__end__"}
 
@@ -49,6 +54,10 @@ CASES = [
     ("requirements", create_requirements_graph, REQ_ATLAS, REQ_TOTAL),
     ("implementation_spec", create_implementation_spec_graph, SPEC_ATLAS,
      SPEC_TOTAL),
+    # #2733: the third graph, and the last to get an atlas. It is the stage
+    # where runs get furthest, so its node positions are the ones the report
+    # most needs from a record rather than from a log grep.
+    ("testing", build_testing_workflow, IMPL_ATLAS, IMPL_TOTAL),
 ]
 
 

--- a/tests/unit/test_testing_atlas.py
+++ b/tests/unit/test_testing_atlas.py
@@ -1,0 +1,150 @@
+"""The implementation graph knows where it is, and says so (#2733).
+
+`tests/unit/test_graph_atlas.py` already pins this atlas to the compiled graph
+in both directions, for all three workflows. What it cannot check is the thing
+#2733 was actually filed for: that entering a node in THIS stage writes a
+`node.enter` record, so the report reads a machine-written position instead of
+grepping node markers out of a prose log.
+
+That matters more here than in the other two stages. Counted over boostgauge's
+180 runs, 45 of the 135 failures were in the implementation stage, and the
+furthest run in the whole record -- `run-issue4-172600`, three tests passing at
+72% coverage -- stopped at N5.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from assemblyzero.speedrun.convergence import (
+    EVENT_NODE_ENTER,
+    furthest_by_run,
+    read_records,
+)
+from assemblyzero.workflows.narration import narrated
+from assemblyzero.workflows.testing.atlas import ATLAS, TOTAL_STEPS
+
+GRAPH_SOURCE = (
+    Path(__file__).resolve().parents[2]
+    / "assemblyzero" / "workflows" / "testing" / "graph.py"
+)
+
+#: Nodes that exist only to loop back, plus the exit. None is on the forward
+#: path, so none consumes an ordinal.
+OFF_PATH = {"N1_5_revise_test_plan", "N4c_augment_tests", "HALT"}
+
+
+class TestTheAtlasIsWellFormed:
+    def test_the_forward_path_is_numbered_without_gaps(self):
+        ordinals = sorted(
+            entry["ordinal"] for name, entry in ATLAS.items()
+            if name not in OFF_PATH
+        )
+        assert ordinals == list(range(1, TOTAL_STEPS + 1))
+
+    def test_total_steps_counts_the_forward_path_and_nothing_else(self):
+        assert TOTAL_STEPS == len(ATLAS) - len(OFF_PATH)
+
+    def test_a_loop_or_an_exit_consumes_no_ordinal(self):
+        """A run that dies inside a loop node reports the forward node it came
+        from as its furthest position, which is the truth about how far it
+        got."""
+        for name in OFF_PATH:
+            assert ATLAS[name]["ordinal"] is None, name
+
+    def test_every_entry_says_what_the_node_is_for(self):
+        for name, entry in ATLAS.items():
+            assert entry["title"].strip(), name
+            assert entry["goal"].strip(), name
+            assert entry["teach"].strip(), name
+
+
+class TestEveryNodeIsWrapped:
+    def test_the_graph_adds_no_node_that_skips_narration(self):
+        """A node added with a bare `workflow.add_node(...)` narrates nothing
+        and records nothing, and would be invisible to the report while
+        looking perfectly healthy in the graph. Read off the source, because
+        the wrapper deliberately borrows the wrapped function's `__name__` and
+        so leaves no marker to inspect at runtime."""
+        tree = ast.parse(GRAPH_SOURCE.read_text(encoding="utf-8"))
+
+        # The one legitimate `add_node` is inside `_add` itself, which is the
+        # helper that does the wrapping. Everything outside it is a node that
+        # would go in unwrapped.
+        helpers = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "_add"
+        ]
+        assert len(helpers) == 1, "expected exactly one _add helper"
+        inside_helper = {
+            node.lineno for node in ast.walk(helpers[0])
+            if isinstance(node, ast.Call)
+        }
+
+        bare = sorted(
+            node.lineno for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_node"
+            and node.lineno not in inside_helper
+        )
+        assert bare == [], (
+            f"add_node called directly at line(s) {bare}; use the local _add "
+            "helper so the node narrates and records (#2733)"
+        )
+
+    def test_the_helper_adds_one_node_per_atlas_entry(self):
+        tree = ast.parse(GRAPH_SOURCE.read_text(encoding="utf-8"))
+        added = {
+            node.args[0].value for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name) and node.func.id == "_add"
+            and node.args and isinstance(node.args[0], ast.Constant)
+        }
+        assert added == set(ATLAS)
+
+
+class TestEnteringANodeWritesTheRecord:
+    def test_it_records_the_node_the_stage_and_the_ordinal(self, tmp_path):
+        wrapped = narrated(
+            "N5_verify_green", lambda state: {"ok": True},
+            ATLAS, TOTAL_STEPS, stage="impl",
+        )
+        assert wrapped({"repo_root": str(tmp_path)}) == {"ok": True}
+
+        records, unreadable = read_records(tmp_path)
+        assert unreadable == 0
+        entries = [r for r in records if r["event"] == EVENT_NODE_ENTER]
+        assert len(entries) == 1
+        assert entries[0]["stage"] == "impl"
+        assert entries[0]["node"] == "N5_verify_green"
+        assert entries[0]["ordinal"] == ATLAS["N5_verify_green"]["ordinal"]
+        assert entries[0]["total"] == TOTAL_STEPS
+
+    def test_the_furthest_node_is_readable_from_the_record(self, tmp_path, monkeypatch):
+        """The whole point: how far into the implementation stage a run got,
+        without parsing a log. `run-issue4-172600` is the shape -- scaffolded,
+        implemented, and stopped in the green loop."""
+        monkeypatch.setenv("SPEEDRUN_RUN_TAG", "run-issue4-172600")
+        from assemblyzero.speedrun.convergence import record_stage_enter
+
+        record_stage_enter(tmp_path, "impl", 3, 5)
+        for node in ("N2_scaffold_tests", "N4_implement_code", "N5_verify_green"):
+            narrated(node, lambda state: {}, ATLAS, TOTAL_STEPS, stage="impl")(
+                {"repo_root": str(tmp_path)}
+            )
+
+        records, _ = read_records(tmp_path)
+        assert furthest_by_run(records) == {
+            "run-issue4-172600": ("impl", "N5_verify_green")
+        }
+
+    def test_a_run_with_no_repo_root_records_nothing_and_still_runs(self):
+        """Narration and recording never cost a run. A node invoked with no
+        repository to write to returns its result and files nothing."""
+        wrapped = narrated(
+            "N0_load_lld", lambda state: {"ok": True},
+            ATLAS, TOTAL_STEPS, stage="impl",
+        )
+        assert wrapped({}) == {"ok": True}


### PR DESCRIPTION
## The stage where runs get furthest could not say where it was

An **atlas** is the map of a workflow graph: one entry per node, with its title, its goal, its position on the forward path, and the edges out of it. Two of the three graphs had one. The testing graph — which runs the implementation stage — did not, so its nodes narrated nothing and, after #2721, recorded nothing either.

That gap sat in the worst possible place. Counted over boostgauge's 180 runs, 45 of the 135 failures were in the implementation stage, and the furthest run in the whole record — `run-issue4-172600`, three tests passing at 72% coverage — stopped at N5. For every one of those, the report's "furthest node" column still came from grepping node markers out of a prose log, which is exactly the practice #2721 set out to end.

## What changed

`assemblyzero/workflows/testing/atlas.py` describes all sixteen nodes. Thirteen sit on the forward path and carry ordinals 1 through 13. `N1_5_revise_test_plan` and `N4c_augment_tests` are loops back to earlier nodes and carry no ordinal, following the convention the requirements atlas already states: a run that dies inside a loop reports the forward node it came from as its furthest position, which is the truth about how far it got.

`build_testing_workflow` adds every node through a local `_add` helper that wraps it in `narrated(..., stage="impl")` — the one place a node already announces itself, so a graph cannot grow a node that forgets to record.

## The atlas was written against the compiled graph, not against the source

I dumped the compiled graph's real nodes and edges first and authored from that. `tests/unit/test_graph_atlas.py` now runs its four existing drift checks over this graph as a third case: every graph node in the atlas, every atlas entry in the graph, every atlas successor a real edge, and every real edge an atlas successor.

**That guard paid for itself twice, immediately.**

`N2_5_validate_tests` really does have an edge to `N4_implement_code` in the compiled graph. It is declared in the router's mapping dictionary and has not been returned since #2331 removed the escalate-to-implementation route, because a suite the validator had just called unusable was entering the coder with the red phase skipped. Omitting it would have failed the fourth check; it is named in the atlas as *never taken*, so the map says what the graph actually contains.

`HALT` has **no inbound edge and no surviving outbound edge**. No router in this graph returns `"HALT"`; every stop routes straight to `END` carrying an `error_message`, which the orchestrator relays. Both other workflows do route to their HALT node. The atlas records this in the entry itself, with an empty `successors` map, and the ruling is filed separately as **#2756** — this matters beyond tidiness, because `create_halt_node` is what writes the halt bundle a stopped run leaves behind, so implementation-stage halts are not producing bundles by the path the other stages use.

## Two things that follow, both worth having

The implementation stage starts printing the `NODE [n/N]` and `NEXT` lines the other two stages print, which is the whole point of #2158.

And **#2731's call recorder now has a node name and ordinal to tag implementation-stage model calls with**, which it did not before. That is why this landed ahead of it.

## Tests

`tests/unit/test_testing_atlas.py`, new, 9 tests, covering what the drift guard structurally cannot:

- the forward path is numbered 1..13 with no gaps, and `TOTAL_STEPS` equals the count of ordinal-bearing entries;
- the two loop nodes and `HALT` carry no ordinal;
- every entry says what its node is for;
- **the graph adds no node that skips narration** — read off the source with the abstract syntax tree, because the wrapper deliberately borrows the wrapped function's `__name__` and leaves nothing to inspect at runtime. The `_add` helper's own `add_node` call is excluded by locating the helper's body rather than by matching a line number;
- the helper adds exactly one node per atlas entry;
- entering a node writes a `node.enter` record carrying stage `impl`, the node name, the atlas ordinal and the total;
- **the furthest node is readable back from the record**, shaped as `run-issue4-172600` was — scaffolded, implemented, stopped in the green loop — and `furthest_by_run` returns `("impl", "N5_verify_green")`;
- a node invoked with no repository to write to returns its result and files nothing, because narration must never cost a run.

The first of those caught a real gap in my own first draft: I had written the check against every `add_node` call in the file, and it flagged the wrapping helper itself.

Full unit suite: 9,913 passed, 21 skipped, 5 xfailed, 7 deselected. Halt sites unchanged at 151, model-output halt rows unchanged at 18; this PR adds no gate and retires none.

Closes #2733
