### PR TITLE
fix: assert the ratchet baseline's denominator, not just its counts (Closes #2780)

### DIFF
--- a/tests/fixtures/gate_registry_baseline.json
+++ b/tests/fixtures/gate_registry_baseline.json
@@ -1,7 +1,7 @@
 {
   "_comment": "The ratchet (#2720). tests/unit/test_gate_registry.py fails when halt_rows_per_stage or model_output_halt_rows rises above this. Lower it when a gate stops halting; raise it only with an operator ruling named in the new row's created_by, in the same PR.",
   "measured_against": {
-    "files_scanned": 184,
+    "files_scanned": 185,
     "halt_sites": 151,
     "gates": 96
   },

--- a/tests/unit/test_routing_policy.py
+++ b/tests/unit/test_routing_policy.py
@@ -116,6 +116,36 @@ class TestTheRatchet:
         baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
         assert halt_counts() == baseline["halt_rows_per_stage"]
 
+    def test_the_denominator_matches_what_it_was_measured_against(self):
+        """`measured_against` exists so a reader can see the denominator
+        without re-running anything, which only works while it is true (#2780).
+
+        The enforced counts were asserted and this block was not, so it could
+        only be right by accident of who last regenerated the baseline: #2736
+        wrote it against 184 walked files, #2733 then added
+        `workflows/testing/atlas.py` -- walked, no halt site in it -- and the
+        stated denominator quietly became wrong while every enforced number
+        stayed right.
+
+        Asserted by re-walking rather than against a literal, or this becomes
+        one more number nobody updates.
+        """
+        from pathlib import Path
+
+        from assemblyzero.core.gate_registry import GATE_REGISTRY, scan_halt_sites
+
+        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+        sites, coverage = scan_halt_sites(Path(__file__).resolve().parents[2])
+        assert baseline["measured_against"] == {
+            "files_scanned": coverage.files_scanned,
+            "halt_sites": len(sites),
+            "gates": len(GATE_REGISTRY),
+        }, (
+            "the baseline's stated denominator no longer matches the tree it "
+            "claims to describe; regenerate with "
+            "`tools/audit_halt_sites.py --write-baseline`"
+        )
+
     def test_the_ratchet_records_what_is_left(self):
         """18 model-output rows still halt. The number is pinned so it can only
         fall: #2723 took it from 24 to 19 by retiring the five stagnation


### PR DESCRIPTION
## A denominator that is quietly wrong looks like evidence

`tests/fixtures/gate_registry_baseline.json` carries a `measured_against` block, and its stated purpose is that "the counts ride with what they were measured against, so a reader can see the denominator without re-running anything."

It said **184** files scanned. `tools/audit_halt_sites.py --check` on `main` reports **185**. The other two figures — 151 halt sites, 96 gates — were right.

## How it drifted, in two merges

#2736 lowered the baseline, which regenerates the whole payload, against a tree of 184 walked files. #2733 then added `assemblyzero/workflows/testing/atlas.py` — under `assemblyzero/workflows/`, so the walker reads it. It contains no halt site, so `halt_sites` did not move and nothing failed.

That is the whole mechanism, and it is worth naming: **the counts the ratchet enforces were asserted, and the denominator that gives them meaning was not.** `TestTheRatchet` checked `halt_rows_per_stage` and `model_output_halt_rows` against the registry; `measured_against` could only ever be right by accident of who last ran `--write-baseline`.

## What changed

The baseline is regenerated, and the ratchet test now asserts `measured_against` **by re-walking the tree**, not against a literal. A literal would be one more number nobody updates, which is the defect rather than the fix. Its failure message says how to regenerate.

Both halves are needed. Regenerating alone fixes today's number and leaves the same drift available tomorrow; asserting alone would have failed this pull request until the number was fixed, which is exactly what the assertion is for.

## Scale, honestly

This is one integer in a fixture and about thirty lines of test. The reason it is worth a pull request rather than a shrug is that this repository keeps building audits to stop confidently stale figures, and the audits' own bookkeeping is not exempt — a reader deciding whether a halt-site count means anything reads the denominator printed beside it.

Found while gathering figures for a session report, which is the right way round.

`tests/unit/test_routing_policy.py` and `tests/unit/test_gate_registry.py`: 48 passed. `--check` still passes on `main`. No halt site added or removed: 151 sites, `impl` 36 halt rows, 18 model-output halt rows.

Closes #2780
