### PR TITLE
fix: say which side of the visual-gate handshake stopped (Closes #2743)

### DIFF
--- a/tests/unit/test_visual_gate_loop.py
+++ b/tests/unit/test_visual_gate_loop.py
@@ -13,8 +13,10 @@ import json
 import subprocess
 import sys
 import threading
+import time
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
@@ -90,45 +92,155 @@ def _forbid_gh(cmd, **kwargs):
     return subprocess.run(cmd, **kwargs)
 
 
-def _submitter(root: Path, answers: list[tuple[str, str]]):
+#: How long `run_gate` waits for a round's `feedback.json`. One constant, used
+#: by every test and by the submitter below, so the two sides of one handshake
+#: cannot be given budgets that disagree (#2743).
+GATE_DEADLINE = 30
+
+#: A loop that needs two rounds gets two of everything.
+GATE_DEADLINE_TWO_ROUNDS = 60
+
+#: The submitter outlives the gate on purpose. Before #2743 it gave up after
+#: 400 polls of 0.05 s -- twenty seconds, INSIDE the gate's thirty -- so on a
+#: loaded machine it could abandon the handshake, die silently in its daemon
+#: thread, and leave the gate to spend its remaining ten seconds and report
+#: `no feedback.json ... after 30s`. That message names the symptom, and
+#: neither the cause nor the side that failed.
+SUBMITTER_MARGIN = 5
+
+
+@dataclass
+class Submitter:
+    """The operator's thread, and what it saw if it did not finish.
+
+    A daemon thread's exception is not a test failure: pytest reports it as a
+    warning, which is easy to miss and impossible to act on. So the thread
+    catches its own failure and the test raises it, carrying what it was
+    waiting for and what was on disk instead.
+    """
+
+    thread: threading.Thread | None = None
+    error: BaseException | None = None
+    delivered: int = 0
+    wanted: int = 0
+    seen: list[str] = field(default_factory=list)
+
+    def diagnosis(self) -> str:
+        return (
+            f"the operator thread delivered {self.delivered} of {self.wanted} "
+            f"scripted answer(s); rounds on disk when it last looked: "
+            f"{', '.join(self.seen) or '(none)'}"
+        )
+
+
+def _submitter(root: Path, answers: list[tuple[str, str]],
+               gate_deadline: float = GATE_DEADLINE) -> Submitter:
     """A thread playing the operator: waits for each served round's pending
-    sentinel, then POSTs the next scripted answer to the page's real URL."""
+    sentinel, then POSTs the next scripted answer to the page's real URL.
+
+    The parameter is **the gate's** deadline, not this thread's; the margin is
+    added here, so a caller cannot set one and forget the other. That is the
+    exact shape of #2743: the submitter's twenty seconds sat INSIDE the gate's
+    thirty, so on a loaded machine it abandoned the handshake, died silently in
+    its daemon thread, and left the gate to report a missing file rather than a
+    missing answer.
+    """
+    deadline = gate_deadline + SUBMITTER_MARGIN
+    state = Submitter(wanted=len(answers))
+
     def play():
         for verb, text in answers:
             url = None
-            for _ in range(400):
+            expiry = time.monotonic() + deadline
+            while time.monotonic() < expiry:
+                names = []
                 for round_dir in bundle_mod.round_dirs(root):
+                    names.append(
+                        round_dir.name + "["
+                        + ",".join(sorted(
+                            p.name for p in round_dir.glob("feedback*.json")
+                        )) + "]"
+                    )
                     pending = round_dir / "feedback-pending.json"
                     if pending.is_file() and not (round_dir / "feedback.json").is_file() \
                             and not (round_dir / "feedback-consumed.json").is_file():
                         url = json.loads(pending.read_text(encoding="utf-8"))["url"]
                         break
+                state.seen = names
                 if url:
                     break
-                import time
                 time.sleep(0.05)
-            assert url, "no served round appeared for the scripted answer"
+            assert url, (
+                f"no round served a pending sentinel within {deadline}s while "
+                f"the scripted answer {verb!r} was waiting to be delivered"
+            )
             data = urllib.parse.urlencode({"verb": verb, "text": text}).encode()
             req = urllib.request.Request(url + "feedback", data=data, method="POST")
             with urllib.request.urlopen(req, timeout=10) as resp:
                 assert resp.status == 200
+            state.delivered += 1
 
-    thread = threading.Thread(target=play, daemon=True)
-    thread.start()
-    return thread
+    def guarded():
+        try:
+            play()
+        except BaseException as exc:  # noqa: BLE001
+            # Kept rather than raised: this is a daemon thread, where an
+            # exception becomes a warning nobody reads. `_settle` raises it.
+            state.error = exc
+
+    state.thread = threading.Thread(target=guarded, daemon=True)
+    state.thread.start()
+    return state
+
+
+def _settle(submitter: Submitter, gate_error: BaseException | None = None) -> None:
+    """Join the operator thread and report ITS failure, not the gate's symptom.
+
+    Called after every `run_gate` in this file, on the success path and the
+    failure path both. When the handshake breaks, what a reader needs is which
+    side stopped and what was on disk; `no feedback.json after 30s` says only
+    that a file the other side was supposed to write is not there.
+    """
+    assert submitter.thread is not None
+    submitter.thread.join(timeout=10)
+    if submitter.error is not None:
+        raise AssertionError(
+            f"the operator thread failed: {submitter.error} -- "
+            f"{submitter.diagnosis()}"
+        ) from (gate_error or submitter.error)
+    if submitter.thread.is_alive():
+        raise AssertionError(
+            f"the operator thread never finished -- {submitter.diagnosis()}"
+        ) from gate_error
+    if gate_error is not None:
+        raise AssertionError(
+            f"the gate failed although the operator thread completed cleanly: "
+            f"{gate_error} -- {submitter.diagnosis()}"
+        ) from gate_error
+    assert submitter.delivered == submitter.wanted, submitter.diagnosis()
+
+
+def _run_gate(submitter: Submitter, *args, **kwargs):
+    """`run_gate`, with the operator thread's story attached to any failure."""
+    try:
+        outcome = run_gate(*args, **kwargs)
+    except BaseException as exc:  # noqa: BLE001
+        _settle(submitter, exc)
+        raise
+    _settle(submitter)
+    return outcome
 
 
 class TestApproveLetsTheRunProceed:
     def test_the_cycle_render_serve_approve_stamp(self, repo, config):
         root = bundle_mod.gate_root(repo, ISSUE)
-        thread = _submitter(root, [("approve", "looks right")])
+        submitter = _submitter(root, [("approve", "looks right")])
 
-        outcome = run_gate(
+        outcome = _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: "[]",
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 30},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE},
         )
-        thread.join(timeout=10)
 
         assert outcome.status == "approved"
         approved = root / "approved" / "approved.png"
@@ -143,15 +255,14 @@ class TestApproveLetsTheRunProceed:
     def test_expected_colours_are_measured_from_the_approved_picture(
         self, repo, config
     ):
-        thread = _submitter(
+        submitter = _submitter(
             bundle_mod.gate_root(repo, ISSUE), [("approve", "")],
         )
-        run_gate(
+        _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: "[]",
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 30},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE},
         )
-        thread.join(timeout=10)
 
         record = json.loads(
             (bundle_mod.gate_root(repo, ISSUE) / "approved" / "approved.json")
@@ -186,17 +297,16 @@ class TestTheModifyLoopIterates:
             "kind": "modify-geometry", "key": "band_inner", "value": 0.88,
             "note": "red bar thinner, further from center",
         }])
-        thread = _submitter(root, [
+        submitter = _submitter(root, [
             ("modify", "red bar should be thinner, start further from center"),
             ("approve", "that is the one"),
-        ])
+        ], gate_deadline=GATE_DEADLINE_TWO_ROUNDS)
 
-        outcome = run_gate(
+        outcome = _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: transport_response,
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 60},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE_TWO_ROUNDS},
         )
-        thread.join(timeout=10)
 
         assert outcome.status == "approved"
         assert outcome.deltas == {"band_inner": 0.88}
@@ -217,17 +327,16 @@ class TestTheModifyLoopIterates:
             "candidates": [[170, 15, 25], [130, 10, 20]],
             "note": "tachometer red, not brick",
         }])
-        thread = _submitter(root, [
+        submitter = _submitter(root, [
             ("modify", "the red seems like a brick red"),
             ("approve", "the first candidate"),
-        ])
+        ], gate_deadline=GATE_DEADLINE_TWO_ROUNDS)
 
-        outcome = run_gate(
+        outcome = _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: transport_response,
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 60},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE_TWO_ROUNDS},
         )
-        thread.join(timeout=10)
 
         assert outcome.status == "approved"
         round2_images = [p.name for p in bundle_mod.bundle_images(root / "round-002")]
@@ -246,14 +355,13 @@ class TestTheHalts:
             "kind": "modify-colour", "key": "needle_rgb", "value": [200, 0, 0],
             "note": "darker needle",
         }])
-        thread = _submitter(root, [("modify", "make the needle darker")])
+        submitter = _submitter(root, [("modify", "make the needle darker")])
 
-        outcome = run_gate(
+        outcome = _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: transport_response,
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 30},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE},
         )
-        thread.join(timeout=10)
 
         assert outcome.status == "halted"
         assert "contradicts a landed ruling" in outcome.error
@@ -261,14 +369,13 @@ class TestTheHalts:
 
     def test_reject_halts_and_writes_the_operators_words(self, repo, config):
         root = bundle_mod.gate_root(repo, ISSUE)
-        thread = _submitter(root, [("reject", "wrong direction entirely")])
+        submitter = _submitter(root, [("reject", "wrong direction entirely")])
 
-        outcome = run_gate(
+        outcome = _run_gate(submitter,
             repo, ISSUE, config, mock=True, runner=_forbid_gh,
             transport=lambda *_: "[]",
-            wait_kwargs={"poll_seconds": 0.05, "deadline": 30},
+            wait_kwargs={"poll_seconds": 0.05, "deadline": GATE_DEADLINE},
         )
-        thread.join(timeout=10)
 
         assert outcome.status == "halted"
         assert "REJECTED" in outcome.error
@@ -315,3 +422,65 @@ class TestResumeReadsTheAnswerOffDisk:
 
         assert outcome.status == "approved"
         assert (root / "approved" / "approved.png").is_file()
+
+
+class TestABrokenHandshakeSaysWhichSideStopped:
+    """#2743. Two failures on 2026-09-03, in unrelated environments on
+    unrelated branches, both in this file and both timing-shaped. The CI one
+    reported `no feedback.json ... after 30s`, which describes a file the OTHER
+    side was supposed to write and names neither the cause nor the side that
+    failed. These tests drive the diagnostic that replaces it, so a future red
+    run in this file is readable rather than re-runnable.
+    """
+
+    def test_the_operator_threads_own_failure_is_what_gets_raised(self, repo):
+        """The defect exactly: the thread gives up, and because it is a daemon
+        its assertion is a warning nobody sees. Here it is raised, with what it
+        was waiting for."""
+        root = bundle_mod.gate_root(repo, ISSUE)
+        root.mkdir(parents=True, exist_ok=True)
+        submitter = _submitter(root, [("approve", "never delivered")],
+                               gate_deadline=-SUBMITTER_MARGIN + 0.2)
+
+        with pytest.raises(AssertionError) as caught:
+            _settle(submitter)
+
+        message = str(caught.value)
+        assert "the operator thread failed" in message
+        assert "no round served a pending sentinel" in message
+        assert "delivered 0 of 1 scripted answer(s)" in message
+
+    def test_the_diagnosis_names_the_rounds_it_could_see(self, repo):
+        """"Nothing was served" and "a round was served and already answered"
+        are different faults, and the message has to tell them apart."""
+        root = bundle_mod.gate_root(repo, ISSUE)
+        round_dir = bundle_mod.next_round_dir(root)
+        (round_dir / "feedback.json").write_text("{}", encoding="utf-8")
+        submitter = _submitter(root, [("approve", "too late")],
+                               gate_deadline=-SUBMITTER_MARGIN + 0.2)
+
+        with pytest.raises(AssertionError) as caught:
+            _settle(submitter)
+
+        assert "round-001[feedback.json]" in str(caught.value)
+
+    def test_a_gate_failure_is_reported_with_the_threads_state_beside_it(self):
+        """When the operator side is clean, the gate's own error survives -- it
+        is not swallowed by the new reporting."""
+        submitter = Submitter(thread=threading.Thread(target=lambda: None))
+        submitter.thread.start()
+
+        with pytest.raises(AssertionError) as caught:
+            _settle(submitter, TimeoutError("no feedback.json after 30s"))
+
+        message = str(caught.value)
+        assert "the gate failed although the operator thread completed" in message
+        assert "no feedback.json after 30s" in message
+
+    def test_the_submitter_always_outlives_the_gate(self):
+        """The ordering that makes the report trustworthy. The margin is added
+        inside `_submitter`, so no caller can pass a gate deadline and leave the
+        thread with a shorter one -- which is the bug this file had."""
+        assert SUBMITTER_MARGIN > 0
+        for gate_deadline in (GATE_DEADLINE, GATE_DEADLINE_TWO_ROUNDS):
+            assert gate_deadline + SUBMITTER_MARGIN > gate_deadline


### PR DESCRIPTION
## The message named the wrong side

Two failures on 2026-09-03, in unrelated environments on unrelated branches, both in `tests/unit/test_visual_gate_loop.py` and both timing-shaped. Neither reproduced. The CI one said:

```
TimeoutError: no feedback.json in .../round-001 after 30s
```

That is a symptom. It names a file **the other side** was supposed to write, and says nothing about which side stopped or why.

## What was waiting on what

Each test starts a daemon thread playing the operator. It polls for a round's `feedback-pending.json`, reads the URL the gate served, and POSTs the scripted answer. Meanwhile `run_gate` waits for `feedback.json` to appear.

**The thread's budget was 400 polls of 0.05 s — twenty seconds — inside the gate's thirty.**

So on a loaded machine the operator thread could give up first. Its `assert url` then raised inside a daemon thread, where pytest reports an exception as a *warning* rather than a failure. The gate spent its remaining ten seconds and reported a missing file. Nothing anywhere said the operator side had abandoned the handshake — which is exactly why the failure read as unreproducible timing rather than as an ordering bug with a silent error path.

The two failing tests were in different classes, which the issue read as pointing at the file's shared waiting machinery. It did.

## What changed — and what did not

**Not** raising 30 to 120. That trades a rare red for a slow suite and leaves the same shape waiting for a slower day.

**The thread keeps its own exception** instead of raising into the void. `_settle` — called after every `run_gate`, on the success path and the failure path both — raises it in the test, along with how many scripted answers were delivered and which round directories and feedback files were on disk when the thread last looked. A gate failure with a clean operator thread is still reported, with that state beside it, so nothing is swallowed by the new reporting.

**`_submitter` takes the gate's deadline and adds the margin itself.** A caller cannot now set one and forget the other. The two-round tests pass their own 60 and get 65; under a plain `deadline=` parameter they would have kept the 35 derived from the single-round constant, which is the same inversion one layer down. Both deadlines are named constants used by both sides rather than repeated literals.

The failure a future reader gets instead:

```
the operator thread failed: no round served a pending sentinel within 35s while
the scripted answer 'approve' was waiting to be delivered -- the operator thread
delivered 0 of 1 scripted answer(s); rounds on disk when it last looked:
round-001[feedback-pending.json]
```

## Tests

Four new ones, driving the diagnostic rather than trusting it:

- the operator thread's own failure is what gets raised, not the gate's symptom;
- the diagnosis names the rounds it could see, so "nothing was ever served" and "a round was served and already answered" are distinguishable — they are different faults;
- a gate failure survives with the thread's clean state attached, so the new reporting adds information and removes none;
- the margin is asserted positive for every gate deadline in the file, which is the ordering the whole report rests on.

The file is 13 tests. Five consecutive runs: 6.3 s, 6.4 s, 6.4 s, 12.3 s, 12.4 s — the slower two while the full suite was contending for the machine, which is the load that produced the original failure. Full unit suite: **9,950 passed**, 21 skipped, 5 xfailed, 7 deselected.

## What this does not do

It does not make the wait event-driven. The gate serves a real page on localhost and waits for a real HTTP POST; driving both sides deterministically would mean changing the gate, not its test, and that is a larger change than the evidence supports. The wall-clock deadline is still there.

What it does is make a red run in this file **readable**. That is the half that decides whether a suite gets read or re-run — and, as the issue notes, replay evidence in a PR body is only worth carrying if a red CI means something.

Closes #2743
