### PR TITLE
feat: check that Section 10 actually holds the test functions (Closes #2741)

### DIFF
--- a/assemblyzero/workflows/implementation_spec/check_classification.py
+++ b/assemblyzero/workflows/implementation_spec/check_classification.py
@@ -147,6 +147,22 @@ CLASSIFICATIONS: dict[str, Classification] = {
             "ValueError' is a fact (#2333)."
         ),
     ),
+    "section_ten_carries_test_functions": Classification(
+        check="section_ten_carries_test_functions",
+        kind=FACT,
+        reads=(
+            "Section 10 of the draft, for a fenced block defining at least one "
+            "`def test_`, through the same extractor the implementation stage "
+            "reads its suite with"
+        ),
+        reason=(
+            "the section holds a test definition or it does not -- a parser "
+            "question over a known document shape, not a judgement about "
+            "whether the tests are any good. `run-issue4-192453` left Section "
+            "10.1 as a pointer to Section 6, and the two checks that grade "
+            "those functions both reported not-applicable (#2741)."
+        ),
+    ),
     "spec_test_functions_have_assertions": Classification(
         check="spec_test_functions_have_assertions",
         kind=FACT,

--- a/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
+++ b/assemblyzero/workflows/implementation_spec/nodes/validate_completeness.py
@@ -218,6 +218,15 @@ def validate_completeness(state: ImplementationSpecState) -> dict[str, Any]:
     checks.append(check_error_paths)
     _log_check(check_error_paths)
 
+    # Check 10a (#2741): Section 10 must actually HOLD the test functions.
+    # It runs before 10b and 10c because both of those read Section 10 and
+    # report "not applicable" when it is empty -- which is what run 12
+    # (run-issue4-192453) produced when it left Section 10.1 as a pointer to
+    # Section 6. Two gates and a contract mechanism, all silent, all green.
+    check_section_ten = check_section_ten_carries_test_functions(spec_draft)
+    checks.append(check_section_ten)
+    _log_check(check_section_ten)
+
     # Check 10b (#2706): Section 10's test functions must survive the
     # scaffolder's validator. The scaffolder emits them verbatim (#2316) and
     # the implementation stage refuses a suite that asserts nothing --
@@ -1849,6 +1858,184 @@ def _test_function_spans(
         spans[fn["name"]] = (start, start + source.count("\n"))
         cursor = idx + len(source)
     return spans
+
+
+#: The Section 10 heading, matched as `extract_test_plan_section` matches it so
+#: the two cannot disagree about where the section starts.
+_SECTION_TEN_HEADING_RE = re.compile(
+    r"^##\s*10\s*\.\s*(?:Test Mapping|Verification\s*(?:&|and)?\s*Testing|"
+    r"Test\s*Plan|Testing)[^\n]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+#: A fenced Python block, and a test definition inside one. Both are closed,
+#: authored shapes over a document format, which is a parser question rather
+#: than a judgement about content (standard 0028a).
+_PY_FENCE_RE = re.compile(r"```(?:python|py)?\s*\n(.*?)```", re.DOTALL)
+_TEST_DEF_RE = re.compile(r"^def\s+test_\w+\s*\(", re.MULTILINE)
+
+#: A cross-reference to somewhere else in the document or the tree. What run 12
+#: put in Section 10.1 instead of its tests. Deliberately NOT a bare "see":
+#: an explicit address is the signal, and a loose one would describe half the
+#: prose in every draft as a pointer.
+_POINTER_RE = re.compile(r"\bSection\s+\d|\btests?/[\w./-]+\.py\b", re.IGNORECASE)
+
+#: A markdown table row. Section 10 legitimately carries a scenario table
+#: alongside its functions, so this is descriptive, never a finding on its own.
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$", re.MULTILINE)
+
+
+def _section_ten_span(spec: str) -> tuple[int, int] | None:
+    """1-based (first, last) line of Section 10, or None when it is absent.
+
+    The span covers the heading through the line before the next H2, which is
+    the region a complaint must cite: a demand to ADD has no existing line to
+    name, and #2686 measured what happens when such a complaint addresses only
+    its heading -- the insertion point stays locked and pinning refuses the very
+    edit the complaint asked for, three times running.
+    """
+    match = _SECTION_TEN_HEADING_RE.search(spec)
+    if match is None:
+        return None
+    first = spec.count("\n", 0, match.start()) + 1
+    rest = spec[match.end():]
+    next_h2 = re.search(r"^##\s", rest, re.MULTILINE)
+    if next_h2 is None:
+        return first, spec.count("\n") + 1
+    return first, first + rest.count("\n", 0, next_h2.start())
+
+
+def _what_section_ten_holds(section: str) -> str:
+    """What is in Section 10 instead of test functions. A closed vocabulary.
+
+    Every member is listed here and the list needs no "etc.", which is the test
+    for whether a closed set is the right tool (standard 0028a, §28a).
+
+    All of them that apply are reported rather than the first one, because the
+    two real examples in the corpus each hold two of these at once and picking
+    one describes the draft wrongly: run 12 of boostgauge #4 has a scenario
+    table AND the pointer that replaced its functions, and the #331 run has a
+    table with a file path in it. Naming only "a pointer" for the second would
+    be a small lie in a message whose whole job is to say what it saw.
+    """
+    found: list[str] = []
+    if _PY_FENCE_RE.findall(section):
+        found.append("a fenced code block with no `def test_` in it")
+    if _TABLE_ROW_RE.search(section):
+        found.append("a table of scenarios")
+    if _POINTER_RE.search(section):
+        found.append("a pointer to test files or another section")
+    if not found:
+        return "prose only" if section.strip() else "nothing"
+    if len(found) == 1:
+        return f"{found[0]}, but no code block defining a test"
+    return (
+        f"{', '.join(found[:-1])} and {found[-1]}, but no code block defining "
+        f"a test"
+    )
+
+
+def check_section_ten_carries_test_functions(spec: str) -> CompletenessCheck:
+    """Section 10 must actually hold the executable test functions (#2741).
+
+    #1870 established Section 10.1 as where they live and #2316 made the
+    scaffolder emit them verbatim. Nothing checked they were there.
+
+    Run 12 of boostgauge #4 (`run-issue4-192453`) put its test functions in
+    Section 6 and left Section 10.1 as one sentence: "See
+    `tests/unit/test_collector.py` ... in Section 6". Section 10 is where the
+    checks look, so `check_spec_test_functions_have_assertions` (#2706) and
+    `check_spec_test_fixtures_resolvable` (#2707) both reported NOT APPLICABLE,
+    and the contract mechanism (#2709) never engaged because it engages on what
+    those checks find. Three pieces of machinery, all landed within a day of
+    that run, all silent -- and the log showed green lines.
+
+    This is a `revise` check by construction and not by choice: a failing
+    completeness check routes the draft back to the drafter, bounded by the
+    review iteration cap, and adds no halt site. The ratchet forbids a new
+    halting gate (#2720), and this one has no business halting anyway -- a
+    drafter that filed its tests one section away has written the content and
+    put it in the wrong drawer, which is the most revisable defect there is.
+
+    **Not applicable stays possible and stays visible.** A spec with no Section
+    10 at all is a different defect with its own check, and this one says it did
+    not run rather than inventing a pass. Losing that distinction is exactly
+    what run 12 did.
+    """
+    span = _section_ten_span(spec)
+    if span is None:
+        return CompletenessCheck(
+            check_name="section_ten_carries_test_functions",
+            passed=True,
+            details=(
+                "No Section 10 heading found — check did not run. A spec with "
+                "no test section is `criteria_have_tests`'s finding, not this "
+                "one's."
+            ),
+        )
+
+    functions = _spec_test_functions(spec)["functions"]
+    if functions:
+        return CompletenessCheck(
+            check_name="section_ten_carries_test_functions",
+            passed=True,
+            details=(
+                f"Section 10 carries {len(functions)} executable test "
+                f"function(s); the scaffolder will emit them verbatim (#2316)."
+            ),
+        )
+
+    from assemblyzero.workflows.testing.nodes.load_lld import (
+        extract_test_plan_section,
+    )
+
+    try:
+        section = extract_test_plan_section(spec)
+    except Exception:  # noqa: BLE001
+        # fail-open: the heading was found above, so the section exists; only
+        # its body could not be sliced. The check still reports the defect and
+        # only loses the detail of what it found instead, which makes the
+        # complaint vaguer rather than absent.
+        section = ""
+
+    first, last = span
+    holds = _what_section_ten_holds(section)
+
+    # Are the functions somewhere else in the draft? That decides whether this
+    # asks for a MOVE or for new content -- and #2560/#2740 showed that a
+    # complaint asking for new content must be recognisable as such, or pinning
+    # refuses the edit it demanded. "Add the block inside that subsection" is
+    # already in `_ADDITION_DEMAND_RE`; the move wording deliberately is not.
+    found_elsewhere = sum(
+        1 for fence in _PY_FENCE_RE.findall(spec)
+        if _TEST_DEF_RE.search(fence)
+    )
+
+    if found_elsewhere:
+        instruction = (
+            f"The draft has {found_elsewhere} fenced block(s) elsewhere that "
+            f"define test functions. Move them into Section 10, in a ```python "
+            f"block, so the stage that runs them can read them."
+        )
+    else:
+        instruction = (
+            "No fenced block anywhere in the draft defines a test function. "
+            "Add the block inside that subsection, in a ```python fence, with "
+            "one runnable function per pass criterion."
+        )
+
+    return CompletenessCheck(
+        check_name="section_ten_carries_test_functions",
+        passed=False,
+        details=(
+            f"Section 10 (lines {first}-{last}) carries no executable test "
+            f"function: it holds {holds}. The implementation stage reads its "
+            f"suite from Section 10 alone (#1870, #2316), so a draft that files "
+            f"the functions elsewhere leaves the checks that grade them with "
+            f"nothing to read — which is how run-issue4-192453 passed two "
+            f"gates that had never looked at anything. {instruction}"
+        ),
+    )
 
 
 def check_spec_test_functions_have_assertions(

--- a/tests/unit/test_check_classification.py
+++ b/tests/unit/test_check_classification.py
@@ -79,12 +79,16 @@ class TestTheSweepIsExhaustive:
         `function_spec_sections_have_examples`, built by #2620 as the path
         back to a hard gate. The fourteenth and fifteenth grade Section 10's
         test functions with the implementation stage's own validator, one
-        stage earlier (#2706, #2707)."""
+        stage earlier (#2706, #2707). The sixteenth checks that Section 10 is
+        holding those functions at all, which is what run-issue4-192453 made
+        necessary by leaving 10.1 as a pointer and sending both of the previous
+        two to not-applicable (#2741)."""
         assert "python_fences_parse" in CLASSIFICATIONS
         assert "function_spec_sections_have_examples" in CLASSIFICATIONS
         assert "spec_test_functions_have_assertions" in CLASSIFICATIONS
         assert "spec_test_fixtures_resolvable" in CLASSIFICATIONS
-        assert len(CLASSIFICATIONS) == 15
+        assert "section_ten_carries_test_functions" in CLASSIFICATIONS
+        assert len(CLASSIFICATIONS) == 16
 
     @pytest.mark.parametrize("name", sorted(CLASSIFICATIONS))
     def test_each_entry_states_what_it_reads_and_why(self, name: str) -> None:

--- a/tests/unit/test_completeness_message_addressability.py
+++ b/tests/unit/test_completeness_message_addressability.py
@@ -195,6 +195,26 @@ class TestAddressableToday:
         assert {"test_req_1_value", "mocker"} <= set(verdict.tokens)
         assert verdict.verdict == ADDRESSED
 
+    def test_section_ten_carries_test_functions_addresses_the_section(self):
+        """#2741, swept before its first live roll.
+
+        A demand to ADD has no existing line to name, so the complaint cites
+        the whole of Section 10 -- heading through the line before the next
+        H2 -- which is the region the missing block goes in. #2686 measured
+        what a heading-only citation does: the insertion point stays locked and
+        pinning refuses the very edit the complaint asked for, three times.
+        """
+        draft = (
+            "# Spec\n\n## 6. Change Instructions\n\nWrite it.\n\n"
+            "## 10. Test Mapping\n\n### 10.1 Per-criterion test functions\n\n"
+            "See `tests/unit/test_collector.py` in Section 6.\n\n"
+            "## 11. Implementation Notes\n\nNothing.\n"
+        )
+        result = vc.check_section_ten_carries_test_functions(draft)
+        assert result["passed"] is False
+        verdict = _classify(result, draft)
+        assert verdict.verdict == ADDRESSED
+
     def test_function_spec_sections_addresses_its_subsection(self):
         """#2620's new hard gate, swept BEFORE it ships rather than discovered
         to deadlock on a live roll (#2617's discipline).
@@ -402,6 +422,7 @@ class TestTheSweepIsExhaustive:
             "check_manifest_traceability",
             "check_spec_test_functions_have_assertions",
             "check_spec_test_fixtures_resolvable",
+            "check_section_ten_carries_test_functions",
         }
         #: Checks this sweep does NOT drive, each with the reason. They need
         #: a real repo tree, a populated symbol table, or an LLD whose

--- a/tests/unit/test_section_ten_carries_tests.py
+++ b/tests/unit/test_section_ten_carries_tests.py
@@ -1,0 +1,237 @@
+"""Section 10 must actually hold the test functions (#2741).
+
+#1870 established Section 10.1 as where executable test functions live and
+#2316 made the scaffolder emit them verbatim. Nothing checked they were there.
+
+Run 12 of boostgauge #4 (`run-issue4-192453`) put its functions in Section 6 and
+left Section 10.1 as one sentence pointing at them. Section 10 is where the
+checks look, so `spec_test_functions_have_assertions` (#2706) and
+`spec_test_fixtures_resolvable` (#2707) both reported NOT APPLICABLE and the
+contract mechanism (#2709) never engaged. Three pieces of machinery, all landed
+within a day of that run, all silent, all printing green.
+
+The fixture below is that draft's Section 10.1 verbatim.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from assemblyzero.workflows.implementation_spec.check_classification import (
+    FACT,
+    CLASSIFICATIONS,
+    is_proxy,
+)
+from assemblyzero.workflows.implementation_spec.nodes.validate_completeness import (
+    check_section_ten_carries_test_functions,
+    check_spec_test_functions_have_assertions,
+)
+from assemblyzero.workflows.implementation_spec.revision_pinning import (
+    demands_additions,
+    named_line_ranges,
+)
+
+CHECK = "section_ten_carries_test_functions"
+
+#: `run-issue4-192453`, 016-spec-draft.md, Section 10.1 verbatim. The sentence
+#: that made two gates go quiet.
+RUN_12_POINTER = (
+    "See `tests/unit/test_collector.py`, "
+    "`tests/integration/test_windows_collector.py`, and "
+    "`tests/benchmark/test_windows_sweep.py` in Section 6 for exactly 1 "
+    "function per requirement criterion mapped from the LLD, strictly "
+    "fulfilling the coverage requirements."
+)
+
+HEAD = textwrap.dedent("""\
+    # Implementation Spec: the collector
+
+    ## 1. Overview
+
+    Implements REQ-1.
+
+    ## 6. Change Instructions
+
+    Write `src/collector.py`.
+    """)
+
+TAIL = textwrap.dedent("""\
+
+    ## 11. Implementation Notes
+
+    Nothing further.
+    """)
+
+TABLE = textwrap.dedent("""\
+    | Test ID | Tests Function | Expected |
+    |---|---|---|
+    | 010 | `test_req_010` | passes |
+    """)
+
+FUNCTIONS = textwrap.dedent("""\
+    ```python
+    import pytest
+
+    def test_req_010_collector_reads():
+        assert collector.read() == 1
+    ```
+    """)
+
+
+def spec(section_ten: str, head: str = HEAD) -> str:
+    return f"{head}\n## 10. Test Mapping\n\n### 10.1 Per-criterion test functions\n\n{section_ten}\n{TAIL}"
+
+
+class TestTheArtifactThatShowedTheProblem:
+    def test_the_run_12_shape_is_refused(self):
+        result = check_section_ten_carries_test_functions(spec(RUN_12_POINTER))
+        assert result["passed"] is False
+        assert result["check_name"] == CHECK
+
+    def test_the_two_checks_it_silenced_still_report_not_applicable(self):
+        """The control, and the reason this check had to exist. #2706's check
+        is not wrong to abstain -- it has nothing to read. It just cannot be
+        the thing that notices why."""
+        old = check_spec_test_functions_have_assertions(spec(RUN_12_POINTER))
+        assert old["passed"] is True
+        assert "not applicable" in old["details"].lower()
+
+    def test_the_complaint_says_what_it_found_instead(self):
+        details = check_section_ten_carries_test_functions(
+            spec(TABLE + "\n" + RUN_12_POINTER)
+        )["details"]
+        assert "a table of scenarios" in details
+        assert "a pointer to test files or another section" in details
+
+    def test_a_section_holding_the_functions_passes(self):
+        result = check_section_ten_carries_test_functions(spec(FUNCTIONS))
+        assert result["passed"] is True
+        assert "1 executable test function" in result["details"]
+
+
+class TestNotApplicableStaysPossibleAndVisible:
+    def test_no_section_ten_means_the_check_did_not_run(self):
+        """A spec with no test section is `criteria_have_tests`'s finding. This
+        one says it did not run rather than inventing a pass -- losing that
+        distinction is exactly what run 12 did."""
+        result = check_section_ten_carries_test_functions(HEAD + TAIL)
+        assert result["passed"] is True
+        assert "did not run" in result["details"]
+
+    def test_the_did_not_run_case_is_counted_as_not_applicable(self):
+        """The node counts a check as not-applicable by looking for that phrase
+        in its details (#1870), so the wording is load-bearing: without it the
+        summary would read this as a verified pass."""
+        result = check_section_ten_carries_test_functions(HEAD + TAIL)
+        assert "not applicable" in result["details"].lower() or "did not run" in (
+            result["details"].lower()
+        )
+
+
+class TestTheComplaintCanBeActedOn:
+    def test_it_cites_the_section_span_so_pinning_can_unlock_it(self):
+        """#2686: a demand to ADD has no existing line to name, and a complaint
+        that addressed only its heading left the insertion point locked -- the
+        drafter wrote the demanded edit three times and pinning refused it three
+        times. The citation has to span the region the edit goes in."""
+        draft = spec(RUN_12_POINTER)
+        details = check_section_ten_carries_test_functions(draft)["details"]
+        ranges = named_line_ranges([details])
+        assert ranges, "the complaint names no line range at all"
+        start, end = ranges[0]
+        assert end > start, "a one-line citation addresses the heading only"
+
+        lines = draft.splitlines()
+        cited = "\n".join(lines[start - 1:end])
+        assert "## 10." in cited, "the citation must cover the section heading"
+        assert "10.1" in cited, "and the subsection the functions belong in"
+
+    def test_asking_for_new_content_is_recognised_as_an_addition_demand(self):
+        """#2560 and #2740: pinning refuses an edit that adds content unless the
+        complaint is recognised as demanding an addition. A draft with no test
+        function anywhere is asking for new content."""
+        details = check_section_ten_carries_test_functions(
+            spec(RUN_12_POINTER)
+        )["details"]
+        assert "Add the block inside that subsection" in details
+        assert demands_additions([details]) is True
+
+    def test_asking_for_a_move_does_not_read_as_a_demand_for_new_tests(self):
+        """When the functions exist elsewhere in the draft, the fix is a move.
+        Saying "add" there would ask the drafter to write tests it has already
+        written, which is how a complaint makes a draft worse."""
+        draft = spec(RUN_12_POINTER, head=HEAD + "\n" + FUNCTIONS)
+        details = check_section_ten_carries_test_functions(draft)["details"]
+        assert "Move them into Section 10" in details
+        assert "Add the block inside that subsection" not in details
+        assert demands_additions([details]) is False
+
+
+class TestItIsAReviseCheckByConstruction:
+    def test_it_is_declared_a_fact_and_keeps_its_authority(self):
+        """An unclassified check would fail the exhaustiveness lint; a check
+        classified as a proxy would be demoted to advisory whenever the
+        reviewer is engaged, which is precisely when run 12 was passing."""
+        assert CHECK in CLASSIFICATIONS
+        assert CLASSIFICATIONS[CHECK].kind == FACT
+        assert is_proxy(CHECK) is False
+
+    def test_it_adds_no_halt_site(self):
+        """The ratchet forbids a new halting gate (#2720). A failing
+        completeness check routes the draft back to the drafter, bounded by the
+        review iteration cap; it returns a CompletenessCheck and raises
+        nothing, so the walker finds no new site."""
+        from assemblyzero.core.gate_registry import renumberings, scan_halt_sites
+
+        root = Path(__file__).resolve().parents[2]
+        sites, _coverage = scan_halt_sites(root)
+        moved, fresh, ghosts = renumberings(sites)
+        assert (moved, fresh, ghosts) == ([], [], [])
+
+
+BOOSTGAUGE = Path("C:/Users/mcwiz/Projects/boostgauge/docs/lineage")
+
+
+@pytest.mark.skipif(
+    not BOOSTGAUGE.is_dir(),
+    reason="the recorded lineage lives in the target repo, not in this one",
+)
+class TestAgainstEveryRecordedDraft:
+    """Measured across the whole corpus, not only the exhibit.
+
+    90 unique spec drafts survive in boostgauge's lineage. The check refuses 12
+    of them, and those 12 are two runs: `run-issue4-192453` (six drafts) and one
+    run of issue #331 (six drafts). Both left Section 10 holding a table and a
+    pointer. Every other draft carries its functions and passes.
+    """
+
+    def _drafts(self) -> list[Path]:
+        seen: dict[str, Path] = {}
+        for path in sorted(BOOSTGAUGE.rglob("*-spec-draft.md")):
+            seen.setdefault(str(path.resolve()), path)
+        return list(seen.values())
+
+    def test_it_refuses_only_the_two_runs_that_moved_their_tests(self):
+        refused = [
+            path for path in self._drafts()
+            if not check_section_ten_carries_test_functions(
+                path.read_text(encoding="utf-8", errors="replace")
+            )["passed"]
+        ]
+        runs = sorted({path.parent.name for path in refused})
+        assert len(refused) == 12, [str(p) for p in refused]
+        assert len(runs) == 2, runs
+
+    def test_every_other_draft_passes(self):
+        drafts = self._drafts()
+        passing = [
+            path for path in drafts
+            if check_section_ten_carries_test_functions(
+                path.read_text(encoding="utf-8", errors="replace")
+            )["passed"]
+        ]
+        assert len(drafts) - len(passing) == 12
+        assert len(passing) == 78


### PR DESCRIPTION
## Two gates and a contract mechanism went quiet, and the log turned green

#1870 established Section 10.1 of an implementation spec as where executable test functions live, and #2316 made the scaffolder emit them verbatim. **Nothing checked they were there.**

Run 12 of boostgauge #4 (`run-issue4-192453`) put its test functions in Section 6 and left Section 10.1 as one sentence:

> See `tests/unit/test_collector.py`, `tests/integration/test_windows_collector.py`, and `tests/benchmark/test_windows_sweep.py` in Section 6 for exactly 1 function per requirement criterion mapped from the LLD, strictly fulfilling the coverage requirements.

Section 10 is where the checks look. So `check_spec_test_functions_have_assertions` (#2706) and `check_spec_test_fixtures_resolvable` (#2707) both reported **not applicable**, and the contract mechanism (#2709) never engaged, because it engages on what those checks find. Three pieces of machinery, all landed within a day of that run, all silent — not because the spec was good, but because the thing they read had been replaced by a cross-reference.

## What changed

`check_section_ten_carries_test_functions` reads Section 10 through **the same extractor the implementation stage reads its suite with**, and fails when the section defines no test function.

The complaint names the section and says what it found instead, from a closed vocabulary: a fenced block with no `def test_` in it, a table of scenarios, a pointer to test files or another section, prose, or nothing. All of the ones that apply are reported rather than the first — the two real examples in the corpus each hold two at once, and naming only one describes the draft wrongly.

**Move versus write is load-bearing.** When test functions exist in a fenced block elsewhere in the draft, the complaint asks for a *move*; when they exist nowhere, it asks for new content and ends with "Add the block inside that subsection", a phrase `_ADDITION_DEMAND_RE` already carries. #2560 and #2740 showed why: pinning refuses an edit that adds content unless the complaint is recognised as demanding an addition. The move wording deliberately is not recognised, so a drafter is never told to write tests it has already written.

**The citation spans the whole section**, heading through the line before the next H2, not the heading line. #2686 measured what a heading-only citation does: the insertion point stays locked and pinning refuses the very edit the complaint asked for, three times running.

## It is a `revise` check by construction, not by choice

A failing completeness check routes the draft back to the drafter, bounded by the review iteration cap. It returns a `CompletenessCheck` and raises nothing, so **no halt site is added**: 151 halt sites and 18 model-output halt rows, unchanged, as the ratchet requires (#2720). A test asserts that directly.

## Measured across every draft the corpus holds

Not just the exhibit. Every spec draft surviving in boostgauge's lineage:

| | |
|---|---|
| unique spec drafts | **90** |
| pass | **78** |
| refused | **12** |
| distinct runs among the refused | **2** |

The twelve are `run-issue4-192453` (six drafts) and one run of issue #331 (six drafts). Both left Section 10 holding a table and a pointer. Every other draft carries its functions.

The discrimination is finer than "which issue": **other runs of issue #331 pass**, with eleven functions in Section 10. The same issue produced both shapes on different runs, and the check tells them apart.

On all six of run 12's drafts, `check_spec_test_functions_have_assertions` reports "not applicable" and this check reports the defect — the before-and-after on the artifact that showed the problem.

## Not applicable stays possible, and stays visible

A draft with no Section 10 at all is `criteria_have_tests`'s finding, not this one's, and this check says **it did not run** rather than inventing a pass. Losing that distinction is exactly what run 12 did, and the node counts not-applicable separately from passed for the same reason (#1870).

## Two exhaustiveness gates caught it, and both are satisfied rather than bypassed

The first full suite run failed twice, correctly:

- `test_check_classification.py` requires every emitted check to be classified and pins the count. The new check is declared a **FACT** — a proxy would be demoted to advisory whenever the adversarial reviewer is engaged, which is precisely when run 12 was passing, so classifying it wrongly would have reproduced the original silence.
- `test_completeness_message_addressability.py` requires every check to be driven by a failing fixture or declared uncovered with a reason. It is now swept, with the addressability assertion above.

## Tests

`tests/unit/test_section_ten_carries_tests.py`, new, 13 tests. Run 12's pointer sentence is the fixture, verbatim. Covered: the run-12 shape is refused while #2706's check still reports not-applicable on it (the control); the complaint names both things it found; a section holding the functions passes; no Section 10 means "did not run" and is counted as not-applicable; the citation spans heading through subsection; asking for new content is recognised by `demands_additions` and asking for a move is not; the check is declared a fact and is not a proxy; no halt site is added; and two tests over the whole 90-draft corpus, skipped when the target repository is not on disk.

Full unit suite: 9,946 passed, 21 skipped, 5 xfailed, 7 deselected.

Closes #2741
