### PR TITLE
feat: the halt-site audit explains a renumbering instead of blaming the neighbours (Closes #2738)

### DIFF
--- a/assemblyzero/core/gate_registry.py
+++ b/assemblyzero/core/gate_registry.py
@@ -984,34 +984,150 @@ def scan_halt_sites(
 # ---------------------------------------------------------------------------
 
 
-def registry_by_key() -> dict[str, Gate]:
-    return {gate.key: gate for gate in GATE_REGISTRY}
+def registry_by_key(registry: tuple[Gate, ...] = ()) -> dict[str, Gate]:
+    return {gate.key: gate for gate in (registry or GATE_REGISTRY)}
 
 
-def site_to_gate() -> dict[str, str]:
+def site_to_gate(registry: tuple[Gate, ...] = ()) -> dict[str, str]:
     """site key -> gate key, over the whole registry."""
     mapping: dict[str, str] = {}
-    for gate in GATE_REGISTRY:
+    for gate in (registry or GATE_REGISTRY):
         for site in gate.sites:
             mapping[site] = gate.key
     return mapping
 
 
-def unregistered(sites: list[HaltSite]) -> list[HaltSite]:
+def unregistered(
+    sites: list[HaltSite], registry: tuple[Gate, ...] = ()
+) -> list[HaltSite]:
     """Walked sites no row names. The gate the ratchet exists to catch."""
-    known = site_to_gate()
+    known = site_to_gate(registry)
     return [site for site in sites if site.key not in known]
 
 
-def phantoms(sites: list[HaltSite]) -> list[tuple[str, str]]:
+def phantoms(
+    sites: list[HaltSite], registry: tuple[Gate, ...] = ()
+) -> list[tuple[str, str]]:
     """(gate key, site key) for registry sites the walker did not find."""
     walked = {site.key for site in sites}
     return [
         (gate.key, site)
-        for gate in GATE_REGISTRY
+        for gate in (registry or GATE_REGISTRY)
         for site in gate.sites
         if site not in walked
     ]
+
+
+@dataclass(frozen=True)
+class Renumbering:
+    """A registry site that moved because a sibling above it was removed.
+
+    Not a new gate and not a missing one: the same return, at a new index,
+    because `index` is positional within a function (#2738).
+    """
+
+    gate_key: str
+    named: str
+    found: str
+    head: str
+
+    def describe(self) -> str:
+        return (
+            f"{self.gate_key} names {self.named}, and the return that prints "
+            f"{self.head[:60]!r} is now at {self.found} -- a sibling return "
+            f"was removed above it. Remap the row to the new index."
+        )
+
+
+def _site_parts(key: str) -> tuple[str, str, str]:
+    """(path, qualname, kind) of a site key, dropping its positional index."""
+    path, qualname, kind, _index = key.rsplit("::", 3)
+    return path, qualname, kind
+
+
+def renumberings(
+    sites: list[HaltSite], registry: tuple[Gate, ...] = ()
+) -> tuple[list[Renumbering], list[HaltSite], list[tuple[str, str]]]:
+    """Tell a renumbered site apart from a new one and a deleted one (#2738).
+
+    Returns (renumbered, still_unregistered, still_phantom).
+
+    A site key is ``path::qualname::kind::index`` and the index is the
+    position of the return among its siblings, so retiring one halt site
+    shifts every later site of the same kind in the same function. The
+    two-way check then reports the NEIGHBOURS as unregistered and phantom
+    and says nothing about the gate that actually moved -- in #2723 it named
+    four gates that had not been touched, which is the wrong first hypothesis
+    to hand a reader in the middle of a gate change.
+
+    A phantom and an unregistered site are the same return when they share a
+    path, a qualname, a kind AND the static message head the walker already
+    computes. Anything unmatched stays in its original list, so a genuinely
+    new gate is still reported as a new gate: this narrows the report, it does
+    not weaken the check.
+
+    Pairing is one-to-one and taken in index order, which matters when several
+    siblings share a head: two returns printing the same text shift by the
+    same amount and in the same order, so the Nth phantom is the Nth found.
+    """
+    fresh = unregistered(sites, registry)
+    ghosts = phantoms(sites, registry)
+
+    #: Unregistered sites, grouped by everything except their index.
+    available: dict[tuple[str, str, str, str], list[HaltSite]] = defaultdict(list)
+    for site in fresh:
+        available[(site.path, site.qualname, site.kind, site.head)].append(site)
+    for group in available.values():
+        group.sort(key=lambda s: s.index)
+
+    matched_sites: set[str] = set()
+    matched_ghosts: set[tuple[str, str]] = set()
+    found: list[Renumbering] = []
+
+    for gate_key, named in sorted(ghosts, key=lambda g: g[1]):
+        try:
+            path, qualname, kind = _site_parts(named)
+        except ValueError:
+            # fail-open: a row naming something that is not a site key at all
+            # is a real defect, and it is REPORTED rather than raised -- this
+            # entry stays in the returned phantom list, where the audit prints
+            # it and the CI gate fails on it. Raising here would replace a
+            # named finding with a traceback and would stop the other rows
+            # being examined at all.
+            continue
+        # The head the registry row expects is not stored on the row -- only
+        # `emits` is, and that is prose for humans. So the head comes from the
+        # candidates themselves, and a group is claimable only if exactly one
+        # head is on offer for this (path, qualname, kind), or one of them
+        # matches the row's `emits`.
+        heads = [
+            key for key in available
+            if key[:3] == (path, qualname, kind) and available[key]
+        ]
+        if not heads:
+            continue
+        chosen = heads[0]
+        if len(heads) > 1:
+            row = registry_by_key(registry).get(gate_key)
+            emits = (row.emits if row else "") or ""
+            preferred = [key for key in heads if emits and emits in key[3]]
+            if len(preferred) != 1:
+                # Ambiguous: several returns in this function moved and their
+                # message heads do not tell them apart. Reported as phantom and
+                # unregistered, unchanged, because a guessed remap is worse
+                # than an honest "work these out by hand".
+                continue
+            chosen = preferred[0]
+        site = available[chosen].pop(0)
+        matched_sites.add(site.key)
+        matched_ghosts.add((gate_key, named))
+        found.append(Renumbering(gate_key, named, site.key, site.head))
+
+    return (
+        sorted(found, key=lambda r: r.named),
+        [site for site in fresh if site.key not in matched_sites],
+        [ghost for ghost in ghosts if ghost not in matched_ghosts],
+    )
 
 
 def halt_counts() -> dict[str, int]:

--- a/tests/unit/test_halt_site_renumbering.py
+++ b/tests/unit/test_halt_site_renumbering.py
@@ -1,0 +1,275 @@
+"""Retiring one halt site renumbers its siblings, and the audit says so (#2738).
+
+A site key is ``path::qualname::kind::index`` and the index is the position of
+the return among its siblings. Removing one therefore shifts every later return
+of the same kind in the same function, and the two-way check reports the
+NEIGHBOURS as unregistered and phantom while saying nothing about the gate that
+actually moved.
+
+Measured in #2723: five stagnation guards stopped returning, and the audit
+reported five unregistered sites and five phantoms naming
+`impl.circuit_breaker`, `impl.green.iteration_cap`, `impl.e2e_cap` and
+`impl.deterministic_failure` -- four gates nobody had touched. It happened again
+in #2736, where retiring `impl.path_enforcement` moved `impl.write_failed` from
+index 3 to index 2.
+
+The check was never wrong; it was illegible at the worst moment. These tests
+drive the real walker over a fixture module, retire one return from it, and
+assert that what comes back names the renumbering rather than the untouched
+siblings.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.core.gate_registry import (
+    ACTION_HALT,
+    JUDGES_MODEL_OUTPUT,
+    Gate,
+    phantoms,
+    renumberings,
+    scan_halt_sites,
+    unregistered,
+)
+
+MODULE = "gates.py"
+
+#: Four halting returns in one function, in order. The shape every gate change
+#: in this repository walks into.
+BEFORE = textwrap.dedent('''
+    def a_node(state):
+        if state.get("one"):
+            return {"error_message": "FIRST: the input is missing"}
+        if state.get("two"):
+            return {"error_message": "SECOND: the draft is empty"}
+        if state.get("three"):
+            return {"error_message": "THIRD: the path is not planned"}
+        if state.get("four"):
+            return {"error_message": "FOURTH: the file could not be written"}
+        return {"error_message": ""}
+''')
+
+#: The same function with the THIRD return retired -- what softening a gate
+#: looks like on disk. FOURTH is untouched and moves from index 3 to index 2.
+AFTER = textwrap.dedent('''
+    def a_node(state):
+        if state.get("one"):
+            return {"error_message": "FIRST: the input is missing"}
+        if state.get("two"):
+            return {"error_message": "SECOND: the draft is empty"}
+        if state.get("four"):
+            return {"error_message": "FOURTH: the file could not be written"}
+        return {"error_message": ""}
+''')
+
+SITE = f"{MODULE}::a_node::return"
+
+
+def _registry(*rows: tuple[str, int]) -> tuple[Gate, ...]:
+    return tuple(
+        Gate(key, "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT, emits,
+             (f"{SITE}::{index}",))
+        for key, index, emits in (
+            (key, index, key.replace("gate.", "").upper()) for key, index in rows
+        )
+    )
+
+
+#: The registry as it stood before the retirement: one row per return.
+REGISTRY_BEFORE = (
+    Gate("gate.first", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+         "FIRST", (f"{SITE}::0",)),
+    Gate("gate.second", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+         "SECOND", (f"{SITE}::1",)),
+    Gate("gate.third", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+         "THIRD", (f"{SITE}::2",)),
+    Gate("gate.fourth", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+         "FOURTH", (f"{SITE}::3",)),
+)
+
+#: The registry mid-change: `gate.third` has been retired to `advise` and its
+#: sites cleared, exactly as #2723 and #2736 did it -- and `gate.fourth` has
+#: NOT yet been remapped, which is the state the audit has to explain.
+REGISTRY_MIDWAY = tuple(g for g in REGISTRY_BEFORE if g.key != "gate.third")
+
+
+@pytest.fixture
+def walked(tmp_path: Path):
+    """Run the real walker over a fixture module, before and after."""
+    scans = 0
+
+    def _scan(source: str):
+        # A fresh directory per call. Two versions of the same module in one
+        # test must not overwrite each other, or the second walk reads the
+        # first one's file and the comparison is vacuous.
+        nonlocal scans
+        scans += 1
+        pkg = tmp_path / f"scan{scans}" / "pkg"
+        pkg.mkdir(parents=True, exist_ok=True)
+        (pkg / MODULE).write_text(source, encoding="utf-8")
+        sites, _coverage = scan_halt_sites(pkg.parent, Path("pkg"))
+        # The walker keys on the path relative to the root it was given, so
+        # `pkg/gates.py` comes back; the fixture registry above spells the site
+        # without the package directory, so normalise here rather than
+        # complicating the constants.
+        return [
+            type(site)(MODULE, site.qualname, site.kind, site.index,
+                       site.line, site.head)
+            for site in sites
+        ]
+    return _scan
+
+
+class TestTheWalkerSeesTheShift:
+    def test_four_returns_become_three_and_the_last_one_moves(self, walked):
+        before = {site.key: site.head for site in walked(BEFORE)}
+        after = {site.key: site.head for site in walked(AFTER)}
+
+        assert len(before) == 4 and len(after) == 3
+        assert before[f"{SITE}::3"].startswith("FOURTH")
+        assert after[f"{SITE}::2"].startswith("FOURTH"), (
+            "the untouched return moved down one index; that is the whole bug"
+        )
+
+
+class TestTheAuditNamesTheRenumberingNotTheNeighbour:
+    def test_before_the_change_everything_agrees(self, walked):
+        moved, fresh, ghosts = renumberings(walked(BEFORE), REGISTRY_BEFORE)
+        assert (moved, fresh, ghosts) == ([], [], [])
+
+    def test_the_untouched_gate_is_reported_as_renumbered(self, walked):
+        moved, fresh, ghosts = renumberings(walked(AFTER), REGISTRY_MIDWAY)
+
+        assert len(moved) == 1
+        rename = moved[0]
+        assert rename.gate_key == "gate.fourth"
+        assert rename.named == f"{SITE}::3"
+        assert rename.found == f"{SITE}::2"
+        assert "FOURTH" in rename.head
+
+        assert fresh == [], "nothing here is a new gate"
+        assert ghosts == [], "nothing here is a deleted gate"
+
+    def test_the_message_says_what_to_do(self, walked):
+        moved, _fresh, _ghosts = renumberings(walked(AFTER), REGISTRY_MIDWAY)
+        described = moved[0].describe()
+        assert "gate.fourth" in described
+        assert "a sibling return was removed above it" in described
+        assert "Remap the row" in described
+
+    def test_the_raw_check_still_blames_the_neighbour(self, walked):
+        """The control. Without #2738 the two-way check reports the untouched
+        gate as both a phantom and an unregistered site, and says nothing about
+        the gate that was actually retired -- which is what handed a reader
+        four wrong names in #2723."""
+        sites = walked(AFTER)
+        assert [s.key for s in unregistered(sites, REGISTRY_MIDWAY)] == [
+            f"{SITE}::2"
+        ]
+        assert phantoms(sites, REGISTRY_MIDWAY) == [
+            ("gate.fourth", f"{SITE}::3")
+        ]
+
+
+class TestItNarrowsTheReportWithoutWeakeningTheCheck:
+    def test_a_genuinely_new_site_is_still_unregistered(self, walked):
+        """A return nothing names must still be reported.
+
+        This fixture retires the third gate AND adds a fifth return, so the
+        function has four returns again. The count is restored, `gate.fourth`
+        still names index 3 -- and index 3 is now the NEW return. So there is
+        no phantom to pair with, no renumbering is reported, and what comes
+        back is one unregistered site: the untouched FOURTH return at index 2.
+
+        The report is honest about what it can see. What it cannot see is that
+        `gate.fourth` is now pointing at somebody else's return, because the
+        two-way check tests coverage rather than pairing. Filed separately; the
+        obvious remedy -- compare each row's `emits` to its site's message head
+        -- is not viable as it stands, because 56 of the 151 named sites
+        legitimately carry a head the row's `emits` does not appear in.
+        """
+        source = AFTER.replace(
+            '    return {"error_message": ""}',
+            '    if state.get("five"):\n'
+            '        return {"error_message": "FIFTH: something new"}\n'
+            '    return {"error_message": ""}',
+        )
+        moved, fresh, ghosts = renumberings(walked(source), REGISTRY_MIDWAY)
+        assert moved == []
+        assert [s.head[:6] for s in fresh] == ["FOURTH"]
+        assert ghosts == []
+
+    def test_a_new_site_with_no_index_collision_is_reported_as_new(self, walked):
+        """The plain case, with nothing retired: a fifth return added to the
+        original four is unregistered, and no row is disturbed."""
+        source = BEFORE.replace(
+            '    return {"error_message": ""}',
+            '    if state.get("five"):\n'
+            '        return {"error_message": "FIFTH: something new"}\n'
+            '    return {"error_message": ""}',
+        )
+        moved, fresh, ghosts = renumberings(walked(source), REGISTRY_BEFORE)
+        assert moved == []
+        assert [s.head[:5] for s in fresh] == ["FIFTH"]
+        assert ghosts == []
+
+    def test_a_genuinely_deleted_site_is_still_a_phantom(self, walked):
+        """A row naming a return that no longer exists anywhere, with no
+        candidate to pair it with, stays a phantom."""
+        registry = REGISTRY_BEFORE + (
+            Gate("gate.absent", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+                 "ABSENT", ("other.py::gone::return::0",)),
+        )
+        moved, fresh, ghosts = renumberings(walked(BEFORE), registry)
+        assert moved == []
+        assert fresh == []
+        assert ghosts == [("gate.absent", "other.py::gone::return::0")]
+
+    def test_two_returns_with_the_same_head_are_not_guessed_at(self, walked):
+        """When several siblings share a message head, the pairing cannot be
+        told apart by head alone. It is left as an honest phantom rather than
+        remapped on a guess -- a wrong remap is worse than 'work this out'."""
+        source = textwrap.dedent('''
+            def a_node(state):
+                if state.get("one"):
+                    return {"error_message": "SAME: a shared head"}
+                if state.get("two"):
+                    return {"error_message": "SAME: a shared head"}
+                return {"error_message": ""}
+        ''')
+        registry = (
+            Gate("gate.x", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+                 "SAME", (f"{SITE}::0", f"{SITE}::5")),
+        )
+        moved, fresh, ghosts = renumberings(walked(source), registry)
+        # ::1 is unregistered and ::5 is a phantom; both share the head, so the
+        # pairing IS made -- one candidate group, one claimant, in index order.
+        assert [r.found for r in moved] == [f"{SITE}::1"]
+        assert fresh == []
+        assert ghosts == []
+
+    def test_a_row_naming_something_that_is_not_a_site_key_survives(self, walked):
+        registry = REGISTRY_BEFORE + (
+            Gate("gate.malformed", "impl", JUDGES_MODEL_OUTPUT, ACTION_HALT,
+                 "MALFORMED", ("not-a-site-key",)),
+        )
+        moved, fresh, ghosts = renumberings(walked(BEFORE), registry)
+        assert moved == []
+        assert ghosts == [("gate.malformed", "not-a-site-key")]
+
+
+class TestTheRealRegistryIsStillClean:
+    def test_main_has_no_renumbering_outstanding(self):
+        """The repository gate, run against the real tree: no row is naming a
+        site that has moved. A PR that retires a halt site and forgets to remap
+        its siblings fails here, now with a message that names the remap."""
+        root = Path(__file__).resolve().parents[2]
+        sites, _coverage = scan_halt_sites(root)
+        moved, fresh, ghosts = renumberings(sites)
+        assert moved == [], [r.describe() for r in moved]
+        assert fresh == []
+        assert ghosts == []

--- a/tools/audit_halt_sites.py
+++ b/tools/audit_halt_sites.py
@@ -37,7 +37,7 @@ from assemblyzero.core.gate_registry import (  # noqa: E402
     HaltSite,
     WalkCoverage,
     halt_counts,
-    phantoms,
+    renumberings,
     scan_halt_sites,
     site_to_gate,
     unregistered,
@@ -95,8 +95,7 @@ def render_tsv(sites: list[HaltSite]) -> str:
 
 
 def render_report(sites: list[HaltSite], coverage: WalkCoverage) -> str:
-    fresh = unregistered(sites)
-    ghosts = phantoms(sites)
+    moved, fresh, ghosts = renumberings(sites)
     by_gate: dict[str, int] = defaultdict(int)
     known = site_to_gate()
     for site in sites:
@@ -116,6 +115,7 @@ def render_report(sites: list[HaltSite], coverage: WalkCoverage) -> str:
         "",
         f"Registry: {len(GATE_REGISTRY)} gate(s); halt-action rows per stage: "
         + ", ".join(f"{s} {n}" for s, n in halt_counts().items()),
+        f"  Renumbered sites (a sibling was retired above them): {len(moved)}",
         f"  Unregistered sites (no row names them): {len(fresh)}",
         f"  Phantom sites (row names, walker cannot find): {len(ghosts)}",
         "",
@@ -128,6 +128,12 @@ def render_report(sites: list[HaltSite], coverage: WalkCoverage) -> str:
             f"{gate.action:<7} {by_gate.get(gate.key, 0)}"
             + ("  (decided in " + gate.decided_in + ")" if gate.decided_in else "")
         )
+    if moved:
+        lines += ["", "RENUMBERED -- the same return, at a new index (#2738):"]
+        for rename in moved:
+            lines.append(f"  {rename.describe()}")
+            lines.append(f"    {rename.named}")
+            lines.append(f"    -> {rename.found}")
     if fresh:
         lines += ["", "UNREGISTERED -- every one must name a row:"]
         for site in fresh:
@@ -163,24 +169,44 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if args.check:
-        fresh = unregistered(sites)
-        ghosts = phantoms(sites)
-        if not fresh and not ghosts:
+        # #2738: separate a renumbering from a real finding BEFORE printing.
+        # A site index is positional, so retiring one halt site shifts every
+        # later site of the same kind in the same function -- and the two-way
+        # check then reports the neighbours while saying nothing about the gate
+        # that moved. In #2723 it named four gates that had not been touched.
+        moved, fresh, ghosts = renumberings(sites)
+        if not fresh and not ghosts and not moved:
             print(
                 f"PASS -- {coverage.files_scanned} files, {len(sites)} halt "
                 f"sites, every one registered; {len(GATE_REGISTRY)} gates, "
                 f"halt rows: {halt_counts()}"
             )
             return 0
-        print(f"FAIL -- {len(fresh)} unregistered site(s), {len(ghosts)} phantom(s)")
+        parts = []
+        if moved:
+            parts.append(f"{len(moved)} renumbered site(s)")
+        if fresh:
+            parts.append(f"{len(fresh)} unregistered site(s)")
+        if ghosts:
+            parts.append(f"{len(ghosts)} phantom(s)")
+        print(f"FAIL -- {', '.join(parts)}")
+        if moved:
+            print()
+            print("RENUMBERED -- the same return, at a new index. A sibling was")
+            print("retired above it; remap the row rather than hunting a new gate:")
+            for rename in moved:
+                print(f"  {rename.describe()}")
+                print(f"    {rename.named}")
+                print(f"    -> {rename.found}")
         for site in fresh:
             print(f"  unregistered: {site.key}  line {site.line}  {site.head[:70]!r}")
         for gate_key, site in ghosts:
             print(f"  phantom: {gate_key} names {site}")
         print()
-        print("Add the site to a GATE_REGISTRY row (or a new row with its issue")
-        print("and the run that justified it); a halt-action row also moves the")
-        print("ratchet baseline. Remove a stale site key from its row.")
+        if fresh or ghosts:
+            print("Add the site to a GATE_REGISTRY row (or a new row with its issue")
+            print("and the run that justified it); a halt-action row also moves the")
+            print("ratchet baseline. Remove a stale site key from its row.")
         return 1
 
     if args.unregistered:


### PR DESCRIPTION
## The audit named four gates nobody had touched

A **halt site** is a place in the workflow code that can end a run, and the walker re-derives every one of them from the source on each run. Its key is `path::qualname::kind::index`, where `index` is the position of that return among its siblings in the same function.

So retiring one halt site shifts every later return of the same kind in that function — and the registry's two-way check then reports the **neighbours** as unregistered and phantom, while saying nothing about the gate that actually moved.

Measured in #2723: five stagnation guards stopped returning, and the audit reported five unregistered sites and five phantoms naming `impl.circuit_breaker`, `impl.green.iteration_cap`, `impl.e2e_cap` and `impl.deterministic_failure`. Four gates nobody had touched.

**It happened again this morning.** #2736 retired `impl.path_enforcement`, which moved `impl.write_failed` from index 3 to index 2 in the same function. That remap was made by hand, by reading the walker's tab-separated output and matching each site to a gate by its message — a mechanical join a person is doing, which is the kind a person gets wrong quietly.

The check was never wrong. It was illegible at the worst possible moment, and the first hypothesis it handed a reader was that they had broken something unrelated.

## What changed

`renumberings()` pairs a phantom with an unregistered site when they share a path, a qualname, a kind **and** the static message head the walker already computes, and returns three lists rather than two: renumbered, still-unregistered, still-phantom. `tools/audit_halt_sites.py` prints the renumbered ones first, in both `--check` and the report:

```
RENUMBERED -- the same return, at a new index. A sibling was
retired above it; remap the row rather than hunting a new gate:
  impl.write_failed names ...::implement_code::raise::3, and the return that
  prints 'Failed to write file: {}' is now at ::2 -- a sibling return was
  removed above it. Remap the row to the new index.
    assemblyzero/.../orchestrator.py::implement_code::raise::3
    -> assemblyzero/.../orchestrator.py::implement_code::raise::2
```

Pairing is one-to-one and taken in index order, so several siblings sharing a message head are still matched correctly — they shift by the same amount and in the same order. Where several heads are on offer for one function and the row's `emits` does not pick one out, **nothing is guessed**: the row stays a phantom, because a wrong remap is worse than "work this out by hand".

`registry_by_key`, `site_to_gate`, `unregistered` and `phantoms` now take an optional registry, so tests can drive the real walker over a fixture module with a fixture registry instead of asserting against the live table.

## It narrows the report without weakening the check

Anything unmatched stays exactly where it was, and three tests pin that: a genuinely new return is still reported as unregistered; a row naming a return that exists nowhere is still a phantom; a row naming something that is not a site key at all is still reported rather than swallowed.

## Tests

`tests/unit/test_halt_site_renumbering.py`, new, 11 tests, all driving the **real walker** over a fixture module with four halting returns — the shape every gate change in this repository walks into.

The core case is the issue's own: retire the third return, leave the fourth untouched, and assert that what comes back names `gate.fourth` as renumbered from index 3 to index 2, with **zero** unregistered and **zero** phantom. A control test asserts that the raw two-way check still blames the neighbour, so the improvement is measured rather than assumed.

`TestTheRealRegistryIsStillClean` runs it against the actual tree: a pull request that retires a halt site and forgets to remap its siblings fails there, now with a message that names the remap.

## What this does NOT fix, found by these tests

Retire a gate **and** add a return in the same function, and the index count is restored: index 3 now holds the new return, the row that owned the fourth return still names index 3, and there is no phantom for this fix to pair with. The row is silently attached to somebody else's return and the check cannot see it — it tests coverage, not pairing.

Filed as **#2776**, with the measurement that rules out the obvious remedy. Comparing each row's `emits` to its site's actual head would catch it exactly, but **56 of the 151 named sites carry a head their row's `emits` does not appear in** — one row covering several differently-worded returns, heads the walker reports as `<call ...>` because the message is built elsewhere, and some genuine drift. A strict check would fire 56 times on mostly-correct rows, and a check that cries wolf is one people wave through, which is how the four wrong names in #2723 came to be shrugged at in the first place.

## Ratchet and suite

Halt sites 151, `impl` halt rows 36, model-output halt rows 18 — all unchanged; this PR adds no gate and retires none. `tools/audit_halt_sites.py --check` still passes on `main`.

Full unit suite: 9,928 passed, 21 skipped, 5 xfailed, 7 deselected. The fail-open repo gate caught the new exception handler and made it carry a written ruling.

Closes #2738
