### PR TITLE
feat: record every model call, as sent and as received (Closes #2731)

### DIFF
--- a/assemblyzero/core/call_recording.py
+++ b/assemblyzero/core/call_recording.py
@@ -1,0 +1,422 @@
+"""Every model call, as sent and as received (#2731).
+
+The launch gate. Twelve launches were allowed on boostgauge #421 and all twelve
+are spent; nothing relaunches until the recorded runs replay past the walls that
+killed them (#2724). That question cannot be answered for two of the four
+recorded runs, and the reason is here rather than in the replay runner.
+
+## What the pipeline persisted, and why a replay outgrew it
+
+The pipeline writes the artifacts it DERIVED from each response, not the
+response. ``NNN-spec-draft.md`` is written after preamble stripping, pinning
+adjudication and decision-table re-assertion; ``NNN-readiness-verdict.md`` is
+markdown assembled from a parsed verdict. Neither is what the model said, and
+nothing at all recorded the edit script a revision round sent or the prompt any
+call was given.
+
+So `assemblyzero.speedrun.replay` reconstructs: it derives SEARCH/REPLACE blocks
+that carry recorded draft N to recorded draft N+1 and answers the round with
+those. Counted over the four runs replayed on 2026-09-03, 0 of 18 synthesised
+scripts failed to PARSE and the first APPLICATION failure landed at round 5 or
+6 — the reconstruction is faithful for about five rounds, and then the
+accumulated difference exceeds one exact-match anchor and the replay stops for a
+reason that has nothing to do with the gate under test.
+
+## What this module does instead
+
+`RecordingProvider` wraps any transport and writes one line per call to
+``calls.jsonl`` in the run-scoped lineage directory the run already claims. The
+prompt as sent, the response as received, in call order, tagged with the stage,
+the node and how many times that node has been entered.
+
+`ReplayProvider` reads that file back and answers call N with recorded response
+N — but only if the prompt the code sends at call N is the prompt the recording
+holds. When it is not, it refuses and says where they differ, which turns "the
+derived blocks stopped applying" into "the prompt at call 6 differs, here is the
+diff". That is the difference between a replay that cannot reach the wall and
+one that reports what changed on the way.
+
+**A recording never costs a run.** Every write here returns False rather than
+raising, exactly as `record_heal` and the convergence record do. The absence is
+visible at the other end: `read_calls` reports what it could not read, and the
+replay says which source it used, so a run with no recording reads as a run with
+no recording and never as a run that replayed clean.
+
+**The drafts and verdicts stay where they are.** They are what a human reads
+when diagnosing a halt, and a raw call log is not a substitute for them.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assemblyzero.core.llm_provider import LLMCallResult, LLMProvider
+
+#: The recording, beside the lineage the run already writes. One per run,
+#: because the lineage directory is run-scoped (#1467).
+CALLS_FILENAME = "calls.jsonl"
+
+#: Set by `speedrun_roll.py` for the whole roll. Absent outside a roll, and
+#: recorded as "" rather than invented, for the reason `convergence` gives.
+RUN_TAG_ENV = "SPEEDRUN_RUN_TAG"
+
+#: How a replay says which source answered it. The report prints this, because
+#: "the recording said so" and "a draft was reconstructed into a rule" are
+#: different evidence and a reader deciding whether to launch is entitled to
+#: know which they have.
+SOURCE_RECORDING = "recording"
+SOURCE_RECONSTRUCTION = "reconstruction"
+
+#: How many lines of prompt difference a divergence report carries. A whole
+#: 60,000-character prompt in an error message is unreadable; the first lines
+#: that differ are the finding.
+DIFF_LINES = 24
+
+
+@dataclass
+class CallContext:
+    """Where the next model call is coming from, as the graph knows it.
+
+    Set by `narrated()` on every node entry -- the one place every node already
+    announces itself -- so a graph cannot grow a node whose calls are recorded
+    without a stage and a node name.
+
+    ``entry`` is how many times this node has been entered in this run. For a
+    loop node that is the round, which is the number a replay's divergence
+    report needs and which no transport could work out for itself.
+    """
+
+    stage: str = ""
+    node: str = ""
+    entry: int = 0
+    audit_dir: str = ""
+
+
+_context = CallContext()
+_entries: dict[tuple[str, str], int] = {}
+
+
+def set_context(stage: str, node: str, audit_dir: str) -> CallContext:
+    """Record that the run has entered ``node`` of ``stage``."""
+    key = (stage, node)
+    _entries[key] = _entries.get(key, 0) + 1
+    global _context
+    _context = CallContext(
+        stage=stage, node=node, entry=_entries[key], audit_dir=audit_dir or ""
+    )
+    return _context
+
+
+def current_context() -> CallContext:
+    return _context
+
+
+def reset_context() -> None:
+    """Forget the current node and every entry count.
+
+    Called between rolls. Without it a second roll in one process continues the
+    first roll's round numbering, and a recording that says round 7 for the
+    first call of a run is worse than one that says nothing.
+    """
+    global _context
+    _context = CallContext()
+    _entries.clear()
+
+
+def calls_path(audit_dir: Path | str) -> Path:
+    return Path(audit_dir) / CALLS_FILENAME
+
+
+def recording_is_armed() -> bool:
+    """Whether there is somewhere to write. False outside a run."""
+    return bool(_context.audit_dir)
+
+
+def current_run_tag() -> str:
+    """The roll's tag, or "" outside a roll. Never invented."""
+    return os.environ.get(RUN_TAG_ENV, "").strip()
+
+
+def _append(audit_dir: str, record: dict) -> bool:
+    try:
+        path = calls_path(audit_dir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return True
+    except Exception:  # noqa: BLE001 - a recording must never cost a roll
+        # fail-open: a run that cannot write its recording still has to finish.
+        # The absence is visible downstream -- `read_calls` returns nothing and
+        # the replay reports that it fell back to reconstruction -- so nothing
+        # here can be mistaken for a run that replayed clean.
+        return False
+
+
+def read_calls(audit_dir: Path | str) -> tuple[list[dict], int]:
+    """Every readable call, in sequence order, and how many lines were not.
+
+    The unreadable count is returned rather than logged, for the reason
+    `convergence.read_records` gives: a caller that reports "11 calls" while
+    silently dropping two corrupt lines is stating a number it did not count.
+    """
+    path = calls_path(audit_dir)
+    if not path.exists():
+        return [], 0
+    calls: list[dict] = []
+    unreadable = 0
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            # fail-open: one truncated line -- a roll killed mid-write -- must
+            # not make the whole recording unreadable. It is COUNTED rather
+            # than dropped, so no caller reports a call count it did not count.
+            unreadable += 1
+            continue
+        if isinstance(parsed, dict) and "seq" in parsed:
+            calls.append(parsed)
+        else:
+            unreadable += 1
+    calls.sort(key=lambda c: int(c.get("seq", 0) or 0))
+    return calls, unreadable
+
+
+class RecordingProvider(LLMProvider):
+    """A transport that writes down what it was asked and what it answered.
+
+    Wraps rather than replaces: the inner provider does the work and every
+    field of its result is passed through untouched. This class only writes a
+    line, and only when the graph has told it where.
+    """
+
+    def __init__(self, inner: LLMProvider, *, audit_dir: str = "") -> None:
+        self.inner = inner
+        self._audit_dir = audit_dir
+
+    @property
+    def provider_name(self) -> str:
+        return self.inner.provider_name
+
+    @property
+    def model(self) -> str:
+        return self.inner.model
+
+    def invoke(
+        self,
+        system_prompt: str,
+        content: str,
+        timeout_seconds: int = 300,
+        response_schema: dict | None = None,
+        json_schema: dict | None = None,
+    ) -> LLMCallResult:
+        started = time.monotonic()
+        result = self.inner.invoke(
+            system_prompt, content, timeout_seconds, response_schema, json_schema
+        )
+        context = current_context()
+        destination = self._audit_dir or context.audit_dir
+        if destination:
+            _append(destination, {
+                "seq": _next_seq(destination),
+                "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "run_tag": current_run_tag(),
+                "stage": context.stage,
+                "node": context.node,
+                "round": context.entry,
+                "provider": self.inner.provider_name,
+                "model": self.inner.model,
+                # Verbatim, both of them. A length or a hash would answer
+                # "did something change" and not "what changed", and the
+                # second question is the one a divergence report exists for.
+                "system_prompt": system_prompt or "",
+                "content": content or "",
+                "response": result.response or "",
+                "success": bool(result.success),
+                "error_message": result.error_message or "",
+                "duration_ms": int((time.monotonic() - started) * 1000),
+                "has_schema": bool(response_schema or json_schema),
+            })
+        return result
+
+
+def _next_seq(audit_dir: str) -> int:
+    """One past the highest sequence number already on disk.
+
+    Counted from the file rather than from a counter in memory, so a resumed
+    run appends after the calls the first process wrote instead of restarting
+    at 1 and producing two call number 1s in one recording.
+    """
+    calls, _ = read_calls(audit_dir)
+    return (max((int(c.get("seq", 0) or 0) for c in calls), default=0)) + 1
+
+
+@dataclass
+class Divergence:
+    """Where a replay stopped fitting the recording."""
+
+    seq: int
+    field: str
+    recorded_head: str
+    actual_head: str
+    diff: str
+
+    def describe(self) -> str:
+        return (
+            f"ReplayProvider: the {self.field} at call {self.seq} differs from "
+            f"the recording, so the recorded response is no longer the response "
+            f"this prompt would have drawn. Replay stops here rather than "
+            f"answering with it (#2731).\n{self.diff}"
+        )
+
+
+class ReplayProvider(LLMProvider):
+    """A transport made of one run's recorded calls, answered in order.
+
+    The difference from `ScriptedProvider`, and the whole of #2731: this
+    matches on the PROMPT, byte for byte, rather than on a regex over a
+    reconstructed rule. Call N is answered with recorded response N only when
+    the code sends recorded prompt N. Anything else is a divergence with a
+    diff, which is a finding a reader can act on, rather than a rule that
+    quietly stopped applying.
+    """
+
+    def __init__(self, calls: list[dict], *, model: str = "replay") -> None:
+        self._calls = sorted(calls, key=lambda c: int(c.get("seq", 0) or 0))
+        self._model = model
+        self._index = 0
+        self.divergence: Divergence | None = None
+        #: (stage, node, round) of each call served, in order. A replay that
+        #: reaches the right end state by the wrong route is a defect an
+        #: end-state assertion does not catch.
+        self.path: list[tuple[str, str, int]] = []
+
+    @property
+    def provider_name(self) -> str:
+        return "replay"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def served(self) -> int:
+        return self._index
+
+    @property
+    def recorded(self) -> int:
+        return len(self._calls)
+
+    def invoke(
+        self,
+        system_prompt: str,
+        content: str,
+        timeout_seconds: int = 300,
+        response_schema: dict | None = None,
+        json_schema: dict | None = None,
+    ) -> LLMCallResult:
+        seq = self._index + 1
+        if self._index >= len(self._calls):
+            return self._refuse(Divergence(
+                seq=seq, field="call count",
+                recorded_head="", actual_head="",
+                diff=(
+                    f"the recording holds {len(self._calls)} call(s) and the "
+                    f"code is making call {seq}. The run has gone further than "
+                    f"the recording did, so there is nothing faithful to "
+                    f"answer with."
+                ),
+            ))
+
+        call = self._calls[self._index]
+        for field_name, actual in (
+            ("system prompt", system_prompt or ""),
+            ("content", content or ""),
+        ):
+            key = "system_prompt" if field_name == "system prompt" else "content"
+            recorded = str(call.get(key, "") or "")
+            if recorded != actual:
+                return self._refuse(Divergence(
+                    seq=seq,
+                    field=field_name,
+                    recorded_head=recorded[:200],
+                    actual_head=actual[:200],
+                    diff=_diff(recorded, actual),
+                ))
+
+        self._index += 1
+        self.path.append((
+            str(call.get("stage", "")),
+            str(call.get("node", "")),
+            int(call.get("round", 0) or 0),
+        ))
+        return LLMCallResult(
+            success=bool(call.get("success", True)),
+            response=str(call.get("response", "") or ""),
+            raw_response=None,
+            error_message=str(call.get("error_message", "") or "") or None,
+            provider="replay",
+            model_used=str(call.get("model", self._model) or self._model),
+            duration_ms=0,
+            attempts=1,
+        )
+
+    def _refuse(self, divergence: Divergence) -> LLMCallResult:
+        self.divergence = divergence
+        return LLMCallResult(
+            success=False,
+            response=None,
+            raw_response=None,
+            error_message=divergence.describe(),
+            provider="replay",
+            model_used=self._model,
+            duration_ms=0,
+            attempts=1,
+        )
+
+
+def _diff(recorded: str, actual: str) -> str:
+    """The first lines where two prompts differ, as a unified diff."""
+    lines = list(difflib.unified_diff(
+        recorded.splitlines(), actual.splitlines(),
+        fromfile="recorded", tofile="sent", lineterm="", n=1,
+    ))
+    if not lines:
+        return "(the texts differ only in trailing whitespace or line endings)"
+    shown = lines[:DIFF_LINES]
+    if len(lines) > DIFF_LINES:
+        shown.append(f"... and {len(lines) - DIFF_LINES} more diff line(s)")
+    return "\n".join(shown)
+
+
+@dataclass
+class RecordingSummary:
+    """What a recording holds, counted for the report."""
+
+    calls: int = 0
+    unreadable: int = 0
+    stages: list[str] = field(default_factory=list)
+    run_tags: list[str] = field(default_factory=list)
+
+    @property
+    def usable(self) -> bool:
+        return self.calls > 0
+
+
+def summarize(audit_dir: Path | str) -> RecordingSummary:
+    """Read a recording and say what is in it, without loading it into a rule."""
+    calls, unreadable = read_calls(audit_dir)
+    return RecordingSummary(
+        calls=len(calls),
+        unreadable=unreadable,
+        stages=sorted({str(c.get("stage", "")) for c in calls if c.get("stage")}),
+        run_tags=sorted({str(c.get("run_tag", "")) for c in calls if c.get("run_tag")}),
+    )

--- a/assemblyzero/core/llm_provider.py
+++ b/assemblyzero/core/llm_provider.py
@@ -1870,6 +1870,38 @@ def get_provider(spec: str, effort: str | None = None) -> LLMProvider:
         >>> reviewer = get_provider("gemini:3.1-pro")
         >>> mock = get_provider("mock:test")
     """
+    return _recorded(_build_provider(spec, effort))
+
+
+def _recorded(provider: "LLMProvider") -> "LLMProvider":
+    """Wrap a transport so its calls are written down, when there is a run.
+
+    #2731. This is the single place every stage asks for a transport, so it is
+    the single place a recording can be attached without every caller having to
+    remember to. The wrap happens ONLY when a graph node has said where the
+    run-scoped lineage directory is; outside a run -- a unit test, a one-off
+    script -- `get_provider` returns exactly what it always returned, which is
+    what keeps the scripted-provider identity contract intact.
+    """
+    try:
+        from assemblyzero.core.call_recording import (
+            RecordingProvider,
+            recording_is_armed,
+        )
+
+        if recording_is_armed():
+            return RecordingProvider(provider)
+    except Exception:  # noqa: BLE001 - a recording never costs a roll
+        # fail-open: if the recorder cannot be reached, the run proceeds on the
+        # bare transport. A missing recording is reported by the replay, which
+        # says it fell back to reconstruction; a roll that dies because it could
+        # not set up a diagnostic is unrecoverable.
+        pass
+    return provider
+
+
+def _build_provider(spec: str, effort: str | None = None) -> "LLMProvider":
+    """The transport itself, before #2731's recording wrap."""
     provider, model = parse_provider_spec(spec)
 
     if provider == "claude":

--- a/assemblyzero/speedrun/replay.py
+++ b/assemblyzero/speedrun/replay.py
@@ -57,6 +57,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from assemblyzero.core.call_recording import (
+    SOURCE_RECONSTRUCTION,
+    SOURCE_RECORDING,
+    summarize,
+)
 from assemblyzero.core.scripted_provider import ScriptedRule
 
 # ---------------------------------------------------------------------------
@@ -577,6 +582,14 @@ class ReplayResult:
     #: that reaches the right end state by the wrong route is a defect an
     #: end-state assertion does not catch.
     path: list[str] = field(default_factory=list)
+    #: Which transport answered: a recording of the actual calls (#2731), or
+    #: rules reconstructed from the drafts and verdicts. The report prints it,
+    #: because "the recording said so" and "a draft was reconstructed into a
+    #: rule" are different evidence and a reader deciding whether to launch is
+    #: entitled to know which they have.
+    source: str = SOURCE_RECONSTRUCTION
+    #: Calls the recording held, when one answered. 0 under reconstruction.
+    recorded_calls: int = 0
 
 
 def classify(
@@ -615,8 +628,8 @@ def render_table(results: list[ReplayResult]) -> str:
     table travels into PR bodies read by people who will not open the doc.
     """
     lines = [
-        "| run | stage | recorded ended at | replay ended at | verdict |",
-        "|---|---|---|---|---|",
+        "| run | stage | answered by | recorded ended at | replay ended at | verdict |",
+        "|---|---|---|---|---|---|",
     ]
     for r in results:
         recorded = f"`{r.recorded_cause}` at round {r.recorded_progress}"
@@ -626,9 +639,53 @@ def render_table(results: list[ReplayResult]) -> str:
             reached = "finished the stage"
         else:
             reached = f"`{r.replay_cause}` at round {r.replay_progress}"
+        # #2731: which transport answered is part of the verdict's weight, not
+        # a footnote. A recording is the calls the run actually made; a
+        # reconstruction is rules derived from the artifacts, exact for about
+        # five rounds. The table says which, on every row.
+        source = (
+            f"{r.source} ({r.recorded_calls} calls)"
+            if r.source == SOURCE_RECORDING else r.source
+        )
         lines.append(
-            f"| {r.tag} | {r.stage} | {recorded} | {reached} | **{r.verdict}** |"
+            f"| {r.tag} | {r.stage} | {source} | {recorded} | {reached} | "
+            f"**{r.verdict}** |"
         )
     shown = [name for name in VERDICTS if any(r.verdict == name for r in results)]
     legend = [f"- **{name}** — {VERDICT_MEANING[name]}" for name in shown]
+    if any(r.source == SOURCE_RECONSTRUCTION for r in results):
+        legend.append(
+            f"- **{SOURCE_RECONSTRUCTION}** — the run recorded no model calls, "
+            "so its responses were rebuilt from the drafts and verdicts it left "
+            "behind. Exact for about five rounds (#2731)."
+        )
+    if any(r.source == SOURCE_RECORDING for r in results):
+        legend.append(
+            f"- **{SOURCE_RECORDING}** — answered from the run's own calls, "
+            "prompt for prompt; a divergence names the call and the diff."
+        )
     return "\n".join([*lines, "", *legend])
+
+
+def recording_for(spec_dir: Path) -> tuple[bool, int, str]:
+    """Whether this run recorded its calls, how many, and what to say about it.
+
+    Returns (usable, calls, note). The note is carried into the result's notes
+    so a reader can tell "this run predates the recorder" from "this run's
+    recording is unreadable" -- two very different reasons for falling back.
+    """
+    summary = summarize(spec_dir)
+    if summary.usable:
+        note = f"answered from {summary.calls} recorded call(s)"
+        if summary.unreadable:
+            note += f"; {summary.unreadable} unreadable line(s) in the recording"
+        return True, summary.calls, note
+    if summary.unreadable:
+        return False, 0, (
+            f"the recording holds {summary.unreadable} unreadable line(s) and "
+            f"no usable call; fell back to reconstruction"
+        )
+    return False, 0, (
+        "this run recorded no model calls (it predates #2731); its responses "
+        "were reconstructed from the drafts and verdicts it left behind"
+    )

--- a/assemblyzero/workflows/narration.py
+++ b/assemblyzero/workflows/narration.py
@@ -99,6 +99,12 @@ def narrated(node_id: str, fn, atlas: dict, total: int, stage: str = ""):
     ``stage`` names the sub-workflow for the record. A caller that omits it
     still narrates, and the record is skipped rather than filed under a blank
     stage that would make two graphs' nodes indistinguishable.
+
+    #2731 adds a third output from the same wrap: the call context every model
+    call made inside this node is recorded against. Here for the same reason
+    the position record is -- this is the one place every node announces
+    itself, so a graph cannot grow a node whose calls are recorded with no
+    stage, no node name and no round.
     """
 
     def _wrapped(state, *args, **kwargs):
@@ -109,6 +115,7 @@ def narrated(node_id: str, fn, atlas: dict, total: int, stage: str = ""):
             pass
         if stage:
             _record_entry(node_id, atlas, total, stage, state)
+            _set_call_context(node_id, stage, state)
         return fn(state, *args, **kwargs)
 
     _wrapped.__name__ = getattr(fn, "__name__", node_id)
@@ -141,4 +148,26 @@ def _record_entry(node_id: str, atlas: dict, total: int, stage: str, state) -> N
         # missing diagnostic, and the missing one is reported -- the factory
         # report names its source, so a run with no records reads as a run with
         # no records rather than as a run that passed.
+        return
+
+
+def _set_call_context(node_id: str, stage: str, state) -> None:
+    """Tell the call recorder which node the next model calls belong to (#2731).
+
+    The audit directory comes from the state key all three workflows already
+    carry, so the recording lands beside the lineage the run writes rather than
+    in a new store. A node with no audit directory in state records nothing,
+    which is the honest outcome: there is no run-scoped place to put it.
+    """
+    try:
+        from assemblyzero.core.call_recording import set_context
+
+        audit_dir = state.get("audit_dir", "") if hasattr(state, "get") else ""
+        set_context(stage, node_id, str(audit_dir or ""))
+    except Exception:  # noqa: BLE001 - the recording never costs a run
+        # fail-open: this runs BEFORE the node does, so an exception here would
+        # take down a node that had not started, to protect a diagnostic. The
+        # cost of continuing is bounded and visible: calls made in this node
+        # are recorded against whichever node was entered last, and the replay
+        # reports the recording it read rather than assuming one exists.
         return

--- a/tests/unit/test_call_recording_roll.py
+++ b/tests/unit/test_call_recording_roll.py
@@ -1,0 +1,431 @@
+"""A roll records its calls, and the recording replays it exactly (#2731).
+
+The launch gate. Replay proves that the gate which killed a recorded run no
+longer kills that run's content, and until now it proved it from a
+reconstruction: rules derived from the drafts and verdicts a run left behind,
+because the pipeline never wrote down the calls themselves. Counted over the
+four runs replayed on 2026-09-03, that reconstruction was faithful for about
+five rounds and then one edit anchor missed, and the replay stopped for a reason
+that had nothing to do with the gate under test.
+
+This suite is the acceptance for the recorder that replaces it. Both rolls below
+run the REAL implementation-spec graph -- the routers, the janitors, the gates,
+the pinning enforcement, the file writes and the halt path -- against a
+throwaway git repository, with only the transport scripted. Each is run twice:
+once answered by fixtures while the recorder writes `calls.jsonl`, and once
+answered by that recording. The two runs must reach the same terminal record.
+
+**Byte-exact is the point.** `ReplayProvider` refuses a call whose prompt is not
+the prompt the recording holds, and the second pass is run against a restored
+copy of the repository at the same absolute path for exactly that reason: a
+replay that tolerated a changed prompt would be answering a question nobody
+asked, which is the failure the reconstruction had and could not name.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.call_recording import (
+    ReplayProvider,
+    read_calls,
+    reset_context,
+    summarize,
+)
+from assemblyzero.core.scripted_provider import (
+    ScriptedProvider,
+    ScriptedRule,
+    set_active,
+)
+from assemblyzero.speedrun.convergence import (
+    OUTCOME_FAILED,
+    OUTCOME_PASSED,
+    read_records,
+    record_terminal,
+    terminals_by_run,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+LLD = """# LLD-999: Add a greeting
+
+* **Status:** Approved 2026-09-04
+
+## 1. Requirements
+
+- REQ-1: `greet(name)` returns `"hello, <name>"`.
+
+## 2. Files Changed
+
+| file | change |
+|---|---|
+| `src/greet.py` | Add |
+
+## 10. Test Plan
+
+| id | scenario | expects |
+|---|---|---|
+| S1 | greet("world") | returns "hello, world" |
+"""
+
+SPEC = """# Implementation Spec: greeting
+
+## 1. Overview
+
+Implements REQ-1.
+
+## 2. Files
+
+- `src/greet.py` (Add)
+
+## 10. Test Plan
+
+### 10.1 Test Functions
+
+```python
+def test_S1_greet_world():
+    from greet import greet
+    assert greet("world") == "hello, world"
+```
+"""
+
+APPROVED = json.dumps({
+    "verdict": "APPROVED",
+    "rationale": "covers REQ-1",
+    "feedback_items": [],
+})
+
+#: The shape that killed run 12 of boostgauge #4: the reviewer escalates a
+#: contradiction in the issue's own acceptance criteria, which no spec can
+#: satisfy, and the run stops at `spec.requirements_conflict`.
+BLOCKED = json.dumps({
+    "verdict": "BLOCKED",
+    "rationale": (
+        "REQUIREMENTS CONFLICT: REQ-1 asks for a lower-case greeting and the "
+        "test plan expects a capitalised one. No spec can satisfy both."
+    ),
+    "feedback_items": ["rule on the casing before this can be drafted"],
+})
+
+PATTERN_DRAFTER = "technical architect creating an Implementation Specification"
+PATTERN_REVIEWER = "Implementation Readiness Review"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+        encoding="utf-8", errors="replace",
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    """A throwaway target repo, plus a pristine copy to restore between passes.
+
+    The restore is what makes the second pass byte-comparable: the spec stage
+    reads the repository to build its prompt, so a replay against a tree the
+    first pass had already written to would be sent a different prompt and
+    would -- correctly -- refuse it.
+    """
+    repo = tmp_path / "target"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)],
+        capture_output=True, text=True, check=True,
+    )
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "base")
+
+    lld_path = tmp_path / "LLD-999.md"
+    lld_path.write_text(LLD, encoding="utf-8")
+
+    pristine = tmp_path / "pristine"
+    shutil.copytree(repo, pristine)
+
+    def restore() -> None:
+        _rmtree(repo)
+        shutil.copytree(pristine, repo)
+        # The lineage directory too, and this one is load-bearing. Left in
+        # place, `generate_spec` recovers the previous pass's draft by globbing
+        # `*-spec-draft.md` out of it and never calls the drafter at all -- the
+        # second pass would start mid-loop, its first call would be the
+        # reviewer's, and the replay would report a divergence that is an
+        # artifact of the harness rather than of the code. Caught exactly that
+        # way while building this test.
+        lineage = tmp_path / "lineage"
+        if lineage.exists():
+            _rmtree(lineage)
+
+    return tmp_path, repo, lld_path, restore
+
+
+def _rmtree(path: Path) -> None:
+    """Remove a tree that contains a git object store, on Windows.
+
+    Git writes its loose objects read-only, and Windows refuses to unlink a
+    read-only file, so a plain `rmtree` raises PermissionError partway through
+    and leaves half a repository behind. Clearing the bit and retrying is the
+    documented remedy.
+    """
+    def _clear_readonly(func, target, _exc):
+        os.chmod(target, stat.S_IWRITE)
+        func(target)
+
+    shutil.rmtree(path, onexc=_clear_readonly)
+
+
+def _state(tmp_path: Path, repo: Path, lld_path: Path) -> dict:
+    return {
+        "issue_number": 999,
+        "lld_path": str(lld_path),
+        "repo_root": str(repo),
+        "assemblyzero_root": str(ROOT),
+        "audit_dir": str(tmp_path / "lineage"),
+        "base_branch": "main",
+        "lld_content": "",
+        "files_to_modify": [],
+        "current_state_snapshots": {},
+        "pattern_references": [],
+        "spec_draft": "",
+        "spec_path": "",
+        "completeness_issues": [],
+        "validation_passed": False,
+        "review_verdict": "BLOCKED",
+        "review_feedback": "",
+        "review_iteration": 0,
+        "review_feedback_history": [],
+        "max_iterations": 3,
+        "human_gate_enabled": False,
+        "next_node": "",
+        "error_message": "",
+        "cost_budget_usd": 0.0,
+        "config_reviewer": "scripted:reviewer",
+        "config_drafter": "scripted:drafter",
+        "config_mock_mode": False,
+        "config_effort": "",
+        "node_costs": {},
+        "node_tokens": {},
+    }
+
+
+def _roll(tmp_path: Path, repo: Path, lld_path: Path, provider) -> dict:
+    """Run the real spec graph with ``provider`` as the only thing mocked."""
+    from assemblyzero.workflows.implementation_spec.graph import (
+        create_implementation_spec_graph,
+    )
+
+    reset_context()
+    set_active(provider)
+    state = _state(tmp_path, repo, lld_path)
+    final = dict(state)
+    try:
+        graph = create_implementation_spec_graph()
+        for event in graph.stream(state, {"recursion_limit": 60}):
+            for node_name, node_output in event.items():
+                if node_name == "__end__" or not node_output:
+                    continue
+                final.update(node_output)
+    finally:
+        set_active(None)
+        reset_context()
+    return final
+
+
+def _recording_in(root: Path) -> Path:
+    """Where the roll actually wrote its recording.
+
+    Discovered rather than assumed, and searched from the whole workspace
+    rather than from the repository, because the two rolls put it in different
+    places: the loader replaces `audit_dir` with a run-scoped lineage directory
+    (#1467) and the finalizer moves that from `active` to `done`, while a roll
+    that halts before finalizing leaves it where the halt found it.
+    """
+    found = sorted(root.glob("**/calls.jsonl"))
+    assert len(found) == 1, (
+        f"expected one recording under {root}, found {found}"
+    )
+    return found[0].parent
+
+
+def _terminal(final: dict, calls: int) -> tuple[str, int, int]:
+    """(gate, round, call count) -- the triple a terminal record carries."""
+    error = str(final.get("error_message", "") or "")
+    gate = "finalize" if final.get("spec_path") and not error else (
+        "spec.requirements_conflict" if "REQUIREMENTS CONFLICT" in error
+        else (error.splitlines() or [""])[0][:60]
+    )
+    return gate, int(final.get("review_iteration", 0) or 0), calls
+
+
+@pytest.mark.parametrize(
+    "name,verdict,expected_gate",
+    [
+        ("a passed roll", APPROVED, "finalize"),
+        ("a halted roll", BLOCKED, "spec.requirements_conflict"),
+    ],
+    ids=["passed", "halted"],
+)
+class TestARecordedRollReplaysExactly:
+    def test_the_roll_records_its_calls_and_the_recording_replays_it(
+        self, workspace, name, verdict, expected_gate
+    ):
+        tmp_path, repo, lld_path, restore = workspace
+        rules = [
+            ScriptedRule("spec-drafter", system_pattern=PATTERN_DRAFTER,
+                         response=SPEC),
+            ScriptedRule("spec-reviewer", system_pattern=PATTERN_REVIEWER,
+                         response=verdict),
+        ]
+
+        # Pass one: fixtures answer, and the recorder writes down every call.
+        scripted = ScriptedProvider(rules, model="mock-roll")
+        first = _roll(tmp_path, repo, lld_path, scripted)
+        recording_dir = _recording_in(tmp_path)
+        calls, unreadable = read_calls(recording_dir)
+        assert unreadable == 0
+        assert calls, "the roll recorded no model calls"
+
+        first_terminal = _terminal(first, len(calls))
+        assert first_terminal[0] == expected_gate, (
+            f"{name} did not reach the gate this test is about: {first}"
+        )
+        record_terminal(
+            tmp_path, outcome=(
+                OUTCOME_PASSED if expected_gate == "finalize" else OUTCOME_FAILED
+            ),
+            furthest_stage="spec", furthest_node="N5_review_spec",
+            gate_key=first_terminal[0], run_tag="pass-one",
+        )
+
+        # Pass two: the recording answers, against a restored tree at the same
+        # absolute path, so every prompt is the prompt pass one sent.
+        restore()
+        replay = ReplayProvider(calls)
+        second = _roll(tmp_path, repo, lld_path, replay)
+
+        assert replay.divergence is None, (
+            f"the replay diverged: {replay.divergence.describe()}"
+            if replay.divergence else ""
+        )
+        assert replay.served == len(calls), (
+            f"served {replay.served} of {len(calls)} recorded call(s)"
+        )
+
+        second_terminal = _terminal(second, replay.served)
+        record_terminal(
+            tmp_path, outcome=(
+                OUTCOME_PASSED if expected_gate == "finalize" else OUTCOME_FAILED
+            ),
+            furthest_stage="spec", furthest_node="N5_review_spec",
+            gate_key=second_terminal[0], run_tag="pass-two",
+        )
+
+        assert second_terminal == first_terminal, (
+            "the replay reached a different place than the roll it replays"
+        )
+
+        # And the same claim read back off the terminal records themselves,
+        # rather than off the two dictionaries this test happens to be holding.
+        records, bad = read_records(tmp_path)
+        assert bad == 0
+        terminals = terminals_by_run(records)
+        assert terminals["pass-one"]["gate_key"] == terminals["pass-two"]["gate_key"]
+        assert terminals["pass-one"]["outcome"] == terminals["pass-two"]["outcome"]
+
+    def test_the_recording_is_tagged_by_stage_node_and_round(
+        self, workspace, name, verdict, expected_gate
+    ):
+        tmp_path, repo, lld_path, _restore = workspace
+        rules = [
+            ScriptedRule("spec-drafter", system_pattern=PATTERN_DRAFTER,
+                         response=SPEC),
+            ScriptedRule("spec-reviewer", system_pattern=PATTERN_REVIEWER,
+                         response=verdict),
+        ]
+        _roll(tmp_path, repo, lld_path, ScriptedProvider(rules, model="mock-roll"))
+        recording_dir = _recording_in(tmp_path)
+        calls, _ = read_calls(recording_dir)
+
+        assert [c["seq"] for c in calls] == list(range(1, len(calls) + 1))
+        assert {c["stage"] for c in calls} == {"spec"}
+        assert calls[0]["node"] == "N2_generate_spec"
+        assert calls[0]["round"] == 1
+        for call in calls:
+            assert call["system_prompt"], "the prompt as sent is the point"
+            assert call["round"] >= 1
+            assert "duration_ms" in call
+
+        summary = summarize(recording_dir)
+        assert summary.usable
+        assert summary.calls == len(calls)
+        assert summary.stages == ["spec"]
+
+
+class TestADivergenceIsNamedRatherThanAnswered:
+    def test_a_code_change_to_the_prompt_stops_the_replay_and_says_where(
+        self, workspace, monkeypatch
+    ):
+        """The whole reason #2731 exists, reproduced.
+
+        A code change edits a prompt, so the recorded response is no longer the
+        response that prompt would have drawn. Under reconstruction that
+        surfaced four rounds later as "the derived blocks stopped applying",
+        which names neither the change nor the call. Here it is the call number
+        and the diff, at the first call the change touches.
+        """
+        tmp_path, repo, lld_path, restore = workspace
+        rules = [
+            ScriptedRule("spec-drafter", system_pattern=PATTERN_DRAFTER,
+                         response=SPEC),
+            ScriptedRule("spec-reviewer", system_pattern=PATTERN_REVIEWER,
+                         response=APPROVED),
+        ]
+        _roll(tmp_path, repo, lld_path, ScriptedProvider(rules, model="mock-roll"))
+        calls, _ = read_calls(_recording_in(tmp_path))
+        restore()
+
+        # Someone edits the drafter's system prompt, the way half the PRs in
+        # this repository do.
+        # `importlib`, not `from ... import generate_spec`: the package
+        # re-exports the NODE FUNCTION under that name, so the plain import
+        # hands back a function with no module attributes to patch.
+        module = importlib.import_module(
+            "assemblyzero.workflows.implementation_spec.nodes.generate_spec"
+        )
+        monkeypatch.setattr(
+            module, "DRAFTER_SYSTEM_PROMPT",
+            module.DRAFTER_SYSTEM_PROMPT + "\nAlways cite the LLD line.",
+        )
+
+        replay = ReplayProvider(calls)
+        final = _roll(tmp_path, repo, lld_path, replay)
+
+        assert replay.divergence is not None
+        assert replay.divergence.seq == 1, "the first call the change touches"
+        assert replay.divergence.field == "system prompt"
+        assert "Always cite the LLD line." in replay.divergence.diff
+        assert "ReplayProvider:" in str(final.get("error_message", ""))
+        assert replay.served == 0, "nothing is answered after a divergence"
+
+    def test_running_past_the_recording_is_a_divergence_not_a_guess(self):
+        replay = ReplayProvider([
+            {"seq": 1, "system_prompt": "s", "content": "c", "response": "r",
+             "success": True},
+        ])
+        assert replay.invoke("s", "c").response == "r"
+        second = replay.invoke("s", "c")
+        assert second.success is False
+        assert "holds 1 call(s)" in second.error_message
+        assert replay.divergence.seq == 2

--- a/tools/replay_run.py
+++ b/tools/replay_run.py
@@ -45,6 +45,12 @@ from assemblyzero.speedrun.factory_report import (  # noqa: E402
     runs_dir,
     scan_run_log,
 )
+from assemblyzero.core.call_recording import (  # noqa: E402
+    SOURCE_RECONSTRUCTION,
+    SOURCE_RECORDING,
+    ReplayProvider,
+    read_calls,
+)
 from assemblyzero.speedrun.replay import (  # noqa: E402
     CALLER_REVIEWER,
     KIND_LLD,
@@ -54,6 +60,7 @@ from assemblyzero.speedrun.replay import (  # noqa: E402
     build_spec_rules,
     classify,
     discover_audit_dirs,
+    recording_for,
     render_table,
     responses_in,
     run_window,
@@ -63,6 +70,33 @@ from assemblyzero.speedrun.replay import (  # noqa: E402
 #: told apart from a gate: a gate is the pipeline saying no to content, and this
 #: is the recording no longer fitting the prompt the code now sends.
 DIVERGENCE_MARK = "ScriptedProvider:"
+
+#: The same distinction for a run answered from its own recorded calls (#2731).
+#: Two marks rather than one, because the two transports fail for genuinely
+#: different reasons and a reader should be able to tell them apart: the
+#: scripted one ran out of matching rules, this one was sent a prompt the
+#: recording does not hold.
+REPLAY_DIVERGENCE_MARK = "ReplayProvider:"
+
+
+def _path_of(provider) -> list[str]:
+    """The stage labels the transport was asked for, in order.
+
+    Both transports keep a path; they spell it differently. `ScriptedProvider`
+    stores a stage label per call, `ReplayProvider` a (stage, node, round)
+    triple taken from the recording. The caller only wants the stage labels, so
+    the shapes are reconciled here rather than at every use.
+    """
+    if hasattr(provider, "stages_called"):
+        return list(provider.stages_called)
+    return [stage for stage, _node, _round in getattr(provider, "path", [])]
+
+
+def _unanswered(provider) -> int:
+    """How many calls the transport could not answer."""
+    if hasattr(provider, "calls"):
+        return sum(1 for c in provider.calls if not c.answered)
+    return 1 if getattr(provider, "divergence", None) else 0
 
 #: The stage this tool can replay today. Runs that died in `impl` need the
 #: testing graph, whose responses the recordings do not carry in call order;
@@ -111,6 +145,17 @@ def replay_spec_stage(
         reconstruction=recon,
     )
 
+    # #2731: prefer the run's own calls when it recorded them. A recording
+    # answers on the prompt, byte for byte, so a divergence names the call and
+    # shows the diff; reconstruction answers on rules derived from the drafts,
+    # which is exact for about five rounds and then stops for a reason that has
+    # nothing to do with the gate under test. Which one answered is reported on
+    # every row rather than assumed.
+    has_recording, recorded_calls, source_note = recording_for(spec_dir)
+    result.source = SOURCE_RECORDING if has_recording else SOURCE_RECONSTRUCTION
+    result.recorded_calls = recorded_calls
+    result.notes.append(source_note)
+
     lld_text = _final_lld(lld_dir)
     if not lld_text.strip():
         result.divergence = (
@@ -132,7 +177,11 @@ def replay_spec_stage(
     audit_dir = out_dir / "lineage"
     audit_dir.mkdir(parents=True, exist_ok=True)
 
-    provider = ScriptedProvider(rules, model="replay")
+    if has_recording:
+        calls, _ = read_calls(spec_dir)
+        provider = ReplayProvider(calls, model="replay")
+    else:
+        provider = ScriptedProvider(rules, model="replay")
     set_active(provider)
     state = {
         "issue_number": issue,
@@ -180,29 +229,29 @@ def replay_spec_stage(
         # rather than continuing with a state that never finished. A silent
         # handler here would let a crashed replay be read as a clean one.
         result.divergence = f"the graph raised {type(exc).__name__}: {exc}"
-        result.path = list(provider.stages_called)
+        result.path = _path_of(provider)
         set_active(None)
         return result
     finally:
         set_active(None)
 
-    result.path = list(provider.stages_called)
+    result.path = _path_of(provider)
     # Counted from the calls the reviewer actually received, not from
     # `review_iteration`: the state key is a node's write, and a run that dies
     # inside the drafter never gets to update it, which reads as round 0 for a
     # loop that plainly ran. The recording's side of this comparison is counted
     # the same way, from the review rounds the log shows.
     result.replay_progress = max(
-        provider.stages_called.count(CALLER_REVIEWER),
+        result.path.count(CALLER_REVIEWER),
         int(final.get("review_iteration", 0) or 0),
     )
     error = str(final.get("error_message", "") or "")
 
-    unmatched = [c for c in provider.calls if not c.answered]
-    if DIVERGENCE_MARK in error or unmatched:
-        result.divergence = error if DIVERGENCE_MARK in error else (
-            f"{len(unmatched)} call(s) the recording could not answer"
-        )
+    unanswered = _unanswered(provider)
+    if DIVERGENCE_MARK in error or REPLAY_DIVERGENCE_MARK in error or unanswered:
+        result.divergence = error if (
+            DIVERGENCE_MARK in error or REPLAY_DIVERGENCE_MARK in error
+        ) else f"{unanswered} call(s) the recording could not answer"
     elif error:
         result.replay_cause = classify_cause(error.splitlines()[0])
         result.notes.append(error.splitlines()[0][:200])


### PR DESCRIPTION
## The replay could not reach the wall, and the recording was why

**Replay** is running a recorded run's own responses back through the current code, with only the model transport replaced, to check whether the gate that killed it still would. It is the launch gate: twelve launches were allowed on boostgauge #421, all twelve are spent, and nothing relaunches until the recorded runs replay past the walls that killed them.

The pipeline persisted the artifacts it *derived* from each response — a spec draft written after preamble stripping and pinning adjudication, a verdict file assembled from a parsed verdict — never the response itself, and nothing at all recorded the prompt a call was given.

So the replay had to **reconstruct**: derive SEARCH/REPLACE blocks that carry recorded draft N to recorded draft N+1, and answer each revision round with those. Counted over the four runs replayed on 2026-09-03: **0 of 18** synthesised edit scripts failed to *parse*, and the first *application* failure landed at **round 5 or 6**. Faithful for about five rounds — and then the replay stopped for a reason that had nothing to do with the gate under test, and said only that the derived blocks had stopped applying.

## What changed

`assemblyzero/core/call_recording.py` writes one JSONL line per model call into `calls.jsonl`, in the run-scoped lineage directory the run already claims — not a new store, per the issue's own constraint. Each line carries **the prompt as sent and the response as received, verbatim**, in call order, tagged with the stage, the node, and how many times that node has been entered. A length or a hash would answer "did something change" and not "what changed", and the second question is the one a divergence report exists for.

The drafts and verdicts stay exactly where they were. They are what a human reads when diagnosing a halt, and a raw call log is not a substitute for them.

**Where the wrap goes.** `RecordingProvider` wraps the transport and only the transport; the inner provider does the work and every field of its result passes through untouched. `get_provider` is the single place every stage asks for a transport, so it is the single place the wrap is attached. It happens **only when a graph node has said where to write**, so outside a run `get_provider` returns exactly what it always returned — which is what keeps the scripted-provider identity contract (`get_provider("scripted:drafter") is provider`) intact.

**Where the context comes from.** `narrated()`, which is already the one place every node announces itself, so a graph cannot grow a node whose calls are recorded with no stage, no node name and no round. **This is why #2733 landed first:** without an atlas, the implementation graph had no node names to tag calls with.

**A recording never costs a run.** Every write returns False rather than raising, as `record_heal` and the convergence record do, and `read_calls` returns a count of lines it could not read rather than dropping them silently. The absence is visible at the other end.

## The replay side

`ReplayProvider` reads the recording back and answers call N with recorded response N — **only if the prompt the code sends at call N is the prompt the recording holds.** Anything else is a refusal naming the call, the field (system prompt or content) and a unified diff.

`tools/replay_run.py` prefers a recording when one exists and falls back to reconstruction when it does not. The table gained an **answered by** column and the legend explains both, because "the recording said so" and "a draft was reconstructed into a rule" are different evidence and a reader deciding whether to launch is entitled to know which they have.

## Acceptance

`tests/unit/test_call_recording_roll.py`. Each roll runs the **real implementation-spec graph** — routers, janitors, gates, pinning enforcement, file writes and the halt path — against a throwaway git repository, with only the transport scripted. Each is run **twice**: once answered by fixtures while the recorder writes, once answered by that recording.

| roll | gate reached | rounds | calls | replay reached |
|---|---|---|---|---|
| passed | `finalize` | 0 | 2 | identical |
| halted | `spec.requirements_conflict` | 0 | 2 | identical |

The halted roll uses the shape that killed run 12 of boostgauge #4: the reviewer escalates a contradiction in the issue's own acceptance criteria. Both comparisons are made **on the terminal records themselves**, written with `record_terminal` and read back off disk, not on the two dictionaries the test happens to be holding.

Two findings from building it, both now pinned by the tests that found them:

- **The second pass must get a clean lineage directory.** Left in place, `generate_spec` recovers the previous pass's draft by globbing `*-spec-draft.md` out of it and never calls the drafter at all — the replay's first call was the reviewer's, and it reported a divergence that was an artifact of the harness. The fixture now clears it, with a comment saying why.
- **`importlib`, not `from ... import generate_spec`.** The package re-exports the node *function* under that name, so the plain import hands back a function with no module attribute to patch. Same shape as yesterday's lesson about import-site greps and monkeypatch targets.

Also covered: a divergence is named rather than answered — a code change to `DRAFTER_SYSTEM_PROMPT` (the way half the pull requests here do) is caught at call 1, in the system prompt, with the added line in the diff, and nothing is served after it; running past the end of a recording is a divergence, not a guess; and every recorded line carries its sequence, stage, node, round, prompt and duration.

## What this does NOT do — read this before treating the launch gate as met

**Runs 8 through 12 of boostgauge #4 were made before the recorder existed. Their recordings do not exist and cannot be manufactured.** The prompts were never written down, and inventing them would be inventing the evidence the launch decision rests on.

So the replay table is unchanged in substance, and still says `reconstruction` on all three replayable runs:

| run | stage | answered by | recorded ended at | replay ended at | verdict |
|---|---|---|---|---|---|
| run-issue4-182119 | spec | reconstruction | `spec.completeness_cap` at round 4 | diverged at round 3 | **diverged** |
| run-issue4-183941 | spec | reconstruction | `spec.review_cap` at round 9 | diverged at round 3 | **diverged** |
| run-issue4-192453 | spec | reconstruction | `spec.requirements_conflict` at round 5 | `spec.requirements_conflict` at round 5 | **same_gate** |

**#2724's acceptance is not met by this pull request and is not claimed to be.** Runs 10 and 11 still cannot reach their walls; runs 8 and 9 are implementation-stage and still not replayable at all. What this changes is that the *next* run will be replayable, faithfully, and a future divergence will name the call and the change rather than the symptom four rounds downstream. **The first real recording comes from the next launch, which is the operator's call.**

## The ratchet

Unchanged and asserted so: 151 halt sites, 96 gates, `impl` 36 halt rows, 18 model-output halt rows. This PR adds no gate and retires none.

Full unit suite: **9,919 passed**, 21 skipped, 5 xfailed, 7 deselected. The fail-open repo gate caught the new exception handler in `narration.py` on the first full run and made it carry a written ruling, which is the gate working.

Closes #2731
